### PR TITLE
Add method get_bin_path to module_common.py

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -202,6 +202,25 @@ class AnsibleModule(object):
         log_args = re.sub(r'login_password=.+ (.*)', r"login_password=NOT_LOGGING_PASSWORD \1", log_args)
         syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % log_args)
 
+    def get_bin_path(self, arg):
+        '''
+        find system executable in PATH.
+        if found return full path; otherwise return None
+        '''
+        sbin_paths = ['/sbin', '/usr/sbin', '/usr/local/sbin']
+        paths = os.environ.get('PATH').split(':')
+        bin_path = None
+        # mangle PATH to include /sbin dirs
+        for p in sbin_paths:
+            if p not in paths and os.path.exists(p):
+                paths.append(p)
+        for d in paths:
+            path = '%s/%s' % (d, arg)
+            if os.path.exists(path) and os.access(path, os.X_OK):
+                bin_path = path
+                break
+        return bin_path
+
     def boolean(self, arg):
         ''' return a bool for the arg '''
         if arg is None or type(arg) == bool:


### PR DESCRIPTION
This is meant to assist all the modules that look for the full path of
an executable.  If it is found and is X_OK, returns the full path.
Otherwise, it returns None.
