### PR TITLE
Add pkg_mgr fact to setup (take 2)

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -54,6 +54,10 @@ class Facts(object):
                     '/etc/vmware-release': 'VMwareESX' }
     SELINUX_MODE_DICT = { 1: 'enforcing', 0: 'permissive', -1: 'disabled' }
 
+    PKG_MGR_DICT = { '/usr/bin/yum' : 'yum',
+                     '/usr/bin/apt-get' : 'apt',
+                     '/usr/bin/zypper' : 'zypper' }
+
     def __init__(self):
         self.facts = {}
         self.get_platform_facts()
@@ -61,6 +65,7 @@ class Facts(object):
         self.get_cmdline()
         self.get_public_ssh_host_keys()
         self.get_selinux_facts()
+        self.get_pkg_mgr_facts()
 
     def populate(self):
         return self.facts
@@ -132,6 +137,12 @@ class Facts(object):
             rsa = 'NA'
         else:
             self.facts['ssh_host_key_rsa_public'] = rsa.split()[1]
+
+    def get_pkg_mgr_facts(self):
+        self.facts['pkg_mgr'] = 'unknown'
+        for (path, name) in Facts.PKG_MGR_DICT.items():
+            if os.path.exists(path):
+                self.facts['pkg_mgr'] = name
 
     def get_selinux_facts(self):
         if not HAVE_SELINUX:

--- a/library/setup
+++ b/library/setup
@@ -54,9 +54,12 @@ class Facts(object):
                     '/etc/vmware-release': 'VMwareESX' }
     SELINUX_MODE_DICT = { 1: 'enforcing', 0: 'permissive', -1: 'disabled' }
 
-    PKG_MGR_DICT = { '/usr/bin/yum' : 'yum',
-                     '/usr/bin/apt-get' : 'apt',
-                     '/usr/bin/zypper' : 'zypper' }
+    # A list of dicts.  If there is a platform with more than one
+    # package manager, put the preferred one last.  If there is an
+    # ansible module, use that as the value for the 'name' key.
+    PKG_MGRS = [ { 'path' : '/usr/bin/yum',     'name' : 'yum' },
+                 { 'path' : '/usr/bin/apt-get', 'name' : 'apt' },
+                 { 'path' : '/usr/bin/zypper',  'name' : 'zypper' } ]
 
     def __init__(self):
         self.facts = {}
@@ -140,9 +143,9 @@ class Facts(object):
 
     def get_pkg_mgr_facts(self):
         self.facts['pkg_mgr'] = 'unknown'
-        for (path, name) in Facts.PKG_MGR_DICT.items():
-            if os.path.exists(path):
-                self.facts['pkg_mgr'] = name
+        for pkg in Facts.PKG_MGRS:
+            if os.path.exists(pkg['path']):
+                self.facts['pkg_mgr'] = pkg['name']
 
     def get_selinux_facts(self):
         if not HAVE_SELINUX:


### PR DESCRIPTION
Same as pull request #1050.

This facilitates playbook decision-making that are package manager based.  It also allows simple package installation across distributions in a single statement:

```
-name: install wget 
 action: $ansible_pkg_mgr name=wget state=present
```

Now implemented with a list of dicts to identify the package manager in use.
