### PR TITLE
Issue122

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -25,6 +25,7 @@ import os
 import sys
 import shlex
 import subprocess
+import syslog
 import traceback
 
 APT_PATH = "/usr/bin/apt-get"
@@ -113,6 +114,8 @@ if not os.path.exists(APT_PATH):
 argfile = sys.argv[1]
 args    = open(argfile, 'r').read()
 items   = shlex.split(args)
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 if not len(items):
     fail_json(msg='the module requires arguments -a')

--- a/library/async_status
+++ b/library/async_status
@@ -28,13 +28,18 @@ import subprocess
 import sys
 import datetime
 import traceback
+import syslog
 
 # ===========================================
 
 # FIXME: better error handling
 
 argsfile = sys.argv[1]
-items = shlex.split(file(argsfile).read())
+args = open(argsfile, 'r').read()
+items = shlex.split(args)
+
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 params = {}
 for x in items:

--- a/library/async_wrapper
+++ b/library/async_wrapper
@@ -30,6 +30,7 @@ import datetime
 import traceback
 import signal
 import time
+import syslog
 
 def daemonize_self():
     # daemonizing code: http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/66012
@@ -75,6 +76,9 @@ time_limit = sys.argv[2]
 wrapped_module = sys.argv[3]
 argsfile = sys.argv[4]
 cmd = "%s %s" % (wrapped_module, argsfile)
+
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % " ".join(sys.argv[1:]))
 
 # setup logging directory
 logdir = os.path.expanduser("~/.ansible_async")

--- a/library/command
+++ b/library/command
@@ -29,9 +29,12 @@ import datetime
 import traceback
 import shlex
 import os
+import syslog
 
 argfile = sys.argv[1]
 args = open(argfile, 'r').read()
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 shell = False
 

--- a/library/copy
+++ b/library/copy
@@ -21,6 +21,7 @@
 import sys
 import os
 import shlex
+import syslog
 
 # ===========================================
 # convert arguments of form a=b c=d
@@ -32,7 +33,11 @@ if len(sys.argv) == 1:
 argfile = sys.argv[1]
 if not os.path.exists(argfile):
     sys.exit(1)
-items = shlex.split(open(argfile, 'r').read())
+
+args = open(argfile, 'r').read()
+items = shlex.split(args)
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 
 params = {}

--- a/library/facter
+++ b/library/facter
@@ -22,4 +22,5 @@
 #    facter
 #    ruby-json
 
+/usr/bin/logger -t ansible-facter Invoked as-is
 /usr/bin/facter --json 2>/dev/null

--- a/library/file
+++ b/library/file
@@ -25,6 +25,7 @@ import shutil
 import stat
 import grp
 import pwd
+import syslog
 try:
     import selinux
     HAVE_SELINUX=True
@@ -125,6 +126,8 @@ def selinux_context(path):
 argfile = sys.argv[1]
 args    = open(argfile, 'r').read()
 items   = shlex.split(args)
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 if not len(items):
     fail_kv(msg='the module requires arguments -a')

--- a/library/git
+++ b/library/git
@@ -31,6 +31,7 @@ import os
 import sys
 import shlex
 import subprocess
+import syslog
 
 # ===========================================
 # Basic support methods
@@ -57,6 +58,8 @@ if not os.path.exists(argfile):
 
 args = open(argfile, 'r').read()
 items = shlex.split(args)
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 if not len(items):
    fail_json(msg="the command module requires arguments (-a)")

--- a/library/group
+++ b/library/group
@@ -26,6 +26,7 @@ import grp
 import shlex
 import subprocess
 import sys
+import syslog
 
 GROUPADD = "/usr/sbin/groupadd"
 GROUPDEL = "/usr/sbin/groupdel"
@@ -131,6 +132,8 @@ if len(sys.argv) == 2 and os.path.exists(sys.argv[1]):
 else:
     args = ' '.join(sys.argv[1:])
 items   = shlex.split(args)
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 if not len(items):
     fail_json(msg='the module requires arguments -a')

--- a/library/ohai
+++ b/library/ohai
@@ -18,4 +18,5 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+/usr/bin/logger -t ansible-ohai Invoked as-is
 /usr/bin/ohai

--- a/library/ping
+++ b/library/ping
@@ -22,4 +22,10 @@ try:
 except ImportError:
     import simplejson as json
 
+import os
+import syslog
+
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked as-is')
+
 print json.dumps({ "ping" : "pong" })

--- a/library/service
+++ b/library/service
@@ -25,6 +25,7 @@ import sys
 import shlex
 import subprocess
 import os.path
+import syslog
 
 # TODO: switch to fail_json and other helper functions
 # like other modules are using
@@ -95,6 +96,8 @@ def _do_enable(name, enable):
 argfile = sys.argv[1]
 args = open(argfile, 'r').read()
 items = shlex.split(args)
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 if not len(items):
     fail_json(dict(failed=True, msg='this module requires arguments (-a)'))

--- a/library/setup
+++ b/library/setup
@@ -31,6 +31,7 @@ import socket
 import struct
 import subprocess
 import traceback
+import syslog
 
 try:
     import json
@@ -294,6 +295,9 @@ except:
    for opt in list_options:
        (k,v) = opt.split("=")
        setup_options[k]=v   
+
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % setup_options)
 
 ansible_file = os.path.expandvars(setup_options.get('metadata', DEFAULT_ANSIBLE_SETUP))
 ansible_dir = os.path.dirname(ansible_file)

--- a/library/slurp
+++ b/library/slurp
@@ -21,6 +21,7 @@ import sys
 import os
 import shlex
 import base64
+import syslog
 
 try:
    import json
@@ -36,7 +37,11 @@ if len(sys.argv) == 1:
 argfile = sys.argv[1]
 if not os.path.exists(argfile):
     sys.exit(1)
-items = shlex.split(open(argfile, 'r').read())
+
+args = open(argfile, 'r').read()
+items = shlex.split(args)
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 params = {}
 for x in items:

--- a/library/user
+++ b/library/user
@@ -27,6 +27,7 @@ import grp
 import shlex
 import subprocess
 import sys
+import syslog
 try:
     import spwd
     HAVE_SPWD=True
@@ -264,6 +265,8 @@ if not os.path.exists(USERDEL):
 argfile = sys.argv[1]
 args    = open(argfile, 'r').read()
 items   = shlex.split(args)
+syslog.openlog('ansible-%s' % os.path.basename(__file__))
+syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 if not len(items):
     fail_json(msg='the module requires arguments -a')

--- a/library/virt
+++ b/library/virt
@@ -27,6 +27,7 @@ except ImportError:
 import os
 import sys
 import subprocess
+import syslog
 try:
     import libvirt
 except ImportError:
@@ -366,6 +367,8 @@ def main():
 
     args = open(argfile, 'r').read()
     items = shlex.split(args)
+    syslog.openlog('ansible-%s' % os.path.basename(__file__))
+    syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
     if not len(items):
         return VIRT_FAILED, msg

--- a/library/yum
+++ b/library/yum
@@ -27,6 +27,7 @@ import datetime
 import shlex
 import re
 import traceback
+import syslog
 
 
 try:
@@ -299,6 +300,8 @@ def main():
 
     args = open(argfile, 'r').read()
     items = shlex.split(args)
+    syslog.openlog('ansible-%s' % os.path.basename(__file__))
+    syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
     if not len(items):
         msg = "the yum module requires arguments (-a)"


### PR DESCRIPTION
Issue #122.  Logs to syslog the arguments passed to the user module.
This uses the default facility, LOG_USER.  It logs to /dev/log, which
should work on most/all linux platforms.  If this is run on MacOSX, it
appears a different syslog address will be required.

Let me know what you think.  I can adjust as necessary.  It will generate this log message:

```
May  8 11:35:07 loki ansible-user: Invoked with name=test state=absent
```
