### PR TITLE
Add extra module path early during playbook parsing.

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -132,6 +132,9 @@ class PlayBook(object):
         else:
             self.inventory    = inventory
 
+        if self.module_path is not None:
+           utils.plugins.module_finder.add_directory(self.module_path)
+
         self.basedir     = os.path.dirname(playbook) or '.'
         utils.plugins.push_basedir(self.basedir)
         vars = extra_vars.copy()

--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -132,7 +132,8 @@ class PluginLoader(object):
         if directory is not None:
             if with_subdir:
                 directory = os.path.join(directory, self.subdir)
-            self._extra_dirs.append(directory)
+            if directory not in self._extra_dirs:
+                self._extra_dirs.append(directory)
 
     def find_plugin(self, name):
         ''' Find a plugin named name '''


### PR DESCRIPTION
This should fix issue #3668

Also prevent an extra module path to be added multiple times.
