### PR TITLE
Pass through error message when repo not found

### DIFF
--- a/library/git
+++ b/library/git
@@ -190,7 +190,7 @@ else:
 
 # handle errors from clone or pull
 
-if out.find('error') != -1:
+if out.find('error') != -1 or err.find('ERROR') != -1:
    fail_json(out=out, err=err)
 
 # switch to version specified regardless of whether


### PR DESCRIPTION
When the repository does not exist, the current Git module returns

```
failed: [localhost] => {"failed": true, "msg": "", "parsed": false}
```

With this PR, it catches the error and returns

```
failed: [localhost] => {"err": "ERROR: Repository not found.\nfatal: The remote end hung up
unexpectedly\n", "failed": true, "out": "Cloning into '/usr/share/admobius/git/admosible'...\n"}
```

This probably isn't the best way of catching errors, but git writes to stderr for non-errors like

```
Switched to a new branch 'feature1'
```

which is annoying, so not sure we can get around it.
