### PR TITLE
apt: Run remove commands noninteractively

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -218,7 +218,7 @@ def remove(m, pkgspec, cache, purge=False):
             purge = '--purge'
         else:
             purge = ''
-        cmd = "%s -q -y %s remove %s" % (APT_GET_CMD, purge,packages)
+        cmd = "%s %s -q -y %s %s remove %s" % (APT_ENVVARS, APT_GET_CMD, DPKG_OPTIONS, purge, packages)
 
         if m.check_mode:
             m.exit_json(changed=True)


### PR DESCRIPTION
I'm seeing ansible hang when trying to remove a package, and the hung process is `whiptail` like in #2763. It looks like we only use `APT_ENVVARS` and `DPKG_OPTIONS` for the `apt` commands in install() and upgrade(). This change uses them in remove() as well, which fixes the hang.
