### PR TITLE
Limit scope of arguments to service_control() in service module

### DIFF
--- a/library/service
+++ b/library/service
@@ -509,40 +509,41 @@ class LinuxService(Service):
 
         # Decide what command to run
         svc_cmd = ''
+        arguments = self.arguments
         if self.svc_cmd:
             if not self.svc_cmd.endswith("systemctl"):
-                # SysV or systemd take the form <cmd> <name> <action>
+                # SysV take the form <cmd> <name> <action>
                 svc_cmd = "%s %s" % (self.svc_cmd, self.name)
             else:
                 # systemd commands take the form <cmd> <action> <name>
                 svc_cmd = self.svc_cmd
-                self.arguments = "%s %s" % (self.name, self.arguments)
+                arguments = "%s %s" % (self.name, arguments)
         elif self.svc_initscript:
             # upstart
             svc_cmd = "%s" % self.svc_initscript
 
         if self.action is not "restart":
             if svc_cmd != '':
-                # upstart
-                rc_state, stdout, stderr = self.execute_command("%s %s %s" % (svc_cmd, self.action, self.arguments), daemonize=True)
+                # upstart or systemd
+                rc_state, stdout, stderr = self.execute_command("%s %s %s" % (svc_cmd, self.action, arguments), daemonize=True)
             else:
-                # SysV or systemd
-                rc_state, stdout, stderr = self.execute_command("%s %s %s" % (self.action, self.name, self.arguments), daemonize=True)
+                # SysV
+                rc_state, stdout, stderr = self.execute_command("%s %s %s" % (self.action, self.name, arguments), daemonize=True)
         else:
             # not all services support restart. Do it the hard way.
             if svc_cmd != '':
-                # upstart
-                rc1, stdout1, stderr1 = self.execute_command("%s %s %s" % (svc_cmd, 'stop', self.arguments), daemonize=True)
+                # upstart or systemd
+                rc1, stdout1, stderr1 = self.execute_command("%s %s %s" % (svc_cmd, 'stop', arguments), daemonize=True)
             else:
-                # SysV or systemd
-                rc1, stdout1, stderr1 = self.execute_command("%s %s %s" % ('stop', self.name, self.arguments), daemonize=True)
+                # SysV
+                rc1, stdout1, stderr1 = self.execute_command("%s %s %s" % ('stop', self.name, arguments), daemonize=True)
 
             if svc_cmd != '':
-                # upstart
-                rc2, stdout2, stderr2 = self.execute_command("%s %s %s" % (svc_cmd, 'start', self.arguments), daemonize=True)
+                # upstart or systemd
+                rc2, stdout2, stderr2 = self.execute_command("%s %s %s" % (svc_cmd, 'start', arguments), daemonize=True)
             else:
-                # SysV or systemd
-                rc2, stdout2, stderr2 = self.execute_command("%s %s %s" % ('start', self.name, self.arguments), daemonize=True)
+                # SysV
+                rc2, stdout2, stderr2 = self.execute_command("%s %s %s" % ('start', self.name, arguments), daemonize=True)
 
             # merge return information
             if rc1 != 0 and rc2 == 0:


### PR DESCRIPTION
This fixes handling of arguments (module argument) in service_control().
It is now locally scoped such that modifications to it, in the case of a
systemd host, do not later impact subsequent calls to service_control().
See issue #2449.

Without patch:
ansible-service[6177]: Command /usr/bin/systemctl stop cups cups , daemonize True

With patch:
ansible-service[6475]: Command /usr/bin/systemctl start cups , daemonize True

I also updated the comments to reflect the case where systemd is really
being called.
