### PR TITLE
Support YAML list of hosts in playbook.

### DIFF
--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -544,6 +544,8 @@ class PlayBook(object):
 
         # get configuration information about the pattern
         pattern  = pg.get('hosts',None)
+        if isinstance(pattern, list):
+            pattern = ';'.join(pattern)
         if self.override_hosts:
             pattern = 'all'
         if pattern is None:


### PR DESCRIPTION
Reading the docs, I was a bit confused as to how to specify multiple hosts/groups in a playbook.  Being YAML, I assumed a normal YAML list would work:

```

---
- hosts: [host1, host2]
```

But this crashes when inventory._matches() assumes hosts is a string.  This patch just checks if hosts is a list, and turns it into a string joined by ';'.
