### PR TITLE
Clearer error message if _load_params fails

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -148,9 +148,12 @@ class AnsibleModule(object):
         args = MODULE_ARGS
         items   = shlex.split(args)
         params = {}
-        for x in items:
-            (k, v) = x.split("=",1)
-            params[k] = v
+        try:
+            for x in items:
+                (k, v) = x.split("=",1)
+                params[k] = v
+        except ValueError:
+            raise ValueError("Could not process task arguments: '%s'. Maybe a = is missing?" % args)
         return (params, args)        
 
     def _log_invocation(self):


### PR DESCRIPTION
Currently, if there's a missing = in the arguments to a task, such as the missing `name=` in the following:

```
- name: restart nova-compute
  action: service nova-compute state=restarted
```

Then the error message that appears when the module runs does not make it immediately clear what the problem is:

```
fatal: [192.168.206.131] => failed to parse: Traceback (most recent call last):
  File "/home/vagrant/.ansible/tmp/ansible-1344170218.07-60536855680190/service", line 406, in <module>
    main()
  File "/home/vagrant/.ansible/tmp/ansible-1344170218.07-60536855680190/service", line 137, in main
    enabled = dict(choices=BOOLEANS)
  File "/home/vagrant/.ansible/tmp/ansible-1344170218.07-60536855680190/service", line 259, in __init__
    (self.params, self.args) = self._load_params()
  File "/home/vagrant/.ansible/tmp/ansible-1344170218.07-60536855680190/service", line 345, in _load_params
    (k, v) = x.split("=",1)
ValueError: need more than 1 value to unpack
```

The proposed change alters the exception traceback message so it looks like this:

```
fatal: [192.168.206.131] => failed to parse: Traceback (most recent call last):
  File "/home/vagrant/.ansible/tmp/ansible-1344170986.23-218915984344484/service", line 409, in <module>
    main()
  File "/home/vagrant/.ansible/tmp/ansible-1344170986.23-218915984344484/service", line 137, in main
    enabled = dict(choices=BOOLEANS)
  File "/home/vagrant/.ansible/tmp/ansible-1344170986.23-218915984344484/service", line 259, in __init__
    (self.params, self.args) = self._load_params()
  File "/home/vagrant/.ansible/tmp/ansible-1344170986.23-218915984344484/service", line 349, in _load_params
    raise ValueError("Could not process task arguments: '%s'. Maybe a = is missing?" % args)
ValueError: Could not process task arguments: 'nova-compute state=restarted'. Maybe a = is missing?
```
