### PR TITLE
Replace os.access with stat calls for checking execute bit

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -76,7 +76,7 @@ class Inventory(object):
                     all.add_host(Host(tokens[0], tokens[1]))
                 else:
                     all.add_host(Host(x))
-        elif os.access(host_list, os.X_OK):
+        elif utils.is_executable(host_list):
             self._is_script = True
             self.parser = InventoryScript(filename=host_list)
             self.groups = self.parser.groups.values()

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -283,7 +283,7 @@ class AnsibleModule(object):
         print self.jsonify(kwargs)
         sys.exit(1)
 
-    def is_executable(path):
+    def is_executable(self, path):
         '''is the given path executable?'''
         return (stat.S_IXUSR & os.stat(path)[stat.ST_MODE] 
                 or stat.S_IXGRP & os.stat(path)[stat.ST_MODE] 

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -49,6 +49,7 @@ import syslog
 import types
 import time
 import shutil
+import stat
 
 try:
     from hashlib import md5 as _md5
@@ -247,7 +248,7 @@ class AnsibleModule(object):
                 paths.append(p)
         for d in paths:
             path = os.path.join(d, arg)
-            if os.path.exists(path) and os.access(path, os.X_OK):
+            if os.path.exists(path) and self.is_executable(path):
                 bin_path = path
                 break
         if required and bin_path is None:
@@ -281,6 +282,12 @@ class AnsibleModule(object):
         kwargs['failed'] = True
         print self.jsonify(kwargs)
         sys.exit(1)
+
+    def is_executable(path):
+        '''is the given path executable?'''
+        return (stat.S_IXUSR & os.stat(path)[stat.ST_MODE] 
+                or stat.S_IXGRP & os.stat(path)[stat.ST_MODE] 
+                or stat.S_IXOTH & os.stat(path)[stat.ST_MODE])
 
     def md5(self, filename):
         ''' Return MD5 hex digest of local file, or None if file is not present. '''

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -32,6 +32,7 @@ import StringIO
 import imp
 import glob
 import subprocess
+import stat
 
 VERBOSITY=0
 
@@ -92,6 +93,12 @@ def is_failed(result):
     ''' is a given JSON result a failed result? '''
 
     return ((result.get('rc', 0) != 0) or (result.get('failed', False) in [ True, 'True', 'true']))
+
+def is_executable(path):
+    '''is the given path executable?'''
+    return (stat.S_IXUSR & os.stat(path)[stat.ST_MODE] 
+            or stat.S_IXGRP & os.stat(path)[stat.ST_MODE] 
+            or stat.S_IXOTH & os.stat(path)[stat.ST_MODE])
 
 def prepare_writeable_dir(tree):
     ''' make sure a directory exists and is writeable '''


### PR DESCRIPTION
Per issue 1057, the function `is_executable` has been added to lib/ansible/utils.py and lib/ansible/module_common.py. This function replaces calls to os.access for testing the presence of the executable bit due to problems with that test on certain platforms (AIX & Solaris). The version in modules_common.py has been added as a method to the AnsibleModule class.

The two os.access/execute-bit tests already present in the code have been replaced with calls to `is_executable`
