### PR TITLE
postgresql_privs: fix wrong codec specification

### DIFF
--- a/library/database/postgresql_privs
+++ b/library/database/postgresql_privs
@@ -224,6 +224,7 @@ postgresql_privs: >
 
 try:
     import psycopg2
+    import psycopg2.extensions
 except ImportError:
     psycopg2 = None
 
@@ -266,7 +267,8 @@ class Connection(object):
 
     @property
     def encoding(self):
-        return self.connection.encoding
+        """Connection encoding in Python-compatible form"""
+        return psycopg2.extensions.encodings[self.connection.encoding]
 
 
     ### Methods for querying database objects


### PR DESCRIPTION
Use psycopg2's mapping from PostgreSQL encoding names to Python codec names.
