### PR TITLE
cleanup Example output in ansible-doc

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -89,8 +89,10 @@ def print_man(doc):
                             subsequent_indent=opt_indent)
 
 
-    for ex in doc['examples']:
-        print "%s%s" % (opt_indent, ex['code'])
+    if 'examples' in doc and len(doc['examples']) > 0:
+        print "Example%s:\n" % ('' if len(doc['examples']) < 2 else 's')
+        for ex in doc['examples']:
+            print "%s\n" % (ex['code'])
 
 def print_snippet(doc):
 


### PR DESCRIPTION
It looked neater (to my eye) indented, but the indentation made multi-line examples look ugly.
