### PR TITLE
Fix copying for more than one host. Fix md5 checks

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -540,6 +540,10 @@ class Runner(object):
     def _executor_internal_inner(self, host, inject, port, is_chained=False):
         ''' decides how to invoke a module '''
 
+        # store module_name and module_args for next run 
+        preserve_module_name = self.module_name
+        preserve_module_args = self.module_args        
+
         # special non-user/non-fact variables:
         # 'groups' variable is a list of host name in each group
         # 'hostvars' variable contains variables for each host name
@@ -595,6 +599,9 @@ class Runner(object):
                 self.module_args = result.result['daisychain_args']
             result2 = self._executor_internal_inner(host, inject, port, is_chained=True)
             result2.result['module'] = self.module_name
+            # restore module_name and module_args after daisychaining!
+            self.module_name = preserve_module_name
+            self.module_args = preserve_module_args
             changed = False
             if result.result.get('changed',False) or result2.result.get('changed',False):
                 changed = True
@@ -658,7 +665,7 @@ class Runner(object):
 
         test = "rc=0; [ -r \"%s\" ] || rc=2; [ -f \"%s\" ] || rc=1" % (path,path)
         md5s = [
-            "(/usr/bin/md5sum %s 2>/dev/null)" % path,
+            "(/usr/bin/md5sum %s | cut -c1-32 2>/dev/null)" % path,
             "(/sbin/md5sum -q %s 2>/dev/null)" % path,
             "(/usr/bin/digest -a md5 -v %s 2>/dev/null)" % path
         ]


### PR DESCRIPTION
When running the copy module with more than one host, the daisychaining
causes the copy module to be skipped for the second host and just the
file module to be run, which causes an error.

Here I preserve the module_name and module_args at the start of
`_executor_internal_inner` and restore it after daisychaining. Better
solutions may exist. This only stopped working in the last couple of days
but I see nothing in the history that might cause it.

One other fix is that md5sum prints the filename after the checksum. This
means that the md5 comparison will always fail as we're comparing a checksum
to a checksum + filename. I've used cut to trim this at the remote end.
