### PR TITLE
Added possibility to define externally the ANSIBLE_ROOT and added a -q quiet option for the env

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -2,19 +2,23 @@
 # usage: source ./hacking/env-setup
 #    modifies environment for running Ansible from checkout
 
-PREFIX_PYTHONPATH="$PWD/lib"
-PREFIX_PATH="$PWD/bin"
-PREFIX_MANPATH="$PWD/docs/man"
+ANSIBLE_ROOT=${ANSIBLE_ROOT:=$PWD}
+
+PREFIX_PYTHONPATH="$ANSIBLE_ROOT/lib"
+PREFIX_PATH="$ANSIBLE_ROOT/bin"
+PREFIX_MANPATH="$ANSIBLE_ROOT/docs/man"
 
 export PYTHONPATH=$PREFIX_PYTHONPATH:$PYTHONPATH
 export PATH=$PREFIX_PATH:$PATH
-export ANSIBLE_LIBRARY="$PWD/library"
+export ANSIBLE_LIBRARY="$ANSIBLE_ROOT/library"
 export MANPATH=$PREFIX_MANPATH:$MANPATH
 
-echo "PATH=$PATH"
-echo "PYTHONPATH=$PYTHONPATH"
-echo "ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY"
-echo "MANPATH=$MANPATH"
+if ! echo "$@" | grep -q '\-q'; then
+				echo "PATH=$PATH"
+				echo "PYTHONPATH=$PYTHONPATH"
+				echo "ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY"
+				echo "MANPATH=$MANPATH"
 
-echo "Reminder: specify your host file with -i"
-echo "Done."
+				echo "Reminder: specify your host file with -i"
+				echo "Done."
+fi


### PR DESCRIPTION
This allows to easily add a script somewhere to invoke the devel copy such as:

``` bash
#!/bin/sh

export ANSIBLE_ROOT=/somewhere/beyond/the/sea
source ${ANSIBLE_ROOT}/hacking/env-setup -q

ansible $@
```
