### PR TITLE
Add Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+install:
+  - pip install PyYAML Jinja2 paramiko
+script:
+  - make tests


### PR DESCRIPTION
Add .travis.yml file to suspport Travis CI.

Once this is enabled on the repo, the ansible tests will be run automatically on each commit and pull request.

To enable Travis CI to run tests against the ansible/ansible repo:
1. Go to https://travis-ci.org
2. Click "Sign in with Github" in the menu bar at the top
3. Click "Accounts" from the drop-down menu at the top where your login appears
4. Click the button on/off button to enable testing on the ansible/ansible repo
