### PR TITLE
Remove inline comments from inventory tokenizing.

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -65,7 +65,7 @@ class InventoryParser(object):
 
         for line in self.lines:
             if line.startswith("["):
-                active_group_name = line.replace("[","").replace("]","").strip()
+                active_group_name = line.split("#")[0].replace("[","").replace("]","").strip()
                 if line.find(":vars") != -1 or line.find(":children") != -1:
                     active_group_name = active_group_name.rsplit(":", 1)[0]
                     if active_group_name not in self.groups:
@@ -78,7 +78,7 @@ class InventoryParser(object):
             elif line.startswith("#") or line == '':
                 pass
             elif active_group_name:
-                tokens = shlex.split(line)
+                tokens = shlex.split(line.split("#")[0])
                 if len(tokens) == 0:
                     continue
                 hostname = tokens[0]

--- a/test/inventory_dir/3comments
+++ b/test/inventory_dir/3comments
@@ -1,0 +1,8 @@
+[major-god] # group with inline comments
+zeus var_a=1 # host with inline comments
+# A comment
+thor
+
+[minor-god] # group with inline comment and unbalanced quotes: ' "
+morpheus # host with inline comments and unbalanced quotes: ' "
+# A comment with unbalanced quotes: ' "


### PR DESCRIPTION
This removes inline comments from the line prior to tokenizing.  It assumes that comments will always be line suffixes (the last part of a line).  

Test included.
