### PR TITLE
Vagrant plugin update

### DIFF
--- a/library/vagrant
+++ b/library/vagrant
@@ -17,7 +17,7 @@
 DOCUMENTATION = '''
 ---
 module: vagrant
-short_description: create a local instance via vagrant
+short_description: create a local instance via vagrant (VirtualBox only)
 description:
      - creates VM instances via vagrant and optionally waits for it to be 'running'. This module has a dependency on python-vagrant.
 version_added: "1.1"
@@ -60,10 +60,20 @@ options:
       - comma separated list of ports to forward to the host. If the port is under 1024, the host port will be the guest port +10000
     required: False
     aliases: []
-  memory:
+  ram:
     description:
       - memory in MB    
     required: False
+  cpus:
+    description:
+      - Number of CPU core allocated to the host. Can not exceed the number of CPU cores available on the hypervisor.
+    required: False
+    default: 1
+  ip:
+    description:
+      - IP address assigned to the host, incremented by 1 for each extra server. Netmask assumed to /24.
+    required: False
+    default: 192.168.179.10
     
 examples:
    - code: 'local_action: vagrant cmd=up box_name=lucid32 vm_name=webserver'
@@ -76,25 +86,29 @@ VAGRANT_FILE = "./Vagrantfile"
 VAGRANT_DICT_FILE = "./Vagrantfile.json"
 VAGRANT_LOCKFILE = "./.vagrant-lock"
 
-VAGRANT_FILE_HEAD = "Vagrant::Config.run do |config|\n"
+VAGRANT_FILE_HEAD = "Vagrant.configure(\"2\") do |config|\n"
 VAGRANT_FILE_BOX_NAME = "  config.vm.box = \"%s\"\n"
 VAGRANT_FILE_VM_STANZA_HEAD = """
   config.vm.define :%s do |%s_config|
-    %s_config.vm.network :hostonly, "%s"
+    %s_config.vm.network :private_network, ip: "%s"
     %s_config.vm.box = "%s"
 """
-VAGRANT_FILE_HOSTNAME_LINE     = "    %s_config.vm.host_name = \"%s\"\n"
-VAGRANT_FILE_PORT_FORWARD_LINE = "    %s_config.vm.forward_port %s, %s\n"  
-VAGRANT_FILE_MEMORY_LINE       = "    %s_config.vm.customize [\"modifyvm\", :id, \"--memory\", %s]\n" 
+VAGRANT_FILE_HOSTNAME_LINE     = "    %s_config.vm.hostname = \"%s\"\n"
+VAGRANT_FILE_PORT_FORWARD_LINE = "    %s_config.vm.forward_port %s, %s\n"
+VAGRANT_FILE_VIRTUALBOX        = "    %s_config.vm.provider :virtualbox do |%s_v|\n"
+VAGRANT_FILE_RAM_LINE          = "        %s_v.customize [\"modifyvm\", :id, \"--memory\", %s]\n" 
+VAGRANT_FILE_CPU_LINE          = "        %s_v.customize [\"modifyvm\", :id, \"--cpus\", %s]\n"
+VAGRANT_FILE_VIRTUALBOX_TAIL   = "    end\n"
 VAGRANT_FILE_VM_STANZA_TAIL="  end\n"
 
 VAGRANT_FILE_TAIL = "\nend\n"
 
 # If this is already a network on your machine, this may fail ... change it here.
-VAGRANT_INT_IP = "192.168.179.%s"
+VAGRANT_INT_IP = "192.168.179.10"
 
 DEFAULT_VM_NAME = "ansible"
 DEFAULT_VM_RAM = 1024
+DEFAULT_VM_CPU = 1
 
 import sys
 import subprocess
@@ -163,7 +177,7 @@ class VagrantWrapper(object):
             
         return changed
              
-    def up(self, box_name, vm_name=None, count=1, box_path=None, ports=[]):    
+    def up(self, box_name, vm_name=None, count=1, box_path=None, ports=[], ram=None, cpus=1, ip=None):    
         '''Fire up a given VM and name it, using vagrant's multi-VM mode.'''
 
         changed = False
@@ -174,7 +188,11 @@ class VagrantWrapper(object):
             raise Exception("You must specify a box name for Vagrant.")
         if box_path != None: 
             changed = self.prepare_box(box_name, box_path)
-        
+
+        # Handle IP address 
+        ip_prefix = ip[0:ip.rfind('.')+1]
+        ip_suffix = ip[ip.rfind('.')+1::]
+
         for icount in range(int(count)):
             
             self._deserialize()
@@ -183,8 +201,13 @@ class VagrantWrapper(object):
             if not this_instance_dict.has_key('box_name'): 
                 this_instance_dict['box_name'] = box_name   
                      
-            this_instance_dict['forward_ports'] = ports  
-            
+            this_instance_dict['forward_ports'] = ports
+            this_instance_dict['ram'] = ram
+            this_instance_dict['cpus'] = cpus
+
+            # Build ip incrementally
+            this_instance_dict['internal_ip'] = ip_prefix + str(int(ip_suffix)+icount)
+
             # Save our changes and run
             inst_array = self._instances()[vm_name]
             inst_array[icount] = this_instance_dict    
@@ -324,9 +347,10 @@ class VagrantWrapper(object):
           N = this_instance_N,
           name = vm_name,
           vagrant_name = name_for_vagrant,
-          internal_ip = VAGRANT_INT_IP % (255-this_instance_N),
+          internal_ip = '',
           forward_ports = [],
           ram = DEFAULT_VM_RAM,
+          cpus = DEFAULT_VM_CPU
         )
 
         # Save this ...
@@ -394,8 +418,14 @@ class VagrantWrapper(object):
                 box_name = instance_dict['box_name']
                 vfile.write(VAGRANT_FILE_VM_STANZA_HEAD % 
                             (name, name, name, ip, name, box_name) )
+                if instance_dict.has_key('ram') or instance_dict.has_key('cpus'):
+                    vfile.write(VAGRANT_FILE_VIRTUALBOX  % (name, name))
                 if instance_dict.has_key('ram'):
-                    vfile.write(VAGRANT_FILE_MEMORY_LINE  % (name, instance_dict['ram'])  )   
+                    vfile.write(VAGRANT_FILE_RAM_LINE  % (name, instance_dict['ram'])  )   
+                if instance_dict.has_key('cpus'):
+                    vfile.write(VAGRANT_FILE_CPU_LINE  % (name, instance_dict['cpus'])  )   
+                if instance_dict.has_key('ram') or instance_dict.has_key('cpus'):
+                    vfile.write(VAGRANT_FILE_VIRTUALBOX_TAIL)
                 vfile.write(VAGRANT_FILE_HOSTNAME_LINE  % (name, name.replace('_','-'))  )       
                 if instance_dict.has_key('forward_ports'):
                     for port in instance_dict['forward_ports']:
@@ -434,6 +464,8 @@ class VagrantWrapper(object):
                       id              = cnf['Host'],
                       public_ip       = cnf['HostName'],
                       internal_ip     = inst['internal_ip'],
+                      cpus            = inst['cpus'],
+                      ram             = inst['ram'],
                       public_dns_name = cnf['HostName'],
                       port            = cnf['Port'],
                       username        = cnf['User'],
@@ -457,9 +489,12 @@ def main():
             box_path=dict(),
             vm_name=dict(),
             forward_ports=dict(),
+            ram=dict(),
+            cpus=dict(),
+            ip=dict(),
             count = dict(default='1'), 
-       )
-   )
+        )
+    )
     
     state = module.params.get('state')
     cmd = module.params.get('cmd')
@@ -467,11 +502,21 @@ def main():
     box_path = module.params.get('box_path')
     vm_name = module.params.get('vm_name')
     forward_ports = module.params.get('forward_ports')     
+    ram = module.params.get('ram')
+    cpus = module.params.get('cpus')
+    ip = module.params.get('ip')
 
     if forward_ports != None:
         forward_ports=forward_ports.split(',')
     if forward_ports == None: 
         forward_ports=[]
+
+    if ram == None:
+        ram = DEFAULT_VM_RAM
+    if cpus == None:
+        cpus = DEFAULT_VM_CPU
+    if ip == None:
+        ip = VAGRANT_INT_IP
 
     count = module.params.get('count') 
  
@@ -489,7 +534,7 @@ def main():
                  
             if state == 'present':
                
-                changd, insts = vgw.up(box_name, vm_name, count, box_path, forward_ports)
+                changd, insts = vgw.up(box_name, vm_name, count, box_path, forward_ports, ram, cpus, ip)
                 module.exit_json(changed = changd, instances = insts)
                  
             if state == 'absent':
@@ -507,7 +552,7 @@ def main():
             
                 if count == None: 
                     count = 1
-                (changd, insts) = vgw.up(box_name, vm_name, count, box_path, forward_ports)
+                (changd, insts) = vgw.up(box_name, vm_name, count, box_path, forward_ports, ram, cpus, ip)
                 module.exit_json(changed = changd, instances = insts)
 
             elif cmd == 'status':

--- a/library/vagrant
+++ b/library/vagrant
@@ -96,6 +96,7 @@ VAGRANT_FILE_VM_STANZA_HEAD = """
 VAGRANT_FILE_HOSTNAME_LINE     = "    %s_config.vm.hostname = \"%s\"\n"
 VAGRANT_FILE_PORT_FORWARD_LINE = "    %s_config.vm.forward_port %s, %s\n"
 VAGRANT_FILE_VIRTUALBOX        = "    %s_config.vm.provider :virtualbox do |%s_v|\n"
+VAGRANT_FILE_VB_NAME_LINE      = "        %s_v.customize [\"modifyvm\", :id, \"--name\", \"%s\"]\n" 
 VAGRANT_FILE_RAM_LINE          = "        %s_v.customize [\"modifyvm\", :id, \"--memory\", %s]\n" 
 VAGRANT_FILE_CPU_LINE          = "        %s_v.customize [\"modifyvm\", :id, \"--cpus\", %s]\n"
 VAGRANT_FILE_VIRTUALBOX_TAIL   = "    end\n"
@@ -418,15 +419,19 @@ class VagrantWrapper(object):
                 box_name = instance_dict['box_name']
                 vfile.write(VAGRANT_FILE_VM_STANZA_HEAD % 
                             (name, name, name, ip, name, box_name) )
-                if instance_dict.has_key('ram') or instance_dict.has_key('cpus'):
-                    vfile.write(VAGRANT_FILE_VIRTUALBOX  % (name, name))
+                vfile.write(VAGRANT_FILE_HOSTNAME_LINE  % (name, name.replace('_','-'))  )       
+
+                # if instance_dict.has_key('ram') or instance_dict.has_key('cpus'):
+                #     vfile.write(VAGRANT_FILE_VIRTUALBOX  % (name, name))
+                vfile.write(VAGRANT_FILE_VIRTUALBOX  % (name, name))
+                vfile.write(VAGRANT_FILE_VB_NAME_LINE  % (name, name)  )   
                 if instance_dict.has_key('ram'):
                     vfile.write(VAGRANT_FILE_RAM_LINE  % (name, instance_dict['ram'])  )   
                 if instance_dict.has_key('cpus'):
                     vfile.write(VAGRANT_FILE_CPU_LINE  % (name, instance_dict['cpus'])  )   
-                if instance_dict.has_key('ram') or instance_dict.has_key('cpus'):
-                    vfile.write(VAGRANT_FILE_VIRTUALBOX_TAIL)
-                vfile.write(VAGRANT_FILE_HOSTNAME_LINE  % (name, name.replace('_','-'))  )       
+                # if instance_dict.has_key('ram') or instance_dict.has_key('cpus'):
+                #     vfile.write(VAGRANT_FILE_VIRTUALBOX_TAIL)
+                vfile.write(VAGRANT_FILE_VIRTUALBOX_TAIL)
                 if instance_dict.has_key('forward_ports'):
                     for port in instance_dict['forward_ports']:
                         port = int(port)
@@ -571,13 +576,13 @@ def main():
                 module.exit_json(changed = changd, config = cnf)
 
             elif cmd == 'ssh':
-            
                 if vm_name == None:
                     module.fail_json(msg = "Error: you must specify a vm_name when calling ssh." )             
                             
-                (changd, cnf) = vgw.config(vm_name)
-                sshcmd = "ssh -i %s -p %s %s@%s" % (cnf["IdentityFile"], cnf["Port"], cnf["User"], cnf["HostName"])
-                sshmsg = "Execute the command \"vagrant ssh %s\"" % (vm_name)
+                (changd, configs) = vgw.config(vm_name)
+                for cnf in configs[vm_name]:
+                    sshcmd = "ssh -i %s -p %s %s@%s" % (cnf["IdentityFile"], cnf["Port"], cnf["User"], cnf["HostName"])
+                    sshmsg = "Execute the command \"vagrant ssh %s\"" % (vm_name)
                 module.exit_json(changed = changd, msg = sshmsg, SshCommand = sshcmd)
            
             elif cmd == 'halt':

--- a/plugins/inventory/vg.py
+++ b/plugins/inventory/vg.py
@@ -1,0 +1,167 @@
+#!/usr/bin/python
+
+"""
+Cobbler external inventory script
+=================================
+
+Ansible has a feature where instead of reading from /etc/ansible/hosts
+as a text file, it can query external programs to obtain the list
+of hosts, groups the hosts are in, and even variables to assign to each host.
+
+To use this, copy this file over /etc/ansible/hosts and chmod +x the file.
+This, more or less, allows you to keep one central database containing
+info about all of your managed instances.
+
+This script is an example of sourcing that data from Cobbler
+(http://cobbler.github.com).  With cobbler each --mgmt-class in cobbler
+will correspond to a group in Ansible, and --ks-meta variables will be
+passed down for use in templates or even in argument lines.
+
+NOTE: The cobbler system names will not be used.  Make sure a
+cobbler --dns-name is set for each cobbler system.   If a system
+appears with two DNS names we do not add it twice because we don't want
+ansible talking to it twice.  The first one found will be used. If no
+--dns-name is set the system will NOT be visible to ansible.  We do
+not add cobbler system names because there is no requirement in cobbler
+that those correspond to addresses.
+
+See http://ansible.github.com/api.html for more info
+
+Tested with Cobbler 2.0.11.
+"""
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible,
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+######################################################################
+
+import os.path
+import sys
+import shlex
+
+try:
+    import lockfile
+except ImportError:
+    pass
+
+try:
+    import vagrant
+except ImportError:
+    print "python-vagrant required for this inventory"
+    sys.exit(1)
+
+try:
+    import json
+except:
+    import simplejson as json
+
+VAGRANT_LOCKFILE = './.vagrant-lock'
+
+class VagrantWrapper(object):
+
+    def __init__(self):
+        '''
+        Wrapper around the python-vagrant module for use with ansible.
+        Note that Vagrant itself is non-thread safe, as is the python-vagrant lib, so we need to lock on basically all operations ...
+        '''
+        # Get a lock
+        self.lock = None
+
+        try:
+            self.lock = lockfile.FileLock(VAGRANT_LOCKFILE)
+            self.lock.acquire()
+        except:
+            # fall back to using flock instead ...
+            try:
+                import fcntl
+                self.lock = open(VAGRANT_LOCKFILE, 'w')
+                fcntl.flock(self.lock, fcntl.LOCK_EX)
+            except:
+                print "Could not get a lock for using vagrant. Install python module \"lockfile\" to use vagrant on non-POSIX filesytems."
+                sys.exit(1)
+            
+        # Initialize vagrant and state files
+        self.vg = vagrant.Vagrant()
+        
+    def __del__(self):
+        '''Clean up file locks'''
+        try:
+            self.lock.release()
+        except:
+            self.lock.close()
+            # Can someone tell me how to unlink that file ?? 
+            # os.unlink(self.lock)
+
+    def list(self):
+        # Vagrant currently doesn't support grouping - we end up with a flat list. Yeah!
+        result = dict(
+            hosts = []
+        )
+        for host in self.vg.status():
+            result['hosts'].append(host)
+        return result
+
+    def host(self, vm_name):
+        # The only valuable info from vagrant are:
+        #  - ip
+        #  - ssh user
+        #  - ssh port
+        #  - ssh key -- damned how to use it ??
+        result = dict(
+            ansible_ssh_host = '',
+            ansible_ssh_port = '',
+            ansible_ssh_user = '',
+            ansible_ssh_private_key = ''
+        )
+        config = self.vg.conf(None, vm_name)
+        result['ansible_ssh_host'] = config['HostName']
+        result['ansible_ssh_user'] = config['User']
+        result['ansible_ssh_port'] = config['Port']
+        result['ansible_ssh_private_key'] = config['IdentityFile']
+
+        return result
+
+
+# NOTE -- this file assumes Ansible is being accessed FROM the vagrant
+# server, so it does not attempt to remote connect to any remote host
+
+###################################################
+# executed with no parameters, return the list of
+# all groups and hosts
+
+if len(sys.argv) == 2 and (sys.argv[1] == '--list'):
+
+    vgw = VagrantWrapper()
+    print vgw.list()
+
+    sys.exit(0)
+
+#####################################################
+# executed with a hostname as a parameter, return the
+# variables for that host
+
+elif len(sys.argv) == 3 and (sys.argv[1] == '--host'):
+
+    vgw = VagrantWrapper()
+    print vgw.host(sys.argv[2])
+
+    sys.exit(0)
+
+else:
+
+    print "usage: --list  ..OR.. --host <hostname>"
+    sys.exit(1)


### PR DESCRIPTION
Convert Vagrantfile format to V2, add CPU, RAM, IP support.

Details:
- **Vagrantfile**; from v1 to v2 - Vagrant is new and V2 is available - pushing forward to the latest version; Note - file format is incompatible with V1...
- **CPU** count; 1 by default, can be raised to max number of CPU core available on the underlying box
- **RAM**; changed --memory to --ram, it was not working yet, it now is; in MB
- **IP**; can specify a "start" IP for the internal network, not hardcoded anymore; IP is incremented by 1 for each new VM if --count > 1
