### PR TITLE
Abort a play at the start when no hosts matches, or no hosts are remaining

### DIFF
--- a/lib/ansible/callback_plugins/noop.py
+++ b/lib/ansible/callback_plugins/noop.py
@@ -63,6 +63,12 @@ class CallbackModule(object):
     def playbook_on_notify(self, host, handler):
         pass
 
+    def on_no_hosts_matched(self):
+        pass
+
+    def on_no_hosts_remaining(self):
+        pass
+
     def playbook_on_task_start(self, name, is_conditional):
         pass
 

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -414,6 +414,14 @@ class PlaybookCallbacks(object):
     def on_notify(self, host, handler):
         call_callback_module('playbook_on_notify', host, handler)
 
+    def on_no_hosts_matched(self):
+        print stringc("no hosts matched", 'red')
+        call_callback_module('playbook_on_no_hosts_matched')
+
+    def on_no_hosts_remaining(self):
+        print stringc("\nFATAL: all hosts have already failed -- aborting", 'red')
+        call_callback_module('playbook_on_no_hosts_remaining')
+
     def on_task_start(self, name, is_conditional):
         msg = "TASK: [%s]" % name
         if is_conditional:


### PR DESCRIPTION
This change makes a distinction between no_hosts_matched and no_hosts_remained.

In both cases we do not start facts-gathering, or run any tasks.

In the case that there are no more hosts remaining, we abort running tasks and abort the playbook.

I also cleaned up the leftovers from the previous patchsets, as these are no longer required.

This closes #1187.

Example playbook:

``` yaml

---
- hosts: emptygroup
  tasks:
  - action: command date
  - action: command false

- hosts: all
  gather_facts: False
  tasks:
  - action: command ls
  - action: command false
  - action: command true

- hosts: all
  tasks:
  - action: command true
  - action: command false

- hosts: all
  tasks:
  - action: command pwd
```
