### PR TITLE
make bin/ansible error output consistent for shell module as for the command module when no arguments are given

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -93,8 +93,9 @@ class Cli(object):
                 print '    %s' % host
             sys.exit(0)
 
-        if options.module_name == 'command' and not options.module_args:
-            print >>sys.stderr, "No argument passed to command module"
+        if ((options.module_name == 'command' or options.module_name == 'shell')
+                and not options.module_args):
+            print >>sys.stderr, "No argument passed to %s module" % options.module_name
             sys.exit(1)
 
         sshpass = None


### PR DESCRIPTION
Without this patch we have:

```
$ ansible -i localhost, all -m command
No argument passed to command module
$ ansible -i localhost, all -m shell
localhost | FAILED | rc=256 >>
no command given
```

With this patch the latter becomes:

```
$ bin/ansible -i localhost, all -m shell
No argument passed to shell module
```
