### PR TITLE
Solaris facts

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -665,7 +665,7 @@ class SunOSHardware(Hardware):
             data = line.split(None, 1)
             key = data[0].strip()
             # "brand" works on Solaris 10 & 11. "implementation" for Solaris 9.
-            if key == 'module':
+            if key == 'module:':
                 brand = ''
             elif key == 'brand':
                 brand = data[1].strip()

--- a/library/system/setup
+++ b/library/system/setup
@@ -669,8 +669,13 @@ class SunOSHardware(Hardware):
                 brand = ''
             elif key == 'brand':
                 brand = data[1].strip()
+            elif key == 'clock_MHz':
+                clock_mhz = data[1].strip()
             elif key == 'implementation':
                 processor = brand or data[1].strip()
+                # Add clock speed to description for SPARC CPU
+                if self.facts['machine'] != 'i86pc':
+                    processor += " @ " + clock_mhz + "MHz"
                 if 'processor' not in self.facts:
                     self.facts['processor'] = []
                 self.facts['processor'].append(processor)

--- a/library/system/setup
+++ b/library/system/setup
@@ -655,7 +655,7 @@ class SunOSHardware(Hardware):
         return self.facts
 
     def get_cpu_facts(self):
-        rc, out, err = module.run_command("/usr/sbin/kstat cpu_info")
+        rc, out, err = module.run_command("/usr/bin/kstat cpu_info")
         self.facts['processor'] = []
         for line in out.split('\n'):
             if len(line) < 1:

--- a/library/system/setup
+++ b/library/system/setup
@@ -655,6 +655,8 @@ class SunOSHardware(Hardware):
         return self.facts
 
     def get_cpu_facts(self):
+        physid = 0
+        sockets = {}
         rc, out, err = module.run_command("/usr/bin/kstat cpu_info")
         self.facts['processor'] = []
         for line in out.split('\n'):
@@ -662,15 +664,33 @@ class SunOSHardware(Hardware):
                 continue
             data = line.split(None, 1)
             key = data[0].strip()
-            # key "brand" works on Solaris 10
-            if key == 'brand':
+            # "brand" works on Solaris 10 & 11. "implementation" for Solaris 9.
+            if key == 'module':
+                brand = ''
+            elif key == 'brand':
+                brand = data[1].strip()
+            elif key == 'implementation':
+                processor = brand or data[1].strip()
                 if 'processor' not in self.facts:
                     self.facts['processor'] = []
-                self.facts['processor'].append(data[1].strip())
-        # Counting cores on Solaris can be complicated. Leave as-is for now.
+                self.facts['processor'].append(processor)
+            elif key == 'chip_id':
+                physid = data[1].strip()
+                if physid not in sockets:
+                    sockets[physid] = 1
+                else:
+                    sockets[physid] += 1
+        # Counting cores on Solaris can be complicated.
         # https://blogs.oracle.com/mandalika/entry/solaris_show_me_the_cpu
-        self.facts['processor_cores'] = 'NA'
-        self.facts['processor_count'] = len(self.facts['processor'])
+        # Treat 'processor_count' as physical sockets and 'processor_cores' as
+        # virtual CPUs visisble to Solaris. Not a true count of cores for modern SPARC as
+        # these processors have: sockets -> cores -> threads/virtual CPU.
+        if len(sockets) > 0:
+            self.facts['processor_count'] = len(sockets)
+            self.facts['processor_cores'] = reduce(lambda x, y: x + y, sockets.values())
+        else:
+            self.facts['processor_cores'] = 'NA'
+            self.facts['processor_count'] = len(self.facts['processor'])
 
     def get_memory_facts(self):
         rc, out, err = module.run_command(["/usr/sbin/prtconf"])

--- a/library/system/setup
+++ b/library/system/setup
@@ -655,13 +655,20 @@ class SunOSHardware(Hardware):
         return self.facts
 
     def get_cpu_facts(self):
-        rc, out, err = module.run_command("/usr/sbin/psrinfo -v")
+        rc, out, err = module.run_command("/usr/sbin/kstat cpu_info")
         self.facts['processor'] = []
         for line in out.split('\n'):
-            if 'processor operates' in line:
+            if len(line) < 1:
+                continue
+            data = line.split(None, 1)
+            key = data[0].strip()
+            # key "brand" works on Solaris 10
+            if key == 'brand':
                 if 'processor' not in self.facts:
                     self.facts['processor'] = []
-                self.facts['processor'].append(line.strip())
+                self.facts['processor'].append(data[1].strip())
+        # Counting cores on Solaris can be complicated. Leave as-is for now.
+        # https://blogs.oracle.com/mandalika/entry/solaris_show_me_the_cpu
         self.facts['processor_cores'] = 'NA'
         self.facts['processor_count'] = len(self.facts['processor'])
 


### PR DESCRIPTION
Change "setup" module so that "ansible_processor" fact returns the CPU type for Solaris.
The fact now closely resembles that from a Linux system.

Example before...
`"ansible_processor": [ "The i386 processor operates at 2400 MHz," ]`
and after...
`"ansible_processor": [ "Intel(r) Core(tm) i5-3210M CPU @ 2.50GHz" ]`
