### PR TITLE
fix remote execution NameError in module 'user'

### DIFF
--- a/library/user
+++ b/library/user
@@ -861,7 +861,7 @@ def main():
         if user.user_exists():
             (rc, out, err) = user.remove_user()
             if rc != 0:
-                module.fail_json(name=name, msg=err, rc=rc)
+                module.fail_json(name=user.name, msg=err, rc=rc)
             result['force'] = user.force
             result['remove'] = user.remove
     elif user.state == 'present':


### PR DESCRIPTION
Bugfix cherrypicked onto release1.0 branch. Original writeup copied for future generations.

Remote execution of module "user" produced this traceback:

Traceback (most recent call last):
File "/root/.ansible/tmp/ansible-1360686502.37-80297117549296/user", line 1665, in
main()
File "/root/.ansible/tmp/ansible-1360686502.37-80297117549296/user", line 864, in main
module.fail_json(name=name, msg=err, rc=rc)
NameError: global name 'name' is not defined

Patch fixes it, and 'make tests' passes all tests but one (which is skipped).
