### PR TITLE
Return the octal mode of a file instead of decimal.

### DIFF
--- a/library/file
+++ b/library/file
@@ -58,7 +58,7 @@ def add_path_info(kwargs):
         kwargs['user']  = user
         kwargs['group'] = group
         st = os.stat(path)
-        kwargs['mode']  = stat.S_IMODE(st[stat.ST_MODE])
+        kwargs['mode']  = oct(stat.S_IMODE(st[stat.ST_MODE]))
         # secontext not yet supported
         if os.path.islink(path):
             kwargs['state'] = 'link'


### PR DESCRIPTION
`ansible node -m template -a "dest=/root/... src=templates/root/... mode=755"`

The file module returned output like:

```
node | success >> {
    "changed": true, 
    "group": "root", 
    "md5sum": "68de71f98247453c169a96ebe6aab59f", 
    "mode": 493, 
    "path": "/root/...", 
    "state": "file", 
    "user": "root"
}
```

While correct, the mode is confusing, especially given the arguments. This commit changes it into:

```
node | success >> {
    "changed": false, 
    "group": "root", 
    "md5sum": "68de71f98247453c169a96ebe6aab59f", 
    "mode": "0755", 
    "path": "/root/...", 
    "state": "file", 
    "user": "root"
}
```
