### PR TITLE
fetch: handle missing remote file gracefully

### DIFF
--- a/lib/ansible/runner/connection/paramiko_ssh.py
+++ b/lib/ansible/runner/connection/paramiko_ssh.py
@@ -141,8 +141,8 @@ class ParamikoConnection(object):
         try:
             sftp.get(in_path, out_path)
         except IOError:
-            traceback.print_exc()
-            raise errors.AnsibleError("failed to transfer file from %s" % in_path)
+            pass
+
         sftp.close()
 
     def close(self):

--- a/lib/ansible/runner/connection/ssh.py
+++ b/lib/ansible/runner/connection/ssh.py
@@ -126,8 +126,7 @@ class SSHConnection(object):
 
     def fetch_file(self, in_path, out_path):
         ''' fetch a file from remote to local '''
-        if not os.path.exists(in_path):
-            raise errors.AnsibleFileNotFound("file or module does not exist: %s" % in_path)
+
         sftp_cmd = ["sftp"] + self.common_args + [self.host]
         p = subprocess.Popen(sftp_cmd, stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
allows fetch to ignore missing files

allows a playbook like ....

---
- hosts: kvm
  user:  ansible
  sudo:  True
  
  tasks:
  - name: mirror important config files ($item)
    action: fetch src=$item dest=/data/transit/configs
    with_items:
        - /etc/passwd
        - /etc/group
        - /etc/bob
        - /etc/sysctl.conf
        - /etc/centos-release
