### PR TITLE
new airbrake_deployment module

### DIFF
--- a/library/monitoring/airbrake_deployment
+++ b/library/monitoring/airbrake_deployment
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2013 Bruce Pennypacker <bruce@pennypacker.org>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: airbrake_deployment
+version_added: "1.2"
+author: Bruce Pennypacker
+short_description: Notify airbrake about app deployments
+description:
+   - Notify airbrake about app deployments (see http://help.airbrake.io/kb/api-2/deploy-tracking)
+options:
+  token:
+    description:
+      - API token.
+    required: true
+  environment:
+    description:
+      - The airbrake environment name, typically 'production', 'staging', etc.
+    required: true
+  user:
+    description:
+      - The username of the person doing the deployment
+    required: false
+  repo:
+    description:
+      - URL of the project repository
+    required: false
+  revision:
+    description:
+      - A hash, number, tag, or other identifier showing what revision was deployed
+    required: false
+
+# informational: requirements for nodes
+requirements: [ urllib, urllib2 ]
+'''
+
+EXAMPLES = '''
+action: airbrake_deployment token=AAAAAA environment='staging'  user='ansible' revision=4.2
+'''
+
+HAS_URLLIB = True
+try:
+    import urllib
+except ImportError:
+    HAS_URLLIB = False
+
+HAS_URLLIB2 = True
+try:
+    import urllib2
+except ImportError:
+    HAS_URLLIB2 = False
+
+# ===========================================
+# Module execution.
+#
+
+def main():
+
+    if not HAS_URLLIB:
+        module.fail_json(msg="urllib is not installed")
+    if not HAS_URLLIB2:
+        module.fail_json(msg="urllib2 is not installed")
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            token=dict(required=True),
+            environment=dict(required=True),
+            user=dict(required=False),
+            repo=dict(required=False),
+            revision=dict(required=False),
+        ),
+        supports_check_mode=True
+    )
+
+    # build list of params
+    params = {}
+
+    if module.params["environment"]:
+        params["deploy[rails_env]"] = module.params["environment"]
+
+    if module.params["user"]:
+        params["deploy[local_username]"] = module.params["user"]
+
+    if module.params["repo"]:
+        params["deploy[scm_repository]"] = module.params["repo"]
+
+    if module.params["revision"]:
+        params["deploy[scm_revision]"] = module.params["revision"]
+
+    params["api_key"] = module.params["token"]
+
+    # If we're in check mode, just exit pretending like we succeeded
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    # Send the data to airbrake
+    try:
+        req = urllib2.Request("https://airbrake.io/deploys", urllib.urlencode(params))
+        result=urllib2.urlopen(req)
+    except Exception, e:
+        module.fail_json(msg="unable to update airbrake: %s" % e)
+    else:
+        if result.code == 200:
+            module.exit_json(changed=True)
+        else:
+            module.fail_json(msg="HTTP result code: %d" % result.code)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()
+


### PR DESCRIPTION
This is my first attempt at a full Ansible module, and it's a pretty simple one.  It sends a notification to Airbrake (http://airbrake.io) of a new deployment, per the API documented at http://help.airbrake.io/discussions/questions/412-deploy-notification-via-api
