### PR TITLE
Fix up other places in makefile to use PYTHON variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,16 +172,16 @@ deb: debian
 # for arch or gentoo, read instructions in the appropriate 'packaging' subdirectory directory
 
 modulepages:
-	PYTHONPATH=./lib hacking/module_formatter.py -A $(VERSION) -t man -o docs/man/man3/ --module-dir=library --template-dir=hacking/templates
+	PYTHONPATH=./lib $(PYTHON) hacking/module_formatter.py -A $(VERSION) -t man -o docs/man/man3/ --module-dir=library --template-dir=hacking/templates
 
 modulejson:
 	mkdir -p docs/json
-	PYTHONPATH=./lib hacking/module_formatter.py -A $(VERSION) -t json -o docs/json --module-dir=library --template-dir=hacking/templates
+	PYTHONPATH=./lib $(PYTHON) hacking/module_formatter.py -A $(VERSION) -t json -o docs/json --module-dir=library --template-dir=hacking/templates
 
 modulejs:
 	mkdir -p docs/js
 	make modulejson
-	PYTHONPATH=./lib hacking/module_formatter.py -A $(VERSION) -t js -o docs/js --module-dir=docs/json --template-dir=hacking/templates
+	PYTHONPATH=./lib $(PYTHON) hacking/module_formatter.py -A $(VERSION) -t js -o docs/js --module-dir=docs/json --template-dir=hacking/templates
 
 # because this requires Sphinx it is not run as part of every build, those building the RPM and so on can ignore this
 


### PR DESCRIPTION
I seem to have missed these make targets the last time, it prevents users from building the rpms if the PYTHON variable is set and things don't quite match up. Only the nosetests aren't using the PYTHON variable now. 
