### PR TITLE
Provide a proper error when the remote_port is not an integer

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -382,6 +382,11 @@ class Runner(object):
         try:
             if actual_port is not None:
                 actual_port = int(actual_port)
+        except ValueError, e:
+            result = dict(failed=True, msg="FAILED: Configured port \"%s\" is not a valid port, expected integer" % actual_port)
+            return ReturnData(host=host, comm_ok=False, result=result)
+
+        try:
             conn = self.connector.connect(actual_host, actual_port)
             if delegate_to or host != actual_host:
                 conn.delegate = host


### PR DESCRIPTION
As reported on the mailinglist, the user received a ValueError when the port number was not templated (fixed in #1649) and therefore it was not an integer. This change will catch the exception and provide a proper error so it is more clear.

Before:

```
fatal: [moria] => Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/ansible/runner/__init__.py", line 233, in _executor
    exec_rc = self._executor_internal(host)
  File "/usr/lib/python2.6/site-packages/ansible/runner/__init__.py", line 289, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port)
  File "/usr/lib/python2.6/site-packages/ansible/runner/__init__.py", line 381, in _executor_internal_inner
    actual_port = int(actual_port)
ValueError: invalid literal for int() with base 10: 'abc'
```

After:

```
fatal: [moria] => {'msg': 'FAILED: Configured port "abc" is not a valid port, expected integer', 'failed': True}
```
