### PR TITLE
Add support for older version of python-apt

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -74,9 +74,17 @@ def package_status(pkgname, version, cache):
     except KeyError:
         fail_json(msg="No package matching '%s' is available" % pkgname)
     if version:
-        return pkg.is_installed and pkg.installed.version == version, False
+        try :
+            return pkg.is_installed and pkg.installed.version == version, False
+        except AttributeError: 
+            #assume older version of python-apt is installed
+            return pkg.isInstalled and pkg.installedVersion == version, False
     else:
-        return pkg.is_installed, pkg.is_upgradable
+        try :
+            return pkg.is_installed, pkg.is_upgradable
+        except AttributeError: 
+            #assume older version of python-apt is installed
+            return pkg.isInstalled, pkg.isUpgradable
 
 def install(pkgspec, cache, upgrade=False, default_release=None):
     name, version = package_split(pkgspec)


### PR DESCRIPTION
regarding this message:
https://groups.google.com/forum/?fromgroups#!topic/ansible-project/gPYqAAzzd58

I figured out a way to support an older version of python-apt, it seems they changed the api here: http://bazaar.launchpad.net/~ubuntu-core-dev/python-apt/ubuntu/revision/175.28.2

but I'm not sure which version of python-apt that went out in. Somewhere between 8 and 12 of ubuntu though. :)
