### PR TITLE
adjusted assemble to use new file attribute handling

### DIFF
--- a/library/assemble
+++ b/library/assemble
@@ -91,12 +91,12 @@ def main():
 
     module = AnsibleModule(
         # not checking because of daisy chain to file module
-        check_invalid_arguments = False,
         argument_spec = dict(
             src = dict(required=True),
             dest = dict(required=True),
             backup=dict(default=False, choices=BOOLEANS),
-        )
+        ),
+        add_file_common_args=True
     )
 
     changed=False
@@ -124,11 +124,11 @@ def main():
         shutil.copy(path, dest)
         changed = True
 
-
+    file_args = module.load_file_common_arguments(module.params)
+    changed = module.set_file_attributes_if_different(file_args, changed)
     # Mission complete
     module.exit_json(src=src, dest=dest, md5sum=destmd5,
-        changed=changed, msg="OK",
-        daisychain="file", daisychain_args=module.params)
+        changed=changed, msg="OK")
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>


### PR DESCRIPTION
It appears that assemble was using older methods (daisychain in exit_json) for handling file attributes. I borrowed the new method from the copy module so that assemble correctly handles file attributes.
