### PR TITLE
digital_ocean: don't assume python is in /usr/bin/python

### DIFF
--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible


### PR DESCRIPTION
This caused a lot of heartache.   Our deployment server has a /usr/bin/python, but it's a different python than the /usr/bin/env python that ansible proper uses, so the problems it caused were subtle.
