### PR TITLE
ansible-doc: skip directories (new library/ format)

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -155,6 +155,8 @@ def main():
                 continue
 
             filename = utils.plugins.module_finder.find_plugin(module)
+            if os.path.isdir(filename):
+                continue
             try:
                 doc, plainexamples = module_docs.get_docstring(filename)
                 desc = tty_ify(doc.get('short_description', '?'))


### PR DESCRIPTION
The new subdirectory format of library/ caused ansible-doc to choke on directory names.
