### PR TITLE
The pause 'prompt' parameter now requires quotes around the message.

### DIFF
--- a/library/pause
+++ b/library/pause
@@ -32,5 +32,5 @@ examples:
     - description: Pause until you can verify updates to an application were successful.
       code: pause
     - description: A helpful reminder of what to look out for post-update.
-      code: pause prompt=Make sure org.foo.FooOverload exception is not present
+      code: pause prompt="Make sure org.foo.FooOverload exception is not present"
 '''


### PR DESCRIPTION
When we were fixing variable interpolation we also started using `parse_kv()` on `module_args`. As a side effect the pause prompt message now requires quotes around it. This corrects that in in the documentation example.
