### PR TITLE
bug fix in first_found search path assembly

### DIFF
--- a/lib/ansible/runner/lookup_plugins/first_found.py
+++ b/lib/ansible/runner/lookup_plugins/first_found.py
@@ -152,7 +152,7 @@ class LookupModule(object):
                     else:
                         for path in pathlist:
                             for fn in filelist:
-                                os.path.join(path, fn)
+                                f = os.path.join(path, fn)
                                 total_search.append(f)
                 else:
                     total_search = [term]


### PR DESCRIPTION
Don't know how this bug slipped in, as my previous patch seemed to have worked (I rely on this plugin for several key playbooks in production, and personally use 1.2 on a daily basis to test it). i probably did some testing with a wrong version I'm afraid. Sorry about that.

I just deployed stuff in production with ansible containing this patch, so this is verified. Doubly verified.
