### PR TITLE
Add 'pause' action plugin and support plugins skipping the host loop.

### DIFF
--- a/lib/ansible/runner/action_plugins/pause.py
+++ b/lib/ansible/runner/action_plugins/pause.py
@@ -1,0 +1,131 @@
+# Copyright 2012, Tim Bielawa <tbielawa@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.callbacks import vv
+from ansible.errors import AnsibleError as ae
+from ansible.runner.return_data import ReturnData
+from ansible.utils import getch
+from termios import tcflush, TCIFLUSH
+import datetime
+import sys
+import time
+
+
+class ActionModule(object):
+    ''' pauses execution for a length or time, or until input is received '''
+
+    PAUSE_TYPES = ['seconds', 'minutes', 'prompt', '']
+    BYPASS_HOST_LOOP = True
+
+    def __init__(self, runner):
+        self.runner = runner
+        # Set defaults
+        self.duration_unit = 'minutes'
+        self.prompt = None
+        self.seconds = None
+        self.result = {'changed': False,
+                       'rc': 0,
+                       'stderr': '',
+                       'stdout': '',
+                       'start': None,
+                       'stop': None,
+                       'delta': None,
+                       }
+
+    def run(self, conn, tmp, module_name, module_args, inject):
+        ''' run the pause actionmodule '''
+        args = self.runner.module_args
+        hosts = ', '.join(map(lambda x: x[1], self.runner.host_set))
+
+        (self.pause_type, sep, pause_params) = args.partition('=')
+
+        if self.pause_type == '':
+            self.pause_type = 'prompt'
+        elif not self.pause_type in self.PAUSE_TYPES:
+            raise ae("invalid parameter for pause, '%s'. must be one of: %s" % \
+                         (self.pause_type, ", ".join(self.PAUSE_TYPES)))
+
+        # error checking
+        if self.pause_type in ['minutes', 'seconds']:
+            try:
+                int(pause_params)
+            except ValueError:
+                raise ae("value given to %s parameter invalid: '%s', must be an integer" % \
+                             self.pause_type, pause_params)
+
+        # The time() command operates in seconds so we need to
+        # recalculate for minutes=X values.
+        if self.pause_type == 'minutes':
+            self.seconds = int(pause_params) * 60
+        elif self.pause_type == 'seconds':
+            self.seconds = int(pause_params)
+            self.duration_unit = 'seconds'
+        else:
+            # if no args are given we pause with a prompt
+            if pause_params == '':
+                self.prompt = "[%s]\nPress enter to continue: " % hosts
+            else:
+                self.prompt = "[%s]\n%s: " % (hosts, pause_params)
+
+        vv("created 'pause' ActionModule: pause_type=%s, duration_unit=%s, calculated_seconds=%s, prompt=%s" % \
+                (self.pause_type, self.duration_unit, self.seconds, self.prompt))
+
+        try:
+            self._start()
+            if not self.pause_type == 'prompt':
+                print "[%s]\nPausing for %s seconds" % (hosts, self.seconds)
+                time.sleep(self.seconds)
+            else:
+                # Clear out any unflushed buffered input which would
+                # otherwise be consumed by raw_input() prematurely.
+                tcflush(sys.stdin, TCIFLUSH)
+                raw_input(self.prompt)
+        except KeyboardInterrupt:
+            while True:
+                print '\nAction? (a)bort/(c)ontinue: '
+                c = getch()
+                if c == 'c':
+                    # continue playbook evaluation
+                    break
+                elif c == 'a':
+                    # abort further playbook evaluation
+                    raise ae('user requested abort!')
+        finally:
+            self._stop()
+
+        return ReturnData(conn=conn, result=self.result)
+
+    def _start(self):
+        ''' mark the time of execution for duration calculations later '''
+        self.start = time.time()
+        self.result['start'] = str(datetime.datetime.now())
+        if not self.pause_type == 'prompt':
+            print "(^C-c = continue early, ^C-a = abort)"
+
+    def _stop(self):
+        ''' calculate the duration we actually paused for and then
+        finish building the task result string '''
+        duration = time.time() - self.start
+        self.result['stop'] = str(datetime.datetime.now())
+        self.result['delta'] = int(duration)
+
+        if self.duration_unit == 'minutes':
+            duration = round(duration / 60.0, 2)
+        else:
+            duration = round(duration, 2)
+
+        self.result['stdout'] = "Paused for %s %s" % (duration, self.duration_unit)


### PR DESCRIPTION
```
<tbielawa>@(griddle)[~/Projects/ansible] 1:13:47  (runner_pause)
$ git log -1
commit 58a4d2f7b4551b6222f9def382cac87970fc3aea
Author: Tim Bielawa <tbielawa@redhat.com>
Date:   Sat Sep 22 02:07:49 2012 -0400

    Add 'pause' action plugin and support plugins skipping the host loop.

<tbielawa>@(griddle)[~/Projects/ansible] 1:13:51  (runner_pause)
$ make tests
PYTHONPATH=./lib nosetests -v
test_complex_enumeration (TestInventory.TestInventory) ... ok
test_complex_exclude (TestInventory.TestInventory) ... ok
test_complex_vars (TestInventory.TestInventory) ... ok
Test the case when playbook 'hosts' var is a list. ... ok
test_script (TestInventory.TestInventory) ... ok
test_script_all (TestInventory.TestInventory) ... ok
test_script_combined (TestInventory.TestInventory) ... ok
test_script_norse (TestInventory.TestInventory) ... ok
test_script_restrict (TestInventory.TestInventory) ... ok
test_script_vars (TestInventory.TestInventory) ... ok
test_simple (TestInventory.TestInventory) ... ok
test_simple_all (TestInventory.TestInventory) ... ok
test_simple_combined (TestInventory.TestInventory) ... ok
test_simple_norse (TestInventory.TestInventory) ... ok
test_simple_port (TestInventory.TestInventory) ... ok
test_simple_restrict (TestInventory.TestInventory) ... ok
test_simple_ungrouped (TestInventory.TestInventory) ... ok
test_simple_vars (TestInventory.TestInventory) ... ok
test_one (TestPlayBook.TestPlaybook) ... ok
test_playbook_vars (TestPlayBook.TestPlaybook) ... ok
test_yaml_hosts_list (TestPlayBook.TestPlaybook) ... ok
test_assemble (TestRunner.TestRunner) ... ok
test_async (TestRunner.TestRunner) ... ok
test_command (TestRunner.TestRunner) ... ok
test_copy (TestRunner.TestRunner) ... ok
test_facter (TestRunner.TestRunner) ... ok
test_fetch (TestRunner.TestRunner) ... ok
test_file (TestRunner.TestRunner) ... ok
test_git (TestRunner.TestRunner) ... ok
test_large_output (TestRunner.TestRunner) ... ok
test_ping (TestRunner.TestRunner) ... ok
test_parse_kv_basic (TestUtils.TestUtils) ... ok
test_template_basic (TestUtils.TestUtils) ... ok
test_template_unicode (TestUtils.TestUtils) ... ok
test_template_varReplace_iterated (TestUtils.TestUtils) ... ok
test_template_whitespace (TestUtils.TestUtils) ... ok
test_varLookup_list (TestUtils.TestUtils) ... ok
test_varReplace_almost_alternative (TestUtils.TestUtils) ... ok
test_varReplace_almost_alternative2 (TestUtils.TestUtils) ... ok
test_varReplace_alternative (TestUtils.TestUtils) ... ok
test_varReplace_alternative_greed (TestUtils.TestUtils) ... ok
test_varReplace_caps (TestUtils.TestUtils) ... ok
test_varReplace_include (TestUtils.TestUtils) ... ok
test_varReplace_include_script (TestUtils.TestUtils) ... ok
test_varReplace_invalid_list (TestUtils.TestUtils) ... ok
test_varReplace_list (TestUtils.TestUtils) ... ok
test_varReplace_list_nolist (TestUtils.TestUtils) ... ok
test_varReplace_list_oob (TestUtils.TestUtils) ... ok
test_varReplace_middle (TestUtils.TestUtils) ... ok
test_varReplace_multiple (TestUtils.TestUtils) ... ok
test_varReplace_nested (TestUtils.TestUtils) ... ok
test_varReplace_nested_int (TestUtils.TestUtils) ... ok
test_varReplace_nested_list (TestUtils.TestUtils) ... ok
test_varReplace_notcomplex (TestUtils.TestUtils) ... ok
test_varReplace_simple (TestUtils.TestUtils) ... ok
test_varReplace_unicode (TestUtils.TestUtils) ... ok

----------------------------------------------------------------------
Ran 56 tests in 42.295s
```
