### PR TITLE
Improvements to wait_for module

### DIFF
--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -92,10 +92,10 @@ def main():
     port = int(params['port'])
     state = params['state']
 
+    start = datetime.datetime.now()
+
     if delay:
         time.sleep(delay)
-
-    start = datetime.datetime.now()
 
     if state == 'stopped':
         ### first wait for the host to go down


### PR DESCRIPTION
This adds a pause_after function, to mirror the delay. Useful when what you are waiting for needs an additional buffer. Yes this could be done with the pause action, but this saves an extra action.

Also, unrelated, make the elapsed time account for the delay time.
