### PR TITLE
Don't override argument specs with FILE_COMMON_ARGUMENTS

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -176,7 +176,9 @@ class AnsibleModule(object):
         self.aliases = {}
         
         if add_file_common_args:
-            self.argument_spec.update(FILE_COMMON_ARGUMENTS)
+            for k, v in FILE_COMMON_ARGUMENTS.iteritems():
+                if k not in self.argument_spec:
+                    self.argument_spec[k] = v
 
         os.environ['LANG'] = MODULE_LANG
         (self.params, self.args) = self._load_params()

--- a/library/copy
+++ b/library/copy
@@ -105,8 +105,8 @@ def main():
     md5sum_dest = None
 
     if os.path.exists(dest):
-        # if not force:
-        #    module.exit_json(msg="file already exists and force is set (%s)" % force, src=src, dest=dest, changed=False)
+        if not force:
+            module.exit_json(msg="file already exists", src=src, dest=dest, changed=False)
         if (os.path.isdir(dest)):
             basename = os.path.basename(src)
             dest = os.path.join(dest, basename)


### PR DESCRIPTION
Doing so will remove aliases, types, etc, leading to #2388 and other issues.

Restores force in copy.
