### PR TITLE
Changes to postgresql to support defaults settings and older psycopg2

### DIFF
--- a/library/postgresql_db
+++ b/library/postgresql_db
@@ -75,11 +75,19 @@ def main():
     encoding = module.params["encoding"]
     state = module.params["state"]
     changed = False
+
+    # To use defaults values, keyword arguments must be absent, so 
+    # check which values are empty and don't include in the **kw
+    # dictionary
+    params_map =  {
+        "login_host":"host",
+        "login_user":"user",
+        "login_password":"password"
+    }
+    kw = dict( (params_map[k], v) for (k, v) in module.params.iteritems() 
+              if k in params_map and v != '' )
     try:
-        db_connection = psycopg2.connect(host=module.params["login_host"],
-                                         user=module.params["login_user"],
-                                         password=module.params["login_password"],
-                                         database="template1")
+        db_connection = psycopg2.connect(database="template1", **kw)
         # Enable autocommit so we can create databases
         db_connection.autocommit = True
         cursor = db_connection.cursor()

--- a/library/postgresql_db
+++ b/library/postgresql_db
@@ -89,7 +89,12 @@ def main():
     try:
         db_connection = psycopg2.connect(database="template1", **kw)
         # Enable autocommit so we can create databases
-        db_connection.autocommit = True
+        if psycopg2.__version__ >= '2.4.2':
+            db_connection.autocommit = True
+        else:
+            db_connection.set_isolation_level(psycopg2
+                                              .extensions
+                                              .ISOLATION_LEVEL_AUTOCOMMIT)
         cursor = db_connection.cursor()
     except Exception, e:
         module.fail_json(msg="unable to connect to database: %s" % e)


### PR DESCRIPTION
For older versions of psycopg2, to use the default postgres connection values, the keywords must be omitted, changed the behavior of the module, to omit keywords when the value is empty (defaulting to postgres default connection values).

Also, psycopg2 versions older than 2.4.2, do use different semantics instead of autocommit. Support that.

These changes are to support RHEL5+EPEL, which provides an older psycopg2.
