### PR TITLE
inject a dictionary of avaiable variables and the environment into executor

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -337,6 +337,8 @@ class Runner(object):
         inject['hostvars'] = HostVars(self.setup_cache, self.inventory)
         inject['group_names'] = host_variables.get('group_names', [])
         inject['groups'] = self.inventory.groups_list()
+        inject['vars'] = self.module_vars
+        inject['environment'] = self.environment
 
         # allow with_foo to work in playbooks...
         items = None


### PR DESCRIPTION
Expose vars & env as a dictionary (as hostvars is done) so that a template can be used to debug a playbook by dumping relevant data structures,

Enables this action:

```
- name: dump everything
  local_action: template 
     src=common/templates/dump.j2 
     dest=./ansible_data_dump.txt 
```

along with this template:

```
Module Variables ("vars"):
--------------------------------
{{ vars | to_nice_json }} 

Environment Variables ("environment"):
--------------------------------
{{ environment | to_nice_json }} 

GROUP NAMES Variables ("group_names"):
--------------------------------
{{ group_names | to_nice_json }}

GROUPS Variables ("groups"):
--------------------------------
{{ groups | to_nice_json }}

HOST Variables ("hostvars"):
--------------------------------
{{ hostvars | to_nice_json }} 
```

To dump a list of relevant data structures in the context of a template, or in a playbook.
