### PR TITLE
Allow custom jinja2 filters.

### DIFF
--- a/examples/playbooks/jinja2_filter.yml
+++ b/examples/playbooks/jinja2_filter.yml
@@ -1,0 +1,8 @@
+---
+
+- hosts: all
+  tasks:
+  # The python module library/custom_filters contains the generate_uuid function
+  - action: jinja2_filter src=library/custom_filters.py name=generate_uuid
+  # Use the generate_uuid filter in a template
+  - action: template src=templates/jinja2_filters.txt dest=/tmp/jinja2_filters.txt

--- a/examples/playbooks/library/custom_filters.py
+++ b/examples/playbooks/library/custom_filters.py
@@ -1,0 +1,4 @@
+import uuid
+
+def generate_uuid(value):
+    return uuid.uuid4()

--- a/examples/playbooks/templates/jinja2_filters.txt
+++ b/examples/playbooks/templates/jinja2_filters.txt
@@ -1,0 +1,1 @@
+UUID: {{ 'nop' | generate_uuid }}

--- a/lib/ansible/runner/action_plugins/jinja2_filter.py
+++ b/lib/ansible/runner/action_plugins/jinja2_filter.py
@@ -27,9 +27,9 @@ from ansible.runner.return_data import ReturnData
 from ansible.utils import path_dwim, parse_kv
 
 class ActionModule(object):
-    ''' Create inventory groups based on variables '''
+    ''' Define custom jinja2 template filters '''
 
-    ### We need to be able to modify the inventory
+    ### We need to be able to return function pointers
     BYPASS_HOST_LOOP = True
 
     def __init__(self, runner):

--- a/lib/ansible/runner/action_plugins/jinja2_filter.py
+++ b/lib/ansible/runner/action_plugins/jinja2_filter.py
@@ -49,14 +49,14 @@ class ActionModule(object):
         if not os.path.exists(module_path):
             raise ae("'%s' does not exist."%(module_path))
 
-        filters = inject.get('ansible_jinja2_filters',[])
+        filters = inject.get('ansible_jinja2_filters',{})
         module = imp.load_source('module', module_path)
         for name in args['name'].strip(',').split(','):
             try:
                 fn = getattr(module, name)
             except AttributeError:
                 raise ae("Module '%s' has no filter '%s'"%(module_path, name))
-            filters.append((name,fn))
+            filters[name] = fn
 
         result = {'changed': False, 'ansible_facts': {'ansible_jinja2_filters': filters}}
 

--- a/lib/ansible/runner/action_plugins/jinja2_filter.py
+++ b/lib/ansible/runner/action_plugins/jinja2_filter.py
@@ -1,0 +1,63 @@
+# Copyright 2012, Jeroen Hoekx <jeroen@hoekx.be>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import imp
+import os
+
+import ansible
+
+from ansible.callbacks import vv
+from ansible.errors import AnsibleError as ae
+from ansible.runner.return_data import ReturnData
+from ansible.utils import parse_kv
+
+class ActionModule(object):
+    ''' Create inventory groups based on variables '''
+
+    ### We need to be able to modify the inventory
+    BYPASS_HOST_LOOP = True
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    def run(self, conn, tmp, module_name, module_args, inject):
+        args = parse_kv(self.runner.module_args)
+        if not 'src' in args:
+            raise ae("'src' is a required argument.")
+        if not 'name' in args:
+            raise ae("'name' is a required argument.")
+
+        vv("created 'jinja2_filter' ActionModule: src=%s name=%s"%(args['src'],args['name']))
+
+        module_path = os.path.join(self.runner.basedir, args['src'])
+
+        if not os.path.exists(module_path):
+            raise ae("'%s' does not exist."%(module_path))
+
+        filters = inject.get('ansible_jinja2_filters',[])
+        module = imp.load_source('module', module_path)
+        for name in args['name'].strip(',').split(','):
+            try:
+                fn = getattr(module, name)
+            except AttributeError:
+                raise ae("Module '%s' has no filter '%s'"%(module_path, name))
+            filters.append((name,fn))
+
+        result = {'changed': False, 'ansible_facts': {'ansible_jinja2_filters': filters}}
+
+        return ReturnData(conn=conn, comm_ok=True, result=result)

--- a/lib/ansible/runner/action_plugins/jinja2_filter.py
+++ b/lib/ansible/runner/action_plugins/jinja2_filter.py
@@ -24,7 +24,7 @@ import ansible
 from ansible.callbacks import vv
 from ansible.errors import AnsibleError as ae
 from ansible.runner.return_data import ReturnData
-from ansible.utils import parse_kv
+from ansible.utils import path_dwim, parse_kv
 
 class ActionModule(object):
     ''' Create inventory groups based on variables '''
@@ -44,7 +44,7 @@ class ActionModule(object):
 
         vv("created 'jinja2_filter' ActionModule: src=%s name=%s"%(args['src'],args['name']))
 
-        module_path = os.path.join(self.runner.basedir, args['src'])
+        module_path = path_dwim(self.runner.basedir, args['src'])
 
         if not os.path.exists(module_path):
             raise ae("'%s' does not exist."%(module_path))

--- a/lib/ansible/template.py
+++ b/lib/ansible/template.py
@@ -222,6 +222,9 @@ def template_from_file(basedir, path, vars):
     environment.filters['from_json'] = json.loads
     environment.filters['to_yaml'] = yaml.dump
     environment.filters['from_yaml'] = yaml.load
+    if 'ansible_jinja2_filters' in vars:
+        for name,filter in vars['ansible_jinja2_filters']:
+            environment.filters[name] = filter
     try:
         data = codecs.open(realpath, encoding="utf8").read()
     except UnicodeDecodeError:

--- a/lib/ansible/template.py
+++ b/lib/ansible/template.py
@@ -223,8 +223,7 @@ def template_from_file(basedir, path, vars):
     environment.filters['to_yaml'] = yaml.dump
     environment.filters['from_yaml'] = yaml.load
     if 'ansible_jinja2_filters' in vars:
-        for name,filter in vars['ansible_jinja2_filters']:
-            environment.filters[name] = filter
+        environment.filters.update(vars['ansible_jinja2_filters'])
     try:
         data = codecs.open(realpath, encoding="utf8").read()
     except UnicodeDecodeError:

--- a/library/jinja2_filter
+++ b/library/jinja2_filter
@@ -1,0 +1,23 @@
+# -*- mode: python -*-
+
+DOCUMENTATION = '''
+---
+module: jinja2_filter
+short_description: Load custom Jinja2 filters
+description:
+  - Load custom Jinja2 filters from a module to use in templates.
+version_added: 0.9
+options:
+  src:
+    description:
+    - The file containing the filters.
+    required: true
+  name:
+    description:
+    - A comma separated list of the names of the filters to import.
+    required: true
+author: Jeroen Hoekx
+examples:
+  - description: Import the 'generate_uuid' function as a filter.
+    code: jinja2_filter src=../library/custom_filters.py name=generate_uuid
+'''


### PR DESCRIPTION
Using an action plugin to define the filters avoids the performance hit
of always importing custom filters.

Examples and documentation included.

See [mailing list](https://groups.google.com/d/topic/ansible-project/uR2tNrHkzPs/discussion) 'discussion'.
