### PR TITLE
Make role syntax consistent with tasks and includes

### DIFF
--- a/docsite/latest/rst/playbooks.rst
+++ b/docsite/latest/rst/playbooks.rst
@@ -501,19 +501,18 @@ Also, should you wish to parameterize roles, by adding variables, you can do so,
     - hosts: webservers
       roles:
         - common
-        - role: foo_app_instance
-          dir: '/opt/a'
-          port: 5000
-        - role: foo_app_instance
-          dir: '/opt/b'
-          port: 5001
+        - role: foo_app_instance dir='/opt/a' port=5000
+        - role: foo_app_instance dir='/opt/b' port=5001
 
-You may also write it all on a single line, which YAML treats exactly the same:
+Note that you may still provide the parameters as a hash, in both forms:
 
     ---
     - hosts: webservers
       roles:
-        - { role: foo_app_instance, dir: '/opt/a', … }
+        - { role: foo_app_instance, dir: '/opt/a', port: 5000 }
+        - role: foo_app_instance
+          dir: '/opt/b'
+          port: 5001
 
 While it's probably not something you should do often, you can also conditionally apply roles like so::
 

--- a/docsite/latest/rst/playbooks.rst
+++ b/docsite/latest/rst/playbooks.rst
@@ -501,15 +501,27 @@ Also, should you wish to parameterize roles, by adding variables, you can do so,
     - hosts: webservers
       roles:
         - common
-        - { role: foo_app_instance, dir: '/opt/a',  port: 5000 }
-        - { role: foo_app_instance, dir: '/opt/b',  port: 5001 }
+        - role: foo_app_instance
+          dir: '/opt/a'
+          port: 5000
+        - role: foo_app_instance
+          dir: '/opt/b'
+          port: 5001
+
+You may also write it all on a single line, which YAML treats exactly the same:
+
+    ---
+    - hosts: webservers
+      roles:
+        - { role: foo_app_instance, dir: '/opt/a', … }
 
 While it's probably not something you should do often, you can also conditionally apply roles like so::
 
     ---
     - hosts: webservers
       roles:
-        - { role: some_role, when: "ansible_os_family == 'RedHat'" }
+        - role: some_role
+          when: "ansible_os_family == 'RedHat'"
 
 This works by applying the conditional to every task in the role.  Conditionals are covered later on in
 the documentation.
@@ -523,7 +535,7 @@ If you want to define certain tasks to happen before AND after roles are applied
       pre_tasks:
         - shell: echo 'hello'
       roles:
-        - { role: some_role }
+        - role: some_role
       tasks:
         - shell: echo 'still busy'
       post_tasks:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -162,6 +162,12 @@ class Play(object):
             with_items = has_dict.get('with_items', None)
             when       = has_dict.get('when', None)
 
+            parts = orig_path.split()
+            if len(parts) > 1 and parts[1].find('=') > 0:
+                orig_path = parts[0]
+                has_dict['role'] = orig_path
+                has_dict.update((k,v) for k,v in map(lambda x: x.split('='), parts[1:]))
+
             path = utils.path_dwim(self.basedir, os.path.join('roles', orig_path))
             if not os.path.isdir(path) and not orig_path.startswith(".") and not orig_path.startswith("/"):
                 path2 = utils.path_dwim(self.basedir, orig_path)


### PR DESCRIPTION
This enables the syntax

```

---
roles:
  - role: rolename param=value foo=bar
```

in addition to the existing dict-based syntax.

I also updated the documentation accordingly, making it sound like this is now the preferred way. I hope that's alright.
