### PR TITLE
Yet another trivial fix for PyDev

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -22,7 +22,7 @@
 import sys
 import getpass
 
-import ansible.runner
+from ansible.runner import Runner
 import ansible.constants as C
 from ansible import utils
 from ansible import errors
@@ -84,7 +84,7 @@ class Cli(object):
         if options.tree:
             utils.prepare_writeable_dir(options.tree)
 
-        runner = ansible.runner.Runner(
+        runner = Runner(
             module_name=options.module_name, module_path=options.module_path,
             module_args=options.module_args,
             remote_user=options.remote_user, remote_pass=sshpass,

--- a/library/file
+++ b/library/file
@@ -293,7 +293,7 @@ def rmtree_error(func, path, exc_info):
 # go...
 
 prev_state = 'absent'
-if os.path.exists(path):
+if os.path.lexists(path):
     if os.path.islink(path):
         prev_state = 'link'
     elif os.path.isfile(path):


### PR DESCRIPTION
For some reason PyDev does not recognize ansible.runner import. Dunno why, so it was simpler to narrow down this import a bit. 
