### PR TITLE
Various cleanup to run_command

### DIFF
--- a/library/command
+++ b/library/command
@@ -99,7 +99,7 @@ def main():
         args = shlex.split(args)
     startd = datetime.datetime.now()
 
-    rc, out, err = module.run_command(args, shell=shell, executable=executable)
+    rc, out, err = module.run_command(args, executable=executable)
 
     endd = datetime.datetime.now()
     delta = endd - startd

--- a/library/facter
+++ b/library/facter
@@ -44,7 +44,7 @@ def main():
     )
 
     cmd = ["/usr/bin/env", "facter", "--json"]
-    rc, out, err = module.run_command(cmd, fail_on_rc_non_zero=True)
+    rc, out, err = module.run_command(cmd, check_rc=True)
     module.exit_json(**json.loads(out))
 
 # this is magic, see lib/ansible/module_common.py

--- a/library/git
+++ b/library/git
@@ -81,7 +81,7 @@ def clone(module, repo, dest, remote):
         pass
     os.chdir(dest_dirname)
     return module.run_command("git clone -o %s %s %s" % (remote, repo, dest),
-                              fail_on_rc_non_zero=True)
+                              check_rc=True)
 
 def has_local_mods(dest):
     os.chdir(dest)
@@ -99,7 +99,7 @@ def reset(module,dest,force):
     os.chdir(dest)
     if not force and has_local_mods(dest):
         module.fail_json(msg="Local modifications exist in repository (force=no).")
-    return module.run_command("git reset --hard HEAD", fail_on_rc_non_zero=True)
+    return module.run_command("git reset --hard HEAD", check_rc=True)
 
 def get_branches(module, dest):
     os.chdir(dest)
@@ -210,7 +210,7 @@ def switch_version(module, dest, remote, version):
         if rc != 0:
             module.fail_json(msg="Failed to checkout branch %s" % branch)
         cmd = "git reset --hard %s" % remote
-    return module.run_command(cmd, fail_on_rc_non_zero=True)
+    return module.run_command(cmd, check_rc=True)
 
 # ===========================================
 

--- a/library/ohai
+++ b/library/ohai
@@ -43,7 +43,7 @@ def main():
         argument_spec = dict()
     )
     cmd = ["/usr/bin/env", "ohai"]
-    rc, out, err = module.run_command(cmd, fail_on_rc_non_zero=True)
+    rc, out, err = module.run_command(cmd, check_rc=True)
     module.exit_json(**json.loads(out))
 
 # this is magic, see lib/ansible/module_common.py

--- a/library/subversion
+++ b/library/subversion
@@ -85,7 +85,7 @@ class Subversion(object):
         if self.password:
             bits.append("--password '%s'" % self.password)
         bits.append(args)
-        rc, out, err = self.module.run_command(' '.join(bits), fail_on_rc_non_zero=True)
+        rc, out, err = self.module.run_command(' '.join(bits), check_rc=True)
         return out.splitlines()
 
     def checkout(self):

--- a/library/supervisorctl
+++ b/library/supervisorctl
@@ -63,7 +63,7 @@ def main():
 
     if state == 'present':
         if not present:
-            module.run_command('%s reread' % SUPERVISORCTL, fail_on_rc_non_zero=True)
+            module.run_command('%s reread' % SUPERVISORCTL, check_rc=True)
             rc, out, err = module.run_command('%s add %s' % (SUPERVISORCTL, name))
 
             if '%s: added process group' % name in out:


### PR DESCRIPTION
- Rename fail_on_rc_non_zero to check_rc, much more succinct.
- Simplify method defintion
- Fix command module and drop shell=shell option; whether to use
  shell is determined by if args is a list.
