### PR TITLE
Add support to ansible-pull to for other source repositories

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -14,8 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
 # ansible-pull is a script that runs ansible in local mode
-# after checking out a playbooks directory from git.  There is an
+# after checking out a playbooks directory from source repo.  There is an
 # example playbook to bootstrap this script in the examples/ dir which
 # installs ansible and sets it up to run on cron.
 
@@ -27,14 +28,14 @@
 # the -d and -U arguments are required; the -C argument is optional.
 #
 # ansible-pull accepts an optional argument to specify a playbook
-# location underneath the workdir and then searches the git repo
+# location underneath the workdir and then searches the source repo
 # for playbooks in the following order, stopping at the first match:
 #
 # 1. $workdir/path/playbook.yml, if specified
 # 2. $workdir/$hostname.yml
 # 3. $workdir/local.yml
 #
-# the git repo must contain at least one of these playbooks.
+# the source repo must contain at least one of these playbooks.
 
 import os
 import shutil
@@ -42,8 +43,9 @@ import subprocess
 import sys
 import datetime
 import socket
-from optparse import OptionParser
+from ansible import utils
 
+DEFAULT_REPO_TYPE = 'git'
 DEFAULT_PLAYBOOK = 'local.yml'
 PLAYBOOK_ERRORS = {1: 'File does not exist',
                     2: 'File is not readable'}
@@ -96,20 +98,24 @@ def select_playbook(path, args):
 def main(args):
     """ Set up and run a local playbook """
     usage = "%prog [options] [playbook.yml]"
-    parser = OptionParser(usage=usage)
+    parser = utils.SortedOptParser(usage=usage)
     parser.add_option('--purge', default=False, action='store_true',
-                      help='purge git checkout after playbook run')
+                      help='purge checkout after playbook run')
     parser.add_option('-o', '--only-if-changed', dest='ifchanged', default=False, action='store_true',
                       help='only run the playbook if the repository has been updated')
     parser.add_option('-d', '--directory', dest='dest', default=None,
-                      help='directory to clone the git repository to')
+                      help='directory to checkout repository to')
     parser.add_option('-U', '--url', dest='url', default=None,
-                      help='URL of the git repository')
+                      help='URL of the playbook repository')
     parser.add_option('-C', '--checkout', dest='checkout',
-                      default="HEAD",
-                      help='branch/tag/commit to checkout; defaults to HEAD')
+                      help='branch/tag/commit to checkout.  '
+                      'Defaults to behavior of repository module.')
     parser.add_option('-i', '--inventory-file', dest='inventory',
                       help="location of the inventory host file")
+    parser.add_option('-m', '--module-name', dest='module_name',
+                      default=DEFAULT_REPO_TYPE,
+                      help='Module name used to check out repository.  '
+                      'Default is %s.' % DEFAULT_REPO_TYPE)
     options, args = parser.parse_args(args)
 
     if not options.dest:
@@ -119,7 +125,7 @@ def main(args):
     options.dest = os.path.abspath(options.dest)
 
     if not options.url:
-        parser.error("URL for git repo not specified, use -h for help")
+        parser.error("URL for repository not specified, use -h for help")
         return 1
 
     now = datetime.datetime.now()
@@ -127,9 +133,16 @@ def main(args):
 
     inv_opts = 'localhost,'
     limit_opts = 'localhost:%s:127.0.0.1' % socket.getfqdn()
-    git_opts = "repo=%s dest=%s version=%s" % (options.url, options.dest, options.checkout)
-    cmd = 'ansible all -c local -i "%s" --limit "%s" -m git -a "%s"' % (
-            inv_opts, limit_opts, git_opts
+    base_opts = '-c local --limit "%s"' % limit_opts
+    repo_opts = "name=%s dest=%s" % (options.url, options.dest)
+    if options.checkout:
+        repo_opts += ' version=%s' % options.checkout
+    path = utils.plugins.module_finder.find_plugin(options.module_name)
+    if path is None:
+        sys.stderr.write("module '%s' not found.\n" % options.module_name)
+        return 1
+    cmd = 'ansible all -i "%s" %s -m %s -a "%s"' % (
+            inv_opts, base_opts, options.module_name, repo_opts
             )
     rc, out = _run(cmd)
     if rc != 0:
@@ -144,7 +157,7 @@ def main(args):
         print >>sys.stderr, "Could not find a playbook to run."
         return 1
 
-    cmd = 'ansible-playbook -c local --limit "%s" %s' % (limit_opts, playbook)
+    cmd = 'ansible-playbook %s %s' % (base_opts, playbook)
     if options.inventory:
         cmd += ' -i "%s"' % options.inventory
     os.chdir(options.dest)

--- a/docs/man/man1/ansible-pull.1.asciidoc.in
+++ b/docs/man/man1/ansible-pull.1.asciidoc.in
@@ -12,7 +12,7 @@ ansible-pull - set up a remote copy of ansible on each managed node
 
 SYNOPSIS
 --------
-ansible -d DEST -U URL [ -C CHECKOUT ] [ -i INVENTORY ] [ <filename.yml> ]
+ansible -d DEST -U URL [options] [ <filename.yml> ]
 
 
 DESCRIPTION
@@ -23,8 +23,9 @@ SSH.
 
 Use ansible-pull to set up a remote copy of ansible on each managed
 node, each set to run via cron and update playbook source via
-git. This inverts the default *push* architecture of ansible into a
-*pull* architecture, which has near-limitless scaling potential.
+a source repository. This inverts the default *push* architecture of
+ansible into a *pull* architecture, which has near-limitless scaling
+potential.
 
 The setup playbook can be tuned to change the cron frequency, logging
 locations, and parameters to ansible-pull.
@@ -41,7 +42,7 @@ OPTIONAL ARGUMENT
 *filename.yml*::
 
 The name of one the YAML format files to run as an ansible playbook.  This can
-be a relative path within the git checkout.  If not provided, ansible-pull
+be a relative path within the checkout.  If not provided, ansible-pull
 will look for a playbook based on the host's fully-qualified domain name and
 finally a playbook named *local.yml*.
 
@@ -51,24 +52,29 @@ OPTIONS
 
 *-d* 'DEST', *--directory=*'DEST'::
 
-Directory to checkout git repository into.
+Directory to checkout repository into.
 
 *-U* 'URL', *--url=*'URL'::
 
-URL of git repository to clone.
+URL of the playbook repository to checkout.
 
 *-C* 'CHECKOUT', *--checkout=*'CHECKOUT'::
 
-Branch/Tag/Commit to checkout.  Defaults to 'HEAD'.
+Branch/Tag/Commit to checkout.  If not provided, uses default behavior
+of module used to check out playbook repository.
 
 *-i* 'PATH', *--inventory=*'PATH'::
 
 The 'PATH' to the inventory hosts file.  This can be a relative path within
-the git checkout.
+the checkout.
 
 *--purge*::
 
-Purge the git checkout after the playbook is run.
+Purge the checkout after the playbook is run.
+
+*-m* 'NAME', *--module-name=*'NAME'::
+
+Module used to checkout playbook repository.  Defaults to git.
 
 
 AUTHOR

--- a/library/source_control/hg
+++ b/library/source_control/hg
@@ -41,6 +41,7 @@ options:
             - The repository address.
         required: true
         default: null
+        aliases: [ name ]
     dest:
         description:
             - Absolute path of where the repository should be cloned to.
@@ -52,6 +53,7 @@ options:
               branch name or even tag. 
         required: false
         default: "default"
+        aliases: [ version ]
     force:
         description:
             - Discards uncommitted changes. Runs C(hg update -C).
@@ -203,9 +205,9 @@ def switch_version(module, dest, revision):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            repo = dict(required=True),	    
+            repo = dict(required=True, aliases=['name']),
             dest = dict(required=True),
-            revision = dict(default="default"),
+            revision = dict(default="default", aliases=['version']),
             force = dict(default='yes', type='bool'),
             purge = dict(default='no', type='bool')
         ),

--- a/library/source_control/subversion
+++ b/library/source_control/subversion
@@ -34,6 +34,7 @@ options:
     description:
       - The subversion URL to the repository.
     required: true
+    aliases: [ name, repository ]
     default: null
   dest:
     description:
@@ -45,6 +46,7 @@ options:
       - Specific revision to checkout.
     required: false
     default: HEAD
+    aliases: [ version ]
   force:
     description:
       - If C(yes), modified files will be discarded. If C(no), module will fail if it encounters modified files.
@@ -141,7 +143,7 @@ def main():
         argument_spec=dict(
             dest=dict(required=True),
             repo=dict(required=True, aliases=['name', 'repository']),
-            revision=dict(default='HEAD', aliases=['rev']),
+            revision=dict(default='HEAD', aliases=['rev', 'version']),
             force=dict(default='yes', type='bool'),
             username=dict(required=False),
             password=dict(required=False),


### PR DESCRIPTION
See issue #3372.  This makes parameters across source_control modules consistent for ansible-pull usage and updates ansible-pull to support other modules for checking out from other 'source repositories'.  The only requirement is that the module support the parameters `name`, `dest`, and `version`.
