### PR TITLE
md5sum on bsd

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -476,8 +476,8 @@ class Runner(object):
         # compare old and new md5 for support of change hooks
         local_md5 = None
         if os.path.exists(dest):
-            local_md5 = os.popen("md5sum %s" % dest).read().split()[0]
-        remote_md5 = self._low_level_exec_command(conn, "md5sum %s" % source, tmp, True).split()[0]
+            local_md5 = os.popen("/usr/bin/md5sum %(file)s 2> /dev/null || /sbin/md5 -q %(file)s" % {"file": dest}).read().split()[0]
+        remote_md5 = self._low_level_exec_command(conn, "/usr/bin/md5sum %(file)s 2> /dev/null || /sbin/md5 -q %(file)s" % {"file": source}, tmp, True).split()[0]
 
         if remote_md5 != local_md5:
             # create the containing directories, if needed
@@ -486,7 +486,7 @@ class Runner(object):
 
             # fetch the file and check for changes
             conn.fetch_file(source, dest)
-            new_md5 = os.popen("md5sum %s" % dest).read().split()[0]
+            new_md5 = os.popen("/usr/bin/md5sum %(file)s 2> /dev/null || /sbin/md5 -q %(file)s" % {"file": dest}).read().split()[0]
             if new_md5 != remote_md5:
                 result = dict(failed=True, msg="md5 mismatch", md5sum=new_md5)
                 return ReturnData(host=conn.host, result=result)

--- a/library/copy
+++ b/library/copy
@@ -60,9 +60,9 @@ if not os.path.exists(src):
 md5sum = None
 changed = False
 if os.path.exists(dest):
-    md5sum = os.popen("md5sum %s" % dest).read().split()[0]
+    md5sum = os.popen("/usr/bin/md5sum %(file)s 2> /dev/null || /sbin/md5 -q %(file)s" % {"file": dest}).read().split()[0]
 
-md5sum2 = os.popen("md5sum %s" % src).read().split()[0]
+md5sum2 = os.popen("/usr/bin/md5sum %(file)s 2> /dev/null || /sbin/md5 -q %(file)s" % {"file": src}).read().split()[0]
 
 if md5sum != md5sum2:
     os.system("cp %s %s" % (src, dest))

--- a/library/file
+++ b/library/file
@@ -180,9 +180,6 @@ changed = False
 # ===========================================
 # support functions
 
-def md5sum(filename):
-    return os.popen("/usr/bin/md5sum %s" % f).read()
-
 def user_and_group(filename):
     st = os.stat(filename)
     uid = st.st_uid

--- a/library/setup
+++ b/library/setup
@@ -345,7 +345,7 @@ md5sum = None
 if not os.path.exists(ansible_file):
     changed = True
 else:
-    md5sum = os.popen("md5sum %s" % ansible_file).read().split()[0]
+    md5sum = os.popen("/usr/bin/md5sum %(file)s 2> /dev/null || /sbin/md5 -q %(file)s" % {"file": ansible_file}).read().split()[0]
 
 # Get some basic facts in case facter or ohai are not installed
 for (k, v) in ansible_facts().items():
@@ -394,7 +394,7 @@ reformat = json.dumps(setup_options, sort_keys=True, indent=4)
 f.write(reformat)
 f.close()
 
-md5sum2 = os.popen("md5sum %s" % ansible_file).read().split()[0]
+md5sum2 = os.popen("/usr/bin/md5sum %(file)s 2> /dev/null || /sbin/md5 -q %(file)s" % {"file": ansible_file}).read().split()[0]
 
 if md5sum != md5sum2:
    changed = True


### PR DESCRIPTION
A few small changes here:
1. Uses the pipeline discussed in IRC to fall back on 'md5' if 'md5sum' isn't found.
2. Uses hardcoded paths for md5sum and md5 commands.  Probably will fail on non-FreeBSD and non-standard Linux remotes, but if someone needs it they can fix later.
3. Removes 'md5sum' function from the 'file' module, it's not used at all.
