### PR TITLE
Fixed a Bug in the service module "state changed" recognition

### DIFF
--- a/library/service
+++ b/library/service
@@ -158,8 +158,6 @@ def main():
     
     if module.params['enabled']:
         rc_enable, out_enable, err_enable = _do_enable(name, enable)
-        if rc == 0:
-            changed = True
         rc += rc_enable
         out += out_enable
         err += err_enable


### PR DESCRIPTION
This reverts a part of the commit abe8d8d4 which breaks the service module.

If you set enable then the services get started regardlessly of their current state. 
Which in some case leads to errors, when the init script complains that the service is already running and exits with return code 1.

There is absolutely no need for these two lines.

Whether the service has to change it's state get's determined by the fact if it's currently running or not.
Changing the "enable at boot" status has nothing to do with this.

Regards

Ingo
