### PR TITLE
Sudo local with password

### DIFF
--- a/lib/ansible/runner/connection_plugins/local.py
+++ b/lib/ansible/runner/connection_plugins/local.py
@@ -51,7 +51,6 @@ class Connection(object):
                 return (p.returncode, '', stdout, stderr)
             else:
                 cmd = "sudo -u {0} -s {1}".format(sudo_user, cmd)
-
         p = subprocess.Popen(cmd, cwd=basedir, shell=True, stdin=None,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()


### PR DESCRIPTION
Ability to access on local machine files/directories owned exclusive by root via sudo.

This is the implementation of a missing feature - from the file comments I understand was low priority but I need it (especially on ubuntu).

I run all test cases and this is my test

``` shell
$ cat sudo_with_password.yaml

---
- hosts: web
  user: silviud
  sudo: True
  vars:
      app_src: /home/silviud/ansible
      app_dst: /root
      app_archive_name: ansible.tgz
  tasks:
    - name: prepare web app
      action: command tar cvfz "$app_dst/$app_archive_name" --exclude-vcs $app_src
      delegate_to: localhost

$ cat ~/.ansible/hosts
[web]
127.0.0.1
$ sudo -k
$ ansible-playbook -vvv  sudo_with_password.yaml -K -k -i ~/.ansible/hosts
$ sudo ls  ~root/ansible.tgz
[sudo] password for silviud:
/root/ansible.tgz
```
