### PR TITLE
Disable pseudo tty's by default, unless explicitely asked (or when using sudo)

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -438,11 +438,14 @@ class Runner(object):
 
     # *****************************************************
 
-    def _low_level_exec_command(self, conn, cmd, tmp, sudoable=False):
+    def _low_level_exec_command(self, conn, cmd, tmp, sudoable=False, executable=None, pty=True):
         ''' execute a command string over SSH, return the output '''
 
+        if not executable:
+            executable = '/bin/sh'
+
         sudo_user = self.sudo_user
-        rc, stdin, stdout, stderr = conn.exec_command(cmd, tmp, sudo_user, sudoable=sudoable)
+        rc, stdin, stdout, stderr = conn.exec_command(cmd, tmp, sudo_user, sudoable=sudoable, executable=executable, pty=pty)
 
         if type(stdout) not in [ str, unicode ]:
             out = ''.join(stdout.readlines())

--- a/lib/ansible/runner/connection_plugins/fireball.py
+++ b/lib/ansible/runner/connection_plugins/fireball.py
@@ -67,7 +67,7 @@ class Connection(object):
 
         return self
 
-    def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False):
+    def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False, executable='/bin/sh', pty=True):
         ''' run a command on the remote host '''
 
         vvv("EXEC COMMAND %s" % cmd)
@@ -79,6 +79,8 @@ class Connection(object):
             mode='command',
             cmd=cmd,
             tmp_path=tmp_path,
+            executable=executable,
+            pty=pty,
         )
         data = utils.jsonify(data)
         data = utils.encrypt(self.key, data)

--- a/lib/ansible/runner/connection_plugins/local.py
+++ b/lib/ansible/runner/connection_plugins/local.py
@@ -17,6 +17,7 @@
 
 import traceback
 import os
+import pipes
 import shutil
 import subprocess
 from ansible import errors
@@ -36,22 +37,37 @@ class Connection(object):
 
         return self
 
-    def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False):
+    def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False, executable='/bin/sh', pty=True):
         ''' run a command on the local host '''
 
-        if self.runner.sudo and sudoable:
+        if not self.runner.sudo or not sudoable:
+            local_cmd = [ executable, '-c', cmd]
+        else:
             if self.runner.sudo_pass:
                 # NOTE: if someone wants to add sudo w/ password to the local connection type, they are welcome
                 # to do so.  The primary usage of the local connection is for crontab and kickstart usage however
                 # so this doesn't seem to be a huge priority
                 raise errors.AnsibleError("sudo with password is presently only supported on the 'paramiko' (SSH) and native 'ssh' connection types")
-            cmd = "sudo -u {0} -s {1}".format(sudo_user, cmd)
+            sudocmd = "sudo -u %s -s %s -c %s" % (sudo_user, executable, cmd)
+            local_cmd = ['/bin/sh', '-c', sudocmd]
 
-        vvv("EXEC %s" % cmd, host=self.host)
-        basedir = self.runner.basedir
-        p = subprocess.Popen(cmd, cwd=basedir, shell=True, stdin=None,
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        vvv("EXEC %s" % local_cmd, host=self.host)
+        try:
+            if pty:
+                import pty
+                master, slave = pty.openpty()
+                p = subprocess.Popen(local_cmd, cwd=self.runner.basedir, executable=executable,
+                                     stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                stdin = os.fdopen(master, 'w', 0)
+            else:
+                raise # Make sure we fall back to no pty's if requested
+        except:
+            p = subprocess.Popen(local_cmd, cwd=self.runner.basedir, executable=executable,
+                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdin = p.stdin
+
         stdout, stderr = p.communicate()
+        stdin.close()
         return (p.returncode, '', stdout, stderr)
 
     def put_file(self, in_path, out_path):

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -96,7 +96,7 @@ class Connection(object):
 
         return ssh
 
-    def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False):
+    def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False, executable='/bin/sh', pty=True):
         ''' run a command on the remote host '''
 
         bufsize = 4096
@@ -107,10 +107,12 @@ class Connection(object):
             if len(str(e)) > 0:
                 msg += ": %s" % str(e)
             raise errors.AnsibleConnectionFailed(msg)
-        chan.get_pty()
+
+        if pty:
+            chan.get_pty()
 
         if not self.runner.sudo or not sudoable:
-            quoted_command = '/bin/sh -c ' + pipes.quote(cmd)
+            quoted_command = executable + ' -c ' + pipes.quote(cmd)
             vvv("EXEC %s" % quoted_command, host=self.host)
             chan.exec_command(quoted_command)
         else:
@@ -123,8 +125,8 @@ class Connection(object):
             # the -p option.
             randbits = ''.join(chr(random.randint(ord('a'), ord('z'))) for x in xrange(32))
             prompt = '[sudo via ansible, key=%s] password: ' % randbits
-            sudocmd = 'sudo -k && sudo -p "%s" -u %s /bin/sh -c %s' % (
-                prompt, sudo_user, pipes.quote(cmd))
+            sudocmd = 'sudo -k && sudo -p "%s" -u %s %s -c %s' % (
+                prompt, sudo_user, executable, pipes.quote(cmd))
             shcmd = '/bin/sh -c ' + pipes.quote(sudocmd)
             vvv("EXEC %s" % shcmd, host=self.host)
             sudo_output = ''

--- a/library/fireball
+++ b/library/fireball
@@ -149,10 +149,25 @@ def command(data):
         return dict(failed=True, msg='internal error: cmd is required')
     if 'tmp_path' not in data:
         return dict(failed=True, msg='internal error: tmp_path is required')
+    if 'executable' not in data:
+        return dict(failed=True, msg='internal error: executable is required')
 
     log("executing: %s" % data['cmd'])
-    p = subprocess.Popen(data['cmd'], shell=True, stdout=subprocess.PIPE, close_fds=True)
+    try:
+        if data['pty']:
+            import pty
+            master, slave = pty.openpty()
+            p = subprocess.Popen(data['cmd'], executable=data['executable'], shell=True, close_fds=True,
+                                 stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdin = os.fdopen(master, 'w', 0)
+        else:
+            raise # Make sure we fall back to no pty's if requested
+    except:
+        p = subprocess.Popen(data['cmd'], executable=data['executable'], shell=True, close_fds=True,
+                             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdin = p.stdin
     (stdout, stderr) = p.communicate()
+    stdin.close()
     if stdout is None:
         stdout = ''
     if stderr is None:

--- a/library/raw
+++ b/library/raw
@@ -4,7 +4,23 @@ DOCUMENTATION = '''
 ---
 module: raw
 short_description: Executes a low-down and dirty SSH command
-options: {}
+options:
+  free_form:
+    description:
+      - the raw module takes a free form command to run
+    required: true
+  executable:
+    description:
+      - change the shell used to execute the command. Should be an absolute path to the executable.
+    required: false
+    default: /bin/sh
+    version_added: "1.0"
+  pty:
+    description:
+      - enable or disable the use of pseudo tty's
+    required: false
+    default: false
+    version_added: "1.0"
 description: 
      - Executes a low-down and dirty SSH command, not going through the module
        subsystem. This is useful and should only be done in two cases. The
@@ -14,8 +30,7 @@ description:
        routers that do not have any Python installed. In any other case, using
        the M(shell) or M(command) module is much more appropriate. Arguments
        given to M(raw) are run directly through the configured remote shell.
-       Standard output, error output and return code are returned when
-       available. There is no change handler support for this module.
+       Standard output, error output and return code are returned.
 examples:
     - description: Example from C(/usr/bin/ansible) to bootstrap a legacy python 2.4 host
       code: ansible newhost.example.com -m raw -a "yum -y install python-simplejson"


### PR DESCRIPTION
After extensive testing I concluded that using `ssh -tt` is hurting raw commands (and if script uses raw, also script). The reason is that `ssh -tt` causes all output going to stdout, rather than separating stdout and stderr.

You can check by doing:

```
$ ssh -q -tt <system> ls /dag/ >/dev/null
$
```

which gives no output because stderr goes straight into /dev/null, contrary to:

```
$ ssh -q -T <system> ls /dag/ >/dev/null
ls: cannot access /dag/: No such file or directory
$
```

For normal command/shell actions, the output is processed beforehand and returned through json, but this is not possible for raw commands (that do not require python). Besides anything run using remote modules has effectively pseudo tty's disabled anyhow (!).

What's more, when using pseudo tty's when running something remotely (using raw), it is possible that some process behaves differently (e.g. menu system or something requiring input). We have seen problems with installers hanging indefinitely because of pseudo tty's where it would work fine outside of Ansible using shmux. I don't think any of the alternative parallel shells or config mgmt software is using pseudo tty's by default.

So the included patch disables pseudo tty's by default, except when explicitely asked for using `pty=yes` or when using sudo (is this needed and when ?). We also enable pseudo tty's by default when using sudo (however, I think we should re-evaluate this and confirm when exactly this is needed).

Another reason for disabling pseudo tty's is that when using local or fireball transport, no pseudo tty's have been available (ever). We can implement this as well, if necessary, but this enforces the fact that at the moment different transports are doing it differently, and even for command, shell and script pseudo tty's were effectively disabled (through Popen).

So if some transports don't have pseudo tty's, and most of the action (command, shell, script) were not using them either, the question begs, who needs them ? And do we want to make them available across the board ? (i.e. using raw/script with `pty=yes` on fireball/local, or using command/shell with `pty=yes` on all transports).

I don't mind cleaning this up.
