### PR TITLE
Added DEFAULT_EXECUTABLE as a constant

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -79,6 +79,13 @@ sudo_exe=sudo
 # the default flags passed to sudo
 # sudo_flags=-H
 
+# all commands executed under sudo are passed as arguments to a shell command
+# This shell command defaults to /bin/sh
+# Changing this helps the situation where a user is only allowed to run
+# e.g. /bin/bash with sudo privileges
+
+# executable = /bin/sh
+
 # how to handle hash defined in several places
 # hash can be merged, or replaced
 # if you use replace, and have multiple hashes named 'x', the last defined

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -95,6 +95,7 @@ DEFAULT_SUDO_EXE          = get_config(p, DEFAULTS, 'sudo_exe', 'ANSIBLE_SUDO_EX
 DEFAULT_SUDO_FLAGS        = get_config(p, DEFAULTS, 'sudo_flags', 'ANSIBLE_SUDO_FLAGS', '-H')
 DEFAULT_HASH_BEHAVIOUR    = get_config(p, DEFAULTS, 'hash_behaviour', 'ANSIBLE_HASH_BEHAVIOUR', 'replace')
 DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBLE_JINJA2_EXTENSIONS', None)
+DEFAULT_EXECUTABLE        = get_config(p, DEFAULTS, 'executable', 'ANSIBLE_EXECUTABLE', '/bin/sh')
 
 DEFAULT_ACTION_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '/usr/share/ansible_plugins/action_plugins'))
 DEFAULT_CALLBACK_PLUGIN_PATH   = shell_expand_path(get_config(p, DEFAULTS, 'callback_plugins',   'ANSIBLE_CALLBACK_PLUGINS', '/usr/share/ansible_plugins/callback_plugins'))

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -527,7 +527,7 @@ class Runner(object):
         ''' execute a command string over SSH, return the output '''
 
         if executable is None:
-            executable = '/bin/sh'
+            executable = C.DEFAULT_EXECUTABLE
 
         sudo_user = self.sudo_user
         rc, stdin, stdout, stderr = conn.exec_command(cmd, tmp, sudo_user, sudoable=sudoable, executable=executable)


### PR DESCRIPTION
Use DEFAULT_EXECUTABLE when no executable is passed to
_low_level_command_exec

Works as a standard constant - can be overridden in all the normal ways
and defaults to /bin/sh

Motiviation is for a user that only has /bin/bash in /etc/sudoers - my real-life test case fails when _low_level_command_exec defaults to /bin/sh and succeeds when I set executable=/bin/bash in my ansible config file
