### PR TITLE
protect PluginLoader._extra_dirs from appending None

### DIFF
--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -70,7 +70,8 @@ class PluginLoader(object):
 
     def add_directory(self, directory):
         """Adds an additional directory to the search path"""
-        self._extra_dirs.append(directory)
+        if directory is not None:
+            self._extra_dirs.append(directory)
 
     def print_paths(self):
         """Returns a string suitable for printing of the search path"""


### PR DESCRIPTION
PluginLoader.add_directory() can receive None from, for example, 
Inventory.add_directory(self.basedir()) if host_list is a custom list.
None has no reasonable interpretation other than ignore it.
