### PR TITLE
Fix the case when a remote user copy a file with sudo priviledge

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -860,12 +860,9 @@ class AnsibleModule(object):
         dest_file = os.path.basename(dest)
         tmp_dest = "%s/.%s.%s.%s" % (dest_dir,dest_file,os.getpid(),time.time())
 
-        try: # leaves tmp file behind when sudo and  not root
-            if os.getenv("SUDO_USER") and os.getuid() != 0:
-               # cleanup will happen by 'rm' of tempdir
-               shutil.copy(src, tmp_dest)
-            else:
-               shutil.move(src, tmp_dest)
+        try: # leaves tmp file behind 
+            # cleanup will happen by 'rm' of tempdir
+            shutil.copy(src, tmp_dest)
             if self.selinux_enabled():
                 self.set_context_if_different(tmp_dest, context, False)
             os.rename(tmp_dest, dest)


### PR DESCRIPTION
In my case, the env var SUDO_USER exists but do the action with uid=0 => move.
The problem happen when the src file is readonly for the root because it was copied by the remote_user.

In any case the clean up will happen at the end. So it doesn't matter if we let the src file.

Note : the unit test "test_copy" doesn't pass in selinux neither before and after this patch. (pass if not selinux).
