### PR TITLE
Delay templating of port

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -69,7 +69,7 @@ class Play(object):
         self._tasks       = ds.get('tasks', [])
         self._handlers    = ds.get('handlers', [])
         self.remote_user  = utils.template(basedir, ds.get('user', self.playbook.remote_user), self.vars)
-        self.remote_port  = utils.template(basedir, ds.get('port', self.playbook.remote_port), self.vars)
+        self.remote_port  = ds.get('port', self.playbook.remote_port)
         self.sudo         = ds.get('sudo', self.playbook.sudo)
         self.sudo_user    = utils.template(basedir, ds.get('sudo_user', self.playbook.sudo_user), self.vars)
         self.transport    = ds.get('connection', self.playbook.transport)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -351,9 +351,9 @@ class Runner(object):
 
         conn = None
         actual_host = inject.get('ansible_ssh_host', host)
-        actual_port = port
+        actual_port = utils.template(self.basedir, port, inject)
         if self.transport in [ 'paramiko', 'ssh' ]:
-            actual_port = inject.get('ansible_ssh_port', port)
+            actual_port = inject.get('ansible_ssh_port', actual_port)
 
         # the delegated host may have different SSH port configured, etc
         # and we need to transfer those, and only those, variables


### PR DESCRIPTION
Otherwise it cannot use the host_vars/group_vars and only takes into account playbook variables.
