### PR TITLE
Avoid crash in module_common when the file cannot be moved/copy

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -815,7 +815,7 @@ class AnsibleModule(object):
             self.fail_json(msg='Could not make backup of %s to %s: %s' % (fn, backupdest, e))
         return backupdest
 
-    def cleanup(tmpfile):
+    def cleanup(self,tmpfile):
         if os.path.exists(tmpfile):
             try:
                 os.unlink(tmpfile)
@@ -856,7 +856,7 @@ class AnsibleModule(object):
                 # rename might not preserve context
                 self.set_context_if_different(dest, context, False)
         except (shutil.Error, OSError, IOError), e:
-            cleanup(tmp_dest)
+            self.cleanup(tmp_dest)
             self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e))
 
     def run_command(self, args, check_rc=False, close_fds=False, executable=None, data=None):


### PR DESCRIPTION
Avoid the following Crash when file cannot be moved/copied in lineinfile module.

invalid output was: Traceback (most recent call last):
  File "/home/kk/.ansible/tmp/ansible-1369793563.52-51180351954149/lineinfile", line 1218, in <module>
    main()
  File "/home/kk/.ansible/tmp/ansible-1369793563.52-51180351954149/lineinfile", line 318, in main
    ins_aft, ins_bef, create, backup, backrefs)
  File "/home/kk/.ansible/tmp/ansible-1369793563.52-51180351954149/lineinfile", line 239, in present
    write_changes(module, lines, dest)
  File "/home/kk/.ansible/tmp/ansible-1369793563.52-51180351954149/lineinfile", line 139, in write_changes
    module.atomic_move(tmpfile, dest)
  File "/home/kk/.ansible/tmp/ansible-1369793563.52-51180351954149/lineinfile", line 1147, in atomic_move
    cleanup(tmp_dest)
NameError: global name 'cleanup' is not defined
