### PR TITLE
Subversion dest should allow ~ expansion

### DIFF
--- a/library/subversion
+++ b/library/subversion
@@ -99,7 +99,7 @@ def main():
         )
     )
 
-    dest     = module.params['dest']
+    dest     = os.path.expanduser(module.params['dest'])
     repo     = module.params['repo']
     revision = module.params['revision']
     force    = module.boolean(module.params['force'])


### PR DESCRIPTION
Used os.path.expanduser on dest to allow e.g. ~/svn/repo as
a destination
