### PR TITLE
Allow copy dest argument to be a directory

### DIFF
--- a/library/copy
+++ b/library/copy
@@ -45,6 +45,9 @@ def main():
             module.fail_json(msg="Destination %s not writable" % (dest))
         if not os.access(dest, os.R_OK):
             module.fail_json(msg="Destination %s not readable" % (dest))
+        # Allow dest to be directory without compromising md5 check
+        if (os.path.isdir(dest)):
+            dest = os.join(dest, os.path.basename(src))
         md5sum_dest = module.md5(dest)
     else:
         if not os.access(os.path.dirname(dest), os.W_OK):


### PR DESCRIPTION
Could have used shutil.copy rather than shutil.copyfile, but this
implementation preserves the md5 comparison to avoid unnecessary copies
