### PR TITLE
Standardise shebangs

### DIFF
--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/ec2_facts
+++ b/library/cloud/ec2_facts
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/virt
+++ b/library/cloud/virt
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/library/commands/command
+++ b/library/commands/command
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Elliott Foster <elliott@fourkitchens.com>
 # Sponsored by Four Kitchens http://fourkitchens.com.

--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Mark Theunissen <mark.theunissen@gmail.com>

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Mark Theunissen <mark.theunissen@gmail.com>
 # Sponsored by Four Kitchens http://fourkitchens.com.

--- a/library/database/postgresql_db
+++ b/library/database/postgresql_db
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/database/postgresql_privs
+++ b/library/database/postgresql_privs
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/database/postgresql_user
+++ b/library/database/postgresql_user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/database/riak
+++ b/library/database/riak
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, James Martin <jmartin@basho.com>, Drew Kerrigan <dkerrigan@basho.com>

--- a/library/files/assemble
+++ b/library/files/assemble
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>

--- a/library/files/copy
+++ b/library/files/copy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/files/file
+++ b/library/files/file
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Jan-Piet Mens <jpmens () gmail.com>

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Daniel Hokka Zakrisson <daniel@hozac.com>

--- a/library/internal/async_status
+++ b/library/internal/async_status
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others

--- a/library/internal/async_wrapper
+++ b/library/internal/async_wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others

--- a/library/messaging/rabbitmq_parameter
+++ b/library/messaging/rabbitmq_parameter
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>

--- a/library/messaging/rabbitmq_plugin
+++ b/library/messaging/rabbitmq_plugin
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>

--- a/library/messaging/rabbitmq_user
+++ b/library/messaging/rabbitmq_user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>

--- a/library/messaging/rabbitmq_vhost
+++ b/library/messaging/rabbitmq_vhost
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>

--- a/library/monitoring/nagios
+++ b/library/monitoring/nagios
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # This file is largely copied from the Nagios module included in the

--- a/library/net_infrastructure/netscaler
+++ b/library/net_infrastructure/netscaler
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/library/network/get_url
+++ b/library/network/get_url
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Jan-Piet Mens <jpmens () gmail.com>

--- a/library/network/slurp
+++ b/library/network/slurp
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/network/uri
+++ b/library/network/uri
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Romeo Theriault <romeot () hawaii.edu>

--- a/library/notification/mail
+++ b/library/notification/mail
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2012 Dag Wieers <dag@wieers.com>

--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Flowroute LLC

--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Matt Wright <matt@nobien.net>

--- a/library/packaging/easy_install
+++ b/library/packaging/easy_install
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Matt Wright <matt@nobien.net>

--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Johan Wiren <johan.wiren.se@gmail.com>

--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Andrew Dunham <andrew@du.nham.ca>

--- a/library/packaging/macports
+++ b/library/packaging/macports
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Jimmy Tang <jcftang@gmail.com>

--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chris Hoffman <christopher.hoffman@gmail.com>

--- a/library/packaging/openbsd_pkg
+++ b/library/packaging/openbsd_pkg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Patrik Lundin <patrik.lundin.swe@gmail.com>

--- a/library/packaging/opkg
+++ b/library/packaging/opkg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Patrick Pelletier <pp.pelletier@gmail.com>

--- a/library/packaging/pacman
+++ b/library/packaging/pacman
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Afterburn

--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Matt Wright <matt@nobien.net>

--- a/library/packaging/pkgin
+++ b/library/packaging/pkgin
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Shaun Zinck

--- a/library/packaging/pkgng
+++ b/library/packaging/pkgng
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, bleader

--- a/library/packaging/rhn_channel
+++ b/library/packaging/rhn_channel
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 DOCUMENTATION = '''
 ---

--- a/library/packaging/svr4pkg
+++ b/library/packaging/svr4pkg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Boyd Adamson <boyd () boydadamson.com>

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Red Hat, Inc

--- a/library/source_control/bzr
+++ b/library/source_control/bzr
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, André Paramés <git@andreparames.com>

--- a/library/source_control/git
+++ b/library/source_control/git
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/source_control/hg
+++ b/library/source_control/hg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #-*- coding: utf-8 -*-
 
 # (c) 2013, Yeukhon Wong <yeukhon@acm.org>

--- a/library/source_control/subversion
+++ b/library/source_control/subversion
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/library/system/cron
+++ b/library/system/cron
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2012, Dane Summers <dsummers@pinedesk.biz>

--- a/library/system/facter
+++ b/library/system/facter
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/filesystem
+++ b/library/system/filesystem
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Alexander Bulimov <lazywolf0@gmail.com>

--- a/library/system/group
+++ b/library/system/group
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>

--- a/library/system/lvg
+++ b/library/system/lvg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Alexander Bulimov <lazywolf0@gmail.com>

--- a/library/system/lvol
+++ b/library/system/lvol
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Jeroen Hoekx <jeroen.hoekx@dsquare.be>, Alexander Bulimov <lazywolf0@gmail.com>

--- a/library/system/mount
+++ b/library/system/mount
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Red Hat, inc

--- a/library/system/ohai
+++ b/library/system/ohai
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/ping
+++ b/library/system/ping
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/seboolean
+++ b/library/system/seboolean
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>
 #

--- a/library/system/selinux
+++ b/library/system/selinux
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Derek Carter<goozbach@friocorte.com>

--- a/library/system/service
+++ b/library/system/service
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/setup
+++ b/library/system/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, David "DaviXX" CHANIAL <david.chanial@gmail.com>

--- a/library/system/user
+++ b/library/system/user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>

--- a/library/system/zfs
+++ b/library/system/zfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Johan Wiren <johan.wiren.se@gmail.com>

--- a/library/utilities/debug
+++ b/library/utilities/debug
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2012 Dag Wieers <dag@wieers.com>

--- a/library/utilities/fail
+++ b/library/utilities/fail
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2012 Dag Wieers <dag@wieers.com>

--- a/library/utilities/fireball
+++ b/library/utilities/fireball
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/utilities/set_fact
+++ b/library/utilities/set_fact
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2013 Dag Wieers <dag@wieers.com>

--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Jeroen Hoekx <jeroen@hoekx.be>

--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Scott Anderson <scottanderson42@gmail.com>

--- a/library/web_infrastructure/supervisorctl
+++ b/library/web_infrastructure/supervisorctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Matt Wright <matt@nobien.net>


### PR DESCRIPTION
Some modules use `#!/usr/bin/python` while some already use `#!/usr/bin/env python`. When running ansible from a virtualenv, any `local_action`s will use the system Python when executing the scripts which hardcode `/usr/bin/python` as the path.

This commit should normalise them all to `/usr/bin/env python` and won't affect people who just use the system Python anyway.
