### PR TITLE
Apt module: add update-cache as alias of update_cache

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -109,7 +109,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             state = dict(default='installed', choices=['installed', 'latest', 'removed']),
-            update_cache = dict(default='no', choices=['yes', 'no']),
+            update_cache = dict(default='no', choices=['yes', 'no'], aliases=['update-cache']),
             purge = dict(default='no', choices=['yes', 'no']),
             package = dict(default=None, aliases=['pkg', 'name']),
             default_release = dict(default=None, aliases=['default-release']),


### PR DESCRIPTION
This will ensure users of previous versions of this module don't have their playbooks break.
