### PR TITLE
Calls to template must be prefixed

### DIFF
--- a/lib/ansible/runner/action_plugins/pause.py
+++ b/lib/ansible/runner/action_plugins/pause.py
@@ -56,7 +56,7 @@ class ActionModule(object):
         args = {}
         if complex_args:
             args.update(complex_args)
-        args.update(parse_kv(template(self.runner.basedir, module_args, inject)))
+        args.update(parse_kv(template.template(self.runner.basedir, module_args, inject)))
 
         # Are 'minutes' or 'seconds' keys that exist in 'args'?
         if 'minutes' in args or 'seconds' in args:


### PR DESCRIPTION
Another example of a6777f7e7

```
from ansible.utils import template
```

no longer allows an unprefixed call to template.
They must be prefixed by utils or template.

Otherwise python tries to make a function call to a module
rather than a function, resulting in a TypeError
