### PR TITLE
doc bug #3562 - fix anchor backlinks and link depths 

### DIFF
--- a/docsite/latest/rst/YAMLSyntax.rst
+++ b/docsite/latest/rst/YAMLSyntax.rst
@@ -11,6 +11,8 @@ and writing YAML in most programming languages.
 You may also wish to read :doc:`playbooks` at the same time to see how this
 is used in practice.
 
+.. contents:: `Table of contents`
+   :depth: 4
 
 YAML Basics
 -----------

--- a/docsite/latest/rst/amazon_web_services.rst
+++ b/docsite/latest/rst/amazon_web_services.rst
@@ -2,8 +2,7 @@ Amazon Web Services
 ===================
 
 .. contents::
-   :depth: 2
-   :backlinks: top
+   :depth: 3
 
 Introduction
 ````````````

--- a/docsite/latest/rst/api.rst
+++ b/docsite/latest/rst/api.rst
@@ -7,8 +7,7 @@ and you can plug in inventory data from external data sources.  Ansible is writt
 API so you have a considerable amount of power across the board.
 
 .. contents:: `Table of contents`
-   :depth: 2
-   :backlinks: top
+   :depth: 4
 
 Python API
 ----------

--- a/docsite/latest/rst/bestpractices.rst
+++ b/docsite/latest/rst/bestpractices.rst
@@ -6,8 +6,7 @@ Here are some tips for making the most of Ansible.
 You can find some example playbooks illustrating these best practices in our `ansible-examples repository <https://github.com/ansible/ansible-examples>`_.  (NOTE: These may not use all of the features in the latest release just yet).
 
 .. contents::
-   :depth: 2
-   :backlinks: top
+   :depth: 7
 
 Content Organization
 ++++++++++++++++++++++

--- a/docsite/latest/rst/contrib.rst
+++ b/docsite/latest/rst/contrib.rst
@@ -6,6 +6,9 @@ curated list, but growing. Everyone is encouraged to add to this
 document, just `edit it on Github <https://github.com/ansible/ansible/blob/devel/docsite/latest/rst/contrib.rst>`_
 and send a pull request!
 
+.. contents:: `Table of contents`
+   :depth: 1
+
 Ansible Modules
 ```````````````
 

--- a/docsite/latest/rst/examples.rst
+++ b/docsite/latest/rst/examples.rst
@@ -11,8 +11,7 @@ using `/usr/bin/ansible-playbook` -- the concepts port over directly.
 (See :doc:`playbooks` for more information about those)
 
 .. contents::
-   :depth: 2
-   :backlinks: top
+   :depth: 1
 
 
 Parallelism and Shell Commands

--- a/docsite/latest/rst/faq.rst
+++ b/docsite/latest/rst/faq.rst
@@ -4,8 +4,7 @@ Frequently Asked Questions
 Here are some commonly-asked questions and their answers.
 
 .. contents::
-   :depth: 2
-   :backlinks: top
+   :depth: 1
 
 How do I handle different machines needing different user accounts or ports to log in with?
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docsite/latest/rst/gettingstarted.rst
+++ b/docsite/latest/rst/gettingstarted.rst
@@ -2,8 +2,7 @@ Getting Started
 ===============
 
 .. contents::
-   :depth: 2
-   :backlinks: top
+   :depth: 3
 
 Requirements
 ````````````

--- a/docsite/latest/rst/glossary.rst
+++ b/docsite/latest/rst/glossary.rst
@@ -9,6 +9,9 @@ when a term comes up on the mailing list.
 
 See the main documentation if you are looking for examples to put all of this into context.
 
+.. contents:: `Table of contents`
+   :depth: 2
+
 Action
 ++++++
 

--- a/docsite/latest/rst/moduledev.rst
+++ b/docsite/latest/rst/moduledev.rst
@@ -8,9 +8,7 @@ Modules can be written in any language and are found in the path specified
 by `ANSIBLE_LIBRARY` or the ``--module-path`` command line option.
 
 .. contents::
-   :depth: 2
-   :backlinks: top
-
+   :depth: 3
 
 Tutorial
 ````````

--- a/docsite/latest/rst/modules.rst
+++ b/docsite/latest/rst/modules.rst
@@ -3,7 +3,6 @@ Ansible Modules
 
 .. contents::
    :depth: 3
-   :backlinks: top
 
 Introduction
 ````````````

--- a/docsite/latest/rst/patterns.rst
+++ b/docsite/latest/rst/patterns.rst
@@ -9,7 +9,6 @@ Ansible's inventory file, which defaults to /etc/ansible/hosts.
 
 .. contents::
    :depth: 2
-   :backlinks: top
 
 .. _inventoryformat:
 

--- a/docsite/latest/rst/playbooks.rst
+++ b/docsite/latest/rst/playbooks.rst
@@ -3,7 +3,6 @@ Playbooks
 
 .. contents::
    :depth: 2
-   :backlinks: top
 
 Introduction
 ````````````

--- a/docsite/latest/rst/playbooks2.rst
+++ b/docsite/latest/rst/playbooks2.rst
@@ -8,7 +8,6 @@ be 90% or more of what they use in Ansible.
 
 .. contents::
    :depth: 2
-   :backlinks: top
 
 Tags
 ````


### PR DESCRIPTION
':backlinks: top' seemed to be the cause of #3562 , this commit fixes backlinks - they do not point back to #content 
anymore but to the actual anchor link.
 As far as I tested, this does fix the issue, although it might need review with css styling, since css is broken when testing locally.
This commit also fixes depths across all docs, setting the right depths equal to the number of sections.
