### PR TITLE
Improved lookup plugins

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -112,7 +112,7 @@ class Play(object):
                     if plugin_name not in self.playbook.lookup_plugins_list:
                         raise errors.AnsibleError("cannot find lookup plugin named %s for usage in with_%s" % (plugin_name, plugin_name))
                     terms = utils.varReplaceWithItems(self.basedir, x[k], task_vars)
-                    items = self.playbook.lookup_plugins_list[plugin_name].LookupModule(None).run(terms)
+                    items = self.playbook.lookup_plugins_list[plugin_name].LookupModule(basedir=self.basedir, runner=None).run(terms)
 
                 for item in items:
                     mv = task_vars.copy()

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -112,7 +112,7 @@ class Play(object):
                     if plugin_name not in self.playbook.lookup_plugins_list:
                         raise errors.AnsibleError("cannot find lookup plugin named %s for usage in with_%s" % (plugin_name, plugin_name))
                     terms = utils.varReplaceWithItems(self.basedir, x[k], task_vars)
-                    items = self.playbook.lookup_plugins_list[plugin_name].LookupModule(basedir=self.basedir, runner=None).run(terms)
+                    items = self.playbook.lookup_plugins_list[plugin_name].LookupModule(basedir=self.basedir, runner=None).run(terms, inject=task_vars)
 
                 for item in items:
                     mv = task_vars.copy()

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -295,7 +295,7 @@ class Runner(object):
         if items_plugin is not None and items_plugin in self.lookup_plugins:
             items_terms = self.module_vars.get('items_lookup_terms', '')
             items_terms = utils.varReplaceWithItems(self.basedir, items_terms, inject)
-            items = self.lookup_plugins[items_plugin].run(items_terms)
+            items = self.lookup_plugins[items_plugin].run(items_terms, inject=inject)
             if type(items) != list:
                 raise errors.AnsibleError("lookup plugins have to return a list: %r" % items)
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -170,12 +170,12 @@ class Runner(object):
         for (k,v) in action_plugin_list.iteritems():
             self.action_plugins[k] = v.ActionModule(self)
         for (k,v) in lookup_plugin_list.iteritems():
-            self.lookup_plugins[k] = v.LookupModule(self)
+            self.lookup_plugins[k] = v.LookupModule(runner=self, basedir=self.basedir)
 
         for (k,v) in utils.import_plugins(os.path.join(self.basedir, 'action_plugins')).iteritems():
             self.action_plugins[k] = v.ActionModule(self)
         for (k,v) in utils.import_plugins(os.path.join(self.basedir, 'lookup_plugins')).iteritems():
-            self.lookup_plugins[k] = v.LookupModule(self)
+            self.lookup_plugins[k] = v.LookupModule(runner=self, basedir=self.basedir)
 
     # *****************************************************
 

--- a/lib/ansible/runner/lookup_plugins/fileglob.py
+++ b/lib/ansible/runner/lookup_plugins/fileglob.py
@@ -21,11 +21,11 @@ from ansible import utils
 
 class LookupModule(object):
 
-    def __init__(self, runner):
-        self.runner = runner
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
 
-    def run(self, terms):
-        return [ f for f in glob.glob(utils.path_dwim(self.runner.basedir, terms)) if os.path.isfile(f) ]
+    def run(self, terms, **kwargs):
+        return [ f for f in glob.glob(utils.path_dwim(self.basedir, terms)) if os.path.isfile(f) ]
 
 
 

--- a/lib/ansible/runner/lookup_plugins/items.py
+++ b/lib/ansible/runner/lookup_plugins/items.py
@@ -15,14 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 class LookupModule(object):
 
-    def __init__(self, runner):
-        self.runner = runner
+    def __init__(self, **kwargs):
+        pass
 
-    def run(self, terms):
+    def run(self, terms, **kwargs):
         return terms
 
 

--- a/lib/ansible/runner/lookup_plugins/template.py
+++ b/lib/ansible/runner/lookup_plugins/template.py
@@ -1,0 +1,27 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible import utils
+
+class LookupModule(object):
+
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
+
+    def run(self, terms, inject=None, **kwargs):
+        return utils.template_from_file(self.basedir, terms, inject)
+


### PR DESCRIPTION
This is based on #1501, I'll rebase once that is merged. (Or I guess this could just be merged instead.)

This makes the lookup plugin API extensible and fixes some of the existing issues with it,
e.g. fileglob not working for includes.

It then uses that to add the variables available at the time for templating, and adds a template lookup plugin. This should in some of the easier cases solve the discussion in #1269.

For more involved cases, I'm working on a $LOOKUP(...) for the variable replacer. That's to follow... 
