### PR TITLE
sleep option for service module which adds a pauze between stopping and ...

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -39,6 +39,14 @@ options:
             commands unless necessary.  C(restarted) will always bounce the
             service.  C(reloaded) will always reload. At least one of state
             and enabled are required.
+    sleep:
+        required: false
+        version_added: "1.3"
+        description:
+        - If the service is being C(restarted) then sleep this many seconds
+          between the stop and start command. This helps to workaround badly
+          behaving init scripts that exit immediately after signaling a process
+          to stop.
     pattern:
         required: false
         version_added: "0.7"
@@ -94,6 +102,7 @@ import re
 import tempfile
 import shlex
 import select
+import time
 
 class Service(object):
     """
@@ -119,6 +128,7 @@ class Service(object):
         self.module         = module
         self.name           = module.params['name']
         self.state          = module.params['state']
+        self.sleep          = module.params['sleep']
         self.pattern        = module.params['pattern']
         self.enable         = module.params['enabled']
         self.runlevel       = module.params['runlevel']
@@ -638,6 +648,9 @@ class LinuxService(Service):
                 # SysV
                 rc1, stdout1, stderr1 = self.execute_command("%s %s %s" % ('stop', self.name, arguments), daemonize=True)
 
+            if self.sleep:
+                time.sleep(self.sleep)
+
             if svc_cmd != '':
                 # upstart or systemd
                 rc2, stdout2, stderr2 = self.execute_command("%s %s %s" % (svc_cmd, 'start', arguments), daemonize=True)
@@ -1013,6 +1026,7 @@ def main():
         argument_spec = dict(
             name = dict(required=True),
             state = dict(choices=['running', 'started', 'stopped', 'restarted', 'reloaded']),
+            sleep = dict(required=False, type='int', default=None),
             pattern = dict(required=False, default=None),
             enabled = dict(choices=BOOLEANS, type='bool'),
             runlevel = dict(required=False, default='default'),


### PR DESCRIPTION
...starting a service using state=restarted. This helps for bad scripts that exist immediatly after signaling a process to stop.
