### PR TITLE
Fixes #2924: User creation always reports 'changed'

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -395,7 +395,7 @@ class User(object):
         groups = []
         info = self.get_pwd_info()
         for group in grp.getgrall():
-            if self.name in group[3] and info[3] != group[2]:
+            if self.name in group.gr_mem and info[3] == group.gr_gid:
                 groups.append(group[0])
         return groups
 


### PR DESCRIPTION
The user_group_membership() method of the User base class is intended to return a list of all groups that the user belongs to.  This is then used to compare against a list of groups requested.  If there is a delta, the difference will be applied.

Unfortunately, there seems to be a typo in the comparison and it checks for not equal on the group id instead of equality.  Hence the returned value was an empty list.  

In addition to fixing the check, i changed to use attr access instead of indexing, as I feel it improves readability.
