### PR TITLE
Respect gem_source option if specified

### DIFF
--- a/library/gem
+++ b/library/gem
@@ -151,7 +151,7 @@ def main():
     if module.params['gem_source'] and module.params['state'] == 'latest':
         module.fail_json(msg="Cannot maintain state=latest when installing from local source")
 
-    if module.params['gem_source'] is not 'null':
+    if not module.params['gem_source']:
         module.params['gem_source'] = module.params['name']
 
     changed = False


### PR DESCRIPTION
Currently, the gem module appears to always override 'gem_source' with the value of the 'name' parameter. It should not do so if gem_source is explicitly specified.

Issue https://github.com/ansible/ansible/issues/2314
