### PR TITLE
test-module arguments file location

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -49,7 +49,7 @@ if len(sys.argv) > 1:
 else:
     args = ""
 
-argspath = os.path.expanduser("/.ansible_test_module_arguments")
+argspath = os.path.expanduser("~/.ansible_test_module_arguments")
 argsfile = open(argspath, 'w')
 argsfile.write(args)
 argsfile.close()


### PR DESCRIPTION
Adding a missing '~' to use the user's home directory instead of the root file system for the module arguments
