### PR TITLE
Service mod.: Proper(?) handling of return code 69

### DIFF
--- a/library/service
+++ b/library/service
@@ -313,9 +313,7 @@ class LinuxService(Service):
 
         # if the job status is still not known check it by response code
         if self.running == None:
-            if rc == 3:
-                self.running = False
-            if rc == 2:
+            if rc in [2, 3, 69]:
                 self.running = False
             elif rc == 0:
                 self.running = True


### PR DESCRIPTION
This adds "69" to the return codes from the status command that should be
considered as not running. At least "django-celery" uses this return code,
maybe others::

```
/venv/bin/python /code/project/manage.py celeryctl status
echo $? # 69 when not running.
```

A bit of googling let me to http://tldp.org/LDP/abs/html/exitcodes.html and
on a Ubuntu Server 12.10 I get::

```
~# cat /usr/include/sysexits.h | grep 69
#define EX_UNAVAILABLE  69  /* service unavailable */
```

I'm not sure if the content of sysexits.h is the same on other OS'es.

All the tests still passes, but I don't know how to test for this specifically.
