### PR TITLE
Make use of yes/no booleans in playbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,13 +256,13 @@ playbooks:
 * error reporting if with_items value is unbound
 * with_items no longer creates lots of tasks, creates one task that makes multiple calls
 * can use host_specific facts inside with_items (see above)
-* at the top level of a playbook, set 'gather_facts: False' to skip fact gathering
+* at the top level of a playbook, set 'gather_facts: no' to skip fact gathering
 * first_available_file and with_items used together will now raise an error
 * to catch typos, like 'var' for 'vars', playbooks and tasks now yell on invalid parameters
 * automatically load (directory_of_inventory_file)/group_vars/groupname and /host_vars/hostname in vars_files
 * playbook is now colorized, set ANSIBLE_NOCOLOR=1 if you do not like this, does not colorize if not a TTY
 * hostvars now preserved between plays (regression in 0.5 from 0.4), useful for sharing vars in multinode configs
-* ignore_errors: True on a task can be used to allow a task to fail and not stop the play
+* ignore_errors: yes on a task can be used to allow a task to fail and not stop the play
 * with_items with the apt/yum module will install/remove/update everything in a single command
 
 inventory:

--- a/docsite/rst/YAMLSyntax.rst
+++ b/docsite/rst/YAMLSyntax.rst
@@ -54,6 +54,8 @@ Ansible doesn't really use these too much, but you can also specify a
 boolean value (true/false) in several forms::
 
     ---
+    create_key: yes
+    needs_agent: no
     knows_oop: True
     likes_emacs: TRUE
     uses_cvs: false

--- a/docsite/rst/playbooks.rst
+++ b/docsite/rst/playbooks.rst
@@ -88,14 +88,14 @@ Support for running things from sudo is also available::
     ---
     - hosts: webservers
       user: yourname
-      sudo: True
+      sudo: yes
 
 You can also login as you, and then sudo to different users than root::
 
     ---
     - hosts: webservers
       user: yourname
-      sudo: True
+      sudo: yes
       sudo_user: postgres
 
 If you need to specify a password to sudo, run `ansible-playbook` with ``--ask-sudo-pass`` (`-K`).

--- a/docsite/rst/playbooks2.rst
+++ b/docsite/rst/playbooks2.rst
@@ -67,7 +67,7 @@ write a task that looks like this::
 
     - name: this will not be counted as a failure
       action: command /bin/false
-      ignore_errors: True
+      ignore_errors: yes
 
 Accessing Complex Variable Data
 ```````````````````````````````
@@ -190,10 +190,10 @@ some other options, but otherwise works equivalently::
    vars_prompt:
      - name: "some_password"
        prompt: "Enter password"
-       private: True
+       private: yes
      - name: "release_version"
        prompt: "Product release version"
-       private: False
+       private: no
 
 
 Passing Variables On The Command Line
@@ -543,7 +543,7 @@ can turn off fact gathering.  This has advantages in scaling ansible in push mod
 systems, mainly, or if you are using Ansible on experimental platforms.   In any play, just do this::
 
     - hosts: whatever
-      gather_facts: False
+      gather_facts: no
 
 Pull-Mode Playbooks
 ```````````````````
@@ -663,9 +663,9 @@ if you have a large number of hosts::
 
     # set up the fireball transport
     - hosts: all
-      gather_facts: False
+      gather_facts: no
       connection: ssh # or paramiko
-      sudo: True
+      sudo: yes
       tasks:
           - action: fireball
 
@@ -683,8 +683,8 @@ any platform.  You will also need gcc and zeromq-devel installed from your packa
 
     ---
     - hosts: all
-      sudo: True
-      gather_facts: False
+      sudo: yes
+      gather_facts: no
       connection: ssh
       tasks:
           - action: easy_install name=pip

--- a/examples/playbooks/group_commands.yml
+++ b/examples/playbooks/group_commands.yml
@@ -3,7 +3,7 @@
 
 - hosts: all
   user: root
-  sudo: True
+  sudo: yes
 
   tasks:
 

--- a/examples/playbooks/intro_example.yml
+++ b/examples/playbooks/intro_example.yml
@@ -13,7 +13,7 @@
 
 # could have also have done:
 #  user: mdehaan
-#  sudo: True
+#  sudo: yes
 
   # make these variables available inside of templates
   # for when we use the 'template' action/module later on...

--- a/examples/playbooks/loop_plugins.yml
+++ b/examples/playbooks/loop_plugins.yml
@@ -6,7 +6,7 @@
 # see lib/ansible/runner/lookup_plugins/fileglob.py -- they can do basically anything!
 
 - hosts: all
-  gather_facts: False
+  gather_facts: no
 
   tasks:
 

--- a/examples/playbooks/postgresql.yml
+++ b/examples/playbooks/postgresql.yml
@@ -7,8 +7,8 @@
 #
 ---
 - hosts: webservers
-  sudo: True
-  gather_facts: False
+  sudo: yes
+  gather_facts: no
 
   tasks:
   - name: ensure apt cache is up to date
@@ -21,9 +21,9 @@
         - python-psycopg2
 
 - hosts: webservers
-  sudo: True
+  sudo: yes
   sudo_user: postgres
-  gather_facts: False
+  gather_facts: no
 
   vars:
     dbname: myapp

--- a/examples/playbooks/prompts.yml
+++ b/examples/playbooks/prompts.yml
@@ -28,16 +28,16 @@
   vars_prompt:
     - name: "some_password"
       prompt: "Enter password"
-      private: True
+      private: yes
     - name: "release_version"
       prompt: "Product release version"
-      private: False
+      private: no
    
     - name: "my_password2"
       prompt: "Enter password2"
-      private: True
+      private: yes
       encrypt: "md5_crypt" 
-      confirm: True
+      confirm: yes
       salt_size: 7
       salt: "foo" 
 

--- a/examples/playbooks/register_logic.yml
+++ b/examples/playbooks/register_logic.yml
@@ -13,7 +13,7 @@
       # available to tasks and templates made further down in the execution flow.  
 
       - action: shell grep hi /etc/motd
-        ignore_errors: True
+        ignore_errors: yes
         register: motd_result
 
       # and here we access the register.  Note that variable is structured data because

--- a/hacking/templates/man.j2
+++ b/hacking/templates/man.j2
@@ -21,9 +21,9 @@
 {% if v.get('choices') %}
 
 .IR Choices :
-{% for choice in v.get('choices',[]) %}@{ choice }@{% if not loop.last %},{%else%}.{%endif%}{% endfor %}{% endif %}
+{% for choice in v.get('choices',[]) %}{% if choice == True %}yes{%elif choice == False %}no{% else %}@{ choice }@{% endif %}{% if not loop.last %},{%else%}.{%endif%}{% endfor %}{% endif %}
 {% if v.get('required') %}(required){% endif %}
-{% if v.get('default') %} (default: @{ v.get('default') }@){% endif %}
+{% if v.get('default') %} (default: {% if v.get('default') == True %}yes{%elif v.get('default') == False %}no{% else %}@{ v.get('default') }@){% endif %}{% endif %}
 {#---------------------------------------------- #}
 {% if v.get('version_added') %}
 (Added in Ansible version @{ v.get('version_added') }@.)

--- a/test/playbook-included.yml
+++ b/test/playbook-included.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   connection: local
-  gather_facts: False
+  gather_facts: no
   tasks:
   - action: debug msg="$variable"
 
@@ -9,6 +9,6 @@
   connection: local
   vars:
   - ugly: var
-  gather_facts: False
+  gather_facts: no
   tasks:
   - action: debug msg="$variable"


### PR DESCRIPTION
At the moment Ansible prefers yes/no for module booleans, however booleans in playbooks are still using True/False, rather than yes/no. This changes modifies boolean uses in playbooks (and man pages) to favor yes/no rather than True/False.

This change includes:
- Adaptation of documentation and examples to favor yes/no
- Modification to manpage output to favor yes/no (the docsite output already favors yes/no)
