### PR TITLE
Fix only_if statements referencing non-string types

### DIFF
--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -269,8 +269,9 @@ def varReplace(raw, vars, do_repr=False, depth=0):
         # original)
 
         try:
-            replacement = unicode(_varLookup(m.group(2), vars, depth))
-            replacement = varReplace(replacement, vars, depth=depth + 1)
+            replacement = _varLookup(m.group(2), vars, depth)
+            if isinstance(replacement, (str, unicode)):
+                replacement = varReplace(replacement, vars, depth=depth + 1)
         except VarNotFoundException:
             replacement = m.group()
 
@@ -282,9 +283,9 @@ def varReplace(raw, vars, do_repr=False, depth=0):
                  (raw[start - 1] == '"' and raw[end] == '"'))):
                 start -= 1
                 end += 1
-        done.append(raw[:start])    # Keep stuff leading up to token
-        done.append(replacement)    # Append replacement value
-        raw = raw[end:]             # Continue with remainder of string
+        done.append(raw[:start])          # Keep stuff leading up to token
+        done.append(unicode(replacement)) # Append replacement value
+        raw = raw[end:]                   # Continue with remainder of string
 
     return ''.join(done)
 

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -251,6 +251,16 @@ class TestUtils(unittest.TestCase):
         res = ansible.utils.varReplace(template, vars, do_repr=True)
         assert eval(res)
 
+    def test_varReplace_repr_nonstr(self):
+        vars = {
+            'foo': True,
+            'bar': 1L,
+        }
+
+        template = '${foo} == $bar'
+        res = ansible.utils.varReplace(template, vars, do_repr=True)
+        assert res == 'True == 1L'
+
     def test_template_varReplace_iterated(self):
         template = 'hello $who'
         vars = {


### PR DESCRIPTION
This fixes e.g. only_if: ${task.changed} which would always
evaluate to true due to it having been replaced by a string for its
boolean value. Also adds a test case to ensure it doesn't get
missed again.
