### PR TITLE
newrelic_deployment notification module

### DIFF
--- a/library/notification/newrelic_deployment
+++ b/library/notification/newrelic_deployment
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2013 Matt Coddington <coddington@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: newrelic_deployment
+author: Matt Coddington
+short_description: Notify newrelic about app deployments
+description:
+   - Notify newrelic about app deployments (see http://newrelic.github.io/newrelic_api/NewRelicApi/Deployment.html)
+options:
+  token:
+    description:
+      - API token.
+    required: true
+  app_name:
+    description:
+      - (one of app_name or application_id are required) The value of app_name in the newrelic.yml file used by the application
+    required: false
+  application_id:
+    description:
+      - (one of app_name or application_id are required) The application id, found in the URL when viewing the application in RPM
+    required: false
+  changelog:
+    description:
+      - A list of changes for this deployment
+    required: false
+  description:
+    description:
+      - Text annotation for the deployment - notes for you
+    required: false
+  revision:
+    description:
+      - A revision number (e.g., git commit SHA)
+    required: false
+  user:
+    description:
+      - The name of the user/process that triggered this deployment
+    required: false
+  appname:
+    description:
+      - Name of the application
+    required: false
+  environment:
+    description:
+      - The environment for this deployment
+    required: false
+
+# informational: requirements for nodes
+requirements: [ urllib, urllib2 ]
+'''
+
+EXAMPLES = '''
+action: newrelic_deployment token=AAAAAA app_name=myapp user='ansible deployment' revision=1.0
+'''
+
+HAS_URLLIB = True
+try:
+    import urllib
+except ImportError:
+    HAS_URLLIB = False
+
+HAS_URLLIB2 = True
+try:
+    import urllib2
+except ImportError:
+    HAS_URLLIB2 = False
+
+# ===========================================
+# Module execution.
+#
+
+def main():
+
+    if not HAS_URLLIB:
+        module.fail_json(msg="urllib is not installed")
+    if not HAS_URLLIB2:
+        module.fail_json(msg="urllib2 is not installed")
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            token=dict(required=True),
+            app_name=dict(required=False),
+            application_id=dict(required=False),
+            changelog=dict(required=False),
+            description=dict(required=False),
+            revision=dict(required=False),
+            user=dict(required=False),
+            appname=dict(required=False),
+            environment=dict(required=False),
+        ),
+        supports_check_mode=True
+    )
+
+    # build list of params
+    params = {}
+    if module.params["app_name"] and module.params["application_id"]:
+        module.fail_json(msg="only one of 'app_name' or 'application_id' can be set")
+
+    if module.params["app_name"]:
+        params["app_name"] = module.params["app_name"]
+    elif module.params["application_id"]:
+        params["application_id"] = module.params["application_id"]
+    else:
+        module.fail_json(msg="you must set one of 'app_name' or 'application_id'")
+    
+    for item in [ "changelog", "description", "revision", "user", "appname", "environment" ]:
+        if module.params[item]:
+            params[item] = module.params[item]
+
+    # If we're in check mode, just exit pretending like we succeeded
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    # Send the data to NewRelic
+    try:
+        req = urllib2.Request("https://rpm.newrelic.com/deployments.xml", urllib.urlencode(params))
+        req.add_header('x-api-key',module.params["token"])
+        urllib2.urlopen(req)
+    except Exception, e:
+        # 201 is an ok response from this service
+        if e.code == 201:
+            module.exit_json(changed=True)
+        else:
+            module.fail_json(msg="unable to update newrelic: %s" % e)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()
+


### PR DESCRIPTION
Module to notify NewRelic of deployments.  Didn't call the module "newrelic" because NewRelic has so many other features/apis that I suspect there'd be some sort of module namespace conflict in the future if I did that.
