### PR TITLE
Arch PKGBUILD fixes

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,12 +1,12 @@
 #Maintainer: Michel Blanc <mblanc@erasme.org>
 pkgname=ansible-git
-pkgver=20121116
-pkgrel=1
+pkgver=20130103
+pkgrel=3
 pkgdesc="A radically simple deployment, model-driven configuration management, and command execution framework"
 arch=('any')
 url="https://github.com/ansible/ansible"
 license=('GPL3')
-depends=('python2' 'python2-yaml' 'python2-paramiko' 'python2-jinja' 'python-simplejson' 'python2-yaml')
+depends=('python2' 'python2-paramiko' 'python2-jinja' 'python2-simplejson' 'python2-yaml')
 makedepends=('git' 'asciidoc' 'fakeroot')
 conflicts=('ansible')
 source=("python-binary.diff")
@@ -39,6 +39,8 @@ package() {
 
   mkdir -p ${pkgdir}/usr/share/ansible
   cp ./library/* ${pkgdir}/usr/share/ansible/
+  cp -r ./examples ${pkgdir}/usr/share/ansible
+
   python2 setup.py install -O1 --root=${pkgdir}
 
   install -D docs/man/man1/ansible.1 ${pkgdir}/usr/share/man/man1/ansible.1

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,10 +1,10 @@
 #Maintainer: Michel Blanc <mblanc@erasme.org>
 pkgname=ansible-git
-pkgver=20130103
-pkgrel=3
+pkgver=20130105
+pkgrel=1
 pkgdesc="A radically simple deployment, model-driven configuration management, and command execution framework"
 arch=('any')
-url="https://github.com/ansible/ansible"
+url="http://ansible.cc"
 license=('GPL3')
 depends=('python2' 'python2-paramiko' 'python2-jinja' 'python2-simplejson' 'python2-yaml')
 makedepends=('git' 'asciidoc' 'fakeroot')


### PR DESCRIPTION
Adds examples in package
Changes json dependency to python2-simplejson, reflecting the new
package name
Removed duplicate python2-yaml

Supersedes #1820
