### PR TITLE
Fix setup module's handling of venet & unknown ipv6 interfaces

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1157,7 +1157,7 @@ class LinuxNetwork(Network):
                         default_ipv6['scope']      = scope
                         default_ipv6['macaddress'] = macaddress
                         default_ipv6['mtu']        = interfaces[device]['mtu']
-                        default_ipv6['type']       = interfaces[device]['type']
+                        default_ipv6['type']       = interfaces[device].get("type", "unknown")
 
                     if not address == '::1':
                         ips['all_ipv6_addresses'].append(address)


### PR DESCRIPTION
This mirrors pull ansible#2803, but is for ipv6 instead of ipv4.
