### PR TITLE
invalidate group cache when adding a new group

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -288,6 +288,7 @@ class Inventory(object):
 
     def add_group(self, group):
         self.groups.append(group)
+        self._groups_list = None  # invalidate internal cache 
 
     def list_hosts(self, pattern="all"):
         return [ h.name for h in self.get_hosts(pattern) ]


### PR DESCRIPTION
I found that when using add_host module, the "groups" vars did not reflect the new group, even though "group_names" and "hostvars" did.

Upshot is that the Inventory._groups_list cache dictionary was not being updated.

Now works as expected. Please prioritize merge.

Thanks,
Rob
