### PR TITLE
Template override

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -31,7 +31,7 @@ import pwd
 # TODO: refactor this file
 
 _LISTRE = re.compile(r"(\w+)\[(\d+)\]")
-
+JINJA2_OVERRIDE='#jinja2:'
 
 def _varFindLimitSpace(basedir, vars, space, part, depth):
     ''' limits the search space of space to part
@@ -277,7 +277,7 @@ def template_from_file(basedir, path, vars):
         raise errors.AnsibleError("unable to read %s" % realpath)
 
     # Get jinja env overrides from template
-    if data.startswith('#env:'):
+    if data.startswith(JINJA2_OVERRIDE):
         eol = data.find('\n')
         line = data[5:eol]
         data = data[eol+1:]

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -275,6 +275,16 @@ def template_from_file(basedir, path, vars):
         raise errors.AnsibleError("unable to process as utf-8: %s" % realpath)
     except:
         raise errors.AnsibleError("unable to read %s" % realpath)
+
+    # Get jinja env overrides from template
+    if data.startswith('#env:'):
+        eol = data.find('\n')
+        line = data[5:eol]
+        data = data[eol+1:]
+        for pair in line.split(','):
+            (key,val) = pair.split(':')
+            setattr(environment,key.strip(),val.strip())
+
     t = environment.from_string(data)
     vars = vars.copy()
     try:

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -279,7 +279,7 @@ def template_from_file(basedir, path, vars):
     # Get jinja env overrides from template
     if data.startswith(JINJA2_OVERRIDE):
         eol = data.find('\n')
-        line = data[5:eol]
+        line = data[len(JINJA2_OVERRIDE):eol]
         data = data[eol+1:]
         for pair in line.split(','):
             (key,val) = pair.split(':')

--- a/test/jinja2_overrides.tpl
+++ b/test/jinja2_overrides.tpl
@@ -1,0 +1,10 @@
+#env: variable_end_string: @@, variable_start_string: @@
+
+{% raw %}
+ if this succeeds you should see '{{ ansible_hostname }}' with the hostname on the line above
+ if this fails you should see '@@ ansible_hostname @@' with the hostname on the line beneath
+{% endraw %}
+
+@@ ansible_hostname @@
+{{ ansible_hostname }}
+

--- a/test/jinja2_overrides.tpl
+++ b/test/jinja2_overrides.tpl
@@ -1,4 +1,4 @@
-#env: variable_end_string: @@, variable_start_string: @@
+#jinja2: variable_end_string: @@, variable_start_string: @@
 
 {% raw %}
  if this succeeds you should see '{{ ansible_hostname }}' with the hostname on the line above


### PR DESCRIPTION
Allows a template to override jinja2 options with a special header that starts with '#jinja2:' and has comma separated key/value pairs (as per request #1625)
