### PR TITLE
Fix to make sure only strings are being joined

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -173,7 +173,7 @@ class AnsibleModule(object):
             if type(choices) == list:
                 if k in self.params:
                     if self.params[k] not in choices:
-                        choices_str=",".join(choices)
+                        choices_str=",".join([str(c) for c in choices])
                         msg="value of %s must be one of: %s, got: %s" % (k, choices_str, self.params[k])
                         self.fail_json(msg=msg)
             else:


### PR DESCRIPTION
Since BOOLEANS also contains integers, joining the list returns an error. Easy to test by giving a wrong value to a boolean argument:

```
service name=httpd enabled=True
```

Since True is not in the allowed BOOLEANS, it will cause the error, which in its turn bails out because it joins strings and integers.
We may want to remove the integers from the choices since '0' and '1' are already in the list as strings. Personally I would expect only strings as arguments, not sure where these could be integers ??
