### PR TITLE
Avoid double colon with 'variable: "prompt"' style

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -321,7 +321,7 @@ class Play(object):
 
         elif type(self.vars_prompt) == dict:
             for (vname, prompt) in self.vars_prompt.iteritems():
-                prompt_msg = "%s: " % prompt
+                prompt_msg = "%s" % prompt
                 if vname not in self.playbook.extra_vars:
                     vars[vname] = self.playbook.callbacks.on_vars_prompt(
                                      varname=vname, private=False, prompt=prompt_msg, default=None


### PR DESCRIPTION
There is a little minor flaw with vars_prompt.

``` yaml

---
- hosts: somehosts
  user: root

  vars_prompt:
    var1: "Name of your bridge?"
```

There are two colons.

``` bash
Name of your bridge?: : 
```

When I use the 'extended' variant for the prompt.

``` yaml

---
- hosts: somehosts
  user: root

  vars_prompt:
    - name: "var1"
      prompt: "Name of your bridge?"
      default: "vnet0"
      private: no
```

The prompt looks like this:

``` bash
Name of your bridge?:
```

This pull request should fix the issue. Beside running the two examples from above I tested it with '--extra-vars="var1=vnet0"' and it seems that the commit have no influence on the variable. It would be nice if somebody could check it and confirm that the double colon occurs.
