### PR TITLE
Prevent permission denied when cloning

### DIFF
--- a/library/git
+++ b/library/git
@@ -80,10 +80,12 @@ def get_version(dest):
 
 def clone(repo, dest, remote):
     ''' makes a new git repo if it does not already exist '''
+    dest_dirname = os.path.dirname(dest)
     try:
-        os.makedirs(os.path.dirname(dest))
+        os.makedirs(dest_dirname)
     except:
         pass
+    os.chdir(dest_dirname)
     return _run("git clone -o %s %s %s" % (remote, repo, dest))
 
 def has_local_mods(dest):


### PR DESCRIPTION
Without read permission to the current working directory, git-clone will
fail:

```
root@host:~$ sudo -u git -H git clone \
  git://github.com/ansible/ansible.git /home/git/ansible
fatal: Could not change back to '/root': Permission denied
```

With ansible:

```
$ ansible host -u root --sudo-user git -m git -a 'repo=git://github.com/ansible/ansible.git dest=/home/git/ansible
127.0.0.1 | FAILED >> {
    "failed": true, 
    "msg": "fatal: Could not change back to '/root': Permission denied\n"
}
```

This commit ensures that the working directory is changed to the
parent-folder of the destination before doing the clone.
