### PR TITLE
Fixed a parsing HEAD problem, when ansible is checked out as a submodule

### DIFF
--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -324,6 +324,11 @@ def _gitinfo():
     result = None
     repo_path = os.path.join(os.path.dirname(__file__), '..', '..', '.git')
     if os.path.exists(repo_path):
+        ''' Check if the .git is a file. If it is a file, it means that we are in a submodule structure. '''
+        if os.path.isfile(repo_path):
+            central_gitdir = yaml.load(open(repo_path))['gitdir'].split('.git')[0]
+            ''' There is a posibility the .git file to have an absolute path. '''
+            repo_path = os.path.join(os.path.relpath(central_gitdir), '.git')
         f = open(os.path.join(repo_path, "HEAD"))
         branch = f.readline().split('/')[-1].rstrip("\n")
         f.close()


### PR DESCRIPTION
Fixed a parsing HEAD problem, when ansible is checked out as a
submodule in git
