### PR TITLE
Fixes for get_remote_head in git module

### DIFF
--- a/library/git
+++ b/library/git
@@ -104,15 +104,32 @@ def reset(module,dest,force):
     return module.run_command("git reset --hard HEAD", check_rc=True)
 
 def get_remote_head(module, dest, version, remote):
+    cmd = ''
+    os.chdir(dest)
     if version == 'HEAD':
         version = get_head_branch(module, dest, remote)
-    os.chdir(dest)
-    cmd = "git ls-remote %s -h refs/heads/%s" % (remote, version)
+    if is_remote_branch(module, dest, remote, version):
+        cmd = 'git ls-remote %s -h refs/heads/%s' % (remote, version)
+    elif is_remote_tag(module, dest, remote, version):
+        cmd = 'git ls-remote %s -t refs/tags/%s' % (remote, version)
+    else:
+        # appears to be a sha1.  return as-is since it appears
+        # cannot check for a specific sha1 on remote
+        return version
     (rc, out, err) = module.run_command(cmd, check_rc=True)
     if len(out) < 1:
         module.fail_json(msg="Could not determine remote revision for %s" % version)
     rev = out.split()[0]
     return rev
+
+def is_remote_tag(module, dest, remote, version):
+    os.chdir(dest)
+    cmd = 'git ls-remote %s -t refs/tags/%s' % (remote, version)
+    (rc, out, err) = module.run_command(cmd)
+    if version in out:
+        return True
+    else:
+        return False
 
 def get_branches(module, dest):
     os.chdir(dest)
@@ -270,11 +287,22 @@ def main():
         # check or get changes from remote
         remote_head = get_remote_head(module, dest, version, remote)
         if module.check_mode:
-            remote_head = remote_head[0:7]
-            if before != remote_head:
-                module.exit_json(changed=True, before=before, after=remote_head)
+            changed = False
+            if remote_head == version:
+                # get_remote_head returned version as-is
+                # were given a sha1 object, see if it is present
+                (rc, out, err) = module.run_command("git show %s" % version)
+                if version in out:
+                    changed = False
+                else:
+                    changed = True
             else:
-                module.exit_json(changed=False, before=before, after=remote_head)
+                remote_head = remote_head[0:7]
+                if before != remote_head:
+                    changed = True
+                else:
+                    changed = False
+            module.exit_json(changed=changed, before=before, after=remote_head)
         (rc, out, err) = fetch(module, repo, dest, version, remote)
         if rc != 0:
             module.fail_json(msg=err)


### PR DESCRIPTION
See issue #2471

This fixes get_remote_head() to be smarter about how to check remote
head.  It checks if it is a remote branch or tag and then checks for the
remote object id associated with it.  If it is sha1, get_remote_head()
returns it as-is since there doesn't appear to be a way to check a
remote repository for a specific object/sha1.  is_remote_tag() is added
to help out the new functionalit in get_remote_head().

In main(), if check_mode is true and version is a sha1, the module now
checks to see if the object is present.
