### PR TITLE
Remove shebang from callbacks.py

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python -tt
 # (C) 2012, Michael DeHaan, <michael.dehaan@gmail.com>
 
 # This file is part of Ansible


### PR DESCRIPTION
It is not +x, and has no **main**.  It draws ire of rpmlint.
