### PR TITLE
Updates Arch linux packaging files

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,13 +1,16 @@
 #Maintainer: Michel Blanc <mblanc@erasme.org>
 pkgname=ansible-git
-pkgver=20120419
+pkgver=20121116
 pkgrel=1
 pkgdesc="A radically simple deployment, model-driven configuration management, and command execution framework"
 arch=('any')
 url="https://github.com/ansible/ansible"
 license=('GPL3')
-depends=('python2' 'python2-yaml' 'python-paramiko>=1.7.7' 'python2-jinja' 'python-simplejson')
+depends=('python2' 'python2-yaml' 'python2-paramiko' 'python2-jinja' 'python-simplejson' 'python2-yaml')
 makedepends=('git' 'asciidoc' 'fakeroot')
+conflicts=('ansible')
+source=("python-binary.diff")
+md5sums=("8f1eb942a01bbf206dbe32bded8725c6")
 
 _gitroot="https://github.com/ansible/ansible"
 _gitname="ansible"
@@ -25,7 +28,9 @@ build() {
 
   msg "GIT checkout done or server timeout"
 
+
   cd "$srcdir/$_gitname"
+  patch -p1 -i $srcdir/python-binary.diff
   make
 }
 
@@ -34,9 +39,11 @@ package() {
 
   mkdir -p ${pkgdir}/usr/share/ansible
   cp ./library/* ${pkgdir}/usr/share/ansible/
-  python setup.py install -O1 --root=${pkgdir}
+  python2 setup.py install -O1 --root=${pkgdir}
 
-  install docs/man/man1/*.1 ${pkgdir}/usr/share/man/man1/
+  install -D docs/man/man1/ansible.1 ${pkgdir}/usr/share/man/man1/ansible.1
+  install -D docs/man/man1/ansible-playbook.1 ${pkgdir}/usr/share/man/man1/ansible-playbook.1
 
-  gzip -9 ${pkgdir}/usr/share/man/man1/*.1
+  gzip -9 ${pkgdir}/usr/share/man/man1/ansible.1
+  gzip -9 ${pkgdir}/usr/share/man/man1/ansible-playbook.1
 }

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -1,0 +1,13 @@
+Arch Packaging Files
+--------------------
+
+The PKGBUILD and patch in this directory are here for reference.
+You should use AUR to install [ansible-git][1], using `yaourt` for instance :
+
+    yaourt -S ansible-git
+
+You can also find a stable AUR package for the stable version of [ansible][1].
+
+  [1]: https://github.com/ramaze/ramaze
+  [2]: https://github.com/paulasmuth/fnordmetric
+

--- a/packaging/arch/python-binary.diff
+++ b/packaging/arch/python-binary.diff
@@ -1,0 +1,30 @@
+Les fichiers binaires ansible.orig/.git/index et ansible/.git/index sont différents
+diff -uNr ansible.orig/Makefile ansible/Makefile
+--- ansible.orig/Makefile	2012-11-16 09:30:00.232106580 +0100
++++ ansible/Makefile	2012-11-16 09:31:06.606482546 +0100
+@@ -24,7 +24,7 @@
+ ASCII2HTMLMAN = a2x -D docs/html/man/ -d manpage -f xhtml
+ MANPAGES := docs/man/man1/ansible.1 docs/man/man1/ansible-playbook.1 docs/man/man1/ansible-pull.1
+ 
+-SITELIB = $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
++SITELIB = $(shell python2 -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
+ 
+ # VERSION file provides one place to update the software version
+ VERSION := $(shell cat VERSION)
+@@ -111,13 +111,13 @@
+ 	rm -rf docs/js
+ 
+ python:
+-	python setup.py build
++	python2 setup.py build
+ 
+ install:
+-	python setup.py install
++	python2 setup.py install
+ 
+ sdist: clean docs
+-	python setup.py sdist -t MANIFEST.in
++	python2 setup.py sdist -t MANIFEST.in
+ 
+ rpmcommon: sdist
+ 	@mkdir -p rpm-build


### PR DESCRIPTION
Added a README.md to explain the purpose of the directory
Fixed dependencies in PKGBUILD
Added patch to change python binary name for arch users, so they
don't end up using python 3 (python links to python3 by default on arch
linux).
