### PR TITLE
further md5 fixes

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -746,7 +746,8 @@ class Runner(object):
         test = "[[ -r %s ]]" % path
         md5s = [
             "(%s && /usr/bin/md5sum %s 2>/dev/null)" % (test,path),
-            "(%s && /sbin/md5sum -q %s 2>/dev/null)" % (test,path)
+            "(%s && /sbin/md5sum -q %s 2>/dev/null)" % (test,path),
+            "(%s && /usr/bin/digest -a md5 -v %s 2>/dev/null)" % (test,path)
         ]
         cmd = " || ".join(md5s)
         cmd = "%s || (echo \"0 %s\")" % (cmd, path)

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -314,7 +314,14 @@ def parse_kv(args):
 
 def local_md5(file):
      ''' compute local md5sum, return None if file is not present '''
-     cmd = "/usr/bin/md5sum %s 2> /dev/null || /sbin/md5 -q %s" % (file,file)
+     #was >>> cmd = "/usr/bin/md5sum %s 2> /dev/null || /sbin/md5 -q %s" % (file,file)
+     md5s = [
+         "(/usr/bin/md5sum %s 2>/dev/null)" % (file),
+         "(/sbin/md5sum -q %s 2>/dev/null)" % (file),
+         "(/usr/bin/digest -a md5 -v %s 2>/dev/null)" % (file)
+     ]
+     cmd = " || ".join(md5s)
+
      if not os.path.exists(file):
          return None
      else:


### PR DESCRIPTION
This is the first of two patches from our discussion.

This one
- add digest as one of the possible md generating OS commands called in a os.popen
- It alters lib/ansible/utils.py to use a similar call to your new code in lib/ansible/runner/**init**.py

This should be applied first.
