### PR TITLE
Feature/document facts

### DIFF
--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -48,7 +48,8 @@ The 'PATH' to the inventory hosts file, which defaults to
 *-M* 'DIRECTORY', *--module-path=*'DIRECTORY'::
 
 The 'DIRECTORY' search path to load modules from. The default is
-'/usr/share/ansible'. See also the ANSIBLE_LIBRARY environment variable.
+'/usr/share/ansible'. This can also be set with the ANSIBLE_LIBRARY
+environment variable.
 
 *-e* 'VARS', *--extra-vars=*'VARS'::
 

--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -47,7 +47,8 @@ The 'PATH' to the inventory hosts file, which defaults to
 
 *-M* 'DIRECTORY', *--module-path=*'DIRECTORY'::
 
-The 'DIRECTORY' to load modules from. The default is '/usr/share/ansible'.
+The 'DIRECTORY' search path to load modules from. The default is
+'/usr/share/ansible'. See also the ANSIBLE_LIBRARY environment variable.
 
 *-e* 'VARS', *--extra-vars=*'VARS'::
 

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -61,7 +61,8 @@ Execute the module called 'NAME'.
 *-M* 'DIRECTORY', *--module-path=*'DIRECTORY'::
 
 The 'DIRECTORY' search path to load modules from. The default is
-'/usr/share/ansible'. See also the ANSIBLE_LIBRARY environment variable.
+'/usr/share/ansible'. This can also be set with the ANSIBLE_LIBRARY
+environment variable.
 
 *-a* \'_ARGUMENTS_', *--args=*\'_ARGUMENTS_'::
 

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -61,7 +61,7 @@ Execute the module called 'NAME'.
 *-M* 'DIRECTORY', *--module-path=*'DIRECTORY'::
 
 The 'DIRECTORY' to load modules from. The default is '/usr/share/ansible'.
-
+See also the ANSIBLE_LIBRARY environment variable.
 
 *-a* \'_ARGUMENTS_', *--args=*\'_ARGUMENTS_'::
 

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -60,8 +60,8 @@ Execute the module called 'NAME'.
 
 *-M* 'DIRECTORY', *--module-path=*'DIRECTORY'::
 
-The 'DIRECTORY' to load modules from. The default is '/usr/share/ansible'.
-See also the ANSIBLE_LIBRARY environment variable.
+The 'DIRECTORY' search path to load modules from. The default is
+'/usr/share/ansible'. See also the ANSIBLE_LIBRARY environment variable.
 
 *-a* \'_ARGUMENTS_', *--args=*\'_ARGUMENTS_'::
 

--- a/docsite/latest/rst/examples.rst
+++ b/docsite/latest/rst/examples.rst
@@ -216,9 +216,9 @@ shell commands or software upgrades only.  Backgrounding the copy module does no
 Gathering Facts
 ```````````````
 
-For each system facts are gathered. These can be used to implement conditional execution of tasks but also just to get ad-hoc information about your system. You can see all facts via:
+For each system facts are gathered. These can be used to implement conditional execution of tasks but also just to get ad-hoc information about your system. You can see all facts via::
 
- $ ansible all -m setup
+    $ ansible all -m setup
 
 Its also possible to filter via and export the facts, see the "setup" module documentation for details how to do that.
 

--- a/docsite/latest/rst/examples.rst
+++ b/docsite/latest/rst/examples.rst
@@ -213,6 +213,16 @@ the remote nodes will be terminated.
 Typically you'll be only be backgrounding long-running
 shell commands or software upgrades only.  Backgrounding the copy module does not do a background file transfer.  :doc:`playbooks` also support polling, and have a simplified syntax for this.
 
+Gathering Facts
+```````````````
+
+For each system facts are gathered. These can be used to implement conditional execution of tasks but also just to get ad-hoc information about your system. You can see all facts via:
+
+ $ ansible all -m setup
+
+Its also possible to filter via and export the facts, see the "setup" module documentation for details how to do that.
+
+
 Limiting Selected Hosts
 ```````````````````````
 

--- a/docsite/latest/rst/gettingstarted.rst
+++ b/docsite/latest/rst/gettingstarted.rst
@@ -204,7 +204,15 @@ further information on using Portfiles with MacPorts.
 Ubuntu and Debian
 +++++++++++++++++
 
-Ubuntu builds are available `in a PPA here <https://launchpad.net/~rquillo/+archive/ansible>`_
+Ubuntu builds are available `in a PPA here <https://launchpad.net/~rquillo/+archive/ansible>`_ and in 13.04 via 
+.. code-block:: bash
+
+ $ sudo apt-get install ansible/raring-backports
+
+In Debian testing/unstable and Ubntu 13.10+ it is available via
+.. code-block:: bach
+
+ $ sudo apt-get install ansible
 
 Debian/Ubuntu package recipes can also be built from the source checkout, run:
 

--- a/docsite/latest/rst/gettingstarted.rst
+++ b/docsite/latest/rst/gettingstarted.rst
@@ -210,7 +210,7 @@ Ubuntu builds are available `in a PPA here <https://launchpad.net/~rquillo/+arch
  $ sudo apt-get install ansible/raring-backports
 
 In Debian testing/unstable and Ubntu 13.10+ it is available via
-.. code-block:: bach
+.. code-block:: bash
 
  $ sudo apt-get install ansible
 

--- a/docsite/latest/rst/gettingstarted.rst
+++ b/docsite/latest/rst/gettingstarted.rst
@@ -204,15 +204,19 @@ further information on using Portfiles with MacPorts.
 Ubuntu and Debian
 +++++++++++++++++
 
-Ubuntu builds are available `in a PPA here <https://launchpad.net/~rquillo/+archive/ansible>`_ and in 13.04 via 
+Ubuntu builds are available `in a PPA here <https://launchpad.net/~rquillo/+archive/ansible>`_.
+
+In Ubuntu 13.04 (raring) its part of the backports repository:
+
 .. code-block:: bash
 
- $ sudo apt-get install ansible/raring-backports
+    $ sudo apt-get install ansible/raring-backports
 
 In Debian testing/unstable and Ubntu 13.10+ it is available via
+
 .. code-block:: bash
 
- $ sudo apt-get install ansible
+    $ sudo apt-get install ansible
 
 Debian/Ubuntu package recipes can also be built from the source checkout, run:
 


### PR DESCRIPTION
Hello,

this branch is based on https://github.com/ansible/ansible/pull/3000 and it adds the latest information about ubuntu/debian and also a small section about the "setup" module.

Please let me know if it looks suitable and feel free to reject if you feel its redundant. 

My rational is that the conditional task execution is a very powerful feature and the "setup" fact gathering includes a wealth of information that is even for ad-hoc calls useful so I felt it should be given more prominent space than just mentioning it in the FAQ only (I implemented a custom is_vmware fact module before I figured out that its already provided (but I could/should have guessed that it is!) :)

Thanks for considering!
 Michael
