### PR TITLE
Add an only_if option to vars_prompt to make prompts conditional

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -172,8 +172,10 @@ class Play(object):
                 encrypt = var.get("encrypt", None)
                 salt_size = var.get("salt_size", None)
                 salt = var.get("salt", None)
+                conditional = var.get("only_if", 'True')
 
-                vars[vname] = self.playbook.callbacks.on_vars_prompt(vname, private, prompt,encrypt, confirm, salt_size, salt)
+                if utils.check_conditional(conditional):
+                    vars[vname] = self.playbook.callbacks.on_vars_prompt(vname, private, prompt,encrypt, confirm, salt_size, salt)
 
         elif type(self.vars_prompt) == dict:
             for (vname, prompt) in self.vars_prompt.iteritems():

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -329,12 +329,8 @@ class Runner(object):
             self.module_args = new_args
         self.module_args = utils.template(self.basedir, self.module_args, inject)
 
-        def _check_conditional(conditional):
-            def is_set(var):
-                return not var.startswith("$")
-            return eval(conditional)
         conditional = utils.template(self.basedir, self.conditional, inject)
-        if not _check_conditional(conditional):
+        if not utils.check_conditional(conditional):
             result = utils.jsonify(dict(skipped=True))
             self.callbacks.on_skipped(host, inject.get('item',None))
             return ReturnData(host=host, result=result)

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -93,6 +93,13 @@ def is_failed(result):
 
     return ((result.get('rc', 0) != 0) or (result.get('failed', False) in [ True, 'True', 'true']))
 
+def check_conditional(conditional):
+    def is_set(var):
+        return not var.startswith("$")
+    def is_unset(var):
+        return var.startswith("$")
+    return eval(conditional)
+
 def prepare_writeable_dir(tree):
     ''' make sure a directory exists and is writeable '''
 


### PR DESCRIPTION
Sometimes you may want to allow variables through host_vars or inventory, but prompt for a value if it is not set or if the value does not conform to something specific. This option allows you to specify when you want to offer a prompt.
