### PR TITLE
Added django_manage command=raw with raw_command and raw_args parameters

### DIFF
--- a/library/django_manage
+++ b/library/django_manage
@@ -28,9 +28,9 @@ description:
 version_added: "1.1"
 options:
   command:
-    choices: [ 'cleanup', 'flush', 'loaddata', 'runfcgi', 'syncdb', 'test', 'validate' ]
+    choices: [ 'cleanup', 'flush', 'loaddata', 'raw', 'syncdb', 'test', 'validate', ]
     description:
-      - The name of the Django management command to run. Allowed commands are cleanup, createcachetable, flush, loaddata, syncdb, test, validate.
+      - The name of the Django management command to run. Allowed commands are cleanup, createcachetable, flush, loaddata, raw, syncdb, test, validate.
     required: true
   app_path:
     description:
@@ -68,6 +68,14 @@ options:
     description:
       - A space-delimited list of fixture file names to load in the database. B(Required) by the 'loaddata' command.
     required: false
+  raw_command:
+    description:
+      - Any valid manage.py command, if the 'raw' command is used. The I(pythonpath), I(settings) and I(virtualenv) parameters will also be used for a raw command if provided.
+    required: false
+  raw_args:
+    description:
+      - If the 'raw' command is used, the contents of this parameter are appended to the manage.py command line.
+    required: false
 notes:
    - U(http://www.virtualenv.org/, virtualenv) must be installed on the remote host if the virtualenv parameter is specified.
    - This module will create a virtualenv if the virtualenv parameter is specified and a virtualenv does not already exist at the given location.
@@ -83,7 +91,7 @@ django_manage: command=cleanup app_path=$django_dir
 # Load the $initial_data fixture into the application
 django_manage: command=loaddata app_path=$django_dir fixtures=$initial_data
 
-#Run syncdb on the application
+# Run syncdb on the application
 django_manage: >
     command=syncdb 
     app_path=$django_dir 
@@ -92,8 +100,18 @@ django_manage: >
     virtualenv=$virtualenv_dir 
     database=$mydb
 
-#Run the SmokeTest test case from the main app. Useful for testing deploys.
-django_manage command=test app_path=django_dir apps=main.SmokeTest
+# Run the SmokeTest test case from the main app. Useful for testing deploys.
+django_manage: command=test app_path=django_dir apps=main.SmokeTest
+
+# Run the Django South migration command as a raw command
+# Generates the command "manage.py migrate --settings=$settings_app_name --pythonpath=$settings_dir myapp --no-initial-data
+django_manage: >
+    command=raw
+    settings=$settings_app_name
+    pythonpath=$settings_dir
+    virtualenv=$virtualenv_dir 
+    raw_command="migrate"
+    raw_args="myapp --no-initial-data"
 """
 
 
@@ -109,7 +127,6 @@ def _fail(module, cmd, out, err, **kwargs):
 
 
 def _ensure_virtualenv(module):
-
     venv_param = module.params['virtualenv']
     if venv_param is None:
         return
@@ -146,14 +163,16 @@ def main():
         createcachetable=('cache_table', 'database', ),
         flush=('database', ),
         loaddata=('database', 'fixtures', ),
+        raw=('raw_args', 'raw_command', ),
         syncdb=('database', ),
         test=('failfast', 'testrunner', 'liveserver', 'apps', ),
         validate=(),
         )
 
     command_required_param_map = dict(
-        loaddata=('fixtures', ),
         createcachetable=('cache_table', ),
+        loaddata=('fixtures', ),
+        raw=('raw_command', ),
         )
 
     # forces --noinput on every command that needs it
@@ -164,12 +183,12 @@ def main():
         )
 
     # These params are allowed for certain commands only
-    specific_params = ('apps', 'database', 'failfast', 'fixtures', 'liveserver', 'testrunner', )
+    specific_params = ('apps', 'database', 'failfast', 'fixtures', 'liveserver', 'raw_args', 'raw_command', 'testrunner', )
 
     # These params are automatically added to the command if present
     general_params = ('settings', 'pythonpath', )
     specific_boolean_params = ('failfast', )
-    end_of_command_params = ('apps', 'cache_table', 'fixtures', )
+    end_of_command_params = ('apps', 'cache_table', 'fixtures', 'raw_args', )
 
     module = AnsibleModule(
         argument_spec=dict(
@@ -185,6 +204,8 @@ def main():
             failfast    = dict(default='no', required=False, choices=BOOLEANS, aliases=['fail_fast']),
             fixtures    = dict(default=None, required=False),
             liveserver  = dict(default=None, required=False, aliases=['live_server']),
+            raw_args    = dict(default=None, required=False),
+            raw_command = dict(default=None, required=False),
             testrunner  = dict(default=None, required=False, aliases=['test_runner']),
         ),
     )
@@ -207,6 +228,9 @@ def main():
     venv = module.params['virtualenv']
 
     _ensure_virtualenv(module)
+
+    if command == 'raw':
+        command = module.params['raw_command']
 
     os.chdir(app_path)
     cmd = "python manage.py %s" % (command, )


### PR DESCRIPTION
Allows any command, wrapped in the virtualenv, pythonpath, app_path, and settings magic of the rest. This will give it some future proofing.

I'm using it for South commands for the moment until I get a little time to write an actual version. I'm thinking a separate django_south module because it's more capable of going state/idempotent than manage.py is. South has commands to introspect the current state of a migration before doing anything, unlike manage.py in general.
