### PR TITLE
Provide userspace_{architecture,bits} facts

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -149,10 +149,20 @@ class Facts(object):
         self.facts['fqdn'] = socket.getfqdn()
         self.facts['hostname'] = platform.node().split('.')[0]
         self.facts['domain'] = '.'.join(self.facts['fqdn'].split('.')[1:])
+        arch_bits = platform.architecture()[0]
+        self.facts['userspace_bits'] = arch_bits.replace('bit', '')
         if self.facts['machine'] == 'x86_64':
             self.facts['architecture'] = self.facts['machine']
+            if self.facts['userspace_bits'] == '64':
+                self.facts['userspace_architecture'] = 'x86_64'
+            elif self.facts['userspace_bits'] == '32':
+                self.facts['userspace_architecture'] = 'i386'
         elif Facts._I386RE.search(self.facts['machine']):
             self.facts['architecture'] = 'i386'
+            if self.facts['userspace_bits'] == '64':
+                self.facts['userspace_architecture'] = 'x86_64'
+            elif self.facts['userspace_bits'] == '32':
+                self.facts['userspace_architecture'] = 'i386'
         else:
             self.facts['architecture'] = self.facts['machine']
         if self.facts['system'] == 'Linux':


### PR DESCRIPTION
When running inside a chroot userspace architecture might not
match that of the actual host.

This patch provides userspace_bits as reported by python's
platform.architecture(). Also provides userspace_architecture fact
if host is an x86 machine.
