### PR TITLE
When a play has no matched hosts from the start, this is not fatal but expected

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -421,7 +421,7 @@ class PlaybookCallbacks(object):
         call_callback_module('playbook_on_notify', host, handler)
 
     def on_no_hosts_matched(self):
-        print stringc("no hosts matched", 'red')
+        print stringc("no hosts matched", 'cyan')
         call_callback_module('playbook_on_no_hosts_matched')
 
     def on_no_hosts_remaining(self):


### PR DESCRIPTION
So we don't want to show it in red, which may indicate something is wrong.
