### PR TITLE
apt now uses module function to find bin path

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -117,8 +117,6 @@ import os
 import datetime
 
 # APT related constants
-APTITUDE_CMD = "aptitude"
-APT_GET_CMD = "apt-get"
 APT_ENVVARS = "DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical"
 DPKG_OPTIONS = '-o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"'
 APT_GET_ZERO = "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded."
@@ -264,6 +262,9 @@ def main():
         import apt_pkg
     except:
         module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")
+
+    global APTITUDE_CMD = module.get_bin_path("aptitude")
+    global APT_GET_CMD = module.get_bin_path("apt-get")
 
     p = module.params
     install_recommends = p['install_recommends']


### PR DESCRIPTION
so now it stops relying on path (does not fix current problem report)
Signed-off-by: Brian Coca <briancoca+dev@gmail.com>
