### PR TITLE
password lookup plugin, with working tests and documentation

### DIFF
--- a/docsite/rst/playbooks2.rst
+++ b/docsite/rst/playbooks2.rst
@@ -209,14 +209,14 @@ some other options, but otherwise works equivalently::
        prompt: "Product release version"
        private: no
 
-If `Passlib <http://pythonhosted.org/passlib/>`_ is installed, vars_prompt can also crypt the 
+If `Passlib <http://pythonhosted.org/passlib/>`_ is installed, vars_prompt can also crypt the
 entered value so you can use it, for instance, with the user module to define a password::
 
    vars_prompt:
      - name: "my_password2"
        prompt: "Enter password2"
        private: yes
-       encrypt: "md5_crypt" 
+       encrypt: "md5_crypt"
        confirm: yes
        salt_size: 7
 
@@ -241,7 +241,7 @@ You can use any crypt scheme supported by `Passlib <http://pythonhosted.org/pass
 - *bsd_nthash* - FreeBSD’s MCF-compatible nthash encoding
 
 However, the only parameters accepted are 'salt' or 'salt_size'. You can use you own salt using
-'salt', or have one generated automatically using 'salt_size'. If nothing is specified, a salt 
+'salt', or have one generated automatically using 'salt_size'. If nothing is specified, a salt
 of size 8 will be generated.
 
 Passing Variables On The Command Line
@@ -604,6 +604,44 @@ Negative numbers are not supported.  This works as follows::
         # create 4 groups
         - group: name=group${item} state=present
           with_sequence: count=4
+
+.. versionadded: 1.1
+
+'with_password' and associated macro "$PASSWORD" generate a random plaintext password and store it in
+a file at a given filepath. If the file exists previously, "$PASSWORD"/'with_password' will retrieve its contents,
+behaving just like $FILE/'with_file'.
+
+Generated passwords contain a random mix of upper and lower case letters in the ASCII alphabets, the
+numbers 0-9 and the punctuation signs ".,:-_". The default length of a generated password is 30 characters.
+This gives us ~ 180 bits of entropy. However, this length can be changed by passing an extra parameter.
+
+This is how it all works, with an exemplary use case, which is generating a different random password for every
+mysql database in a given server pool:
+
+    ---
+    - hosts: all
+
+      tasks:
+
+        # create a mysql user with a random password:
+        - mysql_user: name=$client
+                      password=$PASSWORD(credentials/$client/$tier/$role/mysqlpassword)
+                      priv=$client_$tier_$role.*:ALL
+
+        (...)
+
+        # dump a mysql database with a given password
+        - mysql_db: name=$client_$tier_$role
+                    login_user=$client
+                    login_password=$item
+                    state=dump
+                    target=/tmp/$client_$tier_$role_backup.sql
+          with_password: credentials/$client/$tier/$role/mysqlpassword
+
+        # make a longer or shorter password by appending a length parameter:
+        - mysql_user: name=who_cares
+                      password=$item
+          with_password: files/same/password/everywhere length=4
 
 Setting the Environment (and Working With Proxies)
 ``````````````````````````````````````````````````
@@ -1013,7 +1051,7 @@ number of modules (the CloudFormations module is one) actually require complex a
 You can of course use variables inside these, as noted above.
 
 If using local_action, you can do this::
-      
+
     - name: call a module that requires some complex arguments
       local_action:
         module: foo_module

--- a/lib/ansible/runner/lookup_plugins/password.py
+++ b/lib/ansible/runner/lookup_plugins/password.py
@@ -1,0 +1,66 @@
+# (c) 2012, Daniel Hokka Zakrisson <daniel@hozac.com>
+# (c) 2013, Javie Candeira <javier@candeira.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible import utils, errors
+import os
+import errno
+import random
+from string import ascii_uppercase, ascii_lowercase, digits
+
+
+class LookupModule(object):
+
+    LENGTH = 20
+
+    def __init__(self, length=None, basedir=None, **kwargs):
+        self.basedir = basedir
+
+    def run(self, terms, **kwargs):
+        if isinstance(terms, basestring):
+            terms = [ terms ]
+        ret = []
+
+        for term in terms:
+            # you can't have escaped spaces in yor pathname
+            params = term.split()
+            relpath = params[0]
+            length = LookupModule.LENGTH
+
+            # get non-default length parameter if specified
+            if len(params) > 1:
+                try:
+                    name, length = params[1].split('=')
+                    assert(name.startswith("length"))
+                    length = int(length)
+                except (ValueError, AssertionError) as e:
+                    raise errors.AnsibleError(e)
+
+            # get password or create it if file doesn't exist
+            path = utils.path_dwim(self.basedir, relpath)
+            if not os.path.exists(path):
+                pathdir = os.path.dirname(path)
+                if not os.path.isdir(pathdir):
+                    os.makedirs(pathdir)
+                chars = ascii_uppercase + ascii_lowercase + digits + ".,:-_"
+                password = ''.join(random.choice(chars) for _ in range(length))
+                with open(path, 'w') as f:
+                    f.write(password)
+            ret.append(open(path).read().rstrip())
+
+        return ret
+

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -172,20 +172,20 @@ class TestPlaybook(unittest.TestCase):
        print utils.jsonify(actual, format=True)
        expected =  {
            "localhost": {
-               "changed": 9,
+               "changed": 16,
                "failures": 0,
-               "ok": 14,
+               "ok": 21,
                "skipped": 1,
                "unreachable": 0
-           }   
-       }   
+           }
+       }
        print "**EXPECTED**"
        print utils.jsonify(expected, format=True)
 
        assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
 
        print "len(EVENTS) = %d" % len(EVENTS)
-       assert len(EVENTS) == 60
+       assert len(EVENTS) == 74
 
    def test_includes(self):
        pb = os.path.join(self.test_dir, 'playbook-includer.yml')
@@ -201,14 +201,14 @@ class TestPlaybook(unittest.TestCase):
                "ok": 10,
                "skipped": 0,
                "unreachable": 0
-           }   
-       }   
+           }
+       }
        print "**EXPECTED**"
        print utils.jsonify(expected, format=True)
 
        assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
 
-   def test_playbook_vars(self): 
+   def test_playbook_vars(self):
        test_callbacks = TestCallbacks()
        playbook = ansible.playbook.PlayBook(
            playbook=os.path.join(self.test_dir, 'test_playbook_vars', 'playbook.yml'),

--- a/test/lookup_plugins.yml
+++ b/test/lookup_plugins.yml
@@ -55,3 +55,25 @@
     action: copy src=sample.j2 dest=/tmp/ansible-test-with_lines-data
   - name: cleanup test file
     action: file path=/tmp/ansible-test-with_lines-data state=absent
+
+# password lookup plugin
+  - name: ensure test file doesn't exist
+    # command because file will return differently
+    action: command rm -f /tmp/ansible-test-with_password
+  - name: test LOOKUP and PASSWORD with non existing password file
+    action: command test "$LOOKUP(password, /tmp/ansible-test-with_password)" = "$PASSWORD(/tmp/ansible-test-with_password)"
+  - name: test LOOKUP and PASSWORD with existing password file
+    action: command test "$LOOKUP(password, /tmp/ansible-test-with_password)" = "$PASSWORD(/tmp/ansible-test-with_password)"
+  - name: now test existing password via $item and with_password
+    action: command test "$PASSWORD(/tmp/ansible-test-with_password)" = "$item"
+    with_password:
+      - /tmp/ansible-test-with_password
+  - name: cleanup test file
+    action: file path=/tmp/ansible-test-with_password state=absent
+  - name: now test a password of non-default length (default=20, but here length=8)
+    action: command test "$PASSWORD(/tmp/ansible-test-with_password length=8)" = "$LOOKUP(password, /tmp/ansible-test-with_password)"
+  # - name: did we really create a password of length=8?
+  #   action: command test "`expr length $PASSWORD(/tmp/ansible-test-with_password)`" = "8"
+  - name: cleanup test file, again
+    action: file path=/tmp/ansible-test-with_password state=absent
+


### PR DESCRIPTION
The passsword lookup plugin, as discussed on the IRC channel and explained in added documentation (copied below).

All previous tests pass, and so do a bunch of new ones except for testing non-default lengths of passwords. This last test is commented out in case someone can help me fix it.

Copy of the plugin's documentation at ./docsite/rst/playbooks.rst:

.. versionadded: 1.1

'with_password' and associated macro "$PASSWORD" generate a random plaintext password and store it in
a file at a given filepath. If the file exists previously, "$PASSWORD"/'with_password' will retrieve its contents,
behaving just like $FILE/'with_file'.

Generated passwords contain a random mix of upper and lower case letters in the ASCII alphabets, the
numbers 0-9 and the punctuation signs ".,:-_". The default length of a generated password is 30 characters.
This gives us ~ 180 bits of entropy. However, this length can be changed by passing an extra parameter.

This is how it all works, with an exemplary use case, which is generating a different random password for every
mysql database in a given server pool:

```

---
- hosts: all

  tasks:

    # create a mysql user with a random password:
    - mysql_user: name=$client
                  password=$PASSWORD(credentials/$client/$tier/$role/mysqlpassword)
                  priv=$client_$tier_$role.*:ALL

    (...)

    # dump a mysql database with a given password
    - mysql_db: name=$client_$tier_$role
                login_user=$client
                login_password=$item
                state=dump
                target=/tmp/$client_$tier_$role_backup.sql
      with_password: credentials/$client/$tier/$role/mysqlpassword

    # make a longer or shorter password by appending a length parameter:
    - mysql_user: name=who_cares
                  password=$item
      with_password: files/same/password/everywhere length=4
```
