### PR TITLE
Fixes for raw module usage and failure to open_session()

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -568,7 +568,9 @@ class Runner(object):
 
         module_name = utils.template(self.module_name, inject)
 
-        tmp = self._make_tmp_path(conn)
+        tmp = ''
+        if self.module_name != 'raw':
+            tmp = self._make_tmp_path(conn)
         result = None
 
         handler = getattr(self, "_execute_%s" % self.module_name, None)
@@ -595,7 +597,8 @@ class Runner(object):
 
             del result.result['daisychain']
 
-        self._delete_remote_files(conn, tmp)
+        if self.module_name != 'raw':
+            self._delete_remote_files(conn, tmp)
         conn.close()
 
         if not result.comm_ok:

--- a/lib/ansible/runner/connection/paramiko_ssh.py
+++ b/lib/ansible/runner/connection/paramiko_ssh.py
@@ -81,7 +81,13 @@ class ParamikoConnection(object):
         ''' run a command on the remote host '''
 
         bufsize = 4096
-        chan = self.ssh.get_transport().open_session()
+        try:
+            chan = self.ssh.get_transport().open_session()
+        except Exception, e:
+            msg = "Failed to open session"
+            if len(str(e)) > 0:
+                msg += ": %s" % str(e)
+            raise errors.AnsibleConnectionFailed(msg)
         chan.get_pty()
 
         if not self.runner.sudo or not sudoable:


### PR DESCRIPTION
Commit f9bdfde fixes runner in the case when using the raw module so that it doesn't try to create or remove tmp files on the minion.

Commit 569d377 wraps paramiko's open_session() call in exec_command() in a try/except to catch case where open_session() fails.  This failed for me when using paramiko to connect to a non-unix host via ssh.  Here's the traceback:

```
nodename | FAILED => Traceback (most recent call last):                                                                         
  File "/home/sfromm/Source/ansible/lib/ansible/runner/__init__.py", line 451, in _executor                                     
    exec_rc = self._executor_internal(host)                                                                                     
  File "/home/sfromm/Source/ansible/lib/ansible/runner/__init__.py", line 497, in _executor_internal                            
    return self._executor_internal_inner(host, inject, port)                                                                          
  File "/home/sfromm/Source/ansible/lib/ansible/runner/__init__.py", line 576, in _executor_internal_inner                      
    result = handler(conn, tmp, inject=inject)                                                                                  
  File "/home/sfromm/Source/ansible/lib/ansible/runner/__init__.py", line 240, in _execute_raw
    stdout=self._low_level_exec_command(conn, self.module_args, tmp, sudoable = True)                                           
  File "/home/sfromm/Source/ansible/lib/ansible/runner/__init__.py", line 631, in _low_level_exec_command                       
    stdin, stdout, stderr = conn.exec_command(cmd, tmp, sudo_user, sudoable=sudoable)           
  File "/home/sfromm/Source/ansible/lib/ansible/runner/connection/paramiko_ssh.py", line 84, in exec_command                    
    chan = self.ssh.get_transport().open_session()                                                                              
  File "/usr/lib/python2.6/site-packages/paramiko/transport.py", line 648, in open_session                                  
    return self.open_channel('session')                                                                                         
  File "/usr/lib/python2.6/site-packages/paramiko/transport.py", line 738, in open_channel                                         
    raise e                                                                                                                     
EOFError                
```
