### PR TITLE
updated connection.py to have the same interface for exec_command on both LocalConnection and ParamikoConnection classes

### DIFF
--- a/lib/ansible/connection.py
+++ b/lib/ansible/connection.py
@@ -188,7 +188,7 @@ class LocalConnection(object):
 
         return self
 
-    def exec_command(self, cmd, tmp_path, sudoable=False):
+    def exec_command(self, cmd, tmp_path,sudo_user,sudoable=False):
         ''' run a command on the local host '''
         if self.runner.sudo and sudoable:
             cmd = "sudo -s %s" % cmd


### PR DESCRIPTION
exec_command accepted a different number of parameters for LocalConnection versus ParamikoConnection in connection.py.  This was causing the play in the playbook to bomb out if connection:local was set for a play
