### PR TITLE
Added a ANSIBLE_FORCE_COLOR env var, which forces the color output

### DIFF
--- a/lib/ansible/color.py
+++ b/lib/ansible/color.py
@@ -36,6 +36,9 @@ else:
         # curses returns an error (e.g. could not find terminal)
         ANSIBLE_COLOR=False
 
+if os.getenv("ANSIBLE_FORCE_COLOR") is not None:
+        ANSIBLE_COLOR=True
+
 # --- begin "pretty"
 #
 # pretty - A miniature library that provides a Python print and stdout


### PR DESCRIPTION
When ansible runs under a scheduler like jenkins, colors won't be enabled.

However there exist a jenkins plugin which knows how to parse ansi colors, but it's just a rendering step, it has no control on how the pty gets emulated.

This is why I believe it's useful to have an environmental variable that can force color output
