### PR TITLE
Improve NetBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,11 @@ else
 ifeq ($(OS), Darwin)
 DATE := $(shell date -j -f "%Y-%m-%d %H:%M:%S"  "$(GIT_DATE)" +%Y%m%d%H%M)
 else
+ifeq ($(OS), NetBSD)
+DATE := $(shell date -j -d "$(GIT_DATE)" +%Y%m%d%H%M)
+else
 DATE := $(shell date --utc --date="$(GIT_DATE)" +%Y%m%d%H%M)
+endif
 endif
 endif
 

--- a/library/setup
+++ b/library/setup
@@ -604,9 +604,9 @@ class SunOSHardware(Hardware):
         self.facts['swap_allocated_mb'] = allocated / 1024
         self.facts['swap_reserved_mb'] = reserved / 1024
 
-class FreeBSDHardware(Hardware):
+class GenericBSDHardware(Hardware):
     """
-    FreeBSD-specific subclass of Hardware.  Defines memory and CPU facts:
+    This is a generic BSD subclass of Hardware.  Defines memory and CPU facts:
     - memfree_mb
     - memtotal_mb
     - swapfree_mb
@@ -616,7 +616,7 @@ class FreeBSDHardware(Hardware):
     - processor_count
     - devices
     """
-    platform = 'FreeBSD'
+    platform = 'Generic_BSD'
     DMESG_BOOT = '/var/run/dmesg.boot'
 
     def __init__(self):
@@ -693,6 +693,13 @@ class FreeBSDHardware(Hardware):
                 s = slices.match(device)
                 if s:
                     self.facts['devices'][d.group(1)].append(s.group(1))
+
+class FreeBSDHardware(GenericBSDHardware, Hardware):
+    """
+    This is the FreeBSD Hardware class.
+    It uses the GenericBSDHardware class unchanged.
+    """
+    platform = 'FreeBSD'
 
 class AIX(Hardware):
     """

--- a/library/setup
+++ b/library/setup
@@ -142,7 +142,9 @@ class Facts(object):
         elif Facts._I386RE.search(self.facts['machine']):
             self.facts['architecture'] = 'i386'
         else:
-            self.facts['architecture'] = self.facts['machine']
+            self.facts['architecture'] = platform.processor()
+	if self.facts['architecture'] == '':
+	    self.facts['architecture'] = self.facts['machine']
         if self.facts['system'] == 'Linux':
             self.get_distribution_facts()
         elif self.facts['system'] == 'AIX':

--- a/library/setup
+++ b/library/setup
@@ -634,7 +634,7 @@ class GenericBSDHardware(Hardware):
         rc, out, err = module.run_command("/sbin/sysctl -n hw.ncpu")
         self.facts['processor_count'] = out.strip()
 
-        dmesg_boot = get_file_content(FreeBSDHardware.DMESG_BOOT)
+        dmesg_boot = get_file_content(GenericBSDHardware.DMESG_BOOT)
         if not dmesg_boot:
             rc, dmesg_boot, err = module.run_command("/sbin/dmesg")
         for line in dmesg_boot.split('\n'):
@@ -700,6 +700,49 @@ class FreeBSDHardware(GenericBSDHardware, Hardware):
     It uses the GenericBSDHardware class unchanged.
     """
     platform = 'FreeBSD'
+
+class NetBSDHardware(GenericBSDHardware, Hardware):
+    """
+    This is the NetBSD Hardware class.
+    It uses the GenericBSDHardware class, with
+    the following methods overridden:
+
+    get_memory_facts()
+    get_device_facts()
+    """
+    platform = 'NetBSD'
+
+    def get_memory_facts(self):
+        rc, out, err = module.run_command("/usr/bin/vmstat -s")
+        for line in out.split('\n'):
+            data = line.split(None,1)
+	    if len(data) < 2:
+		continue
+            if data[1] == 'bytes per page':
+                pagesize = long(data[0])
+            if data[1] == 'pages managed':
+                pagecount = long(data[0])
+            if data[1] == 'pages free':
+                freecount = long(data[0])
+        self.facts['memtotal_mb'] = pagesize * pagecount / 1024 / 1024
+        self.facts['memfree_mb'] = pagesize * freecount / 1024 / 1024
+        # Get swapinfo.  swapinfo output looks like:
+        # Device          1M-blocks     Used    Avail Capacity
+        # /dev/ada0p3        314368        0   314368     0%
+        #
+        rc, out, err = module.run_command("/usr/sbin/pstat -sm")
+        lines = out.split('\n')
+        if len(lines[-1]) == 0:
+            lines.pop()
+        data = lines[-1].split()
+        self.facts['swaptotal_mb'] = data[1]
+        self.facts['swapfree_mb'] = data[3]
+
+    def get_device_facts(self):
+	rc, out, err = module.run_command("/sbin/sysctl -n hw.disknames")
+	self.facts['devices'] = {}
+	for device in out.split():
+	    self.facts['devices'][device] = []
 
 class AIX(Hardware):
     """

--- a/library/setup
+++ b/library/setup
@@ -1013,7 +1013,7 @@ class GenericBsdIfconfigNetwork(Network):
             all_ipv4_addresses = [],
             all_ipv6_addresses = [],
         )
-        rc, out, err = module.run_command([ifconfig_path])
+        rc, out, err = module.run_command([ifconfig_path, '-a'])
         for line in out.split('\n'):
             if line:
                 words = line.split()
@@ -1025,6 +1025,8 @@ class GenericBsdIfconfigNetwork(Network):
                 elif words[0] == 'nd6':
                     self.parse_nd6_line(words, current_if, ips)
                 elif words[0] == 'ether':
+                    self.parse_ether_line(words, current_if, ips)
+                elif words[0] == 'address:':
                     self.parse_ether_line(words, current_if, ips)
                 elif words[0] == 'media:':
                     self.parse_media_line(words, current_if, ips)
@@ -1077,6 +1079,10 @@ class GenericBsdIfconfigNetwork(Network):
         current_if['lladdr'] = words[1]
 
     def parse_inet_line(self, words, current_if, ips):
+	# NetBSD indicates secondary ipv4 addresses with the keyword
+	# "alias".  The line is otherwise the same, so simply delete it.
+	if words[1] == 'alias':
+	    del words[1]
         address = {'address': words[1]}
         # deal with hex netmask
         if words[3].startswith('0x'):
@@ -1158,6 +1164,14 @@ class FreeBSDNetwork(GenericBsdIfconfigNetwork, Network):
     It uses the GenericBsdIfconfigNetwork unchanged
     """
     platform = 'FreeBSD'
+
+class NetBSDNetwork(GenericBsdIfconfigNetwork, Network):
+    """
+    This is the NetBSD Network Class.
+    It uses the GenericBsdIfconfigNetwork with
+    a few parsing changes (parse_inet_line):
+    """
+    platform = 'NetBSD'
 
 class Virtual(Facts):
     """

--- a/library/setup
+++ b/library/setup
@@ -143,8 +143,8 @@ class Facts(object):
             self.facts['architecture'] = 'i386'
         else:
             self.facts['architecture'] = platform.processor()
-	if self.facts['architecture'] == '':
-	    self.facts['architecture'] = self.facts['machine']
+        if self.facts['architecture'] == '':
+            self.facts['architecture'] = self.facts['machine']
         if self.facts['system'] == 'Linux':
             self.get_distribution_facts()
         elif self.facts['system'] == 'AIX':

--- a/library/setup
+++ b/library/setup
@@ -1365,6 +1365,28 @@ class LinuxVirtual(Virtual):
                 self.facts['virtualization_role'] = 'host'
                 return
 
+class NetBSDVirtual(Virtual):
+    """
+    This is a NetBSD-specific subclass of Virtual.
+    """
+    platform = 'NetBSD'
+
+    def __init__(self):
+        Virtual.__init__(self)
+
+    def populate(self):
+        self.get_virtual_facts()
+        return self.facts
+
+    def get_virtual_facts(self):
+        if os.path.exists("/kern/xen"):
+            self.facts['virtualization_type'] = 'xen'
+	    if os.path.exists("/kern/xen/privcmd"):
+		self.facts['virtualization_role'] = 'host'
+	    else:
+		self.facts['virtualization_role'] = 'guest'
+	    return
+
 class SunOSVirtual(Virtual):
     """
     This is a SunOS-specific subclass of Virtual.  It defines


### PR DESCRIPTION
- add NetBSD Network support to the FreeBSD/Darwin support
- Fix the Makefile so "gmake tests" can work on NetBSD
- Add a basic implementation of NetBSDHardware to retrieve some hardware facts.
- set "ansible_architecture" in a way that makes more sense when machine name and processor name are different.

Tested on NetBSD 5.1, NetBSD 6.0(amd64 and evbarm), FreeBSD 9.0 and MacOS 10.8.2.
