### PR TITLE
get_url: should always download the file when force is set

### DIFF
--- a/library/get_url
+++ b/library/get_url
@@ -132,7 +132,7 @@ def url_do_get(module, url, dest):
     request = urllib2.Request(url)
     request.add_header('User-agent', USERAGENT)
 
-    if os.path.exists(dest):
+    if os.path.exists(dest) and not module.params['force']:
         t = datetime.datetime.utcfromtimestamp(os.path.getmtime(dest))
         tstamp = t.strftime('%a, %d %b %Y %H:%M:%S +0000')
         request.add_header('If-Modified-Since', tstamp)


### PR DESCRIPTION
As the documentation states, when `force` option is set, get_url module should always download the file regardless of mtime.
