### PR TITLE
We need to include the license when we ship RPMs

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -53,7 +53,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/ansible*
 %{_datadir}/ansible
 %config(noreplace) %{_sysconfdir}/ansible
-%doc README.md PKG-INFO
+%doc README.md PKG-INFO COPYING
 %doc %{_mandir}/man1/ansible*
 
 


### PR DESCRIPTION
We need to include the license when we ship RPMs
