### PR TITLE
Make ignored/skipped different from changed

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -317,7 +317,7 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
         if not parsed and module_msg:
             print stringc("invalid output was: %s" % module_msg, 'red')
         if ignore_errors:
-            print stringc("...ignoring", 'yellow')
+            print stringc("...ignoring", 'cyan')
         super(PlaybookRunnerCallbacks, self).on_failed(host, results, ignore_errors=ignore_errors)
 
     def on_ok(self, host, host_result):
@@ -372,7 +372,7 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
             msg = "skipping: [%s] => (item=%s)" % (host, item)
         else:
             msg = "skipping: [%s]" % host
-        print stringc(msg, 'yellow')
+        print stringc(msg, 'cyan')
         super(PlaybookRunnerCallbacks, self).on_skipped(host, item)
 
     def on_no_hosts(self):


### PR DESCRIPTION
Since a skipped/ignored action is _very_ different from actual changes to a system, it always bothered me that  it was not easily distinguishable when skimming the output. This change makes ignore/skip a different color, and I chose cyan. Contemplated using dark-gray/blue, but prefered something that is readable with most terminal colors.
