### PR TITLE
env-setup tweaks (POSIX-compliance) 2.1

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -14,7 +14,7 @@ esac
 # The below is an alternative to readlink -fn which doesn't exist on OS X
 # Source: http://stackoverflow.com/a/1678636
 FULL_PATH=`python -c "import os; print(os.path.realpath('$HACKING_DIR'))"`
-ANSIBLE_HOME=`dirname "$FULL_PATH"`
+ANSIBLE_HOME=${FULL_PATH%/*}
 
 PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
 PREFIX_PATH="$ANSIBLE_HOME/bin"

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -20,14 +20,23 @@ PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
 PREFIX_PATH="$ANSIBLE_HOME/bin"
 PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 
-[[ "$PYTHONPATH" != "${PREFIX_PYTHONPATH}"* ]] && export PYTHONPATH=$"PREFIX_PYTHONPATH:$PYTHONPATH"
-[[ "$PATH" != "${PREFIX_PATH}"* ]] && export PATH="$PREFIX_PATH:$PATH"
+case "$PYTHONPATH" in
+  (*${PREFIX_PYTHONPATH}*) :;;
+  (*) export PYTHONPATH=$"$PREFIX_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}";;
+esac
+case "$MANPATH" in
+  (*${PREFIX_MANPATH}*) :;;
+  (*) export MANPATH=$"$PREFIX_MANPATH${MANPATH:+:$MANPATH}";;
+esac
+case "$PATH" in
+  (*${PREFIX_PATH}*) :;;
+  (*) export PATH=$"$PREFIX_PATH${PATH:+:$PATH}";;
+esac
 export ANSIBLE_LIBRARY="$ANSIBLE_HOME/library"
-[[ "$MANPATH" != "${PREFIX_MANPATH}"* ]] && export MANPATH="$PREFIX_MANPATH:$MANPATH"
 
 # Print out values unless -q is set
 
-if [ $# -eq 0 -o "$1" != "-q" ] ; then
+if [ $# -eq 0 ] || [ "$1" != "-q" ] ; then
     echo ""
     echo "Setting up Ansible to run out of checkout..."
     echo ""

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -7,23 +7,23 @@
 # When run using source as directed, $0 gets set to bash, so we must use $BASH_SOURCE
 case "$0" in
     (bash)
-        HACKING_DIR=${BASH_SOURCE%/*};;
+        HACKING_DIR="${BASH_SOURCE%/*}";;
     (*)
-        HACKING_DIR=${0%/*};;
+        HACKING_DIR="${0%/*}";;
 esac
 # The below is an alternative to readlink -fn which doesn't exist on OS X
 # Source: http://stackoverflow.com/a/1678636
-FULL_PATH=`python -c "import os; print(os.path.realpath('$HACKING_DIR'))"`
-ANSIBLE_HOME=${FULL_PATH%/*}
+FULL_PATH=$(python -c "import os; print(os.path.realpath('$HACKING_DIR'))")
+ANSIBLE_HOME="${FULL_PATH%/*}"
 
 PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
 PREFIX_PATH="$ANSIBLE_HOME/bin"
 PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 
-[[ $PYTHONPATH != ${PREFIX_PYTHONPATH}* ]] && export PYTHONPATH=$PREFIX_PYTHONPATH:$PYTHONPATH
-[[ $PATH != ${PREFIX_PATH}* ]] && export PATH=$PREFIX_PATH:$PATH
+[[ "$PYTHONPATH" != "${PREFIX_PYTHONPATH}"* ]] && export PYTHONPATH=$"PREFIX_PYTHONPATH:$PYTHONPATH"
+[[ "$PATH" != "${PREFIX_PATH}"* ]] && export PATH="$PREFIX_PATH:$PATH"
 export ANSIBLE_LIBRARY="$ANSIBLE_HOME/library"
-[[ $MANPATH != ${PREFIX_MANPATH}* ]] && export MANPATH=$PREFIX_MANPATH:$MANPATH
+[[ "$MANPATH" != "${PREFIX_MANPATH}"* ]] && export MANPATH="$PREFIX_MANPATH:$MANPATH"
 
 # Print out values unless -q is set
 
@@ -36,7 +36,7 @@ if [ $# -eq 0 -o "$1" != "-q" ] ; then
     echo "ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY"
     echo "MANPATH=$MANPATH"
     echo ""
-    
+
     echo "Remember, you may wish to specify your host file with -i"
     echo ""
     echo "Done!"

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -22,15 +22,15 @@ PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 
 case "$PYTHONPATH" in
   (*${PREFIX_PYTHONPATH}*) :;;
-  (*) export PYTHONPATH=$"$PREFIX_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}";;
+  (*) export PYTHONPATH="$PREFIX_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}";;
 esac
 case "$MANPATH" in
   (*${PREFIX_MANPATH}*) :;;
-  (*) export MANPATH=$"$PREFIX_MANPATH${MANPATH:+:$MANPATH}";;
+  (*) export MANPATH="$PREFIX_MANPATH${MANPATH:+:$MANPATH}";;
 esac
 case "$PATH" in
   (*${PREFIX_PATH}*) :;;
-  (*) export PATH=$"$PREFIX_PATH${PATH:+:$PATH}";;
+  (*) export PATH="$PREFIX_PATH${PATH:+:$PATH}";;
 esac
 export ANSIBLE_LIBRARY="$ANSIBLE_HOME/library"
 

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -1,4 +1,3 @@
-#!/bin/bash
 # usage: source env-setup [-q]
 #        source hacking/env-setup [-q]
 #        . ./env-setup [-q]


### PR DESCRIPTION
This series of commits turns env-setup into a POSIX-compliant shell script, so that it can be used from shells like dash and ksh just the same.

The sourcing error in bash should be history.

Rebased onto current devel.
