### PR TITLE
Add support for a no_change option in command module

### DIFF
--- a/library/command
+++ b/library/command
@@ -65,11 +65,18 @@ options:
     required: false
     default: null
     version_added: "0.9"
+  no_change:
+    description:
+      - if set to yes, force the returned "changed" status to false
+    version_added: "1.1"
+    required: false
+    default: no
+    choices: ['yes', 'no']
 examples:
    - code: "command: /sbin/shutdown -t now"
      description: "Example from Ansible Playbooks"
    - code: "command: /usr/bin/make_database.sh arg1 arg2 creates=/path/to/database"
-     description: "C(creates), C(removes), and C(chdir) can be specified after the command. For instance, if you only want to run a command if a certain file does not exist, use this."
+     description: "C(creates), C(removes), C(no_change), and C(chdir) can be specified after the command. For instance, if you only want to run a command if a certain file does not exist, use this."
 notes:
     -  If you want to run a command through the shell (say you are using C(<),
        C(>), C(|), etc), you actually want the M(shell) module instead. The
@@ -88,6 +95,7 @@ def main():
     chdir = module.params['chdir']
     executable = module.params['executable']
     args  = module.params['args']
+    no_change = module.params['no_change']
 
     if args.strip() == '':
         module.fail_json(rc=256, msg="no command given")
@@ -117,7 +125,7 @@ def main():
         start   = str(startd),
         end     = str(endd),
         delta   = str(delta),
-        changed = True
+        changed = not no_change
     )
 
 # include magic from lib/ansible/module_common.py
@@ -141,11 +149,12 @@ class CommandModule(AnsibleModule):
         params['chdir'] = None
         params['shell'] = False
         params['executable'] = None
+        params['no_change'] = False
         if args.find("#USE_SHELL") != -1:
             args = args.replace("#USE_SHELL", "")
             params['shell'] = True
 
-        r = re.compile(r'(^|\s)(creates|removes|chdir|executable)=(?P<quote>[\'"])?(.*?)(?(quote)(?<!\\)(?P=quote))((?<!\\)(?=\s)|$)')
+        r = re.compile(r'(^|\s)(creates|removes|chdir|executable|no_change)=(?P<quote>[\'"])?(.*?)(?(quote)(?<!\\)(?P=quote))((?<!\\)(?=\s)|$)')
         for m in r.finditer(args):
             v = m.group(4).replace("\\", "")
             if m.group(2) == "creates":
@@ -190,6 +199,13 @@ class CommandModule(AnsibleModule):
                 elif v[0] != '/':
                     self.fail_json(rc=259, msg="the path for 'executable' argument must be fully qualified")
                 params['executable'] = v
+            elif m.group(2) == "no_change":
+                if v in ['yes', 'Yes', 'true', 'True']:
+                    params['no_change'] = True
+                elif v in ['no', 'No', 'false', 'False']:
+                    params['no_change'] = False
+                else:
+                    self.fail_json(rc=260, msg="unsupported value '%s' for no_change" %v)
         args = r.sub("", args)
         params['args'] = args
         return (params, params['args'])


### PR DESCRIPTION
A new argument `no_change=yes` can be passed to the command module which forces a return status of `changed=False`.
This is useful for commands you are sure are not going to modify anything and in combination with register. For example:

```
- action: command ls / no_change=yes
  register: root_files

#do something with ${root_files.stdout}. ex: templates...
```
