### PR TITLE
performance optimization in inventory.groups_list()

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -233,7 +233,8 @@ class Inventory(object):
                 groups[g.name] = [h.name for h in g.get_hosts()]
                 ancestors = g.get_ancestors()
                 for a in ancestors:
-                    groups[a.name] = [h.name for h in a.get_hosts()]
+                    if a.name not in groups:
+                        groups[a.name] = [h.name for h in a.get_hosts()]
             self._groups_list = groups
         return self._groups_list
 


### PR DESCRIPTION
don't calculate all hosts for every parent group of every group
when that parent group was already in the cache

I had a case where running ansible became dead slow, due to heavy group usage (>500), where the same parent groups get a group.get_hosts call over and over again.

This patch makes it 90% more efficient:

``` bash
$ time ansible localhost -m ping -o -c local
localhost | success >> {"changed": false, "ping": "pong"}
real    0m35.008s
user    0m34.646s
sys 0m0.160s

$ . ~/src/ansible/hacking/env-setup 
Setting up Ansible to run out of checkout...
(...)

$ time ansible localhost -m ping -o -c local
localhost | success >> {"changed": false, "ping": "pong"}
real    0m3.589s
user    0m3.380s
sys 0m0.168s
```
