### PR TITLE
Handle instances without keypairs

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -303,7 +303,8 @@ class Ec2Inventory(object):
         self.push(self.inventory, self.to_safe('type_' + instance.instance_type), dest)
         
         # Inventory: Group by key pair
-        self.push(self.inventory, self.to_safe('key_' + instance.key_name), dest)
+        if instance.key_name != None:
+            self.push(self.inventory, self.to_safe('key_' + instance.key_name), dest)
         
         # Inventory: Group by security group
         try:


### PR DESCRIPTION
While I haven't done this, it is possible to bring up an instance without a keypair, so this takes care of that scenario
