### PR TITLE
AnsibleModule now correctly reads param values with '"'.

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -111,7 +111,7 @@ class AnsibleModule(object):
         items   = shlex.split(args)
         params = {}
         for x in items:
-            (k, v) = x.split("=")
+            (k, v) = x.split("=",1)
             params[k] = v
         return (params, args)        
 


### PR DESCRIPTION
Splitting param strings only on first =
