### PR TITLE
library/pip: add support for virtualenv's --system-site-packages.

### DIFF
--- a/library/pip
+++ b/library/pip
@@ -47,6 +47,15 @@ options:
       - An optional path to a I(virtualenv) directory to install into
     required: false
     default: null
+  virtualenv_site_packages:
+    description:
+      - Whether the virtual environment will inherit packages from the
+        global site-packages directory.  Note that if this setting is
+        changed on an already existing virtual environment it will not
+        have any effect, the environment must be deleted and newly
+        created.
+    required: false
+    default: no
   use_mirrors:
     description:
       - Whether to use mirrors when installing python libraries.  If using
@@ -74,7 +83,9 @@ examples:
    - code: "pip: name=flask version=0.8"
      description: Install I(flask) python package on version 0.8.
    - code: "pip: name=flask virtualenv=/my_app/venv"
-     description: "Install I(Flask) (U(http://flask.pocoo.org/)) into the specified I(virtualenv)"
+     description: "Install I(Flask) (U(http://flask.pocoo.org/)) into the specified I(virtualenv), inheriting none of the globally installed modules"
+   - code: "pip: name=flask virtualenv=/my_app/venv virtualenv_site_packages=yes"
+     description: "Install I(Flask) (U(http://flask.pocoo.org/)) into the specified I(virtualenv), inheriting globally installed modules"
    - code: "pip: requirements=/my_app/requirements.txt"
      description: Install specified python requirements.
    - code: "pip: requirements=/my_app/requirements.txt virtualenv=/my_app/venv"
@@ -137,6 +148,7 @@ def main():
             version=dict(default=None, required=False),
             requirements=dict(default=None, required=False),
             virtualenv=dict(default=None, required=False),
+            virtualenv_site_packages=dict(default='no', choices=BOOLEANS),
             use_mirrors=dict(default='yes', choices=BOOLEANS),
             extra_args=dict(default=None, required=False),
         ),
@@ -164,7 +176,10 @@ def main():
     if env:
         virtualenv = module.get_bin_path('virtualenv', True)
         if not os.path.exists(os.path.join(env, 'bin', 'activate')):
-            cmd = '%s %s' % (virtualenv, env)
+            if module.boolean(module.params['virtualenv_site_packages']):
+                cmd = '%s --system-site-packages %s' % (virtualenv, env)
+            else:
+                cmd = '%s %s' % (virtualenv, env)
             rc, out_venv, err_venv = module.run_command(cmd)
             out += out_venv
             err += err_venv


### PR DESCRIPTION
I went with a long option name, virtualenv_system_site_packages, to be consistent with virtualenv's --system-site-packages command line argument, but feel free to shorten it.
