### PR TITLE
Add 'appendat' and 'prependat', which add text at the start/end of a line

### DIFF
--- a/library/lineinfile
+++ b/library/lineinfile
@@ -61,7 +61,7 @@ options:
     default: EOF
     description:
       - Used with C(state=present). If specified, the line will be inserted
-        after the specified regular expression. A special value is
+        after the line with the specified regular expression. A special value is
         available; C(EOF) for inserting the line at the end of the file.
     choices: [ 'EOF', '*regex*' ]
   insertbefore:
@@ -69,10 +69,24 @@ options:
     version_added: 1.1
     description:
       - Used with C(state=present). If specified, the line will be inserted
-        before the specified regular expression. A value is available;
+        before the line with the specified regular expression. A value is available;
          C(BOF) for inserting the line at the beginning of the
         file.
     choices: [ 'BOF', '*regex*' ]
+  appendat:
+    required: false
+    version_added: 1.1
+    description:
+      - Used with C(state=present). If specified, the line will be inserted
+        at the start of the line with the specified regular expression. 
+    choices: [ '*regex*' ]
+  prependat:
+    required: false
+    version_added: 1.1
+    description:
+      - Used with C(state=present). If specified, the line will be inserted
+        at the end of the line with the specified regular expression.
+    choices: [ '*regex*' ]
   create:
     required: false
     choices: [ yes, no ]
@@ -105,6 +119,10 @@ EXAMPLES = """
    lineinfile: dest=/etc/services regexp="^# port for http" insertbefore="^www.*80/tcp" line="# port for http by default"
 
    lineinfile: \\\"dest=/etc/sudoers state=present regexp='^%wheel' line ='%wheel ALL=(ALL) NOPASSWD: ALL'\\\"
+
+   lineinfile: \\\"dest='/etc/passwd' line='#' prependat='^root:' regexp='^#root:' state='present'\\\"
+
+   lineinfile: \\\"dest='/usr/pkg/etc/httpd/httpd.conf' line=' index.php' appendat='DirectoryIndex' regexp='DirectoryIndex.*index.php' state='present'\\\"
 """
    
 
@@ -120,7 +138,7 @@ def check_file_attrs(module, changed, message):
 
     return [ message, changed ]
 
-def present(module, dest, regexp, line, insertafter, insertbefore, create, backup):
+def present(module, dest, regexp, line, insertafter, insertbefore, prependat, appendat, create, backup):
 
     if os.path.isdir(dest):
         module.fail_json(rc=256, msg='Destination %s is a directory !' % dest)
@@ -140,18 +158,27 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create, backu
 
     mre = re.compile(regexp)
     if not mre.search(line):
-        module.fail_json(msg="usage error: line= doesn't match regexp (%s)" % regexp)
+        if prependat is None and appendat is None:
+            module.fail_json(msg="usage error: line= doesn't match regexp (%s)" % regexp)
+        else:
+            # Hard to say - leave and see
+            ''
     
     if insertafter is not None and insertafter not in ('BOF', 'EOF'):
         insre = re.compile(insertafter)
     elif insertbefore is not None and insertbefore not in ('BOF'):
         insre = re.compile(insertbefore)
+    elif prependat is not None:
+        insre = re.compile(prependat)
+    elif appendat is not None:
+        insre = re.compile(appendat)
     else:
         insre = None
 
     # index[0] is the line num where regexp has been found
     # index[1] is the line num where insertafter/inserbefore has been found
-    index = [-1, -1]
+    # index[2] is the line num where appendat/prependat has been found
+    index = [-1, -1, -1]
     for lineno in range(0, len(lines)):
         if mre.search(lines[lineno]):
             index[0] = lineno
@@ -162,21 +189,46 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create, backu
             if insertbefore:
                 # + 1 for the previous line
                 index[1] = lineno
+            if prependat:
+                index[2] = lineno
+            if appendat:
+                index[2] = lineno
 
     # Regexp matched a line in the file
     if index[0] != -1:
-        if lines[index[0]] == line + os.linesep:
+        if prependat is not None:
+	    # Text already present, do nothing
+            msg = ''
+            changed = False
+        elif appendat is not None:
+	    # Text already present, do nothing
             msg = ''
             changed = False
         else:
-            lines[index[0]] = line + os.linesep
-            msg = 'line replaced'
-            changed = True
+            if lines[index[0]] == line + os.linesep:
+                msg = ''
+                changed = False
+            else:
+                lines[index[0]] = line + os.linesep
+                msg = 'line replaced'
+                changed = True
     # Add it to the beginning of the file
     elif insertbefore == 'BOF' or insertafter == 'BOF':
         lines.insert(0, line + os.linesep)
         msg = 'line added'
         changed = True
+    # Append/prepend at the line the appendat/prependat regex was found
+    elif index[2] != -1:
+        if prependat is not None:
+             # Prepend to start of line
+             lines[index[2]] = line + lines[index[2]]
+             msg = 'text prepended'
+             changed = True
+	else:
+             # Append at end of line
+             lines[index[2]] = lines[index[2]].rstrip() + line + os.linesep
+             msg = 'text appended'
+             changed = True
     # Add it to the end of the file if requested or
     # if insertafter=/insertbefore didn't match anything
     # (so default behaviour is to add at the end)
@@ -246,10 +298,12 @@ def main():
             line=dict(aliases=['value']),
             insertafter=dict(default=None),
             insertbefore=dict(default=None),
+            appendat=dict(default=None),
+            prependat=dict(default=None),
             create=dict(default=False, type='bool'),
             backup=dict(default=False, type='bool'),
         ),
-        mutually_exclusive = [['insertbefore', 'insertafter']],
+        mutually_exclusive = [['insertbefore', 'insertafter', 'prependat', 'appendat']],
         add_file_common_args = True,
         supports_check_mode = True
     )
@@ -263,7 +317,9 @@ def main():
         if 'line' not in params:
             module.fail_json(msg='line= is required with state=present')
         present(module, dest, params['regexp'], params['line'],
-                params['insertafter'], params['insertbefore'], create, backup)
+                params['insertafter'], params['insertbefore'], 
+                params['prependat'], params['appendat'], 
+		create, backup)
     else:
         absent(module, dest, params['regexp'], backup)
 


### PR DESCRIPTION
Add 'appendat' and 'prependat', which take regular expressions similar
to 'insertbefore' and 'insertafter'. When matched, the text in 'line'
is appended/prepended to the end/start of the matching line.

This allows to modify a line without fully duplicating its contents
in an ansible playbook.

Examples:
1) Comment out the 'root' user in /etc/passwd:

   lineinfile: dest='/etc/passwd' line='#' prependat='^root:'
    regexp='^#root:' state='present'

2) For Apache, also display index.php files:

   lineinfile: dest='/usr/pkg/etc/httpd/httpd.conf' line=' index.php'
    appendat='DirectoryIndex' regexp='DirectoryIndex.*index.php'
    state='present'

In both examples, the whole contents of the line are not included
in the playbook.
