### PR TITLE
Fixes for git module when it fails.

### DIFF
--- a/library/git
+++ b/library/git
@@ -165,24 +165,24 @@ def main():
     if not os.path.exists(gitconfig):
         (rc, out, err) = clone(repo, dest)
         if rc != 0:
-            module.fail_json(out=out, err=err, rc=rc)
+            module.fail_json(msg=err)
     else:
         # else do a pull   
         before = get_version(dest)
         (rc, out, err) = reset(dest)
         if rc != 0:
-            module.fail_json(out=out, err=err, rc=rc)
+            module.fail_json(msg=err)
         (rc, out, err) = pull(module, repo, dest, version)
 
     # handle errors from clone or pull
     if out.find('error') != -1 or err.find('ERROR') != -1:
-        module.fail_json(out=out, err=err)
+        module.fail_json(msg=err)
 
     # switch to version specified regardless of whether
     # we cloned or pulled
     (rc, out, err) = switch_version(module, dest, remote, version)
     if err.find('error') != -1:
-        module.fail_json(out=out, err=err)
+        module.fail_json(msg=err)
 
     # determine if we changed anything
     after = get_version(dest)

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -191,7 +191,7 @@ class TestRunner(unittest.TestCase):
     def test_git(self):
         if not get_binary("yum"):
             raise SkipTest
-        repo = 'git://github.com/ansible/ansible.git'
+        repo = 'http://github.com/ansible/ansible.git'
         dest = tempfile.mkdtemp()
         result = self._run('git', ['repo=%s' % repo, 'dest=%s' % dest])
         assert 'failed' not in result


### PR DESCRIPTION
module.fail_json arguments were missing a msg
Also repointing test at http://github.com/ as that gets through more corporate firewalls
