### PR TITLE
/var/log/ and Directory write permission check - suggestion

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -31,10 +31,13 @@ import logging
 if constants.DEFAULT_LOG_PATH != '':
     path = constants.DEFAULT_LOG_PATH
 
-    if (os.path.exists(path) and not os.access(path, os.W_OK)) or not os.access(os.path.dirname(path), os.W_OK):
-        sys.stderr.write("log file at %s is not writeable, aborting\n" % path)
+    if (os.path.exists(path)):
+        if not os.access(path, os.W_OK):
+            sys.stderr.write("log file at %s is not writeable, aborting\n" % path)
+            sys.exit(1)
+    else:
+        sys.stderr.write("log file at %s does not exist, aborting\n" % path)
         sys.exit(1)
-
 
     logging.basicConfig(filename=path, level=logging.DEBUG, format='%(asctime)s %(name)s %(message)s')
     mypid = str(os.getpid())


### PR DESCRIPTION
Wanted to use the debug logging earlier and so
created .ansible.cfg in home and uncommented

log_path = /var/log/ansible.log

touch /var/log/ansible.log

Thought 660 would be okay for file permission but then hit an error message.

Looked in lib/ansible/callbacks.py

Error message about not writable is not complaining about file permission,
but directory level permission on /var/log

It looks like it this last portion: ... os.access(os.path.dirname(path), os.W_OK):

which suggest need write permission on directory.

Some extra notes in commit comment.

After edit:
...
test_facter (TestRunner.TestRunner) ... SKIP
## ...

Ran 83 tests in 20.126s

OK (SKIP=1)

Hope that doing a branch to 'debug_log' before asking for pull request is right way of going about things.
