### PR TITLE
with_inventory_hostnames inventory based lookup plugin

### DIFF
--- a/lib/ansible/runner/lookup_plugins/inventory_hostnames.py
+++ b/lib/ansible/runner/lookup_plugins/inventory_hostnames.py
@@ -34,12 +34,12 @@ class LookupModule(object):
 
     def __init__(self, basedir=None, **kwargs):
         self.basedir = basedir
+        self.host_list = kwargs['runner'].inventory.host_list
 
     def run(self, terms, inject=None, **kwargs):
         terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
 
         if not isinstance(terms, list):
             raise errors.AnsibleError("with_inventory_hostnames expects a list")
-
-        return flatten(inventory.Inventory().list_hosts(terms))
+        return flatten(inventory.Inventory(self.host_list).list_hosts(terms))
 

--- a/lib/ansible/runner/lookup_plugins/inventory_hostnames.py
+++ b/lib/ansible/runner/lookup_plugins/inventory_hostnames.py
@@ -1,0 +1,45 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2013, Steven Dossett <sdossett@panath.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.utils import safe_eval
+import ansible.utils as utils
+import ansible.errors as errors
+import ansible.inventory as inventory
+
+def flatten(terms):
+    ret = []
+    for term in terms:
+        if isinstance(term, list):
+            ret.extend(term)
+        else:
+            ret.append(term)
+    return ret
+
+class LookupModule(object):
+
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
+
+    def run(self, terms, inject=None, **kwargs):
+        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
+
+        if not isinstance(terms, list):
+            raise errors.AnsibleError("with_inventory_hostnames expects a list")
+
+        return flatten(inventory.Inventory().list_hosts(terms))
+


### PR DESCRIPTION
Nearly identical to 'with_items' except that inventory.Inventory().list_hosts(terms) is used such that list items can be arbitrarily generated from the full inventory, groups, or other subsets of inventory contents.
