### PR TITLE
check hostname presence

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -329,7 +329,15 @@ class Ec2Inventory(object):
             # Need to load index from cache
             self.load_index_from_cache()
 
+        if not self.args.host in self.index:
+            # try updating the cache
+            self.do_api_calls_update_cache()
+            if not self.args.host in self.index:
+                # host migh not exist anymore
+                return self.json_format_dict({}, True)
+
         (region, instance_id) = self.index[self.args.host]
+
         instance = self.get_instance(region, instance_id)
         instance_vars = {}
         for key in vars(instance):


### PR DESCRIPTION
Hi,
I'd like to propose a patch for this stack dump which happens in case host does not exist in EC2 anymore:

```
 ./ec2.py --host ec2-54-235-235-92.compute-1.amazonaws.com
Traceback (most recent call last):
  File "./ec2.py", line 424, in <module>
    Ec2Inventory()
  File "./ec2.py", line 149, in __init__
    data_to_print = self.get_host_info()
  File "./ec2.py", line 332, in get_host_info
    (region, instance_id) = self.index[self.args.host]
KeyError: 'ec2-54-235-235-92.compute-1.amazonaws.com'
```

With the suggested patch an empty host dict is returned instead

Thanks!
