### PR TITLE
Fix ZFS module issues with spaces in property values

### DIFF
--- a/library/system/zfs
+++ b/library/system/zfs
@@ -316,9 +316,9 @@ class Zfs(object):
         cmd.append('get -H all')
         cmd.append(self.name)
         rc, out, err = self.module.run_command(' '.join(cmd))
-        properties=dict()
+        properties = dict()
         for l in out.splitlines():
-            p, v = l.split()[1:3]
+            p, v = l.split('\t')[1:3]
             properties[p] = v
         return properties
 

--- a/library/system/zfs
+++ b/library/system/zfs
@@ -292,11 +292,9 @@ class Zfs(object):
         if self.module.check_mode:
             self.changed = True
             return
-        cmd = [self.module.get_bin_path('zfs', True)]
-        cmd.append('set')
-        cmd.append(prop + '=' + value)
-        cmd.append(self.name)
-        (rc, err, out) = self.module.run_command(' '.join(cmd))
+        cmd = self.module.get_bin_path('zfs', True)
+        args = [cmd, 'set', prop + '=' + value, self.name]
+        (rc, err, out) = self.module.run_command(args)
         if rc == 0:
             self.changed = True
         else:


### PR DESCRIPTION
These two fixes together make it possible to both set and recognize zfs property values with whitespace. Fixes #3545.
