### PR TITLE
Search multiple paths for modules.

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -716,13 +716,16 @@ class Runner(object):
 
         if module.startswith("/"):
             raise errors.AnsibleFileNotFound("%s is not a module" % module)
-        in_path = os.path.expanduser(os.path.join(self.module_path, module))
-        if not os.path.exists(in_path):
-            raise errors.AnsibleFileNotFound("module not found: %s" % in_path)
 
-        out_path = tmp + module
-        conn.put_file(in_path, out_path)
-        return out_path
+        for module_path in self.module_path.split(os.pathsep):
+            in_path = os.path.expanduser(os.path.join(module_path, module))
+            if os.path.exists(in_path):
+                out_path = tmp + module
+                conn.put_file(in_path, out_path)
+                return out_path
+
+        raise errors.AnsibleFileNotFound("module %s not found in %s" % (module, self.module_path))
+
 
     # *****************************************************
 

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -323,7 +323,7 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False, asyn
     parser.add_option('-K', '--ask-sudo-pass', default=False, dest='ask_sudo_pass', action='store_true',
         help='ask for sudo password')
     parser.add_option('-M', '--module-path', dest='module_path',
-        help="specify path to module library (default=%s)" % constants.DEFAULT_MODULE_PATH, 
+        help="specify paths to module library (default=%s)" % constants.DEFAULT_MODULE_PATH,
         default=constants.DEFAULT_MODULE_PATH)
     parser.add_option('-T', '--timeout', default=constants.DEFAULT_TIMEOUT, type='int',
         dest='timeout', 


### PR DESCRIPTION
Minimal change to allow a list of paths (separated by the typical path
separator) to be searched in sequence for the named module.

However ...

Adding an additional module path (the norm I would expect) is definitely awkward right now because you have to know the path to Ansible's built-in modules. It also makes scripts, etc, dependent on the environment.

I believe the --module-path/--no-default-module-path combination would make things much easier and just as explicit, with a small change in backwards compatibility. See discussion for more, https://groups.google.com/d/topic/ansible-project/4_NkI-MPprI/discussion.
