### PR TITLE
changed lockfile to be opened in write mode

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -68,12 +68,9 @@ def log_lockfile():
     tempdir = tempfile.gettempdir() 
     uid = os.getuid()
     path = os.path.join(tempdir, ".ansible-lock.%s" % uid)
-    if not os.path.exists(path):
-        fh = open(path, 'w')
-        fh.close()   
     return path
 
-LOG_LOCK = open(log_lockfile(), 'r')
+LOG_LOCK = open(log_lockfile(), 'w')
 
 def log_flock():
     fcntl.flock(LOG_LOCK, fcntl.LOCK_EX)


### PR DESCRIPTION
This should fix #2925

Solaris doesn't like exclusive locks on a file opened for read (I'm guessing other unixi will also have issues).

This ONLY happens on ansible 'master', targets don't get locked.
