### PR TITLE
0.4 fix, Remove call to undefined debug() in module 'user'

### DIFF
--- a/library/user
+++ b/library/user
@@ -159,7 +159,6 @@ def user_mod(user, **kwargs):
                             cmd.append('-a')
                             groups_need_mod = True
                 else:
-                   debug("groups differ, trigger usemod")
                    groups_need_mod = True
 
             if groups_need_mod:


### PR DESCRIPTION
I _think_ this is the right way to fix this rare crash.

This looks like a stray debug() that didn't get removed when we stopped using the debug() to stderr idiom.

It only show up in the rare cases when you alter an existing user's groups, but because debug() is undefined, it crashes 'user'.
