### PR TITLE
Better sysctl module file check

### DIFF
--- a/library/sysctl
+++ b/library/sysctl
@@ -155,17 +155,6 @@ def sysctl_check(current_step, **sysctl_args):
     if not os.access(sysctl_args['key_path'], os.R_OK):
         return 1, 'key_path is not a readable file, key seems to be uncheckable'
     
-    # sysctl file exists and openable ?
-    # TODO choose if prefered to use os.access() instead try/catch on open
-    if current_step == 'before':
-        if not os.access(sysctl_args['sysctl_file'], os.W_OK):
-            try:
-                f = open(sysctl_args['sysctl_file'],'w')
-                f.write('')
-                f.close()
-            except IOError, e:
-                return 1, 'unable to create supplied sysctl file (directory missing)'
-
     # no smart checks at this step ?
     if sysctl_args['checks'] == 'none':
         return 0, ''
@@ -245,6 +234,14 @@ def main():
     res,msg = sysctl_check('before', **sysctl_args)
     if res != 0:
         module.fail_json(msg='checks_before failed with: ' + msg)
+
+    if not os.access(sysctl_args['sysctl_file'], os.W_OK):
+        try:
+            f = open(sysctl_args['sysctl_file'],'w')
+            f.write('')
+            f.close()
+        except IOError, e:
+            module.fail_json(msg='unable to create supplied sysctl file (destination directory probably missing)')
 
     # reading the file
     for line in open(sysctl_args['sysctl_file'], 'r').readlines():

--- a/library/sysctl
+++ b/library/sysctl
@@ -238,7 +238,6 @@ def main():
     if not os.access(sysctl_args['sysctl_file'], os.W_OK):
         try:
             f = open(sysctl_args['sysctl_file'],'w')
-            f.write('')
             f.close()
         except IOError, e:
             module.fail_json(msg='unable to create supplied sysctl file (destination directory probably missing)')

--- a/library/sysctl
+++ b/library/sysctl
@@ -158,12 +158,14 @@ def sysctl_check(current_step, **sysctl_args):
     # sysctl file exists and openable ?
     # TODO choose if prefered to use os.access() instead try/catch on open
     if current_step == 'before':
-        try:
-            f = open(sysctl_args['sysctl_file'])
-            f.close()
-        except IOError, e:
-            return 1, 'unable to open supplied sysctl.conf'
-   
+        if not os.access(sysctl_args['sysctl_file'], os.W_OK):
+            try:
+                f = open(sysctl_args['sysctl_file'],'w')
+                f.write('')
+                f.close()
+            except IOError, e:
+                return 1, 'unable to create supplied sysctl file (directory missing)'
+
     # no smart checks at this step ?
     if sysctl_args['checks'] == 'none':
         return 0, ''


### PR DESCRIPTION
When syscl file was missing, sysctl module was complaining about it and
bailing out.
This behaviour prevents usage of /etc/sysctl.d directory, present in
some distributions.
This patch accepts a missing sysctl.conf file so sysctl.d directory can
be used.
However, it will bail out if the destination directory doesn't exist.
