### PR TITLE
Default remote user to current user.

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -17,7 +17,7 @@
 #
 
 import os
-
+from getpass import getuser
 
 DEFAULT_HOST_LIST      = os.environ.get('ANSIBLE_HOSTS',
     '/etc/ansible/hosts')
@@ -30,10 +30,9 @@ DEFAULT_FORKS          = 5
 DEFAULT_MODULE_ARGS    = ''
 DEFAULT_TIMEOUT        = 10
 DEFAULT_POLL_INTERVAL  = 15
-DEFAULT_REMOTE_USER    = 'root'
+DEFAULT_REMOTE_USER    = getuser()
 DEFAULT_REMOTE_PASS    = None
 DEFAULT_SUDO_PASS      = None
 DEFAULT_REMOTE_PORT    = 22
 DEFAULT_TRANSPORT      = 'paramiko'
 DEFAULT_TRANSPORT_OPTS = ['local', 'paramiko']
-


### PR DESCRIPTION
One of Ansible's design goals is "Be usable as non-root."  Defaulting to the current username instead of root makes this easier.  For security reasons, many distros disable the root account altogether, and most disable remote root logins.  The "getting started" example doesn't work unless you're running as root, have copied root's public key around, and enabled remote root login.  These encourage poor security.  It would be nice to use ansible like a multi-way-ssh out of the box, defaulting to the current username like ssh does.  When you want to do remote admin, sudo is the way to go.  Making you go out of your way to use more-convenient but less-secure passwordless root login seems like a good thing.  That said, it is billed as a system admin tool, so I can see people wanting root to be the default.
