### PR TITLE
moved modules listing to utils.py, get modules list at playbook level so...

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -107,6 +107,7 @@ class PlayBook(object):
 
         self.inventory        = ansible.inventory.Inventory(host_list)
         self.inventory.subset(subset)
+        self.modules_list = utils.get_available_modules(self.module_path)  
 
         if not self.inventory._is_script:
             self.global_vars.update(self.inventory.get_group_variables('all'))

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -30,7 +30,7 @@ class Play(object):
        'handlers', 'remote_user', 'remote_port',
        'sudo', 'sudo_user', 'transport', 'playbook',
        'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
-       'basedir', 'modules_list'
+       'basedir'
     ]
 
     # to catch typos and so forth -- these are userland names
@@ -79,7 +79,6 @@ class Play(object):
         self.serial       = ds.get('serial', 0)
 
         self._update_vars_files_for_host(None)
-        self.modules_list = self.playbook.modules_list
 
         self._tasks      = self._load_tasks(self._ds, 'tasks')
         self._handlers   = self._load_tasks(self._ds, 'handlers')
@@ -118,10 +117,10 @@ class Play(object):
                     include_file = utils.template(self.basedir, tokens[0], mv)
                     data = utils.parse_yaml_from_file(utils.path_dwim(self.basedir, include_file))
                     for y in data:
-                         results.append(Task(self,y,module_vars=mv.copy(), modules_list=self.modules_list))
+                         results.append(Task(self,y,module_vars=mv.copy()))
             elif type(x) == dict:
                 task_vars = self.vars.copy()
-                results.append(Task(self,x,module_vars=task_vars, modules_list=self.modules_list))
+                results.append(Task(self,x,module_vars=task_vars))
             else:
                 raise Exception("unexpected task type")
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -30,7 +30,7 @@ class Play(object):
        'handlers', 'remote_user', 'remote_port',
        'sudo', 'sudo_user', 'transport', 'playbook',
        'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
-       'basedir'
+       'basedir', 'modules_list'
     ]
 
     # to catch typos and so forth -- these are userland names
@@ -79,6 +79,7 @@ class Play(object):
         self.serial       = ds.get('serial', 0)
 
         self._update_vars_files_for_host(None)
+        self.modules_list = self.playbook.modules_list
 
         self._tasks      = self._load_tasks(self._ds, 'tasks')
         self._handlers   = self._load_tasks(self._ds, 'handlers')
@@ -117,10 +118,10 @@ class Play(object):
                     include_file = utils.template(self.basedir, tokens[0], mv)
                     data = utils.parse_yaml_from_file(utils.path_dwim(self.basedir, include_file))
                     for y in data:
-                         results.append(Task(self,y,module_vars=mv.copy()))
+                         results.append(Task(self,y,module_vars=mv.copy(), modules_list=self.modules_list))
             elif type(x) == dict:
                 task_vars = self.vars.copy()
-                results.append(Task(self,x,module_vars=task_vars))
+                results.append(Task(self,x,module_vars=task_vars, modules_list=self.modules_list))
             else:
                 raise Exception("unexpected task type")
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -36,12 +36,10 @@ class Task(object):
          'delegate_to', 'local_action', 'transport'
     ]
 
-    def __init__(self, play, ds, module_vars=None, modules_list=None):
+    def __init__(self, play, ds, module_vars=None):
         ''' constructor loads from a task or handler datastructure '''
-        if modules_list is None:
-            modules_list = utils.get_available_modules()
         for x in ds.keys():
-            if x in modules_list:
+            if x in play.playbook.modules_list:
                 ds['action'] = x + " " + ds.get(x, None)
                 ds.pop(x)
             elif not x in Task.VALID_KEYS:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -17,9 +17,6 @@
 
 from ansible import errors
 from ansible import utils
-import ansible.constants as C
-import os
-from os import pathsep
 
 
 class Task(object):
@@ -39,16 +36,10 @@ class Task(object):
          'delegate_to', 'local_action', 'transport'
     ]
 
-    def __init__(self, play, ds, module_vars=None):
+    def __init__(self, play, ds, module_vars=None, modules_list=None):
         ''' constructor loads from a task or handler datastructure '''
-
-        # code to allow for saying "modulename: args" versus "action: modulename args"
-
-        modules_list = set()
-        for path in C.DEFAULT_MODULE_PATH.split(pathsep):
-            if os.path.exists(path):
-                modules_list.update(os.listdir(path))
-        modules_list = list(modules_list)
+        if modules_list is None:
+            modules_list = utils.get_available_modules()
         for x in ds.keys():
             if x in modules_list:
                 ds['action'] = x + " " + ds.get(x, None)

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -675,3 +675,17 @@ def import_plugins(directory):
         if not name.startswith("_"):
             modules[name] = imp.load_source(name, path)
     return modules
+
+def get_available_modules(dirname=None):
+    """
+    returns a list of modules available based on current directory
+    looks in DEFAULT_MODULE_PATH, all subfolders named library and
+    -M option"""
+    modules_list = set()
+    if dirname is None:
+        dirname = C.DEFAULT_MODULE_PATH
+    for path in dirname.split(os.pathsep):
+        if os.path.exists(path):
+            modules_list.update(os.listdir(path))
+    modules_list = list(modules_list)
+    return modules_list


### PR DESCRIPTION
... we dont repeat the listing on each task
- search takes -M into account instead of always using default path
