### PR TITLE
Use opkg module as basis for macports module

### DIFF
--- a/library/macports
+++ b/library/macports
@@ -1,0 +1,148 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Jimmy Tang <jcftang@gmail.com>
+# Based on okpg (Patrick Pelletier <pp.pelletier@gmail.com>), pacman
+# (Afterburn) and pkgin (Shaun Zinck) modules
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: macports
+author: Jimmy Tang
+short_description: Package manager for MacPorts
+description:
+    - Manages MacPorts packages
+version_added: "1.1"
+options:
+    name:
+        description:
+            - name of package to install/remove
+        required: true
+    state:
+        description:
+            - state of the package
+        choices: [ 'present', 'absent' ]
+        required: false
+        default: present
+    update_cache:
+        description:
+            - update the package db first
+        required: false
+notes:  []
+'''
+EXAMPLES = '''
+macports: name=foo state=present
+macports: name=foo state=present update_cache=yes
+macports: name=foo state=absent
+macports: name=foo,bar state=absent
+'''
+
+
+def update_package_db(module, port_path):
+    """ Updates packages list. """
+
+    rc, out, err = module.run_command("%s sync" % port_path)
+
+    if rc != 0:
+        module.fail_json(msg="could not update package db")
+
+
+def query_package(module, port_path, name, state="present"):
+    """ Returns whether a package is installed or not. """
+
+    if state == "present":
+
+        rc, out, err = module.run_command("%s installed | grep -q ^.*%s" % (port_path, name))
+        if rc == 0:
+            return True
+
+        return False
+
+
+def remove_packages(module, port_path, packages):
+    """ Uninstalls one or more packages if installed. """
+
+    remove_c = 0
+    # Using a for loop incase of error, we can report the package that failed
+    for package in packages:
+        # Query the package first, to see if we even need to remove
+        if not query_package(module, port_path, package):
+            continue
+
+        rc, out, err = module.run_command("%s uninstall %s" % (port_path, package))
+
+        if query_package(module, port_path, package):
+            module.fail_json(msg="failed to remove %s: %s" % (package, out))
+
+        remove_c += 1
+
+    if remove_c > 0:
+
+        module.exit_json(changed=True, msg="removed %s package(s)" % remove_c)
+
+    module.exit_json(changed=False, msg="package(s) already absent")
+
+
+def install_packages(module, port_path, packages):
+    """ Installs one or more packages if not already installed. """
+
+    install_c = 0
+
+    for package in packages:
+        if query_package(module, port_path, package):
+            continue
+
+        rc, out, err = module.run_command("%s install %s" % (port_path, package))
+
+        if not query_package(module, port_path, package):
+            module.fail_json(msg="failed to install %s: %s" % (package, out))
+
+        install_c += 1
+
+    if install_c > 0:
+        module.exit_json(changed=True, msg="installed %s package(s)" % (install_c))
+
+    module.exit_json(changed=False, msg="package(s) already present")
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name = dict(aliases=["pkg"], required=True),
+            state = dict(default="present", choices=["present", "installed", "absent", "removed"]),
+            update_cache = dict(default="no", aliases=["update-cache"], type='bool')
+        )
+    )
+
+    port_path = module.get_bin_path('port', True, ['/opt/local/bin'])
+
+    p = module.params
+
+    if p["update_cache"]:
+        update_package_db(module, port_path)
+
+    pkgs = p["name"].split(",")
+
+    if p["state"] in ["present", "installed"]:
+        install_packages(module, port_path, pkgs)
+
+    elif p["state"] in ["absent", "removed"]:
+        remove_packages(module, port_path, pkgs)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+
+main()


### PR DESCRIPTION
This module is pretty simplistic, it is derived from the opkg module. It is
also named dports (as the command is 'port'). The reason for prefixing the
module with 'd' is so that it is not confused with the *BSD port systems and
the commands that they might have.

Installation of packages work, uninstallation is hit or miss as macports doesn't uninstall dependant packages; this is to prevent users from shooting themselves when uninstalling things.

Things to follow after this commit might include
- renaming the module if needed
- add activate/deactivate states
- add a "uninstall inactive" command/alias/state to purge all present and deactivated packages

perhaps a re-factoring of the other modules and this one as this module is derived from a derived module?
