### PR TITLE
fixed shebang in hacking test-module

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #


### PR DESCRIPTION
This fixes the test-module to use /usr/bin/env python rather than /usr/bin/python.

<3
