### PR TITLE
openbsd_pkg: Use ansible run_command().

### DIFF
--- a/library/packaging/openbsd_pkg
+++ b/library/packaging/openbsd_pkg
@@ -19,6 +19,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
+import shlex
 
 DOCUMENTATION = '''
 ---
@@ -53,24 +54,18 @@ EXAMPLES = '''
 - openbsd_pkg: name=nmap state=absent
 '''
 
-# select whether we dump additional debug info through syslog
-syslogging = False
-
 # Function used for executing commands.
-def execute_command(cmd, syslogging):
-    if syslogging:
-        syslog.openlog('ansible-%s' % os.path.basename(__file__))
-        syslog.syslog(syslog.LOG_NOTICE, 'Command %s' % '|'.join(cmd))
-
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    (out, err) = p.communicate()
-    rc = p.returncode
-    return (rc, out, err)
+def execute_command(cmd, module):
+    # Break command line into arguments.
+    # This makes run_command() use shell=False which we need to not cause shell
+    # expansion of special characters like '*'.
+    cmd_args = shlex.split(cmd)
+    return module.run_command(cmd_args)
 
 # Function used for getting the name of a currently installed package.
-def get_current_name(name, specific_version):
+def get_current_name(name, specific_version, module):
     info_cmd = 'pkg_info'
-    (rc, stdout, stderr) = execute_command("%s" % (info_cmd), syslogging)
+    (rc, stdout, stderr) = execute_command("%s" % (info_cmd), module)
     if rc != 0:
         return (rc, stdout, stderr)
 
@@ -86,7 +81,7 @@ def get_current_name(name, specific_version):
     return current_name
 
 # Function used to find out if a package is currently installed.
-def get_package_state(name, specific_version):
+def get_package_state(name, specific_version, module):
     info_cmd = 'pkg_info -e'
 
     if specific_version:
@@ -94,7 +89,7 @@ def get_package_state(name, specific_version):
     else:
         syntax = "%s %s-*"
 
-    rc, stdout, stderr = execute_command(syntax % (info_cmd, name), syslogging)
+    rc, stdout, stderr = execute_command(syntax % (info_cmd, name), module)
 
     if rc == 0:
         return True
@@ -111,7 +106,7 @@ def package_present(name, installed_state, specific_version, module):
     if installed_state is False:
 
         # Attempt to install the package
-        (rc, stdout, stderr) = execute_command("%s %s" % (install_cmd, name), syslogging)
+        (rc, stdout, stderr) = execute_command("%s %s" % (install_cmd, name), module)
 
         # The behaviour of pkg_add is a bit different depending on if a
         # specific version is supplied or not.
@@ -166,10 +161,10 @@ def package_latest(name, installed_state, specific_version, module):
     if installed_state is True:
 
         # Fetch name of currently installed package
-        pre_upgrade_name = get_current_name(name, specific_version)
+        pre_upgrade_name = get_current_name(name, specific_version, module)
 
         # Attempt to upgrade the package
-        (rc, stdout, stderr) = execute_command("%s %s" % (upgrade_cmd, name), syslogging)
+        (rc, stdout, stderr) = execute_command("%s %s" % (upgrade_cmd, name), module)
 
         # Look for output looking something like "nmap-6.01->6.25: ok" to see if
         # something changed (or would have changed). Use \W to delimit the match
@@ -212,7 +207,7 @@ def package_absent(name, installed_state, module):
     if installed_state is True:
 
         # Attempt to remove the package
-        rc, stdout, stderr = execute_command("%s %s" % (remove_cmd, name), syslogging)
+        rc, stdout, stderr = execute_command("%s %s" % (remove_cmd, name), module)
 
         if rc == 0:
             if module.check_mode:
@@ -261,7 +256,7 @@ def main():
         specific_version = False
 
     # Get package state
-    installed_state = get_package_state(name, specific_version)
+    installed_state = get_package_state(name, specific_version, module)
 
     # Perform requested action
     if state in ['installed', 'present']:


### PR DESCRIPTION
This is a follow-up to PR #3600.

This fixes an asterisk glob problem in get_package_state() where a file
in /root/ could cause shell expansion if it matched the package name.
The actual problem is solved by running with shell=False.

This also makes the module use the common ansible run_command function per request.
