### PR TITLE
bug fix: modify get_device_facts to handle servers with multiple pci domains

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -633,7 +633,7 @@ class LinuxHardware(Hardware):
         self.facts['devices'] = {}
         lspci = module.get_bin_path('lspci')
         if lspci:
-            rc, pcidata, err = module.run_command(lspci)
+            rc, pcidata, err = module.run_command([lspci, '-D'])
         else:
             pcidata = None
 
@@ -704,7 +704,9 @@ class LinuxHardware(Hardware):
             d['size'] = module.pretty_bytes(float(d['sectors']) * float(d['sectorsize']))
 
             d['host'] = ""
-            m = re.match(".+/[a-f0-9]+:([a-f0-9]+:[a-f0-9]+\.[a-f0-9]+)/host\d+/", sysdir)
+
+            # domains are numbered (0 to ffff), bus (0 to ff), slot (0 to 1f), and function (0 to 7).
+            m = re.match(".+/([a-f0-9]{4}:[a-f0-9]{2}:[0|1][a-f0-9]\.[0-7])/", sysdir)
             if m and pcidata:
                 pciid = m.group(1)
                 did = re.escape(pciid)


### PR DESCRIPTION
On machines with multiple pci domains get_device_facts would fail to
find a matching pci device causing setup to fail. Also on some platforms
there is additional information between the pci information and 'host'.
Modified get_device_facts to call lspci with the -D option and modified
the regex to account for the pci domain and to be more selective.
