### PR TITLE
Return a friendly error message if aptitude isn't installed

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -286,6 +286,9 @@ def main():
     global APT_GET_CMD
     APT_GET_CMD = module.get_bin_path("apt-get")
 
+    if not APTITUDE_CMD:
+      module.fail_json(msg="Could not find aptitude. Please ensure it is installed.")
+
     p = module.params
     install_recommends = p['install_recommends']
 


### PR DESCRIPTION
Fix for Issue#3101 - changes the error:

<pre>
fatal: [husker.crimson.net.nz] => failed to parse: Traceback (most recent call last):
  File "/home/ansible/.ansible/tmp/ansible-1370213747.54-271802212190720/apt", line 1238, in <module>
    main()
  File "/home/ansible/.ansible/tmp/ansible-1370213747.54-271802212190720/apt", line 318, in main
    upgrade(module, p['upgrade'])
  File "/home/ansible/.ansible/tmp/ansible-1370213747.54-271802212190720/apt", line 232, in upgrade
    apt_cmd_path = m.get_bin_path(apt_cmd, required=True)
  File "/home/ansible/.ansible/tmp/ansible-1370213747.54-271802212190720/apt", line 1049, in get_bin_path
    path = os.path.join(d, arg)
  File "/usr/lib/python2.7/posixpath.py", line 75, in join
    if b.startswith('/'):
AttributeError: 'NoneType' object has no attribute 'startswith'
</pre>


to

<pre>
failed: [starbuck.crimson.net.nz] => {"failed": true}
msg: Could not find aptitude. Please ensure it is installed.
</pre>
