### PR TITLE
switch to hashlib.md5 or md5 instead of OS md5 commands

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -438,7 +438,7 @@ class Runner(object):
         source = utils.template(source, inject, self.setup_cache)
         source = utils.path_dwim(self.basedir, source)
 
-        local_md5 = utils.local_md5(source)
+        local_md5 = utils.md5(source)
         if local_md5 is None:
             result=dict(failed=True, msg="could not find src=%s" % source)
             return ReturnData(host=conn.host, result=result)
@@ -495,7 +495,7 @@ class Runner(object):
         dest   = dest.replace("//","/")
 
         # compare old and new md5 for support of change hooks
-        local_md5 = utils.local_md5(dest)
+        local_md5 = utils.md5(dest)
         remote_md5 = self._remote_md5(conn, tmp, source)
 
         if remote_md5 == '0':
@@ -508,7 +508,7 @@ class Runner(object):
 
             # fetch the file and check for changes
             conn.fetch_file(source, dest)
-            new_md5 = utils.local_md5(dest)
+            new_md5 = utils.md5(dest)
             if new_md5 != remote_md5:
                 result = dict(failed=True, msg="md5 mismatch", md5sum=new_md5)
                 return ReturnData(host=conn.host, result=result)
@@ -746,7 +746,8 @@ class Runner(object):
         test = "[[ -r %s ]]" % path
         md5s = [
             "(%s && /usr/bin/md5sum %s 2>/dev/null)" % (test,path),
-            "(%s && /sbin/md5sum -q %s 2>/dev/null)" % (test,path)
+            "(%s && /sbin/md5sum -q %s 2>/dev/null)" % (test,path),
+            "(%s && /usr/bin/digest -a md5 -v %s 2>/dev/null)" % (test,path)
         ]
         cmd = " || ".join(md5s)
         cmd = "%s || (echo \"0 %s\")" % (cmd, path)

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -26,10 +26,18 @@ import jinja2
 import yaml
 import optparse
 from operator import methodcaller
+
 try:
     import json
 except ImportError:
     import simplejson as json
+
+try:
+    import hashlib 
+    HAVE_HASHLIB=True
+except ImportError: 
+    import md5
+    HAVE_HASHLIB=False
 
 from ansible import errors
 import ansible.constants as C
@@ -312,14 +320,14 @@ def parse_kv(args):
                 options[k]=v
     return options
 
-def local_md5(file):
-     ''' compute local md5sum, return None if file is not present '''
-     cmd = "/usr/bin/md5sum %s 2> /dev/null || /sbin/md5 -q %s" % (file,file)
-     if not os.path.exists(file):
+def md5(filename):
+     ''' compute md5sum, return None if file is not present '''
+     if not os.path.exists(filename):
          return None
+     if HAVE_HASHLIB:
+         return hashlib.md5(file(filename).read()).hexdigest()
      else:
-         c = os.popen(cmd)
-         return c.read().split()[0]
+         return md5.new(file(filename).read()).hexdigest()
 
 
 ####################################################################

--- a/library/assemble
+++ b/library/assemble
@@ -28,6 +28,7 @@ import shlex
 import shutil
 import syslog
 import tempfile
+
 try:
     import hashlib
     HAVE_HASHLIB=True
@@ -64,12 +65,14 @@ def write_temp_file(data):
     os.close(fd)
     return path
 
-def file_digest(path):
-    if HAVE_HASHLIB:
-        digest = hashlib.md5(file(path).read()).hexdigest()
-    else:
-        digest = md5.new(file(path).read()).hexdigest()
-    return digest
+def md5(filename):
+     ''' compute md5sum, return None if file is not present '''
+     if not os.path.exists(filename):
+         return None
+     if HAVE_HASHLIB:
+         return hashlib.md5(file(filename).read()).hexdigest()
+     else:
+         return md5.new(file(filename).read()).hexdigest()
 
 # ===========================================
 
@@ -111,10 +114,10 @@ if not os.path.isdir(src):
     fail_json(msg="Source (%s) is not a directory" % src)
 
 path = write_temp_file(assemble_from_fragments(src))
-pathmd5 = file_digest(path)
+pathmd5 = md5(path)
 
 if os.path.exists(dest):
-    destmd5 = file_digest(dest)
+    destmd5 = md5(dest)
 
 if pathmd5 != destmd5:
     shutil.copy(path, dest)

--- a/library/copy
+++ b/library/copy
@@ -24,6 +24,13 @@ import shlex
 import shutil
 import syslog
 
+try:
+    import hashlib
+    HAVE_HASHLIB=True
+except ImportError:
+    import md5
+    HAVE_HASHLIB=False
+
 # ===========================================
 # convert arguments of form a=b c=d
 # to a dictionary
@@ -38,9 +45,16 @@ def exit_kv(rc=0, **kwargs):
     print dump_kv(kwargs)
     sys.exit(rc)
 
-def md5_sum(f):
-    md5sum = os.popen("/usr/bin/md5sum %(file)s 2>/dev/null || /sbin/md5 -q %(file)s 2>/dev/null || /usr/bin/digest -a md5 -v %(file)s 2>/dev/null" % {"file": f}).read().split()[0]
-    return md5sum
+def md5(filename):
+     ''' compute md5sum, return None if file is not present '''
+     if not os.path.exists(filename):
+         return None
+     if HAVE_HASHLIB:
+         return hashlib.md5(file(filename).read()).hexdigest()
+     else:
+         return md5.new(file(filename).read()).hexdigest()
+
+# ===========================================
 
 if len(sys.argv) == 1:
     exit_kv(rc=1, failed=1, msg="incorrect number of arguments given")
@@ -73,7 +87,7 @@ if not os.path.exists(src):
     exit_kv(rc=1, failed=1, msg="Source %s failed to transfer" % (src))
 if not os.access(src, os.R_OK):
     exit_kv(rc=1, failed=1, msg="Source %s not readable" % (src))
-md5sum_src = md5_sum(src)
+md5sum_src = md5(src)
 
 md5sum_dest = None
 # check if there is no dest file
@@ -83,7 +97,7 @@ if os.path.exists(dest):
         exit_kv(rc=1, failed=1, msg="Destination %s not writable" % (dest))
     if not os.access(dest, os.R_OK):
         exit_kv(rc=1, failed=1, msg="Destination %s not readable" % (dest))
-    md5sum_dest = md5_sum(dest)
+    md5sum_dest = md5(dest)
 else:
     if not os.access(os.path.dirname(dest), os.W_OK):
         exit_kv(rc=1, failed=1, msg="Destination %s not writable" % (os.path.dirname(dest)))

--- a/library/setup
+++ b/library/setup
@@ -34,6 +34,13 @@ import traceback
 import syslog
 
 try:
+    import hashlib
+    HAVE_HASHLIB=True
+except ImportError:
+    import md5
+    HAVE_HASHLIB=False
+
+try:
     import selinux
     HAVE_SELINUX=True
 except ImportError:
@@ -311,9 +318,16 @@ def ansible_facts():
     get_service_facts(facts)
     return facts
 
-def md5_sum(f):
-    md5sum = os.popen("/usr/bin/md5sum %(file)s 2>/dev/null || /sbin/md5 -q %(file)s 2>/dev/null || /usr/bin/digest -a md5 -v %(file)s 2>/dev/null" % {"file": f}).read().split()[0]
-    return md5sum
+def md5(filename):
+     ''' compute md5sum, return None if file is not present '''
+     if not os.path.exists(filename):
+         return None
+     if HAVE_HASHLIB:
+         return hashlib.md5(file(filename).read()).hexdigest()
+     else:
+         return md5.new(file(filename).read()).hexdigest()
+
+# ===========================================
 
 # load config & template variables
 
@@ -351,7 +365,7 @@ md5sum = None
 if not os.path.exists(ansible_file):
     changed = True
 else:
-    md5sum = md5_sum(ansible_file)
+    md5sum = md5(ansible_file)
 
 # Get some basic facts in case facter or ohai are not installed
 for (k, v) in ansible_facts().items():
@@ -400,7 +414,7 @@ reformat = json.dumps(setup_options, sort_keys=True, indent=4)
 f.write(reformat)
 f.close()
 
-md5sum2 = md5_sum(ansible_file)
+md5sum2 = md5(ansible_file)
 
 if md5sum != md5sum2:
    changed = True


### PR DESCRIPTION
This switches to using hashlib.md5 (>+python 2.5) or md5 (python <=2.4) instead of OS calls to md5 commands.
- Dave
