### PR TITLE
now ssh plugin 'respects' .ssh/config user 

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -23,6 +23,7 @@ import pipes
 import random
 import select
 import fcntl
+import pwd
 import ansible.constants as C
 from ansible.callbacks import vvv
 from ansible import errors
@@ -62,7 +63,8 @@ class Connection(object):
         else:
             self.common_args += ["-o", "KbdInteractiveAuthentication=no",
                                  "-o", "PasswordAuthentication=no"]
-        self.common_args += ["-o", "User="+self.user]
+        if self.user != pwd.getpwuid(os.geteuid())[0]:
+            self.common_args += ["-o", "User="+self.user]
         self.common_args += ["-o", "ConnectTimeout=%d" % self.runner.timeout]
 
         return self


### PR DESCRIPTION
This is a small annoyance, but a few people use user overrides in .ssh config, which don't work cause the ssh plugin always specifies user. I made a special case (for when user is the same as current user), which now will respect the .ssh/config and should not break when overriding to a different user.

Signed-off-by: Brian Coca <briancoca+dev@gmail.com>
