### PR TITLE
git mkdir causes problems with older git (can't c/o to existing directory)

### DIFF
--- a/library/git
+++ b/library/git
@@ -87,7 +87,7 @@ def get_version(dest):
 def clone(repo, dest, branch):
    ''' makes a new git repo if it does not already exist '''
    try:
-       os.makedirs(dest)
+       os.makedirs(os.path.dirname(dest))
    except:
        pass
    cmd = "git clone %s %s" % (repo, dest)


### PR DESCRIPTION
Simple fix.
