### PR TITLE
Atomic replace and cron

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -797,7 +797,11 @@ class AnsibleModule(object):
             if self.selinux_enabled():
                 context = self.selinux_default_context(dest)
                 self.set_context_if_different(src, context, False)
-        os.rename(src, dest)
+        try:
+            shutil.copy2(src, dest)
+        except shutil.Error, e:
+            self.fail_json(msg='Could not atomic_replace file: %s to %s: %s' % (src, dest, e))
+            
 
     def run_command(self, args, check_rc=False, close_fds=False, executable=None, data=None):
         '''

--- a/library/cron
+++ b/library/cron
@@ -132,6 +132,7 @@ updates: Mike Grozak
 
 import re
 import tempfile
+import os
 
 def get_jobs_file(module, user, tmpfile, cron_file):
     if cron_file:
@@ -143,11 +144,19 @@ def get_jobs_file(module, user, tmpfile, cron_file):
 
 def install_jobs(module, user, tmpfile, cron_file):
     if cron_file:
-        cmd = "ln -f %s /etc/cron.d/%s" % (tmpfile, cron_file) 
+        cron_file = '/etc/cron.d/%s' % cron_file
+        try:
+            module.atomic_replace(tmpfile, cron_file)
+        except (OSError, IOError), e:
+            return (1, "", str(e))   
+        except:
+            return (1, "", str(e))
+        else:
+            return (0, "", "")
+
     else:
         cmd = "crontab %s %s" % (user, tmpfile)
-
-    return module.run_command(cmd)
+        return module.run_command(cmd)
 
 def get_jobs(tmpfile):
     lines = open(tmpfile).read().splitlines()


### PR DESCRIPTION
This is a patch for the cron module to make it work in situations where /root or /tmp is not on the same fs as /etc

this also fixes up the atomic_replace method to behave slightly better for files across filesystem mounts.

The atomic_replace method change should have testing focused on it heavily to verify I didn't break it all horribly.
