### PR TITLE
Created get_selinux_facts method

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -275,12 +275,10 @@ def get_selinux_facts(facts):
             config_mode = re.search("(enforcing|disabled|permissive)", list[3])
             policyvers = re.search("\d+", list[4])
             type = re.search("(targeted|strict|mls)", list[5])
-            for item in ['mode', 'config_mode', 'policyvers', 'type']:
-                facts['selinux'][item] = item.group()
-#            facts['selinux']['mode'] = mode.group()
-#            facts['selinux']['config_mode'] = config_mode.group()
-#            facts['selinux']['policyvers'] = policyvers.group()
-#            facts['selinux']['type'] = type.group()
+            facts['selinux']['mode'] = mode.group()
+            facts['selinux']['config_mode'] = config_mode.group()
+            facts['selinux']['policyvers'] = policyvers.group()
+            facts['selinux']['type'] = type.group()
     else:
         facts['selinux'] = False
 

--- a/library/setup
+++ b/library/setup
@@ -264,33 +264,23 @@ def get_public_ssh_host_keys(facts):
         facts['ssh_host_key_rsa_public'] = rsa.split()[1]
 
 def get_selinux_facts(facts):
-    if os.path.exists("/etc/sysconfig/selinux"):
-        facts['selinux'] = {}
-        cmd = subprocess.Popen("/usr/sbin/getenforce", shell=True, 
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = cmd.communicate()
-        out = out.rstrip()
-        if err == "": 
-            facts['selinux']['mode'] = out
-        else:
-            facts['selinux']['mode'] = err
-        conf = []
-        for line in open("/etc/sysconfig/selinux").readlines():
-            data = line.split("\n", 1)
-            conf.append(data[0])
-            if 'SELINUX=disabled' in conf:
-                facts['selinux']['mode_configured'] = 'disabled'
-            elif 'SELINUX=enforcing':
-                facts['selinux']['mode_configured'] = 'enforcing'
-            elif 'SELINUX=permissive' in conf:
-                facts['selinux']['mode_configured'] = 'permissive'
-            elif 'SELINUXTYPE=targeted' in conf:
-                facts['selinux']['type'] = 'targeted'
-            elif 'SELINUXTYPE=strict':
-                facts['selinux']['type'] = 'strict'
-            elif 'SELINUXTYPE=mls':
-                facts['selinux']['type'] = 'mls'
-            facts['selinux']['policyvers'] = open("/selinux/policyvers").readlines().pop() # Assuming policyvers is only one line.
+    cmd = subprocess.Popen("/usr/sbin/sestatus", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = cmd.communicate()
+    if err == '':
+        list = out.split("\n")
+        status = re.search("enabled", list[0])
+        if status.group() == "enabled":
+            facts['selinux'] = {}
+            mode = re.search("(enforcing|disabled|permissive)", list[2])
+            config_mode = re.search("(enforcing|disabled|permissive)", list[3])
+            policyvers = re.search("\d+", list[4])
+            type = re.search("(targeted|strict|mls)", list[5])
+            for item in ['mode', 'config_mode', 'policyvers', 'type']:
+                facts['selinux'][item] = item.group()
+#            facts['selinux']['mode'] = mode.group()
+#            facts['selinux']['config_mode'] = config_mode.group()
+#            facts['selinux']['policyvers'] = policyvers.group()
+#            facts['selinux']['type'] = type.group()
     else:
         facts['selinux'] = False
 

--- a/library/setup
+++ b/library/setup
@@ -267,18 +267,22 @@ def get_selinux_facts(facts):
     cmd = subprocess.Popen("/usr/sbin/sestatus", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = cmd.communicate()
     if err == '':
+        facts['selinux'] = {}
         list = out.split("\n")
-        status = re.search("enabled", list[0])
+        status = re.search("(enabled|disabled)", list[0])
         if status.group() == "enabled":
-            facts['selinux'] = {}
             mode = re.search("(enforcing|disabled|permissive)", list[2])
             config_mode = re.search("(enforcing|disabled|permissive)", list[3])
             policyvers = re.search("\d+", list[4])
             type = re.search("(targeted|strict|mls)", list[5])
+            facts['selinux']['status'] = status.group()
             facts['selinux']['mode'] = mode.group()
             facts['selinux']['config_mode'] = config_mode.group()
             facts['selinux']['policyvers'] = policyvers.group()
             facts['selinux']['type'] = type.group()
+        elif status.group() == "disabled":
+            facts['selinux']['status'] = status.group()
+            
     else:
         facts['selinux'] = False
 

--- a/library/setup
+++ b/library/setup
@@ -263,8 +263,40 @@ def get_public_ssh_host_keys(facts):
     else:
         facts['ssh_host_key_rsa_public'] = rsa.split()[1]
 
+def get_selinux_facts(facts):
+    if os.path.exists("/etc/sysconfig/selinux"):
+        facts['selinux'] = {}
+        cmd = subprocess.Popen("/usr/sbin/getenforce", shell=True, 
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = cmd.communicate()
+        out = out.rstrip()
+        if err == "": 
+            facts['selinux']['mode'] = out
+        else:
+            facts['selinux']['mode'] = err
+        conf = []
+        for line in open("/etc/sysconfig/selinux").readlines():
+            data = line.split("\n", 1)
+            conf.append(data[0])
+            if 'SELINUX=disabled' in conf:
+                facts['selinux']['mode_configured'] = 'disabled'
+            elif 'SELINUX=enforcing':
+                facts['selinux']['mode_configured'] = 'enforcing'
+            elif 'SELINUX=permissive' in conf:
+                facts['selinux']['mode_configured'] = 'permissive'
+            elif 'SELINUXTYPE=targeted' in conf:
+                facts['selinux']['type'] = 'targeted'
+            elif 'SELINUXTYPE=strict':
+                facts['selinux']['type'] = 'strict'
+            elif 'SELINUXTYPE=mls':
+                facts['selinux']['type'] = 'mls'
+            facts['selinux']['policyvers'] = open("/selinux/policyvers").readlines().pop() # Assuming policyvers is only one line.
+    else:
+        facts['selinux'] = False
+
 def get_service_facts(facts):
     get_public_ssh_host_keys(facts)
+    get_selinux_facts(facts)
 
 def ansible_facts():
     facts = {}

--- a/library/setup
+++ b/library/setup
@@ -281,8 +281,7 @@ def get_selinux_facts(facts):
             facts['selinux']['policyvers'] = policyvers.group()
             facts['selinux']['type'] = type.group()
         elif status.group() == "disabled":
-            facts['selinux']['status'] = status.group()
-            
+            facts['selinux']['status'] = status.group()            
     else:
         facts['selinux'] = False
 


### PR DESCRIPTION
Will return a dict titled 'selinux', with a nested dict of values from 'sestatus'. If sestatus isn't present 'selinux'  is false.
Tested with selinux disabled, enforcing, and by removing /usr/sbin/sestatus.
