### PR TITLE
Minor typo on site about host_key_checking config section.

### DIFF
--- a/docsite/latest/rst/gettingstarted.rst
+++ b/docsite/latest/rst/gettingstarted.rst
@@ -347,7 +347,7 @@ which results in a interactive experience if using Ansible, from say, cron.
 
 If you wish to disable this behavior and understand the implications, you can do so by editing /etc/ansible/ansible.cfg or ~/.ansible.cfg::
 
-    [default]
+    [defaults]
     host_key_checking = False
 
 Alternatively this can be set by an environment variable:


### PR DESCRIPTION
Section for host_key_checking was `[default]` which is incorrect.. 
