### PR TITLE
Add 'system' option for user and group modules

### DIFF
--- a/library/group
+++ b/library/group
@@ -65,6 +65,8 @@ def group_add(group, **kwargs):
         if key == 'gid' and kwargs[key] is not None:
             cmd.append('-g')
             cmd.append(kwargs[key])
+        elif key == 'system' and kwargs[key] == 'yes':
+            cmd.append('-r')
     cmd.append(group)
     rc = subprocess.call(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if rc == 0:
@@ -142,9 +144,12 @@ for x in items:
 state       = params.get('state','present')
 name        = params.get('name', None)
 gid         = params.get('gid', None)
+system      = params.get('system', 'no')
 
 if state not in [ 'present', 'absent' ]:
     fail_json(msg='invalid state')
+if system not in ['yes', 'no']:
+    fail_json(msg='invalid system')
 if name is None:
     fail_json(msg='name is required')
 
@@ -156,7 +161,7 @@ if state == 'absent':
     exit_json(name=name, changed=changed)
 elif state == 'present':
     if not group_exists(name):
-        changed = group_add(name, gid=gid)
+        changed = group_add(name, gid=gid, system=system)
     else:
         changed = group_mod(name, gid=gid)
 

--- a/library/user
+++ b/library/user
@@ -110,6 +110,8 @@ def user_add(user, **kwargs):
                     cmd.append('-m')
                 else:
                     cmd.append('-M')
+        elif key == 'system' and kwargs[key] == 'yes':
+            cmd.append('-r')
     cmd.append(user)
     rc = subprocess.call(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if rc == 0:
@@ -269,6 +271,7 @@ remove     = params.get('remove', False)
 # ===========================================
 # following options are specific to useradd
 createhome = params.get('createhome', 'yes')
+system     = params.get('system', 'no')
 
 # ===========================================
 # following options are specific to usermod
@@ -278,6 +281,8 @@ if state not in [ 'present', 'absent' ]:
     fail_json(msg='invalid state')
 if createhome not in [ 'yes', 'no' ]:
     fail_json(msg='invalid createhome')
+if system not in ['yes', 'no']:
+    fail_json(msg='invalid system')
 if append not in [ 'yes', 'no' ]:
     fail_json(msg='invalid append')
 if name is None:
@@ -293,7 +298,8 @@ elif state == 'present':
     if not user_exists(name):
         changed = user_add(name, uid=uid, group=group, groups=groups,
                            comment=comment, home=home, shell=shell,
-                           password=password, createhome=createhome)
+                           password=password, createhome=createhome,
+                           system=system)
     else:
         changed = user_mod(name, uid=uid, group=group, groups=groups,
                            comment=comment, home=home, shell=shell,


### PR DESCRIPTION
Creates system accounts/groups; corresponds to the '-r' option for {user,group}add.

The option is only honored when users/groups are added, not when modified.
