### PR TITLE
Added block device facts

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -670,6 +670,23 @@ class AnsibleModule(object):
                 self.set_context_if_different(src, context, False)
         os.rename(src, dest)
 
+    def pretty_bytes(self,size):
+
+        ranges = (
+            (1<<50L, 'ZB'),
+            (1<<50L, 'EB'),
+            (1<<50L, 'PB'),
+            (1<<40L, 'TB'),
+            (1<<30L, 'GB'),
+            (1<<20L, 'MB'),
+            (1<<10L, 'KB'),
+            (1, 'Bytes')
+        )
+        for limit, suffix in ranges:
+            if size >= limit:
+                break
+        return '%.2f %s' % (float(size)/ limit, suffix)
+
 # == END DYNAMICALLY INSERTED CODE ===
 
 """

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -673,8 +673,8 @@ class AnsibleModule(object):
     def pretty_bytes(self,size):
 
         ranges = (
-            (1<<50L, 'ZB'),
-            (1<<50L, 'EB'),
+            (1<<70L, 'ZB'),
+            (1<<60L, 'EB'),
             (1<<50L, 'PB'),
             (1<<40L, 'TB'),
             (1<<30L, 'GB'),

--- a/library/setup
+++ b/library/setup
@@ -468,10 +468,19 @@ class LinuxHardware(Hardware):
                     if partname in mounts:
                         part = mounts[partname]
 
+                    # get start sector
+                    part['start'] = 0
+                    try:
+                        f = open(part_sysdir + "/start")
+                        part['start'] = f.read().rstrip()
+                        f.close()
+                    except IOError:
+                        pass
+
                     # populate sectors
                     part['sectors'] = 0
                     try:
-                        f = open(sysdir + "/size")
+                        f = open(part_sysdir + "/size")
                         part['sectors'] = f.read().rstrip()
                         f.close()
                     except IOError:
@@ -480,7 +489,7 @@ class LinuxHardware(Hardware):
                     # populate sector size
                     part['sectorsize'] = "512"
                     try:
-                        f = open(sysdir + "/queue/hw_sector_size")
+                        f = open(part_sysdir + "/queue/hw_sector_size")
                         part['sectorsize'] = f.read().rstrip()
                         f.close()
                     except IOError:

--- a/library/setup
+++ b/library/setup
@@ -495,7 +495,8 @@ class LinuxHardware(Hardware):
                     except IOError:
                         pass
 
-                    part['size'] = float(part['sectors']) * float(part['sectorsize'])
+                    part['size'] = module.pretty_bytes((float(part['sectors']) *
+                    float(part['sectorsize'])))
                     d['partitions'][partname] = part
 
 

--- a/library/setup
+++ b/library/setup
@@ -418,7 +418,7 @@ class LinuxHardware(Hardware):
 
             # populate metadata
             for key in ['vendor', 'model']:
-                d[key] = get_file_content("/device/" + key)
+                d[key] = get_file_content(sysdir + "/device/" + key)
 
             for key,test in [ ('removable','/removable'), \
                               ('support_discard','/queue/discard_granularity'),

--- a/library/setup
+++ b/library/setup
@@ -541,7 +541,7 @@ class LinuxHardware(Hardware):
             except IOError:
                 pass
 
-            d['size'] = float(d['sectors']) * float(d['sectorsize'])
+            d['size'] = module.pretty_bytes(float(d['sectors']) * float(d['sectorsize']))
 
             # set host info
             d['host'] = ""

--- a/library/setup
+++ b/library/setup
@@ -309,6 +309,7 @@ class LinuxHardware(Hardware):
         self.get_cpu_facts()
         self.get_memory_facts()
         self.get_dmi_facts()
+        self.get_device_facts()
         return self.facts
 
     def get_memory_facts(self):
@@ -364,6 +365,191 @@ class LinuxHardware(Hardware):
                     self.facts[key] = data
             else:
                 self.facts[key] = 'NA'
+
+    def get_device_facts(self):
+        self.facts['devices'] = {}
+        lspci = module.get_bin_path('lspci')
+        if lspci:
+            p = subprocess.Popen([lspci], stdout=subprocess.PIPE)
+            err = p.wait()
+            if err:
+                print "Error running lspci"
+            else:
+                pcidata = p.stdout.read()
+
+        # get mount data to use later
+        mounts = {}
+        try:
+            mtab = open('/etc/mtab')
+            for line in mtab.readlines():
+                if line.startswith('/'):
+                    fields = line.rstrip('\n').split(' ')
+                    mounts[os.path.basename(fields[0])] = { 'mount':fields[1], 'fstype' : fields[2], 'mount_opts': fields[3] }
+        except IOError, e:
+                module.fail_json( msg="failed to open mtab: %s" % e)
+
+        sysfs_no_links = 0
+        for block in os.listdir("/sys/block"):
+            try:
+                if sysfs_no_links == 0:
+                    path = os.readlink(os.path.join("/sys/block/", block))
+                else:
+                    path = block
+            except OSError, e:
+                if e.errno == errno.EINVAL:
+                    path = block
+                    sysfs_no_links = 1
+                else:
+                    continue
+            if re.search("virtual", path):
+                continue
+            if sysfs_no_links == 1:
+                sysdir = os.path.join("/sys/block", path)
+                virtual = 0
+                for folder in os.listdir(sysdir):
+                    if re.search("device", folder):
+                        virtual = 1
+                        break
+                if virtual:
+                    continue
+
+            # start getting device info
+            d = {}
+            sysdir = os.path.join("/sys/block", path)
+            m = re.match(".*/(.+)$", sysdir)
+            diskname = m.group(1)
+
+            # populate metadata
+            for key in ['vendor', 'model']:
+                try:
+                    f = open(sysdir + "/device/%s" % key)
+                    d[key] = f.read().rstrip()
+                    f.close()
+                except IOError:
+                    pass
+
+            for key,test in [ ('removable','/removable'), \
+                              ('support_discard','/queue/discard_granularity'),
+                              ]:
+                d[key] = "No"
+                try:
+                    f = open(sysdir + test)
+                    results = f.read().rstrip()
+                    f.close()
+                    if results:
+                        d[key] = "Yes"
+                except IOError:
+                    d[key] = "Could not determine"
+
+            # populate holders
+            d['holders'] = []
+            for folder in os.listdir(sysdir + "/holders"):
+                if re.search("^dm-.*", folder):
+                    try:
+                        f = open(sysdir + "/holders/" + folder + "/dm/name")
+                        name = f.read().rstrip()
+                        f.close()
+                        d['holders'].append(name)
+                    except IOError:
+                        d['holders'].append(folder)
+                else:
+                    d['holders'].append(folder)
+
+            #self.populate_partitions()
+            d['partitions'] = {}
+            for folder in os.listdir(sysdir):
+                m = re.search("(" + diskname + "\d+)", folder)
+                if m:
+                    part = {}
+                    partname = m.group(1)
+                    part_sysdir = sysdir + "/" + partname
+
+                    # get mount points
+                    if partname in mounts:
+                        part = mounts[partname]
+
+                    # populate sectors
+                    part['sectors'] = 0
+                    try:
+                        f = open(sysdir + "/size")
+                        part['sectors'] = f.read().rstrip()
+                        f.close()
+                    except IOError:
+                        pass
+
+                    # populate sector size
+                    part['sectorsize'] = "512"
+                    try:
+                        f = open(sysdir + "/queue/hw_sector_size")
+                        part['sectorsize'] = f.read().rstrip()
+                        f.close()
+                    except IOError:
+                        pass
+
+                    part['size'] = float(part['sectors']) * float(part['sectorsize'])
+                    d['partitions'][partname] = part
+
+
+            # populate rotational
+            d['rotational'] = "SDD"
+            try:
+                f = open(sysdir + "/queue/rotational")
+                rotation = f.read().rstrip()
+                f.close()
+                if rotation == "1":
+                    d['rotational'] = "Spinning disk"
+            except IOError:
+                d['rotational'] = "Could not determine"
+
+            # populate schedule
+            d['scheduler_mode'] = ""
+            try:
+                f = open(sysdir + "/queue/scheduler")
+                scheduler = f.read().rstrip()
+                f.close()
+                m = re.match(".*?(\[(.*)\])", scheduler)
+                if m:
+                    d['scheduler_mode'] = m.group(2)
+            except IOError:
+                d['scheduler_mode'] = "Could not determine"
+
+            # populate sectors
+            d['sectors'] = 0
+            try:
+                f = open(sysdir + "/size")
+                d['sectors'] = f.read().rstrip()
+                f.close()
+            except IOError:
+                pass
+
+            # populate sector size
+            d['sectorsize'] = "512"
+            try:
+                f = open(sysdir + "/queue/hw_sector_size")
+                d['sectorsize'] = f.read().rstrip()
+                f.close()
+            except IOError:
+                pass
+
+            d['size'] = float(d['sectors']) * float(d['sectorsize'])
+
+            # set host info
+            d['host'] = ""
+            if sysfs_no_links == 1:
+                try:
+                    sysdir = os.readlink(os.path.join(sysdir, "device"))
+                except:
+                    pass
+            m = re.match(".+/\d+:(\w+:\w+\.\w)/host\d+/\s*", sysdir)
+            if m:
+                pciid = m.group(1)
+                did = re.escape(pciid)
+                m = re.search("^" + did + "\s(.*)$", pcidata, re.MULTILINE)
+                d['host'] = m.group(1)
+
+            # Add device to list
+            self.facts['devices'][diskname] = d
+
 
 class SunOSHardware(Hardware):
     """

--- a/library/setup
+++ b/library/setup
@@ -276,7 +276,7 @@ class LinuxHardware(Hardware):
     - processor_cores
     - processor_count
 
-    In addition, it also defines number of DMI facts.
+    In addition, it also defines number of DMI facts and device facts.
     """
 
     platform = 'Linux'
@@ -379,14 +379,11 @@ class LinuxHardware(Hardware):
 
         # get mount data to use later
         mounts = {}
-        try:
-            mtab = open('/etc/mtab')
-            for line in mtab.readlines():
-                if line.startswith('/'):
-                    fields = line.rstrip('\n').split(' ')
-                    mounts[os.path.basename(fields[0])] = { 'mount':fields[1], 'fstype' : fields[2], 'mount_opts': fields[3] }
-        except IOError, e:
-                module.fail_json( msg="failed to open mtab: %s" % e)
+        mtab = get_file_content('/etc/mtab')
+        for line in mtab.split('\n'):
+            if line.startswith('/'):
+                fields = line.rstrip('\n').split(' ')
+                mounts[os.path.basename(fields[0])] = { 'mount':fields[1], 'fstype' : fields[2], 'mount_opts': fields[3] }
 
         sysfs_no_links = 0
         for block in os.listdir("/sys/block"):
@@ -421,37 +418,23 @@ class LinuxHardware(Hardware):
 
             # populate metadata
             for key in ['vendor', 'model']:
-                try:
-                    f = open(sysdir + "/device/%s" % key)
-                    d[key] = f.read().rstrip()
-                    f.close()
-                except IOError:
-                    pass
+                d[key] = get_file_content("/device/" + key)
 
             for key,test in [ ('removable','/removable'), \
                               ('support_discard','/queue/discard_granularity'),
                               ]:
                 d[key] = "No"
-                try:
-                    f = open(sysdir + test)
-                    results = f.read().rstrip()
-                    f.close()
-                    if results:
-                        d[key] = "Yes"
-                except IOError:
-                    d[key] = "Could not determine"
+                results = get_file_content(sysdir + test)
+                if results:
+                    d[key] = "Yes"
 
             # populate holders
             d['holders'] = []
             for folder in os.listdir(sysdir + "/holders"):
                 if re.search("^dm-.*", folder):
-                    try:
-                        f = open(sysdir + "/holders/" + folder + "/dm/name")
-                        name = f.read().rstrip()
-                        f.close()
-                        d['holders'].append(name)
-                    except IOError:
-                        d['holders'].append(folder)
+                    name = get_file_content(sysdir + "/holders/" + folder + "/dm/name")
+                if name:
+                    d['holders'].append(name)
                 else:
                     d['holders'].append(folder)
 
@@ -468,79 +451,37 @@ class LinuxHardware(Hardware):
                     if partname in mounts:
                         part = mounts[partname]
 
-                    # get start sector
-                    part['start'] = 0
-                    try:
-                        f = open(part_sysdir + "/start")
-                        part['start'] = f.read().rstrip()
-                        f.close()
-                    except IOError:
-                        pass
+                    # populate geometry
+                    part['start'] = get_file_content(part_sysdir + "/start")
+                    part['start'] = part['start'] if part['start'] else 0
+                    part['sectors'] = get_file_content(part_sysdir + "/size")
+                    part['sectors'] = part['sectors'] if part['sectors'] else 0
+                    part['sectorsize'] = get_file_content(part_sysdir + "/queue/hw_sector_size")
+                    part['sectorsize'] = part['sectorsize'] if part['sectorsize'] else 512
+                    part['size'] = module.pretty_bytes((float(part['sectors']) * float(part['sectorsize'])))
 
-                    # populate sectors
-                    part['sectors'] = 0
-                    try:
-                        f = open(part_sysdir + "/size")
-                        part['sectors'] = f.read().rstrip()
-                        f.close()
-                    except IOError:
-                        pass
-
-                    # populate sector size
-                    part['sectorsize'] = "512"
-                    try:
-                        f = open(part_sysdir + "/queue/hw_sector_size")
-                        part['sectorsize'] = f.read().rstrip()
-                        f.close()
-                    except IOError:
-                        pass
-
-                    part['size'] = module.pretty_bytes((float(part['sectors']) *
-                    float(part['sectorsize'])))
                     d['partitions'][partname] = part
 
-
             # populate rotational
-            d['rotational'] = "SDD"
-            try:
-                f = open(sysdir + "/queue/rotational")
-                rotation = f.read().rstrip()
-                f.close()
-                if rotation == "1":
-                    d['rotational'] = "Spinning disk"
-            except IOError:
-                d['rotational'] = "Could not determine"
+            rotation = get_file_content(sysdir + "/queue/rotational")
+            if rotation == "1":
+                d['rotational'] = "Spinning disk"
+            else:
+                d['rotational'] = "SDD"
 
             # populate schedule
-            d['scheduler_mode'] = ""
-            try:
-                f = open(sysdir + "/queue/scheduler")
-                scheduler = f.read().rstrip()
-                f.close()
-                m = re.match(".*?(\[(.*)\])", scheduler)
-                if m:
-                    d['scheduler_mode'] = m.group(2)
-            except IOError:
-                d['scheduler_mode'] = "Could not determine"
+            scheduler = get_file_content(sysdir + "/queue/scheduler")
+            m = re.match(".*?(\[(.*)\])", scheduler)
+            if m:
+                d['scheduler_mode'] = m.group(2)
+            else:
+                d['scheduler_mode'] = ""
 
-            # populate sectors
-            d['sectors'] = 0
-            try:
-                f = open(sysdir + "/size")
-                d['sectors'] = f.read().rstrip()
-                f.close()
-            except IOError:
-                pass
-
-            # populate sector size
-            d['sectorsize'] = "512"
-            try:
-                f = open(sysdir + "/queue/hw_sector_size")
-                d['sectorsize'] = f.read().rstrip()
-                f.close()
-            except IOError:
-                pass
-
+            # populate geometry
+            d['sectors'] = get_file_content(sysdir + "/size")
+            d['sectors'] = d['sectors'] if d['sectors'] else 0
+            d['sectorsize'] = get_file_content(sysdir + "/queue/hw_sector_size")
+            d['sectorsize'] = d['sectorsize'] if d['sectorsize'] else 512
             d['size'] = module.pretty_bytes(float(d['sectors']) * float(d['sectorsize']))
 
             # set host info


### PR DESCRIPTION
Setup now adds block device facts, (linux only for now), mostly copied from:
  https://raw.github.com/kavink/ansible/devel/library/get_devices

tested on debian and gentoo, will probably followup with freeBSD version soon
