### PR TITLE
Add a state parameter to the wait_for module.

### DIFF
--- a/library/wait_for
+++ b/library/wait_for
@@ -30,6 +30,7 @@ def main():
             name=dict(required=True),
             timeout=dict(default=300),
             port=dict(default=22),
+            state=dict(default='started', choices=['started', 'stopped', 'restarted']),
         ),
     )
 
@@ -38,21 +39,40 @@ def main():
     host = params['name']
     timeout = int(params['timeout'])
     port = int(params['port'])
+    state = params['state']
 
-    end = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
+    if state in [ 'stopped', 'restarted']:
+        ### first wait for the host to go down
+        end = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
 
-    while datetime.datetime.now() < end:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            s.connect( (host, port) )
-            s.close()
-            break
-        except:
-            time.sleep(1)
-    else:
-        module.fail_json(msg="Timeout when waiting for %s"%(host))
+        while datetime.datetime.now() < end:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(5)
+            try:
+                s.connect( (host, port) )
+                s.close()
+                time.sleep(1)
+            except:
+                break
+        else:
+            module.fail_json(msg="Timeout when waiting for %s to stop."%(host))
 
-    module.exit_json(msg="%s responds on %s"%(host, port))
+    if state in [ 'started', 'restarted' ]:
+        ### wait for the host to come up
+        end = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
+
+        while datetime.datetime.now() < end:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                s.connect( (host, port) )
+                s.close()
+                break
+            except:
+                time.sleep(1)
+        else:
+            module.fail_json(msg="Timeout when waiting for %s"%(host))
+
+    module.exit_json(msg="State of %s on %s is %s."%(host, port, state))
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>

--- a/library/wait_for
+++ b/library/wait_for
@@ -72,7 +72,7 @@ def main():
         else:
             module.fail_json(msg="Timeout when waiting for %s"%(host))
 
-    module.exit_json(msg="State of %s on %s is %s."%(host, port, state))
+    module.exit_json(state=state, port=port)
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>

--- a/library/wait_for
+++ b/library/wait_for
@@ -27,21 +27,26 @@ def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-            name=dict(required=True),
+            host=dict(default='127.0.0.1'),
             timeout=dict(default=300),
-            port=dict(default=22),
-            state=dict(default='started', choices=['started', 'stopped', 'restarted']),
+            delay=dict(default=0),
+            port=dict(required=True),
+            state=dict(default='started', choices=['started', 'stopped']),
         ),
     )
 
     params = module.params
 
-    host = params['name']
+    host = params['host']
     timeout = int(params['timeout'])
+    delay = int(params['delay'])
     port = int(params['port'])
     state = params['state']
 
-    if state in [ 'stopped', 'restarted']:
+    if delay:
+        time.sleep(delay)
+
+    if state is 'stopped':
         ### first wait for the host to go down
         end = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
 
@@ -57,7 +62,7 @@ def main():
         else:
             module.fail_json(msg="Timeout when waiting for %s to stop."%(host))
 
-    if state in [ 'started', 'restarted' ]:
+    if state is 'started':
         ### wait for the host to come up
         end = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
 


### PR DESCRIPTION
This takes started, stopped and restarted.

Started returns when connecting is possible.
Stopped when connecting is not possible.
Restarted first waits for connecting to be impossible and returns when it is
possible again.

You can now do things like:

```
   - name: Reboot ${inventory_hostname}
     action: command /sbin/reboot

   - name: Wait for ${inventory_hostname}
     action: wait_for name=${inventory_hostname} state=restarted
     delegate_to: firefly
```

Sorry for this not being in the first request, but once you have something, you start to see additional things that are possible.
