### PR TITLE
Command wrapper

### DIFF
--- a/hacking/README.md
+++ b/hacking/README.md
@@ -45,4 +45,14 @@ Authors
 'authors' is a simple script that generates a list of everyone who has
 contributed code to the ansible repository.
 
+Wrapper
+-------
+'wrapper' is for people who already have a directory like ~/bin in the search
+path and who would like to use Ansible from the Git checkout without much
+shell integration (like having to run env-setup):
 
+    $ for cmd in /path/to/ansible/checkout/bin/*; do
+        ln -s /path/to/ansible/checkout/hacking/wrapper ~/bin/${cmd##*/}
+      done
+
+Now you can just call ansible from anywhere and it'll work.

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -2,16 +2,18 @@
 # usage: source ./hacking/env-setup [-q]
 #    modifies environment for running Ansible from checkout
 
-# When run using source as directed, $0 gets set to bash, so we must use $BASH_SOURCE
-if [ -n "$BASH_SOURCE" ] ; then
-    HACKING_DIR=`dirname $BASH_SOURCE`
-else
-    HACKING_DIR="$PWD/hacking"
+if [ -z "$ANSIBLE_HOME" ]; then
+  # When run using source as directed, $0 gets set to bash, so we must use $BASH_SOURCE
+  if [ -n "$BASH_SOURCE" ] ; then
+      HACKING_DIR=`dirname $BASH_SOURCE`
+  else
+      HACKING_DIR="$PWD/hacking"
+  fi
+  # The below is an alternative to readlink -fn which doesn't exist on OS X
+  # Source: http://stackoverflow.com/a/1678636
+  FULL_PATH=`python -c "import os; print(os.path.realpath('$HACKING_DIR'))"`
+  ANSIBLE_HOME=`dirname "$FULL_PATH"`
 fi
-# The below is an alternative to readlink -fn which doesn't exist on OS X
-# Source: http://stackoverflow.com/a/1678636
-FULL_PATH=`python -c "import os; print(os.path.realpath('$HACKING_DIR'))"`
-ANSIBLE_HOME=`dirname "$FULL_PATH"`
 
 PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
 PREFIX_PATH="$ANSIBLE_HOME/bin"

--- a/hacking/wrapper
+++ b/hacking/wrapper
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Ansible wrapper
+#
+# If you have a directory like ~/bin that is already in your path, create
+# symlinks to this file in that directory, one for ansible, one for
+# ansible-playbook. That way, no additional integration/setup is required to
+# use ansible from the Git checkout
+#
+# Copyright © 2013 martin f. krafft <madduck@madduck.net
+# Released under the terms of the Artistic Licence 2.0
+#
+set -eu
+
+SELF="${0##*/}"
+COMMAND="$(readlink -f "$0")"
+CODE_HACKING_PATH="${COMMAND%/*}"
+ANSIBLE_HOME="${CODE_HACKING_PATH%/*}"
+
+# env-setup must be sourced from parent dir
+cd "$ANSIBLE_HOME"
+
+# preserve $PATH
+OLDPATH="$PATH"
+OLDARGS="$@"
+set +u -- -q
+. ./hacking/env-setup
+set -u
+PATH="$OLDPATH"
+eval set -- "$OLDARGS"
+unset OLDPATH OLDARGS
+
+exec "./bin/$SELF" "$@"

--- a/hacking/wrapper
+++ b/hacking/wrapper
@@ -17,6 +17,7 @@ CODE_HACKING_PATH="${COMMAND%/*}"
 ANSIBLE_HOME="${CODE_HACKING_PATH%/*}"
 
 # env-setup must be sourced from parent dir
+OLDPWD="$PWD"
 cd "$ANSIBLE_HOME"
 
 # preserve $PATH
@@ -25,8 +26,11 @@ OLDARGS="$@"
 set +u -- -q
 . ./hacking/env-setup
 set -u
+
+# restore environment
 PATH="$OLDPATH"
 eval set -- "$OLDARGS"
 unset OLDPATH OLDARGS
+cd "$OLDPWD"
 
 exec "./bin/$SELF" "$@"


### PR DESCRIPTION
A command wrapper for people who already have a directory like ~/bin in the search
path and who would like to use Ansible from the Git checkout without much
shell integration (like having to run env-setup).

(One-time) setup information is in the README file.
