### PR TITLE
Allow specification of erlang node name for rabbitmq_user/vhost/parameter actions.

### DIFF
--- a/library/messaging/rabbitmq_parameter
+++ b/library/messaging/rabbitmq_parameter
@@ -47,6 +47,11 @@ options:
       - vhost to apply access privileges.
     required: false
     default: /
+  node:
+    description:
+      - erlang node name of the rabbit we wish to configure
+    required: false
+    default: rabbit
   state:
     description:
       - Specify if user is to be added or removed
@@ -61,20 +66,22 @@ rabbitmq_parameter: component=federation name=local-username value='"guest"' sta
 """
 
 class RabbitMqParameter(object):
-    def __init__(self, module, component, name, value, vhost):
+    def __init__(self, module, component, name, value, vhost, node):
         self.module = module
         self.component = component
         self.name = name
         self.value = value
         self.vhost = vhost
+	self.node = node
 
         self._value = None
 
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+	self._env = module.get_bin_path('env', True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._rabbitmqctl, '-q']
+            cmd = [self._env, 'RABBITMQ_NODENAME=%s' % self.node, self._rabbitmqctl, '-q']
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
         return list()
@@ -105,7 +112,8 @@ def main():
         name=dict(required=True),
         value=dict(default=None),
         vhost=dict(default='/'),
-        state=dict(default='present', choices=['present', 'absent'])
+        state=dict(default='present', choices=['present', 'absent']),
+        node=dict(default='rabbit')
     )
     module = AnsibleModule(
         argument_spec=arg_spec,
@@ -117,8 +125,9 @@ def main():
     value = module.params['value']
     vhost = module.params['vhost']
     state = module.params['state']
+    node = module.params['node']
 
-    rabbitmq_parameter = RabbitMqParameter(module, component, name, value, vhost)
+    rabbitmq_parameter = RabbitMqParameter(module, component, name, value, vhost, node)
 
     changed = False
     if rabbitmq_parameter.get():

--- a/library/messaging/rabbitmq_parameter
+++ b/library/messaging/rabbitmq_parameter
@@ -72,12 +72,12 @@ class RabbitMqParameter(object):
         self.name = name
         self.value = value
         self.vhost = vhost
-	self.node = node
+        self.node = node
 
         self._value = None
 
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
-	self._env = module.get_bin_path('env', True)
+        self._env = module.get_bin_path('env', True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):

--- a/library/messaging/rabbitmq_parameter
+++ b/library/messaging/rabbitmq_parameter
@@ -77,11 +77,10 @@ class RabbitMqParameter(object):
         self._value = None
 
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
-        self._env = module.get_bin_path('env', True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._env, 'RABBITMQ_NODENAME=%s' % self.node, self._rabbitmqctl, '-q']
+            cmd = [self._rabbitmqctl, '-q', '-n', self.node]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
         return list()

--- a/library/messaging/rabbitmq_user
+++ b/library/messaging/rabbitmq_user
@@ -96,7 +96,7 @@ class RabbitMqUser(object):
         self.module = module
         self.username = username
         self.password = password
-	self.node = node
+        self.node = node
         if tags is None:
             self.tags = list()
         else:

--- a/library/messaging/rabbitmq_user
+++ b/library/messaging/rabbitmq_user
@@ -113,11 +113,10 @@ class RabbitMqUser(object):
         self._tags = None
         self._permissions = None
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
-        self._env = module.get_bin_path('env', True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._env, 'RABBITMQ_NODENAME=%s' % self.node, self._rabbitmqctl, '-q']
+            cmd = [self._rabbitmqctl, '-q', '-n', self.node]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
         return list()

--- a/library/messaging/rabbitmq_user
+++ b/library/messaging/rabbitmq_user
@@ -48,6 +48,11 @@ options:
       - vhost to apply access privileges.
     required: false
     default: /
+  node:
+    description:
+      - erlang node name of the rabbit we wish to configure
+    required: false
+    default: rabbit
   configure_priv:
     description:
       - Regular expression to restrict configure actions on a resource
@@ -87,10 +92,11 @@ examples:
 '''
 
 class RabbitMqUser(object):
-    def __init__(self, module, username, password, tags, vhost, configure_priv, write_priv, read_priv):
+    def __init__(self, module, username, password, tags, vhost, configure_priv, write_priv, read_priv, node):
         self.module = module
         self.username = username
         self.password = password
+	self.node = node
         if tags is None:
             self.tags = list()
         else:
@@ -107,10 +113,11 @@ class RabbitMqUser(object):
         self._tags = None
         self._permissions = None
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self._env = module.get_bin_path('env', True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._rabbitmqctl, '-q']
+            cmd = [self._env, 'RABBITMQ_NODENAME=%s' % self.node, self._rabbitmqctl, '-q']
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
         return list()
@@ -179,7 +186,8 @@ def main():
         write_priv=dict(default='^$'),
         read_priv=dict(default='^$'),
         force=dict(default='no', type='bool'),
-        state=dict(default='present', choices=['present', 'absent'])
+        state=dict(default='present', choices=['present', 'absent']),
+        node=dict(default='rabbit')
     )
     module = AnsibleModule(
         argument_spec=arg_spec,
@@ -195,8 +203,9 @@ def main():
     read_priv = module.params['read_priv']
     force = module.params['force']
     state = module.params['state']
+    node = module.params['node']
 
-    rabbitmq_user = RabbitMqUser(module, username, password, tags, vhost, configure_priv, write_priv, read_priv)
+    rabbitmq_user = RabbitMqUser(module, username, password, tags, vhost, configure_priv, write_priv, read_priv, node)
 
     changed = False
     if rabbitmq_user.get():

--- a/library/messaging/rabbitmq_vhost
+++ b/library/messaging/rabbitmq_vhost
@@ -34,6 +34,11 @@ options:
     required: true
     default: null
     aliases: [vhost]
+  node:
+    description:
+      - erlang node name of the rabbit we wish to configure
+    required: false
+    default: rabbit
   tracing:
     description:
       - Enable/disable tracing for a vhost
@@ -51,17 +56,19 @@ examples:
 '''
 
 class RabbitMqVhost(object):
-    def __init__(self, module, name, tracing):
+    def __init__(self, module, name, tracing, node):
         self.module = module
         self.name = name
         self.tracing = tracing
+	self.node = node
 
         self._tracing = False
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self._env = module.get_bin_path('env', True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._rabbitmqctl, '-q']
+            cmd = [self._env, 'RABBITMQ_NODENAME=%s' % self.node, self._rabbitmqctl, '-q']
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
         return list()
@@ -102,7 +109,8 @@ def main():
     arg_spec = dict(
         name=dict(required=True, aliases=['vhost']),
         tracing=dict(default='off', aliases=['trace'], type='bool'),
-        state=dict(default='present', choices=['present', 'absent'])
+        state=dict(default='present', choices=['present', 'absent']),
+        node=dict(default='rabbit'),
     )
 
     module = AnsibleModule(
@@ -113,8 +121,9 @@ def main():
     name = module.params['name']
     tracing = module.params['tracing']
     state = module.params['state']
+    node = module.params['node']
 
-    rabbitmq_vhost = RabbitMqVhost(module, name, tracing)
+    rabbitmq_vhost = RabbitMqVhost(module, name, tracing, node)
 
     changed = False
     if rabbitmq_vhost.get():

--- a/library/messaging/rabbitmq_vhost
+++ b/library/messaging/rabbitmq_vhost
@@ -60,7 +60,7 @@ class RabbitMqVhost(object):
         self.module = module
         self.name = name
         self.tracing = tracing
-	self.node = node
+        self.node = node
 
         self._tracing = False
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)

--- a/library/messaging/rabbitmq_vhost
+++ b/library/messaging/rabbitmq_vhost
@@ -64,11 +64,10 @@ class RabbitMqVhost(object):
 
         self._tracing = False
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
-        self._env = module.get_bin_path('env', True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._env, 'RABBITMQ_NODENAME=%s' % self.node, self._rabbitmqctl, '-q']
+            cmd = [self._rabbitmqctl, '-q', '-n', self.node]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
         return list()


### PR DESCRIPTION
In our environment, we need to run multiple rabbits on a single box, so we need to be able to specify the Erlang node name when configuring users, parameters, and vhosts.

I've not been able to verify 100% that the parameters changes are correct, unfortunately, as we don't have anything that accepts them; but they're isomorphic to the other changes, and the invocation of `rabbitmqctl` looks correct to my eyes.
