### PR TITLE
authorized_key: Set manage_dir default value

### DIFF
--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -59,7 +59,7 @@ options:
     required: false
     choices: [ "present", "absent" ]
     default: "present"
-description: 
+description:
     - "adds or removes authorized keys for particular user accounts"
 author: Brad Olson
 '''
@@ -215,7 +215,7 @@ def main():
            user       = dict(required=True, type='str'),
            key        = dict(required=True, type='str'),
            path       = dict(required=False, type='str'),
-           manage_dir = dict(required=False, type='bool'),
+           manage_dir = dict(required=False, type='bool', default=True),
            state      = dict(default='present', choices=['absent','present'])
         )
     )


### PR DESCRIPTION
This commit fixes a bug where the authorized_key module causes
the ~user/.ssh directory to be owned by root instead of the user,
when the manage_dir argument is not specified.

If the manage_dir argument was not specified, the module behaved as if
manage_dir was set to false, even though it's supposed to default to
true.

This module assumed that an optional argument, with no default
specified, will not be present in the module.params dictionary.

What actually seems to happen is that the argument does appear in
the module.params dictionary with a value of None.

The upside is that this line was evaluating to None instead of
true:

```
manage_dir = params.get("manage_dir", True)
```

I fixed the problem in this particular module by explicitly specifying
the default value for the manage_dir arugment. But if this bug
occurred because of a change in behavior in AnsibleModule, then other
modules may be broken as well.
