### PR TITLE
Teach 'make rpm' to work on EL5 based systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ rpm: rpmcommon
 	--define "_specdir $(RPMSPECDIR)" \
 	--define "_sourcedir %{_topdir}" \
 	--define "_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
+	--define "__python `which $(PYTHON)`" \
 	-ba rpm-build/$(NAME).spec
 	@rm -f rpm-build/$(NAME).spec
 	@echo "#############################################"

--- a/Makefile
+++ b/Makefile
@@ -172,16 +172,16 @@ deb: debian
 # for arch or gentoo, read instructions in the appropriate 'packaging' subdirectory directory
 
 modulepages:
-	PYTHONPATH=./lib hacking/module_formatter.py -A $(VERSION) -t man -o docs/man/man3/ --module-dir=library --template-dir=hacking/templates
+	PYTHONPATH=./lib $(PYTHON) hacking/module_formatter.py -A $(VERSION) -t man -o docs/man/man3/ --module-dir=library --template-dir=hacking/templates
 
 modulejson:
 	mkdir -p docs/json
-	PYTHONPATH=./lib hacking/module_formatter.py -A $(VERSION) -t json -o docs/json --module-dir=library --template-dir=hacking/templates
+	PYTHONPATH=./lib $(PYTHON) hacking/module_formatter.py -A $(VERSION) -t json -o docs/json --module-dir=library --template-dir=hacking/templates
 
 modulejs:
 	mkdir -p docs/js
 	make modulejson
-	PYTHONPATH=./lib hacking/module_formatter.py -A $(VERSION) -t js -o docs/js --module-dir=docs/json --template-dir=hacking/templates
+	PYTHONPATH=./lib $(PYTHON) hacking/module_formatter.py -A $(VERSION) -t js -o docs/js --module-dir=docs/json --template-dir=hacking/templates
 
 # because this requires Sphinx it is not run as part of every build, those building the RPM and so on can ignore this
 

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -14,11 +14,19 @@ Source0: https://github.com/downloads/ansible/ansible/%{name}-%{version}.tar.gz
 Url: http://ansible.github.com
 
 BuildArch: noarch
+%if 0%{?rhel} <= 5
+BuildRequires: python26-devel
+
+Requires: python26-PyYAML
+Requires: python26-paramiko
+Requires: python26-jinja2
+%else
 BuildRequires: python2-devel
 
 Requires: PyYAML
 Requires: python-paramiko
 Requires: python-jinja2
+%endif
 
 %description
 
@@ -32,8 +40,13 @@ are transferred to managed machines automatically.
 Summary: Ansible fireball transport support
 Group: Development/Libraries
 Requires: %{name} = %{version}-%{release}
+%if 0%{?rhel} <= 5
+Requires: python26-keyczar
+Requires: python26-zmq
+%else
 Requires: python-keyczar
 Requires: python-zmq
+%endif
 
 %description fireball
 
@@ -44,8 +57,13 @@ multiple actions, but requires additional supporting packages.
 %package node-fireball
 Summary: Ansible fireball transport - node end support
 Group: Development/Libraries
+%if 0%{?rhel} <= 5
+Requires: python26-keyczar
+Requires: python26-zmq
+%else
 Requires: python-keyczar
 Requires: python-zmq
+%endif
 
 %description node-fireball
 


### PR DESCRIPTION
Assuming python26 and friends are installed, teach the makefile to spit out an RPM. This set of changes has been tested on SL5 and SL6 it spits out an rpm and seems to do the right thing the systems we have here. I would suggest someone test this before pulling, especially as I do not use the fireball mode. Please test!

Also, this depends on #2361 I thought it might be better to have two separate PR's as you might not want the packaging changes.
