### PR TITLE
support for confirming or encrypting vars gathered via vars_prompt

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -20,6 +20,10 @@
 import utils
 import sys
 import getpass
+try:
+    import passlib.hash
+except:
+    pass
 
 #######################################################
 
@@ -226,11 +230,23 @@ class PlaybookCallbacks(object):
     def on_task_start(self, name, is_conditional):
         print utils.task_start_msg(name, is_conditional)
 
-    def on_vars_prompt(self, varname, private=True):
-        msg = 'input for %s: ' % varname
-        if private:
-            return getpass.getpass(msg)
-        return raw_input(msg)
+    def on_vars_prompt(self, msg, private=True, encrypt=False, confirm=False):
+        msg = '%s: ' % msg
+        def prompt(prompt, private):
+            if private:
+                return getpass.getpass(prompt)
+            return raw_input(prompt)
+        if confirm:
+            while True:
+                result = prompt(msg, private)
+                second = prompt("confirm " + msg, private)
+                if result == second: break
+                print "***** VALUES DO NOT MATCH ****"
+        else:
+            result = prompt(msg, private)
+        if encrypt:
+            result = passlib.hash.md5_crypt.encrypt(result)
+        return result
         
     def on_setup_primary(self):
         print "SETUP PHASE ****************************\n"

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -20,10 +20,12 @@
 import utils
 import sys
 import getpass
+from ansible import errors
 try:
     import passlib.hash
+    PASSLIB_AVAILABLE = True
 except:
-    pass
+    PASSLIB_AVAILABLE = False
 
 #######################################################
 
@@ -241,11 +243,14 @@ class PlaybookCallbacks(object):
                 result = prompt(msg, private)
                 second = prompt("confirm " + msg, private)
                 if result == second: break
-                print "***** VALUES DO NOT MATCH ****"
+                print "***** VALUES ENTERED DO NOT MATCH ****"
         else:
             result = prompt(msg, private)
         if encrypt:
-            result = passlib.hash.md5_crypt.encrypt(result)
+            if PASSLIB_AVAILABLE:
+                result = passlib.hash.md5_crypt.encrypt(result)
+            else:
+                raise errors.AnsibleError("passlib must be installed to encrypt vars_prompt values")
         return result
         
     def on_setup_primary(self):

--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -136,9 +136,17 @@ class PlayBook(object):
         if type(vars_prompt) != dict:
             raise errors.AnsibleError("'vars_prompt' section must contain only key/value pairs")
         for vname in vars_prompt:
-            # TODO: make this prompt one line and consider double entry
-            print vars_prompt[vname]
-            vars[vname] = self.callbacks.on_vars_prompt(vname)
+            var_settings = vars_prompt[vname]
+            if type(var_settings) == str:
+                vars[vname] = self.callbacks.on_vars_prompt(var_settings)
+            elif type(var_settings) == dict:
+                prompt = var_settings.get("prompt", "input for %s" % vname)
+                confirm = var_settings.get("confirm", False)
+                encrypt = var_settings.get("encrypt", False)
+                vars[vname] = self.callbacks.on_vars_prompt(prompt, confirm=confirm, encrypt=encrypt)
+            else:
+                raise errors.AnsibleError("'vars_prompt' values must be either a string or a dictionary")
+            print vars[vname]
 
         results = self.extra_vars.copy()
         results.update(vars)


### PR DESCRIPTION
Usage:

``` yaml
- hosts: all
  vars_prompt:
    foo: {prompt: "enter foo", encrypt: true, confirm: true}
```

If the extra features aren't needed, just use foo: some prompt text as usual.

Note that I've also removed the multi-line prompt as suggested in the TODO. Only the prompt provided will be used, with ": " added to the end.

Resolves #258
