### PR TITLE
Add support for Github-flavored Markdown to module_formatter

### DIFF
--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -112,6 +112,16 @@ def rst_ify(text):
 
     return t
 
+def markdown_ify(text):
+
+    t = _ITALIC.sub("_" + r"\1" + "_", text)
+    t = _BOLD.sub("**" + r"\1" + "**", t)
+    t = _MODULE.sub("*" + r"\1" + "*", t)
+    t = _URL.sub("[" + r"\1" + "](" + r"\1" + ")", t)
+    t = _CONST.sub("`" + r"\1" + "`", t)
+
+    return t
+
 # Helper for Jinja2 (format() doesn't work here...)
 def rst_fmt(text, fmt):
     return fmt % (text)
@@ -187,7 +197,7 @@ def main():
     p.add_option("-t", "--type",
             action='store',
             dest='type',
-            choices=['html', 'latex', 'man', 'rst', 'json'],
+            choices=['html', 'latex', 'man', 'rst', 'json', 'markdown'],
             default='latex',
             help="Output type")
     p.add_option("-m", "--module",
@@ -283,6 +293,13 @@ def main():
         env.filters['jpfunc'] = js_ify
         template = env.get_template('js.j2')
         outputname = "%s.js"
+    if options.type == 'markdown':
+        env.filters['jpfunc'] = markdown_ify
+        env.filters['html_ify'] = html_ify
+        template = env.get_template('markdown.j2')
+        outputname = "%s.md"
+        includecmt = ""
+        includefmt = ""
 
     if options.includes_file is not None and includefmt != "":
         incfile = open(options.includes_file, "w")

--- a/hacking/templates/markdown.j2
+++ b/hacking/templates/markdown.j2
@@ -1,0 +1,55 @@
+## @{ module }@
+
+{# ------------------------------------------
+ #
+ # This is Github-flavored Markdown
+ #
+ --------------------------------------------#}
+
+{% if version_added is defined -%}
+New in version @{ version_added }@.
+{% endif %}
+
+{% for desc in description -%}
+@{ desc | jpfunc }@ 
+{% endfor %}
+
+{% if options -%}
+<table>
+<tr>
+<th class="head">parameter</th>
+<th class="head">required</th>
+<th class="head">default</th>
+<th class="head">choices</th>
+<th class="head">comments</th>
+</tr>
+{% for (k,v) in options.iteritems()  %}
+<tr>
+<td>@{ k }@</td>
+<td>{% if v.get('required', False) %}yes{% else %}no{% endif %}</td>
+<td>{% if v['default'] %}@{ v['default'] }@{% endif %}</td>
+<td><ul>{% for choice in v.get('choices',[]) -%}<li>@{ choice }@</li>{% endfor -%}</ul></td>
+<td>{% for desc in v.description -%}@{ desc | html_ify }@{% endfor -%}{% if v['version_added'] %} (added in Ansible @{v['version_added']}@){% endif %}</td>
+</tr>
+{% endfor %}
+</table>
+{% endif %}
+
+{% for example in examples %}
+{% if example['description'] %}
+* @{ example['description'] | jpfunc }@
+{% endif %}
+
+```
+@{ example['code'] }@
+```
+{% endfor %}
+ 
+
+{% if notes %}
+#### Notes
+{% for note in notes %}
+@{ note | jpfunc }@
+{% endfor %}
+{% endif %}
+


### PR DESCRIPTION
- Uses HTML tables and Github-flavored code blocks (3 backticks)
