### PR TITLE
"nagios" module: fix NameError/'host' not defined

### DIFF
--- a/library/nagios
+++ b/library/nagios
@@ -167,6 +167,7 @@ def main():
         )
 
     action = module.params['action']
+    host = module.params['host']
     minutes = module.params['minutes']
     services = module.params['services']
     cmdfile = module.params['cmdfile']


### PR DESCRIPTION
Add missing 'host' variable, which is read a few lines later on in some cases.
