### PR TITLE
Documentation tweak

### DIFF
--- a/library/fail
+++ b/library/fail
@@ -42,7 +42,7 @@ options:
 examples:
     - code: |
         action: fail msg="The system may not be provisioned according to the CMDB status." rc=100
-        only_if: "'$cmdb_status' != 'to-be-staged'"
+            only_if: "'$cmdb_status' != 'to-be-staged'"
 
       description: "Example playbook using fail and only_if together"
 

--- a/library/user
+++ b/library/user
@@ -102,7 +102,11 @@ options:
         description:
             - When used with I(state=absent), behavior is as with
               I(userdel --remove).
-
+examples:
+    - code: user name=johnd comment="John Doe" uid=1040
+      description: "Add the user 'johnd' with a specific uid and a primary group of 'admin'"
+    - code: user name=johnd state=absent remove=yes
+      description: "Remove the user 'johnd'"
 '''
 
 import os


### PR DESCRIPTION
Fix indent of fail module example to prevent unwanted `<blockquote></pre></p> <br/></blockquote>` from showing up in docsite output.
