### PR TITLE
Only inventory "running" EC2 instances. "stopped" is also a valid state ...

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -274,7 +274,7 @@ class Ec2Inventory(object):
         addressable '''
 
         # Only want running instances
-        if instance.state == 'terminated':
+        if instance.state != 'running':
             return
 
         # Select the best destination address


### PR DESCRIPTION
...and these should not be inventoried.
