### PR TITLE
Make sure stdout, stderr and msg are stripped from starting/trailing newlines

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -235,14 +235,15 @@ class Runner(object):
                 raise Exception("unexpected return type: %s" % type(exec_rc))
             # redundant, right?
             if not exec_rc.comm_ok:
-                self.callbacks.on_unreachable(host, exec_rc.result)
+                msg = exec_rc.result.strip('\r\n')
+                self.callbacks.on_unreachable(host, msg)
             return exec_rc
         except errors.AnsibleError, ae:
-            msg = str(ae)
+            msg = str(ae).strip('\r\n')
             self.callbacks.on_unreachable(host, msg)
             return ReturnData(host=host, comm_ok=False, result=dict(failed=True, msg=msg))
         except Exception:
-            msg = traceback.format_exc()
+            msg = traceback.format_exc().strip('\r\n')
             self.callbacks.on_unreachable(host, msg)
             return ReturnData(host=host, comm_ok=False, result=dict(failed=True, msg=msg))
 

--- a/lib/ansible/runner/connection_plugins/fireball.py
+++ b/lib/ansible/runner/connection_plugins/fireball.py
@@ -87,7 +87,7 @@ class Connection(object):
         response = utils.decrypt(self.key, response)
         response = utils.parse_json(response)
 
-        return ('', response.get('stdout',''), response.get('stderr',''))
+        return ('', response.get('stdout','').strip('\r\n'), response.get('stderr','').strip('\r\n'))
 
     def put_file(self, in_path, out_path):
 

--- a/lib/ansible/runner/connection_plugins/local.py
+++ b/lib/ansible/runner/connection_plugins/local.py
@@ -51,7 +51,7 @@ class Connection(object):
         p = subprocess.Popen(cmd, shell=True, stdin=None,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
-        return ("", stdout, stderr)
+        return ("", stdout.strip('\r\n'), stderr.strip('\r\n'))
 
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to local '''

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -144,7 +144,7 @@ class Connection(object):
             except socket.timeout:
                 raise errors.AnsibleError('ssh timed out waiting for sudo.\n' + sudo_output)
 
-        return (chan.makefile('wb', bufsize), chan.makefile('rb', bufsize), '')
+        return (chan.makefile('wb', bufsize), chan.makefile('rb', bufsize).strip('\r\n'), '')
 
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -111,7 +111,7 @@ class Connection(object):
         if p.returncode != 0 and stdout.find('Bad configuration option: ControlPersist') != -1:
             raise errors.AnsibleError('using -c ssh on certain older ssh versions may not support ControlPersist, set ANSIBLE_SSH_ARGS="" (or ansible_ssh_args in the config file) before running again')
 
-        return ('', stdout, '')
+        return ('', stdout.strip('\r\n'), '')
 
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''


### PR DESCRIPTION
This makes it easier to use those properties from callback plugins
