### PR TITLE
restore unit tests erronously removed by bugfix

### DIFF
--- a/library/apt_key
+++ b/library/apt_key
@@ -121,6 +121,56 @@ def return_values(tb=False):
     else:
         return {}
 
+
+# use cues from the environment to mock out functions for testing
+if 'ANSIBLE_TEST_APT_KEY' in environ:
+    orig_download_key = download_key
+    KEY_ADDED=0
+    KEY_REMOVED=0
+    KEY_DOWNLOADED=0
+
+
+    def download_key(url):
+        global KEY_DOWNLOADED
+        KEY_DOWNLOADED += 1
+        return orig_download_key(url)
+
+
+    def find_missing_binaries():
+        return []
+
+
+    def add_key(key):
+        global KEY_ADDED
+        KEY_ADDED += 1
+        return True
+
+
+    def remove_key(key_id):
+        global KEY_REMOVED
+        KEY_REMOVED += 1
+        return True
+
+
+    def return_values(tb=False):
+        extra = dict(
+            added=KEY_ADDED,
+            removed=KEY_REMOVED,
+            downloaded=KEY_DOWNLOADED
+        )
+        if tb:
+            extra['exception'] = format_exc()
+        return extra
+
+
+if environ.get('ANSIBLE_TEST_APT_KEY') == 'none':
+    def key_present(key_id):
+        return False
+else:
+    def key_present(key_id):
+        return key_id == environ['ANSIBLE_TEST_APT_KEY']
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -290,3 +290,63 @@ class TestRunner(unittest.TestCase):
         print result
         assert result['changed'] == False
 
+    def test_apt_key(self):
+        try:
+            key_file = self._get_test_file("apt_key.gpg")
+            key_file_url = 'file://' + urllib2.quote(key_file)
+            key_id = '473041FA'
+
+            os.environ['ANSIBLE_TEST_APT_KEY'] = 'none'
+            # key missing, should download and add
+            result = self._run('apt_key', ['state=present', 'url=' + key_file_url])
+            assert 'failed' not in result
+            assert result['added'] == 1
+            assert result['downloaded'] == 1
+            assert result['removed'] == 0
+            assert result['changed']
+
+            os.environ["ANSIBLE_TEST_APT_KEY"] = key_id
+            # key missing, shouldn't download, no changes
+            result = self._run('apt_key', ['id=12345678', 'state=absent', 'url=' + key_file_url])
+            assert 'failed' not in result
+            assert result['added'] == 0
+            assert result['downloaded'] == 0
+            assert result['removed'] == 0
+            assert not result['changed']
+            # key missing, should download and fail sanity check, no changes
+            result = self._run('apt_key', ['id=12345678', 'state=present', 'url=' + key_file_url])
+            assert 'failed' in result
+            assert result['added'] == 0
+            assert result['downloaded'] == 1
+            assert result['removed'] == 0
+            # key present, shouldn't download, no changes
+            result = self._run('apt_key', ['id=' + key_id, 'state=present', 'url=' + key_file_url])
+            assert 'failed' not in result
+            assert result['added'] == 0
+            assert result['downloaded'] == 0
+            assert result['removed'] == 0
+            assert not result['changed']
+            # key present, should download to get key id
+            result = self._run('apt_key', ['state=present', 'url=' + key_file_url])
+            assert 'failed' not in result
+            assert result['added'] == 0
+            assert result['downloaded'] == 1
+            assert result['removed'] == 0
+            assert not result['changed']
+            # key present, should download to get key id and remove
+            result = self._run('apt_key', ['state=absent', 'url=' + key_file_url])
+            assert 'failed' not in result
+            assert result['added'] == 0
+            assert result['downloaded'] == 1
+            assert result['removed'] == 1
+            assert result['changed']
+            # key present, should remove but not download
+            result = self._run('apt_key', ['id=' + key_id, 'state=absent', 'url=' + key_file_url])
+            assert 'failed' not in result
+            assert result['added'] == 0
+            assert result['downloaded'] == 0
+            assert result['removed'] == 1
+            assert result['changed']
+        finally:
+            # always clean up the environment
+            os.environ.pop('ANSIBLE_TEST_APT_KEY', None)


### PR DESCRIPTION
So, it looks like the fix in pull request #1913 made a few more changes than were necessary (or helpful).

It did one good thing:  fixed the use of subprocess.call where a subprocess.Popen should have been used (this was actually a merge bug caused when I was rebasing it to keep up).

There was intentionally no test of this (i.e. integration tests).  This was because I didn't want to make the test suite dependent on apt-key, since it would only pass on Debian.  I figured that making the test suite Debian-specific was a no-no.

Rather than doing integration testing of apt-key, these are unit tests that verify the correct download / add / removal logic.  Just for a sanity check, I checked out the version merged, and the tests passed (though, again, didn't test what failed).

To further cloud things, the tests used some methods that the committers / reviewers seemed to not recognize.  Ansible tests have two complications that necessitated them:

Firstly, modules aren't imported in the same interpreter as the one doing the testing, so tools like Mock and such can't be used to patch functionality during the test.

Secondly, if you solve the first problem by manually mocking in the module, it's critical to prevent leaking any of the test code into production.  In C, this is typically solved by using #ifdef.  It's possible to do the same thing in Python by wrapping the test code in an "if" at a high level.

<p mood="irked" style="passive-aggressive">
In this case, the reviewers fixed the bug (which was good), then misinterpreted the if statement as an indentation error.  After "fixing that", they had leaked test code into the production code.  Since they didn't appreciate what the tests were actually testing, they "fixed" this by removing the "useless" tests.
</p>


This commit puts the unit tests back in and I have verified that they pass (just as before).  As before, critical application logic is now tested, no test code is defined or executed in production, and the previous bugfix is still present.

If an integration test is strongly desired, I can write one.  Similarly, I'm very receptive to any suggestions on how to test this functionality without this ad-hoc mocking.
