### PR TITLE
whitespaces in FULL_PATH cause an error to get ANSIBLE_PATH

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -11,7 +11,7 @@ fi
 # The below is an alternative to readlink -fn which doesn't exist on OS X
 # Source: http://stackoverflow.com/a/1678636
 FULL_PATH=`python -c "import os; print(os.path.realpath('$HACKING_DIR'))"`
-ANSIBLE_HOME=`dirname $FULL_PATH`
+ANSIBLE_HOME=`dirname "$FULL_PATH"`
 
 PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
 PREFIX_PATH="$ANSIBLE_HOME/bin"


### PR DESCRIPTION
When the library was installed in some path which has whitespaces in it. 
like '/Users/junyoung/test ansible/', the env-setup script doesn't work with this error "usage: dirname path".

solution : path need to be wrapped with double quotes.
