### PR TITLE
Allowed ssh to determine username and port from ~/.ssh/config

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -30,6 +30,8 @@ DEFAULT_POLL_INTERVAL  = os.environ.get('ANSIBLE_POLL_INTERVAL',15)
 DEFAULT_REMOTE_USER    = os.environ.get('ANSIBLE_REMOTE_USER','root')
 DEFAULT_REMOTE_PASS    = None
 DEFAULT_PRIVATE_KEY_FILE    = os.environ.get('ANSIBLE_PRIVATE_KEY_FILE',None)
+DEFAULT_SSH_CONFIG     = os.path.expanduser(os.environ.get(
+                             'ANSIBLE_SSH_CONFIG', '~/.ssh/config'))
 DEFAULT_SUDO_PASS      = None
 DEFAULT_SUDO_USER      = os.environ.get('ANSIBLE_SUDO_USER','root')
 DEFAULT_REMOTE_PORT    = 22

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -111,9 +111,9 @@ class Runner(object):
         forks=C.DEFAULT_FORKS,              # parallelism level
         timeout=C.DEFAULT_TIMEOUT,          # SSH timeout
         pattern=C.DEFAULT_PATTERN,          # which hosts?  ex: 'all', 'acme.example.org'
-        remote_user=C.DEFAULT_REMOTE_USER,  # ex: 'username'
-        remote_pass=C.DEFAULT_REMOTE_PASS,  # ex: 'password123' or None if using key
-        remote_port=C.DEFAULT_REMOTE_PORT,  # if SSH on different ports
+        remote_user=None,                   # ex: 'username'
+        remote_pass=None,                   # ex: 'password123' or None if using key
+        remote_port=None,                   # if SSH on different ports
         private_key_file=C.DEFAULT_PRIVATE_KEY_FILE, # if not using keys/passwords 
         sudo_pass=C.DEFAULT_SUDO_PASS,      # ex: 'password123' or None
         background=0,                       # async poll every X seconds, else 0 for non-async

--- a/lib/ansible/runner/connection/paramiko_ssh.py
+++ b/lib/ansible/runner/connection/paramiko_ssh.py
@@ -25,6 +25,8 @@ import pipes
 import socket
 import random
 from ansible import errors
+import ansible.constants as C
+import pwd
 
 # prevent paramiko warning noise -- see http://stackoverflow.com/questions/3920502/
 HAVE_PARAMIKO=False
@@ -44,8 +46,6 @@ class ParamikoConnection(object):
         self.runner = runner
         self.host = host
         self.port = port
-        if port is None:
-            self.port = self.runner.remote_port
 
     def connect(self):
         ''' activates the connection object '''
@@ -53,7 +53,22 @@ class ParamikoConnection(object):
         if not HAVE_PARAMIKO:
             raise errors.AnsibleError("paramiko is not installed")
 
-        user = self.runner.remote_user
+        para_config = paramiko.SSHConfig()
+        
+        sshconfig = {}
+        try:
+            with open(C.DEFAULT_SSH_CONFIG) as f:
+                para_config.parse(f)
+            sshconfig = para_config.lookup(self.host)
+        except Exception:
+            pass 
+        
+        user = self.runner.remote_user or sshconfig.get(
+            'user', pwd.getpwuid(os.getuid())[0])
+
+        self.port = self.port or int(sshconfig.get(
+            'port', C.DEFAULT_REMOTE_PORT))
+
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 

--- a/lib/ansible/runner/connection/ssh.py
+++ b/lib/ansible/runner/connection/ssh.py
@@ -49,7 +49,8 @@ class SSHConnection(object):
             self.common_args += ["-o", "Port=%d" % (self.port)]
         if self.runner.private_key_file is not None:
             self.common_args += ["-o", "IdentityFile="+self.runner.private_key_file]
-        self.common_args += ["-o", "User="+self.runner.remote_user]
+        if self.runner.remote_user is not None:
+            self.common_args += ["-o", "User="+self.runner.remote_user]
 
         return self
 

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -312,9 +312,8 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False, asyn
             dest='sudo', help="run operations with sudo (nopasswd)")
         parser.add_option('-U', '--sudo-user', dest='sudo_user', help='desired sudo user (default=root)',
             default=None)   # Can't default to root because we need to detect when this option was given
-        parser.add_option('-u', '--user', default=constants.DEFAULT_REMOTE_USER,
-            dest='remote_user', 
-            help='connect as this user (default=%s)' % constants.DEFAULT_REMOTE_USER)
+        parser.add_option('-u', '--user', 
+            dest='remote_user', help='connect as this user')
     
     if connect_opts:
         parser.add_option('-c', '--connection', dest='connection',


### PR DESCRIPTION
The motivation for this is that having the root be the default user is not realistic for most use cases (in my opinion noone should ever ssh as root). 
However, that aside, encoding a username in a playbook is not good when sharing cookbooks
And typing -u <username> every command becomes onerous. 

The changes here use .ssh/config to determine ports and users to use on a per host basis (as that is the most sensible scenario)

default username is still root (where not overridden by command line variable) so the default behaviour should not change for most users (except perhaps those that want to ssh as root but have User set in .ssh/config)

Having seen the email regarding the 0.6 freeze, if you want to leave this until 0.7 then that's understood - this isn't as trivial as some of my previous changes. 
