### PR TITLE
Fix gather_facts assumption that SETUP_CACHE for a host is empty

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -317,7 +317,7 @@ class PlayBook(object):
         if play.gather_facts is False:
             return {}
         elif play.gather_facts is None:
-            host_list = [h for h in host_list if h not in self.SETUP_CACHE]
+            host_list = [h for h in host_list if h not in self.SETUP_CACHE or 'module_setup' not in self.SETUP_CACHE[h]]
             if len(host_list) == 0:
                 return {}
 
@@ -340,6 +340,7 @@ class PlayBook(object):
         # let runner template out future commands
         setup_ok = setup_results.get('contacted', {})
         for (host, result) in setup_ok.iteritems():
+            self.SETUP_CACHE[host].update({'module_setup': True})
             self.SETUP_CACHE[host].update(result.get('ansible_facts', {}))
         return setup_results
 


### PR DESCRIPTION
We now check explicitely for 'module_setup' in the SETUP_CACHE in order to avoid skipping setup because SETUP_CACHE was populated some other way. Other modules can implement the same mechanism to test if they've already run.

This closes #1206 and also closes #1199.
