### PR TITLE
Doc: rabbitmq_user pw change and force

### DIFF
--- a/library/messaging/rabbitmq_user
+++ b/library/messaging/rabbitmq_user
@@ -35,7 +35,9 @@ options:
     aliases: [username, name]
   password:
     description:
-      - Password of user to add
+      - Password of user to add.
+      - To change the password of an existing user, you must also specify
+        C(force=yes).
     required: false
     default: null
   tags:


### PR DESCRIPTION
Document that need to add force=yes to change password of existing user.

Fixes #3237
