### PR TITLE
handle cron_file properly

### DIFF
--- a/library/system/cron
+++ b/library/system/cron
@@ -140,6 +140,7 @@ EXAMPLES = '''
 import re
 import tempfile
 import os
+import shutil
 
 def get_jobs_file(module, user, tmpfile, cron_file):
     if cron_file:
@@ -152,7 +153,8 @@ def get_jobs_file(module, user, tmpfile, cron_file):
 def install_jobs(module, user, tmpfile, cron_file):
     if cron_file:
         cron_file = '/etc/cron.d/%s' % cron_file
-        module.atomic_move(tmpfile, cron_file)
+        shutil.copy(tmpfile, cron_file)
+        return (0, '', '')
     else:
         cmd = "crontab %s %s" % (user, tmpfile)
         return module.run_command(cmd)


### PR DESCRIPTION
In the cron module, if you specify a cron_file, the tmpfile gets moved and then the attempt to read it again (to get a list of all the jobs in it) fails:

```
    if changed:
        # If the file is empty - remove it
        if rm and cron_file:
            remove_job_file(cron_file)
        else:
            if backup:
                module.backup_local(backupfile)
            (rc, out, err) = install_jobs(module,user,tmpfile.name, cron_file)            <-- file is moved here
            if (rc != 0):
                module.fail_json(msg=err)

    # get the list of jobs in file
    jobnames = []
    for j in get_jobs(tmpfile.name):                    <--- tries to re-read the old location here
        jobnames.append(j[0])
    tmpfile.close()

    if not backup:
        os.unlink(backupfile)
        module.exit_json(changed=changed,jobs=jobnames)
    else:
        module.exit_json(changed=changed,jobs=jobnames,backup=backupfile)
```

An example of the error:

```
TASK: [Add cron job for get-hyped] ********************************************
<50.116.33.15> REMOTE_MODULE cron name=hyped job='ruby /opt/get-hyped/get-hyped.rb -d /opt/get-hyped/music -l /home/akerl/.hyped >/dev/null' cron_file=hyped minute=15 user=akerl
fatal: [grego] => failed to parse: Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-1373506268.34-273775692436148/cron", line 1283, in <module>
    main()
  File "/root/.ansible/tmp/ansible-1373506268.34-273775692436148/cron", line 353, in main
    (rc, out, err) = install_jobs(module,user,tmpfile.name, cron_file)
TypeError: 'NoneType' object is not iterable
Exception OSError: (2, 'No such file or directory', '/tmp/tmpb26NJN') in <bound method _TemporaryFileWrapper.__del__ of <closed file '<fdopen>', mode 'w+b' at 0xeabb70>> ignored
```

This fixes it by copying rather than moving. As it's a tempfile, python cleans it up anyways when the script exits.
