### PR TITLE
Add return code and error output to raw module

### DIFF
--- a/lib/ansible/runner/action_plugins/raw.py
+++ b/lib/ansible/runner/action_plugins/raw.py
@@ -34,7 +34,7 @@ class ActionModule(object):
         self.runner = runner
 
     def run(self, conn, tmp, module_name, module_args, inject):
-        return ReturnData(conn=conn, result=dict(
-            stdout=self.runner._low_level_exec_command(conn, module_args.encode('utf-8'), tmp, sudoable=True)
-        ))
+        return ReturnData(conn=conn,
+            result=self.runner._low_level_exec_command(conn, module_args.encode('utf-8'), tmp, sudoable=True)
+        )
 

--- a/lib/ansible/runner/connection_plugins/fireball.py
+++ b/lib/ansible/runner/connection_plugins/fireball.py
@@ -88,7 +88,7 @@ class Connection(object):
         response = utils.decrypt(self.key, response)
         response = utils.parse_json(response)
 
-        return ('', response.get('stdout',''), response.get('stderr',''))
+        return (response.get('rc',None), '', response.get('stdout',''), response.get('stderr',''))
 
     def put_file(self, in_path, out_path):
 

--- a/lib/ansible/runner/connection_plugins/local.py
+++ b/lib/ansible/runner/connection_plugins/local.py
@@ -52,7 +52,7 @@ class Connection(object):
         p = subprocess.Popen(cmd, cwd=basedir, shell=True, stdin=None,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
-        return ("", stdout, stderr)
+        return (p.returncode, '', stdout, stderr)
 
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to local '''

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -145,7 +145,7 @@ class Connection(object):
             except socket.timeout:
                 raise errors.AnsibleError('ssh timed out waiting for sudo.\n' + sudo_output)
 
-        return (chan.makefile('wb', bufsize), chan.makefile('rb', bufsize), '')
+        return (chan.recv_exit_status(), chan.makefile('wb', bufsize), chan.makefile('rb', bufsize), chan.makefile_stderr('rb', bufsize))
 
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''

--- a/library/fireball
+++ b/library/fireball
@@ -159,7 +159,7 @@ def command(data):
         stderr = ''
     log("got stdout: %s" % stdout)
 
-    return dict(stdout=stdout, stderr=stderr)
+    return dict(rc=p.returncode, stdout=stdout, stderr=stderr)
 
 def fetch(data):
     if 'in_path' not in data:

--- a/library/raw
+++ b/library/raw
@@ -13,11 +13,11 @@ description:
        all core modules require it. Another is speaking to any devices such as
        routers that do not have any Python installed. In any other case, using
        the M(shell) or M(command) module is much more appropriate. Arguments
-       given to M(raw) are run directly through the configured remote shell and
-       only output is returned. There is no error detection or change handler
-       support for this module
+       given to M(raw) are run directly through the configured remote shell.
+       Standard output, error output and return code are returned when
+       available. There is no change handler support for this module.
 examples:
-    - code: ansible newhost.example.com -m raw -a "yum -y install python-simplejson"
-      description: Example from C(/usr/bin/ansible) to bootstrap a legacy python 2.4 host
+    - description: Example from C(/usr/bin/ansible) to bootstrap a legacy python 2.4 host
+      code: ansible newhost.example.com -m raw -a "yum -y install python-simplejson"
 author: Michael DeHaan
 '''


### PR DESCRIPTION
Since we use 'raw' heavily on equipment where 'command' and 'shell' are not working (and python may need to be installed first using raw) these improvements are necessary in order to write more complex scripts (with return code handling and separated stdout/stderr).

This patch includes the following changes:
- exec_command() now returns the return code of the command
- _low_level_exec_command() now returns a dict, including 'rc', 'stdout' and 'stderr'
- all users of the above interfaces have been improved to make use of the above changes
- all connection plugins have been modified to return rc and stderr
- fix the newline problem (stdout and stderr would have excess newlines)

In a future commit I intend to add assertions or error handling code to verify the return code in those places where it wasn't done for _low_level_exec_command().
