### PR TITLE
Use && for executing next command if, and only if, command1 returns an e...

### DIFF
--- a/docsite/rst/playbooks.rst
+++ b/docsite/rst/playbooks.rst
@@ -212,7 +212,7 @@ who's successful exit code is not zero, you may wish to do this::
 
    tasks:
      - name: run this command and ignore the result
-       action: shell /usr/bin/somecommand & /bin/true
+       action: shell /usr/bin/somecommand && /bin/true
 
 Variables can be used in action lines.   Suppose you defined
 a variable called 'vhost' in the 'vars' section, you could do this::

--- a/library/apt_repository
+++ b/library/apt_repository
@@ -44,6 +44,7 @@ options:
     choices: [ "present", "absent" ]
 notes:
    - This module works on Debian and Ubuntu only and requires C(apt-add-repository) be available on destination server. To ensure this package is available use the C(apt) module and install the C(python-software-properties) package before using this module.
+   - This module works not on Debian Squeeze (Version 6) as there is no implementation of C(add-apt-repository) in C(python-software-properties)
    - A bug in C(apt-add-repository) always adds C(deb) and C(deb-src) types for repositories (see the issue on Launchpad U(https://bugs.launchpad.net/ubuntu/+source/software-properties/+bug/987264)), if a repo doesn't have source information (eg MongoDB repo from 10gen) the system will fail while updating repositories.
 author: Matt Wright
 examples:


### PR DESCRIPTION
...xit status of zero.

There is a typo in the playbooks.rst file. One should use && instead of & in the example task.
