### PR TITLE
Set paramiko's logging level

### DIFF
--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -20,6 +20,7 @@ import os
 import pipes
 import socket
 import random
+import logging
 from ansible.callbacks import vvv
 from ansible import errors
 from ansible import utils
@@ -31,6 +32,7 @@ with warnings.catch_warnings():
     try:
         import paramiko
         HAVE_PARAMIKO=True
+	logging.getLogger("paramiko").setLevel(logging.WARNING)
     except ImportError:
         pass
 


### PR DESCRIPTION
Explicitly set paramiko's logging level to WARNING.
By default it inherits ansible's DEBUG logging level (set in
callbacks.py) and fills the log file with useless debug messages.
Obviously it only applies if log_path is set in ansible.cfg
