### PR TITLE
copy always returned change=true

### DIFF
--- a/library/copy
+++ b/library/copy
@@ -102,5 +102,5 @@ else:
 
 # mission accomplished
 #print "md5sum=%s changed=%s" % (md5sum_src, changed)
-exit_kv(dest=dest, src=src, changed="md5sum=%s changed=%s" % (md5sum_src, changed))
+exit_kv(dest=dest, src=src, md5sum=md5sum_src, changed=changed)
 


### PR DESCRIPTION
Copy seems to always return changed=true, this allows it to return true or false.

I can't find anything broken by this fix - but maybe you always wanted true returned?
