### PR TITLE
When a package that is not installed is part of a set for removal, yum module exits ok. Fix herein

### DIFF
--- a/library/yum
+++ b/library/yum
@@ -440,15 +440,6 @@ def remove(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         else:
             pkglist = is_installed(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos)
             if not pkglist:
-                res['msg'] += "No Package matching '%s' found installed" % spec
-                module.exit_json(**res)
-
-            found = False
-            for this in pkglist:
-                if is_installed(module, repoq, this, conf_file, en_repos=en_repos, dis_repos=dis_repos):
-                    found = True
-
-            if not found:
                 res['results'].append('%s is not installed' % spec)
                 continue
             pkg = spec
@@ -458,17 +449,14 @@ def remove(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
 
         # FIXME if we ran the remove - check to make sure it actually removed :(
         # look for the pkg in the rpmdb - this is notoriously hard for groups :(
+        res['results'].append(out)
+        res['msg'] += err
+
         if rc != 0:
-            res['changed'] = False
-            res['failed'] = True
             res['rc'] = rc
-            res['results'].append(out)
-            res['msg'] += err
+            module.fail_json(**res)
         else:
             res['changed'] = True
-            res['rc'] = 0
-            res['results'].append(out)
-            res['msg'] += err
 
     module.exit_json(**res)
 


### PR DESCRIPTION
I noticed that removing a list of packages, with one package included that is not installed, causes the whole set (or part, depending on case) to not be removed, and instead exit with rc=0.

After fixing this, I also fixed the return code when removing sets of packages.
