### PR TITLE
ansible_architecture should be the CPU architecture, not the machine name

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -142,6 +142,8 @@ class Facts(object):
         elif Facts._I386RE.search(self.facts['machine']):
             self.facts['architecture'] = 'i386'
         else:
+            self.facts['architecture'] = platform.processor()
+        if self.facts['architecture'] == '':
             self.facts['architecture'] = self.facts['machine']
         if self.facts['system'] == 'Linux':
             self.get_distribution_facts()


### PR DESCRIPTION
Set ansible_architecture to the output of platform.processor(), to get
the cpu architecture, instead of the machine architecture.

If this returns an empty string (it does on some Linux ARM platforms,
for some reason), set it to the same string as ansible_machine.

**\* this is especially helpful in places where these are expected to be different (such as the BSDs, where multiple "machines" may share a single "architecture".
