### PR TITLE
docs fix ansible cfg loading order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -449,7 +449,7 @@ Highlighted Core Changes:
 
 Other Core Changes:
 
-* ansible config file can also go in '.ansible.cfg' in cwd in addition to ~/.ansible.cfg and /etc/ansible/ansible.cfg
+* ansible config file can also go in 'ansible.cfg' in cwd in addition to ~/.ansible.cfg and /etc/ansible/ansible.cfg
 * fix for inventory hosts at API level when hosts spec is a list and not a colon delimited string
 * ansible-pull example now sets up logrotate for the ansible-pull cron job log
 * negative host matching (!hosts) fixed for external inventory script usage

--- a/docsite/latest/rst/examples.rst
+++ b/docsite/latest/rst/examples.rst
@@ -259,8 +259,8 @@ Ansible has an optional configuration file that can be used to tune settings and
 the first config file it finds present:
 
 1. File specified by the ``ANSIBLE_CONFIG`` environment variable
-2. ``ansible.cfg`` in the current working directory. (version 0.8 and up)
-3. ``~/.ansible.cfg``
+2. ``~/.ansible.cfg``
+3. ``ansible.cfg`` in the current working directory. (version 0.8 and up)
 4. ``/etc/ansible/ansible.cfg``
 
 For those running from source, a sample configuration file lives in the examples/ directory.  The RPM will install configuration into /etc/ansible/ansible.cfg automatically.

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -1,6 +1,8 @@
 # config file for ansible -- http://ansible.github.com
+#
 # nearly all parameters can be overridden in ansible-playbook or with command line flags
-# ansible will read ~/.ansible.cfg or /etc/ansible/ansible.cfg, whichever it finds first
+# ansible will read ~/.ansible.cfg, ansible.cfg in the current working directory or
+# /etc/ansible/ansible.cfg, whichever it finds first
 
 [defaults]
 


### PR DESCRIPTION
change loading order of ansible.cfg as specified in the documentation and examples/ansible.cfg to match the actual order ansible.cfg is loaded.
