### PR TITLE
Skip get_ipv6_facts if socket.has_ipv6 is false

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -482,6 +482,8 @@ class LinuxNetwork(Network):
                     self.facts[iface]['ipv4']['network'] = socket.inet_ntoa(struct.pack("!L", ip & mask))
 
     def get_ipv6_facts(self):
+        if not socket.has_ipv6:
+            return
         data = get_file_content('/proc/net/if_inet6')
         if data is None:
             return


### PR DESCRIPTION
A possible solution for problem in issue #643.  I don't have any rhel5 systems older than 5.8 to test against.
