### PR TITLE
Add roles support for the script module

### DIFF
--- a/docsite/latest/rst/bestpractices.rst
+++ b/docsite/latest/rst/bestpractices.rst
@@ -48,12 +48,11 @@ The top level of the directory would contain files and directories like so::
                 main.yml      #  <-- tasks file can include smaller files if warranted
             handlers/         # 
                 main.yml      #  <-- handlers file
-            scripts/          # 
-                foo.sh        #  <-- script files for use with the script resource
             templates/        #  <-- files for use with the template resource
                 ntp.conf.j2   #  <------- templates end in .j2
             files/            #
                 bar.txt       #  <-- files for use with the copy resource
+                foo.sh        #  <-- script files for use with the script resource
 
         webtier/              # same kind of structure as "common" was above, done for the webtier role
         monitoring/           # ""

--- a/docsite/latest/rst/bestpractices.rst
+++ b/docsite/latest/rst/bestpractices.rst
@@ -48,6 +48,8 @@ The top level of the directory would contain files and directories like so::
                 main.yml      #  <-- tasks file can include smaller files if warranted
             handlers/         # 
                 main.yml      #  <-- handlers file
+            scripts/          # 
+                foo.sh        #  <-- script files for use with the script resource
             templates/        #  <-- files for use with the template resource
                 ntp.conf.j2   #  <------- templates end in .j2
             files/            #

--- a/docsite/latest/rst/playbooks.rst
+++ b/docsite/latest/rst/playbooks.rst
@@ -463,14 +463,12 @@ Example project structure::
     roles/
        common/
          files/
-         scripts/
          templates/
          tasks/
          handlers/
          vars/
        webservers/
          files/
-         scripts/
          templates/
          tasks/
          handlers/
@@ -490,7 +488,7 @@ This designates the following behaviors, for each role 'x':
 - If roles/x/handlers/main.yml exists, handlers listed therein will be added to the play
 - If roles/x/vars/main.yml exists, variables listed therein will be added to the play
 - Any copy tasks can reference files in roles/x/files/ without having to path them relatively or absolutely
-- Any script tasks can reference scripts in roles/x/sripts/ without having to path them relatively or absolutely
+- Any script tasks can reference scripts in roles/x/files/ without having to path them relatively or absolutely
 - Any template tasks can reference files in roles/x/templates/ without having to path them relatively or absolutely
 
 If any files are not present, they are just ignored.  So it's ok to not have a 'vars/' subdirectory for the role,

--- a/docsite/latest/rst/playbooks.rst
+++ b/docsite/latest/rst/playbooks.rst
@@ -463,12 +463,14 @@ Example project structure::
     roles/
        common/
          files/
+         scripts/
          templates/
          tasks/
          handlers/
          vars/
        webservers/
          files/
+         scripts/
          templates/
          tasks/
          handlers/
@@ -488,6 +490,7 @@ This designates the following behaviors, for each role 'x':
 - If roles/x/handlers/main.yml exists, handlers listed therein will be added to the play
 - If roles/x/vars/main.yml exists, variables listed therein will be added to the play
 - Any copy tasks can reference files in roles/x/files/ without having to path them relatively or absolutely
+- Any script tasks can reference scripts in roles/x/sripts/ without having to path them relatively or absolutely
 - Any template tasks can reference files in roles/x/templates/ without having to path them relatively or absolutely
 
 If any files are not present, they are just ignored.  So it's ok to not have a 'vars/' subdirectory for the role,
@@ -526,6 +529,8 @@ If you want to define certain tasks to happen before AND after roles are applied
         - shell: echo 'hello'
       roles:
         - { role: some_role }
+      tasks:
+        - shell: echo 'still busy'
       post_tasks:
         - shell: echo 'goodbye'
 

--- a/lib/ansible/runner/action_plugins/script.py
+++ b/lib/ansible/runner/action_plugins/script.py
@@ -42,7 +42,7 @@ class ActionModule(object):
         args    = " ".join(tokens[1:])
         source  = template.template(self.runner.basedir, source, inject)
         if '_original_file' in inject:
-            source = utils.path_dwim_relative(inject['_original_file'], 'scripts', source, self.runner.basedir)
+            source = utils.path_dwim_relative(inject['_original_file'], 'files', source, self.runner.basedir)
         else:
             source = utils.path_dwim(self.runner.basedir, source)
 

--- a/lib/ansible/runner/action_plugins/script.py
+++ b/lib/ansible/runner/action_plugins/script.py
@@ -41,7 +41,10 @@ class ActionModule(object):
         # FIXME: error handling
         args    = " ".join(tokens[1:])
         source  = template.template(self.runner.basedir, source, inject)
-        source  = utils.path_dwim(self.runner.basedir, source)
+        if '_original_file' in inject:
+            source = utils.path_dwim_relative(inject['_original_file'], 'scripts', source, self.runner.basedir)
+        else:
+            source = utils.path_dwim(self.runner.basedir, source)
 
         # transfer the file to a remote tmp location
         source  = source.replace('\x00','') # why does this happen here?


### PR DESCRIPTION
allows to put scripts directly in a dir within the
role:  roles/<role>/scripts/..
Same as the copy and template module.

Tests: http://paste.ubuntu.com/5698156/

As requested in and closes #2969
