### PR TITLE
Teach makefile to accept different versions of python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ ASCII2MAN = a2x -D $(dir $@) -d manpage -f manpage $<
 ASCII2HTMLMAN = a2x -D docs/html/man/ -d manpage -f xhtml
 MANPAGES := docs/man/man1/ansible.1 docs/man/man1/ansible-playbook.1 docs/man/man1/ansible-pull.1 docs/man/man1/ansible-doc.1
 
-SITELIB = $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
+PYTHON=python
+SITELIB = $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
 
 # VERSION file provides one place to update the software version
 VERSION := $(shell cat VERSION)
@@ -114,13 +115,13 @@ clean:
 	rm -rf docs/js
 
 python:
-	python setup.py build
+	$(PYTHON) setup.py build
 
 install:
-	python setup.py install
+	$(PYTHON) setup.py install
 
 sdist: clean docs
-	python setup.py sdist -t MANIFEST.in
+	$(PYTHON) setup.py sdist -t MANIFEST.in
 
 rpmcommon: sdist
 	@mkdir -p rpm-build


### PR DESCRIPTION
This commit makes the Makefile nicer for packagers so they can select versions
of python. E.g. on a RHEL5 system with Python2.6 (installed from EPEL)

```
make PYTHON=python2.6 install
```
