### PR TITLE
Fix service enable on FreeBSD

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -694,7 +694,14 @@ class FreeBsdService(Service):
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
 
-        self.rcconf_key = "%s_enable" % self.name
+        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, 'rcvar', self.arguments))
+        rcvars = shlex.split(stdout, comments=True)
+        if not rcvars:
+            self.module.fail_json(msg="unable to determine rcvar")
+
+        # In rare cases, i.e. sendmail, rcvar can return several key=value pairs
+        # Usually there is just one, however.
+        self.rcconf_key = rcvars[0].split('=')[0]
 
         return self.service_enable_rcconf()
 


### PR DESCRIPTION
Some services have a knob (i.e. rc.conf setting) whose name
differs from that of the script. For example, lockd process
is controlled with a script called lockd, but the rc.conf
value is rpc_lockd_enable.

Fixes issue #3382.
