### PR TITLE
Fix setup module explosion when a route is empty. Closes #909

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -473,7 +473,7 @@ class LinuxNetwork(Network):
                 continue
             words = output.split('\n')[0].split()
             # A valid output starts with the queried address on the first line
-            if words[0] == command[v][-1]:
+            if len(words) > 0 and words[0] == command[v][-1]:
                 for i in range(len(words) - 1):
                     if words[i] == 'dev':
                         interface[v]['interface'] = words[i+1]


### PR DESCRIPTION
Fix setup module explosion when a route is empty. Closes #909
