### PR TITLE
Fix `mongodb_user` compatibility with MongoDB 2.2 (used in Debian 7).

### DIFF
--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -81,11 +81,16 @@ author: Elliott Foster
 
 import ConfigParser
 try:
-    from pymongo import MongoClient
     from pymongo.errors import ConnectionFailure
     from pymongo.errors import OperationFailure
+    from pymongo import MongoClient
 except ImportError:
-    pymongo_found = False
+    try:  # for older PyMongo 2.2
+        from pymongo import Connection as MongoClient
+    except ImportError:
+        pymongo_found = False
+    else:
+        pymongo_found = True
 else:
     pymongo_found = True
 


### PR DESCRIPTION
The module `mongodb_user` could not be used on Debian 7 (released around a month ago) by installing dependencies through official system packages.

The problem is that the package `python-pymongo` that installs PyMongo has version 2.2-4+deb7u1, but the `mongodb_user` module is written for the newer version of PyMongo. It seems that the `Connection` module was renamed to `MongoClient` and maybe some features added (that are not being used). Therefore one can be used as an in-place replacement for the other.
