### PR TITLE
Not for cow lovers: optionally disable cowsay

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -32,6 +32,8 @@ if os.path.exists("/usr/bin/cowsay"):
     cowsay = "/usr/bin/cowsay"
 elif os.path.exists("/usr/games/cowsay"):
     cowsay = "/usr/games/cowsay"
+if os.getenv("ANSIBLE_NOCOWS") is not None:
+    cowsay = None
 
 def call_callback_module(method_name, *args, **kwargs):
    


### PR DESCRIPTION
Cow-lovers look away now!

This cow patch disables use of installed cowsay if `ANSIBLE_NOCOWS=1` is set in the environment.
