### PR TITLE
Add ConnectTimeout=DEFAULT_TIMEOUT to ssh args

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -61,6 +61,7 @@ class Connection(object):
             self.common_args += ["-o", "KbdInteractiveAuthentication=no",
                                  "-o", "PasswordAuthentication=no"]
         self.common_args += ["-o", "User="+self.runner.remote_user]
+        self.common_args += ["-o", "ConnectTimeout="+str(self.runner.timeout)]
 
         return self
 


### PR DESCRIPTION
In response to https://groups.google.com/forum/?fromgroups=#!topic/ansible-project/oPuYQP-zNGA

The only problem with this solution I see so far, is that if someone adds a "ConnectTimeout" earlier in their config (ansible.cfg for instance) then the first occurrence of the option appears to have precedence.
