### PR TITLE
New module 'set_fact' to define host facts

### DIFF
--- a/lib/ansible/runner/action_plugins/set_fact.py
+++ b/lib/ansible/runner/action_plugins/set_fact.py
@@ -1,0 +1,37 @@
+# Copyright 2013 Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible import utils
+from ansible.runner.return_data import ReturnData
+
+class ActionModule(object):
+
+    NEEDS_TMPPATH = False
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
+        ''' handler for running operations on master '''
+
+        # load up options
+        options  = {}
+        if complex_args:
+            options.update(complex_args)
+        options.update(utils.parse_kv(module_args))
+
+        return ReturnData(conn=conn, result=dict(ansible_facts=options))

--- a/library/set_fact
+++ b/library/set_fact
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2013 Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+author: Dag Wieers
+module: set_fact
+short_description: Set host facts from a task
+description:
+     - This module allows you to set host facts from a task. This can be
+       useful for setting facts conditionally or allows to 'export' play
+       variables set by 'vars:' or 'vars_files:' to the playbook scope .
+     - In comparison to variables defined in the playbook, global variables
+       can be set conditionally (like any module) and are available in other
+       plays.
+options:
+  key_value:
+    description:
+      - The C(set_fact) module takes key=value pairs as variables to set
+        in the playbook scope. Or alternatively, accepts complex arguments
+        using the C(args:) statement.
+    required: true
+    default: null
+version_added: "1.2"
+examples:
+    - description: "Example setting host facts using key=value pairs"
+      code: |
+            action: set_fact fact="something" global_fact="${local_var}"'
+    - description: "Example setting host facts using complex arguments"
+      code: |
+            action: set_fact
+            args:
+              fact: something
+              global_fact: ${local_var}
+notes:
+    - You can set play variables using the C(set_var) module.
+'''


### PR DESCRIPTION
This module allows you to set host facts (or export play variables to the playbook scope if you fancy that).

The module also accepts complex arguments.

``` yaml
 - action: set_fact fact="something" global_fact="${local_var}"'
 - action: set_fact
   args:
      fact: something
      global_fact: ${local_var}
```
