### PR TITLE
Replacement of built-in apt_repository.

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -1,148 +1,381 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
+# encoding: utf-8
 
-# (c) 2012, Matt Wright <matt@nobien.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
-# Example:
-# - name: add nginx repo
-#   action: apt_repository repo=ppa:nginx/stable state=present
-#
+# (c) 2013 Alexander Saltanov <asd@mokote.com>
+
+# APT Repository Module
+# - plain python
+# - dead simple API
+# - clean and minimal dependency tree
+# - source addition feature/bug free
+# - support for Debian Squeeze
 
 DOCUMENTATION = '''
 ---
 module: apt_repository
-short_description: Manages apt repositores
+short_description: Add and remove APT repositores
 description:
-  - Manages apt repositories (such as for Debian/Ubuntu).
-version_added: "0.7"
-options:
-  repo:
-    description:
-      - The repository name/value
-    required: true
-    default: null
-  state:
-    description:
-      - The repository state
-    required: false
-    default: present
-    choices: [ "present", "absent" ]
+    - Add or remove an APT repositories in Ubuntu and Debian
 notes:
-   - This module works on Debian and Ubuntu only and requires C(apt-add-repository) be available on the destination server. To ensure this package is available use the M(apt) module and install the C(python-software-properties) package before using this module.
-   - This module cannot be used on Debian Squeeze (Version 6) as there is no C(add-apt-repository) in C(python-software-properties)
-   - A bug in C(apt-add-repository) always adds C(deb) and C(deb-src) types for repositories (see the issue on Launchpad U(https://bugs.launchpad.net/ubuntu/+source/software-properties/+bug/987264)), if a repo doesn't have source information (eg MongoDB repo from 10gen) the system will fail while updating repositories.
-author: Matt Wright
+    - This module works on Debian and Ubuntu and requires only C(python-apt) package.
+    - This module supports Debian Squeeze (version 6) as well as its successors.
+    - This module treats Debian and Ubuntu distributions separately. So PPA could be installed only on Ubuntu machines.
+options:
+    repo:
+        required: true
+        default: none
+        description:
+            - A source string for the repository.
+    state:
+        required: false
+        choices: [ absent, present ]
+        default: present
+        description:
+            - A source string state.
 examples:
-- code: "apt_repository: repo=ppa:nginx/stable"
-  description: Add nginx stable repository from PPA
-- code: "apt_repository: repo='deb http://archive.canonical.com/ubuntu hardy partner'"
-  description: Add specified repository into sources.
-requirements: [ python-apt ]
+    - code: "apt_repository: repo='deb http://archive.canonical.com/ubuntu hardy partner' state=present"
+      description: Add specified repository into sources list.
+    - code: "apt_repository: repo='deb http://archive.canonical.com/ubuntu hardy partner' state=absent"
+      description: Remove specified repository from sources list.
+    - code: "apt_repository: repo='ppa:nginx/stable'"
+      description: On Ubuntu target: add nginx stable repository from PPA and install its signing key. On Debian target if will fail.
+author: Alexander Saltanov
+version_added: "1.0"
 '''
 
-import platform
+import errno
+import glob
+import json
+import os
+import re
+import tempfile
+import urllib2
 
 try:
-    import apt
     import apt_pkg
-    HAVE_PYAPT = True
+    import aptsources.distro
+    distro = aptsources.distro.get_distro()
+    HAVE_PYTHON_APT = True
 except ImportError:
-    HAVE_PYAPT = False
+    HAVE_PYTHON_APT = False
 
-APT = "/usr/bin/apt-get"
-ADD_APT_REPO = 'add-apt-repository'
 
-def check_cmd_needs_y():
-    if platform.dist()[0] == 'debian' or float(platform.dist()[1]) >= 11.10:
-        return True
-    return False
+VALID_SOURCE_TYPES = ('deb', 'deb-src')
 
-def repo_exists(module, repo):
-    configured = False
-    slist = apt_pkg.SourceList()
-    if not slist.read_main_list():
-        module.fail_json(msg="Failed to parse sources.list")
-    for metaindex in slist.list:
-        if repo in metaindex.uri:
-            configured = True
-    return configured
+
+###############################################################################
+# AtomicFile had been copied from
+# https://github.com/sashka/atomicfile/blob/master/atomicfile.py
+umask = os.umask(0)
+os.umask(umask)
+
+
+def copymode(src, dst, mode=None):
+    try:
+        st_mode = os.lstat(src).st_mode & 0o777
+    except OSError as inst:
+        if inst.errno != errno.ENOENT:
+            raise
+        st_mode = mode
+        if st_mode is None:
+            st_mode = ~umask
+        st_mode &= 0o666
+    os.chmod(dst, st_mode)
+
+
+def mktemp(name, createmode=None):
+    d, fn = os.path.split(name)
+    fd, temp = tempfile.mkstemp(prefix='.%s-' % fn, dir=d)
+    os.close(fd)
+
+    copymode(name, temp, createmode)
+    return temp
+
+
+class AtomicFile(object):
+    def __init__(self, name, mode='w+b', createmode=None):
+        self.__name = name
+        self._tempname = mktemp(name, createmode=createmode)
+        self._fp = open(self._tempname, mode)
+
+        self.write = self._fp.write
+        self.fileno = self._fp.fileno
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if exc_type:
+            return
+        self.close()
+
+    def close(self):
+        if not self._fp.closed:
+            self._fp.close()
+            os.rename(self._tempname, self.__name)
+
+    def discard(self):
+        if not self._fp.closed:
+            try:
+                os.unlink(self._tempname)
+            except OSError:
+                pass
+            self._fp.close()
+
+    def __del__(self):
+        if getattr(self, '_fp', None):
+            self.discard()
+
+# End of AtomicFile
+###############################################################################
+
+
+class InvalidSource(Exception):
+    pass
+
+
+# Simple version of aptsources.sourceslist.SourcesList.
+# No advanced logic and no backups inside.
+class SourcesList(object):
+    def __init__(self):
+        self.files = {}  # group sources by file
+        self.default_file = apt_pkg.config.find_file('Dir::Etc::sourcelist')
+
+        # read sources.list
+        self.load(self.default_file)
+
+        # read sources.list.d
+        for file in glob.iglob('%s/*.list' % apt_pkg.config.find_dir('Dir::Etc::sourceparts')):
+            self.load(file)
+
+    def __iter__(self):
+        '''Simple iterator to go over all sources. Empty, non-source, and other not valid lines will be skipped.'''
+        for file, sources in self.files.items():
+            for n, valid, enabled, source, comment in sources:
+                if valid:
+                    yield file, n, enabled, source, comment
+        raise StopIteration
+
+    def _expand_path(self, filename):
+        if '/' in filename:
+            return filename
+        else:
+            return os.path.abspath(os.path.join(apt_pkg.config.find_dir('Dir::Etc::sourceparts'), filename))
+
+    def _suggest_filename(self, line):
+        # It is written it with list comprehensions only to keep it compact, because it is not business critical.
+        remove_protocol = lambda x: x.split('://')[1] if '://' in x else x
+        parts = [remove_protocol(part) for part in line.split() if part not in VALID_SOURCE_TYPES]
+        cleanup = lambda x: '_'.join(re.sub('[^a-zA-Z0-9]', ' ', x).split())
+        return '%s.list' % cleanup(' '.join(parts[:1]))
+
+    def _parse(self, line, raise_if_invalid_or_disabled=False):
+        valid = False
+        enabled = True
+        source = ''
+        comment = ''
+
+        line = line.strip()
+        if line.startswith('#'):
+            enabled = False
+            line = line[1:]
+
+        # Check for another "#" in the line and treat a part after it as a comment.
+        i = line.find('#')
+        if i > 0:
+            comment = line[i+1:].strip()
+            line = line[:i]
+
+        # split a source into substring to meake sure that it is source spec.
+        # useful side effect: duplicated spaces in a valid source spec will be removed.
+        source = line.strip()
+        if source:
+            chunks = source.split()
+            if chunks[0] in VALID_SOURCE_TYPES:
+                valid = True
+                source = ' '.join(chunks)
+
+        # I want to avoid the same check on every operation against user-provided source.
+        # That's why it is here.
+        if raise_if_invalid_or_disabled and (not valid or not enabled):
+            raise InvalidSource(line)
+
+        return valid, enabled, source, comment
+
+    def load(self, file):
+        group = []
+        with open(file, 'r') as f:
+            for n, line in enumerate(f):
+                valid, enabled, source, comment = self._parse(line)
+                group.append((n, valid, enabled, source, comment))
+        self.files[file] = group
+
+    def save(self):
+        for filename, sources in self.files.items():
+            if sources:
+                with AtomicFile(filename, 'w') as f:
+                    for n, valid, enabled, source, comment in sources:
+                        chunks = []
+                        if not enabled:
+                            chunks.append('# ')
+                        chunks.append(source)
+                        if comment:
+                            chunks.append(' # ')
+                            chunks.append(comment)
+                        chunks.append('\n')
+                        line = ''.join(chunks)
+                        f.write(line)
+            else:
+                del self.files[filename]
+                if os.path.exists(filename):
+                    os.remove(filename)
+
+    def dump(self):
+        return '\n'.join([str(i) for i in self])
+
+    def modify(self, file, n, enabled=None, source=None, comment=None):
+        '''
+        This function to be used with iterator, so wo don't care of invalid sources.
+        If source, enabled, or comment is None, original value from line ``n`` will be preserved.
+        '''
+        valid, enabled_old, source_old, comment_old = self.files[file][n][1:]
+        choice = lambda new, old: old if new is None else new
+        self.files[file][n] = (n, valid, choice(enabled, enabled_old), choice(source, source_old), choice(comment, comment_old))
+
+    def _add_valid_source(self, source_new, comment_new, file):
+        # We'll try to reuse disabled source if we have it.
+        # If we have more than one entry, we will enable them all - no advanced logic, remember.
+        found = False
+        for filename, n, enabled, source, comment in self:
+            if source == source_new:
+                self.modify(filename, n, enabled=True)
+                found = True
+
+        if not found:
+            if file is None:
+                file = self.default_file
+            else:
+                file = self._expand_path(file)
+
+            if file not in self.files:
+                self.files[file] = []
+
+            files = self.files[file]
+            files.append((len(files), True, True, source_new, comment_new))
+
+    def add_source(self, line, comment='', file=None):
+        source = self._parse(line, raise_if_invalid_or_disabled=True)[2]
+
+        # Prefer separate files for new sources.
+        self._add_valid_source(source, comment, file=file or self._suggest_filename(source))
+
+    def _remove_valid_source(self, source):
+        # If we have more than one entry, we will remove them all (not comment, remove!)
+        for filename, n, enabled, src, comment in self:
+            if source == src and enabled:
+                self.files[filename].pop(n)
+
+    def remove_source(self, line):
+        source = self._parse(line, raise_if_invalid_or_disabled=True)[2]
+        self._remove_valid_source(source)
+
+
+class UbuntuSourcesList(SourcesList):
+    def __init__(self, add_ppa_signing_keys_callback=None):
+        self.add_ppa_signing_keys_callback = add_ppa_signing_keys_callback
+        super(UbuntuSourcesList, self).__init__()
+
+    def _get_ppa_info(self, owner_name, ppa_name):
+        lp_api = 'https://launchpad.net/api/1.0/~%s/+archive/%s' % (owner_name, ppa_name)
+
+        # I'd rather use ``requests`` here, but I have to stick to standard library.
+        connection = urllib2.urlopen(lp_api, timeout=30)
+        return json.loads(connection.read())
+
+    def _expand_ppa(self, path):
+        ppa = path.split(':')[1]
+        ppa_owner = ppa.split('/')[0]
+        try:
+            ppa_name = ppa.split('/')[1]
+        except IndexError:
+            ppa_name = 'ppa'
+
+        line = 'deb http://ppa.launchpad.net/%s/%s/ubuntu %s main' % (ppa_owner, ppa_name, distro.codename)
+        return line, ppa_owner, ppa_name
+
+    def add_source(self, line, comment='', file=None):
+        if line.startswith('ppa:'):
+            source, ppa_owner, ppa_name = self._expand_ppa(line)
+
+            if self.add_ppa_signing_keys_callback is not None:
+                info = self._get_ppa_info(ppa_owner, ppa_name)
+                command = ['apt-key', 'adv', '--recv-keys', '--keyserver', 'keyserver.ubuntu.com', info['signing_key_fingerprint']]
+                self.add_ppa_signing_keys_callback(command)
+
+            file = file or self._suggest_filename('%s_%s' % (line, distro.codename))
+        else:
+            source = self._parse(line, raise_if_invalid_or_disabled=True)[2]
+            file = file or self._suggest_filename(source)
+        self._add_valid_source(source, comment, file)
+
+    def remove_source(self, line):
+        if line.startswith('ppa:'):
+            source = self._expand_ppa(line)[0]
+        else:
+            source = self._parse(line, raise_if_invalid_or_disabled=True)[2]
+        self._remove_valid_source(source)
+
+
+def get_add_ppa_signing_key_callback(module):
+    def _run_command(command):
+        module.run_command(command, check_rc=True)
+
+    return _run_command if not module.check_mode else None
+
 
 def main():
-    add_apt_repository = None
-
-    arg_spec = dict(
-        repo=dict(required=True),
-        state=dict(default='present', choices=['present', 'absent'])
+    module = AnsibleModule(
+        argument_spec=dict(
+            repo=dict(required=True),
+            state=dict(choices=['present', 'absent'], default='present'),
+        ),
+        supports_check_mode=True,
     )
 
-    module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
-
-    if not HAVE_PYAPT:
-        module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")
-
-    add_apt_repository = module.get_bin_path(ADD_APT_REPO, True)
-    if check_cmd_needs_y():
-        add_apt_repository += ' -y'
+    if not HAVE_PYTHON_APT:
+        module.fail_json(msg='Could not import python modules: apt_pkg. Please install python-apt package.')
 
     repo = module.params['repo']
     state = module.params['state']
+    sourceslist = None
 
-    repo_url = repo
-    if 'ppa:' in repo_url and not 'http://' in repo_url:
-        # looks like ppa:nginx/stable
-        repo_url = repo.split(':')[1]
-    elif len(repo_url.split(' ')) > 1:
-        # could be:
-        # http://myserver/path/to/repo free non-free
-        # deb http://myserver/path/to/repo free non-free
-        for i in repo_url.split():
-            for prot in ['http', 'file', 'ftp']:
-                if prot in i:
-                    repo_url = i
-                    break
-    exists = repo_exists(module, repo_url)
-
-    rc = 0
-    out = ''
-    err = ''
-    if state == 'absent' and exists:
-        if module.check_mode:
-            module.exit_json(changed=True)
-        cmd = '%s "%s" --remove' % (add_apt_repository, repo)
-        rc, out, err = module.run_command(cmd)
-    elif state == 'present' and not exists:
-        if module.check_mode:
-            module.exit_json(changed=True)
-        cmd = '%s "%s"' % (add_apt_repository, repo)
-        rc, out, err = module.run_command(cmd)
+    if isinstance(distro, aptsources.distro.DebianDistribution):
+        sourceslist = SourcesList()
+    elif isinstance(distro, aptsources.distro.UbuntuDistribution):
+        sourceslist = UbuntuSourcesList(add_ppa_signing_keys_callback=get_add_ppa_signing_key_callback(module))
     else:
-        module.exit_json(changed=False, repo=repo, state=state)
+        module.fail_json(msg='Module apt_repository supports only Debian and Ubuntu.')
 
-    if rc != 0:
-        module.fail_json(msg=err)
-    else:
-        changed = True
+    sources_before = sourceslist.dump()  # Cheating, but it perfectly works.
 
-    if state == 'present' and changed:
-        rc, out, err = module.run_command('%s update' % APT)
+    try:
+        if state == 'present':
+            sourceslist.add_source(repo)
+        elif state == 'absent':
+            sourceslist.remove_source(repo)
+    except InvalidSource as err:
+        module.fail_json(msg='Invalid repository string: %s' % unicode(err))
+
+    sources_after = sourceslist.dump()  # Cheating, but it perfectly works.
+    changed = sources_before != sources_after
+
+    if not module.check_mode and changed:
+        try:
+            sourceslist.save()
+        except OSError as err:
+            module.fail_json(msg=unicode(err))
 
     module.exit_json(changed=changed, repo=repo, state=state)
-
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>


### PR DESCRIPTION
It is a rewritten version of apt_repository. I has some fixes for initial version's problems:
1. Debian Squeeze is supported out of box now.
2. deb-src will not be added implicitly.
3. If a source had beed added it must be able to remove it. If you will try this:

```
apt_repository: repo='deb http://ppa.launchpad.net/nginx/stable/ubuntu raring main'
apt_repository: repo='deb http://ppa.launchpad.net/nginx/stable/ubuntu raring additional'
apt_repository: repo='deb http://ppa.launchpad.net/nginx/stable/ubuntu raring additional' state=absent
```

You will have source `deb http://ppa.launchpad.net/nginx/stable/ubuntu raring main additional` in the source list, not any of strings you used in a playbook.

This module has some features may cause not-smooth migration:
1. it uses AtomicFile instead of backup files;
2. if supports PPA repositories only for Ubuntu target machines to prevent failures on plain Debian ones;
3. it requires repository type to be explicitly specified ("deb http://....", or "deb-src http://...")
