### PR TITLE
pip module - run from the system's temp directory to avoid permissions problem

### DIFF
--- a/library/pip
+++ b/library/pip
@@ -19,6 +19,8 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import tempfile
+
 DOCUMENTATION = '''
 ---
 module: pip
@@ -217,6 +219,7 @@ def main():
 
     if module.check_mode:
         module.exit_json(changed=True)
+    os.chdir(tempfile.gettempdir())
     rc, out_pip, err_pip = module.run_command(cmd)
     out += out_pip
     err += err_pip


### PR DESCRIPTION
I ran into a permissions problem installing dependencies with pip from a git repository.

**ansible task:**

``` yaml
- name: install pip dependencies
  pip: requirements=/home/service-user/requirements.txt
       virtualenv=/home/service-user/env
       extra_args='--exists-action w'   # choose action to avoid interactive prompt
  sudo: true 
  sudo_user: service-user
```

**requirements.txt:**

```
-e git+git://github.com/kennethreitz/requests#egg=requests
```

I tracked the issue down to git temporarily switching directories as `service-user` and then being unable to switch back to the directory of the ansible runner user.  [This Stack Overflow  post](http://stackoverflow.com/questions/9851644/git-pulling-depends-on-the-current-dir) discusses a similar issue.

My fix just switches to the system temp directory to run the pip command, a directory that any user should be able to switch back to.
