### PR TITLE
Switch to using hashlib or md5

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -746,7 +746,8 @@ class Runner(object):
         test = "[[ -r %s ]]" % path
         md5s = [
             "(%s && /usr/bin/md5sum %s 2>/dev/null)" % (test,path),
-            "(%s && /sbin/md5sum -q %s 2>/dev/null)" % (test,path)
+            "(%s && /sbin/md5sum -q %s 2>/dev/null)" % (test,path),
+            "(%s && /usr/bin/digest -a md5 -v %s 2>/dev/null)" % (test,path)
         ]
         cmd = " || ".join(md5s)
         cmd = "%s || (echo \"0 %s\")" % (cmd, path)

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -314,7 +314,14 @@ def parse_kv(args):
 
 def local_md5(file):
      ''' compute local md5sum, return None if file is not present '''
-     cmd = "/usr/bin/md5sum %s 2> /dev/null || /sbin/md5 -q %s" % (file,file)
+     #was >>> cmd = "/usr/bin/md5sum %s 2> /dev/null || /sbin/md5 -q %s" % (file,file)
+     md5s = [
+         "(/usr/bin/md5sum %s 2>/dev/null)" % (file),
+         "(/sbin/md5sum -q %s 2>/dev/null)" % (file),
+         "(/usr/bin/digest -a md5 -v %s 2>/dev/null)" % (file)
+     ]
+     cmd = " || ".join(md5s)
+
      if not os.path.exists(file):
          return None
      else:

--- a/library/assemble
+++ b/library/assemble
@@ -28,6 +28,7 @@ import shlex
 import shutil
 import syslog
 import tempfile
+
 try:
     import hashlib
     HAVE_HASHLIB=True
@@ -64,12 +65,18 @@ def write_temp_file(data):
     os.close(fd)
     return path
 
-def file_digest(path):
-    if HAVE_HASHLIB:
-        digest = hashlib.md5(file(path).read()).hexdigest()
-    else:
-        digest = md5.new(file(path).read()).hexdigest()
-    return digest
+def local_md5(filename):
+     ''' compute local md5sum, return None if file is not present '''
+     if os.path.exists(filename):
+         md5val=None
+         if os.path.exists(filename):
+             if HAVE_HASHLIB:
+                 md5val=hashlib.md5(file(filename).read()).hexdigest()
+             else:
+                 md5val=md5.new(file(filename).read()).hexdigest()
+         return md5val
+     else:
+         return None
 
 # ===========================================
 
@@ -111,10 +118,10 @@ if not os.path.isdir(src):
     fail_json(msg="Source (%s) is not a directory" % src)
 
 path = write_temp_file(assemble_from_fragments(src))
-pathmd5 = file_digest(path)
+pathmd5 = local_md5(path)
 
 if os.path.exists(dest):
-    destmd5 = file_digest(dest)
+    destmd5 = local_md5(dest)
 
 if pathmd5 != destmd5:
     shutil.copy(path, dest)

--- a/library/copy
+++ b/library/copy
@@ -24,6 +24,13 @@ import shlex
 import shutil
 import syslog
 
+try:
+    import hashlib
+    HAVE_HASHLIB=True
+except ImportError:
+    import md5
+    HAVE_HASHLIB=False
+
 # ===========================================
 # convert arguments of form a=b c=d
 # to a dictionary
@@ -38,9 +45,20 @@ def exit_kv(rc=0, **kwargs):
     print dump_kv(kwargs)
     sys.exit(rc)
 
-def md5_sum(f):
-    md5sum = os.popen("/usr/bin/md5sum %(file)s 2>/dev/null || /sbin/md5 -q %(file)s 2>/dev/null || /usr/bin/digest -a md5 -v %(file)s 2>/dev/null" % {"file": f}).read().split()[0]
-    return md5sum
+def local_md5(filename):
+     ''' compute local md5sum, return None if file is not present '''
+     if os.path.exists(filename):
+         md5val=None
+         if os.path.exists(filename):
+             if HAVE_HASHLIB:
+                 md5val=hashlib.md5(file(filename).read()).hexdigest()
+             else:
+                 md5val=md5.new(file(filename).read()).hexdigest()
+         return md5val
+     else:
+         return None
+
+# ===========================================
 
 if len(sys.argv) == 1:
     exit_kv(rc=1, failed=1, msg="incorrect number of arguments given")
@@ -73,7 +91,7 @@ if not os.path.exists(src):
     exit_kv(rc=1, failed=1, msg="Source %s failed to transfer" % (src))
 if not os.access(src, os.R_OK):
     exit_kv(rc=1, failed=1, msg="Source %s not readable" % (src))
-md5sum_src = md5_sum(src)
+md5sum_src = local_md5(src)
 
 md5sum_dest = None
 # check if there is no dest file
@@ -83,7 +101,7 @@ if os.path.exists(dest):
         exit_kv(rc=1, failed=1, msg="Destination %s not writable" % (dest))
     if not os.access(dest, os.R_OK):
         exit_kv(rc=1, failed=1, msg="Destination %s not readable" % (dest))
-    md5sum_dest = md5_sum(dest)
+    md5sum_dest = local_md5(dest)
 else:
     if not os.access(os.path.dirname(dest), os.W_OK):
         exit_kv(rc=1, failed=1, msg="Destination %s not writable" % (os.path.dirname(dest)))

--- a/library/setup
+++ b/library/setup
@@ -34,6 +34,13 @@ import traceback
 import syslog
 
 try:
+    import hashlib
+    HAVE_HASHLIB=True
+except ImportError:
+    import md5
+    HAVE_HASHLIB=False
+
+try:
     import selinux
     HAVE_SELINUX=True
 except ImportError:
@@ -311,9 +318,20 @@ def ansible_facts():
     get_service_facts(facts)
     return facts
 
-def md5_sum(f):
-    md5sum = os.popen("/usr/bin/md5sum %(file)s 2>/dev/null || /sbin/md5 -q %(file)s 2>/dev/null || /usr/bin/digest -a md5 -v %(file)s 2>/dev/null" % {"file": f}).read().split()[0]
-    return md5sum
+def local_md5(filename):
+     ''' compute local md5sum, return None if file is not present '''
+     if os.path.exists(filename):
+         md5val=None
+         if os.path.exists(filename):
+             if HAVE_HASHLIB:
+                 md5val=hashlib.md5(file(filename).read()).hexdigest()
+             else:
+                 md5val=md5.new(file(filename).read()).hexdigest()
+         return md5val
+     else:
+         return None
+
+# ===========================================
 
 # load config & template variables
 
@@ -351,7 +369,7 @@ md5sum = None
 if not os.path.exists(ansible_file):
     changed = True
 else:
-    md5sum = md5_sum(ansible_file)
+    md5sum = local_md5(ansible_file)
 
 # Get some basic facts in case facter or ohai are not installed
 for (k, v) in ansible_facts().items():
@@ -400,7 +418,7 @@ reformat = json.dumps(setup_options, sort_keys=True, indent=4)
 f.write(reformat)
 f.close()
 
-md5sum2 = md5_sum(ansible_file)
+md5sum2 = local_md5(ansible_file)
 
 if md5sum != md5sum2:
    changed = True


### PR DESCRIPTION
This second patch 
- switches from using os.popen to call OS commands to generate md5 to using python modules.
- it uses hashlib.md5 for python >= 2.5
- it uses md5 for python 2.4
