### PR TITLE
Fix copy when force=no and update _remote_md5 docs.

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -621,7 +621,7 @@ class Runner(object):
     # *****************************************************
 
     def _remote_md5(self, conn, tmp, path):
-        ''' takes a remote md5sum without requiring python, and returns 0 if no file '''
+        ''' takes a remote md5sum without requiring python, and returns 1 if no file '''
 
         path = pipes.quote(path)
         # The following test needs to be SH-compliant.  BASH-isms will

--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -106,8 +106,8 @@ class ActionModule(object):
             dest = os.path.join(dest, os.path.basename(source))
             remote_md5 = self.runner._remote_md5(conn, tmp, dest)
 
-        # remote_md5 == '0' would mean that the file does not exist.
-        if remote_md5 != '0' and not force:
+        # remote_md5 == '1' would mean that the file does not exist.
+        if remote_md5 != '1' and not force:
             return ReturnData(conn=conn, result=dict(changed=False))
 
         exec_rc = None


### PR DESCRIPTION
I noticed today that when I set force=no on the copy module then the file would not be copied to the destination even if it did not exist. After testing return codes from a few flavors (Mac, Ubuntu, CentOS) of md5 it turns out '1' is returned when a file doesn't exist; not sure about return codes of other flavors.

Previously setting force=no caused copy to subversively
fail when target did not exist on remote host.

Caused by Runner._remote_md5 returning 1
when files don't exist, rather than 0.
