### PR TITLE
Support list indexing in varReplace.

### DIFF
--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -199,6 +199,8 @@ def parse_json(data):
             return { "failed" : True, "parsed" : False, "msg" : data }
         return results
 
+_LISTRE = re.compile(r"(\w+)\[(\d+)\]")
+
 def varLookup(name, vars):
     ''' find the contents of a possibly complex variable in vars. '''
     path = name.split('.')
@@ -206,11 +208,19 @@ def varLookup(name, vars):
     for part in path:
         if part in space:
             space = space[part]
+        elif "[" in part:
+            m = _LISTRE.search(part)
+            if not m:
+                return
+            try:
+                space = space[m.group(1)][int(m.group(2))]
+            except (KeyError, IndexError):
+                return
         else:
             return
     return space
 
-_KEYCRE = re.compile(r"\$(?P<complex>\{){0,1}((?(complex)[\w\.]+|\w+))(?(complex)\})")
+_KEYCRE = re.compile(r"\$(?P<complex>\{){0,1}((?(complex)[\w\.\[\]]+|\w+))(?(complex)\})")
 #                        if { -> complex     if complex, allow . and need trailing }
 
 def varReplace(raw, vars):

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -143,6 +143,56 @@ class TestUtils(unittest.TestCase):
 
         assert res == u'hello wórld'
 
+    def test_varReplace_list(self):
+        template = 'hello ${data[1]}'
+        vars = {
+            'data': [ 'no-one', 'world' ]
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == 'hello world'
+
+    def test_varReplace_invalid_list(self):
+        template = 'hello ${data[1}'
+        vars = {
+            'data': [ 'no-one', 'world' ]
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == template
+
+    def test_varReplace_list_oob(self):
+        template = 'hello ${data[2]}'
+        vars = {
+            'data': [ 'no-one', 'world' ]
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == template
+
+    def test_varReplace_list_nolist(self):
+        template = 'hello ${data[1]}'
+        vars = {
+            'data': { 'no-one': 0, 'world': 1 }
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == template
+
+    def test_varReplace_nested_list(self):
+        template = 'hello ${data[1].msg[0]}'
+        vars = {
+            'data': [ 'no-one', {'msg': [ 'world'] } ]
+        }
+
+        res = ansible.utils.varReplace(template, vars)
+
+        assert res == 'hello world'
+
     #####################################
     ### Template function tests
 


### PR DESCRIPTION
Support things like:

```
- hosts: ...
  vars:
  - mylist:
    - héllo
    - world
  tasks:
  - name: test unicode templating
    action: template src=../templates/unicode.j2 dest=/root/unicode.txt
```

And in the template:

```
Test file
${mylist[0]} ${mylist[1]}
```
