### PR TITLE
Let rabbitmq plugin module use nonstandard path

### DIFF
--- a/library/messaging/rabbitmq_plugin
+++ b/library/messaging/rabbitmq_plugin
@@ -46,6 +46,11 @@ options:
     required: false
     default: enabled
     choices: [enabled, disabled]
+  path:
+    description:
+      - Specify a custom path to a Rabbit
+    required: false
+    default: null
 '''
 
 EXAMPLES = '''
@@ -56,7 +61,11 @@ EXAMPLES = '''
 class RabbitMqPlugins(object):
     def __init__(self, module):
         self.module = module
-        self._rabbitmq_plugins = module.get_bin_path('rabbitmq-plugins', True)
+
+        if module.params['path']:
+            self._rabbitmq_plugins = module.params['path'] + "/sbin/rabbitmq-plugins"
+        else:
+            self._rabbitmq_plugins = module.get_bin_path('rabbitmq-plugins', True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
@@ -78,7 +87,8 @@ def main():
     arg_spec = dict(
         names=dict(required=True, aliases=['name']),
         new_only=dict(default='no', type='bool'),
-        state=dict(default='enabled', choices=['enabled', 'disabled'])
+        state=dict(default='enabled', choices=['enabled', 'disabled']),
+        path=dict(required=False, default=None)
     )
     module = AnsibleModule(
         argument_spec=arg_spec,

--- a/library/messaging/rabbitmq_plugin
+++ b/library/messaging/rabbitmq_plugin
@@ -42,7 +42,7 @@ options:
     choices: [ "yes", "no" ]
   state:
     description:
-      - Specify if pluginss are to be enabled or disabled
+      - Specify if plugins are to be enabled or disabled
     required: false
     default: enabled
     choices: [enabled, disabled]

--- a/library/messaging/rabbitmq_plugin
+++ b/library/messaging/rabbitmq_plugin
@@ -46,9 +46,9 @@ options:
     required: false
     default: enabled
     choices: [enabled, disabled]
-  path:
+  prefix:
     description:
-      - Specify a custom path to a Rabbit
+      - Specify a custom prefix to a Rabbit
     required: false
     default: null
 '''
@@ -62,8 +62,8 @@ class RabbitMqPlugins(object):
     def __init__(self, module):
         self.module = module
 
-        if module.params['path']:
-            self._rabbitmq_plugins = module.params['path'] + "/sbin/rabbitmq-plugins"
+        if module.params['prefix']:
+            self._rabbitmq_plugins = module.params['prefix'] + "/sbin/rabbitmq-plugins"
         else:
             self._rabbitmq_plugins = module.get_bin_path('rabbitmq-plugins', True)
 
@@ -88,7 +88,7 @@ def main():
         names=dict(required=True, aliases=['name']),
         new_only=dict(default='no', type='bool'),
         state=dict(default='enabled', choices=['enabled', 'disabled']),
-        path=dict(required=False, default=None)
+        prefix=dict(required=False, default=None)
     )
     module = AnsibleModule(
         argument_spec=arg_spec,


### PR DESCRIPTION
Sometimes you need to install a Rabbit in a non-standard location. With this commit you can enable/disable plugins for your special Rabbit with

``` yaml
- name: Enable the management plugin
  action: rabbitmq_plugin names=rabbitmq_management path=/custom/path/to/rabbit/ state=enabled
```
