### PR TITLE
Pause tasks (incomplete)

### DIFF
--- a/examples/playbooks/pause.yml
+++ b/examples/playbooks/pause.yml
@@ -1,0 +1,58 @@
+# Pause task example.
+#
+# A typical reason to use a pause task is to verify updates to a
+# critical service before putting it back into a production
+# environment.
+---
+- hosts: EnterpriseyCustomerAppServers
+  # In this environment we verify each server individually to ensure
+  # updates are applied smoothly.
+  serial: 1
+  tasks:
+      # Take the host out of a load balancer before applying updates to it
+      - name: Out Of Rotation
+        action: command /usr/bin/myrotate --disable $inventory_hostname
+        delegate_to: $production_load_balancer
+
+      - name: shutdown the frobnicator
+        action: service name=frobnicator state=stopped
+
+      - name: update the customer frobnication service
+        action: yum name=customer-frobnicator state=latest
+
+      - name: start something up
+        action: service name=frobnicator ensure=started
+
+      - name: verify application
+        pause: prompt=Verify frobnicator application functionality
+
+      # Using the 'prompt' parameter without a value will give you a
+      # default prompt message. "Press enter to continue"
+      - name: verify application
+        pause: prompt
+
+      - name: In Rotation
+        action: command /usr/bin/myrotate --enable $inventory_hostname
+        delegate_to: $production_load_balancer
+
+# Pause accepts 'minutes' and 'seconds' parameters as well. Their
+# syntax is obvious. They do not have defaults.
+- hosts: EnterpriseyDocumentSharingServers
+  tasks:
+      # Typical out of rotation, update, etc, here
+      # ...
+
+      - name: start FrobSpaceDocs
+        action: service name=frobspacedocs ensure=started
+
+      # This java documentation server application is incredibly slow
+      # until it has loaded most of it's documents into cache. We
+      # don't want to start it and immediately put it into rotation,
+      # users will start complaining about the slowness.
+      - name: app loading cache
+        pause: minutes=15
+      # pause: seconds=900
+
+
+      # Typical in rotation steps here
+      # ...

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -166,8 +166,8 @@ class PlayBook(object):
         # if the playbook is invoked with --tags that don't exist at all in the playbooks
         # then we need to raise an error so that the user can correct the arguments.
         unknown_tags = set(self.only_tags) - (matched_tags_all | unmatched_tags_all)
-        unknown_tags.discard('all')       
- 
+        unknown_tags.discard('all')
+
         if len(unknown_tags) > 0:
             unmatched_tags_all.discard('all')
             msg = 'tag(s) not found in playbook: %s.  possible values: %s'
@@ -221,7 +221,14 @@ class PlayBook(object):
             transport=task.play.transport, sudo_pass=self.sudo_pass, is_playbook=True
         )
 
-        if task.async_seconds == 0:
+        if not task.task_type == 'action':
+            try:
+                action = __import__("ansible.playbook.%s" % task.task_type, fromlist=[task.task_type])
+                action_class = getattr(action, task.task_type)
+                results = runner.run_other_action(action_class)
+            except ImportError:
+                raise errors.AnsibleError("unable to locate and load %s" % task.task_type)
+        elif task.async_seconds == 0:
             results = runner.run()
         else:
             results, poller = runner.run_async(task.async_seconds)
@@ -363,4 +370,3 @@ class PlayBook(object):
                     self.inventory.lift_restriction()
 
             self.inventory.lift_also_restriction()
-

--- a/lib/ansible/playbook/pause.py
+++ b/lib/ansible/playbook/pause.py
@@ -1,0 +1,95 @@
+# (c) 2012, Tim Bielawa <tbielawa@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.errors import AnsibleError as ae
+from termios import tcflush, TCIFLUSH
+from ansible.callbacks import vv, vvv
+import datetime
+import time
+import sys
+
+
+class pause(object):
+    ''' pauses execution for a length or time, or until input is received '''
+
+    PAUSE_TYPES = ['seconds', 'minutes', 'prompt']
+
+    def __init__(self, host, module_args):
+        self.result = {'changed': False, 'rc': 0, 'stderr': ''}
+        (self.pause_type, sep, pause_params) = module_args.partition('=')
+        if not self.pause_type in pause.PAUSE_TYPES:
+            raise ae("invalid parameter for pause, '%s'. must be one of: %s" % \
+                         (self.pause_type, ", ".join(pause.PAUSE_TYPES)))
+
+        # Set defaults
+        self.duration_unit = 'minutes'
+        self.prompt = None
+        self.seconds = None
+
+        # The time() command operates in seconds so we need to
+        # recalculate for minutes=X values.
+        if self.pause_type == 'minutes':
+            self.seconds = int(pause_params) * 60
+        elif self.pause_type == 'seconds':
+            self.seconds = int(pause_params)
+            self.duration_unit = 'seconds'
+        else:
+            if pause_params == '':
+                self.prompt = "[%s] Press enter to continue:" % host
+            else:
+                self.prompt = "[%s] %s" % (host, pause_params)
+
+        vvv("created Pause() with pause_type=%s, duration_unit=%s, calculated_seconds=%s, prompt=%s" % \
+                (self.pause_type, self.duration_unit, self.seconds, self.prompt))
+
+    def _start(self):
+        ''' mark the time of execution for duration calculations later '''
+        self.start = time.time()
+        self.result['start'] = str(datetime.datetime.now())
+
+    def _stop(self):
+        ''' calculate the duration we actually paused for and then
+        finish building the task result string '''
+        duration = time.time() - self.start
+        self.result['stop'] = str(datetime.datetime.now())
+        self.result['delta'] = int(duration)
+
+        if self.duration_unit == 'minutes':
+            duration = round(duration / 60.0, 2)
+        else:
+            duration = round(duration, 2)
+
+        self.result['stdout'] = "Paused for %s %s" % (duration, self.duration_unit)
+
+    def run(self):
+        ''' kick off the show '''
+        try:
+            self._start()
+            if not self.pause_type == 'prompt':
+                print "Pausing for %s %s (^C to continue early)" % (self.seconds, self.duration_unit)
+                time.sleep(self.seconds)
+            else:
+                # Clear out any unflushed buffered input which would
+                # otherwise be consumed by raw_input() prematurely.
+                tcflush(sys.stdin, TCIFLUSH)
+                raw_input(self.prompt)
+        except KeyboardInterrupt:
+            vv('caught ^C signal')
+        finally:
+            self._stop()
+
+        return self.result

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -24,17 +24,20 @@ class Task(object):
     __slots__ = [
         'name', 'action', 'only_if', 'async_seconds', 'async_poll_interval',
         'notify', 'module_name', 'module_args', 'module_vars',
-        'play', 'notified_by', 'tags', 'register', 'with_items', 
+        'play', 'notified_by', 'tags', 'register', 'with_items',
         'delegate_to', 'first_available_file', 'ignore_errors',
-        'local_action'
+        'local_action', 'pause', 'task_type'
     ]
 
     # to prevent typos and such
     VALID_KEYS = [
-         'name', 'action', 'only_if', 'async', 'poll', 'notify', 'with_items', 
+         'name', 'action', 'only_if', 'async', 'poll', 'notify', 'with_items',
          'first_available_file', 'include', 'tags', 'register', 'ignore_errors',
-         'delegate_to', 'local_action'
+         'delegate_to', 'local_action', 'pause'
     ]
+
+    # The specific keys which identify a task's true type
+    TASK_TYPES = ['action', 'local_action', 'pause']
 
     def __init__(self, play, ds, module_vars=None):
         ''' constructor loads from a task or handler datastructure '''
@@ -47,31 +50,103 @@ class Task(object):
         self.play        = play
 
         # load various attributes
-        self.name         = ds.get('name', None)
         self.tags         = [ 'all' ]
         self.register     = ds.get('register', None)
 
-        # Both are defined
-        if ('action' in ds) and ('local_action' in ds):
-            raise errors.AnsibleError("the 'action' and 'local_action' attributes can not be used together")
-        # Both are NOT defined
-        elif (not 'action' in ds) and (not 'local_action' in ds):
-            raise errors.AnsibleError("task missing an 'action' attribute")
-        # Only one of them is defined
-        elif 'local_action' in ds:
-            self.action      = ds.get('local_action', '')
-            self.delegate_to = '127.0.0.1'
+        # Lets talk about mutual exclusion for a minute, I hope you
+        # brushed up on your set operations! The following are sets of
+        # some keys that have special grouping conditions:
+        #
+        # All of the keys present in the play, etc
+        present_keys = set(ds.keys())
+        empty = set([])
+        valid_keys = set(Task.VALID_KEYS)
+        # One and Only One of these must be present
+        task_type_keys = set(Task.TASK_TYPES)
+        # Everything you can modify a task with
+        non_type_keys = valid_keys - task_type_keys
+        # You can't mix action and local action
+        task_action_keys = set(['action', 'local_action'])
+        # You can't specify a delegate to a local_action
+        local_action_keys = set(['local_action', 'delegate_to'])
+        # I don't understand how this combination would make any sense
+        pause_delegate = set(['pause', 'delegate_to'])
+        # These don't work either
+        with_files = set(['with_items', 'first_available_file'])
+
+        # Now lets go through and check for problems
+        #
+        # You need to have One and Only One of these
+        if len(task_type_keys & present_keys) > 1:
+            raise errors.AnsibleError("only one of 'action', 'local_action', and 'pause' may be present in a task")
+
+        if len(task_type_keys & present_keys) == empty:
+            raise errors.AnsibleError("one of 'action', 'local_action', or 'pause' must be present in a task")
+
+        # One or the other
+        if len(task_action_keys & present_keys) > 1:
+            raise errors.AnsibleError("only one of 'action' and 'local_action' may be present in a task")
+
+        # Local actions are already delegated
+        if len(local_action_keys & present_keys) > 1:
+            raise errors.AnsibleError("using 'local_action' is not compatable with 'delegate_to'")
+
+        # These don't mix well either
+        if len(with_files & present_keys) > 1:
+            raise errors.AnsibleError("'with_items' and 'first_available_file' are mutually incompatible in a single task")
+
+        # Makes no sense
+        if len(pause_delegate & present_keys) > 1:
+            raise errors.AnsibleError("using 'pause' is not compatable with 'delegate_to'")
+
+        # Last-stop for syntax checking and type identification
+
+        # Consider all present keys, then take away all the modifier
+        # types, your resultant set should be left with exactly 1
+        # item: the task's type. Verify this result by intersecting it
+        # with the task_type_keys set. If only one element remains
+        # then you have identified the type of this task. Any other
+        # result else means that this is a malformed task description.
+        #
+        # With all the condition checking before this block this
+        # should work every time (famous last words) to identify the
+        # task type as well as catch any lingering syntax errors.
+        type_candidate = present_keys - non_type_keys
+        if len(type_candidate & task_type_keys) == 1:
+            self.task_type = type_candidate.pop()
+            self.module_vars['task_type'] = self.task_type
         else:
-            self.action      = ds.get('action', '')
+            desc = []
+            for k,v in ds.iteritems():
+                desc.append("[%s:%s]" % (k, str(v)))
+            raise errors.AnsibleError("syntax error while parsing task: %s" % " ".join(desc))
+
+        # Handle actions and optional delegates
+        if self.task_type ==  'local_action':
+            self.action = ds['local_action']
+            self.delegate_to = '127.0.0.1'
+            self.module_vars['delegate_to'] = self.delegate_to
+            # Override this manually, they're like aliases
+            self.task_type = 'action'
+            self.module_vars['task_type'] = self.task_type
+        elif self.task_type == 'action' in present_keys:
+            self.action = ds['action']
             self.delegate_to = ds.get('delegate_to', None)
+            self.module_vars['delegate_to'] = self.delegate_to
+        else:
+            self.action = ds[self.task_type]
+            self.delegate_to = ds.get('delegate_to', None)
+
+        # Every task needs a name! If it doesn't have a name it must
+        # have either an action or pause statement.
+        if not 'name' in present_keys:
+            self.name = ds['action']
+        else:
+            self.name = ds['name']
 
         # notified by is used by Playbook code to flag which hosts
         # need to run a notifier
         self.notified_by = []
-
-        # if no name is specified, use the action line as the name
-        if self.name is None:
-            self.name = self.action
 
         # load various attributes
         self.only_if = ds.get('only_if', 'True')
@@ -87,14 +162,22 @@ class Task(object):
         if isinstance(self.notify, basestring):
             self.notify = [ self.notify ]
 
-        # split the action line into a module name + arguments
+        # split the action line into: [module-name, 'string of arguments']
         tokens = self.action.split(None, 1)
-        if len(tokens) < 1:
-            raise errors.AnsibleError("invalid/missing action in task. name: %s" % self.name)
-        self.module_name = tokens[0]
-        self.module_args = ''
-        if len(tokens) > 1:
-            self.module_args = tokens[1]
+
+        # non action-type tasks don't start with a module name, so
+        # just pass it the action and let it handle it's own argument
+        # validation
+        if not self.task_type == 'action':
+            self.module_name = self.task_type
+            self.module_args = self.action
+        else:
+            if len(tokens) < 1:
+                raise errors.AnsibleError("invalid/missing action in task. name: %s" % self.name)
+            self.module_name = tokens[0]
+            self.module_args = ''
+            if len(tokens) > 1:
+                self.module_args = tokens[1]
 
         import_tags = self.module_vars.get('tags',[])
         if type(import_tags) in [str,unicode]:
@@ -104,9 +187,6 @@ class Task(object):
         self.name = utils.template(self.name, self.module_vars)
         self.action = utils.template(self.action, self.module_vars)
 
-        # handle mutually incompatible options
-        if self.with_items is not None and self.first_available_file is not None:
-            raise errors.AnsibleError("with_items and first_available_file are mutually incompatible in a single task")
 
         # make first_available_file accessable to Runner code
         if self.first_available_file:
@@ -116,9 +196,6 @@ class Task(object):
         if self.with_items is None:
             self.with_items = [ ]
         self.module_vars['items'] = self.with_items
-
-        # allow runner to see delegate_to option
-        self.module_vars['delegate_to'] = self.delegate_to
 
         # make ignore_errors accessable to Runner code
         self.module_vars['ignore_errors'] = self.ignore_errors
@@ -131,4 +208,3 @@ class Task(object):
             elif type(apply_tags) == list:
                 self.tags.extend(apply_tags)
         self.tags.extend(import_tags)
-

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -549,7 +549,7 @@ class Runner(object):
         try:
             delegate_to = inject.get('delegate_to', None)
             if delegate_to is not None:
-                actual_host = delegate_to    
+                actual_host = delegate_to
             conn = self.connector.connect(actual_host, port)
             if delegate_to is not None:
                 conn._delegate_for = host
@@ -796,6 +796,46 @@ class Runner(object):
             results = self._parallel_exec(hosts)
         else:
             results = [ self._executor(h[1]) for h in hosts ]
+
+        return self._partition_results(results)
+
+    # *****************************************************
+
+    def run_other_action(self, action_class):
+        ''' run a raw python action '''
+
+        # find hosts that match the pattern
+        hosts = self.inventory.list_hosts(self.pattern)
+        if len(hosts) == 0:
+            self.callbacks.on_no_hosts()
+            return dict(contacted={}, dark={})
+
+        hosts = [ (self,x) for x in hosts ]
+        results = []
+
+        # Create a new connection and temporarily override the current
+        # transport. This works in a serial manner only for now.
+        for (self,host) in hosts:
+            conn = connection.Connection(self).connect(host, None, 'internal')
+            action = action_class(host, self.module_args)
+            result = conn.exec_command(action.run)
+            result = ReturnData(conn=conn, host=host, result=result, comm_ok=True)
+            data = result.result
+
+            if 'skipped' in data:
+                self.callbacks.on_skipped(host)
+            elif not result.is_successful():
+                ignore_errors = self.module_vars.get('ignore_errors', False)
+                self.callbacks.on_failed(host, data, ignore_errors)
+                if ignore_errors:
+                    if 'failed' in result.result:
+                        result.result['failed'] = False
+                    if 'rc' in result.result:
+                        result.result['rc'] = 0
+            else:
+                self.callbacks.on_ok(host, data)
+            results.append(result)
+
         return self._partition_results(results)
 
     # *****************************************************

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -35,9 +35,10 @@ class Connection(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def connect(self, host, port=None):
+    def connect(self, host, port=None, transport=None):
         conn = None
-        transport = self.runner.transport
+        if not transport:
+            transport = self.runner.transport
         module = modules.get(transport, None)
         if module is None:
             raise AnsibleError("unsupported connection type: %s" % transport)

--- a/lib/ansible/runner/connection_plugins/internal.py
+++ b/lib/ansible/runner/connection_plugins/internal.py
@@ -1,0 +1,48 @@
+# (c) 2012, Tim Bielawa <tbielawa@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.callbacks import vvv
+
+class Connection(object):
+    ''' Fake internal-type connection '''
+
+    def __init__(self, runner=None, host=None, port=None):
+        self.runner = runner
+        self.host = host
+        self.port = port
+
+    def connect(self, port=None):
+        ''' connect to the local host; nothing to do here '''
+        return self
+
+    def exec_command(self, cmd, tmp_path=None, sudo_user=None, sudoable=False):
+        ''' run a command locally in this process.
+        cmd should be passed as a function reference
+        the return from cmd should be a results dict '''
+        return cmd()
+
+    def put_file(self, in_path, out_path):
+        ''' no need to transfer raw python commands '''
+        pass
+
+    def fetch_file(self, in_path, out_path):
+        ''' irrelevant '''
+        pass
+
+    def close(self):
+        ''' terminate the connection; nothing to do here '''
+        pass


### PR DESCRIPTION
This PR will add pause tasks in playbooks. Pause supports 'minutes', 'seconds', and 'prompt' parameters.

The implementation is done in a general way such that the model is easily extended to new non-action/local_action type tasks in the future.

The pause task is able to handle ^C interrupts without conflicting with the KeyboardInterrupt handler higher up in the Runner stack. I think though that the specific implementation needs a tweak. If you ^C during a pause and actually _need_ to terminate the application you can't just press it once and expect it to quit, you'd have to hold it down. I think there needs to be a more obvious way to impart the correct quit technique, and it needs to be garanteed not to execute another task (like enabling something in a load balancer, for example) before the application fully quits.

First thoughts:
- User hits ^C
- User is prompted: "Quit? (y/n)"
- $needful

I hope you find changes to the CORE API code acceptable. I took extra special care to only make the minimal amount of necessary changes to accomplish this.

I know I have this marked as incomplete in the PR subject, but much to my great surprise I think it actually is functioning as-expected when serial > 1.

Not that these will be features in high demand, but things like only_if are probably not working.

There is an example I added that explain the common use cases. $ENTERPRISEY++;
