### PR TITLE
Documentation: Mention vars_files before the Roles section in playbooks1 chapter

### DIFF
--- a/docsite/latest/rst/playbooks.rst
+++ b/docsite/latest/rst/playbooks.rst
@@ -136,6 +136,11 @@ The `vars` section contains a list of variables and values that can be used in t
          van_halen_port: 5150
          other: 'magic'
 
+.. note::
+   You can also keep variables in separate files and include them alongside inline `vars` with a `vars_files` declaration
+   in the play. See the `Advanced Playbooks chapter <http://ansible.cc/docs/playbooks2.html#variable-file-separation>`_
+   for more info.
+
 These variables can be used later in the playbook like this::
 
     $varname or ${varname} or {{ varname }}


### PR DESCRIPTION
The Roles section assumes some familiarity with vars_files, which the added note attempts to briefly provide.
