### PR TITLE
add better OS detection for BDM

### DIFF
--- a/library/ec2_vol
+++ b/library/ec2_vol
@@ -149,12 +149,16 @@ def main():
     
     # In future this needs to be more dynamic but combining block device mapping best practices
     # (bounds for devices, as above) with instance.block_device_mapping data would be tricky. For me ;)
-       
+
+    # Use password data attribute to tell whether the instance is Windows or Linux
     if device_name is None and instance:
         try:
-            if inst.root_device_type != 'ebs':
+            if inst.get_password_data == '':
                 device_name = '/dev/sdf'
                 attach = volume.attach(inst.id, device_name)
+                while volume.attachment_state() != 'attached':
+                    time.sleep(3)
+                    volume.update()
             else:
                 device_name = '/dev/sdb'
                 attach = volume.attach(inst.id, device_name)
@@ -162,7 +166,7 @@ def main():
                     time.sleep(3)
                     volume.update()
         except boto.exception.BotoServerError, e:
-            module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))           
+            module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
 
     print json.dumps({
         "volume_id": volume.id,

--- a/library/ec2_vol
+++ b/library/ec2_vol
@@ -151,6 +151,7 @@ def main():
     # (bounds for devices, as above) with instance.block_device_mapping data would be tricky. For me ;)
 
     # Use password data attribute to tell whether the instance is Windows or Linux
+
     if device_name is None and instance:
         try:
             if inst.get_password_data == '':
@@ -160,7 +161,7 @@ def main():
                     time.sleep(3)
                     volume.update()
             else:
-                device_name = '/dev/sdb'
+                device_name = '/dev/xvdf'
                 attach = volume.attach(inst.id, device_name)
                 while volume.attachment_state() != 'attached':
                     time.sleep(3)


### PR DESCRIPTION
Referencing #2438 - based on volume best practices detect the OS using password data.

This works against AWS EC2 but not against Eucalyptus (found a bug which I need to file).  

I'd be inclined to merge regardless to see if this can be fixed in Euca 3.3.  For Eucalyptus users it means they must override the block device mapping by ensuring they specify /dev/XXX.  If we can't patch this in Euca, then I'll introduce a workaround in the module this week.
