### PR TITLE
user module check mode bug fix

### DIFF
--- a/library/user
+++ b/library/user
@@ -367,7 +367,7 @@ class User(object):
         if len(cmd) == 1:
             return (None, '', '')
         elif self.module.check_mode:
-            return (True, '', '')
+            return (0, '', '')
 
         cmd.append(self.name)
         return self.execute_command(cmd)


### PR DESCRIPTION
when running in check mode the user module returns an error (with no text) and fails the playbook.

This patch changes it to return a 'changed' status, which I believe is what is expected.
