### PR TITLE
Network facts

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -447,10 +447,10 @@ class LinuxNetwork(Network):
 
     def parse_ip_addr(self):
         interfaces = {}
-        ips = dict( 
-            all_ipv4_addresses = [], 
+        ips = dict(
+            all_ipv4_addresses = [],
             all_ipv6_addresses = [],
-            ipv4_address = None, 
+            ipv4_address = None,
             ipv6_address = None
         )
         ipbin = '/sbin/ip'

--- a/library/setup
+++ b/library/setup
@@ -434,18 +434,115 @@ class LinuxNetwork(Network):
         Network.__init__(self)
 
     def populate(self):
-        interfaces, ips = self.parse_ip_addr()
-
-        self.facts['interfaces'] = interfaces.keys()
-        for iface in interfaces:
-            self.facts[iface] = interfaces[iface]
-
-        for key in ips:
-            self.facts[key] = ips[key]
-
+        ip_path = self.get_ip_path()
+        default_ipv4, default_ipv6 = self.get_default_interfaces(ip_path)
+        interfaces, ips, default_ipv4_alias = self.get_interfaces_tree(ip_path, default_ipv4['address'])
+        default_ipv4['alias'] = default_ipv4_alias
+        interfaces['default_ipv4'] = default_ipv4
+        interfaces['default_ipv6'] = default_ipv6
+        self.facts['interfaces'] = interfaces
+        self.facts['all_ipv4_addresses'] = ips['all_ipv4_addresses']
+        self.facts['all_ipv6_addresses'] = ips['all_ipv6_addresses']
+        # Obsolete
+        obsolete_interfaces = self.get_interfaces_and_aliases_tree(ip_path)[0]
+        for iface in obsolete_interfaces:
+            self.facts[iface] = obsolete_interfaces[iface]
         return self.facts
 
-    def parse_ip_addr(self):
+    def get_ip_path(self):
+        paths = ['/sbin/ip', '/usr/sbin/ip']
+        ip_path = None
+        for path in paths:
+            if os.path.exists(path):
+                ip_path = path
+                break
+        return ip_path
+
+    def get_default_interfaces(self, ip_path):
+        # Use the commands:
+        #     ip -4 route get 8.8.8.8                     -> Google public DNS
+        #     ip -6 route get 2404:6800:400a:800::1012    -> ipv6.google.com
+        # to find out the default outgoing interface, address, and gateway
+        command = dict(
+            v4 = [ip_path, '-4', 'route', 'get', '8.8.8.8'],
+            v6 = [ip_path, '-6', 'route', 'get', '2404:6800:400a:800::1012']
+        )
+        interface = dict(v4 = {}, v6 = {})
+        for v in 'v4', 'v6':
+            output = subprocess.Popen(command[v], stdout=subprocess.PIPE).communicate()[0]
+            words = output.split('\n')[0].split()
+            # A valid output starts with the queried address on the first line
+            if words[0] == command[v][-1]:
+                for i in range(len(words) - 1):
+                    if words[i] == 'dev':
+                        interface[v]['interface'] = words[i+1]
+                    elif words[i] == 'src':
+                        interface[v]['address'] = words[i+1]
+                    elif words[i] == 'via':
+                        interface[v]['gateway'] = words[i+1]
+        return interface['v4'], interface['v6']
+
+
+    def get_interfaces_tree(self, ip_path, default_ipv4_address):
+        interfaces = {}
+        ips = dict(all_ipv4_addresses = [], all_ipv6_addresses = [])
+
+        # Use the command:
+        #     ip addr show
+        # to list all interfaces' information
+        output = subprocess.Popen([ip_path, 'addr', 'show'], stdout=subprocess.PIPE).communicate()[0]
+        for line in output.split('\n'):
+            if line:
+                words = line.split()
+                if not line.startswith(' '):
+                    iface = words[1][0:-1]
+                    interfaces[iface] = {'mtu': words[4], 'ipv4': [], 'ipv6': []}
+                elif words[0].startswith('link/'):
+                    iface_type = words[0].split('/')[1]
+                    interfaces[iface]['type'] = iface_type
+                    if iface_type == 'void':
+                        interfaces[iface]['macaddress'] = 'unknown'
+                    else:
+                        interfaces[iface]['macaddress'] = words[1]
+                elif words[0] == 'inet':
+                    address, netmask_length = words[1].split('/')
+                    address_bin = struct.unpack('!L', socket.inet_aton(address))[0]
+
+                    netmask_bin = (1<<32) - (1<<32>>int(netmask_length))
+                    netmask = socket.inet_ntoa(struct.pack('!L', netmask_bin))
+
+                    network = socket.inet_ntoa(struct.pack('!L', address_bin & netmask_bin))
+
+                    alias = words[-1]
+                    # If this is the default address, note its alias
+                    if address == default_ipv4_address:
+                        default_ipv4_alias = alias
+
+                    interfaces[iface]['ipv4'].append( {
+                            'address': address,
+                            'netmask': netmask,
+                            'network': network,
+                            'alias': alias} )
+
+                    if not address.startswith('127.'):
+                        ips['all_ipv4_addresses'].append(address)
+
+                elif words[0] == 'inet6':
+                    address, prefix = words[1].split('/')
+                    scope = words[3]
+
+                    interfaces[iface]['ipv6'].append( {
+                        'address': address,
+                        'prefix': prefix,
+                        'scope': scope} )
+
+                    if not address == '::1':
+                        ips['all_ipv6_addresses'].append(address)
+
+        return interfaces, ips, default_ipv4_alias
+
+    # Obsolete
+    def get_interfaces_and_aliases_tree(self, ip_path):
         interfaces = {}
         ips = dict(
             all_ipv4_addresses = [],
@@ -453,13 +550,7 @@ class LinuxNetwork(Network):
             ipv4_address = None,
             ipv6_address = None
         )
-        ipbin = '/sbin/ip'
-        if not os.path.exists(ipbin):
-            if os.path.exists('/usr/sbin/ip'):
-                ipbin = '/usr/sbin/ip'
-            else:
-                return interfaces, ips
-        output = subprocess.Popen([ipbin, 'addr', 'show'], stdout=subprocess.PIPE).communicate()[0]
+        output = subprocess.Popen([ip_path, 'addr', 'show'], stdout=subprocess.PIPE).communicate()[0]
         for line in output.split('\n'):
             if line:
                 words = line.split()


### PR DESCRIPTION
Backwards compatible, and fixes a broken scenario: when eth0 has two IPs, the current implementation will create eth0 and eth0:0 interfaces. When it then finds a real eth0:0, it will name it eth0:1.
- Adds new interfaces tree under key `interfaces` (see example below).
  This also does what the old `interfaces` key did.
  Main features of the new tree:
  - An alias for each IPv4 address
  - Adds `type` for each interface, e.g. ether, loopback
  - Distinguishes alias interfaces from additional IPs
  - Reliable (picked from routing table, not just the first non-local address as before) default address, interface, alias, and gateway for each of IPv4 and IPv6
- Keeps old per-interface tree for backwards compatibility

```
"interfaces": {
    "default_ipv4": {
        "interface": "eth0",
        "address": "192.168.1.3",
        "netmask": "255.255.255.0",
        "gateway": "192.168.1.254",
        "alias": "eth0:0"
    },
    "default_ipv6": {
        "interface": "eth1",
        "address": ... ,
        "prefix": ... ,
        "scope": ...,
        "gateway": ...,
    },
    "eth0": {
        "macaddress": xxxx..,
        "mtu": 1500,
        "type": "ether",
        "ipv4": [
            {
                "address": "192.168.1.1",
                "netmask": "255.255.255.0",
                "network": "192.168.1.0",
                "alias": "eth0"
            },
            {
                "address": "192.168.1.2",
                "netmask": "255.255.255.0",
                "network": "192.168.1.0",
                "alias": "eth0"
            },
            {
                "address": "192.168.1.3",
                "netmask": "255.255.255.0",
                "network": "192.168.1.0",
                "alias": "eth0:0"
            }
        ],
        "ipv6": [
            {
                # No changes
                "address": ... ,
                "prefix": ... ,
                "scope": ...
            },
            {
                ...
            }
        ]
    }, # close interfaces.eth0
    "eth1": {
        ...
    }
} # close interfaces
```
