### PR TITLE
Fix CliRunnerCallbacks.on_file_diff in callbacks.py

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -285,8 +285,7 @@ class CliRunnerCallbacks(DefaultRunnerCallbacks):
             utils.write_tree_file(self.options.tree, host, utils.jsonify(result2,format=True))
     
     def on_file_diff(self, host, diff):
-        if self.options.diff:
-            print utils.get_diff(diff)
+        print utils.get_diff(diff)
         super(CliRunnerCallbacks, self).on_file_diff(host, diff)
 
 ########################################################################


### PR DESCRIPTION
When running ansible -C, I get a traceback that ends with
    AttributeError: Values instance has no attribute 'diff'
This fixes on_file_diff to behave similar to
PlaybookRunnerCallbacks.on_file_diff().

```
$ ansible all -m ping -i 'localhost,' -c local -C
localhost | FAILED => Traceback (most recent call last):
  File "/home/stephenf/Source/ansible/lib/ansible/runner/__init__.py", line 297, in _executor
    exec_rc = self._executor_internal(host)
  File "/home/stephenf/Source/ansible/lib/ansible/runner/__init__.py", line 354, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port)
  File "/home/stephenf/Source/ansible/lib/ansible/runner/__init__.py", line 509, in _executor_internal_inner
    self.callbacks.on_file_diff(conn.host, result.diff)
  File "/home/stephenf/Source/ansible/lib/ansible/callbacks.py", line 288, in on_file_diff
    if self.options.diff:
AttributeError: Values instance has no attribute 'diff'

$ git co fix-ansible-cli-check-mode 
Switched to branch 'fix-ansible-cli-check-mode'
$ ansible all -m ping -i 'localhost,' -c local -C

localhost | success >> {
    "changed": false, 
    "ping": "pong"
}
```
