### PR TITLE
Add basic pkgin package management

### DIFF
--- a/library/pkgin
+++ b/library/pkgin
@@ -63,7 +63,7 @@ def query_package(module, name, state="installed"):
 
     if state == "installed":
 
-        (rc, stdout, stderr) = module.run_command("%s list | grep ^%s" % (PKGIN_PATH, name))
+        rc, out, err = module.run_command("%s list | grep ^%s" % (PKGIN_PATH, name))
 
         if rc == 0:
             return True
@@ -80,10 +80,10 @@ def remove_packages(module, packages):
         if not query_package(module, package):
             continue
 
-        module.run_command("%s -y remove %s" % (PKGIN_PATH, package))
+        rc, out, err = module.run_command("%s -y remove %s" % (PKGIN_PATH, package))
 
         if query_package(module, package):
-            module.fail_json(msg="failed to remove %s" % (package))
+            module.fail_json(msg="failed to remove %s: %s" % (package, out))
     
         remove_c += 1
 
@@ -102,10 +102,10 @@ def install_packages(module, packages):
         if query_package(module, package):
             continue
 
-        module.run_command("%s -y install %s" % (PKGIN_PATH, package))
+        rc, out, err = module.run_command("%s -y install %s" % (PKGIN_PATH, package))
 
         if not query_package(module, package):
-            module.fail_json(msg="failed to install %s" % (package))
+            module.fail_json(msg="failed to install %s: %s" % (package, out))
 
         install_c += 1
     

--- a/library/pkgin
+++ b/library/pkgin
@@ -82,7 +82,7 @@ def remove_packages(module, packages):
 
         rc = os.system("%s -y remove %s" % (PKGIN_PATH, package))
 
-        if rc != 0:
+        if query_package(module, package):
             module.fail_json(msg="failed to remove %s" % (package))
     
         remove_c += 1
@@ -104,7 +104,7 @@ def install_packages(module, packages):
 
         rc = os.system("%s -y install %s" % (PKGIN_PATH, package))
 
-        if rc != 0:
+        if not query_package(module, package):
             module.fail_json(msg="failed to install %s" % (package))
 
         install_c += 1

--- a/library/pkgin
+++ b/library/pkgin
@@ -1,0 +1,142 @@
+#!/usr/bin/python -tt
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Shaun Zinck
+# Written by Shaun Zinck <shaun.zinck at gmail.com>
+# Based on pacman module written by Afterburn <http://github.com/afterburn> 
+#  that was based on apt module written by Matthew Williams <matthew@flowroute.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: pkgin
+short_description: Package manager for SmartOS
+description:
+    - Manages SmartOS packages
+
+version_added: "1.0"
+options:
+    name:
+        description:
+            - name of package to install/remove
+        required: true
+
+    state:
+        description:
+            - state of the package installed or absent. 
+        required: false
+
+author: Shaun Zinck
+notes:  []
+examples:
+    - code: "pkgin: name=foo state=installed"
+      description: install package foo"
+    - code: "pkgin: name=foo state=absent"
+      description: remove package foo
+    - code: "pkgin: name=foo,bar state=absent
+      description: remove packages foo and bar 
+      
+'''
+
+
+import json
+import shlex
+import os
+import sys
+
+PKGIN_PATH = "/opt/local/bin/pkgin"
+
+def query_package(module, name, state="installed"):
+
+    if state == "installed":
+
+        rc = os.system("%s list | grep ^%s" % (PKGIN_PATH, name))
+
+        if rc == 0:
+            return True
+
+        return False
+
+
+def remove_packages(module, packages):
+    
+    remove_c = 0
+    # Using a for loop incase of error, we can report the package that failed
+    for package in packages:
+        # Query the package first, to see if we even need to remove
+        if not query_package(module, package):
+            continue
+
+        rc = os.system("%s -y remove %s" % (PKGIN_PATH, package))
+
+        if rc != 0:
+            module.fail_json(msg="failed to remove %s" % (package))
+    
+        remove_c += 1
+
+    if remove_c > 0:
+
+        module.exit_json(changed=True, msg="removed %s package(s)" % remove_c)
+
+    module.exit_json(changed=False, msg="package(s) already absent")
+
+
+def install_packages(module, packages):
+
+    install_c = 0
+
+    for package in packages:
+        if query_package(module, package):
+            continue
+
+        rc = os.system("%s -y install %s" % (PKGIN_PATH, package))
+
+        if rc != 0:
+            module.fail_json(msg="failed to install %s" % (package))
+
+        install_c += 1
+    
+    if install_c > 0:
+        module.exit_json(changed=True, msg="installed %s package(s)" % (install_c))
+
+    module.exit_json(changed=False, msg="package(s) already installed")
+
+
+
+def main():
+    module = AnsibleModule(
+            argument_spec    = dict(
+                state        = dict(default="installed", choices=["installed","absent"]),
+                name         = dict(aliases=["pkg"], required=True)))
+                
+
+    if not os.path.exists(PKGIN_PATH):
+        module.fail_json(msg="cannot find pkgin, looking for %s" % (PKGIN_PATH))
+
+    p = module.params
+
+    pkgs = p["name"].split(",")
+
+    if p["state"] == "installed":
+        install_packages(module, pkgs)
+
+    elif p["state"] == "absent":
+        remove_packages(module, pkgs)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+    
+main()        

--- a/library/pkgin
+++ b/library/pkgin
@@ -63,7 +63,7 @@ def query_package(module, name, state="installed"):
 
     if state == "installed":
 
-        rc = os.system("%s list | grep ^%s" % (PKGIN_PATH, name))
+        (rc, stdout, stderr) = module.run_command("%s list | grep ^%s" % (PKGIN_PATH, name))
 
         if rc == 0:
             return True
@@ -80,7 +80,7 @@ def remove_packages(module, packages):
         if not query_package(module, package):
             continue
 
-        rc = os.system("%s -y remove %s" % (PKGIN_PATH, package))
+        module.run_command("%s -y remove %s" % (PKGIN_PATH, package))
 
         if query_package(module, package):
             module.fail_json(msg="failed to remove %s" % (package))
@@ -102,7 +102,7 @@ def install_packages(module, packages):
         if query_package(module, package):
             continue
 
-        rc = os.system("%s -y install %s" % (PKGIN_PATH, package))
+        module.run_command("%s -y install %s" % (PKGIN_PATH, package))
 
         if not query_package(module, package):
             module.fail_json(msg="failed to install %s" % (package))

--- a/library/setup
+++ b/library/setup
@@ -82,10 +82,11 @@ class Facts(object):
     # A list of dicts.  If there is a platform with more than one
     # package manager, put the preferred one last.  If there is an
     # ansible module, use that as the value for the 'name' key.
-    PKG_MGRS = [ { 'path' : '/usr/bin/yum',     'name' : 'yum' },
-                 { 'path' : '/usr/bin/apt-get', 'name' : 'apt' },
-                 { 'path' : '/usr/bin/zypper',  'name' : 'zypper' },
-                 { 'path' : '/usr/bin/pacman',  'name' : 'pacman' } ]
+    PKG_MGRS = [ { 'path' : '/usr/bin/yum',         'name' : 'yum' },
+                 { 'path' : '/usr/bin/apt-get',     'name' : 'apt' },
+                 { 'path' : '/usr/bin/zypper',      'name' : 'zypper' },
+                 { 'path' : '/usr/bin/pacman',      'name' : 'pacman' }, 
+                 { 'path' : '/opt/local/bin/pkgin', 'name' : 'pkgin' } ]
 
     def __init__(self):
         self.facts = {}


### PR DESCRIPTION
This adds basic pkgin package management.  pkgin is used on Joyent SmartOS machines.  The basics are adding and removing packages, though pkgin supports more features than that. This is based off the pacman module.
