### PR TITLE
Support for colors in ansible-playbook

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -18,6 +18,7 @@
 
 #######################################################
 
+import os
 import sys
 import getpass
 
@@ -26,6 +27,60 @@ import ansible.constants as C
 from ansible import errors
 from ansible import callbacks
 from ansible import utils
+
+ANSIBLE_COLOR=True
+if os.getenv("ANSIBLE_NOCOLOR") is not None:
+    ANSIBLE_COLOR=False
+if not sys.stdout.isatty():
+    ANSIBLE_COLOR=False
+
+# --- begin "pretty"
+#
+# pretty - A miniature library that provides a Python print and stdout
+# wrapper that makes colored terminal text easier to use (eg. without
+# having to mess around with ANSI escape sequences). This code is public
+# domain - there is no license except that you must leave this header.
+#
+# Copyright (C) 2008 Brian Nez <thedude at bri1 dot com>
+#
+# http://nezzen.net/2008/06/23/colored-text-in-python-using-ansi-escape-sequences/
+
+
+codeCodes = {
+    'black':     '0;30',        'bright gray':    '0;37',
+    'blue':      '0;34',        'white':          '1;37',
+    'green':     '0;32',        'bright blue':    '1;34',
+    'cyan':      '0;36',        'bright green':   '1;32',
+    'red':       '0;31',        'bright cyan':    '1;36',
+    'purple':    '0;35',        'bright red':     '1;31',
+    'yellow':    '0;33',        'bright purple':  '1;35',
+    'dark gray': '1;30',        'bright yellow':  '1;33',
+    'normal':    '0'
+}
+
+def stringc(text, color):
+    """String in color."""
+    if ANSIBLE_COLOR:
+        return "\033["+codeCodes[color]+"m"+text+"\033[0m"
+    else:
+        return text
+# --- end "pretty"
+
+def colorize(lead, num, color):
+    """Print `lead' = `num' in `color'"""
+    if num == 0:
+        color='black';
+    if ANSIBLE_COLOR:
+        return "%s%s%-15s" % (stringc(lead, color), stringc("=", color), stringc(str(num), color))
+    else:
+        return "%s=%-4s" % (lead, str(num))
+
+def hostcolor(host, t):
+    if ANSIBLE_COLOR:
+        if t['failures'] != 0 or t['unreachable'] != 0:
+            return "%-41s" % stringc(host, 'red')
+    return "%-30s" % host
+
 
 def main(args):
     ''' run ansible-playbook operations '''
@@ -91,9 +146,13 @@ def main(args):
             print callbacks.banner("PLAY RECAP")
             for h in hosts:
                 t = pb.stats.summarize(h)
-                print "%-30s : ok=%-4s changed=%-4s unreachable=%-4s failed=%-4s " % (h, 
-                   t['ok'], t['changed'], t['unreachable'], t['failures']
-                )
+		print "%-30s : %s %s %s %s " % (
+			hostcolor(h, t),
+			colorize('ok', t['ok'], 'green'),
+			colorize('changed', t['changed'], 'yellow'),
+			colorize('unreachable', t['unreachable'], 'red'),
+			colorize('failed', t['failures'], 'red'))
+
             print "\n"
 
         except errors.AnsibleError, e:


### PR DESCRIPTION
Result looks like this:

![demo](http://666kb.com/i/c5sa2hncu96sue2dd.jpg)

failed and unreachable hosts are marked red.

Would have preferred decent termcap/terminfo library but didn't want to add to Ansible's requirements, which is why I settled for ESC sequences. (_sigh_)
