### PR TITLE
Fix sudo user env

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -544,6 +544,6 @@ def make_sudo_cmd(sudo_user, executable, cmd):
     # the -p option.
     randbits = ''.join(chr(random.randint(ord('a'), ord('z'))) for x in xrange(32))
     prompt = '[sudo via ansible, key=%s] password: ' % randbits
-    sudocmd = 'sudo -k && sudo -S -p "%s" -u %s %s -c %s' % (
+    sudocmd = 'sudo -k && sudo -S -p "%s" -i -u %s %s -c %s' % (
         prompt, sudo_user, executable or '$SHELL', pipes.quote(cmd))
     return ('/bin/sh -c ' + pipes.quote(sudocmd), prompt)


### PR DESCRIPTION
Adds -i to  make_sudo_cmd so target user's environment gets loaded when configurationslike this are used :

```
    - hosts: ubuntu 
      name: Install ruby for the configured ruby user 
      sudo: True 
      sudo_user: rubyuser 
      # should be ${ruby_user}, but can't for now because of #1665 
      tasks: 
      - name: Gets current ruby version 
        action: shell rbenv version 
        register: ruby_current_version
```
