### PR TITLE
Fix undefined 'utils' in template lookup plugin

### DIFF
--- a/lib/ansible/runner/lookup_plugins/template.py
+++ b/lib/ansible/runner/lookup_plugins/template.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-from ansible.utils import template
+from ansible.utils import template, listify_lookup_plugin_terms
 
 class LookupModule(object):
 
@@ -24,7 +24,7 @@ class LookupModule(object):
 
     def run(self, terms, inject=None, **kwargs):
 
-        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
+        terms = listify_lookup_plugin_terms(terms, self.basedir, inject) 
 
         ret = []
         for term in terms:


### PR DESCRIPTION
Straight forward typo I think
