### PR TITLE
Fix for issue 353

### DIFF
--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -666,6 +666,9 @@ class Runner(object):
 
         result, err = self._exec_command(conn, cmd, None, sudoable=False)
         cleaned = result.split("\n")[0].strip() + '/'
+        if self.remote_user != 'root':
+            cmd = 'chmod a+x %s' % cleaned
+            result, err = self._exec_command(conn, cmd, None, sudoable=False)
         return cleaned
 
 


### PR DESCRIPTION
mktemp creates the temp directory 700 only.  If the sudo-user is not
root, the other user will not be able to run the command (Permission
denied error).  This adds the executable bit for all on the temp
directory.

Fixes issue #353.
