### PR TITLE
runner._chain_file_module() calls .get() on error string

### DIFF
--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -456,8 +456,11 @@ class Runner(object):
         (result2, err2, executed2) = self._execute_module(conn, tmp, module, args)
         results2 = self._return_from_module(conn, conn.host, result2, err2, executed)
         (host, ok, data2, err2) = results2
-        new_changed = data2.get('changed', False)
-        data.update(data2)
+        if ok:
+            new_changed = data2.get('changed', False)
+            data.update(data2)
+        else:
+            new_changed = False
         if old_changed or new_changed:
             data['changed'] = True
         return (host, ok, data, "%s%s"%(err,err2))


### PR DESCRIPTION
runner._return_from_module() normally returns a list (?) of `[str,bool,dict,str]`, but on error it returns `[str,bool,str,str]`.  runner._chain_file_module() then tries to call .get() on the third item (`data2`), which fails when it's a string.  This patch only accesses `data2` if the return value was `ok`.  It might be better to return consistent types in both cases, but I'm not sure where/how else the return value is used.
