### PR TITLE
Duplicate/missing import

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -52,7 +52,7 @@ import types
 import time
 import shutil
 import stat
-import stat
+import traceback
 import grp
 import pwd
 import platform


### PR DESCRIPTION
There was a duplicate import of the stat module and the import of the traceback module was missing.  traceback is used in the exception handling for the run_command method.
