### PR TITLE
Import errno to avoid 'NameError: global name 'errno' is not defined'

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -56,6 +56,7 @@ import stat
 import grp
 import pwd
 import platform
+import errno
 
 HAVE_SELINUX=False
 try:


### PR DESCRIPTION
I hit the following exception because errno is referenced but not imported.

```
fatal: [system01] => failed to parse: Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-1354644532.37-246102819320352/copy", line 782, in <module>
    main()
  File "/root/.ansible/tmp/ansible-1354644532.37-246102819320352/copy", line 117, in main
    module.atomic_replace(dest_tmp, dest)
  File "/root/.ansible/tmp/ansible-1354644532.37-246102819320352/copy", line 772, in atomic_replace
    if e.errno != errno.EPERM:
NameError: global name 'errno' is not defined
```
