### PR TITLE
Allow .yaml if .yml tasks/handlers/vars are not found in a role

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -117,6 +117,9 @@ class Play(object):
         #    <rolename>/handlers/main.yml
         #    <rolename>/vars/main.yml
         # and it auto-extends tasks/handlers/vars_files as appropriate if found
+        #
+        # .yaml is also allowed as an extension if .yml files are not
+        # found first.
 
         if roles is None:
             return ds
@@ -153,10 +156,24 @@ class Play(object):
             vars_file = utils.path_dwim(self.basedir, os.path.join(path, 'vars', 'main.yml'))
             if os.path.isfile(task):
                 new_tasks.append(dict(include=task, vars=has_dict))
+            else:
+                task = utils.path_dwim(self.basedir, os.path.join(path, 'tasks', 'main.yaml'))
+                if os.path.isfile(task):
+                    new_tasks.append(dict(include=task, vars=has_dict))
+            
             if os.path.isfile(handler):
                 new_handlers.append(dict(include=handler, vars=has_dict))
+            else:
+                handler = utils.path_dwim(self.basedir, os.path.join(path, 'handlers', 'main.yaml'))
+                if os.path.isfile(handler):
+                    new_handlers.append(dict(include=handler, vars=has_dict))
+
             if os.path.isfile(vars_file):
                 new_vars_files.append(vars_file)
+            else:
+                vars_file = utils.path_dwim(self.basedir, os.path.join(path, 'vars', 'main.yaml'))
+                if os.path.isfile(vars_file):
+                    new_vars_files.append(vars_file)
 
         tasks = ds.get('tasks', None)
         handlers = ds.get('handlers', None)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -125,6 +125,9 @@ class Play(object):
         #    <rolename>/handlers/main.yml
         #    <rolename>/vars/main.yml
         # and it auto-extends tasks/handlers/vars_files as appropriate if found
+        #
+        # .yaml is also allowed as an extension if .yml files are not
+        # found first.
 
         if roles is None:
             return ds
@@ -169,6 +172,16 @@ class Play(object):
                 if with_items:
                     nt['with_items'] = with_items
                 new_tasks.append(nt)
+            else:
+                task = utils.path_dwim(self.basedir, os.path.join(path, 'tasks', 'main.yaml'))
+                if os.path.isfile(task):
+                    nt = dict(include=task, vars=has_dict)
+                    if when: 
+                        nt['when'] = when
+                    if with_items:
+                        nt['with_items'] = with_items
+                    new_tasks.append(nt)
+
             if os.path.isfile(handler):
                 nt = dict(include=handler, vars=has_dict)
                 if when: 
@@ -176,8 +189,22 @@ class Play(object):
                 if with_items:
                     nt['with_items'] = with_items
                 new_handlers.append(nt)
+            else:
+                handler = utils.path_dwim(self.basedir, os.path.join(path, 'handlers', 'main.yaml'))
+                if os.path.isfile(handler):
+                    nt = dict(include=handler, vars=has_dict)
+                    if when: 
+                        nt['when'] = when
+                    if with_items:
+                        nt['with_items'] = with_items
+                    new_handlers.append(nt)
+
             if os.path.isfile(vars_file):
                 new_vars_files.append(vars_file)
+            else:
+                vars_file = utils.path_dwim(self.basedir, os.path.join(path, 'vars', 'main.yaml'))
+                if os.path.isfile(vars_file):
+                    new_vars_files.append(vars_file)
 
         tasks = ds.get('tasks', None)
         handlers = ds.get('handlers', None)

--- a/library/user
+++ b/library/user
@@ -492,6 +492,16 @@ class User(object):
 
         return self.execute_command(cmd)
 
+    def get_ssh_public_key(self):
+        ssh_public_key_file = '%s.pub' % self.get_ssh_key_path()
+        try:
+            f = open(ssh_public_key_file)
+            ssh_public_key = f.read().strip()
+            f.close()
+        except IOError:
+            return None
+        return ssh_public_key
+
     def create_user(self):
         # by default we use the create_user_useradd method
         return self.create_user_useradd()
@@ -1130,6 +1140,7 @@ def main():
             else:
                 result['ssh_fingerprint'] = err.strip()
             result['ssh_key_file'] = user.get_ssh_key_path()
+            result['ssh_public_key'] = user.get_ssh_public_key()
 
 
     module.exit_json(**result)


### PR DESCRIPTION
We discussed this briefly on irc yesterday. This patch allows:

<rolename>/tasks/main.yaml
<rolename>/handlers/main.yaml
<rolename>/vars/main.yaml

in roles. As discussed, .yml files are preferred.
