### PR TITLE
attempt to add service to chkconfig when suggested

### DIFF
--- a/library/service
+++ b/library/service
@@ -464,6 +464,9 @@ class LinuxService(Service):
 
         if self.enable_cmd.endswith("chkconfig"):
             (rc, out, err) = self.execute_command("%s --list %s" % (self.enable_cmd, self.name))
+            if 'chkconfig --add %s' % self.name in err:
+                self.execute_command("%s --add %s" % (self.enable_cmd, self.name))
+                (rc, out, err) = self.execute_command("%s --list %s" % (self.enable_cmd, self.name))
             if not self.name in out:
                 self.module.exit_json(msg="unknown service name")
             state = out.split()[-1]


### PR DESCRIPTION
When chkconfig reports that the service is supported (but not referenced) and gives a suggested command to add it, attempt to add it.
