### PR TITLE
Fix chmod occurring as wrong user when sudo as non-root

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -210,7 +210,8 @@ class Runner(object):
         cmd_mod = ""
         if self.sudo and self.sudo_user != 'root':
             # deal with possible umask issues once sudo'ed to other user
-            cmd_mod = "chmod a+r %s; " % remote_module_path
+            cmd_chmod = "chmod a+r %s" % remote_module_path
+            self._low_level_exec_command(conn, cmd_chmod, tmp, sudoable=False)
 
         cmd = ""
         if not is_new_style:
@@ -232,7 +233,6 @@ class Runner(object):
         cmd = shebang.replace("#!","") + " " + cmd
         if tmp.find("tmp") != -1:
             cmd = cmd + "; rm -rf %s >/dev/null 2>&1" % tmp
-        cmd = cmd_mod + cmd
         res = self._low_level_exec_command(conn, cmd, tmp, sudoable=True)
         return ReturnData(conn=conn, result=res)
 


### PR DESCRIPTION
If you sudo to a non-root user, you get a permission denied error.

Here's an example:

```
$ ansible myserver.example.com -m postgresql_db -a "db=mydatabase" -u ubuntu -s -U postgres
myserver.example.com | FAILED >> {
    "failed": true,
    "msg": "chmod: changing permissions of `/tmp/ansible-
    1351092257.96-157699143369671/postgresql_db': Operation not
    permitted\n/usr/bin/python: can't open file '/tmp/ansible-
    1351092257.96-157699143369671/postgresql_db': [Errno 13]
    Permission denied\n",
    "parsed": false
}
```

The problem is that ansible is doing the chmod as the sudo user when it should be doing it as the remote user.
