### PR TITLE
Fixed example ansible.cfg

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -17,9 +17,10 @@ library = /usr/share/ansible
 module_name = command
 
 # home directory where temp files are stored on remote systems.  Should
-# almost always contain $HOME or be a directory writeable by all users
+# almost always contain home path or be a directory writeable by all users
+# do not use $HOME! use ~ sign instead
 
-remote_tmp = $HOME/.ansible/tmp
+remote_tmp = ~/.ansible/tmp
 
 # the default pattern for ansible-playbooks ("hosts:")
 


### PR DESCRIPTION
Python's config parser won't expand '$HOME'
but can expand '~' sign
