### PR TITLE
--private-key tilde handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ansible Changes By Release
 * SELinux fix for files created by authorized_key module
 * "template override" ??
 * lots of documentation tweaks
+* handle tilde shell character for --private-key
 
 * ...
 

--- a/docsite/rst/gettingstarted.rst
+++ b/docsite/rst/gettingstarted.rst
@@ -197,7 +197,7 @@ Set up SSH agent to avoid retyping passwords:
     $ ssh-agent bash
     $ ssh-add ~/.ssh/id_rsa
 
-(Depending on your setup, you may wish to ansible's --private-key-file option to specify a pem file instead)
+(Depending on your setup, you may wish to ansible's --private-key option to specify a pem file instead)
 
 Now ping all your nodes:
 

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -82,7 +82,7 @@ class Connection(object):
             allow_agent = False
         try:
             ssh.connect(self.host, username=user, allow_agent=allow_agent, look_for_keys=True,
-                key_filename=self.runner.private_key_file, password=self.runner.remote_pass,
+                key_filename=os.path.expanduser(self.runner.private_key_file), password=self.runner.remote_pass,
                 timeout=self.runner.timeout, port=self.port)
         except Exception, e:
             msg = str(e)

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -53,7 +53,7 @@ class Connection(object):
         if self.port is not None:
             self.common_args += ["-o", "Port=%d" % (self.port)]
         if self.runner.private_key_file is not None:
-            self.common_args += ["-o", "IdentityFile="+self.runner.private_key_file]
+            self.common_args += ["-o", "IdentityFile="+os.path.expanduser(self.runner.private_key_file)]
         if self.runner.remote_pass:
             self.common_args += ["-o", "GSSAPIAuthentication=no",
                                  "-o", "PubkeyAuthentication=no"]


### PR DESCRIPTION
Two fixes:
- Handle ~/.ssh/id_blah tilde shell expansion for --private-key for ssh and paramiko.
- Tiny fix to Getting Started (--private-key instead of --private-key-file)

I am a git noob so if you want this split up into two separate pull requests let me know and I can try to figure that out!

-Tim
