### PR TITLE
uri: load JSON for content-type: application/json

### DIFF
--- a/library/uri
+++ b/library/uri
@@ -72,7 +72,7 @@ options:
     default: "GET"
   return_content:
     description:
-      - Whether or not to return the body of the request as a "content" key in the dictionary result.
+      - Whether or not to return the body of the request as a "content" key in the dictionary result. If the reported Content-type is "application/json", then the JSON is additionally loaded into a key called C(json) in the dictionary results.
     required: false
     choices: [ "yes", "no" ]
     default: no
@@ -329,6 +329,14 @@ def main():
     for key, value in resp.iteritems():
         ukey = key.replace("-", "_")  
         uresp[ukey] = value
+
+    if 'content_type' in uresp:
+        if uresp['content_type'].startswith('application/json'):
+            try:
+                js = json.loads(content)
+                uresp['json'] = js
+            except:
+                pass
 
     if resp['status'] != status_code:
         module.fail_json(msg="Status code was not " + status_code, content=content, **uresp)


### PR DESCRIPTION
If the resource consumed by URI returns JSON, load JSON from the returned content string.

Sample playbook:

``` yaml
  - action: uri
            url="http://localhost/jp.cgi"
            dest=/tmp/ph
            return_content=true
    register: body
  - action: template src=t1.j2 dest=/tmp/t1
```

Example template:

```
name = {{ body['json']['name'] }}
```

Example CGI

``` sh
#!/bin/sh

echo "Content-type: application/json"
echo ""
echo '{ "name": "Jane Jolie", "number" : 49 }'
```
