### PR TITLE
Adds commandline parameter --list-tasks

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -63,6 +63,8 @@ def main(args):
         help="dump out a list of hosts, each play will run against, does not run playbook!")
     parser.add_option('--syntax-check', dest='syntax', action='store_true',
         help="do a playbook syntax check on the playbook, do not execute the playbook")
+    parser.add_option('--list-tasks', dest='listtasks', action='store_true',
+        help="do list all tasks that would be executed")
 
     options, args = parser.parse_args(args)
 
@@ -77,7 +79,7 @@ def main(args):
 
     sshpass = None
     sudopass = None
-    if not options.listhosts and not options.syntax:
+    if not options.listhosts and not options.syntax and not options.listtasks:
         options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
         if options.ask_pass:
             sshpass = getpass.getpass(prompt="SSH password: ")
@@ -124,18 +126,32 @@ def main(args):
             only_tags=only_tags,
             check=options.check
         )
-        
-        if options.listhosts:
+
+        if options.listhosts or options.listtasks:
             print 'playbook: %s' % playbook
             playnum = 0
             for (play_ds, play_basedir) in zip(pb.playbook, pb.play_basedirs):
                 playnum += 1
                 play = ansible.playbook.Play(pb, play_ds, play_basedir)
                 label = play.name
-                hosts = pb.inventory.list_hosts(play.hosts)
-                print '  hosts in play %s (%s): #%d' % (playnum, label, len(hosts))
-                for host in hosts:
-                    print '    %s' % host
+                if options.listhosts:
+                    hosts = pb.inventory.list_hosts(play.hosts)
+                    print '  hosts in play %s (%s): #%d' % (playnum, label, len(hosts))
+                    for host in hosts:
+                        print '    %s' % host
+                if options.listtasks:
+                    matched_tags, unmatched_tags = play.compare_tags(pb.only_tags)
+                    unmatched_tags.discard('all')
+                    unknown_tags = set(pb.only_tags) - (matched_tags | unmatched_tags)
+                    if unknown_tags:
+                        msg = 'tag(s) not found in playbook: %s.  possible values: %s'
+                        unknown = ','.join(sorted(unknown_tags))
+                        unmatched = ','.join(sorted(unmatched_tags))
+                        raise errors.AnsibleError(msg % (unknown, unmatched))
+                    print '  tasks in play %s (%s): #%d' % (playnum, label, len(play.tasks()))
+                    for task in play.tasks():
+                        if set(task.tags).intersection(pb.only_tags):
+                            print '    %s' % task.name
             continue
 
         if options.syntax:


### PR DESCRIPTION
Add --list-tasks to ansible-playbook to list all task to be executed.
Supports includes, --tags and --list-hosts (in one call).

See https://gist.github.com/schmic/4733954 for some example output.

Might need some more testing though.
