### PR TITLE
Create a string parser for varReplace instead of using re

### DIFF
--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -261,6 +261,29 @@ class TestUtils(unittest.TestCase):
         res = ansible.utils.varReplace(template, vars, do_repr=True)
         assert res == 'True == 1L'
 
+    def test_varReplace_consecutive_vars(self):
+        vars = {
+            'foo': 'foo',
+            'bar': 'bar',
+        }
+
+        template = '${foo}${bar}'
+        res = ansible.utils.varReplace(template, vars)
+        assert res == 'foobar'
+
+    def test_varReplace_escape_dot(self):
+        vars = {
+            'hostvars': {
+                'test.example.com': {
+                    'foo': 'bar',
+                },
+            },
+        }
+
+        template = '${hostvars.{test.example.com}.foo}'
+        res = ansible.utils.varReplace(template, vars)
+        assert res == 'bar'
+
     def test_template_varReplace_iterated(self):
         template = 'hello $who'
         vars = {


### PR DESCRIPTION
This fixes a few issues,
- ${foo}${bar} would be parsed as a variable named foo}${bar,
  which wouldn't be easily fixed without breaking ${foo.${bar}}
- allows escaping . in variable parts so e.g.
  ${hostvars.{test.example.com}.foo} works

This is slower than using re. 3 million templating calls take about
about twice as long to complete with this compared to the regexp,
from ~65 seconds to ~115 seconds on my laptop.
