### PR TITLE
Revert acceptance of directory as dest for copy

### DIFF
--- a/library/copy
+++ b/library/copy
@@ -49,7 +49,7 @@ def main():
             module.fail_json(msg="Destination %s not readable" % (dest))
         # Allow dest to be directory without compromising md5 check
         if (os.path.isdir(dest)):
-            dest = os.join(dest, os.path.basename(src))
+            module.fail_json(msg="Destination %s cannot be a directory" % (dest))
         md5sum_dest = module.md5(dest)
     else:
         if not os.access(os.path.dirname(dest), os.W_OK):


### PR DESCRIPTION
Although library/copy can be corrected to understand that dest is
a directory, I can't see how to let _execute_copy know this and let the
file module know.

As a better solution than before #733, the copy module now explicitly (rather
than silently) fails when dest is a directory.
