### PR TITLE
documentation: man template: support empty options; add Version 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,4 +161,4 @@ deb: debian
 # for arch or gentoo, read instructions in the appropriate 'packaging' subdirectory directory
 
 manpages:
-	hacking/module_formatter.py -t man -o docs/man/man1/ --module-dir=library --template-dir=hacking/templates
+	hacking/module_formatter.py -A $(VERSION) -t man -o docs/man/man1/ --module-dir=library --template-dir=hacking/templates

--- a/hacking/templates/man.j2
+++ b/hacking/templates/man.j2
@@ -11,7 +11,7 @@
 ." ------ OPTIONS
 ."
 ."
-{% if options is defined -%}
+{% if options -%}
 .SH OPTIONS
 {% for (k,v) in options.iteritems()  %}
 .IP @{ k }@


### PR DESCRIPTION
Ansible version (e.g. 0.8) handling existed in module_formatter and `man` template, it just wasn't invoked properly; fixed that.
