### PR TITLE
hpilo_facts: Various clean ups in documentation and code

### DIFF
--- a/library/hpilo_facts
+++ b/library/hpilo_facts
@@ -37,51 +37,45 @@ options:
   login:
     description:
       - The login name to authenticate to the HP iLO interface.
-    required: false
     default: Administrator
   password:
     description:
       - The password to authenticate to the HP iLO interface.
-    required: false
     default: admin
-  match:
-    description:
-      - An optional string to match against the iLO server name.
-      - This is a safety measure to prevent accidentally using the wrong
-        HP iLO interface with dire consequences.
-    required: false
 examples:
-    - code: |
-            local_action: hpilo_facts host=$ilo_address login=$ilo_login password=$ilo_password match=$inventory_hostname_short
-            only_if: "'$cmdb_hwmodel'.startswith('HP ')
-      description: Task to gather facts from a HP iLO interface only if the system is an HP server
-    - description: Typical output of HP iLO_facts for a physical system
-      code: |
-            - hw_bios_date: "05/05/2011"
-              hw_bios_version: "P68"
-              hw_eth0:
-              - macaddress: "00:11:22:33:44:55"
-                macaddress_dash: "00-11-22-33-44-55"
-              hw_eth1:
-              - macaddress: "00:11:22:33:44:57"
-                macaddress_dash: "00-11-22-33-44-57"
-              hw_eth2:
-              - macaddress: "00:11:22:33:44:5A"
-                macaddress_dash: "00-11-22-33-44-5A"
-              hw_eth3:
-              - macaddress: "00:11:22:33:44:5C"
-                macaddress_dash: "00-11-22-33-44-5C"
-              hw_eth_ilo:
-              - macaddress: "00:11:22:33:44:BA"
-                macaddress_dash: "00-11-22-33-44-BA"
-              hw_product_name: "ProLiant DL360 G7"
-              hw_product_uuid: "ef50bac8-2845-40ff-81d9-675315501dac"
-              hw_system_serial: "ABC12345D6"
-              hw_uuid: "123456ABC78901D2"
+  - description: Task to gather facts from a HP iLO interface only if the system is an HP server
+    code: |
+      - local_action: hpilo_facts host=$ilo_address login=$ilo_login password=$ilo_password
+        only_if: "'$cmdb_hwmodel'.startswith('HP ')
+      - local_action: fail msg="CMDB serial ($cmdb_serialno) does not match hardware serial ($hw_system_serial) !"
+        only_if: "'$cmdb_serialno' != '$hw_system_serial'"
+  - description: Typical output of HP iLO_facts for a physical system
+    code: |
+      - hw_bios_date: "05/05/2011"
+        hw_bios_version: "P68"
+        hw_eth0:
+        - macaddress: "00:11:22:33:44:55"
+          macaddress_dash: "00-11-22-33-44-55"
+        hw_eth1:
+        - macaddress: "00:11:22:33:44:57"
+          macaddress_dash: "00-11-22-33-44-57"
+        hw_eth2:
+        - macaddress: "00:11:22:33:44:5A"
+          macaddress_dash: "00-11-22-33-44-5A"
+        hw_eth3:
+        - macaddress: "00:11:22:33:44:5C"
+          macaddress_dash: "00-11-22-33-44-5C"
+        hw_eth_ilo:
+        - macaddress: "00:11:22:33:44:BA"
+          macaddress_dash: "00-11-22-33-44-BA"
+        hw_product_name: "ProLiant DL360 G7"
+        hw_product_uuid: "ef50bac8-2845-40ff-81d9-675315501dac"
+        hw_system_serial: "ABC12345D6"
+        hw_uuid: "123456ABC78901D2"
 notes:
   - This module ought to be run from a system that can access the HP iLO
-    interface directly, either by using C(local_action) or
-    C(using delegate)_to.
+    interface directly, either by using local_action or
+    using delegate_to.
 '''
 
 import sys
@@ -92,7 +86,7 @@ except ImportError:
     print "failed=True msg='hpilo python module unavailable'"
     sys.exit(1)
 
-### Surpress warnings from hpilo
+# Surpress warnings from hpilo
 warnings.simplefilter('ignore')
 
 def main():
@@ -102,26 +96,14 @@ def main():
             host = dict(required=True),
             login = dict(default='Administrator'),
             password = dict(default='admin'),
-            match = dict(default=None),
         )
     )
 
     host = module.params.get('host')
     login = module.params.get('login')
     password = module.params.get('password')
-    match = module.params.get('match')
 
     ilo = hpilo.Ilo(host, login=login, password=password)
-
-    # If match=string is provided, only reboot server if iLO name matches 'string'
-    if match != None:
-        try:
-            server_name = ilo.get_server_name()
-        except Exception, e:
-            module.fail_json(rc=1, msg='Failed to connect to %s: %s' % (host, e.message))
-
-        if not server_name.lower().startswith(match.lower()):
-            module.fail_json(rc=1, msg='The iLO server name \'%s\' does not match \'%s\'' % (server_name, match))
 
     # TODO: Count number of CPUs, DIMMs and total memory
     data = ilo.get_host_data()
@@ -135,7 +117,7 @@ def main():
             facts['hw_bios_date'] = entry['Date']
         elif entry['type'] == 1: # System Information
             facts['hw_uuid'] = entry['UUID']
-            facts['hw_system_serial'] = entry['Serial Number']
+            facts['hw_system_serial'] = entry['Serial Number'].rstrip()
             facts['hw_product_name'] = entry['Product Name']
             facts['hw_product_uuid'] = entry['cUUID']
         elif entry['type'] == 209: # Embedded NIC MAC Assignment


### PR DESCRIPTION
This commit improves the following items:
- Remove the 'match' functionality, this can now be achieve by using the `fail` module together with `only_if` after running the `hpilo_facts` module. Since this gives more functionality, e.g. comparing server names, but also serial numbers or uuids with other inventory information **and** a proper message, this is prefered. An example is added to show how this is achieved.
- Clean up all C() calls in documentation
- Remove trailing spaces in HP iLO's Serial Number output so that they can be compared to CMDB or other inventory information
