### PR TITLE
Fix broken virtualenv link in pip documentation.

### DIFF
--- a/library/pip
+++ b/library/pip
@@ -106,7 +106,7 @@ examples:
    - code: "pip: requirements=/my_app/requirements.txt extra_args='-i https://example.com/pypi/simple'"
      description: Install specified python requirements and custom Index URL.
 notes:
-   - Please note that U(http://www.virtualenv.org/, virtualenv) must be installed on the remote host if the virtualenv parameter is specified.
+   - Please note that virtualenv (U(http://www.virtualenv.org/)) must be installed on the remote host if the virtualenv parameter is specified.
 requirements: [ "virtualenv", "pip" ]
 author: Matt Wright
 '''


### PR DESCRIPTION
Just a simple docs fix for a broken link.
