### PR TITLE
Indicate errors with exit code.

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -129,9 +129,9 @@ if __name__ == '__main__':
         (runner, results) = cli.run(options, args)
         for result in results['contacted'].values():
             if 'failed' in result or result.get('rc', 0) != 0:
-                sys.exit(1)
+                sys.exit(2)
         if results['dark']:
-            sys.exit(1)
+            sys.exit(2)
     except errors.AnsibleError, e:
         # Generic handler for ansible specific errors
         print "ERROR: %s" % str(e)

--- a/bin/ansible
+++ b/bin/ansible
@@ -127,6 +127,11 @@ if __name__ == '__main__':
     (options, args) = cli.parse()
     try:
         (runner, results) = cli.run(options, args)
+        for result in results['contacted'].values():
+            if 'failed' in result or result.get('rc', 0) != 0:
+                sys.exit(1)
+        if results['dark']:
+            sys.exit(1)
     except errors.AnsibleError, e:
         # Generic handler for ansible specific errors
         print "ERROR: %s" % str(e)

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -140,6 +140,10 @@ def main(args):
                     colorize('failed', t['failures'], 'red'))
 
             print "\n"
+            for h in hosts:
+                stats = pb.stats.summarize(h)
+                if stats['failures'] != 0 or stats['unreachable'] != 0:
+                    sys.exit(1)
 
         except errors.AnsibleError, e:
             print >>sys.stderr, "ERROR: %s" % e

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -143,7 +143,7 @@ def main(args):
             for h in hosts:
                 stats = pb.stats.summarize(h)
                 if stats['failures'] != 0 or stats['unreachable'] != 0:
-                    sys.exit(1)
+                    return 2
 
         except errors.AnsibleError, e:
             print >>sys.stderr, "ERROR: %s" % e


### PR DESCRIPTION
I'm not sure why command module does not set 'failed' to True if command's return code != 0. But changing this breaks tests, so may be this is "by design".
