### PR TITLE
doc typo fix in copy module

### DIFF
--- a/library/copy
+++ b/library/copy
@@ -79,7 +79,7 @@ examples:
      description: "Example from Ansible Playbooks"
    - code: "copy: src=/mine/ntp.conf dest=/etc/ntp.conf owner=root group=root mode=644 backup=yes"
      description: "Copy a new C(ntp.conf) file into place, backing up the original if it differs from the copied version"
-   - code: "copy: src=/mine/sudoers dest=/etc/sudoers validate='visudo -c %s'
+   - code: "copy: src=/mine/sudoers dest=/etc/sudoers validate='visudo -c %s'"
      description: "Copy a new C(sudoers) file into place, after passing validation with visudo"
 author: Michael DeHaan
 notes:


### PR DESCRIPTION
Found this trying to figure out why snippet_generator.py wasn't generating vim snippets for 'copy' (turns out module_docs.get_docstring('copy') was returning nothing)
