### PR TITLE
Add proxy support of apt_key module.

### DIFF
--- a/library/apt_key
+++ b/library/apt_key
@@ -60,7 +60,7 @@ examples:
 '''
 
 # FIXME: standardize into module_common
-from urllib2 import urlopen, URLError
+import urllib2
 from traceback import format_exc
 from re import compile as re_compile
 # FIXME: standardize into module_common
@@ -101,7 +101,11 @@ def download_key(module, url):
     if url is None:
         module.fail_json(msg="needed a URL but was not specified")
     try:
-        connection = urlopen(url)
+        proxy_handler = urllib2.ProxyHandler()
+        opener =  urllib2.build_opener(proxy_handler)
+        urllib2.install_opener(opener)
+
+        connection = urllib2.urlopen(url)
         if connection is None:
             module.fail_json("error connecting to download key from url")
         data = connection.read()


### PR DESCRIPTION
Example passing env variables and used by apt_key:

<pre>
vars:
    env:
       http_proxy: "http://http-proxy.local:3128"
       https_proxy: "http://http-proxy.local:3128"
tasks: 
    - name:  install ceph apt-key 
      apt_key: url=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc state=present 
      environment: $env
</pre>
