### PR TITLE
Enabled the use of extra vars in playbook file paths when including play...

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -130,7 +130,7 @@ class PlayBook(object):
 
         self.basedir     = os.path.dirname(playbook) or '.'
         utils.plugins.push_basedir(self.basedir)
-        vars = {}
+        vars = extra_vars.copy()
         if self.inventory.basedir() is not None:
             vars['inventory_dir'] = self.inventory.basedir()
         self.filename = playbook

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -119,7 +119,8 @@ class TestPlaybook(unittest.TestCase):
        filename = os.path.join(self.stage_dir, filename)
        return filename
 
-   def _run(self, test_playbook, host_list='test/ansible_hosts'):
+   def _run(self, test_playbook, host_list='test/ansible_hosts', 
+            extra_vars=None):
        ''' run a module and get the localhost results '''
        # This ensures tests are independent of eachother
        global EVENTS
@@ -135,6 +136,7 @@ class TestPlaybook(unittest.TestCase):
            timeout      = 5,
            remote_user  = self.user,
            remote_pass  = None,
+           extra_vars   = extra_vars,
            stats            = ans_callbacks.AggregateStats(),
            callbacks        = self.test_callbacks,
            runner_callbacks = self.test_callbacks
@@ -215,6 +217,29 @@ class TestPlaybook(unittest.TestCase):
        print utils.jsonify(expected, format=True)
 
        assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
+
+   def test_templated_includes(self):
+       pb = os.path.join(self.test_dir, 'playbook-templated-includer.yml')
+       actual = self._run(pb, extra_vars={ 'dir': self.test_dir })
+
+       # if different, this will output to screen
+       print "**ACTUAL**"
+       actual_json = utils.jsonify(actual, format=True)
+       print actual_json
+       expected =  {
+           "localhost": {
+               "changed": 0,
+               "failures": 0,
+               "ok": 2,
+               "skipped": 0,
+               "unreachable": 0
+           }
+       }
+       expected_json = utils.jsonify(expected, format=True)
+       print "**EXPECTED**"
+       print expected_json 
+
+       assert actual_json == expected_json
 
    def test_task_includes(self):
        pb = os.path.join(self.test_dir, 'task-includer.yml')

--- a/test/playbook-templated-includer.yml
+++ b/test/playbook-templated-includer.yml
@@ -1,0 +1,2 @@
+---
+- include: "{{dir}}/playbook-included.yml variable=foobar"


### PR DESCRIPTION
...books from other playbooks.

How about this: when including playbooks from other playbooks, Ansible will now use extra-vars as well when generating the file path of the other playbook.

This allows, for example, delivering playbooks as part of Python packages, along with a simple wrapper script that can inject the package directory. Then I can instruct my users to, in their playbooks, simply: 
- include: {{my_app}}/my_playbook.yml.
