### PR TITLE
move ssh module arguments to constants.py

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -41,3 +41,6 @@ DEFAULT_REMOTE_PORT    = 22
 DEFAULT_TRANSPORT      = os.environ.get('ANSIBLE_TRANSPORT','paramiko')
 DEFAULT_TRANSPORT_OPTS = ['local', 'paramiko', 'ssh']
 
+DEFAULT_SSH_ARGS         = os.environ.get('ANSIBLE_SSH_ARGS',
+                           "-o StrictHostKeyChecking=no -o ControlMaster=auto -o ControlPersist=60 -o ControlPath=/tmp/ansible-ssh-%h-%p-%r")
+

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -112,7 +112,7 @@ class Runner(object):
         background=0, basedir=None, setup_cache=None, 
         transport=C.DEFAULT_TRANSPORT, conditional='True', callbacks=None, 
         debug=False, sudo=False, sudo_user=C.DEFAULT_SUDO_USER,
-        module_vars=None, is_playbook=False, inventory=None):
+        module_vars=None, is_playbook=False, inventory=None, ssh_args=C.DEFAULT_SSH_ARGS):
 
         """
         host_list    : path to a host list file, like /etc/ansible/hosts
@@ -138,6 +138,7 @@ class Runner(object):
         module_vars  : provides additional variables to a template.  FIXME: factor this out
         is_playbook  : indicates Runner is being used by a playbook.  affects behavior in various ways.
         inventory    : inventory object, if host_list is not provided
+        ssh_args     : arguments used by ssh transport module
         """
 
         if setup_cache is None:
@@ -182,6 +183,7 @@ class Runner(object):
         self.sudo        = sudo
         self.sudo_pass   = sudo_pass
         self.is_playbook = is_playbook
+        self.ssh_args    = ssh_args
 
         euid = pwd.getpwuid(os.geteuid())[0]
         if self.transport == 'local' and self.remote_user != euid:

--- a/lib/ansible/runner/connection/ssh.py
+++ b/lib/ansible/runner/connection/ssh.py
@@ -27,6 +27,8 @@ import random
 import select
 import fcntl
 
+import ansible.constants as C
+
 from ansible import errors
 
 class SSHConnection(object):
@@ -40,18 +42,11 @@ class SSHConnection(object):
     def connect(self):
         ''' connect to the remote host '''
 
-        self.common_args = ["-o", "StrictHostKeyChecking=no"]
+        self.common_args = shlex.split(C.DEFAULT_SSH_ARGS)
         if self.port is not None:
             self.common_args += ["-o", "Port=%d" % (self.port)]
         if self.runner.private_key_file is not None:
             self.common_args += ["-o", "IdentityFile="+self.runner.private_key_file]
-        extra_args = os.getenv("ANSIBLE_SSH_ARGS", None)
-        if extra_args is not None:
-            self.common_args += shlex.split(extra_args)
-        else:
-            self.common_args += ["-o", "ControlMaster=auto",
-                                 "-o", "ControlPersist=60s",
-                                 "-o", "ControlPath=/tmp/ansible-ssh-%h-%p-%r"]
         self.userhost = "%s@%s" % (self.runner.remote_user, self.host)
 
         return self


### PR DESCRIPTION
This pull moves the SSH_ARGS used by the ssh.py transport out to constants.py.
(So later I can override them with the proposed global config file)

Is this acceptable? Have I done this correctly by referencing the constants class from within ssh.py?
