### PR TITLE
Handle '#' in var strings by splitting on ' #'

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -65,7 +65,7 @@ class InventoryParser(object):
 
         for line in self.lines:
             if line.startswith("["):
-                active_group_name = line.split("#")[0].replace("[","").replace("]","").strip()
+                active_group_name = line.split(" #")[0].replace("[","").replace("]","").strip()
                 if line.find(":vars") != -1 or line.find(":children") != -1:
                     active_group_name = active_group_name.rsplit(":", 1)[0]
                     if active_group_name not in self.groups:
@@ -78,7 +78,7 @@ class InventoryParser(object):
             elif line.startswith("#") or line == '':
                 pass
             elif active_group_name:
-                tokens = shlex.split(line.split("#")[0])
+                tokens = shlex.split(line.split(" #")[0])
                 if len(tokens) == 0:
                     continue
                 hostname = tokens[0]

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -302,4 +302,4 @@ class TestInventory(unittest.TestCase):
         assert vars == {'inventory_hostname': 'zeus',
                         'inventory_hostname_short': 'zeus',
                         'group_names': ['greek', 'major-god', 'ungrouped'],
-                        'var_a': '1'}
+                        'var_a': '1#2'}

--- a/test/inventory_dir/3comments
+++ b/test/inventory_dir/3comments
@@ -1,5 +1,5 @@
 [major-god] # group with inline comments
-zeus var_a=1 # host with inline comments
+zeus var_a="1#2" # host with inline comments and "#" in the var string
 # A comment
 thor
 


### PR DESCRIPTION
If someone has a " #" in a quoted var string, it
will interpret that as a comment and refuse to
load the inventory file due to an unbalanced
quote. Noisy failure > unexpected behavior.
