### PR TITLE
Jinja2 filter lookup plugin

### DIFF
--- a/examples/playbooks/jinja2_filter.yml
+++ b/examples/playbooks/jinja2_filter.yml
@@ -1,0 +1,10 @@
+---
+
+- hosts: all
+  tasks:
+  # The python module library/custom_filters contains the generate_uuid and
+  # generate_answer functions
+  - action: template src=templates/jinja2_filters.txt dest=/tmp/jinja2_filters.txt
+    with_filters:
+    - src=library/custom_filters.py name=generate_uuid
+    - src=library/custom_filters.py name=generate_answer

--- a/examples/playbooks/library/custom_filters.py
+++ b/examples/playbooks/library/custom_filters.py
@@ -1,0 +1,7 @@
+import uuid
+
+def generate_uuid(value):
+    return uuid.uuid4()
+
+def generate_answer(value):
+    return '42'

--- a/examples/playbooks/templates/jinja2_filters.txt
+++ b/examples/playbooks/templates/jinja2_filters.txt
@@ -1,0 +1,2 @@
+UUID: {{ 'nop' | generate_uuid }}
+The answer: 1+1={{ '1+1' | generate_answer }}

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -112,7 +112,9 @@ class Play(object):
                     if plugin_name not in self.playbook.lookup_plugins_list:
                         raise errors.AnsibleError("cannot find lookup plugin named %s for usage in with_%s" % (plugin_name, plugin_name))
                     terms = utils.varReplaceWithItems(self.basedir, x[k], task_vars)
-                    items = self.playbook.lookup_plugins_list[plugin_name].LookupModule(basedir=self.basedir, runner=None).run(terms, inject=task_vars)
+                    ns, items = self.playbook.lookup_plugins_list[plugin_name].LookupModule(basedir=self.basedir, runner=None).run(terms, inject=task_vars)
+                    if ns != 'items':
+                        raise errors.AnsibleError("Lookup plugin in 'items' namespace expected, got %s"%(ns))
 
                 for item in items:
                     mv = task_vars.copy()

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -112,7 +112,7 @@ class Play(object):
                     if plugin_name not in self.playbook.lookup_plugins_list:
                         raise errors.AnsibleError("cannot find lookup plugin named %s for usage in with_%s" % (plugin_name, plugin_name))
                     terms = utils.varReplaceWithItems(self.basedir, x[k], task_vars)
-                    items = self.playbook.lookup_plugins_list[plugin_name].LookupModule(None).run(terms)
+                    items = self.playbook.lookup_plugins_list[plugin_name].LookupModule(basedir=self.basedir, runner=None).run(terms)
 
                 for item in items:
                     mv = task_vars.copy()

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -112,7 +112,7 @@ class Play(object):
                     if plugin_name not in self.playbook.lookup_plugins_list:
                         raise errors.AnsibleError("cannot find lookup plugin named %s for usage in with_%s" % (plugin_name, plugin_name))
                     terms = utils.varReplaceWithItems(self.basedir, x[k], task_vars)
-                    items = self.playbook.lookup_plugins_list[plugin_name].LookupModule(basedir=self.basedir, runner=None).run(terms)
+                    items = self.playbook.lookup_plugins_list[plugin_name].LookupModule(basedir=self.basedir, runner=None).run(terms, inject=task_vars)
 
                 for item in items:
                     mv = task_vars.copy()

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -295,7 +295,7 @@ class Runner(object):
         if items_plugin is not None and items_plugin in self.lookup_plugins:
             items_terms = self.module_vars.get('items_lookup_terms', '')
             items_terms = utils.varReplaceWithItems(self.basedir, items_terms, inject)
-            items = self.lookup_plugins[items_plugin].run(items_terms)
+            items = self.lookup_plugins[items_plugin].run(items_terms, inject=inject)
             if type(items) != list:
                 raise errors.AnsibleError("lookup plugins have to return a list: %r" % items)
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -170,12 +170,12 @@ class Runner(object):
         for (k,v) in action_plugin_list.iteritems():
             self.action_plugins[k] = v.ActionModule(self)
         for (k,v) in lookup_plugin_list.iteritems():
-            self.lookup_plugins[k] = v.LookupModule(self)
+            self.lookup_plugins[k] = v.LookupModule(runner=self, basedir=self.basedir)
 
         for (k,v) in utils.import_plugins(os.path.join(self.basedir, 'action_plugins')).iteritems():
             self.action_plugins[k] = v.ActionModule(self)
         for (k,v) in utils.import_plugins(os.path.join(self.basedir, 'lookup_plugins')).iteritems():
-            self.lookup_plugins[k] = v.LookupModule(self)
+            self.lookup_plugins[k] = v.LookupModule(runner=self, basedir=self.basedir)
 
     # *****************************************************
 

--- a/lib/ansible/runner/lookup_plugins/fileglob.py
+++ b/lib/ansible/runner/lookup_plugins/fileglob.py
@@ -21,11 +21,11 @@ from ansible import utils
 
 class LookupModule(object):
 
-    def __init__(self, runner):
-        self.runner = runner
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
 
-    def run(self, terms):
-        return [ f for f in glob.glob(utils.path_dwim(self.runner.basedir, terms)) if os.path.isfile(f) ]
+    def run(self, terms, **kwargs):
+        return [ f for f in glob.glob(utils.path_dwim(self.basedir, terms)) if os.path.isfile(f) ]
 
 
 

--- a/lib/ansible/runner/lookup_plugins/fileglob.py
+++ b/lib/ansible/runner/lookup_plugins/fileglob.py
@@ -25,7 +25,7 @@ class LookupModule(object):
         self.basedir = basedir
 
     def run(self, terms, **kwargs):
-        return [ f for f in glob.glob(utils.path_dwim(self.basedir, terms)) if os.path.isfile(f) ]
+        return 'items', [ f for f in glob.glob(utils.path_dwim(self.basedir, terms)) if os.path.isfile(f) ]
 
 
 

--- a/lib/ansible/runner/lookup_plugins/filters.py
+++ b/lib/ansible/runner/lookup_plugins/filters.py
@@ -27,7 +27,8 @@ class LookupModule(object):
         self.runner = runner
 
     def run(self, terms, inject, **kwargs):
-        filters = {}
+        ### lookup plugins have to return a list
+        filters = []
 
         for term in terms:
             args = parse_kv(template(self.runner.basedir, term, inject))
@@ -47,6 +48,6 @@ class LookupModule(object):
                     fn = getattr(module, name)
                 except AttributeError:
                     raise ae("Module '%s' has no filter '%s'"%(module_path, name))
-                filters[name] = fn
+                filters.append( (name, fn) )
 
-        return [{'ansible_jinja2_filters':filters}]
+        return 'ansible_jinja2_filters',filters

--- a/lib/ansible/runner/lookup_plugins/filters.py
+++ b/lib/ansible/runner/lookup_plugins/filters.py
@@ -1,0 +1,52 @@
+# Copyright 2012, Jeroen Hoekx <jeroen@hoekx.be>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import imp
+import os
+
+from ansible.errors import AnsibleError as ae
+from ansible.utils import path_dwim, parse_kv, template
+
+class LookupModule(object):
+
+    def __init__(self, runner, **kwargs):
+        self.runner = runner
+
+    def run(self, terms, inject, **kwargs):
+        filters = {}
+
+        for term in terms:
+            args = parse_kv(template(self.runner.basedir, term, inject))
+            if not 'src' in args:
+                raise ae("'src' is a required argument.")
+            if not 'name' in args:
+                raise ae("'name' is a required argument.")
+
+            module_path = path_dwim(self.runner.basedir, args['src'])
+
+            if not os.path.exists(module_path):
+                raise ae("'%s' does not exist."%(module_path))
+
+            module = imp.load_source('module', module_path)
+            for name in args['name'].strip(',').split(','):
+                try:
+                    fn = getattr(module, name)
+                except AttributeError:
+                    raise ae("Module '%s' has no filter '%s'"%(module_path, name))
+                filters[name] = fn
+
+        return [{'ansible_jinja2_filters':filters}]

--- a/lib/ansible/runner/lookup_plugins/items.py
+++ b/lib/ansible/runner/lookup_plugins/items.py
@@ -15,14 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 class LookupModule(object):
 
-    def __init__(self, runner):
-        self.runner = runner
+    def __init__(self, **kwargs):
+        pass
 
-    def run(self, terms):
+    def run(self, terms, **kwargs):
         return terms
 
 

--- a/lib/ansible/runner/lookup_plugins/items.py
+++ b/lib/ansible/runner/lookup_plugins/items.py
@@ -21,7 +21,7 @@ class LookupModule(object):
         pass
 
     def run(self, terms, **kwargs):
-        return terms
+        return 'items',terms
 
 
 

--- a/lib/ansible/runner/lookup_plugins/template.py
+++ b/lib/ansible/runner/lookup_plugins/template.py
@@ -1,0 +1,27 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible import utils
+
+class LookupModule(object):
+
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
+
+    def run(self, terms, inject=None, **kwargs):
+        return utils.template_from_file(self.basedir, terms, inject)
+

--- a/lib/ansible/runner/lookup_plugins/template.py
+++ b/lib/ansible/runner/lookup_plugins/template.py
@@ -23,5 +23,5 @@ class LookupModule(object):
         self.basedir = basedir
 
     def run(self, terms, inject=None, **kwargs):
-        return utils.template_from_file(self.basedir, terms, inject)
+        return 'items',utils.template_from_file(self.basedir, terms, inject)
 

--- a/lib/ansible/template.py
+++ b/lib/ansible/template.py
@@ -222,11 +222,9 @@ def template_from_file(basedir, path, vars):
     environment.filters['from_json'] = json.loads
     environment.filters['to_yaml'] = yaml.dump
     environment.filters['from_yaml'] = yaml.load
-    if 'item' in vars and type(vars['item'])==dict:
-        if 'ansible_jinja2_filters' in vars['item']:
-            environment.filters.update(vars['item']['ansible_jinja2_filters'])
-            ### remove the functions from items, they can't be pickled
-            vars['item'] = ','.join(vars['item']['ansible_jinja2_filters'].keys())
+    if 'ansible_jinja2_filters' in vars:
+        for name,fn in vars['ansible_jinja2_filters']:
+            environment.filters[name] = fn
     try:
         data = codecs.open(realpath, encoding="utf8").read()
     except UnicodeDecodeError:

--- a/lib/ansible/template.py
+++ b/lib/ansible/template.py
@@ -222,6 +222,11 @@ def template_from_file(basedir, path, vars):
     environment.filters['from_json'] = json.loads
     environment.filters['to_yaml'] = yaml.dump
     environment.filters['from_yaml'] = yaml.load
+    if 'item' in vars and type(vars['item'])==dict:
+        if 'ansible_jinja2_filters' in vars['item']:
+            environment.filters.update(vars['item']['ansible_jinja2_filters'])
+            ### remove the functions from items, they can't be pickled
+            vars['item'] = ','.join(vars['item']['ansible_jinja2_filters'].keys())
     try:
         data = codecs.open(realpath, encoding="utf8").read()
     except UnicodeDecodeError:


### PR DESCRIPTION
This implements custom jinja2 filters as a lookup plugin as discussed in #1503 .

This is based on #1502 .

Example usage:

```
  - action: template src=templates/jinja2_filters.txt dest=/tmp/jinja2_filters.txt
    with_filters:
    - src=library/custom_filters.py name=generate_uuid
    - src=library/custom_filters.py name=generate_answer
```
