### PR TITLE
For ansible --list-hosts benefit apply hosts selection limits early

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -70,6 +70,8 @@ class Cli(object):
         pattern = args[0]
 
         inventory_manager = inventory.Inventory(options.inventory)
+        if options.subset:
+            inventory_manager.subset(options.subset)
         hosts = inventory_manager.list_hosts(pattern)
         if len(hosts) == 0:
             print >>sys.stderr, "No hosts matched"

--- a/docsite/rst/examples.rst
+++ b/docsite/rst/examples.rst
@@ -121,19 +121,19 @@ with yum.
 
 Ensure a package is installed, but don't update it::
 
-    $ ansible webservers -m yum -a "pkg=acme state=installed"
+    $ ansible webservers -m yum -a "name=acme state=installed"
 
 Ensure a package is installed to a specific version::
 
-    $ ansible webservers -m yum -a "pkg=acme-1.5 state=installed"
+    $ ansible webservers -m yum -a "name=acme-1.5 state=installed"
 
 Ensure a package is at the latest version::
 
-    $ ansible webservers -m yum -a "pkg=acme state=latest"
+    $ ansible webservers -m yum -a "name=acme state=latest"
 
 Ensure a package is not installed::
 
-    $ ansible webservers -m yum -a "pkg=acme state=removed"
+    $ ansible webservers -m yum -a "name=acme state=removed"
 
 Currently Ansible only has modules for managing packages with yum and apt.  You can install
 for other packages for now using the command module or (better!) contribute a module


### PR DESCRIPTION
ansible --list-hosts is quite handy for a quick check before running havoc. It is even more if the hosts selection limits, via -l option, are considered. This commit aims to implement that.
