### PR TITLE
lvol module: add support for multiple size formats

### DIFF
--- a/library/system/lvol
+++ b/library/system/lvol
@@ -37,7 +37,10 @@ options:
     required: true
   size:
     description:
-    - The size of the logical volume in megabytes.
+    - The size of the logical volume, according to lvcreate(8) --size, by
+      default in megabytes or optionally with one of [bBsSkKmMgGtTpPeE] units; or
+      according to lvcreate(8) --extents as a percentage of [VG|PVS|FREE];
+      resizing is not supported with percentages.
   state:
     choices: [ "present", "absent" ]
     default: present
@@ -51,6 +54,12 @@ notes:
 EXAMPLES = '''
 # Create a logical volume of 512m.
 - lvol: vg=firefly lv=test size=512
+
+# Create a logical volume of 512g.
+- lvol: vg=firefly lv=test size=512g
+
+# Create a logical volume the size of all remaining space in the volume group
+- lvol: vg=firefly lv=test size=100%FREE
 
 # Extend the logical volume to 1024m.
 - lvol: vg=firefly lv=test size=1024
@@ -92,9 +101,44 @@ def main():
         module.fail_json(msg="No size given.")
 
     if size:
-        size = int(size)
+        # LVCREATE(8) -l --extents option with percentage
+        if '%' in size:
+            size_parts = size.split('%',1)
+            size_percent = int(size_parts[0])
+            if size_percent > 100:
+                module.fail_json(msg="Size percentage cannot be larger than 100%")
+            size_whole = size_parts[1]
+            if size_whole == 'ORIGIN':
+                module.fail_json(msg="Snapshot Volumes are not supported")
+            elif size_whole not in ['VG', 'PVS', 'FREE']:
+                module.fail_json(msg="Specify extents as a percentage of VG|PVS|FREE")
+            size_opt = 'l'
+            size_unit = ''
 
-    rc,current_lvs,err = module.run_command("lvs --noheadings -o lv_name,size --units m --separator ';' %s"%(vg))
+        # LVCREATE(8) -L --size option unit
+        elif size[-1].isalpha():
+            if size[-1] in 'bBsSkKmMgGtTpPeE':
+                size_unit = size[-1]
+                if size[0:-1].isdigit():
+                    size = int(size[0:-1])
+                else:
+                    module.fail_json(msg="Bad size specification for unit %s" % size_unit)
+                size_opt = 'L'
+            else:
+                module.fail_json(msg="Size unit should be one of [bBsSkKmMgGtTpPeE]")
+        # when no unit, megabytes by default
+        elif size.isdigit():
+            size_unit = 'm'
+            size = int(size)
+            size_opt = 'L'
+        else:
+            module.fail_json(msg="Bad size specification")
+
+    if size_opt == 'l':
+        unit = 'm'
+    else:
+        unit = size_unit
+    rc,current_lvs,err = module.run_command("lvs --noheadings -o lv_name,size --units %s --separator ';' %s" % (unit, vg))
 
     if rc != 0:
         module.fail_json(msg="Volume group %s does not exist."%vg, rc=rc, err=err)
@@ -110,13 +154,14 @@ def main():
     else:
         this_lv = None
 
+    msg = ''
     if this_lv is None:
         if state == 'present':
             ### create LV
             if module.check_mode:
                 changed = True
             else:
-                rc,_,err = module.run_command("lvcreate -n %s -L %sm %s"%(lv, size, vg))
+                rc,_,err = module.run_command("lvcreate -n %s -%s %s%s %s"%(lv, size_opt, size, size_unit, vg))
                 if rc == 0:
                     changed = True
                 else:
@@ -131,24 +176,28 @@ def main():
                 module.exit_json(changed=True)
             else:
                 module.fail_json(msg="Failed to remove logical volume %s"%(lv),rc=rc, err=err)
-        ### resize LV
-        tool = None
-        if size > this_lv['size']:
-            tool = 'lvextend'
-        elif size < this_lv['size']:
-            tool = 'lvreduce --force'
 
-        if tool:
-            if module.check_mode:
-                changed = True
-            else:
-                rc,_,err = module.run_command("%s -L %sm %s/%s"%(tool, size, vg, this_lv['name']))
-                if rc == 0:
+        elif size_opt == 'l':
+            module.exit_json(changed=False, msg="Resizing extents with percentage not supported.")
+        else:
+            ### resize LV
+            tool = None
+            if size > this_lv['size']:
+                tool = 'lvextend'
+            elif size < this_lv['size']:
+                tool = 'lvreduce --force'
+
+            if tool:
+                if module.check_mode:
                     changed = True
                 else:
-                    module.fail_json(msg="Unable to resize %s to %sm."%(lv,size),rc=rc,err=err)
+                    rc,_,err = module.run_command("%s -%s %s%s %s/%s"%(tool, size_opt, size, size_unit, vg, this_lv['name']))
+                    if rc == 0:
+                        changed = True
+                    else:
+                        module.fail_json(msg="Unable to resize %s to %s%s"%(lv,size,size_unit),rc=rc,err=err)
 
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed,msg=msg)
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>


### PR DESCRIPTION
extend support for size parameter
- allow specifying a unit, same as lvcreate uses
- still supports no unit, using default megabytes, for backwards compatibility
- add limlited support for 'percentage' based extent size
