### PR TITLE
Fix test so that it is /bin/sh compliant (issue #2742)

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -586,11 +586,9 @@ class Runner(object):
         ''' takes a remote md5sum without requiring python, and returns 0 if no file '''
 
         path = pipes.quote(path)
-        test = ('if [ ! -e \"%s\" ]; then rc=0;'
-                'elif [ -d \"%s\" ]; then rc=3;'
-                'elif [ ! -f \"%s\" ]; then rc=1;'
-                'elif [ ! -r \"%s\" ]; then rc=2;'
-                'else rc=0; fi') % ((path,) * 4)
+        # The following test needs to be SH-compliant.  BASH-isms will
+        # not work if /bin/sh points to a non-BASH shell.
+        test = "rc=0; [ -r \"%s\" ] || rc=2; [ -f \"%s\" ] || rc=1; [ -d \"%s\" ] && rc=3" % ((path,) * 3) 
         md5s = [
             "(/usr/bin/md5sum %s 2>/dev/null)" % path,  # Linux
             "(/sbin/md5sum -q %s 2>/dev/null)" % path,  # ?


### PR DESCRIPTION
The old test used syntax that appeared to be bash-specific and did not
work on platforms where /bin/sh did not point to bash.  See issue #2742
where copy to solaris hosts failed with the error:

```
output: {'stdout': '', 'stderr': '/bin/sh: test: argument expected\n', 'rc': 1}
```
