### PR TITLE
fix arguments to isinstance() in env lookup

### DIFF
--- a/lib/ansible/runner/lookup_plugins/env.py
+++ b/lib/ansible/runner/lookup_plugins/env.py
@@ -27,7 +27,7 @@ class LookupModule(object):
 
         terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
 
-        if isinstance(basestring, terms):
+        if isinstance(terms, basestring):
             terms = [ terms ]
 
         ret = []


### PR DESCRIPTION
Arguments to isinstance() appear to be the wrong way round, and was throwing an error for me.

P.S. New to github and hope I've got this pull request stuff right.
