### PR TITLE
added support for ssh tunneling using ssh's ProxyCommand option

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -111,6 +111,7 @@ class Runner(object):
         remote_user=C.DEFAULT_REMOTE_USER,  # ex: 'username'
         remote_pass=C.DEFAULT_REMOTE_PASS,  # ex: 'password123' or None if using key
         remote_port=None,                   # if SSH on different ports
+        ssh_proxy_cmd=None,                 # ssh proxy command ( -o ProxyCommand ...' )
         private_key_file=C.DEFAULT_PRIVATE_KEY_FILE, # if not using keys/passwords
         sudo_pass=C.DEFAULT_SUDO_PASS,      # ex: 'password123' or None
         background=0,                       # async poll every X seconds, else 0 for non-async
@@ -155,6 +156,7 @@ class Runner(object):
         self.remote_user      = remote_user
         self.remote_pass      = remote_pass
         self.remote_port      = remote_port
+        self.ssh_proxy_cmd    = ssh_proxy_cmd
         self.private_key_file = private_key_file
         self.background       = background
         self.sudo             = sudo
@@ -501,6 +503,7 @@ class Runner(object):
         conn = None
         actual_host = inject.get('ansible_ssh_host', host)
         actual_port = port
+        actual_ssh_proxy_cmd = inject.get('ansible_ssh_proxy_cmd', self.ssh_proxy_cmd)
         actual_user = inject.get('ansible_ssh_user', self.remote_user)
         actual_pass = inject.get('ansible_ssh_pass', self.remote_pass)
         actual_transport = inject.get('ansible_connection', self.transport)
@@ -527,6 +530,7 @@ class Runner(object):
                 actual_port = delegate_info.get('ansible_ssh_port', port)
                 actual_user = delegate_info.get('ansible_ssh_user', actual_user)
                 actual_pass = delegate_info.get('ansible_ssh_pass', actual_pass)
+                actual_ssh_proxy_cmd = delegate_info.get('ansible_ssh_proxy_cmd', actual_ssh_proxy_cmd)
                 actual_private_key_file = delegate_info.get('ansible_ssh_private_key_file', self.private_key_file)
                 actual_transport = delegate_info.get('ansible_connection', self.transport)
                 for i in delegate_info:
@@ -547,7 +551,7 @@ class Runner(object):
             return ReturnData(host=host, comm_ok=False, result=result)
 
         try:
-            conn = self.connector.connect(actual_host, actual_port, actual_user, actual_pass, actual_transport, actual_private_key_file)
+            conn = self.connector.connect(actual_host, actual_port, actual_user, actual_pass, actual_transport, actual_private_key_file, actual_ssh_proxy_cmd)
             if delegate_to or host != actual_host:
                 conn.delegate = host
 

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -31,9 +31,9 @@ class Connection(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def connect(self, host, port, user, password, transport, private_key_file):
+    def connect(self, host, port, user, password, transport, private_key_file, ssh_proxy_cmd):
         conn = None
-        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password, private_key_file=private_key_file)
+        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password, private_key_file=private_key_file, ssh_proxy_cmd=ssh_proxy_cmd)
         if conn is None:
             raise AnsibleError("unsupported connection type: %s" % transport)
         self.active = conn.connect()


### PR DESCRIPTION
This commit introduces a new variable named ansible_ssh_proxy_cmd that can be associated with individual hosts and used to tunnel task executions through a proxy/tunnel host using the ssh transport.

I have a scenario where I need to run ansible tasks against LXC containers created in an Ubuntu VirtualBox machine from an OSX notebook. So ansible needs to ssh into the LXC container through the Ubuntu VM hosting it.

With this commit, it is possible to specify a host such as:

```
[webservers]
app ansible_ssh_user=ubuntu ansible_connection=ssh ansible_ssh_proxy_cmd='ssh vagrant@localhost -p 2222 nc %h %p 2>/dev/null'
```

This will add a new option to the ssh transport:

```
-o 'ProxyCommand ssh vagrant@localhost -p 2222 nc %h %p 2>/dev/null' to the ssh and scp exec command in ssh.py. I have also added this option to the sftp command, but I have no idea if it will work.
```
