### PR TITLE
Keep result pristine for ignore_errors

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -76,11 +76,12 @@ class AggregateStats(object):
         prev = (getattr(self, what)).get(host, 0)
         getattr(self, what)[host] = prev+1
 
-    def compute(self, runner_results, setup=False, poll=False):
+    def compute(self, runner_results, setup=False, poll=False, ignore_errors=False):
         ''' walk through all results and increment stats '''
 
         for (host, value) in runner_results.get('contacted', {}).iteritems():
-            if ('failed' in value and bool(value['failed'])) or ('rc' in value and value['rc'] != 0):
+            if not ignore_errors and (('failed' in value and bool(value['failed'])) or
+                ('rc' in value and value['rc'] != 0)):
                 self._increment('failures', host)
             elif 'skipped' in value and bool(value['skipped']):
                 self._increment('skipped', host)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -246,7 +246,7 @@ class PlayBook(object):
         if results is None:
             results = {}
 
-        self.stats.compute(results)
+        self.stats.compute(results, ignore_errors=task.ignore_errors)
 
         # add facts to the global setup cache
         for host, result in results['contacted'].iteritems():

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -616,11 +616,6 @@ class Runner(object):
             elif not result.is_successful():
                 ignore_errors = self.module_vars.get('ignore_errors', False)
                 self.callbacks.on_failed(host, data, ignore_errors)
-                if ignore_errors:
-                    if 'failed' in result.result:
-                        result.result['failed'] = False
-                    if 'rc' in result.result:
-                        result.result['rc'] = 0
             else:
                 self.callbacks.on_ok(host, data)
         return result


### PR DESCRIPTION
This allows playbooks like

```
- action: command ...
  register: var
- action: command ...
  only_if: "${var.rc} != 0"
```

to work as expected, rather than skipping the second task.
