### PR TITLE
Document the 'default' argument for vars_prompt.

### DIFF
--- a/docsite/latest/rst/playbooks2.rst
+++ b/docsite/latest/rst/playbooks2.rst
@@ -186,6 +186,15 @@ in a push-script::
 
 There are full examples of both of these items in the github examples/playbooks directory.
 
+If you have a variable that changes infrequently, it might make sense to
+provide a default value that can be overriden.  This can be accomplished using
+the default argument::
+
+   vars_prompt:
+     - name: "release_version"
+       prompt: "Product release version"
+       default: "1.0"
+
 An alternative form of vars_prompt allows for hiding input from the user, and may later support
 some other options, but otherwise works equivalently::
 


### PR DESCRIPTION
As far as I can tell, the 'default' argument provided to vars_prompt is an undocumented feature. This patch provides a slight bit of documentation for it so that people can be aware of its existence!
