### PR TITLE
Local chroot support

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -112,6 +112,18 @@ class Cli(object):
         if options.tree:
             utils.prepare_writeable_dir(options.tree)
 
+        if options.chroot:
+            import os
+            if not options.connection == 'local':
+                print >>sys.stderr, "chroot option requires connection 'local'"
+                sys.exit(1)
+            if not os.geteuid() == 0:
+                print >>sys.stderr, "chroot option requires running as root"
+                sys.exit(1)
+            if not os.path.isdir(options.chroot):
+                print >>sys.stderr, "chroot dir %s is not a directory" % options.chroot
+                sys.exit(1)
+
         runner = Runner(
             module_name=options.module_name, module_path=options.module_path,
             module_args=options.module_args,
@@ -124,7 +136,8 @@ class Cli(object):
             sudo_pass=sudopass,sudo_user=options.sudo_user,
             transport=options.connection, subset=options.subset,
             check=options.check,
-            diff=options.check
+            diff=options.check,
+            chroot=options.chroot
         )
 
         if options.seconds:

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -106,6 +106,12 @@ def main(args):
         if not os.path.isfile(playbook):
             raise errors.AnsibleError("the playbook: %s does not appear to be a file" % playbook)
 
+    if options.chroot:
+        if not os.geteuid() == 0:
+            raise errors.AnsibleError("chroot option requires running as root")
+        if not os.path.isdir(options.chroot):
+            raise errors.AnsibleError("chroot dir %s is not a directory" % options.chroot)
+
     # run all playbooks specified on the command line
     for playbook in args:
 
@@ -132,7 +138,8 @@ def main(args):
             private_key_file=options.private_key_file,
             only_tags=only_tags,
             check=options.check,
-            diff=options.diff
+            diff=options.diff,
+            chroot=options.chroot
         )
 
         if options.listhosts or options.listtasks:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -30,7 +30,7 @@ class Play(object):
        'handlers', 'remote_user', 'remote_port',
        'sudo', 'sudo_user', 'transport', 'playbook',
        'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
-       'basedir'
+       'basedir', 'chroot'
     ]
 
     # to catch typos and so forth -- these are userland names
@@ -38,7 +38,8 @@ class Play(object):
     VALID_KEYS = [
        'hosts', 'name', 'vars', 'vars_prompt', 'vars_files',
        'tasks', 'handlers', 'user', 'port', 'include',
-       'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'serial'
+       'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'serial',
+       'chroot'
     ]
 
     # *************************************************
@@ -77,6 +78,10 @@ class Play(object):
         self.gather_facts = ds.get('gather_facts', None)
         self.serial       = int(utils.template(basedir, ds.get('serial', 0), self.vars))
         self.remote_port  = utils.template(basedir, self.remote_port, self.vars)
+        self.chroot       = ds.get('chroot', self.playbook.chroot)
+
+        if self.chroot and not self.transport == 'local':
+            raise errors.AnsibleError("chroot option requires connection 'local'")
 
         self._update_vars_files_for_host(None)
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -27,7 +27,8 @@ class Task(object):
         'play', 'notified_by', 'tags', 'register',
         'delegate_to', 'first_available_file', 'ignore_errors',
         'local_action', 'transport', 'sudo', 'sudo_user', 'sudo_pass',
-        'items_lookup_plugin', 'items_lookup_terms', 'environment'
+        'items_lookup_plugin', 'items_lookup_terms', 'environment',
+        'chroot'
     ]
 
     # to prevent typos and such
@@ -35,7 +36,7 @@ class Task(object):
          'name', 'action', 'only_if', 'async', 'poll', 'notify',
          'first_available_file', 'include', 'tags', 'register', 'ignore_errors',
          'delegate_to', 'local_action', 'transport', 'sudo', 'sudo_user',
-         'sudo_pass', 'when', 'connection', 'environment'
+         'sudo_pass', 'when', 'connection', 'environment', 'chroot'
     ]
 
     def __init__(self, play, ds, module_vars=None, additional_conditions=None):
@@ -110,6 +111,11 @@ class Task(object):
             # delegate_to: localhost should use local transport
             if self.delegate_to in ['127.0.0.1', 'localhost']:
                 self.transport   = 'local'
+
+        if play.chroot and not self.transport == 'local':
+            raise errors.AnsibleError("chroot option requires connection 'local'")
+
+        self.chroot       = play.chroot
 
         # notified by is used by Playbook code to flag which hosts
         # need to run a notifier

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -120,7 +120,8 @@ class Runner(object):
         subset=None,                        # subset pattern
         check=False,                        # don't make any changes, just try to probe for potential changes
         diff=False,                         # whether to show diffs for template files that change
-        environment=None                    # environment variables (as dict) to use inside the command
+        environment=None,                   # environment variables (as dict) to use inside the command
+        chroot=None                         # whether to use a local dir as a chroot when running scripts
         ):
 
         # storage & defaults
@@ -151,6 +152,7 @@ class Runner(object):
         self.sudo_pass        = sudo_pass
         self.is_playbook      = is_playbook
         self.environment      = environment
+        self.chroot           = chroot
 
         # misc housekeeping
         if subset and self.inventory._subset is None:
@@ -159,6 +161,9 @@ class Runner(object):
 
         if self.transport == 'local':
             self.remote_user = pwd.getpwuid(os.geteuid())[0]
+
+        if self.chroot and not self.transport == 'local':
+            raise errors.AnsibleError("chroot option requires connection 'local'")
 
         if module_path is not None:
             for i in module_path.split(os.pathsep):

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -452,6 +452,9 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
         parser.add_option('-c', '--connection', dest='connection',
                           default=C.DEFAULT_TRANSPORT,
                           help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
+        parser.add_option('',   '--chroot', dest='chroot', metavar='DIR',
+                          default=None,
+                          help="chroot to this dir when executing scripts (requires connection 'local' and running as root)")
 
     if async_opts:
         parser.add_option('-P', '--poll', default=constants.DEFAULT_POLL_INTERVAL, type='int',

--- a/library/setup
+++ b/library/setup
@@ -369,7 +369,7 @@ class LinuxHardware(Hardware):
 
     def get_mount_facts(self):
         self.facts['mounts'] = []
-        mtab = get_file_content('/etc/mtab')
+        mtab = get_file_content('/etc/mtab', '')
         for line in mtab.split('\n'):
             if line.startswith('/'):
                 fields = line.rstrip('\n').split()

--- a/library/setup
+++ b/library/setup
@@ -884,30 +884,32 @@ class LinuxVirtual(Virtual):
             self.facts['virtualization_role'] = 'guest'
             return
 
-        for line in open('/proc/self/status').readlines():
-            if re.match('^VxID: \d+', line):
-                self.facts['virtualization_type'] = 'linux_vserver'
-                if re.match('^VxID: 0', line):
-                    self.facts['virtualization_role'] = 'host'
-                else:
-                    self.facts['virtualization_role'] = 'guest'
-                return
+        if os.path.exists('/proc/self/status'):
+            for line in open('/proc/self/status').readlines():
+                if re.match('^VxID: \d+', line):
+                    self.facts['virtualization_type'] = 'linux_vserver'
+                    if re.match('^VxID: 0', line):
+                        self.facts['virtualization_role'] = 'host'
+                    else:
+                        self.facts['virtualization_role'] = 'guest'
+                    return
 
-        for line in open('/proc/cpuinfo').readlines():
-            if re.match('^model name.*QEMU Virtual CPU', line):
-                self.facts['virtualization_type'] = 'kvm'
-            elif re.match('^vendor_id.*User Mode Linux', line):
-                self.facts['virtualization_type'] = 'uml'
-            elif re.match('^model name.*UML', line):
-                self.facts['virtualization_type'] = 'uml'
-            elif re.match('^vendor_id.*PowerVM Lx86', line):
-                self.facts['virtualization_type'] = 'powervm_lx86'
-            elif re.match('^vendor_id.*IBM/S390', line):
-                self.facts['virtualization_type'] = 'ibm_systemz'
-            else:
-                continue
-            self.facts['virtualization_role'] = 'guest'
-            return
+        if os.path.exists('/proc/cpuinfo'):
+            for line in open('/proc/cpuinfo').readlines():
+                if re.match('^model name.*QEMU Virtual CPU', line):
+                    self.facts['virtualization_type'] = 'kvm'
+                elif re.match('^vendor_id.*User Mode Linux', line):
+                    self.facts['virtualization_type'] = 'uml'
+                elif re.match('^model name.*UML', line):
+                    self.facts['virtualization_type'] = 'uml'
+                elif re.match('^vendor_id.*PowerVM Lx86', line):
+                    self.facts['virtualization_type'] = 'powervm_lx86'
+                elif re.match('^vendor_id.*IBM/S390', line):
+                    self.facts['virtualization_type'] = 'ibm_systemz'
+                else:
+                    continue
+                self.facts['virtualization_role'] = 'guest'
+                return
 
         # Beware that we can have both kvm and virtualbox running on a single system
         if os.path.exists("/proc/modules"):


### PR DESCRIPTION
Add support for acting on a local chroot. This could be use for building a preconfigure virtual OS image starting from a raw distro bootstrap.

This feature requires running ansible as `root` and using connection `local`.

Includes two fixes for fails when `/proc` is not mounted.
## Using

Example of use with a Debian boostrap:
- `sudo deboostrap squeeze /tmp/squeeze-chroot`
- `sudo -E ansible-playbook -vvv -c local --chroot=/tmp/squeeze-chroot test.yml`

an example `test.yml` could be:

```

---
- hosts: localhost

  tasks:

     - name: echo something to temp
       shell: echo Yaaayy! >/tmp/foobar.txt

     - name: install a package
       apt: pkg=less state=latest
```

works also by setting `chroot` in the playbook, like:

```

---
- hosts: localhost
  connection: local
  chroot: /tmp/squeeze-chroot
  ...
```

In principle any playbook would work by just adding `-c local --chroot=/path/to/dir`.
## Notes

Assumptions about existence of local files created by actions should not be made. For example `test/lookup_plugings.yml` fails in `test with_sequence, fenceposts 1` because it expects a local `/tmp/seq-00` created by previous action, but the creation actually took place in the chroot (ie: the file created was `$CHROOTDIR/tmp/seq-00` instead of `/tmp/-seq00`).
