### PR TITLE
Improved backrefs example in lineinfile.

### DIFF
--- a/library/lineinfile
+++ b/library/lineinfile
@@ -125,7 +125,7 @@ EXAMPLES = r"""
 
    lineinfile: dest=/etc/sudoers state=present regexp='^%wheel' line ='%wheel ALL=(ALL) NOPASSWD: ALL'
 
-   lineinfile: dest=/opt/jboss-as/bin/standalone.conf state=present regexp='^(.*)Xms(\d+)m(.*)$' line='\\1Xms${xms}m\\3'
+   lineinfile: dest=/opt/jboss-as/bin/standalone.conf regexp='^(.*)Xms(\d+)m(.*)$' line='\\1Xms${xms}m\\3' backrefs=yes
 """
 
 


### PR DESCRIPTION
In v1.1 in `lineinfile` the `backrefs` option was introduced, but the last example was not changed accordingly.
