### PR TITLE
Adding run_in_check_mode parameter to run_command helper

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -775,19 +775,21 @@ class AnsibleModule(object):
                 self.set_context_if_different(src, context, False)
         os.rename(src, dest)
 
-    def run_command(self, args, check_rc=False, close_fds=False, executable=None, data=None, run_in_check_mode=True):
+    def run_command(self, args, check_rc=False, close_fds=False, executable=None, data=None, check_mode=True):
         '''
         Execute a command, returns rc, stdout, and stderr.
         args is the command to run
         If args is a list, the command will be run with shell=False.
         Otherwise, the command will be run with shell=True when args is a string.
         Other arguments:
-        - check_rc (boolean)  Whether to call fail_json in case of
-                              non zero RC.  Default is False.
-        - close_fds (boolean) See documentation for subprocess.Popen().
-                              Default is False.
-        - executable (string) See documentation for subprocess.Popen().
-                              Default is None.
+        - check_rc (boolean)   Whether to call fail_json in case of
+                               non zero RC.  Default is False.
+        - close_fds (boolean)  See documentation for subprocess.Popen().
+                               Default is False.
+        - executable (string)  See documentation for subprocess.Popen().
+                               Default is None.
+        - check_mode (boolean) Whether to run command when in check_mode
+                               Default is True
         '''
         if isinstance(args, list):
             shell = False
@@ -797,7 +799,7 @@ class AnsibleModule(object):
             msg = "Argument 'args' to run_command must be list or string"
             self.fail_json(rc=257, cmd=args, msg=msg)
 
-        if self.check_mode and not run_in_check_mode:
+        if self.check_mode and not check_mode:
             return (0, list(), list())
 
         rc = 0

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -800,7 +800,7 @@ class AnsibleModule(object):
             self.fail_json(rc=257, cmd=args, msg=msg)
 
         if self.check_mode and not check_mode:
-            return (0, list(), list())
+            return (0, '', '')
 
         rc = 0
         msg = None

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -775,7 +775,7 @@ class AnsibleModule(object):
                 self.set_context_if_different(src, context, False)
         os.rename(src, dest)
 
-    def run_command(self, args, check_rc=False, close_fds=False, executable=None, data=None):
+    def run_command(self, args, check_rc=False, close_fds=False, executable=None, data=None, run_in_check_mode=True):
         '''
         Execute a command, returns rc, stdout, and stderr.
         args is the command to run
@@ -796,6 +796,10 @@ class AnsibleModule(object):
         else:
             msg = "Argument 'args' to run_command must be list or string"
             self.fail_json(rc=257, cmd=args, msg=msg)
+
+        if self.check_mode and not run_in_check_mode:
+            return (0, list(), list())
+
         rc = 0
         msg = None
         st_in = None

--- a/library/rabbitmq_plugin
+++ b/library/rabbitmq_plugin
@@ -56,12 +56,10 @@ class RabbitMqPlugins(object):
         self.module = module
         self._rabbitmq_plugins = module.get_bin_path('rabbitmq-plugins', True)
 
-    def _exec(self, args, run_in_check_mode=False):
-        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._rabbitmq_plugins]
-            rc, out, err = self.module.run_command(cmd + args, check_rc=True)
-            return out.splitlines()
-        return list()
+    def _exec(self, args, check_mode=False):
+        cmd = [self._rabbitmq_plugins]
+        rc, out, err = self.module.run_command(cmd + args, check_rc=True, check_mode=check_mode)
+        return out.splitlines()
 
     def get_all(self):
         return self._exec(['list', '-E', '-m'], True)

--- a/library/rabbitmq_user
+++ b/library/rabbitmq_user
@@ -108,12 +108,10 @@ class RabbitMqUser(object):
         self._permissions = None
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
 
-    def _exec(self, args, run_in_check_mode=False):
-        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._rabbitmqctl, '-q']
-            rc, out, err = self.module.run_command(cmd + args, check_rc=True)
-            return out.splitlines()
-        return list()
+    def _exec(self, args, check_mode=False):
+        cmd = [self._rabbitmqctl, '-q']
+        rc, out, err = self.module.run_command(cmd + args, check_rc=True, check_mode=check_mode)
+        return out.splitlines()
 
     def get(self):
         users = self._exec(['list_users'], True)

--- a/library/rabbitmq_vhost
+++ b/library/rabbitmq_vhost
@@ -58,12 +58,10 @@ class RabbitMqVhost(object):
         self._tracing = False
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
 
-    def _exec(self, args, run_in_check_mode=False):
-        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._rabbitmqctl, '-q']
-            rc, out, err = self.module.run_command(cmd + args, check_rc=True)
-            return out.splitlines()
-        return list()
+    def _exec(self, args, check_mode=False):
+        cmd = [self._rabbitmqctl, '-q']
+        rc, out, err = self.module.run_command(cmd + args, check_rc=True, check_mode=check_mode)
+        return out.splitlines()
 
     def get(self):
         vhosts = self._exec(['list_vhosts', 'name', 'tracing'], True)


### PR DESCRIPTION
In using commands quite a bit in modules, I kept on writing boilerplate check mode logic to only run certain commands when check_mode is enabled.  This moves this logic into the core helper function.
