### PR TITLE
Add support for crypted passwords to password lookup

### DIFF
--- a/docsite/latest/rst/playbooks2.rst
+++ b/docsite/latest/rst/playbooks2.rst
@@ -537,6 +537,15 @@ This length can be changed by passing an extra parameter::
                     target=/tmp/{{ client }}_{{ tier }}_{{ role }}_backup.sql
           with_password: credentials/{{ client }}/{{ tier }}/{{ role }}/mysqlpassword length=15
 
+        (...)
+
+        # create an user with a given password
+        - user: name=guestuser
+                state=present
+                uid=5000
+                password={{ item }}
+          with_password: credentials/{{ hostname }}/userpassword encrypt=sha256_crypt
+
 Setting the Environment (and Working With Proxies)
 ``````````````````````````````````````````````````
 

--- a/lib/ansible/runner/lookup_plugins/password.py
+++ b/lib/ansible/runner/lookup_plugins/password.py
@@ -1,5 +1,5 @@
 # (c) 2012, Daniel Hokka Zakrisson <daniel@hozac.com>
-# (c) 2013, Javie Candeira <javier@candeira.com>
+# (c) 2013, Javier Candeira <javier@candeira.com>
 # (c) 2013, Maykel Moya <mmoya@speedyrails.com>
 #
 # This file is part of Ansible


### PR DESCRIPTION
Added new parameter 'encrypt' with same semantics from that of
vars_prompt. When encryption is requested a random salt will be
generated and stored along the password in the form:
'<password> salt=<salt>'.

Also store password with an ending '\n' for easier looking at files
with console tools. File content was being already rstripped so this
is harmless.

Includes a fix for Javier's name following his request.
