### PR TITLE
Fixing syntax error

### DIFF
--- a/lib/ansible/runner/action_plugins/add_host.py
+++ b/lib/ansible/runner/action_plugins/add_host.py
@@ -34,7 +34,7 @@ class ActionModule(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs)
+    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
 
         if self.runner.check:
             return ReturnData(conn=conn, comm_ok=True, result=dict(skipped=True, msg='check mode not supported for this module'))


### PR DESCRIPTION
running install_lib
byte-compiling /usr/lib/python2.6/site-packages/ansible/runner/action_plugins/add_host.py to add_host.pyc
SyntaxError: ('invalid syntax', ('/usr/lib/python2.6/site-packages/ansible/runner/action_plugins/add_host.py', 37, 92, '    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs)\n'))
