### PR TITLE
Recursive Copy module

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -91,6 +91,7 @@ DEFAULT_SCP_IF_SSH        = get_config(p, 'ssh_connection', 'scp_if_ssh',       
 DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')
 DEFAULT_SYSLOG_FACILITY   = get_config(p, DEFAULTS, 'syslog_facility',  'ANSIBLE_SYSLOG_FACILITY', 'LOG_USER')
 DEFAULT_KEEP_REMOTE_FILES = get_config(p, DEFAULTS, 'keep_remote_files', 'ANSIBLE_KEEP_REMOTE_FILES', '0')
+DEFAULT_RCOPY_EXCLUDE     = get_config(p, DEFAULTS, 'rcopy_exclude', 'RCOPY_EXCLUDE', '.DS_Store,Desktop.ini,._*,Thumbs.db,.git,.git*,.svn')
 
 DEFAULT_ACTION_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'action_plugins',     None, '/usr/share/ansible_plugins/action_plugins'))
 DEFAULT_CALLBACK_PLUGIN_PATH   = shell_expand_path(get_config(p, DEFAULTS, 'callback_plugins',   None, '/usr/share/ansible_plugins/callback_plugins'))

--- a/lib/ansible/runner/action_plugins/rcopy.py
+++ b/lib/ansible/runner/action_plugins/rcopy.py
@@ -1,0 +1,96 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import pwd
+import random
+import traceback
+import tempfile
+
+import ansible.constants as C
+from ansible import utils
+from ansible import errors
+from ansible import module_common
+from ansible.runner.return_data import ReturnData
+
+class ActionModule(object):
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    def run(self, conn, tmp, module_name, module_args, inject):
+        ''' handler for file transfer operations '''
+
+        # load up options
+        options = utils.parse_kv(module_args)
+        source  = options.get('src', None)
+        dest    = options.get('dest', None)
+
+        if dest.endswith("/"):
+            base = os.path.basename(source)
+            dest = os.path.join(dest, base)
+
+        if (source is None and not 'first_available_file' in inject) or dest is None:
+            result=dict(failed=True, msg="src and dest are required")
+            return ReturnData(conn=conn, result=result)
+
+        # if we have first_available_file in our vars
+        # look up the files and use the first one we find as src
+        if 'first_available_file' in inject:
+            found = False
+            for fn in inject.get('first_available_file'):
+                fn = utils.template(self.runner.basedir, fn, inject)
+                fn = utils.path_dwim(self.runner.basedir, fn)
+                if os.path.exists(fn):
+                    source = fn
+                    found = True
+                    break
+            if not found:
+                results=dict(failed=True, msg="could not find src in first_available_file list")
+                return ReturnData(conn=conn, result=results)
+
+        source = utils.template(self.runner.basedir, source, inject)
+        source = utils.path_dwim(self.runner.basedir, source)
+
+        local_md5 = utils.md5(source)
+        if local_md5 is None:
+            result=dict(failed=True, msg="could not find src=%s" % source)
+            return ReturnData(conn=conn, result=result)
+
+        remote_md5 = self.runner._remote_md5(conn, tmp, dest)
+
+        exec_rc = None
+        if local_md5 != remote_md5:
+            # transfer the file to a remote tmp location
+            tmp_src = tmp + os.path.basename(source)
+            conn.put_file(source, tmp_src)
+            # fix file permissions when the copy is done as a different user
+            if self.runner.sudo and self.runner.sudo_user != 'root':
+                self.runner._low_level_exec_command(conn, "chmod a+r %s" % tmp_src, tmp)
+
+            # run the copy module
+            module_args = "%s src=%s" % (module_args, tmp_src)
+            return self.runner._execute_module(conn, tmp, 'copy', module_args, inject=inject)
+
+        else:
+            # no need to transfer the file, already correct md5, but still need to call
+            # the file module in case we want to change attributes
+
+            tmp_src = tmp + os.path.basename(source)
+            module_args = "%s src=%s" % (module_args, tmp_src)
+            return self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject)
+

--- a/lib/ansible/runner/action_plugins/rcopy.py
+++ b/lib/ansible/runner/action_plugins/rcopy.py
@@ -20,6 +20,7 @@ import pwd
 import random
 import traceback
 import tempfile
+from collections import defaultdict
 
 import ansible.constants as C
 from ansible import utils
@@ -39,10 +40,6 @@ class ActionModule(object):
         options = utils.parse_kv(module_args)
         source  = options.get('src', None)
         dest    = options.get('dest', None)
-
-        if dest.endswith("/"):
-            base = os.path.basename(source)
-            dest = os.path.join(dest, base)
 
         if (source is None and not 'first_available_file' in inject) or dest is None:
             result=dict(failed=True, msg="src and dest are required")
@@ -66,55 +63,73 @@ class ActionModule(object):
         source = utils.template(self.runner.basedir, source, inject)
         source = utils.path_dwim(self.runner.basedir, source)
 
-        source_files = []
-        results = []
+        # Try to emulate rsync behaviour:
+        # A trailing / on a source name means "copy the contents of this directory".
+        # Without a trailing slash it means "copy the directory".
+        if source.endswith("/"):
+            source_base = source
+        else:
+            source_base = utils.rreplace(os.path.basename(source), '', source)
+
+        file_queue = defaultdict(list)
 
         if os.path.isdir(source):
-            for base_path, sub_folders, files in os.walk(source):
-                for file in files:
-                    source_files.append(os.path.join(base_path, file))
+            for directory, sub_folders, filenames in os.walk(source):
+                directory = utils.lreplace(source_base, '', directory)
+                file_queue[directory] = []
+                for filename in filenames:
+                    file_queue[directory].append(filename)
         else:
-            source_files.append(source)
+            directory = source_base
+            filename = os.path.basename(source)
+            file_queue[directory] = []
+            file_queue[directory].append(filename)
 
         changed = False
 
-        for source_file in source_files:
-            # We need to get a new tmp path for each file, otherwise the copy module deletes the folder.
-            tmp = self.runner._make_tmp_path(conn)
-            local_md5 = utils.md5(source_file)
+        for source_directory, source_files in file_queue.items():
+            source_path = os.path.join(source_base, source_directory.lstrip('/'))
+            dest_path = os.path.join(dest, source_directory.lstrip('/'))
 
-            if local_md5 is None:
-                result = dict(failed=True, msg="could not find src=%s" % source_file)
-                return ReturnData(conn=conn, result=result)
+            for filename in source_files:
+                module_options = options.copy()
 
-            remote_md5 = self.runner._remote_md5(conn, tmp, dest)
+                dest_file = os.path.join(dest_path, filename)
+                source_file = os.path.join(source_path, filename)
 
-            exec_rc = None
-            if local_md5 != remote_md5:
-                # transfer the file to a remote tmp location
+                # We need to get a new tmp path for each file, otherwise the copy module deletes the folder.
+                tmp = self.runner._make_tmp_path(conn)
+                local_md5 = utils.md5(source_file)
+
+                if local_md5 is None:
+                    result = dict(failed=True, msg="could not find src=%s" % source_file)
+                    return ReturnData(conn=conn, result=result)
+
+                remote_md5 = self.runner._remote_md5(conn, tmp, dest)
                 tmp_src = tmp + os.path.basename(source_file)
-                conn.put_file(source_file, tmp_src)
-                # fix file permissions when the copy is done as a different user
-                if self.runner.sudo and self.runner.sudo_user != 'root':
-                    self.runner._low_level_exec_command(conn, "chmod a+r %s" % tmp_src, tmp)
+                module_options.update({'src': tmp_src, 'dest': dest_file})
 
-                # run the copy module
-                module_args = "%s src=%s" % (module_args, tmp_src)
-                module_return = self.runner._execute_module(conn, tmp, 'copy', module_args, inject=inject)
+                module_args = ' '.join(['%s=%s' % (key, value) for (key, value) in module_options.items()])
 
-            else:
-                # no need to transfer the file, already correct md5, but still need to call
-                # the file module in case we want to change attributes
+                exec_rc = None
+                if local_md5 != remote_md5:
+                    # transfer the file to a remote tmp location
+                    conn.put_file(source_file, tmp_src)
+                    # fix file permissions when the copy is done as a different user
+                    if self.runner.sudo and self.runner.sudo_user != 'root':
+                        self.runner._low_level_exec_command(conn, "chmod a+r %s" % tmp_src, tmp)
+                    # run the copy module
+                    module_return = self.runner._execute_module(conn, tmp, 'rcopy', module_args, inject=inject)
+                else:
+                    # no need to transfer the file, already correct md5, but still need to call
+                    # the file module in case we want to change attributes
+                    module_return = self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject)
 
-                tmp_src = tmp + os.path.basename(source_file)
-                module_args = "%s src=%s" % (module_args, tmp_src)
-                module_return = self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject)
-
-            module_result = module_return.result
-            if 'failed' in module_result and module_result['failed'] == True:
-                return module_return
-            if 'changed' in module_result and module_result['changed'] == True:
-                changed = True
+                module_result = module_return.result
+                if 'failed' in module_result and module_result['failed'] == True:
+                    return module_return
+                if 'changed' in module_result and module_result['changed'] == True:
+                    changed = True
 
         res_args = dict(
             dest=dest, src=source, changed=changed

--- a/lib/ansible/runner/action_plugins/rcopy.py
+++ b/lib/ansible/runner/action_plugins/rcopy.py
@@ -66,31 +66,58 @@ class ActionModule(object):
         source = utils.template(self.runner.basedir, source, inject)
         source = utils.path_dwim(self.runner.basedir, source)
 
-        local_md5 = utils.md5(source)
-        if local_md5 is None:
-            result=dict(failed=True, msg="could not find src=%s" % source)
-            return ReturnData(conn=conn, result=result)
+        source_files = []
+        results = []
 
-        remote_md5 = self.runner._remote_md5(conn, tmp, dest)
-
-        exec_rc = None
-        if local_md5 != remote_md5:
-            # transfer the file to a remote tmp location
-            tmp_src = tmp + os.path.basename(source)
-            conn.put_file(source, tmp_src)
-            # fix file permissions when the copy is done as a different user
-            if self.runner.sudo and self.runner.sudo_user != 'root':
-                self.runner._low_level_exec_command(conn, "chmod a+r %s" % tmp_src, tmp)
-
-            # run the copy module
-            module_args = "%s src=%s" % (module_args, tmp_src)
-            return self.runner._execute_module(conn, tmp, 'copy', module_args, inject=inject)
-
+        if os.path.isdir(source):
+            for base_path, sub_folders, files in os.walk(source):
+                for file in files:
+                    source_files.append(os.path.join(base_path, file))
         else:
-            # no need to transfer the file, already correct md5, but still need to call
-            # the file module in case we want to change attributes
+            source_files.append(source)
 
-            tmp_src = tmp + os.path.basename(source)
-            module_args = "%s src=%s" % (module_args, tmp_src)
-            return self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject)
+        changed = False
 
+        for source_file in source_files:
+            # We need to get a new tmp path for each file, otherwise the copy module deletes the folder.
+            tmp = self.runner._make_tmp_path(conn)
+            local_md5 = utils.md5(source_file)
+
+            if local_md5 is None:
+                result = dict(failed=True, msg="could not find src=%s" % source_file)
+                return ReturnData(conn=conn, result=result)
+
+            remote_md5 = self.runner._remote_md5(conn, tmp, dest)
+
+            exec_rc = None
+            if local_md5 != remote_md5:
+                # transfer the file to a remote tmp location
+                tmp_src = tmp + os.path.basename(source_file)
+                conn.put_file(source_file, tmp_src)
+                # fix file permissions when the copy is done as a different user
+                if self.runner.sudo and self.runner.sudo_user != 'root':
+                    self.runner._low_level_exec_command(conn, "chmod a+r %s" % tmp_src, tmp)
+
+                # run the copy module
+                module_args = "%s src=%s" % (module_args, tmp_src)
+                module_return = self.runner._execute_module(conn, tmp, 'copy', module_args, inject=inject)
+
+            else:
+                # no need to transfer the file, already correct md5, but still need to call
+                # the file module in case we want to change attributes
+
+                tmp_src = tmp + os.path.basename(source_file)
+                module_args = "%s src=%s" % (module_args, tmp_src)
+                module_return = self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject)
+
+            module_result = module_return.result
+            if 'failed' in module_result and module_result['failed'] == True:
+                return module_return
+            if 'changed' in module_result and module_result['changed'] == True:
+                changed = True
+
+        res_args = dict(
+            dest=dest, src=source, changed=changed
+        )
+
+        return ReturnData(conn=conn, result=res_args)

--- a/lib/ansible/runner/action_plugins/rcopy.py
+++ b/lib/ansible/runner/action_plugins/rcopy.py
@@ -107,8 +107,8 @@ class ActionModule(object):
 
                 remote_md5 = self.runner._remote_md5(conn, tmp, dest)
                 tmp_src = tmp + os.path.basename(source_file)
-                module_options.update({'src': tmp_src, 'dest': dest_file})
 
+                module_options.update({'src': '"%s"' % tmp_src, 'dest': '"%s"' % dest_file})
                 module_args = ' '.join(['%s=%s' % (key, value) for (key, value) in module_options.items()])
 
                 exec_rc = None

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -473,4 +473,17 @@ def boolean(value):
     else:
         return False
 
+def lreplace(old, new, string):
+    '''
+     If the string starts with the substring old, replace it with substring new and return
+     a copy of the string.
+     '''
+    return string[len(old):] + new if string.startswith(old) else string
+
+def rreplace(old, new, string):
+    '''
+     If the string ends with the substring old, replace it with substring new and return a
+     copy of the string.
+     '''
+    return string[:-len(old)] + new if string.endswith(old) else string
 

--- a/library/rcopy
+++ b/library/rcopy
@@ -1,0 +1,140 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import time
+
+DOCUMENTATION = '''
+---
+module: rcopy
+short_description: Recursively copies files and folders to remote locations.
+description:
+     - The M(copy) module copies a file on the local box to remote locations.
+options:
+  src:
+    description:
+      - Local path to a file to copy to the remote server; can be absolute or relative.
+    required: true
+    default: null
+    aliases: []
+  dest:
+    description:
+      - Remote absolute path where the file should be copied to.
+    required: true
+    default: null
+  backup:
+    description:
+      - Create a backup file including the timestamp information so you can get
+        the original file back if you somehow clobbered it incorrectly.
+    version_added: "0.8"
+    required: false
+    choices: [ "yes", "no" ]
+    default: "no"
+  others:
+    description:
+      - all arguments accepted by the M(file) module also work here
+    required: false
+examples:
+   - code: "rcopy: src=/srv/myfiles/foo.conf dest=/etc/foo.conf owner=foo group=foo mode=0644"
+     description: "Example from Ansible Playbooks"
+   - code: "rcopy: src=/mine/ntp.conf dest=/etc/ntp.conf owner=root group=root mode=644 backup=yes"
+     description: "Copy a new C(ntp.conf) file into place, backing up the original if it differs from the copied version"
+author: Michael DeHaan
+'''
+
+def main():
+
+    module = AnsibleModule(
+        # not checking because of daisy chain to file module
+        argument_spec = dict(
+            src=dict(required=True),
+            dest=dict(required=True),
+            backup=dict(default=False, choices=BOOLEANS),
+        ),
+        add_file_common_args=True
+    )
+
+    src  = os.path.expanduser(module.params['src'])
+    dest = os.path.expanduser(module.params['dest'])
+    backup = module.boolean(module.params.get('backup', False))
+    file_args = module.load_file_common_arguments(module.params)
+
+    if not os.path.exists(src):
+        module.fail_json(msg="Source %s failed to transfer" % (src))
+    if not os.access(src, os.R_OK):
+        module.fail_json(msg="Source %s not readable" % (src))
+
+    md5sum_src = module.md5(src)
+    md5sum_dest = None
+
+    if os.path.exists(dest):
+        if not os.access(dest, os.W_OK):
+            module.fail_json(msg="Destination %s not writable" % (dest))
+        if not os.access(dest, os.R_OK):
+            module.fail_json(msg="Destination %s not readable" % (dest))
+        if (os.path.isdir(dest)):
+            basename = os.path.basename(src)
+            dest = os.path.join(dest, basename)
+        md5sum_dest = module.md5(dest)
+    else:
+        if not os.path.exists(os.path.dirname(dest)):
+            module.fail_json(msg="Destination directory %s does not exist" % (os.path.dirname(dest)))
+        if not os.access(os.path.dirname(dest), os.W_OK):
+            module.fail_json(msg="Destination %s not writable" % (os.path.dirname(dest)))
+
+    backup_file = None
+    if md5sum_src != md5sum_dest or os.path.islink(dest):
+        try:
+            if backup:
+                if os.path.exists(dest):
+                    backup_file = module.backup_local(dest)
+            # allow for conversion from symlink.
+            if os.path.islink(dest):
+                os.unlink(dest)
+                open(dest, 'w').close()
+            #TODO:pid + epoch should avoid most collisions, hostname/mac for those using nfs?
+            # might be an issue with exceeding path length
+            dest_tmp = "%s.%s.%s.tmp" % (dest,os.getpid(),time.time())
+            shutil.copyfile(src, dest_tmp)
+            module.atomic_replace(dest_tmp, dest)
+        except shutil.Error:
+            module.fail_json(msg="failed to copy: %s and %s are the same" % (src, dest))
+        except IOError:
+            module.fail_json(msg="failed to copy: %s to %s" % (src, dest))
+        changed = True
+    else:
+        changed = False
+
+    res_args = dict(
+        dest = dest, src = src, md5sum = md5sum_src, changed = changed
+    )
+    if backup_file:
+        res_args['backup_file'] = backup_file
+
+    module.params['dest'] = dest
+    file_args = module.load_file_common_arguments(module.params)
+    res_args['changed'] = module.set_file_attributes_if_different(file_args, res_args['changed'])
+
+    module.exit_json(**res_args)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()

--- a/library/rcopy
+++ b/library/rcopy
@@ -85,6 +85,9 @@ def main():
     md5sum_src = module.md5(src)
     md5sum_dest = None
 
+    if not os.path.exists(dest):
+        os.makedirs(dest)
+
     if os.path.exists(dest):
         if not os.access(dest, os.W_OK):
             module.fail_json(msg="Destination %s not writable" % (dest))


### PR DESCRIPTION
I needed to have a recursive copy function to help keep track of folders of multiple files, rather than specifiying them individually.

I thought about modifying the copy module to add a recursive parameter, but to avoid introducing unforeseen problems with copy, I cloned it into a new rcopy module for now.

It works exactly the same as copy except it allows directories to be passed in as the src parameter. It recurses through the list of files contained within them and then runs the copy process for each file individually. 

I have created both an action_plugin, and a module. The module is unchanged from copy, with the exception of a call to os.makedirs(dest) if the dest parent folder does not exist.

It mimics rsync behaviour with the traling slashes on src:

``` python
# A trailing / on a source name means "copy the contents of this directory".
# Without a trailing slash it means "copy the directory".
# Trailing slashes on destinations make no difference.
```

There is also an exclude file mask applied, for which i've added a value to constants.py. This is a comma separated list of filename paths that should be excluded from the upload - typically hidden files like .DS_Store, Thumbs.db, VCS files, etc.

```
rcopy_exclude=.DS_Store,Desktop.ini,._*,Thumbs.db,.git,.git*,.svn

```
