### PR TITLE
Do not register variable if host has been skipped

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -298,6 +298,9 @@ class PlayBook(object):
 
         # add facts to the global setup cache
         for host, result in contacted.iteritems():
+            # Skip register variable if host is skipped
+            if result.get('skipped', False):
+                continue
             facts = result.get('ansible_facts', {})
             self.SETUP_CACHE[host].update(facts)
             if task.register:


### PR DESCRIPTION
Executive summary: skipping a host corrupts a variable (when it is registered)

We have a play existing out of multiple tasks that check a condition, if one of these tasks fails we want to skip all next tasks in the playbook. I noticed that if we skip a task because a certain condition is met, and this task has a register-attribute, I loose the value in the variable. Which means we cannot use that variable in subsequent tasks to evaluate because it was skipped:

```
- action: command test -d /some/directory
  register: task

- action: command test -f /some/directory/file
  register: task
  only_if: '${task.rc} == 0'

- action: do something else
  only_if: '${task.rc} == 0'
```

In the above example, if the second task is skipped (because the first failed), the third action will end with a "SyntaxError: invalid syntax" complaining about the unsubstituted ${task.rc} (even though it was set by the first task and used for skipping the second).

The following play demonstrates the problem:

```
- name: Test register on ignored tasks
  hosts: all
  gather_facts: no

  vars:
    skip: true
    task: { 'rc': 666 }

  tasks:
  - action: debug msg='skip = ${skip}, task.rc = ${task.rc}'

  - name: Skip this task, just to test if task has changed
    action: command ls
    register: task
    only_if: '${skip} != True'

  - action: debug msg='skip = ${skip}, task.rc = ${task.rc}'

  - name: Now use task value
    action: command echo 'Works !'
    only_if: '${task.rc} == 0'
```

And the enclosed fix, fixes the above problem.
