### PR TITLE
Change "raw" functionality to "custom"

### DIFF
--- a/library/django
+++ b/library/django
@@ -21,21 +21,24 @@
 
 DOCUMENTATION = '''
 ---
-module: django_manage
+module: django
 short_description: Manages a Django application.
 description:
      - Manages a Django application using the I(manage.py) application frontend to I(django-admin). With the I(virtualenv) parameter, all management commands will be executed by the given I(virtualenv) installation.
 version_added: "1.1"
 options:
-  command:
-    choices: [ 'cleanup', 'flush', 'loaddata', 'raw', 'syncdb', 'test', 'validate', ]
-    description:
-      - The name of the Django management command to run. Allowed commands are cleanup, createcachetable, flush, loaddata, raw, syncdb, test, validate.
-    required: true
   app_path:
     description:
       - The path to the root of the Django application where B(manage.py) lives.
     required: true
+  command:
+    choices: [ 'cleanup', 'createcachetable', 'flush', 'loaddata', 'syncdb', 'test', 'validate', ]
+    description:
+      - The name of the Django management command to run. Allowed commands are cleanup, createcachetable, flush, loaddata, syncdb, test, validate. Required if not using the "custom" parameter.
+    required: false
+  custom:
+    description:
+      - A custom admin command. Required if not using the "command" parameter.
   settings:
     description:
       - The Python path to the application's settings module, such as 'myapp.settings'.
@@ -56,6 +59,10 @@ options:
     description:
       - The name of the table used for database-backed caching. Used by the 'createcachetable' command.
     required: false
+  custom_change:
+    description:
+      - A string to look for in the output of a custom command. If the string is present, the command will be considered to have changed state on the server. Used by the 'custom' command.
+    required: false
   database:
     description:
       - The database to target. Used by the 'createcachetable', 'flush', 'loaddata', and 'syncdb' commands.
@@ -68,31 +75,24 @@ options:
     description:
       - A space-delimited list of fixture file names to load in the database. B(Required) by the 'loaddata' command.
     required: false
-  raw_command:
-    description:
-      - Any valid manage.py command, if the 'raw' command is used. The I(pythonpath), I(settings) and I(virtualenv) parameters will also be used for a raw command if provided.
-    required: false
-  raw_args:
-    description:
-      - If the 'raw' command is used, the contents of this parameter are appended to the manage.py command line.
-    required: false
 notes:
    - U(http://www.virtualenv.org/, virtualenv) must be installed on the remote host if the virtualenv parameter is specified.
    - This module will create a virtualenv if the virtualenv parameter is specified and a virtualenv does not already exist at the given location.
    - This module assumes English error messages for the 'createcachetable' command to detect table existence, unfortunately.
+   - The user is responsible for adding --noinput to custom commands that require it.
 requirements: [ "virtualenv", "django" ]
 author: Scott Anderson
 '''
 
 EXAMPLES = """
 # Run cleanup on the application installed in '$django_dir'.
-django_manage: command=cleanup app_path=$django_dir
+django: command=cleanup app_path=$django_dir
 
 # Load the $initial_data fixture into the application
-django_manage: command=loaddata app_path=$django_dir fixtures=$initial_data
+django: command=loaddata app_path=$django_dir fixtures=$initial_data
 
 # Run syncdb on the application
-django_manage: >
+django: >
     command=syncdb 
     app_path=$django_dir 
     settings=$settings_app_name 
@@ -103,15 +103,16 @@ django_manage: >
 # Run the SmokeTest test case from the main app. Useful for testing deploys.
 django_manage: command=test app_path=django_dir apps=main.SmokeTest
 
-# Run the Django South migration command as a raw command
-# Generates the command "manage.py migrate --settings=$settings_app_name --pythonpath=$settings_dir myapp --no-initial-data
-django_manage: >
-    command=raw
+# Run the Django South migration command as a custom command (note that South support will be a separate module soon).
+# Generates the command:
+# "manage.py migrate --settings=$settings_app_name --pythonpath=$settings_dir myapp --no-initial-data --noinput"
+# and checks the output for the string "Migrating forwards to" to detect changes.
+django: >
+    custom="migrate myapp --no-initial-data --noinput"
+    custom_change="Migrating forwards to"
     settings=$settings_app_name
     pythonpath=$settings_dir
     virtualenv=$virtualenv_dir 
-    raw_command="migrate"
-    raw_args="myapp --no-initial-data"
 """
 
 
@@ -161,9 +162,9 @@ def main():
     command_allowed_param_map = dict(
         cleanup=(),
         createcachetable=('cache_table', 'database', ),
+        custom=("custom_change", ),
         flush=('database', ),
         loaddata=('database', 'fixtures', ),
-        raw=('raw_args', 'raw_command', ),
         syncdb=('database', ),
         test=('failfast', 'testrunner', 'liveserver', 'apps', ),
         validate=(),
@@ -172,7 +173,6 @@ def main():
     command_required_param_map = dict(
         createcachetable=('cache_table', ),
         loaddata=('fixtures', ),
-        raw=('raw_command', ),
         )
 
     # forces --noinput on every command that needs it
@@ -183,35 +183,48 @@ def main():
         )
 
     # These params are allowed for certain commands only
-    specific_params = ('apps', 'database', 'failfast', 'fixtures', 'liveserver', 'raw_args', 'raw_command', 'testrunner', )
+    specific_params = ('apps', 'database', 'failfast', 'fixtures', 'liveserver', 'testrunner', )
 
     # These params are automatically added to the command if present
-    general_params = ('settings', 'pythonpath', )
+    common_params = ('settings', 'pythonpath', )
     specific_boolean_params = ('failfast', )
-    end_of_command_params = ('apps', 'cache_table', 'fixtures', 'raw_args', )
+    end_of_command_params = ('apps', 'cache_table', 'fixtures', )
 
     module = AnsibleModule(
         argument_spec=dict(
-            command     = dict(default=None, required=True, choices=command_allowed_param_map.keys()),
-            app_path    = dict(default=None, required=True),
-            settings    = dict(default=None, required=False),
-            pythonpath  = dict(default=None, required=False, aliases=['python_path']),
-            virtualenv  = dict(default=None, required=False, aliases=['virtual_env']),
+            # Required parameters
+            app_path      = dict(default=None, required=True),
 
-            apps        = dict(default=None, required=False),
-            cache_table = dict(default=None, required=False),
-            database    = dict(default=None, required=False),
-            failfast    = dict(default='no', required=False, choices=BOOLEANS, aliases=['fail_fast']),
-            fixtures    = dict(default=None, required=False),
-            liveserver  = dict(default=None, required=False, aliases=['live_server']),
-            raw_args    = dict(default=None, required=False),
-            raw_command = dict(default=None, required=False),
-            testrunner  = dict(default=None, required=False, aliases=['test_runner']),
+            # Exclusive parameters; one of them must be present
+            command       = dict(default=None, required=False, choices=command_allowed_param_map.keys()),
+            custom        = dict(default=None, required=False),
+
+            # Common (general) 
+            settings      = dict(default=None, required=False),
+            pythonpath    = dict(default=None, required=False, aliases=['python_path']),
+            virtualenv    = dict(default=None, required=False, aliases=['virtual_env']),
+
+            apps          = dict(default=None, required=False),
+            cache_table   = dict(default=None, required=False),
+            custom_change = dict(default=None, required=False),
+            database      = dict(default=None, required=False),
+            failfast      = dict(default='no', required=False, choices=BOOLEANS, aliases=['fail_fast']),
+            fixtures      = dict(default=None, required=False),
+            liveserver    = dict(default=None, required=False, aliases=['live_server']),
+            raw_args      = dict(default=None, required=False),
+            raw_command   = dict(default=None, required=False),
+            testrunner    = dict(default=None, required=False, aliases=['test_runner']),
         ),
     )
 
-    command = module.params['command']
     app_path = module.params['app_path']
+    command = module.params['command']
+    custom = module.params['custom']
+    custom_change = module.params['custom_change']
+
+    if not command and not custom:
+        module.fail_json(msg='Must include one of either "command" or "custom"')
+
     virtualenv = module.params['virtualenv']
 
     for param in specific_params:
@@ -225,12 +238,15 @@ def main():
         if not module.params[param]:
             module.fail_json(msg='%s param is required for command=%s' % (param, command))
 
-    venv = module.params['virtualenv']
-
     _ensure_virtualenv(module)
 
-    if command == 'raw':
-        command = module.params['raw_command']
+    custom_args = None
+    if custom:
+        pieces = custom.split(' ', 1)
+        if len(pieces) == 1:
+            command = custom
+        else:
+            command, custom_args = pieces
 
     os.chdir(app_path)
     cmd = "python manage.py %s" % (command, )
@@ -238,7 +254,7 @@ def main():
     if command in noinput_commands:
         cmd = '%s --noinput' % cmd
 
-    for param in general_params:
+    for param in common_params:
         if module.params[param]:
             cmd = '%s --%s=%s' % (cmd, param, module.params[param])
 
@@ -251,6 +267,9 @@ def main():
         if module.params[param]:
             cmd = '%s %s' % (cmd, module.params[param])
 
+    if custom_args:
+        cmd = '%s %s' % (cmd, custom_args)
+
     rc, out, err = module.run_command(cmd)
     if rc != 0:
         if command == 'createcachetable' and 'table' in err and 'already exists' in err:
@@ -261,7 +280,13 @@ def main():
     changed = False
 
     lines = out.split('\n')
-    filt = globals().get(command + "_filter_output", None)
+
+    filt = None
+    if custom and custom_change:
+        filt = lambda line: custom_change in line
+    else:
+        filt = globals().get(command + "_filter_output", None)
+
     if filt:
         filtered_output = filter(filt, out.split('\n'))
         if len(filtered_output):

--- a/library/django_manage
+++ b/library/django_manage
@@ -21,7 +21,7 @@
 
 DOCUMENTATION = '''
 ---
-module: django
+module: django_manage
 short_description: Manages a Django application.
 description:
      - Manages a Django application using the I(manage.py) application frontend to I(django-admin). With the I(virtualenv) parameter, all management commands will be executed by the given I(virtualenv) installation.
@@ -86,13 +86,13 @@ author: Scott Anderson
 
 EXAMPLES = """
 # Run cleanup on the application installed in '$django_dir'.
-django: command=cleanup app_path=$django_dir
+django_manage: command=cleanup app_path=$django_dir
 
 # Load the $initial_data fixture into the application
-django: command=loaddata app_path=$django_dir fixtures=$initial_data
+django_manage: command=loaddata app_path=$django_dir fixtures=$initial_data
 
 # Run syncdb on the application
-django: >
+django_manage: >
     command=syncdb 
     app_path=$django_dir 
     settings=$settings_app_name 
@@ -107,7 +107,7 @@ django_manage: command=test app_path=django_dir apps=main.SmokeTest
 # Generates the command:
 # "manage.py migrate --settings=$settings_app_name --pythonpath=$settings_dir myapp --no-initial-data --noinput"
 # and checks the output for the string "Migrating forwards to" to detect changes.
-django: >
+django_manage: >
     custom="migrate myapp --no-initial-data --noinput"
     custom_change="Migrating forwards to"
     settings=$settings_app_name

--- a/library/django_manage
+++ b/library/django_manage
@@ -28,9 +28,9 @@ description:
 version_added: "1.1"
 options:
   command:
-    choices: [ 'cleanup', 'flush', 'loaddata', 'runfcgi', 'syncdb', 'test', 'validate' ]
+    choices: [ 'cleanup', 'flush', 'loaddata', 'raw', 'syncdb', 'test', 'validate', ]
     description:
-      - The name of the Django management command to run. Allowed commands are cleanup, createcachetable, flush, loaddata, syncdb, test, validate.
+      - The name of the Django management command to run. Allowed commands are cleanup, createcachetable, flush, loaddata, raw, syncdb, test, validate.
     required: true
   app_path:
     description:
@@ -68,6 +68,14 @@ options:
     description:
       - A space-delimited list of fixture file names to load in the database. B(Required) by the 'loaddata' command.
     required: false
+  raw_command:
+    description:
+      - Any valid manage.py command, if the 'raw' command is used. The I(pythonpath), I(settings) and I(virtualenv) parameters will also be used for a raw command if provided.
+    required: false
+  raw_args:
+    description:
+      - If the 'raw' command is used, the contents of this parameter are appended to the manage.py command line.
+    required: false
 notes:
    - U(http://www.virtualenv.org/, virtualenv) must be installed on the remote host if the virtualenv parameter is specified.
    - This module will create a virtualenv if the virtualenv parameter is specified and a virtualenv does not already exist at the given location.
@@ -83,7 +91,7 @@ django_manage: command=cleanup app_path=$django_dir
 # Load the $initial_data fixture into the application
 django_manage: command=loaddata app_path=$django_dir fixtures=$initial_data
 
-#Run syncdb on the application
+# Run syncdb on the application
 django_manage: >
     command=syncdb 
     app_path=$django_dir 
@@ -92,8 +100,18 @@ django_manage: >
     virtualenv=$virtualenv_dir 
     database=$mydb
 
-#Run the SmokeTest test case from the main app. Useful for testing deploys.
-django_manage command=test app_path=django_dir apps=main.SmokeTest
+# Run the SmokeTest test case from the main app. Useful for testing deploys.
+django_manage: command=test app_path=django_dir apps=main.SmokeTest
+
+# Run the Django South migration command as a raw command
+# Generates the command "manage.py migrate --settings=$settings_app_name --pythonpath=$settings_dir myapp --no-initial-data
+django_manage: >
+    command=raw
+    settings=$settings_app_name
+    pythonpath=$settings_dir
+    virtualenv=$virtualenv_dir 
+    raw_command="migrate"
+    raw_args="myapp --no-initial-data"
 """
 
 
@@ -109,7 +127,6 @@ def _fail(module, cmd, out, err, **kwargs):
 
 
 def _ensure_virtualenv(module):
-
     venv_param = module.params['virtualenv']
     if venv_param is None:
         return
@@ -146,14 +163,16 @@ def main():
         createcachetable=('cache_table', 'database', ),
         flush=('database', ),
         loaddata=('database', 'fixtures', ),
+        raw=('raw_args', 'raw_command', ),
         syncdb=('database', ),
         test=('failfast', 'testrunner', 'liveserver', 'apps', ),
         validate=(),
         )
 
     command_required_param_map = dict(
-        loaddata=('fixtures', ),
         createcachetable=('cache_table', ),
+        loaddata=('fixtures', ),
+        raw=('raw_command', ),
         )
 
     # forces --noinput on every command that needs it
@@ -164,12 +183,12 @@ def main():
         )
 
     # These params are allowed for certain commands only
-    specific_params = ('apps', 'database', 'failfast', 'fixtures', 'liveserver', 'testrunner', )
+    specific_params = ('apps', 'database', 'failfast', 'fixtures', 'liveserver', 'raw_args', 'raw_command', 'testrunner', )
 
     # These params are automatically added to the command if present
     general_params = ('settings', 'pythonpath', )
     specific_boolean_params = ('failfast', )
-    end_of_command_params = ('apps', 'cache_table', 'fixtures', )
+    end_of_command_params = ('apps', 'cache_table', 'fixtures', 'raw_args', )
 
     module = AnsibleModule(
         argument_spec=dict(
@@ -185,6 +204,8 @@ def main():
             failfast    = dict(default='no', required=False, choices=BOOLEANS, aliases=['fail_fast']),
             fixtures    = dict(default=None, required=False),
             liveserver  = dict(default=None, required=False, aliases=['live_server']),
+            raw_args    = dict(default=None, required=False),
+            raw_command = dict(default=None, required=False),
             testrunner  = dict(default=None, required=False, aliases=['test_runner']),
         ),
     )
@@ -207,6 +228,9 @@ def main():
     venv = module.params['virtualenv']
 
     _ensure_virtualenv(module)
+
+    if command == 'raw':
+        command = module.params['raw_command']
 
     os.chdir(app_path)
     cmd = "python manage.py %s" % (command, )


### PR DESCRIPTION
Removed the raw functionality in preference to custom: adds the parameters "custom" and "custom_change".

"custom" contains a full Django admin command, including custom arguments, as you indicated a preference for.

"custom_change", if present, contains a string to look for in the command output that indicates that changes were made.
