### PR TITLE
PEP-8 fix: always compare with None using 'is' or 'is not'.

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -132,7 +132,7 @@ def regular_generic_msg(hostname, result, oneline, caption):
 
 def banner(msg):
 
-    if cowsay != None:
+    if cowsay is not None:
         cmd = subprocess.Popen([cowsay, "-W", "60", msg],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (out, err) = cmd.communicate()

--- a/library/apt
+++ b/library/apt
@@ -202,7 +202,7 @@ def main():
     if module.boolean(p['update_cache']):
         cache.update()
         cache.open(progress=None)
-        if p['package'] == None:
+        if p['package'] is None:
             module.exit_json(changed=False)
 
     force_yes = module.boolean(p['force'])

--- a/library/git
+++ b/library/git
@@ -87,7 +87,7 @@ def has_local_mods(dest):
     os.chdir(dest)
     cmd = "git status -s"
     lines = os.popen(cmd).read().splitlines()
-    lines = filter(lambda c: re.search('^\\?\\?.*$',c) == None,lines)
+    lines = filter(lambda c: re.search('^\\?\\?.*$',c) is None,lines)
     return len(lines) > 0
 
 def reset(module,dest,force):

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -285,7 +285,7 @@ def main():
         module.fail_json(msg="when supplying login arguments, both login_user and login_password must be provided")
 
     try:
-        if module.params["login_unix_socket"] != None:
+        if module.params["login_unix_socket"] is not None:
             db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db="mysql")
         else:
             db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")

--- a/library/selinux
+++ b/library/selinux
@@ -147,10 +147,10 @@ def main():
 
     # check to see if policy is set if state is not 'disabled'
     if (state != 'disabled'):
-        if (policy == '' or policy == None):
+        if (policy == '' or policy is None):
             module.fail_json(msg='policy is required if state is not \'disabled\'')
     else:
-        if (policy == '' or policy == None):
+        if (policy == '' or policy is None):
             policy = config_policy
 
     # check changed values and run changes

--- a/library/service
+++ b/library/service
@@ -236,7 +236,7 @@ class Service(object):
                     break
 
     def check_service_changed(self):
-        if self.state and self.running == None:
+        if self.state and self.running is None:
             self.module.fail_json(msg="failed determining the current service state => state stays unchanged")
         # Find out if state has changed
         if not self.running and self.state in ["started", "running"]:
@@ -377,7 +377,7 @@ class LinuxService(Service):
         rc, status_stdout, status_stderr = self.service_control()
 
         # Check if we have upstart on the system and then the job state
-        if self.svc_initctl != None and self.running is None:
+        if self.svc_initctl is not None and self.running is None:
             # check the job status by upstart response
             initctl_rc, initctl_status_stdout, initctl_status_stderr = self.execute_command("%s status %s" % (self.svc_initctl, self.name))
             if initctl_status_stdout.find("stop/waiting") != -1:
@@ -386,14 +386,14 @@ class LinuxService(Service):
                 self.running = True
 
         # if the job status is still not known check it by response code
-        if self.running == None:
+        if self.running is None:
             if rc in [2, 3, 4, 69]:
                 self.running = False
             elif rc == 0:
                 self.running = True
 
         # if the job status is still not known check it by status output keywords
-        if self.running == None:
+        if self.running is None:
             # first tranform the status output that could irritate keyword matching
             cleanout = status_stdout.lower().replace(self.name.lower(), '')
             if "stop" in cleanout:
@@ -414,7 +414,7 @@ class LinuxService(Service):
                 self.running = False
 
         # if the job status is still not known check it by special conditions
-        if self.running == None:
+        if self.running is None:
             if self.name == 'iptables' and status_stdout.find("ACCEPT") != -1:
                 # iptables status command output is lame
                 # TODO: lookup if we can use a return code for this instead?

--- a/library/virt
+++ b/library/virt
@@ -322,7 +322,7 @@ class Virt(object):
         """
 
         conn = libvirt.openReadOnly(None)
-        if conn == None:
+        if conn is None:
             return (-1,'Failed to open connection to the hypervisor')
         try:
             domV = conn.lookupByName(vmid)

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -283,7 +283,7 @@ class Ec2Inventory(object):
         else:
             dest =  getattr(instance, self.destination_variable)
 
-        if dest == None:
+        if dest is None:
             # Skip instances we cannot address (e.g. private VPC subnet)
             return
 
@@ -303,7 +303,7 @@ class Ec2Inventory(object):
         self.push(self.inventory, self.to_safe('type_' + instance.instance_type), dest)
         
         # Inventory: Group by key pair
-        if instance.key_name != None:
+        if instance.key_name is not None:
             self.push(self.inventory, self.to_safe('key_' + instance.key_name), dest)
         
         # Inventory: Group by security group


### PR DESCRIPTION
http://www.python.org/dev/peps/pep-0008/

  Comparisons to singletons like None should always be done with is or
  is not, never the equality operators.

  Also, beware of writing if x when you really mean if x is not None
  -- e.g. when testing whether a variable or argument that defaults to
  None was set to some other value. The other value might have a type
  (such as a container) that could be false in a boolean context!
