### PR TITLE
zfs: documentation no longer breaks the formatting in webdocs

### DIFF
--- a/library/zfs
+++ b/library/zfs
@@ -25,6 +25,7 @@ module: zfs
 short_description: Manage zfs
 description:
   - Manages ZFS file systems on Solaris and FreeBSD. Can manage file systems, volumes and snapshots. See zfs(1M) for more information about the properties.
+version_added: "1.1"
 options:
   name:
     description:

--- a/library/zfs
+++ b/library/zfs
@@ -23,9 +23,8 @@ DOCUMENTATION = '''
 ---
 module: zfs
 short_description: Manage zfs
-description: >
-    Manages ZFS file systems on Solaris and FreeBSD. Can manage file systems, volumes
-    and snapshots. See zfs(1M) for more information about the properties.
+description:
+  - Manages ZFS file systems on Solaris and FreeBSD. Can manage file systems, volumes and snapshots. See zfs(1M) for more information about the properties.
 options:
   name:
     description:


### PR DESCRIPTION
I also set version_added to 1.1
