### PR TITLE
Devel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Ansible Changes By Release
 
 0.6 "Cabo" ------------ pending
 
+* inventory file can use a line of the form base[beg:end:step] to define a
+  set of hosts that use such a numerical range for hostnames 
 * groups variable available as a hash to return the hosts in each group name
 * fetch module now does not fail a system when requesting file paths (ex: logs) that don't exist
 * apt module now takes an optional install-recommends=yes|no (default yes)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # useful targets:
 #   make sdist ---------------- produce a tarball
 #   make rpm  ----------------- produce RPMs
-#   make debian --------------- produce a dpkg (FIXME?)
+#   make deb ------------------ produce a DEB
 #   make docs ----------------- rebuild the manpages (results are checked in)
 #   make tests ---------------- run the tests
 #   make pyflakes, make pep8 -- source code checks  

--- a/docs/man/man1/ansible.1
+++ b/docs/man/man1/ansible.1
@@ -140,7 +140,13 @@ Connection type to use\&. Possible options are
 .RE
 .SH "INVENTORY"
 .sp
-Ansible stores the hosts it can potentially operate on in an inventory file\&. The syntax is one host per line\&. Groups headers are allowed and are included on their own line, enclosed in square brackets\&.
+Ansible stores the hosts it can potentially operate on in an inventory
+file\&. The syntax is one host per line\&. Optionally, a single line can be
+used to define a set of hosts that are named using a numerical range using
+the form head[beg:end:step]tail, where if beg is left out, it defaults to
+0, and if step is left out, it defaults to 1\&. An example:
+mail[1:6:2].example.com, where 'head' is 'mail', beg is 1, end is 6, step
+is 2, and 'tail' is '.example.com'\&. Groups headers are allowed and are included on their own line, enclosed in square brackets\&.
 .SH "FILES"
 .sp
 /etc/ansible/hosts \(em Default inventory file

--- a/examples/hosts
+++ b/examples/hosts
@@ -16,6 +16,8 @@ bikeshed.org
 bastion.secure.bikeshed.org
 192.168.100.1
 192.168.100.10
+# An example for host expansion that uses default beg and step
+mail[:5].example.com
 
 # Ex 2: A collection of hosts belonging to the 'webservers' group
 [webservers]
@@ -26,6 +28,8 @@ wheel.colors.com
 192.168.1.110
 # Your personal website also runs a webserver:
 myserver.com
+# An example for host expansion that uses beg, end, and step 
+www[1:6:2].example.com
 
 # Ex 3: A collection of database servers in the 'dbservers' group
 [dbservers]
@@ -35,3 +39,5 @@ db02.intranet.mydomain.net
 10.25.1.57
 # Perhaps you serve a db off your personal server too:
 myserver.com
+# An example for host expansion that uses beg, end, and the default step 
+db[1:6]-node.example.com

--- a/lib/ansible/inventory/expand_hosts.py
+++ b/lib/ansible/inventory/expand_hosts.py
@@ -1,0 +1,130 @@
+#
+# $Id: expand_hosts.py,v 1.9 2012/07/22 16:17:57 fangchin Exp $
+#
+# (c) 2012, Zettar Inc.
+# Written by Chin Fang <fangchin@zettar.com>
+#
+# This file is part of Ansible
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+#
+'''
+This module is for enhancing ansible's inventory parsing capability such
+that it can deal with hostnames specified using a simple pattern in the
+form of [beg:end:step], example: [1:5:2] where if beg is not specified, it
+defaults to 0. If step is not specified, it defaults to 1.
+'''
+import sys
+from pprint import pprint
+
+def detect_range(line = None):
+    '''
+    A helper function that checks a given line to see if it contains
+    a range pattern. The following are examples:
+
+    o node[1:6]
+    o node[1:6:2]
+    o node[1:6].example.com
+    o node[1:6:2].example.com
+    o node[1:6]-webserver
+    o node[1:6:2]-database
+
+    Returnes True if the given line contains a pattern, else False.
+    '''
+    if (not line.startswith("[") and 
+        line.lstrip().find("[") != -1 and 
+        (line.rstrip().endswith("]") or
+         line.rstrip().find("]") != -1) and
+        line.index("[") < line.index("]")):   
+        return True
+    else:
+        return False
+        
+def expand_hostname_range(line = None):
+    '''
+    A helper function that expands a given line that contains a pattern
+    specified in def detect_range, and returns a list that consists
+    of the expanded version.
+
+    The '[' and ']' characters are used to maintain the pseudo-code
+    appearance. They are replaced in this function with '|' to ease
+    the string splitting.
+
+    References: http://ansible.github.com/patterns.html#hosts-and-groups
+    '''
+    all_hosts = []
+    if line:
+        # A hostname such as node[1:6:2]-webserver is considered to consists
+        # three parts: 
+        # head: 'node'
+        # nrange: [1:6:2]
+        # tail: '-webserver'
+        
+        (head, nrange, tail) = line.replace('[','|').replace(']','|').split('|')
+        bounds = nrange.split(":")
+        lbounds = len(bounds)
+        beg = bounds[0]
+        end = bounds[1]
+        lbounds = len(bounds)
+        if lbounds == 2:
+            step = 1
+        elif lbounds == 3:
+            step = bounds[2]
+        else:
+            raise ValueError("host range incorrectly specified!")
+        
+        if not beg:
+            beg = "0"
+            
+        if not end:
+            raise ValueError("host range incorrectly specified!")
+            
+        if not step:
+            step = "1"
+               
+        for _ in range(int(beg), int(end), int(step)):
+            hname = ''.join((head, str(_), tail))
+            all_hosts.append(hname)
+                   
+        return all_hosts
+
+def main():
+    '''
+    A function for self-testing.
+    '''
+    test_data = ["mail.example.com",
+                 "www.example.com",
+                 "db.example.com",
+                 "node[:6]", 
+                 "node[1:6]",
+                 "node[1:6:2]",
+                 "node[:5].example.com",
+                 "node[1:6].example.com",
+                 "node[1:6:2].example.com",
+                 "node[:6]-webserver", 
+                 "node[1:6]-webserver",
+                 "node[1:6:2]-webserver"]
+
+    for data in test_data:
+        print "===> testing %s..." % data
+        if detect_range(data):
+            all_hosts = expand_hostname_range(data)
+            pprint(all_hosts)
+        else:
+            print data
+
+    return 0
+    
+if __name__ == '__main__':
+    sys.exit(main())

--- a/lib/ansible/inventory/expand_hosts.py
+++ b/lib/ansible/inventory/expand_hosts.py
@@ -30,7 +30,7 @@ from pprint import pprint
 
 def detect_range(line = None):
     '''
-    A helper function that checks a given line to see if it contains
+    A helper function that checks a given host line to see if it contains
     a range pattern. The following are examples:
 
     o node[1:6]
@@ -43,10 +43,10 @@ def detect_range(line = None):
     Returnes True if the given line contains a pattern, else False.
     '''
     if (not line.startswith("[") and 
-        line.lstrip().find("[") != -1 and 
-        (line.rstrip().endswith("]") or
-         line.rstrip().find("]") != -1) and
-        line.index("[") < line.index("]")):   
+        line.find("[") != -1 and 
+        line.find(":") != -1 and
+        line.find("]") != -1 and
+        line.index("[") < line.index(":") < line.index("]")):   
         return True
     else:
         return False
@@ -59,17 +59,17 @@ def expand_hostname_range(line = None):
 
     The '[' and ']' characters are used to maintain the pseudo-code
     appearance. They are replaced in this function with '|' to ease
-    the string splitting.
+    string splitting.
 
     References: http://ansible.github.com/patterns.html#hosts-and-groups
     '''
     all_hosts = []
     if line:
-        # A hostname such as node[1:6:2]-webserver is considered to consists
+        # A hostname such as db[1:6:2]-node is considered to consists
         # three parts: 
-        # head: 'node'
-        # nrange: [1:6:2]
-        # tail: '-webserver'
+        # head: 'db'
+        # nrange: [1:6:2]; range is a built-in. Can't use the name
+        # tail: '-node'
         
         (head, nrange, tail) = line.replace('[','|').replace(']','|').split('|')
         bounds = nrange.split(":")
@@ -103,7 +103,12 @@ def main():
     '''
     A function for self-testing.
     '''
-    test_data = ["mail.example.com",
+    test_data = ["[webservers]",
+                 "[dbservers]",
+                 "[webservers:!phoenix]",
+                 "[atlanta:vars]",
+                 "[southeast:childern]",
+                 "mail.example.com",
                  "www.example.com",
                  "db.example.com",
                  "node[:6]", 
@@ -122,7 +127,7 @@ def main():
             all_hosts = expand_hostname_range(data)
             pprint(all_hosts)
         else:
-            print data
+            print "!!! Not expanded!!! %s" % data
 
     return 0
     

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -86,7 +86,8 @@ class InventoryParser(object):
                 # Two cases to check:
                 # 0. A hostname that contains a range pesudo-code and a port
                 # 1. A hostname that contains just a port
-                if (hostname.find("]") != -1 and 
+                if (hostname.find("[") != -1 and
+                    hostname.find("]") != -1 and
                     hostname.find(":") != -1 and
                     (hostname.rindex("]") < hostname.rindex(":")) or
                     (hostname.find("]") == -1 and hostname.find(":") != -1)):


### PR DESCRIPTION
# Summary

This is a small enhancement to the latest ansible devel in response to the mailing list post [simple pattern in /etc/ansible/hosts file so as to be DRY?](https://groups.google.com/forum/#!topic/ansible-project/SJ-1QIyYtHc).  The enhancement enables the use of a host line in the inventory file with the format `base[beg:end:step]tail`.  For example, in `data[1:6:2]-node.example.com`, `data` is the base, `beg` is 1, `end` is 6, `step` is 2, and `-node.example.com` is the tail. If left out, `beg` defaults to 0, and `step` defaults to 1.

Note that since YAML inventory format is deprecated, so I only did the enhancement to the `lib/ansible/inventory/ini.py`.  I also added a small module `lib/ansible/inventory/expand_hosts.py` with integrated self-tests.
# Details

I have followed the instructions in the `README.md` closely. After the enhancements, `make tests` still all pass.  The following is a list of files that I have changed:
1. `CHANGELOG.md` - added a brief description about what has been done.
2. `Makefile` - fixed the instruction for making a deb package
3. `docs/man/man1/ansible.1` - updated the **INVENTORY** sub-section.
4. `example/hosts` - updated with a few additional examples
5. `lib/ansible/inventory/expand_hosts.py` - the aforementioned small module
6. `lib/ansible/inventory/ini.py` - added necessary import statements and additional checks in `_parse_base_groups(self)`

Thanks for creating this wonderful tool.  I hope you find this enhancement good enough to be included in the distribution.

Regards,

Chin Fang, Zettar Inc.
