### PR TITLE
Create a Jinja2 environment allowing includes

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -586,8 +586,7 @@ class Runner(object):
 
         # template the source data locally
         try:
-            resultant = utils.template_from_file(utils.path_dwim(self.basedir, source),
-                                                 inject, self.setup_cache, no_engine=False)
+            resultant = utils.template_from_file(self.basedir, source, inject, self.setup_cache)
         except Exception, e:
             result = dict(failed=True, msg=str(e))
             return ReturnData(host=conn.host, comm_ok=False, result=result)

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -203,39 +203,6 @@ class TestUtils(unittest.TestCase):
 
         assert res == 'hello world'
 
-    #####################################
-    ### Template function tests
-
-    def test_template_basic(self):
-        template = 'hello {{ who }}'
-        vars = {
-            'who': 'world',
-        }
-
-        res = ansible.utils.template(template, vars, {}, no_engine=False)
-
-        assert res == 'hello world'
-
-    def test_template_whitespace(self):
-        template = 'hello {{ who }}\n'
-        vars = {
-            'who': 'world',
-        }
-
-        res = ansible.utils.template(template, vars, {}, no_engine=False)
-
-        assert res == 'hello world\n'
-
-    def test_template_unicode(self):
-        template = 'hello {{ who }}'
-        vars = {
-            'who': u'wórld',
-        }
-
-        res = ansible.utils.template(template, vars, {}, no_engine=False)
-
-        assert res == u'hello wórld'
-
     def test_template_varReplace_iterated(self):
         template = 'hello $who'
         vars = {
@@ -246,6 +213,36 @@ class TestUtils(unittest.TestCase):
         res = ansible.utils.template(template, vars)
 
         assert res == u'hello oh great one'
+
+    #####################################
+    ### Template function tests
+
+    def test_template_basic(self):
+        vars = {
+            'who': 'world',
+        }
+
+        res = ansible.utils.template_from_file("test", "template-basic", vars, {})
+
+        assert res == 'hello world'
+
+    def test_template_whitespace(self):
+        vars = {
+            'who': 'world',
+        }
+
+        res = ansible.utils.template_from_file("test", "template-whitespace", vars, {})
+
+        assert res == 'hello world\n'
+
+    def test_template_unicode(self):
+        vars = {
+            'who': u'wórld',
+        }
+
+        res = ansible.utils.template_from_file("test", "template-basic", vars, {})
+
+        assert res == u'hello wórld'
 
     #####################################
     ### key-value parsing

--- a/test/template-basic
+++ b/test/template-basic
@@ -1,0 +1,1 @@
+hello {{ who }}

--- a/test/template-whitespace
+++ b/test/template-whitespace
@@ -1,0 +1,1 @@
+hello {{ who }}


### PR DESCRIPTION
In doing this, I've separated out the one place that uses Jinja2 (the template module) and made template_from_file (of which it is the only user) Jinja2 only. This leads to $vars not working in templates, although I'm not sure that's a problem. This also avoids the performance hit of doing Jinja2 multiple times, as it is unlikely to ever be needed.
