### PR TITLE
Only append non_unique parameter if a uid is provided as well to user module

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -270,8 +270,8 @@ class User(object):
             cmd.append('-u')
             cmd.append(self.uid)
 
-        if self.non_unique:
-            cmd.append('-o')
+            if self.non_unique:
+                cmd.append('-o')
 
         if self.group is not None:
             if not self.group_exists(self.group):
@@ -320,8 +320,8 @@ class User(object):
             cmd.append('-u')
             cmd.append(self.uid)
 
-        if self.non_unique:
-            cmd.append('-o')
+            if self.non_unique:
+                cmd.append('-o')
 
         if self.group is not None:
             if not self.group_exists(self.group):
@@ -578,8 +578,8 @@ class FreeBsdUser(User):
             cmd.append('-u')
             cmd.append(self.uid)
 
-        if self.non_unique:
-            cmd.append('-o')
+            if self.non_unique:
+                cmd.append('-o')
 
         if self.comment is not None:
             cmd.append('-c')
@@ -643,8 +643,8 @@ class FreeBsdUser(User):
             cmd.append('-u')
             cmd.append(self.uid)
 
-        if self.non_unique:
-            cmd.append('-o')
+            if self.non_unique:
+                cmd.append('-o')
 
         if self.comment is not None and info[4] != self.comment:
             cmd.append('-c')
@@ -739,8 +739,8 @@ class OpenBSDUser(User):
             cmd.append('-u')
             cmd.append(self.uid)
 
-        if self.non_unique:
-            cmd.append('-o')
+            if self.non_unique:
+                cmd.append('-o')
 
         if self.group is not None:
             if not self.group_exists(self.group):
@@ -794,8 +794,8 @@ class OpenBSDUser(User):
             cmd.append('-u')
             cmd.append(self.uid)
 
-        if self.non_unique:
-            cmd.append('-o')
+            if self.non_unique:
+                cmd.append('-o')
 
         if self.group is not None:
             if not self.group_exists(self.group):
@@ -889,8 +889,8 @@ class NetBSDUser(User):
             cmd.append('-u')
             cmd.append(self.uid)
 
-        if self.non_unique:
-            cmd.append('-o')
+            if self.non_unique:
+                cmd.append('-o')
 
         if self.group is not None:
             if not self.group_exists(self.group):
@@ -946,8 +946,8 @@ class NetBSDUser(User):
             cmd.append('-u')
             cmd.append(self.uid)
 
-        if self.non_unique:
-            cmd.append('-o')
+            if self.non_unique:
+                cmd.append('-o')
 
         if self.group is not None:
             if not self.group_exists(self.group):
@@ -1049,8 +1049,8 @@ class SunOS(User):
             cmd.append('-u')
             cmd.append(self.uid)
 
-        if self.non_unique:
-            cmd.append('-o')
+            if self.non_unique:
+                cmd.append('-o')
 
         if self.group is not None:
             if not self.group_exists(self.group):
@@ -1111,8 +1111,8 @@ class SunOS(User):
             cmd.append('-u')
             cmd.append(self.uid)
 
-        if self.non_unique:
-            cmd.append('-o')
+            if self.non_unique:
+                cmd.append('-o')
 
         if self.group is not None:
             if not self.group_exists(self.group):


### PR DESCRIPTION
I use this line in a playbook:
action: user name=backups uid=33 home="/home/backups" non_unique=yes group=www-data

User creation works fine, but the next run I get the error:
msg: usermod: -o flag is only allowed with the -u flag

This is because the info[2] != int(self.uid) condition is not true (uid is not modified) on executing usermod. If this is the case the -o flag should not be added.

Also in this commit: -o should not be added to useradd if the uid is not set according to the useradd manpage. Granted, this should never occur, if a user adds non_unique=yes in ansible they should provide uid. I changed useradd too to silently drop the -o flag if this happens.
