### PR TITLE
Added additional filter options for instances for EC2 and Eucalyptus

### DIFF
--- a/library/ec2
+++ b/library/ec2
@@ -293,8 +293,26 @@ def main():
     for inst in running_instances:
         d = {
            'id': inst.id,
+           'ami_launch_index': inst.ami_launch_index,
+           'private_ip': inst.private_ip_address,
+           'private_dns_name': inst.private_dns_name,
            'public_ip': inst.ip_address,
-           'public_dns_name': inst.public_dns_name
+           'dns_name': inst.dns_name,
+           'public_dns_name': inst.public_dns_name,
+           'state_code': inst.state_code,
+           'architecture': inst.architecture,
+           'image_id': inst.image_id,
+           'key_name': inst.key_name,
+           'virtualization_type': inst.virtualization_type,
+           'placement': inst.placement,
+           'kernel': inst.kernel,
+           'ramdisk': inst.ramdisk,
+           'launch_time': inst.launch_time,
+           'instance_type': inst.instance_type,
+           'root_device_type': inst.root_device_type,
+           'root_device_name': inst.root_device_name,
+           'state': inst.state,
+           'hypervisor': inst.hypervisor
             }
         instance_dict_array.append(d)
 


### PR DESCRIPTION
Added the following filter options:

```
       'ami_launch_index': inst.ami_launch_index,
       'private_ip': inst.private_ip_address,
       'private_dns_name': inst.private_dns_name,
       'dns_name': inst.dns_name,
       'state_code': inst.state_code,
       'architecture': inst.architecture,
       'image_id': inst.image_id,
       'key_name': inst.key_name,
       'virtualization_type': inst.virtualization_type,
       'placement': inst.placement,
       'kernel': inst.kernel,
       'ramdisk': inst.ramdisk,
       'launch_time': inst.launch_time,
       'instance_type': inst.instance_type,
       'root_device_type': inst.root_device_type,
       'root_device_name': inst.root_device_name,
       'state': inst.state,
       'hypervisor': inst.hypervisor
```

Allows more flexibility when dealing with the ec2 module in plays.
