### PR TITLE
Revert redundant local transport enforcement

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -399,13 +399,10 @@ class Runner(object):
                 actual_host = delegate_to
 
         try:
-            transport = None # use Runner setting
-            if delegate_to and actual_host in [ '127.0.0.1', 'localhost' ]:
-                transport = 'local'
-            conn = self.connector.connect(actual_host, int(actual_port), transport=transport)
+            # connect
+            conn = self.connector.connect(actual_host, int(actual_port))
             if delegate_to:
                 conn.delegate = host
-
 
         except errors.AnsibleConnectionFailed, e:
             result = dict(failed=True, msg="FAILED: %s" % str(e))

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -40,13 +40,12 @@ class Connection(object):
         self.runner = runner
         self.modules = None
 
-    def connect(self, host, port, transport=None):
+    def connect(self, host, port):
         if self.modules is None:
             self.modules = modules.copy()
             self.modules.update(utils.import_plugins(os.path.join(self.runner.basedir, 'connection_plugins')))
         conn = None
-        if transport is None:
-            transport = self.runner.transport
+        transport = self.runner.transport
         module = self.modules.get(transport, None)
         if module is None:
             raise AnsibleError("unsupported connection type: %s" % transport)


### PR DESCRIPTION
This reverts commit a908bd6a8fd744c950322e0a3f678c4cba083abf, as
this is already handled by the task object.
