### PR TITLE
Setting trim_blocks to True

### DIFF
--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -371,7 +371,7 @@ def template(basedir, text, vars):
 def template_from_file(basedir, path, vars):
     ''' run a file through the templating engine '''
 
-    environment = jinja2.Environment(loader=jinja2.FileSystemLoader(basedir), trim_blocks=False)
+    environment = jinja2.Environment(loader=jinja2.FileSystemLoader(basedir), trim_blocks=True)
     environment.filters['to_json'] = json.dumps
     environment.filters['from_json'] = json.loads
     environment.filters['to_yaml'] = yaml.dump


### PR DESCRIPTION
Setting trim_blocks to True so that newlines after a template block get trimmed.

This is useful, for example, when a particularly picky service's configuration file syntax requires _no_ empty lines, and a loop is used inside a Jinja2 template for creating said config files.
