### PR TITLE
Added an extra check for target nodes with selinux but without libselinux-python package installed

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -84,6 +84,9 @@ try:
     import selinux
     HAVE_SELINUX=True
 except ImportError:
+    if os.path.exists("/selinux/enforce"):
+        sys.stderr.write('Error: ansible requires the package libselinux-python on nodes with selinux, none found!')
+        sys.exit(1)
     pass
 
 try:


### PR DESCRIPTION
This PR will modify the common module so that it will fail for nodes with selinux but without the correct libselinux-python package installed. If you don't want ansible to notify the users that they need the correct package to let ansible handle correctly the selinux contexts, just feel free to ignore that PR ...
