### PR TITLE
Support optional custom template variable markers.

### DIFF
--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -509,6 +509,7 @@ class Runner(object):
         source   = options.get('src', None)
         dest     = options.get('dest', None)
         metadata = options.get('metadata', None)
+        var_pattern = options.pop('var_pattern', None)
         if (source is None and 'first_available_file' not in self.module_vars) or dest is None:
             return (host, True, dict(failed=True, msg="src and dest are required"), '')
 
@@ -562,7 +563,8 @@ class Runner(object):
         # template the source data locally
         try:
             resultant = utils.template_from_file(utils.path_dwim(self.basedir, source),
-                                                 inject, self.setup_cache, no_engine=False)
+                                                 inject, self.setup_cache, no_engine=False,
+                                                 var_pattern=var_pattern)
         except Exception, e:
             return (host, False, dict(failed=True, msg=str(e)), '')
         xfered = self._transfer_str(conn, tmp, 'source', resultant)

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -254,7 +254,7 @@ def varReplace(raw, vars):
 
     return ''.join(done)
 
-def template(text, vars, setup_cache, no_engine=True):
+def template(text, vars, setup_cache, no_engine=True, var_pattern=None):
     ''' run a text buffer through the templating engine '''
     vars = vars.copy()
     vars['hostvars'] = setup_cache
@@ -264,7 +264,9 @@ def template(text, vars, setup_cache, no_engine=True):
         # in a later context when more variables are available
         return text
     else:
-        template = jinja2.Template(text)
+        var_pattern = (var_pattern or "{{ }}").split()
+        template = jinja2.Template(text, variable_start_string=var_pattern[0],
+                                   variable_end_string=var_pattern[1])
         res = template.render(vars)
         if text.endswith('\n') and not res.endswith('\n'):
             res = res + '\n'
@@ -273,10 +275,10 @@ def template(text, vars, setup_cache, no_engine=True):
 def double_template(text, vars, setup_cache):
     return template(template(text, vars, setup_cache), vars, setup_cache)
 
-def template_from_file(path, vars, setup_cache, no_engine=True):
+def template_from_file(path, vars, setup_cache, no_engine=True, var_pattern=None):
     ''' run a file through the templating engine '''
     data = codecs.open(path, encoding="utf8").read()
-    return template(data, vars, setup_cache, no_engine=no_engine)
+    return template(data, vars, setup_cache, no_engine=no_engine, var_pattern=var_pattern)
 
 def parse_yaml(data):
     return yaml.load(data)

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -235,3 +235,9 @@ class TestUtils(unittest.TestCase):
         res = ansible.utils.template(template, vars, {}, no_engine=False)
 
         assert res == u'hello wórld'
+
+    def test_template_var_pattern(self):
+        template ='{{"[=msg=]"}, []}'
+        vars = {'msg': 'hello'}
+        expected ='{{"hello"}, []}'
+        assert ansible.utils.template(template, vars, {}, no_engine=False, var_pattern='[= =]') == expected


### PR DESCRIPTION
Jinja's default, {{ }}, is not always appropriate. For example, Erlang
uses {...} for tuples and it's not uncommon to have a tuple nested in
another tuple, e.g. {{term1, [term2, term3]}, ...}.
