### PR TITLE
betterment of facter and ohai path. used get_bin_path function in lib/an...

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1641,8 +1641,9 @@ def run_setup(module):
     # if facter is installed, and we can use --json because
     # ruby-json is ALSO installed, include facter data in the JSON
 
-    if os.path.exists("/usr/bin/facter"):
-        rc, out, err = module.run_command("/usr/bin/facter --json")
+    facter_path = module.get_bin_path("facter")
+    if facter_path:
+        rc, out, err = module.run_command("%s --json" % facter_path)
         facter = True
         try:
             facter_ds = json.loads(out)
@@ -1656,8 +1657,9 @@ def run_setup(module):
     # because it contains a lot of nested stuff we can't use for
     # templating w/o making a nicer key for it (TODO)
 
-    if os.path.exists("/usr/bin/ohai"):
-        rc, out, err = module.run_command("/usr/bin/ohai")
+    ohai_path = module.get_bin_path("ohai")
+    if ohai_path:
+        rc, out, err = module.run_command(ohai_path)
         ohai = True
         try:
             ohai_ds = json.loads(out)


### PR DESCRIPTION
# As you pointed out

betterment of facter and ohai path. used get_bin_path function in lib/ansible/module_common.py

``` diff
--- a/library/system/setup
+++ b/library/system/setup
@@ -1641,8 +1641,9 @@ def run_setup(module):
     # if facter is installed, and we can use --json because
     # ruby-json is ALSO installed, include facter data in the JSON

-    if os.path.exists("/usr/bin/facter"):
-        rc, out, err = module.run_command("/usr/bin/facter --json")
+    facter_path = module.get_bin_path("facter")
+    if facter_path:
+        rc, out, err = module.run_command("%s --json" % facter_path)
         facter = True
         try:
             facter_ds = json.loads(out)
@@ -1656,8 +1657,9 @@ def run_setup(module):
     # because it contains a lot of nested stuff we can't use for
     # templating w/o making a nicer key for it (TODO)

-    if os.path.exists("/usr/bin/ohai"):
-        rc, out, err = module.run_command("/usr/bin/ohai")
+    ohai_path = module.get_bin_path("ohai")
+    if ohai_path:
+        rc, out, err = module.run_command(ohai_path)
         ohai = True
         try:
             ohai_ds = json.loads(out)
```
