### PR TITLE
concatenating stdout and stderr in runner/__init__'s _low_level_exec_command

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -616,9 +616,16 @@ class Runner(object):
         stdin, stdout, stderr = conn.exec_command(cmd, tmp, sudo_user, sudoable=sudoable)
 
         if type(stdout) != str:
-            return "\n".join(stdout.readlines())
+            out = "\n".join(stdout.readlines())
         else:
-            return stdout
+            out = stdout
+        
+        if type(stderr) != str:
+            err = "\n".join(stderr.readlines())
+        else:
+            err = stderr
+
+        return out + err
 
     # *****************************************************
 


### PR DESCRIPTION
This patches #740. It still returns a failed to parse error though more gracefully.
