### PR TITLE
No_log params

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -592,11 +592,9 @@ class AnsibleModule(object):
         passwd_keys = ['password', 'login_password']
         
         for param in self.params:
-            no_log = False
-            if self.aliases:
-                canon  = self.aliases.get(param, param)
-                arg_opts = self.argument_spec[canon]
-                no_log = arg_opts.get('no_log', False)
+            canon  = self.aliases.get(param, param)
+            arg_opts = self.argument_spec.get(canon, {})
+            no_log = arg_opts.get('no_log', False)
                 
             if no_log:
                 log_args[param] = 'NOT_LOGGING_PARAMETER'

--- a/library/command
+++ b/library/command
@@ -129,7 +129,7 @@ def main():
 class CommandModule(AnsibleModule):
 
     def _handle_aliases(self):
-        pass
+        return {}
 
     def _check_invalid_arguments(self):
         pass

--- a/library/ec2
+++ b/library/ec2
@@ -153,7 +153,7 @@ def main():
             ramdisk = dict(),
             wait = dict(choices=BOOLEANS, default=False),
             ec2_url = dict(aliases=['EC2_URL']),
-            ec2_secret_key = dict(aliases=['EC2_SECRET_KEY']),
+            ec2_secret_key = dict(aliases=['EC2_SECRET_KEY'], no_log=True),
             ec2_access_key = dict(aliases=['EC2_ACCESS_KEY']),
             user_data = dict(),
             instance_tags = dict(),


### PR DESCRIPTION
this adds a no_log attribute option to all parameters
it keeps the value of the parameter of modules from showing up in syslog.

example of it included in the ec2 module
