### PR TITLE
Always search the standard modules, even when you add additional module paths

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -160,7 +160,7 @@ def main():
             if module in module_docs.BLACKLIST_MODULES:
                 continue
 
-            filename = utils.plugins.module_finder.find_plugin(module)
+            filename = utils.plugins.module_finder.find(module)
             if os.path.isdir(filename):
                 continue
             try:
@@ -191,7 +191,7 @@ def main():
  
     for module in args:
 
-        filename = utils.plugins.module_finder.find_plugin(module)
+        filename = utils.plugins.module_finder.find(module)
         if filename is None:
             sys.stderr.write("module %s not found in %s\n" % (module,
                     print_paths(utils.plugins.module_finder)))

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -710,7 +710,7 @@ class Runner(object):
             raise errors.AnsibleFileNotFound("%s is not a module" % module_name)
 
         # Search module path(s) for named module.
-        in_path = utils.plugins.module_finder.find_plugin(module_name)
+        in_path = utils.plugins.module_finder.find(module_name)
         if in_path is None:
             raise errors.AnsibleFileNotFound("module %s not found in %s" % (module_name, utils.plugins.module_finder.print_paths()))
 

--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -23,43 +23,35 @@ import imp
 import ansible.constants as C
 from ansible import errors
 
-MODULE_CACHE = {}
-PATH_CACHE = {}
-PLUGIN_PATH_CACHE = {}
 _basedirs = []
 
 def push_basedir(basedir):
     if basedir not in _basedirs:
         _basedirs.insert(0, basedir)
 
-class PluginLoader(object):
+class BaseLoader(object):
 
     '''
-    PluginLoader loads plugins from the configured plugin directories.
+    BaseLoader is the base class for plug-in and module loaders in this module.
 
-    It searches for plugins by iterating through the combined list of
-    play basedirs, configured paths, and the python path.
-    The first match is used.
+    It searches for files (plug-ins or modules) by iterating through
+    the combined list of play basedirs and configured
+    paths. Subclasses may add additional paths by overriding the
+    _get_default_paths method.
+
+    The first file found is used.
+
     '''
 
-    def __init__(self, class_name, package, config, subdir, aliases={}):
+    def __init__(self, config, subdir, file_suffix="", aliases={}):
 
-        self.class_name         = class_name
-        self.package            = package
         self.config             = config
         self.subdir             = subdir
+        self.file_suffix        = file_suffix
         self.aliases            = aliases
 
-        if not class_name in MODULE_CACHE:
-            MODULE_CACHE[class_name] = {}
-        if not class_name in PATH_CACHE:
-            PATH_CACHE[class_name] = None
-        if not class_name in PLUGIN_PATH_CACHE:
-            PLUGIN_PATH_CACHE[class_name] = {}
-
-        self._module_cache      = MODULE_CACHE[class_name]
-        self._paths             = PATH_CACHE[class_name]
-        self._plugin_path_cache = PLUGIN_PATH_CACHE[class_name]
+        self._paths = None
+        self._found_cache = {}
 
         self._extra_dirs = []
 
@@ -73,20 +65,9 @@ class PluginLoader(object):
                 ret.append(i)
         return os.pathsep.join(ret)
 
-    def _get_package_paths(self):
-        ''' Gets the path of a Python package '''
-
-        paths = []
-        if not self.package:
-            return []
-        if not hasattr(self, 'package_path'):
-            m = __import__(self.package)
-            parts = self.package.split('.')[1:]
-            self.package_path = os.path.join(os.path.dirname(m.__file__), *parts)
-            paths.append(self.package_path)
-            return paths
-        else:
-            return [ self.package_path ]
+    def _get_default_paths(self):
+        ''' Subclasses may override this method to append search paths '''
+        return []
 
     def _get_paths(self):
         ''' Return a list of paths to search for plugins in '''
@@ -106,8 +87,10 @@ class PluginLoader(object):
                 if fullpath not in ret:
                     ret.append(fullpath)
 
-        # look in any configured plugin paths, allow one level deep for subcategories 
+        # look in any configured paths, allow one level deep for subcategories
         configured_paths = self.config.split(os.pathsep)
+        # search default paths, such as the standard plug-ins, last
+        configured_paths.extend(self._get_default_paths())
         for path in configured_paths:
             path = os.path.expanduser(path)
             contents = glob.glob("%s/*" % path)
@@ -115,9 +98,6 @@ class PluginLoader(object):
                 if os.path.isdir(c):
                     ret.append(c)       
             ret.append(path)
-
-        # look for any plugins installed in the package subtree
-        ret.extend(self._get_package_paths())
 
         self._paths = ret
 
@@ -134,37 +114,58 @@ class PluginLoader(object):
                 directory = os.path.join(directory, self.subdir)
             self._extra_dirs.append(directory)
 
-    def find_plugin(self, name):
-        ''' Find a plugin named name '''
+    def find(self, name):
+        ''' Find a file named with the given name and file_suffix '''
 
-        if 'name' in self._plugin_path_cache:
-            return self._plugin_path_cache[name]
-
-        suffix = ".py"
-        if not self.class_name:
-            suffix = ""
+        if name in self._found_cache:
+            return self._found_cache[name]
 
         for i in self._get_paths():
-            path = os.path.join(i, "%s%s" % (name, suffix))
+            path = os.path.join(i, "%s%s" % (name, self.file_suffix))
             if os.path.exists(path):
-                self._plugin_path_cache[name] = path
+                self._found_cache[name] = path
                 return path
 
         return None
 
-    def has_plugin(self, name):
-        ''' Checks if a plugin named name exists '''
+    def __contains__(self, name):
+        ''' Checks if we can find a file named name '''
 
-        return self.find_plugin(name) is not None
+        return self.find(name) is not None
 
-    __contains__ = has_plugin
+class PluginLoader (BaseLoader):
+
+    '''
+    Loads Ansible plug-ins.
+
+    Plug-ins may be loaded from the play basedirs, configured paths,
+    or from the default ansible packages found on Python's path.  The
+    first plug-in found is used.
+
+    '''
+
+    def __init__(self, class_name, package, config, subdir, aliases={}):
+        BaseLoader.__init__(self, config, subdir, file_suffix=".py",
+                            aliases=aliases)
+        self.class_name = class_name
+        self.package = package
+        self._module_cache = {}
+
+    def _get_default_paths(self):
+        ''' return the path to the appropriate standard plug-ins '''
+
+        if not hasattr(self, 'package_path'):
+            m = __import__(self.package)
+            parts = self.package.split('.')[1:]
+            self.package_path = os.path.join(os.path.dirname(m.__file__), *parts)
+        return [ self.package_path ]
 
     def get(self, name, *args, **kwargs):
         ''' instantiates a plugin of the given name using arguments '''
 
         if name in self.aliases:
             name = self.aliases[name]
-        path = self.find_plugin(name)
+        path = self.find(name)
         if path is None:
             return None
         if path not in self._module_cache:
@@ -182,6 +183,18 @@ class PluginLoader(object):
                 if path not in self._module_cache:
                     self._module_cache[path] = imp.load_source('.'.join([self.package, name]), path)
                 yield getattr(self._module_cache[path], self.class_name)(*args, **kwargs)
+
+class ModuleLoader (BaseLoader):
+    '''
+    Loads Ansible modules.
+
+    Modules may be loaded from the play basedirs, configured paths, or
+    from the default Ansible modules.  The first module found is used.
+
+    '''
+    def _get_default_paths(self):
+        ''' returns the path to the standard Ansible modules '''
+        return [C.DIST_MODULE_PATH]
 
 action_loader = PluginLoader(
     'ActionModule',   
@@ -205,13 +218,6 @@ connection_loader = PluginLoader(
     aliases={'paramiko': 'paramiko_ssh'}
 )
 
-module_finder = PluginLoader(
-    '', 
-    '', 
-    C.DEFAULT_MODULE_PATH, 
-    'library'
-)
-
 lookup_loader = PluginLoader(
     'LookupModule',   
     'ansible.runner.lookup_plugins', 
@@ -233,4 +239,7 @@ filter_loader = PluginLoader(
     'filter_plugins'
 )
 
-
+module_finder = ModuleLoader(
+    C.DEFAULT_MODULE_PATH,
+    'library'
+)

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -386,8 +386,9 @@ class TestUtils(unittest.TestCase):
     ### plugins
 
     def test_loaders_expanduser_each_dir(self):
-        # Test that PluginLoader will call expanduser on each path
-        # when it splits its "config" argument.
+        # Test that BaseLoader, superclass of PluginLoader and
+        # ModuleLoader, will call expanduser on each path when it
+        # splits its "config" argument.
         home_dir = os.path.expanduser("~")
         if home_dir == "~":
             raise SkipTest("your platform doesn't expand ~ in paths")
@@ -397,7 +398,7 @@ class TestUtils(unittest.TestCase):
             raise SkipTest("~ expands to non-absolute path %r" % (home_dir,))
         # Unfortunately we have to create temporary directories in
         # your home directory; the directories have to exist for
-        # PluginLoader to accept them.
+        # BaseLoader to accept them.
         abs_dirs, tilde_dirs = [], []
         try:
             for _ in range(2):
@@ -407,9 +408,7 @@ class TestUtils(unittest.TestCase):
                 tilde_dir = os.path.join("~", os.path.relpath(temp_dir,
                                                               home_dir))
                 tilde_dirs.append(tilde_dir)
-            loader = ansible.utils.plugins.PluginLoader(
-                "",
-                "",
+            loader = ansible.utils.plugins.BaseLoader(
                 os.pathsep.join(tilde_dirs),
                 "something_under_basedir"
             )


### PR DESCRIPTION
Prior to this commit, if you had an ansible.cfg such as

```
[defaults]
library = ansible-addons/library
action_plugins = ansible-addons/action_plugins
lookup_plugins = ansible-addons/lookup_plugins
```

Ansible would still find standard Ansible action and lookup plug-ins
(e.g. the template.py action plug-in), but it would no longer find the
standard modules (e.g. the template module).  The user's custom module
path would entirely replace the standard module path.  You could, of
course, add the standard module directory in your ansible.cfg as well,
but that's a pain and it also differs from how all the plug-in
configuration variables work.

This behavior with respect to modules was due to the fact that
ansible/utils/plugins.py was using PluginLoader to find modules, and
PluginLoader was not entirely suited to finding modules.

This commit refactors PluginLoader into a BaseLoader class and two
subclasses, PluginLoader and ModuleLoader.  ModuleLoader now allows
the user to configure an additional directory for modules while still
searching the standard Ansible modules.  In other words, the above
ansible.cfg will now work as expected.

Other significant changes:
- Renamed the "find_plugin" method to "find".  The only callers
  outside ansible.utils.plugins were using it on module_finder, so
  they weren't finding "plugins" anyway, but modules.  All of those
  callers were changed to just "find".
- The has_plugin method is gone.  I found no callers.  __contains__
  was being used, so it remains and its behavior is unchanged.
- All the standard *_plugins packages, such as
  ansible.runner.action_plugins, will now be searched for
  "categorized" plug-ins.  For example, action_loader.find("bar")
  would find $site_packages/ansible/runner/action_plugins/foo/bar.py
  if it existed.  This behavior is incidental, a side-effect of the
  implementation, but it seems harmless so I left it in.
- The module-level *_CACHE variables in plugins.py are gone.  They
  weren't really important, since all users of this code seem to just
  use the module-level instances of PluginLoader (and now
  ModuleLoader), which each have their own caches.
