### PR TITLE
fix copy for sudo non root

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -836,8 +836,11 @@ class AnsibleModule(object):
                 except OSError, e:
                     sys.stderr.write("could not cleanup %s: %s" % (tmp_dest, e))
 
-        try:
-            shutil.move(src, tmp_dest)
+        try: # leaves tmp file behind when sudo and  not root
+            if os.getenv("SUDO_USER") and os.getuid() != 0:
+               shutil.copy(src, tmp_dest)
+            else:
+               shutil.move(src, tmp_dest)
             if self.selinux_enabled():
                 self.set_context_if_different(tmp_dest, context, False)
             os.rename(tmp_dest, dest)


### PR DESCRIPTION
fixed case #2837 in which move fails after remote user copies file and sudo to non root does the move
