### PR TITLE
no uses get_bin_path for 2nd use of ip tool

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1110,7 +1110,8 @@ class LinuxNetwork(Network):
                     path = os.path.join(path, 'bonding', 'all_slaves_active')
                     if os.path.exists(path):
                         interfaces[device]['all_slaves_active'] = open(path).read() == '1'
-            output = subprocess.Popen(['/sbin/ip', 'addr', 'show', device], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
+            ip_path = module.get_bin_path("ip")
+            output = subprocess.Popen([ip_path, 'addr', 'show', device], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
             for line in output.split('\n'):
 
                 if not line: 


### PR DESCRIPTION
 (fixes reported issue with openwrt)

module needs this added to many tool invocations, but his is a start

Signed-off-by: Brian Coca <briancoca+dev@gmail.com>
