### PR TITLE
Ensure files created by authorized_key have correct selinux context

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -275,6 +275,12 @@ class AnsibleModule(object):
             group = str(gid)
         return (user, group)
 
+    def set_default_selinux_context(self, path, changed):
+        if not HAVE_SELINUX or not self.selinux_enabled():
+            return changed
+        context = self.selinux_default_context(path)
+        return self.set_context_if_different(path, context, False)
+
     def set_context_if_different(self, path, context, changed):
 
         if not HAVE_SELINUX or not self.selinux_enabled():
@@ -657,6 +663,10 @@ class AnsibleModule(object):
                     raise
             if self.selinux_enabled():
                 context = self.selinux_context(dest)
+                self.set_context_if_different(src, context, False)
+        else:
+            if self.selinux_enabled():
+                context = self.selinux_default_context(dest)
                 self.set_context_if_different(src, context, False)
         os.rename(src, dest)
 

--- a/library/authorized_key
+++ b/library/authorized_key
@@ -97,6 +97,8 @@ def keyfile(module, user, write=False):
 
     if not os.path.exists(sshdir):
         os.mkdir(sshdir, 0700)
+        if module.selinux_enabled():
+            module.set_default_selinux_context(sshdir, False)
     os.chown(sshdir, uid, gid)
     os.chmod(sshdir, 0700)
 
@@ -105,6 +107,8 @@ def keyfile(module, user, write=False):
             f = open(keysfile, "w") #touches file so we can set ownership and perms
         finally:
             f.close()
+        if module.selinux_enabled():
+            module.set_default_selinux_context(keysfile, False)
 
     os.chown(keysfile, uid, gid)
     os.chmod(keysfile, 0600)


### PR DESCRIPTION
Three changes:
- Add set_default_selinux_context() to module_common that sets
  a file's context according to the defaults in the policy
- In atomic_replace(), set the default context for the file if
  selinux is enabled and the destination file does not exist.
- In authorized_key, set the default context when creating
  $HOME/.ssh and $HOME/.ssh/authorized_keys.  If these already
  exist, this won't touch them.

See issue #1762
