### PR TITLE
Fix regex that allows passwords to get into syslog, use journal if available.

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -55,9 +55,16 @@ try:
 except ImportError:
     from md5 import md5 as _md5
 
+try:
+  from systemd import journal
+  has_journal = True
+except ImportError:
+  import syslog
+  has_journal = False
+
 class AnsibleModule(object):
 
-    def __init__(self, argument_spec, bypass_checks=False, no_log=False, 
+    def __init__(self, argument_spec, bypass_checks=False, no_log=False,
         check_invalid_arguments=True, mutually_exclusive=None, required_together=None,
         required_one_of=None):
 
@@ -144,7 +151,7 @@ class AnsibleModule(object):
             non_zero = [ c for c in counts if c > 0 ]
             if len(non_zero) > 0:
                 if 0 in counts:
-                    self.fail_json(msg="parameters are required together: %s" % check) 
+                    self.fail_json(msg="parameters are required together: %s" % check)
 
     def _check_required_arguments(self):
         ''' ensure all required arguments are present '''
@@ -198,11 +205,26 @@ class AnsibleModule(object):
 
     def _log_invocation(self):
         ''' log that ansible ran the module '''
-        syslog.openlog('ansible-%s' % os.path.basename(__file__))
-        # Sanitize possible password argument when logging
-        log_args = re.sub(r'password=.+ (.*)', r"password=NOT_LOGGING_PASSWORD \1", self.args)
-        log_args = re.sub(r'login_password=.+ (.*)', r"login_password=NOT_LOGGING_PASSWORD \1", log_args)
-        syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % log_args)
+        # Sanitize possible password argument when logging.
+        log_args = dict()
+        passwd_keys = ['password', 'login_password']
+        for param in self.params:
+            if param in passwd_keys:
+                log_args[param] = 'NOT_LOGGING_PASSWORD'
+            else:
+                log_args[param] = self.params[param]
+
+        if (has_journal):
+            journal_args = ["MESSAGE=Ansible module invoked", "MODULE=%s" % os.path.basename(__file__)]
+            for arg in log_args:
+                journal_args.append(arg.upper() + "=" + str(log_args[arg]))
+            journal.sendv(*journal_args)
+        else:
+            msg = ''
+            syslog.openlog('ansible-%s' % os.path.basename(__file__))
+            for arg in log_args:
+                msg = msg + arg + '=' + str(log_args[arg]) + ' '
+            syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % msg)
 
     def get_bin_path(self, arg, required=False, opt_dirs=[]):
         '''


### PR DESCRIPTION
This does two things:
1. There was a bug in the previous regex, where if the password parameter was the last argument on the line, the regex wouldn't match, as it requires a space afterwards to match. Therefore, passwords can be stored in syslog.
2. If the systemd journal is available, it will log to that instead of syslog. To test, use Fedora 17 and install the [python-systemd](https://github.com/systemd/python-systemd) package. Run `sudo journalctl -f --output=json` to monitor log. Run an ansible command. The log entries look like:

``` json
{
  "MESSAGE" : "Ansible module invoked",
  "MODULE" : "file",
  "SRC" : "None",
  "GROUP" : "None",
  "STATE" : "absent",
  "SELEVEL" : "None",
  "SEUSER" : "None",
  "SEROLE" : "None",
  "MODE" : "None",
  "OWNER" : "None",
  "PATH" : "/home/mark/test",
  "PASSWORD" : "NOT_LOGGING_PASSWORD",
  "SETYPE" : "None",
}
```
