### PR TITLE
ec2_vol: correctly follow Amazon's volume name instructions.

### DIFF
--- a/library/ec2_vol
+++ b/library/ec2_vol
@@ -58,7 +58,7 @@ examples:
               sudo: False
               with_items: ${ec2.instances}
               register: ec2_vol
-     description: "Advanced - attaching multiple volumes to multiple instances"
+     description: "Advanced - attaching multiple volumes to multiple instances.  Make sure to turn off sudo if you have it on otherwise it'll try to sudo on your local system."
 requirements: [ "boto" ]
 author: Lester Wade
 '''

--- a/library/ec2_vol
+++ b/library/ec2_vol
@@ -55,6 +55,7 @@ examples:
               register: ec2
             - name: Create volumes and attach
               local_action: ec2_vol instance=${item.id} volume_size=5
+              sudo: False
               with_items: ${ec2.instances}
               register: ec2_vol
      description: "Advanced - attaching multiple volumes to multiple instances"

--- a/library/ec2_vol
+++ b/library/ec2_vol
@@ -36,7 +36,7 @@ options:
     aliases: []
   device_name:
     description:
-      - device id to override device mapping. Assumes /dev/sdf for instance-store, /dev/sdb for EBS.
+      - device id to override device mapping. Assumes /dev/sdb for instance-store, /dev/sdf for EBS.
     required: false
     default: null
     aliases: []
@@ -153,10 +153,10 @@ def main():
     if device_name is None and instance:
         try:
             if inst.root_device_type != 'ebs':
-                device_name = '/dev/sdf'
+                device_name = '/dev/sdb'
                 attach = volume.attach(inst.id, device_name)
             else:
-                device_name = '/dev/sdb'
+                device_name = '/dev/sdf'
                 attach = volume.attach(inst.id, device_name)
                 while volume.attachment_state() != 'attached':
                     time.sleep(3)


### PR DESCRIPTION
Follow up to 8617b6df903e90c3c1a659df79de164625e0782f, reading [1]
suggests that EBS volumes should mounted at /dev/sd[f-p] while
instance store volumes are mounted at /dev/sd[b-e].

[1] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
