### PR TITLE
Make exception more specific (OSError) in setup module for selinux call

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -126,7 +126,7 @@ class Facts(object):
             self.facts['selinux']['status'] = 'enabled'
             try:
                 self.facts['selinux']['policyvers'] = selinux.security_policyvers()
-            except:
+            except OSError, e:
                 self.facts['selinux']['policyvers'] = 'unknown'
             try:
                 (rc, configmode) = selinux.selinux_getenforcemode()


### PR DESCRIPTION
Poked at libselinux source and it looks like they python wrapped bits only throw OSError.
