### PR TITLE
Template the variable prompt to customize the message

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -165,7 +165,7 @@ class Play(object):
                     raise errors.AnsibleError("'vars_prompt' item is missing 'name:'")
 
                 vname = var['name']
-                prompt = "%s: " % var.get("prompt", vname)
+                prompt = util.template(None, "%s: " % var.get("prompt", vname), self.vars)
                 private = var.get("private", True)
 
                 confirm = var.get("confirm", False)


### PR DESCRIPTION
We have a password-prompt for a configurable login name. Since we require to ask the password for this specific login, it is important to indicate what password needs to be prov ided on the prompt. So the prompt needs to be templated. That's what this patch does.
