### PR TITLE
Add support for virtual packages in apt module

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -208,13 +208,24 @@ def main():
     force_yes = module.boolean(p['force'])
 
     packages = p['package'].split(',')
+    # virtual packages are 'expanded' below to their providing packages
+    packages_expanded = []
     latest = p['state'] == 'latest'
     for package in packages:
+        package_name, package_version = package_split(package)
+        if cache.is_virtual_package(package_name):
+            providing_packages = cache.get_providing_packages(package_name)
+            for pkg in providing_packages:
+                packages_expanded.append(pkg.shortname)
+        else:
+            packages_expanded.append(package)
+
         if package.count('=') > 1:
             module.fail_json(msg="invalid package spec: %s" % package)
         if latest and '=' in package:
             module.fail_json(msg='version number inconsistent with state=latest: %s' % package)
 
+    packages = packages_expanded
     if p['state'] == 'latest':
         install(module, packages, cache, upgrade=True,
                 default_release=p['default_release'],


### PR DESCRIPTION
Virtual packages in apt repos are provided from other 'providing'
packages. With this commit, ansible's apt module is taught to
to install these packages, if the name of a virtual package is
given as the package to be installed.
