### PR TITLE
Docs generator: fixed option (type) validation error

### DIFF
--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -164,7 +164,7 @@ def main():
     p.add_option("-t", "--type",
             action='store',
             dest='type',
-            choices=['html', 'latex', 'man', 'rst', 'json', 'markdown'],
+            choices=['html', 'latex', 'man', 'rst', 'json', 'markdown', 'js'],
             default='latex',
             help="Output type")
     p.add_option("-m", "--module",


### PR DESCRIPTION
Fixed error on validation that block javascript documentation generation.

This block the automatic generation of docs used to have  AngularJS version of docs.
