### PR TITLE
Prevent premature variable substitution in tasks

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -65,7 +65,11 @@ class Play(object):
 
         self._update_vars_files_for_host(None)
 
-        self._ds = ds         = template.template(basedir, ds, self.vars)
+        for key in ds:
+            if key != 'tasks':
+               ds[key] = template.template(basedir, ds[key], self.vars) 
+
+        self._ds = ds         
 
         hosts = ds.get('hosts')
         if hosts is None:

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -257,3 +257,31 @@ class TestPlaybook(unittest.TestCase):
        play = ansible.playbook.Play(playbook, playbook.playbook[0], os.getcwd())
        assert play.hosts == ';'.join(('host1', 'host2', 'host3'))
 
+   def test_playbook_when(self):
+       test_callbacks = TestCallbacks()
+       playbook = ansible.playbook.PlayBook(
+           playbook=os.path.join(self.test_dir, 'playbook-when.yml'),
+           host_list='test/ansible_hosts',
+           extra_vars={ 'external' : 'xyz', 'identity': 'identity' },
+           stats=ans_callbacks.AggregateStats(),
+           callbacks=test_callbacks,
+           runner_callbacks=test_callbacks
+       )
+       actual = playbook.run()
+
+       # if different, this will output to screen
+       print "**ACTUAL**"
+       print utils.jsonify(actual, format=True)
+       expected =  {
+           "localhost": {
+               "changed": 0,
+               "failures": 0,
+               "ok": 3,
+               "skipped": 3,
+               "unreachable": 0
+           }
+       }
+       print "**EXPECTED**"
+       print utils.jsonify(expected, format=True)
+
+       assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)

--- a/test/playbook-when.yml
+++ b/test/playbook-when.yml
@@ -1,0 +1,27 @@
+---
+- hosts: all
+  connection: local
+  gather_facts: False
+
+  vars: 
+    internal: "print me"
+
+  tasks: 
+  - action: debug msg="skip me"
+    when_unset: $internal
+
+  - action: debug msg="$internal"
+    when_set: $internal
+
+  - action: debug msg="skip me"
+    when_unset: $external
+
+  - action: debug msg="$external"
+    when_set: $external
+
+  - action: debug msg="run me"
+    when_unset: $this_var_does_not_exist
+
+  - action: debug msg="skip me"
+    when_set: $this_var_does_not_exist
+


### PR DESCRIPTION
Wasn't sure whether to raise an issue or a pull-request without a fix. Here's my PR that at least contains a test case. 

Here templating goes too far
Need to test if a value is set (or unset) - but the value is substituted
before the test

Test with

```
ansible-playbook -i test/ansible_hosts -e 'external=xyz' test/playbook-when.yml
```
