### PR TITLE
Add support for mongodb 2.4 roles and otherDBRoles and implicit auth

### DIFF
--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -1,0 +1,226 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+
+
+DOCUMENTATION = '''
+---
+module: ec2_group
+short_description: maintain an ec2 VPC security group.
+description:
+    - maintains ec2 security groups. This module has a dependency on python-boto >= 2.5
+options:
+  name:
+    description:
+      - name of the security group.
+    required: true
+  description:
+    description:
+      - description of the security group.
+    required: true
+  vpc_id:
+    description:
+      - ID of the VPC to create the group in.
+    required: true
+  rules:
+    description:
+      - List of firewall rules to enforce in this group (see example).
+    required: true
+  region:
+    description:
+      - the EC2 region to use
+    required: false
+    default: null
+    aliases: []
+  ec2_url:
+    description:
+      - url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints)
+    required: false
+    default: null
+    aliases: []
+  ec2_secret_key:
+    description:
+      - ec2 secret key
+    required: false
+    default: null
+    aliases: []
+  ec2_access_key:
+    description:
+      - ec2 access key
+    required: false
+    default: null
+    aliases: []
+requirements: [ "boto" ]
+'''
+
+EXAMPLES = '''
+- name: example ec2 group
+  local_action:
+    module: ec2_group
+    name: example
+    description: an example EC2 group
+    vpc_id: 12345
+    region: eu-west-1a
+    ec2_secret_key: SECRET
+    ec2_access_key: ACCESS
+    rules:
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: 10.0.0.0/8
+      - proto: udp
+        from_port: 10050
+        to_port: 10050
+        cidr_ip: 10.0.0.0/8
+      - proto: udp
+        from_port: 10051
+        to_port: 10051
+        group_id: abcdef
+'''
+
+try:
+    import boto.ec2
+except ImportError:
+    print "failed=True msg='boto required for this module'"
+    sys.exit(1)
+
+
+def addRulesToLookup(rules, prefix, dict):
+    for rule in rules:
+        for grant in rule.grants:
+            dict["%s-%s-%s-%s-%s-%s" % (prefix, rule.ip_protocol, rule.from_port, rule.to_port,
+                                        grant.group_id, grant.cidr_ip)] = rule
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True),
+            description=dict(required=True),
+            vpc_id=dict(),
+            rules=dict(),
+            ec2_url=dict(aliases=['EC2_URL']),
+            ec2_secret_key=dict(aliases=['EC2_SECRET_KEY'], no_log=True),
+            ec2_access_key=dict(aliases=['EC2_ACCESS_KEY']),
+            region=dict(choices=['eu-west-1', 'sa-east-1', 'us-east-1', 'ap-northeast-1', 'us-west-2', 'us-west-1', 'ap-southeast-1', 'ap-southeast-2']),
+        ),
+        supports_check_mode=True,
+    )
+    name = module.params['name']
+    description = module.params['description']
+    vpc_id = module.params['vpc_id']
+    rules = module.params['rules']
+    ec2_url = module.params.get('ec2_url')
+    ec2_secret_key = module.params.get('ec2_secret_key')
+    ec2_access_key = module.params.get('ec2_access_key')
+    region = module.params.get('region')
+
+    changed = False
+
+    # allow eucarc environment variables to be used if ansible vars aren't set
+    if not ec2_url and 'EC2_URL' in os.environ:
+        ec2_url = os.environ['EC2_URL']
+    if not ec2_secret_key and 'EC2_SECRET_KEY' in os.environ:
+        ec2_secret_key = os.environ['EC2_SECRET_KEY']
+    if not ec2_access_key and 'EC2_ACCESS_KEY' in os.environ:
+        ec2_access_key = os.environ['EC2_ACCESS_KEY']
+
+    # If we have a region specified, connect to its endpoint.
+    if region:
+        try:
+            ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=ec2_access_key, aws_secret_access_key=ec2_secret_key)
+        except boto.exception.NoAuthHandlerFound, e:
+            module.fail_json(msg=str(e))
+    # Otherwise, no region so we fallback to the old connection method
+    else:
+        try:
+            if ec2_url:  # if we have an URL set, connect to the specified endpoint
+                ec2 = boto.connect_ec2_endpoint(ec2_url, ec2_access_key, ec2_secret_key)
+            else:  # otherwise it's Amazon.
+                ec2 = boto.connect_ec2(ec2_access_key, ec2_secret_key)
+        except boto.exception.NoAuthHandlerFound, e:
+            module.fail_json(msg=str(e))
+
+    # find the group if present
+    group = None
+    groups = {}
+    for curGroup in ec2.get_all_security_groups():
+        groups[curGroup.id] = curGroup
+
+        if curGroup.name == name and curGroup.vpc_id == vpc_id:
+            group = curGroup
+
+    # if found, check the group parameters are correct
+    if group:
+        group_in_use = False
+        rs = ec2.get_all_instances()
+        for r in rs:
+            for i in r.instances:
+                group_in_use |= reduce(lambda x, y: x | (y.name == 'public-ssh'), i.groups, False)
+
+        if group.description != description:
+            if group_in_use:
+                module.fail_json(msg="Group description does not match, but it is in use so cannot be changed.")
+            group.delete()
+            group = None
+
+    # if the group doesn't exist, create it now
+    if not group:
+        if not module.check_mode:
+            group = ec2.create_security_group(name, description, vpc_id=vpc_id)
+        changed = True
+
+    # create a lookup for all existing rules on the group
+    groupRules = {}
+    if group:
+        addRulesToLookup(group.rules, 'in', groupRules)
+
+    # Now, go through all the defined rules and ensure they are there.
+    if rules:
+        for rule in rules:
+            group_id = None
+            ip = None
+            if 'group_id' in rule and 'cidr_ip' in rule:
+                module.fail_json(msg="Specify group_id OR cidr_ip, not both")
+            elif 'group_id' in rule:
+                group_id = rule['group_id']
+            elif 'cidr_ip' in rule:
+                ip = rule['cidr_ip']
+
+            if rule['proto'] == 'all':
+                rule['proto'] = -1
+                rule['from_port'] = None
+                rule['to_port'] = None
+
+            ruleId = "%s-%s-%s-%s-%s-%s" % ('in', rule['proto'], rule['from_port'], rule['to_port'], group_id, ip)
+            if ruleId in groupRules:
+                del groupRules[ruleId]
+                continue
+
+            grantGroup = None
+            if group_id:
+                grantGroup = groups[group_id]
+
+            if not module.check_mode:
+                group.authorize(rule['proto'], rule['from_port'], rule['to_port'], ip, grantGroup)
+            changed = True
+
+    # Finally, remove anything left in the groupRules -- these will be defunct rules
+    for rule in groupRules.itervalues():
+        for grant in rule.grants:
+            grantGroup = None
+            if grant.group_id:
+                grantGroup = groups[grant.group_id]
+            if not module.check_mode:
+                group.revoke(rule.ip_protocol, rule.from_port, rule.to_port, grant.cidr_ip, grantGroup)
+            changed = True
+
+    if not group:
+        module.exit_json(changed=changed, group_id=None)
+    module.exit_json(changed=changed, group_id=group.id)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -67,6 +67,21 @@ options:
         required: false
         default: present
         choices: [ "present", "absent" ]
+    roles:
+        description:
+            - Comma separated list of mongodb 2.4 role names
+        required: false
+        default: null
+    otherDBRoles:
+        description:
+            - Pipe and comma separated list of mongodb 2.4 databases and role names, e.g db1:read|db2:readWrite,dbAdmin
+        required: false
+        default: null
+    check_implicit_admin:
+        description:
+            - Check if mongodb is allows login with no username/password before trying supplied credentials.
+        required: false
+        default: false
 notes:
     - Requires the pymongo Python package on the remote host, version 2.4.2+. This
       can be installed using pip or the OS package manager. @see http://api.mongodb.org/python/current/installation.html
@@ -101,10 +116,18 @@ else:
 # MongoDB module specific support methods.
 #
 
-def user_add(client, db_name, user, password):
+def user_add(client, db_name, user, password, roles, otherDBRoles):
     try:
         db = client[db_name]
-        db.add_user(user, password)
+        kwargs = {}
+        if roles:
+            kwargs['roles'] = roles
+        if otherDBRoles:
+            kwargs['otherDBRoles'] = otherDBRoles
+            if 'roles' not in kwargs:
+                kwargs['roles'] = []
+        db.add_user(user, password, **kwargs)
+
     except OperationFailure:
         return False
 
@@ -152,6 +175,9 @@ def main():
             user=dict(required=True, aliases=['name']),
             password=dict(aliases=['pass']),
             state=dict(default='present', choices=['absent', 'present']),
+            roles=dict(default=None),
+            otherDBRoles=dict(default=None),
+            check_implicit_admin=dict(default=False)
         )
     )
 
@@ -166,6 +192,20 @@ def main():
     user = module.params['user']
     password = module.params['password']
     state = module.params['state']
+    roles = module.params['roles']
+    otherDBRoles = module.params['otherDBRoles']
+    check_implicit_admin = module.params['check_implicit_admin']
+
+    if roles is not None:
+        roles = roles.split(',')
+    if otherDBRoles is not None:
+        tmp = {}
+        for r in otherDBRoles.split('|'):
+            if ':' not in r:
+                continue
+            (dbName, dbRoles) = r.split(':')
+            tmp[dbName] = dbRoles.split(',')
+        otherDBRoles = tmp
 
     try:
         client = MongoClient(login_host, int(login_port))
@@ -177,6 +217,14 @@ def main():
         elif login_password is None and login_user is not None:
             module.fail_json(msg='when supplying login arguments, both login_user and login_password must be provided')
 
+        if check_implicit_admin:
+            try:
+                client.admin.collection_names()
+                login_user = None
+                login_password = None
+            except:
+                pass
+
         if login_user is not None and login_password is not None:
             client.admin.authenticate(login_user, login_password)
 
@@ -186,7 +234,7 @@ def main():
     if state == 'present':
         if password is None:
             module.fail_json(msg='password parameter required when adding a user')
-        if user_add(client, db_name, user, password) is not True:
+        if user_add(client, db_name, user, password, roles, otherDBRoles) is not True:
             module.fail_json(msg='Unable to add or update user, check login_user and login_password are correct and that this user has access to the admin collection')
     elif state == 'absent':
         if user_remove(client, db_name, user) is not True:

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -72,6 +72,11 @@ options:
     required: false
     default: present
     choices: [ "present", "absent" ]
+  check_implicit_admin:
+    description:
+      - Check if mysql allows login as root/nopassword before trying supplied credentials. Allows bootstrapping without my.cnf file.
+    required: false
+    default: false
 notes:
    - Requires the MySQLdb Python package on the remote host. For Ubuntu, this
      is as easy as apt-get install python-mysqldb.
@@ -316,6 +321,13 @@ def load_mycnf():
     creds = dict(user=user,passwd=passwd)
     return creds
 
+def connect(module, login_user, login_password):
+    if module.params["login_unix_socket"]:
+        db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db="mysql")
+    else:
+        db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
+    return db_connection.cursor()
+
 # ===========================================
 # Module execution.
 #
@@ -332,6 +344,7 @@ def main():
             host=dict(default="localhost"),
             state=dict(default="present", choices=["absent", "present"]),
             priv=dict(default=None),
+            check_implicit_admin=dict(default=False),
         )
     )
     user = module.params["user"]
@@ -339,6 +352,7 @@ def main():
     host = module.params["host"]
     state = module.params["state"]
     priv = module.params["priv"]
+    check_implicit_admin = module.params['check_implicit_admin']
 
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")
@@ -365,12 +379,16 @@ def main():
     elif login_password is None or login_user is None:
         module.fail_json(msg="when supplying login arguments, both login_user and login_password must be provided")
 
+    cursor = None
     try:
-        if module.params["login_unix_socket"]:
-            db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db="mysql")
-        else:
-            db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
-        cursor = db_connection.cursor()
+        if check_implicit_admin:
+            try:
+                cursor = connect(module, 'root', '')
+            except:
+                pass
+
+        if not cursor:
+            cursor = connect(module, login_user, login_password)
     except Exception, e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials")
 

--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -82,6 +82,11 @@ options:
     required: false
     default: "yes"
     choices: [ "yes", "safe", "full", "dist"]
+  requirements:
+    description:
+      - Text file containing names of packages to install, one per line.
+    required: false
+    default: null
 requirements: [ python-apt, aptitude ]
 author: Matthew Williams
 notes:
@@ -237,7 +242,7 @@ def upgrade(m, mode="yes"):
         # apt-get dist-upgrade
         apt_cmd = APT_GET_CMD
         upgrade_command = "dist-upgrade"
-    elif mode == "full": 
+    elif mode == "full":
         # aptitude full-upgrade
         apt_cmd = APTITUDE_CMD
         upgrade_command = "full-upgrade"
@@ -268,10 +273,11 @@ def main():
             default_release = dict(default=None, aliases=['default-release']),
             install_recommends = dict(default='yes', aliases=['install-recommends'], type='bool'),
             force = dict(default='no', type='bool'),
-            upgrade = dict(choices=['yes', 'safe', 'full', 'dist'])
+            upgrade = dict(choices=['yes', 'safe', 'full', 'dist']),
+            requirements = dict(default=None, required=False)
         ),
-        mutually_exclusive = [['package', 'upgrade']],
-        required_one_of = [['package', 'upgrade', 'update_cache']],
+        mutually_exclusive = [['package', 'upgrade', 'requirements']],
+        required_one_of = [['package', 'upgrade', 'update_cache', 'requirements']],
         supports_check_mode = True
     )
 
@@ -334,7 +340,12 @@ def main():
         if p['upgrade']:
             upgrade(module, p['upgrade'])
 
-        packages = p['package'].split(',')
+        if p['requirements']:
+            f = open(p['requirements'])
+            packages = [x.strip() for x in f.readlines()]
+            f.close()
+        else:
+            packages = p['package'].split(',')
         latest = p['state'] == 'latest'
         for package in packages:
             if package.count('=') > 1:


### PR DESCRIPTION
Hi, this add support for mongodb 2.4's fine grained security roles.

It also adds an optional "check_implicit_auth" parameter: When you enable admin on mongodb, but haven't created any admin users yet, it starts up, and allows logins with no username/password. Enabling this option means ansible will first try and connect with no username/password even if you supply one. Solves an irritating bootstrap problem after enabling auth for the first time.
