### PR TITLE
add .ansible.cfg to FILES section of ansible man page

### DIFF
--- a/docs/man/man1/ansible.1
+++ b/docs/man/man1/ansible.1
@@ -166,6 +166,8 @@ Ranges of hosts are also supported\&. For more information and additional option
 /etc/ansible/hosts \(em Default inventory file
 .sp
 /usr/share/ansible/ \(em Default module library
+.sp
+$HOME/.ansible.cfg \(em User configuration file (overrides /etc/ansible/ansible.cfg)
 .SH "ENVIRONMENT"
 .sp
 The following environment variables may specified\&.


### PR DESCRIPTION
This documents (briefly) the fact that ~/.ansible.cfg exists and can be used to override /etc/ansible/ansible.cfg.
