### PR TITLE
Fixed tests to reflect desired configuration behaviour

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -29,8 +29,6 @@ def get_config(p, section, key, env_var, default):
         try:
             return p.get(section, key)
         except:
-            if env_var is not None:
-                return os.environ.get(env_var, default)
             return default
     else:
         return default

--- a/test/TestConstants.py
+++ b/test/TestConstants.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from ansible.constants import get_config
+import ConfigParser
+import random
+import string
+import os
+
+
+def random_string(length):
+    return ''.join(random.choice(string.ascii_uppercase) for x in range(6))
+
+p = ConfigParser.ConfigParser()
+p.read(os.path.join(os.path.dirname(__file__), 'ansible.cfg'))
+
+class TestConstants(unittest.TestCase):
+
+    #####################################
+    ### get_config unit tests
+
+    
+    def test_configfile_and_env_both_set(self):
+        r = random_string(6)
+        env_var = 'ANSIBLE_TEST_%s' % r
+        os.environ[env_var] = r
+
+        res = get_config(p, 'defaults', 'test_key', env_var, 'default')
+        del os.environ[env_var]
+
+        assert res == r
+
+
+    def test_configfile_set_env_not_set(self):
+        r = random_string(6)
+        env_var = 'ANSIBLE_TEST_%s' % r
+        assert env_var not in os.environ
+        
+        res = get_config(p, 'defaults', 'test_key', env_var, 'default')
+
+        print res
+        assert res == 'test_value'
+
+
+    def test_configfile_not_set_env_set(self):
+        r = random_string(6)
+        env_var = 'ANSIBLE_TEST_%s' % r
+        os.environ[env_var] = r
+
+        res = get_config(p, 'defaults', 'doesnt_exist', env_var, 'default')
+        del os.environ[env_var]
+
+        assert res == r
+
+
+    def test_configfile_not_set_env_not_set(self):
+        r = random_string(6)
+        env_var = 'ANSIBLE_TEST_%s' % r
+        assert env_var not in os.environ
+        
+        res = get_config(p, 'defaults', 'doesnt_exist', env_var, 'default')
+
+        assert res == 'default'

--- a/test/ansible.cfg
+++ b/test/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+
+test_key = test_value


### PR DESCRIPTION
Test for when environment variable and configuration file
variable both set now tests that the environment variable takes
precedence

Removed logic that would never be triggered from
lib/ansible/constants.py
