### PR TITLE
Allow regex to be used to select hosts in addition to fnmatch pattern

### DIFF
--- a/docs/man/man1/ansible.1
+++ b/docs/man/man1/ansible.1
@@ -2,12 +2,21 @@
 .\"     Title: ansible
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.75.2 <http://docbook.sf.net/>
-.\"      Date: 11/03/2012
+.\"      Date: 12/04/2012
 .\"    Manual: System administration commands
 .\"    Source: Ansible 0.9
 .\"  Language: English
 .\"
-.TH "ANSIBLE" "1" "11/03/2012" "Ansible 0\&.9" "System administration commands"
+.TH "ANSIBLE" "1" "12/04/2012" "Ansible 0\&.9" "System administration commands"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
 .\" -----------------------------------------------------------------
 .\" * set default formatting
 .\" -----------------------------------------------------------------
@@ -25,7 +34,7 @@ ansible \- run a command somewhere else
 ansible <host\-pattern> [\-f forks] [\-m module_name] [\-a args]
 .SH "DESCRIPTION"
 .sp
-\fBAnsible\fR is an extra\-simple tool/framework/API for doing \'remote things\' over SSH\&.
+\fBAnsible\fR is an extra\-simple tool/framework/API for doing \*(Aqremote things\*(Aq over SSH\&.
 .SH "ARGUMENTS"
 .PP
 \fBhost\-pattern\fR
@@ -73,7 +82,7 @@ to load modules from\&. The default is
 \fI/usr/share/ansible\fR\&.
 .RE
 .PP
-\fB\-a\fR \'\fIARGUMENTS\fR\', \fB\-\-args=\fR\'\fIARGUMENTS\fR\'
+\fB\-a\fR \*(Aq\fIARGUMENTS\fR\*(Aq, \fB\-\-args=\fR\*(Aq\fIARGUMENTS\fR\*(Aq
 .RS 4
 The
 \fIARGUMENTS\fR

--- a/docs/man/man1/ansible.1
+++ b/docs/man/man1/ansible.1
@@ -156,6 +156,11 @@ is mostly useful for crontab or kickstarts\&.
 .RS 4
 Further limits the selected host/group patterns\&.
 .RE
+.PP
+\fB\-l\fR \fI~REGEX\fR, \fB\-\-limit=\fR\fI~REGEX\fR
+.RS 4
+Further limits hosts with a regex pattern\&.
+.RE
 .SH "INVENTORY"
 .sp
 Ansible stores the hosts it can potentially operate on in an inventory file\&. The syntax is one host per line\&. Groups headers are allowed and are included on their own line, enclosed in square brackets that start the line\&.

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -117,6 +117,10 @@ and 'local'.  'local' is mostly useful for crontab or kickstarts.
 
 Further limits the selected host/group patterns.
 
+*-l* '\~REGEX', *--limit=*'~REGEX'::
+
+Further limits hosts with a regex pattern.
+
 INVENTORY
 ---------
 

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -19,6 +19,7 @@
 
 import fnmatch
 import os
+import re
 
 import subprocess
 import ansible.constants as C
@@ -92,7 +93,10 @@ class Inventory(object):
                 raise errors.AnsibleError("YAML inventory support is deprecated in 0.6 and removed in 0.7, see the migration script in examples/scripts in the git checkout")
 
     def _match(self, str, pattern_str):
-        return fnmatch.fnmatch(str, pattern_str)
+        if pattern_str.startswith('~'):
+            return re.search(pattern_str[1:], str)
+        else:
+            return fnmatch.fnmatch(str, pattern_str)
 
     def get_hosts(self, pattern="all"):
         """ 
@@ -164,7 +168,7 @@ class Inventory(object):
         a tuple of (start, stop) or None
         """
 
-        if not "[" in pattern:
+        if not "[" in pattern or pattern.startswith('~'):
             return (pattern, None)
         (first, rest) = pattern.split("[")
         rest = rest.replace("]","")

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -158,6 +158,14 @@ class TestInventory(unittest.TestCase):
         print "EXPECTED=%s" % sorted(expected_hosts)
         assert sorted(hosts) == sorted(expected_hosts)
 
+    def test_regex_exclude(self):
+        inventory = self.complex_inventory()
+        hosts = inventory.list_hosts("~rtp_[ac]")
+        expected_hosts = ['rtp_a', 'rtp_c']
+        print "HOSTS=%s" % sorted(hosts)
+        print "EXPECTED=%s" % sorted(expected_hosts)
+        assert sorted(hosts) == sorted(expected_hosts)
+
     def test_complex_enumeration(self):
 
 


### PR DESCRIPTION
commit 48069adf0f47b09f675a9ba59360ca216b695ceb
Author: Gregory Duchatelet skygreg@gmail.com
Date:   Tue Nov 27 10:13:08 2012 +0100

```
Removing this plugin from this branch.
```

commit 15400fffe643ad3e66d6b5a296fe62d36d9a617a
Author: Gregory Duchatelet skygreg@gmail.com
Date:   Tue Nov 27 09:53:16 2012 +0100

```
Enhance _match function in inventory with regex.
--limit ~regex could be used to filter hosts or group with a regex.
Tested on cli and ansible-playbook.
```

commit 63c1b2e17ec6daa282e0a3af2249bda8f734dcd3
Author: Gregory Duchatelet skygreg@gmail.com
Date:   Tue Nov 27 09:03:41 2012 +0100

```
Revert pull request #1684
```

commit 7c2c6fee3a856c52c1960b96ec2e7ca1112c35a1
Merge: f023a2f dd5a847
Author: Gregory Duchatelet skygreg@gmail.com
Date:   Tue Nov 27 08:52:53 2012 +0100

```
Merge remote branch 'upstream/devel' into devel
```

commit f023a2f3df4a4c2ab2dfcc5aa42c57c02358a47a
Author: Gregory Duchatelet skygreg@gmail.com
Date:   Mon Nov 26 20:52:27 2012 +0100

```
Add an inventory plugin to fetch groups and host from our CMDB.
```

commit c64193b4c67053e6e197b89c7143b9770cf71f23
Author: Gregory Duchatelet skygreg@gmail.com
Date:   Mon Nov 26 20:43:30 2012 +0100

```
Added possibility to filter hosts from a group, with a regex, separating
groupname and regex with a ~
Usage in group pattern: group~filterpattern
Samples:
ansible group~server-0[1236] -m ping
ansible web~proxy -m ping
ansible web~(proxy|frontend) -m ping
```
