### PR TITLE
UPDATE: Allow subdirs in host/group_vars and vars files extensions

### DIFF
--- a/lib/ansible/inventory/vars_plugins/group_vars.py
+++ b/lib/ansible/inventory/vars_plugins/group_vars.py
@@ -28,7 +28,9 @@ def vars_file_matches(f, name):
     # - the basename of the file, stripped its extension, equals 'name'
     if os.path.basename(f) == name:
         return True
-    elif '.'.join(os.path.basename(f).split('.')[:-1]) == name:
+    elif os.path.basename(f) == '.'.join([name, 'yml']):
+        return True
+    elif os.path.basename(f) == '.'.join([name, 'yaml']):
         return True
     else:
         return False
@@ -72,6 +74,9 @@ class VarsModule(object):
         for x in groups:
             group_vars_dir = os.path.join(basedir, "group_vars")
             group_vars_files = vars_files(group_vars_dir, x)
+            if len(group_vars_files) > 1:
+                raise errors.AnsibleError("Found more than one file for group '%s': %s"
+                                  % (x, group_vars_files))
             for path in group_vars_files:
                 data = utils.parse_yaml_from_file(path)
                 if type(data) != dict:
@@ -85,6 +90,9 @@ class VarsModule(object):
         # load vars in inventory_dir/hosts_vars/name_of_host
         host_vars_dir = os.path.join(basedir, "host_vars")
         host_vars_files = vars_files(host_vars_dir, host.name)
+        if len(host_vars_files) > 1:
+            raise errors.AnsibleError("Found more than one file for host '%s': %s"
+                                  % (host.name, host_vars_files))
         for path in host_vars_files:
             data = utils.parse_yaml_from_file(path)
             if type(data) != dict:


### PR DESCRIPTION
Update to Morgan Hamill's patch that allows subdirs in host/group_vars, originally in https://github.com/ansible/ansible/pull/2664 

Only 1 file per host or group is allowed.
Files can be named to the host or group name, or have optionally an extension .yml or .yaml

If more than one file is found for a given host or group, an error is raised for it.

```
serge@cyberlab:~/tmp$ cat inventory 
[group]
localhost

[project1]
localghost ansible_ssh_host=localhost

[staging[
localpc ansible_ssh_host=localhost
localdev ansible_ssh_host=localhost
```

```
serge@cyberlab:~/tmp$ tree
.
├── group_vars
│   ├── group
│   ├── group.yml
│   ├── production
│   │   └── project1
│   └── project1
├── host_vars
│   ├── localpc.yaml
│   └── project1
│       └── localpc
│       └── localdev
├── inventory
└── vars_plugins -> ../src/ansible/lib/ansible/inventory/vars_plugins/
```

```
serge@cyberlab:~/tmp$ ../src/ansible/bin/ansible -i inventory all -m debug -o

localpc | FAILED => Found more than one file for host 'localpc': ['host_vars/localpc.yaml', 'host_vars/project1/localpc']
localghost | FAILED => Found more than one file for group 'project1': ['group_vars/production/project1', 'group_vars/project1']
localhost | FAILED => Found more than one file for group 'group': ['group_vars/group', 'group_vars/group.yml']
localdev | success >> {"msg": "Hello world!"}
```
