### PR TITLE
module_formatter: .rst now correctly handles code examples

### DIFF
--- a/hacking/templates/man.j2
+++ b/hacking/templates/man.j2
@@ -46,6 +46,10 @@
 .SH EXAMPLES
 {% for e in examples %}
 .PP
+{% if e['description'] %}
+@{ e['description'] | jpfunc }@
+{% endif %}
+
 .nf
 @{ e['code'] }@
 .fi

--- a/hacking/templates/rst.j2
+++ b/hacking/templates/rst.j2
@@ -45,9 +45,11 @@
 
 {% for example in examples %}
     {% if example['description'] %}<p>@{ example['description'] | html_ify }@</p>{% endif %}
-    <p><pre>
-    @{ example['code'] }@
-    </pre></p>
+    <p>
+    <pre>
+@{ example['code'] | indent(4, True) }@
+    </pre>
+    </p>
 {% endfor %}
     <br/>
 

--- a/library/cron
+++ b/library/cron
@@ -101,7 +101,7 @@ options:
 examples:
    - code: cron name="check dirs" hour="5,2" job="ls -alh > /dev/null"
      description: Ensure a job that runs at 2 and 5 exists. Creates an entry like "* 5,2 * * ls -alh > /dev/null"
-   - code: name="an old job" cron job="/some/dir/job.sh" state=absent
+   - code: cron name="an old job" cron job="/some/dir/job.sh" state=absent
      description: 'Ensure an old job is no longer present. Removes any job that is preceded by "#Ansible: an old job" in the crontab'
 requirements: cron
 author: Dane Summers

--- a/library/debug
+++ b/library/debug
@@ -48,7 +48,7 @@ options:
     required: false
     default: "no"
 examples:
-    - code:
+    - code: |
         - local_action: debug msg="System $inventory_hostname has uuid $ansible_product_uuid"
         - local_action: debug msg="System $inventory_hostname lacks a gateway" fail=yes
           only_if: "is_unset('${ansible_default_ipv4.gateway}')"

--- a/library/fireball
+++ b/library/fireball
@@ -51,8 +51,7 @@ examples:
                  sudo: yes
                  tasks:
                      - action: fireball 
-
-               - hosts: devservers
+           - hosts: devservers
                  connection: fireball
                  tasks:
                      - action: command /usr/bin/anything


### PR DESCRIPTION
- fixed template (it was the template), adding indentation with Jinja2
  - added description of code examples to man-page template (was missing)
  - fixed fireball, cron, and debug module examples to confrom
