### PR TITLE
(git module) Resolve incompatability between depth and version

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -99,7 +99,7 @@ def get_version(git_path, dest):
     sha = sha[0].split()[1]
     return sha
 
-def clone(git_path, module, repo, dest, remote, depth):
+def clone(git_path, module, repo, dest, remote, depth, version):
     ''' makes a new git repo if it does not already exist '''
     dest_dirname = os.path.dirname(dest)
     try:
@@ -108,6 +108,8 @@ def clone(git_path, module, repo, dest, remote, depth):
         pass
     os.chdir(dest_dirname)
     cmd = [ git_path, 'clone', '-o', remote, '--recursive' ]
+    if version:
+        cmd.extend([ '--branch', str(version) ])
     if depth:
         cmd.extend([ '--depth', str(depth) ])
     cmd.extend([ repo, dest ])
@@ -317,7 +319,7 @@ def main():
     if not os.path.exists(gitconfig):
         if module.check_mode:
             module.exit_json(changed=True)
-        (rc, out, err) = clone(git_path, module, repo, dest, remote, depth)
+        (rc, out, err) = clone(git_path, module, repo, dest, remote, depth, version)
     elif not update:
         # Just return having found a repo already in the dest path
         # this does no checking that the repo is the actual repo


### PR DESCRIPTION
The git module is unable to checkout the specified `version` when the
repository is cloned with a reduced history (`depth`).  However, if the
repository is already cloned, subsequent git module calls will update the
repository (default update=True), then properly checkout the specified
`version`.  To allow the initial call to properly clone the specified
`version`, at the specified `depth`, this patch adds the `--branch` parameter
when cloning the repository.
