### PR TITLE
add when_{failed,changed}, and extended when_{set,unset}

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -135,6 +135,11 @@ def is_failed(result):
 
     return ((result.get('rc', 0) != 0) or (result.get('failed', False) in [ True, 'True', 'true']))
 
+def is_changed(result):
+    ''' is a given JSON result a changed result? '''
+
+    return (result.get('changed', False) in [ True, 'True', 'true'])
+
 def check_conditional(conditional):
 
     def is_set(var):
@@ -484,6 +489,8 @@ def compile_when_to_only_if(expression):
 
     # when: set $variable
     # when: unset $variable
+    # when: failed $json_result
+    # when: changed $json_result
     # when: int $x >= $z and $y < 3
     # when: int $x in $alist
     # when: float $x > 2 and $y <= $z
@@ -497,9 +504,27 @@ def compile_when_to_only_if(expression):
 
     # when_set / when_unset
     if tokens[0] in [ 'set', 'unset' ]:
-        if len(tokens) != 2:
-            raise errors.AnsibleError("usage: when: <set|unset> <$variableName>")
-        return "is_%s('''%s''')" % (tokens[0], tokens[1])
+        tcopy = tokens[1:]
+        for (i,t) in enumerate(tokens[1:]):
+            if t.find("$") != -1:
+                tcopy[i] = "is_%s('''%s''')" % (tokens[0], t)
+            else:
+                tcopy[i] = t
+        return " ".join(tcopy)
+
+
+
+    # when_failed / when_changed
+    elif tokens[0] in [ 'failed', 'changed' ]:
+        tcopy = tokens[1:]
+        for (i,t) in enumerate(tokens[1:]):
+            if t.find("$") != -1:
+                tcopy[i] = "is_%s(%s)" % (tokens[0], t)
+            else:
+                tcopy[i] = t
+        return " ".join(tcopy)
+
+
 
     # when_integer / when_float / when_string
     elif tokens[0] in [ 'integer', 'float', 'string' ]:


### PR DESCRIPTION
This commit extends the 'when_' conditions to failed and changed
json results

Since I've seen the following suggested solutions a few time in the mailing list:

```
only_if: is_failed($res)
only_if: $res.changed == True
```

They might not occur a lot, but I think the when_ syntax makes them more readable and much easier to remember.

Additionally it makes when_*'s behave more alike in that they all except 
{and,or,not} logic, as opposed to only when_{int,str,flt,bool} accepting additional logic.

My test playbooks for these features can be [found here](https://github.com/fdavis/ansible-when-playbooks).
