### PR TITLE
Include the changelog in the distribution tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.md packaging/rpm/ansible.spec COPYING
+include README.md packaging/rpm/ansible.spec COPYING CHANGELOG.md
 include examples/hosts
 include examples/ansible.cfg
 graft examples/playbooks


### PR DESCRIPTION
For packaging purposes, can we please have the CHANGELOG.md file in the release tarball, so it can be dropped in /usr/share/doc/ansible-<version>?
