### PR TITLE
Add support for shallow clones in the git module

### DIFF
--- a/library/git
+++ b/library/git
@@ -56,6 +56,14 @@ options:
             - If C(yes), any modified files in the working
               repository will be discarded.  Prior to 0.7, this was always
               'yes' and could not be disabled.
+    depth:
+        required: false
+        default: null
+        version_added: "1.2"
+        description:
+            - Create a shallow clone with a history truncated to the specified
+              number or revisions. The minimum possible value is C(1), otherwise
+              ignored.
 examples:
     - code: "git: repo=git://foosball.example.org/path/to/repo.git dest=/srv/checkout version=release-0.22"
       description: Example git checkout from Ansible Playbooks
@@ -74,7 +82,7 @@ def get_version(dest):
     sha = sha[0].split()[1]
     return sha
 
-def clone(module, repo, dest, remote):
+def clone(module, repo, dest, remote, depth):
     ''' makes a new git repo if it does not already exist '''
     dest_dirname = os.path.dirname(dest)
     try:
@@ -82,8 +90,11 @@ def clone(module, repo, dest, remote):
     except:
         pass
     os.chdir(dest_dirname)
-    return module.run_command("git clone -o %s %s %s" % (remote, repo, dest),
-                              check_rc=True)
+    cmd = [ module.get_bin_path('git', True), 'clone', '-o', remote ]
+    if depth:
+        cmd.extend([ '--depth', str(depth) ])
+    cmd.extend([ repo, dest ])
+    return module.run_command(cmd, check_rc=True)
 
 def has_local_mods(dest):
     os.chdir(dest)
@@ -92,7 +103,7 @@ def has_local_mods(dest):
     lines = filter(lambda c: not re.search('^\\?\\?.*$', c), lines)
     return len(lines) > 0
 
-def reset(module,dest,force):
+def reset(module, dest, force):
     '''
     Resets the index and working tree to HEAD.
     Discards any changes to tracked files in working
@@ -251,7 +262,8 @@ def main():
             repo=dict(required=True, aliases=['name']),
             version=dict(default='HEAD'),
             remote=dict(default='origin'),
-            force=dict(default='yes', type='bool')
+            force=dict(default='yes', type='bool'),
+            depth=dict(default=None, type='int'),
         ),
         supports_check_mode=True
     )
@@ -261,6 +273,7 @@ def main():
     version = module.params['version']
     remote  = module.params['remote']
     force   = module.params['force']
+    depth   = module.params['depth']
 
     gitconfig = os.path.join(dest, '.git', 'config')
 
@@ -273,7 +286,7 @@ def main():
     if not os.path.exists(gitconfig):
         if module.check_mode:
             module.exit_json(changed=True)
-        (rc, out, err) = clone(module, repo, dest, remote)
+        (rc, out, err) = clone(module, repo, dest, remote, depth)
     else:
         # else do a pull
         local_mods = has_local_mods(dest)


### PR DESCRIPTION
I'm suggesting to add support for shallow clones in the git module. It's an interesting feature for deployment environments where the full history is not really needed. It saves bandwidth, disk space and the clones are much faster when the history is really big.
