### PR TITLE
Add support to removes control param

### DIFF
--- a/library/command
+++ b/library/command
@@ -114,6 +114,21 @@ class CommandModule(AnsibleModule):
                         rc=0
                     )
                 args = args.replace(x,'')
+            elif x.startswith("removes="):
+                # do not run the command if the line contains removes=filename
+                # and the filename do not exists.  This allows idempotence
+                # of command executions.
+                (k,v) = x.split("=",1)
+                if not os.path.exists(v):
+                    self.exit_json(
+                        cmd=args,
+                        stdout="skipped, since %s do not exists" % v,
+                        skipped=True,
+                        changed=False,
+                        stderr=False,
+                        rc=0
+                    )
+                args = args.replace(x,'')
             elif x.startswith("chdir="):
                 (k,v) = x.split("=", 1)
                 v = os.path.expanduser(v)


### PR DESCRIPTION
Execute action only if specified file using param removes exist (execute reverse control of creates).

Some usage eg.:

``` yaml
- name: enable apache2 default websites
  action: command /usr/sbin/a2ensite $item creates=/etc/apache2/sites-enabled/$item
  with_items:
    - default
    - default-ssl

- name: disable apache2 default websites
  action: command /usr/sbin/a2dissite $item removes=/etc/apache2/sites-enabled/$item
  with_items:
    - default
    - default-ssl
```
