### PR TITLE
Update path_dwim() to return absolute path

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -168,14 +168,17 @@ def prepare_writeable_dir(tree):
         exit("Cannot write to path %s" % tree)
 
 def path_dwim(basedir, given):
-    ''' make relative paths work like folks expect '''
+    '''
+    make relative paths work like folks expect.
+    if a relative path is provided, convert it to an absolute path.
+    '''
 
     if given.startswith("/"):
         return given
     elif given.startswith("~/"):
         return os.path.expanduser(given)
     else:
-        return os.path.join(basedir, given)
+        return os.path.abspath(os.path.join(basedir, given))
 
 def json_loads(data):
     ''' parse a JSON string and return a data structure '''


### PR DESCRIPTION
If path_dwim() is provided a relative path to a file, it will now return an
absolute path of the playbook directory + the relative file path.

See issue #1815.
