### PR TITLE
make name the parameter, with hostname as alias

### DIFF
--- a/lib/ansible/runner/action_plugins/add_host.py
+++ b/lib/ansible/runner/action_plugins/add_host.py
@@ -49,15 +49,15 @@ class ActionModule(object):
         result = {'changed': True}
 
         # Parse out any hostname:port patterns
-        new_hostname = args.get('hostname', args.get('name', None))
-        vv("creating host via 'add_host': hostname=%s" % new_hostname)
+        new_name = args.get('name', args.get('hostname', None))
+        vv("creating host via 'add_host': hostname=%s" % new_name)
 
-        if ":" in new_hostname:
-            new_hostname, new_port = new_hostname.split(":")
+        if ":" in new_name:
+            new_name, new_port = new_name.split(":")
             args['ansible_ssh_port'] = new_port
         
         # create host and get inventory    
-        new_host = Host(new_hostname)
+        new_host = Host(new_name)
         inventory = self.runner.inventory
         
         # Add any variables to the new_host
@@ -83,7 +83,7 @@ class ActionModule(object):
             vv("added host to group via add_host module: %s" % group_name)
             result['new_groups'] = groupnames.split(",")
             
-        result['new_host'] = new_hostname
+        result['new_host'] = new_name
         
         return ReturnData(conn=conn, comm_ok=True, result=result)
 

--- a/library/inventory/add_host
+++ b/library/inventory/add_host
@@ -10,6 +10,7 @@ description:
 version_added: "0.9"
 options:
   name:
+    aliases: [ 'hostname' ]
     description:
     - The hostname/ip of the host to add to the inventory, can include a colon and a port number.
     required: true     
@@ -23,10 +24,10 @@ author: Seth Vidal
 
 EXAMPLES = '''
 # add host to group 'just_created' with variable foo=42
-- add_host: hostname=${ip_from_ec2} groups=just_created foo=42
+- add_host: name=${ip_from_ec2} groups=just_created foo=42
 
 # add a host with a non-standard port local to your machines
-- add_host: hostname='${new_ip}:${new_port}' 
+- add_host: name='${new_ip}:${new_port}' 
 
 # add a host alias that we reach through a tunnel
 - add_host: hostname=${new_ip}


### PR DESCRIPTION
name is used throughout Ansible, it's the "standard". This change
applies that standard to the add_host routine and updates the docs to
reflect that. Related to https://github.com/ansible/ansible/pull/3254
