### PR TITLE
Minor spelling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,7 @@ Other core changes:
 
 * fix for template calls when last character is '$'
 * if ansible_python_interpreter is set on a delegated host, it now works as intended
-* --limit can now take "," as seperator as well as ";" or ":"
+* --limit can now take "," as separator as well as ";" or ":"
 * msg is now displaced with newlines when a task fails
 * if any with_ plugin has no results in a list (empty list for with_items, etc), the task is now skipped
 * various output formatting fixes/improvements
@@ -502,7 +502,7 @@ internals:
 * support for older versions of python-apt in the apt module
 * a new "assemble" module, for constructing files from pieces of files (inspired by Puppet "fragments" idiom)
 * ability to override most default values with ANSIBLE_FOO environment variables
-* --module-path parameter can support multiple directories seperated with the OS path seperator
+* --module-path parameter can support multiple directories separated with the OS path separator
 * with_items can take a variable of type list
 * ansible_python_interpreter variable available for systems with more than one Python
 * BIOS and VMware "fact" upgrades

--- a/docsite/rst/examples.rst
+++ b/docsite/rst/examples.rst
@@ -226,7 +226,7 @@ also works with ``ansible-playbook``::
 
     $ ansible webservers:dbservers -m command -a "/bin/foo xyz" --limit region
 
-Assuming version 0.9 or later, as with other host patterns, values to limit can be seperated with ";", ":", or ",".
+Assuming version 0.9 or later, as with other host patterns, values to limit can be separated with ";", ":", or ",".
 
 Now let's talk about range selection.   Suppose you have 1000 servers in group 'datacenter', but only want to target one at a time.  This is also easy::
 

--- a/docsite/rst/patterns.rst
+++ b/docsite/rst/patterns.rst
@@ -185,7 +185,7 @@ variables to groups.  These variables can be used by /usr/bin/ansible-playbook, 
    southeast
 
 If you need to store lists or hash data, or prefer to keep host and group specific variables
-seperate from the inventory file, see the next section.
+separate from the inventory file, see the next section.
 
 Splitting Out Host and Group Specific Data
 ++++++++++++++++++++++++++++++++++++++++++

--- a/docsite/rst/playbooks.rst
+++ b/docsite/rst/playbooks.rst
@@ -414,7 +414,7 @@ Tips and Tricks
 
 Look at the bottom of the playbook execution for a summary of the nodes that were executed
 and how they performed.   General failures and fatal "unreachable" communication attempts are
-kept seperate in the counts.
+kept separate in the counts.
 
 If you ever want to see detailed output from successful modules as well as unsuccessful ones,
 use the '--verbose' flag.  This is available in Ansible 0.5 and later.

--- a/docsite/rst/playbooks2.rst
+++ b/docsite/rst/playbooks2.rst
@@ -324,7 +324,7 @@ In Ansible 0.8, a few shortcuts are available for testing whether a variable is 
 
 There is a matching 'is_unset' that works the same way.  Quoting the variable inside the function is mandatory.
 
-When combining `only_if` with `with_items`, be aware that the `only_if` statement is processed seperately for each item.
+When combining `only_if` with `with_items`, be aware that the `only_if` statement is processed separately for each item.
 This is by design::
 
     tasks:
@@ -343,7 +343,7 @@ Conditional Execution (Simplified)
 
 In Ansible 0.9, we realized that only_if was a bit syntactically complicated, and exposed too much Python
 to the user.  As a result, the 'when' set of keywords was added.  The 'when' statements do not have
-to be quoted or casted to specify types, but you should seperate any variables used with whitespace.  In
+to be quoted or casted to specify types, but you should separate any variables used with whitespace.  In
 most cases users will be able to use 'when', but for more complex cases, only_if may still be required.
 
 Here are various examples of 'when' in use.  'when' is incompatible with 'only_if' in the same task::

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -632,7 +632,7 @@ class AnsibleModule(object):
 
     def _log_invocation(self):
         ''' log that ansible ran the module '''
-        # TODO: generalize a seperate log function and make log_invocation use it
+        # TODO: generalize a separate log function and make log_invocation use it
         # Sanitize possible password argument when logging.
         log_args = dict()
         passwd_keys = ['password', 'login_password']

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -681,7 +681,7 @@ class Runner(object):
     # *****************************************************
 
     def _partition_results(self, results):
-        ''' seperate results by ones we contacted & ones we didn't '''
+        ''' separate results by ones we contacted & ones we didn't '''
 
         if results is None:
             return None

--- a/library/sysctl
+++ b/library/sysctl
@@ -29,7 +29,7 @@ version_added: "1.0"
 options:
     name:
         description:
-            - this is the short path, decimal seperated, to the sysctl entry
+            - this is the short path, decimal separated, to the sysctl entry
         required: true
         default: null
         aliases: [ 'key' ]


### PR DESCRIPTION
Trivial changes of the spelling of "seperator" to "separator".
