### PR TITLE
Require paramiko 1.10+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='ansible',
       author_email='michael.dehaan@gmail.com',
       url='http://ansible.github.com/',
       license='GPLv3',
-      install_requires=['paramiko', 'jinja2', "PyYAML"],
+      install_requires=['paramiko>=1.10', 'jinja2', "PyYAML"],
       package_dir={ 'ansible': 'lib/ansible' },
       packages=[
          'ansible',


### PR DESCRIPTION
With the stock paramiko 1.9 package in Ubuntu 12.04, I was getting these errors:

```
$ ansible all -m ping
dev.aws.slice-data.com | FAILED => FAILED: global name 'hash_hostname' is not defined
www.aws.slice-data.com | FAILED => FAILED: global name 'hash_hostname' is not defined
...

$ head /etc/ansible/hosts
www.aws.slice-data.com ansible_ssh_user=ubuntu
dev.aws.slice-data.com
```

This stems from a bug in paramiko 1.9 where it's referencing a nonexistent global called hash_hostname.
