### PR TITLE
Return dest. Require "thirsty" if dest is dir.

### DIFF
--- a/library/get_url
+++ b/library/get_url
@@ -148,7 +148,7 @@ def main():
         if os.path.isdir(dest):
             module.fail_json(msg="non-thirsty mode needs a filename for a destination, not a directory")
         if os.path.exists(dest):
-            module.exit_json(msg="file already exists", changed=False)
+            module.exit_json(msg="file already exists", dest=dest, url=url, changed=False)
 
     # download to tmpsrc
     tmpsrc, info = url_get(module, url, dest)

--- a/library/get_url
+++ b/library/get_url
@@ -145,11 +145,10 @@ def main():
     thirsty = module.boolean(module.params['thirsty'])
 
     if not thirsty:
-        if os.path.exists(dest):
-            module.exit_json(msg="file already exists", changed=False)
         if os.path.isdir(dest):
             module.fail_json(msg="non-thirsty mode needs a filename for a destination, not a directory")
-
+        if os.path.exists(dest):
+            module.exit_json(msg="file already exists", changed=False)
 
     # download to tmpsrc
     tmpsrc, info = url_get(module, url, dest)


### PR DESCRIPTION
The file destination is returned.

The check for the destination being a directory is now done before
checking if the file exists, that way the user is informed that the
thirsty argument is required.
