### PR TITLE
Test for play.vars_files == None, avoiding nasty traceback.

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -280,8 +280,9 @@ class PlayBook(object):
         rc = self._do_setup_step(play) # pattern, vars, user, port, sudo, sudo_user, transport, None)
 
         # now with that data, handle contentional variable file imports!
-        if len(play.vars_files) > 0:
+        if play.vars_files and len(play.vars_files) > 0:
             rc = self._do_setup_step(play, play.vars_files)
+        #else: warn "You have a vars_files section but didn't state any vars files??
 
         # run all the top level tasks, these get run on every node
         for task in play.tasks():


### PR DESCRIPTION
Ignores for now. Could warn or fail.

Playbook test for no vars_files with len(), but that excepts if play.vars_files==None, as can happen when there's a vars_files section with no vars files listed. 

Design considerations:
1. What is the ansible way: ignore, warn, or fail with message (instead of traceback)?
2. Would it be better to alter the playbook parser to ensure a zero-length play.vars_files?
3. Should change be backported to 0.4
