### PR TITLE
Allow caller to disable logging on remote systems

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -42,6 +42,11 @@ remote_user=root
 # default module name for /usr/bin/ansible
 module_name = command
 
+# Ansible modules log their invocations using the 'user' facility of syslog or
+# systemd, by default. The following can be used to change that. Use 'off' to
+# disable logging on remote systems.
+#syslog_facility=LOG_USER
+
 # use this shell for commands executed under sudo
 # you may need to change this to bin/bash in rare instances
 # if sudo is constrained

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -40,6 +40,8 @@ MODULE_ARGS = <<INCLUDE_ANSIBLE_MODULE_ARGS>>
 MODULE_LANG = <<INCLUDE_ANSIBLE_MODULE_LANG>>
 MODULE_COMPLEX_ARGS = <<INCLUDE_ANSIBLE_MODULE_COMPLEX_ARGS>>
 
+LOGGING_DISABLED = False
+
 BOOLEANS_TRUE = ['yes', 'on', '1', 'true', 1]
 BOOLEANS_FALSE = ['no', 'off', '0', 'false', 0]
 BOOLEANS = BOOLEANS_TRUE + BOOLEANS_FALSE
@@ -209,7 +211,8 @@ class AnsibleModule(object):
             self._check_required_one_of(required_one_of)
 
         self._set_defaults(pre=False)
-        if not no_log:
+        # LOGGING_DISABLED would get set in ansible.cfg on the caller system
+        if not (LOGGING_DISABLED or no_log):
             self._log_invocation()
 
     def load_file_common_arguments(self, params):

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -742,7 +742,11 @@ class Runner(object):
                 facility = C.DEFAULT_SYSLOG_FACILITY
                 if 'ansible_syslog_facility' in inject:
                     facility = inject['ansible_syslog_facility']
-                module_data = module_data.replace('syslog.LOG_USER', "syslog.%s" % facility)
+                if facility in [ 'off', 'no', 'false', 'False' ]:
+                    module_data = module_data.replace('LOGGING_DISABLED = False',
+                                                      'LOGGING_DISABLED = True')
+                else:
+                    module_data = module_data.replace('syslog.LOG_USER', "syslog.%s" % facility)
 
         lines = module_data.split("\n")
         shebang = None


### PR DESCRIPTION
This commit introduces a new possible value for the syslog_facility
configuration option, namely 'off' (or '0', 'no', 'false'…).

If the syslog_facility is set to any of those values, then a constant at
the top of the modules_common code is changed accordingly, effectively
causing the invocation to the logging function to be skipped (as if the
module had set the no_log property of the AnsibleModule base class.

Signed-off-by: martin f. krafft madduck@madduck.net
