### PR TITLE
fixed module shebangs

### DIFF
--- a/library/ec2
+++ b/library/ec2
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python -tt
+#!/usr/bin/python -tt
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/vagrant
+++ b/library/vagrant
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -tt
+#!/usr/bin/python -tt
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify


### PR DESCRIPTION
ec2 and vagrant had non standard shebangs, breaking the interpreter overrides
Signed-off-by: Brian Coca <briancoca+dev@gmail.com>
