### PR TITLE
Allow skipped tasks to be hidden in playbook output

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -57,6 +57,10 @@ timeout = 10
 # Turn off ${old_style} variables here if you like.
 #legacy_playbook_variables = yes
 
+# Should the display output of a play include tasks that were skipped on some
+# or all hosts? If not, then you can turn this on
+#hide_skipped_tasks = yes
+
 # list any Jinja2 extensions to enable here:
 #jinja2_extensions = jinja2.ext.do,jinja2.ext.i18n
 

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -495,12 +495,14 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
         super(PlaybookRunnerCallbacks, self).on_error(host, err)
 
     def on_skipped(self, host, item=None):
-        msg = ''
-        if item:
-            msg = "skipping: [%s] => (item=%s)" % (host, item)
-        else:
-            msg = "skipping: [%s]" % host
-        display(msg, color='cyan')
+        if not constants.HIDE_SKIPPED_TASKS:
+            msg = ''
+            if item:
+                msg = "skipping: [%s] => (item=%s)" % (host, item)
+            else:
+                msg = "skipping: [%s]" % host
+            display(msg, color='cyan')
+
         super(PlaybookRunnerCallbacks, self).on_skipped(host, item)
 
     def on_no_hosts(self):

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -112,6 +112,8 @@ ZEROMQ_PORT                    = int(get_config(p, 'fireball', 'zeromq_port', 'A
 
 DEFAULT_UNDEFINED_VAR_BEHAVIOR = get_config(p, DEFAULTS, 'error_on_undefined_vars', 'ANSIBLE_ERROR_ON_UNDEFINED_VARS', False)
 
+HIDE_SKIPPED_TASKS        = get_config(p, DEFAULTS, 'hide_skipped_tasks', 'HIDE_SKIPPED_TASKS', False)
+
 # non-configurable things
 DEFAULT_SUDO_PASS         = None
 DEFAULT_REMOTE_PASS       = None


### PR DESCRIPTION
By setting 'hide_skipped_tasks' to True in the configuration file, one
can now inhibit the display when a task was skipped. This is useful
information to some, but takes away screen estate and obscures more
relevant information for others.

Signed-off-by: martin f. krafft madduck@madduck.net
