### PR TITLE
Backport fix in copy module to prevent all copies change files

### DIFF
--- a/library/copy
+++ b/library/copy
@@ -95,5 +95,5 @@ else:
 
 # mission accomplished
 #print "md5sum=%s changed=%s" % (md5sum_src, changed)
-exit_kv(dest=dest, src=src, changed="md5sum=%s changed=%s" % (md5sum_src, changed))
+exit_kv(dest=dest, src=src, md5sum=md5sum_src, changed=changed)
 


### PR DESCRIPTION
I propose we backport this fix to the master branch to release a 0.5.1 (which may include other important fixes). I think this issue is important enough to get it out to EPEL, Fedora and other repositories for people to evaluate.
