### PR TITLE
don't parse subdirs in host/group_vars

### DIFF
--- a/lib/ansible/inventory/vars_plugins/group_vars.py
+++ b/lib/ansible/inventory/vars_plugins/group_vars.py
@@ -47,7 +47,7 @@ class VarsModule(object):
             p = os.path.join(basedir, "group_vars/%s" % x)
             paths = [p, '.'.join([p, 'yml']), '.'.join([p, 'yaml'])]
             for path in paths:
-                if os.path.exists(path):
+                if os.path.exists(path) and not os.path.isdir(path):
                     data = utils.parse_yaml_from_file(path)
                     if type(data) != dict:
                         raise errors.AnsibleError("%s must be stored as a dictionary/hash" % path)
@@ -57,7 +57,7 @@ class VarsModule(object):
         p = os.path.join(basedir, "host_vars/%s" % host.name)
         paths = [p, '.'.join([p, 'yml']), '.'.join([p, 'yaml'])]
         for path in paths:
-            if os.path.exists(path):
+            if os.path.exists(path) and not os.path.isdir(path):
                 data = utils.parse_yaml_from_file(path)
                 if type(data) != dict:
                     raise errors.AnsibleError("%s must be stored as a dictionary/hash" % path)


### PR DESCRIPTION
... as those are not supported in core vars_plugins/group_vars.py but might be used by other vars_plugins

Without this patch, and having sub directories beneath host/group_vars yields an error, as the core plugin tries to "read" from the directory, and returns a (wrong) error:

``` [bash]
[mstr] serge@goldorak:~/acd$ ansible -m ping localhost
localhost | FAILED => file not found: ./hosts/group_vars/all
[mstr] serge@goldorak:~/acd$ ls -ld ./hosts/group_vars/all
drwxrwxr-x 2 serge serge 4096 May 11 00:27 ./hosts/group_vars/all
[mstr] serge@goldorak:~/acd$ ls -ld ./hosts/group_vars/all/all
-rw-rw-r-- 1 serge serge 1386 May 11 00:27 ./hosts/group_vars/all/all
```

(this error returned by utils.parse_yaml_from_file)

In core, it should just ignore subdirectories, as those are not supported (as per previous discussion #2664). Subdirectories should however be allowed to exist, as other vars_plugins might be handling them (as in my usecase using the custom https://github.com/ansible-contrib/ansible-plugins/blob/stable/vars_plugins/group_vars_dirs.py)
