### PR TITLE
Small spelling correction to authorized_key module docs

### DIFF
--- a/library/authorized_key
+++ b/library/authorized_key
@@ -48,7 +48,7 @@ options:
     version_added: "1.2"
   manage_dir:
     description:
-      - Wheter this module should manage the directory of the authorized_keys file
+      - Whether this module should manage the directory of the authorized_keys file
     required: false
     choices: [ "yes", "no" ]
     default: "yes"


### PR DESCRIPTION
Seriously, nothing more complicated than a small docs fix.
