### PR TITLE
proper bin path now called

### DIFF
--- a/library/supervisorctl
+++ b/library/supervisorctl
@@ -58,7 +58,7 @@ def main():
 
     SUPERVISORCTL = module.get_bin_path('supervisorctl', True)
 
-    rc, out, err = module.run_command('%s status' % supervisorctl)
+    rc, out, err = module.run_command('%s status' % SUPERVISORCTL)
     present = name in out
 
     if state == 'present':
@@ -73,7 +73,7 @@ def main():
 
         module.exit_json(changed=False, name=name, state=state)
 
-    rc, out, err = module.run_command('%s status %s' % (supervisorctl, name))
+    rc, out, err = module.run_command('%s status %s' % (SUPERVISORCTL, name))
     running = 'RUNNING' in out
 
     if running and state == 'started':


### PR DESCRIPTION
I think there is a problem calling supervisorctl resulting in the following error:

``` traceback
 Traceback (most recent call last):
  File "/home/chris/.ansible/tmp/ansible-1359456294.14-216819041490139/supervisorctl", line 815, in <module>
    main()
  File "/home/chris/.ansible/tmp/ansible-1359456294.14-216819041490139/supervisorctl", line 61, in main
    rc, out, err = module.run_command('%s status' % supervisorctl)
NameError: global name 'supervisorctl' is not defined
```
