### PR TITLE
Make copy module idempotent.

### DIFF
--- a/library/copy
+++ b/library/copy
@@ -54,11 +54,10 @@ changed = False
 if os.path.exists(dest):
     md5sum = os.popen("md5sum %s" % dest).read().split()[0]
 
-os.system("cp %s %s" % (src, dest))
-
-md5sum2 = os.popen("md5sum %s" % dest).read().split()[0]
+md5sum2 = os.popen("md5sum %s" % src).read().split()[0]
 
 if md5sum != md5sum2:
+    os.system("cp %s %s" % (src, dest))
     changed = True
 
 # mission accomplished


### PR DESCRIPTION
Check md5sum before overwriting a file. Unconditionally copying changes the timestamp.

This is necessary for Red Hat Cluster Suite for example. If you use HA-LVM it checks if lvm.conf is older than the initrd.
