### PR TITLE
Allow inventory to be read from a pipe

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -90,12 +90,8 @@ class Inventory(object):
                 self.parser = InventoryScript(filename=host_list)
                 self.groups = self.parser.groups.values()
             else:
-                data = file(host_list).read()
-                if not data.startswith("---"):
-                    self.parser = InventoryParser(filename=host_list)
-                    self.groups = self.parser.groups.values()
-                else:
-                    raise errors.AnsibleError("YAML inventory support is deprecated in 0.6 and removed in 0.7, see the migration script in examples/scripts in the git checkout")
+                self.parser = InventoryParser(filename=host_list)
+                self.groups = self.parser.groups.values()
 
             utils.plugins.vars_loader.add_directory(self.basedir(), with_subdir=True)
         else:

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -33,11 +33,11 @@ class InventoryParser(object):
 
     def __init__(self, filename=C.DEFAULT_HOST_LIST):
 
-        fh = open(filename)
-        self.lines = fh.readlines()
-        self.groups = {}
-        self.hosts = {}
-        self._parse()
+        with open(filename) as fh:
+            self.lines = fh.readlines()
+            self.groups = {}
+            self.hosts = {}
+            self._parse()
 
     def _parse(self):
 


### PR DESCRIPTION
As discussed in https://github.com/ansible/ansible/issues/3166 , this PR removes the double read of a given hosts file, thereby allowing it to accept a shell pipe.
