### PR TITLE
Getting negative host pattern matching to work with external inventory

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -109,8 +109,8 @@ class Inventory(object):
 
         # exclude hosts mentioned in a negative pattern
         if len(negative_patterns):
-            exclude_hosts = self._get_hosts(negative_patterns)
-            hosts = [ h for h in hosts if h not in exclude_hosts ]
+            exclude_hosts = [ h.name for h in self._get_hosts(negative_patterns) ]
+            hosts = [ h for h in hosts if h.name not in exclude_hosts ]
 
         # exclude hosts not in a subset, if defined
         if self._subset:


### PR DESCRIPTION
Getting negative host pattern matching to work with external inventory (same as commit 4caf85e37bdff284c337086ff3ce46b1dcfd8751, but for excluded hosts as well as subsets)
