### PR TITLE
changed get_mount_facts to ignore mount types 'none'

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -547,16 +547,17 @@ class LinuxHardware(Hardware):
         for line in mtab.split('\n'):
             if line.startswith('/'):
                 fields = line.rstrip('\n').split()
-                statvfs_result = os.statvfs(fields[1])
-                self.facts['mounts'].append(
-                    {'mount': fields[1],
-                     'device':fields[0],
-                     'fstype': fields[2],
-                     'options': fields[3],
-                     # statvfs data
-                     'size_total': statvfs_result.f_bsize * statvfs_result.f_blocks,
-                     'size_available': statvfs_result.f_bsize * (statvfs_result.f_bavail),
-                     })
+                if(fields[2] != 'none'):
+                    statvfs_result = os.statvfs(fields[1])
+                    self.facts['mounts'].append(
+                        {'mount': fields[1],
+                         'device':fields[0],
+                         'fstype': fields[2],
+                         'options': fields[3],
+                         # statvfs data
+                         'size_total': statvfs_result.f_bsize * statvfs_result.f_blocks,
+                         'size_available': statvfs_result.f_bsize * (statvfs_result.f_bavail),
+                         })
 
     def get_device_facts(self):
         self.facts['devices'] = {}


### PR DESCRIPTION
I added a check to see if the mount type is none, then ignore getting the facts
Use Case : I ran into a problem on machines where bind/unbound is running in a chroot, it gave me permission denied on setup module execution for those mounts
