### PR TITLE
Dealing with invalid symlinks and symlink permissions

### DIFF
--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -230,6 +230,14 @@ class TestRunner(unittest.TestCase):
         assert self._run('file', ['dest=' + filedemo, 'state=absent'])['changed']
         assert not os.path.exists(filedemo)
         assert not self._run('file', ['dest=' + filedemo, 'state=absent'])['changed']
+
+        # Make sure that we can deal safely with bad symlinks
+        os.symlink('/tmp/non_existent_target', filedemo)
+        assert self._run('file', ['dest=' + tmp_dir, 'state=directory recurse=yes mode=701'])['changed']
+        assert not self._run('file', ['dest=' + tmp_dir, 'state=directory', 'recurse=yes', 'owner=' + str(os.getuid())])['changed']
+        assert os.path.islink(filedemo)
+        assert self._run('file', ['dest=' + filedemo, 'state=absent'])['changed']
+        assert not os.path.exists(filedemo)
         os.rmdir(tmp_dir)
 
     def test_large_output(self):


### PR DESCRIPTION
Currently the file module does not handle invalid symlinks well; it tends to crash out when it encounters them, since os.stat tries to follow them. This patch fixes those crashes, and also uses lstat and lchown in a number of strategic places to set permissions on the symlink itself, rather than the target of the symlink, which is typically what is really desired.
