### PR TITLE
Adds `--exclude-tags` option to filter out tasks

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -65,6 +65,8 @@ def main(args):
         help="set additional key=value variables from the CLI")
     parser.add_option('-t', '--tags', dest='tags', default='all',
         help="only run plays and tasks tagged with these values")
+    parser.add_option('--exclude-tags', dest='xtags', default='',
+        help="only run plays and tasks not tagged with these values")
     # FIXME: list hosts is a common option and can be moved to utils/__init__.py
     parser.add_option('--list-hosts', dest='listhosts', action='store_true',
         help="dump out a list of hosts, each play will run against, does not run playbook!")
@@ -101,6 +103,7 @@ def main(args):
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
     extra_vars = utils.parse_kv(options.extra_vars)
     only_tags = options.tags.split(",")
+    exclude_tags = options.xtags.split(",")
 
     for playbook in args:
         if not os.path.exists(playbook):
@@ -135,6 +138,7 @@ def main(args):
             extra_vars=extra_vars,
             private_key_file=options.private_key_file,
             only_tags=only_tags,
+            exclude_tags=exclude_tags,
             check=options.check,
             diff=options.diff
         )
@@ -154,9 +158,10 @@ def main(args):
                     for host in hosts:
                         print '    %s' % host
                 if options.listtasks:
-                    matched_tags, unmatched_tags = play.compare_tags(pb.only_tags)
+                    all_tags = pb.only_tags + pb.exclude_tags
+                    matched_tags, unmatched_tags = play.compare_tags(all_tags)
                     unmatched_tags.discard('all')
-                    unknown_tags = set(pb.only_tags) - (matched_tags | unmatched_tags)
+                    unknown_tags = set(all_tags) - (matched_tags | unmatched_tags)
                     if unknown_tags:
                         msg = 'tag(s) not found in playbook: %s.  possible values: %s'
                         unknown = ','.join(sorted(unknown_tags))
@@ -164,7 +169,8 @@ def main(args):
                         raise errors.AnsibleError(msg % (unknown, unmatched))
                     print '  play #%d (%s): task count=%d' % (playnum, label, len(play.tasks()))
                     for task in play.tasks():
-                        if set(task.tags).intersection(pb.only_tags):
+                        if (set(task.tags).intersection(pb.only_tags) and
+                            not set(task.tags).intersection(pb.exclude_tags)):
                             print '    %s' % task.name
                 print ''
             continue

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -103,7 +103,7 @@ def main(args):
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
     extra_vars = utils.parse_kv(options.extra_vars)
     only_tags = options.tags.split(",")
-    exclude_tags = options.xtags.split(",")
+    exclude_tags = filter(None, options.xtags.split(","))
 
     for playbook in args:
         if not os.path.exists(playbook):

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -60,6 +60,7 @@ class PlayBook(object):
         sudo_user        = C.DEFAULT_SUDO_USER,
         extra_vars       = None,
         only_tags        = None,
+        exclude_tags     = None,
         subset           = C.DEFAULT_SUBSET,
         inventory        = None,
         check            = False,
@@ -93,6 +94,8 @@ class PlayBook(object):
             extra_vars = {}
         if only_tags is None:
             only_tags = [ 'all' ]
+        if exclude_tags is None:
+            exclude_tags = []
 
         self.check            = check
         self.diff             = diff
@@ -113,6 +116,7 @@ class PlayBook(object):
         self.global_vars      = {}
         self.private_key_file = private_key_file
         self.only_tags        = only_tags
+        self.exclude_tags     = exclude_tags
 
         self.callbacks.playbook = self
         self.runner_callbacks.playbook = self
@@ -455,6 +459,9 @@ class PlayBook(object):
                         if (x==y):
                             should_run = True
                             break
+                if set(self.exclude_tags).intersection(task.tags):
+                    should_run = False
+
                 if should_run:
                     if not self._run_task(play, task, False):
                         # whether no hosts matched is fatal or not depends if it was on the initial step.


### PR DESCRIPTION
This commit implements --exclude-tags option of ansible-playbook command, which can be used to filter out tasks tagged with any of the given comma-separated tags.

```
# Execute tasks tagged as `hadoop`, but not as `hbase` or `zookeeper`
ansible-playbook -i hosts playbook.yml --tags=hadoop --exclude-tags=hbase,zookeeper
```

The implementation is pretty simple and I find this feature quite useful sometimes.
What do you think?
