### PR TITLE
Only gather facts once per node per playbook run

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -314,8 +314,12 @@ class PlayBook(object):
         host_list = [ h for h in self.inventory.list_hosts(play.hosts)
             if not (h in self.stats.failures or h in self.stats.dark) ]
 
-        if not play.gather_facts:
+        if play.gather_facts is False:
             return {}
+        elif play.gather_facts is None:
+            host_list = [h for h in host_list if h not in self.SETUP_CACHE]
+            if len(host_list) == 0:
+                return {}
 
         self.callbacks.on_setup()
         self.inventory.restrict_to(host_list)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -75,7 +75,7 @@ class Play(object):
         self.sudo_user    = utils.template(basedir, ds.get('sudo_user', self.playbook.sudo_user), playbook.extra_vars)
         self.transport    = ds.get('connection', self.playbook.transport)
         self.tags         = ds.get('tags', None)
-        self.gather_facts = ds.get('gather_facts', True)
+        self.gather_facts = ds.get('gather_facts', None)
         self.serial       = ds.get('serial', 0)
 
         self._update_vars_files_for_host(None)


### PR DESCRIPTION
Unless gather_facts: True is on the play.

Fixes issue #1199, I thought I had already PR'd this.
