### PR TITLE
Added lightweight though less-than-perfect logic to respect --home and -...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,18 @@ from distutils.core import setup
 
 # find library modules
 from ansible.constants import DIST_MODULE_PATH
-data_files = [ (DIST_MODULE_PATH, glob('./library/*')) ]
+from shlex import shlex
+
+def getopt_basedir():
+   lexer = shlex(' '.join(sys.argv[1:]))
+   lexer.whitespace += '='
+   lexer.whitespace_split = True
+   for tok in lexer:
+      if tok in ('--home','--root'):
+         return os.path.join(lexer.next(), 'share/ansible/')
+   return DIST_MODULE_PATH
+
+data_files = [ (getopt_basedir(), glob('./library/*')) ]
 
 print "DATA FILES=%s" % data_files
 


### PR DESCRIPTION
This related to #1277.

Let's say you have to install ansible to an alternative location because you cannot write to /usr/share. So you do a python setup.py install --home ~/ansible. That fails with a permission denied trying to write the library/\* modules to /usr/share/ansible. The problem is that the logic added in #1277 doesn't take the --home or --root params in to consideration. It get checks if real_prefix is set and if not it uses the standard /usr/share despite whatever command line override was used. The rest of the files bin/\* etc _are_ installed in the alternate location though.

I could easily install ansible manually in the alternate location, but I want to make this easy for others and myself so I came up with this patch. 

Trying to get the options that distutils collects and processes seemed near impossible. They are really buried in that package and there don't seem to be any hooks to effect the change we need. Using the usual getopt or argparse is also problematic because used have to create a profile for each and every command line option setup.py may need to pass on for the user. So I settled for some fairly lightweight though less-than-perfect logic to respect at least respect --home and --root in setup.py when installing data files. 

Follow up points:
- Should we also respect ANSIBLE_LIBRARY?
- Are there any other command line options we should also monitor and respect when installing the data files or are these two options sufficient for all options?
