### PR TITLE
Misc fixes when using -O override_hosts

### DIFF
--- a/lib/ansible/inventory.py
+++ b/lib/ansible/inventory.py
@@ -44,7 +44,7 @@ class Inventory(object):
 
         if host_list:
             if type(host_list) == list:
-                self.groups = self._groups_from_override_hosts(host_list)
+                self.groups = self._groups_from_override_hosts(host_list).values()
             elif os.access(host_list, os.X_OK):
                 self._is_script = True
                 self.parser = InventoryScript(filename=host_list)

--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -110,6 +110,7 @@ class PlayBook(object):
         if override_hosts is not None:
             if type(override_hosts) != list:
                 raise errors.AnsibleError("override hosts must be a list")
+            self.inventory = ansible.inventory.Inventory(override_hosts)
             if not self.inventory._is_script:
                 self.global_vars.update(ansible.inventory.Inventory(host_list).get_group_variables('all'))
 


### PR DESCRIPTION
I bumped into a couple bugs when using -O override_hosts with ansible-playbook today.  Commit 
086fc64a fixes the error:

```
ansible-playbook -O test -i ~/ansible_hosts testme.yml 
Traceback (most recent call last):
  File "/home/stephenf/Source/ansible/bin/ansible-playbook", line 109, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/home/stephenf/Source/ansible/bin/ansible-playbook", line 86, in main
    extra_vars=extra_vars
  File "/home/stephenf/Source/ansible/lib/ansible/playbook.py", line 113, in __init__
    if not self.inventory._is_script:
AttributeError: 'PlayBook' object has no attribute 'inventory'
```

Once the above is fixed, another bug showed up in inventory.py where self.groups was set to a dict instead of a list.  Commit 18943149   takes just the values of the dict returned by _groups_from_override_hosts().
