### PR TITLE
allow ansible-pull to specify playbook; improve option parsing

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -28,6 +28,7 @@
 import os
 import subprocess
 import sys
+import datetime
 from optparse import OptionParser
 
 DEFAULT_PLAYBOOK = 'local.yml'
@@ -45,25 +46,49 @@ def main(args):
     """ Set up and run a local playbook """
     usage = "%prog [options]"
     parser = OptionParser()
-    parser.add_option('-d', '--directory', dest='dest', default=None,
-                      help='Directory to checkout git repository')
-    parser.add_option('-U', '--url', dest='url',
+    parser.add_option('-d',
+                      '--directory',
+                      dest='dest',
                       default=None,
-                      help='URL of git repository')
-    parser.add_option('-C', '--checkout', dest='checkout',
+                      help='REQUIRED.  Directory for git repo clone and playbook run root.')
+    parser.add_option('-U',
+                      '--url',
+                      dest='url',
+                      default=None,
+                      help='REQUIRED.  URL of git repo; if needed, specify credentials as https://<username>:<password>@github.com/...')
+    parser.add_option('-C',
+                      '--checkout',
+                      dest='checkout',
                       default="HEAD",
                       help='Branch/Tag/Commit to checkout.  Defaults to HEAD.')
+    parser.add_option('-P',
+                      '--playbook',
+                      dest='playbook',
+                      default='%s' % DEFAULT_PLAYBOOK,
+                      help='Playbook to run.  Defaults to %s.' % DEFAULT_PLAYBOOK)
     options, args = parser.parse_args(args)
+
+    if not options.dest:
+      parser.error("directory for git clone and playbook run not specified, use -h for help")
+      return 1
+
+    if not options.url:
+      parser.error("URL for git repo not specified, use -h for help")
+      return 1
+
+    now = datetime.datetime.now()
+    print now.strftime("ansible-pull_started: %Y%m%d-%H%M"), "\n"
 
     git_opts = "repo=%s dest=%s version=%s" % (options.url, options.dest, options.checkout)
     cmd = 'ansible all -c local -m git -a "%s"' % git_opts
-    print "cmd=%s" % cmd
+    print "cmd=%s" % cmd, "\n"
     rc = _run(cmd)
     if rc != 0:
         return rc
 
+    cmd = 'ansible-playbook -c local %s' % options.playbook
+    print "cmd=%s" % cmd
     os.chdir(options.dest)
-    cmd = 'ansible-playbook -c local %s' % DEFAULT_PLAYBOOK
     rc = _run(cmd)
     return rc
 

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -85,6 +85,13 @@ def main(args):
     now = datetime.datetime.now()
     print now.strftime("ansible-pull_started: %Y%m%d-%H%M-%S"), "\n"
 
+    git_opts = "repo=%s dest=%s version=%s" % (options.url, options.dest, options.checkout)
+    cmd = 'ansible all -c local -m git -a "%s"' % git_opts
+    print "cmd=%s" % cmd, "\n"
+    rc = _run(cmd)
+    if rc != 0:
+        return rc
+
     hostname = "%s.yml" % platform.node()
 
     if not args:
@@ -123,14 +130,6 @@ def main(args):
             return 1
 
     print
-
-    git_opts = "repo=%s dest=%s version=%s" % (options.url, options.dest, options.checkout)
-    cmd = 'ansible all -c local -m git -a "%s"' % git_opts
-    print "cmd=%s" % cmd, "\n"
-    rc = _run(cmd)
-    if rc != 0:
-        return rc
-
 
     cmd = 'ansible-playbook -c local %s' % playbook
     print "cmd=%s" % cmd

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -1,15 +1,25 @@
 #!/usr/bin/env python
 
-# ansible-pull is a script that runs ansible in local mode
-# after checking out a playbooks directory from git.  There is an
-# example playbook to bootstrap this script in the examples/ dir which
+# ansible-pull is a script that runs ansible in local mode after
+# checking out a playbooks directory from git.  There is an example
+# playbook to bootstrap this script in the examples/ dir which
 # installs ansible and sets it up to run on cron.
 #
 # usage:
-#   ansible-pull -d /var/ansible/local -U http://wherever/content.git -C production
+#   ansible-pull -d /var/lib/ansible -U http://wherever/content.git [-C production] [path/playbook.yml]
 #
-# the git repo must contain a playbook named 'local.yml'
-
+# the -d and -U arguments are required; the -C argument is optional.
+#
+# ansible-pull accepts an optional argument to specify a playbook
+# location underneath the workdir and then searches the git repo
+# for playbooks in the following order, stopping at the first match:
+#
+# 1. $workdir/path/playbook.yml, if specified
+# 2. $workdir/$hostname.yml
+# 3. $workdir/local.yml
+#
+# the git repo must contain at least one of these playbooks.
+#
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>
 #
 # Ansible is free software: you can redistribute it and/or modify
@@ -29,6 +39,7 @@ import os
 import subprocess
 import sys
 import datetime
+import platform
 from optparse import OptionParser
 
 DEFAULT_PLAYBOOK = 'local.yml'
@@ -44,8 +55,8 @@ def _run(cmd):
 
 def main(args):
     """ Set up and run a local playbook """
-    usage = "%prog [options]"
-    parser = OptionParser()
+    usage = "%prog [options] [path/playbook.yml]"
+    parser = OptionParser(usage=usage)
     parser.add_option('-d',
                       '--directory',
                       dest='dest',
@@ -61,11 +72,6 @@ def main(args):
                       dest='checkout',
                       default="HEAD",
                       help='Branch/Tag/Commit to checkout.  Defaults to HEAD.')
-    parser.add_option('-P',
-                      '--playbook',
-                      dest='playbook',
-                      default='%s' % DEFAULT_PLAYBOOK,
-                      help='Playbook to run.  Defaults to %s.' % DEFAULT_PLAYBOOK)
     options, args = parser.parse_args(args)
 
     if not options.dest:
@@ -77,7 +83,46 @@ def main(args):
       return 1
 
     now = datetime.datetime.now()
-    print now.strftime("ansible-pull_started: %Y%m%d-%H%M"), "\n"
+    print now.strftime("ansible-pull_started: %Y%m%d-%H%M-%S"), "\n"
+
+    hostname = "%s.yml" % platform.node()
+
+    if not args:
+      try:
+        with open('%s/%s' % (options.dest, hostname)) as f: pass
+        playbook = hostname
+        print 'using playbook %s/%s' % (options.dest, hostname)
+      except IOError as e:
+        print 'playbook %s/%s does not exist, falling back to %s' % (options.dest, hostname, DEFAULT_PLAYBOOK)
+        try:
+          with open('%s/%s' % (options.dest, DEFAULT_PLAYBOOK)) as f: pass
+          playbook = DEFAULT_PLAYBOOK
+          print 'using playbook %s/%s' % (options.dest, DEFAULT_PLAYBOOK)
+        except IOError as e:
+          print 'playbook %s/%s does not exist, no playbooks to run; use -h for help' % (options.dest, DEFAULT_PLAYBOOK)
+          return 1
+    else:
+      try:
+        with open('%s/%s' % (options.dest, args[0])) as f: pass
+        playbook = args[0]
+        print 'using playbook %s/%s' % (options.dest, args[0])
+      except IOError as e:
+        print 'playbook %s/%s does not exist, falling back to %s' % (options.dest, args[0], hostname)
+        try:
+          with open('%s/%s' % (options.dest, hostname)) as f: pass
+          playbook = hostname
+          print 'using playbook %s/%s' % (options.dest, hostname)
+        except IOError as e:
+          print 'playbook %s/%s does not exist, falling back to %s' % (options.dest, hostname, DEFAULT_PLAYBOOK)
+          try:
+            with open('%s/%s' % (options.dest, DEFAULT_PLAYBOOK)) as f: pass
+            playbook = DEFAULT_PLAYBOOK
+            print 'using playbook %s/%s' % (options.dest, DEFAULT_PLAYBOOK)
+          except IOError as e:
+            print 'playbook %s/%s does not exist, no playbooks to run; use -h for help' % (options.dest, DEFAULT_PLAYBOOK)
+            return 1
+
+    print
 
     git_opts = "repo=%s dest=%s version=%s" % (options.url, options.dest, options.checkout)
     cmd = 'ansible all -c local -m git -a "%s"' % git_opts
@@ -86,7 +131,8 @@ def main(args):
     if rc != 0:
         return rc
 
-    cmd = 'ansible-playbook -c local %s' % options.playbook
+
+    cmd = 'ansible-playbook -c local %s' % playbook
     print "cmd=%s" % cmd
     os.chdir(options.dest)
     rc = _run(cmd)

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -39,7 +39,7 @@ import os
 import subprocess
 import sys
 import datetime
-import platform
+import socket
 from optparse import OptionParser
 
 DEFAULT_PLAYBOOK = 'local.yml'
@@ -92,7 +92,7 @@ def main(args):
     if rc != 0:
         return rc
 
-    hostname = "%s.yml" % platform.node()
+    hostname = "%s.yml" % socket.getfqdn()
 
     if not args:
       try:

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -11,14 +11,9 @@
 # the -d and -U arguments are required; the -C argument is optional.
 #
 # ansible-pull accepts an optional argument to specify a playbook
-# location underneath the workdir and then searches the git repo
-# for playbooks in the following order, stopping at the first match:
-#
-# 1. $workdir/path/playbook.yml, if specified
-# 2. $workdir/$hostname.yml
-# 3. $workdir/local.yml
-#
-# the git repo must contain at least one of these playbooks.
+# location underneath the workdir.  if no playbook is specified, it
+# will attempt to use $hostname.yml and then local.yml at the top
+# level of the workdir.
 #
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>
 #
@@ -53,6 +48,22 @@ def _run(cmd):
         print err
     return cmd.returncode
 
+def auto_detect_playbook():
+  # method assumes that os.chdir(options.dest) call has occurred
+  playbook = "%s.yml" % socket.getfqdn()  # equivalent to ${ansible_fqdn}.yml
+  try:
+    with open(playbook) as f: pass
+    print "using playbook %s" % playbook
+    return playbook
+  except IOError as e:
+    try:
+      with open(DEFAULT_PLAYBOOK) as f: pass
+      print 'using playbook %s' % DEFAULT_PLAYBOOK
+      return DEFAULT_PLAYBOOK
+    except IOError as e:
+      print 'FAILED: playbook %s does not exist' % DEFAULT_PLAYBOOK
+      sys.exit(1)
+
 def main(args):
     """ Set up and run a local playbook """
     usage = "%prog [options] [path/playbook.yml]"
@@ -76,11 +87,11 @@ def main(args):
 
     if not options.dest:
       parser.error("directory for git clone and playbook run not specified, use -h for help")
-      return 1
+      sys.exit(1)
 
     if not options.url:
       parser.error("URL for git repo not specified, use -h for help")
-      return 1
+      sys.exit(1)
 
     now = datetime.datetime.now()
     print now.strftime("ansible-pull_started: %Y%m%d-%H%M-%S"), "\n"
@@ -92,48 +103,23 @@ def main(args):
     if rc != 0:
         return rc
 
-    hostname = "%s.yml" % socket.getfqdn()
+    os.chdir(options.dest)
 
-    if not args:
+    if args:
+      playbook = args[0]
       try:
-        with open('%s/%s' % (options.dest, hostname)) as f: pass
-        playbook = hostname
-        print 'using playbook %s/%s' % (options.dest, hostname)
+        with open(playbook) as f: pass
+        print "using playbook %s" % playbook
       except IOError as e:
-        print 'playbook %s/%s does not exist, falling back to %s' % (options.dest, hostname, DEFAULT_PLAYBOOK)
-        try:
-          with open('%s/%s' % (options.dest, DEFAULT_PLAYBOOK)) as f: pass
-          playbook = DEFAULT_PLAYBOOK
-          print 'using playbook %s/%s' % (options.dest, DEFAULT_PLAYBOOK)
-        except IOError as e:
-          print 'playbook %s/%s does not exist, no playbooks to run; use -h for help' % (options.dest, DEFAULT_PLAYBOOK)
-          return 1
+        print 'FAILED: playbook %s does not exist' % playbook
+        sys.exit(1)
     else:
-      try:
-        with open('%s/%s' % (options.dest, args[0])) as f: pass
-        playbook = args[0]
-        print 'using playbook %s/%s' % (options.dest, args[0])
-      except IOError as e:
-        print 'playbook %s/%s does not exist, falling back to %s' % (options.dest, args[0], hostname)
-        try:
-          with open('%s/%s' % (options.dest, hostname)) as f: pass
-          playbook = hostname
-          print 'using playbook %s/%s' % (options.dest, hostname)
-        except IOError as e:
-          print 'playbook %s/%s does not exist, falling back to %s' % (options.dest, hostname, DEFAULT_PLAYBOOK)
-          try:
-            with open('%s/%s' % (options.dest, DEFAULT_PLAYBOOK)) as f: pass
-            playbook = DEFAULT_PLAYBOOK
-            print 'using playbook %s/%s' % (options.dest, DEFAULT_PLAYBOOK)
-          except IOError as e:
-            print 'playbook %s/%s does not exist, no playbooks to run; use -h for help' % (options.dest, DEFAULT_PLAYBOOK)
-            return 1
+      playbook = auto_detect_playbook()
 
     print
 
     cmd = 'ansible-playbook -c local %s' % playbook
     print "cmd=%s" % cmd
-    os.chdir(options.dest)
     rc = _run(cmd)
     return rc
 


### PR DESCRIPTION
This branch adds a "-P, --playbook" parameter to ansible-pull, which makes it easier to specify a custom playbook that should run on a pull-based node.  The new parameter is optional, and the top-level local.yml file is still the default.  This concept behind adding this parameter is intended to help with scale-out so that you can have many nodes that each run against their own custom playbook, so that you can have distinctions between web servers and database servers, for example.

Within a playbook repo, a new directory structure houses the custom playbooks, per node:

nodes/${ansible_fqdn}.yml

ansible-pull is called against it from a cronjob, running every 30m:

ansible-pull -d /var/lib/ansible -U https://${username}:${password}@github.com/${username}/${repo}.git -P nodes/${ansible_fqdn}.yml

ansible-pull will now spit out a starting date and time "ansible-pull_started:", to help with reading the log file output over time.

Example playbook updates to support this updated ansible-pull are bundled into a separate pull request.
