### PR TITLE
fixes #1767 parsing serial from extra_vars

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -406,7 +406,7 @@ class PlayBook(object):
             # do N forks all the way through before moving to next
             while len(all_hosts) > 0:
                 play_hosts = []
-                for x in range(int(play.serial)):
+                for x in range(play.serial):
                     if len(all_hosts) > 0:
                         play_hosts.append(all_hosts.pop())
                 serialized_batch.append(play_hosts)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -406,7 +406,7 @@ class PlayBook(object):
             # do N forks all the way through before moving to next
             while len(all_hosts) > 0:
                 play_hosts = []
-                for x in range(play.serial):
+                for x in range(int(play.serial)):
                     if len(all_hosts) > 0:
                         play_hosts.append(all_hosts.pop())
                 serialized_batch.append(play_hosts)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -75,7 +75,7 @@ class Play(object):
         self.transport    = ds.get('connection', self.playbook.transport)
         self.tags         = ds.get('tags', None)
         self.gather_facts = ds.get('gather_facts', None)
-        self.serial       = ds.get('serial', 0)
+        self.serial       = utils.template_ds(basedir, ds.get('serial', 0), self.vars)
 
         if isinstance(self.remote_port, basestring):
             self.remote_port = utils.template(basedir, self.remote_port, self.vars)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -75,7 +75,7 @@ class Play(object):
         self.transport    = ds.get('connection', self.playbook.transport)
         self.tags         = ds.get('tags', None)
         self.gather_facts = ds.get('gather_facts', None)
-        self.serial       = utils.template_ds(basedir, ds.get('serial', 0), self.vars)
+        self.serial       = int(utils.template_ds(basedir, ds.get('serial', 0), self.vars))
 
         if isinstance(self.remote_port, basestring):
             self.remote_port = utils.template(basedir, self.remote_port, self.vars)


### PR DESCRIPTION
serial as a variable:

```
dominis@shuriken:~/work/ansible (devel=)$ cat /tmp/a.yml

---
- hosts: ${pool}
  serial: ${servar}
  port: ${port}
  gather_facts: False
  tasks:

    - name: write a file
      action: shell touch /tmp/foo

    - name: delete it
      action: shell rm -f /tmp/foo
```

```
dominis@shuriken:~/work/ansible (devel=)$ python bin/ansible-playbook /tmp/a.yml -e "servar=1 pool=app-pool port=2223"

PLAY [app-pool] ********************* 

TASK: [write a file] ********************* 
changed: [c.local]

TASK: [delete it] ********************* 
changed: [c.local]

TASK: [write a file] ********************* 
changed: [b.local]

TASK: [delete it] ********************* 
changed: [b.local]

TASK: [write a file] ********************* 
changed: [a.local]

TASK: [delete it] ********************* 
changed: [a.local]

PLAY RECAP ********************* 
a.local                        : ok=2    changed=2    unreachable=0    failed=0    
b.local                        : ok=2    changed=2    unreachable=0    failed=0    
c.local                        : ok=2    changed=2    unreachable=0    failed=0    
```

serial defined in the yml still works fine:

```
dominis@shuriken:~/work/ansible (devel=)$ cat /tmp/a.yml 

---
- hosts: ${pool}
  serial: 2
  port: ${port}
  gather_facts: False
  tasks:

    - name: write a file
      action: shell touch /tmp/foo

    - name: delete it
      action: shell rm -f /tmp/foo
```

```
dominis@shuriken:~/work/ansible (devel=)$ python bin/ansible-playbook /tmp/a.yml -e "pool=app-pool port=2223" 

PLAY [app-pool] ********************* 

TASK: [write a file] ********************* 
changed: [c.local]
changed: [b.local]

TASK: [delete it] ********************* 
changed: [c.local]
changed: [b.local]

TASK: [write a file] ********************* 
changed: [a.local]

TASK: [delete it] ********************* 
changed: [a.local]

PLAY RECAP ********************* 
a.local                        : ok=2    changed=2    unreachable=0    failed=0    
b.local                        : ok=2    changed=2    unreachable=0    failed=0    
c.local                        : ok=2    changed=2    unreachable=0    failed=0 
```
