### PR TITLE
Update various modules for check_mode

### DIFF
--- a/library/apt_key
+++ b/library/apt_key
@@ -130,6 +130,7 @@ def main():
             key=dict(required=False),
             state=dict(required=False, choices=['present', 'absent'], default='present')
         ),
+        supports_check_mode=True
     )
 
     key_id          = module.params['id']
@@ -153,6 +154,8 @@ def main():
             if key_id and key_id in keys:
                 module.exit_json(changed=False)
             else:
+                if module.check_mode:
+                    module.exit_json(changed=True)
                 add_key(module, data)
                 changed=False
                 keys2 = all_keys(module)
@@ -165,6 +168,8 @@ def main():
         if not key_id:
             module.fail_json(msg="key is required")
         if key_id in keys:
+            if module.check_mode:
+                module.exit_json(changed=True)
             if remove_key(module, key_id):
                 changed=True
             else:

--- a/library/apt_repository
+++ b/library/apt_repository
@@ -90,7 +90,7 @@ def main():
         state=dict(default='present', choices=['present', 'absent'])
     )
 
-    module = AnsibleModule(argument_spec=arg_spec)
+    module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
 
     if not HAVE_PYAPT:
         module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")
@@ -119,9 +119,13 @@ def main():
     out = ''
     err = ''
     if state == 'absent' and exists:
+        if module.check_mode:
+            module.exit_json(changed=True)
         cmd = '%s "%s" --remove' % (add_apt_repository, repo)
         rc, out, err = module.run_command(cmd)
     elif state == 'present' and not exists:
+        if module.check_mode:
+            module.exit_json(changed=True)
         cmd = '%s "%s"' % (add_apt_repository, repo)
         rc, out, err = module.run_command(cmd)
     else:

--- a/library/easy_install
+++ b/library/easy_install
@@ -86,7 +86,7 @@ def main():
         virtualenv_command=dict(default='virtualenv', required=False),
     )
 
-    module = AnsibleModule(argument_spec=arg_spec)
+    module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
 
     name = module.params['name']
     env = module.params['virtualenv']
@@ -102,6 +102,8 @@ def main():
         virtualenv = module.get_bin_path(virtualenv_command, True)
 
         if not os.path.exists(os.path.join(env, 'bin', 'activate')):
+            if module.check_mode:
+                module.exit_json(changed=True)
             command = '%s %s' % (virtualenv, env)
             if site_packages:
                 command += ' --system-site-packages'
@@ -116,6 +118,8 @@ def main():
     installed = _is_package_installed(module, name, easy_install)
 
     if not installed:
+        if module.check_mode:
+            module.exit_json(changed=True)
         cmd = '%s %s' % (easy_install, name)
         rc_pip, out_pip, err_pip = module.run_command(cmd)
 

--- a/library/pip
+++ b/library/pip
@@ -165,6 +165,7 @@ def main():
         ),
         required_one_of=[['name', 'requirements']],
         mutually_exclusive=[['name', 'requirements']],
+        supports_check_mode=True
     )
 
     state = module.params['state']
@@ -188,6 +189,8 @@ def main():
     if env:
         virtualenv = module.get_bin_path(virtualenv_command, True)
         if not os.path.exists(os.path.join(env, 'bin', 'activate')):
+            if module.check_mode:
+                module.exit_json(changed=True)
             if module.params['virtualenv_site_packages']:
                 cmd = '%s --system-site-packages %s' % (virtualenv, env)
             else:
@@ -210,6 +213,8 @@ def main():
     elif requirements:
         cmd += ' -r %s' % requirements
 
+    if module.check_mode:
+        module.exit_json(changed=True)
     rc, out_pip, err_pip = module.run_command(cmd)
     out += out_pip
     err += err_pip

--- a/library/seboolean
+++ b/library/seboolean
@@ -160,7 +160,8 @@ def main():
             name=dict(required=True),
             persistent=dict(default='no', type='bool'),
             state=dict(required=True, type='bool')
-        )
+        ),
+        supports_check_mode=True
     )
 
     if not HAVE_SELINUX:
@@ -188,6 +189,8 @@ def main():
         result['changed'] = False
         module.exit_json(**result)
 
+    if module.check_mode:
+        module.exit_json(changed=True)
     if persistent:
         r = semanage_boolean_value(module, name, state)
     else:

--- a/library/selinux
+++ b/library/selinux
@@ -124,7 +124,8 @@ def main():
             policy=dict(required=False),
             state=dict(choices=['enforcing', 'permissive', 'disabled'], required=True),
             configfile=dict(aliases=['conf','file'], default='/etc/selinux/config')
-        )
+        ),
+        supports_check_mode=True
     )
 
     # global vars
@@ -155,16 +156,22 @@ def main():
 
     # check changed values and run changes
     if (policy != runtime_policy):
+        if module.check_mode:
+            module.exit_json(changed=True)
         # cannot change runtime policy
         msgs.append('reboot to change the loaded policy')
         changed=True
 
     if (policy != config_policy):
+        if module.check_mode:
+            module.exit_json(changed=True)
         msgs.append('config policy changed from \'%s\' to \'%s\'' % (config_policy, policy))
         set_config_policy(policy, configfile)
         changed=True
 
     if (state != runtime_state):
+        if module.check_mode:
+            module.exit_json(changed=True)
         if (state == 'disabled'):
             msgs.append('state change will take effect next reboot')
         else:
@@ -176,6 +183,8 @@ def main():
         changed=True
 
     if (state != config_state):
+        if module.check_mode:
+            module.exit_json(changed=True)
         msgs.append('config state changed from \'%s\' to \'%s\'' % (config_state, state))
         set_config_state(state, configfile)
         changed=True

--- a/library/slurp
+++ b/library/slurp
@@ -51,7 +51,8 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             src = dict(required=True, aliases=['path']),
-        )
+        ),
+        supports_check_mode=True
     )
     source = module.params['src']
 

--- a/library/subversion
+++ b/library/subversion
@@ -132,7 +132,8 @@ def main():
             force=dict(default='yes', type='bool'),
             username=dict(required=False),
             password=dict(required=False),
-        )
+        ),
+        supports_check_mode=True
     )
 
     dest = os.path.expanduser(module.params['dest'])
@@ -147,11 +148,15 @@ def main():
     if not os.path.exists(dest):
         before = None
         local_mods = False
+        if module.check_mode:
+            module.exit_json(changed=True)
         svn.checkout()
     elif os.path.exists("%s/.svn" % (dest, )):
         # Order matters. Need to get local mods before switch to avoid false
         # positives. Need to switch before revert to ensure we are reverting to
         # correct repo.
+        if module.check_mode:
+            module.exit_json(changed=True)
         before = svn.get_revision()
         local_mods = svn.has_local_mods()
         svn.switch()

--- a/library/supervisorctl
+++ b/library/supervisorctl
@@ -51,7 +51,7 @@ def main():
         state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped'])
     )
 
-    module = AnsibleModule(argument_spec=arg_spec)
+    module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
 
     name = module.params['name']
     state = module.params['state']
@@ -63,6 +63,8 @@ def main():
 
     if state == 'present':
         if not present:
+            if module.check_mode:
+                module.exit_json(changed=True)
             module.run_command('%s reread' % SUPERVISORCTL, check_rc=True)
             rc, out, err = module.run_command('%s add %s' % (SUPERVISORCTL, name))
 
@@ -80,6 +82,8 @@ def main():
         module.exit_json(changed=False, name=name, state=state)
 
     if running and state == 'stopped':
+        if module.check_mode:
+            module.exit_json(changed=True)
         rc, out, err = module.run_command('%s stop %s' % (SUPERVISORCTL, name))
 
         if '%s: stopped' % name in out:
@@ -88,6 +92,8 @@ def main():
         module.fail_json(msg=out)
 
     elif state == 'restarted':
+        if module.check_mode:
+            module.exit_json(changed=True)
         rc, out, err = module.run_command('%s update %s' % (SUPERVISORCTL, name))
         rc, out, err = module.run_command('%s restart %s' % (SUPERVISORCTL, name))
 
@@ -97,6 +103,8 @@ def main():
         module.fail_json(msg=out)
 
     elif not running and state == 'started':
+        if module.check_mode:
+            module.exit_json(changed=True)
         rc, out, err = module.run_command('%s start %s' % (SUPERVISORCTL, name))
 
         if '%s: started' % name in out:

--- a/library/svr4pkg
+++ b/library/svr4pkg
@@ -128,8 +128,9 @@ def main():
             state = dict(required = True, choices=['present', 'absent']),
             src = dict(default = None),
             proxy = dict(default = None)
-            )
-        )
+        ),
+        supports_check_mode=True
+    )
     state = module.params['state']
     name = module.params['name']
     src = module.params['src']
@@ -146,6 +147,8 @@ def main():
             module.fail_json(name=name,
                              msg="src is required when state=present")
         if not package_installed(module, name):
+            if module.check_mode:
+                module.exit_json(changed=True)
             (rc, out, err) = package_install(module, name, src, proxy)
             # Stdout is normally empty but for some packages can be
             # very long and is not often useful
@@ -154,6 +157,8 @@ def main():
 
     elif state == 'absent':
         if package_installed(module, name):
+            if module.check_mode:
+                module.exit_json(changed=True)
             (rc, out, err) = package_uninstall(module, name, src)
             out = out[:75]
 


### PR DESCRIPTION
This updates the following modules to support check_mode:
- apt_key
- apt_repository
- easy_install
- pip - will always report changed due to the way it handles state
- seboolean
- selinux
- slurp - since nothing changes, it just adds that it supports
  check_mode
- subversion - reports changed when checking out new repo and
  when updating.
- supervisorctl
- svr4pkg

See issue #2114.
