### PR TITLE
Move get_docstring from module_formatter into ansible/utils

### DIFF
--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -29,12 +29,9 @@ import optparse
 import time
 import datetime
 import subprocess
-import traceback
+import ansible.utils
+from ansible.utils import module_docs
 
-# modules that are ok that they do not have documentation strings
-BLACKLIST_MODULES = [
-   'async_wrapper'
-]
 
 # Get parent directory of the directory this script lives in
 MODULEDIR=os.path.abspath(os.path.join(
@@ -132,28 +129,6 @@ def rst_xline(width, char="="):
 
 def load_examples_section(text):
     return text.split('***BREAK***')
-
-def get_docstring(filename, verbose=False):
-    """
-    Search for assignment of the DOCUMENTATION variable in the given file.
-    Parse that from YAML and return the YAML doc or None.
-    """
-
-    doc = None
-
-    try:
-        # Thank you, Habbie, for this bit of code :-)
-        M = ast.parse(''.join(open(filename)))
-        for child in M.body:
-            if isinstance(child, ast.Assign):
-                if 'DOCUMENTATION' in (t.id for t in child.targets):
-                    doc = yaml.load(child.value.s)
-
-    except:
-        traceback.print_exc()
-        print "unable to parse %s" % filename
-    return doc
-
 
 def return_data(text, options, outputname, module):
     if options.output_dir is not None:
@@ -326,9 +301,9 @@ def main():
                 js_data.append(j)
             continue
 
-        doc = get_docstring(fname, verbose=options.verbose)
+        doc = ansible.utils.module_docs.get_docstring(fname, verbose=options.verbose)
 
-        if doc is None and module not in BLACKLIST_MODULES:
+        if doc is None and module not in ansible.utils.module_docs.BLACKLIST_MODULES:
             sys.stderr.write("*** ERROR: CORE MODULE MISSING DOCUMENTATION: %s ***\n" % module)
             #sys.exit(1)
 

--- a/lib/ansible/utils/module_docs.py
+++ b/lib/ansible/utils/module_docs.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+import sys
+import ast
+import yaml
+import traceback
+
+# modules that are ok that they do not have documentation strings
+BLACKLIST_MODULES = [
+   'async_wrapper',
+]
+
+def get_docstring(filename, verbose=False):
+    """
+    Search for assignment of the DOCUMENTATION variable in the given file.
+    Parse that from YAML and return the YAML doc or None.
+    """
+
+    doc = None
+
+    try:
+        # Thank you, Habbie, for this bit of code :-)
+        M = ast.parse(''.join(open(filename)))
+        for child in M.body:
+            if isinstance(child, ast.Assign):
+                if 'DOCUMENTATION' in (t.id for t in child.targets):
+                    doc = yaml.load(child.value.s)
+
+    except:
+        traceback.print_exc()
+        print "unable to parse %s" % filename
+    return doc

--- a/library/ec2
+++ b/library/ec2
@@ -86,10 +86,8 @@ options:
 examples:
    - code: "local_action: ec2 keypair=admin instance_type=m1.large image=emi-40603AD1 wait=true group=webserver"
      description: "Examples from Ansible Playbooks"
-   - code: 
 requirements: [ "euca2ools" ]
 author: Seth Vidal
-
 '''
 
 import euca2ools.commands.euca.runinstances


### PR DESCRIPTION
This moves get_docstring() from the module_formatter into ansible/utils, as discussed in #1572

Furthermore, fixes broken DOCUMENTATION string in module `ec2`. 
