### PR TITLE
Support systemd template service unit files

### DIFF
--- a/library/service
+++ b/library/service
@@ -499,7 +499,7 @@ class LinuxService(Service):
 
         self.changed = True
 
-        if self.module.check_mode and changed:
+        if self.module.check_mode and self.changed:
             self.module.exit_json(changed=True)
 
         return self.execute_command("%s %s %s" % args)

--- a/library/service
+++ b/library/service
@@ -369,10 +369,20 @@ class LinuxService(Service):
         elif location.get('systemctl', None):
 
             # verify service is managed by systemd
-            rc, out, err = self.execute_command("%s --all" % (location['systemctl']))
-            look_for = "%s.service" % self.name
-            if look_for in out:
-                self.enable_cmd = location['systemctl']
+            rc, out, err = self.execute_command("%s list-unit-files" % (location['systemctl']))
+
+            # adjust the service name to account for template service unit files
+            index = self.name.find('@')
+            if index == -1:
+                name = self.name
+            else:
+                name = self.name[:index+1]
+
+            look_for = "%s.service" % name
+            for line in out.splitlines():
+               if line.startswith(look_for):
+                   self.enable_cmd = location['systemctl']
+                   break
 
         # Locate a tool for runtime service management (start, stop etc.)
         self.svc_cmd = ''
@@ -473,10 +483,15 @@ class LinuxService(Service):
                 return
 
         if self.enable_cmd.endswith("systemctl"):
-            (rc, out, err) = self.execute_command("%s is-enabled %s.service" % (self.enable_cmd, self.name))
-            if self.enable and rc == 0:
-                return
-            elif not self.enable and rc == 1:
+            (rc, out, err) = self.execute_command("%s show %s.service" % (self.enable_cmd, self.name))
+
+            d = dict(line.split('=', 1) for line in out.splitlines())
+            if "UnitFileState" in d:
+                if self.enable and d["UnitFileState"] == "enabled":
+                    return
+                elif not self.enable and d["UnitFileState"] == "disabled":
+                    return
+            elif not self.enable:
                 return
 
         # we change argument depending on real binary used


### PR DESCRIPTION
This pull request fixes too issues:
1. There is a compilation error when trying to run the service module on a systemd system in --check mode.
2. The service module's systemd logic does not permit usage with template unit files.  For an example, it is unable to manage the WOL service as described at https://wiki.archlinux.org/index.php/Wake-on-LAN#With_systemd
