### PR TITLE
Fixed module rhn_register name in examples section

### DIFF
--- a/library/packaging/rhn_register
+++ b/library/packaging/rhn_register
@@ -46,19 +46,19 @@ options:
         default: []
 
 examples:
-    - code: rhnreg_ks state=absent username=joe_user password=somepass
+    - code: rhn_register state=absent username=joe_user password=somepass
       description: Unregister system from RHN.
 
-    - code: rhnreg_ks state=present username=joe_user password=somepass
+    - code: rhn_register state=present username=joe_user password=somepass
       description: Register as user I(joe_user) with password I(somepass) and auto-subscribe to available content.
 
-    - code: rhnreg_ks state=present activationkey=1-222333444 enable_eus=true
+    - code: rhn_register state=present activationkey=1-222333444 enable_eus=true
       description: Register with activationkey I(1-222333444) and enable extended update support.
 
-    - code: rhnreg_ks state=present username=joe_user password=somepass server_url=https://xmlrpc.my.satellite/XMLRPC
+    - code: rhn_register state=present username=joe_user password=somepass server_url=https://xmlrpc.my.satellite/XMLRPC
       description: Register as user I(joe_user) with password I(somepass) against a satellite server specified by I(server_url).
 
-    - code: rhnreg_ks state=present username=joe_user password=somepass channels=rhel-x86_64-server-6-foo-1,rhel-x86_64-server-6-bar-1
+    - code: rhn_register state=present username=joe_user password=somepass channels=rhel-x86_64-server-6-foo-1,rhel-x86_64-server-6-bar-1
       description: Register as user I(joe_user) with password I(somepass) and enable channels I(rhel-x86_64-server-6-foo-1) and I(rhel-x86_64-server-6-bar-1).
 '''
 


### PR DESCRIPTION
Examples showed that modules name is rhnreq_ks, when it actually is rhn_register.
