### PR TITLE
Added rename of elb_regions to regions

### DIFF
--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -53,6 +53,11 @@ options:
       - AWS Access API key
     required: false
     default: None
+  elb_region:
+    description:
+      - AWS Region the load balancer is in
+    required: false
+    default: None
 
 """
 
@@ -83,6 +88,7 @@ import os
 
 try:
     import boto
+    from boto.ec2.elb import regions as elb_regions
 except ImportError:
     print "failed=True msg='boto required for this module'"
     sys.exit(1)
@@ -92,12 +98,23 @@ class ElbManager:
     """Handles EC2 instance ELB registration and de-registration"""
 
     def __init__(self, module, instance_id=None, ec2_elbs=None,
-                 ec2_access_key=None, ec2_secret_key=None):
+                 ec2_access_key=None, ec2_secret_key=None, elb_region_name=None):
         self.ec2_access_key = ec2_access_key
         self.ec2_secret_key = ec2_secret_key
         self.module = module
         self.instance_id = instance_id
+        self.elb_region = None
+
+        if elb_region_name is not None:
+          for region in elb_regions():
+            if region.name == elb_region_name:
+              self.elb_region = region
+
+          if self.elb_region is None:
+            self.module.fail_json(msg=str("Invalid region"))
+
         self.lbs = self._get_instance_lbs(ec2_elbs)
+
         # if there are no ELBs to operate on
         # there will be no changes made
         if len(self.lbs) > 0:
@@ -140,7 +157,7 @@ class ElbManager:
                   are attached to self.instance_id"""
 
         try:
-            elb = boto.connect_elb(self.ec2_access_key, self.ec2_secret_key)
+            elb = boto.connect_elb(self.ec2_access_key, self.ec2_secret_key, region=self.elb_region)
         except boto.exception.NoAuthHandlerFound, e:
             self.module.fail_json(msg=str(e))
         elbs = elb.get_all_load_balancers()
@@ -165,13 +182,15 @@ def main():
             instance_id={'required': True},
             ec2_elbs={'default': None, 'required': False},
             ec2_secret_key={'default': None, 'aliases': ['EC2_SECRET_KEY']},
-            ec2_access_key={'default': None, 'aliases': ['EC2_ACCESS_KEY']}
+            ec2_access_key={'default': None, 'aliases': ['EC2_ACCESS_KEY']},
+            elb_region={'required': False, 'default': None}
         )
     )
 
     ec2_secret_key = module.params['ec2_secret_key']
     ec2_access_key = module.params['ec2_access_key']
     ec2_elbs = module.params['ec2_elbs']
+    elb_region = module.params['elb_region']
 
     if module.params['state'] == 'present' and 'ec2_elbs' not in module.params:
         module.fail_json(msg="ELBs are required for registration")
@@ -183,7 +202,7 @@ def main():
 
     instance_id = module.params['instance_id']
     elb_man = ElbManager(module, instance_id, ec2_elbs, ec2_access_key,
-                         ec2_secret_key)
+                         ec2_secret_key, elb_region)
 
     if module.params['state'] == 'present':
         elb_man.register()

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -106,12 +106,12 @@ class ElbManager:
         self.elb_region = None
 
         if region_name is not None:
-          for region in elb_regions():
-            if region.name == region_name:
-              self.elb_region = region
+            for region in elb_regions():
+                if region.name == region_name:
+                    self.elb_region = region
 
-          if self.elb_region is None:
-            self.module.fail_json(msg=str("Invalid region"))
+            if self.elb_region is None:
+                self.module.fail_json(msg=str("Invalid region"))
 
         self.lbs = self._get_instance_lbs(ec2_elbs)
 

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -53,7 +53,7 @@ options:
       - AWS Access API key
     required: false
     default: None
-  elb_region:
+  region:
     description:
       - AWS Region the load balancer is in
     required: false
@@ -98,16 +98,16 @@ class ElbManager:
     """Handles EC2 instance ELB registration and de-registration"""
 
     def __init__(self, module, instance_id=None, ec2_elbs=None,
-                 ec2_access_key=None, ec2_secret_key=None, elb_region_name=None):
+                 ec2_access_key=None, ec2_secret_key=None, region_name=None):
         self.ec2_access_key = ec2_access_key
         self.ec2_secret_key = ec2_secret_key
         self.module = module
         self.instance_id = instance_id
         self.elb_region = None
 
-        if elb_region_name is not None:
+        if region_name is not None:
           for region in elb_regions():
-            if region.name == elb_region_name:
+            if region.name == region_name:
               self.elb_region = region
 
           if self.elb_region is None:
@@ -183,14 +183,14 @@ def main():
             ec2_elbs={'default': None, 'required': False},
             ec2_secret_key={'default': None, 'aliases': ['EC2_SECRET_KEY']},
             ec2_access_key={'default': None, 'aliases': ['EC2_ACCESS_KEY']},
-            elb_region={'required': False, 'default': None}
+            region={'required': False, 'default': None}
         )
     )
 
     ec2_secret_key = module.params['ec2_secret_key']
     ec2_access_key = module.params['ec2_access_key']
     ec2_elbs = module.params['ec2_elbs']
-    elb_region = module.params['elb_region']
+    region = module.params['region']
 
     if module.params['state'] == 'present' and 'ec2_elbs' not in module.params:
         module.fail_json(msg="ELBs are required for registration")
@@ -202,7 +202,7 @@ def main():
 
     instance_id = module.params['instance_id']
     elb_man = ElbManager(module, instance_id, ec2_elbs, ec2_access_key,
-                         ec2_secret_key, elb_region)
+                         ec2_secret_key, region)
 
     if module.params['state'] == 'present':
         elb_man.register()


### PR DESCRIPTION
This is a re-posting of the other PR.

Since its better to discuss it here,

@lwade that code path only fires if the:

```
if region_name is not None:
```

Its there to catch the case of specifying a bad region rather than silently falling back to us-east-1. Do you see if this behavior is broken?

@mpdehaan if this PR is fine, i'll open a different one with the indentation fixed
