### PR TITLE
Workaround for when HP iLO is in a state it won't accept requests

### DIFF
--- a/library/hpilo_boot
+++ b/library/hpilo_boot
@@ -24,8 +24,8 @@ author: Dag Wieers
 module: hpilo_boot
 short_description: Boot system using specific media through HP iLO interface
 description:
-  - 'This module boots a system through its HP iLO interface. The boot media
-    can be one of: cdrom, floppy, hdd, network or usb.'
+  - "This module boots a system through its HP iLO interface. The boot media
+    can be one of: cdrom, floppy, hdd, network or usb."
   - This module requires the hpilo python module.
 version_added: "0.8"
 options:
@@ -36,23 +36,19 @@ options:
   login:
     description:
       - The login name to authenticate to the HP iLO interface.
-    required: false
     default: Administrator
   password:
     description:
       - The password to authenticate to the HP iLO interface.
-    required: false
     default: admin
   match:
     description:
       - An optional string to match against the iLO server name.
       - This is a safety measure to prevent accidentally using the wrong
         HP iLO interface with dire consequences.
-    required: false
   media:
     description:
       - The boot media to boot the system from
-    required: false
     default: network
     choices: [ "cdrom", "floppy", "hdd", "network", "normal", "usb" ]
   image:
@@ -62,7 +58,6 @@ options:
       - protocol is either C(http) or C(https)
       - "username:password is optional"
       - port is optional
-    required: false
   state:
     description:
       - The state of the boot media.
@@ -71,25 +66,23 @@ options:
       - "boot_always: Boot from the device each time the serveris rebooted"
       - "connect: Connect the virtual media device and set to boot_always"
       - "disconnect: Disconnects the virtual media device and set to no_boot"
-    required: true
     default: boot_once
     choices: [ "boot_always", "boot_once", "connect", "disconnect", "no_boot" ]
   force:
     description:
       - Whether to force a reboot (even when the system is already booted)
-    required: false
     default: no
     choices: [ "yes", "no" ]
 examples:
-  - code: |
+  - description: Task to boot a system using an ISO from an HP iLO interface only if the system is an HP server
+    code: |
       local_action: hpilo_boot host=$ilo_address login=$ilo_login password=$ilo_password match=$inventory_hostname_short media=cdrom image=$iso_url
       only_if: "'$cmdb_hwmodel'.startswith('HP ')
-    description: Task to boot a system using an ISO from an HP iLO interface only if the system is an HP server
 notes:
   - To use a USB key image you need to specify floppy as boot media.
   - This module ought to be run from a system that can access the HP iLO
     interface directly, either by using C(local_action) or
-    C(using delegate)_to.
+    using C(delegate_to).
 '''
 
 import sys
@@ -141,12 +134,12 @@ def main():
 
     if media:
 
-### FIXME: In the below case iLO fails for a short period of time due to the server rebooting
-#  File "/usr/lib/python2.6/site-packages/hpilo.py", line 381, in _parse_message
-#    raise IloError("Error communicating with iLO: %s" % child.get('MESSAGE'))
-#hpilo.IloError: Error communicating with iLO: Problem manipulating EV
-
-        ilo.set_one_time_boot(media)
+        # Workaround for: Error communicating with iLO: Problem manipulating EV
+        try:
+            ilo.set_one_time_boot(media)
+        except hpilo.IloError:
+            time.sleep(60)
+            ilo.set_one_time_boot(media)
 
         # TODO: Verify if image URL exists/works
         if image:


### PR DESCRIPTION
This workaround is recommended from HP iLO's documentation, but may not be sufficient in all cases. Time will tell.

I also made a few cosmetic changes with no impact.
