### PR TITLE
Documentation: Links are the best kinds of instructions

### DIFF
--- a/docsite/latest/rst/contrib.rst
+++ b/docsite/latest/rst/contrib.rst
@@ -8,7 +8,8 @@ Ansible Resources
 
 User contributed playbooks, modules, and articles. This is a small
 curated list, but growing. Everyone is encouraged to add to this
-document, just send in a github pull request to docsite/rst/contrib.rst!
+document, just `edit it on Github <https://github.com/ansible/ansible/blob/devel/docsite/latest/rst/contrib.rst>`_
+and send a pull request!
 
 Ansible Modules
 ```````````````


### PR DESCRIPTION
Link people right to this page on Github, so they can click "edit" right there. No need for them to search for the repo, figure out that the docsite isn't a separate repo, and navigate to the given dir.
