### PR TITLE
Feature vars prompt confirm crypt

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -20,6 +20,10 @@
 import utils
 import sys
 import getpass
+try:
+    import passlib.hash
+except:
+    pass
 
 #######################################################
 
@@ -226,11 +230,23 @@ class PlaybookCallbacks(object):
     def on_task_start(self, name, is_conditional):
         print utils.task_start_msg(name, is_conditional)
 
-    def on_vars_prompt(self, varname, private=True):
-        msg = 'input for %s: ' % varname
-        if private:
-            return getpass.getpass(msg)
-        return raw_input(msg)
+    def on_vars_prompt(self, msg, private=True, encrypt=False, confirm=False):
+        msg = '%s: ' % msg
+        def prompt(prompt, private):
+            if private:
+                return getpass.getpass(prompt)
+            return raw_input(prompt)
+        if confirm:
+            while True:
+                result = prompt(msg, private)
+                second = prompt("confirm " + msg, private)
+                if result == second: break
+                print "***** VALUES DO NOT MATCH ****"
+        else:
+            result = prompt(msg, private)
+        if encrypt:
+            result = passlib.hash.md5_crypt.encrypt(result)
+        return result
         
     def on_setup_primary(self):
         print "SETUP PHASE ****************************\n"

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -20,10 +20,12 @@
 import utils
 import sys
 import getpass
+from ansible import errors
 try:
     import passlib.hash
+    PASSLIB_AVAILABLE = True
 except:
-    pass
+    PASSLIB_AVAILABLE = False
 
 #######################################################
 
@@ -241,11 +243,14 @@ class PlaybookCallbacks(object):
                 result = prompt(msg, private)
                 second = prompt("confirm " + msg, private)
                 if result == second: break
-                print "***** VALUES DO NOT MATCH ****"
+                print "***** VALUES ENTERED DO NOT MATCH ****"
         else:
             result = prompt(msg, private)
         if encrypt:
-            result = passlib.hash.md5_crypt.encrypt(result)
+            if PASSLIB_AVAILABLE:
+                result = passlib.hash.md5_crypt.encrypt(result)
+            else:
+                raise errors.AnsibleError("passlib must be installed to encrypt vars_prompt values")
         return result
         
     def on_setup_primary(self):

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -232,7 +232,7 @@ class PlaybookCallbacks(object):
     def on_task_start(self, name, is_conditional):
         print utils.task_start_msg(name, is_conditional)
 
-    def on_vars_prompt(self, msg, private=True, encryption=None, confirm=False, salt_size=None, salt=None):
+    def on_vars_prompt(self, msg, private=True, encrypt=None, confirm=False, salt_size=None, salt=None):
         msg = '%s: ' % msg
         def prompt(prompt, private):
             if private:
@@ -246,12 +246,12 @@ class PlaybookCallbacks(object):
                 print "***** VALUES ENTERED DO NOT MATCH ****"
         else:
             result = prompt(msg, private)
-        if encryption:
+        if encrypt:
             if PASSLIB_AVAILABLE:
                 try:
-                    crypt = getattr(passlib.hash, encryption)
+                    crypt = getattr(passlib.hash, encrypt)
                 except:
-                    raise errors.AnsibleError("passlib does not support '%s' algorithm" % encryption) 
+                    raise errors.AnsibleError("passlib does not support '%s' algorithm" % encrypt) 
                 if salt_size:
                     result = crypt.encrypt(result, salt_size=salt_size)
                 elif salt:

--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -142,8 +142,10 @@ class PlayBook(object):
             elif type(var_settings) == dict:
                 prompt = var_settings.get("prompt", "input for %s" % vname)
                 confirm = var_settings.get("confirm", False)
-                encrypt = var_settings.get("encrypt", False)
-                vars[vname] = self.callbacks.on_vars_prompt(prompt, confirm=confirm, encrypt=encrypt)
+                encryption = var_settings.get("encryption", False)
+                salt_size = var_settings.get("salt_size", None)
+                salt = var_settings.get("salt", None)
+                vars[vname] = self.callbacks.on_vars_prompt(prompt, confirm=confirm, encryption=encryption, salt_size=salt_size, salt=salt)
             else:
                 raise errors.AnsibleError("'vars_prompt' values must be either a string or a dictionary")
             print vars[vname]

--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -136,9 +136,17 @@ class PlayBook(object):
         if type(vars_prompt) != dict:
             raise errors.AnsibleError("'vars_prompt' section must contain only key/value pairs")
         for vname in vars_prompt:
-            # TODO: make this prompt one line and consider double entry
-            print vars_prompt[vname]
-            vars[vname] = self.callbacks.on_vars_prompt(vname)
+            var_settings = vars_prompt[vname]
+            if type(var_settings) == str:
+                vars[vname] = self.callbacks.on_vars_prompt(var_settings)
+            elif type(var_settings) == dict:
+                prompt = var_settings.get("prompt", "input for %s" % vname)
+                confirm = var_settings.get("confirm", False)
+                encrypt = var_settings.get("encrypt", False)
+                vars[vname] = self.callbacks.on_vars_prompt(prompt, confirm=confirm, encrypt=encrypt)
+            else:
+                raise errors.AnsibleError("'vars_prompt' values must be either a string or a dictionary")
+            print vars[vname]
 
         results = self.extra_vars.copy()
         results.update(vars)

--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -142,10 +142,10 @@ class PlayBook(object):
             elif type(var_settings) == dict:
                 prompt = var_settings.get("prompt", "input for %s" % vname)
                 confirm = var_settings.get("confirm", False)
-                encryption = var_settings.get("encryption", False)
+                encrypt = var_settings.get("encrypt", False)
                 salt_size = var_settings.get("salt_size", None)
                 salt = var_settings.get("salt", None)
-                vars[vname] = self.callbacks.on_vars_prompt(prompt, confirm=confirm, encryption=encryption, salt_size=salt_size, salt=salt)
+                vars[vname] = self.callbacks.on_vars_prompt(prompt, confirm=confirm, encrypt=encrypt, salt_size=salt_size, salt=salt)
             else:
                 raise errors.AnsibleError("'vars_prompt' values must be either a string or a dictionary")
             print vars[vname]

--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -148,7 +148,6 @@ class PlayBook(object):
                 vars[vname] = self.callbacks.on_vars_prompt(prompt, confirm=confirm, encrypt=encrypt, salt_size=salt_size, salt=salt)
             else:
                 raise errors.AnsibleError("'vars_prompt' values must be either a string or a dictionary")
-            print vars[vname]
 
         results = self.extra_vars.copy()
         results.update(vars)


### PR DESCRIPTION
Example:

``` yaml
  vars_prompt:
    foo: {prompt: "enter foo", encryption: "md5_crypt", confirm: true, salt_size: 7, salt: "foo"}
    bar: {prompt: "enter bar", encryption: "sha512_crypt", confirm: false, salt: "foo"}
```
