### PR TITLE
Wired in Michael's usage string optparse style.

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -57,7 +57,7 @@ class Cli(object):
 
         parser = utils.make_parser(
 	    options,
-            usage='ansible <host-pattern> [options]',
+            usage='%prog <host-pattern> [options]',
             runas_opts=True, 
             async_opts=True,
             output_opts=True, 

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -32,7 +32,7 @@ def main(args):
     ''' run ansible-playbook operations '''
 
     # create parser for CLI options
-    usage = "ansible-playbook playbook.yml [options]"
+    usage = "%prog playbook.yml [options]"
     options = {
        '-e' : dict(long='--extra-vars', dest='extra_vars',
                    help='pass in extra key=value variables from outside the playbook'),

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -32,7 +32,7 @@ def main(args):
     ''' run ansible-playbook operations '''
 
     # create parser for CLI options
-    usage = "%prog playbook.yml [options]"
+    usage = "%prog <playbook-file1 [playbook-file2...]> [options]"
     options = {
        '-e' : dict(long='--extra-vars', dest='extra_vars',
                    help='pass in extra key=value variables from outside the playbook'),
@@ -43,7 +43,9 @@ def main(args):
     options, args = parser.parse_args(args)
 
     if len(args) == 0:
-        print >> sys.stderr, "playbook path is a required argument"
+        parser.print_help(file=sys.stderr)
+        #QUESTION for M.D. This would match bin/ansible's behavior. Do we want them consistent?
+        #parser.print_help()
         return 1
 
     sshpass = None

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -284,7 +284,9 @@ def make_parser(add_options, constants=C, usage="", output_opts=False, runas_opt
     )
     options.update(add_options)
 
+    #NOTE: optparse deprecated in Python >= 2.7. 
     parser = optparse.OptionParser()
+    parser.set_usage(usage)
     names = sorted(options.keys())
     for n in names:
         data  = options[n].copy()


### PR DESCRIPTION
Just a quick patch to show the usage string intended for 'ansible.' (I didn't patch ansible-playbook yet but can do if you like the patch.)
