### PR TITLE
Improves lineinfile and adds file attr option (take #3)

### DIFF
--- a/library/lineinfile
+++ b/library/lineinfile
@@ -103,10 +103,11 @@ examples:
 """
    
 
-def check_file(module, changed, message=""):
+def check_file_attrs(module, changed, message):
 
     file_args = module.load_file_common_arguments(module.params)
     if module.set_file_attributes_if_different(file_args, False):
+
         if changed:
             message += " and "
         changed = True
@@ -129,6 +130,8 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create, backu
         f = open(dest, 'rb')
         lines = f.readlines()
         f.close()
+
+    msg = ""
 
     mre = re.compile(regexp)
     if not mre.search(line):
@@ -182,9 +185,6 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create, backu
         msg = 'line added'
         changed = True
 
-    file_args = module.load_file_common_arguments(module.params)
-    changed = module.set_file_attributes_if_different(file_args, changed)
-
     if changed and not module.check_mode:
         if backup and os.path.exists(dest):
             module.backup_local(dest)
@@ -192,7 +192,7 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create, backu
         f.writelines(lines)
         f.close()
 
-    [ msg, changed ] = check_file(module, changed, msg)
+    [ msg, changed ] = check_file_attrs(module, changed, msg)
     module.exit_json(changed=changed, msg=msg)
 
 def absent(module, dest, regexp, backup):
@@ -203,6 +203,7 @@ def absent(module, dest, regexp, backup):
         module.exit_json(changed=False, msg="file not present")
 
     msg = ""
+
     f = open(dest, 'rb')
     lines = f.readlines()
     f.close()
@@ -228,8 +229,7 @@ def absent(module, dest, regexp, backup):
     if changed:
         msg = "%s line(s) removed" % len(found)
 
-    [ msg, changed ] = check_file(module, changed, msg)
-
+    [ msg, changed ] = check_file_attrs(module, changed, msg)
     module.exit_json(changed=changed, found=len(found), msg=msg)
 
 def main():

--- a/library/lineinfile
+++ b/library/lineinfile
@@ -87,14 +87,32 @@ options:
      description:
        - Create a backup file including the timestamp information so you can
          get the original file back if you somehow clobbered it incorrectly.
+  others:
+     description:
+       - All arguments accepted by the M(file) module also work here. If you 
+       use file arguments with C(state=absent) and the file exists, it's perms, 
+       ownership or SE linux context will be updated if needed.
+     required: false
 examples:
    - code: 'lineinfile: dest=/etc/selinux/config regexp=^SELINUX= line=SELINUX=disabled'
    - code: 'lineinfile: dest=/etc/sudoers state=absent regexp="^%wheel"'
+   - code: "lineinfile: dest=/etc/host regexp='^127\.0\.0\.1' line='127.0.0.1 localhost' owner=root group=root mode=0644"
    - code: 'lineinfile: dest=/etc/httpd/conf/httpd.conf regexp="^Listen " insertafter="^#Listen " line="Listen 8080"'
    - code: 'lineinfile: dest=/etc/services regexp="^# port for http" insertbefore="^www.*80/tcp" line="# port for http by default"'
    - code: "lineinfile: \\\"dest=/etc/sudoers state=present regexp='^%wheel' line ='%wheel ALL=(ALL) NOPASSWD: ALL'\\\""
 """
    
+
+def check_file(module, changed, message=""):
+
+    file_args = module.load_file_common_arguments(module.params)
+    if module.set_file_attributes_if_different(file_args, False):
+        if changed:
+            message += " and "
+        changed = True
+        message += "ownership, perms or SE linux context changed"
+
+    return [ message, changed ]
 
 def present(module, dest, regexp, line, insertafter, insertbefore, create, backup):
 
@@ -164,6 +182,9 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create, backu
         msg = 'line added'
         changed = True
 
+    file_args = module.load_file_common_arguments(module.params)
+    changed = module.set_file_attributes_if_different(file_args, changed)
+
     if changed and not module.check_mode:
         if backup and os.path.exists(dest):
             module.backup_local(dest)
@@ -171,9 +192,17 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create, backu
         f.writelines(lines)
         f.close()
 
+    [ msg, changed ] = check_file(module, changed, msg)
     module.exit_json(changed=changed, msg=msg)
 
 def absent(module, dest, regexp, backup):
+
+    if os.path.isdir(dest):
+        module.fail_json(rc=256, msg='Destination %s is a directory !' % dest)
+    elif not os.path.exists(dest):
+        module.exit_json(changed=False, msg="file not present")
+
+    msg = ""
     f = open(dest, 'rb')
     lines = f.readlines()
     f.close()
@@ -195,7 +224,13 @@ def absent(module, dest, regexp, backup):
         f = open(dest, 'wb')
         f.writelines(lines)
         f.close()
-    module.exit_json(changed=changed, found=len(found))
+
+    if changed:
+        msg = "%s line(s) removed" % len(found)
+
+    [ msg, changed ] = check_file(module, changed, msg)
+
+    module.exit_json(changed=changed, found=len(found), msg=msg)
 
 def main():
     module = AnsibleModule(
@@ -209,21 +244,23 @@ def main():
             create=dict(default=False, choices=BOOLEANS),
             backup=dict(default=False, choices=BOOLEANS),
         ),
-    mutually_exclusive = [['insertbefore', 'insertafter']],
-    supports_check_mode = True
+        mutually_exclusive = [['insertbefore', 'insertafter']],
+        add_file_common_args=True,
+        supports_check_mode = True
     )
 
     params = module.params
     create = module.boolean(module.params.get('create', False))
     backup = module.boolean(module.params.get('backup', False))
+    dest   = os.path.expanduser(params['dest'])
 
     if params['state'] == 'present':
         if 'line' not in params:
             module.fail_json(msg='line= is required with state=present')
-        present(module, params['dest'], params['regexp'], params['line'],
+        present(module, dest, params['regexp'], params['line'],
                 params['insertafter'], params['insertbefore'], create, backup)
     else:
-        absent(module, params['dest'], params['regexp'], backup)
+        absent(module, dest, params['regexp'], backup)
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>


### PR DESCRIPTION
Added path expanding for dest in lineinfile
Added common file arguments to lineinfile so the module gets owner,
group, mode and SE options.
Decorated existing example to demonstate usage of file options and added
a couple more examples
Message is not set accordingly when file attributes were changed
'absent' handling code now handles the case where the file doesn't
exists (was issuing a Traceback before)
File attribute handling code has been added to the 'absent' handling
function too.
File attributes handling has been grouped in 'def check_file' since it's
required in both places.
'absent' mode now returns a message like it's counterpart 'present',
telling if file attributes were altered and if lines have matched.

**Note:** 
Kept the behaviour where, when called with `state=absent`, permissions ARE fixed if needed, and documented it. Seems more consistent and logical to me. Since files (or some of it's lines) managed by lineinfile are probably not pushed via ansible, this is is only way to set perms, ownership or linux context without using another file action.
Even if they're pushed via Ansible, I don't see much downside in doing this. May be few cons when file is maintained elsewhere with file (scenario of setting a different file mode in different playbooks, sounds like a playbook problem to me); this also introduce more perms checking perms when module is used. Not a big deal IMHO.

_No kitten were harmed in creating this pull request_
