### PR TITLE
Fixed bug where if destination was unspecified, changed would not be set...

### DIFF
--- a/library/network/uri
+++ b/library/network/uri
@@ -394,6 +394,8 @@ def main():
             file_args['path'] = dest
             changed = module.set_file_attributes_if_different(file_args, changed)
         resp['path'] = dest
+    else:
+        changed = False
 
     # Transmogrify the headers, replacing '-' with '_', since variables dont work with dashes.
     uresp = {}


### PR DESCRIPTION
The changed variable wasn't set to a default so if dest wasn't specified the playbook would error out with an UnboundLocalError. Defaulted to changed = False if no dest specified.
