### PR TITLE
Update packaging/arch/PKGBUILD

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,12 +1,12 @@
 #Maintainer: Michel Blanc <mblanc@erasme.org>
 pkgname=ansible-git
-pkgver=20130123
+pkgver=20130131
 pkgrel=1
 pkgdesc="A radically simple deployment, model-driven configuration management, and command execution framework"
 arch=('any')
 url="http://ansible.cc"
 license=('GPL3')
-depends=('python2' 'python2-paramiko' 'python2-jinja' 'python2-simplejson' 'python2-yaml')
+depends=('python2' 'python2-paramiko' 'python2-jinja' 'python2-yaml')
 makedepends=('git' 'asciidoc' 'fakeroot')
 conflicts=('ansible')
 source=("python-binary.diff")


### PR DESCRIPTION
Removes python2-json dependancy which is not required on Arch (python 2.7)
