### PR TITLE
Display default value in prompt when using vars_prompt

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -581,7 +581,9 @@ class PlaybookCallbacks(object):
 
     def on_vars_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False, salt_size=None, salt=None, default=None):
 
-        if prompt:
+        if prompt and default:
+            msg = "%s [%s]: " % (prompt, default)
+        elif prompt:
             msg = "%s: " % prompt
         else:
             msg = 'input for %s: ' % varname


### PR DESCRIPTION
If a default value is provided to a vars_prompt entry, display it when prompting the user.  This way, there will be no confusion as to if a default was set and if so, what it was set to.
