### PR TITLE
CLI: ansible-doc shows lists of modules & module docs on command-line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ OS = $(shell uname -s)
 # directory of the target file ($@), kinda like `dirname`.
 ASCII2MAN = a2x -D $(dir $@) -d manpage -f manpage $<
 ASCII2HTMLMAN = a2x -D docs/html/man/ -d manpage -f xhtml
-MANPAGES := docs/man/man1/ansible.1 docs/man/man1/ansible-playbook.1 docs/man/man1/ansible-pull.1
+MANPAGES := docs/man/man1/ansible.1 docs/man/man1/ansible-playbook.1 docs/man/man1/ansible-pull.1 docs/man/man1/ansible-doc.1
 
 SITELIB = $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
 

--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 # (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
 #
 # This file is part of Ansible
@@ -33,11 +34,7 @@ from ansible import errors
 from ansible.utils import module_docs
 import ansible.constants as C
 
-
-# Get parent directory of the directory this script lives in
-MODULEDIR=os.path.abspath(os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), os.pardir, 'library'
-    ))
+MODULEDIR = C.DEFAULT_MODULE_PATH
 
 T_LISTING = '''{{ "%-20s" | format(module) }}  {{ short_description | jpfunc | truncate(70) }}'''
 
@@ -58,10 +55,10 @@ T_MODULEDOC = '''
 {% endfor %}
 
 {% if options %}
-   Options:
+   Options (= is mandatory):
 {% for k in option_keys %}
 {% set v = options[k] %}
-   o {{ k }}
+    {% if v.get('required', False) %}={% else %}-{% endif %} {{ k }}
 {% for desc in v.description %}{{ desc|jpfunc| wordwrap(width=60)|indent(10,indentfirst=True) }}
 {% endfor %}
          {% if v.get('choices') %} Choices : {% for choice in v.get('choices',[]) %}{{ choice }}{% if not loop.last %},{%else%}.{%endif%}{% endfor %}
@@ -85,9 +82,6 @@ Note: {% for note in notes %}
 {% endif %}
 '''
 
-# There is a better way of doing this!
-# TODO: somebody add U(text, http://foo.bar/) as described by Tim in #991
-
 _ITALIC = re.compile(r"I\(([^)]+)\)")
 _BOLD   = re.compile(r"B\(([^)]+)\)")
 _MODULE = re.compile(r"M\(([^)]+)\)")
@@ -96,11 +90,11 @@ _CONST  = re.compile(r"C\(([^)]+)\)")
 
 def tty_ify(text):
 
-    t = _ITALIC.sub("_" + r"\1" + "_", text)
-    t = _BOLD.sub("*" + r"\1" + "*", t)
-    t = _MODULE.sub("[" + r"\1" + "]", t)
-    t = _URL.sub(r"\1", t)
-    t = _CONST.sub("`" + r"\1" + "'", t)
+    t = _ITALIC.sub("`" + r"\1" + "'", text)    # `word'
+    t = _BOLD.sub("*" + r"\1" + "*", t)         # *word*
+    t = _MODULE.sub("[" + r"\1" + "]", t)       # [word]
+    t = _URL.sub(r"\1", t)                      # word
+    t = _CONST.sub("`" + r"\1" + "'", t)        # `word'
 
     return t
 
@@ -148,9 +142,12 @@ def main():
         # list all modules
         ls_templ = env.from_string(T_LISTING)
         paths = utils.plugins.module_finder._get_paths()
+	module_list = []
         for path in paths:
             # os.system("ls -C %s" % (path))
             for module in os.listdir(path):
+	    	module_list.append(module)
+	for module in sorted(module_list):
                 filename = utils.plugins.module_finder.find_plugin(module)
 
                 try:
@@ -159,10 +156,10 @@ def main():
                     print text.rstrip()
                 except:
                     pass
-            
+
         sys.exit()
 
-    tmpl = env.from_string(T_SNIPPET)
+    snip_tmpl = env.from_string(T_SNIPPET)
     full_tmpl = env.from_string(T_MODULEDOC)
 
     for module_name in options.module_list:
@@ -187,14 +184,14 @@ def main():
             for (k,v) in doc['options'].iteritems():
                 all_keys.append(k)
             all_keys = sorted(all_keys)
-            doc['option_keys'] = all_keys 
+            doc['option_keys'] = all_keys
 
             doc['filename']         = filename
             doc['docuri']           = doc['module'].replace('_', '-')
             doc['now_date']         = datetime.date.today().strftime('%Y-%m-%d')
 
         if options.show_snippet:
-            text = tmpl.render(doc)
+            text = snip_tmpl.render(doc)
             print text.rstrip()
         else:
             text = full_tmpl.render(doc)

--- a/docs/man/man1/ansible-doc.1.asciidoc.in
+++ b/docs/man/man1/ansible-doc.1.asciidoc.in
@@ -1,0 +1,70 @@
+ansible-doc(1)
+=========
+:doctype:manpage
+:man source:   Ansible
+:man version:  %VERSION%
+:man manual:   System administration commands
+
+NAME
+----
+ansible-doc - show documentation on Ansible modules
+
+
+SYNOPSIS
+--------
+ansible-doc [-M module_dir] [-l] [-s] [-m module]
+
+
+DESCRIPTION
+-----------
+
+*ansible-doc* displays information on modules installed in Ansible
+libraries. It displays a terse listing of modules and their short
+descriptions, provides a printout of their DOCUMENTATION strings,
+and it can create a short "snippet" which can be pasted into a
+playbook.
+
+
+OPTIONS
+-------
+
+*-M* 'directory', *--module-dir=*'directory'::
+
+Add an additional directory to the default path for finding module libraries.
+
+
+*-s*, *--snippet=*::
+
+Produce a snippet which can be copied into a playbook for modification, like
+a kind of task template.
+
+*-m*,'module', *--module=*'module'::
+
+Use this module.
+
+
+*-l*, *--list=*::
+
+Produce a terse listing of modules and a short description of each.
+
+AUTHOR
+------
+
+*ansible-doc* was originally written by Jan-Piet Mens.
+
+
+COPYRIGHT
+---------
+
+Copyright © 2012, Jan-Piet Mens
+
+Ansible is released under the terms of the GPLv3 License.
+
+
+SEE ALSO
+--------
+
+*ansible-playbook*(1), *ansible*(1)
+
+Extensive documentation as well as IRC and mailing list info
+is available on the ansible home page: <https://ansible.github.com/>

--- a/hacking/ansible-doc.py
+++ b/hacking/ansible-doc.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+import sys
+import yaml
+import codecs
+import json
+import ast
+from jinja2 import Environment, FunctionLoader, Template
+import re
+import optparse
+import time
+import datetime
+from ansible import utils
+from ansible import errors
+from ansible.utils import module_docs
+import ansible.constants as C
+
+
+# Get parent directory of the directory this script lives in
+MODULEDIR=os.path.abspath(os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), os.pardir, 'library'
+    ))
+
+T_LISTING = '''{{ "%-20s" | format(module) }}  {{ short_description | jpfunc | truncate(70) }}'''
+
+T_SNIPPET = '''
+- name: {{ short_description | jpfunc }}
+  action: {{ module }}
+{% for k in option_keys %}
+{% set v = options[k] %}
+        {{ "%-20s" | format(k + '=') }}    # {{ v.description[0] | truncate(50) | jpfunc }}
+{% endfor -%}
+'''
+
+T_MODULEDOC = '''
+> {{ module | upper }}  ({{filename}})
+
+{% for desc in description %}
+{{ desc | jpfunc | wordwrap(width=70) | indent(indentfirst=True) }}
+{% endfor %}
+
+{% if options %}
+   Options:
+{% for k in option_keys %}
+{% set v = options[k] %}
+   o {{ k }}
+{% for desc in v.description %}{{ desc|jpfunc| wordwrap(width=60)|indent(10,indentfirst=True) }}
+{% endfor %}
+         {% if v.get('choices') %} Choices : {% for choice in v.get('choices',[]) %}{{ choice }}{% if not loop.last %},{%else%}.{%endif%}{% endfor %}
+{% endif %}
+
+{% endfor %}
+{% endif %}
+
+{# ." ------ NOTES #}
+{% if notes %}
+Note: {% for note in notes %}
+{{ note | jpfunc |wordwrap(width=80) | indent(6) }}
+{% endfor %}
+{% endif %}
+
+{# ------ EXAMPLES #}
+{% if examples is defined %}
+{% for e in examples %}
+    {{ e['code'] }}
+{% endfor %}
+{% endif %}
+'''
+
+# There is a better way of doing this!
+# TODO: somebody add U(text, http://foo.bar/) as described by Tim in #991
+
+_ITALIC = re.compile(r"I\(([^)]+)\)")
+_BOLD   = re.compile(r"B\(([^)]+)\)")
+_MODULE = re.compile(r"M\(([^)]+)\)")
+_URL    = re.compile(r"U\(([^)]+)\)")
+_CONST  = re.compile(r"C\(([^)]+)\)")
+
+def tty_ify(text):
+
+    t = _ITALIC.sub("_" + r"\1" + "_", text)
+    t = _BOLD.sub("*" + r"\1" + "*", t)
+    t = _MODULE.sub("[" + r"\1" + "]", t)
+    t = _URL.sub(r"\1", t)
+    t = _CONST.sub("`" + r"\1" + "'", t)
+
+    return t
+
+def main():
+
+    p = optparse.OptionParser(
+        version='%prog 1.0',
+        usage='usage: %prog [options] ',
+        description='Show Ansible module documentation',
+    )
+
+    p.add_option("-M", "--module-dir",
+            action="store",
+            dest="module_dir",
+            default=MODULEDIR,
+            help="Ansible modules/ directory")
+    p.add_option("-l", "--list",
+            action="store_true",
+            default=False,
+            dest='list_dir',
+            help='List available modules')
+    p.add_option("-s", "--snippet",
+            action="store_true",
+            default=False,
+            dest='show_snippet',
+            help='Show playbook snippet for module')
+    p.add_option("-m", "--module",
+            action='append',
+            default=[],
+            dest='module_list',
+            help="Add modules to process in module_dir")
+    p.add_option('-V', action='version', help='Show version number and exit')
+
+    (options, args) = p.parse_args()
+
+    env = Environment(
+        trim_blocks=True,
+    )
+    env.filters['jpfunc'] = tty_ify
+
+    if options.module_dir is not None:
+        utils.plugins.vars_loader.add_directory(options.module_dir)
+
+    if options.list_dir:
+        # list all modules
+        ls_templ = env.from_string(T_LISTING)
+        paths = utils.plugins.module_finder._get_paths()
+        for path in paths:
+            # os.system("ls -C %s" % (path))
+            for module in os.listdir(path):
+                filename = utils.plugins.module_finder.find_plugin(module)
+
+                try:
+                    doc = utils.module_docs.get_docstring(filename)
+                    text = ls_templ.render(doc)
+                    print text.rstrip()
+                except:
+                    pass
+            
+        sys.exit()
+
+    tmpl = env.from_string(T_SNIPPET)
+    full_tmpl = env.from_string(T_MODULEDOC)
+
+    for module_name in options.module_list:
+
+        filename = utils.plugins.module_finder.find_plugin(module_name)
+        if filename is None:
+            sys.exit("module %s not found in %s" % (module_name,
+                    utils.plugins.module_finder.print_paths()))
+
+        if filename.endswith(".swp"):
+            continue
+
+        doc = utils.module_docs.get_docstring(filename)
+
+        if doc is None and module not in ansible.utils.module_docs.BLACKLIST_MODULES:
+            sys.stderr.write("*** ERROR: MODULE MISSING DOCUMENTATION: %s ***\n" % module)
+            sys.exit(1)
+
+        if not doc is None:
+
+            all_keys = []
+            for (k,v) in doc['options'].iteritems():
+                all_keys.append(k)
+            all_keys = sorted(all_keys)
+            doc['option_keys'] = all_keys 
+
+            doc['filename']         = filename
+            doc['docuri']           = doc['module'].replace('_', '-')
+            doc['now_date']         = datetime.date.today().strftime('%Y-%m-%d')
+
+        if options.show_snippet:
+            text = tmpl.render(doc)
+            print text.rstrip()
+        else:
+            text = full_tmpl.render(doc)
+            print text.rstrip()
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(name='ansible',
       scripts=[
          'bin/ansible',
          'bin/ansible-playbook',
-         'bin/ansible-pull'
+         'bin/ansible-pull',
+         'bin/ansible-doc'
       ],
       data_files=data_files
 )


### PR DESCRIPTION
## Show listing of all modules

ansible-doc -l

```
...
ohai                  Returns inventory data from _Ohai_
pause                 Pause playbook execution
ping                  Try to connect to host and return `pong` on success.
pip                   Manages Python library dependencies.
postgresql_db         Add or remove PostgreSQL databases from a remote host.
postgresql_user       Adds or removes a users (roles) from a PostgreSQL database.
raw                   Executes a low-down and dirty SSH command
script                Runs a local script on a remote node
seboolean             Toggles SELinux booleans.
selinux               Change policy and state of SELinux
service               Manage services.
setup                 Gathers facts about remote hosts
shell                 Execute commands in nodes.
slurp                 Slurps a file from remote nodes
subversion            Deploys a subversion repository.
supervisorctl         Manage the state of a program or group of programs running via ...
svr4pkg               Manage Solaris SVR4 packages
template              Templates a file out to a remote server.
user                  Manage user accounts
virt                  Manages virtual machines supported by libvirt
wait_for              Waits for a given port to become accessible on a server.
yum                   Manages packages with the _yum_ package manager
```
## Display manual of one module

ansible-doc -m yum

```
> YUM  (/Users/jpm/Auto/pubgit/ansible/ansible/library/yum)

    Will install, upgrade, remove, and list packages with the _yum_
    package manager.

   Options:
   o disablerepo
          _repoid_ of repositories to disable for the install/update
          operation These repos will not persist beyond the
          transaction Multiple repos separated with a ',' New in
          version 0.9.
   o enablerepo
          Repoid of repositories to enable for the install/update
          operation. These repos will not persist beyond the
          transaction multiple repos separated with a ',' New in
          version 0.9.
   o list
          various non-idempotent commands for usage with
          `/usr/bin/ansible` and _not_ playbooks. See examples.
   o name
          package name, or package specifier with version, like
          `name-1.0`.
   o state
          whether to install (`present`, `latest`), or remove
          (`absent`) a package. Choices : present,latest,absent.


    yum name=httpd state=latest
    yum name=httpd state=removed
    yum name=httpd enablerepo=testing state=installed
```
## for insertion into playbook

ansible-doc -s -m yum

``` yaml
- name: Manages packages with the _yum_ package manager
  action: yum
        disablerepo=            # _repoid_ of repositories to disable for the ...
        enablerepo=             # Repoid of repositories to enable for the ...
        list=                   # various non-idempotent commands for usage with ...
        name=                   # package name, or package specifier with version, ...
        state=                  # whether to install (`present`, `latest`), or ...
```
