### PR TITLE
Fixing logical error in detecting virtual device.

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -387,7 +387,7 @@ class LinuxHardware(Hardware):
             return
 
         for block in block_devs:
-            virtual = 0
+            virtual = 1
             sysfs_no_links = 0
             try:
                 path = os.readlink(os.path.join("/sys/block/", block))
@@ -403,7 +403,7 @@ class LinuxHardware(Hardware):
             if sysfs_no_links == 1:
                 for folder in os.listdir(sysdir):
                     if re.search("device", folder):
-                        virtual = 1
+                        virtual = 0
                         break
                 if virtual:
                     continue


### PR DESCRIPTION
Redoing my pull request:

So In my Centos 5.9 machine, if there is RAID mount ansible will crash, as it cannot find scheduler file. The reason being, this should be a virtual device as there is no "device" folder under e.g. /sys/block/md0/

Here is the crash:

[kk@u1 ansible]$ ansible q3 -m setup -k -u root --tree=/tmp/facts
SSH password:
q3 | FAILED => failed to parse: /sys/block/md0
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-1360629441.14-171498703486275/setup", line 1797, in ?
    main()
  File "/root/.ansible/tmp/ansible-1360629441.14-171498703486275/setup", line 1050, in main
    data = run_setup(module)
  File "/root/.ansible/tmp/ansible-1360629441.14-171498703486275/setup", line 1000, in run_setup
    facts = ansible_facts()
  File "/root/.ansible/tmp/ansible-1360629441.14-171498703486275/setup", line 990, in ansible_facts
    facts.update(Hardware().populate())
  File "/root/.ansible/tmp/ansible-1360629441.14-171498703486275/setup", line 312, in populate
    self.get_device_facts()
  File "/root/.ansible/tmp/ansible-1360629441.14-171498703486275/setup", line 439, in get_device_facts
    m = re.match("._?([(._)])", scheduler)
  File "/usr/lib64/python2.4/sre.py", line 129, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or buffer
