### PR TITLE
ignore unicode errors in stdout

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -127,6 +127,9 @@ def jsonify(result, format=False):
     if result is None:
         return "{}"
     result2 = result.copy()
+    for key, value in result2.items():
+      if type(value) is str:
+        result2[key] = value.decode('utf-8', 'ignore')
     if format:
         return json.dumps(result2, sort_keys=True, indent=4)
     else:

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -128,8 +128,8 @@ def jsonify(result, format=False):
         return "{}"
     result2 = result.copy()
     for key, value in result2.items():
-      if type(value) is str:
-        result2[key] = value.decode('utf-8', 'ignore')
+        if type(value) is str:
+            result2[key] = value.decode('utf-8', 'ignore')
     if format:
         return json.dumps(result2, sort_keys=True, indent=4)
     else:


### PR DESCRIPTION
When running 'pacman -Syu' on a fresh Arch deployment via the 'raw' module, I get the following traceback:

```
TASK: [Upgrade packages] ******************************************************
fatal: [grego] => Traceback (most recent call last):
  File "/usr/local/brew/lib/python2.7/site-packages/ansible/runner/__init__.py", line 344, in _executor
    exec_rc = self._executor_internal(host)
  File "/usr/local/brew/lib/python2.7/site-packages/ansible/runner/__init__.py", line 416, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/usr/local/brew/lib/python2.7/site-packages/ansible/runner/__init__.py", line 592, in _executor_internal_inner
    self.callbacks.on_ok(host, data)
  File "/usr/local/brew/lib/python2.7/site-packages/ansible/callbacks.py", line 449, in on_ok
    msg = "%s: [%s] => %s" % (ok_or_changed, host, utils.jsonify(host_result2))
  File "/usr/local/brew/lib/python2.7/site-packages/ansible/utils/__init__.py", line 133, in jsonify
    return json.dumps(result2, sort_keys=True)
  File "/usr/local/brew/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 250, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/usr/local/brew/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 209, in encode
    chunks = list(chunks)
  File "/usr/local/brew/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/usr/local/brew/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 390, in _iterencode_dict
    yield _encoder(value)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xe4 in position 24462: invalid continuation byte
```

This appears to occur because the output has odd unicode characters when it imports somebody's GPG key. Here's a sample output when I run `pacman -Syu` myself (not via ansible):

http://bpaste.net/show/nFx3E9cZdgOEmv3egvt9/

(wall of text, but I believe the relevant bits are the GPG keys around lines 152-290)

This patch sanitizes the keys being thrown back to local ansible and drops out the unicode that would have otherwise bombed it out.
