### PR TITLE
Prevent facter stderr messages from confusing ansible

### DIFF
--- a/library/facter
+++ b/library/facter
@@ -22,4 +22,4 @@
 #    facter
 #    ruby-json
 
-/usr/bin/facter --json
+/usr/bin/facter --json 2>/dev/null


### PR DESCRIPTION
Seems that whenever facter outputs messages on stderr (e.g. "dnsdomainname: Name or service not known"), ansible treats this as a fatal error.
