### PR TITLE
Fix behaviour when file handles a path with tilde

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -254,8 +254,11 @@ class AnsibleModule(object):
             return context
         try:
             ret = selinux.lgetfilecon(path)
-        except:
-            self.fail_json(path=path, msg='failed to retrieve selinux context')
+        except OSError, e:
+            if e.errno == errno.ENOENT:
+                self.fail_json(path=path, msg='path %s does not exist' % path)
+            else:
+                self.fail_json(path=path, msg='failed to retrieve selinux context')
         if ret[0] == -1:
             return context
         context = ret[1].split(':')

--- a/library/file
+++ b/library/file
@@ -139,7 +139,7 @@ def main():
 
     params = module.params
     state  = params['state']
-    path   = os.path.expanduser(params['path'])
+    params['path'] = path = os.path.expanduser(params['path'])
 
     # source is both the source of a symlink or an informational passing of the src for a template module
     # or copy module, even if this module never uses it, it is needed to key off some things


### PR DESCRIPTION
Two problems here
- unchecked exception handling and erroneous assumption as to why
  an exception might fire
- although the file module expands the path, when using file_args
  the unexpanded path is passed.

Expected result: ~/path/to/file should work fine
Actual result: exception is because it doesn't find file with a message
about not being able to get the selinux context
