### PR TITLE
Fix for issue 604

### DIFF
--- a/library/git
+++ b/library/git
@@ -148,10 +148,9 @@ def pull(repo, dest, branch):
    else:
       m = re.search( '^\s+%s$' % branch, gbranch_out, flags=re.M ) #see if we've already checked it out
       if m is None:
-         cmd = "git checkout -b %s origin/%s" % (branch, branch)
+         cmd = "git checkout --track -b %s origin/%s" % (branch, branch)
 
       else:
-         (out, err) = switchLocalBranch( branch )
          cmd = "git pull -u origin"
 
    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
Do not switch to master branch in pull()
Add --track to git checkout, when checking out a remote branch to track.

For issue #604 (magical linkage, ho!)
