### PR TITLE
EC2 module should report back the public_dns_name too

### DIFF
--- a/library/ec2
+++ b/library/ec2
@@ -181,7 +181,7 @@ def main():
         d = {
            'id': inst.id,
            'public_ip': inst.ip_address,
-	   'public_dns_name': inst.public_dns_name
+           'public_dns_name': inst.public_dns_name
             }
         instances.append(d)
 

--- a/library/ec2
+++ b/library/ec2
@@ -181,6 +181,7 @@ def main():
         d = {
            'id': inst.id,
            'public_ip': inst.ip_address,
+	   'public_dns_name': inst.public_dns_name
             }
         instances.append(d)
 


### PR DESCRIPTION
This PR adds the public_dns_name attribute to the JSON returned from EC2 module.

I use this to create a CNAME for the newly created instance, which boils roughly down to this:

```
    - name: Launch new EC2 instance
      local_action: ec2
        keypair=${keypair}
        group=${security_group}
        instance_type=${instance_type}
        image=${image}
        wait=true
      register: ec2
    - name: Create a CNAME record
      local_action: cname
        $project. $name ${ec2.instances[0].public_dns_name}
```

Before I had to store user_data and then read from that when creating a CNAME, which seems a bit silly, if the public_dns_name is right there.
