### PR TITLE
Check for terminal capabilities if curses is available

### DIFF
--- a/lib/ansible/color.py
+++ b/lib/ansible/color.py
@@ -21,8 +21,20 @@ import sys
 ANSIBLE_COLOR=True
 if os.getenv("ANSIBLE_NOCOLOR") is not None:
     ANSIBLE_COLOR=False
-if not sys.stdout.isatty():
+elif not sys.stdout.isatty():
     ANSIBLE_COLOR=False
+else:
+    try:
+        import curses
+        curses.setupterm()
+        if curses.tigetnum('colors') < 0:
+            ANSIBLE_COLOR=False
+    except ImportError:
+        # curses library was not found
+        pass
+    except curses.error:
+        # curses returns an error (e.g. could not find terminal)
+        ANSIBLE_COLOR=False
 
 # --- begin "pretty"
 #


### PR DESCRIPTION
Normally curses is part of the standard library, but this was not
always the case in the past.

The ANSIBLE_COLOR environment variable and the tty-check have
priority over the curses method (as they are both faster than
the curses test).
