### PR TITLE
pip module -- sudo_user permission problem fix

### DIFF
--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -201,6 +201,7 @@ def main():
                 cmd = '%s --system-site-packages %s' % (virtualenv, env)
             else:
                 cmd = '%s %s' % (virtualenv, env)
+            os.chdir(tempfile.gettempdir())
             rc, out_venv, err_venv = module.run_command(cmd)
             out += out_venv
             err += err_venv


### PR DESCRIPTION
Similar to https://github.com/ansible/ansible/pull/2418, when attempting to create a new virtualenv and where user was 'root', and sudo_user was some other user, I kept hitting permissions problems:

```
failed: [admin] => {"cmd": "/usr/local/bin/virtualenv /usr/home/server/.ve/", "failed": true, "item": ""}
msg: stdout: New python executable in /usr/home/server/.ve/bin/python2.7
Not overwriting existing python script /usr/home/server/.ve/bin/python (you must use /usr/home/server/.ve/bin/python2.7)
Installing setuptools.............done.
Installing pip.........
  Complete output from command /usr/home/server/.ve/bin/python2.7 -x /usr/home/server/.ve/bin/easy_install /usr/local/lib/pytho...ort/pip-1.3.1.tar.gz:
  Processing pip-1.3.1.tar.gz
Running pip-1.3.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-S2PTGg/pip-1.3.1/egg-dist-tmp-UXZl7t
warning: no files found matching '*.html' under directory 'docs'
warning: no previously-included files matching '*.txt' found under directory 'docs/_build'
no previously-included directories found matching 'docs/_build/_sources'
error: /root: Permission denied
----------------------------------------
...Installing pip...done.

:stderr: Traceback (most recent call last):
  File "/usr/local/bin/virtualenv", line 9, in <module>
    load_entry_point('virtualenv==1.9.1', 'console_scripts', 'virtualenv')()
  File "/usr/local/lib/python2.7/site-packages/virtualenv-1.9.1-py2.7.egg/virtualenv.py", line 979, in main
    no_pip=options.no_pip)
  File "/usr/local/lib/python2.7/site-packages/virtualenv-1.9.1-py2.7.egg/virtualenv.py", line 1094, in create_environment
    install_pip(py_executable, search_dirs=search_dirs, never_download=never_download)
  File "/usr/local/lib/python2.7/site-packages/virtualenv-1.9.1-py2.7.egg/virtualenv.py", line 667, in install_pip
    filter_stdout=_filter_setup)
  File "/usr/local/lib/python2.7/site-packages/virtualenv-1.9.1-py2.7.egg/virtualenv.py", line 1057, in call_subprocess
    % (cmd_desc, proc.returncode))
OSError: Command /usr/home/server/.ve/bin/python2.7 -x /usr/home/server/.ve/bin/easy_install /usr/local/lib/pytho...ort/pip-1.3.1.tar.gz failed with error code 1
```

FATAL: all hosts have already failed -- aborting

This proposed patch fixes the above problem.
