### PR TITLE
Accept numeric user and group parameters

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -369,9 +369,12 @@ class AnsibleModule(object):
         user, group = self.user_and_group(path)
         if owner != user:
             try:
-                uid = pwd.getpwnam(owner).pw_uid
-            except KeyError:
-                self.fail_json(path=path, msg='chown failed: failed to look up user %s' % owner)
+                uid = int(owner)
+            except ValueError:
+                try:
+                    uid = pwd.getpwnam(owner).pw_uid
+                except KeyError:
+                    self.fail_json(path=path, msg='chown failed: failed to look up user %s' % owner)
             if self.check_mode:
                 return True
             try:
@@ -390,9 +393,12 @@ class AnsibleModule(object):
             if self.check_mode:
                 return True
             try:
-                gid = grp.getgrnam(group).gr_gid
-            except KeyError:
-                self.fail_json(path=path, msg='chgrp failed: failed to look up group %s' % group)
+                gid = int(group)
+            except ValueError:
+                try:
+                    gid = grp.getgrnam(group).gr_gid
+                except KeyError:
+                    self.fail_json(path=path, msg='chgrp failed: failed to look up group %s' % group)
             try:
                 os.chown(path, -1, gid)
             except OSError:


### PR DESCRIPTION
`AnsibleModule.user_and_group` will return numeric IDs if no entry exists in `/etc/passwd` and `/etc/group`, but `AnsibleModule.set_owner_if_different` and `set_group_if_different` will not accept numeric IDs- users and groups must exist in the password database.

This PR makes these calls orthogonal, as the output from `user_and_group` can be passed to `set_owner_if_different` and the right thing happens.
