### PR TITLE
fix: if a path is symlink and trying to chmod, OSError Exception will be raised

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -435,7 +435,9 @@ class AnsibleModule(object):
                 else:
                     os.chmod(path, mode)
             except OSError, e:
-                if e.errno == errno.ENOENT: # Can't set mode on broken symbolic links
+                if os.path.islink(path) and e.errno == errno.EPERM:  # Can't set mode on symbolic links
+                    pass
+                elif e.errno == errno.ENOENT: # Can't set mode on broken symbolic links
                     pass
                 else:
                     raise e


### PR DESCRIPTION
Create symlink to exists file using file module with force=yes will fail. From the document, it should be work, I think.
the playbook is this,

```
    - name: make symlink to exists file
      file: src=/bin/ls dest=/tmp/ls-tmp state=link force=yes mode=0644
```

and error:

```
Traceback (most recent call last):
  File "/home/shirou/.ansible/tmp/ansible-1374584668.83-164111205615212/file", line 1254, in <module>
    main()
  File "/home/shirou/.ansible/tmp/ansible-1374584668.83-164111205615212/file", line 316, in main
    changed   = module.set_mode_if_different(path, file_args['mode'], changed)
  File "/home/shirou/.ansible/tmp/ansible-1374584668.83-164111205615212/file", line 732, in set_mode_if_different
    raise e
OSError: [Errno 1] Operation not permitted: '/tmp/ls-tmp'
```

with python 2.7.3 and ubuntu 12.10

This Pull request will fix this exception by adding check about islink and the error is Operation not permitted(EPERM).
