### PR TITLE
Give each task its own module_vars

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -116,8 +116,9 @@ class Play(object):
                         mv[k] = utils.varReplaceWithItems(self.basedir, v, mv)
                     include_file = utils.template(self.basedir, tokens[0], mv)
                     data = utils.parse_yaml_from_file(utils.path_dwim(self.basedir, include_file))
+                    print data
                     for y in data:
-                         results.append(Task(self,y,module_vars=mv))
+                         results.append(Task(self,y,module_vars=mv.copy()))
             elif type(x) == dict:
                 task_vars = self.vars.copy()
                 results.append(Task(self,x,module_vars=task_vars))


### PR DESCRIPTION
Otherwise each task will overwrite the previous' items, among
other things.
