### PR TITLE
Automatic verbosity on the debug module

### DIFF
--- a/lib/ansible/callback_plugins/noop.py
+++ b/lib/ansible/callback_plugins/noop.py
@@ -33,7 +33,7 @@ class CallbackModule(object):
     def runner_on_failed(self, host, res, ignore_errors=False):
         pass
 
-    def runner_on_ok(self, host, res):
+    def runner_on_ok(self, host, res, always_verbose=False):
         pass
 
     def runner_on_error(self, host, msg):

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -203,8 +203,8 @@ class DefaultRunnerCallbacks(object):
     def on_failed(self, host, res, ignore_errors=False):
         call_callback_module('runner_on_failed', host, res, ignore_errors=ignore_errors)
 
-    def on_ok(self, host, res):
-        call_callback_module('runner_on_ok', host, res)
+    def on_ok(self, host, res, always_verbose=False):
+        call_callback_module('runner_on_ok', host, res, always_verbose=always_verbose)
 
     def on_error(self, host, msg):
         call_callback_module('runner_on_error', host, msg)
@@ -244,9 +244,9 @@ class CliRunnerCallbacks(DefaultRunnerCallbacks):
         self._on_any(host,res)
         super(CliRunnerCallbacks, self).on_failed(host, res, ignore_errors=ignore_errors)
 
-    def on_ok(self, host, res):
+    def on_ok(self, host, res, always_verbose=False):
         self._on_any(host,res)
-        super(CliRunnerCallbacks, self).on_ok(host, res)
+        super(CliRunnerCallbacks, self).on_ok(host, res, always_verbose=always_verbose)
 
     def on_unreachable(self, host, res):
         if type(res) == dict:
@@ -351,7 +351,7 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
             print stringc("...ignoring", 'cyan')
         super(PlaybookRunnerCallbacks, self).on_failed(host, results, ignore_errors=ignore_errors)
 
-    def on_ok(self, host, host_result):
+    def on_ok(self, host, host_result, always_verbose=False):
         item = host_result.get('item', None)
 
         host_result2 = host_result.copy()
@@ -361,9 +361,11 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
         if changed:
             ok_or_changed = 'changed'
 
+        verbose = always_verbose or self.verbose
+
         # show verbose output for non-setup module results if --verbose is used
         msg = ''
-        if not self.verbose or host_result2.get("verbose_override",None) is not None:
+        if not verbose or host_result2.get("verbose_override", None) is not None:
             if item:
                 msg = "%s: [%s] => (item=%s)" % (ok_or_changed, host, item)
             else:
@@ -382,7 +384,7 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
                 print stringc(msg, 'green')
             else:
                 print stringc(msg, 'yellow')
-        super(PlaybookRunnerCallbacks, self).on_ok(host, host_result)
+        super(PlaybookRunnerCallbacks, self).on_ok(host, host_result, always_verbose=always_verbose)
 
     def on_error(self, host, err):
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -552,7 +552,7 @@ class Runner(object):
             else:
                 if self.diff:
                     self.callbacks.on_file_diff(conn.host, result.diff)
-                self.callbacks.on_ok(host, data)
+                self.callbacks.on_ok(host, data, result.always_verbose)
         return result
 
     # *****************************************************

--- a/lib/ansible/runner/action_plugins/debug.py
+++ b/lib/ansible/runner/action_plugins/debug.py
@@ -41,4 +41,4 @@ class ActionModule(object):
         else:
             result = dict(msg=args['msg'])
 
-        return ReturnData(conn=conn, result=result)
+        return ReturnData(conn=conn, result=result, always_verbose=True)

--- a/lib/ansible/runner/return_data.py
+++ b/lib/ansible/runner/return_data.py
@@ -20,10 +20,10 @@ from ansible import utils
 class ReturnData(object):
     ''' internal return class for runner execute methods, not part of public API signature '''
 
-    __slots__ = [ 'result', 'comm_ok', 'host', 'diff', 'flags' ]
+    __slots__ = [ 'result', 'comm_ok', 'host', 'diff', 'flags', 'always_verbose' ]
 
     def __init__(self, conn=None, host=None, result=None, 
-        comm_ok=True, diff=dict(), flags=None):
+        comm_ok=True, diff=dict(), flags=None, always_verbose=False):
 
         # which host is this ReturnData about?
         if conn is not None:
@@ -45,6 +45,7 @@ class ReturnData(object):
         if type(self.result) in [ str, unicode ]:
             self.result = utils.parse_json(self.result)
 
+        self.always_verbose = always_verbose
 
         if self.host is None:
             raise Exception("host not set")

--- a/library/debug
+++ b/library/debug
@@ -27,8 +27,8 @@ description:
        for debugging variables or expressions without necessarily halting
        the playbook. Useful for debugging together with the only_if directive.
 
-       In order to see the debug message, you need to run ansible in verbose
-       mode (using the C(-v) option).
+       Since Ansible version 1.2, the verbose mode is activated by default on
+       this module so C(-v) is not needed anymore.
 version_added: "0.8"
 options:
   msg:

--- a/plugins/callbacks/log_plays.py
+++ b/plugins/callbacks/log_plays.py
@@ -54,7 +54,7 @@ class CallbackModule(object):
     def runner_on_failed(self, host, res, ignore_errors=False):
         log(host, 'FAILED', res)
 
-    def runner_on_ok(self, host, res):
+    def runner_on_ok(self, host, res, always_verbose=False):
         log(host, 'OK', res)
 
     def runner_on_error(self, host, msg):

--- a/plugins/callbacks/osx_say.py
+++ b/plugins/callbacks/osx_say.py
@@ -37,7 +37,7 @@ class CallbackModule(object):
     def runner_on_failed(self, host, res, ignore_errors=False):
         say("Failure on host %s" % host, FAILED_VOICE)
 
-    def runner_on_ok(self, host, res):
+    def runner_on_ok(self, host, res, always_verbose=False):
         say("pew", LASER_VOICE)
 
     def runner_on_error(self, host, msg):

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -49,7 +49,7 @@ class TestCallbacks(object):
     def on_failed(self, host, results, ignore_errors):
         EVENTS.append([ 'failed', [ host, results, ignore_errors ]])
 
-    def on_ok(self, host, result):
+    def on_ok(self, host, result, always_verbose):
         # delete certain info from host_result to make test comparisons easier
         host_result = result.copy()
         for k in [ 'ansible_job_id', 'results_file', 'md5sum', 'delta', 'start', 'end' ]:
@@ -58,7 +58,7 @@ class TestCallbacks(object):
         for k in host_result.keys():
             if k.startswith('facter_') or k.startswith('ohai_'):
                 del host_result[k]
-        EVENTS.append([ 'ok', [ host, host_result ]])
+        EVENTS.append([ 'ok', [ host, host_result, always_verbose ]])
 
     def on_play_start(self, pattern):
         EVENTS.append([ 'play start', [ pattern ]])


### PR DESCRIPTION
Currently, the debug module messages are not shown by ansible unless the user is using the verbose mode (the -v option). It would be nice that the verbosity was automatic on the debug module as @mpdehaan suggested in the chatroom.

A module could force the verbosity mode by passing an extra parameter to the ReturnData constructor. The runner could pass that option to callbacks.on_ok as a boolean, something like ignore_errors in the on_failed method. Thoughts?
