### PR TITLE
Enhanced mount module to make 'src' optional

### DIFF
--- a/library/mount
+++ b/library/mount
@@ -131,7 +131,7 @@ def set_mount(**kwargs):
     to_write = []
 
     if not exists:
-        if args['src'] is None:
+        if args['src'] is None and args['state'] not in ['only_if_mounted', 'only_if_present']:
             msg="Error: no 'src' provided but '%s' not found in fstab. Can't add mount point without all required parameters." % (args['name'])
             return 1, msg
         if args['state'] in ['only_if_mounted', 'only_if_present']: 

--- a/library/mount
+++ b/library/mount
@@ -128,13 +128,17 @@ def set_mount(**kwargs):
 
     changed = False
     args, exists, current = read_fstab(args)
-    if not exists and args['src'] is None:
-        msg="Error: no 'src' provided but '%s' not found in fstab. Can't add mount point without all required parameters." % (args['name'])
-        return 1, msg
     to_write = []
 
     if not exists:
-    # Not found, write new line and final point.
+        if args['src'] is None:
+            msg="Error: no 'src' provided but '%s' not found in fstab. Can't add mount point without all required parameters." % (args['name'])
+            return 1, msg
+        if args['state'] in ['only_if_mounted', 'only_if_present']: 
+            msg="Error: %s not found in fstab." % (args['name'])
+            return 1, msg
+
+    # Not found and line valid, write new line and final point.
         for line in current:
             to_write.append(line)
         to_write.append(new_line % args)
@@ -235,7 +239,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-            state  = dict(required=True, choices=['present', 'absent', 'mounted', 'unmounted']),
+            state  = dict(required=True, choices=['present', 'absent', 'mounted', 'unmounted', 'only_if_present', 'only_if_mounted']),
             name   = dict(required=True),
             opts   = dict(default=None),
             passno = dict(default=None),
@@ -252,7 +256,8 @@ def main():
     rc = 0
     args = {
         'name': module.params['name'],
-        'fstype': module.params['fstype']
+        'fstype': module.params['fstype'],
+        'state': module.params['state']
     }
     if module.params['src'] is not None:
         args['src'] = module.params['src']
@@ -271,6 +276,8 @@ def main():
     # unmounted == do not change fstab state, but unmount
     # present == add to fstab, do not change mount state
     # mounted == add to fstab if not there and make sure it is mounted, if it has changed in fstab then remount it
+    # only_if_present == modify line in fstab, only if present, do not change mount state
+    # only_if_mounted == modify line in fstab, only if present, if it has changed then remount it.
 
     state = module.params['state']
     name  = module.params['name']
@@ -299,7 +306,7 @@ def main():
 
         module.exit_json(changed=changed, **args)
 
-    if state in ['mounted', 'present']:
+    if state in ['mounted', 'present', 'only_if_mounted', 'only_if_present']:
         name, changed = set_mount(**args)
         if name == 1:
             module.fail_json(msg=changed)

--- a/library/mount
+++ b/library/mount
@@ -63,9 +63,9 @@ options:
     description:
       - If C(mounted) or C(unmounted), the device will be actively mounted or unmounted
         as well as just configured in I(fstab). C(absent) and C(present) only deal with
-        I(fstab).
+        I(fstab). C(only_if_present) and C(only_if_mounted) only deal if the line already exists in I(fstab).
     required: true
-    choices: [ "present", "absent", "mounted", "unmounted" ]
+    choices: [ "present", "absent", "mounted", "unmounted", "only_if_present", "only_if_mounted" ]
     default: null
 examples:
    - code: "mount: name=/mnt/dvd src=/dev/sr0 fstype=iso9660 opts=ro state=present"

--- a/library/mount
+++ b/library/mount
@@ -37,7 +37,7 @@ options:
   src:
     description:
       - device to be mounted on I(name).
-    required: true
+    required: false
     default: null
   fstype:
     description:
@@ -75,7 +75,6 @@ requirements: []
 author: Seth Vidal
 '''
 
-
 def write_fstab(lines, dest):
 
     fs_w = open(dest, 'w')
@@ -84,6 +83,34 @@ def write_fstab(lines, dest):
 
     fs_w.flush()
     fs_w.close()
+
+def read_fstab(args):
+    """ read mount points in fstab """
+
+    fstab = []
+    exists = False
+    for line in open(args['fstab'], 'r').readlines():
+        if line.strip().startswith('#'):
+            fstab.append(line)
+            continue
+        if len(line.split()) != 6:
+            # not sure what this is or why it is here
+            # but it is not our fault so leave it be
+            fstab.append(line)
+            continue
+        ld = {}
+        ld['src'], ld['name'], ld['fstype'], ld['opts'], ld['dump'], ld['passno']  = line.split()
+        if ld['name'] == args['name']:
+           # Fill 'src' arg if it is empty
+           if args['src'] is None:
+               args['src'] = ld['src']
+           # And yes, a line matches the name pattern
+           exists = True
+           fstab.append(line)
+        else:
+           fstab.append(line)
+    
+    return (args, exists, fstab)
 
 def set_mount(**kwargs):
     """ set/change a mount point location in fstab """
@@ -99,44 +126,35 @@ def set_mount(**kwargs):
 
     new_line = '%(src)s %(name)s %(fstype)s %(opts)s %(dump)s %(passno)s\n'
 
-    to_write = []
-    exists = False
     changed = False
-    for line in open(args['fstab'], 'r').readlines():
-        if not line.strip():
-            to_write.append(line)
-            continue
-        if line.strip().startswith('#'):
-            to_write.append(line)
-            continue
-        if len(line.split()) != 6:
-            # not sure what this is or why it is here
-            # but it is not our fault so leave it be
-            to_write.append(line)
-            continue
-
-        ld = {}
-        ld['src'], ld['name'], ld['fstype'], ld['opts'], ld['dump'], ld['passno']  = line.split()
-
-        if ld['name'] != args['name']:
-            to_write.append(line)
-            continue
-
-        # it exists - now see if what we have is different
-        exists = True
-        for t in ('src', 'fstype','opts', 'dump', 'passno'):
-            if ld[t] != args[t]:
-                changed = True
-                ld[t] = args[t]
-
-        if changed:
-            to_write.append(new_line % ld)
-        else:
-            to_write.append(line)
+    args, exists, current = read_fstab(args)
+    if not exists and args['src'] is None:
+        msg="Error: no 'src' provided but '%s' not found in fstab. Can't add mount point without all required parameters." % (args['name'])
+        return 1, msg
+    to_write = []
 
     if not exists:
+    # Not found, write new line and final point.
+        for line in current:
+            to_write.append(line)
         to_write.append(new_line % args)
         changed = True
+    else:
+        for line in current:
+            if len(line.split()) != 6:
+                to_write.append(line)
+                continue
+            ld = {}
+            ld['src'], ld['name'], ld['fstype'], ld['opts'], ld['dump'], ld['passno']  = line.split()
+            if ld['name'] != args['name']:
+                to_write.append(line)
+            else:
+                for t in ('src', 'fstype','opts', 'dump', 'passno'):
+                    if ld[t] != args[t]:
+                        changed = True
+                        ld[t] = args[t]
+                if changed:
+                    to_write.append(new_line % ld)
 
     if changed:
         write_fstab(to_write, args['fstab'])
@@ -156,30 +174,29 @@ def unset_mount(**kwargs):
     )
     args.update(kwargs)
 
-    to_write = []
     changed = False
-    for line in open(args['fstab'], 'r').readlines():
-        if not line.strip():
-            to_write.append(line)
-            continue
-        if line.strip().startswith('#'):
-            to_write.append(line)
-            continue
-        if len(line.split()) != 6:
-            # not sure what this is or why it is here
-            # but it is not our fault so leave it be
-            to_write.append(line)
-            continue
+    args, exists, current = read_fstab(args)
+    to_write = []
 
-        ld = {}
-        ld['src'], ld['name'], ld['fstype'], ld['opts'], ld['dump'], ld['passno']  = line.split()
+    # If not found, no need to go further. Otherwise:
+    if exists:
+        for line in current:
+            if len(line.split()) != 6:
+                to_write.append(line)
+                continue
+            ld = {}
+            ld['src'], ld['name'], ld['fstype'], ld['opts'], ld['dump'], ld['passno']  = line.split()
 
-        if ld['name'] != args['name']:
-            to_write.append(line)
-            continue
+            if ld['name'] != args['name']:
+                to_write.append(line)
+                continue
 
-        # if we got here we found a match - continue and mark changed
-        changed = True
+            # name matches, src too ?
+            if ld['src'] != args['src']:
+                continue
+
+            # if we got here we found a match - continue and mark changed
+            changed = True
 
     if changed:
         write_fstab(to_write, args['fstab'])
@@ -223,19 +240,24 @@ def main():
             opts   = dict(default=None),
             passno = dict(default=None),
             dump   = dict(default=None),
-            src    = dict(required=True),
+            src    = dict(default=None),
             fstype = dict(required=True),
-            fstab  = dict(default=None)
+            fstab  = dict(default=None),
+            delmp  = dict(default=None)
         )
     )
 
     changed = False
+    exists = False
     rc = 0
     args = {
         'name': module.params['name'],
-        'src': module.params['src'],
         'fstype': module.params['fstype']
     }
+    if module.params['src'] is not None:
+        args['src'] = module.params['src']
+    else:
+        args['src'] = None
     if module.params['passno'] is not None:
         args['passno'] = module.params['passno']
     if module.params['opts'] is not None:
@@ -260,7 +282,7 @@ def main():
                 if res:
                     module.fail_json(msg="Error unmounting %s: %s" % (name, msg))
 
-            if os.path.exists(name):
+            if os.path.exists(name) and module.params['delmp'] is not None:
                 try:
                     os.rmdir(name)
                 except (OSError, IOError), e:
@@ -279,6 +301,8 @@ def main():
 
     if state in ['mounted', 'present']:
         name, changed = set_mount(**args)
+        if name == 1:
+            module.fail_json(msg=changed)
         if state == 'mounted':
             if not os.path.exists(name):
                 try:

--- a/library/mount
+++ b/library/mount
@@ -136,7 +136,7 @@ def set_mount(**kwargs):
             return 1, msg
         if args['state'] in ['only_if_mounted', 'only_if_present']: 
             msg="Error: %s not found in fstab." % (args['name'])
-            return 1, msg
+            return 0, msg
 
     # Not found and line valid, write new line and final point.
         for line in current:
@@ -308,6 +308,8 @@ def main():
 
     if state in ['mounted', 'present', 'only_if_mounted', 'only_if_present']:
         name, changed = set_mount(**args)
+        if name == 0:
+            module.exit_json(changed=changed, **args)
         if name == 1:
             module.fail_json(msg=changed)
         if state == 'mounted':


### PR DESCRIPTION
Enhancement of "mount" module from Seth Vidal : 
- Made 'src' parameter optional : 
  I wanted to be able to act on lines in fstab like this : 
  - SERVER 1 = /dev/mapper/vg0_lv_home /home ext4 defaults 1 2
  - SERVER 2 = /dev/mapper/LogVol00/lv-home /home ext4 defaults 1 2
    where 'src' are different but 'name' is the same. If 'src' is provided, a test is made like before, elsewhere it looks only at 'name' parameter.
- Added a parameter 'delmp' (means "delete mount point", can be rename if you want) for the unset_mount and unmount functions, because removing the directory under the mount point, without ask for it before, was too dangerous, IMHO (think : for some reason I want to umount /tmp, but I don't want to remove the directory !!)
- Added 2 states only_if_present and only_if_mounted to modify a line ONLY IF it is present in fstab.

Tested here, please test and validate if you find this useful.
