### PR TITLE
mkfs module to create filesystems with mkfs command

### DIFF
--- a/library/mkfs
+++ b/library/mkfs
@@ -1,0 +1,106 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Alexander Bulimov <lazywolf0@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+author: Alexander Bulimov
+module: mkfs
+short_description: Makes file system on block device
+description:
+  - This module creates file system.
+version_added: "1.2"
+options:
+  fstype:
+    description:
+    - File System type to be created.
+    required: true
+  dev:
+    description:
+    - Target block device.
+    required: true
+  force:
+    choices: [ "yes", "no" ]
+    default: "no"
+    description:
+    - If yes, allows to create new filesystem on devices that already has filesystem.
+    required: false
+  opts:
+    description:
+    - List of options to be passed to mkfs command.
+examples:
+  - description: Create a ext2 filesystem on /dev/sdb1.
+    code: mkfs fstype=ext2 dev=/dev/sdb1
+  - description: Create a ext4 filesystem on /dev/sdb1 and check disk blocks.
+    code: mkfs fstype=ext4 dev=/dev/sdb1 opts="-cc"
+notes:
+  - uses mkfs command
+'''
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            fstype=dict(required=True),
+            dev=dict(required=True),
+            opts=dict(),
+            force=dict(type='bool', default='no'),
+        ),
+        supports_check_mode=True,
+    )
+
+    dev = module.params['dev']
+    fstype = module.params['fstype']
+    opts = module.params['opts']
+    force = module.boolean(module.params['force'])
+
+    changed = False
+
+    if not os.path.exists(dev):
+        module.fail_json(msg="Device %s not found."%dev)
+
+    rc,raw_fs,err = module.run_command("blkid -o value -s TYPE %s"%(dev))
+    fs = raw_fs.strip()
+
+
+    if fs == fstype:
+        module.exit_json(changed=False)
+    elif fs and not force:
+        module.fail_json(msg="'%s' is already used as %s, use force=yes to ignore"%(dev,fs), rc=rc, err=err)
+
+    ### create fs
+
+    if module.check_mode:
+        changed = True
+    else:
+        cmd = None
+        if opts is None:
+            cmd = "mkfs -t %s '%s'"%(fstype, dev)
+        else:
+            cmd = "mkfs -t %s %s '%s'"%(fstype, opts, dev)
+        rc,_,err = module.run_command(cmd)
+        if rc == 0:
+            changed = True
+        else:
+            module.fail_json(msg="Creating filesystem %s on device '%s' failed"%(fstype,dev), rc=rc, err=err)
+
+    module.exit_json(changed=changed)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()


### PR DESCRIPTION
I've made this simple module to use in clean-OS deployment. Module just wraps mkfs command to make it idempotent.
