### PR TITLE
Fix reinplace in macports package to work on both 10.7 and 10.8

### DIFF
--- a/packaging/macports/sysutils/ansible/Portfile
+++ b/packaging/macports/sysutils/ansible/Portfile
@@ -38,8 +38,8 @@ depends_lib-append      port:py${python.version}-jinja2 \
 patch {
     fs-traverse f ${worksrcpath} {
         if {[file isfile ${f}]} {
-            reinplace "s#/etc/ansible#${prefix}/etc/ansible#g" ${f}
-            reinplace "s#/usr/share/ansible#${prefix}/share/ansible#g" ${f}
+            reinplace -locale C "s#/etc/ansible#${prefix}/etc/ansible#g" ${f}
+            reinplace -locale C "s#/usr/share/ansible#${prefix}/share/ansible#g" ${f}
         }
     }
 }


### PR DESCRIPTION
This is a macports packaging fix, I had to install ansible on a few of my colleagues laptops today to reproduce a development/test/integration environment and came across some differences in macports/osx between 10.7 and 10.8.

reinplace on OSX 10.8 seems to behave differently, this change has been tested
on a few 10.8 and 10.7 machines.

It seems to work for me, but please test!
