### PR TITLE
Handle Unicode strings in commands

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -1,6 +1,6 @@
 # config file for ansible -- http://ansible.github.com
 # nearly all parameters can be overridden in ansible-playbook or with command line flags
-# ansible will read ~/.ansible.cfg or /etc/ansible.cfg, whichever it finds first
+# ansible will read ~/.ansible.cfg or /etc/ansible/ansible.cfg, whichever it finds first
 
 [defaults]
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -212,7 +212,7 @@ class Runner(object):
     def _execute_raw(self, conn, tmp, inject=None):
         ''' execute a non-module command for bootstrapping, or if there's no python on a device '''
         return ReturnData(conn=conn, result=dict(
-            stdout=self._low_level_exec_command(conn, self.module_args, tmp, sudoable = True)
+            stdout=self._low_level_exec_command(conn, self.module_args.encode('utf-8'), tmp, sudoable = True)
         ))
 
     # ***************************************************

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -215,6 +215,10 @@ def template(text, vars):
     ''' run a text buffer through the templating engine until it no longer changes '''
 
     prev_text = ''
+    try:
+        text = text.decode('utf-8')
+    except UnicodeEncodeError:
+        pass # already unicode
     depth = 0
     while prev_text != text:
         depth = depth + 1


### PR DESCRIPTION
These two patches allow ansible to execute commands containing non-ASCII strings (UTF-8 encoding is assumed). Tested using the shell/command modules and using the raw module, which required an extra patch.
