### PR TITLE
Vault (ie. encryption) functionality

### DIFF
--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+# (c) 2013, Jan-Piet Mens <jpmens()gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+########################################################
+
+import os
+import sys
+import optparse
+
+import ansible.constants as C
+from ansible import errors
+from ansible.utils import version
+
+HAVE_VAULT=1
+try:
+    import keyczar.readers
+    import keyczar.keys
+    import base64
+except ImportErrror:
+    HAVE_VAULT=None
+########################################################
+
+def main():
+
+    p = optparse.OptionParser(
+        version=version("%prog"),
+        usage='usage: %prog [options] file',
+        description='Create variable for Ansible vault'
+    )
+
+    p.add_option("-K", "--keystore",
+            action="store",
+            dest="keystore",
+            default=C.ANSIBLE_VAULT_KEYSTORE,
+            help="Keystore directory (default: %s)" % C.ANSIBLE_VAULT_KEYSTORE)
+    p.add_option("-k", "--key",
+            action="store",
+            default=C.ANSIBLE_VAULT_DEFAULTKEY,
+            dest='keyname',
+            help='Key name. (default: %s)' % C.ANSIBLE_VAULT_DEFAULTKEY)
+    p.add_option("-V", "--var",
+            action="store",
+            default=None,
+            dest='varname',
+            help='Variable name')
+    p.add_option('-v', action='version', help='Show version number and exit')
+
+    (options, args) = p.parse_args()
+
+    if HAVE_VAULT is None:
+        sys.exit("ERROR: Vault is not available; keyczar is not installed")
+
+    if options.keyname is None:
+        sys.exit("ERROR: keyname must be specified")
+
+    keydir = "%s/%s" % (options.keystore, options.keyname)
+    if not os.path.isdir(keydir):
+        sys.exit("ERROR: keystore %s is not a directory" % keydir)
+
+    if len(args) != 1:
+        p.print_help()
+
+    # Load key from keystore
+    try:
+        filereader = keyczar.readers.FileReader(keydir)
+        key = filereader.GetKey(1)
+
+        aeskey = keyczar.keys.AesKey.Read(key)
+    except keyczar.errors.KeyczarError, e:
+        sys.exit("ERROR: Key doesn't exist in keydirectory: %s" % e)
+
+    for filename in args:
+        try:
+            if filename == '-':
+                f = sys.stdin
+            else:
+                f = open(filename, 'rb')
+        except IOError:
+            sys.exit("ERROR: Cannot open %s for reading" % filename)
+
+        # Read base64-encoded string, decode, and pass the resulting
+        # clear text to Keyczar for decrypting.
+
+        cleartext = f.read()
+        f.close()
+
+        ciphertext = aeskey.Encrypt(cleartext)
+        base64_str =  base64.b64encode(ciphertext)
+
+        if options.varname is not None:
+            print "%s: \"%s\"" % (options.varname, base64_str)
+        else:
+            print base64_str
+   
+if __name__ == '__main__':
+    main()

--- a/docs/man/man1/ansible-vault.1.asciidoc.in
+++ b/docs/man/man1/ansible-vault.1.asciidoc.in
@@ -1,0 +1,63 @@
+ansible-vault(1)
+==============
+:doctype:manpage
+:man source:   Ansible
+:man version:  %VERSION%
+:man manual:   System administration commands
+
+NAME
+----
+ansible-vault - encrypt file to add to Ansible vault
+
+
+SYNOPSIS
+--------
+ansible-vault [-K keystore ] [-k keyname] [-V var] filename
+
+
+DESCRIPTION
+-----------
+
+*ansible-vault* reads the specified filename (or stdin, if - is used)
+and encrypts and base64-encodes its content using the key in keystore.
+
+OPTIONS
+-------
+
+*-K* 'directory', *--keystore=*'directory'::
+
+The directory which contains "key" directories. Default can be specified
+in *ansible.cfg*.
+
+*-k*, *--key=*::
+
+Use the specified key for encryption. Default can be specified in
+*ansible.cfg*.
+
+*-V* 'varname', *--var=*'varname'::
+
+Optionally specify the name of a variable which will be printed; this
+enables you to copy/paste the output of *ansible-vault* into a vars file.
+
+AUTHOR
+------
+
+ansible-vault was originally created by Jan-Piet Mens. See the AUTHORS file
+for a complete list of contributors.
+
+
+COPYRIGHT
+---------
+
+Copyright © 2013, Jan-Piet Mens
+
+Ansible is released under the terms of the GPLv3 License.
+
+
+SEE ALSO
+--------
+
+*ansible-playbook*(1), *ansible*(1), *ansible-pull*(1), *ansible-doc*(1)
+
+Extensive documentation as well as IRC and mailing list info
+is available on the ansible home page: <https://ansible.github.com/>

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -100,4 +100,12 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansib
 # (default is sftp)
 #scp_if_ssh = True
 
+# Ansible Vault enables you to store encrypted variables within your
+# playbooks, vars files, etc. You add them as Base64-encoded encrypted
+# values, and a Jinja2 filter can decrypt them on the fly. 
+# keystore is the base directory for all keys. This directory contains
+# directories indexed by 'key' names
 
+[vault]
+keystore = /etc/ansible/keystore
+# key = mykey

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -107,6 +107,8 @@ DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     '
 DEFAULT_LOG_PATH               = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
 
 ANSIBLE_NOCOWS                 = get_config(p, DEFAULTS, 'nocows', 'ANSIBLE_NOCOWS', None)
+ANSIBLE_VAULT_KEYSTORE         = get_config(p, 'vault', 'keystore', 'ANSIBLE_VAULT_KEYSTORE', '/etc/ansible/keystore')
+ANSIBLE_VAULT_DEFAULTKEY       = get_config(p, 'vault', 'key', 'ANSIBLE_VAULT_DEFAULTKEY', None)
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
 ZEROMQ_PORT                    = int(get_config(p, 'fireball', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099))
 

--- a/lib/ansible/runner/filter_plugins/vault.py
+++ b/lib/ansible/runner/filter_plugins/vault.py
@@ -1,0 +1,106 @@
+# (c) 2013, Jan-Piet Mens <jpmens()gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os.path
+from ansible import errors
+from ansible import constants
+import base64
+HAVE_VAULT=1
+try:
+    import keyczar.readers
+    import keyczar.keys
+except ImportError:
+    HAVE_VAULT=None
+
+def vault(*a, **kw):
+    ''' Decrypt the base64-encded value in `a' using the vault
+        Supported keywords:
+        keystore=       path to key store
+        outfile=        path into which to write output (e.g. binary data)
+                        in this case, the template returns an empty string ""
+                        unless return= is set
+        return=         String which is to be printed instead-of default
+    '''
+
+    if HAVE_VAULT is None:
+        raise errors.AnsibleError("|Vault not available: Keyczar not installed")
+    if len(a) < 1:
+        raise errors.AnsibleError("|Vault filter expects base64 string and key name")
+
+    instr = str(a[0])        # base64-encoded ciphertext
+
+    keyname = constants.ANSIBLE_VAULT_DEFAULTKEY
+    if len(a) == 2:
+        keyname = a[1]
+
+    if type(instr) != str or len(instr) < 1:
+        raise errors.AnsibleError("|Vault input must be string")
+    if type(keyname) != str:
+        raise errors.AnsibleError("|Vault keyname must be string")
+
+    keystore = constants.ANSIBLE_VAULT_KEYSTORE
+    if 'keystore' in kw:
+        keystore = kw['keystore']
+
+    outfile = None
+    if 'outfile' in kw:
+        outfile = kw['outfile']
+
+    returnval = None
+    if 'return' in kw:
+        returnval = kw['return']
+
+    keydir = "%s/%s" % (keystore, keyname)
+
+    try:
+        filereader = keyczar.readers.FileReader(keydir)
+        key = filereader.GetKey(1)
+    except keyczar.errors.KeyczarError:
+        raise errors.AnsibleError("Vault cannot access keydir %s" % keydir)
+
+    try:
+        aeskey = keyczar.keys.AesKey.Read(key)
+        ciphertext = base64.b64decode(instr)
+        cleartext = aeskey.Decrypt(ciphertext)
+    except TypeError:
+        raise errors.AnsibleError("Vault cannot decrypt input. Is it base64?")
+    except keyczar.errors.InvalidSignatureError:
+        raise errors.AnsibleError("Vault cannot decrypt input. Wrong key used?")
+    except:
+        raise errors.AnsibleError("Vault cannot decrypt input.")
+
+    if outfile is not None:
+        try:
+            f = open(outfile, 'wb')
+        except:
+            raise errors.AnsibleError("Vault cannot open output file %s" % outfile)
+
+        f.write(cleartext)
+        if returnval is not None:
+            return returnval
+        return ""
+
+    return cleartext
+
+class FilterModule(object):
+    ''' More Ansible core jinja2 filters '''
+
+    def filters(self):
+        return {
+            # decrypt
+            'vault': vault,
+        }


### PR DESCRIPTION
As hinted-to and dicsussed on the mailing-list, I'm adding a "vault" (thanks to @vincentvdk for the name :) functionality to Ansible, in order to allow having encrypted vars in vars files, playbooks, etc.

These encrypted vars can be decrypted in templates. This is what it looks like in a playbook:

``` yaml

---
- hosts: 127.0.0.1
  gather_facts: false
  connection: local
  vars:
    - mypasswd: "AHchx1Va5fPc51B3HrbMTvO/MGfCIK3cT273PgIeoZdEAY6lg+GEmejsl4tGfCNKxMFP7tM7Y7kl"
  tasks:
  - action: template src=vault.in dest=/tmp/vault.out
```

The encrypted and base64-encoded variable can be used with the `vault` filter in a template:

``` jinja2
My secret password: {{ mypasswd | vault }}
with explicit key:  {{ mypasswd | vault('ckey') }}
```

To get this output:

```
My secret password: totallysecret
with explicit key:  totallysecret
```

The first example above uses a default keyname (configured in `ansible.cfg`, whereas the
second used a specific key name. (You can have as many keys as you want.)
### Getting started

Ansible vault requires Keyzcar on the management host (`pip install python-keyczar`), which is also used by fireball mode, so you may have this requirement already.
1. Create the keystore directory. This should be _outside_ of your playbook repository, obviously, but you can share it with team members who need access to the keys.
   
   mkdir /etc/ansible/keystore
2. Choose a key name, say, `ckey`, and make its directory
   
   mkdir /etc/ansible/keystore/ckey
3. Create an initial key set for the `ckey` key name: (`keyczart` is a utility provided by Keyczar)
   
   keyczart create --location=/etc/ansible/keystore/ckey --purpose=crypt 
4. Generate a symmetric key and store it at that location
   
   keyczart addkey --location=/etc/ansible/keystore/ckey --size=256
5. Configure Ansible (`ansible.cfg`) to use the keystore and (optionally) the new key as default:

``` ini
[vault]
keystore = /etc/ansible/keystore
key = ckey
```
### Creating encrypted vars

Now we can use that key to encrypt variables and use them in vars files, playbooks, etc.

Verify that `ansible-vault` will use your keystore and key names. It will print the defaults
it is using when you give it `-h`.

```
ansible-vault -h
```

Create a var, say, `"mypasswd"` which will be encrypted. (Note the use of `-` as filename):

``` bash
echo -n totallysecret | ansible-vault -V mypasswd -
mypasswd: "AHchx1Va5fPc51B3HrbMTvO/MGfCIK3cT273PgIeoZdEAY6lg+GEmejsl4tGfCNKxMFP7tM7Y7kl"
```

Copy the line `mypasswd.*$` to your vars and use in a template as shown above.
### Binary data

If the output of `vault` is binary data (eg. you've encrypted an image), this has to be handled in a special way, because Jinja2 doesn't handle non-UTF-8 data in templates.

Invoke the `vault` filter with a parameter specifying the name of an output file on the managing node, and then you can `copy` this file to the managed nodes. For example, in a template:

``` jinja2
image >>{{ jjolie  | vault(outfile='/tmp/vault-binary.out') }}<<
```

This would produce an empty string instead of the `{{ ... }}`, and the specified file will contain the decrypted binary data.

The `vault()` filter also supports a `return=` keyword with which I can set what it will "print". This allows me to do something like this

``` yaml
- action: copy
            src={{ imgdata | vault(outfile='/tmp/t1.out', return='/tmp/t1.out') }}
            dest=/tmp/jjolie.jpg
```

in which `vault` decrypts into the specified tmp file, returns a "file name" which is then used by `copy`.
