### PR TITLE
Adds .travis.yml configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq python2.7-dev
+#notifications:
+#  email:
+#    - someone@somewhere.org
+install:
+  - pip install paramiko
+  - pip install jinja2
+  - pip install PyYAML
+# command to run tests
+script: make tests


### PR DESCRIPTION
Allows automated builds and tests on travis-ci for python 2.6 & 2.7.
Also runs tests for pull requests so it can be seen easily if the PR breaks any test.
Even if it's not enabled for ansible main repo, it can be interesting for forkers to have it.

In this case, the notification part of the travis config file should be commented out and filled accordingly so the last commiter doesn't get bugged by the fork's CI process.
