### PR TITLE
Fixes in apt module doc: typos, examples

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -85,19 +85,19 @@ options:
 requirements: [ python-apt, aptitude ]
 author: Matthew Williams
 notes:
-   - Two of the upgrade modes (C(full) and C(dist)) require C(aptitude), otherwise
+   - Three of the upgrade modes (C(full), C(safe) and its alias C(yes)) require C(aptitude), otherwise
      C(apt-get) suffices.
 examples:
     - code: "apt: pkg=foo update_cache=yes"
       description: Update repositories cache and install C(foo) package
-    - code: "apt: pkg=foo state=removed"
+    - code: "apt: pkg=foo state=absent"
       description: Remove C(foo) package
-    - code: "apt: pkg=foo state=installed"
+    - code: "apt: pkg=foo state=present"
       description: Install the package C(foo)
-    - code: "apt: pkg=foo=1.00 state=installed"
+    - code: "apt: pkg=foo=1.00 state=present"
       description: Install the version '1.00' of package C(foo)
     - code: "apt: pkg=nginx state=latest default_release=squeeze-backports update_cache=yes"
-      description: Update the repository cache and update package C(ngnix) to latest version using default release C(squeeze-backport)
+      description: Update the repository cache and update package C(nginx) to latest version using default release C(squeeze-backport)
     - code: "apt: pkg=openjdk-6-jdk state=latest install_recommends=no"
       description: Install latest version of C(openjdk-6-jdk) ignoring C(install-reccomends)
     - code: "apt: upgrade=dist"


### PR DESCRIPTION
@medhaan: following our discussion on irc, fixes in library/packagin/apt documentation examples.
