### PR TITLE
None is unfortunately not an integer

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -402,7 +402,9 @@ class Runner(object):
             transport = None # use Runner setting
             if delegate_to and actual_host in [ '127.0.0.1', 'localhost' ]:
                 transport = 'local'
-            conn = self.connector.connect(actual_host, int(actual_port), transport=transport)
+            if actual_port is not None:
+                actual_port = int(actual_port)
+            conn = self.connector.connect(actual_host, actual_port, transport=transport)
             if delegate_to:
                 conn.delegate = host
 


### PR DESCRIPTION
Fixes tracebacks for all transports not paramiko and ssh.
