### PR TITLE
Don't explicitly set SSH Port if it is the default (so it can be overrid...

### DIFF
--- a/lib/ansible/runner/connection/ssh.py
+++ b/lib/ansible/runner/connection/ssh.py
@@ -25,6 +25,7 @@ import select
 import fcntl
 from ansible.callbacks import vvv
 from ansible import errors
+import ansible.constants as C
 
 class SSHConnection(object):
     ''' ssh based connections '''
@@ -48,7 +49,7 @@ class SSHConnection(object):
                                  "-o", "ControlPersist=60s",
                                  "-o", "ControlPath=/tmp/ansible-ssh-%h-%p-%r"]
         self.common_args += ["-o", "StrictHostKeyChecking=no"]
-        if self.port is not None:
+        if self.port is not None and self.port != C.DEFAULT_REMOTE_PORT:
             self.common_args += ["-o", "Port=%d" % (self.port)]
         if self.runner.private_key_file is not None:
             self.common_args += ["-o", "IdentityFile="+self.runner.private_key_file]


### PR DESCRIPTION
Hello,

This is a fix for the SSH connection type - by default it sends a '-o Port=22' along to the ssh command which has the unfortunate side affect of overriding any Port setting one might have setup in an ssh-config file and passed to ansible via ANSIBLE_SSH_ARGS (ie, ANSIBLE_SSH_ARGS='-F some-ssh-config' ansible ...). Since the default is already port 22, this fix suppresses '-o Port=22' unless the connection is actually using a non-standard port.

Thanks, 

Dane
