### PR TITLE
Added a provision for passing a server password to IRC

### DIFF
--- a/library/notification/irc
+++ b/library/notification/irc
@@ -56,6 +56,10 @@ options:
     description:
       - Channel name
     required: true
+  passwd:
+    description:
+      - Server password
+    required: false
 
 # informational: requirements for nodes
 requirements: [ socket ]
@@ -80,7 +84,7 @@ from time import sleep
 import socket
 
 def send_msg(channel, msg, server='localhost', port='6667',
-        nick="ansible", color='black'):
+        nick="ansible", color='black', passwd=False):
     '''send message to IRC'''
 
     colornumbers = {
@@ -100,6 +104,8 @@ def send_msg(channel, msg, server='localhost', port='6667',
 
     irc = socket.socket( socket.AF_INET, socket.SOCK_STREAM )
     irc.connect( ( server, int(port) ) )
+    if passwd:
+        irc.send( 'PASS %s\r\n' % passwd )
     irc.send( 'NICK %s\r\n' % nick )
     irc.send( 'USER %s %s %s :ansible IRC\r\n' % (nick, nick, nick))
     time.sleep(1)
@@ -125,7 +131,8 @@ def main():
             msg = dict(required = True),
             color = dict(default="black", choices=["yellow", "red", "green",
                                                   "blue", "black"]),
-            channel = dict(required = True)
+            channel = dict(required = True),
+            passwd = dict()
         ),
         supports_check_mode=True
     )
@@ -136,9 +143,10 @@ def main():
     msg     = module.params["msg"]
     color   = module.params["color"]
     channel = module.params["channel"]
+    passwd  = module.params["passwd"]
 
     try:
-        send_msg(channel, msg, server, port, nick, color)
+        send_msg(channel, msg, server, port, nick, color, passwd)
     except Exception, e:
         module.fail_json(msg="unable to send to IRC: %s" % e)
 


### PR DESCRIPTION
To connect to a ZNC IRC proxy a server password is required.  ZNC is nice of this kind of transient connection since it doesn't care if you re-connect frequently (unlike most IRC server configuration). 
