### PR TITLE
Allow using the yum module without repoquery

### DIFF
--- a/library/yum
+++ b/library/yum
@@ -23,13 +23,15 @@
 
 import traceback
 import os
+import subprocess
 
 def_qf = "%{name}-%{version}-%{release}.%{arch}"
 repoquery='/usr/bin/repoquery'
 yumbin='/usr/bin/yum'
+rpmbin = '/bin/rpm'
 
 def is_installed(repoq, pkgspec, qf=def_qf):
-    cmd = repoq + "--disablerepo=\* --pkgnarrow=installed --qf '%s' %s " % (qf, pkgspec)
+    cmd = repoq + ["--disablerepo=*", "--pkgnarrow=installed", "--qf", qf, pkgspec]
     rc,out,err = run(cmd)
     if rc == 0:
         return [ p for p in out.split('\n') if p.strip() ]
@@ -37,7 +39,7 @@ def is_installed(repoq, pkgspec, qf=def_qf):
     return []
 
 def is_available(repoq, pkgspec, qf=def_qf):
-    cmd = repoq + "--qf '%s' %s " % (qf, pkgspec)
+    cmd = repoq + ["--qf", qf, pkgspec]
     rc,out,err = run(cmd)
     if rc == 0:
         return [ p for p in out.split('\n') if p.strip() ]
@@ -46,32 +48,12 @@ def is_available(repoq, pkgspec, qf=def_qf):
 
 
 def is_update(repoq, pkgspec, qf=def_qf):
-    cmd = repoq + "--pkgnarrow=updates --qf '%s' %s " % (qf, pkgspec)
+    cmd = repoq + ["--pkgnarrow=updates", "--qf", qf, pkgspec]
     rc,out,err = run(cmd)
     if rc == 0:
         return set([ p for p in out.split('\n') if p.strip() ])
 
     return []
-
-
-def what_provides(repoq, req_spec, qf=def_qf):
-    cmd = repoq + "--qf '%s' --whatprovides %s" % (qf, req_spec)
-    rc,out,err = run(cmd)
-    ret = []
-    if rc == 0:
-        ret = set([ p for p in out.split('\n') if p.strip() ])
-
-    return ret
-
-def local_nvra(path):
-    """return nvra of a local rpm passed in"""
-
-    cmd = "/bin/rpm -qp --qf='%%{name}-%%{version}-%%{release}.%%{arch}\n' %s'" % path
-    rc, out, err = run(cmd)
-    if rc != 0:
-        return None
-    nvra = out.split('\n')[0]
-    return nvra
 
 
 def pkg_to_dict(pkgstr):
@@ -98,7 +80,7 @@ def pkg_to_dict(pkgstr):
     return d
 
 def repolist(repoq, qf="%{repoid}"):
-    cmd = repoq + "--qf '%s' -a" % (qf)
+    cmd = repoq + ["--qf", qf, "-a"]
     rc,out,err = run(cmd)
     ret = []
     if rc == 0:
@@ -108,9 +90,9 @@ def repolist(repoq, qf="%{repoid}"):
 
 def list_stuff(conf_file, stuff):
     qf = "%{name}|%{epoch}|%{version}|%{release}|%{arch}|%{repoid}"
-    repoq = '%s --plugins --quiet  -q ' % repoquery
+    repoq = [repoquery, '--plugins', '--quiet', '-q']
     if conf_file and os.path.exists(conf_file):
-        repoq = '%s -c %s --plugins --quiet  -q ' % (repoquery,conf_file)
+        repoq += ['-c', conf_file]
 
     if stuff == 'installed':
         return [ pkg_to_dict(p) for p in is_installed(repoq, '-a', qf=qf) if p.strip() ]
@@ -125,7 +107,7 @@ def list_stuff(conf_file, stuff):
 
 def run(command):
     try:
-        cmd = subprocess.Popen(command, shell=True,
+        cmd = subprocess.Popen(command,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = cmd.communicate()
     except (OSError, IOError), e:
@@ -146,227 +128,75 @@ def run(command):
 
     return rc, out, err
 
+def install(module, items, yum_basecmd, latest=False):
+    res = {'changed': False}
 
-def install(module, items, repoq, yum_basecmd):
-    res = {}
-    res['results'] = []
-    res['msg'] = ''
-    res['rc'] = 0
-    res['changed'] = False
-
-    for spec in items:
-        pkg = None
-
-        # check if pkgspec is installed (if possible for idempotence)
-        # localpkg
-        if spec.endswith('.rpm'):
-            # get the pkg name-v-r.arch
-            nvra = local_nvra(spec)
-            # look for them in the rpmdb
-            if is_installed(repoq, nvra):
-                # if they are there, skip it
-                continue
-            pkg = spec
-        #groups :(
-        elif  spec.startswith('@'):
-            # complete wild ass guess b/c it's a group
-            pkg = spec
-
-        # range requires or file-requires or pkgname :(
-        else:
-            # look up what pkgs provide this
-            pkglist = what_provides(repoq, spec)
-            if not pkglist:
-                res['msg'] += "No Package matching '%s' found available, installed or updated" % spec
-                res['failed'] = True
-                module.exit_json(**res)
-
-            # if any of them are installed
-            # then nothing to do
-
-            found = False
-            for this in pkglist:
-                if is_installed(repoq, this):
-                    found = True
-                    res['results'].append('%s providing %s is already installed' % (this, spec))
-
-            if found:
-                continue
-            # if not - then pass in the spec as what to install
-            # we could get here if nothing provides it but that's not
-            # the error we're catching here
-            pkg = spec
-
-        cmd = "%s install '%s'" % (yum_basecmd, pkg)
-        rc, out, err = run(cmd)
-        # FIXME - if we did an install - go and check the rpmdb to see if it actually installed
-        # look for the pkg in rpmdb
-        # look for the pkg via obsoletes
-        if rc:
-            res['changed'] = False
-            res['rc'] = rc
-            res['results'].append(out)
-            res['msg'] += err
-        else:
+    if not latest:
+        to_install = []
+        for item in items:
+            rc, out, err = run([rpmbin, "-q",  "--whatprovides", item])
+            if rc != 0:
+                to_install.append(item)
+        if len(to_install) > 0:
             res['changed'] = True
-            res['rc'] = 0
-            res['results'].append(out)
-            res['msg'] += err
+    else:
+        rc, out, err = run(yum_basecmd + ["check-update"] + items)
+        if rc == 100:
+            res['changed'] = True
+            to_install = items
+        elif rc != 0:
+            module.exit_json(failed=True, msg=err)
 
-    module.exit_json(**res)
-
-
-def remove(module, items, repoq, yum_basecmd):
-    res = {}
-    res['results'] = []
-    res['msg'] = ''
-    res['changed'] = False
-    res['rc'] = 0
-
-    for spec in items:
-        pkg = None
-
-        # group remove - hope you like things dying!
-        if spec.startswith('@'):
-            pkg = spec
-        # req or pkgname remove
-        else:
-            pkglist = what_provides(repoq, spec)
-            if not pkglist:
-                res['msg'] += "No Package matching '%s' found available, installed or updated" % spec
-                res['failed']=True
-                module.exit_json(**res)
-
-            found = False
-            for this in pkglist:
-                if is_installed(repoq, this):
-                    found = True
-
-            if not found:
-                res['results'].append('%s is not installed' % spec)
-                continue
-            pkg = spec
-
-        cmd = "%s remove '%s'" % (yum_basecmd, pkg)
-        rc, out, err = run(cmd)
-
-        # FIXME if we ran the remove - check to make sure it actually removed :(
-        # look for the pkg in the rpmdb - this is notoriously hard for groups :(
+    if len(to_install) > 0:
+        rc, out, err = run(yum_basecmd + ["--obsoletes", "install"] + to_install)
         if rc != 0:
-            res['changed'] = False
-            res['failed'] = True
-            res['rc'] = rc
-            res['results'].append(out)
-            res['msg'] += err
-        else:
-            res['changed'] = True
-            res['rc'] = 0
-            res['results'].append(out)
-            res['msg'] += err
+            module.exit_json(failed=True, msg=err)
+        for item in to_install:
+            rc, out, err = run([rpmbin, "-q",  "--whatprovides", item])
+            if rc != 0:
+                module.exit_json(failed=True, msg="%s could not be installed" % item)
 
     module.exit_json(**res)
 
-def latest(module, items, repoq, yum_basecmd):
-    res = {}
-    res['results'] = []
-    res['msg'] = ''
-    res['changed'] = False
-    res['rc'] = 0
+def remove(module, items, yum_basecmd):
+    res = {'changed': False}
 
-    for spec in items:
-        pkg = None
-        basecmd = 'update'
-        # groups, again
-        if spec.startswith('@'):
-            pkg = spec
-        # dep/pkgname  - find it
-        else:
-            pkglist = what_provides(repoq, spec)
-            if not pkglist:
-                res['msg'] += "No Package matching '%s' found available, installed or updated" % spec
-                res['failed']=True
-                module.exit_json(**res)
-            found = False
-            nothing_to_do = False
-            can_be_installed = True
-            for this in pkglist:
-                if is_installed(repoq, this):
-                    if is_update(repoq, this):
-                        found = True
-                    else:
-                        nothing_to_do = True
-
-            if nothing_to_do:
-                res['results'].append("All packages providing %s are up to date" % spec)
-                continue
-
-            if not found:
-                basecmd = 'install'
-            else:
-                basecmd = 'update'
-
-
-            pkg = spec
-
-        cmd = "%s %s '%s'" % (yum_basecmd, basecmd, pkg)
-        rc, out, err = run(cmd)
-
-        # FIXME if it is - update it and check to see if it applied
-        # check to see if there is no longer an update available for the pkgspec
-        if rc:
-            changed = False
-            failed = True
-        else:
-            changed = True
-            failed = False
-
-
-        if rc:
-            res['changed'] = False
-            res['failed'] = True
-            res['rc'] = rc
-            res['results'].append(out)
-            res['msg'] += err
-        else:
-            res['changed'] = True
-            res['rc'] = 0
-            res['results'].append(out)
-            res['msg'] += err
+    to_remove = []
+    for item in items:
+        rc, out, err = run([rpmbin, "-q",  "--whatprovides", "--qf", "%{NAME}\n", item])
+        if rc == 0:
+            to_remove.append(out.strip())
+    if len(to_remove) > 0:
+        res['changed'] = True
+        rc, out, err = run(yum_basecmd + ["remove"] + to_remove)
+        if rc != 0:
+            module.exit_json(failed=True, msg=err)
+        res['out'] = out
+        res['err'] = err
+        for item in to_remove:
+            rc, out, err = run([rpmbin, "-q", item])
+            if rc == 0:
+                module.exit_json(failed=True, msg="%s was not removed" % item)
 
     module.exit_json(**res)
-
-
 
 def ensure(module, state, pkgspec, conf_file):
-    res = {}
-    stdout = ""
-    stderr = ""
-
     # take multiple args comma separated
-    items = [pkgspec]
-    if pkgspec.find(',') != -1:
-        items = pkgspec.split(',')
+    items = pkgspec.split(',')
 
-    yum_basecmd = '%s -d 1 -y ' % yumbin
-    repoq = '%s --show-duplicates --plugins --quiet  -q ' % repoquery
+    yum_basecmd = [yumbin, '-d', '1', '-y']
     if conf_file and os.path.exists(conf_file):
-        yum_basecmd = '%s -c %s -d 1 -y' % (yumbin, conf_file)
-        repoq = '%s --show-duplicates -c %s --plugins --quiet  -q ' % (repoquery,conf_file)
+        yum_basecmd += ['-c', conf_file]
 
     if state in ['installed', 'present']:
-        install(module, items, repoq, yum_basecmd)
+        install(module, items, yum_basecmd)
     elif state in ['removed', 'absent']:
-        remove(module, items, repoq, yum_basecmd)
+        remove(module, items, yum_basecmd)
     elif state == 'latest':
-        latest(module, items, repoq, yum_basecmd)
+        install(module, items, yum_basecmd, latest=True)
 
     # should be caught by AnsibleModule argument_spec
     return dict(changed=False, failed=True, results='', errors='unexpected state')
-
-
-def remove_only(pkgspec):
-    # remove this pkg and only this pkg - fail if it will require more to remove
-    pass
 
 def main():
     # state=installed pkg=pkgspec
@@ -396,17 +226,15 @@ def main():
     if params['list'] and params['pkg']:
         module.fail_json(msg="expected 'list=' or 'name=', but not both")
 
-
-    if not os.path.exists(repoquery):
-        module.fail_json(msg="%s is required to run this module. Please install the yum-utils package." % repoquery)
-
     if params['list']:
+        if not os.path.exists(repoquery):
+            module.fail_json(msg="%s is required to use list= with this module. Please install the yum-utils package." % repoquery)
         results = dict(results=list_stuff(params['conf_file'], params['list']))
         module.exit_json(**results)
 
     else:
         pkg = params['pkg']
-        if 'pkg' is None:
+        if pkg is None:
             module.fail_json(msg="expected 'list=' or 'name='")
         else:
             state = params['state']


### PR DESCRIPTION
It is still required to use list=..., but the typical install and remove
won't need it.
