### PR TITLE
Catch exception when logging to systemd journal fails

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -692,7 +692,12 @@ class AnsibleModule(object):
             journal_args.append("MODULE=%s" % os.path.basename(__file__))
             for arg in log_args:
                 journal_args.append(arg.upper() + "=" + str(log_args[arg]))
-            journal.sendv(*journal_args)
+            try:
+                journal.sendv(*journal_args)
+            except IOError, e:
+                # fall back to syslog since logging to journal failed
+                syslog.openlog(module, 0, syslog.LOG_USER)
+                syslog.syslog(syslog.LOG_NOTICE, msg)
         else:
             syslog.openlog(module, 0, syslog.LOG_USER)
             syslog.syslog(syslog.LOG_NOTICE, msg)


### PR DESCRIPTION
systemd journal will throw IOError exception when journal.sendv() fails.
This catches that and falls back to syslog.  See issue #2773.
