### PR TITLE
quick and dirty bugfix for irc module

### DIFF
--- a/library/notification/irc
+++ b/library/notification/irc
@@ -76,6 +76,7 @@ local_action: irc port=6669
 # IRC module support methods.
 #
 
+from time import sleep
 import socket
 
 def send_msg(channel, msg, server='localhost', port='6667',
@@ -101,10 +102,13 @@ def send_msg(channel, msg, server='localhost', port='6667',
     irc.connect( ( server, int(port) ) )
     irc.send( 'NICK %s\r\n' % nick )
     irc.send( 'USER %s %s %s :ansible IRC\r\n' % (nick, nick, nick))
-    irc.send( 'JOIN #%s\r\n' % channel )
+    time.sleep(1)
+    irc.send( 'JOIN %s\r\n' % channel )
     irc.send( 'PRIVMSG %s :%s\r\n' % (channel, message))
+    time.sleep(1)
     irc.send( 'PART %s\r\n' % channel)
     irc.send( 'QUIT\r\n' )
+    time.sleep(1)
     irc.close()
 
 # ===========================================


### PR DESCRIPTION
there's an extra '#' in the JOIN string which breaks strict ircd parsers, preventing the bot from joining a channel.  Also, testing has shown that shadowIRCd discards any buffered input on login, so throwing the whole session at it before the handshaking is completed gets us nowhere. for now, I add sleeps, (for later I will maybe put some recv() calls in there.)
