### PR TITLE
Devel

### DIFF
--- a/library/ec2
+++ b/library/ec2
@@ -352,7 +352,6 @@ def main():
            'architecture': inst.architecture,
            'image_id': inst.image_id,
            'key_name': inst.key_name,
-           'virtualization_type': inst.virtualization_type,
            'placement': inst.placement,
            'kernel': inst.kernel,
            'ramdisk': inst.ramdisk,

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -175,7 +175,13 @@ class Ec2Inventory(object):
         ''' Reads the settings from the ec2.ini file '''
 
         config = ConfigParser.SafeConfigParser()
-        config.read(os.path.dirname(os.path.realpath(__file__)) + '/ec2.ini')
+        # compatibility with /etc/ansible/hosts/ec2.py and ec2.ini in /etc/ansible/
+        # or with ec2.py and ec2.ini in the same dir.
+        # Checks current directory first.
+        if os.path.isfile(os.path.dirname(os.path.realpath(__file__)) + '/ec2.ini'):
+            config.read(os.path.dirname(os.path.realpath(__file)) + '/ec2.ini')
+        else:
+            config.read(os.path.dirname(os.path.realpath(__file__)) + '/../ec2.ini')
 
         # is eucalyptus?
         self.eucalyptus_host = None


### PR DESCRIPTION
fixed ec2 module:
- no longer expects virtualization_type to be returned by boto

fixed ec2.py:
- will now check up one directory for the ec2.ini file.
  this allows you to place ec2.py in /etc/ansible/hosts/
  and ec2.ini in /etc/ansible/
