### PR TITLE
Invoke cowsay without going through the shell

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -121,8 +121,8 @@ def regular_generic_msg(hostname, result, oneline, caption):
 def banner(msg):
 
     if cowsay != None:
-        cmd = subprocess.Popen("%s -W 60 \"%s\"" % (cowsay, msg),
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        cmd = subprocess.Popen([cowsay, "-W", "60", msg],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (out, err) = cmd.communicate()
         return "%s\n" % out
     else:


### PR DESCRIPTION
This fixes variables getting expanded by the shell, especially cases where variables expand to values the shell deems unparseable (e.g. with_items with dicts), which leaves me without cows and thus very sad. With this I get cows every time!
