### PR TITLE
Ohai and facter modules should not use the ansible_facts API.

### DIFF
--- a/library/facter
+++ b/library/facter
@@ -22,6 +22,4 @@
 #    facter
 #    ruby-json
 
-echo '{ "ansible_facts":'
 /usr/bin/facter --json
-echo '}'

--- a/library/ohai
+++ b/library/ohai
@@ -18,6 +18,4 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-echo '{ "ansible_facts":'
 /usr/bin/ohai
-echo '}'

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -85,7 +85,7 @@ class TestRunner(unittest.TestCase):
        if not get_binary("facter"):
            raise SkipTest
        result = self._run('facter',[])
-       assert "hostname" in result['ansible_facts']
+       assert "hostname" in result
 
    # temporarily disbabled since it occasionally hangs
    # ohai's fault, setup module doesn't actually run this
@@ -95,7 +95,7 @@ class TestRunner(unittest.TestCase):
    #    if not get_binary("facter"):
    #            raise SkipTest
    #    result = self._run('ohai',[])
-   #    assert "hostname" in result['ansible_facts']
+   #    assert "hostname" in result
 
    def test_copy(self):
        # test copy module, change trigger, etc


### PR DESCRIPTION
They are meant to be used in standalone scripts.
