### PR TITLE
Yaml inventory variable list

### DIFF
--- a/lib/ansible/inventory_parser.py
+++ b/lib/ansible/inventory_parser.py
@@ -54,12 +54,12 @@ class InventoryParser(object):
 
     def _parse_base_groups(self):
 
-        undefined = Group(name='undefined')
+        ungrouped = Group(name='ungrouped')
         all = Group(name='all')
-        all.add_child_group(undefined)
+        all.add_child_group(ungrouped)
 
-        self.groups = dict(all=all, undefined=undefined)
-        active_group_name = 'undefined'
+        self.groups = dict(all=all, ungrouped=ungrouped)
+        active_group_name = 'ungrouped'
 
         for line in self.lines:
             if line.startswith("["):

--- a/lib/ansible/inventory_parser_yaml.py
+++ b/lib/ansible/inventory_parser_yaml.py
@@ -63,7 +63,12 @@ class InventoryParserYaml(object):
 
             elif type(item) == dict and 'host' in item:
                 host = self._make_host(item['host'])
-                for (k,v) in item.get('vars',{}).items():
+                vars = item.get('vars', {})
+                if type(vars)==list:
+                    varlist, vars = vars, {}
+                    for subitem in varlist:
+                        vars.update(subitem)
+                for (k,v) in vars.items():
                    host.set_variable(k,v)
 
             elif type(item) == dict and 'group' in item:

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -258,6 +258,14 @@ class TestInventory(unittest.TestCase):
                         'hammer':True,
                         'inventory_hostname': 'thor'}
 
+    def test_yaml_list_vars(self):
+        inventory = self.yaml_inventory()
+        vars = inventory.get_variables('zeus')
+        assert vars == {'ansible_ssh_port': 3001,
+                        'group_names': ['greek', 'ruler'],
+                        'inventory_hostname': 'zeus',
+                        'ntp_server': 'olympus.example.com'}
+
     def test_yaml_change_vars(self):
         inventory = self.yaml_inventory()
         vars = inventory.get_variables('thor')

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -221,11 +221,11 @@ class TestInventory(unittest.TestCase):
         expected_hosts=['thor', 'odin', 'loki']
         self.compare(hosts, expected_hosts)
 
-    def test_simple_ungrouped(self):
+    def test_yaml_ungrouped(self):
         inventory = self.yaml_inventory()
         hosts = inventory.list_hosts("ungrouped")
 
-        expected_hosts=['jupiter','zeus']
+        expected_hosts=['jupiter']
         self.compare(hosts, expected_hosts)
 
     def test_yaml_combined(self):

--- a/test/yaml_hosts
+++ b/test/yaml_hosts
@@ -6,7 +6,9 @@
     moon: titan
     moon2: enceladus
 
-- zeus
+- host: zeus
+  vars:
+  - ansible_ssh_port: 3001
 
 - group: greek
   hosts:


### PR DESCRIPTION
Support yaml inventory list variables syntax:

```
- host: myhost
  vars:
  - vara: 1
  - varb: 2
```

This was lost in the rewrite. For group vars, the code was still present.

Also rename a test that had an identical name and fix the resulting failure.
