### PR TITLE
Wrong target for link?

### DIFF
--- a/examples/playbooks/README.md
+++ b/examples/playbooks/README.md
@@ -3,6 +3,5 @@ Playbook Examples
 
 Playbook examples have moved.
 
-See [the Ansible-Examples repo](https://github.com/ansible/ansible-examples/tree/master/language_features).
-
+See [the Ansible-Examples repo](https://github.com/ansible/ansible-examples).
 


### PR DESCRIPTION
Came to here from http://www.ansibleworks.com/docs/bestpractices.html, but I think the link here meant to go to https://github.com/ansible/ansible-examples and not https://github.com/ansible/ansible-examples/tree/master/language_features?
