### PR TITLE
Unicode fixes

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -136,6 +136,9 @@ def command_generic_msg(hostname, result, oneline, caption):
     stderr = result.get('stderr', '')
     msg    = result.get('msg', '')
 
+    hostname = hostname.encode('utf-8')
+    caption  = caption.encode('utf-8')
+
     if not oneline:
         buf = "%s | %s | rc=%s >>\n" % (hostname, caption, result.get('rc',0))
         if stdout:

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -212,7 +212,7 @@ class Runner(object):
     def _execute_raw(self, conn, tmp, inject=None):
         ''' execute a non-module command for bootstrapping, or if there's no python on a device '''
         return ReturnData(conn=conn, result=dict(
-            stdout=self._low_level_exec_command(conn, self.module_args, tmp, sudoable = True)
+            stdout=self._low_level_exec_command(conn, self.module_args.encode('utf-8'), tmp, sudoable = True)
         ))
 
     # ***************************************************

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -215,6 +215,10 @@ def template(text, vars):
     ''' run a text buffer through the templating engine until it no longer changes '''
 
     prev_text = ''
+    try:
+        text = text.decode('utf-8')
+    except UnicodeEncodeError:
+        pass # already unicode
     depth = 0
     while prev_text != text:
         depth = depth + 1


### PR DESCRIPTION
These patches allow execution of commands containing characters outside ASCII, as well as receiving command results containing such characters.

They assume the local encoding is UTF-8.
