### PR TITLE
Fail ansible-playbook when the hosts list (with applied subset) is empty

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -68,6 +68,11 @@ def main(args):
         parser.print_help(file=sys.stderr)
         return 1
 
+    inventory = ansible.inventory.Inventory(options.inventory)
+    inventory.subset(options.subset)
+    if len(inventory.list_hosts()) == 0:
+        raise errors.AnsibleError("provided hosts list is empty")
+
     sshpass = None
     sudopass = None
     if not options.listhosts:


### PR DESCRIPTION
When the inventory is empty, or the provided --limit subset returns an empty intersection, we don't want to loop over all plays but bail out at the very start.
