### PR TITLE
Support iteration over command output in with_items.

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -258,6 +258,8 @@ class PlayBook(object):
             facts = result.get('ansible_facts', {})
             self.SETUP_CACHE[host].update(facts)
             if task.register:
+                if 'stdout' in result:
+                    result['stdout_lines'] = result['stdout'].splitlines()
                 self.SETUP_CACHE[host][task.register] = result
 
         # flag which notify handlers need to be run

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -181,3 +181,20 @@ class TestPlaybook(unittest.TestCase):
        )
        play = ansible.playbook.Play(playbook, playbook.playbook[0], os.getcwd())
        assert play.hosts == ';'.join(('host1', 'host2', 'host3'))
+
+   def test_results_list(self):
+       # Test that we can iterate over the lines of a command's stdout in a register variable.
+       test_callbacks = TestCallbacks()
+       playbook = ansible.playbook.PlayBook(
+           playbook=os.path.join(self.test_dir, 'results_list.yml'),
+           host_list='test/ansible_hosts',
+           stats=ans_callbacks.AggregateStats(),
+           callbacks=test_callbacks,
+           runner_callbacks=test_callbacks
+       )
+       result = playbook.run()
+       self.assertIn('localhost', result)
+       self.assertIn('ok', result['localhost'])
+       self.assertEqual(result['localhost']['ok'], 6)
+       self.assertIn('failures', result['localhost'])
+       self.assertEqual(result['localhost']['failures'], 0)

--- a/test/results_list.yml
+++ b/test/results_list.yml
@@ -1,0 +1,19 @@
+---
+# Test iterating over lines of stdout stored in a register.
+- hosts: localhost
+  vars:
+    small_file: /etc/resolv.conf
+    temp_file: /tmp/ansible_result_list.tmp
+
+  tasks:
+  - action: command cat $small_file
+    register: result
+
+  - action: file dest=$temp_file state=absent
+
+  - action: shell echo '$item' >> $temp_file
+    with_items: ${result.stdout_lines}
+
+  - action: command diff $small_file $temp_file
+
+  - action: file dest=$temp_file state=absent


### PR DESCRIPTION
This lets you access a command's stdout in a register as a list of lines.

When the result of a command is stored in a register, this splits its stdout 
into a list (using universal newlines) and stores it in the `stdout_lines` field 
of the result object.  You can do whatever you want with it, but in particular 
you can loop over the lines using `with_items`.

Here is an example:

```

---
- name: Ensure only trusted RPM signing keys are present.
  hosts: all
  sudo: True  
  vars:
    trusted_keys: [RPM-GPG-KEY-CentOS-5, RPM-GPG-KEY-EPEL, RPM-GPG-KEY-rpmforge-dag]

  tasks:
  - name: Copy RPM signing keys
    action: copy src=etc/pki/rpm-gpg/$item dest=/etc/pki/rpm-gpg/$item
    with_items: $trusted_keys

  - name: Get list of all keys
    action: command ls -1 /etc/pki/rpm-gpg
    register: all_keys

  - name: Remove untrusted keys
    action: file dest=/etc/pki/rpm-gpg/$item state=absent
    with_items: ${all_keys.stdout_lines}
    only_if: "'$item' not in $trusted_keys"
```

Unit test included.
