### PR TITLE
Pacman module: recursive remove support

### DIFF
--- a/library/packaging/pacman
+++ b/library/packaging/pacman
@@ -45,6 +45,14 @@ options:
         default: "no"
         choices: [ "yes", "no" ]
 
+    recursive:
+        description:
+            - remove all not explicitly installed dependencies not required
+              by other packages of the package to remove
+        required: false
+        default: "no"
+        choices: [ "yes", "no" ]
+
 author: Afterburn
 notes:  []
 '''
@@ -58,6 +66,9 @@ EXAMPLES = '''
 
 # Remove packages foo and bar 
 - pacman: name=foo,bar state=absent
+
+# Recursively remove package baz
+- pacman: name=baz state=absent recursive=yes
 
 # Update the package database (pacman -Syy) and install bar (bar will be the updated if a newer version exists) 
 - pacman: name=bar, state=installed, update_cache=yes
@@ -92,6 +103,10 @@ def update_package_db(module):
          
 
 def remove_packages(module, packages):
+    if module.params["recursive"]:
+        args = "Rs"
+    else:
+        args = "R"
     
     remove_c = 0
     # Using a for loop incase of error, we can report the package that failed
@@ -100,7 +115,7 @@ def remove_packages(module, packages):
         if not query_package(module, package):
             continue
 
-        rc = os.system("pacman -R %s --noconfirm > /dev/null" % (package))
+        rc = os.system("pacman -%s %s --noconfirm > /dev/null" % (args, package))
 
         if rc != 0:
             module.fail_json(msg="failed to remove %s" % (package))
@@ -141,6 +156,7 @@ def main():
             argument_spec    = dict(
                 state        = dict(default="installed", choices=["installed","absent"]),
                 update_cache = dict(default="no", aliases=["update-cache"], type='bool'),
+                recursive    = dict(default="no", type='bool'),
                 name         = dict(aliases=["pkg"], required=True)))
                 
 


### PR DESCRIPTION
When using:

``` sh
pacman: name=vim state=absent recursive=yes
```

Vim and all its dependencies not required by other packages will be removed. Dependencies of vim which were explicitly installed are also left alone.

It should be debated whether this should be the default option as it's the behaviour you'd want in almost all cases.
