### PR TITLE
Add a group_by action plugin.

### DIFF
--- a/examples/playbooks/group_by.yml
+++ b/examples/playbooks/group_by.yml
@@ -1,0 +1,14 @@
+---
+# Example playbook to demonstrate the group_by action plugin.
+
+- hosts: all
+  # This runs the setup module to gather facts
+  tasks:
+  # Use the ansible_machine variable to create a group for every value,
+  # prefix the group name with 'ansible-'
+  - action: group_by var=ansible_machine prefix=ansible
+
+- hosts: ansible-x86_64
+  tasks:
+  # Run ping on all x86_64 machines
+  - action: ping

--- a/examples/playbooks/group_by.yml
+++ b/examples/playbooks/group_by.yml
@@ -12,3 +12,12 @@
   tasks:
   # Run ping on all x86_64 machines
   - action: ping
+
+- hosts: all
+  tasks:
+  ### Create a group of all kvm hosts
+  - action: group_by key=ansible_virtualization_type,ansible_virtualization_role
+
+- hosts: kvm-host
+  tasks:
+  - action: ping

--- a/examples/playbooks/group_by.yml
+++ b/examples/playbooks/group_by.yml
@@ -6,7 +6,7 @@
   tasks:
   # Use the ansible_machine variable to create a group for every value,
   # prefix the group name with 'ansible-'
-  - action: group_by var=ansible_machine prefix=ansible
+  - action: group_by key=ansible_machine prefix=ansible
 
 - hosts: ansible-x86_64
   tasks:

--- a/examples/playbooks/group_by.yml
+++ b/examples/playbooks/group_by.yml
@@ -21,3 +21,12 @@
 - hosts: kvm-host
   tasks:
   - action: ping
+
+- hosts: all
+  tasks:
+  ### Group based on a complex variable (IPv4 network)
+  - action: group_by key=ansible_default_ipv4.network prefix=network
+
+- hosts: network-192.168.1.0
+  tasks:
+  - action: ping

--- a/lib/ansible/runner/action_plugins/group_by.py
+++ b/lib/ansible/runner/action_plugins/group_by.py
@@ -32,9 +32,9 @@ class ActionModule(object):
 
     def run(self, conn, tmp, module_name, module_args, inject):
         args = parse_kv(template(self.runner.basedir, module_args, inject))
-        if not 'var' in args:
-            raise ae("'var' is a required argument.")
-        variable = args['var']
+        if not 'key' in args:
+            raise ae("'key' is a required argument.")
+        variable = args['key']
         if 'prefix' in args:
             prefix = "%s-"%(args['prefix'])
         else:

--- a/lib/ansible/runner/action_plugins/group_by.py
+++ b/lib/ansible/runner/action_plugins/group_by.py
@@ -34,7 +34,7 @@ class ActionModule(object):
         args = parse_kv(template(self.runner.basedir, module_args, inject))
         if not 'key' in args:
             raise ae("'key' is a required argument.")
-        variable = args['key']
+        variables = args['key'].rstrip(',').split(',')
         if 'prefix' in args:
             prefix = "%s-"%(args['prefix'])
         else:
@@ -48,8 +48,12 @@ class ActionModule(object):
         groups = {}
         for _,host in self.runner.host_set:
             data = self.runner.setup_cache[host]
-            if variable in data:
-                group_name = "%s%s"%(prefix,data[variable].replace(' ','-'))
+            values = []
+            for variable in variables:
+                if variable in data:
+                    values.append(data[variable].replace(' ','-'))
+            if len(values) == len(variables):
+                group_name = "%s%s"%(prefix,"-".join(values))
                 if group_name not in groups:
                     groups[group_name] = []
                 groups[group_name].append(host)

--- a/lib/ansible/runner/action_plugins/group_by.py
+++ b/lib/ansible/runner/action_plugins/group_by.py
@@ -19,7 +19,7 @@ import ansible
 
 from ansible.errors import AnsibleError as ae
 from ansible.runner.return_data import ReturnData
-from ansible.utils import parse_kv, template
+from ansible.utils import parse_kv, template, varLookup, VarNotFoundException
 
 class ActionModule(object):
     ''' Create inventory groups based on variables '''
@@ -50,8 +50,11 @@ class ActionModule(object):
             data = self.runner.setup_cache[host]
             values = []
             for variable in variables:
-                if variable in data:
-                    values.append(data[variable].replace(' ','-'))
+                try:
+                    val = varLookup(variable, data)
+                    values.append(val.replace(' ','-'))
+                except VarNotFoundException:
+                    pass
             if len(values) == len(variables):
                 group_name = "%s%s"%(prefix,"-".join(values))
                 if group_name not in groups:

--- a/lib/ansible/runner/action_plugins/group_by.py
+++ b/lib/ansible/runner/action_plugins/group_by.py
@@ -35,6 +35,11 @@ class ActionModule(object):
         if not 'var' in args:
             raise ae("'var' is a required argument.")
         variable = args['var']
+        if 'prefix' in args:
+            prefix = "%s-"%(args['prefix'])
+        else:
+            prefix = ""
+
         inventory = self.runner.inventory
 
         result = {'changed': False}
@@ -44,7 +49,7 @@ class ActionModule(object):
         for _,host in self.runner.host_set:
             data = self.runner.setup_cache[host]
             if variable in data:
-                group_name = data[variable].replace(' ','-')
+                group_name = "%s%s"%(prefix,data[variable].replace(' ','-'))
                 if group_name not in groups:
                     groups[group_name] = []
                 groups[group_name].append(host)

--- a/lib/ansible/runner/action_plugins/group_by.py
+++ b/lib/ansible/runner/action_plugins/group_by.py
@@ -1,0 +1,67 @@
+# Copyright 2012, Jeroen Hoekx <jeroen@hoekx.be>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import ansible
+
+from ansible.runner.return_data import ReturnData
+
+class ActionModule(object):
+    ''' Create inventory groups based on variables '''
+
+    ### We need to be able to modify the inventory
+    BYPASS_HOST_LOOP = True
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    def run(self, conn, tmp, module_name, module_args, inject):
+        variables = module_args.strip().split(',')
+        inventory = self.runner.inventory
+
+        result = {'changed': False}
+
+        for variable in variables:
+            if not variable:
+                continue ### ignore trailing comma
+            variable = variable.strip()
+
+            ### find all returned groups
+            groups = {}
+            for _,host in self.runner.host_set:
+                data = self.runner.setup_cache[host]
+                if variable in data:
+                    if data[variable] not in groups:
+                        groups[data[variable]] = []
+                    groups[data[variable]].append(host)
+
+            result[variable] = groups
+
+            ### add to inventory
+            for group, hosts in groups.items():
+                inv_group = inventory.get_group(group)
+                if not inv_group:
+                    inv_group = ansible.inventory.Group(name=group)
+                    inventory.add_group(inv_group)
+                for host in hosts:
+                    inv_host = inventory.get_host(host)
+                    if not inv_host:
+                        inv_host = ansible.inventory.Host(name=host)
+                    if inv_group not in inv_host.get_groups():
+                        result['changed'] = True
+                        inv_group.add_host(inv_host)
+
+        return ReturnData(conn=conn, comm_ok=True, result=result)

--- a/lib/ansible/utils.py
+++ b/lib/ansible/utils.py
@@ -221,6 +221,10 @@ _LISTRE = re.compile(r"(\w+)\[(\d+)\]")
 class VarNotFoundException(Exception):
     pass
 
+def varLookup(key, vars):
+    ''' Look up a complex key in vars '''
+    return _varLookup(key.split('.'), vars)
+
 def _varLookup(path, vars, depth=0):
     ''' find the contents of a possibly complex variable in vars. '''
 

--- a/library/group_by
+++ b/library/group_by
@@ -1,0 +1,24 @@
+# -*- mode: python -*-
+
+DOCUMENTATION = '''
+---
+module: group_by
+short_description: Create Ansible groups based on facts
+description:
+  - Use facts to create ad-hoc groups that can be used later in a playbook.
+version_added: 0.9
+options:
+  var:
+    description:
+    - The variable whose values will be used as groups
+    required: true
+  prefix:
+    description:
+    - A prefix to add to created group names.
+author: Jeroen Hoekx
+examples:
+  - description: Create groups based on the machine architecture
+    code: group_by var=ansible_machine prefix=ansible
+notes:
+  - Spaces in group names are converted to dashes '-'.
+'''

--- a/library/group_by
+++ b/library/group_by
@@ -8,7 +8,7 @@ description:
   - Use facts to create ad-hoc groups that can be used later in a playbook.
 version_added: 0.9
 options:
-  var:
+  key:
     description:
     - The variable whose values will be used as groups
     required: true
@@ -18,7 +18,7 @@ options:
 author: Jeroen Hoekx
 examples:
   - description: Create groups based on the machine architecture
-    code: group_by var=ansible_machine prefix=ansible
+    code: group_by key=ansible_machine prefix=ansible
 notes:
   - Spaces in group names are converted to dashes '-'.
 '''

--- a/library/group_by
+++ b/library/group_by
@@ -19,6 +19,8 @@ author: Jeroen Hoekx
 examples:
   - description: Create groups based on the machine architecture
     code: group_by key=ansible_machine prefix=ansible
+  - description: Create groups like 'kvm-host'
+    code: group_by key=ansible_virtualization_type,ansible_virtualization_role
 notes:
   - Spaces in group names are converted to dashes '-'.
 '''


### PR DESCRIPTION
Example usage:

```

---

- hosts: all
  gather_facts: false
  tasks:
  - local_action: is_provisioned host=${inventory_hostname}
  - local_action: pause seconds=1
  - local_action: group_by is_provisioned, color

- hosts: unprovisioned
  gather_facts: false
  tasks:
  - action: ping

- hosts: blue
  gather_facts: false
  tasks:
  - action: ping
```

With `is_provisioned`:

```
#!/usr/bin/env python

def main():
    module = AnsibleModule(
        argument_spec = dict(
            host=dict(required=True),
        )
    )

    if module.params['host'] in ['firefly']:
        ansible_facts={'is_provisioned':'unprovisioned', 'color':'blue'}
        module.exit_json(ansible_facts=ansible_facts)
    elif module.params['host'] in ['mole']:
        ansible_facts={'is_provisioned':'unprovisioned', 'color':'red'}
        module.exit_json(ansible_facts=ansible_facts)
    else:
        module.exit_json(ok="ok")

# this is magic, see lib/ansible/module_common.py
#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
main()
```

Result:

```
PLAY [all] ********************* 

TASK: [is_provisioned host=${inventory_hostname}] ********************* 
ok: [firefly] => {"ansible_facts": {"color": "blue", "is_provisioned": "unprovisioned"}}
ok: [testsys] => {"ok": "ok"}
ok: [mole] => {"ansible_facts": {"color": "red", "is_provisioned": "unprovisioned"}}

TASK: [pause seconds=1] ********************* 
(^C-c = continue early, ^C-a = abort)
[testsys, firefly, mole]
Pausing for 1 seconds

TASK: [group_by is_provisioned, color] ********************* 
changed: [testsys] => {"changed": true, 
   "color": {"blue": ["firefly"], "red": ["mole"]},
   "is_provisioned": {"unprovisioned": ["firefly", "mole"]}
}

PLAY [unprovisioned] ********************* 

TASK: [ping] ********************* 
ok: [firefly] => {"ping": "pong"}
ok: [mole] => {"ping": "pong"}

PLAY [blue] ********************* 

TASK: [ping] ********************* 
ok: [firefly] => {"ping": "pong"}
```

This is branched from 0.8, on trunk not even 'pause' was working.
