### PR TITLE
Fixes Arch building file

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 #Maintainer: Michel Blanc <mblanc@erasme.org>
 pkgname=ansible-git
-pkgver=20130131
+pkgver=20130311
 pkgrel=1
 pkgdesc="A radically simple deployment, model-driven configuration management, and command execution framework"
 arch=('any')
@@ -10,7 +10,7 @@ depends=('python2' 'python2-paramiko' 'python2-jinja' 'python2-yaml')
 makedepends=('git' 'asciidoc' 'fakeroot')
 conflicts=('ansible')
 source=("python-binary.diff")
-md5sums=("8f1eb942a01bbf206dbe32bded8725c6")
+md5sums=("ab81876d8d4c86c27d137e3d86c25a3a")
 
 _gitroot="https://github.com/ansible/ansible"
 _gitname="ansible"

--- a/packaging/arch/python-binary.diff
+++ b/packaging/arch/python-binary.diff
@@ -1,30 +1,11 @@
-Les fichiers binaires ansible.orig/.git/index et ansible/.git/index sont différents
-diff -uNr ansible.orig/Makefile ansible/Makefile
---- ansible.orig/Makefile	2012-11-16 09:30:00.232106580 +0100
-+++ ansible/Makefile	2012-11-16 09:31:06.606482546 +0100
-@@ -24,7 +24,7 @@
- ASCII2HTMLMAN = a2x -D docs/html/man/ -d manpage -f xhtml
- MANPAGES := docs/man/man1/ansible.1 docs/man/man1/ansible-playbook.1 docs/man/man1/ansible-pull.1
+--- ansible.orig/Makefile	2013-03-11 23:12:32.586322115 +0100
++++ ansible/Makefile	2013-03-11 23:12:59.375487971 +0100
+@@ -28,7 +28,7 @@
+ ASCII2MAN = @echo "ERROR: AsciiDoc 'a2x' command is not installed but is required to build $(MANPAGES)" && exit 1
+ endif
  
--SITELIB = $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
-+SITELIB = $(shell python2 -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
+-PYTHON=python
++PYTHON=python2
+ SITELIB = $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
  
  # VERSION file provides one place to update the software version
- VERSION := $(shell cat VERSION)
-@@ -111,13 +111,13 @@
- 	rm -rf docs/js
- 
- python:
--	python setup.py build
-+	python2 setup.py build
- 
- install:
--	python setup.py install
-+	python2 setup.py install
- 
- sdist: clean docs
--	python setup.py sdist -t MANIFEST.in
-+	python2 setup.py sdist -t MANIFEST.in
- 
- rpmcommon: sdist
- 	@mkdir -p rpm-build


### PR DESCRIPTION
Arch python binary patch was broken since improvement in 785068d. This
change fixes patch, removing most of the lines thanks to the new PYTHON
variable.
New source package already uploaded on AUR.
