### PR TITLE
Avoid traceback when vars file has no vars items. Could warn or fail instead.

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -186,5 +186,7 @@ class Play(object):
 
                 fpath = utils.path_dwim(self.playbook.basedir, utils.template(filename, self.vars))
                 new_vars = utils.parse_yaml_from_file(fpath)
-                self.playbook.SETUP_CACHE[host].update(new_vars)
+                if new_vars:
+                    self.playbook.SETUP_CACHE[host].update(new_vars)
+                #else: could warn if vars file contains no vars. 
 


### PR DESCRIPTION
When there are no items, python-yaml returns None, not []. Right now gives traceback that could confuse. Suggest ignore, warn, or fail. Current patch simply ignores.
