### PR TITLE
always restart the program when state=restarted

### DIFF
--- a/library/supervisorctl
+++ b/library/supervisorctl
@@ -87,11 +87,11 @@ def main():
 
         module.fail_json(msg=out)
 
-    elif running and state == 'restarted':
+    elif state == 'restarted':
         rc, out, err = module.run_command('%s update %s' % (SUPERVISORCTL, name))
         rc, out, err = module.run_command('%s restart %s' % (SUPERVISORCTL, name))
 
-        if '%s: stopped' % name in out and '%s: started' % name in out:
+        if '%s: started' % name in out:
             module.exit_json(changed=True, name=name, state=state)
 
         module.fail_json(msg=out)
@@ -103,9 +103,6 @@ def main():
             module.exit_json(changed=True, name=name, state=state)
 
         module.fail_json(msg=out)
-
-    elif not running and state == 'restarted':
-        module.fail_json(msg='Could not restart `%s` because it is not running' % name)
 
     module.exit_json(changed=False, name=name, state=state)
 


### PR DESCRIPTION
The supervisorctl module  current behavior is 
1. when state = restarted , it will not restart the program if it is not running 
2. when state = started , it will not reload  the config file

I run into a problem:
1. have a  bad version of  supervisor  config  in server . (bad argument, the program won't started) 
2.  upload an new version of config that works 
3.  `supervisorctl  name=xxxx  state=started`    or 
     `supervisorctl  name=xxxx  state=restarted`  will make it using the latest config and start the program . 

I suggest the change the behavior  of the `restarted`  state, which should  start the program if it is not running .   Other similar modules works that way  , for example  `service`  module . 
