### PR TITLE
Complete the change from $FILE{} to $FILE()

### DIFF
--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -321,7 +321,7 @@ def varReplace(raw, vars, depth=0):
 
     return ''.join(done)
 
-_FILEPIPECRE = re.compile(r"\$(?P<special>FILE|PIPE)\(([^\}]+)\)")
+_FILEPIPECRE = re.compile(r"\$(?P<special>FILE|PIPE)\(([^\)]+)\)")
 def varReplaceFilesAndPipes(basedir, raw):
     done = [] # Completed chunks to return
 


### PR DESCRIPTION
Otherwise, parsing e.g. '$FILE(myfile)'.find("stuff") will include
everything up to the last ) as the filename.
