### PR TITLE
fix documentation for authorized_key in advanced playbooks page in docsite

### DIFF
--- a/docsite/rst/playbooks2.rst
+++ b/docsite/rst/playbooks2.rst
@@ -443,7 +443,8 @@ This syntax will remain in future versions, though we will also will provide way
 is an example using the authorized_key module, which requires the actual text of the SSH key as a parameter::
 
     tasks:
-        - authorized_key: name=$item key='$FILE(/keys/$item)'
+        - name: enable key-based ssh access for users
+          authorized_key: user=$item key='$FILE(/keys/$item)'
           with_items:
              - pinky
              - brain


### PR DESCRIPTION
Minimal fix for the authorized_key example in the Advanced Playbooks page in the docsite.
