### PR TITLE
datadog_event module requires urllib2, not httplib2.

### DIFF
--- a/library/monitoring/datadog_event
+++ b/library/monitoring/datadog_event
@@ -16,7 +16,7 @@ description:
 version_added: "1.3"
 author: Artūras 'arturaz' Šlajus <x11@arturaz.net>
 notes: []
-requirements: [httplib2]
+requirements: [urllib2]
 options:
     api_key:
         description: ["Your DataDog API key."]


### PR DESCRIPTION
A small documentation fix.
