### PR TITLE
Fix hostname expansion bug in inventory parser

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -93,28 +93,24 @@ class InventoryParser(object):
                         hostname = tokens2[0]
                         port     = tokens2[1]
 
-                host = None
-                _all_hosts = []
-                if hostname in self.hosts:
-                    host = self.hosts[hostname]
-                    _all_hosts.append(host)
+                hostnames = []
+                if detect_range(hostname):
+                    hostnames = expand_hostname_range(hostname)
                 else:
-                    if detect_range(hostname):
-                        _hosts = expand_hostname_range(hostname)
-                        for _ in _hosts:
-                            host = Host(name=_, port=port)
-                            self.hosts[_] = host
-                            _all_hosts.append(host)
+                    hostnames = [hostname]
+
+                for hn in hostnames:
+                    host = None
+                    if hn in self.hosts:
+                        host = self.hosts[hn]
                     else:
-                        host = Host(name=hostname, port=port)
-                        self.hosts[hostname] = host
-                        _all_hosts.append(host)
-                if len(tokens) > 1:
-                    for t in tokens[1:]:
-                        (k,v) = t.split("=")
-                        host.set_variable(k,v)
-                for _ in _all_hosts:
-                    self.groups[active_group_name].add_host(_)
+                        host = Host(name=hn, port=port)
+                        self.hosts[hn] = host
+                    if len(tokens) > 1:
+                        for t in tokens[1:]:
+                            (k,v) = t.split("=")
+                            host.set_variable(k,v)
+                    self.groups[active_group_name].add_host(host)
 
     # [southeast:children]
     # atlanta

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -150,6 +150,17 @@ class TestInventory(unittest.TestCase):
         print expected
         assert vars == expected
 
+    def test_complex_group_names(self):
+        inventory = self.complex_inventory()
+        tests = {
+            'host1': [ 'role1' ],
+            'host2': [ 'role1', 'role2' ],
+            'host3': [ 'role2' ]
+        }
+        for host, roles in tests.iteritems():
+            group_names = inventory.get_variables(host)['group_names']
+            assert sorted(group_names) == sorted(roles)
+
     def test_complex_exclude(self):
         inventory = self.complex_inventory()
         hosts = inventory.list_hosts("nc:florida:!triangle:!orlando")

--- a/test/complex_hosts
+++ b/test/complex_hosts
@@ -73,4 +73,9 @@ d=100002
 [us:vars]
 c=1000000
 
+[role1]
+host[1:2]
+
+[role2]
+host[2:3]
 


### PR DESCRIPTION
In the following case,

```
[role1]
host[1:2]

[role2]
host[2:3]
```

host2 should be in both groups, but due to a bug in inventory parser, it isn't.

Fixed it and added a test case.
