### PR TITLE
Git module: fix for relative paths

### DIFF
--- a/library/git
+++ b/library/git
@@ -225,7 +225,7 @@ def main():
         )
     )
 
-    dest    = os.path.expanduser(module.params['dest'])
+    dest    = os.path.abspath(os.path.expanduser(module.params['dest']))
     repo    = module.params['repo']
     version = module.params['version']
     remote  = module.params['remote']


### PR DESCRIPTION
Make the destination path absolute in the git module.

This fixes a bug where the git module would attempt to chdir into an invalid directory because of multiple chdir calls against a relative path.

I ran into this because I was using the git module with delegation to make some changes locally to a git repository before pushing it up to deploy a webserver. On my local machine, I only care about the git paths relative to the playbook.
