### PR TITLE
Update tests to reflect changes to including playbooks using with_items

### DIFF
--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -201,7 +201,7 @@ class TestPlaybook(unittest.TestCase):
            "localhost": {
                "changed": 0,
                "failures": 0,
-               "ok": 10,
+               "ok": 6,
                "skipped": 0,
                "unreachable": 0
            }

--- a/test/playbook-includer.yml
+++ b/test/playbook-includer.yml
@@ -1,6 +1,7 @@
 ---
 - include: playbook-included.yml variable=foobar
 - include: playbook-included.yml variable=foofoo
+# The with_items below has zero effect - variable will be passed through as $item unless set as an extra_var
 - include: playbook-included.yml variable=$item
   with_items:
   - foo


### PR DESCRIPTION
Commit 290780d13f changed behaviour so that using with_items in
conjunction with playbook inclusion no longer has an effect

This changes the results of running playbook-includer.yml from 10 oks to 6 oks, causing the TestPlayBook:test_includes to fail. This fixes that test. 

I have also updated the playbook to note that the with_items no longer
has an effect
