### PR TITLE
enforce no enteractiveness installing pkg with apt

### DIFF
--- a/library/apt
+++ b/library/apt
@@ -154,14 +154,17 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None, install_reco
         else:
             force_yes = ''
 
-        cmd = "%s --option Dpkg::Options::=--force-confold -q -y %s install %s" % (APT_GET_CMD, force_yes, packages)
+        if m.check_mode:
+            check_arg = '--simulate'
+        else:
+            check_arg = ''
+
+        cmd = "%s %s -y %s %s %s install %s" % (APT_ENVVARS, APT_GET_CMD, DPKG_OPTIONS, force_yes, check_arg, packages)
+
         if default_release:
             cmd += " -t '%s'" % (default_release,)
         if not install_recommends:
             cmd += " --no-install-recommends"
-
-        if m.check_mode:
-            m.exit_json(changed=True)
 
         rc, out, err = m.run_command(cmd)
         if rc:


### PR DESCRIPTION
use the same env vars and dpkg options as for the upgrade function
also link check mode to --simulate option when installing a pkg

fixes #2763
