### PR TITLE
Fix installing to virtualenvs.

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -17,6 +17,7 @@
 
 import os
 import pwd
+import sys
 import ConfigParser
 
 def get_config(p, section, key, env_var, default):
@@ -60,7 +61,7 @@ active_user   = pwd.getpwuid(os.geteuid())[0]
 
 # Needed so the RPM can call setup.py and have modules land in the
 # correct location. See #1277 for discussion
-DIST_MODULE_PATH = '/usr/share/ansible/'
+DIST_MODULE_PATH = os.path.join(sys.prefix, 'share/ansible/')
 
 # sections in config file
 DEFAULTS='defaults'

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -61,7 +61,10 @@ active_user   = pwd.getpwuid(os.geteuid())[0]
 
 # Needed so the RPM can call setup.py and have modules land in the
 # correct location. See #1277 for discussion
-DIST_MODULE_PATH = os.path.join(sys.prefix, 'share/ansible/')
+if getattr(sys, "real_prefix", None):
+    DIST_MODULE_PATH = os.path.join(sys.prefix, 'share/ansible/')
+else:
+    DIST_MODULE_PATH = '/usr/share/ansible/'
 
 # sections in config file
 DEFAULTS='defaults'


### PR DESCRIPTION
I have changed `DIST_MODULE_PATH` so that it's relative, rather than absolute. I don't have RHEL, so I don't know if the system prefix is the same as Ubuntu (`/usr/`), but this should work regardless (it might get installed under `/usr/local/lib/ansible/`, though). Someone should test it.

Hopefully this resolves #1410 so we can get #595.
