### PR TITLE
add config to disable legacy variable substitution

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -102,6 +102,13 @@ sudo_exe=sudo
 #
 # hash_behaviour=replace
 
+# How to handle variable replacement - as of 1.2, Jinja2 variable syntax is
+# preferred, but we still support the old $variable replacement too.
+# If you change var_replace_behavior to jinja2 then Ansible will no longer
+# try to do replacement on $variable style variables.
+#
+# var_replace_behavior=legacy
+
 # if you need to use jinja2 extensions, you can list them here
 # use a coma to separate extensions, e.g. :
 # jinja2_extensions=jinja2.ext.do,jinja2.ext.i18n

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -94,6 +94,7 @@ DEFAULT_KEEP_REMOTE_FILES = get_config(p, DEFAULTS, 'keep_remote_files', 'ANSIBL
 DEFAULT_SUDO_EXE          = get_config(p, DEFAULTS, 'sudo_exe', 'ANSIBLE_SUDO_EXE', 'sudo')
 DEFAULT_SUDO_FLAGS        = get_config(p, DEFAULTS, 'sudo_flags', 'ANSIBLE_SUDO_FLAGS', '-H')
 DEFAULT_HASH_BEHAVIOUR    = get_config(p, DEFAULTS, 'hash_behaviour', 'ANSIBLE_HASH_BEHAVIOUR', 'replace')
+DEFAULT_VAR_REPLACE_BEHAVIOR = get_config(p, DEFAULTS, 'var_replace_behavior', 'ANSIBLE_VAR_REPLACE_BEHAVIOR', 'legacy')
 DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBLE_JINJA2_EXTENSIONS', None)
 DEFAULT_EXECUTABLE        = get_config(p, DEFAULTS, 'executable', 'ANSIBLE_EXECUTABLE', '/bin/sh')
 

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -142,6 +142,11 @@ def _legacy_varFind(basedir, text, vars, lookup_fatal, depth, expand_lists):
     original data in the caller.
     '''
 
+    # short circuit this whole function if we have specified we don't want
+    # legacy var replacement
+    if C.DEFAULT_VAR_REPLACE_BEHAVIOR == 'jinja2':
+        return None
+
     start = text.find("$")
     if start == -1:
         return None


### PR DESCRIPTION
I've tested this by showing it still replaces $var in both templates and tasks by default, however when I add "var_replace_behavior = jinja2" to ansible.cfg it no longer replaces $var.  Seems right to me!
