### PR TITLE
Support for Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ docsite/_static/*.png
 docsite/_static/websupport.js
 # deb building stuff...
 debian/
+# Vagrant stull
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,21 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+#
+# See hacking/VAGRANT.md for setup instructions
+#
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise64"
+
+  config.vm.synced_folder ".", "/opt/ansible", :id => "vagrant-root"
+  config.vm.provision :shell, :path => "hacking/vagrant-provision.sh"
+
+  config.vm.provider :virtualbox do |vb|
+    config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  end
+
+  config.vm.provider :vmware_fusion do |v|
+    config.vm.box_url = "http://files.vagrantup.com/precise64_vmware_fusion.box"
+  end
+end

--- a/hacking/VAGRANT.md
+++ b/hacking/VAGRANT.md
@@ -1,0 +1,27 @@
+Vagrant Setup
+=============
+
+Prerequisites
+-------------
+
+1. [Vagrant 1.1+](http://www.vagrantup.com/)
+2. [VirtualBox](https://www.virtualbox.org/) or some other VM provider
+[supported by Vagrant](http://docs.vagrantup.com/v2/providers/index.html)
+
+
+Setup
+-----
+
+1. Run `vagrant up`. That command will:
+    1. Download a VM image of Ubuntu 12.04
+    2. Create a VM instance based on that image
+    3. Provision it with necessary packages
+2. Run `vagrant ssh`. That command will SSH you inside a VM.
+3. Once inside a VM, go to `/opt/ansible` and run some tests:
+
+    ```bash
+    cd /opt/ansible
+    make tests
+    ```
+
+4. You're good to go!

--- a/hacking/vagrant-provision.sh
+++ b/hacking/vagrant-provision.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    git \
+    python-nose \
+    python-yaml \
+    python-jinja2 \
+    wamerican


### PR DESCRIPTION
This should help make easier to run tests for contributors on OSX and Windows.
See `hacking/VAGRANT.md` for setup instructions.
