### PR TITLE
ec2_facts: add ansible_ec2_placement_region key/value pair for EC2 regio...

### DIFF
--- a/library/ec2_facts
+++ b/library/ec2_facts
@@ -45,6 +45,15 @@ class Ec2Metadata(object):
     ec2_sshdata_uri  = 'http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key'
     ec2_userdata_uri = 'http://169.254.169.254/latest/user-data/'
 
+    AWS_REGIONS = ('ap-northeast-1',
+                   'ap-southeast-1',
+                   'ap-southeast-2',
+                   'eu-west-1',
+                   'sa-east-1',
+                   'us-east-1',
+                   'us-west-1',
+                   'us-west-2')
+
     def __init__(self, ec2_metadata_uri=None, ec2_sshdata_uri=None, ec2_userdata_uri=None):
         self.uri_meta = ec2_metadata_uri or self.ec2_metadata_uri
         self.uri_user = ec2_userdata_uri or self.ec2_userdata_uri
@@ -104,12 +113,32 @@ class Ec2Metadata(object):
                 newkey = key.replace(':','_').replace('-','_')
                 data[newkey] = value
 
+    def add_ec2_region(self, data):
+        """Use the 'ansible_ec2_placement_availability_zone' key/value
+        pair to add 'ansible_ec2_placement_region' key/value pair with
+        the EC2 region name.
+        """
+
+        # Only add a 'ansible_ec2_placement_region' key if the
+        # 'ansible_ec2_placement_availability_zone' exists.
+        zone = data.get('ansible_ec2_placement_availability_zone')
+        if zone is not None:
+            # Use the zone name as the region name unless the zone
+            # name starts with a known AWS region name.
+            region = zone
+            for r in self.AWS_REGIONS:
+                if zone.startswith(r):
+                    region = r
+                    break
+            data['ansible_ec2_placement_region'] = region
+
     def run(self):
         self.fetch(self.uri_meta) # populate _data
         data = self._mangle_fields(self._data, self.uri_meta)
         data[self._prefix % 'user-data'] = self._fetch(self.uri_user)
         data[self._prefix % 'public-key'] = self._fetch(self.uri_ssh)
         self.fix_invalid_varnames(data)
+        self.add_ec2_region(data)
         return data
 
 def main():


### PR DESCRIPTION
I'm setting up per-region, not per availability-zone, NTP servers, so adding a new key/value pair makes it easier than using

```
if ansible_ec2_placement_availability_zone.startswith('us-west-1')
```

/cc @silviud
