### PR TITLE
Expands path on file operations

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -307,6 +307,7 @@ class AnsibleModule(object):
         return changed
 
     def set_owner_if_different(self, path, owner, changed):
+        path = os.path.expanduser(path)
         if owner is None:
             return changed
         user, group = self.user_and_group(path)
@@ -323,6 +324,7 @@ class AnsibleModule(object):
         return changed
 
     def set_group_if_different(self, path, group, changed):
+        path = os.path.expanduser(path)
         if group is None:
             return changed
         old_user, old_group = self.user_and_group(path)
@@ -340,7 +342,6 @@ class AnsibleModule(object):
 
     def set_mode_if_different(self, path, mode, changed):
         path = os.path.expanduser(path)
-
         if mode is None:
             return changed
         try:

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -262,6 +262,7 @@ class AnsibleModule(object):
         return context
 
     def user_and_group(self, filename):
+        filename = os.path.expanduser(filename)
         st = os.stat(filename)
         uid = st.st_uid
         gid = st.st_gid
@@ -338,6 +339,8 @@ class AnsibleModule(object):
         return changed
 
     def set_mode_if_different(self, path, mode, changed):
+        path = os.path.expanduser(path)
+
         if mode is None:
             return changed
         try:


### PR DESCRIPTION
Path might have to be expanded on some operations but it seems that for some operations, paths
containing '~' are not.
Using os.path.expanduser in appropriate places solves the problem, but
this might be required in many other places.

In the example below, system_accounts is an array containing 'root' and 'example' : 

```
$ cat example-playbooks/ssh/bootstrap-ssh.yml

---
- hosts: ubuntu
  user: example
  sudo: True

  tasks:
    - include: tasks/setup-keys.yml

  handlers:
    - include: handlers/sshd.yml

$ cat example-playbooks/ssh/tasks/setup_keys.yml

    - name: creates account ssh directory
      action: file path=~$item/.ssh owner=$item group=$item mode=0644 state=directory
      with_items: ${system_accounts}

$ ansible-playbook --limit rns0.example.lan example-playbooks/ssh/bootstrap-ssh.yml -kK
SSH password: 
sudo password: 

PLAY [ubuntu] ********************* 

GATHERING FACTS ********************* 
ok: [rns0.example.lan]

TASK: [creates account ssh directory] ********************* 
fatal: [rns0.example.lan] => failed to parse: 
Traceback (most recent call last):
  File "/home/example/.ansible/tmp/ansible-1357227920.79-118674212055964/file", line 902, in <module>
    main()
  File "/home/example/.ansible/tmp/ansible-1357227920.79-118674212055964/file", line 209, in main
    changed = module.set_directory_attributes_if_different(file_args, changed)
  File "/home/example/.ansible/tmp/ansible-1357227920.79-118674212055964/file", line 614, in set_directory_attributes_if_different
    file_args['path'], file_args['owner'], changed
  File "/home/example/.ansible/tmp/ansible-1357227920.79-118674212055964/file", line 537, in set_owner_if_different
    user, group = self.user_and_group(path)
  File "/home/example/.ansible/tmp/ansible-1357227920.79-118674212055964/file", line 491, in user_and_group
    st = os.stat(filename)
OSError: [Errno 2] No such file or directory: '~example/.ssh'


FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************* 
rns0.example.lan                : ok=1    changed=0    unreachable=1    failed=0   
$
```
