### PR TITLE
Added su capability

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -77,11 +77,15 @@ class Cli(object):
         sudopass = None
         if options.ask_pass:
             sshpass = getpass.getpass(prompt="SSH password: ")
-        if options.ask_sudo_pass:
+        if options.su:
+            sudopass = getpass.getpass(
+                prompt="%s password: " % options.sudo_user)
+        elif options.ask_sudo_pass:
             sudopass = getpass.getpass(prompt="sudo password: ")
             options.sudo = True
-        if options.sudo_user:
+        if options.sudo_user and not options.su:
             options.sudo = True
+
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
         if options.tree:
             utils.prepare_writeable_dir(options.tree)
@@ -92,9 +96,9 @@ class Cli(object):
             remote_user=options.remote_user, remote_pass=sshpass,
             inventory=inventory_manager, timeout=options.timeout,
             private_key_file=options.private_key_file,
-            forks=options.forks,
-            pattern=pattern,
-            callbacks=self.callbacks, sudo=options.sudo,
+            forks=options.forks, 
+            pattern=pattern, su=options.su,
+            callbacks=self.callbacks, sudo=options.sudo, 
             sudo_pass=sudopass,sudo_user=options.sudo_user,
             transport=options.connection
         )

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -68,10 +68,13 @@ def main(args):
     sudopass = None
     if options.ask_pass:
         sshpass = getpass.getpass(prompt="SSH password: ")
-    if options.ask_sudo_pass:
+    if options.su:
+        sudopass = getpass.getpass(
+            prompt="%s password: " % options.sudo_user)
+    elif options.ask_sudo_pass:
         sudopass = getpass.getpass(prompt="sudo password: ")
         options.sudo = True
-    if options.sudo_user:
+    if options.sudo_user and not options.su:
         options.sudo = True
     options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
     extra_vars = utils.parse_kv(options.extra_vars)
@@ -99,6 +102,7 @@ def main(args):
             sudo=options.sudo,
             sudo_user=options.sudo_user,
             sudo_pass=sudopass,
+            su=options.su,
             extra_vars=extra_vars,
             private_key_file=options.private_key_file,
             only_tags=only_tags,

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -28,7 +28,7 @@ class Play(object):
     __slots__ = [
        'hosts', 'name', 'vars', 'vars_prompt', 'vars_files',
        'handlers', 'remote_user', 'remote_port',
-       'sudo', 'sudo_user', 'transport', 'playbook',
+       'su', 'sudo', 'sudo_user', 'transport', 'playbook', 
        'tags', 'gather_facts', '_ds', '_handlers', '_tasks'
     ]
 
@@ -37,7 +37,7 @@ class Play(object):
     VALID_KEYS = [
        'hosts', 'name', 'vars', 'vars_prompt', 'vars_files',
        'tasks', 'handlers', 'user', 'port', 'include',
-       'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts'
+       'su', 'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts'
     ]
 
     # *************************************************
@@ -70,6 +70,7 @@ class Play(object):
         self._handlers    = ds.get('handlers', [])
         self.remote_user  = ds.get('user', self.playbook.remote_user)
         self.remote_port  = ds.get('port', self.playbook.remote_port)
+        self.su           = ds.get('su', self.playbook.su)
         self.sudo         = ds.get('sudo', self.playbook.sudo)
         self.sudo_user    = ds.get('sudo_user', self.playbook.sudo_user)
         self.transport    = ds.get('connection', self.playbook.transport)
@@ -88,7 +89,7 @@ class Play(object):
         elif type(self.tags) != list:
             self.tags = []
 
-        if self.sudo_user != 'root':
+        if self.sudo_user != 'root' and not self.su:
             self.sudo = True
 
     # *************************************************

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -367,7 +367,9 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False, asyn
         parser.add_option('-u', '--user', default=constants.DEFAULT_REMOTE_USER,
             dest='remote_user',
             help='connect as this user (default=%s)' % constants.DEFAULT_REMOTE_USER)
-
+        parser.add_option('-S', '--su', default=False, action="store_true",
+            dest='su', help="elevate privileges using su before commands")
+    
     if connect_opts:
         parser.add_option('-c', '--connection', dest='connection',
                           choices=C.DEFAULT_TRANSPORT_OPTS,


### PR DESCRIPTION
Uses -S command line flag - no flag needed for setting
password, that gets requested automatically

sudo and su paths are now handled differently for the password prompt. 

Have tested this with su and sudo users, both seem to work the same as before. Having reread the discussion on #744, I hope there are not enough fundamental reasons not to accept this as I have explained my use case. 

While this may be better implemented in a different way after further abstracting the connection type, this is what I need for my purposes right now. 
