### PR TITLE
Allow destination paths in the hg module to include a tilde (~)

### DIFF
--- a/library/source_control/hg
+++ b/library/source_control/hg
@@ -211,7 +211,7 @@ def main():
         ),
     )
     repo = module.params['repo']
-    dest = module.params['dest']
+    dest = os.path.expanduser(module.params['dest'])
     revision = module.params['revision']
     force = module.params['force']
     purge = module.params['purge']


### PR DESCRIPTION
Fixes issue #3360 - Inconsistent behavior of the hg module w.r.t. dest path
