### PR TITLE
Add ability to specify syslog facility for modules

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -35,6 +35,7 @@ import traceback
 import optparse
 import ansible.utils as utils
 import ansible.module_common as module_common
+import ansible.constants as C
 
 try:
     import json
@@ -83,6 +84,7 @@ def boilerplate_module(modfile, args):
         module_data = module_data.replace(module_common.REPLACER, module_common.MODULE_COMMON)
         encoded_args = "\"\"\"%s\"\"\"" % args.replace("\"","\\\"")
         module_data = module_data.replace(module_common.REPLACER_ARGS, encoded_args)
+        module_data = module_data.replace('syslog.LOG_USER', "syslog.%s" % C.DEFAULT_SYSLOG_FACILITY)
 
         modfile2_path = os.path.expanduser("~/.ansible_module_generated")
         print "* including generated source, if any, saving to: %s" % modfile2_path

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -88,6 +88,7 @@ DEFAULT_REMOTE_PORT       = int(get_config(p, DEFAULTS, 'remote_port',      'ANS
 DEFAULT_TRANSPORT         = get_config(p, DEFAULTS, 'transport',        'ANSIBLE_TRANSPORT',        'paramiko')
 DEFAULT_SCP_IF_SSH        = get_config(p, DEFAULTS, 'scp_if_ssh',       'ANSIBLE_SCP_IF_SSH',       False)
 DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')
+DEFAULT_SYSLOG_FACILITY   = get_config(p, DEFAULTS, 'syslog_facility',  'ANSIBLE_SYSLOG_FACILITY', 'LOG_USER')
 
 DEFAULT_ACTION_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'action_plugins',     None, '/usr/share/ansible_plugins/action_plugins'))
 DEFAULT_CALLBACK_PLUGIN_PATH   = shell_expand_path(get_config(p, DEFAULTS, 'callback_plugins',   None, '/usr/share/ansible_plugins/callback_plugins'))

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -539,7 +539,7 @@ class AnsibleModule(object):
             journal.sendv(*journal_args)
         else:
             msg = ''
-            syslog.openlog('ansible-%s' % os.path.basename(__file__))
+            syslog.openlog('ansible-%s' % os.path.basename(__file__), 0, syslog.LOG_USER)
             for arg in log_args:
                 msg = msg + arg + '=' + str(log_args[arg]) + ' '
             if msg:

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -531,6 +531,11 @@ class Runner(object):
             module_data = module_data.replace(module_common.REPLACER, module_common.MODULE_COMMON)
             encoded_args = "\"\"\"%s\"\"\"" % module_args.replace("\"","\\\"")
             module_data = module_data.replace(module_common.REPLACER_ARGS, encoded_args)
+            if is_new_style:
+                facility = C.DEFAULT_SYSLOG_FACILITY
+                if 'ansible_syslog_facility' in inject:
+                    facility = inject['ansible_syslog_facility']
+                module_data = module_data.replace('syslog.LOG_USER', "syslog.%s" % facility)
 
         # use the correct python interpreter for the host
         if 'ansible_python_interpreter' in inject:


### PR DESCRIPTION
Update constants.py so that one can specify environmental variable
ANSIBLE_SYSLOG_FACILITY or syslog_facility in ansible.cfg to define
the syslog facility to use.  Alternatively, you can specify
ansible_syslog_facility in inventory.  Runner now replaces
the syslog facility in the openlog() call with the default or
the injected variables ansible_syslog_facility.

This also updates hacking/test-module to behave similarly.

See issue #1342
