### PR TITLE
New module 'set' to define local variables (in scope of play)

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -115,6 +115,7 @@ class Runner(object):
         sudo=False,                         # whether to run sudo or not
         sudo_user=C.DEFAULT_SUDO_USER,      # ex: 'root'
         module_vars=None,                   # a playbooks internals thing
+        play=None,                          # a plays internals thing
         is_playbook=False,                  # running from playbook or not?
         inventory=None,                     # reference to Inventory object
         subset=None,                        # subset pattern
@@ -138,6 +139,7 @@ class Runner(object):
         self.inventory        = utils.default(inventory, lambda: ansible.inventory.Inventory(host_list))
 
         self.module_vars      = utils.default(module_vars, lambda: {})
+        self.play             = play
         self.sudo_user        = sudo_user
         self.connector        = connection.Connection(self)
         self.conditional      = conditional
@@ -331,6 +333,8 @@ class Runner(object):
             port = self.remote_port
 
         inject = {}
+        if self.play:
+            inject.update(self.play.vars)
         inject.update(host_variables)
         inject.update(self.module_vars)
         inject.update(self.setup_cache[host])

--- a/lib/ansible/runner/action_plugins/set.py
+++ b/lib/ansible/runner/action_plugins/set.py
@@ -1,0 +1,38 @@
+# Copyright 2013 Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible import utils
+from ansible.runner.return_data import ReturnData
+import pprint
+
+class ActionModule(object):
+
+    NEEDS_TMPPATH = False
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
+        ''' handler for file transfer operations '''
+
+        # load up options
+        options  = {}
+        if complex_args:
+            options.update(complex_args)
+        options.update(utils.parse_kv(module_args))
+
+        return ReturnData(conn=conn, result=dict(ansible_vars=options))

--- a/library/set
+++ b/library/set
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2013 Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+author: Dag Wieers
+module: set
+short_description: Set local variables (for this play)
+description:
+     - This module sets one or more local variables (scope of the play).
+     - In comparison to playbook variables, using the C(set) module can
+       create variables using conditions, but these variables are only
+       set for the local scope (the play itself).
+     - If you would like to create global variables (host facts) you can
+       use the C(global) module.
+options:
+  key_value:
+    description:
+      - The C(set) module takes key=value pairs as variables to set in the
+        local (play) scope. Or alternatively, accepts complex arguments using the
+        C(args:) statement.
+    required: true
+    default: null
+version_added: "1.2"
+examples:
+    - description: "Example setting local variables using key=value pairs"
+      code: |
+            action: set var1="something" var2="${password}"'
+    - description: "Example setting local variables using complex arguments"
+      code: |
+            action: set
+            args:
+              var1: something
+              var2: ${password}
+'''


### PR DESCRIPTION
This module allows you to set local variables in the scope of the play.

For this we have to make sure Runner() has access to play variables so we can inject these variables during the run of a play. Previously the play variables were static at the start of Runner() but now they can change during a play. I used the same mechanism as 'ansible_facts' so if a module returns 'ansible_vars' it sets local variables.

The module also accepts complex arguments.

``` yaml
 - action: set var1="something" var2="${password}"'
 - action: set
   args:
      var1: something
      var2: ${password}
```

There was some confusion before, but this would set a variable that is the _same_ for all hosts, just as 'vars:' and 'vars_files:' would set. Limited in use.
