### PR TITLE
Inventory class - lambda fails on attribute access - g.name is a string not the group obje...

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -296,7 +296,7 @@ class Inventory(object):
         return [ h.name for h in self.get_hosts(pattern) ]
 
     def list_groups(self):
-        return sorted([ g.name for g in self.groups ], key=lambda x: x.name)
+        return sorted([ g.name for g in self.groups ], key=lambda x: x)
 
     # TODO: remove this function
     def get_restriction(self):


### PR DESCRIPTION
Looks like there is a small bug into the Inventory.list_groups function.

```
locals()
{'group': <ansible.inventory.group.Group object at 0x884f77c>, 'i': <ansible.inventory.group.Group object at 0x884f77c>, '__builtins__': <module '__builtin__' (built-in)>, 'inv': <ansible.inventory.Inventory object at 0x8856cec>, '__package__': None, 'Runner': <class 'ansible.runner.Runner'>, 'hosts': ['127.0.0.1', 'ec2-somehosts'], 'Inventory': <class 'ansible.inventory.Inventory'>, '__name__': '__main__', '__doc__': None}
type(inv)
<class 'ansible.inventory.Inventory'>
inv.groups
[<ansible.inventory.group.Group object at 0x884f77c>]
inv.list_groups
<bound method Inventory.list_groups of <ansible.inventory.Inventory object at 0x8856cec>>
inv.list_groups()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/Environments/ansible2/lib/python2.6/site-packages/ansible/inventory/__init__.py", line 299, in list_groups
    return sorted([ g.name for g in self.groups ], key=lambda x: x.name)
  File "/root/Environments/ansible2/lib/python2.6/site-packages/ansible/inventory/__init__.py", line 299, in <lambda>
    return sorted([ g.name for g in self.groups ], key=lambda x: x.name)
AttributeError: 'str' object has no attribute 'name'
```

May be reported as a bug as well.
