### PR TITLE
added 'runtime duration' to ansible-playbook output

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -115,7 +115,7 @@ def main(args):
         playbook_cb = callbacks.PlaybookCallbacks(verbose=utils.VERBOSITY)
         if options.step:
             playbook_cb.step = options.step
-        runner_cb = callbacks.PlaybookRunnerCallbacks(stats, verbose=utils.VERBOSITY)
+        runner_cb = callbacks.PlaybookRunnerCallbacks(stats, verbose=utils.VERBOSITY, show_runtime=options.show_runtime)
 
         pb = ansible.playbook.PlayBook(
             playbook=playbook,
@@ -196,6 +196,9 @@ def main(args):
                 stats = pb.stats.summarize(h)
                 if stats['failures'] != 0 or stats['unreachable'] != 0:
                     return 2
+
+            if options.show_runtime:
+                print "PLAY RUNTIME: %s" % pb.runtime
 
         except errors.AnsibleError, e:
             print >>sys.stderr, "ERROR: %s" % e

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -307,9 +307,10 @@ class CliRunnerCallbacks(DefaultRunnerCallbacks):
 class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
     ''' callbacks used for Runner() from /usr/bin/ansible-playbook '''
 
-    def __init__(self, stats, verbose=utils.VERBOSITY):
+    def __init__(self, stats, verbose=utils.VERBOSITY, show_runtime=False):
         self.verbose = verbose
         self.stats = stats
+        self.show_runtime = show_runtime
         self._async_notified = {}
 
     def on_unreachable(self, host, results):
@@ -380,6 +381,9 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
             else:
                 if 'ansible_job_id' not in host_result or 'finished' in host_result2:
                     msg = "%s: [%s] => %s" % (ok_or_changed, host, utils.jsonify(host_result2))
+
+        if self.show_runtime:
+            msg = "%s (%s)" % (msg, host_result2.get('runtime','00:00:00'))
 
         if msg != '':
             if not changed:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -24,6 +24,7 @@ import ansible.callbacks
 import os
 import shlex
 import collections
+import time
 from play import Play
 
 SETUP_CACHE = collections.defaultdict(dict)
@@ -200,6 +201,7 @@ class PlayBook(object):
 
     def run(self):
         ''' run all patterns in the playbook '''
+        starttime = time.time()
         plays = []
         matched_tags_all = set()
         unmatched_tags_all = set()
@@ -241,6 +243,7 @@ class PlayBook(object):
         results = {}
         for host in self.stats.processed.keys():
             results[host] = self.stats.summarize(host)
+        self.runtime = utils.duration(time.time() - starttime)
         return results
 
     # *****************************************************

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -414,7 +414,12 @@ def getch():
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
     return ch
 
-####################################################################
+def duration(secs):
+    m,s = divmod(secs, 60)
+    h,m = divmod(m, 60)
+    return "%d:%02d:%02d" % (h, m, s)
+
+###################################################################
 # option handling code for /usr/bin/ansible and ansible-playbook
 # below this line
 
@@ -451,6 +456,8 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
     parser.add_option('-M', '--module-path', dest='module_path',
         help="specify path(s) to module library (default=%s)" % constants.DEFAULT_MODULE_PATH,
         default=None)
+    parser.add_option('-r','--runtime', default=False, dest='show_runtime', action='store_true',
+        help="runtime: print task and playbook runtime durations")
 
     if subset_opts:
         parser.add_option('-l', '--limit', default=constants.DEFAULT_SUBSET, dest='subset',


### PR DESCRIPTION
A new switch -r --runtime, adds runtime output per task/host and total per playbook

Signed-off-by: Brian Coca <briancoca+dev@gmail.com>
