### PR TITLE
postgresql_db fails with owner containing a "-"

### DIFF
--- a/library/postgresql_db
+++ b/library/postgresql_db
@@ -78,7 +78,7 @@ else:
 #
 
 def set_owner(cursor, db, owner):
-    query = "ALTER DATABASE %s OWNER TO %s" % (db, owner)
+    query = "ALTER DATABASE \"%s\" OWNER TO \"%s\"" % (db, owner)
     cursor.execute(query)
     return True
 
@@ -95,7 +95,7 @@ def db_exists(cursor, db):
 
 def db_delete(cursor, db):
     if db_exists(cursor, db):
-        query = "DROP DATABASE %s" % db
+        query = "DROP DATABASE \"%s\"" % db
         cursor.execute(query)
         return True
     else:
@@ -104,9 +104,9 @@ def db_delete(cursor, db):
 def db_create(cursor, db, owner, template, encoding):
     if not db_exists(cursor, db):
         if owner:
-            owner = " OWNER %s" % owner
+            owner = " OWNER \"%s\"" % owner
         if template:
-            template = " TEMPLATE %s" % template
+            template = " TEMPLATE \"%s\"" % template
         if encoding:
             encoding = " ENCODING '%s'" % encoding
         query = "CREATE DATABASE %s%s%s%s" % (db, owner, template, encoding)

--- a/library/postgresql_db
+++ b/library/postgresql_db
@@ -49,6 +49,11 @@ options:
       - Name of the role to set as owner of the database
     required: false
     default: null
+  template:
+    description:
+      - Template used to create the database
+    required: false
+    default: null
   state:
     description:
       - The database state

--- a/library/postgresql_user
+++ b/library/postgresql_user
@@ -136,7 +136,7 @@ def user_exists(cursor, user):
 
 def user_add(cursor, user, password, role_attr_flags):
     """Create a new user with write access to the database"""
-    query = "CREATE USER %(user)s with PASSWORD '%(password)s' %(role_attr_flags)s"
+    query = "CREATE USER \"%(user)s\" with PASSWORD '%(password)s' %(role_attr_flags)s"
     cursor.execute(query % {"user": user, "password": password, "role_attr_flags": role_attr_flags})
     return True
 
@@ -154,11 +154,11 @@ def user_alter(cursor, user, password, role_attr_flags):
 
         if password is not None:
             # Update the role attributes, including password.
-            alter = "ALTER USER %(user)s WITH PASSWORD '%(password)s' %(role_attr_flags)s"
+            alter = "ALTER USER \"%(user)s\" WITH PASSWORD '%(password)s' %(role_attr_flags)s"
             cursor.execute(alter % {"user": user, "password": password, "role_attr_flags": role_attr_flags})
         else:
             # Update the role attributes, excluding password.
-            alter = "ALTER USER %(user)s WITH %(role_attr_flags)s"
+            alter = "ALTER USER \"%(user)s\" WITH %(role_attr_flags)s"
             cursor.execute(alter % {"user": user, "role_attr_flags": role_attr_flags})
         # Grab new role attributes.
         cursor.execute(select, {"user": user})
@@ -175,7 +175,7 @@ def user_delete(cursor, user):
     """Try to remove a user. Returns True if successful otherwise False"""
     cursor.execute("SAVEPOINT ansible_pgsql_user_delete")
     try:
-        cursor.execute("DROP USER %s" % user)
+        cursor.execute("DROP USER \"%s\"" % user)
     except:
         cursor.execute("ROLLBACK TO SAVEPOINT ansible_pgsql_user_delete")
         cursor.execute("RELEASE SAVEPOINT ansible_pgsql_user_delete")
@@ -185,7 +185,7 @@ def user_delete(cursor, user):
     return True
 
 def has_table_privilege(cursor, user, table, priv):
-    query = 'SELECT has_table_privilege(%s, %s, %s)'
+    query = 'SELECT has_table_privilege(\'%s\', \'%s\', \'%s\')'
     cursor.execute(query, (user, table, priv))
     return cursor.fetchone()[0]
 
@@ -202,14 +202,14 @@ def get_table_privileges(cursor, user, table):
 
 def grant_table_privilege(cursor, user, table, priv):
     prev_priv = get_table_privileges(cursor, user, table)
-    query = 'GRANT %s ON TABLE %s TO %s' % (priv, table, user)
+    query = 'GRANT %s ON TABLE \"%s\" TO \"%s\"' % (priv, table, user)
     cursor.execute(query)
     curr_priv = get_table_privileges(cursor, user, table)
     return len(curr_priv) > len(prev_priv)
 
 def revoke_table_privilege(cursor, user, table, priv):
     prev_priv = get_table_privileges(cursor, user, table)
-    query = 'REVOKE %s ON TABLE %s FROM %s' % (priv, table, user)
+    query = 'REVOKE %s ON TABLE \"%s\" FROM \"%s\"' % (priv, table, user)
     cursor.execute(query)
     curr_priv = get_table_privileges(cursor, user, table)
     return len(curr_priv) < len(prev_priv)
@@ -235,20 +235,20 @@ def get_database_privileges(cursor, user, db):
     return o
 
 def has_database_privilege(cursor, user, db, priv):
-    query = 'SELECT has_database_privilege(%s, %s, %s)'
+    query = 'SELECT has_database_privilege(\'%s\', \'%s\', \'%s\')'
     cursor.execute(query, (user, db, priv))
     return cursor.fetchone()[0]
 
 def grant_database_privilege(cursor, user, db, priv):
     prev_priv = get_database_privileges(cursor, user, db)
-    query = 'GRANT %s ON DATABASE %s TO %s' % (priv, db, user)
+    query = 'GRANT %s ON DATABASE \"%s\" TO \"%s\"' % (priv, db, user)
     cursor.execute(query)
     curr_priv = get_database_privileges(cursor, user, db)
     return len(curr_priv) > len(prev_priv)
 
 def revoke_database_privilege(cursor, user, db, priv):
     prev_priv = get_database_privileges(cursor, user, db)
-    query = 'REVOKE %s ON DATABASE %s FROM %s' % (priv, db, user)
+    query = 'REVOKE %s ON DATABASE \"%s\" FROM \"%s\"' % (priv, db, user)
     cursor.execute(query)
     curr_priv = get_database_privileges(cursor, user, db)
     return len(curr_priv) < len(prev_priv)

--- a/library/postgresql_user
+++ b/library/postgresql_user
@@ -185,7 +185,7 @@ def user_delete(cursor, user):
     return True
 
 def has_table_privilege(cursor, user, table, priv):
-    query = 'SELECT has_table_privilege(\'%s\', \'%s\', \'%s\')'
+    query = 'SELECT has_table_privilege(%s, %s, %s)'
     cursor.execute(query, (user, table, priv))
     return cursor.fetchone()[0]
 
@@ -235,7 +235,7 @@ def get_database_privileges(cursor, user, db):
     return o
 
 def has_database_privilege(cursor, user, db, priv):
-    query = 'SELECT has_database_privilege(\'%s\', \'%s\', \'%s\')'
+    query = 'SELECT has_database_privilege(%s, %s, %s)'
     cursor.execute(query, (user, db, priv))
     return cursor.fetchone()[0]
 


### PR DESCRIPTION
```
TASK: [postgresql_db db=cartoterra owner=www-cartoterra template=template_postgis] ********************* 
failed: [192.168.122.216] => {"failed": true}
msg: Database query failed: ERREUR:  erreur de syntaxe sur ou près de « - »
LINE 1: CREATE DATABASE cartoterra OWNER www-cartoterra TEMPLATE tem...
                                            ^


FATAL: all hosts have already failed -- aborting
```
