### PR TITLE
Updates to address issues #202 and #205

### DIFF
--- a/examples/scripts/cobbler_external_inventory.py
+++ b/examples/scripts/cobbler_external_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Cobbler external inventory script

--- a/examples/scripts/uptime.py
+++ b/examples/scripts/uptime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 # example of getting the uptime of all hosts, 10 at a time
 

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #

--- a/lib/ansible/connection.py
+++ b/lib/ansible/connection.py
@@ -18,11 +18,15 @@
 
 ################################################
 
+from __future__ import with_statement
 import warnings
 # prevent paramiko warning noise
 # see http://stackoverflow.com/questions/3920502/
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
+if hasattr(warnings, "catch_warnings"):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        import paramiko
+else:
     import paramiko
 
 import traceback

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -24,7 +24,16 @@ import re
 import jinja2
 import yaml
 import optparse
-from operator import methodcaller
+try:
+    from operator import methodcaller
+
+except ImportError:
+    def methodcaller(name, *args, **kwargs):
+        def caller(obj):
+            return getattr(obj, name)(*args, **kwargs)
+
+        return caller
+
 try:
     import json
 except ImportError:

--- a/library/apt
+++ b/library/apt
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # (c) 2012, Flowroute LLC
 # Written by Matthew Williams <matthew@flowroute.com>
 # Based on yum module written by Seth Vidal <skvidal at fedoraproject.org>

--- a/library/async_status
+++ b/library/async_status
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others
 #

--- a/library/async_wrapper
+++ b/library/async_wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others
 #

--- a/library/command
+++ b/library/command
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others
 #

--- a/library/copy
+++ b/library/copy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #

--- a/library/failtest
+++ b/library/failtest
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #

--- a/library/fetch
+++ b/library/fetch
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #

--- a/library/file
+++ b/library/file
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #

--- a/library/git
+++ b/library/git
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #

--- a/library/ping
+++ b/library/ping
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #

--- a/library/service
+++ b/library/service
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #

--- a/library/setup
+++ b/library/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #

--- a/library/template
+++ b/library/template
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #

--- a/library/user
+++ b/library/user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>
 #

--- a/library/virt
+++ b/library/virt
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python 
 """
 Virt management features
 

--- a/library/yum
+++ b/library/yum
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # (c) 2012, Red Hat, Inc
 # Written by Seth Vidal <skvidal at fedoraproject.org>
 #


### PR DESCRIPTION
These updates should take care of the python2.5 issues.  paramiko doesn't seem to be issuing any warnings, so only trying to do the catch_warnings if that attribute exists on the module seems to do the trick.  Changed the references to Python in the shebang line to use the "env" util, which also seems to work.

That said, I'm _just_ starting to learn about ansible so I don't know all of the implications of these changes.
