### PR TITLE
Help git module work when working in 'no branch' scenario

### DIFF
--- a/library/git
+++ b/library/git
@@ -146,7 +146,27 @@ def is_current_branch(module, dest, branch):
     else:
         return True
 
-def pull(module, repo, dest, version):
+def is_not_a_branch(module, dest):
+    branches = get_branches(module, dest)
+    for b in branches:
+        if b.startswith('* ') and 'no branch' in b:
+            return True
+    return False
+
+def get_head_branch(module, dest, remote):
+    os.chdir(dest)
+    head = ''
+    cmd = "git remote show %s" % remote
+    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = cmd.communicate()
+    if cmd.returncode != 0:
+        module.fail_json(msg="Could not determine HEAD branch via git remote show")
+    for line in out.split('\n'):
+        if 'HEAD branch' in line:
+            head = line.split()[-1].strip()
+    return head
+
+def pull(module, repo, dest, version, remote):
     ''' updates repo from remote sources '''
     os.chdir(dest)
     branches = get_branches(module, dest)
@@ -158,8 +178,13 @@ def pull(module, repo, dest, version):
         (rc, out, err) = switch_version(module, dest, remote, version)
         if rc != 0:
             module.fail_json(msg=err)
+    if is_not_a_branch(module, dest):
+        head_branch = get_head_branch(module, dest, remote)
+        (rc, out, err) = switch_version(module, dest, remote, head_branch)
+        if rc != 0:
+            module.fail_json(msg=err)
 
-    cmd = "git pull -u origin"
+    cmd = "git pull -u %s" % remote
     cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = cmd.communicate()
     rc = cmd.returncode
@@ -176,7 +201,7 @@ def switch_version(module, dest, remote, version):
             cmd = "git checkout --force %s" % version
     else:
         # is there a better way to do this?
-        cmd = "git rebase origin"
+        cmd = "git rebase %s" % remote
     cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (out, err) = cmd.communicate()
     rc = cmd.returncode
@@ -220,7 +245,7 @@ def main():
         (rc, out, err) = reset(module,dest,force)
         if rc != 0:
             module.fail_json(msg=err)
-        (rc, out, err) = pull(module, repo, dest, version)
+        (rc, out, err) = pull(module, repo, dest, version, remote)
         if rc != 0:
             module.fail_json(msg=err)
 


### PR DESCRIPTION
Detect when on a 'no branch' branch.  If so, checkout the HEAD branch
as reported by 'git remote show <remote>'.  That should put the repo
back on a branch such that git can then merge changes as necessary.
In addition, removed hard-coded references to origin and replaced
with remote var.

See issue #1412.
