### PR TITLE
Add rabbitmq_vhost module.

### DIFF
--- a/examples/playbooks/rabbitmq.yml
+++ b/examples/playbooks/rabbitmq.yml
@@ -28,6 +28,9 @@
   - name: remove default guest user
     rabbitmq_user: user=guest state=absent
 
+  - name: ensure vhost /test is present
+    rabbitmq_vhost: name=/test state=present
+
   handlers:
   - name: restart rabbitmq
     service: name=rabbitmq-server state=restarted

--- a/library/rabbitmq_vhost
+++ b/library/rabbitmq_vhost
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Matt Cordial <matt.cordial@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = '''
+---
+module: rabbitmq_vhost
+short_description: Manage the state of a virtual host in RabbitMQ
+description:
+  - Manage the state of a virtual host in RabbitMQ
+options:
+  name:
+    description:
+      - The name of the vhost to manage
+    required: true
+    default: null
+  state:
+    description:
+      - The state of vhost
+    required: true
+    default: null
+    choices: [ "present", "absent" ]
+examples:
+   - code: "rabbitmq_vhost: name=/test state=present"
+     description: Ensure that the vhost /test exists.
+author: Matt Cordial
+'''
+
+
+def main():
+    arg_spec = dict(
+        name=dict(required=True),
+        state=dict(required=False, choices=['present', 'absent'])
+    )
+
+    module = AnsibleModule(argument_spec=arg_spec)
+
+    name = module.params['name']
+    state = module.params['state']
+
+    RABBITMQCTL = module.get_bin_path('rabbitmqctl', True)
+
+    present = False
+    rc, out, err = module.run_command('%s list_vhosts' % RABBITMQCTL)
+    for line in out.splitlines():
+        if line.strip() == name:
+            present = True
+            break
+
+    if state == 'present' and present:
+        module.exit_json(changed=False, name=name, state=state)
+
+    if state == 'present' and not present:
+        rc, out, err = module.run_command('%s add_vhost %s' % (RABBITMQCTL, name))
+        if '...done' in out:
+            module.exit_json(changed=True, name=name, state=state)
+        else:
+            module.fail_json(msg=out, name=name, state=state)
+
+    if state == 'absent' and not present:
+        module.exit_json(changed=False, name=name, state=state)
+
+    if state == 'absent' and present:
+        rc, out, err = module.run_command('%s delete_vhost %s' % (RABBITMQCTL, name))
+        if '...done' in out:
+            module.exit_json(changed=True, name=name, state=state)
+        else:
+            module.fail_json(msg=out, name=name, state=state)
+
+    module.exit_json(changed=False, name=name, state=state)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+
+main()


### PR DESCRIPTION
Simply ensures existence or non-existence of a RabbitMQ vhost.
