### PR TITLE
Avoid extra shell

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -72,7 +72,7 @@ DEFAULTS='defaults'
 # configurable things
 DEFAULT_HOST_LIST         = shell_expand_path(get_config(p, DEFAULTS, 'hostfile',         'ANSIBLE_HOSTS',            '/etc/ansible/hosts'))
 DEFAULT_MODULE_PATH       = shell_expand_path(get_config(p, DEFAULTS, 'library',          'ANSIBLE_LIBRARY',          DIST_MODULE_PATH))
-DEFAULT_REMOTE_TMP        = shell_expand_path(get_config(p, DEFAULTS, 'remote_tmp',       'ANSIBLE_REMOTE_TEMP',      '$HOME/.ansible/tmp'))
+DEFAULT_REMOTE_TMP        = get_config(p, DEFAULTS, 'remote_tmp',       'ANSIBLE_REMOTE_TEMP',      '$HOME/.ansible/tmp')
 DEFAULT_MODULE_NAME       = get_config(p, DEFAULTS, 'module_name',      None,                       'command')
 DEFAULT_PATTERN           = get_config(p, DEFAULTS, 'pattern',          None,                       '*')
 DEFAULT_FORKS             = get_config(p, DEFAULTS, 'forks',            'ANSIBLE_FORKS',            5)

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -57,6 +57,17 @@ import grp
 import pwd
 import platform
 import errno
+import optparse
+
+def get_cl_options():
+    parser = optparse.OptionParser()
+    parser.add_option("--cleanup",
+                      action="store", type="string",
+                      dest="directory_to_cleanup")
+    return parser.parse_args()[0]
+
+def get_directory_to_cleanup():
+    return get_cl_options().directory_to_cleanup
 
 HAVE_SELINUX=False
 try:
@@ -626,13 +637,25 @@ class AnsibleModule(object):
     def from_json(self, data):
         return json.loads(data)
 
+    def sys_exit(self, rc):
+        ''' do the actual exiting, possibly cleaning up '''
+        d = get_directory_to_cleanup()
+        if d is not None:
+            if not d.startswith('/'):
+                # sanitise this directory a bit, just to be safe:
+                d = os.path.expanduser(os.path.join('~', d))
+            if os.getcwd().startswith(d):
+                os.chdir('/')
+            shutil.rmtree(d)
+        sys.exit(rc)
+
     def exit_json(self, **kwargs):
         ''' return from the module, without error '''
         self.add_path_info(kwargs)
         if not kwargs.has_key('changed'):
             kwargs['changed'] = False
         print self.jsonify(kwargs)
-        sys.exit(0)
+        self.sys_exit(0)
 
     def fail_json(self, **kwargs):
         ''' return from the module, with an error message '''
@@ -640,7 +663,7 @@ class AnsibleModule(object):
         assert 'msg' in kwargs, "implementation error -- msg to explain the error is required"
         kwargs['failed'] = True
         print self.jsonify(kwargs)
-        sys.exit(1)
+        self.sys_exit(1)
 
     def is_executable(self, path):
         '''is the given path executable?'''

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -254,7 +254,7 @@ class Runner(object):
         if not shebang:
             raise errors.AnsibleError("module is missing interpreter line")
 
-        cmd = " ".join([environment_string, shebang.replace("#!",""), cmd])
+        cmd = " ".join([environment_string, shebang.replace("#!",""), cmd]).strip()
         if tmp.find("tmp") != -1 and C.DEFAULT_KEEP_REMOTE_FILES != '1' and not persist_files:
             cmd = cmd + "; rm -rf %s >/dev/null 2>&1" % tmp
         res = self._low_level_exec_command(conn, cmd, tmp, sudoable=True)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -558,6 +558,9 @@ class Runner(object):
         cmd = ' && '.join((cmd, 'cd %s' % basetmp, 'pwd'))
         executable = '/bin/sh'
         result = self._low_level_exec_command(conn, cmd, None, sudoable=False)
+        if result['rc'] != 0:
+            raise errors.AnsibleError('Cannot create remote temporary directory: '
+                                      '%s' % basetmp)
         rc = utils.last_non_blank_line(result['stdout']).strip() + '/'
         return rc
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -485,9 +485,6 @@ class Runner(object):
     def _low_level_exec_command(self, conn, cmd, tmp, sudoable=False, executable=None):
         ''' execute a command string over SSH, return the output '''
 
-        if executable is None:
-            executable = '/bin/sh'
-
         sudo_user = self.sudo_user
         rc, stdin, stdout, stderr = conn.exec_command(cmd, tmp, sudo_user, sudoable=sudoable, executable=executable)
 
@@ -557,7 +554,8 @@ class Runner(object):
 
         cmd = ' && '.join((cmd, 'cd %s' % basetmp, 'pwd'))
         executable = '/bin/sh'
-        result = self._low_level_exec_command(conn, cmd, None, sudoable=False)
+        result = self._low_level_exec_command(conn, cmd, None, sudoable=False,
+                                              executable=executable)
         if result['rc'] != 0:
             raise errors.AnsibleError('Cannot create remote temporary directory: '
                                       '%s' % basetmp)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -256,7 +256,7 @@ class Runner(object):
 
         cmd = " ".join([environment_string, shebang.replace("#!",""), cmd]).strip()
         if tmp.find("tmp") != -1 and C.DEFAULT_KEEP_REMOTE_FILES != '1' and not persist_files:
-            cmd = cmd + "; rm -rf %s >/dev/null 2>&1" % tmp
+            cmd += " --cleanup %s" % tmp.rstrip('/')
         res = self._low_level_exec_command(conn, cmd, tmp, sudoable=True)
         data = utils.parse_json(res['stdout'])
         if 'parsed' in data and data['parsed'] == False:

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -549,7 +549,14 @@ class Runner(object):
         cmd = 'mkdir -p '
         if self.remote_user != 'root':
             cmd += '-m755 '
-        cmd += '%s && echo %s' % (basetmp, basetmp)
+        cmd += basetmp
+
+        # we need to obtain the full path of the generated directory, which
+        # seems the most efficient way to expand the directory according to
+        # remote rules (e.g. $HOME and ~ expansion), so use a shell command:
+
+        cmd = ' && '.join((cmd, 'cd %s' % basetmp, 'pwd'))
+        executable = '/bin/sh'
         result = self._low_level_exec_command(conn, cmd, None, sudoable=False)
         rc = utils.last_non_blank_line(result['stdout']).strip() + '/'
         return rc

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -546,15 +546,13 @@ class Runner(object):
         if self.sudo and self.sudo_user != 'root':
             basetmp = os.path.join('/tmp', basefile)
 
-        cmd = 'mkdir -p %s' % basetmp
+        cmd = 'mkdir -p '
         if self.remote_user != 'root':
-            cmd += ' && chmod a+rx %s' % basetmp
-        cmd += ' && echo %s' % basetmp
-
+            cmd += '-m755 '
+        cmd += '%s && echo %s' % (basetmp, basetmp)
         result = self._low_level_exec_command(conn, cmd, None, sudoable=False)
         rc = utils.last_non_blank_line(result['stdout']).strip() + '/'
         return rc
-
 
     # *****************************************************
 

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -612,10 +612,10 @@ def make_sudo_cmd(sudo_user, executable, cmd):
     # the -p option.
     randbits = ''.join(chr(random.randint(ord('a'), ord('z'))) for x in xrange(32))
     prompt = '[sudo via ansible, key=%s] password: ' % randbits
-    sudocmd = '%s -k && %s %s -S -p "%s" -u %s %s -c %s' % (
-        C.DEFAULT_SUDO_EXE, C.DEFAULT_SUDO_EXE, C.DEFAULT_SUDO_FLAGS,
+    sudocmd = '%s -k %s -S -p "%s" -u %s %s -c %s' % (
+        C.DEFAULT_SUDO_EXE, C.DEFAULT_SUDO_FLAGS,
         prompt, sudo_user, executable or '$SHELL', pipes.quote(cmd))
-    return ('/bin/sh -c ' + pipes.quote(sudocmd), prompt)
+    return (sudocmd, prompt)
 
 def get_diff(before_string, after_string):
     # called by --diff usage in playbook and runner via callbacks


### PR DESCRIPTION
This patch series removes a couple of extra shell calls:
1. All modules using the `module_common.py` infrastructure now clean up their own temporary holding directory, so they can be called directly via SSH, rather than via a shell;
2. Low-level commands are now generally not executed in a subshell;
3. Sudo-invocations don't need a subshell either, I think that the use of `sudo -k` was erroneous and is now integrated into a single sudo call.

As far as I can tell, only the creation of the remote directory requires the use of a subshell, since we need to chain multiple commands together to get the full path of the directory created.
