### PR TITLE
add bsd md5 support to fetch module

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -461,9 +461,12 @@ class Runner(object):
 
         test = "rc=0; [ -r \"%s\" ] || rc=2; [ -f \"%s\" ] || rc=1" % (path,path)
         md5s = [
-            "(/usr/bin/md5sum %s 2>/dev/null)" % path,
-            "(/sbin/md5sum -q %s 2>/dev/null)" % path,
-            "(/usr/bin/digest -a md5 %s 2>/dev/null)" % path
+            "(/usr/bin/md5sum %s 2>/dev/null)" % path,  # Linux
+            "(/sbin/md5sum -q %s 2>/dev/null)" % path,  # ?
+            "(/usr/bin/digest -a md5 %s 2>/dev/null)" % path,   # Solaris 10+
+            "(/sbin/md5 -q %s 2>/dev/null)" % path,     # Freebsd
+            "(/usr/bin/md5 -n %s 2>/dev/null)" % path,  # Netbsd
+            "(/bin/md5 -q %s 2>/dev/null)" % path       # Openbsd
         ]
 
         cmd = " || ".join(md5s)


### PR DESCRIPTION
I fired up openbsd, netbsd and freebsd VM's and found they all use the md5 command to check md5 checksums. They all have it in different places though and one uses a different switch. Long story short, I updated the code to be able to deal with all the BSD variations. I also put comments on which lines are for which OS's.
