### PR TITLE
Set LANG in module_common.py

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -84,6 +84,8 @@ def boilerplate_module(modfile, args):
         module_data = module_data.replace(module_common.REPLACER, module_common.MODULE_COMMON)
         encoded_args = "\"\"\"%s\"\"\"" % args.replace("\"","\\\"")
         module_data = module_data.replace(module_common.REPLACER_ARGS, encoded_args)
+        encoded_lang = "\"\"\"%s\"\"\"" % C.DEFAULT_MODULE_LANG
+        module_data = module_data.replace(module_common.REPLACER_LANG, encoded_lang)
         module_data = module_data.replace('syslog.LOG_USER', "syslog.%s" % C.DEFAULT_SYSLOG_FACILITY)
 
         modfile2_path = os.path.expanduser("~/.ansible_module_generated")

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -77,6 +77,7 @@ DEFAULT_MODULE_NAME       = get_config(p, DEFAULTS, 'module_name',      None,   
 DEFAULT_PATTERN           = get_config(p, DEFAULTS, 'pattern',          None,                       '*')
 DEFAULT_FORKS             = get_config(p, DEFAULTS, 'forks',            'ANSIBLE_FORKS',            5)
 DEFAULT_MODULE_ARGS       = get_config(p, DEFAULTS, 'module_args',      'ANSIBLE_MODULE_ARGS',      '')
+DEFAULT_MODULE_LANG       = get_config(p, DEFAULTS, 'module_lang',      'ANSIBLE_MODULE_LANG',      'C')
 DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE_TIMEOUT',          10)
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15)
 DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      active_user)

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -17,12 +17,14 @@
 
 REPLACER = "#<<INCLUDE_ANSIBLE_MODULE_COMMON>>"
 REPLACER_ARGS = "<<INCLUDE_ANSIBLE_MODULE_ARGS>>"
+REPLACER_LANG = "<<INCLUDE_ANSIBLE_MODULE_LANG>>"
 
 MODULE_COMMON = """
 
 # == BEGIN DYNAMICALLY INSERTED CODE ==
 
 MODULE_ARGS = <<INCLUDE_ANSIBLE_MODULE_ARGS>>
+MODULE_LANG = <<INCLUDE_ANSIBLE_MODULE_LANG>>
 
 BOOLEANS_TRUE = ['yes', 'on', '1', 'true', 1]
 BOOLEANS_FALSE = ['no', 'off', '0', 'false', 0]
@@ -143,6 +145,7 @@ class AnsibleModule(object):
         if add_file_common_args:
             self.argument_spec.update(FILE_COMMON_ARGUMENTS)
 
+        os.environ['LANG'] = MODULE_LANG
         (self.params, self.args) = self._load_params()
 
         self._legal_inputs = []

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -537,6 +537,8 @@ class Runner(object):
             module_data = module_data.replace(module_common.REPLACER, module_common.MODULE_COMMON)
             encoded_args = "\"\"\"%s\"\"\"" % module_args.replace("\"","\\\"")
             module_data = module_data.replace(module_common.REPLACER_ARGS, encoded_args)
+            encoded_lang = "\"\"\"%s\"\"\"" % C.DEFAULT_MODULE_LANG
+            module_data = module_data.replace(module_common.REPLACER_LANG, encoded_lang)
             if is_new_style:
                 facility = C.DEFAULT_SYSLOG_FACILITY
                 if 'ansible_syslog_facility' in inject:


### PR DESCRIPTION
Add constant DEFAULT_MODULE_LANG that defaults to C.  Can be set via
environment variable ANSIBLE_MODULE_LANG or configuration variable
module_lang.  Updated test-module to have same behavior.

Intended to address issue #1644.
