### PR TITLE
dpkg -l does not install package, use dpkg -i <package-file> instead

### DIFF
--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -9,6 +9,6 @@ To create an Ansible DEB package:
     cd ansible
     make deb
 
-The debian package file will be placed in the `../` directory. This can then be added to an APT repository or installed with `dpkg -l`.
+The debian package file will be placed in the `../` directory. This can then be added to an APT repository or installed with `dpkg -i <package-file>`.
 
 Note that `dpkg -i` does not resolve dependencies


### PR DESCRIPTION
Small typo in packaging/debian/README.md which might need fixing...
