### PR TITLE
library/apt: consistently use underscores in examples.

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -70,7 +70,7 @@ options:
 author: Matthew Williams
 notes: []
 examples:
-    - code: "apt: pkg=foo update-cache=yes"
+    - code: "apt: pkg=foo update_cache=yes"
       description: Update repositories cache and install C(foo) package
     - code: "apt: pkg=foo state=removed"
       description: Remove C(foo) package
@@ -78,9 +78,9 @@ examples:
       description: Install the package C(foo)
     - code: "apt: pkg=foo=1.00 state=installed"
       description: Install the version '1.00' of package C(foo)
-    - code: "apt: pkg=nginx state=latest default-release=squeeze-backports update-cache=yes"
+    - code: "apt: pkg=nginx state=latest default_release=squeeze-backports update_cache=yes"
       description: Update the repository cache and update package C(ngnix) to latest version using default release C(squeeze-backport)
-    - code: "apt: pkg=openjdk-6-jdk state=latest install-recommends=no"
+    - code: "apt: pkg=openjdk-6-jdk state=latest install_recommends=no"
       description: Install latest version of C(openjdk-6-jdk) ignoring C(install-reccomends)
 '''
 


### PR DESCRIPTION
To be consistent with the table showing available options, use
underscores in the example tasks, not hyphens, as the table doesn't
list hyphenated versions of option names, so it looks like the
examples could have typos in them.
