### PR TITLE
LinuxService: avoid enforcing systemd even if init.d script was found

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -390,7 +390,7 @@ class LinuxService(Service):
                     break
 
         # Locate a tool for runtime service management (start, stop etc.)
-        self.svc_cmd = ''
+        self.svc_cmd = None
         if location.get('service', None) and os.path.exists("/etc/init.d/%s" % self.name):
             # SysV init script
             self.svc_cmd = location['service']
@@ -405,7 +405,7 @@ class LinuxService(Service):
                     self.svc_initscript = initscript
 
         # couldn't find anything yet, assume systemd
-        if self.svc_initscript is None:
+        if self.svc_cmd is None and self.svc_initscript is None:
             if location.get('systemctl'):
                 self.svc_cmd = location['systemctl']
 


### PR DESCRIPTION
there's some logic error in [get_service_tool()](https://github.com/ansible/ansible/blob/391fb98ee24474274448740fe49f2c80041a5da6/library/system/service#L392), that even if init.d script is found, an systemd is enforced if systemctl binary is found from system

the thing is that first "else" portion is not reached and therefore self.svc_initscript is not defined, which assumes init.d based script was not found

before:

```
# ansible webservers -m service -a "name=httpd state=started"
localhost | FAILED >> {
    "failed": true, 
    "msg": "Failed to get D-Bus connection: No connection to service manager.\n"
}
```

after:

```
# ansible webservers -m service -a "name=httpd state=started"
localhost | success >> {
    "changed": false, 
    "name": "httpd", 
    "state": "started"
}
```

some extra defailts from that system:

```
# which systemctl
/bin/systemctl
# if systemd_booted; then echo yes; else echo no; fi
no
# ls -ld /etc/init.d/httpd 
-rwxr-xr-- 1 root root 3410 apr   12 18:54 /etc/init.d/httpd
```
