### PR TITLE
file module should check invalid arguments (fixes #2135)

### DIFF
--- a/library/file
+++ b/library/file
@@ -136,7 +136,6 @@ def main():
     global module
 
     module = AnsibleModule(
-        check_invalid_arguments = False,
         argument_spec = dict(
             state = dict(choices=['file','directory','link','absent'], default='file'),
             path  = dict(aliases=['dest', 'name'], required=True),


### PR DESCRIPTION
This fixes #2135.

In latest _devel_ `template`, `group`, `user` and `lineinfile` complaint on unsupported param. Only missing fix is for `file`.

PD: Tried to reopen PR #2139 after rebasing but GH included lot of commits so I'm filing this one.
