### PR TITLE
fixing test_one

### DIFF
--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -33,7 +33,7 @@ class TestCallbacks(object):
     def on_setup(self):
         EVENTS.append([ 'primary_setup' ])
  
-    def on_skipped(self, host):
+    def on_skipped(self, host, item=None):
         EVENTS.append([ 'skipped', [ host ]])
 
     def on_import_for_host(self, host, filename):


### PR DESCRIPTION
Added an extra item parameter to on_skipped callback in TestCallbacks to prevent it (silently) failing at the skipped task, which then causes the remaining on change handlers to not fire.
