### PR TITLE
Module hpilo_facts to add facts from HP iLO interfaces

### DIFF
--- a/library/hpilo_facts
+++ b/library/hpilo_facts
@@ -1,0 +1,167 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2012 Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+author: Dag Wieers
+module: hpilo_facts
+short_description: Gather facts for a systel through HP iLO interface
+description:
+  - This module gathers facts for a specific system using its HP iLO interface.
+    These facts include hardware and network related information useful
+    for provisioning (e.g. macaddress, uuid).
+  - This module requires the hpilo python module.
+version_added: "0.8"
+options:
+  host:
+    description:
+      - The HP iLO hostname/address that is linked to the physical system.
+    required: true
+  login:
+    description:
+      - The login name to authenticate to the HP iLO interface.
+    required: false
+    default: Administrator
+  password:
+    description:
+      - The password to authenticate to the HP iLO interface.
+    required: false
+    default: admin
+  match:
+    description:
+      - An optional string to match against the iLO server name.
+      - This is a safety measure to prevent accidentally using the wrong
+        HP iLO interface with dire consequences.
+    required: false
+examples:
+    - code: |
+        local_action: hpilo_facts host=$ilo_address login=$ilo_login password=$ilo_password match=$inventory_hostname_short
+        only_if: "'$cmdb_hwmodel'.startswith('HP ')
+      description: Task to gather facts from a HP iLO interface only if the system is an HP server
+    - code:
+      - hw_bios_date: "05/05/2011"
+        hw_bios_version: "P68"
+        hw_eth0:
+        - macaddress: "00:11:22:33:44:55
+          macaddress_dash: "00-11-22-33-44-55"
+        hw_eth1:
+        - macaddress: "00:11:22:33:44:57"
+          macaddress_dash: "00-11-22-33-44-57"
+        hw_eth2:
+        - macaddress: "00:11:22:33:44:5A"
+          macaddress_dash: "00-11-22-33-44-5A
+        hw_eth3:
+        - macaddress: "00:11:22:33:44:5C"
+          macaddress_dash: "00-11-22-33-44-5C"
+        hw_eth_ilo:
+        - macaddress: "00:11:22:33:44:BA"
+          macaddress_dash: "00-11-22-33-44-BA"
+        hw_product_name: "ProLiant DL360 G7"
+        hw_product_uuid: "ef50bac8-2845-40ff-81d9-675315501dac"
+        hw_system_serial: "ABC12345D6      "
+        hw_uuid: "123456ABC78901D2"
+      description: Typical output of HP iLO_facts for a physical system
+notes:
+  - This module ought to be run from a system that can access the HP iLO
+    interface directly, either by using C(local_action) or
+    C(using delegate)_to.
+'''
+
+import sys
+import warnings
+try:
+    import hpilo
+except ImportError:
+    print "failed=True msg='hpilo python module unavailable'"
+    sys.exit(1)
+
+### Surpress warnings from hpilo
+warnings.simplefilter('ignore')
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            host = dict(required=True),
+            login = dict(default='Administrator'),
+            password = dict(default='admin'),
+            match = dict(default=None),
+        )
+    )
+
+    host = module.params['host']
+    login = module.params['login']
+    password = module.params['password']
+
+    ilo = hpilo.Ilo(host, login=login, password=password)
+
+    # If match=string is provided, only reboot server if iLO name matches 'string'
+    if module.params['match'] != None:
+        try:
+            server_name = ilo.get_server_name()
+        except Exception, e:
+            module.fail_json(rc=1, msg='Failed to connect to %s: %s' % (host, e.message))
+
+        if not server_name.lower().startswith(module.params['match'].lower()):
+            module.fail_json(rc=1, msg='The iLO server name \'%s\' does not match \'%s\'' % (server_name, module.params['match']))
+
+    # TODO: Count number of CPUs, DIMMs and total memory
+    data = ilo.get_host_data()
+    facts = {}
+    for entry in data:
+        if not entry.has_key('type'): continue
+        if entry['type'] == 0: # BIOS Information
+            facts['hw_bios_version'] = entry['Family']
+            facts['hw_bios_date'] = entry['Date']
+        elif entry['type'] == 1: # System Information
+            facts['hw_uuid'] = entry['UUID']
+            facts['hw_system_serial'] = entry['Serial Number']
+            facts['hw_product_name'] = entry['Product Name']
+            facts['hw_product_uuid'] = entry['cUUID']
+        elif entry['type'] == 209: # Embedded NIC MAC Assignment
+            for (name, value) in [ (e['name'], e['value']) for e in entry['fields'] ]:
+                if name.startswith('Port'):
+                    try:
+                        factname = 'hw_eth' + str(int(value) - 1)
+                    except:
+                        factname = 'hw_eth_ilo'
+                elif name.startswith('MAC'):
+                    facts[factname] = {
+                        'macaddress': value.replace('-', ':'),
+                        'macaddress_dash': value
+                    }
+        elif entry['type'] == 209: # HPQ NIC iSCSI MAC Info
+            for (name, value) in [ (e['name'], e['value']) for e in entry['fields'] ]:
+                if name.startswith('Port'):
+                    try:
+                        factname = 'hw_iscsi' + str(int(value) - 1)
+                    except:
+                        factname = 'hw_iscsi_ilo'
+                elif name.startswith('MAC'):
+                    facts[factname] = {
+                        'macaddress': value.replace('-', ':'),
+                        'macaddress_dash': value
+                    }
+
+    module.exit_json(ansible_facts=facts)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()


### PR DESCRIPTION
This module gathers facts from the hardware interface by querying HP iLO. The facts include network info (vlan, macaddress) and system info (cpu, memory, uuid) information. Useful information for provisioning and management.

This module was previously named ilo_facts and mentioned in #1080, #1085, #1125 and #1217.
