### PR TITLE
Added parameter to the apt-get install command to prevent interactive conflict resolution

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -82,7 +82,7 @@ def install(pkgspec, cache, upgrade=False, default_release=None):
     name, version = package_split(pkgspec)
     installed, upgradable = package_status(name, version, cache)
     if not installed or (upgrade and upgradable):
-        cmd = "%s -q -y install '%s'" % (APT, pkgspec)
+        cmd = "%s --option Dpkg::Options::=--force-confold -q -y install '%s'" % (APT, pkgspec)
         if default_release:
             cmd += " -t '%s'" % (default_release,)
         rc, out, err = run_apt(cmd)


### PR DESCRIPTION
action: apt pkg=package status=installed  can hang if apt-get enters interactive mode and asks the user how to solve a configuration file conflict. 

Test code:
- name: create a conflict
  action: shell echo "BLA=1" > /etc/default/haproxy
- name: install haproxy
  action: apt pkg=haproxy state=installed 
