### PR TITLE
Documentation of svr4pkg module breaks 'make rpm'

### DIFF
--- a/library/svr4pkg
+++ b/library/svr4pkg
@@ -48,7 +48,7 @@ options:
   src:
     description:
       - Specifies the location to install the package from. Required when C(state=present).
-      - Can be any path acceptable to the C(pkgadd) command's C(-d) option. e.g.: C(somefile.pkg), C(/dir/with/pkgs), C(http:/server/mypkgs.pkg).
+      - "Can be any path acceptable to the C(pkgadd) command's C(-d) option. e.g.: C(somefile.pkg), C(/dir/with/pkgs), C(http:/server/mypkgs.pkg)."
       - If using a file or directory, they must already be accessible by the host. See the I(copy) module for a way to get them there.
   proxy:
     description:
@@ -57,7 +57,7 @@ options:
 examples:
   - code: svr4pkg name=CSWcommon src=/tmp/cswpkgs.pkg state=present
     description: Install a package from an already copied file
-  - code: svr4pkg name=CSWpkgutil src=http://get.opencsw.org/now state=present
+  - code: 'svr4pkg name=CSWpkgutil src=http://get.opencsw.org/now state=present'
     description: Install a package directly from an http site
   - code: svr4pkg name=SUNWgnome-sound-recorder state=absent
     description: Ensure that a package is not installed.


### PR DESCRIPTION
Without this fix, generating documentation results in:

```
Traceback (most recent call last):
  File "hacking/module_formatter.py", line 376, in <module>
    main()
  File "hacking/module_formatter.py", line 365, in main
    text = template.render(doc)
  File "/usr/lib64/python2.6/site-packages/jinja2/environment.py", line 669, in render
    return self.environment.handle_exception(exc_info, True)
  File "hacking/templates/man.j2", line 20, in top-level template code
    {% for desc in v.description %}@{ desc | jpfunc }@{% endfor %}
  File "hacking/module_formatter.py", line 94, in man_ify
    t = _ITALIC.sub(r'\\fI' + r"\1" + r"\\fR", text)
TypeError: expected string or buffer
```
