### PR TITLE
fix AWS page heading styles for 'pending information'

### DIFF
--- a/docsite/latest/rst/amazon_web_services.rst
+++ b/docsite/latest/rst/amazon_web_services.rst
@@ -127,22 +127,22 @@ And in your playbook::
     hosts: /chroot/path
 
 Pending Information
-===================
+```````````````````
 
 In the future look here for more topics.
 
 Using Ansible's S3 module
-`````````````````````````
++++++++++++++++++++++++++
 
 these modules are documented on the module page, more walk throughs coming soon
 
 Using Ansible's Elastic Load Balancer Support
-`````````````````````````````````````````````
++++++++++++++++++++++++++++++++++++++++++++++
 
 these modules are documented on the module page, more walk throughs coming soon
 
 Using Ansible's Cloud Formation Module
-``````````````````````````````````````
+++++++++++++++++++++++++++++++++++++++
 
 these modules are documented on the module page, more walk throughs coming soon
 


### PR DESCRIPTION
...the old styling had Pending Information coming up as a top-level chapter.
