### PR TITLE
Fix error handling when switching versions

### DIFF
--- a/library/git
+++ b/library/git
@@ -58,11 +58,6 @@ def reset(dest):
     rc = cmd.returncode
     return (rc, out, err)
 
-def switchLocalBranch( branch ):
-    cmd = "git checkout %s" % branch
-    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    return cmd.communicate()
-
 def get_branches(module, dest):
     os.chdir(dest)
     branches = []
@@ -156,7 +151,7 @@ def main():
 
     gitconfig = os.path.join(dest, '.git', 'config')
 
-    out, err, status = (None, None, None)
+    rc, out, err, status = (0, None, None, None)
 
     # if there is no git configuration, do a clone operation
     # else pull and switch the version
@@ -180,7 +175,7 @@ def main():
     # switch to version specified regardless of whether
     # we cloned or pulled
     (rc, out, err) = switch_version(module, dest, remote, version)
-    if err.find('error') != -1:
+    if rc != 0:
         module.fail_json(msg=err)
 
     # determine if we changed anything


### PR DESCRIPTION
git module used to check stderr for the string 'error' after calling
switch_version().  This changes that to just look at the return code to
determine whether the command failed.  If the rc is not zero, the git
module will call fail_json().

The problem is that git checkout will summarize the commit message,
such as:

```
HEAD is now at ea38409... removing artificial error
```

When the string 'error' is the commit message, this check will
erroneously think the command failed.

This also removes the method switchLocalBranch() since it is no longer
used.
