### PR TITLE
fail when service cannot be found by chkconfig

### DIFF
--- a/library/service
+++ b/library/service
@@ -465,7 +465,7 @@ class LinuxService(Service):
         if self.enable_cmd.endswith("chkconfig"):
             (rc, out, err) = self.execute_command("%s --list %s" % (self.enable_cmd, self.name))
             if not self.name in out:
-                self.module.exit_json(msg="unknown service name")
+                self.module.fail_json(msg="unknown service name")
             state = out.split()[-1]
             if self.enable and ( "3:on" in out and "5:on" in out ):
                 return


### PR DESCRIPTION
When unable to set a service as enabled due to the service not existing in chkconfig, it should probably fail instead of reporting success
