### PR TITLE
Extended the search for the pip binary

### DIFF
--- a/library/pip
+++ b/library/pip
@@ -29,14 +29,14 @@ def _get_full_name(name, version=None):
 
 
 def _find_pip(module, env):
-    paths = ['/usr/local/bin', '/usr/bin']
+    paths = os.environ["PATH"].split(os.pathsep)
 
     if env:
         paths = [os.path.join(env, 'bin')] + paths
 
     for p in paths:
         pe = p + '/pip'
-        if os.path.exists(pe):
+        if os.access(pe, os.X_OK):
             return pe
 
     module.fail_json(msg='pip is not installed')


### PR DESCRIPTION
There is no guarantee that pip is installed in /usr/bin or
/usr/local/bin - changed the search to use the whole path, and
ensures that pip is executable
