### PR TITLE
Handle 'groups=' (empty string) in user module (Linux)

### DIFF
--- a/library/user
+++ b/library/user
@@ -48,7 +48,9 @@ options:
     groups:
         required: false
         description:
-            - Puts the user in this comma-delimited list of groups.
+            - Puts the user in this comma-delimited list of groups. When set to
+              the empty string ('groups='), the user is removed from all groups
+              except the primary group.
     append:
         required: false
         description:
@@ -249,9 +251,10 @@ class User(object):
             cmd.append(self.group)
 
         if self.groups is not None:
-            for g in self.groups.split(','):
-                if not self.group_exists(g):
-                    self.module.fail_json(msg="Group %s does not exist" % (g))
+            if self.groups != '':
+                for g in self.groups.split(','):
+                    if not self.group_exists(g):
+                        self.module.fail_json(msg="Group %s does not exist" % (g))
             cmd.append('-G')
             cmd.append(self.groups)
 
@@ -301,23 +304,29 @@ class User(object):
 
         if self.groups is not None:
             current_groups = self.user_group_membership()
-            groups = self.groups.split(',')
-            for g in groups:
-                if not self.group_exists(g):
-                    self.module.fail_json(msg="Group %s does not exist" % (g))
-
-            group_diff = set(sorted(current_groups)).symmetric_difference(set(sorted(groups)))
             groups_need_mod = False
+            groups = []
 
-            if group_diff:
-                if self.append:
-                    for g in groups:
-                        if g in group_diff:
-                            cmd.append('-a')
-                            groups_need_mod = True
-                            break
-                else:
+            if self.groups == '':
+                if current_groups and not self.append:
                     groups_need_mod = True
+            else:
+                groups = self.groups.split(',')
+                for g in groups:
+                    if not self.group_exists(g):
+                        self.module.fail_json(msg="Group %s does not exist" % (g))
+
+                group_diff = set(sorted(current_groups)).symmetric_difference(set(sorted(groups)))
+
+                if group_diff:
+                    if self.append:
+                        for g in groups:
+                            if g in group_diff:
+                                cmd.append('-a')
+                                groups_need_mod = True
+                                break
+                    else:
+                        groups_need_mod = True
 
             if groups_need_mod:
                 cmd.append('-G')


### PR DESCRIPTION
Hi,
I noticed that the user module would not let me remove a user from all (non-primary) groups. Example (assuming groups a, b already exist):
1. Add a user to two groups

```
$ ansible -i hosts -s vm1 -m user -a 'name=testuser groups=a,b'
vm1 | success >> {
    "append": false, 
    "changed": true, 
    "comment": "", 
    "group": 507, 
    "groups": "a,b", 
    "home": "/home/testuser", 
    "name": "testuser", 
    "shell": "/bin/bash", 
    "state": "present", 
    "uid": 505
}
$ ssh vm1 groups testuser
testuser : testuser a b
```
1. Remove from 1st group works

```
$ ansible -i hosts -s vm1 -m user -a 'name=testuser groups=a'
vm1 | success >> {
    "append": false, 
    "changed": true, 
    "comment": "", 
    "group": 507, 
    "groups": "a", 
    "home": "/home/testuser", 
    "name": "testuser", 
    "shell": "/bin/bash", 
    "state": "present", 
    "uid": 505
}
$ ssh vm1 groups testuser
testuser : testuser a
```
1. Remove from 2nd group **fails**

```
$ ansible -i hosts -s vm1 -m user -a 'name=testuser groups='
vm1 | FAILED >> {
    "failed": true, 
    "msg": "Group  does not exist"
}
$ ssh vm1 groups testuser
testuser : testuser a
```

This patch makes step 3 work by allowing you to pass `groups=`. This relies on the fact that `usermod`/`useradd` accepts `-G ""` to mean "no groups" for exactly this purpose on Linux. I don't have access to FreeBSD or SunOS to test this, so I did _not_ patch the `FreeBsdUser` and `SunOS` user subclasses.

Last step with patch:

```
$ ansible -i hosts -s vm1 -m user -a 'name=testuser groups='
vm1 | success >> {
    "append": false, 
    "changed": true, 
    "comment": "", 
    "group": 507, 
    "groups": "", 
    "home": "/home/testuser", 
    "name": "testuser", 
    "shell": "/bin/bash", 
    "state": "present", 
    "uid": 505
}
$ ssh vm1 groups testuser
testuser : testuser
```
