### PR TITLE
Implement git commit date into RPM release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,12 @@ rpm: rpmcommon
 	--define "_srcrpmdir %{_topdir}" \
 	--define "_specdir $(RPMSPECDIR)" \
 	--define "_sourcedir %{_topdir}" \
+	--define "_rpmfilename $(RPMNVR).%%{ARCH}.rpm" \
 	-ba rpm-build/$(NAME).spec
 	@rm -f rpm-build/$(NAME).spec
 	@echo "#############################################"
 	@echo "Ansible RPM is built:"
-	@echo "    rpm-build/noarch/$(RPMNVR).noarch.rpm"
+	@echo "    rpm-build/$(RPMNVR).noarch.rpm"
 	@echo "#############################################"
 
 debian: sdist


### PR DESCRIPTION
With this patch one can do `make rpm` and get an RPM file that looks like:

  rpm-build/ansible-0.6-0.git201208010541.el6.noarch.rpm

My goal was to not rewrite the original SPEC file, and/or the tarball. In other
projects what I tend to do is prepare the SPEC file in the tarball with the
correct version/release so that rpmbuild works on the (released) tarball as
well. If this is wanted, we will have to rewrite the SPEC file on the fly as
part of creating the tarball.

Also if there is no git or .git/ available, we will use the current time.

We can do something similar for Debian packages (and the tarball) if wanted.
