### PR TITLE
Make --oneline return one line (except with multiline output)

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -153,9 +153,9 @@ def command_generic_msg(hostname, result, oneline, caption):
         return buf + "\n"
     else:
         if stderr:
-            return "%s | %s | rc=%s | (stdout) %s (stderr) %s\n" % (hostname, caption, rc, stdout, stderr)
+            return "%s | %s | rc=%s | (stdout) %s (stderr) %s" % (hostname, caption, rc, stdout, stderr)
         else:
-            return "%s | %s | rc=%s | (stdout) %s\n" % (hostname, caption, rc, stdout)
+            return "%s | %s | rc=%s | (stdout) %s" % (hostname, caption, rc, stdout)
 
 def host_report_msg(hostname, module_name, result, oneline):
     ''' summarize the JSON results for a particular host '''


### PR DESCRIPTION
Currently the message prepared for --oneline mode adds a newline to the msg-string, which is then printed (adding another newline). This change removes the added newline so that successes and failures do not differ in output (except if the output is multiline).
