### PR TITLE
Add message reporting skipped action in cli callback

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -237,6 +237,7 @@ class CliRunnerCallbacks(DefaultRunnerCallbacks):
         super(CliRunnerCallbacks, self).on_unreachable(host, res)
 
     def on_skipped(self, host, item=None):
+        print "%s | skipped" % (host)
         super(CliRunnerCallbacks, self).on_skipped(host, item)
 
     def on_error(self, host, err):


### PR DESCRIPTION
Looks like this:

$ ansible all -i 'localhost,' -u root -m command -a "creates=/tmp/foo touch /tmp/foo"
localhost | success | rc=0 >>

$ ansible all -i 'localhost,' -u root -m command -a "creates=/tmp/foo touch /tmp/foo"
localhost | skipped

For issue #1007.
