### PR TITLE
Added check for undeclared variables in file templates

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -135,6 +135,9 @@ filter_plugins     = /usr/share/ansible_plugins/filter_plugins
 # in your environment
 # nocows           = 1
 
+# set to 1 to validate that variables in file templates are declared.
+# validate_template_vars = 1	
+
 [paramiko_connection]
 
 # nothing to configure yet

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -107,6 +107,7 @@ DEFAULT_LOG_PATH               = shell_expand_path(get_config(p, DEFAULTS, 'log_
 
 ANSIBLE_NOCOWS                 = get_config(p, DEFAULTS, 'nocows', 'ANSIBLE_NOCOWS', None)
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
+ANSIBLE_VALIDATE_TEMPLATE_VARS = get_config(p, DEFAULTS, 'validate_template_vars', 'ANSIBLE_VALIDATE_TEMPLATE_VARS', None)
 ZEROMQ_PORT                    = int(get_config(p, 'fireball', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099))
 
 # non-configurable things

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -20,6 +20,7 @@ import re
 import codecs
 import jinja2
 from jinja2.runtime import StrictUndefined
+from jinja2 import meta
 import yaml
 import json
 from ansible import errors
@@ -439,6 +440,15 @@ def template_from_file(basedir, path, vars):
         managed_str,
         time.localtime(os.path.getmtime(realpath))
     )
+
+    # Ensure all template variables are defined
+    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(open(realpath).read())))
+    undeclared_vars = []
+    for varname in template_vars:
+        if varname not in vars:
+            undeclared_vars.append(varname)
+    if undeclared_vars:
+        raise KeyError("undeclared variable(s) in template: %s" % ', '.join(undeclared_vars))
 
     # This line performs deep Jinja2 magic that uses the _jinja2_vars object for vars
     # Ideally, this could use some API where setting shared=True and the object won't get

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -441,14 +441,15 @@ def template_from_file(basedir, path, vars):
         time.localtime(os.path.getmtime(realpath))
     )
 
-    # Ensure all template variables are defined
-    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(unicode(open(realpath).read(), "utf8"))))
-    undeclared_vars = []
-    for varname in template_vars:
-        if varname not in vars and varname not in t.globals:
-            undeclared_vars.append(varname)
-    if undeclared_vars:
-        raise KeyError("undeclared variable(s) in template: %s" % ', '.join(undeclared_vars))
+    # Ensure all template variables are defined if enabled
+    if C.ANSIBLE_VALIDATE_TEMPLATE_VARS is not None:
+        template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(unicode(open(realpath).read(), "utf8"))))
+        undeclared_vars = []
+        for varname in template_vars:
+            if varname not in vars and varname not in t.globals:
+                undeclared_vars.append(varname)
+        if undeclared_vars:
+            raise KeyError("undeclared variable(s) in template: %s" % ', '.join(undeclared_vars))
 
     # This line performs deep Jinja2 magic that uses the _jinja2_vars object for vars
     # Ideally, this could use some API where setting shared=True and the object won't get

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -442,10 +442,10 @@ def template_from_file(basedir, path, vars):
     )
 
     # Ensure all template variables are defined
-    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(open(realpath).read().encode("string-escape"))))
+    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(unicode(open(realpath).read(), "utf8"))))
     undeclared_vars = []
     for varname in template_vars:
-        if varname not in vars:
+        if varname not in vars and varname not in t.globals:
             undeclared_vars.append(varname)
     if undeclared_vars:
         raise KeyError("undeclared variable(s) in template: %s" % ', '.join(undeclared_vars))

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -442,7 +442,7 @@ def template_from_file(basedir, path, vars):
     )
 
     # Ensure all template variables are defined
-    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(open(realpath).read())))
+    template_vars=list(jinja2.meta.find_undeclared_variables(jinja2.Environment().parse(open(realpath).read().encode("string-escape"))))
     undeclared_vars = []
     for varname in template_vars:
         if varname not in vars:


### PR DESCRIPTION
Templates can have variables that are not defined. (i.e. it may work with a stage hosts file but a developer may have forgotten to add the variables when using prod hosts). This contribution intends to error when a template variable in a file is seen as undeclared. Fixed some Unicode issues with initial approach and am now checking globals to include things like lookups. Also added a 'conditional' check, defaulted to disabled, so as not to affect existing templates, overridden in ansible.cfg.

For testing - I wasn't sure if you wanted a test case created since it intends to fail the run.. There are no other such existing tests I could find that handle failed playbooks, only successful ones. Related, I'm not sure if KeyError is the best way to handle the failure, and also, when running, it appears to have a status of unreachable instead of failed. If you have suggestions, feel free to add.
