### PR TITLE
minor freebsd user fixes

### DIFF
--- a/library/user
+++ b/library/user
@@ -551,7 +551,7 @@ class FreeBsdUser(User):
         # create the user
         (rc, out, err) = self.execute_command(cmd)
         if rc is not None and rc != 0:
-            module.fail_json(name=self.name, msg=err, rc=rc)
+            self.module.fail_json(name=self.name, msg=err, rc=rc)
 
         # we have to set the password in a second command
         if self.password is not None:
@@ -600,7 +600,7 @@ class FreeBsdUser(User):
             groups = self.groups.split(',')
             for g in groups:
                 if not self.group_exists(g):
-                    module.fail_json(msg="Group %s does not exist" % (g))
+                    self.module.fail_json(msg="Group %s does not exist" % (g))
 
             group_diff = set(sorted(current_groups)).symmetric_difference(set(sorted(groups)))
             groups_need_mod = False
@@ -618,14 +618,14 @@ class FreeBsdUser(User):
                 cmd.append('-G')
                 new_groups = groups
                 if self.append:
-                    new_groups.append(current_groups)           
+                    new_groups.extend(current_groups)           
                 cmd.append(','.join(new_groups))
 
         # modify the user if cmd will do anything
         if cmd_len != len(cmd):
             (rc, out, err) = self.execute_command(cmd)
             if rc is not None and rc != 0:
-                module.fail_json(name=self.name, msg=err, rc=rc)
+                self.module.fail_json(name=self.name, msg=err, rc=rc)
         else:
             (rc, out, err) = (None, '', '')
 


### PR DESCRIPTION
add 'self' to the module.fail_json calls that had it missing in the freebsd subclass. There are other calls to module.fail_json in the user module that aren't using 'self'. I haven't had a chance to test yet if they should all have it or not. But it did appear to need them on the solaris subclass so I assumed it needed them on the freebsd subclass as well.

The other fix is to replace an 'append' with an 'extend' since the append was appending a list to a string instead of extending the string with the list items.
