### PR TITLE
Allows defining array variables in an inventory file

### DIFF
--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -48,6 +48,14 @@ class Group(object):
 
         self.vars[key] = value
 
+    def append_variable(self, key, value):
+
+        arr = self.vars.get(key, [])
+        if not type(arr) is list:
+            raise Exception("unexpected array variable: %s" % key)
+        arr.append(value)
+        self.vars[key] = arr
+
     def get_hosts(self):
 
         hosts = set()

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -165,9 +165,13 @@ class InventoryParser(object):
                     raise errors.AnsibleError("variables assigned to group must be in key=value form")
                 else:
                     (k, v) = [e.strip() for e in line.split("=", 1)]
+
                     # When the value is a single-quoted or double-quoted string
                     if re.match(r"^(['\"]).*\1$", v):
                         # Unquote the string
-                        group.set_variable(k, re.sub(r"^['\"]|['\"]$", '', v))
+                        v = re.sub(r"^['\"]|['\"]$", '', v)
+
+                    if k.endswith("[]"):
+                        group.append_variable(k[:-2], v)
                     else:
                         group.set_variable(k, v)

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -148,6 +148,7 @@ class TestInventory(unittest.TestCase):
         expected = dict(
             a='1', b='2', c='3', d='10002', e='10003', f='10004 != 10005',
             g='  g  ', h='  h  ', i="'  i  \"", j='"  j',
+            array_var=['Hello', 'World'],
             rga='1', rgb='2', rgc='3',
             inventory_hostname='rtp_a', inventory_hostname_short='rtp_a',
             group_names=[ 'eastcoast', 'nc', 'redundantgroup', 'redundantgroup2', 'redundantgroup3', 'rtp', 'us' ]

--- a/test/complex_hosts
+++ b/test/complex_hosts
@@ -40,6 +40,8 @@ e =   10003
    h = '  h  '
     i = '  i  "
     j  = "  j  
+array_var[] = Hello
+array_var[] = World
 
 [rtp]
 rtp_a


### PR DESCRIPTION
Currently we can define only simple string variables in an inventory file, but I think it would be nice if we could put array variables as well.

``` ini
[cluster]
node1
node2

[cluster:vars]
log_path = /log
data_paths[] = /data1
data_paths[] = /data2
data_paths[] = /data3
```

I know this can be easily done with YML vars file, but when I want to run the same playbook, and its corresponding vars files, on a different set of machines with slightly different configurations, I find it more convenient to put cluster-wide variables in each inventory file.

Let me know what you think. Thanks.
