### PR TITLE
Added a proxy and a use_proxy option to get_url

### DIFF
--- a/library/get_url
+++ b/library/get_url
@@ -56,12 +56,25 @@ options:
     choices: [ "yes", "no" ]
     default: "no"
     aliases: [ "thirsty" ]
+  use_proxy:
+    description:
+      - By default, if the C(proxy) option is not specified, and the
+        environment variable C(<protocol>_proxy) is set on the target host,
+        request will be sent through the proxy. To override this behaviour,
+        set C(use_proxy=no).
+    required: false
+    default: yes
+    choices: [yes, no]
+  proxy:
+    description:
+      - Sends requests through a proxy.
+    required: false
   others:
     description:
       - all arguments accepted by the M(file) module also work here
     required: false
 notes:
-    - This module doesn't yet support configuration for proxies.
+    - This module does not yet support authentication for proxies.
 # informational: requirements for nodes
 requirements: [ urllib2, urlparse ]
 author: Jan-Piet Mens
@@ -94,7 +107,7 @@ def url_filename(url):
         return 'index.html'
     return fn
 
-def url_do_get(module, url, dest):
+def url_do_get(module, url, dest, use_proxy, proxy):
     """
     Get url and return request and info
     Credits: http://stackoverflow.com/questions/7006574/how-to-download-file-from-ftp
@@ -103,7 +116,10 @@ def url_do_get(module, url, dest):
     USERAGENT = 'ansible-httpget'
     info = dict(url=url, dest=dest)
     r = None
+    handlers = []
+
     parsed = urlparse.urlparse(url)
+
     if '@' in parsed[1]:
         credentials, netloc = parsed[1].split('@', 1)
         if ':' in credentials:
@@ -123,12 +139,21 @@ def url_do_get(module, url, dest):
 
         authhandler = urllib2.HTTPBasicAuthHandler(passman)
         # create the AuthHandler
+        handlers.append(authhandler)
 
-        opener = urllib2.build_opener(authhandler)
-        urllib2.install_opener(opener)
         #reconstruct url without credentials
         url = urlparse.urlunparse(parsed)
 
+    if not use_proxy:
+        proxyhandler = urllib2.ProxyHandler({})
+        handlers.append(proxyhandler)
+    elif proxy is not None:
+        parsedproxy = urlparse.urlparse(proxy)
+        proxyhandler = urllib2.ProxyHandler({parsedproxy[0]: proxy})
+        handlers.append(proxyhandler)
+
+    opener = urllib2.build_opener(*handlers)
+    urllib2.install_opener(opener)
     request = urllib2.Request(url)
     request.add_header('User-agent', USERAGENT)
 
@@ -151,14 +176,14 @@ def url_do_get(module, url, dest):
 
     return r, info
 
-def url_get(module, url, dest):
+def url_get(module, url, dest, use_proxy, proxy):
     """
     Download url and store at dest.
     If dest is a directory, determine filename from url.
     Return (tempfile, info about the request)
     """
 
-    req, info = url_do_get(module, url, dest)
+    req, info = url_do_get(module, url, dest, use_proxy, proxy)
 
     # TODO: should really handle 304, but how? src file could exist (and be newer) but empty
     if info['status'] == 304:
@@ -195,7 +220,10 @@ def main():
         argument_spec = dict(
             url = dict(required=True),
             dest = dict(required=True),
-            force = dict(default='no', aliases=['thirsty'], type='bool')
+            force = dict(default='no', aliases=['thirsty'], type='bool'),
+            #use_proxy = dict(default='yes', choices=BOOLEANS, type='bool'),
+            use_proxy = dict(default='yes', type='bool'),
+            proxy = dict(default=None)
         ),
         add_file_common_args=True
     )
@@ -203,6 +231,8 @@ def main():
     url  = module.params['url']
     dest = os.path.expanduser(module.params['dest'])
     force = module.params['force']
+    use_proxy = module.params['use_proxy']
+    proxy = module.params['proxy']
 
     if os.path.isdir(dest):
         dest = os.path.join(dest, url_filename(url))
@@ -212,7 +242,7 @@ def main():
             module.exit_json(msg="file already exists", dest=dest, url=url, changed=False)
 
     # download to tmpsrc
-    tmpsrc, info = url_get(module, url, dest)
+    tmpsrc, info = url_get(module, url, dest, use_proxy, proxy)
     md5sum_src   = None
     md5sum_dest  = None
 


### PR DESCRIPTION
Note that I did not create the default behaviour of using the environment variable, this is a default in urllib2, and this happens with the current ansible get_url module, which is giving us troubles right now, hence this new option.
