### PR TITLE
Fix empty requirements specifications in modules documentation

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -86,7 +86,7 @@ def print_man(doc):
                             subsequent_indent=opt_indent)
 
 
-    if 'requirements' in doc and len(doc['requirements']) > 0:
+    if 'requirements' in doc and doc['requirements'] is not None and len(doc['requirements']) > 0:
         req = ", ".join(doc['requirements'])
         print "Requirements:%s\n" % textwrap.fill(tty_ify(req), initial_indent="  ",
                             subsequent_indent=opt_indent)

--- a/library/files/template
+++ b/library/files/template
@@ -53,7 +53,7 @@ examples:
 notes:
   - Since Ansible version 0.9, templates are loaded with C(trim_blocks=True).
   - 'You can override jinja2 settings by adding a special header to template file. 
-    i.e. c(#jinja2: trim_blocks: False)'
-requirements: null
+    i.e. C(#jinja2: trim_blocks: False)'
+requirements: []
 author: Michael DeHaan
 '''

--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -64,7 +64,7 @@ examples:
    - code: "wait_for: port=8000 delay=10"
      description: "Example from Ansible Playbooks"
 notes: []
-requirements: null
+requirements: []
 author: Jeroen Hoekx
 '''
 


### PR DESCRIPTION
And also be liberal in what ansible-doc accepts as an empty
requirements specification.

While here fix a typo in template module documentation
wrt jinja2 overrides example.
