### PR TITLE
(library/ec2) VPC Enhanced Support, vpc_private_ip_address, group_name vs. group_id

### DIFF
--- a/library/ec2
+++ b/library/ec2
@@ -128,11 +128,40 @@ options:
     required: false
     default: null
     aliases: []
+    
+  vpc_private_ip_address:
+    version_added: "1.1"
+    description:
+      - the specific VPC IP Address to launch the instance (VPC)
+    required: false
+    default: null
+    aliases: []
+  
 examples:
    - code: 'local_action: ec2 keypair=admin instance_type=m1.large image=emi-40603AD1 wait=true group=webserver count=3 group=webservers'
      description: "Examples from Ansible Playbooks"
+     
+   VPC example:
+   - action: Create a VPC/EC2 instance (AWS-VPC-EC2)
+   local_action:
+                ec2
+                count=1
+                ec2_access_key=AJIYDSNKDYGISHIH
+                ec2_secret_key=jYF766HBbuyg8B8Y79967V7bh9776v877gg8
+                image=ami-7ecf5c17
+                key_name=my-ec2-ssh-key.pub
+                instance_tags='{"Name":"My VPC Instance Test 01"}'
+                instance_type=t1.micro
+                group=MY-VPC-SPECIFIC-SECURITY-GROUP-24
+                ###group_id=sg-ad878w9
+                wait=true
+                vpc_private_ip_address="10.0.2.100"
+                vpc_subnet_id=subnet-89j8qhf                        #Id for my subnet vpc eg: 10.0.2.*
+     register: ec2
+     description: "Examples from SamukaSmk Playbooks"
+     
 requirements: [ "boto" ]
-author: Seth Vidal, Tim Gerla, Lester Wade
+author: Seth Vidal, Tim Gerla, Lester Wade, Samuel Sampaio
 '''
 
 import sys
@@ -163,6 +192,7 @@ def main():
             ec2_access_key = dict(aliases=['EC2_ACCESS_KEY']),
             user_data = dict(),
             instance_tags = dict(),
+            vpc_private_ip_address = dict(aliases=['private_ip_address']),
             vpc_subnet_id = dict(),
         )
     )
@@ -183,6 +213,7 @@ def main():
     ec2_access_key = module.params.get('ec2_access_key')
     user_data = module.params.get('user_data')
     instance_tags = module.params.get('instance_tags')
+    vpc_private_ip_address = module.params.get('vpc_private_ip_address')
     vpc_subnet_id = module.params.get('vpc_subnet_id')
 
     # allow eucarc environment variables to be used if ansible vars aren't set
@@ -193,6 +224,7 @@ def main():
     if not ec2_access_key and 'EC2_ACCESS_KEY' in os.environ:
         ec2_access_key = os.environ['EC2_ACCESS_KEY']
 
+
     try:
         if ec2_url: # if we have an URL set, connect to the specified endpoint 
             ec2 = boto.connect_ec2_endpoint(ec2_url, ec2_access_key, ec2_secret_key)
@@ -200,16 +232,27 @@ def main():
             ec2 = boto.connect_ec2(ec2_access_key, ec2_secret_key)
     except boto.exception.NoAuthHandlerFound, e:
         module.fail_json(msg = str(e))
-    
-    # Here we try to lookup the group name from the security group id - if group_id is set.
 
+    if group_id and group_name:
+        module.fail_json(msg = str("Use only one type of parameter (group_name) or (group_id)"))
+        sys.exit(1)    
+        
     try:
-        if group_id:
+        # Here we try to lookup the group id from the security group name - if group is set.
+        if group_name:
+            grp_details = ec2.get_all_security_groups()
+            for id in range(0, len(grp_details)):
+                if str(group_name) in str(grp_details[id]):
+                    group_id = str(grp_details[id].id)
+        # Now we try to lookup the group id testing if group exists.                    
+        elif group_id:
             grp_details = ec2.get_all_security_groups(group_ids=group_id)
-            grp_item = grp_details[0]
-            group_name = grp_item.name
     except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
+            
+            
+            
+            
 
     # Both min_count and max_count equal count parameter. This means the launch request is explicit (we want count, or fail) in how many instances we want.
 
@@ -218,11 +261,12 @@ def main():
                                 min_count = count, 
                                 max_count = count,
                                 monitoring_enabled = monitoring,
-                                security_groups = [group_name],
+                                security_group_ids = [group_id],
                                 instance_type = instance_type,
                                 kernel_id = kernel,
                                 ramdisk_id = ramdisk,
                                 subnet_id = vpc_subnet_id,
+                                private_ip_address = vpc_private_ip_address,
                                 user_data = user_data)
     except boto.exception.BotoServerError, e:
         module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))


### PR DESCRIPTION
Hi EveryOne!

I'm Samuel, AWS DevOps, new in this community.

Firstly i'd like to thank the helping of IRC.

I have some clients with AWS/EC2 infrastructure, generally with VPC Private Cloud,
ip addresses manageable and specific security groups.

When i used the ec2/boto pluggin, i realized that was create specific for "ec2 public clouds"
so i decided the improve this support.

The requirements are as follows:

1.) Create a machine, in the vpc private cloud;
2.) This machine needs have a specific IP delimited;
3.) Close the ports, with a specific security groups;

Following the examples, i create my own playbook.

---
- name: Manager of VPC instances (AWS-VPC-EC2) 
  hosts: 127.0.0.1
  connection: local
  user: root
  gather_facts: false  
  tasks:
  - name: Create a VPC instance (AWS-VPC-EC2) 
    local_action: 
                ec2
                count=1
                ec2_access_key=AJIYDSNKDYGISHIH
                ec2_secret_key=jYF766HBbuyg8B8Y79967V7bh9776v877gg8
                image=ami-7ecf5c17
                key_name=samukasmk.pub
                vpc_subnet_id=subnet-89j8qhf
                instance_tags='{"Name":"My Test VPC Instance"}'
                instance_type=t1.micro
                group=MY-VPC-SPECIFIC-SECURITY-GROUP-24
                wait=true
                ###group_id=sg-ad878w9
    register: ec2

The first problem that i found: 
msg: InvalidParameterCombination: The parameter groupName cannot be used with the parameter subnet

This is a Response of Boto Library.

Researching in the (boto library) for the resolution, i discovery that AWS API does not accepts, launch some
VPC instance, passing the security group NAME.

In the http://boto.readthedocs.org/en/latest/ref/ec2.html i got the resolution,
Pass the security group ID parameter (security_group_ids) instead the security group NAME parameter (security_groups).

CHANGE THIS:

```
try:
    if group_id:
        grp_details = ec2.get_all_security_groups(group_ids=group_id)
        grp_item = grp_details[0]
        group_name = grp_item.name
except boto.exception.NoAuthHandlerFound, e:
        module.fail_json(msg = str(e))

try:
    res = ec2.run_instances(image, key_name = key_name,
                            min_count = count, 
                            max_count = count,
                            monitoring_enabled = monitoring,
                            security_groups = [group_name],
                            instance_type = instance_type,
                            kernel_id = kernel,
                            ramdisk_id = ramdisk,
                            subnet_id = vpc_subnet_id,
                            user_data = user_data)
```

FOR THAT:

```
try:

    ### [Samuka-SMk]: Lock for pass 2 different security groups definitions
    if group_id and group_name:
        print "ERROR: pass group_name or group_id"

    ### [Samuka-SMk]: Test Valid the security group ID, instead we got a exception
    if group_id:
        grp_details = ec2.get_all_security_groups(group_ids=group_id)

    ### [Samuka-SMk]: Get the security group ID, with the security group NAME
    if group_name:
        grp_details = ec2.get_all_security_groups()
        for id in range(0, len(grp_details)):
            if str(group_name) in str(grp_details[id]):
                group_id = str(grp_details[id].id)

except boto.exception.NoAuthHandlerFound, e:
        module.fail_json(msg = str(e))

try:
    res = ec2.run_instances(image, key_name = key_name,
                            min_count = count, 
                            max_count = count,
                            monitoring_enabled = monitoring,
                            security_group_ids = [group_id],
                            instance_type = instance_type,
                            kernel_id = kernel,
                            ramdisk_id = ramdisk,
                            subnet_id = vpc_subnet_id,
                            user_data = user_data)
```

This Resolved my first problem!!

But i still need to pass the (SPECIFIC VPC PRIVATE IP)

I Create the new Argument;

```
module = AnsibleModule(
    argument_spec = dict(
    ...
    vpc_private_ip_address = dict(aliases=['private_ip_address']),
    ...
    )
)
```

   vpc_private_ip_address = module.params.get('vpc_private_ip_address')

And i pass the new argument, for the boto library:

```
try:
    res = ec2.run_instances(image, key_name = key_name,
                            min_count = count, 
                            max_count = count,
                            monitoring_enabled = monitoring,
                            security_group_ids = [group_id],
                            instance_type = instance_type,
                            kernel_id = kernel,
                            ramdisk_id = ramdisk,
                            subnet_id = vpc_subnet_id,
                            private_ip_address = vpc_private_ip_address,
                            user_data = user_data)
```

The new Playbook for my new features:

---
- name: Manager of VPC instances (AWS-VPC-EC2) 
  hosts: 127.0.0.1
  connection: local
  user: root
  gather_facts: false
  tasks:
  - name: Create a VPC instance (AWS-VPC-EC2) 
    local_action: 
                ec2
                count=1
                ec2_access_key=AJIYDSNKDYGISHIH
                ec2_secret_key=jYF766HBbuyg8B8Y79967V7bh9776v877gg8
                image=ami-7ecf5c17
                key_name=samukasmk.pub
                instance_tags='{"Name":"My VPC Instance Test 01"}'
                instance_type=t1.micro
                group=MY-VPC-SPECIFIC-SECURITY-GROUP-24
                wait=true
                vpc_subnet_id=subnet-89j8qhf
                vpc_private_ip_address="10.0.4.88"
                ###group_id=sg-ad878w9
    register: ec2

Testing My New Features:

SamukaSMk@stryck3r:~/Projects/smk-ansible/playbooks$ ansible-playbook ec2-playbooks/launch-instance-ec2.yml
TASK: [Create a VPC instance (AWS-VPC-EC2)] ********************\* 
changed: [127.0.0.1]

That's All Folks Guys!
