### PR TITLE
Update secontext behavior in file module

### DIFF
--- a/examples/playbooks/file_secontext.yml
+++ b/examples/playbooks/file_secontext.yml
@@ -9,4 +9,10 @@
       action: file path=/etc/exports seuser=unconfined_u
     - name: Set selinux context back to default value
       action: file path=/etc/exports context=default
-  
+    - name: Create empty file
+      action: command /bin/touch /tmp/foo
+    - name: Change setype of /tmp/foo
+      action: file path=/tmp/foo setype=default_t
+    - name: Try to set secontext to default, but this will fail
+            because of the lack of a default in the policy
+      action: file path=/tmp/foo context=default

--- a/examples/playbooks/file_secontext.yml
+++ b/examples/playbooks/file_secontext.yml
@@ -1,0 +1,12 @@
+---
+# This is a demo of how to manage the selinux context using the file module
+- hosts: test
+  user: root
+  tasks:
+    - name: Change setype of /etc/exports to non-default value
+      action: file path=/etc/exports setype=etc_t
+    - name: Change seuser of /etc/exports to non-default value
+      action: file path=/etc/exports seuser=unconfined_u
+    - name: Set selinux context back to default value
+      action: file path=/etc/exports context=default
+  

--- a/library/file
+++ b/library/file
@@ -72,6 +72,21 @@ def add_path_info(kwargs):
         kwargs['state'] = 'absent'
     return kwargs 
  
+# If selinux fails to find a default, return an array of None
+def selinux_default_context(path, mode=0):
+    context = [None, None, None, None]
+    if not HAVE_SELINUX:
+        return context
+    try:
+        ret = selinux.matchpathcon(path, mode)
+    except OSError:
+        return context
+    if ret[0] == -1:
+        return context
+    context = ret[1].split(':')
+    debug("got default secontext=%s" % ret[1])
+    return context
+
 # ===========================================
 
 argfile = sys.argv[1]
@@ -107,7 +122,15 @@ seuser    = params.get('seuser', None)
 serole    = params.get('serole', None)
 setype    = params.get('setype', None)
 selevel   = params.get('serange', 's0')
+context   = params.get('context', None)
 secontext = [seuser, serole, setype, selevel]
+
+if context is not None:
+    if context != 'default':
+        fail_json(msg='invalid context: %s' % context)
+    if seuser is not None or serole is not None or setype is not None:
+        fail_json(msg='cannot define context=default and seuser, serole or setype')
+    secontext = selinux_default_context(path)
 
 if state not in [ 'file', 'directory', 'link', 'absent']:
     fail_json(msg='invalid state: %s' % state)
@@ -148,34 +171,14 @@ def selinux_context(path):
     debug("got current secontext=%s" % ret[1])
     return context
 
-# If selinux fails to find a default, return an array of None
-def selinux_default_context(path, mode=0):
-    context = [None, None, None, None]
-    print >>sys.stderr, path
-    if not HAVE_SELINUX:
-        return context
-    try:
-        ret = selinux.matchpathcon(path, mode)
-    except OSError:
-        return context
-    if ret[0] == -1:
-        return context
-    context = ret[1].split(':')
-    debug("got default secontext=%s" % ret[1])
-    return context
-
 def set_context_if_different(path, context, changed):
     if not HAVE_SELINUX:
         return changed
     cur_context = selinux_context(path)
-    new_context = selinux_default_context(path)
+    new_context = list(cur_context)
     for i in range(len(context)):
         if context[i] is not None and context[i] != cur_context[i]:
-            debug('new context was %s' % new_context[i])
             new_context[i] = context[i]
-            debug('new context is %s' % new_context[i])
-        elif new_context[i] is None:
-            new_context[i] = cur_context[i]
     debug("current secontext is %s" % ':'.join(cur_context))
     debug("new secontext is %s" % ':'.join(new_context))
     if cur_context != new_context:


### PR DESCRIPTION
Per discussion, adds context=default to file module to specify a return to default selinux context.  Drops implicit behavior of reverting selinux context if se\* options are removed.
