### PR TITLE
pip module - expand user home directory variables in virtualenv parameter

### DIFF
--- a/library/pip
+++ b/library/pip
@@ -188,6 +188,7 @@ def main():
     virtualenv_command = module.params['virtualenv_command']
 
     if env:
+        env = os.path.expanduser(env)
         virtualenv = module.get_bin_path(virtualenv_command, True)
         if not os.path.exists(os.path.join(env, 'bin', 'activate')):
             if module.check_mode:


### PR DESCRIPTION
Just a one-liner to expand home directories - I'm installing a service with a virtualenv in the home directory of the user that runs it, something like:

``` yaml
- name: install django, for example
  pip: name=django
       version=1.5
       virtualenv=~myservice/env
```

Without this patch, the task is looking for the virtualenv in `/home/ansible-ssh-user/~myservice/env` without the intended expansion.
