### PR TITLE
added validate option to copy

### DIFF
--- a/library/copy
+++ b/library/copy
@@ -64,6 +64,12 @@ options:
     choices: [ "yes", "no" ]
     default: "yes"
     aliases: [ "thirsty" ]
+  validate:
+    description:
+      - validation to run before copying into place
+    required: false
+    default: ""
+    version_added: "1.2"
   others:
   others:
     description:
@@ -74,6 +80,8 @@ examples:
      description: "Example from Ansible Playbooks"
    - code: "copy: src=/mine/ntp.conf dest=/etc/ntp.conf owner=root group=root mode=644 backup=yes"
      description: "Copy a new C(ntp.conf) file into place, backing up the original if it differs from the copied version"
+   - code: "copy: src=/mine/sudoers dest=/etc/sudoers validate='visudo -c %s'
+     description: "Copy a new C(sudoers) file into place, after passing validation with visdo"
 author: Michael DeHaan
 '''
 
@@ -88,6 +96,7 @@ def main():
             dest              = dict(required=True),
             backup            = dict(default=False, type='bool'),
             force             = dict(default=True, aliases=['thirsty'], type='bool'),
+            validate          = dict(required=False, aliases=['nocakeforjpmens'],type='str'),
         ),
         add_file_common_args=True,
     )
@@ -97,6 +106,7 @@ def main():
     backup = module.params['backup']
     force  = module.params['force']
     original_basename = module.params.get('original_basename',None)
+    validate = module.params.get('validate',None)
 
     if not os.path.exists(src):
         module.fail_json(msg="Source %s failed to transfer" % (src))
@@ -136,6 +146,10 @@ def main():
             # might be an issue with exceeding path length
             dest_tmp = "%s.%s.%s.tmp" % (dest,os.getpid(),time.time())
             shutil.copyfile(src, dest_tmp)
+            if validate:
+               (rc,out,err) = module.run_command(validate % dest_tmp)
+               if rc != 0:
+                 module.fail_json(msg="failed to validate: rc:%s error:%s" % (rc,err))
             module.atomic_replace(dest_tmp, dest)
         except shutil.Error:
             module.fail_json(msg="failed to copy: %s and %s are the same" % (src, dest))


### PR DESCRIPTION
lets you add a validation check to files you are copying (ie. visudo -c), if validation fails it returns the error output from the check.

sample playbook:

```
- hosts: all
  tasks:
    - copy: src=files/collectd.conf dest=/etc/collectd.conf validate='/usr/sbin/collectd -tC %s'
```
