### PR TITLE
Hostvars for connections

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -393,7 +393,7 @@ class Runner(object):
             return ReturnData(host=host, comm_ok=False, result=result)
 
         try:
-            conn = self.connector.connect(actual_host, actual_port)
+            conn = self.connector.connect(actual_host, actual_port, inject)
             if delegate_to or host != actual_host:
                 conn.delegate = host
 

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -31,10 +31,10 @@ class Connection(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def connect(self, host, port):
+    def connect(self, host, port, inject):
         conn = None
         transport = self.runner.transport
-        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port)
+        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, inject)
         if conn is None:
             raise AnsibleError("unsupported connection type: %s" % transport)
         self.active = conn.connect()

--- a/lib/ansible/runner/connection_plugins/fireball.py
+++ b/lib/ansible/runner/connection_plugins/fireball.py
@@ -34,7 +34,7 @@ except ImportError:
 class Connection(object):
     ''' ZeroMQ accelerated connection '''
 
-    def __init__(self, runner, host, port):
+    def __init__(self, runner, host, port, inject):
 
         self.runner = runner
 
@@ -51,6 +51,8 @@ class Connection(object):
             self.port = constants.ZEROMQ_PORT
         else:
             self.port = port
+
+        self.inject = inject.copy()
 
     def connect(self):
         ''' activates the connection object '''

--- a/lib/ansible/runner/connection_plugins/local.py
+++ b/lib/ansible/runner/connection_plugins/local.py
@@ -29,11 +29,12 @@ from ansible.callbacks import vvv
 class Connection(object):
     ''' Local based connections '''
 
-    def __init__(self, runner, host, port):
+    def __init__(self, runner, host, port, inject):
         self.runner = runner
         self.host = host
         # port is unused, since this is local
         self.port = port 
+        self.inject = inject.copy()
 
     def connect(self, port=None):
         ''' connect to the local host; nothing to do here '''

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -43,7 +43,7 @@ SFTP_CONNECTION_CACHE = {}
 class Connection(object):
     ''' SSH based connections with Paramiko '''
 
-    def __init__(self, runner, host, port=None):
+    def __init__(self, runner, host, port=None, inject={}):
 
         self.ssh = None
         self.sftp = None
@@ -52,6 +52,7 @@ class Connection(object):
         self.port = port
         if port is None:
             self.port = self.runner.remote_port
+        self.inject = inject.copy()
 
     def _cache_key(self):
         return "%s__%s__" % (self.host, self.remote_user)

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -58,7 +58,7 @@ class Connection(object):
         return "%s__%s__" % (self.host, self.remote_user)
 
     def connect(self):
-        self.remote_user = self.runner.remote_user
+        self.remote_user = self.inject.get('ssh_user', self.runner.remote_user)
         cache_key = self._cache_key()
         if cache_key in SSH_CONNECTION_CACHE:
             self.ssh = SSH_CONNECTION_CACHE[cache_key]
@@ -73,7 +73,7 @@ class Connection(object):
             raise errors.AnsibleError("paramiko is not installed")
 
         # remote user and port set earlier to make caching work right
-        self.remote_pass = self.runner.remote_pass
+        self.remote_pass = self.inject.get('ssh_pass', self.runner.remote_pass)
         self.sudo = self.runner.sudo
         self.sudo_user = self.runner.sudo_user
         self.private_key_file = self.runner.private_key_file

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -54,9 +54,10 @@ class Connection(object):
             self.port = self.runner.remote_port
 
     def _cache_key(self):
-        return "%s__%s__" % (self.host, self.runner.remote_user)
+        return "%s__%s__" % (self.host, self.remote_user)
 
     def connect(self):
+        self.remote_user = self.runner.remote_user
         cache_key = self._cache_key()
         if cache_key in SSH_CONNECTION_CACHE:
             self.ssh = SSH_CONNECTION_CACHE[cache_key]
@@ -70,27 +71,32 @@ class Connection(object):
         if not HAVE_PARAMIKO:
             raise errors.AnsibleError("paramiko is not installed")
 
-        user = self.runner.remote_user
+        # remote user and port set earlier to make caching work right
+        self.remote_pass = self.runner.remote_pass
+        self.sudo = self.runner.sudo
+        self.sudo_user = self.runner.sudo_user
+        self.private_key_file = self.runner.private_key_file
+        self.timeout = self.runner.timeout
 
-        vvv("ESTABLISH CONNECTION FOR USER: %s on PORT %s TO %s" % (user, self.port, self.host), host=self.host)
+        vvv("ESTABLISH CONNECTION FOR USER: %s on PORT %s TO %s" % (self.remote_user, self.port, self.host), host=self.host)
 
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         allow_agent = True
-        if self.runner.remote_pass is not None:
+        if self.remote_pass is not None:
             allow_agent = False
         try:
-            ssh.connect(self.host, username=user, allow_agent=allow_agent, look_for_keys=True,
-                key_filename=self.runner.private_key_file, password=self.runner.remote_pass,
-                timeout=self.runner.timeout, port=self.port)
+            ssh.connect(self.host, username=self.remote_user, allow_agent=allow_agent, look_for_keys=True,
+                key_filename=self.private_key_file, password=self.remote_pass,
+                timeout=self.timeout, port=self.port)
         except Exception, e:
             msg = str(e)
             if "PID check failed" in msg:
                 raise errors.AnsibleError("paramiko version issue, please upgrade paramiko on the machine running ansible")
             elif "Private key file is encrypted" in msg:
                 msg = 'ssh %s@%s:%s : %s\nTo connect as a different user, use -u <username>.' % (
-                    user, self.host, self.port, msg)
+                    self.remote_user, self.host, self.port, msg)
                 raise errors.AnsibleConnectionFailed(msg)
             else:
                 raise errors.AnsibleConnectionFailed(msg)
@@ -110,7 +116,7 @@ class Connection(object):
             raise errors.AnsibleConnectionFailed(msg)
         chan.get_pty()
 
-        if not self.runner.sudo or not sudoable:
+        if not self.sudo or not sudoable:
             if executable:
                 quoted_command = executable + ' -c ' + pipes.quote(cmd)
             else:
@@ -123,7 +129,7 @@ class Connection(object):
             sudo_output = ''
             try:
                 chan.exec_command(shcmd)
-                if self.runner.sudo_pass:
+                if self.sudo_pass:
                     while not sudo_output.endswith(prompt):
                         chunk = chan.recv(bufsize)
                         if not chunk:
@@ -134,7 +140,7 @@ class Connection(object):
                                 raise errors.AnsibleError('ssh connection ' +
                                     'closed waiting for password prompt')
                         sudo_output += chunk
-                    chan.sendall(self.runner.sudo_pass + '\n')
+                    chan.sendall(self.sudo_pass + '\n')
             except socket.timeout:
                 raise errors.AnsibleError('ssh timed out waiting for sudo.\n' + sudo_output)
 
@@ -155,7 +161,7 @@ class Connection(object):
             raise errors.AnsibleError("failed to transfer file to %s" % out_path)
 
     def _connect_sftp(self):
-        cache_key = "%s__%s__" % (self.host, self.runner.remote_user)
+        cache_key = "%s__%s__" % (self.host, self.remote_user)
         if cache_key in SFTP_CONNECTION_CACHE:
             return SFTP_CONNECTION_CACHE[cache_key]
         else:

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -31,10 +31,11 @@ from ansible import utils
 class Connection(object):
     ''' ssh based connections '''
 
-    def __init__(self, runner, host, port):
+    def __init__(self, runner, host, port, inject):
         self.runner = runner
         self.host = host
         self.port = port
+        self.inject = inject.copy()
 
     def connect(self):
         ''' connect to the remote host '''

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -40,8 +40,8 @@ class Connection(object):
     def connect(self):
         ''' connect to the remote host '''
 
-        self.remote_user = self.runner.remote_user
-        self.remote_pass = self.runner.remote_pass
+        self.remote_user = self.inject.get('ssh_user', self.runner.remote_user)
+        self.remote_pass = self.inject.get('ssh_pass', self.runner.remote_pass)
         self.sudo = self.runner.sudo
         self.sudo_user = self.runner.sudo_user
         self.private_key_file = self.runner.private_key_file


### PR DESCRIPTION
Same commits requested for [1814](https://github.com/ansible/ansible/pull/1814), just on a new branch (and slightly rebased).  Original request text:

I'm currently struggling with a cloud provider that only offers randomly-generated root passwords on VM creation. This creates a bit of trouble in that I have to do some hackery to get the VMs to the point that I can SSH with a key-file. While I could run an individual run of ansible for each new host with the password on the commandline, this was less than optimal.

Since the inventory file seems to be the best place to put per-host values, I decided to put the passwords there. This also fits well into my plan to eventually write an inventory plugin which could fill these in trivially from the API.

To support this, I made the following changes:

Isolated the connection from the runner insofar as copying the variables off of the runner onto the connection. This prevented needed to mutate the runner each loop for different hostvars, which seemed bad.
Passed the inject dictionary down into connections. This was trivial because it's already available well before the connections are created. It also separated the general functionality of per-host config settings from the specific feature of adding support for SSH settings in the config file.
Actually use the inject dictionary for shadowing the execution-wide defaults for SSH username and password.
For the last change, I had to decide whether to have the inventory settings shadow the global settings or not. I chose to do so, though it's trivial to do it the other way around. If that's a sticking point (I'm agnostic, as I don't plan to use both together), please merge the first two commits (to minimize merging fun) and I'll rewrite the last one.

Thanks!
