### PR TITLE
Allow = symbols in variable values in host inventory

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -168,7 +168,7 @@ class InventoryParser(object):
                 if line.find("=") == -1:
                     raise errors.AnsibleError("variables assigned to group must be in key=value form")
                 else:
-                    (k,v) = line.split("=")
+                    (k,v) = line.split("=",1)
                     group.set_variable(k,v)
 
 


### PR DESCRIPTION
Setting a variable in the host inventory file to an ssh authorized key causes this error:

```
.../ansible/lib/ansible/inventory/ini.py", line 171, in _parse_group_variables
    (k,v) = line.split("=")
ValueError: too many values to unpack
```

Resolved by using `split("=",1)`.
