### PR TITLE
Further refine remote branch tracking in b1ec6e8

### DIFF
--- a/library/git
+++ b/library/git
@@ -197,14 +197,14 @@ def switch_version(module, dest, remote, version):
     os.chdir(dest)
     cmd = ''
     if version != 'HEAD':
-        if not is_local_branch(module, dest, version) and is_remote_branch(module, dest, remote, version):
-            cmd = "git checkout --track -b %s %s/%s" % (version, remote, version)
-        elif is_local_branch(module, dest, version):
-            cmd = "git checkout --force %s" % version
-            (rc, out, err) = _run("git checkout --force %s" % version)
-            if rc != 0:
-                module.fail_json(msg="Failed to checkout branch %s" % version)
-            cmd = "git reset --hard %s/%s" % (remote, version)
+        if is_remote_branch(module, dest, remote, version):
+            if not is_local_branch(module, dest, version):
+                cmd = "git checkout --track -b %s %s/%s" % (version, remote, version)
+            else:
+                (rc, out, err) = _run("git checkout --force %s" % version)
+                if rc != 0:
+                    module.fail_json(msg="Failed to checkout branch %s" % version)
+                cmd = "git reset --hard %s/%s" % (remote, version)
         else:
             cmd = "git checkout --force %s" % version
     else:


### PR DESCRIPTION
Move operations that are dependant on a remote branch under a if
is_remote_branch() conditional.  While at it, remove assignment to cmd
string in same block that wasn't used when calling _run().

This followed some discussion with @dhozac earlier today on irc.
