### PR TITLE
forking least possible

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -886,6 +886,9 @@ class Runner(object):
         # host.
         p = utils.plugins.action_loader.get(self.module_name, self)
 
+        if self.forks == 0 or self.forks > len(hosts):
+            self.forks = len(hosts)
+
         if p and getattr(p, 'BYPASS_HOST_LOOP', None):
 
             # Expose the current hostgroup to the bypassing plugins


### PR DESCRIPTION
now if you set fork to 0 or a number higher than the number of hosts it will be readjusted to the number of hosts runner is going to deal with.
Signed-off-by: Brian Coca <briancoca+dev@gmail.com>

Did this a few dozen times and results were pretty consistent, needs a lot of testing, specially with multiple plays per book.

test: time ansible -m setup -f 50 -i 'localhost,' localhost -c local > /dev/null

Before:
real    0m3.240s
user    0m1.820s
sys     0m0.880s

After:
real    0m1.291s
user    0m0.860s
sys     0m0.180s
