### PR TITLE
The double single-quoting, together with a "failed" string is confusing

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -156,7 +156,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None, install_reco
 
         rc, out, err = run_apt(cmd)
         if rc:
-            m.fail_json(msg="'apt-get install %s' failed: %s" % (packages, err))
+            m.fail_json(msg="Failed to run \"apt-get install %s\"; %s" % (packages, err))
         else:
             m.exit_json(changed=True)
     else:


### PR DESCRIPTION
This is reported on the mailinglist, and it felt like the user made a mistake:

```
failed: [pi] => {"failed": true}
msg: 'apt-get install 'libjna-java' ' failed: E: Sub-process  /usr/bin/dpkg returned an error code (2)
```

Now it wil show:

```
failed: [pi] => {"failed": true}
msg: Failed to run "apt-get install 'libjna-java' "; E: Sub-process  /usr/bin/dpkg returned an error code (2)
```

Which is marginally better.
