### PR TITLE
Collate commands in a single ssh roundtrip and check return code where possible

### DIFF
--- a/lib/ansible/runner/action_plugins/async.py
+++ b/lib/ansible/runner/action_plugins/async.py
@@ -15,18 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import pwd
-import random
-import traceback
-import tempfile
-
-import ansible.constants as C
-from ansible import utils
-from ansible import errors
-from ansible import module_common
-from ansible.runner.return_data import ReturnData
-
 class ActionModule(object):
 
     def __init__(self, runner):
@@ -41,7 +29,6 @@ class ActionModule(object):
             module_args += " #USE_SHELL"
 
         (module_path, is_new_style, shebang) = self.runner._copy_module(conn, tmp, module_name, module_args, inject)
-        self.runner._low_level_exec_command(conn, "chmod a+rx %s" % module_path, tmp)
 
         return self.runner._execute_module(conn, tmp, 'async_wrapper', module_args,
            async_module=module_path,

--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -16,15 +16,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import pwd
-import random
-import traceback
-import tempfile
 
-import ansible.constants as C
 from ansible import utils
 from ansible import errors
-from ansible import module_common
 from ansible.runner.return_data import ReturnData
 
 class ActionModule(object):
@@ -78,8 +72,9 @@ class ActionModule(object):
         xfered = self.runner._transfer_str(conn, tmp, 'source', resultant)
         # fix file permissions when the copy is done as a different user
         if self.runner.sudo and self.runner.sudo_user != 'root':
-            self.runner._low_level_exec_command(conn, "chmod a+r %s" % xfered, 
-                tmp)
+            chmod = self.runner._low_level_exec_command(conn, "chmod a+r %s" % xfered, tmp)
+            if chmod['rc'] != 0 or chmod['stderr'] != '':                                                                                                                                 
+                raise errors.AnsibleError('FAILED: ' + chmod['stderr'])
 
         # run the copy module
         module_args = "%s src=%s dest=%s" % (module_args, xfered, dest)


### PR DESCRIPTION
Related to PR #1748 and #1800 I looked into all possible calls to `_low_level_exec_command()` and tried to collate as many as possible as well as verify return code and output:
- async: Moving one chmod up to exec_module() and collate
- copy: Test return code and stderr output
- script: Test return code and stderr output
- template: Test return code and stderr output
- exec_module(): Collate sudo chmod into one single roundtrip to run module
- _remote_md5(): Test return code and stdout, add stderr to debugging
- _remote_md5(): simplify code
- _make_tmp_path(): Test return code and stderr
- all: clean up imports

If one of the preparation commands (mkdir, chmod, rm) fails, we get a proper error:

```
TASK: [copy src=test31.yml dest=/tmp/test31.yml] *********************
fatal: [localhost] => FAILED: mkdir: cannot create directory `/root/.ansible/tmp/ansible-1356408824.92-182593391072662': Permission denied
```

This patch set requires the pty patch set to enforce stdout/stderr separation.
