### PR TITLE
Allow modules to return facts.

### DIFF
--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -397,6 +397,12 @@ class PlayBook(object):
             module_args, module_vars, remote_user, async_seconds, 
             async_poll_interval, only_if, sudo, transport, port)
 
+        # add facts to the global setup cache
+        for host, result in results['contacted'].iteritems():
+            if "ansible_facts" in result:
+                for k,v in result['ansible_facts'].iteritems():
+                    SETUP_CACHE[host][k]=v
+
         self.stats.compute(results)
 
         # if no hosts are matched, carry on, unlike /bin/ansible
@@ -528,7 +534,8 @@ class PlayBook(object):
         if vars_files is None:
             # first pass only or we'll erase good work
             for (host, result) in setup_ok.iteritems():
-                SETUP_CACHE[host] = result
+                if 'ansible_facts' in result:
+                    SETUP_CACHE[host] = result['ansible_facts']
 
     # *****************************************************
 

--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -301,9 +301,9 @@ class Runner(object):
         ''' allows discovered variables to be used in templates and action statements '''
 
         host = conn.host
-        try:
-            var_result = utils.parse_json(result)
-        except:
+        if 'ansible_facts' in result:
+            var_result = result['ansible_facts']
+        else:
             var_result = {}
 
         # note: do not allow variables from playbook to be stomped on
@@ -328,10 +328,12 @@ class Runner(object):
         module = self._transfer_module(conn, tmp, module_name)
         (result, err, executed) = self._execute_module(conn, tmp, module, self.module_args)
 
-        if module_name == 'setup':
-            self._add_result_to_setup_cache(conn, result)
+        (host, ok, data, err) = self._return_from_module(conn, host, result, err, executed)
 
-        return self._return_from_module(conn, host, result, err, executed)
+        if ok:
+            self._add_result_to_setup_cache(conn, data)
+
+        return (host, ok, data, err)
 
     # *****************************************************
 

--- a/library/facter
+++ b/library/facter
@@ -22,4 +22,6 @@
 #    facter
 #    ruby-json
 
+echo '{ "ansible_facts":'
 /usr/bin/facter --json
+echo '}'

--- a/library/ohai
+++ b/library/ohai
@@ -18,4 +18,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+echo '{ "ansible_facts":'
 /usr/bin/ohai
+echo '}'

--- a/library/setup
+++ b/library/setup
@@ -362,9 +362,11 @@ md5sum2 = os.popen("md5sum %s" % ansible_file).read().split()[0]
 if md5sum != md5sum2:
    changed = True
 
-setup_options['written'] = ansible_file
-setup_options['changed'] = changed
-setup_options['md5sum']  = md5sum2 
+setup_result = {}
+setup_result['written'] = ansible_file
+setup_result['changed'] = changed
+setup_result['md5sum']  = md5sum2 
+setup_result['ansible_facts'] = setup_options
 
-print json.dumps(setup_options)
+print json.dumps(setup_result)
 

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -85,15 +85,17 @@ class TestRunner(unittest.TestCase):
        if not get_binary("facter"):
            raise SkipTest
        result = self._run('facter',[])
-       assert "hostname" in result
+       assert "hostname" in result['ansible_facts']
 
    # temporarily disbabled since it occasionally hangs
    # ohai's fault, setup module doesn't actually run this
    # to get ohai's "facts" anyway
    #
    #def test_ohai(self):
+   #    if not get_binary("facter"):
+   #            raise SkipTest
    #    result = self._run('ohai',[])
-   #    assert "hostname" in result
+   #    assert "hostname" in result['ansible_facts']
 
    def test_copy(self):
        # test copy module, change trigger, etc


### PR DESCRIPTION
If the module result contains "ansible_facts", that will be added to the setup cache.

This fixes #203.

Example module:

``` python
#!/usr/bin/env python

import json
import sys

print json.dumps( {"ansible_facts": {"myname":"jeroen"}} )
sys.exit(0)
```

Example playbook:

```
- hosts: all
  vars:
  - testvar: "ok"
  tasks:
  - name: ping
    action: ping all
  - name: custom facts
    action: custom
  - name: test
    action: template src=../templates/root/facts.txt dest=/root/facts.txt
```

Template:

```
Facts:
{{ ansible_kernel }}
{{ hostvars['rh6oranode2']['ansible_eth0']['ipv4']['address'] }}
{{ myname }}
Above {{ testvar }}.
```

Result:

```
[root@rh6oranode1 ~]# cat facts.txt 
Facts:
2.6.32-220.el6.x86_64
192.168.122.52
jeroen
Above ok.
```

Facter/Ohai only dummy-tested since I don't have them on my systems.

Also, what's the use of `_add_result_to_setup_cache` in Runner? When run in a subprocess, the global setup cache can't be modified? I probably miss something in my understanding...
