### PR TITLE
yum url support

### DIFF
--- a/library/yum
+++ b/library/yum
@@ -371,7 +371,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                     # this might be an url spec
                     fp = urllib.URLopener().open(spec)
                     fp.close()
-                except (urllib.error.URLerror, IOError) as e:
+                except IOError as e:
                     res['msg'] += "error opening url '%s': %s" % (spec, e)
                     module.fail_json(**res)
                 if fp.code != 200:

--- a/library/yum
+++ b/library/yum
@@ -371,7 +371,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
             elif "://" in spec:
                 # this might be an url spec
                 # parse the spec and check whether it is installed
-                # its not bulletproof but might prove uesful
+                # a false-negative is an option here
                 try:
                     path = urllib2.urlparse.urlparse(spec)[2]
                 except ValueError as e:
@@ -434,6 +434,14 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
             module.exit_json(changed=True)
 
         rc, out, err = module.run_command(cmd)
+
+        if rc == 1 and 'Nothing to do' in err:
+            # avoid failing in the 'Nothing To Do' case
+            # happens if a URL--nevra translation yields a false-negative with
+            # regards to the installation status
+            rc = 0
+            err = ''
+            out = ''
 
         res['rc'] += rc
         res['results'].append(out)

--- a/library/yum
+++ b/library/yum
@@ -24,6 +24,7 @@
 import traceback
 import os
 import yum
+import urllib
 
 DOCUMENTATION = '''
 ---
@@ -366,8 +367,16 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         if spec.endswith('.rpm'):
             # get the pkg name-v-r.arch
             if not os.path.exists(spec):
-                res['msg'] += "No Package file matching '%s' found on system" % spec
-                module.fail_json(**res)
+                try:
+                    # this might be an url spec
+                    fp = urllib.URLopener().open(spec)
+                    fp.close()
+                except Exception as e:
+                    res['msg'] += "error opening url '%s': %s" % (spec, e)
+                    module.fail_json(**res)
+                if fp.code != 200:
+                    res['msg'] += "error opening url '%s'; code: %s" % (spec, fp.code)
+                    module.fail_json(**res)
 
             nvra = local_nvra(module, spec)
             # look for them in the rpmdb

--- a/library/yum
+++ b/library/yum
@@ -24,7 +24,7 @@
 import traceback
 import os
 import yum
-import urllib
+import urllib2
 
 DOCUMENTATION = '''
 ---
@@ -365,21 +365,25 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         # check if pkgspec is installed (if possible for idempotence)
         # localpkg
         if spec.endswith('.rpm'):
-            # get the pkg name-v-r.arch
-            if not os.path.exists(spec):
+            if os.path.exists(spec):
+                # get the pkg name-v-r.arch
+                nvra = local_nvra(module, spec)
+            elif "://" in spec:
+                # this might be an url spec
+                # parse the spec and check whether it is installed
+                # its not bulletproof but might prove uesful
                 try:
-                    # this might be an url spec
-                    fp = urllib.URLopener().open(spec)
-                    fp.close()
-                except IOError as e:
-                    res['msg'] += "error opening url '%s': %s" % (spec, e)
+                    path = urllib2.urlparse.urlparse(spec)[2]
+                except ValueError as e:
+                    res['msg'] += "Error parsing url '%s': %s" % (spec, e)
                     module.fail_json(**res)
-                if fp.code != 200:
-                    res['msg'] += "error opening url '%s'; code: %s" % (spec, fp.code)
-                    module.fail_json(**res)
+                # a hack to extract nvra from the URL path field
+                nvra = os.path.basename(path).rstrip('.rpm')
+            else:
+                res['msg'] += "No Package file matching '%s' found on system" % spec
+                module.fail_json(**res)
 
-            nvra = local_nvra(module, spec)
-            # look for them in the rpmdb
+            # look for the pkg name-v-r.arch in the rpmdb
             if is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos):
                 # if they are there, skip it
                 continue

--- a/library/yum
+++ b/library/yum
@@ -371,7 +371,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                     # this might be an url spec
                     fp = urllib.URLopener().open(spec)
                     fp.close()
-                except Exception as e:
+                except (urllib.error.URLerror, IOError) as e:
                     res['msg'] += "error opening url '%s': %s" % (spec, e)
                     module.fail_json(**res)
                 if fp.code != 200:


### PR DESCRIPTION
Hi,

I'd like to propose a patch for the yum module to avoid stacks like this when a URL is provided rather than package name/path:

```
msg: No Package file matching 'https://rhuiqerpm.s3.amazonaws.com/python-coverage-3.6-0.2.b3.el6.x86_64.rpm' found on system
```

The patch goal is to try handling the rpm spec as if it was a URL in case it wasn't found on the system. It adds a dependency on urllib.

Thanks!
