### PR TITLE
Back to one extra check for pip

### DIFF
--- a/library/pip
+++ b/library/pip
@@ -135,10 +135,7 @@ def main():
         out += out_venv
         err += err_venv
 
-    pip = module.get_bin_path('python-pip', False, ['%s/bin' % env])
-    if not pip:
-        pip = module.get_bin_path('pip-python', False, ['%s/bin' % env])
-
+    pip = module.get_bin_path('pip-python', False, ['%s/bin' % env])
     if not pip:
         pip = module.get_bin_path('pip', True, ['%s/bin' % env])
 


### PR DESCRIPTION
Checking for pip-python will always work. Might as well drop the other one.

I haven't been behind a computer for the last couple of hours and I wanted to bring this in earlier, but considering the fact that the new check will always work, we might as well drop the other one.
