### PR TITLE
Allow host like selectors in tags

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -521,7 +521,7 @@ class PlayBook(object):
                 # only run the task if the requested tags match
                 should_run = False
                 for x in task.tags:
-                    if utils.evaluatePattern(x,self.only_tags):
+                    if utils.evaluate_tag_pattern(x,self.only_tags):
                         should_run = True
                         break
 

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -520,12 +520,10 @@ class PlayBook(object):
 
                 # only run the task if the requested tags match
                 should_run = False
-                for x in self.only_tags:
-
-                    for y in task.tags:
-                        if (x==y):
-                            should_run = True
-                            break
+                for x in task.tags:
+                    if utils.evaluatePattern(x,self.only_tags):
+                        should_run = True
+                        break
 
                 if should_run:
                     if not self._run_task(play, task, False):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -390,7 +390,13 @@ class Play(object):
         all_tags = []
         for task in self._tasks:
             if not task.meta:
-                all_tags.extend(task.tags)
+                for tag in task.tags:
+                    patterns= tag.split(":")
+                    for pattern in patterns:
+                        if pattern[0] == "!" or pattern[0] == "&":
+                            all_tags.append(pattern[3:])
+                        else:
+                            all_tags.append(pattern)
 
         # compare the lists of tags using sets and return the matched and unmatched
         all_tags_set = set(all_tags)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -226,6 +226,12 @@ class Task(object):
                 self.tags.extend(apply_tags)
         self.tags.extend(import_tags)
 
+        # remove all tag if a task has specific demands
+        for tag in self.tags:
+            if tag.find("&") != -1 or tag.find("!") != -1:
+                self.tags.remove("all")
+                break
+
         if self.when is not None:
             if self.only_if != 'True':
                 raise errors.AnsibleError('when obsoletes only_if, only use one or the other')

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -791,4 +791,21 @@ def combine_vars(a, b):
     else:
         return dict(a.items() + b.items())
 
-
+def evaluatePattern(expr, envs):
+    negationOnly= True
+    anyMatch= False
+    patterns= expr.split(":")
+    for pattern in patterns:
+        if pattern[0] != '!':
+            negationOnly= False 
+        interMatch= pattern[0] != '&'
+        for env in envs:
+            if pattern[0] == '!' and pattern[1:] == env:
+                return False
+            elif pattern[0] == '&' and pattern[1:] == env:
+                interMatch= True
+            elif pattern == env:
+                anyMatch= True
+        if not interMatch:
+            return False
+    return negationOnly or anyMatch

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -791,21 +791,21 @@ def combine_vars(a, b):
     else:
         return dict(a.items() + b.items())
 
-def evaluatePattern(expr, envs):
-    negationOnly= True
-    anyMatch= False
+def evaluate_tag_pattern(expr, envs):
+    negation_only= True
+    any_match= False
     patterns= expr.split(":")
     for pattern in patterns:
         if pattern[0] != '!':
-            negationOnly= False 
-        interMatch= pattern[0] != '&'
+            negation_only= False 
+        inter_match= pattern[0] != '&'
         for env in envs:
             if pattern[0] == '!' and pattern[1:] == env:
                 return False
             elif pattern[0] == '&' and pattern[1:] == env:
-                interMatch= True
+                inter_match= True
             elif pattern == env:
-                anyMatch= True
-        if not interMatch:
+                any_match= True
+        if not inter_match:
             return False
-    return negationOnly or anyMatch
+    return negation_only or any_match


### PR DESCRIPTION
This allows task's tags to to have selectors alike hosts: one can do dbserver:webserver:&bleeding-edge:!stable in a single tag.
