### PR TITLE
add import sys to virt module b/c it needs it if the libvirt python

### DIFF
--- a/library/virt
+++ b/library/virt
@@ -19,6 +19,8 @@ VIRT_FAILED = 1
 VIRT_SUCCESS = 0
 VIRT_UNAVAILABLE=2
 
+import sys
+
 try:
     import libvirt
 except ImportError:


### PR DESCRIPTION
module is missing
