### PR TITLE
Feature: lookup external data for variable expansion

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -86,3 +86,9 @@ DEFAULT_SUBSET            = None
 
 ANSIBLE_SSH_ARGS          = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
 ZEROMQ_PORT               = int(get_config(p, 'fireball', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099))
+
+LOOKUPS='lookups'
+
+redisurl        = get_config(p, LOOKUPS, 'redisurl',        None,       'redis://localhost:6379/')
+ldapurl         = get_config(p, LOOKUPS, 'ldapurl',         None,       None)
+inipath         = get_config(p, LOOKUPS, 'inipath',         None,       None)

--- a/lib/ansible/lookups.py
+++ b/lib/ansible/lookups.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+
+# (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+import ansible.constants as C
+import ConfigParser
+
+HAVE_DNS=False
+try:
+    import dns.resolver
+    HAVE_DNS=True
+except ImportError:
+    pass
+
+HAVE_REDIS=False
+try:
+    import redis        # https://github.com/andymccurdy/redis-py/
+    HAVE_REDIS=True
+except ImportError:
+    pass
+
+HAVE_LDAP=False
+try:
+    import ldap, ldapurl
+    HAVE_LDAP=True
+except:
+    pass
+
+# Lookup types in this file are alphabetically ordered (though they
+# need not be).
+
+# ==============================================================
+# DNSTXT: DNS TXT records
+#
+#       key=domainname
+#
+#   eg: key=www.example.com
+# TODO: configurable resolver IPs
+# --------------------------------------------------------------
+
+def _lookup_dnstxt(params):
+
+    if HAVE_DNS == False:
+        return "ENODNSTXT"
+
+    if not 'key' in params:
+        return "ENOKEY"
+
+    domain = params['key']
+
+    string = []
+    answers = dns.resolver.query(domain, 'TXT')
+    for rdata in answers:
+        s = rdata.to_text()
+        print s
+        string.append(s[1:-1])  # Strip outside quotes on TXT rdata
+
+    return ''.join(string)
+
+# ==============================================================
+# environment
+#
+#       key=variablename
+#       default=string      returned if $variablename not found
+#                           default is ""
+#
+#   eg: key=HOME
+# --------------------------------------------------------------
+
+def _lookup_env(params):
+    
+    if not 'key' in params:
+        return "ENOKEY"
+
+    return os.getenv(params['key'], params.get('default', ''))
+
+# ==============================================================
+# inifile
+
+#       section=
+#       key=
+#       default=            returned if key not found
+#
+# --------------------------------------------------------------
+
+def _lookup_inifile(params):
+
+    if C.inipath is None:
+        return "ENOINIFILE"
+    
+    if not 'section' in params or not 'key' in params:
+        return "ENOKEY"
+
+    section = params['section']
+    key     = params['key']
+    default = params.get('default', "")
+
+    cp = ConfigParser.ConfigParser()
+    try:
+        f = open(C.inipath)
+        cp.readfp(f)
+    except IOError:
+        return "ENOINIFILE"
+
+    try:
+        if cp.has_section(section) == True:
+            value = cp.get(section, key)
+            return value
+    except:
+        return default
+
+
+# ==============================================================
+# LDAP
+#       key=domainname
+#
+#   eg: key=www.example.com
+#
+# cfg:
+#   [lookups]
+#   ldapurl=ldap://localhost:389/dc=company,dc=example,dc=net
+# --------------------------------------------------------------
+
+def _lookup_ldap(params):
+
+    if HAVE_LDAP == False:
+        return "ENOLDAP"
+
+    if not 'key' in params:
+        return "ENOKEY"
+
+    if C.ldapurl is None:
+        return "ENOLDAPURL"
+
+    ldap_url = ldapurl.LDAPUrl(C.ldapurl)
+
+    uri = "%s://%s" % (ldap_url.urlscheme, ldap_url.hostport)
+
+    try:
+        con = ldap.initialize(uri)
+    except:
+        return None
+
+    filter = "(%s=%s)" % (params['key'], params['value'])  # FIXME ESCAPING
+    attr = params['attrib']
+
+    try:
+        res = con.search_s(ldap_url.dn, ldap.SCOPE_SUBTREE, filter, [ str(attr)] )
+    except:
+        return "ENOLDAPSEARCH"
+
+    con.unbind()
+
+    for dn, entry in res:
+        for a in entry:
+            if a.upper() == attr.upper():
+                return ''.join(entry[a])    # DECISION: join attribute values?
+
+    return "ldapnotfound"
+
+# ==============================================================
+# Redis: GET key
+#
+#       key=key
+#   eg: key=name
+#
+# cfg:
+#   [lookups]
+#   redis=redis://localhost:6379/
+#
+# TODO:
+#   Add support for urlparse to use authentication
+# --------------------------------------------------------------
+
+
+def _lookup_redis(params):
+
+    if HAVE_REDIS == False:
+        return "ENOREDIS"
+
+    if not 'key' in params:
+        return "ENOKEY"
+
+    url = C.redisurl
+
+    # urlsplit on Python 2.6.1 is broken. Hmm. Probably also the reason
+    # Redis' from_url() doesn't work here.
+
+    p = '(?P<scheme>[^:]+)://?(?P<host>[^:/ ]+).?(?P<port>[0-9]*).*'
+
+    try:
+        m = re.search(p, url)
+        host = m.group('host') 
+        port = int(m.group('port'))
+    except AttributeError:
+        return "EBADURL"
+
+    try:
+        conn = redis.Redis(host=host, port=port)
+        res = conn.get(params['key'])
+        if res is None:
+            res = ""
+        return res
+    except:
+        return "ENOREDIS"
+
+
+# ==============================================================
+# ext_lookup: dispatcher
+
+def ext_lookup(type, params):
+
+    func_name = "_lookup_%s" % type
+
+    print "@@@@@@@@@@@@@@--> ", func_name
+    print "@@@@@@@@@@@@@@--> ", params
+
+    try:
+        result = globals()[func_name](params)
+    except:
+        raise
+        result = "ENOLOOKUPTYPE"
+
+    return result
+

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -36,6 +36,7 @@ import stat
 import termios
 import tty
 from multiprocessing import Manager
+from ansible import lookups
 
 VERBOSITY=0
 
@@ -328,7 +329,7 @@ def varReplace(raw, vars, do_repr=False, depth=0):
 
     return ''.join(done)
 
-_FILEPIPECRE = re.compile(r"\$(?P<special>FILE|PIPE)\(([^\}]+)\)")
+_FILEPIPECRE = re.compile(r"\$(?P<special>FILE|PIPE|LOOKUP)\(([^\}]+)\)")
 def varReplaceFilesAndPipes(basedir, raw):
     done = [] # Completed chunks to return
 
@@ -354,6 +355,39 @@ def varReplaceFilesAndPipes(basedir, raw):
             if p.returncode != 0:
                 raise VarNotFoundException()
             replacement = stdout
+        elif m.group(1) == "LOOKUP":
+            replacement = ""
+
+# m.group(2) contains the LOOKUP options (e.g. "ldap;sn=Mens,attrib=displayName")
+# Split out the lookup type and its options
+
+            ltype = m.group(2).split(';')[0]
+            options = m.group(2).split(';')[1]
+
+            items   = options.split(',')
+            params = {}
+            for x in items:
+                (k, v) = x.split("=", 1)
+                params[k] = v
+
+            replacement = lookups.ext_lookup(ltype, params)
+
+#
+#            kw = m.group(2).split(';')
+#
+#            if kw[0] == 'redis':
+#                key = kw[1]
+#                args = {
+#                    "key" : key
+#                }
+#                replacement = stab_redis(args)
+#
+#            if kw[0] == 'env':
+#                key = kw[1]
+#                args = {
+#                    "key" : key
+#                }
+#                replacement = stab_env(args)
 
         start, end = m.span()
         done.append(raw[:start])    # Keep stuff leading up to token


### PR DESCRIPTION
This implements a proof of concept for two new lookup types (**lots** planned) which can be used to look up data externally from Playbooks. 

``` yaml

---
- hosts: 127.0.0.1
  gather_facts: false
  connection: local
  vars:
  - resp: $STAB(redis;a1)
  - resp: $STAB(env;HOME)
  tasks:
  - action: command /bin/echo ${resp}
  - action: template src=stab1.in dest=/tmp/s1
```

I repeat, that it's a PoC, but I'd very much like to expand on this. 

Ideas for lookup types:
- Redis: `get` the value of a key.
- Environment: obtain a copy of, say, `$HOME`
- LDAP: search for `attribute=value` and return the value of a named attribute type
- memcached: pass in a key (hash) and return the string
- zeromq: same
- CSV: from a configured CSV file (specified in, say, `ansible.cfg`) retrieve an option from a particular section.
- sql: SELECT, etc. from PgSQL, MySQL, SQLite3
- etc., etc., etc.

Need I say more? ;-)

BTW, the name _stab_ is from a beautiful function in the venerable _sendmail_ daemon; during a debugging session years and years ago, I stumbled over that and thought it a good name. :-) But I'm sure we can call it LOOKUP()
