### PR TITLE
Fix for LocalConnection

### DIFF
--- a/lib/ansible/connection.py
+++ b/lib/ansible/connection.py
@@ -193,9 +193,10 @@ class ParamikoConnection(object):
 class LocalConnection(object):
     ''' Local based connections '''
 
-    def __init__(self, runner, host):
+    def __init__(self, runner, host, port=None):
         self.runner = runner
         self.host = host
+        self.port = port
 
     def connect(self, port=None):
         ''' connect to the local host; nothing to do here '''


### PR DESCRIPTION
Make LocalConnection match the arguments passed to it from
Connection.connect().  The latter passes three arguments: runner, host,
and None.  The former accepted two: runner and host.  The former now
accepts three for consistency with ParamikoConnection.
