### PR TITLE
Use runner's basedir as cwd for -c local

### DIFF
--- a/lib/ansible/runner/connection_plugins/local.py
+++ b/lib/ansible/runner/connection_plugins/local.py
@@ -48,7 +48,7 @@ class Connection(object):
             cmd = "sudo -u {0} -s {1}".format(sudo_user, cmd)
 
         vvv("EXEC %s" % cmd, host=self.host)
-        p = subprocess.Popen(cmd, shell=True, stdin=None,
+        p = subprocess.Popen(cmd, cwd=self.runner.basedir, shell=True, stdin=None,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
         return ("", stdout, stderr)


### PR DESCRIPTION
This ensures that local_action commands have the same path requirements as other modules. It does however change how -c local works a little bit...
