### PR TITLE
More useful error message for if not HAVE_SELINUX

### DIFF
--- a/library/seboolean
+++ b/library/seboolean
@@ -164,7 +164,7 @@ def main():
     )
 
     if not HAVE_SELINUX:
-        module.fail_json(msg="SELinux not supported on this host.")
+        module.fail_json(msg="This module requires libselinux-python support")
 
     if not HAVE_SEMANAGE:
         module.fail_json(msg="This module requires libsemanage-python support")


### PR DESCRIPTION
Currently, if libselinux-python is not installed, the seboolean module errors with a message saying "SELinux not supported on this host". This is not necessarily true, because the only test that is done is to try and import the Python selinux module, which is not a good indication of whether or not SELinux is supported.

This simple patch changes the error message to inform the user he has to install libselinux-python, instead of claiming that SELinux is not supported.
