### PR TITLE
added error checking on connect_to_region() in ec2.py

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -244,7 +244,11 @@ class Ec2Inventory(object):
                 conn.APIVersion = '2010-08-31'
             else:
                 conn = ec2.connect_to_region(region)
-            
+
+            if conn is None:
+               print("AWS is down or region name: %s likely not supported.  connection to region failed." % region)
+               sys.exit(1)
+ 
             reservations = conn.get_all_instances()
             for reservation in reservations:
                 for instance in reservation.instances:
@@ -278,6 +282,10 @@ class Ec2Inventory(object):
             conn.APIVersion = '2010-08-31'
         else:
             conn = ec2.connect_to_region(region)
+
+        if conn is None:
+           print("AWS is down or region name: %s likely not supported.  connection to region failed." % region)
+           sys.exit(1)
 
         reservations = conn.get_all_instances([instance_id])
         for reservation in reservations:

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -245,9 +245,10 @@ class Ec2Inventory(object):
             else:
                 conn = ec2.connect_to_region(region)
 
-            if conn is None:
-               print("AWS is down or region name: %s likely not supported.  connection to region failed." % region)
-               sys.exit(1)
+        # connect_to_region will fail "silently" by returning None if the region name is wrong or not supported
+        if conn is None:
+            print("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
+            sys.exit(1)
  
             reservations = conn.get_all_instances()
             for reservation in reservations:
@@ -283,9 +284,10 @@ class Ec2Inventory(object):
         else:
             conn = ec2.connect_to_region(region)
 
+        # connect_to_region will fail "silently" by returning None if the region name is wrong or not supported
         if conn is None:
-           print("AWS is down or region name: %s likely not supported.  connection to region failed." % region)
-           sys.exit(1)
+            print("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
+            sys.exit(1)
 
         reservations = conn.get_all_instances([instance_id])
         for reservation in reservations:


### PR DESCRIPTION
if a bad region name is placed in ec2.ini for the ec2.py external inventory module the current code fails with a

AttributeError: 'NoneType' object has no attribute 'get_all_instances'

exception, because the connection object returned by Boto is of type None.

This pull request adds basic error checking around this to make a poorly formatted name easier to diagnose.  Tried to follow error checking examples from elsewhere in the project.

error before

[jclaybaugh@ansible1 ansible]$ ./ec2-test.py 
Traceback (most recent call last):
  File "./ec2-test.py", line 512, in <module>
    Ec2Inventory()
  File "./ec2-test.py", line 146, in **init**
    self.do_api_calls_update_cache()
  File "./ec2-test.py", line 230, in do_api_calls_update_cache
    self.get_instances_by_region(region)
  File "./ec2-test.py", line 249, in get_instances_by_region
    reservations = conn.get_all_instances()
AttributeError: 'NoneType' object has no attribute 'get_all_instances'

error after

[jclaybaugh@ansible1 ansible]$ ./ec2.py --list
region name: 'all' likely not supported.  connection to region failed.
make tests pass

My first pull request and I am not sure if this goes to the Ansible project or the original submitter of the ec2 inventory module.

thanks
Jonathan
