### PR TITLE
in case spec not found, try handling it as an url

### DIFF
--- a/library/yum
+++ b/library/yum
@@ -24,6 +24,7 @@
 import traceback
 import os
 import yum
+import urllib2
 
 DOCUMENTATION = '''
 ---
@@ -364,13 +365,25 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         # check if pkgspec is installed (if possible for idempotence)
         # localpkg
         if spec.endswith('.rpm'):
-            # get the pkg name-v-r.arch
-            if not os.path.exists(spec):
+            if os.path.exists(spec):
+                # get the pkg name-v-r.arch
+                nvra = local_nvra(module, spec)
+            elif "://" in spec:
+                # this might be an url spec
+                # parse the spec and check whether it is installed
+                # a false-negative is an option here
+                try:
+                    path = urllib2.urlparse.urlparse(spec)[2]
+                except ValueError as e:
+                    res['msg'] += "Error parsing url '%s': %s" % (spec, e)
+                    module.fail_json(**res)
+                # a hack to extract nvra from the URL path field
+                nvra = os.path.basename(path).rstrip('.rpm')
+            else:
                 res['msg'] += "No Package file matching '%s' found on system" % spec
                 module.fail_json(**res)
 
-            nvra = local_nvra(module, spec)
-            # look for them in the rpmdb
+            # look for the pkg name-v-r.arch in the rpmdb
             if is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos):
                 # if they are there, skip it
                 continue
@@ -421,6 +434,14 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
             module.exit_json(changed=True)
 
         rc, out, err = module.run_command(cmd)
+
+        if rc == 1 and 'Nothing to do' in err:
+            # avoid failing in the 'Nothing To Do' case
+            # happens if a URL--nevra translation yields a false-negative with
+            # regards to the installation status
+            rc = 0
+            err = ''
+            out = ''
 
         res['rc'] += rc
         res['results'].append(out)


### PR DESCRIPTION
Re-submitting squashed commits for review based on discussion from pull request #2515...

more specific error handling

fixed exception handling to match the specs for ullib from http://docs.python.org/2/library/urllib.html

check installation state of a rpm url by the url path

'Nothing to do' error now ignored
