### PR TITLE
Handles unix platforms that do not support inet_ntop emitting a message that breaks return json data.

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -496,11 +496,14 @@ class LinuxNetwork(Network):
             prefix = int(l[2], 16)
             str_addr = ':'.join( [ l[0][i:i+4] for i in range(0, len(l[0]), 4) ] )
             # Normalize ipv6 address from format in /proc/net/if_inet6
-            addr = socket.inet_ntop(socket.AF_INET6,
-                                    socket.inet_pton(socket.AF_INET6, str_addr))
-            self.facts[iface]['ipv6'].append( { 'address': addr,
-                                                'prefix': prefix,
-                                                'scope': scope } )
+            try:
+                addr = socket.inet_ntop(socket.AF_INET6,
+                    socket.inet_pton(socket.AF_INET6, str_addr))
+                self.facts[iface]['ipv6'].append( { 'address': addr,
+                                                    'prefix': prefix,
+                                                    'scope': scope } )
+            except socket.error:
+                return
 
 class Virtual(Facts):
     """


### PR DESCRIPTION
I was getting this error on Red Hat 5.6 boxes:

"socket.error: can't use AF_INET6, IPv6 is disabled"

This caused an ugly stackdump to be returned for each node because the JSON that was returned is invalid. The exception at the end of the stackdump is:

ValueError: No closing quotation

This patch handles it by wrapping the call in a try and if it fails it does not append its data to the ansible_facts data structure and simply returns nothing.
