### PR TITLE
Add option create= to lineinfile module

### DIFF
--- a/library/lineinfile
+++ b/library/lineinfile
@@ -181,7 +181,7 @@ def main():
             regexp=dict(required=True),
             line=dict(aliases=['value']),
             insertafter=dict(default='EOF'),
-            create=dict(default=false, choices=BOOLEANS),
+            create=dict(default=False, choices=BOOLEANS),
             backup=dict(default=False, choices=BOOLEANS),
         ),
     )

--- a/library/lineinfile
+++ b/library/lineinfile
@@ -65,6 +65,14 @@ options:
         file, and C(EOF) for inserting the line at the end of the file.
     choices: [ BOF, EOF ]
     default: EOF
+  create:
+    required: false
+    choices: [ yes, no ]
+    default: no
+    description:
+      - Used with C(state=present). If specified, the file will be created
+        if it does not already exist. By default it will fail if the file
+        is missing.
   backup:
      required: false
      default: no
@@ -76,10 +84,21 @@ examples:
    - code: 'lineinfile: dest=/etc/sudoers state=absent regexp="^%wheel"'
 '''
 
-def present(module, dest, regexp, line, insertafter, backup):
-    f = open(dest, 'rb')
-    lines = f.readlines()
-    f.close()
+def present(module, dest, regexp, line, insertafter, create, backup):
+
+    if os.path.isdir(dest):
+        module.fail_json(rc=256, msg='Destination %s is a directory !' % dest)
+    elif not os.path.exists(dest):
+        if not create:
+            module.fail_json(rc=257, msg='Destination %s does not exist !' % dest)
+        destpath = os.path.dirname(dest)
+        if not os.path.exists(destpath):
+            os.makedirs(destpath)
+        lines = []
+    else:
+        f = open(dest, 'rb')
+        lines = f.readlines()
+        f.close()
 
     mre = re.compile(regexp)
     if not mre.search(line):
@@ -162,18 +181,20 @@ def main():
             regexp=dict(required=True),
             line=dict(aliases=['value']),
             insertafter=dict(default='EOF'),
+            create=dict(default=false, choices=BOOLEANS),
             backup=dict(default=False, choices=BOOLEANS),
         ),
     )
 
     params = module.params
+    create = module.boolean(module.params.get('create', False))
     backup = module.boolean(module.params.get('backup', False))
 
     if params['state'] == 'present':
         if 'line' not in params:
             module.fail_json(msg='line= is required with state=present')
         present(module, params['dest'], params['regexp'], params['line'],
-                params['insertafter'], backup)
+                params['insertafter'], create, backup)
     else:
         absent(module, params['dest'], params['regexp'], backup)
 


### PR DESCRIPTION
We use the lineinfile module to modify configuration files of a proprietary application. This application reads configuration options from files, but does not require those files to exist (if the default options are fine). However this application may modify the configuration file at will, so we cannot copy or template those files. And after a silent install the configuration may not exist (depending on the response file).

Whatever the case, during deployment we need to make sure some configuration options are set after the installation.

So the cleanest way to handle this situation is to allow the lineinfile module to create the file if it is missing (and this is the expected behavior). When I proposed this behavior, @sergevanginderachter needed the same functionality and was now working around it as well.
