### PR TITLE
Set default selinux context with '_default'

### DIFF
--- a/library/file
+++ b/library/file
@@ -170,17 +170,14 @@ seuser    = params.get('seuser', None)
 serole    = params.get('serole', None)
 setype    = params.get('setype', None)
 selevel   = params.get('serange', 's0')
-context   = params.get('context', None)
 secontext = [seuser, serole, setype]
 if selinux_mls_enabled():
     secontext.append(selevel)
 
-if context is not None:
-    if context != 'default':
-        fail_json(msg='invalid context: %s' % context)
-    if seuser is not None or serole is not None or setype is not None:
-        fail_json(msg='cannot define context=default and seuser, serole or setype')
-    secontext = selinux_default_context(path)
+default_secontext = selinux_default_context(path)
+for i in range(len(default_secontext)):
+    if i is not None and secontext[i] == '_default':
+        secontext[i] = default_secontext[i]
 
 if state not in [ 'file', 'directory', 'link', 'absent']:
     fail_json(msg='invalid state: %s' % state)


### PR DESCRIPTION
This removes the 'context' option and replaces it with checks for
'_default' value for seuser, serole, setype, or (maybe) selevel.
If '_default' is provided _and_ there is a default context for the given
file, this will set the file context to the available default.

Related to pull request #66 and #88 on ansible.github.com repo.  Tested on debian, centos5, and centos6, and with selinux disabled and enforcing on the latter two distributions.
