### PR TITLE
Updated the file module to handle the case where the UID for the file doesn't exist on the system.

### DIFF
--- a/library/file
+++ b/library/file
@@ -184,8 +184,16 @@ def user_and_group(filename):
     st = os.stat(filename)
     uid = st.st_uid
     gid = st.st_gid
-    user = pwd.getpwuid(uid)[0]
-    group = grp.getgrgid(gid)[0]
+    try:
+        user = pwd.getpwuid(uid)[0]
+    except KeyError:
+        #print('unknown user')
+        user = 'UID' + str(uid)
+    try:
+        group = grp.getgrgid(gid)[0]
+    except KeyError:
+        #print('unknown group')
+        group = 'GID' + str(gid)
     return (user, group)
 
 def set_context_if_different(path, context, changed):

--- a/library/file
+++ b/library/file
@@ -187,11 +187,11 @@ def user_and_group(filename):
     try:
         user = pwd.getpwuid(uid)[0]
     except KeyError:
-        user = 'UID' + str(uid)
+        user = str(uid)
     try:
         group = grp.getgrgid(gid)[0]
     except KeyError:
-        group = 'GID' + str(gid)
+        group = str(gid)
     return (user, group)
 
 def set_context_if_different(path, context, changed):

--- a/library/file
+++ b/library/file
@@ -187,12 +187,10 @@ def user_and_group(filename):
     try:
         user = pwd.getpwuid(uid)[0]
     except KeyError:
-        #print('unknown user')
         user = 'UID' + str(uid)
     try:
         group = grp.getgrgid(gid)[0]
     except KeyError:
-        #print('unknown group')
         group = 'GID' + str(gid)
     return (user, group)
 


### PR DESCRIPTION
Simple patch

Used to raise a KeyError exception.

Now returns `UIDXXXX` or `GIDXXXX` when it's an unknown uid or gid on the system.
