### PR TITLE
Support JSON in --extra-vars.

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -98,7 +98,10 @@ def main(args):
         if options.sudo_user or options.ask_sudo_pass:
             options.sudo = True
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
-    extra_vars = utils.parse_kv(options.extra_vars)
+    if options.extra_vars[0] in '[{':
+        extra_vars = utils.json_loads(options.extra_vars)
+    else:
+        extra_vars = utils.parse_kv(options.extra_vars)
     only_tags = options.tags.split(",")
 
     for playbook in args:

--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -51,7 +51,8 @@ The 'DIRECTORY' to load modules from. The default is '/usr/share/ansible'.
 
 *-e* 'VARS', *--extra-vars=*'VARS'::
 
-Extra variables to inject into a playbook, in key=value key=value format.
+Extra variables to inject into a playbook, in key=value key=value format or
+as JSON (objects and arrays).
 
 *-f* 'NUM', *--forks=*'NUM'::
 


### PR DESCRIPTION
If --extra-vars starts with either a '{' or a '[', it will be assumed
we are dealing with JSON and parse the data as such.
