### PR TITLE
Service command handling fix when no upstart config file

### DIFF
--- a/library/service
+++ b/library/service
@@ -283,7 +283,7 @@ class Service(object):
         RCFILE = open(self.rcconf_file, "r")
         new_rc_conf = []
 
-        # Build a list containing the possibly modified file. 
+        # Build a list containing the possibly modified file.
         for rcline in RCFILE:
             # Parse line removing whitespaces, quotes, etc.
             rcarray = shlex.split(rcline, comments=True)
@@ -294,7 +294,7 @@ class Service(object):
                         # Since the proper entry already exists we can stop iterating.
                         changed = False
                         break
-                    else: 
+                    else:
                         # We found the key but the value is wrong, replace with new entry.
                         rcline = entry
                         changed = True
@@ -363,14 +363,17 @@ class LinuxService(Service):
         elif location.get('update-rc.d', None) and os.path.exists("/etc/init/%s.conf" % self.name):
             # service is managed by upstart
             self.enable_cmd = location['update-rc.d']
+        elif location.get('update-rc.d', None) and os.path.exists("/etc/init.d/%s" % self.name):
+            # service is managed by with SysV init scripts, but with update-rc.d
+            self.enable_cmd = location['update-rc.d']
         elif location.get('systemctl', None):
-            
+
             # verify service is managed by systemd
             rc, out, err = self.execute_command("%s --all" % (location['systemctl']))
             look_for = "%s.service" % self.name
             if look_for in out:
                 self.enable_cmd = location['systemctl']
-       
+
         # Locate a tool for runtime service management (start, stop etc.)
         self.svc_cmd = ''
         if location.get('service', None) and os.path.exists("/etc/init.d/%s" % self.name):
@@ -512,7 +515,7 @@ class LinuxService(Service):
                 # systemd commands take the form <cmd> <action> <name>
                 svc_cmd = self.svc_cmd
                 self.arguments = "%s %s" % (self.name, self.arguments)
-        elif self.svc_initscript: 
+        elif self.svc_initscript:
             # upstart
             svc_cmd = "%s" % self.svc_initscript
 
@@ -531,7 +534,7 @@ class LinuxService(Service):
             else:
                 # SysV or systemd
                 rc1, stdout1, stderr1 = self.execute_command("%s %s %s" % ('stop', self.name, self.arguments), daemonize=True)
-            
+
             if svc_cmd != '':
                 # upstart
                 rc2, stdout2, stderr2 = self.execute_command("%s %s %s" % (svc_cmd, 'start', self.arguments), daemonize=True)
@@ -587,7 +590,7 @@ class FreeBsdService(Service):
         for rcfile in rcfiles:
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
-        
+
         self.rcconf_key = "%s_enable" % self.name
 
         # FIXME: detect the enablement state rather than just running the command
@@ -681,7 +684,7 @@ class NetBsdService(Service):
         for rcfile in rcfiles:
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
-        
+
         self.rcconf_key = "%s" % self.name
 
         return self.service_enable_rcconf()
@@ -764,10 +767,10 @@ def main():
     if service.module.params['enabled']:
         result['enabled'] = service.module.params['enabled']
 
-    if not service.module.params['state']: 
+    if not service.module.params['state']:
         status = service.get_service_status()
         if status is None:
-            result['state'] = 'absent' 
+            result['state'] = 'absent'
         elif status is False:
             result['state'] = 'started'
         else:


### PR DESCRIPTION
Fixed the service command not working

On Ubuntu 1[02].04 the service name was not recognized because
there is a SysV style init script, but not an upstart config file.

Example: The `ntp` client.

Also removed extra spaces at the end of the lines, while at it.
