### PR TITLE
Introduce group_names in template variables.

### DIFF
--- a/lib/ansible/inventory.py
+++ b/lib/ansible/inventory.py
@@ -81,13 +81,19 @@ class Inventory(object):
     def get_variables(self, host):
         """ Return the variables associated with this host. """
 
+        variables = {}
         if host in self._variables:
-            return self._variables[host].copy()
+            variables.update(self._variables[host].copy())
 
-        if not self._is_script:
-            return {}
+        if self._is_script:
+            variables.update(self._get_variables_from_script(host))
 
-        return self._get_variables_from_script(host)
+        variables['group_names'] = []
+        for name,hosts in self.groups.iteritems():
+            if host in hosts:
+                variables['group_names'].append(name)
+
+        return variables
 
     # *****************************************************
 

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -85,13 +85,13 @@ class TestInventory(unittest.TestCase):
         inventory = self.simple_inventory()
         vars = inventory.get_variables('thor')
 
-        assert vars == {}
+        assert vars == {'group_names': ['norse']}
 
     def test_simple_port(self):
         inventory = self.simple_inventory()
         vars = inventory.get_variables('hera')
 
-        assert vars == {'ansible_ssh_port': 3000}
+        assert vars == {'ansible_ssh_port': 3000, 'group_names': ['greek']}
 
     ### Inventory API tests
 
@@ -146,7 +146,7 @@ class TestInventory(unittest.TestCase):
         inventory = self.script_inventory()
         vars = inventory.get_variables('thor')
 
-        assert vars == {"hammer":True}
+        assert vars == {"hammer":True, 'group_names': ['norse']}
 
     ### Tests for yaml inventory file
 
@@ -205,7 +205,7 @@ class TestInventory(unittest.TestCase):
         inventory = self.yaml_inventory()
         vars = inventory.get_variables('thor')
 
-        assert vars == {"hammer":True}
+        assert vars == {"hammer":True, 'group_names': ['norse']}
 
     def test_yaml_change_vars(self):
         inventory = self.yaml_inventory()
@@ -214,19 +214,30 @@ class TestInventory(unittest.TestCase):
         vars["hammer"] = False
 
         vars = inventory.get_variables('thor')
-        assert vars == {"hammer":True}
+        assert vars == {"hammer":True, 'group_names': ['norse']}
 
     def test_yaml_host_vars(self):
         inventory = self.yaml_inventory()
         vars = inventory.get_variables('saturn')
 
-        assert vars == {"moon":"titan", "moon2":"enceladus"}
+        assert vars == {"moon":"titan",
+                        "moon2":"enceladus",
+                        'group_names': ['multiple']}
 
     def test_yaml_port(self):
         inventory = self.yaml_inventory()
         vars = inventory.get_variables('hera')
 
-        assert vars == {'ansible_ssh_port': 3000, 'ntp_server': 'olympus.example.com'}
+        assert vars == {'ansible_ssh_port': 3000,
+                        'ntp_server': 'olympus.example.com',
+                        'group_names': ['greek']}
+
+    def test_yaml_multiple_groups(self):
+        inventory = self.yaml_inventory()
+        vars = inventory.get_variables('odin')
+
+        assert 'group_names' in vars
+        assert sorted(vars['group_names']) == [ 'norse', 'ruler' ]
 
     ### Test Runner class method
 

--- a/test/yaml_hosts
+++ b/test/yaml_hosts
@@ -25,6 +25,11 @@
   - odin
   - loki
 
+- group: ruler
+  hosts:
+  - zeus
+  - odin
+
 - group: multiple
   hosts:
   - saturn


### PR DESCRIPTION
This is a list of all the groups a host is in. Fixes issue #196.

Example:

In a template:

```
{% if 'oracle' in group_names %}
This is an oracle node
{% else %}
This is not oracle
{% endif %}
```

After running this on three nodes:

```
(ansible)[jeroen@firefly work]$ ansible all -m shell -a 'cat /root/group-template.txt'
rh6oranode1 | success | rc=0 >>
This is an oracle node

rh6oranode2 | success | rc=0 >>
This is an oracle node

rh6rear | success | rc=0 >>
This is not oracle
```
