### PR TITLE
Arguments to setup module should be json.

### DIFF
--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -275,6 +275,8 @@ class Runner(object):
             return [ utils.smjson(dict(skipped=True)), None, 'skipped' ]
 
         if self.module_name == 'setup':
+            if not args:
+                args = {}
             args = self._add_setup_vars(inject, args)
             args = self._add_setup_metadata(args)
 


### PR DESCRIPTION
Before:

```
$ ansible myhost -m setup -u jeroen
...
        "facter_hostname": "myhost", 
        "group_names": "['rear',~~~'test',~~~'ungrouped']", 
        "inventory_hostname": "myhost",
...
```

After:

```
...
        "facter_hostname": "myhost", 
        "group_names": [
            "rear", 
            "test", 
            "ungrouped"
        ], 
        "inventory_hostname": "myhost",
...
```
