### PR TITLE
Fixed the installation of library directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ from distutils.core import setup
 
 # find library modules
 from ansible.constants import DIST_MODULE_PATH
-data_files = [ (DIST_MODULE_PATH, glob('./library/*')) ]
+dirs=os.listdir("./library/")
+data_files = []
+for i in dirs:
+    data_files.append((DIST_MODULE_PATH + i, glob('./library/' + i + '/*')))
 
 print "DATA FILES=%s" % data_files
 


### PR DESCRIPTION
Author: Ton Kersten github@tonkersten.com
Date:   Mon Apr 29 10:44:30 2013 +0200

```
Fixed the installation of library directories

When running install the `setup.py` give error

changing mode of /usr/bin/ansible-doc to 755
running install_data
error: can't copy './library/utilities': doesn't exist or not a regular file
make: *** [install] Error 1

While debugging and chatting on IRC 'benno' came up with this patch, which works on
CentOS 6.4 and on Ubuntu.
```
