### PR TITLE
adds 'groups' variable, essentially making hosts file accessible as a var

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -290,6 +290,12 @@ class Runner(object):
         inject.update(host_variables)
         inject.update(self.module_vars)
 
+        group_hosts = {}
+        for g in self.inventory.groups:
+            group_hosts[g.name] = map((lambda x: x.get_variables()),g.hosts)
+
+        inject['groups'] = group_hosts
+
         if self.module_name == 'setup':
             if not args:
                 args = {}


### PR DESCRIPTION
Major use case:
  When one server needs to be "aware" of other servers.  Examples:
a) allows a template that is dependent upon how servers are configured in the hosts file: a config file for an app proxy/load balancer can see all of the servers in the [webapp] group in the host files and enumerate them in the config.
b) configure iptables to only accept incoming connections from a servers in a specific group.

I'm currently using this to setup hosts files, hadoop cluster, iptables

Note: It seems from the comments that keys aspect of the vars system are due for a re-factor.  Its not clear to me if I've put this code in the right place?
