### PR TITLE
Add a flatten lookup plugin

### DIFF
--- a/lib/ansible/runner/lookup_plugins/flatten.py
+++ b/lib/ansible/runner/lookup_plugins/flatten.py
@@ -1,0 +1,27 @@
+# (c) 2012, Daniel Hokka Zakrisson <daniel@hozac.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+class LookupModule(object):
+
+    def __init__(self, **kwargs):
+        pass
+
+    def run(self, terms, **kwargs):
+        ret = []
+        for i in terms:
+            ret.extend(i)
+        return ret

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -174,7 +174,7 @@ class TestPlaybook(unittest.TestCase):
            "localhost": {
                "changed": 7,
                "failures": 0,
-               "ok": 9,
+               "ok": 10,
                "skipped": 1,
                "unreachable": 0
            }   
@@ -185,7 +185,7 @@ class TestPlaybook(unittest.TestCase):
        assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
 
        print "len(EVENTS) = %d" % len(EVENTS)
-       assert len(EVENTS) == 26
+       assert len(EVENTS) == 33
 
    def test_includes(self):
        pb = os.path.join(self.test_dir, 'playbook-includer.yml')

--- a/test/lookup_plugins.yml
+++ b/test/lookup_plugins.yml
@@ -4,6 +4,8 @@
   connection: local
   vars:
     empty_list: []
+    list1: [1, 2, 3]
+    list2: [4, 5, 6]
   tasks:
   - name: test with_items
     action: command true
@@ -36,3 +38,9 @@
     action: copy src=sample.j2 dest=/tmp/ansible-test-with_lines-data
   - name: cleanup test file
     action: file path=/tmp/ansible-test-with_lines-data state=absent
+
+  - name: test flatten
+    action: debug msg="$item"
+    with_flatten:
+    - $list1
+    - $list2


### PR DESCRIPTION
This merges two or more lists together into one, allowing constructs like

```
  vars:
    defaults: [a, b, c]
  tasks:
  - action: ...
    with_flatten:
    - $defaults
    - $groupvar
    - $hostvar
```
