### PR TITLE
Fixed a parsing HEAD problem, when ansible is checked out as a submodule

### DIFF
--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -323,13 +323,19 @@ def _gitinfo():
     ''' returns a string containing git branch, commit id and commit date '''
     result = None
     repo_path = os.path.join(os.path.dirname(__file__), '..', '..', '.git')
+    ''' Check if the .git is a file. If it is a file, it means that we are in a submodule structure. '''
     if os.path.exists(repo_path):
         ''' Check if the .git is a file. If it is a file, it means that we are in a submodule structure. '''
         if os.path.isfile(repo_path):
-            repo_path = repo_path.split('.git')[0]
-            central_gitdir = yaml.load(open(repo_path))['gitdir'].split('.git')[0]
-            ''' There is a posibility the .git file to have an absolute path. '''
-            repo_path = os.path.join(repo_path, os.path.relpath(central_gitdir), '.git')
+            try:
+                central_gitdir = yaml.load(open(repo_path)).get('gitdir').split('.git')[0]
+                repo_path = repo_path.split('.git')[0]
+                ''' There is a posibility the .git file to have an absolute path. '''
+                repo_path = os.path.join(repo_path, os.path.relpath(central_gitdir), '.git')
+            except IOError:
+                exit("Could not load .git file.") 
+            except AttributeError:
+                exit("There is no gitdir attribute in .git file.")
         f = open(os.path.join(repo_path, "HEAD"))
         branch = f.readline().split('/')[-1].rstrip("\n")
         f.close()

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -323,7 +323,7 @@ def _gitinfo():
     ''' returns a string containing git branch, commit id and commit date '''
     result = None
     repo_path = os.path.join(os.path.dirname(__file__), '..', '..', '.git')
-    ''' Check if the .git is a file. If it is a file, it means that we are in a submodule structure. '''
+    
     if os.path.exists(repo_path):
         ''' Check if the .git is a file. If it is a file, it means that we are in a submodule structure. '''
         if os.path.isfile(repo_path):

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -326,9 +326,10 @@ def _gitinfo():
     if os.path.exists(repo_path):
         ''' Check if the .git is a file. If it is a file, it means that we are in a submodule structure. '''
         if os.path.isfile(repo_path):
+            repo_path = repo_path.split('.git')[0]
             central_gitdir = yaml.load(open(repo_path))['gitdir'].split('.git')[0]
             ''' There is a posibility the .git file to have an absolute path. '''
-            repo_path = os.path.join(os.path.relpath(central_gitdir), '.git')
+            repo_path = os.path.join(repo_path, os.path.relpath(central_gitdir), '.git')
         f = open(os.path.join(repo_path, "HEAD"))
         branch = f.readline().split('/')[-1].rstrip("\n")
         f.close()

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -324,6 +324,11 @@ def _gitinfo():
     result = None
     repo_path = os.path.join(os.path.dirname(__file__), '..', '..', '.git')
     if os.path.exists(repo_path):
+        ''' Check if the .git is a file. If it is a file, it means that we are in a submodule structure. '''
+        if os.path.isfile(repo_path):
+            central_gitdir = yaml.load(open(repo_path))['gitdir'].split('.git')[0]
+            ''' There is a posibility the .git file to have an absolute path. '''
+            repo_path = os.path.join(os.path.relpath(central_gitdir), '.git')
         f = open(os.path.join(repo_path, "HEAD"))
         branch = f.readline().split('/')[-1].rstrip("\n")
         f.close()

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -325,17 +325,15 @@ def _gitinfo():
     repo_path = os.path.join(os.path.dirname(__file__), '..', '..', '.git')
     
     if os.path.exists(repo_path):
-        ''' Check if the .git is a file. If it is a file, it means that we are in a submodule structure. '''
+        # Check if the .git is a file. If it is a file, it means that we are in a submodule structure.
         if os.path.isfile(repo_path):
             try:
                 central_gitdir = yaml.load(open(repo_path)).get('gitdir').split('.git')[0]
                 repo_path = repo_path.split('.git')[0]
-                ''' There is a posibility the .git file to have an absolute path. '''
+                # There is a posibility the .git file to have an absolute path.
                 repo_path = os.path.join(repo_path, os.path.relpath(central_gitdir), '.git')
-            except IOError:
-                exit("Could not load .git file.") 
-            except AttributeError:
-                exit("There is no gitdir attribute in .git file.")
+            except (IOError, AttributeError):
+                return 'n/a'
         f = open(os.path.join(repo_path, "HEAD"))
         branch = f.readline().split('/')[-1].rstrip("\n")
         f.close()


### PR DESCRIPTION
Fixed a parsing HEAD problem, when ansible is checked out as a
submodule in git
