### PR TITLE
Print the task name (if any) when complaining

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -87,7 +87,7 @@ class Task(object):
             raise errors.AnsibleError("the 'action' and 'local_action' attributes can not be used together")
         # Both are NOT defined
         elif (not 'action' in ds) and (not 'local_action' in ds):
-            raise errors.AnsibleError("task missing an 'action' attribute")
+            raise errors.AnsibleError("'action' or 'local_action' attribute missing in task \"%s\"" % ds.get('name', '<Unnamed>'))
         # Only one of them is defined
         elif 'local_action' in ds:
             self.action      = ds.get('local_action', '')


### PR DESCRIPTION
After spending 10 minutes to find which playbook had an action/local_action missing, I changed the error to include the task name (if set). The error eventually was caused because I added a name to a task, but the dash before the existing action was not removed.
