### PR TITLE
Added support of an optional init method for action modules like rsync that need to alter the connection and other inject data before it's established.

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -503,6 +503,8 @@ class Runner(object):
             self.callbacks.on_skipped(host, inject.get('item',None))
             return ReturnData(host=host, result=result)
 
+        if getattr(handler, 'setup', None) is not None:
+            handler.setup(module_name, inject)
         conn = None
         actual_host = inject.get('ansible_ssh_host', host)
         actual_port = port


### PR DESCRIPTION
This is a potential solution to #3612 that is blocking #3173. 
