### PR TITLE
added su capability

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -77,11 +77,15 @@ class Cli(object):
         sudopass = None
         if options.ask_pass:
             sshpass = getpass.getpass(prompt="SSH password: ")
-        if options.ask_sudo_pass:
+        if options.su:
+            sudopass = getpass.getpass(
+                prompt="%s password: " % options.sudo_user)
+        elif options.ask_sudo_pass:
             sudopass = getpass.getpass(prompt="sudo password: ")
             options.sudo = True
-        if options.sudo_user:
+        if options.sudo_user and not options.su:
             options.sudo = True
+
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
         if options.tree:
             utils.prepare_writeable_dir(options.tree)
@@ -93,7 +97,7 @@ class Cli(object):
             inventory=inventory_manager, timeout=options.timeout, 
             private_key_file=options.private_key_file,
             forks=options.forks, 
-            pattern=pattern, 
+            pattern=pattern, su=options.su,
             callbacks=self.callbacks, sudo=options.sudo, 
             sudo_pass=sudopass,sudo_user=options.sudo_user,
             transport=options.connection, verbose=options.verbose

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -68,10 +68,13 @@ def main(args):
     sudopass = None
     if options.ask_pass:
         sshpass = getpass.getpass(prompt="SSH password: ")
-    if options.ask_sudo_pass:
+    if options.su:
+        sudopass = getpass.getpass(
+            prompt="%s password: " % options.sudo_user)
+    elif options.ask_sudo_pass:
         sudopass = getpass.getpass(prompt="sudo password: ")
         options.sudo = True
-    if options.sudo_user:
+    if options.sudo_user and not options.su:
         options.sudo = True
     options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
     extra_vars = utils.parse_kv(options.extra_vars)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -55,6 +55,7 @@ class PlayBook(object):
         callbacks        = None,
         runner_callbacks = None,
         stats            = None,
+        su               = False,
         sudo             = False,
         sudo_user        = C.DEFAULT_SUDO_USER,
         extra_vars       = None,
@@ -75,6 +76,7 @@ class PlayBook(object):
         runner_callbacks: more callbacks, this time for the runner API
         stats:            holds aggregrate data about events occuring to each host
         sudo:             if not specified per play, requests all plays use sudo mode
+        su:               if not specified per play, requests all plays use su mode
         """
 
         self.SETUP_CACHE = SETUP_CACHE
@@ -98,6 +100,7 @@ class PlayBook(object):
         self.callbacks        = callbacks
         self.runner_callbacks = runner_callbacks
         self.stats            = stats
+        self.su               = su
         self.sudo             = sudo
         self.sudo_pass        = sudo_pass
         self.sudo_user        = sudo_user

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -28,7 +28,7 @@ class Play(object):
     __slots__ = [ 
        'hosts', 'name', 'vars', 'vars_prompt', 'vars_files', 
        'handlers', 'remote_user', 'remote_port',
-       'sudo', 'sudo_user', 'transport', 'playbook', 
+       'su', 'sudo', 'sudo_user', 'transport', 'playbook', 
        'tags', 'gather_facts', '_ds', '_handlers', '_tasks'
     ]
 
@@ -37,7 +37,7 @@ class Play(object):
     VALID_KEYS = [
        'hosts', 'name', 'vars', 'vars_prompt', 'vars_files',
        'tasks', 'handlers', 'user', 'port', 'include',
-       'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts'
+       'su', 'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts'
     ]
 
     # *************************************************
@@ -70,6 +70,7 @@ class Play(object):
         self._handlers    = ds.get('handlers', [])
         self.remote_user  = ds.get('user', self.playbook.remote_user)
         self.remote_port  = ds.get('port', self.playbook.remote_port)
+        self.su           = ds.get('su', self.playbook.su)
         self.sudo         = ds.get('sudo', self.playbook.sudo)
         self.sudo_user    = ds.get('sudo_user', self.playbook.sudo_user)
         self.transport    = ds.get('connection', self.playbook.transport)
@@ -88,7 +89,7 @@ class Play(object):
         elif type(self.tags) != list:
             self.tags = []
 
-        if self.sudo_user != 'root':
+        if self.sudo_user != 'root' and not self.su:
             self.sudo = True
 
     # *************************************************

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -124,6 +124,7 @@ class Runner(object):
         callbacks=None,                     # used for output
         verbose=False,                      # whether to show more or less
         sudo=False,                         # whether to run sudo or not
+        su=False,                           # whether to run su or not
         sudo_user=C.DEFAULT_SUDO_USER,      # ex: 'root'
         module_vars=None,                   # a playbooks internals thing 
         is_playbook=False,                  # running from playbook or not?
@@ -154,6 +155,7 @@ class Runner(object):
         self.private_key_file = private_key_file
         self.background       = background
         self.sudo             = sudo
+        self.su               = su
         self.sudo_pass        = sudo_pass
         self.is_playbook      = is_playbook
 
@@ -211,7 +213,7 @@ class Runner(object):
 
         (remote_module_path, is_new_style) = self._copy_module(conn, tmp, module_name, inject)
         cmd = "chmod +x %s" % remote_module_path
-        if self.sudo and self.sudo_user != 'root':
+        if (self.sudo or self.su) and self.sudo_user != 'root':
             # deal with possible umask issues once sudo'ed to other user
             cmd = "chmod 555 %s" % remote_module_path
         self._low_level_exec_command(conn, cmd, tmp)
@@ -645,7 +647,7 @@ class Runner(object):
         basetmp = os.path.join(C.DEFAULT_REMOTE_TMP, basefile)
         if self.remote_user == 'root':
             basetmp = os.path.join('/var/tmp', basefile)
-        elif self.sudo and self.sudo_user != 'root':
+        elif (self.sudo or self.su) and self.sudo_user != 'root':
             basetmp = os.path.join('/tmp', basefile)
 
         cmd = 'mkdir -p %s' % basetmp

--- a/lib/ansible/runner/connection/local.py
+++ b/lib/ansible/runner/connection/local.py
@@ -36,13 +36,20 @@ class LocalConnection(object):
     def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False):
         ''' run a command on the local host '''
 
-        if self.runner.sudo and sudoable:
+        if (self.runner.sudo or self.runner.su) and sudoable:
+            if self.runner.su:
+                # handle the password somehow
+                raise errors.AnsibleError("no current way to handle the password dialogue without using pexpect")
             if self.runner.sudo_pass:
                 # NOTE: if someone wants to add sudo w/ password to the local connection type, they are welcome
                 # to do so.  The primary usage of the local connection is for crontab and kickstart usage however
                 # so this doesn't seem to be a huge priority
-                raise errors.AnsibleError("sudo with password is presently only supported on the paramiko (SSH) connection type")
-            cmd = "sudo -s %s" % cmd
+                if self.runner.sudo:
+                    raise errors.AnsibleError("sudo with password is presently only supported on the paramiko (SSH) connection type")
+            if self.runner.sudo:
+                cmd = "sudo -u {0} -s {1}".format(sudo_user, cmd)
+            if self.runner.su:
+                cmd = "su {0} -c {1}".format(sudo_user, cmd)
 
         p = subprocess.Popen(cmd, shell=True, stdin=None,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -315,6 +315,8 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False, asyn
         parser.add_option('-u', '--user', default=constants.DEFAULT_REMOTE_USER,
             dest='remote_user', 
             help='connect as this user (default=%s)' % constants.DEFAULT_REMOTE_USER)
+        parser.add_option('-S', '--su', default=False, action="store_true",
+            dest='su', help="elevate privileges using su before commands")
     
     if connect_opts:
         parser.add_option('-c', '--connection', dest='connection',


### PR DESCRIPTION
I have tested this to a reasonable degree, it seems to work well with my use cases. 

There are some definite improvements to be made to how configurations are applied, but I've seen you allude to that elsewhere. That would reduce the repeated code in ansible and ansible-playbook. Anyway, one for another time. 

This adds a -S command line flag, it currently reuses --sudo_user (-U). It automatically asks for a password for the relevant user. 

The one area of contention might be the change to paramiko_ssh - I've removed the random prompt used in the -p argument to sudo so that the same code can be used for sudo and su. If there was a compelling reason for the randbits, it might make sense to use slightly different code paths at that point. 
