### PR TITLE
Fix --include-dependencies parameter on RubyGems >= 2.0.0

### DIFF
--- a/library/gem
+++ b/library/gem
@@ -66,6 +66,16 @@ gem: name=rake gem_source=/path/to/gems/rake-1.0.gem state=present
 
 import re
 
+def get_rubygems_version(module):
+    cmd = [module.get_bin_path('gem', True), '--version']
+    (rc, out, err) = module.run_command(cmd, check_rc=True)
+
+    match = re.match(r'^(\d+)\.(\d+)\.(\d+)', out)
+    if not match:
+        return None
+
+    return tuple(int(x) for x in match.groups())
+
 def get_installed_versions(module, remote=False):
 
     cmd = [ module.get_bin_path('gem', True) ]
@@ -118,14 +128,21 @@ def install(module):
 
     if module.check_mode:
         return
+
+    ver = get_rubygems_version(module)
+    major = ver[0] if ver else None
+
     cmd = [ module.get_bin_path('gem', True) ]
     cmd.append('install')
     if module.params['version']:
         cmd.extend([ '--version', module.params['version'] ])
     if module.params['repository']:
         cmd.extend([ '--source', module.params['repository'] ])
-    if module.params['include_dependencies']:
-        cmd.append('--include-dependencies')
+    if not module.params['include_dependencies']:
+        cmd.append('--ignore-dependencies')
+    else:
+        if major and major < 2:
+            cmd.append('--include-dependencies')
     cmd.append('--no-rdoc')
     cmd.append('--no-ri')
     cmd.append(module.params['gem_source'])


### PR DESCRIPTION
Related to #2414

Since I'm not sure what version of RubyGems started making the `--install-dependencies` flag  the default, I've decided to include it in everything that won't break - i.e. every version before major version 2.  I also have the command now use the `--ignore-dependencies` flag, since this is, I assume, the expected behavior.
