### PR TITLE
Fix apt purge

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -152,7 +152,11 @@ def package_status(m, pkgname, version, cache, state):
             m.fail_json(msg="No package matching '%s' is available" % pkgname)
         else:
             return False, False, False
-    has_files = len(pkg.installed_files) > 0
+    try:
+        has_files = len(pkg.installed_files) > 0
+    except AttributeError:
+        has_files = False  # older python-apt cannot be used to determine non-purged
+
     if version:
         try :
             return pkg.is_installed and fnmatch.fnmatch(pkg.installed.version, version), False, has_files

--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -210,9 +210,10 @@ def remove(m, pkgspec, cache, purge=False):
     if len(packages) == 0:
         m.exit_json(changed=False)
     else:
-        purge = ''
         if purge:
             purge = '--purge'
+        else:
+            purge = ''
         cmd = "%s -q -y %s remove %s" % (APT_GET_CMD, purge,packages)
 
         if m.check_mode:

--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -151,25 +151,26 @@ def package_status(m, pkgname, version, cache, state):
         if state == 'install':
             m.fail_json(msg="No package matching '%s' is available" % pkgname)
         else:
-            return False, False
+            return False, False, False
+    has_files = len(pkg.installed_files) > 0
     if version:
         try :
-            return pkg.is_installed and fnmatch.fnmatch(pkg.installed.version, version), False
+            return pkg.is_installed and fnmatch.fnmatch(pkg.installed.version, version), False, has_files
         except AttributeError:
             #assume older version of python-apt is installed
-            return pkg.isInstalled and fnmatch.fnmatch(pkg.installedVersion, version), False
+            return pkg.isInstalled and fnmatch.fnmatch(pkg.installedVersion, version), False, has_files
     else:
         try :
-            return pkg.is_installed, pkg.is_upgradable
+            return pkg.is_installed, pkg.is_upgradable, has_files
         except AttributeError:
             #assume older version of python-apt is installed
-            return pkg.isInstalled, pkg.isUpgradable
+            return pkg.isInstalled, pkg.isUpgradable, has_files
 
 def install(m, pkgspec, cache, upgrade=False, default_release=None, install_recommends=True, force=False):
     packages = ""
     for package in pkgspec:
         name, version = package_split(package)
-        installed, upgradable = package_status(m, name, version, cache, state='install')
+        installed, upgradable, has_files = package_status(m, name, version, cache, state='install')
         if not installed or (upgrade and upgradable):
             packages += "'%s' " % package
 
@@ -203,8 +204,8 @@ def remove(m, pkgspec, cache, purge=False):
     packages = ""
     for package in pkgspec:
         name, version = package_split(package)
-        installed, upgradable = package_status(m, name, version, cache, state='remove')
-        if installed:
+        installed, upgradable, has_files = package_status(m, name, version, cache, state='remove')
+        if installed or (has_files and purge):
             packages += "'%s' " % package
 
     if len(packages) == 0:


### PR DESCRIPTION
First of all, purging was altogether broken, that's now fixed.

But these changes also let APT deal with removed-but-not-purged packages later. This wasn't the case, as the package would no longer be installed, and so the apt module wouldn't do anything, even if `purge=yes` was set.
