### PR TITLE
Fix bug from copy-paste

### DIFF
--- a/library/mysql_user
+++ b/library/mysql_user
@@ -298,7 +298,7 @@ def main():
             login_password = ""
         else:
             login_user = mycnf_creds["user"]
-            login_password = mycnf_creds["password"]
+            login_password = mycnf_creds["passwd"]
     elif login_password is None or login_user is None:
         module.fail_json(msg="when supplying login arguments, both login_user and login_password must be provided")
 


### PR DESCRIPTION
I made this branch to fix logging of passwords in syslog, as mentioned in the previous pull request, but I found that this happens automatically:

```
Feb 28 19:54:52 ansible-dev ansible-.ansible_module_generated: Invoked with login_user=None login_host=localhost host=localhost login_unix_socket=None state=present user=mark login_password=NOT_LOGGING_PASSWORD password=NOT_LOGGING_PASSWORD priv=None
```

However, in testing this, I discovered a bug that was introduced by my last PR. I modified the function `load_mycnf()` in `mysql_db` and tested it, then copied the modified function to `mysql_user`, because hey... they're identical, right? Well, not really... turns out someone had modified the name of the internal variable that holds the password _in only one of the mysql modules_, thus, the assumption that the shared code is equal no longer held.

This is definitely the problem with not allowing modules to actually share code, and having duplicate copies of functions. Not really sure how to fix this, but if there is some Python magic that can be used we should consider it, because errors like this are bound to creep in.
