### PR TITLE
Fix pkgin query_package for certain package names

### DIFF
--- a/library/packaging/pkgin
+++ b/library/packaging/pkgin
@@ -66,7 +66,7 @@ def query_package(module, pkgin_path, name, state="present"):
         rc, out, err = module.run_command("%s list | grep ^%s" % (pkgin_path, name))
 
         if rc == 0:
-	    return name == '-'.join(out.split(' ')[0].split('-')[:-1])
+            return name == '-'.join(out.split(' ')[0].split('-')[:-1])
 
         return False
 

--- a/library/packaging/pkgin
+++ b/library/packaging/pkgin
@@ -3,7 +3,7 @@
 
 # (c) 2013, Shaun Zinck
 # Written by Shaun Zinck <shaun.zinck at gmail.com>
-# Based on pacman module written by Afterburn <http://github.com/afterburn> 
+# Based on pacman module written by Afterburn <http://github.com/afterburn>
 #  that was based on apt module written by Matthew Williams <matthew@flowroute.com>
 #
 # This module is free software: you can redistribute it and/or modify
@@ -49,7 +49,7 @@ EXAMPLES = '''
 # remove package foo
 - pkgin: name=foo state=absent
 
-# remove packages foo and bar 
+# remove packages foo and bar
 - pkgin: name=foo,bar state=absent
 '''
 
@@ -66,13 +66,13 @@ def query_package(module, pkgin_path, name, state="present"):
         rc, out, err = module.run_command("%s list | grep ^%s" % (pkgin_path, name))
 
         if rc == 0:
-            return True
+	    return name == '-'.join(out.split(' ')[0].split('-')[:-1])
 
         return False
 
 
 def remove_packages(module, pkgin_path, packages):
-    
+
     remove_c = 0
     # Using a for loop incase of error, we can report the package that failed
     for package in packages:
@@ -84,7 +84,7 @@ def remove_packages(module, pkgin_path, packages):
 
         if query_package(module, pkgin_path, package):
             module.fail_json(msg="failed to remove %s: %s" % (package, out))
-    
+
         remove_c += 1
 
     if remove_c > 0:
@@ -108,7 +108,7 @@ def install_packages(module, pkgin_path, packages):
             module.fail_json(msg="failed to install %s: %s" % (package, out))
 
         install_c += 1
-    
+
     if install_c > 0:
         module.exit_json(changed=True, msg="present %s package(s)" % (install_c))
 
@@ -136,5 +136,5 @@ def main():
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-    
-main()        
+
+main()


### PR DESCRIPTION
The current implementation returns "false positives" for packages with names that other packages' names start with.

E.g.: when `gcc47-libs` is already installed and `gcc47` is to be installed, the later's installation is skipped because it is considered to be also already installed.

Search for available or installed packages by package name:

```
$ pkgin search gcc47
gcc47-libs-4.7.2nb4 = The GNU Compiler Collection (GCC) support shared libraries.
gcc47-4.7.2nb3       The GNU Compiler Collection (GCC) - 4.7 Release Series
```

The current implementation only checks for the return code being 0, which results in reporting `gcc47` to be installed, even when it's not (but `gcc47-libs` is):

```
$ pkgin list | grep gcc47
gcc47-libs-4.7.2nb4  The GNU Compiler Collection (GCC) support shared libraries.
```

The fix proposed in this PR fixes this behavior with an additional check that compares the _complete_ package name (minus the version appendix).
