### PR TITLE
Allow vars_files sequences without a default

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -275,7 +275,7 @@ class Play(object):
                         self.playbook.callbacks.on_not_import_for_host(host, filename4)
                     if found:
                         break
-                if not found:
+                if not found and host is not None:
                     raise errors.AnsibleError(
                         "%s: FATAL, no files matched for vars_files import sequence: %s" % (host, sequence)
                     )


### PR DESCRIPTION
Currently, if you have say

``` yaml
- hosts:
  vars_files:
  - [ "vars/packages-$ansible_pkg_mgr.yml" ]
...
```

and create a packages-yum.yml, you will get an error such as

```
ERROR: None: FATAL, no files matched for vars_files import sequence: [u'vars/packages-$ansible_pkg_mgr.yml']
```

This is from the initial vars_files import where host is None, and no facts are available. I don't think it should be enforced to have a default.
