### PR TITLE
remove hardcoded unix dir separator in first_found

### DIFF
--- a/lib/ansible/runner/lookup_plugins/first_found.py
+++ b/lib/ansible/runner/lookup_plugins/first_found.py
@@ -152,7 +152,7 @@ class LookupModule(object):
                     else:
                         for path in pathlist:
                             for fn in filelist:
-                                f = path + '/' + fn
+                                os.path.join(path, fn)
                                 total_search.append(f)
                 else:
                     total_search = [term]


### PR DESCRIPTION
use os.path.join instead of hardcoded unix separator in first_found lookup plugin
