### PR TITLE
make delegate_to localhost act like local_action

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -62,6 +62,11 @@ class Task(object):
             self.action      = ds.get('local_action', '')
             self.delegate_to = '127.0.0.1'
             self.transport   = 'local'
+        # delegate_to: localhost should use local transport
+        elif (ds.get('delegate_to', None) in ['127.0.0.1', 'localhost']):
+            self.action		 = ds.get('action', '')
+            self.delegate_to = '127.0.0.1'
+            self.transport   = 'local'
         else:
             self.action      = ds.get('action', '')
             self.delegate_to = ds.get('delegate_to', None)


### PR DESCRIPTION
If delegate_to is localhost then use the local transport.  There are two motivations for this:

a) Make local_action have the same behavior as delegate_to: localhost to save confusion.

b) My delegate_to is a host specific variable.  Sometimes its a remote machine, sometimes it localhost.  For localhost I want to use the local transport.
