### PR TITLE
Make package version comparison use globbing.

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -115,6 +115,7 @@ warnings.filterwarnings('ignore', "apt API not stable yet", FutureWarning)
 
 import os
 import datetime
+import fnmatch
 
 # APT related constants
 APTITUDE_CMD = "aptitude"
@@ -143,10 +144,10 @@ def package_status(m, pkgname, version, cache, state):
             return False, False
     if version:
         try :
-            return pkg.is_installed and pkg.installed.version == version, False
+            return pkg.is_installed and fnmatch.fnmatch(pkg.installed.version, version), False
         except AttributeError:
             #assume older version of python-apt is installed
-            return pkg.isInstalled and pkg.installedVersion == version, False
+            return pkg.isInstalled and fnmatch.fnmatch(pkg.installedVersion, version), False
     else:
         try :
             return pkg.is_installed, pkg.is_upgradable


### PR DESCRIPTION
I have something like:

  apt: pkg={{ item }} state=present
  with_items:
    - python-pysqlite2=2.6.3-*
    - python-paramiko=1.7.7.1-*

But due to the use of *'s in the version specifications, the apt ansible
module always reports changed: true. This patch fixes that.
