### PR TITLE
Add NetBSD support for 'service' module, and add an example to 'lineinfile'

### DIFF
--- a/library/lineinfile
+++ b/library/lineinfile
@@ -82,7 +82,7 @@ options:
          get the original file back if you somehow clobbered it incorrectly.
 examples:
    - code: 'lineinfile: dest=/etc/selinux/config regexp=^SELINUX= line=SELINUX=disabled'
-   - code: "lineinfile: \\\"dest=/usr/pkg/etc/sudoers state=present regexp='^%wheel' line ='%wheel ALL=(ALL) NOPASSWD: ALL'\\\""
+   - code: "lineinfile: \\\"dest=/etc/sudoers state=present regexp='^%wheel' line ='%wheel ALL=(ALL) NOPASSWD: ALL'\\\""
    - code: 'lineinfile: dest=/etc/sudoers state=absent regexp="^%wheel"'
    - code: 'lineinfile: dest=/etc/httpd/conf/httpd.conf regexp="^Listen " insertafter="^#Listen " line="Listen 8080"'
 """

--- a/library/lineinfile
+++ b/library/lineinfile
@@ -82,6 +82,7 @@ options:
          get the original file back if you somehow clobbered it incorrectly.
 examples:
    - code: 'lineinfile: dest=/etc/selinux/config regexp=^SELINUX= line=SELINUX=disabled'
+   - code: "lineinfile: \\\"dest=/usr/pkg/etc/sudoers state=present regexp='^%wheel' line ='%wheel ALL=(ALL) NOPASSWD: ALL'\\\""
    - code: 'lineinfile: dest=/etc/sudoers state=absent regexp="^%wheel"'
    - code: 'lineinfile: dest=/etc/httpd/conf/httpd.conf regexp="^Listen " insertafter="^#Listen " line="Listen 8080"'
 """

--- a/library/service
+++ b/library/service
@@ -552,6 +552,65 @@ class OpenBsdService(Service):
         return self.execute_command("%s %s" % (self.svc_cmd, self.action))
 
 # ===========================================
+# Subclass: NetBSD
+
+class NetBsdService(Service):
+    """
+    This is the NetBSD Service manipulation class - it uses the /etc/rc.conf
+    file for controlling services started at boot, check status and perform
+    direct service manipulation. Init scripts in /etc/rcd are used for
+    controlling services (start/stop) as well as for controlling the current
+    state.
+    """
+
+    platform = 'NetBSD'
+    distribution = None
+
+    def get_service_tools(self):
+        initpaths = [ '/etc/rc.d' ]		# better: $rc_directories - how to get in here? Run: sh -c '. /etc/rc.conf ; echo $rc_directories'
+
+        for initdir in initpaths:
+	    initscript = "%s/%s" % (initdir,self.name)
+	    if os.path.isfile(initscript):
+	        self.svc_initscript = initscript
+
+        if not self.svc_initscript:
+            self.module.fail_json(msg='unable to find rc.d script')
+
+    def service_enable(self):
+        if self.enable:
+            self.rcconf_value = "YES"
+        else:
+            self.rcconf_value = "NO"
+
+        rcfiles = [ '/etc/rc.conf' ]		# Overkill?
+        for rcfile in rcfiles:
+            if os.path.isfile(rcfile):
+                self.rcconf_file = rcfile
+        
+        self.rcconf_key = "%s" % self.name
+
+        return self.service_enable_rcconf()
+
+    def get_service_status(self):
+        self.svc_cmd = "%s" % self.svc_initscript
+        rc, stdout, stderr = self.execute_command("%s %s" % (self.svc_cmd, 'onestatus'))
+        if rc == 1:
+            self.running = False
+        elif rc == 0:
+            self.running = True
+
+    def service_control(self):
+        if self.action is "start":
+            self.action = "onestart"
+        if self.action is "stop":
+            self.action = "onestop"
+
+        self.svc_cmd = "%s" % self.svc_initscript
+        return self.execute_command("%s %s" % (self.svc_cmd, self.action))
+
+
+# ===========================================
 # Main control flow
 
 def main():


### PR DESCRIPTION
1) Add NetBSD support to the 'service' module, tested on NetBSD 6.0/i386
2) Add an example to the 'lineinfile' module which shows how to add an entry to the sudoers file that contains a colon. 
