### PR TITLE
Use plugin system for modules

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -68,7 +68,7 @@ class Inventory(object):
                 host_list = [ h for h in host_list if h and h.strip() ]
 
         else:
-            utils.plugins.push_basedir(self.basedir())
+            utils.plugins.vars_loader.add_directory(self.basedir())
 
         if type(host_list) == list:
             all = Group('all')

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -44,7 +44,7 @@ class PlayBook(object):
     def __init__(self,
         playbook         = None,
         host_list        = C.DEFAULT_HOST_LIST,
-        module_path      = C.DEFAULT_MODULE_PATH,
+        module_path      = None,
         forks            = C.DEFAULT_FORKS,
         timeout          = C.DEFAULT_TIMEOUT,
         remote_user      = C.DEFAULT_REMOTE_USER,
@@ -110,17 +110,11 @@ class PlayBook(object):
         self.inventory           = ansible.inventory.Inventory(host_list)
         self.inventory.subset(subset)
 
-        self.modules_list        = utils.get_available_modules(self.module_path)
-
         if not self.inventory._is_script:
             self.global_vars.update(self.inventory.get_group_variables('all'))
 
         self.basedir     = os.path.dirname(playbook)
         (self.playbook, self.play_basedirs) = self._load_playbook_from_file(playbook)
-        self.module_path = self.module_path + os.pathsep + os.path.join(self.basedir, "library")
-
-        for i in self.play_basedirs:
-            utils.plugins.push_basedir(i)
 
     # *****************************************************
 
@@ -137,6 +131,7 @@ class PlayBook(object):
             raise errors.AnsibleError("parse error: playbooks must be formatted as a YAML list")
 
         basedir = os.path.dirname(path)
+        utils.plugins.push_basedir(basedir)
         for play in playbook_data:
             if type(play) != dict:
                 raise errors.AnsibleError("parse error: each play in a playbook must a YAML dictionary (hash), recieved: %s" % play)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -44,7 +44,7 @@ class Task(object):
         for x in ds.keys():
 
             # code to allow for saying "modulename: args" versus "action: modulename args"
-            if x in play.playbook.modules_list:
+            if x in utils.plugins.module_finder:
                 ds['action'] = x + " " + ds[x]
                 ds.pop(x)
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -151,6 +151,8 @@ class Runner(object):
         if self.transport == 'local':
             self.remote_user = pwd.getpwuid(os.geteuid())[0]
 
+        utils.plugins.push_basedir(self.basedir)
+
         # ensure we are using unique tmp paths
         random.seed()
 

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -463,20 +463,6 @@ def filter_leading_non_json_lines(buf):
             filtered_lines.write(line + '\n')
     return filtered_lines.getvalue()
 
-def get_available_modules(dirname=None):
-    """
-    returns a list of modules available based on current directory
-    looks in DEFAULT_MODULE_PATH, all subfolders named library and
-    -M option"""
-    modules_list = set()
-    if dirname is None:
-        dirname = C.DEFAULT_MODULE_PATH
-    for path in dirname.split(os.pathsep):
-        if os.path.exists(path):
-            modules_list.update(os.listdir(path))
-    modules_list = list(modules_list)
-    return modules_list
-
 def boolean(value):
     val = str(value)
     if val.lower() in [ "true", "t", "y", "1", "yes" ]:

--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -46,29 +46,43 @@ class PluginLoader(object):
 
     def _get_package_path(self):
         """Gets the path of a Python package"""
+        if not self.package:
+            return []
         if not hasattr(self, 'package_path'):
             m = __import__(self.package)
             parts = self.package.split('.')[1:]
             self.package_path = os.path.join(os.path.dirname(m.__file__), *parts)
-        return self.package_path
+        return [self.package_path]
 
     def _get_paths(self):
         """Return a list of paths to search for plugins in
 
         The list is searched in order."""
-        return self._extra_dirs +
-            [os.path.join(basedir, self.subdir) for basedir in _basedirs] +
-            self.config.split(os.pathsep) +
-            [self._get_package_path()]
+        return self._extra_dirs + \
+            [os.path.join(basedir, self.subdir) for basedir in _basedirs] + \
+            self.config.split(os.pathsep) + \
+            self._get_package_path()
 
     def add_directory(self, directory):
         """Adds an additional directory to the search path"""
         self._extra_dirs.append(directory)
 
+    def print_paths(self):
+        """Returns a string suitable for printing of the search path"""
+        # Uses a list to get the order right
+        ret = []
+        for i in self._get_paths():
+            if i not in ret:
+                ret.append(i)
+        return os.pathsep.join(ret)
+
     def find_plugin(self, name):
         """Find a plugin named name"""
+        suffix = ".py"
+        if not self.class_name:
+            suffix = ""
         for i in self._get_paths():
-            path = os.path.join(i, "%s.py" % name)
+            path = os.path.join(i, "%s%s" % (name, suffix))
             if os.path.exists(path):
                 return path
         return None
@@ -101,6 +115,7 @@ class PluginLoader(object):
 action_loader     = PluginLoader('ActionModule',   'ansible.runner.action_plugins',     C.DEFAULT_ACTION_PLUGIN_PATH,     'action_plugins')
 callback_loader   = PluginLoader('CallbackModule', 'ansible.callback_plugins',          C.DEFAULT_CALLBACK_PLUGIN_PATH,   'callback_plugins')
 connection_loader = PluginLoader('Connection',     'ansible.runner.connection_plugins', C.DEFAULT_CONNECTION_PLUGIN_PATH, 'connection_plugins', aliases={'paramiko': 'paramiko_ssh'})
+module_finder     = PluginLoader('',               '',                                  C.DEFAULT_MODULE_PATH,            'library')
 lookup_loader     = PluginLoader('LookupModule',   'ansible.runner.lookup_plugins',     C.DEFAULT_LOOKUP_PLUGIN_PATH,     'lookup_plugins')
 vars_loader       = PluginLoader('VarsModule',     'ansible.inventory.vars_plugins',    C.DEFAULT_VARS_PLUGIN_PATH,       'vars_plugins')
 filter_loader     = PluginLoader('FilterModule',   'ansible.runner.filter_plugins',     C.DEFAULT_FILTER_PLUGIN_PATH,     'filter_plugins')

--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -42,6 +42,7 @@ class PluginLoader(object):
         self.subdir = subdir
         self.aliases = aliases
         self._module_cache = {}
+        self._extra_dirs = []
 
     def _get_package_path(self):
         """Gets the path of a Python package"""
@@ -55,7 +56,14 @@ class PluginLoader(object):
         """Return a list of paths to search for plugins in
 
         The list is searched in order."""
-        return [os.path.join(basedir, self.subdir) for basedir in _basedirs] + self.config.split(os.pathsep) + [self._get_package_path()]
+        return self._extra_dirs +
+            [os.path.join(basedir, self.subdir) for basedir in _basedirs] +
+            self.config.split(os.pathsep) +
+            [self._get_package_path()]
+
+    def add_directory(self, directory):
+        """Adds an additional directory to the search path"""
+        self._extra_dirs.append(directory)
 
     def find_plugin(self, name):
         """Find a plugin named name"""


### PR DESCRIPTION
This makes module finding use the same code as everything else that deals with basedirs and plugins. This fixes

```
tasks:
- custom: arguments
```

as it would previously not add local modules to its list of available modules, made especially confusing by it listing said path in the error message.

It also adds a few other features, such as using modules from your current directory/library when using ansible, so you don't have to make a playbook to run your own modules or specify -M `pwd`/library every time.
