### PR TITLE
Test case and fix for shlex.split unicode bug

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -194,7 +194,7 @@ class Play(object):
                 task_vars['_original_file'] = original_file
 
             if 'include' in x:
-                tokens = shlex.split(x['include'])
+                tokens = shlex.split(str(x['include']))
                 items = ['']
                 included_additional_conditions = list(additional_conditions)
                 for k in x:

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -211,6 +211,27 @@ class TestPlaybook(unittest.TestCase):
 
        assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
 
+   def test_task_includes(self):
+       pb = os.path.join(self.test_dir, 'task-includer.yml')
+       actual = self._run(pb)
+
+       # if different, this will output to screen
+       print "**ACTUAL**"
+       print utils.jsonify(actual, format=True)
+       expected =  {
+           "localhost": {
+               "changed": 0,
+               "failures": 0,
+               "ok": 1,
+               "skipped": 0,
+               "unreachable": 0
+           }
+       }
+       print "**EXPECTED**"
+       print utils.jsonify(expected, format=True)
+
+       assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
+
    def test_playbook_vars(self):
        test_callbacks = TestCallbacks()
        playbook = ansible.playbook.PlayBook(

--- a/test/task-included.yml
+++ b/test/task-included.yml
@@ -1,0 +1,2 @@
+---
+- action: debug msg="$internal"

--- a/test/task-includer.yml
+++ b/test/task-includer.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  connection: local
+  gather_facts: no
+  vars:
+  - internal: xyz
+
+  tasks:
+  - include: task-included.yml internal=$internal


### PR DESCRIPTION
When operating on a unicode string in python 2.6, shlex.split returns
a result that does not work with the file constructor.

This causes task includes to fail because python cannot open the included task.

To reproduce this requires a task include that is templated (this is
because the templated string is a unicode result, whereas a non-
templated string is a non-unicode string)

```
[will@centos6.3] $ python
Python 2.6.6 (r266:84292, Sep 11 2012, 08:34:23)
[GCC 4.4.6 20120305 (Red Hat 4.4.6-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import shlex
>>> shlex.split(u'abc')
['a\x00\x00\x00b\x00\x00\x00c\x00\x00\x00']

[will@fedora17] $ python
Python 2.7.3 (default, Jul 24 2012, 10:05:38)
[GCC 4.7.0 20120507 (Red Hat 4.7.0-5)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import shlex
>>> shlex.split(u'abc')
['abc']
```

The proposed fix (coercing the include parameters to string before the
shlex.split) may not be ideal but it does fix the bug for my test case.
