### PR TITLE
allow ansible_ssh_host to be templated

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -536,6 +536,8 @@ class Runner(object):
 
         conn = None
         actual_host = inject.get('ansible_ssh_host', host)
+        # allow ansible_ssh_host to be templated
+        actual_host = template.template(self.basedir, actual_host, inject, fail_on_undefined=True)
         actual_port = port
         actual_user = inject.get('ansible_ssh_user', self.remote_user)
         actual_pass = inject.get('ansible_ssh_pass', self.remote_pass)
@@ -560,6 +562,8 @@ class Runner(object):
             try:
                 delegate_info = inject['hostvars'][delegate_to]
                 actual_host = delegate_info.get('ansible_ssh_host', delegate_to)
+                # allow ansible_ssh_host to be templated
+                actual_host = template.template(self.basedir, actual_host, inject, fail_on_undefined=True)
                 actual_port = delegate_info.get('ansible_ssh_port', port)
                 actual_user = delegate_info.get('ansible_ssh_user', actual_user)
                 actual_pass = delegate_info.get('ansible_ssh_pass', actual_pass)


### PR DESCRIPTION
Use case: e.g. dual homed hosts on production and management network

The inventory_hostname is the regular host name and matches the
dns name on the production network; ansible connects to the host
through a management network; the dns name on the management network
is standardized and equals ${inventory_hostname}-mgt.mynetwork.com

Now this can be configured as the default in group_vars/all:

   ansible_ssh_host: {{ inventory_hostname + '-mgt.mynetwork.com' }}
