### PR TITLE
Have ansible respect private_key_file option

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -21,7 +21,7 @@ module_name = command
 
 remote_tmp = $HOME/.ansible/tmp
 
-# the default pattern for ansible-playbooks ("hosts:") 
+# the default pattern for ansible-playbooks ("hosts:")
 
 pattern = *
 
@@ -62,7 +62,7 @@ remote_port=22
 #remote_user=root
 
 # if set, always use this private key file for authentication, same as if passing
-# --private-key-file to ansible or ansible-playbook
+# --private-key to ansible or ansible-playbook
 
 #private_key_file=/path/to/file
 

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -394,7 +394,7 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
         default=constants.DEFAULT_HOST_LIST)
     parser.add_option('-k', '--ask-pass', default=False, dest='ask_pass', action='store_true',
         help='ask for SSH password')
-    parser.add_option('--private-key', default=None, dest='private_key_file',
+    parser.add_option('--private-key', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
         help='use this file to authenticate the connection')
     parser.add_option('-K', '--ask-sudo-pass', default=False, dest='ask_sudo_pass', action='store_true',
         help='ask for sudo password')


### PR DESCRIPTION
The ansible command-line tool was ignoring the private_key_file option. This patch passes it as the default value if not overridden by command-line argument.

Also fixes a typo in the comment of the example ansible.cfg file.
