### PR TITLE
Correctly add ungrouped hosts to 'ungrouped' in YAML inventory.

### DIFF
--- a/lib/ansible/inventory/yaml.py
+++ b/lib/ansible/inventory/yaml.py
@@ -53,25 +53,13 @@ class InventoryParserYaml(object):
         all.add_child_group(ungrouped)
 
         self.groups = dict(all=all, ungrouped=ungrouped)
+        grouped_hosts = []
 
         yaml = utils.parse_yaml(data)
+
+        # first add all groups
         for item in yaml:
-
-            if type(item) in [ str, unicode ]:
-                host = self._make_host(item)
-                ungrouped.add_host(host)
-
-            elif type(item) == dict and 'host' in item:
-                host = self._make_host(item['host'])
-                vars = item.get('vars', {})
-                if type(vars)==list:
-                    varlist, vars = vars, {}
-                    for subitem in varlist:
-                        vars.update(subitem)
-                for (k,v) in vars.items():
-                   host.set_variable(k,v)
-
-            elif type(item) == dict and 'group' in item:
+            if type(item) == dict and 'group' in item:
                 group = Group(item['group'])
 
                 for subresult in item.get('hosts',[]):
@@ -79,6 +67,7 @@ class InventoryParserYaml(object):
                     if type(subresult) in [ str, unicode ]:
                         host = self._make_host(subresult)
                         group.add_host(host)
+                        grouped_hosts.append(host)
                     elif type(subresult) == dict:
                         host = self._make_host(subresult['host'])
                         vars = subresult.get('vars',{})
@@ -92,6 +81,7 @@ class InventoryParserYaml(object):
                         else:
                             raise errors.AnsibleError("unexpected type for variable")
                         group.add_host(host)
+                        grouped_hosts.append(host)
 
                 vars = item.get('vars',{})
                 if type(vars) == dict:
@@ -106,3 +96,22 @@ class InventoryParserYaml(object):
 
                 self.groups[group.name] = group
                 all.add_child_group(group)
+
+        # add host definitions
+        for item in yaml:
+            if type(item) in [ str, unicode ]:
+                host = self._make_host(item)
+                if host not in grouped_hosts:
+                    ungrouped.add_host(host)
+
+            elif type(item) == dict and 'host' in item:
+                host = self._make_host(item['host'])
+                vars = item.get('vars', {})
+                if type(vars)==list:
+                    varlist, vars = vars, {}
+                    for subitem in varlist:
+                        vars.update(subitem)
+                for (k,v) in vars.items():
+                   host.set_variable(k,v)
+                if host not in grouped_hosts:
+                    ungrouped.add_host(host)

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -222,14 +222,14 @@ class TestInventory(unittest.TestCase):
         inventory = self.yaml_inventory()
         hosts = inventory.list_hosts()
         print hosts
-        expected_hosts=['jupiter', 'saturn', 'zeus', 'hera', 'poseidon', 'thor', 'odin', 'loki']
+        expected_hosts=['jupiter', 'saturn', 'mars', 'zeus', 'hera', 'poseidon', 'thor', 'odin', 'loki']
         self.compare(hosts, expected_hosts)
 
     def test_yaml_all(self):
         inventory = self.yaml_inventory()
         hosts = inventory.list_hosts('all')
 
-        expected_hosts=['jupiter', 'saturn', 'zeus', 'hera', 'poseidon', 'thor', 'odin', 'loki']
+        expected_hosts=['jupiter', 'saturn', 'mars', 'zeus', 'hera', 'poseidon', 'thor', 'odin', 'loki']
         self.compare(hosts, expected_hosts)
 
     def test_yaml_norse(self):
@@ -243,7 +243,7 @@ class TestInventory(unittest.TestCase):
         inventory = self.yaml_inventory()
         hosts = inventory.list_hosts("ungrouped")
 
-        expected_hosts=['jupiter']
+        expected_hosts=['jupiter', 'mars']
         self.compare(hosts, expected_hosts)
 
     def test_yaml_combined(self):

--- a/test/yaml_hosts
+++ b/test/yaml_hosts
@@ -6,6 +6,8 @@
     moon: titan
     moon2: enceladus
 
+- host: mars
+
 - host: zeus
   vars:
   - ansible_ssh_port: 3001


### PR DESCRIPTION
First add groups while parsing. In a second pass, add any hosts to the groups.

Without doing this the following hosts file (or any without explicitly defined groups) would fail:

```

---
- host: <myserver>
  vars:
  - ansible_python_interpreter: /usr/bin/python2
```

Take 2, now with tests and different implementation as discussed in #505.
