### PR TITLE
Make the CPU facts Hyperthreading aware

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -518,7 +518,9 @@ class LinuxHardware(Hardware):
     def get_cpu_facts(self):
         i = 0
         physid = 0
+        coreid = 0
         sockets = {}
+        cores = {}
         if not os.access("/proc/cpuinfo", os.R_OK):
             return
         self.facts['processor'] = []
@@ -536,14 +538,20 @@ class LinuxHardware(Hardware):
                 physid = data[1].strip()
                 if physid not in sockets:
                     sockets[physid] = 1
+            elif key == 'core id':
+                coreid = data[1].strip()
+                if coreid not in sockets:
+                    cores[coreid] = 1
             elif key == 'cpu cores':
                 sockets[physid] = int(data[1].strip())
-        if len(sockets) > 0:
-            self.facts['processor_count'] = len(sockets)
-            self.facts['processor_cores'] = reduce(lambda x, y: x + y, sockets.values())
-        else:
-            self.facts['processor_count'] = i
-            self.facts['processor_cores'] = 'NA'
+            elif key == 'siblings':
+                cores[coreid] = int(data[1].strip())
+        self.facts['processor_count'] = sockets and len(sockets) or i
+        self.facts['processor_cores'] = sockets.values() and sockets.values()[0] or 1
+        self.facts['processor_threads_per_core'] = ((cores.values() and
+            cores.values()[0] or 1) / self.facts['processor_cores'])
+        self.facts['processor_vcpus'] = (self.facts['processor_threads_per_core'] *
+            self.facts['processor_count'] * self.facts['processor_cores'])
 
     def get_dmi_facts(self):
         ''' learn dmi facts from system


### PR DESCRIPTION
Regarding and building on #3409, the CPU fact in setup also doesn't handle Hyperthreads correctly. I've run the below against Darren's gist referenced in that issue, and get:

```
{'processor_vcpus': 2, 'processor_threads_per_core': 1, 'processor_cores': 1, 'processor_count': 2}
{'processor_vcpus': 4, 'processor_threads_per_core': 4, 'processor_cores': 1, 'processor_count': 1}
{'processor_vcpus': 24, 'processor_threads_per_core': 2, 'processor_cores': 6, 'processor_count': 2}
```

For a dual VCPU KVM install, a 4 CPU EC2 instance (Xen) and a dual CPU, 6 core, Hyperthreaded physical host. I've followed [this page](http://www.richweb.com/cpu_info) which, while not an authority, was the clearest write up of how this is supposed to work that I could find.

I've also removed the special casing for one CPU which returned the `processor_cores` as NA - even a Raspberry Pi technically has one "core". The value `processor_vcpus` matches up with what `top(1)` and other Linux utilities give for their CPU count (that is; they are things that can have a process run on them, whether a full core or a hardware thread).

I've avoided Python's ternary syntax as it's only for 2.5 and higher, and I believe we're still aiming to be 2.4 compatible?
