### PR TITLE
Fixed bad Indentation on all Python files

### DIFF
--- a/examples/scripts/cobbler_external_inventory.py
+++ b/examples/scripts/cobbler_external_inventory.py
@@ -120,8 +120,8 @@ if len(sys.argv) == 2:
     results = {}
     for t in tokens:
         if t.find("=") != -1:
-           (k,v) = t.split("=",1)
-           results[k]=v
+            (k,v) = t.split("=",1)
+            results[k]=v
     print json.dumps(results)
     sys.exit(0)
 

--- a/examples/scripts/uptime.py
+++ b/examples/scripts/uptime.py
@@ -12,8 +12,8 @@ results = ansible.runner.Runner(
 ).run()
 
 if results is None:
-   print "No hosts found"
-   sys.exit(1)
+    print "No hosts found"
+    sys.exit(1)
 
 print "UP ***********"
 for (hostname, result) in results['contacted'].items():

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -162,9 +162,9 @@ class Inventory(object):
     def restrict_to(self, restriction, append_missing=False):
         """ Restrict list operations to the hosts given in restriction """
    
-    if type(restriction) != list:
-        restriction = [ restriction ]
-    self._restriction = restriction
+        if type(restriction) != list:
+            restriction = [ restriction ]
+        self._restriction = restriction
 
     def lift_restriction(self):
         """ Do not restrict list operations """

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -52,7 +52,7 @@ class Inventory(object):
 
         if type(host_list) in [ str, unicode ]:
             if host_list.find(",") != -1:
-               host_list = host_list.split(",")
+                host_list = host_list.split(",")
 
         if type(host_list) == list:
             all = Group('all')
@@ -108,8 +108,8 @@ class Inventory(object):
 
     def get_host(self, hostname):
         for group in self.groups:
-           for host in group.get_hosts():
-               if hostname == host.name:
+            for host in group.get_hosts():
+                if hostname == host.name:
                     return host
         return None
 
@@ -162,9 +162,9 @@ class Inventory(object):
     def restrict_to(self, restriction, append_missing=False):
         """ Restrict list operations to the hosts given in restriction """
    
-	if type(restriction) != list:
-	    restriction = [ restriction ]
-	self._restriction = restriction
+    if type(restriction) != list:
+        restriction = [ restriction ]
+    self._restriction = restriction
 
     def lift_restriction(self):
         """ Do not restrict list operations """

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -31,7 +31,7 @@ class Group(object):
         self.child_groups = []
         self.parent_groups = []
         if self.name is None:
-           raise Exception("group name is required")
+            raise Exception("group name is required")
 
     def add_child_group(self, group):
         if self == group:
@@ -57,7 +57,7 @@ class Group(object):
         vars = {}
         # FIXME: verify this variable override order is what we want
         for ancestor in self.get_ancestors():
-           vars.update(ancestor.get_variables())
+            vars.update(ancestor.get_variables())
         vars.update(self.vars)
         return vars
 

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -79,9 +79,9 @@ class InventoryParser(object):
                 hostname = tokens[0]
                 port = C.DEFAULT_REMOTE_PORT
                 if hostname.find(":") != -1:
-                   tokens2  = hostname.split(":")
-                   hostname = tokens2[0]
-                   port     = tokens2[1]
+                    tokens2  = hostname.split(":")
+                    hostname = tokens2[0]
+                    port     = tokens2[1]
                 host = None
                 if hostname in self.hosts:
                     host = self.hosts[hostname]
@@ -89,9 +89,9 @@ class InventoryParser(object):
                     host = Host(name=hostname, port=port)
                     self.hosts[hostname] = host
                 if len(tokens) > 1:
-                   for t in tokens[1:]:
-                      (k,v) = t.split("=")
-                      host.set_variable(k,v)
+                    for t in tokens[1:]:
+                        (k,v) = t.split("=")
+                        host.set_variable(k,v)
                 self.groups[active_group_name].add_host(host)
 
     # [southeast:children]
@@ -134,7 +134,7 @@ class InventoryParser(object):
                 line = line.replace("[","").replace(":vars]","")
                 group = self.groups.get(line, None)
                 if group is None:
-                   raise errors.AnsibleError("can't add vars to undefined group: %s" % line)
+                    raise errors.AnsibleError("can't add vars to undefined group: %s" % line)
             elif line.startswith("#"):
                 pass
             elif line.startswith("["):

--- a/lib/ansible/inventory/yaml.py
+++ b/lib/ansible/inventory/yaml.py
@@ -69,7 +69,7 @@ class InventoryParserYaml(object):
                     for subitem in varlist:
                         vars.update(subitem)
                 for (k,v) in vars.items():
-                   host.set_variable(k,v)
+                    host.set_variable(k,v)
 
             elif type(item) == dict and 'group' in item:
                 group = Group(item['group'])
@@ -84,8 +84,8 @@ class InventoryParserYaml(object):
                         vars = subresult.get('vars',{})
                         if type(vars) == list:
                             for subitem in vars:
-                               for (k,v) in subitem.items():
-                                   host.set_variable(k,v) 
+                                for (k,v) in subitem.items():
+                                    host.set_variable(k,v) 
                         elif type(vars) == dict:
                             for (k,v) in subresult.get('vars',{}).items():
                                 host.set_variable(k,v)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -317,20 +317,20 @@ class Runner(object):
     # *****************************************************
 
     def _save_setup_result_to_disk(self, conn, result):
-       ''' cache results of calling setup '''
+        ''' cache results of calling setup '''
 
-       dest = os.path.expanduser("~/.ansible_setup_data")
-       user = getpass.getuser()
-       if user == 'root':
-           dest = "/var/lib/ansible/setup_data"
-       if not os.path.exists(dest):
-           os.makedirs(dest)
+        dest = os.path.expanduser("~/.ansible_setup_data")
+        user = getpass.getuser()
+        if user == 'root':
+            dest = "/var/lib/ansible/setup_data"
+        if not os.path.exists(dest):
+            os.makedirs(dest)
 
-       fh = open(os.path.join(dest, conn.host), "w")
-       fh.write(result)
-       fh.close()
+        fh = open(os.path.join(dest, conn.host), "w")
+        fh.write(result)
+        fh.close()
 
-       return result
+        return result
 
     # *****************************************************
 

--- a/library/apt
+++ b/library/apt
@@ -117,7 +117,7 @@ def remove(pkgspec, cache, purge=False):
 # ===========================================
 
 if not os.path.exists(APT_PATH):
-   fail_json(msg="Cannot find apt-get")
+    fail_json(msg="Cannot find apt-get")
 
 argfile = sys.argv[1]
 args    = open(argfile, 'r').read()

--- a/library/assemble
+++ b/library/assemble
@@ -42,12 +42,12 @@ except ImportError:
 # Support methods
 
 def exit_json(rc=0, **kwargs):
-   print json.dumps(kwargs)
-   sys.exit(rc)
+    print json.dumps(kwargs)
+    sys.exit(rc)
 
 def fail_json(**kwargs):
-   kwargs['failed'] = True
-   exit_json(rc=1, **kwargs)
+    kwargs['failed'] = True
+    exit_json(rc=1, **kwargs)
 
 def assemble_from_fragments(path):
     ''' assemble a file from a directory of fragments '''
@@ -74,11 +74,11 @@ def file_digest(path):
 # ===========================================
 
 if len(sys.argv) == 1:
-   fail_json(msg="the assemble module requires arguments (-a)")
+    fail_json(msg="the assemble module requires arguments (-a)")
 
 argfile = sys.argv[1]
 if not os.path.exists(argfile):
-   fail_json(msg="Argument file not found")
+    fail_json(msg="Argument file not found")
 
 args = open(argfile, 'r').read()
 items = shlex.split(args)
@@ -86,7 +86,7 @@ syslog.openlog('ansible-%s' % os.path.basename(__file__))
 syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 if not len(items):
-   fail_json(msg="the assemble module requires arguments (-a)")
+    fail_json(msg="the assemble module requires arguments (-a)")
 
 params = {}
 for x in items:

--- a/library/async_status
+++ b/library/async_status
@@ -85,26 +85,26 @@ if mode == 'cleanup':
 
 data = file(log_path).read()
 try:
-   data = json.loads(data)
+    data = json.loads(data)
 except Exception, e:
-   if data == '':
-       # file not written yet?  That means it is running
-       print json.dumps({
-           "results_file" : log_path,
-           "ansible_job_id" : jid,
-           "started" : 1,
-       })
-   else:
-       print json.dumps({
-           "failed" : True,
-           "ansible_job_id" : jid,
-           "results_file" : log_path,
-           "msg" : "Could not parse job output: %s" % data,
-       })
-   sys.exit(0)
+    if data == '':
+        # file not written yet?  That means it is running
+        print json.dumps({
+            "results_file" : log_path,
+            "ansible_job_id" : jid,
+            "started" : 1,
+        })
+    else:
+        print json.dumps({
+            "failed" : True,
+            "ansible_job_id" : jid,
+            "results_file" : log_path,
+            "msg" : "Could not parse job output: %s" % data,
+        })
+    sys.exit(0)
 
 if not data.has_key("started"):
-   data['finished'] = 1
+    data['finished'] = 1
 data['ansible_job_id'] = jid
 
 print json.dumps(data)

--- a/library/command
+++ b/library/command
@@ -39,27 +39,27 @@ syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 shell = False
 
 if args.find("#USE_SHELL") != -1:
-   args = args.replace("#USE_SHELL", "")
-   shell = True
+    args = args.replace("#USE_SHELL", "")
+    shell = True
 
 check_args = shlex.split(args)
 for x in check_args:
-   if x.startswith("creates="):
-       # do not run the command if the line contains creates=filename
-       # and the filename already exists.  This allows idempotence 
-       # of command executions.
-       (k,v) = x.split("=",1)
-       if os.path.exists(v):
-           print json.dumps({
-               "cmd"     : args,
-               "stdout"  : "skipped, since %s exists" % v,
-               "skipped" : True,
-               "changed" : False,
-               "stderr"  : "",
-               "rc"      : 0,
-           })
-           sys.exit(0)
-       args = args.replace(x,'')
+    if x.startswith("creates="):
+        # do not run the command if the line contains creates=filename
+        # and the filename already exists.  This allows idempotence 
+        # of command executions.
+        (k,v) = x.split("=",1)
+        if os.path.exists(v):
+            print json.dumps({
+                "cmd"     : args,
+                "stdout"  : "skipped, since %s exists" % v,
+                "skipped" : True,
+                "changed" : False,
+                "stderr"  : "",
+                "rc"      : 0,
+            })
+            sys.exit(0)
+        args = args.replace(x,'')
        
 
 if not shell:
@@ -89,9 +89,9 @@ endd = datetime.datetime.now()
 delta = endd - startd
 
 if out is None:
-   out = ''
+    out = ''
 if err is None:
-   err = ''
+    err = ''
 
 result = {
    "cmd"     : args,

--- a/library/copy
+++ b/library/copy
@@ -38,11 +38,11 @@ def exit_kv(rc=0, **kwargs):
     sys.exit(rc)
 
 if len(sys.argv) == 1:
-	exit_kv(rc=1, failed=1, msg="incorrect number of arguments given")
+    exit_kv(rc=1, failed=1, msg="incorrect number of arguments given")
 
 argfile = sys.argv[1]
 if not os.path.exists(argfile):
-	exit_kv(rc=1, failed=1, msg="file %s does not exist" % (argfile))
+    exit_kv(rc=1, failed=1, msg="file %s does not exist" % (argfile))
 
 args = open(argfile, 'r').read()
 items = shlex.split(args)
@@ -64,7 +64,7 @@ if dest:
  
 # raise an error if there is no src file
 if not os.path.exists(src):
-	exit_kv(rc=1, failed=1, msg="Source %s failed to transfer" % (src))
+    exit_kv(rc=1, failed=1, msg="Source %s failed to transfer" % (src))
 
 md5sum = None
 changed = False

--- a/library/file
+++ b/library/file
@@ -141,10 +141,10 @@ for x in items:
 state     = params.get('state','file')
 path      = params.get('path', params.get('dest', params.get('name', None)))
 if path:
-   path = os.path.expanduser(path)
+    path = os.path.expanduser(path)
 src       = params.get('src', None)
 if src:
-   src = os.path.expanduser(src)
+    src = os.path.expanduser(src)
 dest      = params.get('dest', None)
 mode      = params.get('mode', None)
 owner     = params.get('owner', None)
@@ -209,58 +209,58 @@ def set_context_if_different(path, context, changed):
     return changed
     
 def set_owner_if_different(path, owner, changed):
-   if owner is None:
-       return changed
-   user, group = user_and_group(path)
-   if owner != user:
-       rc = os.system("/bin/chown -R %s %s 2>/dev/null" % (owner, path))
-       if rc != 0:
-           fail_kv(path=path, msg='chown failed')
-       return True
+    if owner is None:
+        return changed
+    user, group = user_and_group(path)
+    if owner != user:
+        rc = os.system("/bin/chown -R %s %s 2>/dev/null" % (owner, path))
+        if rc != 0:
+            fail_kv(path=path, msg='chown failed')
+        return True
 
-   return changed
+    return changed
     
 def set_group_if_different(path, group, changed):
-   if group is None:
-       return changed
-   old_user, old_group = user_and_group(path)
-   if old_group != group:
-       rc = os.system("/bin/chgrp -R %s %s" % (group, path))
-       if rc != 0:
-           fail_kv(path=path, msg='chgrp failed')
-       return True
-   return changed
+    if group is None:
+        return changed
+    old_user, old_group = user_and_group(path)
+    if old_group != group:
+        rc = os.system("/bin/chgrp -R %s %s" % (group, path))
+        if rc != 0:
+            fail_kv(path=path, msg='chgrp failed')
+        return True
+    return changed
 
 def set_mode_if_different(path, mode, changed):
-   if mode is None:
-       return changed
-   try:
-       # FIXME: support English modes
-       mode = int(mode, 8)
-   except Exception, e:
-       fail_kv(path=path, msg='mode needs to be something octalish', details=str(e))  
+    if mode is None:
+        return changed
+    try:
+        # FIXME: support English modes
+        mode = int(mode, 8)
+    except Exception, e:
+        fail_kv(path=path, msg='mode needs to be something octalish', details=str(e))  
  
-   st = os.stat(path)
-   prev_mode = stat.S_IMODE(st[stat.ST_MODE])
+    st = os.stat(path)
+    prev_mode = stat.S_IMODE(st[stat.ST_MODE])
 
-   if prev_mode != mode:
-       # FIXME: comparison against string above will cause this to be executed
-       # every time
-       try:
-           os.chmod(path, mode)
-       except Exception, e:
-           fail_kv(path=path, msg='chmod failed', details=str(e))
+    if prev_mode != mode:
+        # FIXME: comparison against string above will cause this to be executed
+        # every time
+        try:
+            os.chmod(path, mode)
+        except Exception, e:
+            fail_kv(path=path, msg='chmod failed', details=str(e))
 
-       st = os.stat(path)
-       new_mode = stat.S_IMODE(st[stat.ST_MODE])
+        st = os.stat(path)
+        new_mode = stat.S_IMODE(st[stat.ST_MODE])
 
-       if new_mode != prev_mode:
-           return True
-   return changed
+        if new_mode != prev_mode:
+            return True
+    return changed
 
 
 def rmtree_error(func, path, exc_info):
-   fail_kv(path=path, msg='failed to remove directory')
+    fail_kv(path=path, msg='failed to remove directory')
 
 # ===========================================
 # go...

--- a/library/git
+++ b/library/git
@@ -37,12 +37,12 @@ import syslog
 # Basic support methods
 
 def exit_json(rc=0, **kwargs):
-   print json.dumps(kwargs)
-   sys.exit(rc)
+    print json.dumps(kwargs)
+    sys.exit(rc)
 
 def fail_json(**kwargs):
-   kwargs['failed'] = True
-   exit_json(rc=1, **kwargs)
+    kwargs['failed'] = True
+    exit_json(rc=1, **kwargs)
 
 # ===========================================
 # convert arguments of form a=b c=d
@@ -50,11 +50,11 @@ def fail_json(**kwargs):
 # FIXME: make more idiomatic
 
 if len(sys.argv) == 1:
-   fail_json(msg="the command module requires arguments (-a)")
+    fail_json(msg="the command module requires arguments (-a)")
 
 argfile = sys.argv[1]
 if not os.path.exists(argfile):
-   fail_json(msg="Argument file not found")
+    fail_json(msg="Argument file not found")
 
 args = open(argfile, 'r').read()
 items = shlex.split(args)
@@ -62,7 +62,7 @@ syslog.openlog('ansible-%s' % os.path.basename(__file__))
 syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % args)
 
 if not len(items):
-   fail_json(msg="the command module requires arguments (-a)")
+    fail_json(msg="the command module requires arguments (-a)")
 
 params = {}
 for x in items:
@@ -77,97 +77,97 @@ version = params.get('version', 'HEAD')
 # ===========================================
 
 def get_version(dest):
-   ''' samples the version of the git repo '''
-   os.chdir(dest)
-   cmd = "git show --abbrev-commit"
-   sha = os.popen(cmd).read().split("\n")
-   sha = sha[0].split()[1]
-   return sha
+    ''' samples the version of the git repo '''
+    os.chdir(dest)
+    cmd = "git show --abbrev-commit"
+    sha = os.popen(cmd).read().split("\n")
+    sha = sha[0].split()[1]
+    return sha
 
 def clone(repo, dest, branch):
-   ''' makes a new git repo if it does not already exist '''
-   try:
-       os.makedirs(dest)
-   except:
-       pass
-   cmd = "git clone %s %s" % (repo, dest)
-   cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-   (out, err) = cmd.communicate()
-   rc = cmd.returncode
+    ''' makes a new git repo if it does not already exist '''
+    try:
+        os.makedirs(dest)
+    except:
+        pass
+    cmd = "git clone %s %s" % (repo, dest)
+    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (out, err) = cmd.communicate()
+    rc = cmd.returncode
    
-   if branch is None or rc != 0: 
-     return (out, err)
+    if branch is None or rc != 0: 
+        return (out, err)
 
-   os.chdir(dest)
-   cmd = "git checkout -b %s origin/%s" % (branch, branch) 
-   cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-   return cmd.communicate()
+    os.chdir(dest)
+    cmd = "git checkout -b %s origin/%s" % (branch, branch) 
+    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return cmd.communicate()
 
 def reset(dest):
-   '''
-   Resets the index and working tree to HEAD.
-   Discards any changes to tracked files in working
-   tree since that commit.
-   '''
-   os.chdir(dest)
-   cmd = "git reset --hard HEAD"
-   cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-   (out, err) = cmd.communicate()
-   rc = cmd.returncode
-   return (rc, out, err)
+    '''
+    Resets the index and working tree to HEAD.
+    Discards any changes to tracked files in working
+    tree since that commit.
+    '''
+    os.chdir(dest)
+    cmd = "git reset --hard HEAD"
+    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (out, err) = cmd.communicate()
+    rc = cmd.returncode
+    return (rc, out, err)
 
 def switchLocalBranch( branch ):
-   cmd = "git checkout %s" % branch
-   cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-   return cmd.communicate()
+    cmd = "git checkout %s" % branch
+    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return cmd.communicate()
 
 def pull(repo, dest, branch):
-   ''' updates repo from remote sources '''
-   os.chdir(dest)
-   cmd = "git branch -a"
-   cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-   (gbranch_out, gbranch_err) = cmd.communicate()
+    ''' updates repo from remote sources '''
+    os.chdir(dest)
+    cmd = "git branch -a"
+    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (gbranch_out, gbranch_err) = cmd.communicate()
 
-   try:
-      m = re.search( '^\* (\S+|\(no branch\))$', gbranch_out, flags=re.M )
-      cur_branch = m.group(1)
-      m = re.search( '\s+remotes/origin/HEAD -> origin/(\S+)', gbranch_out, flags=re.M )
-      default_branch = m.group(1)
-   except:
-      fail_json(msg="could not determine branch data - received: %s" % gbranch_out)
+    try:
+        m = re.search( '^\* (\S+|\(no branch\))$', gbranch_out, flags=re.M )
+        cur_branch = m.group(1)
+        m = re.search( '\s+remotes/origin/HEAD -> origin/(\S+)', gbranch_out, flags=re.M )
+        default_branch = m.group(1)
+    except:
+        fail_json(msg="could not determine branch data - received: %s" % gbranch_out)
 
-   if branch is None:
-      if cur_branch != default_branch:
-         (out, err) = switchLocalBranch( default_branch )
+    if branch is None:
+        if cur_branch != default_branch:
+            (out, err) = switchLocalBranch( default_branch )
 
-      cmd = "git pull -u origin"
+        cmd = "git pull -u origin"
 
-   elif branch == cur_branch:
-      cmd = "git pull -u origin"
+    elif branch == cur_branch:
+        cmd = "git pull -u origin"
 
-   else:
-      m = re.search( '^\s+%s$' % branch, gbranch_out, flags=re.M ) #see if we've already checked it out
-      if m is None:
-         cmd = "git checkout -b %s origin/%s" % (branch, branch)
+    else:
+        m = re.search( '^\s+%s$' % branch, gbranch_out, flags=re.M ) #see if we've already checked it out
+        if m is None:
+            cmd = "git checkout -b %s origin/%s" % (branch, branch)
 
-      else:
-         (out, err) = switchLocalBranch( branch )
-         cmd = "git pull -u origin"
+        else:
+            (out, err) = switchLocalBranch( branch )
+            cmd = "git pull -u origin"
 
-   cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-   return cmd.communicate()
+    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return cmd.communicate()
 
 def switchver(version, dest):
-   ''' once pulled, switch to a particular SHA or tag '''
-   os.chdir(dest)
-   if version != 'HEAD':
-      cmd = "git checkout %s --force" % version
-   else:
-      # is there a better way to do this?
-      cmd = "git rebase origin"
-   cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-   (out, err) = cmd.communicate()
-   return (out, err)
+    ''' once pulled, switch to a particular SHA or tag '''
+    os.chdir(dest)
+    if version != 'HEAD':
+        cmd = "git checkout %s --force" % version
+    else:
+        # is there a better way to do this?
+        cmd = "git rebase origin"
+    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (out, err) = cmd.communicate()
+    return (out, err)
  
 
 gitconfig = os.path.join(dest, '.git', 'config')
@@ -179,26 +179,26 @@ out, err, status = (None, None, None)
 
 before = None
 if not os.path.exists(gitconfig):
-   (out, err) = clone(repo, dest, branch)
+    (out, err) = clone(repo, dest, branch)
 else:
-   # else do a pull   
-   before = get_version(dest)
-   (rc, out, err) = reset(dest)
-   if rc != 0:
-      fail_json(out=out, err=err)
-   (out, err) = pull(repo, dest, branch)
+    # else do a pull   
+    before = get_version(dest)
+    (rc, out, err) = reset(dest)
+    if rc != 0:
+        fail_json(out=out, err=err)
+    (out, err) = pull(repo, dest, branch)
 
 # handle errors from clone or pull
 
 if out.find('error') != -1:
-   fail_json(out=out, err=err)
+    fail_json(out=out, err=err)
 
 # switch to version specified regardless of whether
 # we cloned or pulled
 
 (out, err) = switchver(version, dest)
 if err.find('error') != -1:
-   fail_json(out=out, err=err)
+    fail_json(out=out, err=err)
 
 # determine if we changed anything
 
@@ -206,6 +206,6 @@ after = get_version(dest)
 changed = False
 
 if before != after:
-   changed = True
+    changed = True
 
 exit_json(changed=changed, before=before, after=after)

--- a/library/setup
+++ b/library/setup
@@ -321,13 +321,13 @@ if not os.path.exists(argfile):
 
 setup_options = open(argfile).read().strip()
 try:
-   setup_options = json.loads(setup_options)
+    setup_options = json.loads(setup_options)
 except:
-   list_options = shlex.split(setup_options)
-   setup_options = {}
-   for opt in list_options:
-       (k,v) = opt.split("=")
-       setup_options[k]=v   
+    list_options = shlex.split(setup_options)
+    setup_options = {}
+    for opt in list_options:
+        (k,v) = opt.split("=")
+        setup_options[k]=v   
 
 syslog.openlog('ansible-%s' % os.path.basename(__file__))
 syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % setup_options)
@@ -355,36 +355,36 @@ for (k, v) in ansible_facts().items():
 # ruby-json is ALSO installed, include facter data in the JSON
 
 if os.path.exists("/usr/bin/facter"):
-   cmd = subprocess.Popen("/usr/bin/facter --json", shell=True,
+    cmd = subprocess.Popen("/usr/bin/facter --json", shell=True,
        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-   out, err = cmd.communicate()
-   facter = True
-   try:
-       facter_ds = json.loads(out)
-   except:
-       facter = False
-   if facter:
-       for (k,v) in facter_ds.items():
-           setup_options["facter_%s" % k] = v
+    out, err = cmd.communicate()
+    facter = True
+    try:
+        facter_ds = json.loads(out)
+    except:
+        facter = False
+    if facter:
+        for (k,v) in facter_ds.items():
+            setup_options["facter_%s" % k] = v
 
 # ditto for ohai, but just top level string keys
 # because it contains a lot of nested stuff we can't use for
 # templating w/o making a nicer key for it (TODO)
 
 if os.path.exists("/usr/bin/ohai"):
-   cmd = subprocess.Popen("/usr/bin/ohai", shell=True,
+    cmd = subprocess.Popen("/usr/bin/ohai", shell=True,
        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-   out, err = cmd.communicate()
-   ohai = True
-   try:
-       ohai_ds = json.loads(out)
-   except:
-       ohai = False
-   if ohai:
-       for (k,v) in ohai_ds.items():
-           if type(v) == str or type(v) == unicode:
-               k2 = "ohai_%s" % k
-               setup_options[k2] = v
+    out, err = cmd.communicate()
+    ohai = True
+    try:
+        ohai_ds = json.loads(out)
+    except:
+        ohai = False
+    if ohai:
+        for (k,v) in ohai_ds.items():
+            if type(v) == str or type(v) == unicode:
+                k2 = "ohai_%s" % k
+                setup_options[k2] = v
 
 # write the template/settings file using
 # instructions from server
@@ -397,7 +397,7 @@ f.close()
 md5sum2 = os.popen("/usr/bin/md5sum %(file)s 2> /dev/null || /sbin/md5 -q %(file)s" % {"file": ansible_file}).read().split()[0]
 
 if md5sum != md5sum2:
-   changed = True
+    changed = True
 
 setup_result = {}
 setup_result['written'] = ansible_file

--- a/library/slurp
+++ b/library/slurp
@@ -24,9 +24,9 @@ import base64
 import syslog
 
 try:
-   import json
+    import json
 except ImportError:
-   import simplejson as json
+    import simplejson as json
 
 # ===========================================
 # convert arguments of form a=b c=d

--- a/library/user
+++ b/library/user
@@ -159,7 +159,7 @@ def user_mod(user, **kwargs):
                             cmd.append('-a')
                             groups_need_mod = True
                 else:
-                   groups_need_mod = True
+                    groups_need_mod = True
 
             if groups_need_mod:
                 cmd.append('-G')

--- a/library/yum
+++ b/library/yum
@@ -122,9 +122,9 @@ def run_yum(command):
         out = ''
 
         if out is None:
-           out = ''
+            out = ''
         if err is None:
-           err = ''
+            err = ''
     else:
         rc = cmd.returncode
         

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -12,9 +12,9 @@ import os
 import shutil
 import time
 try:
-   import json
+    import json
 except:
-   import simplejson as json
+    import simplejson as json
 
 EVENTS = []
 
@@ -97,64 +97,64 @@ class TestCallbacks(object):
 
 class TestPlaybook(unittest.TestCase):
 
-   def setUp(self):
-       self.user = getpass.getuser()
-       self.cwd = os.getcwd()
-       self.test_dir = os.path.join(self.cwd, 'test')
-       self.stage_dir = self._prepare_stage_dir()
+    def setUp(self):
+        self.user = getpass.getuser()
+        self.cwd = os.getcwd()
+        self.test_dir = os.path.join(self.cwd, 'test')
+        self.stage_dir = self._prepare_stage_dir()
 
-       if os.path.exists('/tmp/ansible_test_data_copy.out'):
-           os.unlink('/tmp/ansible_test_data_copy.out')
-       if os.path.exists('/tmp/ansible_test_data_template.out'):
-           os.unlink('/tmp/ansible_test_data_template.out')
+        if os.path.exists('/tmp/ansible_test_data_copy.out'):
+            os.unlink('/tmp/ansible_test_data_copy.out')
+        if os.path.exists('/tmp/ansible_test_data_template.out'):
+            os.unlink('/tmp/ansible_test_data_template.out')
 
-   def _prepare_stage_dir(self):
-       stage_path = os.path.join(self.test_dir, 'test_data')
-       if os.path.exists(stage_path):
-           shutil.rmtree(stage_path, ignore_errors=False)
-           assert not os.path.exists(stage_path)
-       os.makedirs(stage_path)
-       assert os.path.exists(stage_path)
-       return stage_path
+    def _prepare_stage_dir(self):
+        stage_path = os.path.join(self.test_dir, 'test_data')
+        if os.path.exists(stage_path):
+            shutil.rmtree(stage_path, ignore_errors=False)
+            assert not os.path.exists(stage_path)
+        os.makedirs(stage_path)
+        assert os.path.exists(stage_path)
+        return stage_path
 
-   def _get_test_file(self, filename):
-       # get a file inside the test input directory
-       filename = os.path.join(self.test_dir, filename)
-       assert os.path.exists(filename)
-       return filename
+    def _get_test_file(self, filename):
+        # get a file inside the test input directory
+        filename = os.path.join(self.test_dir, filename)
+        assert os.path.exists(filename)
+        return filename
  
-   def _get_stage_file(self, filename):
-       # get a file inside the test output directory
-       filename = os.path.join(self.stage_dir, filename)
-       return filename
+    def _get_stage_file(self, filename):
+        # get a file inside the test output directory
+        filename = os.path.join(self.stage_dir, filename)
+        return filename
 
-   def _run(self, test_playbook):
-       ''' run a module and get the localhost results '''
-       self.test_callbacks = TestCallbacks()
-       self.playbook = ansible.playbook.PlayBook(
-           playbook     = test_playbook,
-           host_list    = 'test/ansible_hosts',
-           module_path  = 'library/',
-           forks        = 1,
-           timeout      = 5,
-           remote_user  = self.user,
-           remote_pass  = None,
-           stats            = ans_callbacks.AggregateStats(),
-           callbacks        = self.test_callbacks,
-           runner_callbacks = self.test_callbacks
-       )
-       result = self.playbook.run()
-       # print utils.bigjson(dict(events=EVENTS))
-       return result
+    def _run(self, test_playbook):
+        ''' run a module and get the localhost results '''
+        self.test_callbacks = TestCallbacks()
+        self.playbook = ansible.playbook.PlayBook(
+            playbook     = test_playbook,
+            host_list    = 'test/ansible_hosts',
+            module_path  = 'library/',
+            forks        = 1,
+            timeout      = 5,
+            remote_user  = self.user,
+            remote_pass  = None,
+            stats            = ans_callbacks.AggregateStats(),
+            callbacks        = self.test_callbacks,
+            runner_callbacks = self.test_callbacks
+        )
+        result = self.playbook.run()
+        # print utils.bigjson(dict(events=EVENTS))
+        return result
 
-   def test_one(self):
-       pb = os.path.join(self.test_dir, 'playbook1.yml')
-       actual = self._run(pb)
+    def test_one(self):
+        pb = os.path.join(self.test_dir, 'playbook1.yml')
+        actual = self._run(pb)
 
-       # if different, this will output to screen 
-       print "**ACTUAL**"
-       print utils.bigjson(actual)
-       expected =  { 
+        # if different, this will output to screen 
+        print "**ACTUAL**"
+        print utils.bigjson(actual)
+        expected =  { 
             "127.0.0.2": {
                 "changed": 9, 
                 "failures": 0, 
@@ -163,25 +163,25 @@ class TestPlaybook(unittest.TestCase):
                 "unreachable": 0
             }
        }
-       print "**EXPECTED**"
-       print utils.bigjson(expected)
-       assert utils.bigjson(expected) == utils.bigjson(actual)
+        print "**EXPECTED**"
+        print utils.bigjson(expected)
+        assert utils.bigjson(expected) == utils.bigjson(actual)
 
-       # make sure the template module took options from the vars section
-       data = file('/tmp/ansible_test_data_template.out').read()
-       print data
-       assert data.find("ears") != -1, "template success"
+        # make sure the template module took options from the vars section
+        data = file('/tmp/ansible_test_data_template.out').read()
+        print data
+        assert data.find("ears") != -1, "template success"
 
-   def test_yaml_hosts_list(self):
-       # Make sure playbooks support hosts: [host1, host2]
-       # TODO: Actually run the play on more than one host
-       test_callbacks = TestCallbacks()
-       playbook = ansible.playbook.PlayBook(
-           playbook=os.path.join(self.test_dir, 'hosts_list.yml'),
-           host_list='test/ansible_hosts',
-           stats=ans_callbacks.AggregateStats(),
-           callbacks=test_callbacks,
-           runner_callbacks=test_callbacks
-       )
-       play = ansible.playbook.Play(playbook, playbook.playbook[0])
-       assert play.hosts == ';'.join(('host1', 'host2', 'host3'))
+    def test_yaml_hosts_list(self):
+        # Make sure playbooks support hosts: [host1, host2]
+        # TODO: Actually run the play on more than one host
+        test_callbacks = TestCallbacks()
+        playbook = ansible.playbook.PlayBook(
+            playbook=os.path.join(self.test_dir, 'hosts_list.yml'),
+            host_list='test/ansible_hosts',
+            stats=ans_callbacks.AggregateStats(),
+            callbacks=test_callbacks,
+            runner_callbacks=test_callbacks
+        )
+        play = ansible.playbook.Play(playbook, playbook.playbook[0])
+        assert play.hosts == ';'.join(('host1', 'host2', 'host3'))


### PR DESCRIPTION
The Indentations were a little bit messy.

Most of them are 4-Spaces which is ok and recommended by Python PEP 8

But I also found several of these:
- Mixing of 4-Space and 3-Space Tabs
- Mixing of 4-Space and 2-Space Tabs
- Mixing of Spaces-Tabs and real Tab
- Also mixing of different Indentation Styles within a single line

The Interpreter is very friendly to those things, but there are situations in which you change a line in a block with faulty indentation and you use a correct one and you're left with a traceback...

We should really avoid this and use the recommended code styling like most of the code the project.

All developers should activate the "-t" switch for the python interpreter.
So at least you get warned when you mix tabs and spaces which is the worst of it all.
