### PR TITLE
Handle AnsibleUndefinedVariable's raised from lookup plugins like jinja2 UndefinedError's

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -509,7 +509,7 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
 
         res = jinja2.utils.concat(t.root_render_func(t.new_context(_jinja2_vars(basedir, vars, t.globals), shared=True)))
         return res
-    except jinja2.exceptions.UndefinedError:
+    except (jinja2.exceptions.UndefinedError, errors.AnsibleUndefinedVariable):
         if fail_on_undefined:
             raise
         else:


### PR DESCRIPTION
This allows lookup plugins that fail to find a requested variable to fail the same way as simple jinja2 interpolation variable-not-found errors. Specifically, the error should be ignored when `fail_on_undefined` is false. In my case, my custom lookup plugin was failing when used as the `name` property of a task, which caused the whole playbook execution to incorrectly fail.
