### PR TITLE
Allow "=" in k-v values.

### DIFF
--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -295,7 +295,7 @@ def parse_kv(args):
         vargs = shlex.split(args, posix=True)
         for x in vargs:
             if x.find("=") != -1:
-                k, v = x.split("=")
+                k, v = x.split("=", 1)
                 options[k]=v
     return options
 

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -235,3 +235,10 @@ class TestUtils(unittest.TestCase):
         res = ansible.utils.template(template, vars, {}, no_engine=False)
 
         assert res == u'hello wórld'
+
+    #####################################
+    ### key-value parsing
+
+    def test_parse_kv_basic(self):
+        assert (ansible.utils.parse_kv('a=simple b="with space" c="this=that"') ==
+                {'a': 'simple', 'b': 'with space', 'c': 'this=that'})


### PR DESCRIPTION
Fixes module arg parsing when a value contains an equals char. Includes test.
