### PR TITLE
enable EC2 inventory module to use Name tag as destination

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -31,6 +31,12 @@ destination_variable = public_dns_name
 # this to 'ip_address' will return the public IP address. For instances in a
 # private subnet, this should be set to 'private_ip_address', and Ansible must
 # be run from with EC2.
+# If you do have your own DNS servers running in your VPC, you can specifc
+# the ec2_tag_Name as the destination attribute (or any other tag). This can
+# also be a prefered list, so that if the EC2 name tag is missing it falls
+# back to the private IP address.
+# e.g. vpc_destination_variable = ec2_tag_Name, private_ip_address
+#
 vpc_destination_variable = ip_address
 
 # API calls to EC2 are slow. For this reason, we cache the results of an API

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -31,7 +31,7 @@ destination_variable = public_dns_name
 # this to 'ip_address' will return the public IP address. For instances in a
 # private subnet, this should be set to 'private_ip_address', and Ansible must
 # be run from with EC2.
-# If you do have your own DNS servers running in your VPC, you can specifc
+# If you do have your own DNS servers running in your VPC, you can specify
 # the ec2_tag_Name as the destination attribute (or any other tag). This can
 # also be a prefered list, so that if the EC2 name tag is missing it falls
 # back to the private IP address.

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -307,19 +307,21 @@ class Ec2Inventory(object):
         dest = None
         if instance.subnet_id:
                 for dest_var in [i.strip() for i in self.vpc_destination_variable.split(",")]:
+                         tag = dest_var[len('ec2_tag_'):]
                          if hasattr(instance, dest_var):
                                 dest = getattr(instance, dest_var)
                                 break
-                         elif dest_var[8:] in instance.tags:
-                                dest = instance.tags[dest_var[8:]]
+                         elif tag in instance.tags:
+                                dest = instance.tags[tag]
                                 break
         else:
                for dest_var in [i.strip() for i in self.destination_variable.split(",")]:
+                         tag = dest_var[len('ec2_tag_'):]
                          if hasattr(instance, dest_var):
                                 dest = getattr(instance, dest_var)
                                 break
-                         elif dest_var[8:] in instance.tags:
-                                dest = instance.tags[dest_var[8:]]
+                         elif tag in instance.tags:
+                                dest = instance.tags[tag]
                                 break
 
         if not dest:

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -304,10 +304,23 @@ class Ec2Inventory(object):
             return
 
         # Select the best destination address
+        dest = None
         if instance.subnet_id:
-            dest = getattr(instance, self.vpc_destination_variable)
+                for dest_var in [i.strip() for i in self.vpc_destination_variable.split(",")]:
+                         if hasattr(instance, dest_var):
+                                dest = getattr(instance, dest_var)
+                                break
+                         elif dest_var[8:] in instance.tags:
+                                dest = instance.tags[dest_var[8:]]
+                                break
         else:
-            dest =  getattr(instance, self.destination_variable)
+               for dest_var in [i.strip() for i in self.destination_variable.split(",")]:
+                         if hasattr(instance, dest_var):
+                                dest = getattr(instance, dest_var)
+                                break
+                         elif dest_var[8:] in instance.tags:
+                                dest = instance.tags[dest_var[8:]]
+                                break
 
         if not dest:
             # Skip instances we cannot address (e.g. private VPC subnet)


### PR DESCRIPTION
Allows you to use the EC2 tag Name (or any other tag) as a destination address so that the hostname shows up correctly during playbook runs. Requires the names to be resolvable in DNS of course. The implementation allows you to specify a list of instance attributes to try in order, so if the Name tag is not available, you can have it fall back to some other attribute such as the private_ip_address.
