### PR TITLE
Use repr on replacements for only_if

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -317,7 +317,7 @@ class Runner(object):
                 new_args = new_args + "%s='%s' " % (k,v)
             module_args = new_args
 
-        conditional = utils.template(self.basedir, self.conditional, inject)
+        conditional = utils.template(self.basedir, self.conditional, inject, do_repr=True)
         if not utils.check_conditional(conditional):
             result = utils.jsonify(dict(skipped=True))
             self.callbacks.on_skipped(host, inject.get('item',None))

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -174,12 +174,13 @@ _LISTRE = re.compile(r"(\w+)\[(\d+)\]")
 class VarNotFoundException(Exception):
     pass
 
-def _varLookup(name, vars):
+def _varLookup(name, vars, depth=0):
     ''' find the contents of a possibly complex variable in vars. '''
 
     path = name.split('.')
     space = vars
     for part in path:
+        part = varReplace(part, vars, depth=depth + 1)
         if part in space:
             space = space[part]
         elif "[" in part:
@@ -194,7 +195,7 @@ def _varLookup(name, vars):
             raise VarNotFoundException()
     return space
 
-_KEYCRE = re.compile(r"\$(?P<complex>\{){0,1}((?(complex)[\w\.\[\]]+|\w+))(?(complex)\})")
+_KEYCRE = re.compile(r"\$(?P<complex>\{){0,1}((?(complex)[\w\.\[\]\$\{\}]+|\w+))(?(complex)\})")
 
 def varLookup(varname, vars):
     ''' helper function used by with_items '''
@@ -207,9 +208,12 @@ def varLookup(varname, vars):
     except VarNotFoundException:
         return None
 
-def varReplace(raw, vars, do_repr=False):
+def varReplace(raw, vars, do_repr=False, depth=0):
     ''' Perform variable replacement of $variables in string raw using vars dictionary '''
     # this code originally from yum
+
+    if (depth > 20):
+        raise errors.AnsibleError("template recursion depth exceeded")
 
     done = [] # Completed chunks to return
 
@@ -223,7 +227,8 @@ def varReplace(raw, vars, do_repr=False):
         # original)
 
         try:
-            replacement = unicode(_varLookup(m.group(2), vars))
+            replacement = unicode(_varLookup(m.group(2), vars, depth))
+            replacement = varReplace(replacement, vars, depth=depth + 1)
         except VarNotFoundException:
             replacement = m.group()
 
@@ -284,13 +289,7 @@ def template(basedir, text, vars, do_repr=False):
         text = text.decode('utf-8')
     except UnicodeEncodeError:
         pass # already unicode
-    depth = 0
-    while prev_text != text:
-        depth = depth + 1
-        if (depth > 20):
-            raise errors.AnsibleError("template recursion depth exceeded")
-        prev_text = text
-        text = varReplace(unicode(text), vars, do_repr)
+    text = varReplace(unicode(text), vars, do_repr)
     text = varReplaceFilesAndPipes(basedir, text)
     return text
 

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -207,7 +207,7 @@ def varLookup(varname, vars):
     except VarNotFoundException:
         return None
 
-def varReplace(raw, vars):
+def varReplace(raw, vars, do_repr=False):
     ''' Perform variable replacement of $variables in string raw using vars dictionary '''
     # this code originally from yum
 
@@ -228,6 +228,13 @@ def varReplace(raw, vars):
             replacement = m.group()
 
         start, end = m.span()
+        if do_repr:
+            replacement = repr(replacement)
+            if (start > 0 and
+                ((raw[start - 1] == "'" and raw[end] == "'") or
+                 (raw[start - 1] == '"' and raw[end] == '"'))):
+                start -= 1
+                end += 1
         done.append(raw[:start])    # Keep stuff leading up to token
         done.append(replacement)    # Append replacement value
         raw = raw[end:]             # Continue with remainder of string
@@ -269,7 +276,7 @@ def varReplaceFilesAndPipes(basedir, raw):
     return ''.join(done)
 
 
-def template(basedir, text, vars):
+def template(basedir, text, vars, do_repr=False):
     ''' run a text buffer through the templating engine until it no longer changes '''
 
     prev_text = ''
@@ -283,7 +290,7 @@ def template(basedir, text, vars):
         if (depth > 20):
             raise errors.AnsibleError("template recursion depth exceeded")
         prev_text = text
-        text = varReplace(unicode(text), vars)
+        text = varReplace(unicode(text), vars, do_repr)
     text = varReplaceFilesAndPipes(basedir, text)
     return text
 

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -202,6 +202,55 @@ class TestUtils(unittest.TestCase):
 
         assert res == 'hello world'
 
+    def test_varReplace_repr_basic(self):
+        vars = {
+            'color': '$favorite_color',
+            'favorite_color': 'blue',
+        }
+
+        template = '$color == "blue"'
+        res = ansible.utils.varReplace(template, vars, do_repr=True)
+        assert eval(res)
+
+    def test_varReplace_repr_varinvar(self):
+        vars = {
+            'foo': 'foo',
+            'bar': 'bar',
+            'foobar': '$foo$bar',
+            'var': {
+                'foo': 'foo',
+                'foobar': '$foo$bar',
+            },
+        }
+
+        template = '$foobar == "foobar"'
+        res = ansible.utils.varReplace(template, vars, do_repr=True)
+        assert eval(res)
+
+    def test_varReplace_repr_varindex(self):
+        vars = {
+            'foo': 'foo',
+            'var': {
+                'foo': 'bar',
+            },
+        }
+
+        template = '${var.$foo} == "bar"'
+        res = ansible.utils.varReplace(template, vars, do_repr=True)
+        assert eval(res)
+
+    def test_varReplace_repr_varpartindex(self):
+        vars = {
+            'foo': 'foo',
+            'var': {
+                'foobar': 'foobar',
+            },
+        }
+
+        template = '${var.${foo}bar} == "foobar"'
+        res = ansible.utils.varReplace(template, vars, do_repr=True)
+        assert eval(res)
+
     def test_template_varReplace_iterated(self):
         template = 'hello $who'
         vars = {


### PR DESCRIPTION
While testing this, I noticed that the implementation has a few limitations, e.g. ${var.$other_var} will not work, and neither will vars in vars.
