### PR TITLE
Allow caller to disable logging on remote systems 2.0

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -42,6 +42,11 @@ remote_user=root
 # default module name for /usr/bin/ansible
 module_name = command
 
+# Ansible modules log their invocations using the 'user' facility of syslog or
+# systemd, by default. The following can be used to change that. Use 'off' to
+# disable logging on remote systems.
+#syslog_facility=LOG_USER
+
 # use this shell for commands executed under sudo
 # you may need to change this to bin/bash in rare instances
 # if sudo is constrained

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -84,13 +84,21 @@ def boilerplate_module(modfile, args):
 
     if included_boilerplate:
 
+        facility = C.DEFAULT_SYSLOG_FACILITY
+        if 'ansible_syslog_facility' in inject:
+            facility = inject['ansible_syslog_facility']
+        if facility in [ 'off', 'no', 'false', 'False' ]:
+            facility = 'None'
+        else:
+            facility = "syslog.%s" % facility
+        module_data = module_data.replace('syslog.LOG_USER', facility)
+
         module_data = module_data.replace(module_common.REPLACER, module_common.MODULE_COMMON)
         encoded_args = repr(str(args))
         module_data = module_data.replace(module_common.REPLACER_ARGS, encoded_args)
         encoded_lang = repr(C.DEFAULT_MODULE_LANG)
         empty_complex = repr("{}")
         module_data = module_data.replace(module_common.REPLACER_LANG, encoded_lang)
-        module_data = module_data.replace('syslog.LOG_USER', "syslog.%s" % C.DEFAULT_SYSLOG_FACILITY)
         module_data = module_data.replace(module_common.REPLACER_COMPLEX, empty_complex)
 
         modfile2_path = os.path.expanduser("~/.ansible_module_generated")

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -85,8 +85,6 @@ def boilerplate_module(modfile, args):
     if included_boilerplate:
 
         facility = C.DEFAULT_SYSLOG_FACILITY
-        if 'ansible_syslog_facility' in inject:
-            facility = inject['ansible_syslog_facility']
         if facility in [ 'off', 'no', 'false', 'False' ]:
             facility = 'None'
         else:

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -688,7 +688,10 @@ class AnsibleModule(object):
         # Sanitize possible password argument when logging.
         log_args = dict()
         passwd_keys = ['password', 'login_password']
-        
+        facility = syslog.LOG_USER # Alert! This value may get replaced by the runner
+        if facility is None:       # So this conditional could actually be true!
+            return
+
         for param in self.params:
             canon  = self.aliases.get(param, param)
             arg_opts = self.argument_spec.get(canon, {})
@@ -719,10 +722,10 @@ class AnsibleModule(object):
                 journal.sendv(*journal_args)
             except IOError, e:
                 # fall back to syslog since logging to journal failed
-                syslog.openlog(module, 0, syslog.LOG_USER)
+                syslog.openlog(module, 0, facility)
                 syslog.syslog(syslog.LOG_NOTICE, msg)
         else:
-            syslog.openlog(module, 0, syslog.LOG_USER)
+            syslog.openlog(module, 0, facility)
             syslog.syslog(syslog.LOG_NOTICE, msg)
 
     def get_bin_path(self, arg, required=False, opt_dirs=[]):

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -742,7 +742,11 @@ class Runner(object):
                 facility = C.DEFAULT_SYSLOG_FACILITY
                 if 'ansible_syslog_facility' in inject:
                     facility = inject['ansible_syslog_facility']
-                module_data = module_data.replace('syslog.LOG_USER', "syslog.%s" % facility)
+                if facility in [ 'off', 'no', 'false', 'False' ]:
+                    facility = 'None'
+                else:
+                    facility = "syslog.%s" % facility
+                module_data = module_data.replace('syslog.LOG_USER', facility)
 
         lines = module_data.split("\n")
         shebang = None


### PR DESCRIPTION
This commit introduces a new possible value for the syslog_facility
configuration option, namely 'off' (or '0', 'no', 'false'…).

If the syslog_facility is set to any of those values, then the log
invocation will return without logging.

Signed-off-by: martin f. krafft madduck@madduck.net
