### PR TITLE
Disable PasswordAuthentication when using -c ssh

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -76,6 +76,6 @@ remote_port=22
 # will result in poor performance, so use transport=paramiko on older platforms rather than
 # removing it
 
-ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r
+ssh_args=-o PasswordAuthentication=no -o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r
 
 


### PR DESCRIPTION
If PasswordAuthentication is enabled (which is the default) ansible will spawn (multiple) ssh's with a password-prompt which corrupts the terminal, and cannot be properly used.

So it is better to not allow for password-based authentication using `-c ssh`. The result is that authentication fails but Ansible continues to work
