### PR TITLE
Fix sudo_user copy error

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -867,8 +867,8 @@ class AnsibleModule(object):
             # Optimistically try a rename, solves some corner cases and can avoid useless work.
             os.rename(src, dest)
         except (IOError,OSError), e:
-            # only try workarounds for errno 18 (cross device) and 1 (not permited)
-            if e.errno != errno.EPERM and e.errno != errno.EXDEV:
+            # only try workarounds for errno 18 (cross device), 1 (not permited) and 13 (permission denied)
+            if e.errno != errno.EPERM and e.errno != errno.EXDEV and e.errno != errno.EACCES:
                 self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e))
 
             dest_dir = os.path.dirname(dest)


### PR DESCRIPTION
Treat errno 13 (permission denied) as one of the special cases in atomic_move.

This type of error can occur because of sudo'ing to non-root user.

Fixes #3705
