### PR TITLE
Added variable expansion to task sudo_user parameter

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -94,7 +94,7 @@ class Task(object):
         self.args         = ds.get('args', {})
 
         if self.sudo:
-            self.sudo_user    = ds.get('sudo_user', play.sudo_user)
+            self.sudo_user    = utils.template(play.basedir, ds.get('sudo_user', play.sudo_user), play.vars)
             self.sudo_pass    = ds.get('sudo_pass', play.playbook.sudo_pass)
         else:
             self.sudo_user    = None


### PR DESCRIPTION
This should fix #1665 - it just performs the same variable expansion at the task level that is being done at the play level.
