### PR TITLE
Allow YAML hashes to work with hierarchical host/group vars

### DIFF
--- a/test/test_playbook_vars/group_vars/hash_default
+++ b/test/test_playbook_vars/group_vars/hash_default
@@ -1,0 +1,4 @@
+---
+properties:
+  keyA: this will remain default
+  keyB: this will be overridden

--- a/test/test_playbook_vars/group_vars/hash_override
+++ b/test/test_playbook_vars/group_vars/hash_override
@@ -1,0 +1,7 @@
+---
+properties:
+  keyB: the override value
+  keyC: a new value
+
+sibling:
+  key1: as long as the siblings dont clash, the hashes should be merged

--- a/test/test_playbook_vars/group_vars/hash_sibling
+++ b/test/test_playbook_vars/group_vars/hash_sibling
@@ -1,0 +1,3 @@
+---
+sibling:
+  key2: test

--- a/test/test_playbook_vars/hosts
+++ b/test/test_playbook_vars/hosts
@@ -4,3 +4,15 @@ host2
 [group]
 host1
 host2
+
+[hash_default:children]
+hash_override
+hash_sibling
+
+[hash_override]
+host1
+host2
+
+[hash_sibling]
+host1
+host2


### PR DESCRIPTION
As the inventory allows hashes (or associate arrays), when used in
a hierarchy the hashes should be merged (previous situation was that
the new hash replaced the old one entirely).

As this isn't simple, I've added test cases which I'm pleased to report
failed before the code fix and pass afterwards

Basic idea in JSON:

parent group:
  properties = { 'keyA': 'x', 'keyB': 'y' }

child group:
  properties = { 'keyB': 'z', 'keyC': 'a' }

After the merge we expect
  properties = { 'keyA': 'x', 'keyB': 'z', 'keyC': 'a' }

previously the result would have just been the child properties, losing keyA
