### PR TITLE
Fixes apt_repository always reporting file uri repos as changed

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -111,8 +111,10 @@ def main():
         # http://myserver/path/to/repo free non-free
         # deb http://myserver/path/to/repo free non-free
         for i in repo_url.split():
-            if 'http' in i:
-                repo_url = i
+            for prot in ['http', 'file', 'ftp']:
+              if prot in i:
+                  repo_url = i
+                  break
     exists = repo_exists(module, repo_url)
 
     rc = 0


### PR DESCRIPTION
Adding a local file repo with apt_repository would always report that it had changed, even if it was there already, e.g:

``` yml
apt_repository: repo='deb file:/opt/repo /'
```

always returned:

```
changed: [172.16.32.16] => {"changed": true, "item": "", "repo": "deb file:/opt/repo /", "state": "present"}
```

Resubmit of https://github.com/ansible/ansible/pull/2971 to not use any() to support Python 2.4.
