### PR TITLE
Local chroot support v2

### DIFF
--- a/lib/ansible/runner/connection_plugins/chroot.py
+++ b/lib/ansible/runner/connection_plugins/chroot.py
@@ -1,0 +1,122 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import traceback
+import os
+import pipes
+import shutil
+import subprocess
+import select
+import fcntl
+from ansible import errors
+from ansible import utils
+from ansible.callbacks import vvv
+
+class Connection(object):
+    ''' Local based connections '''
+
+    def __init__(self, runner, host, port, **kwargs):
+        self.chroot = host
+
+        if os.geteuid() != 0:
+            raise errors.AnsibleError("chroot connection requires running as root")
+
+        # we're running as root on the local system so do some
+        # trivial checks for ensuring 'host' is actually a chroot'able dir
+        if not os.path.isdir(self.chroot):
+            raise errors.AnsibleError("%s is not a directory" % self.chroot)
+
+        chrootsh = os.path.join(self.chroot, 'bin/sh')
+        if not utils.is_executable(chrootsh):
+            raise errors.AnsibleError("%s does not look like a chrootable dir (/bin/sh missing)" % self.chroot)
+
+        self.runner = runner
+        self.host = host
+        # port is unused, since this is local
+        self.port = port
+
+    def connect(self, port=None):
+        ''' connect to the chroot; nothing to do here '''
+
+        vvv("THIS IS A LOCAL CHROOT DIR", host=self.chroot)
+
+        return self
+
+    def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False, executable='/bin/sh'):
+        ''' run a command on the chroot '''
+
+        # We enter chroot as root so sudo stuff can be ignored
+
+        chroot_cmd = '/usr/sbin/chroot'
+
+        if executable:
+            local_cmd = [chroot_cmd, self.chroot, executable, '-c', cmd]
+        else:
+            local_cmd = '%s "%s" %s' % (chroot_cmd, self.chroot, cmd)
+
+        vvv("EXEC %s" % (local_cmd), host=self.chroot)
+        p = subprocess.Popen(local_cmd, shell=isinstance(local_cmd, basestring),
+                             cwd=self.runner.basedir,
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        stdout, stderr = p.communicate()
+        return (p.returncode, '', stdout, stderr)
+
+    def put_file(self, in_path, out_path):
+        ''' transfer a file from local to chroot '''
+
+        if not out_path.startswith(os.path.sep):
+            out_path = os.path.join(os.path.sep, out_path)
+        normpath = os.path.normpath(out_path)
+        out_path = os.path.join(self.chroot, normpath[1:])
+
+        vvv("PUT %s TO %s" % (in_path, out_path), host=self.chroot)
+        if not os.path.exists(in_path):
+            raise errors.AnsibleFileNotFound("file or module does not exist: %s" % in_path)
+        try:
+            shutil.copyfile(in_path, out_path)
+        except shutil.Error:
+            traceback.print_exc()
+            raise errors.AnsibleError("failed to copy: %s and %s are the same" % (in_path, out_path))
+        except IOError:
+            traceback.print_exc()
+            raise errors.AnsibleError("failed to transfer file to %s" % out_path)
+
+    def fetch_file(self, in_path, out_path):
+        ''' fetch a file from chroot to local '''
+
+        if not in_path.startswith(os.path.sep):
+            in_path = os.path.join(os.path.sep, in_path)
+        normpath = os.path.normpath(in_path)
+        in_path = os.path.join(self.chroot, normpath[1:])
+
+        vvv("FETCH %s TO %s" % (in_path, out_path), host=self.chroot)
+        if not os.path.exists(in_path):
+            raise errors.AnsibleFileNotFound("file or module does not exist: %s" % in_path)
+        try:
+            shutil.copyfile(in_path, out_path)
+        except shutil.Error:
+            traceback.print_exc()
+            raise errors.AnsibleError("failed to copy: %s and %s are the same" % (in_path, out_path))
+        except IOError:
+            traceback.print_exc()
+            raise errors.AnsibleError("failed to transfer file to %s" % out_path)
+
+    def close(self):
+        ''' terminate the connection; nothing to do here '''
+        pass

--- a/library/setup
+++ b/library/setup
@@ -967,30 +967,32 @@ class LinuxVirtual(Virtual):
             self.facts['virtualization_role'] = 'guest'
             return
 
-        for line in open('/proc/self/status').readlines():
-            if re.match('^VxID: \d+', line):
-                self.facts['virtualization_type'] = 'linux_vserver'
-                if re.match('^VxID: 0', line):
-                    self.facts['virtualization_role'] = 'host'
-                else:
-                    self.facts['virtualization_role'] = 'guest'
-                return
+        if os.path.exists('/proc/self/status'):
+            for line in open('/proc/self/status').readlines():
+                if re.match('^VxID: \d+', line):
+                    self.facts['virtualization_type'] = 'linux_vserver'
+                    if re.match('^VxID: 0', line):
+                        self.facts['virtualization_role'] = 'host'
+                    else:
+                        self.facts['virtualization_role'] = 'guest'
+                    return
 
-        for line in open('/proc/cpuinfo').readlines():
-            if re.match('^model name.*QEMU Virtual CPU', line):
-                self.facts['virtualization_type'] = 'kvm'
-            elif re.match('^vendor_id.*User Mode Linux', line):
-                self.facts['virtualization_type'] = 'uml'
-            elif re.match('^model name.*UML', line):
-                self.facts['virtualization_type'] = 'uml'
-            elif re.match('^vendor_id.*PowerVM Lx86', line):
-                self.facts['virtualization_type'] = 'powervm_lx86'
-            elif re.match('^vendor_id.*IBM/S390', line):
-                self.facts['virtualization_type'] = 'ibm_systemz'
-            else:
-                continue
-            self.facts['virtualization_role'] = 'guest'
-            return
+        if os.path.exists('/proc/cpuinfo'):
+            for line in open('/proc/cpuinfo').readlines():
+                if re.match('^model name.*QEMU Virtual CPU', line):
+                    self.facts['virtualization_type'] = 'kvm'
+                elif re.match('^vendor_id.*User Mode Linux', line):
+                    self.facts['virtualization_type'] = 'uml'
+                elif re.match('^model name.*UML', line):
+                    self.facts['virtualization_type'] = 'uml'
+                elif re.match('^vendor_id.*PowerVM Lx86', line):
+                    self.facts['virtualization_type'] = 'powervm_lx86'
+                elif re.match('^vendor_id.*IBM/S390', line):
+                    self.facts['virtualization_type'] = 'ibm_systemz'
+                else:
+                    continue
+                self.facts['virtualization_role'] = 'guest'
+                return
 
         # Beware that we can have both kvm and virtualbox running on a single system
         if os.path.exists("/proc/modules"):

--- a/library/setup
+++ b/library/setup
@@ -388,7 +388,7 @@ class LinuxHardware(Hardware):
 
     def get_mount_facts(self):
         self.facts['mounts'] = []
-        mtab = get_file_content('/etc/mtab')
+        mtab = get_file_content('/etc/mtab', '')
         for line in mtab.split('\n'):
             if line.startswith('/'):
                 fields = line.rstrip('\n').split()


### PR DESCRIPTION
Add support for acting on a local chroot. This could be used for building a preconfigured virtual OS image starting from a raw distro bootstrap.

Requires running ansible as `root`.

Includes two fixes for fails when `/proc` is not mounted.
## Using

Example of use with a Debian boostrap:

```
$ sudo deboostrap squeeze /tmp/squeeze-chroot
$ sudo chroot /tmp/squeeze-chroot apt-get update
$ sudo chroot /tmp/squeeze-chroot apt-get -V --no-install-recommends install python python-apt
$ sudo -E ansible-playbook -vvv -c chroot -i '/tmp/squeeze-chroot,' all -m setup
$ sudo -E ansible-playbook -vvv -c chroot -i '/tmp/squeeze-chroot,' test-playbook.yml
```

an example `test-playbook.yml` could be:

```

---
- hosts: all
  tasks:
    - name: echo something to temp
      shell: "echo Yaaayy!" >/tmp/foobar.txt

    - name: installs a package
      apt: pkg=less state=latest
```
## Notes

Same as #2082 but now `chroot` is an independent connection type as suggested.
