### PR TITLE
Teach the macports module to activate/deactivate packages

### DIFF
--- a/library/macports
+++ b/library/macports
@@ -34,7 +34,7 @@ options:
     state:
         description:
             - state of the package
-        choices: [ 'present', 'absent' ]
+        choices: [ 'present', 'absent', 'active', 'inactive' ]
         required: false
         default: present
     update_cache:
@@ -49,7 +49,8 @@ EXAMPLES = '''
 macports: name=foo state=present
 macports: name=foo state=present update_cache=yes
 macports: name=foo state=absent
-macports: name=foo,bar state=absent
+macports: name=foo state=active
+macports: name=foo state=inactive
 '''
 
 
@@ -68,6 +69,14 @@ def query_package(module, port_path, name, state="present"):
     if state == "present":
 
         rc, out, err = module.run_command("%s installed | grep -q ^.*%s" % (port_path, name))
+        if rc == 0:
+            return True
+
+        return False
+
+    elif state == "active":
+
+        rc, out, err = module.run_command("%s installed %s | grep -q active" % (port_path, name))
         if rc == 0:
             return True
 
@@ -120,11 +129,61 @@ def install_packages(module, port_path, packages):
     module.exit_json(changed=False, msg="package(s) already present")
 
 
+def activate_packages(module, port_path, packages):
+    """ Activate a package if it's inactive. """
+
+    activate_c = 0
+
+    for package in packages:
+        if not query_package(module, port_path, package):
+           module.fail_json(msg="failed to activate %s, package(s) not present" % (package))
+
+        if query_package(module, port_path, package, state="active"):
+            continue
+
+        rc, out, err = module.run_command("%s activate %s" % (port_path, package))
+
+        if not query_package(module, port_path, package, state="active"):
+            module.fail_json(msg="failed to activate %s: %s" % (package, out))
+
+        activate_c += 1
+
+    if activate_c > 0:
+        module.exit_json(changed=True, msg="activated %s package(s)" % (activate_c))
+
+    module.exit_json(changed=False, msg="package(s) already active")
+
+
+def deactivate_packages(module, port_path, packages):
+    """ Deactivate a package if it's active. """
+
+    deactivated_c = 0
+
+    for package in packages:
+        if not query_package(module, port_path, package):
+           module.fail_json(msg="failed to activate %s, package(s) not present" % (package))
+
+        if not query_package(module, port_path, package, state="active"):
+            continue
+
+        rc, out, err = module.run_command("%s deactivate %s" % (port_path, package))
+
+        if query_package(module, port_path, package, state="active"):
+            module.fail_json(msg="failed to deactivated %s: %s" % (package, out))
+
+        deactivated_c += 1
+
+    if deactivated_c > 0:
+        module.exit_json(changed=True, msg="deactivated %s package(s)" % (deactivated_c))
+
+    module.exit_json(changed=False, msg="package(s) already inactive")
+
+
 def main():
     module = AnsibleModule(
         argument_spec = dict(
             name = dict(aliases=["pkg"], required=True),
-            state = dict(default="present", choices=["present", "installed", "absent", "removed"]),
+            state = dict(default="present", choices=["present", "installed", "absent", "removed", "active", "inactive"]),
             update_cache = dict(default="no", aliases=["update-cache"], type='bool')
         )
     )
@@ -143,6 +202,12 @@ def main():
 
     elif p["state"] in ["absent", "removed"]:
         remove_packages(module, port_path, pkgs)
+
+    elif p["state"] == "active":
+        activate_packages(module, port_path, pkgs)
+
+    elif p["state"] == "inactive":
+        deactivate_packages(module, port_path, pkgs)
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>


### PR DESCRIPTION
Deactivating a package from macports does not remove the files, it
just unstages it from the runtime environment. Activating a package
re-enables it.

This PR takes comments from #2343 and is a resubmission.
