### PR TITLE
Escape args injected in new style modules

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -85,10 +85,10 @@ def boilerplate_module(modfile, args):
     if included_boilerplate:
 
         module_data = module_data.replace(module_common.REPLACER, module_common.MODULE_COMMON)
-        encoded_args = "\"\"\"%s\"\"\"" % args.replace("\"","\\\"")
+        encoded_args = repr(str(args))
         module_data = module_data.replace(module_common.REPLACER_ARGS, encoded_args)
-        encoded_lang = "\"\"\"%s\"\"\"" % C.DEFAULT_MODULE_LANG
-        empty_complex = "\"\"\"%s\"\"\"" % "{}"
+        encoded_lang = repr(C.DEFAULT_MODULE_LANG)
+        empty_complex = repr("{}")
         module_data = module_data.replace(module_common.REPLACER_LANG, encoded_lang)
         module_data = module_data.replace('syslog.LOG_USER', "syslog.%s" % C.DEFAULT_SYSLOG_FACILITY)
         module_data = module_data.replace(module_common.REPLACER_COMPLEX, empty_complex)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -699,9 +699,11 @@ class Runner(object):
                 module_style = 'non_native_want_json'
 
             complex_args_json = utils.jsonify(complex_args)
-            encoded_args = "\"\"\"%s\"\"\"" % module_args.replace("\"","\\\"")
-            encoded_lang = "\"\"\"%s\"\"\"" % C.DEFAULT_MODULE_LANG
-            encoded_complex = "\"\"\"%s\"\"\"" % complex_args_json.replace("\\", "\\\\")
+            # We force conversion of module_args to str because module_common calls shlex.split,
+            # a standard library function that incorrectly handles Unicode input before Python 2.7.3.
+            encoded_args = repr(str(module_args))
+            encoded_lang = repr(C.DEFAULT_MODULE_LANG)
+            encoded_complex = repr(complex_args_json)
 
             module_data = module_data.replace(module_common.REPLACER, module_common.MODULE_COMMON)
             module_data = module_data.replace(module_common.REPLACER_ARGS, encoded_args)

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -126,7 +126,7 @@ EXAMPLES = r"""
 
    lineinfile: dest=/etc/sudoers state=present regexp='^%wheel' line='%wheel ALL=(ALL) NOPASSWD: ALL'
 
-   lineinfile: dest=/opt/jboss-as/bin/standalone.conf regexp='^(.*)Xms(\d+)m(.*)$' line='\\1Xms${xms}m\\3' backrefs=yes
+   lineinfile: dest=/opt/jboss-as/bin/standalone.conf regexp='^(.*)Xms(\d+)m(.*)$' line='\1Xms${xms}m\3' backrefs=yes
 """
 
 def write_changes(module,lines,dest):

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -470,7 +470,7 @@ class TestRunner(unittest.TestCase):
         # The order of the test cases is important
 
         # The regexp doesn't match, so the line will not be added anywhere.
-        testline = r'\\1: Line added by default at the end of the file.'
+        testline = r'\1: Line added by default at the end of the file.'
         testcase = ('lineinfile', [
                     "dest=%s" % sample,
                     "regexp='^(First): '",
@@ -485,7 +485,7 @@ class TestRunner(unittest.TestCase):
 
         # insertafter with EOF
         # The regexp doesn't match, so the line will not be added anywhere.
-        testline = r'\\1: Line added with insertafter=EOF'
+        testline = r'\1: Line added with insertafter=EOF'
         testcase = ('lineinfile', [
                     "dest=%s" % sample,
                     "insertafter=EOF",
@@ -501,7 +501,7 @@ class TestRunner(unittest.TestCase):
 
         # with invalid insertafter regex
         # The regexp doesn't match, so do nothing.
-        testline = r'\\1: Line added with an invalid insertafter regex'
+        testline = r'\1: Line added with an invalid insertafter regex'
         testcase = ('lineinfile', [
                     "dest=%s" % sample,
                     "insertafter='^abcdefgh'",
@@ -515,7 +515,7 @@ class TestRunner(unittest.TestCase):
 
         # with an insertafter regex
         # The regexp doesn't match, so do nothing.
-        testline = r'\\1: Line added with a valid insertafter regex'
+        testline = r'\1: Line added with a valid insertafter regex'
         testcase = ('lineinfile', [
                     "dest=%s" % sample,
                     "insertafter='^receive messages to '",
@@ -534,7 +534,7 @@ class TestRunner(unittest.TestCase):
         target_line = 'combination of microphone, speaker, keyboard and display. It can send and'
         idx = artifact.index(target_line)
 
-        testline = r'\\1 of megaphone'
+        testline = r'\1 of megaphone'
         testline_after = 'combination of megaphone'
         testcase = ('lineinfile', [
                     "dest=%s" % sample,
@@ -551,7 +551,7 @@ class TestRunner(unittest.TestCase):
         assert target_line not in artifact
 
         # Go again, should be unchanged now.
-        testline = r'\\1 of megaphone'
+        testline = r'\1 of megaphone'
         testline_after = 'combination of megaphone'
         testcase = ('lineinfile', [
                     "dest=%s" % sample,
@@ -567,11 +567,11 @@ class TestRunner(unittest.TestCase):
         f = open(sample, 'a+')
         f.write("1 + 1 = 3" + os.linesep)
         f.close()
-        testline = r"2 + \\g<num> = 3"
+        testline = r"2 + \g<num> = 3"
         testline_after = "2 + 1 = 3"
         testcase = ('lineinfile', [
                     "dest=%s" % sample,
-                    r"regexp='1 \\+ (?P<num>\\d) = 3'",
+                    r"regexp='1 \+ (?P<num>\d) = 3'",
                     "line='%s'" % testline,
                     "backrefs=yes",
                     ])


### PR DESCRIPTION
Here is a patch discussed yesterday on the mailing list: [Is it intentional to authorize Python escaping in YAML playbooks?](https://groups.google.com/d/topic/ansible-project/ZaB6o-eqDzw/discussion)

`make tests` is ok.

Is it good for you?
