### PR TITLE
Get rid of mktemp dependency to support AIX

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -639,7 +639,7 @@ class Runner(object):
         cache = self.setup_cache.get(host, {})
         module_name = utils.template(self.module_name, cache, self.setup_cache)
 
-        tmp = self._get_tmp_path(conn)
+        tmp = self._make_tmp_path(conn)
         result = None
 
         if self.module_name == 'copy':
@@ -691,21 +691,21 @@ class Runner(object):
 
     # *****************************************************
 
-    def _get_tmp_path(self, conn):
-        ''' gets a temporary path on a remote box '''
+    def _make_tmp_path(self, conn):
+        ''' make and return a temporary path on a remote box '''
 
-        basetmp = C.DEFAULT_REMOTE_TMP
+        basefile = 'ansible-%s-%s' % (time.time(), random.randint(0, 2**48))
+        basetmp = os.path.join(C.DEFAULT_REMOTE_TMP, basefile)
         if self.remote_user == 'root':
-            basetmp ="/var/tmp"
-        cmd = "mktemp -d %s/ansible.XXXXXX" % basetmp
+            basetmp = os.path.join('/var/tmp', basefile)
+
+        cmd = 'mkdir -p %s' % basetmp
         if self.remote_user != 'root':
-            cmd = "mkdir -p %s && %s" % (basetmp, cmd)
+            cmd += ' && chmod a+x %s' % basetmp
+        cmd += ' && echo %s' % basetmp
 
         result = self._low_level_exec_command(conn, cmd, None, sudoable=False)
         cleaned = result.split("\n")[0].strip() + '/'
-        if self.remote_user != 'root':
-            cmd = 'chmod a+x %s' % cleaned
-            self._low_level_exec_command(conn, cmd, None, sudoable=False)
         return cleaned
 
 
@@ -720,7 +720,7 @@ class Runner(object):
         if not os.path.exists(in_path):
             raise errors.AnsibleFileNotFound("module not found: %s" % in_path)
 
-        out_path = tmp + module
+        out_path = os.path.join(tmp, module)
         conn.put_file(in_path, out_path)
         return out_path
 


### PR DESCRIPTION
The function call has been renamed to better reflect what it does, and we reduced the number of calls from two to one in case the remote user is not root.

This patch also fixes a string concatenation in _copy_module() that should use os.path.join() instead.

This closes #436

This also fixes #437 for non-root remote users.
