### PR TITLE
Test for python-pip as well as pip

### DIFF
--- a/library/pip
+++ b/library/pip
@@ -135,7 +135,9 @@ def main():
         out += out_venv
         err += err_venv
 
-    pip = module.get_bin_path('pip', True, ['%s/bin' % env])
+    pip = module.get_bin_path('python-pip', False, ['%s/bin' % env])
+    if not pip:
+        pip = module.get_bin_path('pip', True, ['%s/bin' % env])
 
     state = module.params['state']
     name = module.params['name']


### PR DESCRIPTION
On Red Hat, CentOS and Fedora systems, the pip binary will be called python-pip
instead of pip. This commit makes the pip module also check for python-pip.

The reason we check for python-pip _first_, is to have ansible fail on not
finding 'pip' and reporting _that_. This is consistent with current behaviour
and will not confuse users of Debian et al., where the 'python-pip' binary
never exists.

Tested on Fedora 18 and Ubuntu 12.04.
