### PR TITLE
Fix cowsay spacing

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -176,6 +176,8 @@ def main(args):
             pb.run()
 
             hosts = sorted(pb.stats.processed.keys())
+            if callbacks.cowsay:
+                print "\n"
             print callbacks.banner("PLAY RECAP")
             playbook_cb.on_stats(pb.stats)
             for h in hosts:

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -149,7 +149,7 @@ def banner(msg):
         runcmd.append(msg)
         cmd = subprocess.Popen(runcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (out, err) = cmd.communicate()
-        return "%s\n" % out
+        return "%s" % out
     else:
         return "\n%s ********************* " % msg
 

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -438,6 +438,8 @@ class PlayBook(object):
                             should_run = True
                             break
                 if should_run:
+                    if ansible.callbacks.cowsay:
+                        print "\n"
                     if not self._run_task(play, task, False):
                         # whether no hosts matched is fatal or not depends if it was on the initial step.
                         # if we got exactly no hosts on the first step (setup!) then the host group


### PR DESCRIPTION
The cow speaking is a header, it should be "visually" grouped with the rest of the task output. Current output is like:

```
 COWSAY
 blank line
 blank line
 TASK OUTPUT
 blank line
 COWSAY
 blank line
 blank line
 TASK OUTPUT
 blank line
```

I think this should be 1 _blank line_ between the cow and the current task output and 2 _blank lines_ between one task and the next.

When using `ANSIBLE_NOCOWS=1` output is correctly grouped:

```
TASK: [foo task] *********************
TASK OUTPUT
blank line
TASK: [bar task] *********************
TASK OUTPUT
blank line
```
