### PR TITLE
Fix inventory API groups

### DIFF
--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -35,6 +35,7 @@ class InventoryScript(object):
         self.groups = self._parse()
 
     def _parse(self):
+        all_hosts = {}
 
         groups = {}
         self.raw = utils.parse_json(self.data)
@@ -45,7 +46,9 @@ class InventoryScript(object):
             group = groups[group_name] = Group(group_name)
             host = None
             for hostname in hosts:
-                host = Host(hostname)
+                if not hostname in all_hosts:
+                    all_hosts[hostname] = Host(hostname)
+                host = all_hosts[hostname]
                 group.add_host(host)
                 # FIXME: hack shouldn't be needed
                 all.add_host(host)

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -246,3 +246,13 @@ class TestInventory(unittest.TestCase):
         actual_hosts = inventory.get_hosts(host_names)
         actual_host_names = [host.name for host in actual_hosts]
         assert host_names == actual_host_names
+
+    def test_script_multiple_groups(self):
+        inventory = self.script_inventory()
+        vars = inventory.get_variables('zeus')
+
+        print "VARS=%s" % vars
+        
+        assert vars == {'inventory_hostname': 'zeus',
+                        'inventory_hostname_short': 'zeus',
+                        'group_names': ['greek', 'major-god']}

--- a/test/inventory_api.py
+++ b/test/inventory_api.py
@@ -13,7 +13,7 @@ parser.add_option('-e', '--extra-vars', default=None, dest="extra")
 options, args = parser.parse_args()
 
 systems = {
-    "ungouped": [ "jupiter", "saturn" ],
+    "ungrouped": [ "jupiter", "saturn" ],
     "greek": [ "zeus", "hera", "poseidon" ],
     "norse": [ "thor", "odin", "loki" ]
 }

--- a/test/inventory_api.py
+++ b/test/inventory_api.py
@@ -15,13 +15,15 @@ options, args = parser.parse_args()
 systems = {
     "ungrouped": [ "jupiter", "saturn" ],
     "greek": [ "zeus", "hera", "poseidon" ],
-    "norse": [ "thor", "odin", "loki" ]
+    "norse": [ "thor", "odin", "loki" ],
+    "major-god": [ "zeus", "odin" ],
 }
 
 variables = {
     "thor": {
         "hammer": True
-        }
+        },
+    "zeus": {},
 }
 
 if options.list_hosts == True:


### PR DESCRIPTION
The inventory API handling created a new Host object for every host. One host can be in multiple groups. `group_names` would only show one of them.
