### PR TITLE
Mysql grant

### DIFF
--- a/library/mysql_user
+++ b/library/mysql_user
@@ -175,7 +175,7 @@ def privileges_get(cursor, user,host):
             module.fail_json(msg="unable to parse the MySQL grant string")
         privileges = res.group(1).split(", ")
         privileges = ['ALL' if x=='ALL PRIVILEGES' else x for x in privileges]
-        if res.group(3) == " WITH GRANT OPTION":
+        if res.group(3) == "WITH GRANT OPTION":
           privileges.append('GRANT')
         db = res.group(2).replace('`', '')
         output[db] = privileges

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -170,11 +170,13 @@ def privileges_get(cursor, user,host):
     cursor.execute("SHOW GRANTS FOR %s@%s", (user,host))
     grants = cursor.fetchall()
     for grant in grants:
-        res = re.match("GRANT\ (.+)\ ON\ (.+)\ TO", grant[0])
+        res = re.match("GRANT\ (.+)\ ON\ (.+)\ TO\ '.+'@'.+'[\ IDENTIFIED\ BY\ PASSWORD\ '.+']?\ ?(.*)", grant[0])
         if res is None:
             module.fail_json(msg="unable to parse the MySQL grant string")
         privileges = res.group(1).split(", ")
         privileges = ['ALL' if x=='ALL PRIVILEGES' else x for x in privileges]
+        if res.group(3) == " WITH GRANT OPTION":
+          privileges.append('GRANT')
         db = res.group(2).replace('`', '')
         output[db] = privileges
     return output
@@ -205,8 +207,12 @@ def privileges_revoke(cursor, user,host,db_table):
     cursor.execute(query)
 
 def privileges_grant(cursor, user,host,db_table,priv):
-    priv_string = ",".join(priv)
+
+    priv_string = ",".join(filter(lambda x: x != 'GRANT', priv))
     query = "GRANT %s ON %s TO '%s'@'%s'" % (priv_string,db_table,user,host)
+    if 'GRANT' in priv:
+      query = query + " WITH GRANT OPTION"
+    
     cursor.execute(query)
 
 def load_mycnf():
@@ -285,7 +291,7 @@ def main():
         else:
             if password is None:
                 module.fail_json(msg="password parameter required when adding a user")
-            changed = user_add(cursor, user, host, password, priv)
+            changed = user_add(cursor, user, host, password, priv, grant)
     elif state == "absent":
         if user_exists(cursor, user, host):
             changed = user_delete(cursor, user, host)

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -291,7 +291,7 @@ def main():
         else:
             if password is None:
                 module.fail_json(msg="password parameter required when adding a user")
-            changed = user_add(cursor, user, host, password, priv, grant)
+            changed = user_add(cursor, user, host, password, priv)
     elif state == "absent":
         if user_exists(cursor, user, host):
             changed = user_delete(cursor, user, host)


### PR DESCRIPTION
Suggestion to add GRANT privilege for a user.

usage:
e.g. priv=_._:ALL,GRANT

the GRANT privilege is not included in ALL, since this is not the case either in the MySQL query. This works well, however, though this is backwards compatible with almost all cases, this change will remove the WITH GRANT OPTION for users that already have it defined in MySQL but do not have it specified in their playbook task.

so, I don't know how you'd like to handle this. Any other options for implementing a fully backwards compatible solution? How do you usually deal with this? You could add an additional module field 'grant' with a default 'as_is' and other options 'enable' 'disable', but the code will look a lot uglier (I tried that first :))
