### PR TITLE
fix Makefile date command error on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,11 @@ endif
 ifeq ($(OS), FreeBSD)
 DATE := $(shell date -j -f "%Y-%m-%d %H:%M:%s"  "$(GIT_DATE)" +%Y%m%d%H%M)
 else
+ifeq ($(OS), Darwin)
+DATE := $(shell date -j -f "%Y-%m-%d %H:%M:%S"  "$(GIT_DATE)" +%Y%m%d%H%M)
+else
 DATE := $(shell date --date="$(GIT_DATE)" +%Y%m%d%H%M)
+endif
 endif
 
 # RPM build parameters


### PR DESCRIPTION
```
$ echo $GIT_DATE
2012-09-18 21:34:55 -0400

# broken form #1 -- "--date" option not supported

$ date --date="$(GIT_DATE)" +%Y%m%d%H%M
-bash: GIT_DATE: command not found
date: illegal option -- -
usage: date [-jnu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ... 
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]

# broken form #2 -- lowercase "s", unintended output

$ date -j -f "%Y-%m-%d %H:%M:%s" "$GIT_DATE" +%Y%m%d%H%M
Warning: Ignoring 6 extraneous characters in date string ( -0400)
196912311900

# correct form, with extra character warning

$ date -j -f "%Y-%m-%d %H:%M:%S" "$GIT_DATE" +%Y%m%d%H%M
Warning: Ignoring 6 extraneous characters in date string ( -0400)
201209182134
```
