### PR TITLE
Extra vars from file

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -94,10 +94,20 @@ def main(args):
         options.ask_sudo_pass = options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
         ( sshpass, sudopass ) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass)
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
-    if options.extra_vars and options.extra_vars[0] in '[{':
-        extra_vars = utils.json_loads(options.extra_vars)
-    else:
-        extra_vars = utils.parse_kv(options.extra_vars)
+
+    extra_vars = {}
+    if options.extra_vars:
+        if options.extra_vars.startswith("@"):
+            # Argument is a JSON file
+            with open(options.extra_vars[1:]) as fd:
+                extra_vars = utils.json_loads(fd.read())
+        elif options.extra_vars[0] in '[{':
+            # Arguments as JSON
+            extra_vars = utils.json_loads(options.extra_vars)
+        else:
+            # Arguments as Key-value
+            extra_vars = utils.parse_kv(options.extra_vars)
+
     only_tags = options.tags.split(",")
     skip_tags = options.skip_tags
     if options.skip_tags is not None:

--- a/docsite/latest/rst/playbooks2.rst
+++ b/docsite/latest/rst/playbooks2.rst
@@ -74,7 +74,7 @@ Overriding Changed Result
 .. versionadded:: 1.3
 
 When a shell/command or other module runs it will typically report
-"changed" status based on whether it thinks it affected machine state.  
+"changed" status based on whether it thinks it affected machine state.
 
 Sometimes you will know, based on the return code
 or output that it did not make any changes, and wish to override
@@ -289,6 +289,9 @@ As of Ansible 1.2, you can also pass in extra vars as quoted JSON, like so::
 
 The key=value form is obviously simpler, but it's there if you need it!
 
+As of Ansible 1.3, extra vars can be loaded from a JSON file with the "@" syntax::
+
+    --extra-vars "@some_file.json"
 
 Conditional Execution
 `````````````````````
@@ -822,7 +825,7 @@ The 'register' keyword decides what variable to save a result in.  The resulting
           - shell: echo "motd contains the word hi"
             when: motd_contents.stdout.find('hi') != -1
 
-As shown previously, the registered variable's string contents are accessible with the 'stdout' value. 
+As shown previously, the registered variable's string contents are accessible with the 'stdout' value.
 The registered result can be used in the "with_items" of a task if it is converted into
 a list (or already is a list) as shown below.  "stdout_lines" is already available on the object as
 well though you could also call "home_dirs.stdout.split()" if you wanted, and could split by other


### PR DESCRIPTION
This pull request adds the ability for extra-vars to be loaded from a file with the "@" syntax, just as it's done for --limit option.

For example:

```
--extra-vars "@some_file.json"
```
