### PR TITLE
Default mode for template files.

### DIFF
--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -45,6 +45,9 @@ class ActionModule(object):
 
         source   = options.get('src', None)
         dest     = options.get('dest', None)
+        # default mode is 0644
+        if options.get('mode', None) == None:
+            module_args = "%s mode=0644" % module_args
 
         if (source is None and 'first_available_file' not in inject) or dest is None:
             result = dict(failed=True, msg="src and dest are required")

--- a/library/files/template
+++ b/library/files/template
@@ -16,6 +16,7 @@ description:
        the template's machine, C(template_uid) the owner, C(template_path) the
        relative path of the template, C(template_fullpath) is the absolute path of the 
        template, and C(template_run_date) is the date that the template was rendered."
+     - The file permission is set to 0644 when the C(mode) option is not specified.
 options:
   src:
     description:


### PR DESCRIPTION
The default mode for the template files is 0644.

The template module lacks a default mode for the file, that is undefined and may be different depending on the environment. E.g., when the file must be created, and a ssh connection is used, the mode of the destination file is set to 0600, when paramiko is used it is set to 0644.

This is due to the fact that the _transfer_str() method creates the file through the mkstemp() method (from mkstemp doc: "The file is readable and writable only by the creating user ID") and the ssh copy conserves the mode of the file, while, evidently, paramiko uses the umask of the target machine.

NOTE. This patch could break a configuration where the 'mode' option was used (with a value different from 0644) and now it is no longer used. In this case the file mode is set to 0644 insted of being conserved to the current value.

[Test results: test_large_output fails in the parent commit too]
