### PR TITLE
Typo: name parameter should be user 

### DIFF
--- a/docsite/rst/playbooks2.rst
+++ b/docsite/rst/playbooks2.rst
@@ -402,7 +402,7 @@ This syntax will remain in future versions, though we will also will provide way
 is an example using the authorized_key module, which requires the actual text of the SSH key as a parameter::
 
     tasks:
-        - authorized_key name=$item key=$FILE(/keys/$user1)
+        - authorized_key user=$item key=$FILE(/keys/$user1)
           with_items:
              - pinky
              - brain


### PR DESCRIPTION
The authorized_key module doesn't have a _name_ parameter.
It should be user

PS: very first github pull request. So I hope I did it right...
