### PR TITLE
Indexed items lookup plugin

### DIFF
--- a/lib/ansible/runner/lookup_plugins/indexed_items.py
+++ b/lib/ansible/runner/lookup_plugins/indexed_items.py
@@ -1,0 +1,44 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.utils import safe_eval
+import ansible.utils as utils
+import ansible.errors as errors
+
+def flatten(terms):
+    ret = []
+    for term in terms:
+        if isinstance(term, list):
+            ret.extend(term)
+        else:
+            ret.append(term)
+    return ret
+
+class LookupModule(object):
+
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
+
+    def run(self, terms, inject=None, **kwargs):
+        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
+
+        if not isinstance(terms, list):
+            raise errors.AnsibleError("with_indexed_items expects a list")
+
+        items = flatten(terms)
+        return zip(range(len(items)), items)
+

--- a/test/lookup_plugins.yml
+++ b/test/lookup_plugins.yml
@@ -77,3 +77,28 @@
   - name: cleanup test file, again
     action: file path=/tmp/ansible-test-with_password state=absent
 
+# indexed_items lookup plugin
+  - name: create directory for indexed_items
+    file: path=/tmp/ansible-test-with_indexed_items-data state=directory
+  - name: test indexed_items
+    shell: echo "{{ item.0 }}" > /tmp/ansible-test-with_indexed_items-data/{{ item.1 }}
+    with_indexed_items:
+    - a
+    - b
+    - c
+  - name: check indexed_items content
+    shell: test -f /tmp/ansible-test-with_indexed_items-data/{{ item.1 }} &&
+           test "{{ item.0 }}" = "$(cat /tmp/ansible-test-with_indexed_items-data/{{ item.1 }})"
+    with_indexed_items:
+    - a
+    - b
+    - c
+  - name: cleanup indexed_items test
+    file: path=/tmp/ansible-test-with_indexed_items-data/{{ item.1 }} state=absent
+    with_indexed_items:
+    - a
+    - b
+    - c
+  - name: remove with_indexed_items directory
+    file: path=/tmp/ansible-test-with_indexed_items-data state=absent
+


### PR DESCRIPTION
Added support for 'with_indexed_items' as per @mpdehaan's suggestion, which includes an integer index value with each item iterated over. It can be used like this:

```
- name: My Task
  shell: echo Host Number {{ item.0 }} is {{ item.1 }}
  with_indexed_items:  groups.mygroup
```
