### PR TITLE
Add DIST_MODULE_PATH so setup.py and ansible.spec can live in harmony

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -60,12 +60,16 @@ p = load_config_file()
 
 active_user   = pwd.getpwuid(os.geteuid())[0]
 
+# Needed so the RPM can call setup.py and have modules land in the
+# correct location. See #1277 for discussion
+DIST_MODULE_PATH = '/usr/share/ansible/'
+
 # sections in config file
 DEFAULTS='defaults'
 
 # configurable things
 DEFAULT_HOST_LIST         = shell_expand_path(get_config(p, DEFAULTS, 'hostfile',         'ANSIBLE_HOSTS',            '/etc/ansible/hosts'))
-DEFAULT_MODULE_PATH       = shell_expand_path(get_config(p, DEFAULTS, 'library',          'ANSIBLE_LIBRARY',          '/usr/share/ansible'))
+DEFAULT_MODULE_PATH       = shell_expand_path(get_config(p, DEFAULTS, 'library',          'ANSIBLE_LIBRARY',          DIST_MODULE_PATH))
 DEFAULT_REMOTE_TMP        = shell_expand_path(get_config(p, DEFAULTS, 'remote_tmp',       'ANSIBLE_REMOTE_TEMP',      '$HOME/.ansible/tmp'))
 DEFAULT_MODULE_NAME       = get_config(p, DEFAULTS, 'module_name',      None,                       'command')
 DEFAULT_PATTERN           = get_config(p, DEFAULTS, 'pattern',          None,                       '*')

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ from ansible import __version__, __author__
 from distutils.core import setup
 
 # find library modules
-from ansible.constants import DEFAULT_MODULE_PATH
-data_files = [ (DEFAULT_MODULE_PATH, glob('./library/*')) ]
+from ansible.constants import DIST_MODULE_PATH
+data_files = [ (DIST_MODULE_PATH, glob('./library/*')) ]
 
 print "DATA FILES=%s" % data_files
 


### PR DESCRIPTION
```
<tbielawa>@(deepfryer)[~/Projects/ansible] 13:19:46  (devel⚡)
$ grep -E "^library" ~/.ansible.cfg
library = /fail/usr/share/ansible
<tbielawa>@(deepfryer)[~/Projects/ansible] 13:19:52  (devel⚡)
$ file /fail/usr/share/ansible
/fail/usr/share/ansible: ERROR: cannot open `/fail/usr/share/ansible' (No such file or directory)

<tbielawa>@(deepfryer)[~/Projects/ansible] 13:20:08  (devel⚡)
$ make rpm
Cleaning up distutils stuff
rm -rf build
rm -rf dist
...
...
+ exit 0
#############################################
Ansible RPM is built:
    rpm-build/ansible-0.8-0.git201210111156.fc17.noarch.rpm
#############################################
```
