### PR TITLE
Fixed an error in the get_cpu_facts of the AIX class

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -870,19 +870,29 @@ class AIX(Hardware):
 
     def get_cpu_facts(self):
         self.facts['processor'] = []
-        rc, out, err = module.run_command("/usr/sbin/lsattr -El proc0 -a type")
-        data = out.split(' ')
-        self.facts['processor'] = data[1]
-        rc, out, err = module.run_command("/usr/sbin/lsattr -El proc0 -a smt_threads")
-        data = out.split(' ')
-        self.facts['processor_cores'] = int(data[1])
+
+
         rc, out, err = module.run_command("/usr/sbin/lsdev -Cc processor")
         i = 0
         for line in out.split('\n'):
-            data = line.split(':')
+
             if 'Available' in line:
+                if i == 0:
+                    data = line.split(' ')
+                    cpudev = data[0]
+
                 i += 1
         self.facts['processor_count'] = int(i)
+
+        rc, out, err = module.run_command("/usr/sbin/lsattr -El " + cpudev + " -a type")
+
+        data = out.split(' ')
+        self.facts['processor'] = data[1]
+
+        rc, out, err = module.run_command("/usr/sbin/lsattr -El " + cpudev + " -a smt_threads")
+
+        data = out.split(' ')
+        self.facts['processor_cores'] = int(data[1])
 
     def get_memory_facts(self):
         pagesize = 4096


### PR DESCRIPTION
assumed proc0 as the first processor but can be different in a LPAR environment
