### PR TITLE
added docs about in template overrides

### DIFF
--- a/library/template
+++ b/library/template
@@ -44,6 +44,8 @@ examples:
      description: "Example from Ansible Playbooks"
 notes:
   - Since Ansible version 0.9, templates are loaded with C(trim_blocks=True).
+  - You can override jinja2 settings by adding a special header to template file. 
+    i.e. c(#jinja2: trim_blocks: False)
 requirements: null
 author: Michael DeHaan
 '''


### PR DESCRIPTION
small documentation better than no documentation
Signed-off-by: Brian Coca bcoca@tablethotels.com
