### PR TITLE
Keep ansible-playbook from bombing without extra-vars

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -98,7 +98,7 @@ def main(args):
         if options.sudo_user or options.ask_sudo_pass:
             options.sudo = True
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
-    if options.extra_vars[0] in '[{':
+    if options.extra_vars and options.extra_vars[0] in '[{':
         extra_vars = utils.json_loads(options.extra_vars)
     else:
         extra_vars = utils.parse_kv(options.extra_vars)


### PR DESCRIPTION
A recent change to ansible-playbook to support json extra-vars
also inadvertently broke the script when no extra-vars are
provided. Simply checking to make sure it is defined and truthy
should take care of the issue.

This appears to fix issues #3086 and #3088.
