### PR TITLE
add support for callback_plugins/ relative to playbook

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -41,7 +41,11 @@ if constants.DEFAULT_LOG_PATH != '':
     user = getpass.getuser()
     logger = logging.getLogger("p=%s u=%s | " % (mypid, user))
 
-callback_plugins = [x for x in utils.plugins.callback_loader.all()]
+callback_plugins = []
+
+def load_callback_plugins():
+    global callback_plugins
+    callback_plugins = [x for x in utils.plugins.callback_loader.all()]
 
 def get_cowsay_info():
     if constants.ANSIBLE_NOCOWS is not None:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -129,11 +129,13 @@ class PlayBook(object):
             self.inventory    = inventory
 
         self.basedir     = os.path.dirname(playbook) or '.'
+        utils.plugins.push_basedir(self.basedir)
         vars = {}
         if self.inventory.basedir() is not None:
             vars['inventory_dir'] = self.inventory.basedir()
         self.filename = playbook
         (self.playbook, self.play_basedirs) = self._load_playbook_from_file(playbook, vars)
+        ansible.callbacks.load_callback_plugins()
 
     # *****************************************************
 

--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -28,7 +28,8 @@ PLUGIN_PATH_CACHE = {}
 _basedirs = []
 
 def push_basedir(basedir):
-    _basedirs.insert(0, basedir)
+    if basedir not in _basedirs:
+        _basedirs.insert(0, basedir)
 
 class PluginLoader(object):
 


### PR DESCRIPTION
Hi @mpdehaan. This PR only to get feedback on implementation details.

As discussed on irc, callbacks are initialized too early by `lib/ansible/playbook/__init__.py` (at utils import), way before any basedir gets pushed.

You told me to patch `ansible-playbook`and to push basedir there, but the place where callback_loader() is loaded lives in `lib/ansible/playbook`, so it has to happen there, at least AFAICS.

I checked other plugin types, but those all work with optional *_plugins/ dirs relative to basedirs. So only callback_plugins have a problem here.

This patch moves the initialization (calling `utils.plugins.callback_loader.all()`) into a function, which gets loaded only after the playbook code can do an extra `utils.plugins.push_basedir()` call.

Optionally, I patched the `push_basedir` function to only push a new basedir, not every basedir call (which gets multiple basedirs repeated in `_basedir`)

Questions:
- Can you confirm if this patch is done the way it should or you would expect? I got a little confused when searching where callbacks got initialized, but I think this is the only place to patch.
- This patch only adds support for playbooks, hence for the `bin/ansible-playbook` command. Didn't look into `bin/ansible` support yet, but I'd expect this would also need this extra support, if only to be consequent as other plugins work with that. Not sure yet what the basedir is in this case. just cwd, or something relative to the inventory.
