### PR TITLE
Revert the import of C in script

### DIFF
--- a/lib/ansible/runner/action_plugins/script.py
+++ b/lib/ansible/runner/action_plugins/script.py
@@ -18,6 +18,7 @@
 import os
 import shlex
 
+import ansible.constants as C
 from ansible import utils
 from ansible import errors
 from ansible.runner.return_data import ReturnData


### PR DESCRIPTION
In PR #1804 the use of C in script was moved to _low_level_execute_command()
So we cannot get rid of this one now. Should have run my test playbooks earlier :-/
