### PR TITLE
Adds configurable jinja2 extension loading

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -89,6 +89,13 @@ sudo_exe=sudo
 #
 # hash_behaviour=replace
 
+# if you need to use jinja2 extensions, you can list them here
+# use a coma to separate extensions, e.g. :
+# jinja_extensions=jinja2.ext.do,jinja2.ext.i18n
+# no extensions are loaded by default
+
+#jinja_extensions=
+
 # if set, always use this private key file for authentication, same as if passing
 # --private-key to ansible or ansible-playbook
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -91,10 +91,10 @@ sudo_exe=sudo
 
 # if you need to use jinja2 extensions, you can list them here
 # use a coma to separate extensions, e.g. :
-# jinja_extensions=jinja2.ext.do,jinja2.ext.i18n
+# jinja2_extensions=jinja2.ext.do,jinja2.ext.i18n
 # no extensions are loaded by default
 
-#jinja_extensions=
+#jinja2_extensions=
 
 # if set, always use this private key file for authentication, same as if passing
 # --private-key to ansible or ansible-playbook

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -94,6 +94,7 @@ DEFAULT_KEEP_REMOTE_FILES = get_config(p, DEFAULTS, 'keep_remote_files', 'ANSIBL
 DEFAULT_SUDO_EXE          = get_config(p, DEFAULTS, 'sudo_exe', 'ANSIBLE_SUDO_EXE', 'sudo')
 DEFAULT_SUDO_FLAGS        = get_config(p, DEFAULTS, 'sudo_flags', 'ANSIBLE_SUDO_FLAGS', '-H')
 DEFAULT_HASH_BEHAVIOUR    = get_config(p, DEFAULTS, 'hash_behaviour', 'ANSIBLE_HASH_BEHAVIOUR', 'replace')
+DEFAULT_JINA_EXTENSIONS   = get_config(p, DEFAULTS, 'jinja_extensions', 'ANSIBLE_JINA_EXTENSIONS', None)
 
 DEFAULT_ACTION_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '/usr/share/ansible_plugins/action_plugins'))
 DEFAULT_CALLBACK_PLUGIN_PATH   = shell_expand_path(get_config(p, DEFAULTS, 'callback_plugins',   'ANSIBLE_CALLBACK_PLUGINS', '/usr/share/ansible_plugins/callback_plugins'))

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -94,7 +94,7 @@ DEFAULT_KEEP_REMOTE_FILES = get_config(p, DEFAULTS, 'keep_remote_files', 'ANSIBL
 DEFAULT_SUDO_EXE          = get_config(p, DEFAULTS, 'sudo_exe', 'ANSIBLE_SUDO_EXE', 'sudo')
 DEFAULT_SUDO_FLAGS        = get_config(p, DEFAULTS, 'sudo_flags', 'ANSIBLE_SUDO_FLAGS', '-H')
 DEFAULT_HASH_BEHAVIOUR    = get_config(p, DEFAULTS, 'hash_behaviour', 'ANSIBLE_HASH_BEHAVIOUR', 'replace')
-DEFAULT_JINA_EXTENSIONS   = get_config(p, DEFAULTS, 'jinja_extensions', 'ANSIBLE_JINA_EXTENSIONS', None)
+DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBLE_JINJA2_EXTENSIONS', None)
 
 DEFAULT_ACTION_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '/usr/share/ansible_plugins/action_plugins'))
 DEFAULT_CALLBACK_PLUGIN_PATH   = shell_expand_path(get_config(p, DEFAULTS, 'callback_plugins',   'ANSIBLE_CALLBACK_PLUGINS', '/usr/share/ansible_plugins/callback_plugins'))

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -319,12 +319,12 @@ def template_from_file(basedir, path, vars):
     to load them with the jinja environment
     '''
     jinja_exts = []
-    if C.DEFAULT_JINA_EXTENSIONS:
+    if C.DEFAULT_JINJA2_EXTENSIONS:
         '''
         Let's make sure the configuration directive doesn't contain spaces
         and split extensions in an array
         '''
-        jinja_exts = C.DEFAULT_JINA_EXTENSIONS.replace(" ", "").split(',')
+        jinja_exts = C.DEFAULT_JINJA2_EXTENSIONS.replace(" ", "").split(',')
 
     environment = jinja2.Environment(loader=loader, trim_blocks=True, extensions=jinja_exts)
     for filter_plugin in utils.plugins.filter_loader.all():

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -313,7 +313,20 @@ def template_from_file(basedir, path, vars):
     from ansible import utils
     realpath = utils.path_dwim(basedir, path)
     loader=jinja2.FileSystemLoader([basedir,os.path.dirname(realpath)])
-    environment = jinja2.Environment(loader=loader, trim_blocks=True)
+
+    '''
+    if some extensions are set via jinja_extensions in ansible.cfg, we try
+    to load them with the jinja environment
+    '''
+    jinja_exts = []
+    if C.DEFAULT_JINA_EXTENSIONS:
+        '''
+        Let's make sure the configuration directive doesn't contain spaces
+        and split extensions in an array
+        '''
+        jinja_exts = C.DEFAULT_JINA_EXTENSIONS.replace(" ", "").split(',')
+
+    environment = jinja2.Environment(loader=loader, trim_blocks=True, extensions=jinja_exts)
     for filter_plugin in utils.plugins.filter_loader.all():
         filters = filter_plugin.filters()
         if not isinstance(filters, dict):


### PR DESCRIPTION
Jinja extensions adds features to the jinja2 templating engine. This
patch allows module loading for the templating engine via an
ansible.cfg configuration key (jinja_extensions).
The default behaviour doesn't change (no module loading).
Requested modules can be added coma separated in ansible.cfg

Adds whitespace handling in jinja_extension config

Added whitespace handling in jinja_extension configuration directive, so
things stay safe if user adds spaces around comas in the directives
list.

Adds config example for jinja_extensions

Added config example with multiple extentions for jinja_extensions
