### PR TITLE
improve output formating for playbook

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -87,7 +87,7 @@ def main(args):
             print callbacks.banner("PLAY RECAP")
             for h in hosts:
                 t = pb.stats.summarize(h)
-                print "%-30s : ok=%4s changed=%4s unreachable=%4s failed=%4s " % (h, 
+                print "%-30s : ok=%-4s changed=%-4s unreachable=%-4s failed=%-4s " % (h, 
                    t['ok'], t['changed'], t['unreachable'], t['failures']
                 )
             print "\n"

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -84,7 +84,7 @@ def banner(msg):
         (out, err) = cmd.communicate()
         res = "%s\n" % out 
     else:
-        res = "%s ********************* \n" % msg
+        res = "\n%s ********************* " % msg
     return res
   
 
@@ -190,7 +190,7 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
     def on_ok(self, host, host_result):
         # show verbose output for non-setup module results if --verbose is used
         if not self.verbose or host_result.get("verbose_override",None) is not None:
-            print "ok: [%s]\n" % (host)
+            print "ok: [%s]" % (host)
         else:
             print "ok: [%s] => %s" % (host, utils.smjson(host_result))
 
@@ -225,7 +225,7 @@ class PlaybookCallbacks(object):
         self.verbose = verbose
 
     def on_start(self):
-        print "\n"
+        pass
 
     def on_notify(self, host, handler):
         pass


### PR DESCRIPTION
Outut from running a playbook looks a little awkward to me - this alters it slightly.
## Before

 ANSIBLE_SSH_ARGS="" ANSIBLE_REMOTE_USER=ansible ansible-playbook ~/playbooks/config_delta/config.delta.yml -v -c ssh

PLAY [kvm] ********************\* 

SETUP PHASE ********************\* 

ok: [office.starground.co.uk]

ok: [jabber.starground.co.uk]

ok: [zabbix.starground.co.uk]

TASK: [fetch src=/etc/passwd dest=/data/transit/configs] ********************\* 

ok: [jabber.starground.co.uk] => {"changed": false, "md5sum": "cbfc11f217062bb0eab9e4a7a0359631"}
ok: [zabbix.starground.co.uk] => {"changed": false, "md5sum": "4bdb5afeca6c234d970c8aee6707d30b"}
ok: [office.starground.co.uk] => {"changed": false, "md5sum": "522e1b4769cf88ae53cdcd2dce281475"}
TASK: [fetch src=/etc/bob dest=/data/transit/configs] ********************\* 

ok: [jabber.starground.co.uk] => {"changed": false, "msg": "missing remote file"}
ok: [zabbix.starground.co.uk] => {"changed": false, "msg": "missing remote file"}
ok: [office.starground.co.uk] => {"changed": false, "msg": "missing remote file"}
TASK: [fetch src=/etc/group dest=/data/transit/configs] ********************\* 

ok: [office.starground.co.uk] => {"changed": false, "md5sum": "efd2c18fa8c5ff3938b1c794158ccfe6"}
ok: [jabber.starground.co.uk] => {"changed": true, "md5sum": "0f17fd9b46ad65a234017b5d8b646ccd"}
ok: [zabbix.starground.co.uk] => {"changed": true, "md5sum": "fbfd8e3b160604c41afa32ab662c96a7"}
TASK: [fetch src=/etc/sysctl.conf dest=/data/transit/configs] ********************\* 

ok: [jabber.starground.co.uk] => {"changed": true, "md5sum": "c97839af771c8447b9fc23090b4e8d0f"}
ok: [office.starground.co.uk] => {"changed": true, "md5sum": "c97839af771c8447b9fc23090b4e8d0f"}
ok: [zabbix.starground.co.uk] => {"changed": true, "md5sum": "c97839af771c8447b9fc23090b4e8d0f"}
TASK: [fetch src=/etc/centos-release dest=/data/transit/configs] ********************\* 

ok: [jabber.starground.co.uk] => {"changed": true, "md5sum": "2cefca706f95cdd38a06a990780e9709"}
ok: [office.starground.co.uk] => {"changed": true, "md5sum": "2cefca706f95cdd38a06a990780e9709"}
ok: [zabbix.starground.co.uk] => {"changed": true, "md5sum": "2cefca706f95cdd38a06a990780e9709"}
PLAY RECAP ********************\* 

jabber.starground.co.uk        : ok=   6 changed=   3 unreachable=   0 failed=   0 
office.starground.co.uk        : ok=   6 changed=   2 unreachable=   0 failed=   0 
zabbix.starground.co.uk        : ok=   6 changed=   3 unreachable=   0 failed=   0 

---
## After

ANSIBLE_SSH_ARGS="" ANSIBLE_REMOTE_USER=ansible ansible-playbook ~/playbooks/config_delta/config.delta.yml -c ssh -v

PLAY [kvm] ********************\* 

SETUP PHASE ********************\* 
ok: [jabber.starground.co.uk]
ok: [office.starground.co.uk]
ok: [zabbix.starground.co.uk]

TASK: [fetch src=/etc/passwd dest=/data/transit/configs] ********************\* 
ok: [office.starground.co.uk] => {"changed": false, "md5sum": "522e1b4769cf88ae53cdcd2dce281475"}
ok: [jabber.starground.co.uk] => {"changed": false, "md5sum": "cbfc11f217062bb0eab9e4a7a0359631"}
ok: [zabbix.starground.co.uk] => {"changed": false, "md5sum": "4bdb5afeca6c234d970c8aee6707d30b"}

TASK: [fetch src=/etc/bob dest=/data/transit/configs] ********************\* 
ok: [jabber.starground.co.uk] => {"changed": false, "msg": "missing remote file"}
ok: [zabbix.starground.co.uk] => {"changed": false, "msg": "missing remote file"}
ok: [office.starground.co.uk] => {"changed": false, "msg": "missing remote file"}

TASK: [fetch src=/etc/group dest=/data/transit/configs] ********************\* 
ok: [jabber.starground.co.uk] => {"changed": false, "md5sum": "0f17fd9b46ad65a234017b5d8b646ccd"}
ok: [office.starground.co.uk] => {"changed": false, "md5sum": "efd2c18fa8c5ff3938b1c794158ccfe6"}
ok: [zabbix.starground.co.uk] => {"changed": false, "md5sum": "fbfd8e3b160604c41afa32ab662c96a7"}

TASK: [fetch src=/etc/sysctl.conf dest=/data/transit/configs] ********************\* 
ok: [jabber.starground.co.uk] => {"changed": false, "md5sum": "c97839af771c8447b9fc23090b4e8d0f"}
ok: [office.starground.co.uk] => {"changed": false, "md5sum": "c97839af771c8447b9fc23090b4e8d0f"}
ok: [zabbix.starground.co.uk] => {"changed": false, "md5sum": "c97839af771c8447b9fc23090b4e8d0f"}

TASK: [fetch src=/etc/centos-release dest=/data/transit/configs] ********************\* 
ok: [jabber.starground.co.uk] => {"changed": false, "md5sum": "2cefca706f95cdd38a06a990780e9709"}
ok: [office.starground.co.uk] => {"changed": false, "md5sum": "2cefca706f95cdd38a06a990780e9709"}
ok: [zabbix.starground.co.uk] => {"changed": false, "md5sum": "2cefca706f95cdd38a06a990780e9709"}

PLAY RECAP ********************\* 
jabber.starground.co.uk        : ok=6    changed=0    unreachable=0    failed=0
office.starground.co.uk        : ok=6    changed=0    unreachable=0    failed=0
zabbix.starground.co.uk        : ok=6    changed=0    unreachable=0    failed=0

---
