### PR TITLE
Remove leftover debug statement in template code.

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -453,7 +453,6 @@ def template_from_string(basedir, data, vars):
         try:
             t = environment.from_string(data)
         except Exception, e:
-            print "DEBUG: data = %s" % data
             if 'recursion' in str(e):
                 raise errors.AnsibleError("recursive loop detected in template string: %s" % data)
             else:


### PR DESCRIPTION
A normal template action was showing as:

```
TASK: [template src=../templates/developer-rhel6.ks dest=/var/www/mrepo/kickstart/${inventory_hostname}.ks] *** 
DEBUG: data = {{ ../templates/ssh-keys/...pub }}
DEBUG: data = {{ ../templates/ssh-keys/...pub }}
DEBUG: data = {{ ../templates/ssh-keys/....pub }}
```
