### PR TITLE
Support For Hosts Only Accessible Via Forwarding

### DIFF
--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -44,6 +44,11 @@ class Group(object):
         self.hosts.append(host)
         host.add_group(self)
 
+    def cleanup_host(self, host):
+
+        if host in self.hosts:
+            self.hosts.remove(host)
+
     def set_variable(self, key, value):
 
         self.vars[key] = value

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -291,6 +291,10 @@ class Runner(object):
         ''' executes any module one or more times '''
 
         host_variables = self.inventory.get_variables(host)
+
+        if host.find(':') != -1:
+            host = host.split(':')[0]
+
         if self.transport in [ 'paramiko', 'ssh' ]:
             port = host_variables.get('ansible_ssh_port', self.remote_port)
             if port is None:


### PR DESCRIPTION
Right now, the Ansible inventory matches one host to one address. In the case of NAT on firewalls or, as in my case, demo servers that constantly move networks and use remote ssh forwards to a connection manager, only the final server read by the inventory gets changed by a play. This change treats different ports as a separate host without modifying too much.

I didn't want to do too much refactoring since I think the inventory system looks great as it is now, so I worked this into the current system and it has been working just fine for the 15 or so hosts I have to manage this way. I tried to add in a nickname feature as well, just so they could be more easily referenced, but it turned out to be a bigger project than I have time for at the moment.
