### PR TITLE
Loading order of ansible.cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -449,7 +449,7 @@ Highlighted Core Changes:
 
 Other Core Changes:
 
-* ansible config file can also go in '.ansible.cfg' in cwd in addition to ~/.ansible.cfg and /etc/ansible/ansible.cfg
+* ansible config file can also go in 'ansible.cfg' in cwd in addition to ~/.ansible.cfg and /etc/ansible/ansible.cfg
 * fix for inventory hosts at API level when hosts spec is a list and not a colon delimited string
 * ansible-pull example now sets up logrotate for the ansible-pull cron job log
 * negative host matching (!hosts) fixed for external inventory script usage

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -1,6 +1,8 @@
 # config file for ansible -- http://ansible.github.com
+#
 # nearly all parameters can be overridden in ansible-playbook or with command line flags
-# ansible will read ~/.ansible.cfg or /etc/ansible/ansible.cfg, whichever it finds first
+# ansible will ansible.cfg in current directory, ~/.ansible.cfg or /etc/ansible/ansible.cfg
+# whichever it finds first.
 
 [defaults]
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -34,8 +34,8 @@ def get_config(p, section, key, env_var, default):
 
 def load_config_file():
     p = ConfigParser.ConfigParser()
-    path1 = os.path.expanduser(os.environ.get('ANSIBLE_CONFIG', "~/.ansible.cfg"))
-    path2 = os.getcwd() + "/ansible.cfg"
+    path1 = os.getcwd() + "/ansible.cfg"
+    path2 = os.path.expanduser(os.environ.get('ANSIBLE_CONFIG', "~/.ansible.cfg"))
     path3 = "/etc/ansible/ansible.cfg"
 
     if os.path.exists(path1):


### PR DESCRIPTION
These patches will modify the order in which ansible.cfg is loaded.

Documentation say: ./ansible.cfg > ~/.ansible.cfg > /etc/ansible/ansible.cfg
But it was loaded as: ~/.ansible.cfg > ./ansible.cfg > /etc/ansible/ansible.cfg

It also fixes a type in the changelog where it is referred to as '.ansible.cfg'.
And adds the loading of ./ansible.cfg to the comments in the ansible.cfg file itself, which only stated ~/.ansible.cfg and /etc/ansible/ansible.cfg
