### PR TITLE
svr4pkg doesn't work on Sol10

### DIFF
--- a/library/packaging/svr4pkg
+++ b/library/packaging/svr4pkg
@@ -74,7 +74,7 @@ def package_installed(module, name):
     cmd = [module.get_bin_path('pkginfo', True)]
     cmd.append('-q')
     cmd.append(name)
-    rc, out, err = module.run_command(' '.join(cmd), shell=False)
+    rc, out, err = module.run_command(' '.join(cmd))
     if rc == 0:
         return True
     else:


### PR DESCRIPTION
--- This has already been written in issue ansible/ansible#3547

While removing a package from Solaris 10, I always receive the following error:

```
rc, out, err = module.run_command(' '.join(cmd), shell=False)
TypeError: run_command() got an unexpected keyword argument 'shell'
```

I fixed it with modifying the svr4pkg module (old code is commented out)

```
    #rc, out, err = module.run_command(' '.join(cmd), shell=False)
    rc, out, err = module.run_command(' '.join(cmd))
```
