### PR TITLE
ec2 module: added support for attribute-based idempotency

### DIFF
--- a/docsite/latest/rst/amazon_web_services.rst
+++ b/docsite/latest/rst/amazon_web_services.rst
@@ -38,13 +38,13 @@ The ec2 module provides the ability to provision EC2 instance(s).  Typically the
 * **Idempotent provisioning** (enabled with the idempotent_attribute option). By using the idempotent_attribute, the provisioning will ensure that at least count=N instances are running.  If N instance are already running, no new instances will be provisioned.
 
 Non-idempotent provisioning
-++++++++++++++
++++++++++++++++++++++++++++
 
 Each time the following ad-hoc command is run, five instances will be provisioned:
 
 .. code-block:: bash
 
-    # ansible localhost -m ec2 -a "count=5 image=ami-6e649707 instance_type=m1.large keypair=mykey group=webservers wait=yes"
+    ansible localhost -m ec2 -a "count=5 image=ami-6e649707 instance_type=m1.large keypair=mykey group=webservers wait=yes"
 
 In a play, this might look like (assuming the parameters are held as vars)::
 
@@ -74,10 +74,10 @@ With the host group now created, the second play in your provision playbook migh
 The method above ties the configuration of a host with the provisioning step.  This isn't always ideal and leads us onto the next section.
 
 Idempotent provisioning
-++++++++++++++
++++++++++++++++++++++++
 Idempotent provisioning provides a simple mechanism for maintaing a specified number of instances running in a particular host group.
 
-Using the ec2 inventory plugin ([documented in the API chapter](http://ansible.cc/docs/api.html#external-inventory-scripts>)) it is possible to group hosts by security group, machine image (AMI) or instance tags. Instance tags in particular provide a flexible way of marking instances as belonging to a particular host group.
+Using the ec2 inventory plugin it is possible to group hosts by security group, machine image (AMI) or instance tags. Instance tags in particular provide a flexible way of marking instances as belonging to a particular host group.
 
 The following example shows how one can idempotently provision a group of 5 hosts tagged as webservers::
 
@@ -101,6 +101,13 @@ If this play is run when 3 EC2 instances with the tag `'{"name":"webserver"}'` a
       tasks:
       ...
 
+If the above playbook were called `provision_webservers.yml`, then it could be run from the command line using
+
+```bash
+ansible-playbook provision_werbservers.yml -i hosts/
+```
+where the `hosts/` folder contains both files defining host groups, and the `ec2.py` inventory plugin. Only by putting all of these files together in a folder, and specifying that entire folder as the hosts location can locally defined hosts and those provided by the ec2 inventory plugin be combined.
+
 Note that the value of the `idempotency_attribute` option can also be `image`, `group` (security group), `group_id` (security group id) or `client-token`. The `client-token` is set using the `id` option.
 
 
@@ -118,7 +125,7 @@ You may wish to schedule a regular refresh of the inventory cache to accomodate 
 
 .. code-block:: bash
    
-    # ./ec2.py --refresh-cache
+    ./ec2.py --refresh-cache
 
 Put this into a crontab as appropriate to make calls from your Ansible master server to the EC2 API endpoints and gather host information.  The aim is to keep the view of hosts as up-to-date as possible, so schedule accordingly. Playbook calls could then also be scheduled to act on the refreshed hosts inventory after each refresh.  This approach means that machine images can remain "raw", containing no payload and OS-only.  Configuration of the workload is handled entirely by Ansible.  
 

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -205,7 +205,7 @@ EXAMPLES = '''
     wait: yes 
     count: 5 
     instance_tags: '{"db":"postgres"}' monitoring=yes'
-    idempotence_attribte: instance_tags
+    idempotence_attribute: instance_tags
 
 # VPC example
 - local_action: 

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -204,8 +204,8 @@ EXAMPLES = '''
     image: ami-6e649707 
     wait: yes 
     count: 5 
-    instance_tags: '{"db":"postgres"}' monitoring=yes'
-    idempotence_attribute: instance_tags
+    instance_tags: '{"db":"postgres"}'
+    idempotency_attribute: instance_tags
 
 # VPC example
 - local_action: 

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -28,9 +28,14 @@ options:
     required: true
     default: null
     aliases: ['keypair']
+  idempotency_attribute:
+    description:
+      - Enable idempotent mode by specifying an attribute here. Supported attributes: token | instance_tags | group | group_id | image
+    default: null
+    aliases: []
   id:
     description:
-      - identifier for this instance or set of instances, so that the module will be idempotent with respect to EC2 instances.
+      - The value of id is an ec2 client-token. If specified, it is used for idempotent provisioning based on client-token.
     required: false
     default: null
     aliases: []
@@ -190,6 +195,18 @@ EXAMPLES = '''
     count: 5 
     instance_tags: '{"db":"postgres"}' monitoring=yes'
 
+# Example of provisioning instances idempotently based on tags
+- local_action: 
+    module: ec2 
+    keypair: mykey 
+    group: databases 
+    instance_type: m1.large 
+    image: ami-6e649707 
+    wait: yes 
+    count: 5 
+    instance_tags: '{"db":"postgres"}' monitoring=yes'
+    idempotence_attribte: instance_tags
+
 # VPC example
 - local_action: 
     module: ec2 
@@ -215,6 +232,7 @@ def main():
         argument_spec = dict(
             key_name = dict(required=True, aliases = ['keypair']),
             id = dict(),
+            idempotency_attribute = dict(),
             group = dict(),
             group_id = dict(),
             region = dict(choices=['eu-west-1', 'sa-east-1', 'us-east-1', 'ap-northeast-1', 'us-west-2', 'us-west-1', 'ap-southeast-1', 'ap-southeast-2']),
@@ -240,6 +258,7 @@ def main():
 
     key_name = module.params.get('key_name')
     id = module.params.get('id')
+    idempotency_attribute = module.params.get('idempotency_attribute')
     group_name = module.params.get('group')
     group_id = module.params.get('group_id')
     region = module.params.get('region')
@@ -305,18 +324,40 @@ def main():
     except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
 
-    # Lookup any instances that much our run id.
-    
+    # If an idempotency_attribtue is specified, look for already running instances in order to not duplicate them
+
     running_instances = []
     count_remaining = int(count)
-        
-    if id != None:
-        filter_dict = {'client-token':id, 'instance-state-name' : 'running'}
+
+    if not(idempotency_attribute is None) or not(id is None):
+        if not(idempotency_attribute is None):
+            if idempotency_attribute == "instance_tags":
+                if instance_tags is None:
+                    module.fail_json(msg = "Idempotency attribute set to id, so a value for the id option must also be provided.")
+                filter_dict = dict(("tag:" + tn, tv) for tn, tv in module.from_json(instance_tags).items())
+            elif idempotency_attribute == "image":
+                filter_dict = {"image-id": image}
+            elif idempotency_attribute == "group":
+                filter_dict = {"group-name": group_name}
+            elif idempotency_attribute == "group_id":
+                filter_dict = {"group-id": group_id}
+            elif idempotency_attribute == "id":
+                if id is None:
+                    module.fail_json(msg = "Idempotency attribute set to id, so a value for the id option must also be provided.")
+                filter_dict = {'client-token':id}
+            else:
+                module.fail_json(msg = "Idempotency attribute '%s' not supported. Supported attribtues: instance_tags, image, group, group_id, and id." % idempotency_attribute)
+        # In order to support backwards compatibility, if the id is specified and the idempotency attribute is not, we still select previous instances based on the id
+        elif not(id is None):
+            filter_dict = {'client-token':id}
+
         previous_reservations = ec2.get_all_instances(None, filter_dict)
         for res in previous_reservations:
             for prev_instance in res.instances:
-                running_instances.append(prev_instance)
-        count_remaining = count_remaining - len(running_instances) 
+                if prev_instance.state in ("pending", "running"): # Ignore terminated instances and those shutting down
+                    running_instances.append(prev_instance)
+    count_remaining = count_remaining - len(running_instances) 
+    
     
     # Both min_count and max_count equal count parameter. This means the launch request is explicit (we want count, or fail) in how many instances we want.
     
@@ -380,7 +421,10 @@ def main():
     
         for inst in this_res.instances:
             running_instances.append(inst)
-        
+        changed = True
+    else:
+        changed = False
+
     instance_dict_array = []
     for inst in running_instances:
         d = {
@@ -408,7 +452,7 @@ def main():
             }
         instance_dict_array.append(d)
 
-    module.exit_json(changed=True, instances=instance_dict_array)
+    module.exit_json(changed=changed, instances=instance_dict_array)
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>


### PR DESCRIPTION
As discussed on the mailing list and in the irc channel, the aws modules would ideally provide better support for idempotent operations.

This pull request implements extended support for idempotently provisioning ec2 instances using the ec2 module. The "id" option is extended. If id is set to "tags", "group", "group_id", or "image", then new instances will be provisioned only if there are not already count=N such instances with the specified attribute. For example, if

``` yml
  instance_tags: '{"db":"postgres"}'
  id: tag
  count: 5
  idempotence_attribute: instance_tags
```

then new instances will be provisioned only if there are not already five instances with the tag db: postgres key-value pair.

An example is included in the EXAMPLES string.

Note that this pull request should not break backwards compatibility.  I have tested this module and it appears to work, but someone needs to make sure that upon exiting, the module correctly indicates whether anything has changed.

(A similar pull request was submitted [here](https://github.com/ansible/ansible/pull/3249), but then closed.)
