### PR TITLE
Fetch destination path can now be overriden.

### DIFF
--- a/lib/ansible/runner/action_plugins/fetch.py
+++ b/lib/ansible/runner/action_plugins/fetch.py
@@ -46,14 +46,26 @@ class ActionModule(object):
         options.update(utils.parse_kv(module_args))
         source = options.get('src', None)
         dest = options.get('dest', None)
+        flat = options.get('flat', False)
+        flat = utils.boolean(flat)
         fail_on_missing = options.get('fail_on_missing', False)
         fail_on_missing = utils.boolean(fail_on_missing)
         if source is None or dest is None:
             results = dict(failed=True, msg="src and dest are required")
             return ReturnData(conn=conn, result=results)
 
-        # files are saved in dest dir, with a subdir for each host, then the filename
-        dest   = "%s/%s/%s" % (utils.path_dwim(self.runner.basedir, dest), conn.host, source)
+        if flat:
+            if dest.endswith("/"):
+                # if the path ends with "/", we'll use the source filename as the
+                # destination filename
+                base = os.path.basename(source)
+                dest = os.path.join(dest, base)
+            if not dest.startswith("/"):
+                # if dest does not start with "/", we'll assume a relative path
+                dest = utils.path_dwim(self.runner.basedir, dest)
+        else:
+           # files are saved in dest dir, with a subdir for each host, then the filename
+           dest   = "%s/%s/%s" % (utils.path_dwim(self.runner.basedir, dest), conn.host, source)
         dest   = dest.replace("//","/")
 
         # calculate md5 sum for the remote file

--- a/library/network/fetch
+++ b/library/network/fetch
@@ -7,7 +7,7 @@ short_description: Fetches a file from remote nodes
 description:
      - This module works like M(copy), but in reverse. It is used for fetching
        files from remote machines and storing them locally in a file tree,
-       organized by hostname. Note that this module is written to transfer 
+       organized by hostname. Note that this module is written to transfer
        log files that might not be present, so a missing remote file won't
        be an error unless fail_on_missing is set to 'yes'.
 version_added: "0.2"
@@ -34,9 +34,22 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "no"
+  flat:
+    version_added: "1.2"
+    description:
+      Allows you to override the default behavior of prepending hostname/path/to/file to
+      the destination.  If dest ends with '/', it will use the basename of the source
+      file, similar to the copy module.  Obvioiusly this is only handy if the filenames
+      are unqiue.
 examples:
    - code: "fetch: src=/var/log/messages dest=/home/logtree"
      description: "Example from Ansible Playbooks"
+   - code: "fetch: src=/tmp/somefile dest="/tmp/beefcake-{{ ansible_hostname }}" flat=yes"
+     description: "Copies a file from remote machine and stores it at the absolute path /tmp/beefcake-{{ ansible_hostname }}"
+   - code: "fetch: src=/tmp/uniquefile dest="/tmp/special/" flat=yes"
+     description: "Copies a file from remote machine and stores it at the absolute path /tmp/special"
+   - code: "fetch: src=/tmp/uniquefile dest="special/" flat=yes"
+     description: "Copies a file from remote machine and stores it in special/uniquefile relative to the playbook"
 requirements: []
 author: Michael DeHaan
 '''


### PR DESCRIPTION
Allows you to override the default behavior of prepending hostname/path/to/file to the destination.  If dest ends with '/', it will use the basename of the source file, similar to the copy module.  Obvioiusly this is only handy if the filenames are unique.
