### PR TITLE
ansible-pull "bootstrapping" improvements

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -43,6 +43,7 @@ import sys
 import datetime
 import socket
 from optparse import OptionParser
+import ansible.constants as C
 
 DEFAULT_PLAYBOOK = 'local.yml'
 PLAYBOOK_ERRORS = { 1: 'File does not exist',
@@ -102,6 +103,9 @@ def main(args):
     parser.add_option('-C', '--checkout', dest='checkout',
                       default="HEAD",
                       help='Branch/Tag/Commit to checkout.  Defaults to HEAD.')
+    parser.add_option('-i', '--inventory-file', dest='inventory',
+                      help="specify inventory host file (default=%s)" % C.DEFAULT_HOST_LIST,
+                      default=C.DEFAULT_HOST_LIST)
     options, args = parser.parse_args(args)
 
     if not options.dest:
@@ -128,7 +132,7 @@ def main(args):
         print >>sys.stderr, "Could not find a playbook to run."
         return 1
 
-    cmd = 'ansible-playbook -c local --limit "%s" %s' % (limit_opts, playbook)
+    cmd = 'ansible-playbook -c local -i "%s" --limit "%s" %s' % (options.inventory, limit_opts, playbook)
     os.chdir(options.dest)
     rc = _run(cmd)
 

--- a/examples/hosts
+++ b/examples/hosts
@@ -42,3 +42,6 @@ db02.intranet.mydomain.net
 
 db-[99:101]-node.example.com
 
+# localhost
+# Best to have this handy for ansible-pull
+127.0.0.1


### PR DESCRIPTION
ansible-pull currently requires several things to be functional :
- 127.0.0.1 must be in default (`/etc/ansible/hosts`) inventory file (for the `ansible` step)
- `/etc/ansible/host` must match the playbook pulled if we want to use the real node hostname instead of 127.0.0.1 (and thus, use a "real life" playbook, pulled by different nodes) in the `ansible-playbook` step

This patch should solve this and allow :
- additional step towards zero conf ansible-pull bootstrapping : set hostname (and add in `/etc/hosts`), install ansible, kick `ansible-pull`, you should be set)
- no need to configure `/etc/ansible/hosts` for the `ansible` step
- use of real inventory file (only file is supported, as previously) so shared playbooks will have proper variables for the current host, use host_vars/group_vars properly, etc...

This promotes reuse since it allows easy deploying a fleet of machines, hidden behind firewalls/NAT gateways, using a single playbook.

_Caveat_: 127.0.0.1 is now in `/etc/ansible/hosts`. How this could lead to local deployment mayhem with fresh installs (e.g. new user running a random downloaded playbook with -l localhost) might have to be considered. 
