### PR TITLE
add_host changes to allow vars

### DIFF
--- a/lib/ansible/runner/action_plugins/add_host.py
+++ b/lib/ansible/runner/action_plugins/add_host.py
@@ -48,8 +48,21 @@ class ActionModule(object):
 
         result = {'changed': True}
 
-        new_host = Host(args['hostname'])
+        # Parse out any hostname:port patterns
+        new_hostname = args['hostname']
+        if ":" in new_hostname:
+            new_hostname, new_port = new_hostname.split(":")
+            args['ansible_ssh_port'] = new_port
+        
+        # create host and get inventory    
+        new_host = Host(new_hostname)
         inventory = self.runner.inventory
+        
+        # Add any variables to the new_host
+        for k in args.keys():
+            if k != 'hostname' and k != 'groupname':
+                new_host.set_variable(k, args[k]) 
+                
         
         # add the new host to the 'all' group
         allgroup = inventory.get_group('all')

--- a/library/add_host
+++ b/library/add_host
@@ -5,13 +5,14 @@ DOCUMENTATION = '''
 module: add_host
 short_description: add a host (and alternatively a group) to the ansible-playbook in-memory inventory
 description:
-  - Use variables to create new hosts and groups in inventory for use in later plays of the same playbook
+  - Use variables to create new hosts and groups in inventory for use in later plays of the same playbook. 
+    Takes variables so you can define the new hosts more fully.
 version_added: 0.9
 options:
   hostname:
     description:
     - The hostname/ip of the host to add to the inventory
-    required: true
+    required: true     
   groupname:
     description:
     - The groupname to add the hostname to.
@@ -20,4 +21,6 @@ author: Seth Vidal
 examples:
   - description: add host to group 'just_created'
     code: add_host hostname=${ip_from_ec2create} groupname=just_created
+  - description add a host with a non-standard port local to your machines
+    code: add_host hostname='${new_ip}:${new_port}' ansible_ssh_port='${new_port}' ansible_ssh_host='${new_ip}' groupname=cloud_hosts
 '''


### PR DESCRIPTION
Added in code to the add_host module to parse out variables and set them on hosts, and in addition parse out a hostname of the form "hostname:port" into appropriate variables.
