### PR TITLE
Added check for undeclared variables in file templates

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -20,6 +20,7 @@ import re
 import codecs
 import jinja2
 from jinja2.runtime import StrictUndefined
+from jinja2 import meta
 import yaml
 import json
 from ansible import errors
@@ -439,6 +440,15 @@ def template_from_file(basedir, path, vars):
         managed_str,
         time.localtime(os.path.getmtime(realpath))
     )
+
+    # Ensure all template variables are defined
+    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(open(realpath).read())))
+    undeclared_vars = []
+    for varname in template_vars:
+        if varname not in vars:
+            undeclared_vars.append(varname)
+    if undeclared_vars:
+        raise KeyError("undeclared variable(s) in template: %s" % ', '.join(undeclared_vars))
 
     # This line performs deep Jinja2 magic that uses the _jinja2_vars object for vars
     # Ideally, this could use some API where setting shared=True and the object won't get

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -442,10 +442,10 @@ def template_from_file(basedir, path, vars):
     )
 
     # Ensure all template variables are defined
-    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(open(realpath).read().encode("string-escape"))))
+    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(unicode(open(realpath).read(), "utf8"))))
     undeclared_vars = []
     for varname in template_vars:
-        if varname not in vars:
+        if varname not in vars and varname not in t.globals:
             undeclared_vars.append(varname)
     if undeclared_vars:
         raise KeyError("undeclared variable(s) in template: %s" % ', '.join(undeclared_vars))

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -442,7 +442,7 @@ def template_from_file(basedir, path, vars):
     )
 
     # Ensure all template variables are defined
-    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(open(realpath).read())))
+    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(open(realpath).read().encode("string-escape"))))
     undeclared_vars = []
     for varname in template_vars:
         if varname not in vars:


### PR DESCRIPTION
Templates can have variables that are not defined. (i.e. it may work with a stage hosts file but a developer may have forgotten to add the variables when using prod hosts). This contribution intends to error when a template variable in a file is seen as undeclared. Fixed some Unicode issues with initial approach and am now checking globals to include things like lookups.

For testing - I wasn't sure if you wanted a test case created since it intends to fail the run.. There are no other such existing tests I could find that handle failed playbooks, only successful ones. Related, I'm not sure if KeyError is the best way to handle the failure, and also, when running, it appears to have a status of unreachable instead of failed. If you have suggestions, feel free to add.
