### PR TITLE
Set result to skipped when vol group is missing and lv state=absent

### DIFF
--- a/library/system/lvol
+++ b/library/system/lvol
@@ -142,7 +142,7 @@ def main():
 
     if rc != 0:
         if state == 'absent':
-            module.exit_json(changed=False,skipped=True,stdout="Skipping because volume group %s does not exist." % vg,stderr=False)
+            module.exit_json(changed=False,stdout="Volume group %s does not exist." % vg, stderr=False)
         else:
             module.fail_json(msg="Volume group %s does not exist."%vg, rc=rc, err=err)
 

--- a/library/system/lvol
+++ b/library/system/lvol
@@ -141,7 +141,10 @@ def main():
     rc,current_lvs,err = module.run_command("lvs --noheadings -o lv_name,size --units %s --separator ';' %s" % (unit, vg))
 
     if rc != 0:
-        module.fail_json(msg="Volume group %s does not exist."%vg, rc=rc, err=err)
+        if state == 'absent':
+            module.exit_json(changed=False,skipped=True,stdout="Skipping because volume group %s does not exist." % vg,stderr=False)
+        else:
+            module.fail_json(msg="Volume group %s does not exist."%vg, rc=rc, err=err)
 
     changed = False
 


### PR DESCRIPTION
Fixes issue #3714 - lvol module state=absent fails (with error) if
the volume group doesn't exist
