### PR TITLE
Add working CPU model fact for some ARM devices

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -246,7 +246,9 @@ class LinuxHardware(Hardware):
         for line in open("/proc/cpuinfo").readlines():
             data = line.split(":", 1)
             key = data[0].strip()
-            if key == 'model name':
+            # model name is for Intel arch, Processor (mind the uppercase P)
+            # works for some ARM devices, like the Sheevaplug.
+            if key == 'model name' or key == 'Processor':
                 if 'processor' not in self.facts:
                     self.facts['processor'] = []
                 self.facts['processor'].append(data[1].strip())


### PR DESCRIPTION
Works on Sheevaplug, probably works on Rasberry Pi as well: has same /proc/cpuinfo layout
