### PR TITLE
check type of task explicitly

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -104,6 +104,8 @@ class Play(object):
             tasks = []
 
         for x in tasks:
+            if not isinstance(x, dict):
+                raise errors.AnsibleError("expecting dict; got: %s" % x)
             task_vars = self.vars.copy()
             task_vars.update(vars)
             if 'include' in x:


### PR DESCRIPTION
Hi,

I'd like to propose a patch for this kind of stack one receives in case of wrong item type in playbook tasks list such as:

``` yaml
tasks:
- include path.yml
```

Results to:

```
Traceback (most recent call last):
  File "/usr/bin/ansible-playbook", line 209, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/usr/bin/ansible-playbook", line 180, in main
    pb.run()
  File "/usr/lib/python2.6/site-packages/ansible/playbook/__init__.py", line 202, in run
    play = Play(self, play_ds, play_basedir)
  File "/usr/lib/python2.6/site-packages/ansible/playbook/play.py", line 83, in __init__
    self._tasks      = self._load_tasks(self._ds.get('tasks', []))
  File "/usr/lib/python2.6/site-packages/ansible/playbook/play.py", line 110, in _load_tasks
    tokens = shlex.split(x['include'])
TypeError: string indices must be integers, not str
```

Patched:

```
ERROR: expecting dict; got: include path.yml
```

Thanks!
