### PR TITLE
change error message on check_conditional when variable does not exist

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -143,7 +143,10 @@ def check_conditional(conditional):
     def is_unset(var):
         return var.startswith("$")
 
-    return eval(conditional.replace("\n", "\\n"))
+    try:
+        return eval(conditional.replace("\n", "\\n"))
+    except SyntaxError as e:
+        raise errors.AnsibleError("Could not evaluate the expression: " + conditional)
 
 def is_executable(path):
     '''is the given path executable?'''


### PR DESCRIPTION
So if I run 
   ansible-playbook setup.yml --syntax-check
Ansible returns that the syntax is fine.
But when I run the play Python throws a SyntaxError on the non-existing variable.

Currently Ansible outputs a SyntaxError with traceback, my idea outputs as follows
  fatal: [localhost] => Could not evaluate the expression: ${non_existing_variable}

Below is the gist with the example playbook, and example output.

  setup.yml
https://gist.github.com/4283029
  original output
https://gist.github.com/4283051
  my output
https://gist.github.com/4283331
