### PR TITLE
changed atomic_replace to atomic_move

### DIFF
--- a/library/authorized_key
+++ b/library/authorized_key
@@ -161,7 +161,7 @@ def writekeys(module, filename, keys):
     except IOError, e:
         module.fail_json(msg="Failed to write to file %s: %s" % (tmp_path, str(e)))
     f.close()
-    module.atomic_replace(tmp_path, filename)
+    module.atomic_move(tmp_path, filename)
 
 def enforce_state(module, params):
     """

--- a/library/copy
+++ b/library/copy
@@ -19,7 +19,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import shutil
 import time
 
 DOCUMENTATION = '''
@@ -135,15 +134,14 @@ def main():
             if os.path.islink(dest):
                 os.unlink(dest)
                 open(dest, 'w').close()
-            # TODO:pid + epoch should avoid most collisions, hostname/mac for those using nfs?
-            # might be an issue with exceeding path length
-            dest_tmp = "%s.%s.%s.tmp" % (dest,os.getpid(),time.time())
-            shutil.copyfile(src, dest_tmp)
-            module.atomic_replace(dest_tmp, dest)
-        except shutil.Error:
-            module.fail_json(msg="failed to copy: %s and %s are the same" % (src, dest))
-        except IOError:
-            module.fail_json(msg="failed to copy: %s to %s" % (src, dest))
+        except (OSError, IOError), e:
+            module.fail_json(msg="failed to copy: %s to %s cause:%s" % (src, dest, e))
+
+        if not module.atomic_move(src, dest):
+            try:
+                os.unlink(src) # cleanup tmp files on failure
+            except OSError, e:
+                sys.stderr.write("failed to clean up tmp file %s: %s\n" % (src, e))
         changed = True
     else:
         changed = False

--- a/library/cron
+++ b/library/cron
@@ -145,15 +145,7 @@ def get_jobs_file(module, user, tmpfile, cron_file):
 def install_jobs(module, user, tmpfile, cron_file):
     if cron_file:
         cron_file = '/etc/cron.d/%s' % cron_file
-        try:
-            module.atomic_replace(tmpfile, cron_file)
-        except (OSError, IOError), e:
-            return (1, "", str(e))   
-        except:
-            return (1, "", str(e))
-        else:
-            return (0, "", "")
-
+        module.atomic_move(tmpfile, cron_file)
     else:
         cmd = "crontab %s %s" % (user, tmpfile)
         return module.run_command(cmd)

--- a/library/service
+++ b/library/service
@@ -334,7 +334,7 @@ class Service(object):
             os.close(TMP_RCCONF)
 
             # Replace previous rc.conf.
-            self.module.atomic_replace(tmp_rcconf_file, self.rcconf_file)
+            self.module.atomic_move(tmp_rcconf_file, self.rcconf_file)
 
 # ===========================================
 # Subclass: Linux

--- a/library/sysctl
+++ b/library/sysctl
@@ -110,10 +110,10 @@ def write_sysctl(module, lines, **sysctl_args):
         module.fail_json(msg="Failed to write to file %s: %s" % (tmp_path, str(e)))
     f.flush()
     f.close()
-    
+
     # replace the real one
-    module.atomic_replace(tmp_path, sysctl_args['sysctl_file']) 
-    
+    module.atomic_move(tmp_path, sysctl_args['sysctl_file'])
+
     # end
     return sysctl_args
 


### PR DESCRIPTION
which is what most consumers seemed to expect anyways. Moved the code to ensure atomic move into the function vs expecting each module to implement it itself. Hopefully this will prevent problems as seen in #2698 which then lead to #2715.

Also updated modules that used it, so now tmp files won't get left behind even if successful. I left the modules as responsible for cleanup on fail, implemented it in copy but don't know the rest well enough, maybe in subsequent PR.
