### PR TITLE
Fixup unicode varReplace templating.

### DIFF
--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -235,7 +235,7 @@ def varReplace(raw, vars):
         # original)
         varname = m.group(2).lower()
 
-        replacement = str(varLookup(varname, vars) or m.group())
+        replacement = unicode(varLookup(varname, vars) or m.group())
 
         start, end = m.span()
         done.append(raw[:start])    # Keep stuff leading up to token

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import unittest
 
@@ -131,6 +133,16 @@ class TestUtils(unittest.TestCase):
 
         assert res == 'hello 2'
 
+    def test_varReplace_unicode(self):
+        template = 'hello $who'
+        vars = {
+            'who': u'wórld',
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == u'hello wórld'
+
     #####################################
     ### Template function tests
 
@@ -153,3 +165,13 @@ class TestUtils(unittest.TestCase):
         res = ansible.utils.template(template, vars, {}, no_engine=False)
 
         assert res == 'hello world\n'
+
+    def test_template_unicode(self):
+        template = 'hello {{ who }}'
+        vars = {
+            'who': u'wórld',
+        }
+
+        res = ansible.utils.template(template, vars, {}, no_engine=False)
+
+        assert res == u'hello wórld'


### PR DESCRIPTION
The original patches should have conflicted?
53bde0bf517d1302c80f80180f85995efa36a00e vs efde61e53729964f3e740dcbb9c52f889186719d
