### PR TITLE
Let paths to roles be relative to playbook if started with '.'

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -162,7 +162,13 @@ class Play(object):
             with_items = has_dict.get('with_items', None)
             when       = has_dict.get('when', None)
 
-            path = utils.path_dwim(self.basedir, os.path.join('roles', orig_path))
+            if orig_path.startswith("."):
+                # a leading dot makes roles be resolved relative to the
+                # playbook directory, not a subdirectory 'roles/'
+                path = utils.path_dwim(self.basedir, orig_path)
+            else:
+                path = utils.path_dwim(self.basedir, os.path.join('roles', orig_path))
+
             if not os.path.isdir(path) and not orig_path.startswith(".") and not orig_path.startswith("/"):
                 path2 = utils.path_dwim(self.basedir, orig_path)
                 if not os.path.isdir(path2):


### PR DESCRIPTION
Currently, if you want to point to a role directory, you need to use
absolute paths (which isn't ideal); if you use a relative path, then
that is always relative to the roles/ subdirectory.

If you want to include a role that is in a subdirectory of the
playbook, e.g. 'foo/bar', then you need to use '..':

  ../foo/bar   →   basedir/roles/../foo/bar   →   basedir/foo/bar

This commit changes the origin for the resolution of the relative path
to the directory of the playbook, if the rolename starts with a '.':

  ./foo/bar   →   basedir/foo/bar

Current users just keep on saying 'foo' to get at 'roles/foo'

But if you say e.g. './foo', then this means './foo', not
'/roles/foo'.

Signed-off-by: martin f. krafft madduck@madduck.net
