### PR TITLE
Refactored Ansible command options

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -44,15 +44,15 @@ class Cli(object):
         ''' create an options parser for bin/ansible '''
 
         parser = utils.base_parser(
-            constants=C, 
-            runas_opts=True, 
-            subset_opts=True, 
+            constants=C,
+            usage='%prog <host-pattern> [options]',
             async_opts=True,
-            output_opts=True, 
-            connect_opts=True, 
             check_opts=True,
+            connect_opts=True,
             diff_opts=False,
-            usage='%prog <host-pattern> [options]'
+            output_opts=True,
+            runas_opts=True,
+            subset_opts=True
         )
 
         parser.add_option('-a', '--args', dest='module_args',
@@ -60,8 +60,6 @@ class Cli(object):
         parser.add_option('-m', '--module-name', dest='module_name',
             help="module name to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
             default=C.DEFAULT_MODULE_NAME)
-        parser.add_option('--list-hosts', dest='listhosts', action='store_true',
-            help="dump out a list of hosts matching input pattern, does not execute any modules!")
 
         options, args = parser.parse_args()
         self.callbacks.options = options

--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -120,16 +120,16 @@ def main():
         description='Show Ansible module documentation',
     )
 
-    p.add_option("-M", "--module-path",
-            action="store",
-            dest="module_path",
-            default=MODULEDIR,
-            help="Ansible modules/ directory")
     p.add_option("-l", "--list",
             action="store_true",
             default=False,
             dest='list_dir',
             help='List available modules')
+    p.add_option("-M", "--module-path",
+            action="store",
+            dest="module_path",
+            default=MODULEDIR,
+            help="Ansible modules/ directory")
     p.add_option("-s", "--snippet",
             action="store_true",
             default=False,

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -52,31 +52,28 @@ def main(args):
     ''' run ansible-playbook operations '''
 
     # create parser for CLI options
-    usage = "%prog playbook.yml"
     parser = utils.base_parser(
-        constants=C, 
-        usage=usage, 
-        connect_opts=True, 
-        runas_opts=True, 
-        subset_opts=True, 
+        constants=C,
+        usage = '%prog playbook.yml',
         check_opts=True,
-        diff_opts=True
+        connect_opts=True,
+        diff_opts=True,
+        runas_opts=True,
+        subset_opts=True
     )
+
     parser.add_option('-e', '--extra-vars', dest="extra_vars", default=None,
         help="set additional key=value variables from the CLI")
-    parser.add_option('-t', '--tags', dest='tags', default='all',
-        help="only run plays and tasks tagged with these values")
-    # FIXME: list hosts is a common option and can be moved to utils/__init__.py
-    parser.add_option('--list-hosts', dest='listhosts', action='store_true',
-        help="dump out a list of hosts, each play will run against, does not run playbook!")
-    parser.add_option('--syntax-check', dest='syntax', action='store_true',
-        help="do a playbook syntax check on the playbook, do not execute the playbook")
     parser.add_option('--list-tasks', dest='listtasks', action='store_true',
-        help="do list all tasks that would be executed")
+        help="list all tasks that would be executed")
+    parser.add_option('--start-at-task', dest='start_at',
+        help="start the playbook at the task matching this name")
     parser.add_option('--step', dest='step', action='store_true',
         help="one-step-at-a-time: confirm each task before running")
-    parser.add_option('--start-at-task', dest='start_at', 
-        help="start the playbook with a task matching this name")
+    parser.add_option('--syntax-check', dest='syntax', action='store_true',
+        help="perform a syntax check on the playbook, but do not execute it")
+    parser.add_option('-t', '--tags', dest='tags', default='all',
+        help="only run plays and tasks tagged with these values")
 
     options, args = parser.parse_args(args)
 

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -93,17 +93,17 @@ def main(args):
     """ Set up and run a local playbook """
     usage = "%prog [options] [playbook.yml]"
     parser = OptionParser(usage=usage)
-    parser.add_option('--purge', default=False, action='store_true',
-                      help='Purge git checkout after playbook run')
-    parser.add_option('-d', '--directory', dest='dest', default=None,
-                      help='Directory to clone git repository to')
-    parser.add_option('-U', '--url', dest='url', default=None,
-                      help='URL of git repository')
     parser.add_option('-C', '--checkout', dest='checkout',
                       default="HEAD",
-                      help='Branch/Tag/Commit to checkout.  Defaults to HEAD.')
+                      help='branch/tag/commit to checkout; defaults to HEAD')
+    parser.add_option('-d', '--directory', dest='dest', default=None,
+                      help='directory to clone the git repository to')
     parser.add_option('-i', '--inventory-file', dest='inventory',
-                      help="specify inventory host file")
+                      help="location of the inventory host file")
+    parser.add_option('--purge', default=False, action='store_true',
+                      help='purge git checkout after playbook run')
+    parser.add_option('-U', '--url', dest='url', default=None,
+                      help='URL of the git repository')
     options, args = parser.parse_args(args)
 
     if not options.dest:


### PR DESCRIPTION
- Moved the --list-hosts option that is common to both `ansible` and
  `ansible-playbook` into utils/**init**.py (corrects a FIXME)
- Wrote new help text for the --list-hosts option that makes sense
  for both of the commands that it applies to
- Changed the usage argument in `ansible-playbook` so that it is
  setup in the base_parser method the same way that it is in
  the `ansible` executable
- Alphabetized all base_parser *_opts arguments in `ansible` and
  `ansible-playbook` to make them easier to locate
- Alphabetized base_parser *_opts arguments and if statements in
  utils/__init__.py
- Alphabetized all add_option statements (using --option-name) in
  `ansible`, `ansible-doc`, `ansible-playbook`, `ansible-pull` and
  utils/**init**.py (within each *_opts if statement group)
- Updated the help text for several options to correct typos,
  clarify meaning, improve readability, or fix grammatical errors.
  In the case of `ansible-pull`, I changed the help text so that it
  adheres to the same standards as the other executables (e.g. the
  initial word in each line is lowercase).
