### PR TITLE
Proposed fix for raw output

### DIFF
--- a/lib/ansible/runner.py
+++ b/lib/ansible/runner.py
@@ -339,7 +339,7 @@ class Runner(object):
     def _execute_raw(self, conn, host, tmp):
         ''' execute a non-module command for bootstrapping, or if there's no python on a device '''
         stdout, stderr = self._exec_command( conn, self.module_args, tmp, sudoable = True )
-        data = dict(stdout=stdout)
+        data = dict(stdout=stdout.strip().split('\r\n\n' or '\n'))
         if stderr:
             data['stderr'] = stderr
         return (host, True, data, '')


### PR DESCRIPTION
Hi,

Here is a fix for removing the literal newlines we talked about on the mailinglist (http://groups.google.com/group/ansible-project/browse_thread/thread/220133ac44b8f1e0). Not sure if this is the right/best way to solve it and the output still contains some brackets and stuff but it outputs data on separate lines like in the "ls -l /tmp" example below:

mytesthost | success >> {
    "stdout": [
        "total 4", 
        "-rw------- 1 user user    0 2012-06-01 10:44 testing.txt", 
        "drwx------ 2 root root 4096 2012-05-20 17:57 vmware-root"
    ]
}

Cheers,
//Jon
