### PR TITLE
Fix templates for non root sudo_user

### DIFF
--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -70,7 +70,10 @@ class ActionModule(object):
             return ReturnData(conn=conn, comm_ok=False, result=result)
 
         xfered = self.runner._transfer_str(conn, tmp, 'source', resultant)
-
+        # fix file permissions when the copy is done as a different user
+        if self.runner.sudo and self.runner.sudo_user != 'root':
+            self.runner._low_level_exec_command(conn, "chmod a+r %s" % xfered, 
+                tmp)
         # run the copy module, queue the file module
         self.runner.module_args = "%s src=%s dest=%s" % (self.runner.module_args, xfered, dest)
         return self.runner._execute_module(conn, tmp, 'copy', self.runner.module_args, inject=inject).daisychain('file')


### PR DESCRIPTION
When using template module, if a restrictive umask is set, the
sudo_user won't be able to read the /tmp/ansible-dir/source file
after it is copied across following _transfer_str

I wonder if this behaviour shouldn't be abstracted somehow (as
this correction also happens after put_file in the copy module too)
