### PR TITLE
Adds PKGBUILD file for Arch linux

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,44 @@
+#Maintainer: Michel Blanc <mblanc@erasme.org>
+pkgname=ansible-git
+pkgver=20120419
+pkgrel=1
+pkgdesc="A radically simple deployment, model-driven configuration management, and command execution framework"
+arch=('any')
+url="https://github.com/ansible/ansible"
+license=('GPL3')
+depends=('python2' 'python-paramiko>=1.7.7' 'python2-jinja' 'python-simplejson')
+makedepends=('git' 'asciidoc')
+
+_gitroot="https://github.com/ansible/ansible"
+_gitname="ansible"
+
+build() {
+  cd "$srcdir"
+  msg "Connecting to GIT server...."
+
+  if [ -d $_gitname ] ; then
+    cd $_gitname && git pull origin
+    msg "The local files are updated."
+  else
+    git clone $_gitroot $_gitname
+  fi
+
+  msg "GIT checkout done or server timeout"
+
+  cd "$srcdir/$_gitname"
+  make
+}
+
+package() {
+  cd "$srcdir/$_gitname"
+
+  mkdir -p ${pkgdir}/usr/share/ansible
+  cp ./library/* ${pkgdir}/usr/share/ansible/
+  python setup.py install -O1 --root=${pkgdir}
+
+  install -D docs/man/man1/ansible.1 ${pkgdir}/usr/share/man/man1/ansible.1
+  install -D docs/man/man1/ansible-playbook.1 ${pkgdir}/usr/share/man/man1/ansible-playbook.1
+
+  gzip -9 ${pkgdir}/usr/share/man/man1/ansible.1
+  gzip -9 ${pkgdir}/usr/share/man/man1/ansible-playbook.1
+}

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -6,8 +6,8 @@ pkgdesc="A radically simple deployment, model-driven configuration management, a
 arch=('any')
 url="https://github.com/ansible/ansible"
 license=('GPL3')
-depends=('python2' 'python-paramiko>=1.7.7' 'python2-jinja' 'python-simplejson')
-makedepends=('git' 'asciidoc')
+depends=('python2' 'python2-yaml' 'python-paramiko>=1.7.7' 'python2-jinja' 'python-simplejson')
+makedepends=('git' 'asciidoc' 'fakeroot')
 
 _gitroot="https://github.com/ansible/ansible"
 _gitname="ansible"


### PR DESCRIPTION
This PR adds a PKGBUILD for Arch Linux.
It's been tested on a fresh and updated Arch install.
Under arch, a symlink has to be created so python points to python2 and _not_ python3, e.g. : `sudo ln -sf /usr/bin/python2 /usr/bin/python`
