### PR TITLE
Reference ansible_lsb.major_release, not ansible_lsb.major_version

### DIFF
--- a/docsite/latest/rst/playbooks2.rst
+++ b/docsite/latest/rst/playbooks2.rst
@@ -310,7 +310,7 @@ Tip: Sometimes you'll get back a variable that's a string and you'll want to do 
 
     tasks:
       - shell: echo "only on Red Hat 6, derivatives, and later"
-        when: ansible_os_family == "RedHat" and ansible_lsb.major_version|int >= 6
+        when: ansible_os_family == "RedHat" and ansible_lsb.major_release|int >= 6
 
 Variables defined in the playbooks or inventory can also be used.
 


### PR DESCRIPTION
As identified in #3269, I was using the wrong attribute of the ansible_lsb fact.  Looks like I copied the typo from the source.  This pull request fixes the same typo in docsite/latest/rst/playbooks2.rst.  Pretty small fix.
