### PR TITLE
Fixes for OS X tests

### DIFF
--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -128,7 +128,7 @@ class TestRunner(unittest.TestCase):
         assert result['stdout'] == 'hi'
         assert result['stderr'] == ''
 
-        result = self._run('command', [ "/bin/false" ])
+        result = self._run('command', [ "false" ])
         assert result['rc'] == 1
         assert 'failed' not in result
 

--- a/test/playbook1.yml
+++ b/test/playbook1.yml
@@ -18,10 +18,10 @@
   tasks:
 
   - name: test basic success command
-    action: command /bin/true
+    action: command true
 
   - name: test basic success command 2
-    action: command /bin/true
+    action: command true
 
   - name: test basic shell, plus two ways to dereference a variable
     action: shell echo $HOME $port {{ port }}


### PR DESCRIPTION
OS X has true and false in /usr/bin rather than /bin

These changes just allow the system to find true and false as normal from $PATH - so I've changed e.g. command /bin/true to command true
