### PR TITLE
Fix nested loop for more than 3 elements

### DIFF
--- a/lib/ansible/runner/lookup_plugins/nested.py
+++ b/lib/ansible/runner/lookup_plugins/nested.py
@@ -34,7 +34,7 @@ def combine(a,b):
     results = []
     for x in a:
         for y in b:
-            results.append([x,y])
+            results.append(flatten([x,y]))
     return results
 
 class LookupModule(object):

--- a/test/lookup_plugins.yml
+++ b/test/lookup_plugins.yml
@@ -55,6 +55,15 @@
     action: copy src=sample.j2 dest=/tmp/ansible-test-with_lines-data
   - name: cleanup test file
     action: file path=/tmp/ansible-test-with_lines-data state=absent
+    
+    # Test nested loop
+  - name: test nested loop with more than 3 elements
+    command: test "{{ item[0] }}, {{ item[1] }}, {{ item[2] }}, {{ item[3] }}" = "red, 1, up, top"
+    with_nested:
+    - [ 'red' ]
+    - [ 1 ]
+    - [ 'up']
+    - [ 'top']
 
 # password lookup plugin
   - name: ensure test file doesn't exist


### PR DESCRIPTION
- combine flatten list for each nested level instead once at the end
