### PR TITLE
login_unix_socket option for mysql modules

### DIFF
--- a/library/mysql_db
+++ b/library/mysql_db
@@ -71,6 +71,7 @@ def main():
             login_user=dict(default=None),
             login_password=dict(default=None),
             login_host=dict(default="localhost"),
+            login_unix_socket=dict(default=None),
             db=dict(required=True, aliases=['name']),
             encoding=dict(default=""),
             collation=dict(default=""),
@@ -103,7 +104,10 @@ def main():
         module.fail_json(msg="when supplying login arguments, both login_user and login_password must be provided")
 
     try:
-        db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
+        if module.params["login_unix_socket"] != None:
+            db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db="mysql")
+        else:
+            db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
         cursor = db_connection.cursor()
     except Exception as e:
         module.fail_json(msg="unable to connect, check login_user and login_password are correct, or alternatively check ~/.my.cnf contains credentials")

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -164,6 +164,7 @@ def main():
             login_user=dict(default=None),
             login_password=dict(default=None),
             login_host=dict(default="localhost"),
+            login_unix_socket=dict(default=None),
             user=dict(required=True, aliases=['name']),
             password=dict(default=None),
             host=dict(default="localhost"),
@@ -203,7 +204,10 @@ def main():
         module.fail_json(msg="when supplying login arguments, both login_user and login_password must be provided")
 
     try:
-        db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
+        if module.params["login_unix_socket"] != None:
+            db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db="mysql")
+        else:
+            db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
         cursor = db_connection.cursor()
     except Exception as e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials")


### PR DESCRIPTION
Hi there,

I added a login_unix_socket option for two mysql modules.
This is very handy if you have more than one mysql installation on a system or if you have completely custom paths.

Can be used in a Playbook like this:

```
- name: Create database
  action: mysql_db login_unix_socket=/path/to/sock login_user="root" login_password="mySecretPw" db=dbname state=present

- name: Create db-user
  action: mysql_user login_unix_socket=/path/to/sock login_user="root" login_password="mySecretPw" name=username password="mySecretPw" priv=*.*:ALL state=present
```

Regards 

Ingo
