### PR TITLE
optimization when adding child groups

### DIFF
--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -35,9 +35,12 @@ class Group(object):
 
         if self == group:
             raise Exception("can't add group to itself")
-        self.child_groups.append(group)
-        group.depth = max([self.depth+1, group.depth])
-        group.parent_groups.append(self)
+
+        # don't add if it's already there
+        if not group in self.child_groups:
+            self.child_groups.append(group)
+            group.depth = max([self.depth+1, group.depth])
+            group.parent_groups.append(self)
 
     def add_host(self, host):
 


### PR DESCRIPTION
the depth patch from yesterday solves part of my problem, which is ok, but also introduced the creation of several groups with the same name (yes, i have some groups spawn over different ini files, but that also happens with the 'all' group)

at a certain point when running a playbook this heavily slows down the run, probably because the code looks at too many groups to resolve variables)

either without my use case, this patch does some optimization as to not add a child group when it's already defined.
