### PR TITLE
support complete username/port/ssh_config (ie, -F ssh_config) configurat...

### DIFF
--- a/lib/ansible/runner/connection/ssh.py
+++ b/lib/ansible/runner/connection/ssh.py
@@ -41,18 +41,19 @@ class SSHConnection(object):
         ''' connect to the remote host '''
 
         self.common_args = ["-o", "StrictHostKeyChecking=no"]
-        if self.port is not None:
-            self.common_args += ["-o", "Port=%d" % (self.port)]
-        if self.runner.private_key_file is not None:
-            self.common_args += ["-o", "IdentityFile="+self.runner.private_key_file]
+        self.common_args += ["-o", "ControlMaster=auto",
+                             "-o", "ControlPersist=60s",
+                             "-o", "ControlPath=/tmp/ansible-ssh-%h-%p-%r"]
         extra_args = os.getenv("ANSIBLE_SSH_ARGS", None)
         if extra_args is not None:
             self.common_args += shlex.split(extra_args)
+            self.userhost = self.host
         else:
-            self.common_args += ["-o", "ControlMaster=auto",
-                                 "-o", "ControlPersist=60s",
-                                 "-o", "ControlPath=/tmp/ansible-ssh-%h-%p-%r"]
-        self.userhost = "%s@%s" % (self.runner.remote_user, self.host)
+            if self.port is not None:
+                self.common_args += ["-o", "Port=%d" % (self.port)]
+            if self.runner.private_key_file is not None:
+                self.common_args += ["-o", "IdentityFile="+self.runner.private_key_file]
+            self.userhost = "%s@%s" % (self.runner.remote_user, self.host)
 
         return self
 


### PR DESCRIPTION
I wanted the ability to control the port/username/etc settings from outside of ansible. I modified the 'ssh' connection to support this ability:
- if you specify ANSIBLE_SSH_ARGS then ansible will not supply user/port to the ssh commands.

Users can then control these themselves. For instance:
- ANSIBLE_SSH_ARGS="-F my_ssh_config" ansible all -c ssh -i ansiblefile -a uname
- ANSIBLE_SSH_ARGS="-o Port=1234 -o IdentityFile=~/.ssh/x.private -o User=admin" ansible all -c ssh -i 
  ansiblefile -a uname
- ANSIBLE_SSH_ARGS="-o ProxyCommand=..." ansible all -c ssh -i 
  ansiblefile -a uname
