### PR TITLE
Allow user-specified $ansible_managed string

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -66,6 +66,14 @@ remote_port=22
 
 #private_key_file=/path/to/file
 
+# format of string $ansible_managed available within Jinja2 templates, replacing
+# {file}, {host} and {uid} with template filename, host and owner respectively.
+# The resulting string is passed through strftime(3) so it may contain any
+# time-formatting specifiers.
+#
+# Example: ansible_managed = DONT TOUCH {file}: call {uid} at {host} for changes
+ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
+
 [paramiko_connection]
 
 # nothing to configure yet

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -78,6 +78,7 @@ DEFAULT_PRIVATE_KEY_FILE  = shell_expand_path(get_config(p, DEFAULTS, 'private_k
 DEFAULT_SUDO_USER         = get_config(p, DEFAULTS, 'sudo_user',        'ANSIBLE_SUDO_USER',        'root')
 DEFAULT_REMOTE_PORT       = int(get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      22))
 DEFAULT_TRANSPORT         = get_config(p, DEFAULTS, 'transport',        'ANSIBLE_TRANSPORT',        'paramiko')
+DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')
 
 # non-configurable things
 DEFAULT_REMOTE_PASS       = None

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -408,9 +408,15 @@ def template_from_file(basedir, path, vars):
     vars['template_path']   = realpath
     vars['template_mtime']  = datetime.datetime.fromtimestamp(os.path.getmtime(realpath))
     vars['template_uid']    = template_uid
-    vars['ansible_managed'] = "%s on %s, modified %s by %s" % (
-        vars['template_path'], vars['template_host'], vars['template_mtime'],
-        vars['template_uid'] )
+
+    managed_default = C.DEFAULT_MANAGED_STR
+    managed_str = managed_default.format(
+                    host = vars['template_host'],
+                    uid  = vars['template_uid'],
+                    file = vars['template_path']
+                    )
+    vars['ansible_managed'] = time.strftime(managed_str,
+                                time.localtime(os.path.getmtime(realpath)))
 
     res = t.render(vars)
     if data.endswith('\n') and not res.endswith('\n'):


### PR DESCRIPTION
Allow specification of format of `$ansible_manged` string passed to templates:
1. allows flexibile positioning (or omission) of host, filename, and userid
2. allows for user-specified timestamps with strftime(3) formats.
3. prefixes `"Ansible manged"` to default string.

I think this takes care of making `$ansible_managed` in templates very flexible and solves open issues in https://github.com/ansible/ansible/pull/1195 as well as in https://github.com/ansible/ansible/pull/1198
