### PR TITLE
get module (with new module-magic-code!)

### DIFF
--- a/library/get
+++ b/library/get
@@ -1,0 +1,230 @@
+#!/usr/bin/python
+
+# (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ansible -m get -a "url=http://some.place/some.file dest=/tmp/file"
+#
+# args
+#    url=
+#    dest=
+#        if dest= is a file, url is copied to that file
+#        if dest= is a directory, determine name from url= and store it in dest/
+# TODO:
+#    timeout=
+#    Support gzip compression? 
+#        http://www.diveintopython.net/http_web_services/gzip_compression.html
+
+import sys
+import os
+import shlex
+import shutil
+import syslog
+import datetime
+import tempfile
+
+try:
+    from hashlib import md5 as _md5
+except ImportError: 
+    from md5 import md5 as _md5
+
+# Le truc magique: I love this!
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+
+def md5(filename):
+    ''' Return MD5 hex digest of local file, or None if file is not present. '''
+    if not os.path.exists(filename):
+        return None
+    digest = _md5()
+    blocksize = 64 * 1024
+    infile = open(filename, 'rb')
+    block = infile.read(blocksize)
+    while block:
+        digest.update(block)
+        block = infile.read(blocksize)
+    infile.close()
+    return digest.hexdigest()
+
+# ===========================================
+# url handling
+
+def url_filename(url):
+    return os.path.basename(urlparse.urlsplit(url)[2])
+
+def url_do_get(url, dest):
+    """Get url and return request and info
+       Credits: http://stackoverflow.com/questions/7006574/how-to-download-file-from-ftp
+    """
+    USERAGENT = 'ansible-httpget'
+    info = {}
+    info['url'] = url
+    r = None
+
+    if dest:
+        if os.path.isdir(dest):
+            destpath = "%s/%s" % (dest, url_filename(url))
+        else:
+            destpath = dest
+    else:
+        destpath = url_filename(url)
+
+    info['destpath'] = destpath
+
+    request = urllib2.Request(url)
+    request.add_header('User-agent', USERAGENT)
+
+    if os.path.exists(destpath):
+        t = datetime.datetime.utcfromtimestamp(os.path.getmtime(destpath))
+        tstamp = t.strftime('%a, %d %b %Y %H:%M:%S +0000')
+        request.add_header('If-Modified-Since', tstamp)
+
+    try:
+        r = urllib2.urlopen(request)
+
+        dinfo = dict(r.info())
+        for x in dinfo:
+             info[x] = dinfo[x]
+
+        info['msg'] = "OK %s octets" % info.get('Content-length', 'unknown')
+        info['status'] = 200
+    except urllib2.HTTPError as e:
+        info['msg'] = "%s" % e
+        info['status'] = e.code
+        return r, info
+    except urllib2.URLError as e:
+        info['msg'] = "URLrror %s" % e
+        if 'code' in e:
+            info['status'] = e.code
+        else:
+            info['status'] = '-1'
+        return r, info
+
+    return r, info
+
+def url_get(url, dest):
+    """Get url and store at dest. If dest is a directory, determine filename
+       from url, otherwise dest is a file
+       Return info about the request.
+    """
+
+    req, info = url_do_get(url, dest)
+
+    # TODO: should really handle 304, but how? src file could exist (and be
+    #       newer) but be empty ...
+
+    if info['status'] == 304:
+        module.exit_json(url=url, dest=info.get('destpath', dest), changed=False, msg=info.get('msg', ''))
+
+    # We have the data. Create a temporary file and copy content into that
+    # to do the MD5-thing
+
+    if info['status'] == 200:
+        destpath = info['destpath']
+
+        fd, tempname = tempfile.mkstemp()
+        f = os.fdopen(fd, 'wb')
+        shutil.copyfileobj(req, f)
+        f.close()
+        req.close()
+
+        return tempname, info
+    else:
+        msg="Source URL %s failed to transfer: httpcode=%s, msg=%s" % (url, info['status'], info['msg'])
+        module.fail_json(msg=msg)
+
+# ===========================================
+
+module = AnsibleModule(
+    argument_spec = dict(
+        url = dict(required=True),
+	dest = dict(required=True),
+    )
+)
+
+url = module.params.get('url', '')
+dest = module.params.get('dest', '')
+
+if url == "":
+    module.fail_json(msg="url= URL missing")
+if dest == "":
+    module.fail_json(msg="dest= missing")
+
+dest = os.path.expanduser(dest)
+
+try:
+    import urllib2
+except ImportError: 
+    module.fail_json(msg="urllib2 is not installed")
+import urlparse
+import socket
+
+
+# Here we go... if this succeeds, tmpsrc is the name of a temporary file
+# containing slurped content. If it fails, we've already raised an error
+# to Ansible
+
+tmpsrc, info = url_get(url, dest)
+
+md5sum_src = None
+
+dest = info.get('destpath', None)
+
+# raise an error if there is no tmpsrc file
+if not os.path.exists(tmpsrc):
+    os.remove(tmpsrc)
+    module.fail_json( msg="Source %s failed to transfer" % (tmpsrc))
+if not os.access(tmpsrc, os.R_OK):
+    os.remove(tmpsrc)
+    module.fail_json( msg="Source %s not readable" % (tmpsrc))
+md5sum_src = md5(tmpsrc)
+
+
+md5sum_dest = None
+# check if there is no dest file
+if os.path.exists(dest):
+    # raise an error if copy has no permission on dest
+    if not os.access(dest, os.W_OK):
+        os.remove(tmpsrc)
+        module.fail_json( msg="Destination %s not writable" % (dest))
+    if not os.access(dest, os.R_OK):
+        os.remove(tmpsrc)
+        module.fail_json( msg="Destination %s not readable" % (dest))
+    md5sum_dest = md5(dest)
+else:
+    if not os.access(os.path.dirname(dest), os.W_OK):
+        os.remove(tmpsrc)
+        module.fail_json( msg="Destination %s not writable" % (os.path.dirname(dest)))
+
+if md5sum_src != md5sum_dest:
+    # was os.system("cp %s %s" % (src, dest))
+    try:
+        shutil.copyfile(tmpsrc, dest)
+    except shutil.Error:
+        os.remove(tmpsrc)
+        module.fail_json( msg="failed to copy: %s and %s are the same" % (tmpsrc, dest)) 
+    except IOError:
+        os.remove(tmpsrc)
+        module.fail_json( msg="failed to copy: %s to %s" % (tmpsrc, dest)) 
+    changed = True
+else:
+    changed = False
+
+# Mission complete
+
+os.remove(tmpsrc)
+module.exit_json(url=url, dest=dest, src=tmpsrc, md5sum=md5sum_src, changed=changed, msg=info.get('msg', ''))
+


### PR DESCRIPTION
Usage: ansible -m get -a "url=http://xxxxxxx  dest=fileordirctory"

url= tested with http://, ftp://.
dest= can be a file, in which case that is used, or a directory, in which case basename of URL is used as filename.

Handling of HTTP 304 unmodified works, but I'm not terribly pleased with it: if existing file is, say, empty but newer than URL, I don't overwrite; this certainly needs work.

In fact this whole module probably needs a LOT of work by somebody who really knows Python ... ;-)
