### PR TITLE
Don't turn on sudo for all tasks when setting the sudo_user or ask_sudo_pass

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -95,8 +95,6 @@ def main(args):
         options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
         options.ask_sudo_pass = options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
         ( sshpass, sudopass ) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass)
-        if options.sudo_user or options.ask_sudo_pass:
-            options.sudo = True
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
     if options.extra_vars and options.extra_vars[0] in '[{':
         extra_vars = utils.json_loads(options.extra_vars)


### PR DESCRIPTION
This also relates to to Issue #3297.

If you specify the sudo_user or the ask_sudo_pass values, you shouldn't have sudo be turned on by default for all tasks.  It should still be executed as the currently executing user, and you can then choose to also sudo=true, or do it per playbook or per task within ansible.

Otherwise, you really have no way of specifying the password for a sudo user, and still use the originally executing user to run your tasks/playbooks.
