### PR TITLE
Add support for additional EXAMPLES string in Ansible modules

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -91,6 +91,9 @@ def print_man(doc):
         for ex in doc['examples']:
             print "%s\n" % (ex['code'])
 
+    if 'plainexamples' in doc and doc['plainexamples'] is not None:
+        print doc['plainexamples']
+
 def print_snippet(doc):
 
     desc = tty_ify("".join(doc['short_description']))
@@ -153,7 +156,7 @@ def main():
 
             filename = utils.plugins.module_finder.find_plugin(module)
             try:
-                doc = module_docs.get_docstring(filename)
+                doc, plainexamples = module_docs.get_docstring(filename)
                 desc = tty_ify(doc.get('short_description', '?'))
                 if len(desc) > 55:
                     desc = desc + '...'
@@ -180,7 +183,7 @@ def main():
             continue
 
         try:
-            doc = module_docs.get_docstring(filename)
+            doc, plainexamples = module_docs.get_docstring(filename)
         except:
             traceback.print_exc()
             sys.stderr.write("ERROR: module %s has a documentation error formatting or is missing documentation\n" % module)
@@ -197,6 +200,7 @@ def main():
             doc['filename']         = filename
             doc['docuri']           = doc['module'].replace('_', '-')
             doc['now_date']         = datetime.date.today().strftime('%Y-%m-%d')
+            doc['plainexamples']    = plainexamples
 
             if options.show_snippet:
                 print_snippet(doc)

--- a/docsite/rst/moduledev.rst
+++ b/docsite/rst/moduledev.rst
@@ -354,6 +354,19 @@ for URL, module, italic, and constant-width respectively. It is suggested
 to use ``C()`` for file and option names, and ``I()`` when referencing
 parameters; module names should be specifies as ``M(module)``.
 
+Examples (which typically contain colons, quotes, etc.) are difficult
+to format with YAML, so these can (alternatively, or additionally) be
+written in plain text in an ``EXAMPLES`` string within the module
+like this::
+
+    EXAMPLES = '''
+    - action: modulename opt1=arg1 opt2=arg2
+    '''
+
+The ``module_formatter.py`` script and ``ansible-doc(1)`` append the
+``EXAMPLES`` blob after any existing ``examples`` you may have in the
+YAML ``DOCUMENTATION`` string.
+
 Building & Testing
 ++++++++++++++++++
 

--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -296,7 +296,7 @@ def main():
                 js_data.append(j)
             continue
 
-        doc = ansible.utils.module_docs.get_docstring(fname, verbose=options.verbose)
+        doc, examples = ansible.utils.module_docs.get_docstring(fname, verbose=options.verbose)
 
         if doc is None and module not in ansible.utils.module_docs.BLACKLIST_MODULES:
             sys.stderr.write("*** ERROR: CORE MODULE MISSING DOCUMENTATION: %s ***\n" % module)
@@ -314,6 +314,7 @@ def main():
             doc['docuri']           = doc['module'].replace('_', '-')
             doc['now_date']         = datetime.date.today().strftime('%Y-%m-%d')
             doc['ansible_version']  = options.ansible_version
+            doc['plainexamples']    = examples  #plain text
 
             if options.includes_file is not None and includefmt != "":
                 incfile.write(includefmt % module)

--- a/hacking/templates/man.j2
+++ b/hacking/templates/man.j2
@@ -56,6 +56,13 @@
 .fi
 {% endfor %}
 {% endif %}
+." ------ PLAINEXAMPLES
+{% if plainexamples is defined %}
+.nf
+@{ plainexamples }@
+.fi
+{% endif %}
+
 ." ------- AUTHOR
 {% if author is defined %}
 .SH AUTHOR

--- a/hacking/templates/markdown.j2
+++ b/hacking/templates/markdown.j2
@@ -44,7 +44,11 @@ New in version @{ version_added }@.
 @{ example['code'] }@
 ```
 {% endfor %}
- 
+{% if plainexamples -%}
+```
+@{ plainexamples }@
+```
+{% endif %}
 
 {% if notes %}
 #### Notes

--- a/hacking/templates/rst.j2
+++ b/hacking/templates/rst.j2
@@ -54,6 +54,14 @@
 {% endfor %}
     <br/>
 
+{% if plainexamples %}
+.. raw:: html
+
+    <pre>
+@{ plainexamples | escape | indent(4, True) }@
+    </pre>
+{% endif %}
+
 {% if notes %}
 .. raw:: html
 

--- a/lib/ansible/utils/module_docs.py
+++ b/lib/ansible/utils/module_docs.py
@@ -30,11 +30,14 @@ BLACKLIST_MODULES = [
 
 def get_docstring(filename, verbose=False):
     """
-    Search for assignment of the DOCUMENTATION variable in the given file.
-    Parse that from YAML and return the YAML doc or None.
+    Search for assignment of the DOCUMENTATION and EXAMPLES variables
+    in the given file.
+    Parse DOCUMENTATION from YAML and return the YAML doc or None
+    together with EXAMPLES, as plain text.
     """
 
     doc = None
+    plainexamples = None
 
     try:
         # Thank you, Habbie, for this bit of code :-)
@@ -43,8 +46,11 @@ def get_docstring(filename, verbose=False):
             if isinstance(child, ast.Assign):
                 if 'DOCUMENTATION' in (t.id for t in child.targets):
                     doc = yaml.load(child.value.s)
+                if 'EXAMPLES' in (t.id for t in child.targets):
+                    plainexamples = child.value.s[1:]  # Skip first empty line
     except:
         if verbose == True:
             traceback.print_exc()
             print "unable to parse %s" % filename
-    return doc
+    return doc, plainexamples
+


### PR DESCRIPTION
Writing up examples in the YAML DOCUMENTATION can (admittedly) be a bit of a pain due to the escaping of colons, etc.

We've created an additional, and optional variable which can be defined in modules, called `EXAMPLES`. This is meant to be a plain-text (i.e. unparsed) string in which to document examples for playbooks. Note, that this can be used in addition to or instead of _examples_ in the DOCUMENTATION string.

Support of this is now added and tested for
- ansible-doc (1)
- hacking/module_formatter
- rST template
- Markdown template
- man page template

The following fictitious example uses both:

``` python
examples:
   - code: "get_url: url=http://example.com/path/file.conf dest=/etc/foo.conf mode=0440"
     description: "Example from Ansible Playbooks"
notes:
    - This module doesn't yet support configuration for proxies.
# informational: requirements for nodes
requirements: [ urllib2, urlparse ]
author: Jan-Piet Mens
'''

EXAMPLES = '''
- action: get_url
    url="http://colon:one@two.three/name='Jane Jolie' and:
      something other '" with some quotes
- template: src=/tmp/me.to:oo dest=/tmp/other--file
'''
```

When run through the module formatter, the result looks like this (on the Web pages)

![jmbp-491](https://f.cloud.github.com/assets/60706/167492/c5afb3a0-79d8-11e2-9262-2ef70268bc85.png)
