### PR TITLE
Venv command

### DIFF
--- a/library/easy_install
+++ b/library/easy_install
@@ -39,6 +39,15 @@ options:
         I(virtualenv) does not exist, it is created automatically
     required: false
     default: null
+  virtualenv_site_packages:
+    description:
+      - Whether the virtual environment will inherit packages from the
+        global site-packages directory.  Note that if this setting is
+        changed on an already existing virtual environment it will not
+        have any effect, the environment must be deleted and newly
+        created.
+    required: false
+    default: no
 examples:
    - code: "easy_install: name=pip"
      description: "Examples from Ansible Playbooks"
@@ -55,13 +64,6 @@ requirements: [ "virtualenv" ]
 author: Matt Wright
 '''
 
-def _ensure_virtualenv(module, env, virtualenv):
-    if os.path.exists(os.path.join(env, 'bin', 'activate')):
-        return 0, '', ''
-    else:
-        return module.run_command('%s %s' % (virtualenv, env))
-
-
 def _is_package_installed(module, name, easy_install):
     cmd = '%s --dry-run %s' % (easy_install, name)
     rc, status_stdout, status_stderr = module.run_command(cmd)
@@ -71,7 +73,8 @@ def _is_package_installed(module, name, easy_install):
 def main():
     arg_spec = dict(
         name=dict(required=True),
-        virtualenv=dict(default=None, required=False)
+        virtualenv=dict(default=None, required=False),
+        virtualenv_site_packages=dict(default='no', choices=BOOLEANS),
     )
 
     module = AnsibleModule(argument_spec=arg_spec)
@@ -79,6 +82,7 @@ def main():
     name = module.params['name']
     env = module.params['virtualenv']
     easy_install = module.get_bin_path('easy_install', True, ['%s/bin' % env])
+    site_packages = module.boolean(module.params['virtualenv_site_packages'])
 
     rc = 0
     err = ''
@@ -86,14 +90,16 @@ def main():
 
     if env:
         virtualenv = module.get_bin_path('virtualenv', True)
-        if virtualenv is None:
-            module.fail_json(msg='virtualenv is not installed')
 
-        rc_venv, out_venv, err_venv = _ensure_virtualenv(module, env, virtualenv)
+        if not os.path.exists(os.path.join(env, 'bin', 'activate')):
+            command = '%s %s' % (virtualenv, env)
+            if site_packages:
+                command += ' --system-site-packages'
+            rc_venv, out_venv, err_venv = module.run_command('%s %s' % (virtualenv, env))
 
-        rc += rc_venv
-        out += out_venv
-        err += err_venv
+            rc += rc_venv
+            out += out_venv
+            err += err_venv
 
     cmd = None
     changed = False

--- a/library/easy_install
+++ b/library/easy_install
@@ -48,6 +48,12 @@ options:
         created.
     required: false
     default: no
+  virtualenv_command:
+    description:
+      - The command to create the virtual environment with. For example
+        C(pyvenv), C(virtualenv), C(virtualenv2).
+    required: false
+    default: virtualenv
 examples:
    - code: "easy_install: name=pip"
      description: "Examples from Ansible Playbooks"
@@ -75,6 +81,7 @@ def main():
         name=dict(required=True),
         virtualenv=dict(default=None, required=False),
         virtualenv_site_packages=dict(default='no', choices=BOOLEANS),
+        virtualenv_command=dict(default='virtualenv', required=False),
     )
 
     module = AnsibleModule(argument_spec=arg_spec)
@@ -83,13 +90,14 @@ def main():
     env = module.params['virtualenv']
     easy_install = module.get_bin_path('easy_install', True, ['%s/bin' % env])
     site_packages = module.boolean(module.params['virtualenv_site_packages'])
+    virtualenv_command = module.params['virtualenv_command']
 
     rc = 0
     err = ''
     out = ''
 
     if env:
-        virtualenv = module.get_bin_path('virtualenv', True)
+        virtualenv = module.get_bin_path(virtualenv_command, True)
 
         if not os.path.exists(os.path.join(env, 'bin', 'activate')):
             command = '%s %s' % (virtualenv, env)

--- a/library/pip
+++ b/library/pip
@@ -56,6 +56,12 @@ options:
         created.
     required: false
     default: no
+  virtualenv_command:
+    description:
+      - The command to create the virtual environment with. For example
+        C(pyvenv), C(virtualenv), C(virtualenv2).
+    required: false
+    default: virtualenv
   use_mirrors:
     description:
       - Whether to use mirrors when installing python libraries.  If using
@@ -86,6 +92,8 @@ examples:
      description: "Install I(Flask) (U(http://flask.pocoo.org/)) into the specified I(virtualenv), inheriting none of the globally installed modules"
    - code: "pip: name=flask virtualenv=/my_app/venv virtualenv_site_packages=yes"
      description: "Install I(Flask) (U(http://flask.pocoo.org/)) into the specified I(virtualenv), inheriting globally installed modules"
+   - code: "pip: name=flask virtualenv=/my_app/venv virtualenv_command=virtualenv-2.7"
+     description: "Install I(Flask) (U(http://flask.pocoo.org/)) into the specified I(virtualenv), using Python 2.7"
    - code: "pip: requirements=/my_app/requirements.txt"
      description: Install specified python requirements.
    - code: "pip: requirements=/my_app/requirements.txt virtualenv=/my_app/venv"
@@ -149,6 +157,7 @@ def main():
             requirements=dict(default=None, required=False),
             virtualenv=dict(default=None, required=False),
             virtualenv_site_packages=dict(default='no', choices=BOOLEANS),
+            virtualenv_command=dict(default='virtualenv', required=False),
             use_mirrors=dict(default='yes', choices=BOOLEANS),
             extra_args=dict(default=None, required=False),
         ),
@@ -172,9 +181,10 @@ def main():
     out = ''
 
     env = module.params['virtualenv']
+    virtualenv_command = module.params['virtualenv_command']
 
     if env:
-        virtualenv = module.get_bin_path('virtualenv', True)
+        virtualenv = module.get_bin_path(virtualenv_command, True)
         if not os.path.exists(os.path.join(env, 'bin', 'activate')):
             if module.boolean(module.params['virtualenv_site_packages']):
                 cmd = '%s --system-site-packages %s' % (virtualenv, env)


### PR DESCRIPTION
Update `pip` and `easy_install` modules to support a virtualenv_command parameter to create virtualenvs with a specific python version.

Also add no-site-packages support to `easy_install` module. The `pip` module already had that option.

As discussed in #2017.
