### PR TITLE
Updating changelog for 1.0

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+ansible (1.0) unstable; urgency=low
+
+  * 1.0 release
+
+ -- Michael DeHaan <michael.dehaan@gmail.com>  Fri, 01 Feb 2012 22:00:00 -0400
+
 ansible (0.9) unstable; urgency=low
   
   * 0.9 release 


### PR DESCRIPTION
Updating changelog for 1.0 since it was missed during the 1.0 release, and this file is used for the version of the DEB file.
