### PR TITLE
Enable negated patterns

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -136,6 +136,11 @@ class Inventory(object):
         finds hosts that match a list of patterns. Handles negative
         matches as well as intersection matches.
         """
+        try:
+            if patterns[0].startswith("!"):
+                patterns.insert(0, "all")
+        except IndexError:
+            pass
 
         hosts = set()
         for p in patterns:


### PR DESCRIPTION
A host pattern of the form '!foo' by itself does not work, but
'all:!foo' does. If the first pattern is a negation, this commit
automatically prepends 'all'.

Signed-off-by: martin f. krafft madduck@madduck.net
