### PR TITLE
make --list-hosts expand out extra vars in the hosts: field

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -131,7 +131,8 @@ def main(args):
                     label = 'unnamed'
                     if 'name' in play:
                         label = play['name']
-                    hosts = pb.inventory.list_hosts(play['hosts'])
+                    tmp_hosts = utils.template(pb.basedir, play['hosts'], extra_vars)
+                    hosts = pb.inventory.list_hosts(tmp_hosts)
                     print '  hosts in play %s (%s): #%d' % (playnum, label, len(hosts))
                     for host in hosts:
                         print '    %s' % host


### PR DESCRIPTION
simple expansion of hosts using extra_vars, if possible. This doesn't normally happen b/c hosts in plays do not get expanded until play.run()
