### PR TITLE
Verify /proc/modules is readable (issue #2990)

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1633,7 +1633,7 @@ class LinuxVirtual(Virtual):
                 return
 
         # Beware that we can have both kvm and virtualbox running on a single system
-        if os.path.exists("/proc/modules"):
+        if os.path.exists("/proc/modules") and os.access('/proc/modules', os.R_OK):
             modules = []
             for line in open("/proc/modules").readlines():
                 data = line.split(" ", 1)


### PR DESCRIPTION
Makes sure /proc/modules is also readable before attempting to read from it.  See issue #2990.
