### PR TITLE
pass in int() args to get_pty

### DIFF
--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -123,8 +123,8 @@ class Connection(object):
             # we give it one, and we try to initialise from the calling
             # environment
             chan.get_pty(term=os.getenv('TERM', 'vt100'),
-                         width=os.getenv('COLUMNS', 0),
-                         height=os.getenv('LINES', 0))
+                         width=int(os.getenv('COLUMNS', 0)),
+                         height=int(os.getenv('LINES', 0)))
             shcmd, prompt = utils.make_sudo_cmd(sudo_user, executable, cmd)
             vvv("EXEC %s" % shcmd, host=self.host)
             sudo_output = ''


### PR DESCRIPTION
If LINES or COLUMNS was set, get_pty was failing because it was
expecting an int value to be passed in.  This was causing the following traceback:

```
fatal: [localhost] => Traceback (most recent call last):
  File "/home/szinck/ansible/lib/ansible/runner/__init__.py", line 298, in _executor
    exec_rc = self._executor_internal(host)
  File "/home/szinck/ansible/lib/ansible/runner/__init__.py", line 355, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port)
  File "/home/szinck/ansible/lib/ansible/runner/__init__.py", line 483, in _executor_internal_inner
    result = handler.run(conn, tmp, module_name, module_args, inject, self.complex_args)
  File "/home/szinck/ansible/lib/ansible/runner/action_plugins/normal.py", line 55, in run
    return self.runner._execute_module(conn, tmp, module_name, module_args, inject=inject, complex_args=complex_args)
  File "/home/szinck/ansible/lib/ansible/runner/__init__.py", line 286, in _execute_module
    res = self._low_level_exec_command(conn, cmd, tmp, sudoable=True)
  File "/home/szinck/ansible/lib/ansible/runner/__init__.py", line 523, in _low_level_exec_command
    rc, stdin, stdout, stderr = conn.exec_command(cmd, tmp, sudo_user, sudoable=sudoable, executable=executable)
  File "/home/szinck/ansible/lib/ansible/runner/connection_plugins/paramiko_ssh.py", line 129, in exec_command
    height=os.getenv('LINES', 0))
  File "build/bdist.solaris-2.11-i86pc/egg/paramiko/channel.py", line 151, in get_pty
    m.add_int(width)
  File "build/bdist.solaris-2.11-i86pc/egg/paramiko/message.py", line 226, in add_int
    self.packet.write(struct.pack('>I', n))
error: cannot convert argument to integer
```
