### PR TITLE
Handle SSH failures when creating remote tmpdir

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -707,7 +707,9 @@ class Runner(object):
         # Catch any other failure conditions here; files should never be
         # written directly to /.
         if rc == '/':
-            raise errors.AnsibleError('refusing to use / as a temporary directory.')
+            raise errors.AnsibleError('failed to resolve remote temporary '
+                                      'directory from %s: `%s` returned '
+                                      'empty string' % (basetmp, cmd))
         return rc
 
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -700,7 +700,14 @@ class Runner(object):
         cmd += ' && echo %s' % basetmp
 
         result = self._low_level_exec_command(conn, cmd, None, sudoable=False)
+        if result['rc'] != 0:
+            raise errors.AnsibleError('could not create temporary directory: '
+                                      'SSH exited with return code %d' % result['rc'])
         rc = utils.last_non_blank_line(result['stdout']).strip() + '/'
+        # Catch any other failure conditions here; files should never be
+        # written directly to /.
+        if rc == '/':
+            raise errors.AnsibleError('refusing to use / as a temporary directory.')
         return rc
 
 


### PR DESCRIPTION
Bail out if the SSH command fails rather than continuing with an empty tmp variable. Without error checking, an (e.g.) SSH timeout will result in a temporary directory of '/' being set, and module files are then written directly under /, which is Bad and can break other tools; instead should fail fast with an informative error message. 

Pull request for the release branch as this looks like a bug to me, but let me know if it'd be more suitable for devel. 
