### PR TITLE
Add support for connection type in ansible_hosts file

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -447,6 +447,7 @@ class Runner(object):
                 actual_port = delegate_info.get('ansible_ssh_port', port)
                 actual_user = delegate_info.get('ansible_ssh_user', actual_user)
                 actual_pass = delegate_info.get('ansible_ssh_pass', actual_pass)
+                actual_transport = delegate_info.get('ansible_connection', self.transport)
                 for i in delegate_info:
                     if i.startswith("ansible_") and i.endswith("_interpreter"):
                         inject[i] = delegate_info[i]

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -317,7 +317,8 @@ class Runner(object):
         ''' executes any module one or more times '''
 
         host_variables = self.inventory.get_variables(host)
-        if self.transport in [ 'paramiko', 'ssh' ]:
+        host_connection = host_variables.get('ansible_connection', self.transport)
+        if host_connection in [ 'paramiko', 'ssh' ]:
             port = host_variables.get('ansible_ssh_port', self.remote_port)
             if port is None:
                 port = C.DEFAULT_REMOTE_PORT
@@ -423,7 +424,8 @@ class Runner(object):
         actual_port = port
         actual_user = inject.get('ansible_ssh_user', self.remote_user)
         actual_pass = inject.get('ansible_ssh_pass', self.remote_pass)
-        if self.transport in [ 'paramiko', 'ssh' ]:
+        actual_transport = inject.get('ansible_connection', self.transport)
+        if actual_transport in [ 'paramiko', 'ssh' ]:
             actual_port = inject.get('ansible_ssh_port', port)
 
         # the delegated host may have different SSH port configured, etc
@@ -463,7 +465,7 @@ class Runner(object):
             return ReturnData(host=host, comm_ok=False, result=result)
 
         try:
-            conn = self.connector.connect(actual_host, actual_port, actual_user, actual_pass)
+            conn = self.connector.connect(actual_host, actual_port, actual_user, actual_pass, actual_transport)
             if delegate_to or host != actual_host:
                 conn.delegate = host
 

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -31,9 +31,8 @@ class Connection(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def connect(self, host, port, user, password):
+    def connect(self, host, port, user, password, transport):
         conn = None
-        transport = self.runner.transport
         conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password)
         if conn is None:
             raise AnsibleError("unsupported connection type: %s" % transport)


### PR DESCRIPTION
This enables support for a variable `ansible_connection` in the hosts file, which allows setting a per-host connection type. For example:

```
[hosts]
localhost ansible_connection=local
host1
host2
```

I find it useful to manage servers and my local laptop (which doesn't run an SSH server) with the same set of playbooks in one run.
