### PR TITLE
Update get_url

### DIFF
--- a/library/get_url
+++ b/library/get_url
@@ -68,7 +68,7 @@ author: Jan-Piet Mens
 '''
 
 EXAMPLES='''
-get_url: url=http://example.com/path/file.conf dest=/etc/foo.conf mode=0440"
+get_url: url=http://example.com/path/file.conf dest=/etc/foo.conf mode=0440
 '''
 
 


### PR DESCRIPTION
Small syntactic correction: Removed trailing double-quote from example.
