### PR TITLE
set checkout destination directory to be full path

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -116,6 +116,8 @@ def main(args):
         parser.error("Missing required directory argument")
         return 1
 
+    options.dest = os.path.abspath(options.dest)
+
     if not options.url:
         parser.error("URL for git repo not specified, use -h for help")
         return 1


### PR DESCRIPTION
we chdir into this path and read the playbook/inventory if a
non-absolute path is given on the command line, that will fail
