### PR TITLE
setup - Minimal generic network handling via netifaces module

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -58,6 +58,12 @@ except ImportError:
     HAVE_SELINUX=False
 
 try:
+    import netifaces
+    HAVE_NETIFACES=True
+except ImportError:
+    HAVE_NETIFACES=False
+
+try:
     import json
 except ImportError:
     import simplejson as json
@@ -624,7 +630,10 @@ class Network(Facts):
     def __new__(cls, *arguments, **keyword):
         subclass = cls
         for sc in Network.__subclasses__():
-            if sc.platform == platform.system():
+            if ((sc.platform == platform.system())
+                or (sc.platform == 'Generic_Netifaces' 
+                    and HAVE_NETIFACES 
+                    and subclass is cls)):
                 subclass = sc
         return super(cls, subclass).__new__(subclass, *arguments, **keyword)
 
@@ -640,7 +649,7 @@ class LinuxNetwork(Network):
     - interfaces (a list of interface names)
     - interface_<name> dictionary of ipv4, ipv6, and mac address information.
     - all_ipv4_addresses and all_ipv6_addresses: lists of all configured addresses.
-    - ipv4_address and ipv6_address: the first non-local address for each family.
+    - default_ipv4 and default_ipv6: the first non-local address for each family.
     """
     platform = 'Linux'
 
@@ -785,6 +794,59 @@ class LinuxNetwork(Network):
                         ips['all_ipv6_addresses'].append(address)
 
         return interfaces, ips
+
+class NetifacesNetwork(Network):
+    """
+    This is a generic subclass of Network using the netifaces portable network
+    interfaces module.  It defines
+    - interfaces (a list of interface names)
+    - interface_<name> dictionary of ipv4, ipv6, and mac address information.
+    - all_ipv4_addresses and all_ipv6_addresses: lists of all configured addresses.
+    It currently does not define 
+    - default_ipv4 and default_ipv6
+    - type, mtu and network on interfaces
+    """
+    platform = 'Generic_Netifaces'
+
+    def __init__(self):
+        Network.__init__(self)
+
+    def populate(self):
+        all_ipv4_addresses = []
+        all_ipv6_addresses = []
+        interfaces = netifaces.interfaces()
+        self.facts['interfaces'] = interfaces
+        for iface in interfaces:
+            ifinfo = netifaces.ifaddresses(iface)
+            interface = {'device': iface,
+                         'ipv4': [],
+                         'ipv6': []}
+            if netifaces.AF_LINK in ifinfo.keys():
+                interface['macaddress'] = ifinfo[netifaces.AF_LINK][0]['addr']
+            if netifaces.AF_INET in ifinfo.keys():
+                interface['ipv4'] = []
+                for set in ifinfo[netifaces.AF_INET]:
+                    info = {'address': set['addr'],
+                            'netmask': set['netmask']}
+                    # calculate the network
+                    address_bin = struct.unpack('!L', socket.inet_aton(info['address']))[0]
+                    netmask_bin = struct.unpack('!L', socket.inet_aton(info['netmask']))[0]
+                    info['network'] = socket.inet_ntoa(struct.pack('!L', address_bin & netmask_bin))
+                    interface['ipv4'].append(info)
+                    if not set['addr'].startswith('127.'):
+                        all_ipv4_addresses.append(set['addr'])
+            if netifaces.AF_INET6 in ifinfo.keys():
+                for set in ifinfo[netifaces.AF_INET6]:
+                    info = {'address': set['addr'],
+                            'netmask': set['netmask']}
+                    interface['ipv6'].append(info)
+                    if not set['addr'] == '::1' and not set['addr'] == 'fe80::1%lo0':
+                        all_ipv6_addresses.append(set['addr'])
+            self.facts[iface] = interface
+        self.facts['all_ipv4_addresses'] = all_ipv4_addresses
+        self.facts['all_ipv6_addresses'] = all_ipv6_addresses
+        return self.facts
+
 
 class Virtual(Facts):
     """


### PR DESCRIPTION
Gets some network information across platforms where netifaces is installed.
Less info that other mechanisms, but should work on wide variety of platforms.
