### PR TITLE
allow the user to set a breakpoint in task execution by defining a task ...

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -77,6 +77,8 @@ def main(args):
         help="one-step-at-a-time: confirm each task before running")
     parser.add_option('--start-at-task', dest='start_at', 
         help="start the playbook with a task matching this name")
+    parser.add_option('--pause-at-task', dest='pause_at',
+        help="pause the playbook with a task matching this name")
 
     options, args = parser.parse_args(args)
 
@@ -116,6 +118,8 @@ def main(args):
             playbook_cb.step = options.step
         if options.start_at:
             playbook_cb.start_at = options.start_at
+        if options.pause_at:
+            playbook_cb.pause_at = options.pause_at
         runner_cb = callbacks.PlaybookRunnerCallbacks(stats, verbose=utils.VERBOSITY)
 
         pb = ansible.playbook.PlayBook(

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -533,6 +533,10 @@ class PlaybookCallbacks(object):
         msg = "TASK: [%s]" % name
         if is_conditional:
             msg = "NOTIFIED: [%s]" % name
+
+        if hasattr(self, 'pause_at'): #wait for user input
+            if name == self.pause_at or fnmatch.fnmatch(name, self.pause_at):
+                raw_input('Paused at task "%s", press enter to continue: ' % name)
         
         if hasattr(self, 'start_at'):
             if name == self.start_at or fnmatch.fnmatch(name, self.start_at):


### PR DESCRIPTION
...to pause at

Given a list of ordered tasks as returned by --list-tasks, this new option allows the user to tell the playbook to stop and wait for input at any task by name.

  --pause-at-task=PAUSE_AT
                        pause the playbook with a task matching this name

The usecase is allowing a user to define a breakpoint within the aggregate run of complex nested tasks and then to debug the system or new ansible modules.
