### PR TITLE
Template using module_vars early

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -149,6 +149,9 @@ class Task(object):
             # allow the user to list comma delimited tags
             import_tags = import_tags.split(",")
 
+        self.name = utils.template(None, self.name, self.module_vars)
+        self.action = utils.template(None, self.action, self.module_vars)
+
         # handle mutually incompatible options
         incompatibles = [ x for x in [ self.first_available_file, self.items_lookup_plugin ] if x is not None ]
         if len(incompatibles) > 1:

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -215,7 +215,8 @@ def template(basedir, text, vars, expand_lists=False):
     except UnicodeEncodeError:
         pass # already unicode
     text = varReplace(unicode(text), vars, expand_lists=expand_lists)
-    text = _varReplaceLookups(basedir, text, vars)
+    if basedir is not None:
+        text = _varReplaceLookups(basedir, text, vars)
     return text
 
 def template_from_file(basedir, path, vars):


### PR DESCRIPTION
Since no basedir is available at that time, avoid invoking
lookup plugins since they assume it is present.
