### PR TITLE
Fixing bug with unicode templates

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -301,7 +301,7 @@ def md5s(data):
     ''' Return MD5 hex digest of data. '''
 
     digest = _md5()
-    digest.update(data)
+    digest.update(data.encode('utf-8'))
     return digest.hexdigest()
 
 def md5(filename):

--- a/test/sample.j2
+++ b/test/sample.j2
@@ -1,4 +1,4 @@
-Are you pondering what I'm pondering?
+Are you pondering what I'm pøndering?
 
 I think so Brain, but {{ answer }}
 


### PR DESCRIPTION
The utils.md5s() function would break when calculating checksums
for non-ascii characters. Convert to utf-8 first.
