### PR TITLE
Made $groups and $group_names variables accessible in with_items

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -35,7 +35,7 @@ class Inventory(object):
     """
 
     __slots__ = [ 'host_list', 'groups', '_restriction', '_also_restriction', '_subset', '_is_script',
-                  'parser', '_vars_per_host', '_vars_per_group', '_hosts_cache' ]
+                  'parser', '_vars_per_host', '_vars_per_group', '_hosts_cache', '_groups_list' ]
 
     def __init__(self, host_list=C.DEFAULT_HOST_LIST):
 
@@ -49,6 +49,7 @@ class Inventory(object):
         self._vars_per_host  = {}
         self._vars_per_group = {}
         self._hosts_cache    = {}
+        self._groups_list    = {} 
 
         # the inventory object holds a list of groups
         self.groups = []
@@ -212,6 +213,17 @@ class Inventory(object):
                     results.append(group)
                     continue
         return results
+
+    def groups_list(self):
+        if not self._groups_list:
+            groups = {}
+            for g in self.groups:
+                groups[g.name] = [h.name for h in g.get_hosts()]
+                ancestors = g.get_ancestors()
+                for a in ancestors:
+                    groups[a.name] = [h.name for h in a.get_hosts()]
+            self._groups_list = groups
+        return self._groups_list
 
     def get_groups(self):
         return self.groups

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -250,17 +250,15 @@ class Runner(object):
         inject.update(self.module_vars)
         inject.update(self.setup_cache[host])
         inject['hostvars'] = self.setup_cache
+        inject['group_names'] = host_variables.get('group_names', [])
+        inject['groups'] = self.inventory.groups_list()
 
         # allow with_items to work in playbooks...
         # apt and yum are converted into a single call, others run in a loop
 
         items = self.module_vars.get('items', [])
         if isinstance(items, basestring) and items.startswith("$"):
-            items = items.replace("$","")
-            if items in inject:
-                items = inject[items]
-            else:
-                raise errors.AnsibleError("unbound variable in with_items: %s" % items)
+            items = utils.varLookup(items, inject)
         if type(items) != list:
             raise errors.AnsibleError("with_items only takes a list: %s" % items)
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -319,11 +319,7 @@ class Runner(object):
         # 'hostvars' variable contains variables for each host name
         #  ... and is set elsewhere
         # 'inventory_hostname' is also set elsewhere
-        group_hosts = {}
-        for g in self.inventory.groups:
-            group_hosts[g.name] = [ h.name for h in g.hosts ]
-        inject['groups'] = group_hosts
-
+        inject['groups'] = self.inventory.groups_list()
         # allow module args to work as a dictionary
         # though it is usually a string
         new_args = ""


### PR DESCRIPTION
This patch is specifically for use in with_items: in a playbook as mentioned in the Advanced Playbooks docs for Jinja templates.
