### PR TITLE
Always add vars to a play.

### DIFF
--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -91,8 +91,9 @@ class PlayBook(object):
 
     def _get_vars(self, play, dirname):
         ''' load the vars section from a play '''
-
-        vars = play.get('vars', {})
+        if play.get('vars') is None:
+            play['vars'] = {}
+        vars = play['vars']
         if type(vars) != dict:
             raise errors.AnsibleError("'vars' section must contain only key/value pairs")
         vars_prompt = play.get('vars_prompt', {})


### PR DESCRIPTION
A play without vars section would fail to use variables given in an include. They would be added to the dict returned by play.get, but the dict would not be added to the play.
