### PR TITLE
fix missing json module for issue #3363 print JSON error as string instead

### DIFF
--- a/library/system/selinux
+++ b/library/system/selinux
@@ -61,7 +61,7 @@ import sys
 try:
     import selinux
 except ImportError:
-    print json.dumps(failed=True, msg='python-selinux required for this module')
+    print "failed=True msg='python-selinux required for this module'"
     sys.exit(1)
 
 # getter subroutines
@@ -200,3 +200,4 @@ def main():
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 
 main()
+


### PR DESCRIPTION
selinux module was missing import of json module for returning error when python-selinux module does not exist.

Instead of importing json module, now returning the JSON directly as string instead.
