### PR TITLE
Document: OpenStack inventory script needs grizzly

### DIFF
--- a/docsite/latest/rst/api.rst
+++ b/docsite/latest/rst/api.rst
@@ -306,7 +306,8 @@ To see the complete list of variables available for an instance, run the script 
 Example: OpenStack Inventory Script
 ```````````````````````````````````
 
-Though not detailed here in as much depth as the EC2 module, there's also a OpenStack Nova external inventory source in the plugins directory.  See the inline comments in the module source for how to use it.
+Though not detailed here in as much depth as the EC2 module, there's also a OpenStack Compute external inventory source in the plugins directory. It requires the Grizzly release of OpenStack or
+later. See the inline comments in the module source for how to use it.
 
 Callback Plugins
 ----------------


### PR DESCRIPTION
The OpenStack Inventory script uses the OS-EXT-IPS:type parameter
to distinguish between fixed and floating IP addresses.
This was only added in the Grizzly release, see
https://bugs.launchpad.net/nova/+bug/1117784

Specify in the docs that this inventory script requires Grizzly
or greater.
