### PR TITLE
#1303: add sudo option to tasks

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -223,8 +223,8 @@ class PlayBook(object):
             private_key_file=self.private_key_file,
             setup_cache=self.SETUP_CACHE, basedir=task.play.basedir,
             conditional=task.only_if, callbacks=self.runner_callbacks,
-            sudo=task.play.sudo, sudo_user=task.play.sudo_user,
-            transport=task.transport, sudo_pass=self.sudo_pass, is_playbook=True
+            sudo=task.sudo, sudo_user=task.sudo_user,
+            transport=task.transport, sudo_pass=task.sudo_pass, is_playbook=True
         )
 
         if task.async_seconds == 0:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -29,14 +29,15 @@ class Task(object):
         'notify', 'module_name', 'module_args', 'module_vars',
         'play', 'notified_by', 'tags', 'register', 'with_items', 
         'delegate_to', 'first_available_file', 'ignore_errors',
-        'local_action', 'transport'
+        'local_action', 'transport', 'sudo', 'sudo_user', 'sudo_pass'
     ]
 
     # to prevent typos and such
     VALID_KEYS = [
          'name', 'action', 'only_if', 'async', 'poll', 'notify', 'with_items', 
          'first_available_file', 'include', 'tags', 'register', 'ignore_errors',
-         'delegate_to', 'local_action', 'transport'
+         'delegate_to', 'local_action', 'transport', 'sudo', 'sudo_user',
+         'sudo_pass'
     ]
 
     def __init__(self, play, ds, module_vars=None):
@@ -63,6 +64,13 @@ class Task(object):
         self.name         = ds.get('name', None)
         self.tags         = [ 'all' ]
         self.register     = ds.get('register', None)
+        self.sudo         = ds.get('sudo', play.sudo)
+        if self.sudo is True:
+            self.sudo_user    = ds.get('sudo_user', play.sudo_user)
+            self.sudo_pass    = ds.get('sudo_pass', play.playbook.sudo_pass)
+        else:
+            self.sudo_user    = None
+            self.sudo_pass    = None
         
         # Both are defined
         if ('action' in ds) and ('local_action' in ds):


### PR DESCRIPTION
- allows to specify sudo options by task

``` yaml
- hosts: my host
  sudo: True
  tasks:
    - local_action: command touch /tmp/blah
      sudo: False
```
