### PR TITLE
Add support for same SSH and sudo password (follow up to pull request #2545)

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -97,14 +97,20 @@ class Cli(object):
             print >>sys.stderr, "No argument passed to command module"
             sys.exit(1)
 
+        options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
+        options.ask_sudo_pass= options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
+        options.same_pass = options.same_pass or C.DEFAULT_SAME_PASS
         sshpass = None
         sudopass = None
-        options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
+        if options.same_pass and (not(options.ask_pass) or options.ask_sudo_pass):
+            raise errors.AnsibleError("incompatible password options")
         if options.ask_pass:
             sshpass = getpass.getpass(prompt="SSH password: ")
-        options.ask_sudo_pass= options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
         if options.ask_sudo_pass:
             sudopass = getpass.getpass(prompt="sudo password: ")
+            options.sudo = True
+        if options.same_pass:
+            sudopass = sshpass
             options.sudo = True
         if options.sudo_user:
             options.sudo = True

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -90,11 +90,17 @@ def main(args):
     sudopass = None
     if not options.listhosts and not options.syntax and not options.listtasks:
         options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
+        options.ask_sudo_pass = options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
+        options.same_pass = options.same_pass or C.DEFAULT_SAME_PASS
+        if options.same_pass and (not(options.ask_pass) or options.ask_sudo_pass):
+            raise errors.AnsibleError("incompatible password options")
         if options.ask_pass:
             sshpass = getpass.getpass(prompt="SSH password: ")
-        options.ask_sudo_pass = options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
         if options.ask_sudo_pass:
             sudopass = getpass.getpass(prompt="sudo password: ")
+            options.sudo = True
+        if options.same_pass:
+            sudopass = sshpass
             options.sudo = True
         if options.sudo_user:
             options.sudo = True

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -82,6 +82,7 @@ DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15)
 DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      active_user)
 DEFAULT_ASK_PASS          = get_config(p, DEFAULTS, 'ask_pass',  'ANSIBLE_ASK_PASS',    False)
+DEFAULT_SAME_PASS         = get_config(p, DEFAULTS, 'same_pass', 'ANSIBLE_SAME_PASS', False)
 DEFAULT_PRIVATE_KEY_FILE  = shell_expand_path(get_config(p, DEFAULTS, 'private_key_file', 'ANSIBLE_PRIVATE_KEY_FILE', None))
 DEFAULT_SUDO_USER         = get_config(p, DEFAULTS, 'sudo_user',        'ANSIBLE_SUDO_USER',        'root')
 DEFAULT_ASK_SUDO_PASS     = get_config(p, DEFAULTS, 'ask_sudo_pass',    'ANSIBLE_ASK_SUDO_PASS',    False)

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -426,6 +426,8 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
         help='use this file to authenticate the connection')
     parser.add_option('-K', '--ask-sudo-pass', default=False, dest='ask_sudo_pass', action='store_true',
         help='ask for sudo password')
+    parser.add_option('-j', '--same-pass', default=False, dest='same_pass', action='store_true',
+        help='use SSH password for sudo')
     parser.add_option('-M', '--module-path', dest='module_path',
         help="specify path(s) to module library (default=%s)" % constants.DEFAULT_MODULE_PATH,
         default=None)


### PR DESCRIPTION
- option --same-pass/-j
- configuration file 'same_pass' item
- environment variable ANSIBLE_SAME_PASS
