### PR TITLE
fix: setup.py to install modules as well (issue #847)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,15 @@
 
 import os
 import sys
+from glob import glob
 
 sys.path.insert(0, os.path.abspath('lib'))
 from ansible import __version__, __author__
 from distutils.core import setup
+
+# find library modules
+from ansible.constants import DEFAULT_MODULE_PATH
+data_files = [ (DEFAULT_MODULE_PATH, glob('./library/*')) ]
 
 setup(name='ansible',
       version=__version__,
@@ -31,5 +36,6 @@ setup(name='ansible',
          'bin/ansible',
          'bin/ansible-playbook',
          'bin/ansible-pull'
-      ]
+      ],
+      data_files=data_files
 )


### PR DESCRIPTION
I tested this change on:
- CentOS 5.8
  - Python 2.4  (install only)
  - Python 2.6
- Ubuntu 11.04
  - Python 2.6
  - Python 2.7

Ansible was successfully installed and run on each platform.  I was expecting something to break but it didn't.  If a platform can be identified where it doesn't work, it can be easily blacklisted with a another line or two.
