### PR TITLE
Fix 'sequence' plugin error.

### DIFF
--- a/lib/ansible/runner/lookup_plugins/sequence.py
+++ b/lib/ansible/runner/lookup_plugins/sequence.py
@@ -173,7 +173,10 @@ class LookupModule(object):
     def run(self, terms, inject=None, **kwargs):
         results = []
 
-        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
+        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
+
+        if isinstance(terms, basestring):
+            terms = [ terms ]
 
         for term in terms:
             try:


### PR DESCRIPTION
If 'terms' is a string, replace it with a single item list.

Missed one before.
