### PR TITLE
Enable apt module to handle multiply packages (comma separated)

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -69,15 +69,23 @@ def package_status(m, pkgname, version, cache):
             return pkg.isInstalled, pkg.isUpgradable
 
 def install(m, pkgspec, cache, upgrade=False, default_release=None, install_recommends=True, force=False):
-    name, version = package_split(pkgspec)
-    installed, upgradable = package_status(m, name, version, cache)
-    if not installed or (upgrade and upgradable):
+    packages = list()
+    for package in pkgspec:
+        name, version = package_split(package)
+        installed, upgradable = package_status(m, name, version, cache)
+        if not installed or (upgrade and upgradable):
+            packages.append(package)
+    
+    if len(packages) >0:
         if force:
             force_yes = '--force-yes'
         else:
             force_yes = ''
 
-        cmd = "%s --option Dpkg::Options::=--force-confold -q -y %s install '%s'" % (APT, force_yes, pkgspec)
+        cmd = "%s --option Dpkg::Options::=--force-confold -q -y %s install " % (APT, force_yes)
+        for package in packages:
+            cmd += " '%s'" % package
+            
         if default_release:
             cmd += " -t '%s'" % (default_release,)
         if not install_recommends:
@@ -92,16 +100,23 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None, install_reco
         m.exit_json(changed=False)
 
 def remove(m, pkgspec, cache, purge=False):
-    name, version = package_split(pkgspec)
-    installed, upgradable = package_status(m, name, version, cache)
-    if not installed:
+    packages = list()
+    for package in pkgspec:
+        name, version = package_split(package)
+        installed, upgradable = package_status(m, name, version, cache)
+        if installed:
+            packages.append(name)
+    
+    if len(packages) == 0:
         m.exit_json(changed=False)
     else:
         purge = '--purge' if purge else ''
-        cmd = "%s -q -y %s remove '%s'" % (APT, purge, name)
+        cmd = "%s -q -y %s remove" % (APT, purge)
+        for package in packages:
+            cmd += "  '%s'" % package
         rc, out, err = run_apt(cmd)
         if rc:
-            m.fail_json(msg="'apt-get remove %s' failed: %s" % (name, err))
+            m.fail_json(msg="'apt-get remove %s' failed: %s" % (packages, err))
         m.exit_json(changed=True)
 
 
@@ -145,23 +160,26 @@ def main():
             module.exit_json(changed=False)
 
     force_yes = module.boolean(p['force'])
-
-    if p['package'].count('=') > 1:
-        module.fail_json(msg='invalid package spec')
+    
+    packages = p['package'].split(',')
+    for package in packages:
+        if package.count('=') > 1:
+            module.fail_json(msg="invalid package spec: %s" % packages)
 
     if p['state'] == 'latest':
-        if '=' in p['package']:
-            module.fail_json(msg='version number inconsistent with state=latest')
-        install(module, p['package'], cache, upgrade=True,
-                  default_release=p['default_release'],
-                  install_recommends=install_recommends,
-                  force=force_yes)
+        for package in packages:
+            if '=' in package:
+                module.fail_json(msg='version number inconsistent with state=latest')
+        install(module, packages, cache, upgrade=True,
+                default_release=p['default_release'],
+                install_recommends=install_recommends,
+                force=force_yes)
 
     elif p['state'] == 'installed':
-        install(module, p['package'], cache, default_release=p['default_release'],
+        install(module, packages, cache, default_release=p['default_release'],
                   install_recommends=install_recommends,force=force_yes)
     elif p['state'] == 'removed':
-        remove(module, p['package'], cache, purge = module.boolean(p['purge']))
+        remove(module, packages, cache, purge = module.boolean(p['purge']))
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>

--- a/library/apt
+++ b/library/apt
@@ -90,7 +90,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None, install_reco
 
         rc, out, err = run_apt(cmd)
         if rc:
-            m.fail_json(msg="'apt-get install %s' failed: %s" % (pkgspec, err))
+            m.fail_json(msg="'apt-get install %s' failed: %s" % (packages, err))
         else:
             m.exit_json(changed=True)
     else:

--- a/library/apt
+++ b/library/apt
@@ -69,23 +69,20 @@ def package_status(m, pkgname, version, cache):
             return pkg.isInstalled, pkg.isUpgradable
 
 def install(m, pkgspec, cache, upgrade=False, default_release=None, install_recommends=True, force=False):
-    packages = list()
+    packages = ""
     for package in pkgspec:
         name, version = package_split(package)
         installed, upgradable = package_status(m, name, version, cache)
         if not installed or (upgrade and upgradable):
-            packages.append(package)
+            packages += "'%s' " % package
     
-    if len(packages) >0:
+    if len(packages) != 0:
         if force:
             force_yes = '--force-yes'
         else:
             force_yes = ''
 
-        cmd = "%s --option Dpkg::Options::=--force-confold -q -y %s install " % (APT, force_yes)
-        for package in packages:
-            cmd += " '%s'" % package
-            
+        cmd = "%s --option Dpkg::Options::=--force-confold -q -y %s install %s" % (APT, force_yes,packages)
         if default_release:
             cmd += " -t '%s'" % (default_release,)
         if not install_recommends:
@@ -100,20 +97,18 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None, install_reco
         m.exit_json(changed=False)
 
 def remove(m, pkgspec, cache, purge=False):
-    packages = list()
+    packages = ""
     for package in pkgspec:
         name, version = package_split(package)
         installed, upgradable = package_status(m, name, version, cache)
         if installed:
-            packages.append(name)
+            packages += "'%s' " % package
     
     if len(packages) == 0:
         m.exit_json(changed=False)
     else:
         purge = '--purge' if purge else ''
-        cmd = "%s -q -y %s remove" % (APT, purge)
-        for package in packages:
-            cmd += "  '%s'" % package
+        cmd = "%s -q -y %s remove %s" % (APT, purge,packages)
         rc, out, err = run_apt(cmd)
         if rc:
             m.fail_json(msg="'apt-get remove %s' failed: %s" % (packages, err))
@@ -162,19 +157,18 @@ def main():
     force_yes = module.boolean(p['force'])
     
     packages = p['package'].split(',')
+    latest = p['state'] == 'latest' 
     for package in packages:
         if package.count('=') > 1:
-            module.fail_json(msg="invalid package spec: %s" % packages)
+            module.fail_json(msg="invalid package spec: %s" % package)
+        if latest and '=' in package:
+            module.fail_json(msg='version number inconsistent with state=latest: %s' % package)
 
     if p['state'] == 'latest':
-        for package in packages:
-            if '=' in package:
-                module.fail_json(msg='version number inconsistent with state=latest')
         install(module, packages, cache, upgrade=True,
                 default_release=p['default_release'],
                 install_recommends=install_recommends,
                 force=force_yes)
-
     elif p['state'] == 'installed':
         install(module, packages, cache, default_release=p['default_release'],
                   install_recommends=install_recommends,force=force_yes)


### PR DESCRIPTION
I modified the apt module to handle multiply packages with one action. You can use comma separated list even with version hints. Remove and install functions checks whether the packages in the list are installed/updatable/not installed and they only add package to the querry, if all conditions are met. 

See #279
