### PR TITLE
Get --limit working by comparing host names instead of objects.

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -114,11 +114,15 @@ class Inventory(object):
             positive_subsetp = [ p for p in self._subset if not p.startswith("!") ]
             negative_subsetp = [ p for p in self._subset if p.startswith("!") ]
             if len(positive_subsetp):
-                positive_subset = self._get_hosts(positive_subsetp)
-                hosts = [ h for h in hosts if (h in positive_subset) ]
+                positive_subset = []
+                for h in self._get_hosts(positive_subsetp):
+                    positive_subset.append(h.name)
+                hosts = [ h for h in hosts if (h.name in positive_subset) ]
             if len(negative_subsetp):
-                negative_subset = self._get_hosts(negative_subsetp)
-                hosts = [ h for h in hosts if (h not in negative_subset)]
+                negative_subset = []
+                for h in self._get_hosts(negative_subsetp):
+                    negative_subset.append(h.name)
+                hosts = [ h for h in hosts if (h.name not in negative_subset)]
 
         # exclude hosts mentioned in any restriction (ex: failed hosts)
         if self._restriction is not None:


### PR DESCRIPTION
I am not sure if I am fixing the cause or a symptom here, but it works.

Previously, the subset code compared objects in hosts with objects in positive_subset. For me, using ec2_external_inventory.py, the objects in `hosts` did not match the objects in `positive_subset`, while the hostname was the same, the objects lived in different locations in memory, so the resulting list was empty.

By modifying the code to compare host names, --limit is doing the correct thing.

An alternative might be to ensure `positive_subset` contains the exact same objects that live in `hosts`, but I did not look into that.
