### PR TITLE
Add a split filter.

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -61,6 +61,15 @@ def bool(a):
     else:
         return False
 
+def split(a, **kw):
+    sep = kw.get('sep', None)
+    maxsplit = kw.get('maxsplit', None)
+    if maxsplit:
+        return a.split(sep, maxsplit)
+    else:
+        return a.split(sep)
+
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -93,5 +102,8 @@ class FilterModule(object):
 
             # value as boolean
             'bool': bool,
+
+            # misc
+            'split': split,
         }
     


### PR DESCRIPTION
Often it is convenient to pass an argument on the command line that could be used as an iterable.  This patch provides a 'split' filter which mimics the python str.split interface.

An example playbook using it:

```

---
- hosts: localhost
  tasks:
    - debug: msg="{{ item }}"
      with_items: "{{ foo|split(sep=',') }}"
```

Executing it:

```
$ ansible-playbook test.yml -e "foo=1,2,3"

PLAY [localhost] ************************************************************** 

GATHERING FACTS *************************************************************** 
ok: [localhost]

TASK: [debug msg="{{item}}"] ************************************************** 
ok: [localhost] => (item=1) => {"item": "1", "msg": "1"}
ok: [localhost] => (item=2) => {"item": "2", "msg": "2"}
ok: [localhost] => (item=3) => {"item": "3", "msg": "3"}

PLAY RECAP ******************************************************************** 
localhost                  : ok=2    changed=0    unreachable=0    failed=0   
```
