### PR TITLE
Allow local plays to execute when --ask-sudo-pass is used on the command line

### DIFF
--- a/lib/ansible/runner/connection/local.py
+++ b/lib/ansible/runner/connection/local.py
@@ -37,12 +37,12 @@ class LocalConnection(object):
         ''' run a command on the local host '''
 
         if self.runner.sudo and sudoable:
+            if self.runner.sudo_pass:
+                # NOTE: if someone wants to add sudo w/ password to the local connection type, they are welcome
+                # to do so.  The primary usage of the local connection is for crontab and kickstart usage however
+                # so this doesn't seem to be a huge priority
+                raise errors.AnsibleError("sudo with password is presently only supported on the paramiko (SSH) connection type")
             cmd = "sudo -s %s" % cmd
-        if self.runner.sudo_pass:
-            # NOTE: if someone wants to add sudo w/ password to the local connection type, they are welcome
-            # to do so.  The primary usage of the local connection is for crontab and kickstart usage however
-            # so this doesn't seem to be a huge priority
-            raise errors.AnsibleError("sudo with password is presently only supported on the paramiko (SSH) connection type")
 
         p = subprocess.Popen(cmd, shell=True, stdin=None,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/lib/ansible/runner/connection/local.py
+++ b/lib/ansible/runner/connection/local.py
@@ -37,12 +37,12 @@ class LocalConnection(object):
         ''' run a command on the local host '''
 
         if self.runner.sudo and sudoable:
-            if self.runner.sudo_pass:
-                # NOTE: if someone wants to add sudo w/ password to the local connection type, they are welcome
-                # to do so.  The primary usage of the local connection is for crontab and kickstart usage however
-                # so this doesn't seem to be a huge priority
-                raise errors.AnsibleError("sudo with password is presently only supported on the paramiko (SSH) connection type")
             cmd = "sudo -s %s" % cmd
+        if self.runner.sudo and sudoable and self.runner.sudo_pass:
+            # NOTE: if someone wants to add sudo w/ password to the local connection type, they are welcome
+            # to do so.  The primary usage of the local connection is for crontab and kickstart usage however
+            # so this doesn't seem to be a huge priority
+            raise errors.AnsibleError("sudo with password is presently only supported on the paramiko (SSH) connection type")
 
         p = subprocess.Popen(cmd, shell=True, stdin=None,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/lib/ansible/runner/connection/local.py
+++ b/lib/ansible/runner/connection/local.py
@@ -37,12 +37,12 @@ class LocalConnection(object):
         ''' run a command on the local host '''
 
         if self.runner.sudo and sudoable:
+            if self.runner.sudo_pass:
+                # NOTE: if someone wants to add sudo w/ password to the local connection type, they are welcome
+                # to do so.  The primary usage of the local connection is for crontab and kickstart usage however
+                # so this doesn't seem to be a huge priority
+                raise errors.AnsibleError("sudo with password is presently only supported on the paramiko (SSH) connection type")
             cmd = "sudo -s %s" % cmd
-        if self.runner.sudo and sudoable and self.runner.sudo_pass:
-            # NOTE: if someone wants to add sudo w/ password to the local connection type, they are welcome
-            # to do so.  The primary usage of the local connection is for crontab and kickstart usage however
-            # so this doesn't seem to be a huge priority
-            raise errors.AnsibleError("sudo with password is presently only supported on the paramiko (SSH) connection type")
 
         p = subprocess.Popen(cmd, shell=True, stdin=None,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
When mixing a local play with remote plays using sudo and --ask-sudo-pass on the command line, I get an error 'sudo with password is presently only supported on the paramiko (SSH) connection type'. But sudo is not used in the local play, and I force it with sudo: False in the play.
