### PR TITLE
Issue #3079: Initializing key_exists in case the S3 bucket does not exis...

### DIFF
--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -173,7 +173,8 @@ def main():
     else:
         key_name = dest
 
-    # Check to see if the key already exists 
+    # Check to see if the key already exists
+    key_exists = False
     if bucket_exists is True:
         try:
             key_check = bucket.get_key(key_name)


### PR DESCRIPTION
I think this should fix the problem. If the bucket doesn't exists then obviously the key doesn't exist as well. So it is safe to initialize it to False.
