### PR TITLE
Raise error on undefined vars in template strings

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -96,6 +96,7 @@ DEFAULT_SUDO_FLAGS        = get_config(p, DEFAULTS, 'sudo_flags', 'ANSIBLE_SUDO_
 DEFAULT_HASH_BEHAVIOUR    = get_config(p, DEFAULTS, 'hash_behaviour', 'ANSIBLE_HASH_BEHAVIOUR', 'replace')
 DEFAULT_LEGACY_PLAYBOOK_VARIABLES = get_config(p, DEFAULTS, 'legacy_playbook_variables', 'ANSIBLE_LEGACY_PLAYBOOK_VARIABLES', 'yes')
 DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBLE_JINJA2_EXTENSIONS', None)
+DEFAULT_JINJA2_UNDEFINED = get_config(p, DEFAULTS, 'jinja2_undefined', 'ANSIBLE_JINJA2_UNDEFINED', 'noop')
 DEFAULT_EXECUTABLE        = get_config(p, DEFAULTS, 'executable', 'ANSIBLE_EXECUTABLE', '/bin/sh')
 
 DEFAULT_ACTION_PLUGIN_PATH     = shell_expand_path(get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '/usr/share/ansible_plugins/action_plugins'))

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -16,6 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import sys
 import re
 import codecs
 import jinja2
@@ -485,5 +486,7 @@ def template_from_string(basedir, data, vars):
         res = jinja2.utils.concat(t.root_render_func(t.new_context(_jinja2_vars(basedir, vars, t.globals), shared=True)))
         return res
     except jinja2.exceptions.UndefinedError, e:
-        raise errors.AnsibleError(str(e))
+        if C.DEFAULT_JINJA2_UNDEFINED == 'strict':
+            raise errors.AnsibleError(str(e)), None, sys.exc_info()[2]
+        return data
 

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -484,7 +484,6 @@ def template_from_string(basedir, data, vars):
  
         res = jinja2.utils.concat(t.root_render_func(t.new_context(_jinja2_vars(basedir, vars, t.globals), shared=True)))
         return res
-    except jinja2.exceptions.UndefinedError:
-        # this shouldn't happen due to undeclared check above
-        return data
+    except jinja2.exceptions.UndefinedError, e:
+        raise errors.AnsibleError(str(e))
 

--- a/test/TestTemplates.py
+++ b/test/TestTemplates.py
@@ -1,0 +1,12 @@
+import unittest
+from ansible.utils import template
+from ansible.errors import AnsibleError
+
+class TestUndefinedTemplateVarible(unittest.TestCase):
+
+    def test_undefined_var_raises_error(self):
+        self.assertRaises(
+            AnsibleError,
+            template.template_from_string,
+            '.', '{{ undefined_var }}', {},
+        )

--- a/test/TestTemplates.py
+++ b/test/TestTemplates.py
@@ -1,12 +1,26 @@
 import unittest
 from ansible.utils import template
 from ansible.errors import AnsibleError
+import ansible.constants as C
+
+CURRENT_VAL = str(C.DEFAULT_JINJA2_UNDEFINED)
 
 class TestUndefinedTemplateVarible(unittest.TestCase):
 
-    def test_undefined_var_raises_error(self):
+    def tearDown(self):
+        C.DEFAULT_JINJA2_UNDEFINED = CURRENT_VAL
+
+    def test_undefined_var_raises_error_when_strict(self):
+        C.DEFAULT_JINJA2_UNDEFINED = 'strict'
         self.assertRaises(
             AnsibleError,
             template.template_from_string,
             '.', '{{ undefined_var }}', {},
         )
+
+    def test_undefined_var_noops_when_noop(self):
+        C.DEFAULT_JINJA2_UNDEFINED = 'noop'
+        templ = '{{ undefined_var }}'
+        res = template.template_from_string('.', templ, {})
+        self.assertEqual(res, templ)
+


### PR DESCRIPTION
Currently, if you have an undefined variable in a template string in a playbook, the _un-rendered_ template is returned - this has caught us out a couple of times (users named "{{ username }}"!), so I wanted to see if I could turn on jinja2's "StrictUndefined" behaviour - however the code already [uses this](https://github.com/ansible/ansible/blob/devel/lib/ansible/utils/template.py#L465), but squashes the exception and returns the template un-rendered explicitly. It looks like this isn't intentional though, so here's a quick patch and test to fix it.
