### PR TITLE
The git module crashes if a large commit was done

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -88,9 +88,9 @@ import tempfile
 def get_version(dest):
     ''' samples the version of the git repo '''
     os.chdir(dest)
-    cmd = "git show --abbrev-commit"
-    sha = os.popen(cmd).readline().split("\n")
-    sha = sha[0].split()[1]
+    cmd = "git log -1 --format='%h'"
+    sha = os.popen(cmd).read().split("\n")
+    sha = sha[0]
     return sha
 
 def clone(module, repo, dest, remote, depth):
@@ -323,7 +323,8 @@ def main():
             if remote_head == version:
                 # get_remote_head returned version as-is
                 # were given a sha1 object, see if it is present
-                (rc, out, err) = module.run_command("git show %s" % version)
+                cmd = "git log -1 --format='%%H' %s" % version
+                (rc, out, err) = module.run_command(cmd)
                 if version in out:
                     changed = False
                 else:

--- a/library/source_control/git
+++ b/library/source_control/git
@@ -89,7 +89,7 @@ def get_version(dest):
     ''' samples the version of the git repo '''
     os.chdir(dest)
     cmd = "git show --abbrev-commit"
-    sha = os.popen(cmd).read().split("\n")
+    sha = os.popen(cmd).readline().split("\n")
     sha = sha[0].split()[1]
     return sha
 


### PR DESCRIPTION
I have a repo that contains code libraries—thousands of files. It was causing Ansible’s git module to crash.

**CAUSE & SUGGESTED FIX**

The git module uses `git show --abbrev-commit` to sample the current version of the repo. This is inefficient, because it outputs the entire diff of the commit.

If the commit is large enough, it will cause Ansible’s git module to crash and the task to fail.

I’ve fixed this by having the git module only read the first line of `git show` output. (It only uses the first line anyway.)
