### PR TITLE
Fix path for service command.

### DIFF
--- a/library/service
+++ b/library/service
@@ -23,7 +23,7 @@ except ImportError:
     import simplejson as json
 import sys
 import shlex
-import subprocess,os
+import subprocess
 
 # TODO: switch to fail_json and other helper functions
 # like other modules are using

--- a/library/service
+++ b/library/service
@@ -23,14 +23,15 @@ except ImportError:
     import simplejson as json
 import sys
 import shlex
-import subprocess
+import subprocess,os
 
 # TODO: switch to fail_json and other helper functions
 # like other modules are using
 
 # ===========================================
 
-SERVICE = '/sbin/service'
+SERVICE='service'
+
 
 def _run(cmd):
     # returns (rc, stdout, stderr) from shell command


### PR DESCRIPTION
Remove the path of service command to get rid of file not found error.
On Ubuntu, service program is found at /usr/sbin/service.
