### PR TITLE
Added cases for 'dead but subsys locked' status

### DIFF
--- a/library/service
+++ b/library/service
@@ -101,6 +101,8 @@ def _get_service_status(name, pattern):
     if running == None:
         if rc == 3:
             running = False
+        if rc == 2:
+            running = False
         elif rc == 0:
             running = True
 
@@ -119,6 +121,8 @@ def _get_service_status(name, pattern):
         elif 'could not access pid file' in cleanout:
             running = False
         elif 'is dead and pid file exists' in cleanout:
+            running = False
+        elif 'dead but subsys locked' in cleanout:
             running = False
 
     # if the job status is still not known check it by special conditions


### PR DESCRIPTION
Patched the service module to include the return code for RH based sytems (2) "dead but subsys locked" and also the output keywords.
