### PR TITLE
Improve async output, refactor async code

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -21,7 +21,6 @@
 
 import sys
 import getpass
-import time
 
 import ansible.runner
 import ansible.constants as C
@@ -40,7 +39,6 @@ class Cli(object):
     def __init__(self):
         self.stats = callbacks.AggregateStats()
         self.callbacks = callbacks.CliRunnerCallbacks()
-        self.silent_callbacks = callbacks.DefaultRunnerCallbacks()
 
     # ----------------------------------------------     
 
@@ -85,8 +83,6 @@ class Cli(object):
 
         if options.tree:
             utils.prepare_writeable_dir(options.tree)
-        if options.seconds:
-            print "background launch...\n\n"
 
         runner = ansible.runner.Runner(
             module_name=options.module_name, module_path=options.module_path,
@@ -94,72 +90,32 @@ class Cli(object):
             remote_user=options.remote_user, remote_pass=sshpass,
             inventory=inventory_manager, timeout=options.timeout, 
             forks=options.forks, 
-            background=options.seconds, pattern=pattern, 
+            pattern=pattern, 
             callbacks=self.callbacks, sudo=options.sudo, 
             sudo_pass=sudopass,
             transport=options.connection, debug=options.debug
         )
-        return (runner, runner.run())
 
+        if options.seconds:
+            print "background launch...\n\n"
+            results, poller = runner.runAsync(options.seconds)
+            results = self.poll_while_needed(poller, options)
+        else:
+            results = runner.run()
 
-    # ----------------------------------------------
-
-    def get_polling_runner(self, old_runner, jid):
-        return ansible.runner.Runner(
-            module_name='async_status', module_path=old_runner.module_path,
-            module_args="jid=%s" % jid, remote_user=old_runner.remote_user,
-            remote_pass=old_runner.remote_pass, inventory=old_runner.inventory,
-            timeout=old_runner.timeout, forks=old_runner.forks,
-            pattern='*', callbacks=self.silent_callbacks, 
-        )
-
-    # ----------------------------------------------
-
-    def hosts_to_poll(self, results):
-        hosts = []
-        for (host, res) in results['contacted'].iteritems():
-            if res.get('started',False):
-                hosts.append(host)
-        return hosts
+        return (runner, results)
 
     # ----------------------------------------------     
 
-    def poll_if_needed(self, runner, results, options, args):
+    def poll_while_needed(self, poller, options):
         ''' summarize results from Runner '''
 
-        if results is None:
-           exit("No hosts matched")
-
         # BACKGROUND POLL LOGIC when -B and -P are specified
-        # FIXME: refactor
         if options.seconds and options.poll_interval > 0:
-            poll_hosts = results['contacted'].keys()
-            if len(poll_hosts) == 0:
-                exit("no jobs were launched successfully")
-            ahost = poll_hosts[0]
-            jid = results['contacted'][ahost].get('ansible_job_id', None)
-            if jid is None:
-                exit("unexpected error: unable to determine jid")
+            poller.wait(options.seconds, options.poll_interval)
 
-            clock = options.seconds
-            while (clock >= 0):
-                runner.inventory.restrict_to(poll_hosts)
-                polling_runner = self.get_polling_runner(runner, jid)
-                poll_results = polling_runner.run()
-                runner.inventory.lift_restriction()
-                if poll_results is None:
-                    break
-                for (host, host_result) in poll_results['contacted'].iteritems():
-                    # override last result with current status result for report
-                    results['contacted'][host] = host_result
-                    print utils.async_poll_status(jid, host, clock, host_result)
-                for (host, host_result) in poll_results['dark'].iteritems():
-                    print "FAILED: %s => %s" % (host, host_result)
-                clock = clock - options.poll_interval
-                time.sleep(options.poll_interval)
-                poll_hosts = self.hosts_to_poll(poll_results)
-                if len(poll_hosts)==0:
-                    break
+        return poller.results
+
 
 ########################################################
 
@@ -172,6 +128,4 @@ if __name__ == '__main__':
         # Generic handler for ansible specific errors
         print "ERROR: %s" % str(e)
         sys.exit(1)
-    else:
-        cli.poll_if_needed(runner, results, options, args)
 

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -50,7 +50,7 @@ class AggregateStats(object):
             elif 'skipped' in value and bool(value['skipped']):
                 self._increment('skipped', host)
             elif 'changed' in value and bool(value['changed']):
-                if not setup:
+                if not setup and not poll:
                     self._increment('changed', host)
                 self._increment('ok', host)
             else:
@@ -98,6 +98,15 @@ class DefaultRunnerCallbacks(object):
     def on_no_hosts(self):
         pass
 
+    def on_async_poll(self, host, res, jid, clock):
+        pass
+
+    def on_async_ok(self, host, res, jid):
+        pass
+
+    def on_async_failed(self, host, res, jid):
+        pass
+
 ########################################################################
 
 class CliRunnerCallbacks(DefaultRunnerCallbacks):
@@ -108,10 +117,14 @@ class CliRunnerCallbacks(DefaultRunnerCallbacks):
         self.options = None 
 
     def on_failed(self, host, res):
-        self._on_any(host,res)
+        invocation = res.get('invocation','')
+        if not invocation.startswith('async_status'):
+            self._on_any(host,res)
 
     def on_ok(self, host, res):
-        self._on_any(host,res)
+        invocation = res.get('invocation','')
+        if not invocation.startswith('async_status'):
+            self._on_any(host,res)
  
     def on_unreachable(self, host, res):
         print "%s | FAILED => %s" % (host, res)
@@ -126,6 +139,15 @@ class CliRunnerCallbacks(DefaultRunnerCallbacks):
     
     def on_no_hosts(self):
         print >>sys.stderr, "no hosts matched\n"
+
+    def on_async_poll(self, host, res, jid, clock):
+        print "<job %s> polling on %s, %s remaining"%(jid, host, clock)
+
+    def on_async_ok(self, host, res, jid):
+        print "<job %s> finished on %s => %s"%(jid, host, utils.bigjson(res))
+
+    def on_async_failed(self, host, res, jid):
+        print "<job %s> FAILED on %s => %s"%(jid, host, utils.bigjson(res))
 
     def _on_any(self, host, result):
         print utils.host_report_msg(host, self.options.module_name, result, self.options.one_line)
@@ -168,6 +190,15 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
     def on_no_hosts(self):
         print "no hosts matched or remaining\n"
 
+    def on_async_poll(self, host, res, jid, clock):
+        print "<job %s> polling on %s, %s remaining"%(jid, host, clock)
+
+    def on_async_ok(self, host, res, jid):
+        print "<job %s> finished on %s"%(jid, host)
+
+    def on_async_failed(self, host, res, jid):
+        print "<job %s> FAILED on %s"%(jid, host)
+
 ########################################################################
 
 class PlaybookCallbacks(object):
@@ -205,10 +236,3 @@ class PlaybookCallbacks(object):
 
     def on_play_start(self, pattern):
         print "PLAY [%s] ****************************\n" % pattern
-
-    def on_async_confused(self, msg):
-        print msg
-
-    def on_async_poll(self, jid, host, clock, host_result):
-        print utils.async_poll_status(jid, host, clock, host_result)
-

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -170,14 +170,6 @@ def path_dwim(basedir, given):
     else:
         return os.path.join(basedir, given)
 
-def async_poll_status(jid, host, clock, result):
-    if 'finished' in result:
-        return "<job %s> finished on %s" % (jid, host)
-    elif 'failed' in result:
-        return "<job %s> FAILED on %s" % (jid, host)
-    else:
-        return "<job %s> polling on %s, %s remaining" % (jid, host, clock)
-
 def json_loads(data):
     return json.loads(data)
 

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -74,11 +74,14 @@ class TestCallbacks(object):
     def on_play_start(self, pattern):
         EVENTS.append([ 'play start', [ pattern ]])
 
-    def on_async_confused(self, msg):
-        EVENTS.append([ 'async confused', [ msg ]])
+    def on_async_ok(self, host, res, jid):
+        EVENTS.append([ 'async ok', [ host ]])
 
-    def on_async_poll(self, jid, host, clock, host_result):
+    def on_async_poll(self, host, res, jid, clock):
         EVENTS.append([ 'async poll', [ host ]])
+
+    def on_async_failed(self, host, res, jid):
+        EVENTS.append([ 'async failed', [ host ]])
 
     def on_unreachable(self, host, msg):
         EVENTS.append([ 'failed/dark', [ host, msg ]])


### PR DESCRIPTION
This improves async output in playbooks and in `ansible`. Async operations are now pleasant and straightforward to use from script (#254 ).

If playbooks and cli should diverge in the future, it's granular enough to allow this (both in callbacks and the polling code).

It's mostly additions in `runner.py` and `callback.py`, but a lot of code was removed from `playbook.py` and `/bin/ansible` for a moderate overall reduction.

Any existing script using the old way of async operations should still work, since that was left untouched.

Playbook example:

```
(ansible)[jeroen@firefly work]$ ansible-playbook ../rh6clu/playbooks/sleep.yml 


PLAY [oracle] ****************************

SETUP PHASE ****************************

ok: [rh6oranode1]

ok: [rh6oranode2]


TASK: [command /root/longrun.sh] *********

ok: [rh6oranode1] => async_wrapper /root/longrun.sh

ok: [rh6oranode2] => async_wrapper /root/longrun.sh

<job 20096457581> polling on rh6oranode2, 28 remaining
<job 20096457581> polling on rh6oranode1, 28 remaining
<job 20096457581> polling on rh6oranode2, 26 remaining
<job 20096457581> polling on rh6oranode1, 26 remaining
<job 20096457581> finished on rh6oranode1
<job 20096457581> polling on rh6oranode2, 24 remaining
<job 20096457581> finished on rh6oranode2


PLAY RECAP **********************


rh6oranode1                    : ok=   3 changed=   1 unreachable=   0 failed=   0 
rh6oranode2                    : ok=   3 changed=   1 unreachable=   0 failed=   0
```

If it times out:

```
<job 386981866955> polling on rh6oranode2, 10 remaining
<job 386981866955> polling on rh6oranode2, 8 remaining
<job 386981866955> polling on rh6oranode2, 6 remaining
<job 386981866955> polling on rh6oranode2, 4 remaining
<job 386981866955> polling on rh6oranode2, 2 remaining
<job 386981866955> polling on rh6oranode2, 0 remaining
failed: [rh6oranode2] => {"failed": 1, "msg": "timed out", "rc": null}
```

Command line example:

```
(ansible)[jeroen@firefly work]$ ansible oracle -a '/root/longrun.sh' --background=30 --poll=2
background launch...


rh6oranode1 | success >> {
    "ansible_job_id": "696048164456", 
    "results_file": "/root/.ansible_async/696048164456", 
    "started": 1
}

rh6oranode2 | success >> {
    "ansible_job_id": "696048164456", 
    "results_file": "/root/.ansible_async/696048164456", 
    "started": 1
}

<job 696048164456> polling on rh6oranode2, 28 remaining
<job 696048164456> polling on rh6oranode1, 28 remaining
<job 696048164456> polling on rh6oranode2, 26 remaining
<job 696048164456> polling on rh6oranode1, 26 remaining
<job 696048164456> finished on rh6oranode1 => {
    "ansible_job_id": "696048164456", 
    "changed": true, 
    "cmd": [
        "/root/longrun.sh"
    ], 
    "delta": "0:00:08.014740", 
    "end": "2012-04-29 17:48:51.200269", 
    "finished": 1, 
    "rc": 0, 
    "start": "2012-04-29 17:48:43.185529", 
    "stderr": "", 
    "stdout": ""
}
<job 696048164456> polling on rh6oranode2, 24 remaining
<job 696048164456> finished on rh6oranode2 => {
    "ansible_job_id": "696048164456", 
    "changed": true, 
    "cmd": [
        "/root/longrun.sh"
    ], 
    "delta": "0:00:11.014929", 
    "end": "2012-04-29 17:48:54.620449", 
    "finished": 1, 
    "rc": 0, 
    "start": "2012-04-29 17:48:43.605520", 
    "stderr": "", 
    "stdout": ""
}
```
