### PR TITLE
Allow specifying args directly to actions using module: syntax

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -379,7 +379,8 @@ class AnsibleModule(object):
             return changed
         try:
             # FIXME: support English modes
-            mode = int(mode, 8)
+            if not isinstance(mode, int):
+                mode = int(mode, 8)
         except Exception, e:
             self.fail_json(path=path, msg='mode needs to be something octalish', details=str(e))
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -115,6 +115,14 @@ class Task(object):
             self.delegate_to = ds.get('delegate_to', None)
             self.transport   = ds.get('connection', ds.get('transport', play.transport))
 
+        if isinstance(self.action, dict):
+            if 'module' not in self.action:
+                raise errors.AnsibleError("'module' attribute missing from action in task \"%s\"" % ds.get('name', '%s' % self.action))
+            if self.args:
+                raise errors.AnsibleError("'args' cannot be combined with dict 'action' in task \"%s\"" % ds.get('name', '%s' % self.action))
+            self.args = self.action
+            self.action = self.args.pop('module')
+
         # delegate_to can use variables
         if not (self.delegate_to is None):
             # delegate_to: localhost should use local transport

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -47,6 +47,13 @@ class Task(object):
             if x in utils.plugins.module_finder:
                 if 'action' in ds:
                     raise errors.AnsibleError("multiple actions specified in task %s" % (ds.get('name', ds['action'])))
+                if isinstance(ds[x], dict):
+                    if 'args' in ds:
+                        raise errors.AnsibleError("can't combine args: and a dict for %s: in task %s" % (x, ds.get('name', "%s: %s" % (x, ds[x]))))
+                    ds['args'] = ds[x]
+                    ds[x] = ''
+                elif ds[x] is None:
+                    ds[x] = ''
                 if not isinstance(ds[x], basestring):
                     raise errors.AnsibleError("action specified for task %s has invalid type %s" % (ds.get('name', "%s: %s" % (x, ds[x])), type(ds[x])))
                 ds['action'] = x + " " + ds[x]

--- a/lib/ansible/runner/action_plugins/add_host.py
+++ b/lib/ansible/runner/action_plugins/add_host.py
@@ -39,7 +39,10 @@ class ActionModule(object):
         if self.runner.check:
             return ReturnData(conn=conn, comm_ok=True, result=dict(skipped=True, msg='check mode not supported for this module'))
 
-        args = parse_kv(module_args)
+        args = {}
+        if complex_args:
+            args.update(complex_args)
+        args.update(parse_kv(module_args))
         if not 'hostname' in args and not 'name' in args:
             raise ae("'name' is a required argument.")
 

--- a/lib/ansible/runner/action_plugins/async.py
+++ b/lib/ansible/runner/action_plugins/async.py
@@ -33,7 +33,7 @@ class ActionModule(object):
             module_name = 'command'
             module_args += " #USE_SHELL"
 
-        (module_path, is_new_style, shebang) = self.runner._copy_module(conn, tmp, module_name, module_args, inject)
+        (module_path, is_new_style, shebang) = self.runner._copy_module(conn, tmp, module_name, module_args, inject, complex_args=complex_args)
         self.runner._low_level_exec_command(conn, "chmod a+rx %s" % module_path, tmp)
 
         return self.runner._execute_module(conn, tmp, 'async_wrapper', module_args,

--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -32,7 +32,10 @@ class ActionModule(object):
         ''' handler for file transfer operations '''
 
         # load up options
-        options = utils.parse_kv(module_args)
+        options = {}
+        if complex_args:
+            options.update(complex_args)
+        options.update(utils.parse_kv(module_args))
         source  = options.get('src', None)
         dest    = options.get('dest', None)
 
@@ -93,7 +96,7 @@ class ActionModule(object):
 
             # run the copy module
             module_args = "%s src=%s" % (module_args, tmp_src)
-            return self.runner._execute_module(conn, tmp, 'copy', module_args, inject=inject)
+            return self.runner._execute_module(conn, tmp, 'copy', module_args, inject=inject, complex_args=complex_args)
 
         else:
             # no need to transfer the file, already correct md5, but still need to call
@@ -103,7 +106,7 @@ class ActionModule(object):
             module_args = "%s src=%s" % (module_args, tmp_src)
             if self.runner.check:
                 module_args = "%s CHECKMODE=True" % module_args
-            return self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject)
+            return self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject, complex_args=complex_args)
 
     def _get_diff_data(self, conn, tmp, inject, destination, source):
         peek_result = self.runner._execute_module(conn, tmp, 'file', "path=%s diff_peek=1" % destination, inject=inject, persist_files=True)

--- a/lib/ansible/runner/action_plugins/debug.py
+++ b/lib/ansible/runner/action_plugins/debug.py
@@ -29,7 +29,10 @@ class ActionModule(object):
         self.runner = runner
 
     def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
-        args = utils.parse_kv(module_args)
+        args = {}
+        if complex_args:
+            args.update(complex_args)
+        args.update(utils.parse_kv(module_args))
         if not 'msg' in args:
             args['msg'] = 'Hello world!'
 

--- a/lib/ansible/runner/action_plugins/fail.py
+++ b/lib/ansible/runner/action_plugins/fail.py
@@ -33,7 +33,10 @@ class ActionModule(object):
         # note: the fail module does not need to pay attention to check mode
         # it always runs.
 
-        args = utils.parse_kv(module_args)
+        args = {}
+        if complex_args:
+            args.update(complex_args)
+        args.update(utils.parse_kv(module_args))
         if not 'msg' in args:
             args['msg'] = 'Failed as requested from task'
 

--- a/lib/ansible/runner/action_plugins/fetch.py
+++ b/lib/ansible/runner/action_plugins/fetch.py
@@ -40,7 +40,10 @@ class ActionModule(object):
             return ReturnData(conn=conn, comm_ok=True, result=dict(skipped=True, msg='check mode not (yet) supported for this module'))
 
         # load up options
-        options = utils.parse_kv(module_args)
+        options = {}
+        if complex_args:
+            options.update(complex_args)
+        options.update(utils.parse_kv(module_args))
         source = options.get('src', None)
         dest = options.get('dest', None)
         if source is None or dest is None:

--- a/lib/ansible/runner/action_plugins/group_by.py
+++ b/lib/ansible/runner/action_plugins/group_by.py
@@ -37,7 +37,10 @@ class ActionModule(object):
         # the group_by module does not need to pay attention to check mode.
         # it always runs.
 
-        args = parse_kv(self.runner.module_args)
+        args = {}
+        if complex_args:
+            args.update(complex_args)
+        args.update(utils.parse_kv(module_args))
         if not 'key' in args:
             raise ae("'key' is a required argument.")
 

--- a/lib/ansible/runner/action_plugins/pause.py
+++ b/lib/ansible/runner/action_plugins/pause.py
@@ -53,7 +53,10 @@ class ActionModule(object):
         # flag, it always runs
 
         hosts = ', '.join(self.runner.host_set)
-        args = parse_kv(template(self.runner.basedir, module_args, inject))
+        args = {}
+        if complex_args:
+            args.update(complex_args)
+        args.update(parse_kv(template(self.runner.basedir, module_args, inject)))
 
         # Are 'minutes' or 'seconds' keys that exist in 'args'?
         if 'minutes' in args or 'seconds' in args:

--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -37,7 +37,10 @@ class ActionModule(object):
             raise errors.AnsibleError("in current versions of ansible, templates are only usable in playbooks")
 
         # load up options
-        options  = utils.parse_kv(module_args)
+        options  = {}
+        if complex_args:
+            options.update(complex_args)
+        options.update(utils.parse_kv(module_args))
         source   = options.get('src', None)
         dest     = options.get('dest', None)
 
@@ -106,9 +109,9 @@ class ActionModule(object):
             if self.runner.check:
                 return ReturnData(conn=conn, comm_ok=True, result=dict(changed=True), diff=dict(before_header=dest, after_header=source, before=dest_contents, after=resultant))
             else:
-                res = self.runner._execute_module(conn, tmp, 'copy', module_args, inject=inject)
+                res = self.runner._execute_module(conn, tmp, 'copy', module_args, inject=inject, complex_args=complex_args)
                 res.diff = dict(before=dest_contents, after=resultant)
                 return res
         else:
-            return self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject)
+            return self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject, complex_args=complex_args)
 


### PR DESCRIPTION
Makes things like

```
- name: do complex things with complex module
  complex:
    setting_a: true
    setting_b:
    - foo
    - bar
```

possible.

Fixes #2228.
