### PR TITLE
Add dpkg module

### DIFF
--- a/library/dpkg
+++ b/library/dpkg
@@ -94,6 +94,7 @@ def package_from_url(m, url):
     import tarfile
     import io
     import re
+    import apt
 
     try:
         debfile = urllib.urlopen(url)
@@ -130,7 +131,7 @@ def package_from_url(m, url):
         # Failed to populate Record; bad format of the control
         m.fail_json(msg="Invalid control file's content format from url '%s'" % url)
 
-    return dict(record=record, debfile=debfile, header=header)
+    return (record, debfile, header)
 
 def package_from_file(m, path):
     '''
@@ -139,6 +140,8 @@ def package_from_file(m, path):
         - package record (apt.package.Record) to query package_status
         - empty debfile and header (just to remain compliant with package_from_url return)
     '''
+    import apt
+
     try:
         pkg = debfile.DebPackage(path)
     except: 
@@ -147,7 +150,7 @@ def package_from_file(m, path):
     control = pkg.control_content('control')
     record = apt.package.Record(control)
 
-    return dict(record=record, debfile=None, header=None)
+    return (record, None, None)
 
 def package_status(m, pkgname, version, cache):
     try:
@@ -167,10 +170,84 @@ def package_status(m, pkgname, version, cache):
             #assume older version of python-apt is installed
             return pkg.isInstalled, pkg.isUpgradable
 
+def missing_dependencies(m, depends, cache):
+    """
+    Check the dependencies against apt cache
+    Returns:
+    - True + [] if dependencies are matched (or none)
+    - False + missing [] dependencies if dependencies are not matched
+    """
+    if not depends or len(depends) == 0:
+        return (False, [])
+
+    missing = False
+    missing_deps = []
+
+    from distutils.version import StrictVersion
+    import operator
+    operator_dict = {
+        '>': operator.gt,
+        '>=': operator.ge,
+        '=': operator.eq,
+        '<': operator.lt,
+        '<=': operator.le
+    }
+
+    dependencies = [ dep.strip() for dep in depends.split(',') ]
+    for dep in dependencies:
+        try:
+            pkg = cache[dep.split()[0]]
+        except KeyError:
+            missing = True
+            missing_deps.append(dep)
+            continue
+
+        # Package is missing if .. not installed
+        try:
+            if not pkg.is_installed:
+                missing = True
+                missing_deps.append(dep)
+                continue
+        except AttributeError:
+            if not pkg.isInstalled:
+                missing = True
+                missing_deps.append(dep)
+                continue
+
+        # Check version
+        version = None
+        try:
+            versionSpec = dep.split('(')[1].split(')')[0]
+            version = versionSpec.split(None, 1)
+        except:
+            pass
+
+        if version:
+            op = '='
+            if len(version) == 2:
+                op = version[0]
+                version = version[1]
+
+            # Version needs to be a string of integers - debian / ubuntu doesn't always comply...
+            m_pkg_version = re.search('([a-zA-Z0-9\.]*)', pkg.installed.version)
+            if m:
+                pkg_version = m_pkg_version.groups()[0]
+            else:
+                m.exit_json(msg="Error while parsing package (dependency) version: '%s" % pkg.installed.version)
+
+            match_version = operator_dict[op](StrictVersion(pkg_version), StrictVersion(version))
+            if not match_version:
+                missing = True
+                missing_deps.append(dep)
+                continue
+
+    return (missing, missing_deps)
+
 def install(m, record, debfile, content, cache, force=False):
     package = ""
     name = record['Package']
     version = record['Version']
+    depends = record['Depends']
 
     installed, upgradable = package_status(m, name, version, cache)    
     if not installed or upgradable:
@@ -194,8 +271,14 @@ def install(m, record, debfile, content, cache, force=False):
         if force:
             force_all = '--force-all'
         else:
-            force_all = ''
-
+            # Look for missing dependencies
+            missing, missing_deps = missing_dependencies(m, depends, cache)
+            if missing:
+                m.exit_json(msg="Not installing, missing dependencies: '%s', use --force to install" 
+                              % ', '.join(missing_deps))
+            else: 
+                force_all = ''
+    
         cmd = "%s --install --force-confold %s %s" % (DPKG, force_all, package)
 
         if m.check_mode:
@@ -224,14 +307,14 @@ def remove(m, record, cache, purge=False):
         purge = ''
         if purge:
             purge = '--purge'
-        cmd = "%s -q -y %s remove %s" % (APT, purge, packages)
+        cmd = "%s -q -y %s remove %s" % (APT, purge, package)
 
         if m.check_mode:
             m.exit_json(changed=True)
 
         rc, out, err = m.run_command(cmd)
         if rc:
-            m.fail_json(msg="'apt-get remove %s' failed: %s" % (packages, err))
+            m.fail_json(msg="'apt-get remove %s' failed: %s" % (package, err))
         m.exit_json(changed=True)
 
 def main():
@@ -250,13 +333,13 @@ def main():
 
     try:
         import apt
-        import apt_pkg
-        from apt import debfile
     except:
-        module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")
+        module.fail_json(msg="Could not import python modules: apt. Please install python-apt package.")
 
     if not os.path.exists(APT_PATH):
         module.fail_json(msg="Cannot find apt-get")
+    if not os.path.exists(DPKG_PATH):
+        module.fail_json(msg="Cannot find dpkg")
 
     p = module.params
 

--- a/library/dpkg
+++ b/library/dpkg
@@ -170,14 +170,14 @@ def package_status(m, pkgname, version, cache, state):
             #assume older version of python-apt is installed
             return pkg.isInstalled, pkg.isUpgradable
 
-def install(m, record, debfile, content, cache, install_recommends=True, force=False):
+def install(m, record, debfile, content, cache, force=False):
     package = ""
     name = record['Package']
     version = record['Version']
 
     installed, upgradable = package_status(m, name, version, cache, state='install')    
     if not installed or upgradable:
-        if content:
+        if m.params['url']:
             # Fetch the remaining file from url
             try: 
                 content += debfile.read()
@@ -195,13 +195,11 @@ def install(m, record, debfile, content, cache, install_recommends=True, force=F
 
     if len(package) != 0:
         if force:
-            force_yes = '--force-yes'
+            force_all = '--force-all'
         else:
-            force_yes = ''
+            force_all = ''
 
-        cmd = "%s --install --force-confold %s %s" % (DPKG, force_yes, package)
-        if not install_recommends:
-            cmd += " --no-install-recommends"
+        cmd = "%s --install --force-confold %s %s" % (DPKG, force_all, package)
 
         if m.check_mode:
             m.exit_json(changed=True)
@@ -214,21 +212,22 @@ def install(m, record, debfile, content, cache, install_recommends=True, force=F
     else:
         m.exit_json(changed=False)
 
-def remove(m, pkgspec, cache, purge=False):
-    packages = ""
-    for package in pkgspec:
-        name, version = package_split(package)
-        installed, upgradable = package_status(m, name, version, cache, state='remove')
-        if installed:
-            packages += "'%s' " % package
+def remove(m, record, cache, purge=False):
+    package = ""
+    name = record['Package']
+    version = record['Version']
 
-    if len(packages) == 0:
+    installed, upgradable = package_status(m, name, version, cache, state='remove')
+    if installed:
+        package = name
+
+    if len(package) == 0:
         m.exit_json(changed=False)
     else:
         purge = ''
         if purge:
             purge = '--purge'
-        cmd = "%s -q -y %s remove %s" % (APT, purge,packages)
+        cmd = "%s -q -y %s remove %s" % (APT, purge, packages)
 
         if m.check_mode:
             m.exit_json(changed=True)
@@ -245,7 +244,6 @@ def main():
             purge = dict(default='no', type='bool'),
             url = dict(default=None),
             package = dict(default=None, aliases=['pkg', 'name']),
-            install_recommends = dict(default='yes', aliases=['install-recommends'], type='bool'),
             force = dict(default='no', type='bool'),
         ),
         mutually_exclusive = [['package', 'url']],
@@ -264,12 +262,11 @@ def main():
         module.fail_json(msg="Cannot find apt-get")
 
     p = module.params
-    install_recommends = p['install_recommends']
 
     try:
         cache = apt.Cache()
 
-        force_yes = p['force']
+        force_all = p['force']
 
         if p['url']:
             record, debfile, header = package_from_url(module, p['url'])
@@ -277,8 +274,7 @@ def main():
             record, debfile, header = package_from_file(module, p['package'])
 
         if p['state'] in [ 'installed', 'present' ]:
-            install(module, record, debfile, header, cache, install_recommends=install_recommends,
-                      force=force_yes, )
+            install(module, record, debfile, header, cache, force=force_all)
         elif p['state'] in [ 'removed', 'absent' ]:
             remove(module, record, cache, p['purge'])
 

--- a/library/dpkg
+++ b/library/dpkg
@@ -149,14 +149,11 @@ def package_from_file(m, path):
 
     return dict(record=record, debfile=None, header=None)
 
-def package_status(m, pkgname, version, cache, state):
+def package_status(m, pkgname, version, cache):
     try:
         pkg = cache[pkgname]
     except KeyError:
-        if state == 'install':
-            m.fail_json(msg="No package matching '%s' is available" % pkgname)
-        else:
-            return False, False
+        return False, False
     if version:
         try :
             return pkg.is_installed and pkg.installed.version == version, False
@@ -175,7 +172,7 @@ def install(m, record, debfile, content, cache, force=False):
     name = record['Package']
     version = record['Version']
 
-    installed, upgradable = package_status(m, name, version, cache, state='install')    
+    installed, upgradable = package_status(m, name, version, cache)    
     if not installed or upgradable:
         if m.params['url']:
             # Fetch the remaining file from url
@@ -217,7 +214,7 @@ def remove(m, record, cache, purge=False):
     name = record['Package']
     version = record['Version']
 
-    installed, upgradable = package_status(m, name, version, cache, state='remove')
+    installed, upgradable = package_status(m, name, version, cache)
     if installed:
         package = name
 
@@ -243,7 +240,7 @@ def main():
             state = dict(default='installed', choices=['installed', 'removed', 'absent', 'present']),
             purge = dict(default='no', type='bool'),
             url = dict(default=None),
-            package = dict(default=None, aliases=['pkg', 'name']),
+            package = dict(default=None, aliases=['pkg', 'name', 'path']),
             force = dict(default='no', type='bool'),
         ),
         mutually_exclusive = [['package', 'url']],

--- a/library/dpkg
+++ b/library/dpkg
@@ -141,6 +141,7 @@ def package_from_file(m, path):
         - empty debfile and header (just to remain compliant with package_from_url return)
     '''
     import apt
+    from apt import debfile
 
     try:
         pkg = debfile.DebPackage(path)

--- a/library/dpkg
+++ b/library/dpkg
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2012, Flowroute LLC
-# Written by Matthew Williams <matthew@flowroute.com>
-# Based on yum module written by Seth Vidal <skvidal at fedoraproject.org>
+# (c) 2013, Devo.ps
+# Written by Vincent Viallet <vincent@devo.ps>
+# Based on apt module
 #
 # This module is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/library/dpkg
+++ b/library/dpkg
@@ -1,0 +1,276 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Flowroute LLC
+# Written by Matthew Williams <matthew@flowroute.com>
+# Based on yum module written by Seth Vidal <skvidal at fedoraproject.org>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = '''
+---
+module: dpkg
+short_description: Manages dpkg packages
+description:
+  - Manages I(dpkg) packages (such as for Debian/Ubuntu).
+options:
+  url:
+    description:
+      - A package url or package specifier with version, like C(http://example.com/foo.deb)
+    required: true
+    default: null
+  pkg:
+    description:
+      - A deb file full path, like C(/bar/foo.deb)
+    required: true
+    default: null
+  state:
+    description:
+      - Indicates the desired package state
+    required: false
+    default: present
+    choices: [ "absent", "present" ]
+  purge:
+    description:
+     - Will force purging of configuration files if the module state is set to I(absent).
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
+  force:
+    description:
+      - If C(yes), force installs/removes.
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
+author: Vincent Viallet
+notes: []
+examples:
+    - code: "dpkg: pkg=/bar/foo.deb state=present"
+      description: Install package (foo.deb) from folder /bar
+    - code: "dpkg: url=http://example.com/foo.deb state=installed"
+      description: Install the package C(http://example.com/foo.deb)
+requirements: [ python-apt, aptitude ]
+'''
+
+import traceback
+# added to stave off future warnings about apt api
+import warnings
+warnings.filterwarnings('ignore', "apt API not stable yet", FutureWarning)
+
+# APT related constants
+APT_PATH = "/usr/bin/apt-get"
+APT = "DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical %s" % APT_PATH
+
+# Empirical size in bytes to fetch .deb header and extract package info
+# without downloading the entire file
+HEADER_SIZE = 5000
+
+# def package_split(pkgspec):
+#     parts = pkgspec.split('=')
+#     if len(parts) > 1:
+#         return parts[0], parts[1]
+#     else:
+#         return parts[0], None
+
+# Get package from URL, fetching 
+def package_from_url(m, url):
+    '''
+    Fetch the first HEADER_SIZE bytes of the file located at URL.
+    Attempt to extract the .deb package info.
+    Returns 
+        - package record (apt.package.Record) to query package_status
+        - debfile; (urllib) to resume reading if file need to be installed
+        - header; to append to if remaining file is to be read
+    '''
+    import urllib
+    import tarfile
+    import io
+    import re
+
+    try:
+        debfile = urllib.urlopen(url)
+    except: 
+        m.fail_json(msg="Can not fetch url '%s'" % url)
+
+    # Little trick to extract the package info from the beginning of the deb file:
+    # - extract the control.tar.gz file that holds the package info (done via regex)
+    # - untar and extract the './control' file
+    # - populate a apt.package.Record with the content of the 'control' file
+    header = debfile.read(HEADER_SIZE)
+    match = re.search(b'control\.tar\.gz[^\n]*\n(.*)data\.tar\.gz', header, re.DOTALL)
+    if match:
+        match_data = match.groups()[0]
+    else:
+        # Can not find a match; either not deb file or HEADER_SIZE is too small
+        m.fail_json(msg="Can not find control file from url '%s'" % url)
+
+    try:
+        control_fo = io.BytesIO(match_data)
+        control_tar = tarfile.open(fileobj=control_fo)
+        control = control_tar.extractfile('./control')
+    except: 
+        # Failed either to open the tar file or extract the ./control
+        m.fail_json(msg="Invalid control file in Debian package from url '%s'" % url)
+
+    try:
+        record = apt.package.Record(control.read())
+    except:
+        # Failed to populate Record; bad format of the control
+        m.fail_json(msg="Invalid control file's content format from url '%s'" % url)
+
+    return dict(record=record, debfile=debfile, header=header)
+
+def package_from_file(m, path):
+    '''
+    Open the file at path with debfile.DebPackage and attempt to read its info
+    Returns 
+        - package record (apt.package.Record) to query package_status
+    '''
+    try:
+        pkg = debfile.DebPackage(path)
+    except: 
+        m.fail_json(msg="Can not open package '%s', ensure the file exists and is a valid deb package." % path)
+
+    control = pkg.control_content('control')
+    record = apt.package.Record(control)
+
+    return dict(record=record)
+
+def package_status(m, pkgname, version, cache, state):
+    try:
+        pkg = cache[pkgname]
+    except KeyError:
+        if state == 'install':
+            m.fail_json(msg="No package matching '%s' is available" % pkgname)
+        else:
+            return False, False
+    if version:
+        try :
+            return pkg.is_installed and pkg.installed.version == version, False
+        except AttributeError:
+            #assume older version of python-apt is installed
+            return pkg.isInstalled and pkg.installedVersion == version, False
+    else:
+        try :
+            return pkg.is_installed, pkg.is_upgradable
+        except AttributeError:
+            #assume older version of python-apt is installed
+            return pkg.isInstalled, pkg.isUpgradable
+
+def install(m, pkgspec, cache, install_recommends=True, force=False):
+    packages = ""
+    for package in pkgspec:
+        name, version = package_split(package)
+        installed, upgradable = package_status(m, name, version, cache, state='install')
+        if not installed or (upgrade and upgradable):
+            packages += "'%s' " % package
+
+    if len(packages) != 0:
+        if force:
+            force_yes = '--force-yes'
+        else:
+            force_yes = ''
+
+        cmd = "%s --option Dpkg::Options::=--force-confold -q -y %s install %s" % (APT, force_yes,packages)
+        if default_release:
+            cmd += " -t '%s'" % (default_release,)
+        if not install_recommends:
+            cmd += " --no-install-recommends"
+
+        if m.check_mode:
+            m.exit_json(changed=True)
+
+        rc, out, err = m.run_command(cmd)
+        if rc:
+            m.fail_json(msg="'apt-get install %s' failed: %s" % (packages, err))
+        else:
+            m.exit_json(changed=True)
+    else:
+        m.exit_json(changed=False)
+
+def remove(m, pkgspec, cache, purge=False):
+    packages = ""
+    for package in pkgspec:
+        name, version = package_split(package)
+        installed, upgradable = package_status(m, name, version, cache, state='remove')
+        if installed:
+            packages += "'%s' " % package
+
+    if len(packages) == 0:
+        m.exit_json(changed=False)
+    else:
+        purge = ''
+        if purge:
+            purge = '--purge'
+        cmd = "%s -q -y %s remove %s" % (APT, purge,packages)
+
+        if m.check_mode:
+            m.exit_json(changed=True)
+
+        rc, out, err = m.run_command(cmd)
+        if rc:
+            m.fail_json(msg="'apt-get remove %s' failed: %s" % (packages, err))
+        m.exit_json(changed=True)
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            state = dict(default='installed', choices=['installed', 'removed', 'absent', 'present']),
+            purge = dict(default='no', type='bool'),
+            url = dict(default=None),
+            package = dict(default=None, aliases=['pkg', 'name']),
+            install_recommends = dict(default='yes', aliases=['install-recommends'], type='bool'),
+            force = dict(default='no', type='bool'),
+        ),
+        mutually_exclusive = [['package', 'url']],
+        required_one_of = [['package', 'url']],
+        supports_check_mode = True
+    )
+
+    try:
+        import apt
+        import apt_pkg
+        from apt import debfile
+    except:
+        module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")
+
+    if not os.path.exists(APT_PATH):
+        module.fail_json(msg="Cannot find apt-get")
+
+    p = module.params
+    install_recommends = p['install_recommends']
+
+    try:
+        cache = apt.Cache()
+
+        force_yes = p['force']
+
+        urls = p['url'].split(',')
+        packages = p['package'].split(',')
+        latest = p['state'] == 'latest'
+
+        if p['state'] in [ 'installed', 'present' ]:
+            install(module, packages, cache, install_recommends=install_recommends,
+                      force=force_yes)
+        elif p['state'] in [ 'removed', 'absent' ]:
+            remove(module, packages, cache, p['purge'])
+
+    except apt.cache.LockFailedException:
+        module.fail_json(msg="Failed to lock apt for exclusive operation")
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+
+main()

--- a/library/dpkg
+++ b/library/dpkg
@@ -71,18 +71,14 @@ warnings.filterwarnings('ignore', "apt API not stable yet", FutureWarning)
 
 # APT related constants
 APT_PATH = "/usr/bin/apt-get"
+DPKG_PATH = "/usr/bin/dpkg"
 APT = "DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical %s" % APT_PATH
+DPKG = "DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical %s" % DPKG_PATH
 
 # Empirical size in bytes to fetch .deb header and extract package info
 # without downloading the entire file
+# 5Kb is more that enough, could be reduced down to ~2-3Kb - remain safe
 HEADER_SIZE = 5000
-
-# def package_split(pkgspec):
-#     parts = pkgspec.split('=')
-#     if len(parts) > 1:
-#         return parts[0], parts[1]
-#     else:
-#         return parts[0], None
 
 # Get package from URL, fetching 
 def package_from_url(m, url):
@@ -108,7 +104,11 @@ def package_from_url(m, url):
     # - extract the control.tar.gz file that holds the package info (done via regex)
     # - untar and extract the './control' file
     # - populate a apt.package.Record with the content of the 'control' file
-    header = debfile.read(HEADER_SIZE)
+    try: 
+        header = debfile.read(HEADER_SIZE)
+    except:
+        m.fail_json(msg="Failed to fetch package from url '%s'" % m.params['url'])
+
     match = re.search(b'control\.tar\.gz[^\n]*\n(.*)data\.tar\.gz', header, re.DOTALL)
     if match:
         match_data = match.groups()[0]
@@ -137,6 +137,7 @@ def package_from_file(m, path):
     Open the file at path with debfile.DebPackage and attempt to read its info
     Returns 
         - package record (apt.package.Record) to query package_status
+        - empty debfile and header (just to remain compliant with package_from_url return)
     '''
     try:
         pkg = debfile.DebPackage(path)
@@ -146,7 +147,7 @@ def package_from_file(m, path):
     control = pkg.control_content('control')
     record = apt.package.Record(control)
 
-    return dict(record=record)
+    return dict(record=record, debfile=None, header=None)
 
 def package_status(m, pkgname, version, cache, state):
     try:
@@ -169,23 +170,36 @@ def package_status(m, pkgname, version, cache, state):
             #assume older version of python-apt is installed
             return pkg.isInstalled, pkg.isUpgradable
 
-def install(m, pkgspec, cache, install_recommends=True, force=False):
-    packages = ""
-    for package in pkgspec:
-        name, version = package_split(package)
-        installed, upgradable = package_status(m, name, version, cache, state='install')
-        if not installed or (upgrade and upgradable):
-            packages += "'%s' " % package
+def install(m, record, debfile, content, cache, install_recommends=True, force=False):
+    package = ""
+    name = record['Package']
+    version = record['Version']
 
-    if len(packages) != 0:
+    installed, upgradable = package_status(m, name, version, cache, state='install')    
+    if not installed or upgradable:
+        if content:
+            # Fetch the remaining file from url
+            try: 
+                content += debfile.read()
+            except:
+                m.fail_json(msg="Failed to fetch package from url '%s'" % m.params['url'])
+
+            # Save file locally to be processed by dpkg
+            pkg_file_name = "%s_%s_%s.deb" % (name, version, record['Architecture'])
+            pkg_file = open(pkg_file_name, 'wb')
+            pkg_file.write(content)
+            pkg_file.close()
+            package = pkg_file_name
+        else:
+            package = m.params['package']
+
+    if len(package) != 0:
         if force:
             force_yes = '--force-yes'
         else:
             force_yes = ''
 
-        cmd = "%s --option Dpkg::Options::=--force-confold -q -y %s install %s" % (APT, force_yes,packages)
-        if default_release:
-            cmd += " -t '%s'" % (default_release,)
+        cmd = "%s --install --force-confold %s %s" % (DPKG, force_yes, package)
         if not install_recommends:
             cmd += " --no-install-recommends"
 
@@ -194,7 +208,7 @@ def install(m, pkgspec, cache, install_recommends=True, force=False):
 
         rc, out, err = m.run_command(cmd)
         if rc:
-            m.fail_json(msg="'apt-get install %s' failed: %s" % (packages, err))
+            m.fail_json(msg="'dpkg --install %s' failed: %s" % (package, err))
         else:
             m.exit_json(changed=True)
     else:
@@ -257,15 +271,16 @@ def main():
 
         force_yes = p['force']
 
-        urls = p['url'].split(',')
-        packages = p['package'].split(',')
-        latest = p['state'] == 'latest'
+        if p['url']:
+            record, debfile, header = package_from_url(module, p['url'])
+        else:
+            record, debfile, header = package_from_file(module, p['package'])
 
         if p['state'] in [ 'installed', 'present' ]:
-            install(module, packages, cache, install_recommends=install_recommends,
-                      force=force_yes)
+            install(module, record, debfile, header, cache, install_recommends=install_recommends,
+                      force=force_yes, )
         elif p['state'] in [ 'removed', 'absent' ]:
-            remove(module, packages, cache, p['purge'])
+            remove(module, record, cache, p['purge'])
 
     except apt.cache.LockFailedException:
         module.fail_json(msg="Failed to lock apt for exclusive operation")


### PR DESCRIPTION
Add support for dpkg command; --install and --remove

Packages can be specified either as a local deb file, or remote URL (http or ftp or .. it rely on urllib).

Idempotence is ensured by validating against the apt cache - a package that match the same name and version is not to be re-installed.

When a remote package is provided:
- the header of the file is fetched (the first 5k) and the `control.tar.gz` file is extracted to fetch the package info and avoid downloading the next 20MB
- an apt.package.Record is created from that file
- the cache is checked against installed versions.
- if the package is meant to be installed, the remaining part of the remote file is fetched (only 1 connection to the remote server is required)

Whichever a local or a remote .deb file is requested, a dependency check is performed against the apt-cache to ensure we don't install a package that miss dependencies... A package is not installed if dependencies and their versions are not matching what is installed on the box. However ... if you specify force=yes in the arguments then it will be installed, then deal with it if this is breaking stuff...

Not to lie, I struggled with the partial download of a remote file to extract the .deb info, figure out the format, extract the embedded tar.gz but in the end .. I'm freaking happy of the result!
