### PR TITLE
fix ansible-playbook manpges regarding option for syntax check

### DIFF
--- a/docs/man/man1/ansible-playbook.1
+++ b/docs/man/man1/ansible-playbook.1
@@ -87,7 +87,7 @@ Desired sudo user (default=root)\&.
 Run only these tags from the playbook
 .RE
 .PP
-\fB\-\-check\-syntax\fR
+\fB\-\-syntax\-check\fR
 .RS 4
 Look for syntax errors in the playbook, but don\(cqt run anything
 .RE

--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -77,7 +77,7 @@ Desired sudo user (default=root).
 
 Run only these tags from the playbook
 
-*--check-syntax*::
+*--syntax-check*::
 
 Look for syntax errors in the playbook, but don't run anything
 


### PR DESCRIPTION
ansible-playbook knows of the --syntax-check option to check the playbook yaml syntax. the manpages talk about --check-syntax instead. fix manpages assuming the code is the truth
