### PR TITLE
Ensure the tmp_path is sufficiently open.

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -662,7 +662,7 @@ class Runner(object):
             basetmp = os.path.join('/tmp', basefile)
 
         cmd = 'mkdir -p %s' % basetmp
-        if self.remote_user != 'root':
+        if self.remote_user != 'root' or (self.sudo and self.sudo_user != 'root'):
             cmd += ' && chmod a+rx %s' % basetmp
         cmd += ' && echo %s' % basetmp
 


### PR DESCRIPTION
On my FreeBSD vagrant target, the problem I was running into is that my umask values were set to 0027.  Hence, ansible was creating directories in /tmp/ansible-randomstring that were then 750.  When placing the module into /tmp/ansible-randomstring/module, it made sure to chmod a+r it, but my user was still unable to get into that directory (as the sudo_user executing the task did not belong to the wheel group).  This patch makes sure that the randomly generated path is accessible enough by checking if sudo_user isn't root and then opening the directory if so.
