### PR TITLE
Properly template list of hosts in playbooks.

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -37,10 +37,16 @@ class Play(object):
 
         # TODO: more error handling
 
+        hosts = ds.get('hosts')
+        if hosts is None:
+            raise errors.AnsibleError('hosts declaration is required')
+        elif isinstance(hosts, list):
+            hosts = ';'.join(hosts)
+        hosts = utils.template(hosts, playbook.extra_vars, {})
+
         self._ds         = ds
         self.playbook    = playbook
-        self.hosts       = ds.get('hosts', None)
-        self.hosts       = utils.template(self.hosts, self.playbook.extra_vars, {})
+        self.hosts       = hosts 
         self.name        = ds.get('name', self.hosts)
         self.vars        = ds.get('vars', {})
         self.vars_files  = ds.get('vars_files', [])
@@ -56,10 +62,6 @@ class Play(object):
         self._tasks      = self._load_tasks(self._ds, 'tasks')
         self._handlers   = self._load_tasks(self._ds, 'handlers')
 
-        if self.hosts is None:
-            raise errors.AnsibleError('hosts declaration is required')
-        if isinstance(self.hosts, list):
-            self.hosts = ';'.join(self.hosts)
         if self.sudo_user != 'root':
             self.sudo = True
 

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -172,3 +172,16 @@ class TestPlaybook(unittest.TestCase):
        print data
        assert data.find("ears") != -1, "template success"
 
+   def test_yaml_hosts_list(self):
+       # Make sure playbooks support hosts: [host1, host2]
+       # TODO: Actually run the play on more than one host
+       test_callbacks = TestCallbacks()
+       playbook = ansible.playbook.PlayBook(
+           playbook=os.path.join(self.test_dir, 'hosts_list.yml'),
+           host_list='test/ansible_hosts',
+           stats=ans_callbacks.AggregateStats(),
+           callbacks=test_callbacks,
+           runner_callbacks=test_callbacks
+       )
+       play = ansible.playbook.Play(playbook, playbook.playbook[0])
+       assert play.hosts == ';'.join(('host1', 'host2', 'host3'))

--- a/test/hosts_list.yml
+++ b/test/hosts_list.yml
@@ -1,0 +1,5 @@
+# Test that playbooks support YAML lists of hosts.
+---
+- hosts: [host1, host2, host3]
+  tasks:
+  - action: command true


### PR DESCRIPTION
In playbooks, hosts can be a YAML list. We templated the list before
converting it to a semicolon-separated string, which actually templated its
repr. This converts to a string first. A basic unit test is included.
