### PR TITLE
replaced && by || 

### DIFF
--- a/docsite/rst/playbooks.rst
+++ b/docsite/rst/playbooks.rst
@@ -220,7 +220,7 @@ who's successful exit code is not zero, you may wish to do this::
 
    tasks:
      - name: run this command and ignore the result
-       action: shell /usr/bin/somecommand && /bin/true
+       action: shell /usr/bin/somecommand || /bin/true
 
 If the action line is getting too long for comfort you can break it on
 a space and indent any continuation lines::


### PR DESCRIPTION
In the example, you want /bin/true to be executed if the first command has an error return code. Combining command with && will run the second only if the first is successful. Combining them with ||, the second will be run only of the first fails, what is wanted here.
