### PR TITLE
Raise exception when sudo user does not exist

### DIFF
--- a/lib/ansible/runner/connection/paramiko_ssh.py
+++ b/lib/ansible/runner/connection/paramiko_ssh.py
@@ -105,7 +105,12 @@ class ParamikoConnection(object):
                     while not sudo_output.endswith(prompt):
                         chunk = chan.recv(bufsize)
                         if not chunk:
-                            raise errors.AnsibleError('ssh connection closed waiting for sudo password prompt')
+                            if 'unknown user' in sudo_output:
+                                raise errors.AnsibleError(
+                                    'user %s does not exist' % sudo_user)
+                            else:
+                                raise errors.AnsibleError('ssh connection ' +
+                                    'closed waiting for password prompt')
                         sudo_output += chunk
                     chan.sendall(self.runner.sudo_pass + '\n')
             except socket.timeout:


### PR DESCRIPTION
sudo can fail before getting to the password prompt if a user does not exist

<pre>
[will@tangerine ansible (sudo_missing_user)]$ sudo -u bobbins echo hello
sudo: unknown user: bobbins
sudo: unable to initialize policy plugin
</pre>

Fix raises a distinct exception when that occurs
