### PR TITLE
supervisorctl: add command-line options as module parameters

### DIFF
--- a/library/web_infrastructure/supervisorctl
+++ b/library/web_infrastructure/supervisorctl
@@ -32,6 +32,26 @@ options:
       - The name of the I(supervisord) program/process to manage
     required: true
     default: null
+  config:
+    description:
+      - configuration file path, passed as -c to supervisorctl
+    required: false
+    default: null
+  serverurl:
+    description:
+      - URL on which supervisord server is listening, passed as -s to supervisorctl
+    required: false
+    default: null
+  username:
+    description:
+      - username to use for authentication with server, passed as -u to supervisorctl
+    required: false
+    default: null
+  password:
+    description:
+      - password to use for authentication with server, passed as -p to supervisorctl
+    required: false
+    default: null
   state:
     description:
       - The state of service
@@ -45,11 +65,19 @@ author: Matt Wright
 EXAMPLES = '''
 # Manage the state of program to be in 'started' state.
 - supervisorctl: name=my_app state=started
+
+# Restart another_app using an alternate config file
+- supervisorctl: name=another_app state=restart config=/var/opt/my_project/supervisord.conf
+
 '''
 
 def main():
     arg_spec = dict(
         name=dict(required=True),
+        config=dict(required=False),
+        serverurl=dict(required=False),
+        username=dict(required=False),
+        password=dict(required=False),
         state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped'])
     )
 
@@ -57,18 +85,33 @@ def main():
 
     name = module.params['name']
     state = module.params['state']
+    config = module.params.get('config')
+    serverurl = module.params.get('serverurl')
+    username = module.params.get('username')
+    password = module.params.get('password')
 
-    SUPERVISORCTL = module.get_bin_path('supervisorctl', True)
+    supervisorctl_args = [ module.get_bin_path('supervisorctl', True) ]
+    if config:    supervisorctl_args.extend(['-c', config])
+    if serverurl: supervisorctl_args.extend(['-s', serverurl])
+    if username:  supervisorctl_args.extend(['-u', username])
+    if password:  supervisorctl_args.extend(['-p', password])
 
-    rc, out, err = module.run_command('%s status' % SUPERVISORCTL)
+    def run_supervisorctl(cmd, name=None, **kwargs):
+        args = list(supervisorctl_args)  # copy the master args
+        args.append(cmd)
+        if name:
+            args.append(name)
+        return module.run_command(args, **kwargs)
+
+    rc, out, err = run_supervisorctl('status')
     present = name in out
 
     if state == 'present':
         if not present:
             if module.check_mode:
                 module.exit_json(changed=True)
-            module.run_command('%s reread' % SUPERVISORCTL, check_rc=True)
-            rc, out, err = module.run_command('%s add %s' % (SUPERVISORCTL, name))
+            run_supervisorctl('reread', check_rc=True)
+            rc, out, err = run_supervisorctl('add', name)
 
             if '%s: added process group' % name in out:
                 module.exit_json(changed=True, name=name, state=state)
@@ -77,7 +120,7 @@ def main():
 
         module.exit_json(changed=False, name=name, state=state)
 
-    rc, out, err = module.run_command('%s status %s' % (SUPERVISORCTL, name))
+    rc, out, err = run_supervisorctl('status', name)
     running = 'RUNNING' in out
 
     if running and state == 'started':
@@ -86,7 +129,7 @@ def main():
     if running and state == 'stopped':
         if module.check_mode:
             module.exit_json(changed=True)
-        rc, out, err = module.run_command('%s stop %s' % (SUPERVISORCTL, name))
+        rc, out, err = run_supervisorctl('stop', name)
 
         if '%s: stopped' % name in out:
             module.exit_json(changed=True, name=name, state=state)
@@ -96,8 +139,8 @@ def main():
     elif state == 'restarted':
         if module.check_mode:
             module.exit_json(changed=True)
-        rc, out, err = module.run_command('%s update %s' % (SUPERVISORCTL, name))
-        rc, out, err = module.run_command('%s restart %s' % (SUPERVISORCTL, name))
+        rc, out, err = run_supervisorctl('update', name)
+        rc, out, err = run_supervisorctl('restart', name)
 
         if '%s: started' % name in out:
             module.exit_json(changed=True, name=name, state=state)
@@ -107,7 +150,7 @@ def main():
     elif not running and state == 'started':
         if module.check_mode:
             module.exit_json(changed=True)
-        rc, out, err = module.run_command('%s start %s' % (SUPERVISORCTL, name))
+        rc, out, err = run_supervisorctl('start',name)
 
         if '%s: started' % name in out:
             module.exit_json(changed=True, name=name, state=state)

--- a/library/web_infrastructure/supervisorctl
+++ b/library/web_infrastructure/supervisorctl
@@ -37,7 +37,7 @@ options:
       - configuration file path, passed as -c to supervisorctl
     required: false
     default: null
-  serverurl:
+  server_url:
     description:
       - URL on which supervisord server is listening, passed as -s to supervisorctl
     required: false
@@ -66,8 +66,11 @@ EXAMPLES = '''
 # Manage the state of program to be in 'started' state.
 - supervisorctl: name=my_app state=started
 
-# Restart another_app using an alternate config file
-- supervisorctl: name=another_app state=restart config=/var/opt/my_project/supervisord.conf
+# Restart my_app, reading supervisorctl configuration from a specified file.
+- supervisorctl: name=my_app state=restart config=/var/opt/my_project/supervisord.conf
+
+# Restart my_app, connecting to supervisord with credentials and server URL.
+- supervisorctl: name=my_app state=restart username=test password=testpass server_url=http://localhost:9001
 
 '''
 
@@ -75,7 +78,7 @@ def main():
     arg_spec = dict(
         name=dict(required=True),
         config=dict(required=False),
-        serverurl=dict(required=False),
+        server_url=dict(required=False),
         username=dict(required=False),
         password=dict(required=False),
         state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped'])
@@ -86,15 +89,15 @@ def main():
     name = module.params['name']
     state = module.params['state']
     config = module.params.get('config')
-    serverurl = module.params.get('serverurl')
+    server_url = module.params.get('server_url')
     username = module.params.get('username')
     password = module.params.get('password')
 
     supervisorctl_args = [ module.get_bin_path('supervisorctl', True) ]
-    if config:    supervisorctl_args.extend(['-c', config])
-    if serverurl: supervisorctl_args.extend(['-s', serverurl])
-    if username:  supervisorctl_args.extend(['-u', username])
-    if password:  supervisorctl_args.extend(['-p', password])
+    if config:     supervisorctl_args.extend(['-c', config])
+    if server_url: supervisorctl_args.extend(['-s', server_url])
+    if username:   supervisorctl_args.extend(['-u', username])
+    if password:   supervisorctl_args.extend(['-p', password])
 
     def run_supervisorctl(cmd, name=None, **kwargs):
         args = list(supervisorctl_args)  # copy the master args


### PR DESCRIPTION
Yesterday pull request #3435 (issue #1674) came out while I was simultaneously working on this.  This is a similar idea (pass module parameters to command-line), but I put all the relevant arguments (missing ones are more for interactive use) and I also refactored the module for DRY.

Adds more parameters which may be passed to supervisorctl:  config, serverurl, username, password

Also refactored the various `module.run_command(build_a_string)` calls into a single `run_supervisorctl` function.
