### PR TITLE
Documentation html tweaks

### DIFF
--- a/docsite/_static/ansible-local.css
+++ b/docsite/_static/ansible-local.css
@@ -1,0 +1,4 @@
+/* Local CSS tweaks for ansible */
+.dropdown-menu {
+    overflow-y: auto;
+}

--- a/docsite/_static/ansible-local.css
+++ b/docsite/_static/ansible-local.css
@@ -2,3 +2,7 @@
 .dropdown-menu {
     overflow-y: auto;
 }
+
+h2 {
+    padding-top: 40px;
+}

--- a/docsite/_themes/bootstrap/layout.html
+++ b/docsite/_themes/bootstrap/layout.html
@@ -1,6 +1,6 @@
 {% extends "basic/layout.html" %}
 {% set script_files = script_files + ['_static/bootstrap-dropdown.js', '_static/bootstrap-scrollspy.js'] %}
-{% set css_files = ['_static/bootstrap.css', '_static/bootstrap-sphinx.css'] + css_files %}
+{% set css_files = ['_static/bootstrap.css', '_static/bootstrap-sphinx.css', '_static/ansible-local.css'] + css_files %}
 
 {# Sidebar: Rework into our Boostrap nav section. #}
 {% macro navBar() %}
@@ -96,6 +96,20 @@
    var s = document.getElementsByTagName('script')[0];
 s.parentNode.insertBefore(ga, s);
  })();
+
+</script>
+<script type="text/javascript">
+// Set the maximum height of drop down menus to just less than the height
+// of the viewport.
+var set_max_menu_height = function () {
+
+  // set menu max height to 75 less than viewport height
+  $('.dropdown-menu').css('max-height', $(window).height() - 75); 
+}
+
+// Set this when we set the page up and on each resize.
+$(window).resize(set_max_menu_height);
+$(window).ready(set_max_menu_height);
 
 </script>
 

--- a/docsite/_themes/bootstrap/localtoc.html
+++ b/docsite/_themes/bootstrap/localtoc.html
@@ -1,5 +1,5 @@
 <li class="dropdown" data-dropdown="dropdown">
   <a href="#"
-     class="dropdown-toggle">{{ _('Page') }}</a>
+     class="dropdown-toggle">{{ _('Section') }}</a>
   <span class="localtoc">{{ toc }}</span>
 </li>


### PR DESCRIPTION
3 commits, which:-
- Change the title of the within page menu from Page to Section
- Add js to make the dropdown menu length to be limited by viewport length, scrolling within that
- Increase the top padding on h2 elements so following link from menu does not have the title hidden under the menu bar (crude, but works well).
