### PR TITLE
Further tweak how to find pip in virtualenv on centos/redhat/fedora

### DIFF
--- a/library/pip
+++ b/library/pip
@@ -153,10 +153,20 @@ def main():
         out += out_venv
         err += err_venv
 
-    pip = module.get_bin_path('python-pip', False, ['%s/bin' % env])
-    if not pip:
-        pip = module.get_bin_path('pip-python', False, ['%s/bin' % env])
+    # On Debian and Ubuntu, pip is pip.
+    # On Fedora18 and up, pip is python-pip.
+    # On Fedora17 and below, CentOS and RedHat 6 and 5, pip is pip-python.
+    # On Fedora, CentOS, and RedHat, the exception is in the virtualenv.
+    # There, pip is just pip.
+    # Try pip with the virtualenv directory first.
+    pip = module.get_bin_path('pip', False, ['%s/bin' % env])
 
+    for p in ['python-pip', 'pip-python']:
+        if not pip:
+            pip = module.get_bin_path(p, False, ['%s/bin' % env])
+
+    # pip should have been found by now.  The final call to get_bin_path
+    # will trigger fail_json.
     if not pip:
         pip = module.get_bin_path('pip', True, ['%s/bin' % env])
 


### PR DESCRIPTION
In a virtualenv, pip is called just pip.  This fixes the pip module to
search for the virtualenv pip first before trying the pip-python and
python-pip variants.  Without this, pip module would not install to the
virtualenv when that parameter is provided.

I also added some comments to describe the logic presently there.

See issue #1713.
