### PR TITLE
Simple zypper module to install, remove, or upgrades packages.

### DIFF
--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -73,7 +73,7 @@ author: Patrick Callahan
 # Function used for getting the name of a currently installed package.
 def get_current_name(m, name):
     cmd = '/bin/rpm -q --qf \'%{NAME}-%{VERSION}\''
-    (rc, stdout, stderr) = m.run_command("%s" % (cmd))
+    (rc, stdout, stderr) = m.run_command("%s %s" % (cmd, name))
 
     if rc != 0:
         return (rc, stdout, stderr)

--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -1,0 +1,225 @@
+#!/usr/bin/python -tt
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Patrick Callahan <pmc@patrickcallahan.com>
+# based on
+#     openbsd_pkg
+#         (c) 2013
+#         Patrik Lundin <patrik.lundin.swe@gmail.com>
+#
+#     yum
+#         (c) 2012, Red Hat, Inc
+#         Written by Seth Vidal <skvidal at fedoraproject.org>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+DOCUMENTATION = '''
+---
+module: zypper
+author: Patrick Callahan
+version_added: "1.x"
+short_description: Manage packages on SuSE and openSuSE
+description:
+    - Manage packages on SuSE and openSuSE using the zypper and rpm tools.
+options:
+    name:
+        description:
+        - package name or package specifier wth version C(name) or C(name-1.0).
+        required: true
+        aliases: [ 'pkg' ]
+    state:
+        description:
+          - C(present) will make sure the package is installed.
+            C(latest)  will make sure the latest version of the package is installed.
+            C(absent)  will make sure the specified package is not installed.
+        required: false
+        choices: [ present, latest, absent ]
+        default: "present"
+    disable_gpg_check:
+        description:
+          - Whether to disable to GPG signature checking of the package
+            signature being installed. Has an effect only if state is
+            I(present) or I(latest).
+        required: false
+        default: "no"
+        choices: [ "yes", "no" ]
+        aliases: []
+
+examples:
+    - code: "zypper: name=nmap state=present"
+    - code: "zypper: name=nmap state=latest"
+    - code: "zypper: name=nmap state=absent"
+notes: []
+# informational: requirements for nodes
+requirements: [ zypper, rpm ]
+author: Patrick Callahan
+'''
+
+# Function used for getting the name of a currently installed package.
+def get_current_name(m, name):
+    cmd = '/bin/rpm -q --qf \'%{NAME}-%{VERSION}\''
+    (rc, stdout, stderr) = m.run_command("%s" % (cmd))
+
+    if rc != 0:
+        return (rc, stdout, stderr)
+
+    syntax = "%s"
+
+    for line in stdout.splitlines():
+        if syntax % name in line:
+            current_name = line.split()[0]
+
+    return current_name
+
+# Function used to find out if a package is currently installed.
+def get_package_state(m, name):
+    cmd = ['/bin/rpm', '--query', '--info', name]
+
+    rc, stdout, stderr = m.run_command(cmd, check_rc=False)
+
+    if rc == 0:
+        return True
+    else:
+        return False
+
+# Function used to make sure a package is present.
+def package_present(m, name, installed_state, disable_gpg_check):
+    if installed_state is False:
+        cmd = ['/usr/bin/zypper', '--non-interactive']
+        # add global options before zypper command
+        if disable_gpg_check:
+            cmd.append('--no-gpg-check')
+
+        cmd.extend(['install', '--auto-agree-with-licenses'])
+        cmd.append(name)
+        rc, stdout, stderr = m.run_command(cmd, check_rc=False)
+
+        if rc == 0:
+            changed=True
+        else:
+            changed=False
+    else:
+        rc = 0
+        stdout = ''
+        stderr = ''
+        changed=False
+
+    return (rc, stdout, stderr, changed)
+
+# Function used to make sure a package is the latest available version.
+def package_latest(m, name, installed_state, disable_gpg_check):
+
+    if installed_state is True:
+        cmd = ['/usr/bin/zypper', '--non-interactive', 'update', '--auto-agree-with-licenses', name]
+        pre_upgrade_name = ''
+        post_upgrade_name = ''
+
+        # Compare the installed package before and after to know if we changed anything.
+        pre_upgrade_name = get_current_name(m, name)
+
+        rc, stdout, stderr = m.run_command(cmd, check_rc=False)
+
+        post_upgrade_name = get_current_name(m, name)
+
+        if pre_upgrade_name == post_upgrade_name:
+            changed = False
+        else:
+            changed = True
+
+        return (rc, stdout, stderr, changed)
+
+    else:
+        # If package was not installed at all just make it present.
+        return package_present(m, name, installed_state, disable_gpg_check)
+
+# Function used to make sure a package is not installed.
+def package_absent(m, name, installed_state):
+    if installed_state is True:
+        cmd = ['/usr/bin/zypper', '--non-interactive', 'remove', name]
+        rc, stdout, stderr = m.run_command(cmd)
+
+        if rc == 0:
+            changed=True
+        else:
+            changed=False
+    else:
+        rc = 0
+        stdout = ''
+        stderr = ''
+        changed=False
+
+    return (rc, stdout, stderr, changed)
+
+# ===========================================
+# Main control flow
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name = dict(required=True, aliases=['pkg']),
+            state = dict(required=False, default='present', choices=['absent', 'installed', 'latest', 'present', 'removed']),
+            disable_gpg_check = dict(required=False, default='no', choices=BOOLEANS, type='bool'),
+        ),
+        supports_check_mode = False
+    )
+
+
+    params = module.params
+
+    name  = params['name']
+    state = params['state']
+    disable_gpg_check = params['disable_gpg_check']
+
+    rc = 0
+    stdout = ''
+    stderr = ''
+    result = {}
+    result['name'] = name
+    result['state'] = state
+
+    # Decide if the name contains a version number.
+    match = re.search("-[0-9]", name)
+    if match:
+        specific_version = True
+    else:
+        specific_version = False
+
+    # Get package state
+    installed_state = get_package_state(module, name)
+
+    # Perform requested action
+    if state in ['installed', 'present']:
+        (rc, stdout, stderr, changed) = package_present(module, name, installed_state, disable_gpg_check)
+    elif state in ['absent', 'removed']:
+        (rc, stdout, stderr, changed) = package_absent(module, name, installed_state)
+    elif state == 'latest':
+        (rc, stdout, stderr, changed) = package_latest(module, name, installed_state, disable_gpg_check)
+
+    if rc != 0:
+        if stderr:
+            module.fail_json(msg=stderr)
+        else:
+            module.fail_json(msg=stdout)
+
+    result['changed'] = changed
+
+    module.exit_json(**result)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()


### PR DESCRIPTION
Tested on openSuSE 12.3 and should work on SuSE 11. ansible.spec needs some changes to build on SuSE. Not a lot of python coding so it may not be idiomatic python.

Here's the output of some of my testing.

Script started on Thu 06 Jun 2013 09:50:07 PM EDT

patrickc@linux-sngq:~/Projects/ansible/rpm-build> rpm -qi zsh

Name        : zsh
Version     : 5.0.2
Release     : 2.9.1
Architecture: x86_64
Install Date: Wed 05 Jun 2013 12:03:00 AM EDT
Group       : System/Shells
Size        : 7232480
License     : MIT
Signature   : RSA/SHA256, Thu 02 May 2013 08:36:34 AM EDT, Key ID b88b2fd43dbdc284
Source RPM  : zsh-5.0.2-2.9.1.src.rpm
Build Date  : Mon 22 Apr 2013 10:01:07 AM EDT
Build Host  : build09
Relocations : (not relocatable)
Packager    : http://bugs.opensuse.org
Vendor      : openSUSE
URL         : http://www.zsh.org
Summary     : Shell with comprehensive completion
Description :
Zsh is a UNIX command interpreter (shell) that resembles the Korn shell
(ksh). It is not completely compatible. It includes many enhancements,
notably in the command-line editor, options for customizing its
behavior, file name globbing, features to make C-shell (csh) users feel
at home, and extra features drawn from tcsh (another `custom' shell).
Zsh is well known for its command line completion.
Distribution: openSUSE 12.3

patrickc@linux-sngq:~/Projects/ansible/rpm-build> ansible localhost -m zypper -a "name=zsh state=present" -K
sudo password: 

localhost | success >> {
    "changed": false, 
    "name": "zsh", 
    "state": "present"
}

patrickc@linux-sngq:~/Projects/ansible/rpm-build> ansible localhost -m zypper -a "name=zsh state=present" -K
sudo password: 

localhost | success >> {
    "changed": false, 
    "name": "zsh", 
    "state": "present"
}

patrickc@linux-sngq:~/Projects/ansible/rpm-build> ansible localhost -m zypper -a "pkg=zsh state=present" -K
sudo password: 

localhost | success >> {
    "changed": false, 
    "name": "zsh", 
    "state": "latest"
}

patrickc@linux-sngq:~/Projects/ansible/rpm-build> ansible localhost -m zypper -a "pkg=zsh state=latest" -K
sudo password: 

localhost | success >> {
    "changed": true, 
    "name": "zsh", 
    "state": "absent"
}

patrickc@linux-sngq:~/Projects/ansible/rpm-build> ansible localhost -m zypper -a "pkg=zsh state=absent" -K
sudo password: 

localhost | success >> {
    "changed": false, 
    "name": "foo", 
    "state": "absent"
}

patrickc@linux-sngq:~/Projects/ansible/rpm-build> ansible localhost -m zypper -a "pkg=foo state=absent" -K
sudo password: 

localhost | FAILED >> {
    "failed": true, 
    "msg": "No provider of 'foo' found.\n"
}

patrickc@linux-sngq:~/Projects/ansible/rpm-build> ansible localhost -m zypper -a "pkg=foo state=present" -K

localhost | success >> {
    "changed": true, 
    "name": "zsh", 
    "state": "present"
}

patrickc@linux-sngq:~/Projects/ansible/rpm-build> rpm -qi zsh

Name        : zsh
Version     : 5.0.2
Release     : 2.9.1
Architecture: x86_64
Install Date: Thu 06 Jun 2013 09:55:07 PM EDT
Group       : System/Shells
Size        : 7232480
License     : MIT
Signature   : RSA/SHA256, Thu 02 May 2013 08:36:34 AM EDT, Key ID b88b2fd43dbdc284
Source RPM  : zsh-5.0.2-2.9.1.src.rpm
Build Date  : Mon 22 Apr 2013 10:01:07 AM EDT
Build Host  : build09
Relocations : (not relocatable)
Packager    : http://bugs.opensuse.org
Vendor      : openSUSE
URL         : http://www.zsh.org
Summary     : Shell with comprehensive completion
Description :
Zsh is a UNIX command interpreter (shell) that resembles the Korn shell
(ksh). It is not completely compatible. It includes many enhancements,
notably in the command-line editor, options for customizing its
behavior, file name globbing, features to make C-shell (csh) users feel
at home, and extra features drawn from tcsh (another `custom' shell).
Zsh is well known for its command line completion.
Distribution: openSUSE 12.3
