### PR TITLE
Changed python interpreter to be consistent in these modules as compared...

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Flowroute LLC

--- a/library/cloudformation
+++ b/library/cloudformation
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/ec2
+++ b/library/ec2
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python -tt
+#!/usr/bin/python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/ec2_facts
+++ b/library/ec2_facts
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/ec2_vol
+++ b/library/ec2_vol
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/pkgin
+++ b/library/pkgin
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Shaun Zinck

--- a/library/s3
+++ b/library/s3
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/vagrant
+++ b/library/vagrant
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -tt
+#!/usr/bin/python 
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify


### PR DESCRIPTION
.... to all others.  ec2 and vagrant were badly broken but I've also gone ahead and removed the -tt options on other modules.  I am presuming that the tt options aren't required since its pretty much redundant when ansible is calling the modules?
