### PR TITLE
Allow ansible_managed to expand fqdn

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -66,7 +66,7 @@ timeout = 10
 
 # format of string {{ ansible_managed }} available within Jinja2 
 # templates indicates to users editing templates files will be replaced.
-# replacing {file}, {host} and {uid} and strftime codes with proper values.
+# replacing {file}, {host}, {fqdn} and {uid} and strftime codes with proper values.
 ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
 
 # if set, Ansible will raise errors when attempting to redeference Jinja2

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -28,6 +28,7 @@ import time
 import subprocess
 import datetime
 import pwd
+import socket
 
 class Globals(object):
 
@@ -439,6 +440,10 @@ def template_from_file(basedir, path, vars):
     except:
         template_uid = os.stat(realpath).st_uid
     vars['template_host']   = os.uname()[1]
+    try:
+        vars['template_fqdn'] = socket.getfqdn() or vars['template_host']
+    except:
+        pass
     vars['template_path']   = realpath
     vars['template_mtime']  = datetime.datetime.fromtimestamp(os.path.getmtime(realpath))
     vars['template_uid']    = template_uid
@@ -448,6 +453,7 @@ def template_from_file(basedir, path, vars):
     managed_default = C.DEFAULT_MANAGED_STR
     managed_str = managed_default.format(
         host = vars['template_host'],
+        fqdn = vars['template_fqdn'],
         uid  = vars['template_uid'],
         file = vars['template_path']
     )


### PR DESCRIPTION
This provides the slot {fqdn} for the ansible_managed string, in
addition to {host} (fallback value in case the FQDN cannot be
determined).

Signed-off-by: martin f. krafft madduck@madduck.net
