### PR TITLE
Skip check of primary group when checking other group membership

### DIFF
--- a/library/user
+++ b/library/user
@@ -314,7 +314,7 @@ def user_group_membership(user):
     groups = []
     info = get_pwd_info(user)
     for group in grp.getgrall():
-        if user in group[3] and info[3] != group[2]:
+        if user in group[3]:
             groups.append(group[0])
     return groups
 


### PR DESCRIPTION
See issue #1439.  When collecting auxiliary group membership information, the user module used to skip a group if it was the user's primary group.  This drops that check since grp.getgrall() doesn't report primary group anyway.
