### PR TITLE
Support single handlers for notify.

### DIFF
--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -364,6 +364,8 @@ class PlayBook(object):
         # we would only trigger restarting Apache on half of the nodes
 
         subtasks = task.get('notify', [])
+        if isinstance(subtasks, basestring):
+            subtasks = [subtasks]
         if len(subtasks) > 0:
             for host, results in results.get('contacted',{}).iteritems():
                 if results.get('changed', False):


### PR DESCRIPTION
`notify:` could only take a list of handlers; this lets it take just one, so you can just write

```
notify: restart ssh
```

instead of

```
notify:
- restart ssh
```
