### PR TITLE
Add support for mongodb 2.4, and implicit authentication

### DIFF
--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -67,6 +67,22 @@ options:
         required: false
         default: present
         choices: [ "present", "absent" ]
+    roles:
+        description:
+            - Comma separated list of mongodb 2.4 role names
+        required: false
+        default: null
+    other_db_roles:
+        description:
+            - Pipe and comma separated list of mongodb 2.4 databases and role names, syntax: DATABASE:ROLE1,...|DATABASE2:ROLE1,ROLE2,...
+              e.g db1:read|db2:readWrite,dbAdmin
+        required: false
+        default: null
+    check_implicit_admin:
+        description:
+            - Check if mongodb allows login with no username/password before trying supplied credentials.
+        required: false
+        default: false
 notes:
     - Requires the pymongo Python package on the remote host, version 2.4.2+. This
       can be installed using pip or the OS package manager. @see http://api.mongodb.org/python/current/installation.html
@@ -101,10 +117,18 @@ else:
 # MongoDB module specific support methods.
 #
 
-def user_add(client, db_name, user, password):
+def user_add(client, db_name, user, password, roles, otherDBRoles):
     try:
         db = client[db_name]
-        db.add_user(user, password)
+        kwargs = {}
+        if roles:
+            kwargs['roles'] = roles
+        if otherDBRoles:
+            kwargs['otherDBRoles'] = otherDBRoles
+            if 'roles' not in kwargs:
+                kwargs['roles'] = []
+        db.add_user(user, password, **kwargs)
+
     except OperationFailure:
         return False
 
@@ -152,6 +176,9 @@ def main():
             user=dict(required=True, aliases=['name']),
             password=dict(aliases=['pass']),
             state=dict(default='present', choices=['absent', 'present']),
+            roles=dict(default=None),
+            other_db_roles=dict(default=None),
+            check_implicit_admin=dict(default=False)
         )
     )
 
@@ -166,6 +193,20 @@ def main():
     user = module.params['user']
     password = module.params['password']
     state = module.params['state']
+    roles = module.params['roles']
+    otherDBRoles = module.params['other_db_roles']
+    check_implicit_admin = module.params['check_implicit_admin']
+
+    if roles is not None:
+        roles = roles.split(',')
+    if otherDBRoles is not None:
+        tmp = {}
+        for r in otherDBRoles.split('|'):
+            if ':' not in r:
+                continue
+            (dbName, dbRoles) = r.split(':')
+            tmp[dbName] = dbRoles.split(',')
+        otherDBRoles = tmp
 
     try:
         client = MongoClient(login_host, int(login_port))
@@ -177,16 +218,24 @@ def main():
         elif login_password is None and login_user is not None:
             module.fail_json(msg='when supplying login arguments, both login_user and login_password must be provided')
 
+        if check_implicit_admin:
+            try:
+                client.admin.collection_names()
+                login_user = None
+                login_password = None
+            except OperationFailure:
+                pass
+
         if login_user is not None and login_password is not None:
             client.admin.authenticate(login_user, login_password)
 
-    except ConnectionFailure as e:
+    except (ConnectionFailure, OperationFailure) as e:
         module.fail_json(msg='unable to connect to database, check login_user and login_password are correct')
 
     if state == 'present':
         if password is None:
             module.fail_json(msg='password parameter required when adding a user')
-        if user_add(client, db_name, user, password) is not True:
+        if user_add(client, db_name, user, password, roles, otherDBRoles) is not True:
             module.fail_json(msg='Unable to add or update user, check login_user and login_password are correct and that this user has access to the admin collection')
     elif state == 'absent':
         if user_remove(client, db_name, user) is not True:


### PR DESCRIPTION
Hi, updated pull request including the fixes you asked for.

The pipe/colon thing: I'm trying to represent this sort of JSON structure:
{'database': ['role1, 'role2', 'role3'],
 'database2': ['role1', 'role2']
}

so the above would be: database:role1,role2,role3|database2:role1,role2

I'm happy to change the representation though, just let me know.

I had to add OperationFailure to the outer exception handler as my version of pymongo (2.5.2) throws that if authentication fails.
