### PR TITLE
Support scp in an ssh connection

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -60,6 +60,10 @@ sudo_user=root
 
 transport=paramiko
 
+# the following makes ansible use scp if the connection type is ssh (default is sftp)
+
+scp_if_ssh=True
+
 # remote SSH port to be used when --port or "port:" or an equivalent inventory
 # variable is not specified.
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -60,10 +60,6 @@ sudo_user=root
 
 transport=paramiko
 
-# the following makes ansible use scp if the connection type is ssh (default is sftp)
-
-scp_if_ssh=True
-
 # remote SSH port to be used when --port or "port:" or an equivalent inventory
 # variable is not specified.
 
@@ -107,5 +103,9 @@ vars_plugins       = /usr/share/ansible_plugins/vars_plugins
 # removing it
 
 ssh_args=-o PasswordAuthentication=no -o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r
+
+# the following makes ansible use scp if the connection type is ssh (default is sftp)
+
+#scp_if_ssh=True
 
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -86,6 +86,7 @@ DEFAULT_SUDO_USER         = get_config(p, DEFAULTS, 'sudo_user',        'ANSIBLE
 DEFAULT_ASK_SUDO_PASS     = get_config(p, DEFAULTS, 'ask_sudo_pass',    'ANSIBLE_ASK_SUDO_PASS',    False)
 DEFAULT_REMOTE_PORT       = int(get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      22))
 DEFAULT_TRANSPORT         = get_config(p, DEFAULTS, 'transport',        'ANSIBLE_TRANSPORT',        'paramiko')
+DEFAULT_SCP_IF_SSH        = get_config(p, DEFAULTS, 'scp_if_ssh',       'ANSIBLE_SCP_IF_SSH',       False)
 DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')
 
 DEFAULT_ACTION_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'action_plugins',     None, '/usr/share/ansible_plugins/action_plugins'))


### PR DESCRIPTION
Added a config option for using scp instead of sftp when connection type is ssh

*Added a boolean to ansible constants
*Added an example usage line in examples/ansible.cfg
*Modified put_file and fetch_file to run scp if scp_if_ssh is true.

Refers to #1279
