### PR TITLE
remove verbose option on digest call

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -463,7 +463,7 @@ class Runner(object):
         md5s = [
             "(/usr/bin/md5sum %s 2>/dev/null)" % path,
             "(/sbin/md5sum -q %s 2>/dev/null)" % path,
-            "(/usr/bin/digest -a md5 -v %s 2>/dev/null)" % path
+            "(/usr/bin/digest -a md5 %s 2>/dev/null)" % path
         ]
 
         cmd = " || ".join(md5s)


### PR DESCRIPTION
The fetch module wasn't working on solaris 10 because the call to the digest command was using the "verbose" option, which was causing the md5 checksum to be displayed in the wrong field. Removing the verbose option fixes that and fetch module now works as expected on solaris 10.
