### PR TITLE
Updated runner.py to support calling the proper conn.exec_command().  

### DIFF
--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -648,7 +648,10 @@ class Runner(object):
     def _exec_command(self, conn, cmd, tmp, sudoable=False):
         ''' execute a command string over SSH, return the output '''
         sudo_user = self.sudo_user
-        stdin, stdout, stderr = conn.exec_command(cmd, tmp, sudo_user, sudoable=sudoable)
+        if self.transport == 'local' :
+          stdin, stdout, stderr = conn.exec_command(cmd, tmp, sudoable=sudoable)
+        else :
+          stdin, stdout, stderr = conn.exec_command(cmd, tmp, sudo_user, sudoable=sudoable)
         err=None
         out=None
         if type(stderr) != str:


### PR DESCRIPTION
If the conn class is LocalConnection it does not require the sudoUser parameter
