### PR TITLE
Template the source file of the copy module.

### DIFF
--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -368,7 +368,11 @@ class Runner(object):
         dest   = options.get('dest', None)
         if source is None or dest is None:
             return (host, True, dict(failed=True, msg="src and dest are required"), '')
-        
+
+        # apply templating to source argument
+        inject = self.setup_cache.get(conn.host,{})
+        source = utils.template(source, inject)
+
         # transfer the file to a remote tmp location
         tmp_src = tmp + source.split('/')[-1]
         conn.put_file(utils.path_dwim(self.basedir, source), tmp_src)

--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -463,6 +463,10 @@ class Runner(object):
             else:
                 metadata = '~/.ansible/setup'
 
+        # apply templating to source argument
+        inject = self.setup_cache.get(conn.host,{})
+        source = utils.template(source, inject)
+
         # first copy the source template over
         temppath = tmp + os.path.split(source)[-1]
         conn.put_file(utils.path_dwim(self.basedir, source), temppath)


### PR DESCRIPTION
In a playbook, given that this works:

```

---
- hosts: all
  vars:
    port: 5150
  tasks:
  - name: test basic shell, plus two ways to dereference a variable
    action: shell echo $HOME $port {{ port }}
```

I expect this to work too:

```

---
- hosts: all
  vars:
    template: "../templates"
  tasks:
  - name: DNS configuration
    action: copy src=$template/etc/resolv.conf dest=/etc/resolv.conf
```

It currently fails because we template the arguments after we try to copy the file.

This is a quick fix, but we really need to rethink/refactor our templating strategy. We template far too often. With this fix 14 times per copy play for two nodes!
