### PR TITLE
Fix correct variable expansion in includes only_if.

### DIFF
--- a/lib/ansible/playbook.py
+++ b/lib/ansible/playbook.py
@@ -160,8 +160,7 @@ class PlayBook(object):
                 include_vars[k] = v
         inject_vars = play_vars.copy()
         inject_vars.update(include_vars)
-        included = utils.template_from_file(path, inject_vars, SETUP_CACHE, no_engine=True)
-        included = utils.parse_yaml(included)
+        included = utils.parse_yaml_from_file(path)
         for x in included:
             if len(include_vars):
                 x["vars"] = include_vars

--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -262,13 +262,14 @@ class Runner(object):
         async_jid=None, async_module=None, async_limit=None):
         ''' runs a module that has already been transferred '''
 
-        inject = self.setup_cache.get(conn.host,{})
+        inject = self.setup_cache.get(conn.host,{}).copy()
+        host_variables = self.inventory.get_variables(conn.host)
+        inject.update(host_variables)
+        inject.update(self.module_vars)
+
         conditional = utils.double_template(self.conditional, inject, self.setup_cache)
         if not eval(conditional):
             return [ utils.smjson(dict(skipped=True)), None, 'skipped' ]
-
-        host_variables = self.inventory.get_variables(conn.host)
-        inject.update(host_variables)
 
         if self.module_name == 'setup':
             args = self._add_setup_vars(inject, args)

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -172,3 +172,28 @@ class TestPlaybook(unittest.TestCase):
        print data
        assert data.find("ears") != -1, "template success"
 
+   def test_includes(self):
+        pb = os.path.join(self.test_dir, 'playbook_includes.yml')
+        actual = self._run(pb)
+
+        for i, event in enumerate(EVENTS):
+            print "EVENT %s"%(i)
+            print event
+
+            if i == 6:
+                assert 'blue' in event[1][1]['cmd']
+
+            if i == 8:
+                assert 'quack' in event[1][1]['cmd']
+
+            if i == 10:
+                assert 'RAN' in event[1][1]['cmd']
+
+            if i == 12:
+                assert 'RAN' in event[1][1]['cmd']
+
+            if i == 14:
+                assert 'red' in event[1][1]['cmd']
+
+            if i == 18 or i == 20:
+                assert 'skipped' in event[0]

--- a/test/common_vars.yml
+++ b/test/common_vars.yml
@@ -1,3 +1,4 @@
 ---
 duck: quack
 cow: moo
+extguard: " '$favcolor' == 'blue' "

--- a/test/playbook_included.yml
+++ b/test/playbook_included.yml
@@ -1,0 +1,14 @@
+---
+- name: test vars
+  action: shell echo $favcolor
+
+- name: test vars_files
+  action: shell echo $duck
+
+- name: test vars condition
+  action: shell echo RAN
+  only_if: $guard
+
+- name: test vars_files condition
+  action: shell echo RAN
+  only_if: $extguard

--- a/test/playbook_includes.yml
+++ b/test/playbook_includes.yml
@@ -1,0 +1,15 @@
+---
+# Test correct variable expansion in included files and only if
+- hosts: all
+  vars:
+    favcolor: "blue"
+    guard: ' "$favcolor" == "blue" '
+  vars_files:
+  - common_vars.yml
+
+  tasks:
+
+  - include: playbook_included.yml
+
+  # test overrides of variables
+  - include: playbook_included.yml favcolor=red


### PR DESCRIPTION
There's no need to run the complete include through the templating engine anymore since we removed jinja support?

Several variables were not included before the conditional was evaluated.

This most likely fixes #241.
