### PR TITLE
Ignore failure of stop command if start succeeds with state=restarted

### DIFF
--- a/library/service
+++ b/library/service
@@ -225,6 +225,7 @@ def main():
         # ===========================================
         # run change commands if we need to
         if changed:
+
             if state in ['started', 'running']:
                 rc_state, stdout, stderr = _run("%s %s start" % (SERVICE, name))
             elif state == 'stopped':
@@ -234,9 +235,14 @@ def main():
             elif state == 'restarted':
                 rc1, stdout1, stderr1 = _run("%s %s stop" % (SERVICE, name))
                 rc2, stdout2, stderr2 = _run("%s %s start" % (SERVICE, name))
-                rc_state = rc + rc1 + rc2
-                stdout = stdout1 + stdout2
-                stderr = stderr1 + stderr2
+                if rc1 != 0 and rc2 == 0:
+                    rc_state = rc + rc2
+                    stdout = stdout2
+                    stderr = stderr2
+                else:
+                    rc_state = rc + rc1 + rc2
+                    stdout = stdout1 + stdout2
+                    stderr = stderr1 + stderr2
 
             out += stdout
             err += stderr


### PR DESCRIPTION
In some cases (see issue #1067) with state=restarted, a failure to stop
the service (which wasn't running) would appear to the module to be a
failure to restart the service even though it successfully started the
service.  This changes the behavior of the service module to focus
on the return code of the start command.  If the rc of stop is not
0 and the rc of start does equal 0, it considers the service
successfully restarted.  It then ignores the rc, stdout, and stderr
from the unsuccessful stop command.

Please let me know if you have any questions or comments.
