### PR TITLE
Make debug module always verbose in playbooks

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -434,6 +434,7 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
 
         host_result2 = host_result.copy()
         host_result2.pop('invocation', None)
+        verbose_always = host_result2.pop('verbose_always', None)
         changed = host_result.get('changed', False)
         ok_or_changed = 'ok'
         if changed:
@@ -441,7 +442,8 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
 
         # show verbose output for non-setup module results if --verbose is used
         msg = ''
-        if not self.verbose or host_result2.get("verbose_override",None) is not None:
+        if (not self.verbose or host_result2.get("verbose_override",None) is not
+                None) and verbose_always is None:
             if item:
                 msg = "%s: [%s] => (item=%s)" % (ok_or_changed, host, item)
             else:

--- a/lib/ansible/runner/action_plugins/debug.py
+++ b/lib/ansible/runner/action_plugins/debug.py
@@ -46,4 +46,7 @@ class ActionModule(object):
         else:
             result = dict(msg=args['msg'])
 
+        # force flag to make debug output module always verbose
+        result['verbose_always'] = True
+
         return ReturnData(conn=conn, result=result)


### PR DESCRIPTION
Created a new flag 'verbose_always' handled by
on_ok callback, similar to the 'verbose_override'
flag used by the setup module.

tests: http://sprunge.us/YXOT
