### PR TITLE
Load plugins from playbook basedir and configured directories

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -22,10 +22,15 @@ import os
 import subprocess
 import os.path
 from ansible.color import stringc
+import ansible.constants as C
 
 dirname = os.path.dirname(__file__)
 callbacks = utils.import_plugins(os.path.join(dirname, 'callback_plugins'))
 callbacks = [ c.CallbackModule() for c in callbacks.values() ]
+def load_more_callbacks(dirname):
+    callbacks.extend([c.CallbackModule() for c in utils.import_plugins(dirname).values()])
+for i in C.DEFAULT_CALLBACK_PLUGIN_PATH.split(os.pathsep):
+    load_more_callbacks(i)
 
 cowsay = None
 if os.path.exists("/usr/bin/cowsay"):
@@ -45,9 +50,6 @@ def call_callback_module(method_name, *args, **kwargs):
         for method in methods:
             if method is not None:
                 method(*args, **kwargs)
-
-def load_more_callbacks(dirname):
-    callbacks.extend([c.CallbackModule() for c in utils.import_plugins(dirname).values()])
 
 def vv(msg, host=None):
     return verbose(msg, host=host, caplevel=1)

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -46,6 +46,9 @@ def call_callback_module(method_name, *args, **kwargs):
             if method is not None:
                 method(*args, **kwargs)
 
+def load_more_callbacks(dirname):
+    callbacks.extend([c.CallbackModule() for c in utils.import_plugins(dirname).values()])
+
 def vv(msg, host=None):
     return verbose(msg, host=host, caplevel=1)
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -84,6 +84,11 @@ DEFAULT_REMOTE_PORT       = int(get_config(p, DEFAULTS, 'remote_port',      'ANS
 DEFAULT_TRANSPORT         = get_config(p, DEFAULTS, 'transport',        'ANSIBLE_TRANSPORT',        'paramiko')
 DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')
 
+DEFAULT_ACTION_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'action_plugins',     None, '/usr/share/ansible_plugins/action_plugins'))
+DEFAULT_CALLBACK_PLUGIN_PATH   = shell_expand_path(get_config(p, DEFAULTS, 'callback_plugins',   None, '/usr/share/ansible_plugins/callback_plugins'))
+DEFAULT_CONNECTION_PLUGIN_PATH = shell_expand_path(get_config(p, DEFAULTS, 'connection_plugins', None, '/usr/share/ansible_plugins/connection_plugins'))
+DEFAULT_LOOKUP_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'lookup_plugins',     None, '/usr/share/ansible_plugins/lookup_plugins'))
+
 # non-configurable things
 DEFAULT_REMOTE_PASS       = None
 DEFAULT_SUDO_PASS         = None

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -112,8 +112,7 @@ class PlayBook(object):
         self.inventory.subset(subset)
 
         self.modules_list        = utils.get_available_modules(self.module_path)
-        lookup_plugins_dir = os.path.join(plugins_dir, 'lookup_plugins')
-        self.lookup_plugins_list = utils.import_plugins(lookup_plugins_dir)
+        self.lookup_plugins_list = ansible.runner.lookup_plugin_list
 
         if not self.inventory._is_script:
             self.global_vars.update(self.inventory.get_group_variables('all'))

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -20,6 +20,7 @@ import ansible.runner
 import ansible.constants as C
 from ansible import utils
 from ansible import errors
+import ansible.callbacks
 import os
 import collections
 from play import Play
@@ -120,6 +121,9 @@ class PlayBook(object):
         self.basedir     = os.path.dirname(playbook)
         (self.playbook, self.play_basedirs) = self._load_playbook_from_file(playbook)
         self.module_path = self.module_path + os.pathsep + os.path.join(self.basedir, "library")
+        ansible.callbacks.load_more_callbacks(os.path.join(self.basedir, "callback_plugins"))
+
+        self.lookup_plugins_list.update(utils.import_plugins(os.path.join(self.basedir, 'lookup_plugins')))
 
     # *****************************************************
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -47,8 +47,13 @@ except ImportError:
 
 dirname = os.path.dirname(__file__)
 action_plugin_list = utils.import_plugins(os.path.join(dirname, 'action_plugins'))
+for i in reversed(C.DEFAULT_ACTION_PLUGIN_PATH.split(os.pathsep)):
+    action_plugin_list.update(utils.import_plugins(i))
 lookup_plugin_list = utils.import_plugins(os.path.join(dirname, 'lookup_plugins')) 
-        
+for i in reversed(C.DEFAULT_LOOKUP_PLUGIN_PATH.split(os.pathsep)):
+    lookup_plugin_list.update(utils.import_plugins(i))
+
+
 ################################################
 
 def _executor_hook(job_queue, result_queue):

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -167,6 +167,11 @@ class Runner(object):
         for (k,v) in lookup_plugin_list.iteritems():
             self.lookup_plugins[k] = v.LookupModule(self)
 
+        for (k,v) in utils.import_plugins(os.path.join(self.basedir, 'action_plugins')).iteritems():
+            self.action_plugins[k] = v.ActionModule(self)
+        for (k,v) in utils.import_plugins(os.path.join(self.basedir, 'lookup_plugins')).iteritems():
+            self.lookup_plugins[k] = v.LookupModule(self)
+
     # *****************************************************
 
     def _delete_remote_files(self, conn, files):

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -20,10 +20,14 @@
 
 from ansible import utils
 from ansible.errors import AnsibleError
+import ansible.constants as C
 
+import os
 import os.path
 dirname = os.path.dirname(__file__)
 modules = utils.import_plugins(os.path.join(dirname, 'connection_plugins'))
+for i in reversed(C.DEFAULT_CONNECTION_PLUGIN_PATH.split(os.pathsep)):
+    modules.update(utils.import_plugins(i))
 
 # rename this module
 modules['paramiko'] = modules['paramiko_ssh']

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -34,11 +34,15 @@ class Connection(object):
 
     def __init__(self, runner):
         self.runner = runner
+        self.modules = None
 
     def connect(self, host, port):
+        if self.modules is None:
+            self.modules = modules.copy()
+            self.modules.update(utils.import_plugins(os.path.join(self.runner.basedir, 'connection_plugins')))
         conn = None
         transport = self.runner.transport
-        module = modules.get(transport, None)
+        module = self.modules.get(transport, None)
         if module is None:
             raise AnsibleError("unsupported connection type: %s" % transport)
         conn = module.Connection(self.runner, host, port)


### PR DESCRIPTION
This time, with tests passing on CentOS 6 and including support for lookup plugins. Also squashed it down to two commits for basedir and configuration.
