### PR TITLE
add "size_{total,free}" to the "mount" facts

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -561,9 +561,9 @@ class LinuxHardware(Hardware):
                      'device':fields[0],
                      'fstype': fields[2],
                      'options': fields[3],
-                     # statvfs
+                     # statvfs data
                      'size_total': statvfs_result.f_bsize * statvfs_result.f_blocks,
-                     'size_free': statvfs_result.f_bsize * statvfs_result.f_bfree,
+                     'size_available': statvfs_result.f_bsize * (statvfs_result.f_bavail),
                      })
 
     def get_device_facts(self):

--- a/library/system/setup
+++ b/library/system/setup
@@ -555,7 +555,16 @@ class LinuxHardware(Hardware):
         for line in mtab.split('\n'):
             if line.startswith('/'):
                 fields = line.rstrip('\n').split()
-                self.facts['mounts'].append({'mount': fields[1], 'device':fields[0], 'fstype': fields[2], 'options': fields[3]})
+                statvfs_result = os.statvfs(fields[1])
+                self.facts['mounts'].append(
+                    {'mount': fields[1],
+                     'device':fields[0],
+                     'fstype': fields[2],
+                     'options': fields[3],
+                     # statvfs
+                     'size_total': statvfs_result.f_bsize * statvfs_result.f_blocks,
+                     'size_free': statvfs_result.f_bsize * statvfs_result.f_bfree,
+                     })
 
     def get_device_facts(self):
         self.facts['devices'] = {}


### PR DESCRIPTION
This tiny branch adds size_{total,free} to the "ansible_mounts" facts via os.statvfs().

I was looking into writing a ansible helper that will warn about hosts with a full /boot partition and noticed that it seems to be not part of the standard facts gathering. Writing a custom facts modul is trivial of course but I wondered if the size information is useful for more people so I pushed this branch. If you feel it does not fit well into the standard facts gathering that is fine of course and I will just write my custom module :)

The new output looks something like this:
        "ansible_mounts": [
            {
                "device": "/dev/sda1", 
                "fstype": "ext4", 
                "mount": "/", 
                "options": "rw,errors=remount-ro", 
                "size_available": 75809128448, 
                "size_total": 241773051904
            }
