### PR TITLE
Added cwd to tempdir in git clone method. Fixes usage with sudo.

### DIFF
--- a/library/git
+++ b/library/git
@@ -24,6 +24,7 @@
 # that. Contribs welcome! -- MPD
 
 import re
+import tempfile
 
 def get_version(dest):
     ''' samples the version of the git repo '''
@@ -40,7 +41,7 @@ def clone(repo, dest):
     except:
         pass
     cmd = "git clone %s %s" % (repo, dest)
-    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=tempfile.gettempdir())
     (out, err) = cmd.communicate()
     rc = cmd.returncode
     return (rc, out, err)


### PR DESCRIPTION
Without this patch git clone has a problem when it's used with sudo.

The git clone command needs write permission to the current directory.
Let's say you connect as userA and sudo to userB who has no write permission on the homedir of userA, then the command fails.

This patch just changes the working directory to the systems default directory which should be writable for everybody.

Regards

Ingo
