### PR TITLE
Add name_tag option to set name tag on created disk.

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -361,8 +361,15 @@ class PlayBook(object):
 
         # add facts to the global setup cache
         for host, result in contacted.iteritems():
-            facts = result.get('ansible_facts', {})
-            self.SETUP_CACHE[host].update(facts)
+            if 'results' in result:
+                # task ran with_ lookup plugin, so facts are encapsulated in
+                # multiple list items in the results key
+                for res in result['results']:
+                    facts = res.get('ansible_facts', {})
+                    self.SETUP_CACHE[host].update(facts)
+            else:
+                facts = result.get('ansible_facts', {})
+                self.SETUP_CACHE[host].update(facts)
             # extra vars need to always trump - so update  again following the facts
             self.SETUP_CACHE[host].update(self.extra_vars)
             if task.register:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -361,15 +361,8 @@ class PlayBook(object):
 
         # add facts to the global setup cache
         for host, result in contacted.iteritems():
-            if 'results' in result:
-                # task ran with_ lookup plugin, so facts are encapsulated in
-                # multiple list items in the results key
-                for res in result['results']:
-                    facts = res.get('ansible_facts', {})
-                    self.SETUP_CACHE[host].update(facts)
-            else:
-                facts = result.get('ansible_facts', {})
-                self.SETUP_CACHE[host].update(facts)
+            facts = result.get('ansible_facts', {})
+            self.SETUP_CACHE[host].update(facts)
             # extra vars need to always trump - so update  again following the facts
             self.SETUP_CACHE[host].update(self.extra_vars)
             if task.register:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -361,8 +361,16 @@ class PlayBook(object):
 
         # add facts to the global setup cache
         for host, result in contacted.iteritems():
-            facts = result.get('ansible_facts', {})
-            self.SETUP_CACHE[host].update(facts)
+            if 'results' in result:
+                # task ran with_ lookup plugin, so facts are encapsulated in
+                # multiple list items in the results key
+                for res in result['results']:
+                    if type(res) == dict:
+                        facts = res.get('ansible_facts', {})
+                        self.SETUP_CACHE[host].update(facts)
+            else:
+                facts = result.get('ansible_facts', {})
+                self.SETUP_CACHE[host].update(facts)
             # extra vars need to always trump - so update  again following the facts
             self.SETUP_CACHE[host].update(self.extra_vars)
             if task.register:

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -24,9 +24,9 @@ version_added: "1.1"
 options:
   instance:
     description:
-      - instance ID if you wish to attach the volume. 
+      - instance ID if you wish to attach the volume.
     required: false
-    default: null 
+    default: null
     aliases: []
   volume_size:
     description:
@@ -40,6 +40,12 @@ options:
     required: false
     default: null
     aliases: []
+  name_tag:
+    description:
+      - value for Name tag
+    required: false
+    default: null
+    aliases: []
   region:
     description:
       - region in which to create the volume
@@ -48,7 +54,7 @@ options:
     aliases: []
   zone:
     description:
-      - zone in which to create the volume, if unset uses the zone the instance is in (if set) 
+      - zone in which to create the volume, if unset uses the zone the instance is in (if set)
     required: false
     default: null
     aliases: []
@@ -58,30 +64,30 @@ author: Lester Wade
 
 EXAMPLES = '''
 # Simple attachment action
-- local_action: 
-    module: ec2_vol 
-    instance: XXXXXX 
-    volume_size: 5 
+- local_action:
+    module: ec2_vol
+    instance: XXXXXX
+    volume_size: 5
     device_name: sdd
-   
-# Playbook example combined with instance launch 
-- local_action: 
-    module: ec2 
+
+# Playbook example combined with instance launch
+- local_action:
+    module: ec2
     keypair: "{{ keypair }}"
     image: "{{ image }}"
-    wait: yes 
+    wait: yes
     count: 3
     register: ec2
-- local_action: 
-    module: ec2_vol 
-    instance: "{{ item.id }} " 
+- local_action:
+    module: ec2_vol
+    instance: "{{ item.id }} "
     volume_size: 5
     with_items: ec2.instances
     register: ec2_vol
 '''
 
 # Note: this module needs to be made idempotent. Possible solution is to use resource tags with the volumes.
-# if state=present and it doesn't exist, create, tag and attach. 
+# if state=present and it doesn't exist, create, tag and attach.
 # Check for state by looking for volume attachment with tag (and against block device mapping?).
 # Would personally like to revisit this in May when Eucalyptus also has tagging support (3.3).
 
@@ -100,6 +106,7 @@ def main():
             instance = dict(),
             volume_size = dict(required=True),
             device_name = dict(),
+            name_tag = dict(),
             region = dict(),
             zone = dict(),
             ec2_url = dict(aliases=['EC2_URL']),
@@ -111,6 +118,7 @@ def main():
     instance = module.params.get('instance')
     volume_size = module.params.get('volume_size')
     device_name = module.params.get('device_name')
+    name_tag = module.params.get('name_tag')
     region = module.params.get('region')
     zone = module.params.get('zone')
     ec2_url = module.params.get('ec2_url')
@@ -124,24 +132,24 @@ def main():
         ec2_secret_key = os.environ['EC2_SECRET_KEY']
     if not ec2_access_key and 'EC2_ACCESS_KEY' in os.environ:
         ec2_access_key = os.environ['EC2_ACCESS_KEY']
-    
+
     # If we have a region specified, connect to its endpoint.
-    if region: 
+    if region:
         try:
             ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=ec2_access_key, aws_secret_access_key=ec2_secret_key)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
     # Otherwise, no region so we fallback to the old connection method
-    else: 
+    else:
         try:
-            if ec2_url: # if we have an URL set, connect to the specified endpoint 
+            if ec2_url: # if we have an URL set, connect to the specified endpoint
                 ec2 = boto.connect_ec2_endpoint(ec2_url, ec2_access_key, ec2_secret_key)
             else: # otherwise it's Amazon.
                 ec2 = boto.connect_ec2(ec2_access_key, ec2_secret_key)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
 
-    # Here we need to get the zone info for the instance. This covers situation where 
+    # Here we need to get the zone info for the instance. This covers situation where
     # instance is specified but zone isn't.
     # Useful for playbooks chaining instance launch with volume create + attach and where the
     # zone doesn't matter to the user.
@@ -167,6 +175,10 @@ def main():
     except boto.exception.BotoServerError, e:
         module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
 
+    # Set Name tag if given
+    if name_tag != "":
+        ec2.create_tags ([volume.id], {"Name": name_tag})
+
     # Attach the created volume.
 
     if device_name and instance:
@@ -176,11 +188,11 @@ def main():
                 time.sleep(3)
                 volume.update()
         except boto.exception.BotoServerError, e:
-            module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))           
-   
+            module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
+
     # If device_name isn't set, make a choice based on best practices here:
     # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
-    
+
     # In future this needs to be more dynamic but combining block device mapping best practices
     # (bounds for devices, as above) with instance.block_device_mapping data would be tricky. For me ;)
 

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -24,9 +24,9 @@ version_added: "1.1"
 options:
   instance:
     description:
-      - instance ID if you wish to attach the volume. 
+      - instance ID if you wish to attach the volume.
     required: false
-    default: null 
+    default: null
     aliases: []
   volume_size:
     description:
@@ -47,6 +47,12 @@ options:
     required: false
     default: null
     aliases: []
+  name_tag:
+    description:
+      - value for Name tag
+    required: false
+    default: null
+    aliases: []
   region:
     description:
       - region in which to create the volume
@@ -55,7 +61,7 @@ options:
     aliases: []
   zone:
     description:
-      - zone in which to create the volume, if unset uses the zone the instance is in (if set) 
+      - zone in which to create the volume, if unset uses the zone the instance is in (if set)
     required: false
     default: null
     aliases: []
@@ -65,38 +71,38 @@ author: Lester Wade
 
 EXAMPLES = '''
 # Simple attachment action
-- local_action: 
-    module: ec2_vol 
-    instance: XXXXXX 
-    volume_size: 5 
+- local_action:
+    module: ec2_vol
+    instance: XXXXXX
+    volume_size: 5
     device_name: sdd
 
-# Example using custom iops params   
-- local_action: 
-    module: ec2_vol 
-    instance: XXXXXX 
-    volume_size: 5 
+# Example using custom iops params
+- local_action:
+    module: ec2_vol
+    instance: XXXXXX
+    volume_size: 5
     iops: 200
     device_name: sdd
-		
-# Playbook example combined with instance launch 
-- local_action: 
-    module: ec2 
+
+# Playbook example combined with instance launch
+- local_action:
+    module: ec2
     keypair: "{{ keypair }}"
     image: "{{ image }}"
-    wait: yes 
+    wait: yes
     count: 3
     register: ec2
-- local_action: 
-    module: ec2_vol 
-    instance: "{{ item.id }} " 
+- local_action:
+    module: ec2_vol
+    instance: "{{ item.id }} "
     volume_size: 5
     with_items: ec2.instances
     register: ec2_vol
 '''
 
 # Note: this module needs to be made idempotent. Possible solution is to use resource tags with the volumes.
-# if state=present and it doesn't exist, create, tag and attach. 
+# if state=present and it doesn't exist, create, tag and attach.
 # Check for state by looking for volume attachment with tag (and against block device mapping?).
 # Would personally like to revisit this in May when Eucalyptus also has tagging support (3.3).
 
@@ -116,6 +122,7 @@ def main():
             volume_size = dict(required=True),
             iops = dict(),
             device_name = dict(),
+            name_tag = dict(),
             region = dict(),
             zone = dict(),
             ec2_url = dict(aliases=['EC2_URL']),
@@ -128,6 +135,7 @@ def main():
     volume_size = module.params.get('volume_size')
     iops = module.params.get('iops')
     device_name = module.params.get('device_name')
+    name_tag = module.params.get('name_tag')
     region = module.params.get('region')
     zone = module.params.get('zone')
     ec2_url = module.params.get('ec2_url')
@@ -141,24 +149,24 @@ def main():
         ec2_secret_key = os.environ['EC2_SECRET_KEY']
     if not ec2_access_key and 'EC2_ACCESS_KEY' in os.environ:
         ec2_access_key = os.environ['EC2_ACCESS_KEY']
-    
+
     # If we have a region specified, connect to its endpoint.
-    if region: 
+    if region:
         try:
             ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=ec2_access_key, aws_secret_access_key=ec2_secret_key)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
     # Otherwise, no region so we fallback to the old connection method
-    else: 
+    else:
         try:
-            if ec2_url: # if we have an URL set, connect to the specified endpoint 
+            if ec2_url: # if we have an URL set, connect to the specified endpoint
                 ec2 = boto.connect_ec2_endpoint(ec2_url, ec2_access_key, ec2_secret_key)
             else: # otherwise it's Amazon.
                 ec2 = boto.connect_ec2(ec2_access_key, ec2_secret_key)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
 
-    # Here we need to get the zone info for the instance. This covers situation where 
+    # Here we need to get the zone info for the instance. This covers situation where
     # instance is specified but zone isn't.
     # Useful for playbooks chaining instance launch with volume create + attach and where the
     # zone doesn't matter to the user.
@@ -192,6 +200,10 @@ def main():
     except boto.exception.BotoServerError, e:
         module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
 
+    # Set Name tag if given
+    if name_tag != "":
+        ec2.create_tags ([volume.id], {"Name": name_tag})
+
     # Attach the created volume.
 
     if device_name and instance:
@@ -201,11 +213,11 @@ def main():
                 time.sleep(3)
                 volume.update()
         except boto.exception.BotoServerError, e:
-            module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))           
-   
+            module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
+
     # If device_name isn't set, make a choice based on best practices here:
     # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
-    
+
     # In future this needs to be more dynamic but combining block device mapping best practices
     # (bounds for devices, as above) with instance.block_device_mapping data would be tricky. For me ;)
 


### PR DESCRIPTION
Add option to give a name to created ec2 volumes, with a lot of volumes they easily get lost otherwise.

Probably this approach needs to be revisited when generic tagging is going to be supported, but this is at least a step forward.

PS: new pull request to make sure it is a clean request.
