### PR TITLE
Change message when a play matches no hosts

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -421,7 +421,7 @@ class PlaybookCallbacks(object):
         call_callback_module('playbook_on_notify', host, handler)
 
     def on_no_hosts_matched(self):
-        print stringc("no hosts matched", 'red')
+        print stringc("skipping: no hosts matched", 'cyan')
         call_callback_module('playbook_on_no_hosts_matched')
 
     def on_no_hosts_remaining(self):


### PR DESCRIPTION
I guess my previous pull request was confusing, by changing the message to something we already do for tasks, it makes it more clear.

Just like we say:

```
TASK: [foo bar]
skipping: [system01]
```

The message now is more clear:

```
PLAY [wagawaga] *******************************
skipping: no hosts matched
```

It makes it clear that we are skipping the play, just as is done for a task when a condition is not met.
