### PR TITLE
add restart_delay to handle slow stopping services

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -609,7 +609,10 @@ class AnsibleModule(object):
             elif wanted == 'int':
                 if not isinstance(value, int):
                     if isinstance(value, basestring):
-                        self.params[k] = int(value)
+                        try:
+                            self.params[k] = int(value)
+                        except ValueError:
+                            is_invalid = True
                     else:
                         is_invalid = True
             else:

--- a/library/service
+++ b/library/service
@@ -75,6 +75,7 @@ import os
 import tempfile
 import shlex
 import select
+import time
 
 class Service(object):
     """
@@ -102,6 +103,7 @@ class Service(object):
         self.state          = module.params['state']
         self.pattern        = module.params['pattern']
         self.enable         = module.params['enabled']
+        self.restart_delay  = module.params['restart_delay']
         self.changed        = False
         self.running        = None
         self.action         = None
@@ -556,6 +558,11 @@ class LinuxService(Service):
                 # SysV
                 rc1, stdout1, stderr1 = self.execute_command("%s %s %s" % ('stop', self.name, arguments), daemonize=True)
 
+            # add generic time.sleep of N seconds to play nicer with
+            # applications that take some time to stop
+            if self.restart_delay is not None:
+                time.sleep(float(self.restart_delay))
+
             if svc_cmd != '':
                 # upstart or systemd
                 rc2, stdout2, stderr2 = self.execute_command("%s %s %s" % (svc_cmd, 'start', arguments), daemonize=True)
@@ -852,6 +859,7 @@ def main():
             state = dict(choices=['running', 'started', 'stopped', 'restarted', 'reloaded']),
             pattern = dict(required=False, default=None),
             enabled = dict(choices=BOOLEANS, type='bool'),
+            restart_delay = dict(required=False, default=None),
             arguments = dict(aliases=['args'], default=''),
         ),
         supports_check_mode=True

--- a/library/service
+++ b/library/service
@@ -51,6 +51,13 @@ options:
         choices: [ "yes", "no" ]
         description:
         - Whether the service should start on boot.
+    restart_delay:
+        required: false
+        choices: [ number of seconds ]
+        description:
+        - Number of seconds to wait before attempting to start an
+          application on state=restarted. Useful for init scripts that 
+          are slow to stop and/or return before the application is stopped.
     arguments:
         description:
         - Additional arguments provided on the command line
@@ -62,6 +69,8 @@ examples:
       code: "service: name=httpd state=stopped"
     - description: Example action to restart service httpd, in all cases
       code: "service: name=httpd state=restarted"
+    - description: Example action to restart service sensu-server and wait 10s to start back up
+      code: "service: name=sensu-server state=restarted restart_delay=10"
     - description: Example action to reload service httpd, in all cases
       code: "service: name=httpd state=reloaded"
     - description: Example action to start service foo, based on running process /usr/bin/foo
@@ -859,7 +868,7 @@ def main():
             state = dict(choices=['running', 'started', 'stopped', 'restarted', 'reloaded']),
             pattern = dict(required=False, default=None),
             enabled = dict(choices=BOOLEANS, type='bool'),
-            restart_delay = dict(required=False, default=None),
+            restart_delay = dict(required=False, default=None, type='int'),
             arguments = dict(aliases=['args'], default=''),
         ),
         supports_check_mode=True


### PR DESCRIPTION
Add restart_delay to service module to allow users to define a wait or restart delay on state=restarted. Several services aren't stopped before the service module attempts to start, resulting is services that are stopped.
