### PR TITLE
Second pass at OSX support.

### DIFF
--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -432,13 +432,10 @@ class Runner(object):
         if os.path.exists(dest):
             utils.get_md5sum(dest)
 
-        remote_md5 = self._exec_command(conn, """python -c 'import hashlib
-        import sys
-        md5 = hashlib.md5()
-        with open(sys.argv[1]) as f:
-            for chunk in iter(lambda: f.read(128), b""):
-        md5.update(chunk)
-        print md5.hexdigest()' %s""" % source, tmp, True)[0]
+        try:
+            remote_md5 = self._exec_command(conn, "md5sum %s" % source, tmp, True)[0].split()[0]
+        except:
+            remote_md5 = self._exec_command(conn, "md5 -q %s" % source, tmp, True)[0]
 
         if remote_md5 != local_md5:
             # create the containing directories, if needed

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -24,6 +24,7 @@ import re
 import jinja2
 import yaml
 import optparse
+import hashlib
 from operator import methodcaller
 try:
     import json
@@ -330,4 +331,10 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False, asyn
 
     return parser
 
-
+def get_md5sum(filename):
+    ''' get the md5sum for a given file '''
+    md5 = hashlib.md5()
+    with open(filename) as f:
+        for chunk in iter(lambda: f.read(128), b''):
+            md5.update(chunk)
+    return md5.hexdigest()

--- a/library/copy
+++ b/library/copy
@@ -21,6 +21,14 @@
 import sys
 import os
 import shlex
+import hashlib
+
+def get_md5sum(filename):
+    md5 = hashlib.md5()
+    with open(filename) as f:
+        for chunk in iter(lambda: f.read(128), b''):
+            md5.update(chunk)
+    return md5.hexdigest()
 
 # ===========================================
 # convert arguments of form a=b c=d
@@ -55,9 +63,8 @@ if not os.path.exists(src):
 md5sum = None
 changed = False
 if os.path.exists(dest):
-    md5sum = os.popen("md5sum %s" % dest).read().split()[0]
-
-md5sum2 = os.popen("md5sum %s" % src).read().split()[0]
+    md5sum = get_md5sum(dest)
+md5sum2 = get_md5sum(src)
 
 if md5sum != md5sum2:
     os.system("cp %s %s" % (src, dest))

--- a/library/file
+++ b/library/file
@@ -29,6 +29,7 @@ import shutil
 import stat
 import grp
 import pwd
+import hashlib
 try:
     import selinux
     HAVE_SELINUX=True
@@ -146,7 +147,11 @@ changed = False
 # support functions
 
 def md5sum(filename):
-    return os.popen("/usr/bin/md5sum %s" % f).read()
+    md5 = hashlib.md5()
+    with open(filename) as f:
+        for chunk in iter(lambda: f.read(128), b''):
+            md5.update(chunk)
+    return md5.hexdigest()
 
 def user_and_group(filename):
     st = os.stat(filename)

--- a/library/setup
+++ b/library/setup
@@ -30,6 +30,7 @@ import shlex
 import socket
 import struct
 import subprocess
+import hashlib
 import traceback
 
 try:
@@ -70,6 +71,13 @@ def get_file_content(path):
     else:
         data = None
     return data
+
+def get_md5sum(filename):
+    md5 = hashlib.md5()
+    with open(filename) as f:
+        for chunk in iter(lambda: f.read(128), b''):
+            md5.update(chunk)
+    return md5.hexdigest()
 
 # platform.dist() is deprecated in 2.6
 # in 2.6 and newer, you should use platform.linux_distribution()
@@ -226,29 +234,31 @@ def get_iface_hwaddr(iface):
 def get_network_facts(facts):
     facts['fqdn'] = socket.gethostname()
     facts['hostname'] = facts['fqdn'].split('.')[0]
-    facts['interfaces'] = get_interfaces()
-    for iface in facts['interfaces']:
-        facts[iface] = { 'macaddress': get_iface_hwaddr(iface) }
-        # This is lame, but there doesn't appear to be a good way
-        # to get all addresses for both IPv4 and IPv6.
-        cmd = subprocess.Popen("/sbin/ifconfig %s" % iface, shell=True,
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = cmd.communicate()
-        for line in out.split('\n'):
-            data = line.split()
-            if 'inet addr' in line:
-                if 'ipv4' not in facts[iface]:
-                    facts[iface]['ipv4'] = {}
-                facts[iface]['ipv4'] = { 'address': data[1].split(':')[1],
-                                         'netmask': data[-1].split(':')[1] }
-            if 'inet6 addr' in line:
-                (ip, prefix) = data[2].split('/')
-                scope = data[3].split(':')[1].lower()
-                if 'ipv6' not in facts[iface]:
-                    facts[iface]['ipv6'] = []
-                facts[iface]['ipv6'].append( { 'address': ip,
-                                               'prefix': prefix,
-                                               'scope': scope } )
+    # TODO: Only support Linux interfaces facts right now, need to support the rest
+    if facts['system'] == "Linux":
+        facts['interfaces'] = get_interfaces()
+        for iface in facts['interfaces']:
+            facts[iface] = { 'macaddress': get_iface_hwaddr(iface) }
+            # This is lame, but there doesn't appear to be a good way
+            # to get all addresses for both IPv4 and IPv6.
+            cmd = subprocess.Popen("/sbin/ifconfig %s" % iface, shell=True,
+                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            out, err = cmd.communicate()
+            for line in out.split('\n'):
+                data = line.split()
+                if 'inet addr' in line:
+                    if 'ipv4' not in facts[iface]:
+                        facts[iface]['ipv4'] = {}
+                    facts[iface]['ipv4'] = { 'address': data[1].split(':')[1],
+                                             'netmask': data[-1].split(':')[1] }
+                if 'inet6 addr' in line:
+                    (ip, prefix) = data[2].split('/')
+                    scope = data[3].split(':')[1].lower()
+                    if 'ipv6' not in facts[iface]:
+                        facts[iface]['ipv6'] = []
+                    facts[iface]['ipv6'].append( { 'address': ip,
+                                                   'prefix': prefix,
+                                                   'scope': scope } )
     return facts
 
 def get_public_ssh_host_keys(facts):
@@ -295,7 +305,7 @@ except:
        (k,v) = opt.split("=")
        setup_options[k]=v   
 
-ansible_file = setup_options.get('metadata', DEFAULT_ANSIBLE_SETUP)
+ansible_file = os.path.expanduser(setup_options.get('metadata', DEFAULT_ANSIBLE_SETUP))
 ansible_dir = os.path.dirname(ansible_file)
 
 # create the config dir if it doesn't exist
@@ -308,7 +318,7 @@ md5sum = None
 if not os.path.exists(ansible_file):
     changed = True
 else:
-    md5sum = os.popen("md5sum %s" % ansible_file).read().split()[0]
+    md5sum = get_md5sum(ansible_file)
 
 # Get some basic facts in case facter or ohai are not installed
 for (k, v) in ansible_facts().items():
@@ -357,7 +367,7 @@ reformat = json.dumps(setup_options, sort_keys=True, indent=4)
 f.write(reformat)
 f.close()
 
-md5sum2 = os.popen("md5sum %s" % ansible_file).read().split()[0]
+md5sum2 = get_md5sum(ansible_file)
 
 if md5sum != md5sum2:
    changed = True

--- a/library/slurp
+++ b/library/slurp
@@ -33,7 +33,7 @@ except ImportError:
 
 if len(sys.argv) == 1:
     sys.exit(1)
-argfile = sys.argv[1]
+argfile = os.path.expanduser(sys.argv[1])
 if not os.path.exists(argfile):
     sys.exit(1)
 items = shlex.split(open(argfile, 'r').read())

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -145,14 +145,14 @@ class TestRunner(unittest.TestCase):
    def test_command(self):
    
        # test command module, change trigger, etc
-       result = self._run('command', [ "/bin/echo", "hi" ])
+       result = self._run('command', [ "echo", "hi" ])
        assert "failed" not in result
        assert "msg" not in result
        assert result['rc'] == 0
        assert result['stdout'] == 'hi'
        assert result['stderr'] == ''
    
-       result = self._run('command', [ "/bin/false" ])
+       result = self._run('command', [ "false" ])
        assert result['rc'] == 1
        assert 'failed' not in result
    
@@ -161,7 +161,7 @@ class TestRunner(unittest.TestCase):
        assert 'failed' in result
        assert 'rc' not in result
 
-       result = self._run('shell', [ "/bin/echo", "$HOME" ])
+       result = self._run('shell', [ "echo", "$HOME" ])
        assert 'failed' not in result
        assert result['rc'] == 0 
    

--- a/test/playbook1.yml
+++ b/test/playbook1.yml
@@ -18,10 +18,10 @@
   tasks:
 
   - name: test basic success command
-    action: command /bin/true
+    action: command true
 
   - name: test basic success command 2
-    action: command /bin/true
+    action: command true
 
   - name: test basic shell, plus two ways to dereference a variable
     action: shell echo $HOME $port {{ port }}


### PR DESCRIPTION
Mostly to do with how we get md5sum of a file and the users home directory of a file and the users home directory.

This one now uses a try/catch instead of a python one liner for remote file md5 calc

This has been tested on:

OSX Lion (10.7.3)
Ubuntu 10.04 LTS
