### PR TITLE
Fix distribution detection - return string instead of functions

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -96,10 +96,10 @@ def get_distribution():
     ''' return the distribution name '''
     if platform.system() == 'Linux':
         try:
-            distribution = platform.linux_distribution()[0].capitalize
+            distribution = platform.linux_distribution()[0].capitalize()
         except:
             # FIXME: MethodMissing, I assume?
-            distribution = platform.dist()[0].capitalize
+            distribution = platform.dist()[0].capitalize()
     else:
         distribution = None
     return distribution


### PR DESCRIPTION
Withous this fix get_distribution() returns functions instead of pure strings, thus setting distribution in subclasses does not work at all.

Discovered in 0.9
