### PR TITLE
[devel] ansible-playbook hangs if not passed --extra-vars

### DIFF
--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -267,11 +267,12 @@ def parse_yaml_from_file(path):
 def parse_kv(args):
     ''' convert a string of key/value items to a dict '''
     options = {}
-    vargs = shlex.split(args, posix=True) 
-    for x in vargs:
-        if x.find("=") != -1:
-            k, v = x.split("=")
-            options[k]=v
+    if not args is None:
+        vargs = shlex.split(args, posix=True)
+        for x in vargs:
+            if x.find("=") != -1:
+                k, v = x.split("=")
+                options[k]=v
     return options
 
 class SortedOptParser(optparse.OptionParser):


### PR DESCRIPTION
The default `None` value for `extra_vars` ends up getting passed down to `shlex.split()`, which causes it to attempt to read from `stdin`.
