### PR TITLE
Add ./library to module search path.

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -114,6 +114,8 @@ class PlayBook(object):
         self.basedir    = os.path.dirname(playbook)
         self.playbook  = utils.parse_yaml_from_file(playbook)
 
+        self.module_path = self.module_path + os.pathsep + os.path.join(self.basedir, "library")
+
     # *****************************************************
         
     def run(self):


### PR DESCRIPTION
Only for playbooks.

It allows for custom modules in the best practices directory structure.
Bundling custom modules along with playbooks is useful to deliver a complete ansible package to customers. I need a solution for that.
