### PR TITLE
Added ansible_ssh_config variable

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -116,6 +116,7 @@ class Runner(object):
         remote_user=C.DEFAULT_REMOTE_USER,  # ex: 'username'
         remote_pass=C.DEFAULT_REMOTE_PASS,  # ex: 'password123' or None if using key
         remote_port=None,                   # if SSH on different ports
+        ssh_config=None,                    # ssh config file
         private_key_file=C.DEFAULT_PRIVATE_KEY_FILE, # if not using keys/passwords
         sudo_pass=C.DEFAULT_SUDO_PASS,      # ex: 'password123' or None
         background=0,                       # async poll every X seconds, else 0 for non-async
@@ -165,6 +166,7 @@ class Runner(object):
         self.remote_user      = remote_user
         self.remote_pass      = remote_pass
         self.remote_port      = remote_port
+        self.ssh_config       = ssh_config
         self.private_key_file = private_key_file
         self.background       = background
         self.sudo             = sudo
@@ -541,6 +543,7 @@ class Runner(object):
         # allow ansible_ssh_host to be templated
         actual_host = template.template(self.basedir, actual_host, inject, fail_on_undefined=True)
         actual_port = port
+        actual_ssh_config = inject.get('ansible_ssh_config', self.ssh_config)
         actual_user = inject.get('ansible_ssh_user', self.remote_user)
         actual_pass = inject.get('ansible_ssh_pass', self.remote_pass)
         actual_transport = inject.get('ansible_connection', self.transport)
@@ -569,6 +572,7 @@ class Runner(object):
                 actual_port = delegate_info.get('ansible_ssh_port', port)
                 actual_user = delegate_info.get('ansible_ssh_user', actual_user)
                 actual_pass = delegate_info.get('ansible_ssh_pass', actual_pass)
+                actual_ssh_config = delegate_info.get('ansible_ssh_config', actual_ssh_config)
                 actual_private_key_file = delegate_info.get('ansible_ssh_private_key_file', self.private_key_file)
                 actual_transport = delegate_info.get('ansible_connection', self.transport)
                 for i in delegate_info:
@@ -593,7 +597,7 @@ class Runner(object):
             return ReturnData(host=host, comm_ok=False, result=result)
 
         try:
-            conn = self.connector.connect(actual_host, actual_port, actual_user, actual_pass, actual_transport, actual_private_key_file)
+            conn = self.connector.connect(actual_host, actual_port, actual_user, actual_pass, actual_transport, actual_private_key_file, actual_ssh_config)
             if delegate_to or host != actual_host:
                 conn.delegate = host
 

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -31,9 +31,9 @@ class Connection(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def connect(self, host, port, user, password, transport, private_key_file):
+    def connect(self, host, port, user, password, transport, private_key_file, ssh_config):
         conn = None
-        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password, private_key_file=private_key_file)
+        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password, private_key_file=private_key_file, ssh_config=ssh_config)
         if conn is None:
             raise AnsibleError("unsupported connection type: %s" % transport)
         self.active = conn.connect()


### PR DESCRIPTION
This variable enables to provide a different ssh config file (ssh option -F)
in inventories so that connection parameters can be adjusted without
poking at the user's default .ssh/config file.

This pull request is related to https://github.com/ansible/ansible/pull/2970 discussion and largely inspired from @rodlogic pull request.
