### PR TITLE
Failing setup module if selinux is enabled but no libselinux-python is installed

### DIFF
--- a/library/setup
+++ b/library/setup
@@ -75,7 +75,12 @@ ansible all -m setup -a 'filter=ansible_eth[0-2]'
 try:
     import selinux
     HAVE_SELINUX=True
+    HAVE_SELINUX_PYTHON_MISSING=False
 except ImportError:
+    HAVE_SELINUX_PYTHON_MISSING=False
+    import os
+    if os.path.exists("/selinux/enforce"):
+        HAVE_SELINUX_PYTHON_MISSING=True
     HAVE_SELINUX=False
 
 try:
@@ -1579,6 +1584,8 @@ def main():
         supports_check_mode = True,
     )
     data = run_setup(module)
+    if HAVE_SELINUX_PYTHON_MISSING:
+        module.fail_json(msg="Selinux is active but libselinux-python is not installed")
     module.exit_json(**data)
 
 # this is magic, see lib/ansible/module_common.py


### PR DESCRIPTION
This change will fail the setup module if it detects Selinux on the target node, but that libselinux-python package isn't installed, and so that prevents future issues when playbooks/tasks are played on a selinux enabled node but that no selinux context can be applied (for example the authorized_keys module for correct selinux context on ~/.ssh/authorized_keys). Don't know if that the best way to handle it, but I'd prefer myself seeing Ansible alerting the users for a missing package, than playbooks all marked OK in green when it doesn't work as expected in the background. It's to be noted that CentOS/RHEL 6.x when installed in "minimal" way (aka only @core packages group) don't have libselinux-python rpm package installed, and that's how i discovered the "issue" ....
