### PR TITLE
network_facts: gather facts based on network information for provisioning

### DIFF
--- a/lib/ansible/runner/action_plugins/network_facts.py
+++ b/lib/ansible/runner/action_plugins/network_facts.py
@@ -1,0 +1,36 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from ansible import utils
+
+class ActionModule(object):
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    def run(self, conn, tmp, module_name, module_args, inject):
+        ''' handler for file transfer operations '''
+
+        # load up options
+        options = utils.parse_kv(module_args)
+        inventory = options.get('inventory', None)
+        tmp_inventory = tmp + os.path.basename(inventory)
+        conn.put_file(inventory, tmp_inventory)
+
+        module_args = "%s inventory=%s" % (module_args, tmp_inventory)
+        return self.runner._execute_module(conn, tmp, 'network_facts', module_args, inject=inject)

--- a/library/network_facts
+++ b/library/network_facts
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2012 Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: network_facts
+short_description: Match a host in a network inventory and return network-based facts.
+description:
+     - The network_facts module enables one to have a separate network-related inventory. The module uses DNS to provide ipaddress, domain and fqdn facts, but can also use a separate yaml inventory describing the various networks and facts related to this network. So typically you would define vlans, network-ranges, netmasks, gateways and facts related to each network (e.g. domain search path, dns servers, ntp servers, ...) or location-based information (datacenter, environment, ...).
+     - Typically this module is run as a local_action
+options:
+  host:
+    description:
+      - The host name, ip-address or FQDN of a system, usually this is set to $inventory_hostname
+    required: true
+    default: null
+  inventory:
+    description:
+      - Path to the network inventory
+    required: false
+    default: network-inventory.yml
+  full:
+    description:
+      - Boolean to determine whether we want to do a single DNS lookup (to get the ipaddress) or multiple DNS lookups (for domain and fqdn information). More DNS lookups is slower.
+    required: false
+    choices: [ "yes", "no" ]
+    default: "no"
+  gw:
+    description:
+      - Strategy for the default gateway address if not gateway has been defined for a specific CIDR.
+    required: false
+    choices: [ "none", "first", "last" ]
+    default: "last"
+version_added: "0.8"
+examples:
+   - code: local_action host=$inventory_hostname inventory=/etc/ansible/network-inventory.yml full=yes
+     description: "Run the $inventory_hostname through the network inventory"
+author: Dag Wieers
+'''
+
+import socket
+import yaml
+try:
+    import netaddr
+except ImportError:
+    print "failed=True msg='netaddr python module unavailable'"
+    sys.exit(1)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            # Provided host can be IP address, hostname or FQDN
+            host = dict(required=True),
+            # FIXME: Allow to query a specific name server for DNS lookup
+#            nameserver = dict(),
+            full = dict(default=False, choices=BOOLEANS),
+            inventory = dict(),
+            gw = dict(default='last', choices=['none', 'first', 'last'])
+        )
+    )
+
+    host = module.params['host']
+    full = module.params['full']
+    gw = module.params['gw']
+
+    inventory = None
+    if 'inventory' in module.params.keys():
+        inventory = os.path.expanduser(module.params['inventory'])
+
+        if not os.path.exists(inventory):
+            module.fail_json(rc=11, msg="Inventory %s failed to transfer" % inventory)
+        if not os.access(inventory, os.R_OK):
+            module.fail_json(rc=12, msg="Inventory %s not readable" % inventory)
+
+    # Get IP address from DNS
+    try:
+        ipaddress = socket.gethostbyname(host)
+    except:
+        module.fail_json(rc=1, msg='IP address lookup for host %(host)s failed' % module.params)
+
+    ip = netaddr.IPAddress(ipaddress)
+    facts = {
+        'network_ipaddress': str(ip),
+        'network_ipaddress_hex': ('%08x' % ip).upper(),
+    }
+
+    # Do all DNS lookups if requested (so we get FQDN, aliases and more)
+    if full:
+        # Get FQDN from DNS
+        try:
+            fqdn = socket.getfqdn(host)
+        except:
+            module.fail_json(rc=2, msg='FQDN lookup for host %(host)s failed' % module.params)
+
+        # FIXME: We can also return the reverse namelookup and aliases, if needed
+
+        if ipaddress == fqdn == host:
+            module.fail_json(rc=3, msg='Name lookup for host %(host)s failed' % module.params)
+
+        facts['network_hostname'] = fqdn.split('.')[0]
+        facts['network_fqdn'] = fqdn
+        facts['network_domainname'] = '.'.join(fqdn.split('.')[1:])
+
+    ### Most useful information comes from a separate inventory file
+    ### The inventory file _requires_ at least a cidr entry
+    if inventory:
+        networks = yaml.load(open(inventory))
+
+        # Find the network
+        for network in networks:
+
+            net = netaddr.IPNetwork(network['cidr'])
+            if ip not in net:
+                continue
+
+            # We have a match !
+            facts['network_broadcast'] = str(net.broadcast)
+            facts['network_netmask'] = str(net.netmask)
+            facts['network_network'] = str(net.network)
+            facts['network_bits'] = net.prefixlen
+
+            for key in network:
+                factname = 'network_'+key
+                facts[factname] = network[key]
+
+            # If no gateway is specified, take the last address from the range
+            if 'gateway' not in network.keys():
+                if gw == 'first':
+                    facts['network_gateway'] = str(netaddr.IPAddress(net.first + 1))
+                elif gw == 'last':
+                    facts['network_gateway'] = str(netaddr.IPAddress(net.last - 1))
+            break
+        else:
+            module.fail_json(rc=13, msg='Network for host %(host)s is missing from %(inventory)s' % module.params)
+
+    module.exit_json(ansible_facts=facts)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()


### PR DESCRIPTION
This module enables you to map a system to a network, and import the facts related to this network. Anything can be a network-related fact just by adding it to the network-inventory yaml file. The module has its own name-space.

The syntax of the yaml file only requires that a cidr-attribute exists for each entry. Based on the gw-option, a gateway strategy will add a gateway attribute (first or last address) if one is missing. Everything else is optional depending on your use-case.

Here is an example _network-inventory.yml_:

``` yaml

---
- vlan: 10
  cidr: '10.1.10.0/25'
  description: Production servers in DMZ2
  nameservers: [ 10.1.2.10, 10.1.3.10 ]
  domains: [ prod.corp.intra, hw.corp.intra, mgmt.corp.intra ]
  environment: prod
  datacenter: brussels
  tier: dmz2
  gateway: 10.1.10.232
- vlan: 15
  cidr: '10.2.12.0/25'
  description: QA servers in DMZ3
  nameservers: [ 10.1.2.10, 10.1.3.10 ]
  domains: [ nonprod.corp.intra, hw.corp.intra, mgmt.corp.intra ]
  environment: nonprod
  datacenter: antwerp
  tier: dmz3
- vlan: 20
  cidr: 10.3.148.0/22
  description: Management servers in Trusted
  environment: nonprod
  datacenter: antwerp
  tier: trusted
```

And here's how one would be using it for provisioning systems:

``` yaml
- name: kickstart
  hosts: all
  gather_facts: False

  vars:
    rhel_version: 6.3
    kickstart_file: /var/www/html/ks/${inventory_hostname_short}.cfg
    iso_image: /iso/ks/${inventory_hostname_short}.iso
    rhel_pxeboot: /var/www/mrepo/rhel${rhel_version}-x86_64/disc1/images/pxeboot/.
    isolinux_bin: /usr/share/syslinux/isolinux.bin
    syslinux_dir: /usr/share/syslinux/.

  tasks:
  ### Get network facts
  - local_action: network_facts host='${inventory_hostname_short}' inventory=../network-inventory.yml full=yes

  ### Get iLO facts
  - local_action: ilo_facts host='${cmdb_ilo_address}.${hwdomain}' login='${ilologin}' password='${ilopassword}' match='${inventory_hostname_short}'
    only_if: " '${cmdb_hwtype}'.startswith('HP ') "

  ### Get ESX facts
  - local_action: esx_facts host='${cmdb_esx_server}.${hwdomain}' login='${esxlogin}' password='${esxpassword}' vmname='${cmdb_uuid}'
    only_if: " '${cmdb_hwtype}'.startswith('VMWare ') "

  ### Create a custom boot ISO (use network_facts info for kickstart templating)
  - local_action: command mktemp -d
    register: tempdir
  - local_action: command cp -av ${rhel_pxeboot} ${isolinux_bin} ${tempdir.stdout}
  - local_action: template src=../templates/kickstart/isolinux.cfg dest=${tempdir.stdout}/isolinux.cfg
  - local_action: template src=../templates/kickstart/ks.cfg dest=${tempdir.stdout}/ks.cfg
  - local_action: command mkisofs -r -N -allow-leading-dots -d -J -T -b isolinux.bin -c boot.cat -no-emul-boot -V "Custom RHEL${rhel_version} for ${inventory_hostname_short}" -boot-load-size 4 -boot-info-table -o ${iso_image} ${tempdir.stdout}
  - local_action: command rm -rf ${tempdir.stdout}

  ### Create a custome PXE configuration (based on iLO or ESX information), we do everything BECAUSE WE CAN !!
  - local_action: template src=../templates/kickstart/ks.cfg dest=${kickstart_file}
  - local_action: template src=../templates/kickstart/pxelinux.cfg dest=/var/lib/tftpboot/pxelinux.cfg/${inventory_hostname_short}
  - local_action: template src=../templates/kickstart/pxelinux.cfg dest=/var/lib/tftpboot/pxelinux.cfg/${network_ipaddress_hex}
  - local_action: template src=../templates/kickstart/pxelinux.cfg dest=/var/lib/tftpboot/pxelinux.cfg/${hw_eth0.macaddress_dash}
  - local_action: template src=../templates/kickstart/pxelinux.cfg dest=/var/lib/tftpboot/pxelinux.cfg/${hw_product_uuid}

  ### Safeguard to protect production systems
  - local_action: fail msg="System is not set to 'to-be-staged' in CMDB"
    only_if: "'$cmdb_status' != 'to-be-staged'"

  ### Kick off iLO provisioning
  - local_action: ilo_boot host='${cmdb_ilo_address}.${hwdomain}' login='${ilologin}' password='${ilopassword}' media='cdrom' image='http://${ansible_server}/iso/ks/${inventory_hostname_short}.iso' state='boot_once' match='${inventory_hostname_short}' force='yes'
    only_if: " '${cmdb_hwtype}'.startswith('HP ') "

  ### Kick off ESX provisioning
  - local_action: esx_boot host='${cmdb_esx_server}.${hwdomain}' login='${esxlogin}' password='${esxpassword}' vmname='${cmdb_uuid}' media='cdrom' image='[nfs-datastore] /iso/ks/${inventory_hostname_short}.iso' state='boot_once' match='${inventory_hostname_short}' force='yes'
    only_if: " '${cmdb_hwtype}'.startswith('VMWare ') "

  ### Revoke any existing host keys (needs a separate ansible module)
  - local_action: command ssh-keygen -R ${inventory_hostname_short}
    ignore_errors: True
  - local_action: command ssh-keygen -R ${inventory_hostname}
    ignore_errors: True
  - local_action: command ssh-keygen -R ${network_ipaddress}
    ignore_errors: True

  ### Wait for the post-install SSH to become available
  - local_action: wait_for host=$inventory_hostname port=22 state=started timeout=1800 delay=180

  ### Remove PXE boot configuration
  - local_action: file dest=/var/lib/tftpboot/pxelinux.cfg/${network_ipaddress_hex} state=absent
  - local_action: file dest=/var/lib/tftpboot/pxelinux.cfg/${hw_eth0.macaddress_dash} state=absent
  - local_action: file dest=/var/lib/tftpboot/pxelinux.cfg/${hw_product_uuid} state=absent

  ### Disconnect images
  - local_action: esx_boot host='${cmdb_esx_server}.${hwdomain}' login='${esxlogin}' password='${esxpassword}' vmname='${cmdb_uuid}' media='cdrom' state='disconnect' match='${inventory_hostname_short}'
    only_if: " '${cmdb_hwtype}'.startswith('VMWare ')"

  ### Now continue with provisioning !
```

This module was already mentioned in #1085, #1125 and #1206.
