### PR TITLE
disabled appending file with garbage when regexp didn't match.

### DIFF
--- a/library/lineinfile
+++ b/library/lineinfile
@@ -184,10 +184,14 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create, backu
     # Add it to the end of the file if requested or
     # if insertafter=/insertbefore didn't match anything
     # (so default behaviour is to add at the end)
-    elif insertafter == 'EOF' or index[1] == -1:
+    elif insertafter == 'EOF':
         lines.append(line + os.linesep)
         msg = 'line added'
         changed = True
+    # Do nothing if regexp didn't match
+    elif index[1] == -1:
+        msg = ''
+        changed = False 
     # insertafter/insertbefore= matched
     else:
         lines.insert(index[1], line + os.linesep)


### PR DESCRIPTION
When using lineinfile module, lines was appended with garbage when regular expression didn't match. 
Using example: lineinfile dest=/tmp/grub.conf state=present regexp='^(splashimage=.*)$' line="#\1"
when regexp was not found originally lineinfile module would append file with "#\1". 
I believe better is do nothing if regexp returned false.
