### PR TITLE
Fixed bug where a host entry in the inventory represented as a dict w/o ...

### DIFF
--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -63,6 +63,8 @@ class InventoryScript(object):
 
             if not isinstance(data, dict):
                 data = {'hosts': data}
+            elif not any(k in data for k in ('hosts','vars')):
+                data = {'hosts': [group_name], 'vars': data}
 
             if 'hosts' in data:
 


### PR DESCRIPTION
Fixed bug where a host entry in the inventory represented as a dict w/o a hosts or vars key was treated as a group and its vars essentially ignored.

See for more: https://github.com/ansible/ansible/pull/2834 
