### PR TITLE
Use platform.node to find out the hostname (#2663)

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -41,7 +41,7 @@ import shutil
 import subprocess
 import sys
 import datetime
-import socket
+import platform
 from optparse import OptionParser
 
 DEFAULT_PLAYBOOK = 'local.yml'
@@ -75,7 +75,7 @@ def select_playbook(path, args):
             return None
         return playbook
     else:
-        hostpb = "%s/%s.yml" % (path, socket.getfqdn())
+        hostpb = "%s/%s.yml" % (path, platform.node)
         localpb = "%s/%s" % (path, DEFAULT_PLAYBOOK)
         errors = []
         for pb in [hostpb, localpb]:
@@ -115,7 +115,7 @@ def main(args):
     now = datetime.datetime.now()
     print >>sys.stderr, now.strftime("Starting ansible-pull at %F %T")
 
-    limit_opts = 'localhost:%s:127.0.0.1' % socket.getfqdn()
+    limit_opts = 'localhost:%s:127.0.0.1' % platform.node()
     git_opts = "repo=%s dest=%s version=%s" % (options.url, options.dest, options.checkout)
     cmd = 'ansible all -c local --limit "%s" -m git -a "%s"' % (limit_opts, git_opts)
     rc = _run(cmd)

--- a/library/netscaler
+++ b/library/netscaler
@@ -89,7 +89,7 @@ import json
 import urllib
 import urllib2
 import base64
-import socket
+import platform
 
 
 class netscaler(object):
@@ -153,7 +153,7 @@ def main():
             user = dict(required=True),
             password = dict(required=True),
             action = dict(default='enable', choices=['enable','disable']),
-            name = dict(default=socket.gethostname()),
+            name = dict(default=platform.node()),
             type = dict(default='server', choices=['service', 'server'])
         )
     )

--- a/library/setup
+++ b/library/setup
@@ -138,7 +138,7 @@ class Facts(object):
         self.facts['kernel'] = platform.release()
         self.facts['machine'] = platform.machine()
         self.facts['python_version'] = platform.python_version()
-        self.facts['fqdn'] = socket.getfqdn()
+        self.facts['fqdn'] = platform.node()
         self.facts['hostname'] = self.facts['fqdn'].split('.')[0]
         self.facts['domain'] = '.'.join(self.facts['fqdn'].split('.')[1:])
         if self.facts['machine'] == 'x86_64':


### PR DESCRIPTION
Use `platform.node()` instead of `socket.getfqdn()` or
`socket.gethostname` as discussed on bug #2663 [1]

[1] https://github.com/ansible/ansible/issues/2663#issuecomment-16341359
