### PR TITLE
pkg option of apt is not required

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -31,7 +31,7 @@ options:
   pkg:
     description:
       - A package name or package specifier with version, like C(foo) or C(foo=1.0)
-    required: true
+    required: false
     default: null
   state:
     description:


### PR DESCRIPTION
You can use apt module with update_cache and without specifying a
package. Update the docs to reflect this.
