### PR TITLE
Allow the remote port to be templated per play

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -69,7 +69,7 @@ class Play(object):
         self._tasks       = ds.get('tasks', [])
         self._handlers    = ds.get('handlers', [])
         self.remote_user  = utils.template(basedir, ds.get('user', self.playbook.remote_user), self.vars)
-        self.remote_port  = ds.get('port', self.playbook.remote_port)
+        self.remote_port  = utils.template(basedir, ds.get('port', self.playbook.remote_port), self.vars)
         self.sudo         = ds.get('sudo', self.playbook.sudo)
         self.sudo_user    = utils.template(basedir, ds.get('sudo_user', self.playbook.sudo_user), self.vars)
         self.transport    = ds.get('connection', self.playbook.transport)


### PR DESCRIPTION
This was requested on the mailinglist and seems useful.

So you can basically do:

```
 - name: Some play
   hosts: web-servers
   port: ${ssh_port}
```
