### PR TITLE
Allow the remote MD5 checks to be run via sudo

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -638,7 +638,7 @@ class Runner(object):
 
         cmd = " || ".join(md5s)
         cmd = "%s; %s || (echo \"${rc}  %s\")" % (test, cmd, path)
-        data = self._low_level_exec_command(conn, cmd, tmp, sudoable=False)
+        data = self._low_level_exec_command(conn, cmd, tmp, sudoable=True)
         data2 = utils.last_non_blank_line(data['stdout'])
         try:
             return data2.split()[0]


### PR DESCRIPTION
If specified, using sudo for the remote MD5 checks can skip needlessly transferring the files if they already match but the destination directory is inaccessible w/o sudo.
