### PR TITLE
mysql_db/user: Use password for my.cnf

### DIFF
--- a/library/mysql_db
+++ b/library/mysql_db
@@ -131,7 +131,7 @@ def load_mycnf():
         return False
     try:
         config.readfp(open(mycnf))
-        creds = dict(user=config.get('client', 'user'),passwd=config.get('client', 'pass'))
+        creds = dict(user=config.get('client', 'user'),passwd=config.get('client', 'password'))
     except (ConfigParser.NoOptionError, IOError):
         return False
     return creds

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -213,7 +213,13 @@ def privileges_revoke(cursor, user,host,db_table):
     query = "REVOKE ALL PRIVILEGES ON %s FROM '%s'@'%s'" % (db_table,user,host)
     cursor.execute(query)
     query = "REVOKE GRANT OPTION ON %s FROM '%s'@'%s'" % (db_table,user,host)
-    cursor.execute(query)
+    try:
+        cursor.execute(query)
+    except MySQLdb.OperationalError, e:
+        # 1141 -> There is no such grant defined for user ... on host ...
+        # If this exception is raised, there is no need to revoke the GRANT privilege
+        if e.args[0] != 1141 or not e.args[1].startswith("There is no such grant defined for user"):
+            raise e
 
 def privileges_grant(cursor, user,host,db_table,priv):
 

--- a/library/mysql_user
+++ b/library/mysql_user
@@ -230,7 +230,7 @@ def load_mycnf():
         return False
     try:
         config.readfp(open(mycnf))
-        creds = dict(user=config.get('client', 'user'),password=config.get('client', 'pass'))
+        creds = dict(user=config.get('client', 'user'),password=config.get('client', 'password'))
     except (ConfigParser.NoOptionError, IOError):
         return False
     return creds


### PR DESCRIPTION
According to the MySQL docs[0] the password should be stored after
'password=' instead of 'pass='.

[0] http://dev.mysql.com/doc/refman/5.1/en/password-security-user.html
