### PR TITLE
BUGFIX - --start-at-task= works only with --step

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -554,6 +554,7 @@ class PlaybookCallbacks(object):
             else:
                 self.skip_task = True
         else:
+            self.skip_task = False
             display(banner(msg))
 
         call_callback_module('playbook_on_task_start', name, is_conditional)


### PR DESCRIPTION
From issue #2820, --start-at-task does not actually run tasks
unless --step is specified. This appears to be because skip_task
is being evaluated as True in PlayBook._run_task(). This patch
ensures skip_task is set to False in the callback.
