### PR TITLE
Accept symbolic permissions for file argument mode

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -59,7 +59,7 @@ options:
     default: null
     choices: []
     description:
-      - mode the file or directory should be, such as 0644 as would be fed to I(chmod)
+      - mode the file or directory should be, such as 0644 or o=rwx,g=rwx,o=rx as would be fed to I(chmod)
   owner:
     required: false
     default: null

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -194,6 +194,21 @@ class TestRunner(unittest.TestCase):
         assert res['changed']
         assert os.path.isfile(filedemo) and os.stat(filedemo).st_mode == 0100604
 
+        res = self._run('file', ['dest=' + filedemo, 'mode="u=rwx,g=,o=rxt"', 'state=file'])
+        print res
+        assert res['changed']
+        assert os.path.isfile(filedemo) and os.stat(filedemo).st_mode == 33733
+
+        res = self._run('file', ['dest=' + filedemo, 'mode="u=rwsx,g=,o=rxt"', 'state=file'])
+        print res
+        assert res['changed']
+        assert os.path.isfile(filedemo) and os.stat(filedemo).st_mode == 35781
+
+        res = self._run('file', ['dest=' + filedemo, 'mode="u-x"', 'state=file'])
+        print res
+        assert res['changed']
+        assert os.path.isfile(filedemo) and os.stat(filedemo).st_mode == 35717
+
         assert self._run('file', ['dest=' + filedemo, 'state=absent'])['changed']
         assert not os.path.exists(filedemo)
         assert not self._run('file', ['dest=' + filedemo, 'state=absent'])['changed']


### PR DESCRIPTION
Allow syntax like 'u=rwx,g=rw' for the common file argument 'mode', as
per 'chmod' Unix command.

Note that, unlike 'chmod', each listed mode must specify 'u', 'g', 'o',
or 'a' for its target, in order to avoid having to replicate the
behavior of 'chmod +x', for example, which will add execute permissions
only to bits not masked out by the current process's umask.

Mostly, I wanted to be able to use the 'X' permission when setting file
permissions, which sets to execute attribute on a file only if it is a directory or already has the execute bit set for users, group, or other.

Suggestions for improvement are very welcome; it's all a bit ugly (and long).
