### PR TITLE
fix include playbooks feature, update test cases accordingly (also remov...

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -172,23 +172,23 @@ class PlayBook(object):
                 # to set variables
 
                 for t in tokens[1:]:
-
                     (k,v) = t.split("=", 1)
                     incvars[k] = utils.template(basedir, v, incvars)
-                    included_path = utils.path_dwim(basedir, utils.template(basedir, tokens[0], incvars))
-                    (plays, basedirs) = self._load_playbook_from_file(included_path, incvars)
-                    for p in plays:
-                        # support for parameterized play includes works by passing
-                        # those variables along to the subservient play
-                        if 'vars' not in p:
-                            p['vars'] = {}
-                        if isinstance(p['vars'], dict):
-                            p['vars'].update(incvars)
-                        elif isinstance(p['vars'], list):
-                            # nobody should really do this, but handle vars: a=1 b=2
-                            p['vars'].extend([dict(k=v) for k,v in incvars.iteritems()])
-                    accumulated_plays.extend(plays)
-                    play_basedirs.extend(basedirs)
+
+                included_path = utils.path_dwim(basedir, utils.template(basedir, tokens[0], incvars))
+                (plays, basedirs) = self._load_playbook_from_file(included_path, incvars)
+                for p in plays:
+                    # support for parameterized play includes works by passing
+                    # those variables along to the subservient play
+                    if 'vars' not in p:
+                        p['vars'] = {}
+                    if isinstance(p['vars'], dict):
+                        p['vars'].update(incvars)
+                    elif isinstance(p['vars'], list):
+                        # nobody should really do this, but handle vars: a=1 b=2
+                        p['vars'].extend([dict(k=v) for k,v in incvars.iteritems()])
+                accumulated_plays.extend(plays)
+                play_basedirs.extend(basedirs)
             else:
 
                 # this is a normal (non-included play)

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -201,7 +201,7 @@ class TestPlaybook(unittest.TestCase):
            "localhost": {
                "changed": 0,
                "failures": 0,
-               "ok": 10,
+               "ok": 4,
                "skipped": 0,
                "unreachable": 0
            }

--- a/test/playbook-included.yml
+++ b/test/playbook-included.yml
@@ -11,4 +11,4 @@
   - ugly: var
   gather_facts: no
   tasks:
-  - action: debug msg="$variable"
+  - action: debug msg="$anothervariable"

--- a/test/playbook-includer.yml
+++ b/test/playbook-includer.yml
@@ -1,8 +1,3 @@
 ---
-- include: playbook-included.yml variable=foobar
-- include: playbook-included.yml variable=foofoo
-- include: playbook-included.yml variable=$item
-  with_items:
-  - foo
-  - bar
-  - baz
+- include: playbook-included.yml variable=foobar anothervariable=foofoo
+- include: playbook-included.yml variable=foofoo anothervariable=foobar


### PR DESCRIPTION
...ing now unsupported with_items from test data)

This fixes an indentation issue introduced in commit 290780d which included a single playbook for each passed key-value token (or never if no key-value token provided).

I also updated the test data accordingly to catch the wrong behaviour including removal of no longer supported with_items together with included playbooks.
