### PR TITLE
make Runner options conflict errors raise AnsibleErrors not traceback in...

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -185,9 +185,11 @@ class Runner(object):
 
         euid = pwd.getpwuid(os.geteuid())[0]
         if self.transport == 'local' and self.remote_user != euid:
-            raise Exception("User mismatch: expected %s, but is %s" % (self.remote_user, euid))
+            raise errors.AnsibleError("User mismatch: expected %s, but is %s" % (self.remote_user, euid))
         if type(self.module_args) not in [str, unicode, dict]:
-            raise Exception("module_args must be a string or dict: %s" % self.module_args)
+            raise errors.AnsibleError("module_args must be a string or dict: %s" % self.module_args)
+        if self.transport == 'ssh' and self.remote_pass:
+            raise errors.AnsibleError("SSH transport does not support remote passwords, only keys or agents")
 
         self._tmp_paths  = {}
         random.seed()


### PR DESCRIPTION
... general

add catch if -c ssh and -k are passed at the same time since the ssh connection type doesn't
support passwords
