### PR TITLE
Keystone_user module: fix authentication needs tenant_name too

### DIFF
--- a/library/cloud/keystone_user
+++ b/library/cloud/keystone_user
@@ -20,6 +20,11 @@ options:
         - Password of login user
      required: false
      default: 'yes'
+   login_tenant_name:
+     description:
+        - The tenant login_user belongs to
+     required: false
+     default: None
    token:
      description:
         - The token to be uses in case the password is not specified
@@ -88,14 +93,14 @@ else:
     keystoneclient_found = True
 
 
-def authenticate(endpoint, token, login_user, login_password):
+def authenticate(endpoint, token, login_user, login_password, login_tenant_name):
     """Return a keystone client object"""
 
     if token:
         return client.Client(endpoint=endpoint, token=token)
     else:
-        return client.Client(endpoint=endpoint, username=login_user,
-                             password=login_password)
+        return client.Client(auth_url=endpoint, username=login_user,
+                             password=login_password, tenant_name=login_tenant_name)
 
 
 def tenant_exists(keystone, tenant):
@@ -293,11 +298,13 @@ def main():
                           default="http://127.0.0.1:35357/v2.0"),
             token=dict(required=False),
             login_user=dict(required=False),
-            login_password=dict(required=False)
+            login_password=dict(required=False),
+            login_tenant_name=dict(required=False)
         ),
         supports_check_mode=True,
         mutually_exclusive=[['token', 'login_user'],
-                            ['token', 'login_password']]
+                            ['token', 'login_password'],
+                            ['token', 'login_tenant_name']]
     )
 
     if not keystoneclient_found:
@@ -314,8 +321,9 @@ def main():
     token = module.params['token']
     login_user = module.params['login_user']
     login_password = module.params['login_password']
+    login_tenant_name = module.params['login_tenant_name']
 
-    keystone = authenticate(endpoint, token, login_user, login_password)
+    keystone = authenticate(endpoint, token, login_user, login_password, login_tenant_name)
 
     check_mode = module.check_mode
 


### PR DESCRIPTION
The keystone client needs to be passed tenant_name when authenticating the
user/password way. Also it needs auth_url instead of endpoint.
This fix adds login_tenant_name as a module parameter which is consistent
with the other OpenStack modules.
