### PR TITLE
Add a new crontab module

### DIFF
--- a/lib/ansible/runner/action_plugins/crontab.py
+++ b/lib/ansible/runner/action_plugins/crontab.py
@@ -1,0 +1,92 @@
+# (c) 2013, Lukas Lalinsky <lalinsky@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import base64
+import pipes
+from ansible import utils
+from ansible.utils import template
+from ansible.runner.return_data import ReturnData
+
+class ActionModule(object):
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    def _expand_path(self, path, inject, subdir):
+        path = template.template(self.runner.basedir, path, inject)
+        if '_original_file' in inject:
+            return utils.path_dwim_relative(inject['_original_file'], subdir, path, self.runner.basedir)
+        else:
+            return utils.path_dwim(self.runner.basedir, path)
+
+    def _content_from_file(self, path, inject):
+        path = self._expand_path(path, inject, 'files')
+        return open(path).read()
+
+    def _content_from_template(self, path, inject):
+        path = self._expand_path(path, inject, 'templates')
+        return template.template_from_file(self.runner.basedir, path, inject)
+
+    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
+        options = {}
+        if complex_args:
+            options.update(complex_args)
+        options.update(utils.parse_kv(module_args))
+
+        user = options.get('user')
+        file = options.get('file')
+        template = options.get('template')
+
+        if template is None and file is None:
+            result = dict(failed=True, msg='at least one of file or template is required')
+            return ReturnData(conn=conn, result=result)
+
+        if template is not None and file is not None:
+            result = dict(failed=True, msg='only one of file or template can be used')
+            return ReturnData(conn=conn, result=result)
+
+        try:
+            if template is not None:
+                content = self._content_from_template(template, inject)
+            else:
+                content = self._content_from_file(file, inject)
+        except Exception, e:
+            result = dict(failed=True, msg=str(e))
+            return ReturnData(conn=conn, result=result)
+
+        xfered = self.runner._transfer_str(conn, tmp, 'source', content)
+
+        module_args = "%s file=%s" % (module_args, pipes.quote(xfered))
+
+        if self.runner.diff:
+            module_args = "%s return_prev_content=True" % module_args
+
+        if self.runner.check:
+            module_args = "%s CHECKMODE=True" % module_args
+
+        result = self.runner._execute_module(conn, tmp, module_name, module_args, inject=inject, complex_args=complex_args)
+        if not result.is_successful():
+            return result
+
+        if self.runner.diff and 'prev_content' in result.result:
+            result.diff = dict(
+                before = base64.b64decode(result.result.pop('prev_content')),
+                after = content,
+            )
+
+        return result
+

--- a/library/system/crontab
+++ b/library/system/crontab
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2013, Lukas Lalinsky <lalinsky@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: crontab
+short_description: Installs user crontabs from files or templates.
+description:
+  - The M(crontab) module uses a local file or template to install crontab
+    for a particular user.
+  - This is different from the M(cron) module, which maintains individual jobs
+    inside a crontab, while this module maintains the whole crontab.
+options:
+  user:
+    description:
+      - User whose crontab should be installed.
+    required: true
+    default: null
+  file:
+    description:
+      - File with the crontab's content.
+    required: false
+    default: null
+  template:
+    description:
+      - Jinja2-formatted template with the crontab's content.
+    required: false
+    default: null
+examples:
+  - code: "crontab: user=foo file=crontab"
+    description: Install crontab using a file
+  - code: "crontab: user=foo template=crontab.j2"
+    description: Install crontab using a template
+author: Lukas Lalinsky
+'''
+
+import base64
+import tempfile
+
+def get_crontab(module, user):
+    tmpfile = tempfile.NamedTemporaryFile()
+    cmd = "crontab -l -u %s > %s" % (user, tmpfile.name)
+    rc, out, err = module.run_command(cmd)
+    if rc != 0 and rc != 1:
+        module.fail_json(msg=err)
+    content = tmpfile.read()
+    tmpfile.close()
+    return content
+
+
+def install_crontab(module, user, content):
+    tmpfile = tempfile.NamedTemporaryFile()
+    tmpfile.write(content)
+    tmpfile.flush()
+    cmd = "crontab -u %s %s" % (user, tmpfile.name)
+    rc, out, err = module.run_command(cmd)
+    if rc != 0:
+        module.fail_json(msg=err)
+    tmpfile.close()
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            user = dict(default=None, required=True),
+            file = dict(default=None, required=True),
+            template = dict(default=None, required=False),
+            return_prev_content = dict(default=False, type='bool', required=False),
+        ),
+        supports_check_mode=True,
+    )
+
+    params = module.params
+    user = params['user']
+    file = params['file']
+
+    content = open(file).read()
+    prev_content = get_crontab(module, user)
+    if content == prev_content:
+        module.exit_json(changed=False)
+
+    if not module.check_mode:
+        install_crontab(module, user, content)
+    elif params.get('return_prev_content'):
+        module.exit_json(changed=True, prev_content=base64.b64encode(prev_content))
+
+    module.exit_json(changed=True)
+
+
+# include magic from lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()
+


### PR DESCRIPTION
The module can be used to maintain the whole crontab for a particular user, rather than maintaining individual cron jobs with the cron module. It can use a local file or Jinja2 template for the crontab's content.

I couldn't use `/etc/cron.d` with a specific file because that's not supported by the FreeBSD cron and I also needed to maintain environment variables in a crontab, like `MAILTO` and `PATH`, so I wrote this module. It works like the `copy` or `template` modules, but instead of creating a file, it saves the content of the local file/template to a user's crontab.

It supports the check mode and can display diffs. I initially had this implemented a simple module that used syntax like this:

```
crontab: user=xxx content="{{ lookup('template', 'xxx.j2') }}"
```

Eventually I decided that I really want diff support and the `template=xxx.j2` syntax also looks nicer, so I implemented the action plugin for it as well.

I'm not sure if this is something that should be merged to the main module library in ansible, but it works great for my purposes.
