### PR TITLE
with items doesn't display $item in task name anymore.

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -205,6 +205,6 @@ elif state == 'installed':
 elif state == 'removed':
     changed = remove(package, cache, purge == 'yes')
 
-exit_json(changed=changed)
+exit_json(changed=changed, msg="package[s] " + package)
 
 

--- a/library/yum
+++ b/library/yum
@@ -235,7 +235,7 @@ def ensure(my, state, pkgspec):
             if not my.doPackageLists(pkgnarrow='installed', patterns=[pkgspec]).installed:
                 msg = "No Package matching '%s' found available, installed or updated" % pkgspec
                 return { 'changed':False, 'failed':True, 'msg': msg }
-            return { 'changed':False,}
+            return { 'changed':False, 'msg': 'package[s] ' + pkgspec}
 
         # we have something in updates or available
         if not updates:
@@ -255,6 +255,7 @@ def ensure(my, state, pkgspec):
 
 
         res['changed'] = changed
+        res['msg'] = 'package[s] ' + pkgspec
 
         if failed:
             res['failed'] = failed


### PR DESCRIPTION
A recent change somewhere cause the with_items loop to only print the task once. Which keeps the $item iterator from being referenced in the task name.

This change is to add some output to the JSON which will allow playbook authors to see which packages are being installed in the loop. (This used to be done because the task header was repeated/derefed).
