### PR TITLE
Allow task includes to work with with_items

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -261,7 +261,7 @@ class Runner(object):
 
         items = self.module_vars.get('items', [])
         if isinstance(items, basestring) and items.startswith("$"):
-            items = utils.varLookup(items, inject)
+            items = utils.varReplaceWithItems(self.basedir, items, inject)
         if type(items) != list:
             raise errors.AnsibleError("with_items only takes a list: %s" % items)
 

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -278,17 +278,6 @@ def _varFind(text):
     path.append(text[part_start[0]:var_end])
     return {'path': path, 'start': start, 'end': end}
 
-def varLookup(varname, vars):
-    ''' helper function used by with_items '''
-
-    m = _varFind(varname)
-    if not m:
-        return None
-    try:
-        return _varLookup(m['path'], vars)
-    except VarNotFoundException:
-        return None
-
 def varReplace(raw, vars, depth=0):
     ''' Perform variable replacement of $variables in string raw using vars dictionary '''
     # this code originally from yum
@@ -357,6 +346,30 @@ def varReplaceFilesAndPipes(basedir, raw):
         raw = raw[end:]             # Continue with remainder of string
 
     return ''.join(done)
+
+def varReplaceWithItems(basedir, varname, vars):
+    ''' helper function used by with_items '''
+
+    if isinstance(varname, basestring):
+        m = _varFind(varname)
+        if not m:
+            return varname
+        if m['start'] == 0 and m['end'] == len(varname):
+            try:
+                return varReplaceWithItems(basedir, _varLookup(m['path'], vars), vars)
+            except VarNotFoundException:
+                return varname
+        else:
+            return template(basedir, varname, vars)
+    elif isinstance(varname, (list, tuple)):
+        return [varReplaceWithItems(basedir, v, vars) for v in varname]
+    elif isinstance(varname, dict):
+        d = {}
+        for (k, v) in varname.iteritems():
+            d[k] = varReplaceWithItems(basedir, v, vars)
+        return d
+    else:
+        raise Exception("invalid with_items type")
 
 
 def template(basedir, text, vars):


### PR DESCRIPTION
This will allow constructs such as:
### playbook.yml

```

---
- hosts: all
  vars_files:
  - vars/users.yml
  tasks:
  - include: tasks/user.yml user=$item
    with_items: $users
```
### vars/users.yml

```

---
- username: timmy
  gecos: Timmy
  groups:
  - group1
  - group2
```
### tasks/user.yml

```

---
- name: create user ${user.username}
  action: user name=${user.username} comment=${user.gecos}

- name: add user to groups
  action: user name=${user.username} groups=$item append=yes
  with_items: ${user.groups}
```

Among many others. Similarly for deploying the same codebase with a few different settings.
