### PR TITLE
Add ability to name the remote when initially cloning it.

### DIFF
--- a/library/git
+++ b/library/git
@@ -71,13 +71,16 @@ def get_version(dest):
     sha = sha[0].split()[1]
     return sha
 
-def clone(repo, dest):
+def clone(repo, dest, remote):
     ''' makes a new git repo if it does not already exist '''
     try:
         os.makedirs(os.path.dirname(dest))
     except:
         pass
-    cmd = "git clone %s %s" % (repo, dest)
+    if remote:
+        cmd = "git clone -o %s %s %s" % (remote, repo, dest)
+    else:
+        cmd = "git clone %s %s" % (repo, dest)
     cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=tempfile.gettempdir())
     (out, err) = cmd.communicate()
     rc = cmd.returncode
@@ -235,7 +238,7 @@ def main():
     before = None
     local_mods = False
     if not os.path.exists(gitconfig):
-        (rc, out, err) = clone(repo, dest)
+        (rc, out, err) = clone(repo, dest, remote)
         if rc != 0:
             module.fail_json(msg=err)
     else:


### PR DESCRIPTION
Right now, when using the remote parameter to name the remote repo, it only gets used when switching to a version, but not at the initial clone.

say I have a task like this:
- git: repo=git://github.com/ansible/ansible.git dest=/opt/ansible/ansible-0.8/ version=release-0.8 force=yes remote=upstream
- First clone will have a remote 'origin'
- on the next run it will error on the not exisiting remote 'upstream'

I just tested that, and it fails:

TASK: [git repo=git://github.com/ansible/ansible.git dest=/opt/ansible/ansible-devel/ version=devel force=yes remote=upstream] ********************\* 
failed: [ansible-pr-1] => {"failed": true, "msg": "fatal: 'upstream' does not appear to be a git repository\nfatal: The remote end hung up unexpectedly\n"}

See also: 

https://groups.google.com/forum/?fromgroups=#!topic/ansible-project/55lVUxcV9Gk
