### PR TITLE
django_manage: Pass --noinput to migrate

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -177,6 +177,7 @@ def main():
     noinput_commands = (
         'flush',
         'syncdb',
+        'migrate',
         'test',
         'collectstatic',
         )


### PR DESCRIPTION
The django 'migrate' command should receive the --noinput flag, otherwise it can block waiting for user input.
