### PR TITLE
update pydoc to match the source code

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -36,8 +36,8 @@ options:
     description:
       - Indicates the desired package state
     required: false
-    default: present
-    choices: [ "latest", "absent", "present" ]
+    default: installed
+    choices: [ installed', 'removed',"latest", "absent", "present" ]
   update_cache:
     description:
       - Run the equivalent of C(apt-get update) before the operation. Can be run as part of the package installation or as a separate step


### PR DESCRIPTION
I  see there are antother two chioces for the state argument,
 state = dict(default='installed', choices=['installed', 'latest', 'removed', 'absent', 'present']),
so I update the pydoc the match it
