### PR TITLE
Integrate upstream changes from Portfile that exists in macports

### DIFF
--- a/packaging/macports/Portfile
+++ b/packaging/macports/Portfile
@@ -1,52 +1,68 @@
-# $Id$
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+# $Id: Portfile 102428 2013-02-02 18:34:49Z blair@macports.org $
 
-PortSystem         1.0
-PortGroup          python27 1.0
+PortSystem      1.0
+PortGroup       python 1.0
 
-name               ansible
-version            devel
-categories         python
-platforms          darwin
-supported_archs    noarch
-license            GPL-3
-maintainers        nomaintainer
+name            ansible
+version         devel
+categories      sysutils
+supported_archs noarch
 
-description        Model-driven configuration management, multi-node deployment, and remote task execution system.
-long_description   Ansible is a radically simple configuration-management, deployment, task-execution, and multinode orchestration framework.
+maintainers     nomaintainer
 
-homepage           http://www.ansible.cc
+homepage        http://ansible.cc/
+description     SSH-based configuration management and deployment system
+long_description \
+    Ansible is a radically simple model-driven configuration \
+    management, multi-node deployment, and remote task execution \
+    system.  Ansible works over SSH and does not require any software \
+    or daemons to be installed on remote nodes.  Extension modules can \
+    be written in any language and are transferred to managed machines \
+    automatically.
+
+license         GPL-3+
+
+platforms       darwin
 
 fetch.type         git
 git.url            https://github.com/ansible/ansible.git
 git.branch         ${version}
 
-depends_lib-append port:py27-yaml \
-                   port:py27-paramiko \
-                   port:py27-jinja2
+python.default_version  27
+depends_lib-append      port:py${python.version}-jinja2 \
+                        port:py${python.version}-paramiko \
+                        port:py${python.version}-yaml
+# fireball mode requires py-zmq, py-asn1, py-crypto and py-keyczar
 
-python.link_binaries_suffix
-
-post-patch {
-  reinplace "s|/usr/share/ansible|${prefix}/share/ansible|g" ${worksrcpath}/lib/ansible/constants.py ${worksrcpath}/examples/ansible.cfg
-  reinplace "s|/etc/ansible/ansible.cfg|${prefix}/etc/ansible/ansible.cfg|g" ${worksrcpath}/lib/ansible/constants.py ${worksrcpath}/examples/ansible.cfg
-  reinplace "s|/etc/ansible/hosts|${prefix}/etc/ansible/hosts|g" ${worksrcpath}/lib/ansible/constants.py ${worksrcpath}/examples/ansible.cfg
-  reinplace "s|/usr/share/ansible_plugins|${prefix}/${prefix}/share/ansible_plugins|g" ${worksrcpath}/lib/ansible/constants.py ${worksrcpath}/examples/ansible.cfg
+patch {
+    fs-traverse f ${worksrcpath} {
+        if {[file isfile ${f}]} {
+            reinplace "s#/etc/ansible#${prefix}/etc/ansible#g" ${f}
+            reinplace "s#/usr/share/ansible#${prefix}/share/ansible#g" ${f}
+        }
+    }
 }
 
 post-destroot {
+  # documentation and examples
   xinstall -m 644 -W ${worksrcpath} README.md CHANGELOG.md CONTRIBUTING.md COPYING  \
     ${destroot}${prefix}/share/doc/${name}
 
   xinstall -m 755 -d ${destroot}${prefix}/share/doc/examples
   xinstall -m 755 ${worksrcpath}/examples/ansible.cfg ${destroot}${prefix}/share/doc/${name}/examples
-  xinstall -m 755 ${worksrcpath}/examples/ansible.cfg ${worksrcpath}/examples/hosts ${destroot}${prefix}/share/doc/${name}/examples
+  xinstall -m 755 ${worksrcpath}/examples/hosts ${destroot}${prefix}/share/doc/${name}/examples
+
   file copy ${worksrcpath}/examples/playbooks ${destroot}${prefix}/share/doc/${name}/examples/
 
+  # man pages
   xinstall -d 644 ${destroot}${prefix}/share/man/man1
-  eval xinstall -m 755 [glob ${worksrcpath}/docs/man/man1/*] ${destroot}${prefix}/share/man/man1
+  eval xinstall -m 755 [glob ${worksrcpath}/docs/man/man1/*.1] ${destroot}${prefix}/share/man/man1
 
   # install sample config and hosts file
   xinstall -m 755 -d ${destroot}${prefix}/etc/ansible
   xinstall -m 755 ${worksrcpath}/examples/ansible.cfg ${destroot}${prefix}/etc/ansible/ansible.cfg
   xinstall -m 755 ${worksrcpath}/examples/hosts ${destroot}${prefix}/etc/ansible/hosts
 }
+
+python.link_binaries_suffix


### PR DESCRIPTION
See this post - https://groups.google.com/forum/?fromgroups=#!topic/ansible-project/7xdC0MP9MjM

I was not aware that blair had uploaded a portfile to macports already,
this set of changes makes the 'devel' version of the portfile similar
to the upstream. Except the man pages, examples and sample config files are installed.
