### PR TITLE
Fix playbook-local host_vars when running from .

### DIFF
--- a/lib/ansible/inventory/vars_plugins/group_vars.py
+++ b/lib/ansible/inventory/vars_plugins/group_vars.py
@@ -40,7 +40,7 @@ class VarsModule(object):
         """ main body of the plugin, does actual loading """
 
         inventory = self.inventory
-        self.pb_basedir = inventory.playbook_basedir()
+        self.pb_basedir = os.path.abspath(inventory.playbook_basedir())
 
         # sort groups by depth so deepest groups can override the less deep ones
         groupz = sorted(inventory.groups_for_host(host.name), key=lambda g: g.depth)


### PR DESCRIPTION
Since ansible 1.2, it became possible to place a host_vars
directory in the same directory as a playbook, making it possible
to keep host_vars local to that playbook there. However, due to
python's os.path.dirname, a action such as:

 $ ansible-playbook pb.yml

..would not pick up the host_vars as os.path.dirname("pb.yml")
returns "", unlike the unix command dirname that would return
".". Substituting "pb.yml" on the command line with "./pb.yml"
would do the trick, but is not always intuitive. This patch
solves the problem until python solves issue18547 [1].

[1] http://bugs.python.org/issue18547
