### PR TITLE
Fix a typo in the prompt code

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -165,7 +165,7 @@ class Play(object):
                     raise errors.AnsibleError("'vars_prompt' item is missing 'name:'")
 
                 vname = var['name']
-                prompt = util.template(None, "%s: " % var.get("prompt", vname), self.vars)
+                prompt = utils.template(None, "%s: " % var.get("prompt", vname), self.vars)
                 private = var.get("private", True)
 
                 confirm = var.get("confirm", False)


### PR DESCRIPTION
This is unfortunately related to not being able to reuse the same code that was tested.
