### PR TITLE
named actions + modules list in utils.py

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -107,6 +107,7 @@ class PlayBook(object):
 
         self.inventory        = ansible.inventory.Inventory(host_list)
         self.inventory.subset(subset)
+        self.modules_list = utils.get_available_modules(self.module_path)
 
         if not self.inventory._is_script:
             self.global_vars.update(self.inventory.get_group_variables('all'))

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -17,9 +17,6 @@
 
 from ansible import errors
 from ansible import utils
-import ansible.constants as C
-import os
-from os import pathsep
 
 
 class Task(object):
@@ -43,14 +40,8 @@ class Task(object):
         ''' constructor loads from a task or handler datastructure '''
 
         # code to allow for saying "modulename: args" versus "action: modulename args"
-
-        modules_list = set()
-        for path in C.DEFAULT_MODULE_PATH.split(pathsep):
-            if os.path.exists(path):
-                modules_list.update(os.listdir(path))
-        modules_list = list(modules_list)
         for x in ds.keys():
-            if x in modules_list:
+            if x in play.playbook.modules_list:
                 ds['action'] = x + " " + ds.get(x, None)
                 ds.pop(x)
             elif not x in Task.VALID_KEYS:

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -675,3 +675,17 @@ def import_plugins(directory):
         if not name.startswith("_"):
             modules[name] = imp.load_source(name, path)
     return modules
+
+def get_available_modules(dirname=None):
+    """
+    returns a list of modules available based on current directory
+    looks in DEFAULT_MODULE_PATH, all subfolders named library and
+    -M option"""
+    modules_list = set()
+    if dirname is None:
+        dirname = C.DEFAULT_MODULE_PATH
+    for path in dirname.split(os.pathsep):
+        if os.path.exists(path):
+            modules_list.update(os.listdir(path))
+    modules_list = list(modules_list)
+    return modules_list


### PR DESCRIPTION
- one commit
- remove os, pathsep and C from tasks, not needed anymore
- utils.py get_available_modules returns a list of available modules based on given path (or default)
- tasks.py: access playbook's modules_list instead of passing as arguments
