### PR TITLE
adds private_ip param to ec2 module

### DIFF
--- a/library/ec2
+++ b/library/ec2
@@ -135,6 +135,14 @@ options:
     required: false
     default: null
     aliases: []
+  private_ip:
+    version_added: "?.?"
+    description:
+      - the private ip address to assign the instance (from the vpc subnet)
+    required: false
+    defualt: null
+    aliases: []
+
 examples:
    - code: 'local_action: ec2 keypair=admin instance_type=m1.large image=emi-40603AD1 wait=yes group=webserver count=3 group=webservers'
      description: "Examples from Ansible Playbooks"
@@ -172,6 +180,7 @@ def main():
             user_data = dict(),
             instance_tags = dict(),
             vpc_subnet_id = dict(),
+            private_ip = dict(),
         )
     )
 
@@ -193,6 +202,7 @@ def main():
     user_data = module.params.get('user_data')
     instance_tags = module.params.get('instance_tags')
     vpc_subnet_id = module.params.get('vpc_subnet_id')
+    private_ip = module.params.get('private_ip')
 
     # allow eucarc environment variables to be used if ansible vars aren't set
     if not ec2_url and 'EC2_URL' in os.environ:
@@ -250,6 +260,7 @@ def main():
                                 kernel_id = kernel,
                                 ramdisk_id = ramdisk,
                                 subnet_id = vpc_subnet_id,
+                                private_ip_address = private_ip,
                                 user_data = user_data)
         except boto.exception.BotoServerError, e:
             module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))


### PR DESCRIPTION
When using VPC's it is nice to be able to make use of the private subnet by assigning ip addresses to hosts directly.

apollo@ ~/ansible (devel)$ make tests
PYTHONPATH=./lib nosetests -d -v
test_configfile_and_env_both_set (TestConstants.TestConstants) ... ok
test_configfile_not_set_env_not_set (TestConstants.TestConstants) ... ok
test_configfile_not_set_env_set (TestConstants.TestConstants) ... ok
test_configfile_set_env_not_set (TestConstants.TestConstants) ... ok
test_complex_enumeration (TestInventory.TestInventory) ... ok
test_complex_exclude (TestInventory.TestInventory) ... ok
test_complex_group_names (TestInventory.TestInventory) ... ok
test_complex_intersect (TestInventory.TestInventory) ... ok
test_complex_vars (TestInventory.TestInventory) ... ok
test_dir_inventory (TestInventory.TestInventory) ... ok
Test the case when playbook 'hosts' var is a list. ... ok
test_large_range (TestInventory.TestInventory) ... ok
test_regex_exclude (TestInventory.TestInventory) ... ok
test_script (TestInventory.TestInventory) ... ok
test_script_all (TestInventory.TestInventory) ... ok
test_script_combined (TestInventory.TestInventory) ... ok
test_script_multiple_groups (TestInventory.TestInventory) ... ok
test_script_norse (TestInventory.TestInventory) ... ok
test_script_restrict (TestInventory.TestInventory) ... ok
test_script_vars (TestInventory.TestInventory) ... ok
test_simple (TestInventory.TestInventory) ... ok
test_simple_all (TestInventory.TestInventory) ... ok
test_simple_combined (TestInventory.TestInventory) ... ok
test_simple_norse (TestInventory.TestInventory) ... ok
test_simple_port (TestInventory.TestInventory) ... ok
test_simple_restrict (TestInventory.TestInventory) ... ok
test_simple_ungrouped (TestInventory.TestInventory) ... ok
test_simple_vars (TestInventory.TestInventory) ... ok
test_includes (TestPlayBook.TestPlaybook) ... ok
test_lookups (TestPlayBook.TestPlaybook) ... ok
test_one (TestPlayBook.TestPlaybook) ... ok
test_playbook_vars (TestPlayBook.TestPlaybook) ... ok
test_yaml_hosts_list (TestPlayBook.TestPlaybook) ... ok
test_assemble (TestRunner.TestRunner) ... ok
test_async (TestRunner.TestRunner) ... ok
test_command (TestRunner.TestRunner) ... ok
test_copy (TestRunner.TestRunner) ... ok
test_facter (TestRunner.TestRunner) ... SKIP
test_fetch (TestRunner.TestRunner) ... ok
test_file (TestRunner.TestRunner) ... ok
test_git (TestRunner.TestRunner) ... ok
test_large_output (TestRunner.TestRunner) ... ok
Unit tests for the lineinfile module, without backref features. ... ok
Unit tests for the lineinfile module, with backref features. ... ok
test_ping (TestRunner.TestRunner) ... ok
test_parse_kv_basic (TestUtils.TestUtils) ... ok
test_template_basic (TestUtils.TestUtils) ... ok
test_template_ds_basic (TestUtils.TestUtils) ... ok
test_template_unicode (TestUtils.TestUtils) ... ok
test_template_varReplace_iterated (TestUtils.TestUtils) ... ok
test_template_whitespace (TestUtils.TestUtils) ... ok
test_varReplace_almost_alternative (TestUtils.TestUtils) ... ok
test_varReplace_almost_alternative2 (TestUtils.TestUtils) ... ok
test_varReplace_alternative (TestUtils.TestUtils) ... ok
test_varReplace_alternative_greed (TestUtils.TestUtils) ... ok
test_varReplace_caps (TestUtils.TestUtils) ... ok
test_varReplace_consecutive_vars (TestUtils.TestUtils) ... ok
test_varReplace_escape_dot (TestUtils.TestUtils) ... ok
test_varReplace_escaped_var (TestUtils.TestUtils) ... ok
test_varReplace_include (TestUtils.TestUtils) ... ok
test_varReplace_include_script (TestUtils.TestUtils) ... ok
test_varReplace_invalid_list (TestUtils.TestUtils) ... ok
test_varReplace_list (TestUtils.TestUtils) ... ok
test_varReplace_list_join (TestUtils.TestUtils) ... ok
test_varReplace_list_nolist (TestUtils.TestUtils) ... ok
test_varReplace_list_oob (TestUtils.TestUtils) ... ok
test_varReplace_middle (TestUtils.TestUtils) ... ok
test_varReplace_multiple (TestUtils.TestUtils) ... ok
test_varReplace_nested (TestUtils.TestUtils) ... ok
test_varReplace_nested_int (TestUtils.TestUtils) ... ok
test_varReplace_nested_list (TestUtils.TestUtils) ... ok
test_varReplace_notcomplex (TestUtils.TestUtils) ... ok
test_varReplace_simple (TestUtils.TestUtils) ... ok
test_varReplace_trailing_dollar (TestUtils.TestUtils) ... ok
test_varReplace_unicode (TestUtils.TestUtils) ... ok
test_varReplace_var_complex_var (TestUtils.TestUtils) ... ok
test_varReplace_var_part (TestUtils.TestUtils) ... ok
test_varReplace_var_partial_part (TestUtils.TestUtils) ... ok

---

Ran 78 tests in 24.829s

OK (SKIP=1)
