### PR TITLE
Fix git module to update branch to latest when using version=<branch>

### DIFF
--- a/library/git
+++ b/library/git
@@ -199,6 +199,12 @@ def switch_version(module, dest, remote, version):
     if version != 'HEAD':
         if not is_local_branch(module, dest, version) and is_remote_branch(module, dest, remote, version):
             cmd = "git checkout --track -b %s %s/%s" % (version, remote, version)
+        elif is_local_branch(module, dest, version):
+            cmd = "git checkout --force %s" % version
+            (rc, out, err) = _run("git checkout --force %s" % version)
+            if rc != 0:
+                module.fail_json(msg="Failed to checkout branch %s" % version)
+            cmd = "git reset --hard %s/%s" % (remote, version)
         else:
             cmd = "git checkout --force %s" % version
     else:


### PR DESCRIPTION
The git module would not pull in updates to a branch when
version=<branch>.  This updates that block to checkout the branch
and then do a git reset --hard < remote >/< branch >.  This
should now track updates to a branch.

See issue #1722.
