### PR TITLE
Support nested variables in varReplace

### DIFF
--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -545,7 +545,7 @@ class Runner(object):
         source_data = file(utils.path_dwim(self.basedir, source)).read()
         resultant = ''            
         try:
-            resultant = utils.template(source_data, inject, self.setup_cache)
+            resultant = utils.template(source_data, inject, self.setup_cache, no_engine=False)
         except Exception, e:
             return (host, False, dict(failed=True, msg=str(e)), '')
         xfered = self._transfer_str(conn, tmp, 'source', resultant)

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -243,7 +243,7 @@ def varReplace(raw, vars):
 
     return ''.join(done)
 
-def template(text, vars, setup_cache, no_engine=False):
+def template(text, vars, setup_cache, no_engine=True):
     ''' run a text buffer through the templating engine '''
     vars = vars.copy()
     text = varReplace(str(text), vars)

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -140,7 +140,7 @@ class TestUtils(unittest.TestCase):
             'who': 'world',
         }
 
-        res = ansible.utils.template(template, vars, {})
+        res = ansible.utils.template(template, vars, {}, no_engine=False)
 
         assert res == 'hello world'
 
@@ -150,6 +150,6 @@ class TestUtils(unittest.TestCase):
             'who': 'world',
         }
 
-        res = ansible.utils.template(template, vars, {})
+        res = ansible.utils.template(template, vars, {}, no_engine=False)
 
         assert res == 'hello world\n'

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -1,0 +1,155 @@
+import os
+import unittest
+
+import ansible.utils
+
+class TestUtils(unittest.TestCase):
+
+    #####################################
+    ### varLookup function tests
+
+    def test_varLookup_list(self):
+        vars = {
+            'data': {
+                'who': ['joe', 'jack', 'jeff']
+            }
+        }
+
+        res = ansible.utils.varLookup('data.who', vars)
+
+        assert sorted(res) == sorted(vars['data']['who'])
+
+    #####################################
+    ### varReplace function tests
+
+    def test_varReplace_simple(self):
+        template = 'hello $who'
+        vars = {
+            'who': 'world',
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == 'hello world'
+
+    def test_varReplace_multiple(self):
+        template = '$what $who'
+        vars = {
+            'what': 'hello',
+            'who': 'world',
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == 'hello world'
+
+    def test_varReplace_middle(self):
+        template = 'hello $who!'
+        vars = {
+            'who': 'world',
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == 'hello world!'
+
+    def test_varReplace_alternative(self):
+        template = 'hello ${who}'
+        vars = {
+            'who': 'world',
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == 'hello world'
+
+    def test_varReplace_almost_alternative(self):
+        template = 'hello $who}'
+        vars = {
+            'who': 'world',
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == 'hello world}'
+
+    def test_varReplace_almost_alternative2(self):
+        template = 'hello ${who'
+        vars = {
+            'who': 'world',
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == template
+
+    def test_varReplace_alternative_greed(self):
+        template = 'hello ${who} }'
+        vars = {
+            'who': 'world',
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == 'hello world }'
+
+    def test_varReplace_notcomplex(self):
+        template = 'hello $mydata.who'
+        vars = {
+            'data': {
+                'who': 'world',
+            },
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        print res
+        assert res == template
+
+    def test_varReplace_nested(self):
+        template = 'hello ${data.who}'
+        vars = {
+            'data': {
+                'who': 'world'
+            },
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == 'hello world'
+
+    def test_varReplace_nested_int(self):
+        template = '$what ${data.who}'
+        vars = {
+            'data': {
+                'who': 2
+            },
+            'what': 'hello',
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == 'hello 2'
+
+    #####################################
+    ### Template function tests
+
+    def test_template_basic(self):
+        template = 'hello {{ who }}'
+        vars = {
+            'who': 'world',
+        }
+
+        res = ansible.utils.template(template, vars, {})
+
+        assert res == 'hello world'
+
+    def test_template_whitespace(self):
+        template = 'hello {{ who }}\n'
+        vars = {
+            'who': 'world',
+        }
+
+        res = ansible.utils.template(template, vars, {})
+
+        assert res == 'hello world\n'


### PR DESCRIPTION
This fixes #314 .

You can now use nested variables in playbooks
No_engine is the default templating strategy.

That bug is for 0.5, but it bothered me a bit in some of my playbooks. You could pull earlier as it gets rid of a lot of expensive jinja2 calls and seems much snappier.

I made sure you (or I) can use varLookup for #345.

An extract from a playbook:

```
- hosts: ...

  vars:
    iscsi_name: <iqn>
    iscsi_portal:
        eth1: 192.168.130.1
        eth2: 192.168.131.1

  - name: create iscsi config dir
    action: file state=directory dest=/var/lib/iscsi/nodes/<iqn>/$item\,3260\,1
    with_items:
    - ${iscsi_portal.eth1}
    - ${iscsi_portal.eth2}
```

Do we also want to support arrays like `${iscsi_portal[0]}`?
