### PR TITLE
Fetch files through slurp when sudo is required

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -620,7 +620,7 @@ class Runner(object):
 
     # *****************************************************
 
-    def _remote_md5(self, conn, tmp, path):
+    def _remote_md5(self, conn, tmp, path, sudoable=True):
         ''' takes a remote md5sum without requiring python, and returns 0 if no file '''
 
         path = pipes.quote(path)
@@ -638,7 +638,7 @@ class Runner(object):
 
         cmd = " || ".join(md5s)
         cmd = "%s; %s || (echo \"${rc}  %s\")" % (test, cmd, path)
-        data = self._low_level_exec_command(conn, cmd, tmp, sudoable=True)
+        data = self._low_level_exec_command(conn, cmd, tmp, sudoable=sudoable)
         data2 = utils.last_non_blank_line(data['stdout'])
         try:
             return data2.split()[0]

--- a/library/network/fetch
+++ b/library/network/fetch
@@ -34,6 +34,10 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "no"
+notes:
+    - This module loads the entire contents into memory when it must be fetched
+      through sudo, so avoid fetching large files unless they can be read by the 
+      remote user without sudoing.
 examples:
    - code: "fetch: src=/var/log/messages dest=/home/logtree"
      description: "Example from Ansible Playbooks"


### PR DESCRIPTION
If the file can be read without sudoing, fetch it directly. Otherwise,
fetch it through the slurp module. The latter implies reading the
entire file into memory, so warn users against fetching large files
through sudo.
