### PR TITLE
Add --only-if-changed option.

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -99,7 +99,7 @@ def main(args):
     parser = OptionParser(usage=usage)
     parser.add_option('--purge', default=False, action='store_true',
                       help='Purge git checkout after playbook run')
-    parser.add_option('-o', '--only-if-changed', dest='ifchanged', default=False,
+    parser.add_option('-o', '--only-if-changed', dest='ifchanged', default=False, action='store_true',
                       help='Only run the playbook if the repository has been updated')
     parser.add_option('-d', '--directory', dest='dest', default=None,
                       help='Directory to clone git repository to')

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -133,7 +133,8 @@ def main(args):
     if rc != 0:
         return rc
     elif options.ifchanged and '"changed": true' not in out:
-        return "Repository has not changed, quitting."
+        print "Repository has not changed, quitting."
+        return 0
 
     playbook = select_playbook(options.dest, args)
 

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -45,8 +45,9 @@ import socket
 from optparse import OptionParser
 
 DEFAULT_PLAYBOOK = 'local.yml'
-PLAYBOOK_ERRORS = { 1: 'File does not exist',
-                    2: 'File is not readable' }
+PLAYBOOK_ERRORS = {1: 'File does not exist',
+                    2: 'File is not readable'}
+
 
 def _run(cmd):
     print >>sys.stderr, "Running: '%s'" % cmd
@@ -56,7 +57,8 @@ def _run(cmd):
     print out
     if cmd.returncode != 0:
         print >>sys.stderr, err
-    return cmd.returncode
+    return cmd.returncode, out
+
 
 def try_playbook(path):
     if not os.path.exists(path):
@@ -64,6 +66,7 @@ def try_playbook(path):
     if not os.access(path, os.R_OK):
         return 2
     return 0
+
 
 def select_playbook(path, args):
     playbook = None
@@ -89,12 +92,15 @@ def select_playbook(path, args):
             print >>sys.stderr, "\n".join(errors)
         return playbook
 
+
 def main(args):
     """ Set up and run a local playbook """
     usage = "%prog [options] [playbook.yml]"
     parser = OptionParser(usage=usage)
     parser.add_option('--purge', default=False, action='store_true',
                       help='Purge git checkout after playbook run')
+    parser.add_option('-o', '--only-if-changed', dest='ifchanged', default=False,
+                      help='Only run the playbook if the repository has been updated')
     parser.add_option('-d', '--directory', dest='dest', default=None,
                       help='Directory to clone git repository to')
     parser.add_option('-U', '--url', dest='url', default=None,
@@ -123,9 +129,11 @@ def main(args):
     cmd = 'ansible all -c local -i "%s" --limit "%s" -m git -a "%s"' % (
             inv_opts, limit_opts, git_opts
             )
-    rc = _run(cmd)
+    rc, out = _run(cmd)
     if rc != 0:
         return rc
+    elif options.ifchanged and '"changed": true' not in out:
+        return "Repository has not changed, quitting."
 
     playbook = select_playbook(options.dest, args)
 
@@ -137,7 +145,7 @@ def main(args):
     if options.inventory:
         cmd += ' -i "%s"' % options.inventory
     os.chdir(options.dest)
-    rc = _run(cmd)
+    rc, out = _run(cmd)
 
     if options.purge:
         os.chdir('/')


### PR DESCRIPTION
I added an option, `-o`, or `--only-if-changed`, to only run the playbook if the repository has changed. In my use case, there's no sense in running the playbook if the repository hasn't changed, as it's idempotent, so it won't do anything.

Hopefully this can be merged, as it would be _extremely_ useful to me, and I'm sure to other people as well.
