### PR TITLE
Minor doc fix: service module 'state' parameter comments should be processed by RST

### DIFF
--- a/library/service
+++ b/library/service
@@ -35,9 +35,9 @@ options:
         required: false
         choices: [ started, stopped, restarted, reloaded ]
         description:
-          C(Started)/C(stopped) are idempotent actions that will not run
-          commands unless necessary.  C(restarted) will always bounce the
-          service.  C(reloaded) will always reload.
+          - C(started)/C(stopped) are idempotent actions that will not run
+            commands unless necessary.  C(restarted) will always bounce the
+            service.  C(reloaded) will always reload.
     pattern:
         required: false
         version_added: "0.7"


### PR DESCRIPTION
The doc site is currently displaying C(started), C(reloaded), etc. instead of `started`, `reloaded`.
