### PR TITLE
Add optional ability to report execution times for ansible-playbook

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -20,6 +20,7 @@
 
 import sys
 import os
+from datetime import datetime
 
 import ansible.playbook
 import ansible.constants as C
@@ -77,6 +78,8 @@ def main(args):
         help="one-step-at-a-time: confirm each task before running")
     parser.add_option('--start-at-task', dest='start_at', 
         help="start the playbook with a task matching this name")
+    parser.add_option('-r', '--report-times', dest='timers', default=False, action='store_true',
+        help="record playbook and play timings")
 
     options, args = parser.parse_args(args)
 
@@ -177,9 +180,10 @@ def main(args):
         failed_hosts = []
 
         try:
-
+            pb.start_time = datetime.now()
             pb.run()
-
+            pb.finish_time = datetime.now()
+            pb.run_timer = int((pb.finish_time - pb.start_time).total_seconds())
             hosts = sorted(pb.stats.processed.keys())
             display(callbacks.banner("PLAY RECAP"))
             playbook_cb.on_stats(pb.stats)
@@ -215,7 +219,15 @@ def main(args):
                     log_only=True
                 )
 
- 
+            if options.timers:
+                display(callbacks.banner("PLAYBOOK TIMES"))
+                display("Total elapsed time: %sm %ss" % (repr(pb.run_timer / 60), repr(pb.run_timer % 60)))
+                for t in sorted(pb.timers.keys()):
+                    if 'elapsed' in pb.timers[t]:
+                        elapsed = pb.timers[t]['elapsed']
+                    else:
+                        elapsed = int((pb.finish_time - pb.timers[t]['start']).total_seconds())
+                    display("%s: %sm %ss" % (t, repr(elapsed / 60), repr(elapsed % 60)))
             print ""
             if len(failed_hosts) > 0:
                 return 2

--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -116,6 +116,10 @@ and 'local'.  'local' is mostly useful for crontab or kickstarts.
 
 Further limits the selected host/group patterns.
 
+*-r*, *--report-times*::
+
+After the run is complete, report on total elapsed time and any timers set in plays.
+
 
 ENVIRONMENT
 -----------

--- a/docsite/latest/rst/playbooks2.rst
+++ b/docsite/latest/rst/playbooks2.rst
@@ -974,6 +974,53 @@ Which of course means, though more verbose, this is also technically legal synta
     - name: foo
       template: { src: '/templates/motd.j2', dest: '/etc/motd' }
 
+Timers
+``````
+
+.. versionadded:: 1.2
+
+You can set timers throughout playbooks to start and/or end on particular plays. These times will then be reported at the end of the playbook execution, after the play recap
+if you specify the --report-times option. Timers begin just before the execution of the play they are started on and end just after completion of the play, like this::
+
+    hosts: all
+    start_timers:
+        - My first timer
+        - Another timer
+    end_timers:
+        - My first timer
+    tasks:
+        - name: ensure the cobbler package is installed
+          yum: name=cobbler state=installed
+
+If you do not specify a play to end a timer, like this::
+
+    hosts: all
+    start_timers:
+        - My first timer
+        - Another timer
+    tasks:
+        - name: ensure the cobbler package is installed
+          yum: name=cobbler state=installed
+
+it will end at the completion of the playbook. Similarly, if you do not specify the start of a timer the begininning of the execution of the playbook will be used.
+
+    hosts: all
+    end_timers:
+        - My first timer
+        - Another timer
+    tasks:
+        - name: ensure the cobbler package is installed
+          yum: name=cobbler state=installed
+
+The output at the play recap time looks like this::
+
+    PLAYBOOK TIMES **************************************************************** 
+    Total elapsed time: 0m 13s
+    Another timer: 0m 13s
+    My first timer: 0m 13s
+
+The total elapsed time is always reported first, followed by any other timers, in sorted order.
+
 Style Points
 ````````````
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -31,7 +31,8 @@ class Play(object):
        'handlers', 'remote_user', 'remote_port',
        'sudo', 'sudo_user', 'transport', 'playbook',
        'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
-       'basedir', 'any_errors_fatal', 'roles'
+       'basedir', 'any_errors_fatal', 'roles',
+       'start_timers', 'end_timers'
     ]
 
     # to catch typos and so forth -- these are userland names
@@ -40,7 +41,8 @@ class Play(object):
        'hosts', 'name', 'vars', 'vars_prompt', 'vars_files',
        'tasks', 'handlers', 'user', 'port', 'include',
        'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'serial',
-       'any_errors_fatal', 'roles', 'pre_tasks', 'post_tasks'
+       'any_errors_fatal', 'roles', 'pre_tasks', 'post_tasks',
+       'start_timers', 'end_timers'
     ]
 
     # *************************************************
@@ -115,6 +117,12 @@ class Play(object):
         if self.sudo_user != 'root':
             self.sudo = True
         
+        self.start_timers = ds.get('start_timers', [])
+        if type(self.start_timers) != list:
+            raise errors.AnsibleError("value of 'start_timers:' must be a list")
+        self.end_timers = ds.get('end_timers', [])
+        if type(self.end_timers) != list:
+            raise errors.AnsibleError("value of 'end_timers:' must be a list")
 
     # *************************************************
 


### PR DESCRIPTION
I have a requirement from management to report how long it takes to run various system tasks, along with timings for some sub-tasks within those e.g. how long was an HA pair single sided during a deploy.

This commit adds a new --report-times option to ansible-playbook which reports the time taken to run a top-level playbook after the play recap. It also adds the ability to start and stop arbitrary timers on plays using start_timers and end_timers, and reports on them as well. More details in the docs.

If you don't use the option then the output remains exactly is it is now so anything parsing existing output shouldn't be affected.
