### PR TITLE
Adds locale support to the setup module

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -231,7 +231,7 @@ def get_network_facts(facts):
         facts[iface] = { 'macaddress': get_iface_hwaddr(iface) }
         # This is lame, but there doesn't appear to be a good way
         # to get all addresses for both IPv4 and IPv6.
-        cmd = subprocess.Popen("/sbin/ifconfig %s" % iface, shell=True,
+        cmd = subprocess.Popen("LANG=C /sbin/ifconfig %s" % iface, shell=True,
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = cmd.communicate()
         for line in out.split('\n'):
@@ -318,7 +318,7 @@ for (k, v) in ansible_facts().items():
 # ruby-json is ALSO installed, include facter data in the JSON
 
 if os.path.exists("/usr/bin/facter"):
-   cmd = subprocess.Popen("/usr/bin/facter --json", shell=True,
+   cmd = subprocess.Popen("LANG=C /usr/bin/facter --json", shell=True,
        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
    out, err = cmd.communicate()
    facter = True

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,12 +1,12 @@
 #Maintainer: Michel Blanc <mblanc@erasme.org>
 pkgname=ansible-git
 pkgver=20120419
-pkgrel=1
+pkgrel=2
 pkgdesc="A radically simple deployment, model-driven configuration management, and command execution framework"
 arch=('any')
 url="https://github.com/ansible/ansible"
 license=('GPL3')
-depends=('python2' 'python2-yaml' 'python-paramiko>=1.7.7' 'python2-jinja' 'python-simplejson')
+depends=('python2' 'python2-yaml' 'python-paramiko>=1.7.7' 'python2-jinja' 'python-simplejson' 'python2-yaml')
 makedepends=('git' 'asciidoc' 'fakeroot')
 
 _gitroot="https://github.com/ansible/ansible"


### PR DESCRIPTION
When ran on non-english locale systems, setup module fails to get IP
addresses. This commit adds support for non-english locale by enforcing
LANG when executing shell command on minions
