### PR TITLE
Optionally fail task on undefined variables

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -110,6 +110,8 @@ ANSIBLE_NOCOWS                 = get_config(p, DEFAULTS, 'nocows', 'ANSIBLE_NOCO
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
 ZEROMQ_PORT                    = int(get_config(p, 'fireball', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099))
 
+DEFAULT_UNDEFINED_VAR_BEHAVIOR = get_config(p, DEFAULTS, 'error_on_undefined_vars', 'ANSIBLE_ERROR_ON_UNDEFINED_VARS', False)
+
 # non-configurable things
 DEFAULT_SUDO_PASS         = None
 DEFAULT_REMOTE_PASS       = None

--- a/lib/ansible/errors.py
+++ b/lib/ansible/errors.py
@@ -32,3 +32,6 @@ class AnsibleConnectionFailed(AnsibleError):
 
 class AnsibleYAMLValidationFailed(AnsibleError):
     pass
+
+class AnsibleUndefinedVariable(AnsibleError):
+    pass

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -31,6 +31,7 @@ import sys
 import shlex
 import pipes
 import re
+import jinja2
 
 import ansible.constants as C
 import ansible.inventory
@@ -574,8 +575,12 @@ class Runner(object):
             tmp = self._make_tmp_path(conn)
 
         # render module_args and complex_args templates
-        module_args = template.template(self.basedir, module_args, inject)
-        complex_args = template.template(self.basedir, complex_args, inject)
+        try:
+            module_args = template.template(self.basedir, module_args, inject)
+            complex_args = template.template(self.basedir, complex_args, inject)
+        except jinja2.exceptions.UndefinedError, e:
+            raise errors.AnsibleUndefinedVariable("Undefined variables: %s" % str(e))
+
 
         result = handler.run(conn, tmp, module_name, module_args, inject, complex_args)
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -30,7 +30,6 @@ import base64
 import sys
 import shlex
 import pipes
-import re
 import jinja2
 
 import ansible.constants as C
@@ -576,8 +575,8 @@ class Runner(object):
 
         # render module_args and complex_args templates
         try:
-            module_args = template.template(self.basedir, module_args, inject)
-            complex_args = template.template(self.basedir, complex_args, inject)
+            module_args = template.template(self.basedir, module_args, inject, fail_on_undefined=self.error_on_undefined_vars)
+            complex_args = template.template(self.basedir, complex_args, inject, fail_on_undefined=self.error_on_undefined_vars)
         except jinja2.exceptions.UndefinedError, e:
             raise errors.AnsibleUndefinedVariable("Undefined variables: %s" % str(e))
 
@@ -694,16 +693,8 @@ class Runner(object):
 
     # *****************************************************
 
-    def _contains_undefined_vars(self, module_args):
-        ''' return true if there are undefined variables '''
-        return '{{' in module_args
-
     def _copy_module(self, conn, tmp, module_name, module_args, inject, complex_args=None):
         ''' transfer a module over SFTP, does not run it '''
-        if self.error_on_undefined_vars and self._contains_undefined_vars(module_args):
-            vars = re.findall(r'{{(.*?)}}', module_args)
-            raise errors.AnsibleUndefinedVariable("Undefined variables: %s" %
-                ', '.join(vars))
 
         # FIXME if complex args is none, set to {}
 

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -295,7 +295,7 @@ def legacy_varReplace(basedir, raw, vars, lookup_fatal=True, depth=0, expand_lis
 
 # TODO: varname is misnamed here
 
-def template(basedir, varname, vars, lookup_fatal=True, depth=0, expand_lists=True, convert_bare=False):
+def template(basedir, varname, vars, lookup_fatal=True, depth=0, expand_lists=True, convert_bare=False, fail_on_undefined=False):
     ''' templates a data structure by traversing it and substituting for other data structures '''
 
     if convert_bare and isinstance(varname, basestring):
@@ -305,7 +305,7 @@ def template(basedir, varname, vars, lookup_fatal=True, depth=0, expand_lists=Tr
 
     if isinstance(varname, basestring):
         if '{{' in varname or '{%' in varname:
-            varname = template_from_string(basedir, varname, vars)
+            varname = template_from_string(basedir, varname, vars, fail_on_undefined)
         if not '$' in varname:
             return varname
 
@@ -461,7 +461,7 @@ def template_from_file(basedir, path, vars):
         res = res + '\n'
     return template(basedir, res, vars)
 
-def template_from_string(basedir, data, vars):
+def template_from_string(basedir, data, vars, fail_on_undefined=False):
     ''' run a string through the (Jinja2) templating engine '''
 
     try:
@@ -496,7 +496,9 @@ def template_from_string(basedir, data, vars):
         res = jinja2.utils.concat(t.root_render_func(t.new_context(_jinja2_vars(basedir, vars, t.globals), shared=True)))
         return res
     except jinja2.exceptions.UndefinedError:
-        raise
+        if fail_on_undefined:
+            raise
+        else:
         # this shouldn't happen due to undeclared check above
-        # return data
+            return data
 

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -34,7 +34,7 @@ class Globals(object):
     FILTERS = None
 
     def __init__(self):
-        pass    
+        pass
 
 def _get_filters():
     ''' return filter plugin instances '''
@@ -48,7 +48,7 @@ def _get_filters():
     for fp in plugins:
         filters.update(fp.filters())
     Globals.FILTERS = filters
- 
+
     return Globals.FILTERS
 
 def _get_extensions():
@@ -90,7 +90,7 @@ def lookup(name, *args, **kwargs):
 
 def _legacy_varFindLimitSpace(basedir, vars, space, part, lookup_fatal, depth, expand_lists):
     ''' limits the search space of space to part
-    
+
     basically does space.get(part, None), but with
     templating for part and a few more things
     '''
@@ -341,7 +341,7 @@ class _jinja2_vars(object):
     is avoiding duplicating the large hashes that inject tends to be.
     To facilitate using builtin jinja2 things like range, globals are handled
     here.
-    extras is a list of locals to also search for variables. 
+    extras is a list of locals to also search for variables.
     '''
 
     def __init__(self, basedir, vars, globals, *extras):
@@ -417,7 +417,7 @@ def template_from_file(basedir, path, vars):
     except:
         raise errors.AnsibleError("unable to read %s" % realpath)
 
-   
+
 # Get jinja env overrides from template
     if data.startswith(JINJA2_OVERRIDE):
         eol = data.find('\n')
@@ -463,7 +463,7 @@ def template_from_file(basedir, path, vars):
 
 def template_from_string(basedir, data, vars):
     ''' run a string through the (Jinja2) templating engine '''
-    
+
     try:
         if type(data) == str:
             data = unicode(data, 'utf-8')
@@ -487,15 +487,16 @@ def template_from_string(basedir, data, vars):
                 raise errors.AnsibleError("recursive loop detected in template string: %s" % data)
             else:
                 return data
-         
+
         def my_lookup(*args, **kwargs):
             return lookup(*args, basedir=basedir, **kwargs)
- 
+
         t.globals['lookup'] = my_lookup
- 
+
         res = jinja2.utils.concat(t.root_render_func(t.new_context(_jinja2_vars(basedir, vars, t.globals), shared=True)))
         return res
     except jinja2.exceptions.UndefinedError:
+        raise
         # this shouldn't happen due to undeclared check above
-        return data
+        # return data
 


### PR DESCRIPTION
This patch introduces a new configuration option called `error_on_undefined_vars`, which defaults to false.

If this option is set to true, then a task which has unevaluated variables in its arguments will fail instead of running. Output looks like this:

```
TASK: [set rabbitmq password] *************************************************
fatal: [10.20.0.7] => Undefined variables: rabbitmq_user, rabbitmq_password
```
