### PR TITLE
make path to nosetests executable configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,14 @@ ifeq ($(OFFICIAL),)
 endif
 RPMNVR = "$(NAME)-$(VERSION)-$(RPMRELEASE)$(RPMDIST)"
 
+NOSETESTS := nosetests
+
 ########################################################
 
 all: clean python
 
 tests:
-	PYTHONPATH=./lib nosetests -d -v
+	PYTHONPATH=./lib $(NOSETESTS) -d -v
 
 # To force a rebuild of the docs run 'touch VERSION && make docs'
 docs: $(MANPAGES) modulepages


### PR DESCRIPTION
this is to make use python2 on systems when `nosetests` points to python3 or may be missing at all being unsuffixed:

```
$ LC_ALL=C ls -l /usr/bin/nosetests-*
-rwxr-xr-x 1 root root 304 Nov 14 23:22 /usr/bin/nosetests-2.7
-rwxr-xr-x 1 root root 305 Nov 14 23:22 /usr/bin/nosetests-3.3
$ make NOSETEST=nosetests-2.7 tests
```
