### PR TITLE
Fix subversion module's documentation

### DIFF
--- a/library/subversion
+++ b/library/subversion
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 module: subversion
 short_description: Deploys a subversion repository.
 description:
-   - This module is really simple: It checks out from the given branch of a repo or at a particular tag.
+   - This module is really simple, it checks out from the given branch of a repo or at a particular tag.
 version_added: "0.7"
 options:
   repo:

--- a/library/subversion
+++ b/library/subversion
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 module: subversion
 short_description: Deploys a subversion repository.
 description:
-   - This module is really simple, so for now this checks out from the given branch of a repo at a particular SHA or tag. Latest is not supported, you should not be doing that.
+   - This module is really simple: It checks out from the given branch of a repo or at a particular tag.
 version_added: "0.7"
 options:
   repo:


### PR DESCRIPTION
Let our users determine what they want to do with a given module.
Particularily when the mdoule doesn't pose any such restrictions.
