### PR TITLE
If task action is invalid, output the name in error message

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -71,7 +71,7 @@ class Task(object):
         # split the action line into a module name + arguments
         tokens = self.action.split(None, 1)
         if len(tokens) < 1:
-            raise errors.AnsibleError("invalid/missing action in task.\n name: %s\n action: %s" % (self.name, self.action))
+            raise errors.AnsibleError("invalid/missing action in task. name: %s" % self.name)
         self.module_name = tokens[0]
         self.module_args = ''
         if len(tokens) > 1:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -71,7 +71,7 @@ class Task(object):
         # split the action line into a module name + arguments
         tokens = self.action.split(None, 1)
         if len(tokens) < 1:
-            raise errors.AnsibleError("invalid/missing action in task")
+            raise errors.AnsibleError("invalid/missing action in task.\n name: %s\n action: %s" % (self.name, self.action))
         self.module_name = tokens[0]
         self.module_args = ''
         if len(tokens) > 1:


### PR DESCRIPTION
Adds some additional output to help the user debug a task error when it occurs.

Ran into this when my error was putting a `-` in front of action:

```
- name: ensure nova.conf file is present
- action: template src=templates/nova.conf dest=/etc/nova/nova.conf owner=nova group=nova mode=0640
```
