### PR TITLE
Add a mandatory jinja2 filter for use in templates.

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -43,6 +43,12 @@ def failed(*a, **kw):
 def success(*a, **kw):
     return not failed(*a, **kw)
 
+def mandatory(a):
+    ''' Make a variable mandatory '''
+    if not a:
+        raise errors.AnsibleError('Mandatory variable not defined.')
+    return a
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -70,5 +76,7 @@ class FilterModule(object):
             'failed'  : failed,
             'success' : success,
 
+            # variable existence
+            'mandatory': mandatory,
         }
     


### PR DESCRIPTION
This came up as an issue on the BE Ansible user meetup.

People all experienced that sometimes a variable was not defined in certain groups in their inventory and would like to fail if templating fails.

@jpmens wanted to call the variable 'tripel', but we settled on mandatory.

```
Line 1
Line {{ line|mandatory }}
```

```
- hosts: firefly
  tasks:
  - name: Template should fail
    action: template src=../templates/mandatory.j2 dest=/tmp/mandatory.txt
```

```
(ansible)[jeroen@firefly local]$ ansible-playbook plays/required.yml 

PLAY [firefly] **************************************************************** 

GATHERING FACTS *************************************************************** 
ok: [firefly]

TASK: [Template should fail] ************************************************** 
fatal: [firefly] => {'msg': 'Mandatory variable not defined.', 'failed': True}
fatal: [firefly] => {'msg': 'Mandatory variable not defined.', 'failed': True}

FATAL: all hosts have already failed -- aborting

PLAY RECAP ******************************************************************** 
           to retry, use: --limit @/var/tmp/ansible/required.retry

firefly                    : ok=1    changed=0    unreachable=1    failed=0
```

Unfortunately there is no way to get the variable name.
