### PR TITLE
Change modules to use credentials in my.cnf if they are available

### DIFF
--- a/library/mysql_db
+++ b/library/mysql_db
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+import ConfigParser
 try:
     import MySQLdb
 except ImportError:
@@ -43,6 +44,16 @@ def db_create(cursor, db):
     res = cursor.execute(query)
     return True
 
+def load_mycnf():
+    config = ConfigParser.RawConfigParser()
+    mycnf = os.path.expanduser('~/.my.cnf')
+    config.read(mycnf)
+    try:
+        creds = dict(user=config.get('client', 'user'),passwd=config.get('client', 'pass'))
+    except ConfigParser.NoOptionError:
+        return False
+    return creds
+
 # ===========================================
 # Module execution.
 #
@@ -50,8 +61,8 @@ def db_create(cursor, db):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            loginuser=dict(default="root"),
-            loginpass=dict(default=""),
+            loginuser=dict(default=None),
+            loginpass=dict(default=None),
             loginhost=dict(default="localhost"),
             db=dict(required=True),
             state=dict(default="present", choices=["absent", "present"]),
@@ -63,13 +74,29 @@ def main():
 
     db = module.params["db"]
     state = module.params["state"]
-    changed = False
+
+    # Either the caller passes both a username and password with which to connect to
+    # mysql, or they pass neither and allow this module to read the credentials from
+    # ~/.my.cnf.
+    loginpass = module.params["loginpass"]
+    loginuser = module.params["loginuser"]
+    if loginuser is None and loginpass is None:
+        mycnf_creds = load_mycnf()
+        if mycnf_creds is False:
+            module.fail_json(msg="incomplete login arguments passed and can't find them in ~/.my.cnf")
+        else:
+            loginuser = mycnf_creds["user"]
+            loginpass = mycnf_creds["passwd"]
+    elif loginpass is None or loginuser is None:
+        module.fail_json(msg="when supplying login arguments, both user and pass must be provided")
+
     try:
-        db_connection = MySQLdb.connect(host=module.params["loginhost"], user=module.params["loginuser"], passwd=module.params["loginpass"], db="mysql")
+        db_connection = MySQLdb.connect(host=module.params["loginhost"], user=loginuser, passwd=loginpass, db="mysql")
         cursor = db_connection.cursor()
     except Exception as e:
         module.fail_json(msg="unable to connect to database")
 
+    changed = False
     if db_exists(cursor, db):
         if state == "absent":
             changed = db_delete(cursor, db)

--- a/library/mysql_db
+++ b/library/mysql_db
@@ -47,10 +47,10 @@ def db_create(cursor, db):
 def load_mycnf():
     config = ConfigParser.RawConfigParser()
     mycnf = os.path.expanduser('~/.my.cnf')
-    config.read(mycnf)
     try:
+        config.readfp(open(mycnf))
         creds = dict(user=config.get('client', 'user'),passwd=config.get('client', 'pass'))
-    except ConfigParser.NoOptionError:
+    except (ConfigParser.NoOptionError, IOError):
         return False
     return creds
 

--- a/library/mysql_db
+++ b/library/mysql_db
@@ -78,20 +78,20 @@ def main():
     # Either the caller passes both a username and password with which to connect to
     # mysql, or they pass neither and allow this module to read the credentials from
     # ~/.my.cnf.
-    loginpass = module.params["loginpass"]
+    loginpasswd = module.params["loginpasswd"]
     loginuser = module.params["loginuser"]
-    if loginuser is None and loginpass is None:
+    if loginuser is None and loginpasswd is None:
         mycnf_creds = load_mycnf()
         if mycnf_creds is False:
             module.fail_json(msg="incomplete login arguments passed and can't find them in ~/.my.cnf")
         else:
             loginuser = mycnf_creds["user"]
-            loginpass = mycnf_creds["passwd"]
-    elif loginpass is None or loginuser is None:
+            loginpasswd = mycnf_creds["passwd"]
+    elif loginpasswd is None or loginuser is None:
         module.fail_json(msg="when supplying login arguments, both user and pass must be provided")
 
     try:
-        db_connection = MySQLdb.connect(host=module.params["loginhost"], user=loginuser, passwd=loginpass, db="mysql")
+        db_connection = MySQLdb.connect(host=module.params["loginhost"], user=loginuser, passwd=loginpasswd, db="mysql")
         cursor = db_connection.cursor()
     except Exception as e:
         module.fail_json(msg="unable to connect to database")

--- a/library/mysql_db
+++ b/library/mysql_db
@@ -62,7 +62,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             loginuser=dict(default=None),
-            loginpass=dict(default=None),
+            loginpasswd=dict(default=None),
             loginhost=dict(default="localhost"),
             db=dict(required=True),
             state=dict(default="present", choices=["absent", "present"]),

--- a/library/mysql_db
+++ b/library/mysql_db
@@ -47,6 +47,8 @@ def db_create(cursor, db):
 def load_mycnf():
     config = ConfigParser.RawConfigParser()
     mycnf = os.path.expanduser('~/.my.cnf')
+    if not os.path.exists(mycnf):
+        return False
     try:
         config.readfp(open(mycnf))
         creds = dict(user=config.get('client', 'user'),passwd=config.get('client', 'pass'))

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -187,20 +187,20 @@ def main():
     # Either the caller passes both a username and password with which to connect to
     # mysql, or they pass neither and allow this module to read the credentials from
     # ~/.my.cnf.
-    loginpass = module.params["loginpass"]
+    loginpasswd = module.params["loginpasswd"]
     loginuser = module.params["loginuser"]
-    if loginuser is None and loginpass is None:
+    if loginuser is None and loginpasswd is None:
         mycnf_creds = load_mycnf()
         if mycnf_creds is False:
             module.fail_json(msg="incomplete login arguments passed and can't find them in ~/.my.cnf")
         else:
             loginuser = mycnf_creds["user"]
-            loginpass = mycnf_creds["passwd"]
-    elif loginpass is None or loginuser is None:
+            loginpasswd = mycnf_creds["passwd"]
+    elif loginpasswd is None or loginuser is None:
         module.fail_json(msg="when supplying login arguments, both user and pass must be provided")
 
     try:
-        db_connection = MySQLdb.connect(host=module.params["loginhost"], user=loginuser, passwd=loginpass, db="mysql")
+        db_connection = MySQLdb.connect(host=module.params["loginhost"], user=loginuser, passwd=loginpasswd, db="mysql")
         cursor = db_connection.cursor()
     except Exception as e:
         module.fail_json(msg="unable to connect to database")

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -145,10 +145,10 @@ def privileges_grant(cursor, user,host,db_table,priv):
 def load_mycnf():
     config = ConfigParser.RawConfigParser()
     mycnf = os.path.expanduser('~/.my.cnf')
-    config.read(mycnf)
     try:
+        config.readfp(open(mycnf))
         creds = dict(user=config.get('client', 'user'),passwd=config.get('client', 'pass'))
-    except ConfigParser.NoOptionError:
+    except (ConfigParser.NoOptionError, IOError):
         return False
     return creds
 

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+import ConfigParser
 try:
     import MySQLdb
 except ImportError:
@@ -141,6 +142,16 @@ def privileges_grant(cursor, user,host,db_table,priv):
     query = "GRANT %s ON %s TO '%s'@'%s'" % (priv_string,db_table,user,host)
     cursor.execute(query)
 
+def load_mycnf():
+    config = ConfigParser.RawConfigParser()
+    mycnf = os.path.expanduser('~/.my.cnf')
+    config.read(mycnf)
+    try:
+        creds = dict(user=config.get('client', 'user'),passwd=config.get('client', 'pass'))
+    except ConfigParser.NoOptionError:
+        return False
+    return creds
+
 # ===========================================
 # Module execution.
 #
@@ -148,8 +159,8 @@ def privileges_grant(cursor, user,host,db_table,priv):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            loginuser=dict(default="root"),
-            loginpass=dict(default=""),
+            loginuser=dict(default=None),
+            loginpass=dict(default=None),
             loginhost=dict(default="localhost"),
             user=dict(required=True),
             passwd=dict(default=None),
@@ -173,8 +184,23 @@ def main():
         except:
             module.fail_json(msg="invalid privileges string")
 
+    # Either the caller passes both a username and password with which to connect to
+    # mysql, or they pass neither and allow this module to read the credentials from
+    # ~/.my.cnf.
+    loginpass = module.params["loginpass"]
+    loginuser = module.params["loginuser"]
+    if loginuser is None and loginpass is None:
+        mycnf_creds = load_mycnf()
+        if mycnf_creds is False:
+            module.fail_json(msg="incomplete login arguments passed and can't find them in ~/.my.cnf")
+        else:
+            loginuser = mycnf_creds["user"]
+            loginpass = mycnf_creds["passwd"]
+    elif loginpass is None or loginuser is None:
+        module.fail_json(msg="when supplying login arguments, both user and pass must be provided")
+
     try:
-        db_connection = MySQLdb.connect(host=module.params["loginhost"], user=module.params["loginuser"], passwd=module.params["loginpass"], db="mysql")
+        db_connection = MySQLdb.connect(host=module.params["loginhost"], user=loginuser, passwd=loginpass, db="mysql")
         cursor = db_connection.cursor()
     except Exception as e:
         module.fail_json(msg="unable to connect to database")

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -145,6 +145,8 @@ def privileges_grant(cursor, user,host,db_table,priv):
 def load_mycnf():
     config = ConfigParser.RawConfigParser()
     mycnf = os.path.expanduser('~/.my.cnf')
+    if not os.path.exists(mycnf):
+        return False
     try:
         config.readfp(open(mycnf))
         creds = dict(user=config.get('client', 'user'),passwd=config.get('client', 'pass'))

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -160,7 +160,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             loginuser=dict(default=None),
-            loginpass=dict(default=None),
+            loginpasswd=dict(default=None),
             loginhost=dict(default="localhost"),
             user=dict(required=True),
             passwd=dict(default=None),


### PR DESCRIPTION
We now force a user to either provide _both_ a username and password, or neither. If neither are passed, attempt to load credentials from ~/.my.cnf in the same way that the mysql command line tool would.
