### PR TITLE
fix to file.py, returning a list comprehension.

### DIFF
--- a/lib/ansible/runner/lookup_plugins/file.py
+++ b/lib/ansible/runner/lookup_plugins/file.py
@@ -32,4 +32,4 @@ class LookupModule(object):
             if not os.path.exists(path):
                 raise errors.AnsibleError("%s does not exist" % path)
             ret.append(open(path).read().rstrip())
-        return ret
+        return [ r for r in ret ]


### PR DESCRIPTION
Mimicking items.py and returning a list comprehension of the list, instead
of the list itself. This solves an issue with the apt module:

Before (apt fails):
    <127.0.0.1> REMOTE_MODULE apt package=aptitude
    zip

After (now apt runs fine):
    <127.0.0.1> REMOTE_MODULE apt package=aptitude,zip
