### PR TITLE
Fix to catch the json parse exception when output is broken

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -195,9 +195,8 @@ def parse_json(raw_data):
         results = {}
         try:
             tokens = shlex.split(data)
-        except:
-            print "failed to parse json: "+ data
-            raise
+        except Exception, e:
+            raise errors.AnsibleError("Failed to parse module output: %s (Module broken ? Network issues ? System died ?)\nJSON output: %s" % (str(e), data))
 
         for t in tokens:
             if t.find("=") == -1:


### PR DESCRIPTION
In the case a module returns broken output, we get a traceback. This patch replaces the traceback with a meaningfull error and an indication to what exactly could be the problem.
