### PR TITLE
Fix MySQL 5.6 compatibility

### DIFF
--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -153,8 +153,9 @@ def user_mod(cursor, user, host, password, new_priv):
         # the new specification, then revoke all privileges on it.
         for db_table, priv in curr_priv.iteritems():
             if db_table not in new_priv:
-                privileges_revoke(cursor, user,host,db_table)
-                changed = True
+                if user != "root" and "PROXY" not in priv:
+                    privileges_revoke(cursor, user,host,db_table)
+                    changed = True
 
         # If the user doesn't currently have any privileges on a db.table, then
         # we can perform a straight grant operation.


### PR DESCRIPTION
In MySQL 5.6, the root account created by default during MySQL
installation has the PROXY ... WITH GRANT OPTION privilege for ''@'',
that is, for all users.

The mysql_user module tries to revoke this privilege, but this fails:
_mysql_exceptions.ProgrammingError: (1064, "You have an error in your
SQL syntax; check the manual that corresponds to your MySQL server
version for the right syntax to use near '''@'' FROM 'root'@'localhost''
at line 1")

Quick fix: don't revoke privilege if user is root and the privilege to
revoke contains PROXY.
