### PR TITLE
Check for existence of isatty on stdout before calling it

### DIFF
--- a/lib/ansible/color.py
+++ b/lib/ansible/color.py
@@ -21,7 +21,7 @@ import sys
 ANSIBLE_COLOR=True
 if os.getenv("ANSIBLE_NOCOLOR") is not None:
     ANSIBLE_COLOR=False
-elif not sys.stdout.isatty():
+elif not hasattr(sys.stdout, 'isatty') or not sys.stdout.isatty():
     ANSIBLE_COLOR=False
 else:
     try:


### PR DESCRIPTION
The standard library documentation [states that](http://docs.python.org/2/library/stdtypes.html#file.isatty) file-like objects that are not associated with a real file should not implement the isatty method, so its existence has to be verified before trying to call it.

An example of an environment where this is an issue is WSGI, where the standard output gets replaced by WSGI's own logging object, which lacks an isatty method.
