### PR TITLE
Callback Plugin Context / Naming Fixes

### DIFF
--- a/lib/ansible/callback_plugins/noop.py
+++ b/lib/ansible/callback_plugins/noop.py
@@ -63,10 +63,10 @@ class CallbackModule(object):
     def playbook_on_notify(self, host, handler):
         pass
 
-    def on_no_hosts_matched(self):
+    def playbook_on_no_hosts_matched(self):
         pass
 
-    def on_no_hosts_remaining(self):
+    def playbook_on_no_hosts_remaining(self):
         pass
 
     def playbook_on_task_start(self, name, is_conditional):

--- a/plugins/callbacks/log_plays.py
+++ b/plugins/callbacks/log_plays.py
@@ -90,6 +90,12 @@ class CallbackModule(object):
     def playbook_on_notify(self, host, handler):
         pass
 
+    def playbook_on_no_hosts_matched(self):
+        pass
+
+    def playbook_on_no_hosts_remaining(self):
+        pass
+
     def playbook_on_task_start(self, name, is_conditional):
         pass
 

--- a/plugins/callbacks/osx_say.py
+++ b/plugins/callbacks/osx_say.py
@@ -67,6 +67,12 @@ class CallbackModule(object):
     def playbook_on_notify(self, host, handler):
         say("pew", LASER_VOICE)
 
+    def playbook_on_no_hosts_matched(self):
+        pass
+
+    def playbook_on_no_hosts_remaining(self):
+        pass
+
     def playbook_on_task_start(self, name, is_conditional):
         if not is_conditional:
             say("Starting task: %s" % name, REGULAR_VOICE)


### PR DESCRIPTION
As is, the current play is set for the callback plugins when loading the play, instead of when running it, which will provide the incorrect play to the callback if there are multiple plays in a playbook.  **This pull request sets the current play immediately before running it.**

Neither of the context variables (play/task) are cleared after running the current play/task.  As a result, certain events (e.g., `playbook_on_stats`) will still have a play and task set, even though there is no longer a current play or task.  **This pull request sets the current play/task to None immediately after running it.**

The naming of the `on_no_hosts_matched` and `on_no_hosts_remaining` methods in the noop plugin is incorrect, and these methods will never be called. **This pull request prefixes the method names with `playbook_` so they will be called, and adds these new methods to the sample callback plugins.**
