### PR TITLE
Traceback in git module when version checkout fails

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -271,6 +271,7 @@ def switch_version(git_path, module, dest, remote, version):
                 cmd = "%s reset --hard %s/%s" % (git_path, remote, version)
         else:
             cmd = "%s checkout --force %s" % (git_path, version)
+        branch = version
     else:
         branch = get_head_branch(git_path, module, dest, remote)
         (rc, out, err) = module.run_command("%s checkout --force %s" % (git_path, branch))

--- a/library/source_control/git
+++ b/library/source_control/git
@@ -271,7 +271,6 @@ def switch_version(git_path, module, dest, remote, version):
                 cmd = "%s reset --hard %s/%s" % (git_path, remote, version)
         else:
             cmd = "%s checkout --force %s" % (git_path, version)
-        branch = version
     else:
         branch = get_head_branch(git_path, module, dest, remote)
         (rc, out, err) = module.run_command("%s checkout --force %s" % (git_path, branch))
@@ -280,7 +279,10 @@ def switch_version(git_path, module, dest, remote, version):
         cmd = "%s reset --hard %s" % (git_path, remote)
     (rc, out1, err1) = module.run_command(cmd)
     if rc != 0:
-        module.fail_json(msg="Failed to checkout branch %s" % (branch))
+        if version != 'HEAD':
+            module.fail_json(msg="Failed to checkout %s" % (version))
+        else:
+            module.fail_json(msg="Failed to checkout branch %s" % (branch))
     (rc, out2, err2) = submodule_update(git_path, module, dest)
     return (rc, out1 + out2, err1 + err2)
 


### PR DESCRIPTION
"UnboundLocalError: local variable 'branch' referenced before assignment" is
raised in git, line 282, in switch_version.

Exception is raised when version is not branch and version checkout fails.
E.g. when version is nonexistant commit.

Full traceback:

```
REMOTE_MODULE git repo="ssh://xxx/xxx.git" dest="/xxx" version="a98ef5944f5fe3969accfffa40e76fb43d6b49dc"

failed to parse: Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-1375350491.22-159151807716270/git", line 1306, in <module>
    main()
  File "/root/.ansible/tmp/ansible-1375350491.22-159151807716270/git", line 364, in main
    (rc, out, err) = switch_version(git_path, module, dest, remote, version)
  File "/root/.ansible/tmp/ansible-1375350491.22-159151807716270/git", line 282, in switch_version
    module.fail_json(msg="Failed to checkout branch %s" % (branch))
UnboundLocalError: local variable 'branch' referenced before assignment
```
