### PR TITLE
Prevent apt-get install to enter interactive conflict resolution mode

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -82,7 +82,7 @@ def install(pkgspec, cache, upgrade=False, default_release=None):
     name, version = package_split(pkgspec)
     installed, upgradable = package_status(name, version, cache)
     if not installed or (upgrade and upgradable):
-        cmd = "%s -q -y install '%s'" % (APT, pkgspec)
+        cmd = "%s --option Dpkg::Options::=--force-confold -q -y install '%s'" % (APT, pkgspec)
         if default_release:
             cmd += " -t '%s'" % (default_release,)
         rc, out, err = run_apt(cmd)

--- a/library/setup
+++ b/library/setup
@@ -242,6 +242,9 @@ def get_network_facts(facts):
                     facts[iface]['ipv4'] = {}
                 facts[iface]['ipv4'] = { 'address': data[1].split(':')[1],
                                          'netmask': data[-1].split(':')[1] }
+                ip = struct.unpack("!L", socket.inet_aton(facts[iface]['ipv4']['address']))[0]
+                mask = struct.unpack("!L", socket.inet_aton(facts[iface]['ipv4']['netmask']))[0]
+                facts[iface]['ipv4']['network'] = socket.inet_ntoa(struct.pack("!L", ip & mask))
             if 'inet6 addr' in line:
                 (ip, prefix) = data[2].split('/')
                 scope = data[3].split(':')[1].lower()


### PR DESCRIPTION
In some cases (changed config files), apt-get install can enter an interactive mode where it asks the user how to solve a configuration file conflict (i.e. use the package version of the file, use the user's version, show diff, etc.).

Quick test on a clean machine:
  echo "BLA=bla" > /etc/default/haproxy
  apt-get -q -y install haproxy
