### PR TITLE
Add the wait_for module.

### DIFF
--- a/library/wait_for
+++ b/library/wait_for
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Jeroen Hoekx <jeroen@hoekx.be>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import socket
+import datetime
+import time
+import sys
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            name=dict(required=True),
+            timeout=dict(default=300),
+            port=dict(default=22),
+        ),
+    )
+
+    params = module.params
+
+    host = params['name']
+    timeout = int(params['timeout'])
+    port = int(params['port'])
+
+    end = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
+
+    while datetime.datetime.now() < end:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            s.connect( (host, port) )
+            s.close()
+            break
+        except:
+            time.sleep(1)
+    else:
+        module.fail_json(msg="Timeout when waiting for %s"%(host))
+
+    module.exit_json(msg="%s responds on %s"%(host, port))
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()


### PR DESCRIPTION
This module waits until a specific port on a given host can be connected to.

Very useful in deployments/testing.

Parameters:
- name: name of the host to connect to
- port: port number to connect to
- timeout: number of seconds to wait before giving up (default 300)

Example usage:

```

---

- hosts: rear
  user: root
  gather_facts: false

  vars:
    rear: /tmp/rear-checkout

  tasks:
  - name: ensure guest is running
    action: virt guest=${inventory_hostname} state=running
    delegate_to: fireflash

  - name: Wait for ${inventory_hostname}
    action: wait_for name=${inventory_hostname}
    delegate_to: fireflash

  - name: install rear git
    action: git repo=https://github.com/rear/rear.git dest=$rear

  - name: configure rear
    action: copy src=../config/etc/rear/local.conf dest=${rear}/etc/rear/local.conf

  - name: run rear
    action: command ${rear}/usr/sbin/rear mkbackup
```
