### PR TITLE
postgresql_user: make password optional for new users

### DIFF
--- a/library/postgresql_user
+++ b/library/postgresql_user
@@ -43,9 +43,8 @@ options:
     default: null
   password:
     description:
-      - set the user's password
-    required: true
-    default: null
+      - If specified, set the user's password.
+    required: false
   db:
     description:
       - name of database where permissions will be granted
@@ -141,8 +140,11 @@ def user_exists(cursor, user):
 
 
 def user_add(cursor, user, password, role_attr_flags):
-    """Create a new user with write access to the database"""
-    query = "CREATE USER \"%(user)s\" with PASSWORD '%(password)s' %(role_attr_flags)s"
+    """Create a new database user (role)."""
+    if password is not None:
+        query = "CREATE USER \"%(user)s\" WITH PASSWORD '%(password)s' %(role_attr_flags)s"
+    else:
+        query = "CREATE USER \"%(user)s\" WITH %(role_attr_flags)s"
     cursor.execute(query % {"user": user, "password": password, "role_attr_flags": role_attr_flags})
     return True
 
@@ -424,10 +426,6 @@ def main():
 
             changed = user_alter(cursor, user, password, role_attr_flags)
         else:
-            if password is None:
-                msg = "password parameter required when adding a user"
-                module.fail_json(msg=msg)
-
             if  module.check_mode:  
                 kw['changed'] = True 
                 module.exit_json(**kw)


### PR DESCRIPTION
This allows the creation of group roles not meant for logging in at all, as
well as the creation of user roles meant to be authenticated via different
means (LDAP, ...)

Removing an existing password is currently not possible by means of the
"password" argument. (One could specify "PASSWORD NULL" via the
"role_attr_flags" param, but this might subvert the intended use of
role_attr_flags, therefore I don't think that's a good idea)
