### PR TITLE
document in the man-page that {ansible,ansible-playbook} -M can also be ...

### DIFF
--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -48,7 +48,8 @@ The 'PATH' to the inventory hosts file, which defaults to
 *-M* 'DIRECTORY', *--module-path=*'DIRECTORY'::
 
 The 'DIRECTORY' search path to load modules from. The default is
-'/usr/share/ansible'. See also the ANSIBLE_LIBRARY environment variable.
+'/usr/share/ansible'. This can also be set with the ANSIBLE_LIBRARY
+environment variable.
 
 *-e* 'VARS', *--extra-vars=*'VARS'::
 

--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -47,7 +47,8 @@ The 'PATH' to the inventory hosts file, which defaults to
 
 *-M* 'DIRECTORY', *--module-path=*'DIRECTORY'::
 
-The 'DIRECTORY' to load modules from. The default is '/usr/share/ansible'.
+The 'DIRECTORY' search path to load modules from. The default is
+'/usr/share/ansible'. See also the ANSIBLE_LIBRARY environment variable.
 
 *-e* 'VARS', *--extra-vars=*'VARS'::
 

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -61,7 +61,8 @@ Execute the module called 'NAME'.
 *-M* 'DIRECTORY', *--module-path=*'DIRECTORY'::
 
 The 'DIRECTORY' search path to load modules from. The default is
-'/usr/share/ansible'. See also the ANSIBLE_LIBRARY environment variable.
+'/usr/share/ansible'. This can also be set with the ANSIBLE_LIBRARY
+environment variable.
 
 *-a* \'_ARGUMENTS_', *--args=*\'_ARGUMENTS_'::
 

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -61,7 +61,7 @@ Execute the module called 'NAME'.
 *-M* 'DIRECTORY', *--module-path=*'DIRECTORY'::
 
 The 'DIRECTORY' to load modules from. The default is '/usr/share/ansible'.
-
+See also the ANSIBLE_LIBRARY environment variable.
 
 *-a* \'_ARGUMENTS_', *--args=*\'_ARGUMENTS_'::
 

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -60,8 +60,8 @@ Execute the module called 'NAME'.
 
 *-M* 'DIRECTORY', *--module-path=*'DIRECTORY'::
 
-The 'DIRECTORY' to load modules from. The default is '/usr/share/ansible'.
-See also the ANSIBLE_LIBRARY environment variable.
+The 'DIRECTORY' search path to load modules from. The default is
+'/usr/share/ansible'. See also the ANSIBLE_LIBRARY environment variable.
 
 *-a* \'_ARGUMENTS_', *--args=*\'_ARGUMENTS_'::
 


### PR DESCRIPTION
...overriden with the ANSIBLE_LIBRARY environment.

This is a tiny branch that tweaks the man page to clarify that the -M parameter of ansible and ansible-playbook can also take a search path argument and that the ANSIBLE_LIBRARY environment can also be used to modify the module_path.

The rational is that I wrote a custom facts module and searched a bit before finding a way to set the -M parameter via the environment so that our custom facts module is always included (its detecting if the machine that it runs on is a VMWare virtual machine, if that is a generally useful feature I'm happy to contribute this small module as well in a seperate branch).
