### PR TITLE
Added "executable" option to "shell" and "command" modules

### DIFF
--- a/library/command
+++ b/library/command
@@ -60,6 +60,11 @@ options:
     version_added: "0.6"
     required: false
     default: null
+  executable:
+    description:
+      - change the shell used to execute the command. Should be an absolute path the the executable.
+    required: false
+    default: null
 examples:
    - code: command /sbin/shutdown -t now
      description: "Example from Ansible Playbooks"

--- a/library/command
+++ b/library/command
@@ -75,6 +75,7 @@ def main():
 
     shell = module.params['shell']
     chdir = module.params['chdir']
+    executable = module.params['executable']
     args  = module.params['args']
 
     if args.strip() == '':
@@ -88,7 +89,7 @@ def main():
     startd = datetime.datetime.now()
 
     try:
-        cmd = subprocess.Popen(args, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd = subprocess.Popen(args, executable=executable, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = cmd.communicate()
     except (OSError, IOError), e:
         module.fail_json(cmd=args, msg=str(e))
@@ -134,11 +135,12 @@ class CommandModule(AnsibleModule):
         params = {}
         params['chdir'] = None
         params['shell'] = False
+        params['executable'] = None
         if args.find("#USE_SHELL") != -1:
             args = args.replace("#USE_SHELL", "")
             params['shell'] = True
 
-        r = re.compile(r'(^|\s)(creates|removes|chdir)=(?P<quote>[\'"])?(.*?)(?(quote)(?<!\\)(?P=quote))((?<!\\)(?=\s)|$)')
+        r = re.compile(r'(^|\s)(creates|removes|chdir|executable)=(?P<quote>[\'"])?(.*?)(?(quote)(?<!\\)(?P=quote))((?<!\\)(?=\s)|$)')
         for m in r.finditer(args):
             v = m.group(4).replace("\\", "")
             if m.group(2) == "creates":
@@ -174,6 +176,13 @@ class CommandModule(AnsibleModule):
                 elif v[0] != '/':
                     self.fail_json(msg="the path for 'chdir' argument must be fully qualified")
                 params['chdir'] = v
+            elif m.group(2) == "executable":
+                v = os.path.expanduser(v)
+                if not (os.path.exists(v)):
+                    self.fail_json(msg="cannot use executable '%s': file does not exist" % v)
+                elif v[0] != '/':
+                    self.fail_json(msg="the path for 'executable' argument must be fully qualified")
+                params['executable'] = v
         args = r.sub("", args)
         params['args'] = args
         return (params, params['args'])

--- a/library/shell
+++ b/library/shell
@@ -27,6 +27,11 @@ options:
       - cd into this directory before running the command (0.6 and later)
     required: false
     default: null
+  executable:
+    description:
+      - change the shell used to execute the command. Should be an absolute path the the executable.
+    required: false
+    default: null
 examples:
    - code: shell somescript.sh >> somelog.txt
      description: Execute the command in remote shell


### PR DESCRIPTION
To be used to change the shell used to run the command on the remote host. Gets passed to the executable parameter of the Popen call.

It would probably be best to restrict this to the "shell" module, rather than both "shell" and "command", though I couldn't see how best to do this.
