### PR TITLE
A couple fixes for setup module

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -453,8 +453,13 @@ class LinuxNetwork(Network):
             ipv4_address = None, 
             ipv6_address = None
         )
-
-        output = subprocess.Popen(['/sbin/ip','addr', 'show'], stdout=subprocess.PIPE).communicate()[0]
+        ipbin = '/sbin/ip'
+        if not os.path.exists(ipbin):
+            if os.path.exists('/usr/sbin/ip'):
+                ipbin = '/usr/sbin/ip'
+            else:
+                return interfaces, ips
+        output = subprocess.Popen([ipbin, 'addr', 'show'], stdout=subprocess.PIPE).communicate()[0]
         for line in output.split('\n'):
             if line:
                 words = line.split()

--- a/library/setup
+++ b/library/setup
@@ -454,7 +454,7 @@ class LinuxNetwork(Network):
             ipv6_address = None
         )
 
-        output = subprocess.Popen(['ip','addr'], stdout=subprocess.PIPE).communicate()[0]
+        output = subprocess.Popen(['/sbin/ip','addr', 'show'], stdout=subprocess.PIPE).communicate()[0]
         for line in output.split('\n'):
             if line:
                 words = line.split()


### PR DESCRIPTION
A couple fixes to to how ip is invoked.  First, use full path for ip.  If this isn't used and the user doesn't have ip in his/her PATH, this will trigger a traceback.  This tries to find ip in either /sbin or /usr/sbin.  The second fix is to be explicit about showing current configured addresses.
