### PR TITLE
Fixes apt_repository always reporting file uri repos as changed

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -111,7 +111,7 @@ def main():
         # http://myserver/path/to/repo free non-free
         # deb http://myserver/path/to/repo free non-free
         for i in repo_url.split():
-            if 'http' in i:
+            if any(prot in i for prot in ['http', 'file', 'ftp']):
                 repo_url = i
     exists = repo_exists(module, repo_url)
 


### PR DESCRIPTION
Adding a local file repo with apt_repository would always report that it had changed, even if it was there already, e.g:

``` yml
apt_repository: repo='deb file:/opt/repo /'
```

always returned:

```
changed: [172.16.32.16] => {"changed": true, "item": "", "repo": "deb file:/opt/repo /", "state": "present"}
```
