### PR TITLE
Enforcement of the symlink creation if the 'force' parameter is set to 'yes'

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -150,6 +150,7 @@ def main():
             state = dict(choices=['file','directory','link','hard','absent'], default='file'),
             path  = dict(aliases=['dest', 'name'], required=True),
             recurse  = dict(default='no', type='bool'),
+            force = dict(required=False,default=False,type='bool'),
             diff_peek = dict(default=None),
             validate = dict(required=False, default=None),
         ),
@@ -159,6 +160,7 @@ def main():
 
     params = module.params
     state  = params['state']
+    force = params['force']
     params['path'] = path = os.path.expanduser(params['path'])
 
     # short-circuit for diff_peek
@@ -226,7 +228,10 @@ def main():
         module.exit_json(path=path, changed=True)
 
     if prev_state != 'absent' and prev_state != state:
-        module.fail_json(path=path, msg='refusing to convert between %s and %s for %s' % (prev_state, state, src))
+        if force and prev_state == 'file' and state == 'link':
+            pass
+        else:
+            module.fail_json(path=path, msg='refusing to convert between %s and %s for %s' % (prev_state, state, src))
 
     if prev_state == 'absent' and state == 'absent':
         module.exit_json(path=path, changed=False)
@@ -287,7 +292,14 @@ def main():
                 dolink(src, path, state, module)
                 changed = True
         elif prev_state == 'file':
-            module.fail_json(dest=path, src=src, msg='Cannot link, file exists at destination')
+            if not force:
+                module.fail_json(dest=path, src=src, msg='Cannot link, file exists at destination')
+            else:
+                if module.check_mode:
+                    module.exit_json(changed=True)
+                os.unlink(path)
+                dolink(src, path, state, module)
+                changed = True
         else:
             module.fail_json(dest=path, src=src, msg='unexpected position reached')
 

--- a/library/files/file
+++ b/library/files/file
@@ -120,6 +120,20 @@ options:
     version_added: "1.1"
     description:
       - recursively set the specified file attributes (applies only to state=directory)
+  force:
+    required: false
+    default: "no"
+    choises: [ "yes", "no" ]
+    description:
+      - force the creation of the symlinks in two cases: the source file does
+        not exist (but will appear later); the destination exists and a file (so, we need to unlink the
+        "path" file and create symlink to the "src" file in place of it).
+examples:
+   - code: "file: path=/etc/foo.conf owner=foo group=foo mode=0644"
+     description: Example from Ansible Playbooks
+   - code: "file: src=/file/to/link/to dest=/path/to/symlink owner=foo group=foo state=link"
+   - code: "action: file state=link path=/etc/localtime src=/usr/share/zoneinfo/Europe/Zurich force=yes"
+     description: Force /etc/locatime be the symbolic link to /usr/share/zoneinfo/Europe/Zurich
 notes:
     - See also M(copy), M(template), M(assemble)
 requirements: [ ]

--- a/library/files/file
+++ b/library/files/file
@@ -123,7 +123,7 @@ options:
   force:
     required: false
     default: "no"
-    choises: [ "yes", "no" ]
+    choices: [ "yes", "no" ]
     description:
       - force the creation of the symlinks in two cases: the source file does
         not exist (but will appear later); the destination exists and a file (so, we need to unlink the

--- a/library/files/file
+++ b/library/files/file
@@ -273,7 +273,8 @@ def main():
             abs_src = src
         else:
             module.fail_json(msg="absolute paths are required")
-        if not os.path.exists(abs_src):
+
+        if not os.path.exists(abs_src) and not force:
             module.fail_json(path=path, src=src, msg='src file does not exist')
 
         if prev_state == 'absent':


### PR DESCRIPTION
Dear Ansible Dev Team,

This pull request brings the enforcement of symlink creation in Ansible if the parameter named 'force' is set to 'yes' in two cases:
- the source file does not exist (but will appear later).  
  Example: `action: file state=link path=/var/www/html/animation.gif src=/dev/shm/animation.gif force=yes`
  where /dev/shm/animation.gif is a file, which should be generated later by the script.
- the destination exists and a file (so, we need to unlink the "path" file and create symlink to the "src" file in place of it):  
  Example: `action: file state=link path=/etc/localtime src=/usr/share/zoneinfo/Europe/Zurich force=yes`
