### PR TITLE
Fix errors in lookup plugins.

### DIFF
--- a/lib/ansible/runner/lookup_plugins/dnstxt.py
+++ b/lib/ansible/runner/lookup_plugins/dnstxt.py
@@ -44,8 +44,8 @@ class LookupModule(object):
 
         terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
 
-
-
+        if isinstance(basestring, terms):
+            terms = [ terms ]
 
         ret = []
         for term in terms:

--- a/lib/ansible/runner/lookup_plugins/env.py
+++ b/lib/ansible/runner/lookup_plugins/env.py
@@ -27,6 +27,9 @@ class LookupModule(object):
 
         terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
 
+        if isinstance(basestring, terms):
+            terms = [ terms ]
+
         ret = []
         for term in terms:
             var = term.split()[0]

--- a/lib/ansible/runner/lookup_plugins/fileglob.py
+++ b/lib/ansible/runner/lookup_plugins/fileglob.py
@@ -26,7 +26,7 @@ class LookupModule(object):
 
     def run(self, terms, inject=None, **kwargs):
 
-        utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
+        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
 
         ret = []
 

--- a/lib/ansible/runner/lookup_plugins/sequence.py
+++ b/lib/ansible/runner/lookup_plugins/sequence.py
@@ -16,7 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 from ansible.errors import AnsibleError
-from ansible.utils import parse_kv
+import ansible.utils as utils
 from re import compile as re_compile, IGNORECASE
 
 # shortcut format
@@ -181,7 +181,7 @@ class LookupModule(object):
 
                 try:
                     if not self.parse_simple_args(term):
-                        self.parse_kv_args(parse_kv(term))
+                        self.parse_kv_args(utils.parse_kv(term))
                 except Exception:
                     raise AnsibleError(
                         "unknown error parsing with_sequence arguments: %r"

--- a/lib/ansible/runner/lookup_plugins/template.py
+++ b/lib/ansible/runner/lookup_plugins/template.py
@@ -16,6 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 from ansible.utils import template
+import ansible.utils as utils
 
 class LookupModule(object):
 


### PR DESCRIPTION
Lookup plugins 'sequence' and 'template' now import 'ansible.utils'
appropriately in order to use the 'listify_lookup_plugin_terms'
function.

Also, 'dnstxt' and 'env' now check to see if 'terms' is a string;
without this calls like '{{ lookup('env', 'HOME') }}' fail.

I'm not 100% positive why the latter change is needed, as 'listify_lookup_plugin_terms' _seems_ to replace a string with a single-item list. I didn't look that hard though.
