### PR TITLE
Make only_if expressions easier to make

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -172,7 +172,7 @@ class Play(object):
                 encrypt = var.get("encrypt", None)
                 salt_size = var.get("salt_size", None)
                 salt = var.get("salt", None)
-                conditional = var.get("only_if", 'True')
+                conditional = utils.normalize_conditional(var.get("only_if", 'True'))
 
                 if utils.check_conditional(conditional):
                     vars[vname] = self.playbook.callbacks.on_vars_prompt(vname, private, prompt,encrypt, confirm, salt_size, salt)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -110,7 +110,7 @@ class Runner(object):
         self.module_vars      = utils.default(module_vars, lambda: {})
         self.sudo_user        = sudo_user
         self.connector        = connection.Connection(self)
-        self.conditional      = conditional
+        self.conditional      = utils.normalize_conditional(conditional)
         self.module_path      = module_path
         self.module_name      = module_name
         self.forks            = int(forks)

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -93,6 +93,15 @@ def is_failed(result):
 
     return ((result.get('rc', 0) != 0) or (result.get('failed', False) in [ True, 'True', 'true']))
 
+def normalize_conditional(conditional):
+    if conditional.startswith("'"):
+        conditional = re.sub('(?!\")\${(?P<var>\w[\w\.]*)}(?!\")', '\"${\g<var>}\"', conditional)
+        conditional = re.sub('(?!\")\$(?P<var>\w[\w\.]*)(?!\")', '\"${\g<var>}\"', conditional)
+    else:
+        conditional = re.sub('(?!\')\${(?P<var>\w[\w\.]*)}(?!\')', '\'${\g<var>}\'', conditional)
+        conditional = re.sub('(?!\')\$(?P<var>\w[\w\.]*)(?!\')', '\'${\g<var>}\'', conditional)
+    return conditional
+
 def check_conditional(conditional):
     def is_set(var):
         return not var.startswith("$")


### PR DESCRIPTION
This patch makes it no longer a requirement to quote variables in order to force it to be a string. However the current implementation forces variables in becoming strings for the expression. There might be a better (more expensive) way to do this only for variables that are strings.

Now instead of:

```
only_if: "'${color}' == 'blue'"
only_if: "is_unset('${ipaddress}')"
only_if: "is_set('${ipaddress}')"
only_if: "'${motd_cmdline.stdout}'.find('rd') != -1"
```

one can write:

```
only_if: "$color == 'blue'"
only_if: 'is_unset($ipaddress)'
only_if: 'is_set($ipaddress)'
only_if: '${motd_cmdline.stdout}.find("rd") != -1'
```

This builds on top of previous commit implementing only_if for prompts.
