### PR TITLE
Align vars syntax

### DIFF
--- a/lib/ansible/inventory.py
+++ b/lib/ansible/inventory.py
@@ -216,11 +216,16 @@ class Inventory(object):
 
     def _parse_yaml_host(self, item, variables=[]):
         def set_variables(host, variables):
-            for variable in variables:
-                if len(variable) != 1:
-                    raise errors.AnsibleError("Only one item expected in %s"%(variable))
-                k, v = variable.items()[0]
-                self._set_variable(host, k, v)
+            if type(variables) == list:
+                for variable in variables:
+                    if len(variable) != 1:
+                        raise errors.AnsibleError("Only one item expected in %s"%(variable))
+                    k, v = variable.items()[0]
+                    self._set_variable(host, k, v)
+            elif type(variables) == dict:
+                for k, v in variables.iteritems():
+                    self._set_variable(host, k, v)
+
 
         if type(item) in [str, unicode]:
             set_variables(item, variables)

--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -118,8 +118,18 @@ class PlayBook(object):
         if play.get('vars') is None:
             play['vars'] = {}
         vars = play['vars']
-        if type(vars) != dict:
+        if type(vars) not in [dict, list]:
             raise errors.AnsibleError("'vars' section must contain only key/value pairs")
+
+        # translate a list of vars into a dict
+        if type(vars) == list:
+            varlist = vars
+            vars =  {}
+            for item in varlist:
+                k, v = item.items()[0]
+                vars[k] = v
+            play['vars'] = vars
+
         vars_prompt = play.get('vars_prompt', {})
         if type(vars_prompt) != dict:
             raise errors.AnsibleError("'vars_prompt' section must contain only key/value pairs")

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -220,13 +220,13 @@ class TestInventory(unittest.TestCase):
         inventory = self.yaml_inventory()
         vars = inventory.get_variables('saturn')
 
-        assert vars == {"moon":"titan"}
+        assert vars == {"moon":"titan", "moon2":"enceladus"}
 
     def test_yaml_port(self):
         inventory = self.yaml_inventory()
         vars = inventory.get_variables('hera')
 
-        assert vars == {'ansible_ssh_port': 3000}
+        assert vars == {'ansible_ssh_port': 3000, 'ntp_server': 'olympus.example.com'}
 
     ### Test Runner class method
 

--- a/test/yaml_hosts
+++ b/test/yaml_hosts
@@ -3,7 +3,8 @@
 - jupiter
 - host: saturn
   vars:
-  - moon: titan
+    moon: titan
+    moon2: enceladus
 
 - zeus
 
@@ -14,6 +15,7 @@
   - poseidon
   vars:
   - ansible_ssh_port: 3000
+  - ntp_server: olympus.example.com
 
 - group: norse
   hosts:


### PR DESCRIPTION
This aligns the vars syntax in playbooks and YAML inventory. This fixes #165.

(rebased to a slightly older revision because the 'slurp' module is missing in integration)
