### PR TITLE
cleanup to dmi fact discovery

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -29,12 +29,7 @@ import socket
 import struct
 import datetime
 import getpass
-
-if not os.path.exists('/sys/devices/virtual/dmi/id/product_name'):
-    try:
-        import dmidecode
-    except ImportError:
-        import subprocess
+import subprocess
 
 DOCUMENTATION = '''
 ---
@@ -463,13 +458,10 @@ class LinuxHardware(Hardware):
             self.facts['processor_cores'] = 'NA'
 
     def get_dmi_facts(self):
+        ''' learn dmi facts from system
 
-        def execute(cmd):
-            p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (out, err) = p.communicate()
-            if p.returncode or err:
-                return None
-            return out.rstrip()
+        Try /sys first for dmi related facts.
+        If that is not available, fall back to dmidecode executable '''
 
         if os.path.exists('/sys/devices/virtual/dmi/id/product_name'):
             # Use kernel DMI info, if available
@@ -484,16 +476,16 @@ class LinuxHardware(Hardware):
                             "Rack Mount Chassis", "Sealed-case PC", "Multi-system",
                             "CompactPCI", "AdvancedTCA", "Blade" ]
 
-            DMI_DICT = dict(
-                bios_date       = '/sys/devices/virtual/dmi/id/bios_date',
-                bios_version    = '/sys/devices/virtual/dmi/id/bios_version',
-                form_factor     = '/sys/devices/virtual/dmi/id/chassis_type',
-                product_name    = '/sys/devices/virtual/dmi/id/product_name',
-                product_serial  = '/sys/devices/virtual/dmi/id/product_serial',
-                product_uuid    = '/sys/devices/virtual/dmi/id/product_uuid',
-                product_version = '/sys/devices/virtual/dmi/id/product_version',
-                system_vendor   = '/sys/devices/virtual/dmi/id/sys_vendor',
-            )
+            DMI_DICT = {
+                    'bios_date': '/sys/devices/virtual/dmi/id/bios_date',
+                    'bios_version': '/sys/devices/virtual/dmi/id/bios_version',
+                    'form_factor': '/sys/devices/virtual/dmi/id/chassis_type',
+                    'product_name': '/sys/devices/virtual/dmi/id/product_name',
+                    'product_serial': '/sys/devices/virtual/dmi/id/product_serial',
+                    'product_uuid': '/sys/devices/virtual/dmi/id/product_uuid',
+                    'product_version': '/sys/devices/virtual/dmi/id/product_version',
+                    'system_vendor': '/sys/devices/virtual/dmi/id/sys_vendor'
+                    }
 
             for (key,path) in DMI_DICT.items():
                 data = get_file_content(path)
@@ -508,46 +500,28 @@ class LinuxHardware(Hardware):
                 else:
                     self.facts[key] = 'NA'
 
-        elif 'dmidecode' in sys.modules.keys():
-            # Use python dmidecode, if available
-
-            DMI_DICT = dict(
-                bios_date       = '/dmidecode/BIOSinfo/ReleaseDate',
-                bios_version    = '/dmidecode/BIOSinfo/BIOSrevision',
-                form_factor     = '/dmidecode/ChassisInfo/ChassisType',
-                product_name    = '/dmidecode/SystemInfo/ProductName',
-                product_serial  = '/dmidecode/SystemInfo/SerialNumber',
-                product_uuid    = '/dmidecode/SystemInfo/SystemUUID',
-                product_version = '/dmidecode/SystemInfo/Version',
-                system_vendor   = '/dmidecode/SystemInfo/Manufacturer',
-            )
-
-            dmixml = dmidecode.dmidecodeXML()
-            dmixml.SetResultType(dmidecode.DMIXML_DOC)
-            xmldoc = dmixml.QuerySection('all')
-            dmixp = xmldoc.xpathNewContext()
-
-            for (key,path) in DMI_DICT.items():
-                try:
-                    data = dmixp.xpathEval(path)
-                    if len(data) > 0:
-                        self.facts[key] = data[0].get_content()
-                    else:
-                        self.facts[key] = 'Error'
-                except:
-                    self.facts[key] = 'NA'
-
         else:
             # Fall back to using dmidecode, if available
-
-            self.facts['bios_date'] = execute('dmidecode -s bios-release-date') or 'NA'
-            self.facts['bios_version'] = execute('dmidecode -s bios-version') or 'NA'
-            self.facts['form_factor'] = execute('dmidecode -s chassis-type') or 'NA'
-            self.facts['product_name'] = execute('dmidecode -s system-product-name') or 'NA'
-            self.facts['product_serial'] = execute('dmidecode -s system-serial-number') or 'NA'
-            self.facts['product_uuid'] = execute('dmidecode -s system-uuid') or 'NA'
-            self.facts['product_version'] = execute('dmidecode -s system-version') or 'NA'
-            self.facts['system_vendor'] = execute('dmidecode -s system-manufacturer') or 'NA'
+            dmi_bin = module.get_bin_path('dmidecode')
+            DMI_DICT = {
+                    'bios_date': 'bios-release-date',
+                    'bios_version': 'bios-version',
+                    'form_factor': 'chassis-type',
+                    'product_name': 'system-product-name',
+                    'product_serial': 'system-serial-number',
+                    'product_uuid': 'system-uuid',
+                    'product_version': 'system-version',
+                    'system_vendor': 'system-manufacturer'
+                    }
+            for (k, v) in DMI_DICT.items():
+                if dmi_bin is not None:
+                    (rc, out, err) = module.run_command('%s -s %s' % (dmi_bin, v))
+                    if rc == 0:
+                        self.facts[k] = out.rstrip()
+                    else:
+                        self.facts[k] = 'NA'
+                else:
+                    self.facts[k] = 'NA'
 
     def get_mount_facts(self):
         self.facts['mounts'] = []


### PR DESCRIPTION
When invoking dmidecode, first use module.get_bin_path() and secondly
use module.run_command.
Remove sub function execute() from get_dmi_facts().
Simplify get_dmi_facts() by only using two mechanisms to determine dmi
facts:  first try /sys/devices/virtual/dmi and if not available, use
dmidecode executable.

See issue #3061
