### PR TITLE
git module documentation: removed incorrect use of term 'remote branch' ...

### DIFF
--- a/library/git
+++ b/library/git
@@ -46,7 +46,7 @@ options:
         required: false
         default: "origin"
         description:
-            - Name of the remote branch.
+            - Name of the remote.
     force:
         required: false
         default: "yes"


### PR DESCRIPTION
...(should just be 'remote').
