### PR TITLE
module_formatter.return_data: use UTF-8 encoding

### DIFF
--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -127,7 +127,7 @@ def load_examples_section(text):
 def return_data(text, options, outputname, module):
     if options.output_dir is not None:
         f = open(os.path.join(options.output_dir, outputname % module), 'w')
-        f.write(text)
+        f.write(text.encode('utf-8'))
         f.close()
     else:
         print text


### PR DESCRIPTION
The text parameter can contain non-ASCII characters, so we'll encode it
using UTF-8. For example the DOCUMENTATION of the bzr module has such
characters in the name of the author.
