### PR TITLE
Fix 'timeout' parameter of glance-image module.

### DIFF
--- a/library/cloud/glance_image
+++ b/library/cloud/glance_image
@@ -176,7 +176,7 @@ def _glance_image_create(module, params, client):
                 'copy_from':        params.get('copy_from'),
     }
     try:                
-        timeout = params.get('timeout')
+        timeout = float(params.get('timeout'))
         expire = time.time() + timeout
         image = client.images.create(**kwargs)
         if not params['copy_from']:


### PR DESCRIPTION
The timeout parameter of glance-image was not being parsed into a
numeric type, causing the following error when specifying timeout:

```
msg: Error in creating image: unsupported operand type(s) for +: 'float' and 'str'
```
