### PR TITLE
Support for angry (i.e. failed) cows

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -26,6 +26,7 @@ if os.path.exists("/usr/bin/cowsay"):
     cowsay = "/usr/bin/cowsay"
 elif os.path.exists("/usr/games/cowsay"):
     cowsay = "/usr/games/cowsay"
+cowvoice = voice = os.getenv("ANSIBLE_COWVOICE", "flaming-sheep")
 
 class AggregateStats(object):
     ''' holds stats about per-host activity during playbook runs '''   
@@ -88,10 +89,10 @@ def regular_generic_msg(hostname, result, oneline, caption):
         return "%s | %s >> %s\n" % (hostname, caption, utils.jsonify(result))
 
 
-def banner(msg):
+def banner(msg, opts=""):
 
     if cowsay != None:
-        cmd = subprocess.Popen("%s -W 60 \"%s\"" % (cowsay, msg), 
+        cmd = subprocess.Popen("%s %s -W 60 \"%s\"" % (cowsay, opts, msg), 
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         (out, err) = cmd.communicate()
         return "%s\n" % out 
@@ -261,6 +262,8 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
 
         item = results.get('item', None)
 
+        msg = "FAILED: [%s] => (item=%s) => %s" % (host, item, utils.jsonify(results))
+        print banner(msg, opts="-d -f \"%s\"" % cowvoice)
         if item:
             print "failed: [%s] => (item=%s) => %s" % (host, item, utils.jsonify(results))
         else:

--- a/library/file
+++ b/library/file
@@ -135,7 +135,7 @@ if not len(items):
 
 params = {}
 for x in items:
-    (k, v) = x.split("=")
+    (k, v) = x.split("=",1)
     params[k] = v
 
 state     = params.get('state','file')

--- a/library/get_url
+++ b/library/get_url
@@ -60,7 +60,7 @@ def url_do_get(module, url, dest):
 
     if os.path.isdir(dest):
         urlfilename = url_filename(url)
-        actualdest = "%s/%s" % (dest, url_filename(url))
+        actualdest = "%s/%s" % (dest, urlfilename)
         module.params['path'] = actualdest
     else:
          actualdest = dest


### PR DESCRIPTION
One of Ansible's _wow_ (or should I say: cow?) features is support for _cowsay_. Unfortunately, failed tasks still had smiling cows. This patch fixes that: )

```
 ___________________________________________________________ 
/ FAILED: [127.0.0.1] => (item=None) => {failed: true, msg: \
\ Destination /tmp/u//yyy.cgi not writable}                 /
 ----------------------------------------------------------- 
  \            .    .     .   
   \      .  . .     `  ,     
    \    .; .  : .' :  :  : . 
     \   i..`: i` i.i.,i  i . 
      \   `,--.|i |i|ii|ii|i: 
           UxxU\.'@@@@@@`.||' 
           \__/(@@@@@@@@@@)'  
                (@@@@@@@@)    
                `YY~~~~YY'    
                 ||    ||     
```

If `$ANSIBLE_COWVOICE` is set, that is used instead: e.g.: `export ANSIBLE_COWVOICE=dragon`

```

 ___________________________________________________________ 
/ FAILED: [127.0.0.1] => (item=None) => {failed: true, msg: \
\ Destination /tmp/u//yyy.cgi not writable}                 /
 ----------------------------------------------------------- 
      \                    / \  //\
       \    |\___/|      /   \//  \\
            /0  0  \__  /    //  | \ \    
           /     /  \/_/    //   |  \  \  
           @_^_@'/   \/_   //    |   \   \ 
           //_^_/     \/_ //     |    \    \
        ( //) |        \///      |     \     \
      ( / /) _|_ /   )  //       |      \     _\
    ( // /) '/,_ _ _/  ( ; -.    |    _ _\.-~        .-~~~^-.
  (( / / )) ,-{        _      `-.|.-~-.           .~         `.
 (( // / ))  '/\      /                 ~-. _ .-~      .-~^-.  \
 (( /// ))      `.   {            }                   /      \  \
  (( / ))     .----~-.\        \-'                 .~         \  `. \^-.
             ///.----..>        \             _ -~             `.  ^-`  ^-_
               ///-._ _ _ _ _ _ _}^ - - - - ~                     ~-- ,.-~
                                                                  /.-~

```
