### PR TITLE
increase recursion limit

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -74,6 +74,11 @@ remote_port=22
 # Example: ansible_managed = DONT TOUCH {file}: call {uid} at {host} for changes
 ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
 
+# if set, ansible executes sys.setrecursionlimit() with the given value. If your inventory is very
+# large you may need to increase this value
+
+#recursion_limit=10000
+
 [paramiko_connection]
 
 # nothing to configure yet

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -87,6 +87,7 @@ DEFAULT_ACTION_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'acti
 DEFAULT_CALLBACK_PLUGIN_PATH   = shell_expand_path(get_config(p, DEFAULTS, 'callback_plugins',   None, '/usr/share/ansible_plugins/callback_plugins'))
 DEFAULT_CONNECTION_PLUGIN_PATH = shell_expand_path(get_config(p, DEFAULTS, 'connection_plugins', None, '/usr/share/ansible_plugins/connection_plugins'))
 DEFAULT_LOOKUP_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'lookup_plugins',     None, '/usr/share/ansible_plugins/lookup_plugins'))
+DEFAULT_RECURSION_LIMIT   = int(get_config(p, DEFAULTS, 'recursion_limit', 'RECURSION_LIMIT', 10000))
 
 # non-configurable things
 DEFAULT_REMOTE_PASS       = None

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -53,6 +53,9 @@ lookup_plugin_list = utils.import_plugins(os.path.join(dirname, 'lookup_plugins'
 for i in reversed(C.DEFAULT_LOOKUP_PLUGIN_PATH.split(os.pathsep)):
     lookup_plugin_list.update(utils.import_plugins(i))
 
+# Set recursion limit - the python default for this is 1000, but this needs to be higher
+# for very large inventories
+sys.setrecursionlimit(C.DEFAULT_RECURSION_LIMIT)
 
 ################################################
 


### PR DESCRIPTION
When working with very large inventories, ansible throws an error:
"RuntimeError: maximum recursion depth exceeded while pickling an object"

This patch increases the maximum recursion depth to a new default of 10000 and makes it configurable.
This value is arbitrarily chosen. For reference, with our 800-host inventory with about 50
groups (and hosts being in multiple groups), we need this set to at least 2000, so there should
be some head room with 10k.
