### PR TITLE
Properly template list of hosts in playbooks.

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -37,10 +37,16 @@ class Play(object):
 
         # TODO: more error handling
 
+        hosts = ds.get('hosts')
+        if hosts is None:
+            raise errors.AnsibleError('hosts declaration is required')
+        elif isinstance(hosts, list):
+            hosts = ';'.join(hosts)
+        hosts = utils.template(hosts, playbook.extra_vars, {})
+
         self._ds         = ds
         self.playbook    = playbook
-        self.hosts       = ds.get('hosts', None)
-        self.hosts       = utils.template(self.hosts, self.playbook.extra_vars, {})
+        self.hosts       = hosts 
         self.name        = ds.get('name', self.hosts)
         self.vars        = ds.get('vars', {})
         self.vars_files  = ds.get('vars_files', [])
@@ -56,10 +62,6 @@ class Play(object):
         self._tasks      = self._load_tasks(self._ds, 'tasks')
         self._handlers   = self._load_tasks(self._ds, 'handlers')
 
-        if self.hosts is None:
-            raise errors.AnsibleError('hosts declaration is required')
-        if isinstance(self.hosts, list):
-            self.hosts = ';'.join(self.hosts)
         if self.sudo_user != 'root':
             self.sudo = True
 

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -10,11 +10,10 @@ import ansible.utils as utils
 import ansible.callbacks as ans_callbacks
 import os
 import shutil
-import time
 try:
-   import json
+    import json
 except:
-   import simplejson as json
+    import simplejson as json
 
 EVENTS = []
 
@@ -83,92 +82,98 @@ class TestCallbacks(object):
     def on_async_failed(self, host, res, jid):
         EVENTS.append([ 'async failed', [ host ]])
 
-    def on_unreachable(self, host, msg):
-        EVENTS.append([ 'failed/dark', [ host, msg ]])
-
-    def on_setup_primary(self):
-        pass
-    
-    def on_setup_secondary(self):
-        pass
-
     def on_no_hosts(self):
         pass
 
+
 class TestPlaybook(unittest.TestCase):
 
-   def setUp(self):
-       self.user = getpass.getuser()
-       self.cwd = os.getcwd()
-       self.test_dir = os.path.join(self.cwd, 'test')
-       self.stage_dir = self._prepare_stage_dir()
-
-       if os.path.exists('/tmp/ansible_test_data_copy.out'):
-           os.unlink('/tmp/ansible_test_data_copy.out')
-       if os.path.exists('/tmp/ansible_test_data_template.out'):
-           os.unlink('/tmp/ansible_test_data_template.out')
-
-   def _prepare_stage_dir(self):
-       stage_path = os.path.join(self.test_dir, 'test_data')
-       if os.path.exists(stage_path):
-           shutil.rmtree(stage_path, ignore_errors=False)
-           assert not os.path.exists(stage_path)
-       os.makedirs(stage_path)
-       assert os.path.exists(stage_path)
-       return stage_path
-
-   def _get_test_file(self, filename):
-       # get a file inside the test input directory
-       filename = os.path.join(self.test_dir, filename)
-       assert os.path.exists(filename)
-       return filename
- 
-   def _get_stage_file(self, filename):
-       # get a file inside the test output directory
-       filename = os.path.join(self.stage_dir, filename)
-       return filename
-
-   def _run(self, test_playbook):
-       ''' run a module and get the localhost results '''
-       self.test_callbacks = TestCallbacks()
-       self.playbook = ansible.playbook.PlayBook(
-           playbook     = test_playbook,
-           host_list    = 'test/ansible_hosts',
-           module_path  = 'library/',
-           forks        = 1,
-           timeout      = 5,
-           remote_user  = self.user,
-           remote_pass  = None,
-           stats            = ans_callbacks.AggregateStats(),
-           callbacks        = self.test_callbacks,
-           runner_callbacks = self.test_callbacks
-       )
-       result = self.playbook.run()
-       # print utils.bigjson(dict(events=EVENTS))
-       return result
-
-   def test_one(self):
-       pb = os.path.join(self.test_dir, 'playbook1.yml')
-       actual = self._run(pb)
-
-       # if different, this will output to screen 
-       print "**ACTUAL**"
-       print utils.bigjson(actual)
-       expected =  { 
-            "127.0.0.2": {
-                "changed": 9, 
-                "failures": 0, 
-                "ok": 12, 
-                "skipped": 1, 
-                "unreachable": 0
-            }
-       }
-       print "**EXPECTED**"
-       print utils.bigjson(expected)
-       assert utils.bigjson(expected) == utils.bigjson(actual)
-
-       # make sure the template module took options from the vars section
-       data = file('/tmp/ansible_test_data_template.out').read()
-       print data
-       assert data.find("ears") != -1, "template success"
+    def setUp(self):
+        self.user = getpass.getuser()
+        self.cwd = os.getcwd()
+        self.test_dir = os.path.join(self.cwd, 'test')
+        self.stage_dir = self._prepare_stage_dir()
+    
+        if os.path.exists('/tmp/ansible_test_data_copy.out'):
+            os.unlink('/tmp/ansible_test_data_copy.out')
+        if os.path.exists('/tmp/ansible_test_data_template.out'):
+            os.unlink('/tmp/ansible_test_data_template.out')
+    
+    def _prepare_stage_dir(self):
+        stage_path = os.path.join(self.test_dir, 'test_data')
+        if os.path.exists(stage_path):
+            shutil.rmtree(stage_path, ignore_errors=False)
+            assert not os.path.exists(stage_path)
+        os.makedirs(stage_path)
+        assert os.path.exists(stage_path)
+        return stage_path
+    
+    def _get_test_file(self, filename):
+        # get a file inside the test input directory
+        filename = os.path.join(self.test_dir, filename)
+        assert os.path.exists(filename)
+        return filename
+    
+    def _get_stage_file(self, filename):
+        # get a file inside the test output directory
+        filename = os.path.join(self.stage_dir, filename)
+        return filename
+    
+    def _run(self, test_playbook):
+        ''' run a module and get the localhost results '''
+        self.test_callbacks = TestCallbacks()
+        self.playbook = ansible.playbook.PlayBook(
+            playbook=test_playbook,
+            host_list='test/ansible_hosts',
+            module_path='library/',
+            forks=1,
+            timeout=5,
+            remote_user=self.user,
+            remote_pass=None,
+            stats=ans_callbacks.AggregateStats(),
+            callbacks=self.test_callbacks,
+            runner_callbacks=self.test_callbacks
+        )
+        result = self.playbook.run()
+        # print utils.bigjson(dict(events=EVENTS))
+        return result
+    
+    def test_one(self):
+        pb = os.path.join(self.test_dir, 'playbook1.yml')
+        actual = self._run(pb)
+    
+        # if different, this will output to screen 
+        print "**ACTUAL**"
+        print utils.bigjson(actual)
+        expected = {
+             "127.0.0.2": {
+                 "changed": 9,
+                 "failures": 0,
+                 "ok": 12,
+                 "skipped": 1,
+                 "unreachable": 0
+             }
+        }
+        print "**EXPECTED**"
+        print utils.bigjson(expected)
+        assert utils.bigjson(expected) == utils.bigjson(actual)
+    
+        # make sure the template module took options from the vars section
+        data = file('/tmp/ansible_test_data_template.out').read()
+        print data
+        assert data.find("ears") != -1, "template success"
+    
+    def test_yaml_hosts_list(self):
+        # Make sure playbooks support hosts: [host1, host2]
+        # TODO: Actually run the play on more than one host
+        test_callbacks = TestCallbacks()
+        playbook = ansible.playbook.PlayBook(
+            playbook=os.path.join(self.test_dir, 'hosts_list.yml'),
+            host_list='test/ansible_hosts',
+            stats=ans_callbacks.AggregateStats(),
+            callbacks=test_callbacks,
+            runner_callbacks=test_callbacks
+        )
+        play = ansible.playbook.Play(playbook, playbook.playbook[0])
+        assert play.hosts == ';'.join(('host1', 'host2', 'host3'))
 

--- a/test/hosts_list.yml
+++ b/test/hosts_list.yml
@@ -1,0 +1,5 @@
+# Test that playbooks support YAML lists of hosts.
+---
+- hosts: [host1, host2, host3]
+  tasks:
+  - action: command true


### PR DESCRIPTION
In playbooks, hosts can be a YAML list.  We templated the list before
converting it to a semicolon-separated string, which actually templated its
repr.  This converts to a string first.  A basic unit test is included.  Also
fixed indentation and removed duplicate methods and unused import in
TestPlayBook.py.
