### PR TITLE
Update pacman install to work with groups

### DIFF
--- a/library/pacman
+++ b/library/pacman
@@ -115,10 +115,7 @@ def install_packages(module, packages):
     install_c = 0
 
     for package in packages:
-        if query_package(module, package):
-            continue
-
-        rc = os.system("pacman -S %s --noconfirm > /dev/null" % (package))
+        rc = os.system("pacman -S %s --noconfirm --needed > /dev/null" % (package))
 
         if rc != 0:
             module.fail_json(msg="failed to install %s" % (package))


### PR DESCRIPTION
Update pacman to work with groups (ie "pacman -S base-devel") and save time by skipping the query and replacing it with pacmans --needed option (Do not reinstall the targets that are already up to date).
