### PR TITLE
Listed python sub-packages in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ setup(name='ansible',
       package_dir={ 'ansible': 'lib/ansible' },
       packages=[
          'ansible',
+         'ansible.inventory',
+         'ansible.playbook',
+         'ansible.runner',
       ],
       scripts=[
          'bin/ansible',


### PR DESCRIPTION
Added inventory, playbook, and runner to the packages list in setup.py to better support pythonic deployment.

Update: (I just read some of the others to realise these comments are a bit less formal than log messages) I tried using virtualenv and pip to install ansible under /opt and found this change necessary.
