### PR TITLE
Add /proc/cmdline information to the default facts

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -58,6 +58,7 @@ class Facts(object):
         self.facts = {}
         self.get_platform_facts()
         self.get_distribution_facts()
+        self.get_cmdline()
         self.get_public_ssh_host_keys()
         self.get_selinux_facts()
 
@@ -102,6 +103,17 @@ class Facts(object):
                         self.facts['distribution'] = data.split()[0]
                 else:
                     self.facts['distribution'] = name
+
+    def get_cmdline(self):
+        data = get_file_content('/proc/cmdline')
+        if data:
+            self.facts['cmdline'] = {}
+            for piece in shlex.split(data):
+                item = piece.split('=', 1)
+                if len(item) == 1:
+                    self.facts['cmdline'][item[0]] = True
+                else:
+                    self.facts['cmdline'][item[0]] = item[1]
 
     def get_public_ssh_host_keys(self):
         dsa = get_file_content('/etc/ssh/ssh_host_dsa_key.pub')
@@ -198,7 +210,7 @@ class LinuxHardware(Hardware):
     MEMORY_FACTS = ['MemTotal', 'SwapTotal', 'MemFree', 'SwapFree']
     # DMI bits
     DMI_DICT = dict(
-        form_factor     =  '/sys/devices/virtual/dmi/id/chassis_type',
+        form_factor     = '/sys/devices/virtual/dmi/id/chassis_type',
         product_name    = '/sys/devices/virtual/dmi/id/product_name',
         product_serial  = '/sys/devices/virtual/dmi/id/product_serial',
         product_uuid    = '/sys/devices/virtual/dmi/id/product_uuid',


### PR DESCRIPTION
The use-case here is that based on information in the /proc/cmdline certain actions can be taken.

A practical example in our case is that we have a play at the end of the provisioning phase that reboots the system. Since we don't want to accidentally reboot a system (or restart the network) on a production machine, having a way to separate an Anaconda post-install (sshd in chroot) with a normal system is a good way to make that distinction.

```

---
- name: reboot
  hosts: all
  tasks:
  - action: command init 6
    only_if: "not '${ansible_cmdline.BOOT_IMAGE}'.startswith('$')"
```

A practical problem here is the fact that we cannot simply check whether it is set or empty:

```

---
- name: reboot
  hosts: all
  tasks:
  - action: command init 6
    only_if: "'${ansible_cmdline.BOOT_IMAGE}'"
```

If ansible_cmdline was a string, a simple only_if: "'${ansible_cmdline}'.find(' BOOT_IMAGE=')" was an option, but still not very "beautiful" :-/
