### PR TITLE
setup not python24 compatible in 0.7

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -537,9 +537,9 @@ class LinuxNetwork(Network):
                     # interface name for each address
                     if iface in interfaces:
                         i = 0
-                        while '{0}_{1}'.format(iface, i) in interfaces:
+                        while str(iface) + "_" + str(i) in interfaces:
                             i += 1
-                        iface = '{0}_{1}'.format(iface, i)
+                        iface = str(iface) + "_" + str(i)
 
                     interfaces[iface] = {}
                     interfaces[iface]['macaddress'] = macaddress


### PR DESCRIPTION
Just pulled 0.7 and got tracebacks on python24 systems because str.format doesn't exist.  This seemed to fix it.
