### PR TITLE
allow apt-key module to work with binary key

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -859,7 +859,7 @@ class AnsibleModule(object):
             self.cleanup(tmp_dest)
             self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e))
 
-    def run_command(self, args, check_rc=False, close_fds=False, executable=None, data=None):
+    def run_command(self, args, check_rc=False, close_fds=False, executable=None, data=None, binary_data=False):
         '''
         Execute a command, returns rc, stdout, and stderr.
         args is the command to run
@@ -895,7 +895,8 @@ class AnsibleModule(object):
                                    stderr=subprocess.PIPE)
             if data:
                 cmd.stdin.write(data)
-                cmd.stdin.write('\\n')
+                if not binary_data:
+                    cmd.stdin.write('\\n')
             out, err = cmd.communicate()
             rc = cmd.returncode
         except (OSError, IOError), e:

--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -112,7 +112,7 @@ def download_key(module, url):
 
 def add_key(module, key):
     cmd = "apt-key add -"
-    (rc, out, err) = module.run_command(cmd, data=key, check_rc=True)
+    (rc, out, err) = module.run_command(cmd, data=key, check_rc=True, binary_data=True)
     return True
 
 def remove_key(module, key_id):


### PR DESCRIPTION
I have a perfectly valid apt repository signing key that isn't ascii-armored. The additional characters added to stdin in module.run_command() break the binary encoded key and "apt-key add -" fails. With this patch, my binary key is added successfully.
