### PR TITLE
now copy checks directory writable permissions instead of file

### DIFF
--- a/library/copy
+++ b/library/copy
@@ -86,19 +86,16 @@ def main():
     md5sum_dest = None
 
     if os.path.exists(dest):
-        if not os.access(dest, os.W_OK):
-            module.fail_json(msg="Destination %s not writable" % (dest))
-        if not os.access(dest, os.R_OK):
-            module.fail_json(msg="Destination %s not readable" % (dest))
         if (os.path.isdir(dest)):
             basename = os.path.basename(src)
             dest = os.path.join(dest, basename)
-        md5sum_dest = module.md5(dest)
+        if os.access(dest, os.R_OK):
+            md5sum_dest = module.md5(dest)
     else:
         if not os.path.exists(os.path.dirname(dest)):
             module.fail_json(msg="Destination directory %s does not exist" % (os.path.dirname(dest)))
-        if not os.access(os.path.dirname(dest), os.W_OK):
-            module.fail_json(msg="Destination %s not writable" % (os.path.dirname(dest)))
+    if not os.access(os.path.dirname(dest), os.W_OK):
+        module.fail_json(msg="Destination %s not writable" % (os.path.dirname(dest)))
 
     backup_file = None
     if md5sum_src != md5sum_dest or os.path.islink(dest):


### PR DESCRIPTION
this should fix #1768, but has a side effect:

if file isn't readable, but we can still write to it, copy will succeed, but it
will always be detected as changed since original file cannot be read to verify.
