### PR TITLE
now cleanly catches traceback when conflicting versions of simplejson and python are installed

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -75,6 +75,9 @@ except ImportError:
     except ImportError:
         sys.stderr.write('Error: ansible requires a json module, none found!')
         sys.exit(1)
+    except SyntaxError:
+        sys.stderr.write('SyntaxError: probably due to json and python being for different versions')
+        sys.exit(1)
 
 HAVE_SELINUX=False
 try:


### PR DESCRIPTION
found this while helping user debug on IRC, he was running python2.4 (default python) but pulling in simplejson for 2.7 which does a relative import that causes a SyntaxError
