### PR TITLE
Ssh constants

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -41,3 +41,6 @@ DEFAULT_REMOTE_PORT    = 22
 DEFAULT_TRANSPORT      = os.environ.get('ANSIBLE_TRANSPORT','paramiko')
 DEFAULT_TRANSPORT_OPTS = ['local', 'paramiko', 'ssh']
 
+DEFAULT_SSH_ARGS         = os.environ.get('ANSIBLE_SSH_ARGS',
+                           "-o StrictHostKeyChecking=no -o ControlMaster=auto -o ControlPersist=60 -o ControlPath=/tmp/ansible-ssh-%h-%p-%r")
+

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -112,7 +112,7 @@ class Runner(object):
         background=0, basedir=None, setup_cache=None, 
         transport=C.DEFAULT_TRANSPORT, conditional='True', callbacks=None, 
         debug=False, sudo=False, sudo_user=C.DEFAULT_SUDO_USER,
-        module_vars=None, is_playbook=False, inventory=None):
+        module_vars=None, is_playbook=False, inventory=None, ssh_args=C.DEFAULT_SSH_ARGS):
 
         """
         host_list    : path to a host list file, like /etc/ansible/hosts
@@ -138,6 +138,7 @@ class Runner(object):
         module_vars  : provides additional variables to a template.  FIXME: factor this out
         is_playbook  : indicates Runner is being used by a playbook.  affects behavior in various ways.
         inventory    : inventory object, if host_list is not provided
+        ssh_args     : arguments used by ssh transport module
         """
 
         if setup_cache is None:
@@ -182,6 +183,7 @@ class Runner(object):
         self.sudo        = sudo
         self.sudo_pass   = sudo_pass
         self.is_playbook = is_playbook
+        self.ssh_args    = ssh_args
 
         euid = pwd.getpwuid(os.geteuid())[0]
         if self.transport == 'local' and self.remote_user != euid:

--- a/lib/ansible/runner/connection/ssh.py
+++ b/lib/ansible/runner/connection/ssh.py
@@ -19,6 +19,7 @@
 ################################################
 
 import os
+import re
 import time
 import subprocess
 import shlex
@@ -76,7 +77,7 @@ class SSHConnection(object):
             sudo_output = ''
             ssh_cmd.append(sudocmd)
             p = subprocess.Popen(ssh_cmd, stdin=subprocess.PIPE,
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             if self.runner.sudo_pass:
                 fcntl.fcntl(p.stdout, fcntl.F_SETFL,
                             fcntl.fcntl(p.stdout, fcntl.F_GETFL) | os.O_NONBLOCK)
@@ -89,14 +90,16 @@ class SSHConnection(object):
                             raise errors.AnsibleError('ssh connection closed waiting for sudo password prompt')
                         sudo_output += chunk
                     else:
-                        (stdout, stderr) = p.communicate()
+                        stdout = p.communicate()
+                        # older versions of ssh generate this error which we ignore
+                        stdout = re.sub("tcgetattr: Invalid argument\n", "", stdout)
                         raise errors.AnsibleError('ssh connection error waiting for sudo password prompt')
                 p.stdin.write(self.runner.sudo_pass + '\n')
                 fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
         else:
             ssh_cmd.append(cmd)
             p = subprocess.Popen(ssh_cmd, stdin=subprocess.PIPE,
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         # We can't use p.communicate here because the ControlMaster may have stdout open as well
         p.stdin.close()
@@ -105,6 +108,8 @@ class SSHConnection(object):
             rfd, wfd, efd = select.select([p.stdout], [], [p.stdout], 1)
             if p.stdout in rfd:
                 stdout += os.read(p.stdout.fileno(), 1024)
+                # older versions of ssh generate this error which we ignore
+                stdout = re.sub("tcgetattr: Invalid argument\n", "", stdout)
 
         if p.returncode != 0 and stdout.find('Bad configuration option: ControlPersist') != -1:
             raise errors.AnsibleError('using -c ssh on certain older ssh versions may not support ControlPersist, set ANSIBLE_SSH_ARGS="" before running again')

--- a/lib/ansible/runner/connection/ssh.py
+++ b/lib/ansible/runner/connection/ssh.py
@@ -90,8 +90,6 @@ class SSHConnection(object):
                         sudo_output += chunk
                     else:
                         stdout = p.communicate()
-                        # older versions of ssh generate this error which we ignore
-                        stdout=stdout.replace("tcgetattr: Invalid argument\n", "")
                         raise errors.AnsibleError('ssh connection error waiting for sudo password prompt')
                 p.stdin.write(self.runner.sudo_pass + '\n')
                 fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)

--- a/lib/ansible/runner/connection/ssh.py
+++ b/lib/ansible/runner/connection/ssh.py
@@ -27,6 +27,8 @@ import random
 import select
 import fcntl
 
+import ansible.constants as C
+
 from ansible import errors
 
 class SSHConnection(object):
@@ -40,18 +42,11 @@ class SSHConnection(object):
     def connect(self):
         ''' connect to the remote host '''
 
-        self.common_args = ["-o", "StrictHostKeyChecking=no"]
+        self.common_args = shlex.split(C.DEFAULT_SSH_ARGS)
         if self.port is not None:
             self.common_args += ["-o", "Port=%d" % (self.port)]
         if self.runner.private_key_file is not None:
             self.common_args += ["-o", "IdentityFile="+self.runner.private_key_file]
-        extra_args = os.getenv("ANSIBLE_SSH_ARGS", None)
-        if extra_args is not None:
-            self.common_args += shlex.split(extra_args)
-        else:
-            self.common_args += ["-o", "ControlMaster=auto",
-                                 "-o", "ControlPersist=60s",
-                                 "-o", "ControlPath=/tmp/ansible-ssh-%h-%p-%r"]
         self.userhost = "%s@%s" % (self.runner.remote_user, self.host)
 
         return self

--- a/lib/ansible/runner/connection/ssh.py
+++ b/lib/ansible/runner/connection/ssh.py
@@ -19,7 +19,6 @@
 ################################################
 
 import os
-import re
 import time
 import subprocess
 import shlex
@@ -92,7 +91,7 @@ class SSHConnection(object):
                     else:
                         stdout = p.communicate()
                         # older versions of ssh generate this error which we ignore
-                        stdout = re.sub("tcgetattr: Invalid argument\n", "", stdout)
+                        stdout=stdout.replace("tcgetattr: Invalid argument\n", "")
                         raise errors.AnsibleError('ssh connection error waiting for sudo password prompt')
                 p.stdin.write(self.runner.sudo_pass + '\n')
                 fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
@@ -108,8 +107,8 @@ class SSHConnection(object):
             rfd, wfd, efd = select.select([p.stdout], [], [p.stdout], 1)
             if p.stdout in rfd:
                 stdout += os.read(p.stdout.fileno(), 1024)
-                # older versions of ssh generate this error which we ignore
-                stdout = re.sub("tcgetattr: Invalid argument\n", "", stdout)
+        # older versions of ssh generate this error which we ignore
+        stdout=stdout.replace("tcgetattr: Invalid argument\n", "")
 
         if p.returncode != 0 and stdout.find('Bad configuration option: ControlPersist') != -1:
             raise errors.AnsibleError('using -c ssh on certain older ssh versions may not support ControlPersist, set ANSIBLE_SSH_ARGS="" before running again')


### PR DESCRIPTION
This pull moves the SSH_ARGS used by the ssh.py transport out to constants.py.
(So later I can override them with the proposed global config file)

Is this acceptable? Have I done this correctly by referencing the constants class from within ssh.py?
