### PR TITLE
Make sure we always return 'rc' from the command module

### DIFF
--- a/library/command
+++ b/library/command
@@ -84,7 +84,7 @@ def main():
     args  = module.params['args']
 
     if args.strip() == '':
-        module.fail_json(rc=255, msg="no command given")
+        module.fail_json(rc=256, msg="no command given")
 
     if chdir:
         os.chdir(os.path.expanduser(chdir))
@@ -99,7 +99,7 @@ def main():
     except (OSError, IOError), e:
         module.fail_json(rc=e.errno, msg=str(e), cmd=args)
     except:
-        module.fail_json(rc=254, msg=traceback.format_exc(), cmd=args)
+        module.fail_json(rc=257, msg=traceback.format_exc(), cmd=args)
 
     endd = datetime.datetime.now()
     delta = endd - startd
@@ -178,9 +178,9 @@ class CommandModule(AnsibleModule):
             elif m.group(2) == "chdir":
                 v = os.path.expanduser(v)
                 if not (os.path.exists(v) and os.path.isdir(v)):
-                    self.fail_json(rc=253, msg="cannot change to directory '%s': path does not exist" % v)
+                    self.fail_json(rc=258, msg="cannot change to directory '%s': path does not exist" % v)
                 elif v[0] != '/':
-                    self.fail_json(rc=252, msg="the path for 'chdir' argument must be fully qualified")
+                    self.fail_json(rc=259, msg="the path for 'chdir' argument must be fully qualified")
                 params['chdir'] = v
         args = r.sub("", args)
         params['args'] = args


### PR DESCRIPTION
If this is not a certainty, playbooks will fail without an 'rc' and checking both if there is an rc, and whether the 'rc' is (not) 0 is very complicated. (especially because ${something.rc} will not be substituted and all that)

This is the _expurgated_ version with RC > 255
