### PR TITLE
syslog.openlog does not cope with unicode first argument

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -549,7 +549,7 @@ class AnsibleModule(object):
             journal.sendv(*journal_args)
         else:
             msg = ''
-            syslog.openlog('ansible-%s' % os.path.basename(__file__), 0, syslog.LOG_USER)
+            syslog.openlog('ansible-%s' % str(os.path.basename(__file__)), 0, syslog.LOG_USER)
             for arg in log_args:
                 msg = msg + arg + '=' + str(log_args[arg]) + ' '
             if msg:


### PR DESCRIPTION
It seems that os.path.basename(**file**) can return a unicode
string. In this case syslog.openlog fails. Forcing the result
to a string causes the resulting error to go away.
