### PR TITLE
Write ssh key to temp file

### DIFF
--- a/library/authorized_key
+++ b/library/authorized_key
@@ -68,6 +68,8 @@ import sys
 import os
 import pwd
 import os.path
+import tempfile
+import shutil
 
 def keyfile(user, write=False):
     """
@@ -114,11 +116,16 @@ def readkeys(filename):
     f.close()
     return keys
 
-def writekeys( filename, keys):
+def writekeys(module, filename, keys):
 
-    f = open(filename,"w")
-    f.writelines( (key + "\n" for key in keys) )
+    fd, tmp_path = tempfile.mkstemp()
+    f = open(tmp_path,"w")
+    try:
+        f.writelines( (key + "\n" for key in keys) )
+    except IOError, e:
+        module.fail_json(msg="Failed to write to file %s: %s" % (tmp_path, str(e)))
     f.close()
+    shutil.move(tmp_path, filename)
 
 def enforce_state(module, params):
     """
@@ -139,13 +146,13 @@ def enforce_state(module, params):
         if present:
             module.exit_json(changed=False)
         keys.append(key)
-        writekeys(keyfile(user,write=True), keys)
+        writekeys(module, keyfile(user,write=True), keys)
 
     elif state=="absent":
         if not present:
             module.exit_json(changed=False)
         keys.remove(key)
-        writekeys(keyfile(user,write=True), keys)
+        writekeys(module, keyfile(user,write=True), keys)
 
     params['changed'] = True
     return params

--- a/library/authorized_key
+++ b/library/authorized_key
@@ -118,7 +118,7 @@ def readkeys(filename):
 
 def writekeys(module, filename, keys):
 
-    fd, tmp_path = tempfile.mkstemp()
+    fd, tmp_path = tempfile.mkstemp('', 'tmp', os.path.dirname(filename))
     f = open(tmp_path,"w")
     try:
         f.writelines( (key + "\n" for key in keys) )


### PR DESCRIPTION
Write ssh keys to temp file in $HOME/.ssh before moving it on top of $HOME/.ssh/authorized_keys.  See issue #1211
