### PR TITLE
Fix for issue 602 during initial install

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -154,7 +154,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None, install_reco
         else:
             force_yes = ''
 
-        cmd = "%s --option Dpkg::Options::=--force-confold -q -y %s install %s" % (APT_GET_CMD, force_yes, packages)
+        cmd = "%s %s --option Dpkg::Options::=--force-confold -q -y %s install %s" % (APT_ENVVARS, APT_GET_CMD, force_yes, packages)
         if default_release:
             cmd += " -t '%s'" % (default_release,)
         if not install_recommends:


### PR DESCRIPTION
This is a simple change to the `cmd` string to incorporate `APT_ENVVARS` in the `install()` function.
