### PR TITLE
User: when creating new user, ignore empty groups value

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -279,7 +279,7 @@ class User(object):
             cmd.append('-g')
             cmd.append(self.group)
 
-        if self.groups is not None:
+        if self.groups is not None and len(self.groups):
             groups = self.get_groups_set()
             cmd.append('-G')
             cmd.append(','.join(groups))
@@ -1221,7 +1221,7 @@ class AIX(User):
             cmd.append('-g')
             cmd.append(self.group)
 
-        if self.groups is not None:
+        if self.groups is not None and len(self.groups):
             groups = self.get_groups_set()
             cmd.append('-G')
             cmd.append(','.join(groups))


### PR DESCRIPTION
When trying to create a new user, if I pass a groups parameter of ' ' (empty string), the call to get_groups_set() on library/system/user:283 fails because it checks if ' ' is a valid group.

e.g.

``` yaml
- user: name=${item.name} groups=${item.groups}
  with_items:
    - { name: 'joe', groups='wheel' }
    - { name: 'sally', groups='' }
```

The creation of sally will fail.
