### PR TITLE
mysql_db: use --password= instead of -p in dump/import

### DIFF
--- a/library/mysql_db
+++ b/library/mysql_db
@@ -109,13 +109,13 @@ def db_delete(cursor, db):
     return True
 
 def db_dump(host, user, password, db_name, target):
-    res = os.system("/usr/bin/mysqldump -q -h "+host+"-u "+user+ " -p"+password+" "
+    res = os.system("/usr/bin/mysqldump -q -h "+host+"-u "+user+ " --password="+password+" "
             +db_name+" > "
             +target)
     return (res == 0)
 
 def db_import(host, user, password, db_name, target):
-    res = os.system("/usr/bin/mysql -h "+host+" -u "+user+ " -p"+password+" "
+    res = os.system("/usr/bin/mysql -h "+host+" -u "+user+" --password="+password+" "
             +db_name+" < "
             +target)
     return (res == 0)


### PR DESCRIPTION
Use --password= instead of -p. When mysql sees -p without an argument, it will prompt for a password.

This is useful when you forget to provide a password. The unexpected password prompt causes ansible to hang.

It will also allow you to provide blank passwords (passwordless mysql logins).
