### PR TITLE
Allow 'make rpm' without the need for env-setup

### DIFF
--- a/docsite/Makefile
+++ b/docsite/Makefile
@@ -26,6 +26,6 @@ clean:
 .PHONEY: docs clean
 
 modules: $(FORMATTER) ../hacking/templates/rst.j2
-	$(FORMATTER) -t rst --template-dir=../hacking/templates --module-dir=../library -o rst/modules/ --includes-file=rst/modules/_list.rst
+	PYTHONPATH=../lib $(FORMATTER) -t rst --template-dir=../hacking/templates --module-dir=../library -o rst/modules/ --includes-file=rst/modules/_list.rst
 
 


### PR DESCRIPTION
As it used to be before, 'make rpm' from a cloned repository should work without the need to run hacking/env-setup. It's an easy fix, in line with what we already did for the man-pages.
