### PR TITLE
Use environment python in nova.py

### DIFF
--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Marco Vito Moscaritolo <marco@agavee.com>
 #


### PR DESCRIPTION
Update nova.py to use `/usr/bin/env python` instead of one specified by an absolute path

This makes it usable with virtualenv 
