### PR TITLE
Add an "executable" option to the command and shell modules

### DIFF
--- a/library/shell
+++ b/library/shell
@@ -27,6 +27,12 @@ options:
       - cd into this directory before running the command (0.6 and later)
     required: false
     default: null
+  executable:
+    description:
+      - change the shell used to execute the command. Should be an absolute path to the executable.
+    required: false
+    default: null
+    version_added: "0.9"
 examples:
    - code: "shell: somescript.sh >> somelog.txt"
      description: Execute the command in remote shell


### PR DESCRIPTION
The option will be passed to the Popen object created and will be used to
execute the command instead of the default shell.

Patch applied to latest devel branch
