### PR TITLE
Keep the man3 directory. 'make docs' breaks without it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,10 @@ clean:
 	@echo "Cleaning up editor backup files"
 	find . -type f \( -name "*~" -or -name "#*" \) -delete
 	find . -type f \( -name "*.swp" \) -delete
-	@echo "Cleaning up asciidoc to man transformations and results"
+	@echo "Cleaning up manpage stuff"
 	find ./docs/man -type f -name "*.xml" -delete
 	find ./docs/man -type f -name "*.asciidoc" -delete
+	find ./docs/man/man3 -type f -name "*.3" -delete
 	@echo "Cleaning up output from test runs"
 	rm -rf test/test_data
 	@echo "Cleaning up RPM building stuff"


### PR DESCRIPTION
Without man3 dir:

```
<tbielawa>@(deepfryer)[~/Projects/ansible] 12:25:40  (keep_man3_dir⚡) 
$ make docs
hacking/module_formatter.py -A 0.8 -t man -o docs/man/man3/ --module-dir=library --template-dir=hacking/templates
 processing module source ---> library/apt
Traceback (most recent call last):
  File "hacking/module_formatter.py", line 359, in <module>
    main()
  File "hacking/module_formatter.py", line 323, in main
    f = open(os.path.join(args.output_dir, outputname % module), 'w')
IOError: [Errno 2] No such file or directory: 'docs/man/man3/ansible.apt.3'
make: *** [modulepages] Error 1
```

With man3 dir:

```
$ make docs
hacking/module_formatter.py -A 0.8 -t man -o docs/man/man3/ --module-dir=library --template-dir=hacking/templates
 processing module source ---> library/apt
...
...
 processing module source ---> library/wait_for
 processing module source ---> library/yum
```
