### PR TITLE
 ANSIBLE_REMOTE_TMP environment variable sets where ansible will stuf tm...

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -83,6 +83,7 @@ def main(args):
             sudo=options.sudo,
             sudo_user=options.sudo_user,
             sudo_pass=sudopass,
+	    basetmp=C.DEFAULT_REMOTE_TEMPDIR,
             extra_vars=extra_vars
         )
         try:

--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -96,6 +96,7 @@ ANSIBLE_HOSTS  -- Override the default ansible hosts file
 
 ANSIBLE_LIBRARY -- Override the default ansible module library path
 
+ANSIBLE_REMOTE_TMP -- Override the default ansible remote tmpdir
 
 AUTHOR
 ------

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -135,6 +135,8 @@ ANSIBLE_HOSTS  -- Override the default ansible hosts file
 
 ANSIBLE_LIBRARY -- Override the default ansible module library path
 
+ANSIBLE_REMOTE_TMP -- Override the default ansible remote tmpdir
+
 
 AUTHOR
 ------

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -23,6 +23,8 @@ DEFAULT_HOST_LIST      = os.environ.get('ANSIBLE_HOSTS',
     '/etc/ansible/hosts')
 DEFAULT_MODULE_PATH    = os.environ.get('ANSIBLE_LIBRARY',
     '/usr/share/ansible')
+DEFAULT_REMOTE_TEMPDIR = os.environ.get('ANSIBLE_REMOTE_TMP',
+    '/$HOME/.ansible/tmp')
 
 DEFAULT_MODULE_NAME    = 'command'
 DEFAULT_PATTERN        = '*'

--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -63,6 +63,7 @@ class PlayBook(object):
         stats            = None,
         sudo             = False,
         sudo_user        = C.DEFAULT_SUDO_USER,
+        basetmp          = C.DEFAULT_REMOTE_TEMPDIR,
         extra_vars       = None):
 
         """
@@ -104,6 +105,7 @@ class PlayBook(object):
         self.sudo             = sudo
         self.sudo_pass        = sudo_pass
         self.sudo_user        = sudo_user
+        self.basetmp          = basetmp
         self.extra_vars       = extra_vars
         self.global_vars      = {}
 
@@ -295,7 +297,8 @@ class PlayBook(object):
             setup_cache=SETUP_CACHE, basedir=self.basedir,
             conditional=only_if, callbacks=self.runner_callbacks, 
             debug=self.debug, sudo=sudo, sudo_user=sudo_user,
-            transport=transport, sudo_pass=self.sudo_pass, is_playbook=True
+            transport=transport, sudo_pass=self.sudo_pass,
+            basetmp=self.basetmp, is_playbook=True
         )
 
         if async_seconds == 0:

--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -78,7 +78,7 @@ class Runner(object):
         sudo_pass=C.DEFAULT_SUDO_PASS, background=0, basedir=None, 
         setup_cache=None, transport=C.DEFAULT_TRANSPORT, conditional='True', 
         callbacks=None, debug=False, sudo=False, sudo_user=C.DEFAULT_SUDO_USER,
-        module_vars=None, is_playbook=False, inventory=None):
+        module_vars=None, is_playbook=False, inventory=None,basetmp=C.DEFAULT_REMOTE_TEMPDIR):
 
         """
         host_list    : path to a host list file, like /etc/ansible/hosts
@@ -95,6 +95,7 @@ class Runner(object):
         sudo_pass    : sudo password if using sudo and sudo requires a password
         background   : run asynchronously with a cap of this many # of seconds (if not 0)
         basedir      : paths used by modules if not absolute are relative to here
+        basetmp      : TMPDIR used on remote host
         setup_cache  : this is a internalism that is going away
         transport    : transport mode (paramiko, local)
         conditional  : only execute if this string, evaluated, is True
@@ -118,6 +119,7 @@ class Runner(object):
 
         self.sudo_user = sudo_user
         self.transport = transport
+        self.basetmp   = basetmp
         self.connector = ansible.connection.Connection(self, self.transport, self.sudo_user)
 
         if inventory is None:
@@ -235,7 +237,7 @@ class Runner(object):
 
     def _add_setup_metadata(self, args):
         ''' automatically determine where to store variables for the setup module '''
-        
+        basetmp = self.basetmp
         is_dict = False
         if type(args) == dict:
             is_dict = True
@@ -246,13 +248,13 @@ class Runner(object):
                 if self.remote_user == 'root':
                     args = "%s metadata=/etc/ansible/setup" % args
                 else:
-                    args = "%s metadata=$HOME/.ansible/setup" % args
+                    args = "%s metadata=%s/.ansible/setup" % (args,basetmp)
         else:
             if not 'metadata' in args:
                 if self.remote_user == 'root':
                     args['metadata'] = '/etc/ansible/setup'
                 else:
-                    args['metadata'] = "$HOME/.ansible/setup"
+                    args['metadata'] = "%s/.ansible/setup" % basetmp
         return args   
  
     # *****************************************************
@@ -656,10 +658,9 @@ class Runner(object):
         # The problem with this is that it's executed on the
         # overlord, not on the target so we can't use tempdir and os.path
         # Only support the *nix world for now by using the $HOME env var
-
-        basetmp = "/var/tmp"
-        if self.remote_user != 'root':
-            basetmp = "$HOME/.ansible/tmp"
+        basetmp = self.basetmp
+        if self.remote_user == 'root':
+            basetmp ="/var/tmp"
         cmd = "mktemp -d %s/ansible.XXXXXX" % basetmp
         if self.remote_user != 'root':
             cmd = "mkdir -p %s && %s" % (basetmp, cmd)


### PR DESCRIPTION
...p files on remote host.  Default is /var/tmp for root, and $HOME/.ansible/tmp for non-root

Tested with simple playbooks, and ad-hoc.   
