### PR TITLE
make service module output state if not specified

### DIFF
--- a/library/service
+++ b/library/service
@@ -609,6 +609,10 @@ def main():
         result['enabled'] = service.module.params['enabled']
     if service.state:
         result['state'] = service.state
+    elif service.running:
+        result['state'] = 'running'
+    else:
+        result['state'] = 'stopped'
 
     module.exit_json(**result)
 


### PR DESCRIPTION
I started on this, and my test case was nagios.
For some reason running this on my CentOS 6.3 laptop, nagios is always listed as running.
Its installed, but not enabled or running. I don't know if anyone else has had similar troubles.

I think absent will take some digging through the different service tools output.
I know we'll need to check for
"unknown job" and
"unrecognized service"
for initctl and service respectively.

refers to #2041
