### PR TITLE
validate files: fix usage error in example tasks

### DIFF
--- a/library/files/copy
+++ b/library/files/copy
@@ -30,7 +30,7 @@ description:
 options:
   src:
     description:
-      - Local path to a file to copy to the remote server; can be absolute or relative.  
+      - Local path to a file to copy to the remote server; can be absolute or relative.
     required: false
     default: null
     aliases: []
@@ -75,7 +75,7 @@ options:
     required: false
 author: Michael DeHaan
 notes:
-   - The "copy" module can't be used to recursively copy directory structures to the target machine. Please see the 
+   - The "copy" module can't be used to recursively copy directory structures to the target machine. Please see the
      "Delegation" section of the Advanced Playbooks documentation for a better approach to recursive copies.
 '''
 
@@ -87,7 +87,7 @@ EXAMPLES = '''
 - copy: src=/mine/ntp.conf dest=/etc/ntp.conf owner=root group=root mode=644 backup=yes
 
 # Copy a new "sudoers" file into place, after passing validation with visudo
-- copy: src=/mine/sudoers dest=/etc/sudoers validate='visudo -c %s'
+- copy: src=/mine/sudoers dest=/etc/sudoers validate='visudo -cf %s'
 '''
 
 def main():
@@ -96,7 +96,7 @@ def main():
         # not checking because of daisy chain to file module
         argument_spec = dict(
             src               = dict(required=False),
-            original_basename = dict(required=False), # used to handle 'dest is a directory' via template, a slight hack 
+            original_basename = dict(required=False), # used to handle 'dest is a directory' via template, a slight hack
             content           = dict(required=False, no_log=True),
             dest              = dict(required=True),
             backup            = dict(default=False, type='bool'),

--- a/library/files/template
+++ b/library/files/template
@@ -58,5 +58,5 @@ EXAMPLES = '''
 - template: src=/mytemplates/foo.j2 dest=/etc/file.conf owner=bin group=wheel mode=0644
 
 # Copy a new "sudoers file into place, after passing validation with visudo
-- action: template src=/mine/sudoers dest=/etc/sudoers validate='visudo -c %s'
+- action: template src=/mine/sudoers dest=/etc/sudoers validate='visudo -cf %s'
 '''


### PR DESCRIPTION
visudo requires the -f option to check any other file than the default.
I've added this to the example ansible tasks.
