### PR TITLE
Use yaml.safe_dump rather than yaml.dump. No more "!!python/unicode".

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -25,7 +25,7 @@ class FilterModule(object):
         return {
             'to_json': json.dumps,
             'from_json': json.loads,
-            'to_yaml': yaml.dump,
+            'to_yaml': yaml.safe_dump,
             'from_yaml': yaml.load,
         }
     


### PR DESCRIPTION
Please, replace yaml.dump with yaml.safe_dump which generates more usable YAML output (without !!python/unicode boilterplate).

Simple example:

setup.j2:

```
{{ s|to_yaml }}
```

setup.yml:

```

---
- hosts: localhost
  connection: local
  tasks:
    - action: setup
      register: s
    - action: template src=setup.j2 dest=/tmp/setup.yml
    - action: fetch src=/tmp/setup.yml dest=out
```

output:

```
ansible_facts:
  ansible_all_ipv4_addresses: [10.0.2.15]
  ansible_architecture: x86_64
  ansible_bios_date: 08/21/2012
  ansible_bios_version: A14
  ansible_cmdline: {BOOT_IMAGE: /boot/vmlinuz-3.5.0-23-generic, quiet: true, ro: true,
    root: UUID=a555035f-05fe-4401-895b-665d57291b4e, splash: true, vt.handoff: '7'}
...
```
