### PR TITLE
Basic OpenBSD support for service module

### DIFF
--- a/library/service
+++ b/library/service
@@ -75,6 +75,8 @@ INITCTL = None
 INITSCRIPT = None
 RCCONF = None
 
+SYSTEM = platform.system()
+
 PS_OPTIONS = 'auxww'
 
 def _find_binaries(m,name):
@@ -192,6 +194,14 @@ def _get_service_status(name, pattern):
         elif 'dead but pid file exists' in cleanout:
             running = False
 
+    # if this is OpenBSD use rc.d check
+    if SYSTEM == 'OpenBSD':
+        initscript_rc, initscript_status_stdout, initscript_status_stderr = _run("%s check" % (INITSCRIPT))
+        if initscript_rc == 0:
+             running = True
+        if initscript_rc == 1:
+             running = False
+
     # if the job status is still not known check it by special conditions
     if running == None:
         if name == 'iptables' and status_stdout.find("ACCEPT") != -1:
@@ -223,22 +233,28 @@ def _do_enable(name, enable):
         rc = "NO"
 
     if RCCONF:
-        entry = "%s_enable" % name
-        full_entry = '%s="%s"' % (entry,rc)
-        rc = open(RCCONF,"r+")
-        rctext = rc.read()
-        if re.search("^%s" % full_entry,rctext,re.M) is None:
-            if re.search("^%s" % entry,rctext,re.M) is None:
-                rctext += "\n%s" % full_entry
-            else:
-                rctext = re.sub("^%s.*" % entry,full_entry,rctext,1,re.M)
-            rc.truncate(0)
-            rc.seek(0)
-            rc.write(rctext)
-        rc.close()
+        # OpenBSD uses <service>_flags which is not always boolean
+        if SYSTEM == 'OpenBSD':
+            rc = 1
+            stderr = 'enable not supported on OpenBSD'
+            stdout = ''
+        else:
+            entry = "%s_enable" % name
+            full_entry = '%s="%s"' % (entry,rc)
+            rc = open(RCCONF,"r+")
+            rctext = rc.read()
+            if re.search("^%s" % full_entry,rctext,re.M) is None:
+                if re.search("^%s" % entry,rctext,re.M) is None:
+                    rctext += "\n%s" % full_entry
+                else:
+                    rctext = re.sub("^%s.*" % entry,full_entry,rctext,1,re.M)
+                rc.truncate(0)
+                rc.seek(0)
+                rc.write(rctext)
+            rc.close()
 
-        rc=0
-        stderr=stdout=''
+            rc=0
+            stderr=stdout=''
     else:
         if CHKCONFIG.endswith("update-rc.d"):
             args = (CHKCONFIG, name, enable_disable)

--- a/library/service
+++ b/library/service
@@ -285,7 +285,7 @@ def main():
 
     # Set PS options here if 'ps auxww' will not work on
     # target platform
-    if platform.system() == 'SunOS':
+    if SYSTEM == 'SunOS':
         global PS_OPTIONS
         PS_OPTIONS = '-ef'
 
@@ -335,7 +335,7 @@ def main():
         # run change commands if we need to
         if changed:
 
-            if platform.system() == 'FreeBSD':
+            if SYSTEM == 'FreeBSD':
                 start = "onestart"
                 stop = "onestop"
                 reload = "onereload"


### PR DESCRIPTION
Output without patch against OpenBSD client:

```
# ansible -v all -m service -a 'name=httpd state=running'
hostname | FAILED >> {
    "changed": false,
    "failed": true,
    "msg": "failed determining the current service state => state stays unchanged"
}
```

Not sure if my approach with disabling the "enabled" feature is the "right way" to do it, but I figured it is better than adding broken lines to rc.conf (also OpenBSD uses /etc/rc.conf.local for local modifications).
