### PR TITLE
fetch: Allow to change the local dest path to a direct path

### DIFF
--- a/lib/ansible/runner/action_plugins/fetch.py
+++ b/lib/ansible/runner/action_plugins/fetch.py
@@ -55,12 +55,17 @@ class ActionModule(object):
         
         dest_prefix = options.get('dest_prefix')
         if dest_prefix is None or dest_prefix == 'host_source_path':
-            # files are saved in dest dir, with a subdir for each host, then the filename
+            # files are saved in dest dir, with a subdir for each host, then the filename with their path
             dest   = "%s/%s/%s" % (utils.path_dwim(self.runner.basedir, dest), conn.host, source)
-        elif dest_prefix == 'no':
-            # files are saved with a direct local path
-            dest   = utils.path_dwim(self.runner.basedir, dest) 
-        
+        elif dest_prefix == 'host':
+            # files are saved in dest dir, with a subdir for each host, then the filename *without* their path
+            _, filename = os.path.split(source) 
+            dest   = "%s/%s/%s" % (utils.path_dwim(self.runner.basedir, dest), conn.host, filename)
+        elif dest_prefix == 'simple':
+            # files are saved in dest dir, without their path
+            _, filename = os.path.split(source) 
+            dest   = "%s/%s" % (utils.path_dwim(self.runner.basedir, dest), filename)
+
         dest   = dest.replace("//","/")
         
         # calculate md5 sum for the remote file

--- a/lib/ansible/runner/action_plugins/fetch.py
+++ b/lib/ansible/runner/action_plugins/fetch.py
@@ -52,10 +52,17 @@ class ActionModule(object):
             results = dict(failed=True, msg="src and dest are required")
             return ReturnData(conn=conn, result=results)
 
-        # files are saved in dest dir, with a subdir for each host, then the filename
-        dest   = "%s/%s/%s" % (utils.path_dwim(self.runner.basedir, dest), conn.host, source)
+        
+        dest_prefix = options.get('dest_prefix')
+        if dest_prefix is None or dest_prefix == 'host_source_path':
+            # files are saved in dest dir, with a subdir for each host, then the filename
+            dest   = "%s/%s/%s" % (utils.path_dwim(self.runner.basedir, dest), conn.host, source)
+        elif dest_prefix == 'no':
+            # files are saved with a direct local path
+            dest   = utils.path_dwim(self.runner.basedir, dest) 
+        
         dest   = dest.replace("//","/")
-
+        
         # calculate md5 sum for the remote file
         remote_md5 = self.runner._remote_md5(conn, tmp, source)
 

--- a/library/fetch
+++ b/library/fetch
@@ -36,8 +36,12 @@ options:
     default: "no"
   dest_prefix:
     description:
-      - Describes the type of path to append before the dest 
+      - Defines the destination path. For dest example above, if the 
+        I(dest_prefix) is C(host), the file would be saved in 
+        C(/backup/host.example.com/profile). If the I(dest_prefix) is 
+        C(simple), the file would be saved in C(/backup/profile).
     required: false
+    choices: [ "host_source_path", "host", "simple" ]
     default: host_source_path
 examples:
    - code: "fetch: src=/var/log/messages dest=/home/logtree"

--- a/library/fetch
+++ b/library/fetch
@@ -36,13 +36,17 @@ options:
     default: "no"
   dest_prefix:
     description:
-      - Defines the destination path. For dest example above, if the 
+      - Defines the destination additional path. For example, if the I(dest)
+        directory is C(/backup) and I(dest_prefix) is set to C(simple), a 
+        I(src) file named C(/etc/profile) on host C(host.example.com) if the 
         I(dest_prefix) is C(host), the file would be saved in 
-        C(/backup/host.example.com/profile). If the I(dest_prefix) is 
-        C(simple), the file would be saved in C(/backup/profile).
+        C(/backup/profile). If I(dest_prefix) is set to "host", the file would
+        be saved in C(/backup/host.example.com/host). If I(dest_prefix) is set
+        to C(host_source_path) (default value), the file would be saved into
+        C(/backup/host.example.com/etc/profile).
     required: false
     choices: [ "host_source_path", "host", "simple" ]
-    default: host_source_path
+    default: "host_source_path"
 examples:
    - code: "fetch: src=/var/log/messages dest=/home/logtree"
      description: "Example from Ansible Playbooks"

--- a/library/fetch
+++ b/library/fetch
@@ -34,6 +34,11 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "no"
+  dest_prefix:
+    description:
+      - Describes the type of path to append before the dest 
+    required: false
+    default: host_source_path
 examples:
    - code: "fetch: src=/var/log/messages dest=/home/logtree"
      description: "Example from Ansible Playbooks"


### PR DESCRIPTION
Allows the "fetch" module to change the local destination file or directory to anything we like and not just $host/$source_path .

It doesn't break the compatibility. It adds an optional dest_prefix parameter.

There's no reason for "fetch" to be forced to reproduce the remote path.
