### PR TITLE
Module debug to assist users in understanding Ansible

### DIFF
--- a/library/debug
+++ b/library/debug
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2012 Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: debug
+short_description: Print statements during execution
+description:
+     - This module prints statements during execution and can be useful
+       for debugging variables or expressions without necessarily halting
+       the playbook. Useful for debugging together with the only_if directive.
+
+       In order to see the debug message, you need to run ansible in verbose
+       mode (using the -v option).
+version_added: "0.8"
+options:
+  msg:
+    description:
+      - The customized message that is printed. If ommited, prints a generic
+        message.
+    required: false
+    default: "Hello world!"
+  rc:
+    description:
+      - The return code of the module. If fail=yes, this will default to 1.
+    required: false
+    default: 0
+  fail:
+    description:
+      - A boolean that indicates whether the debug module should fail or not.
+    required: false
+    default: "no"
+examples:
+    - code:
+        - local_action: debug msg="System $inventory_hostname has uuid $ansible_product_uuid"
+        - local_action: debug msg="System $inventory_hostname lacks a gateway" fail=yes
+          only_if: "is_unset('${ansible_default_ipv4.gateway}')"
+        - local_action: debug msg="System $inventory_hostname has gateway ${ansible_default_ipv4.gateway}"
+          only_if: "is_set('${ansible_default_ipv4.gateway}')"
+      description: "Example that prints the loopback address and gateway for each host"
+author: Dag Wieers
+'''
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            fail = dict(default='no', choices=BOOLEANS),
+            msg = dict(default='Hello world!'),
+            rc = dict(default=0),
+        )
+    )
+
+    if module.params['fail'] in BOOLEANS_TRUE and module.params['rc'] == 0:
+        module.params['rc'] = 1
+
+    if module.params['fail'] in BOOLEANS_TRUE:
+        module.fail_json(rc=module.params['rc'], msg=module.params['msg'])
+    else:
+        module.exit_json(msg=module.params['msg'])
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()


### PR DESCRIPTION
After helping someone on IRC he was interested to have this debug module in upstream. This module simply 'prints' a message, and can be ordered to fail if needed. It helps to troubleshoot or understand inventory/facts issues and/or experiment with statements and conditions using only_if.

Here is a small example playbook:

``` yaml
- hosts: all
  tasks:
  - local_action: debug msg="System ${inventory_hostname} has ${ansible_eth0.ipv4.address}"
  - local_action: debug msg="System ${inventory_hostname} lacks a gateway" fail=yes
    only_if: "is_unset('$network_gateway')"
  - local_action: debug msg="System ${inventory_hostname} has gateway ${network_gateway}"
    only_if: "is_set('$network_gateway')"
```

outputting:

```
[root@moria ansible]# ansible-playbook -v -l localhost:x220 test6.yml

PLAY [all] *********************

GATHERING FACTS *********************
ok: [localhost]
ok: [x220]

TASK: [debug msg="System ${inventory_hostname} has ${ansible_eth0.ipv4.address}"] *********************
ok: [localhost] => {"msg": "System localhost has 10.1.2.127"}
ok: [x220] => {"msg": "System x220 has 192.168.1.214"}

TASK: [debug msg="System ${inventory_hostname} lacks a gateway" fail=yes] *********************
failed: [localhost] => {"failed": true, "msg": "System localhost lacks a gateway", "rc": 1}
ok: [x220] => {"msg": "System x220 has gateway 192.168.1.1"}

PLAY RECAP *********************
localhost                      : ok=2    changed=0    unreachable=0    failed=1
x220                           : ok=3    changed=0    unreachable=0    failed=0

```

I had some other plans for the module, like displaying host inventory and complete inventory to help understand inventory and facts modules, but that would require an action-plugin for transfering inventory information etc... And I am not sure this is wanted/best done in a module.
