### PR TITLE
Introduce a group_by playbook parameter to dynamically define groups.

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -282,6 +282,23 @@ class PlayBook(object):
                 if 'stdout' in result:
                     result['stdout_lines'] = result['stdout'].splitlines()
                 self.SETUP_CACHE[host][task.register] = result
+            if task.group_by and result.get(task.group_by, None):
+                groups = result.get(task.group_by)
+
+                if type(groups) != list:
+                    groups = [ groups ]
+
+                inv_host = self.inventory.get_host(host)
+                if not inv_host:
+                    inv_host = ansible.inventory.Host(name=host)
+
+                for group in groups:
+                    inv_group = self.inventory.get_group(group)
+                    if not inv_group:
+                        inv_group = ansible.inventory.Group(name=group)
+                        self.inventory.add_group(inv_group)
+                    if inv_group not in inv_host.get_groups():
+                        inv_group.add_host(inv_host)
 
         # flag which notify handlers need to be run
         if len(task.notify) > 0:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -24,7 +24,7 @@ class Task(object):
     __slots__ = [
         'name', 'action', 'only_if', 'async_seconds', 'async_poll_interval',
         'notify', 'module_name', 'module_args', 'module_vars',
-        'play', 'notified_by', 'tags', 'register',
+        'play', 'notified_by', 'tags', 'register', 'group_by',
         'delegate_to', 'first_available_file', 'ignore_errors',
         'local_action', 'transport', 'sudo', 'sudo_user', 'sudo_pass',
         'items_lookup_plugin', 'items_lookup_terms'
@@ -35,7 +35,7 @@ class Task(object):
          'name', 'action', 'only_if', 'async', 'poll', 'notify',
          'first_available_file', 'include', 'tags', 'register', 'ignore_errors',
          'delegate_to', 'local_action', 'transport', 'sudo', 'sudo_user',
-         'sudo_pass'
+         'sudo_pass', 'group_by',
     ]
 
     def __init__(self, play, ds, module_vars=None):
@@ -68,6 +68,7 @@ class Task(object):
         self.name         = ds.get('name', None)
         self.tags         = [ 'all' ]
         self.register     = ds.get('register', None)
+        self.group_by     = ds.get('group_by', None)
         self.sudo         = ds.get('sudo', play.sudo)
         if self.sudo is True:
             self.sudo_user    = ds.get('sudo_user', play.sudo_user)


### PR DESCRIPTION
Anything that returns a list or a string would do.

Examples:

```

---

- hosts: all
  gather_facts: false
  tasks:
  - local_action: is_provisioned host=${inventory_hostname}
    group_by: is_provisioned

- hosts: unprovisioned
  gather_facts: false
  tasks:
  ...provision...

```

With `is_provisioned` for a simple testcase:

```
#!/usr/bin/env python

def main():
    module = AnsibleModule(
        argument_spec = dict(
            host=dict(required=True),
        )
    )

    if module.params['host'] == 'firefly':
        module.exit_json(is_provisioned=['unprovisioned'])
    else:
        module.exit_json(ok="ok")

# this is magic, see lib/ansible/module_common.py
#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
main()
```

If you prefer not to introduce new playbook syntax, https://github.com/jhoekx/ansible/commits/discover-groups still applies, but has a magic 'ansible_groups' parameter that can be returned.
