### PR TITLE
Document that derived variables' values are always strings, and may have to be casted when used in comparisons.

### DIFF
--- a/docsite/latest/rst/playbooks2.rst
+++ b/docsite/latest/rst/playbooks2.rst
@@ -281,6 +281,15 @@ As a reminder, to see what derived variables are available, you can do::
 
     ansible hostname.example.com -m setup
 
+When using these variables, remember that their values are always strings. Therefore, you may
+have to cast them to an appropiate type before using them in comparisons::
+
+    tasks:
+      - shell: echo "comparisons with derived may have to be casted"
+        when: ansible_lsb.major_version|int >= 5
+
+The available types are `int` and `float`.
+
 Variables defined in the playbooks or inventory can also be used.
 
 If a required variable has not been set, you can skip or fail using Jinja2's 


### PR DESCRIPTION
It is easy for users to misstep on this fact. For example, a user may write the following task that should not be executed when the distro's lsb version is lower than 5::

```
tasks:
  - shell: echo "comparisons with derived may have to be casted"
    when: ansible_lsb.major_version >= 5
```

This comparison doesn't produce an error, and appears to work if the test system should pass it. Actually, the comparison always passes because `ansible_lsb.major_version` evaluates to a non-empty string, and in python a non-empty string is always greater than a number.

This fact, along with an explanation of the right way to write the above task is introduced in the docs by this patch.
