### PR TITLE
Conditional Imports should only import the first vars_file found in list

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -232,6 +232,8 @@ class Play(object):
                             self.vars.update(data)
                     elif host is not None:
                         self.playbook.callbacks.on_not_import_for_host(host, filename4)
+                    if found
+                        break
                 if not found:
                     raise errors.AnsibleError(
                         "%s: FATAL, no files matched for vars_files import sequence: %s" % (host, sequence)


### PR DESCRIPTION
Conditional Imports should only import the first file in the list, not all of them. This change stops looping through the vars_files list as soon as a file is found.
