### PR TITLE
Add this module's namespace to the 'module_' namespace.

### DIFF
--- a/library/hpilo_facts
+++ b/library/hpilo_facts
@@ -124,7 +124,9 @@ def main():
 
     # TODO: Count number of CPUs, DIMMs and total memory
     data = ilo.get_host_data()
-    facts = {}
+    facts = {
+        'module_hw': True,
+    }
     for entry in data:
         if not entry.has_key('type'): continue
         if entry['type'] == 0: # BIOS Information

--- a/library/vsphere_facts
+++ b/library/vsphere_facts
@@ -107,6 +107,7 @@ def main():
 
     data = vm.get_properties()
     facts = {
+        'module_hw': True,
         'hw_name': vm.properties.name,
         'hw_guest_full_name':  vm.properties.config.guestFullName,
         'hw_guest_id': vm.properties.config.guestId,


### PR DESCRIPTION
Much like we currently have _setup_ register the variable `module_setup`, we would like other facts-modules register their own namespace. This means that:
- _network_facts_ registers `module_network`
- _hpilo_facts_ and _vsphere_facts_ registers `module_hw`

Having the `module_` namespace allows us to check whether a certain namespace has already been loaded so we can avoid running the facts module a second time using only_if.

``` yaml
 - action: network_facts host=${ansible_hostname_short}
   only_if: is_unset('$module_network')
```

In retrospect, it would have made more sense to have _setup_ register `module_ansible` instead as the setup module uses the `ansible_` namespace. If you prefer this too, I will make the pull-request.
