### PR TITLE
sysctl module: fixed issue when checks_after fail on comparing keys with...

### DIFF
--- a/library/sysctl
+++ b/library/sysctl
@@ -189,6 +189,7 @@ def sysctl_check(current_step, **sysctl_args):
             output = f.read()
             f.close()
             output = output.strip(' \t\n\r')
+            output = re.sub(r'\s+', ' ', output)
             
             # multi positive integer values separated by spaces as described in issue #2004 :
             if re.search('^([\d\s]+)$', sysctl_args['value']):


### PR DESCRIPTION
Fixed:
failed: [host] => (item=net.ipv4.tcp_wmem) => {"failed": true, "item": "net.ipv4.tcp_wmem"}
msg: checks_after failed with: key seems not set to value even after update/sysctl, founded : <4096     87380   524288>, wanted : <4096 87380 524288>

When sysctl module compare key with values separated by spaces with values read from file it fail.
