### PR TITLE
Add mysql user documentation about idempotent playbooks

### DIFF
--- a/library/mysql_user
+++ b/library/mysql_user
@@ -81,6 +81,12 @@ notes:
      passing credentials. If none are present, the module will attempt to read
      the credentials from C(~/.my.cnf), and finally fall back to using the MySQL
      default login of 'root' with no password.
+   - MySQL server installs with default login_user of 'root' and no password. To secure this user
+     as part of an idempotent playbook, you must create at least two tasks: the first must change the root user's password,
+     without providing any login_user/login_password details. The second must drop a ~/.my.cnf file containing
+     the new root credentials. Subsequent runs of the playbook will then succeed by reading the new credentials from
+     the file.
+
 requirements: [ "ConfigParser", "MySQLdb" ]
 author: Mark Theunissen
 '''


### PR DESCRIPTION
Does the postgres module have similar requirements? Perhaps this documentation should be generalized and placed somewhere as a best practice? 
