### PR TITLE
use lgetfilecon_raw instead of lgetfilecon to not depend on local level ...

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -315,7 +315,7 @@ class AnsibleModule(object):
         if not HAVE_SELINUX or not self.selinux_enabled():
             return context
         try:
-            ret = selinux.lgetfilecon(self._to_filesystem_str(path))
+            ret = selinux.lgetfilecon_raw(self._to_filesystem_str(path))
         except OSError, e:
             if e.errno == errno.ENOENT:
                 self.fail_json(path=path, msg='path %s does not exist' % path)


### PR DESCRIPTION
...translation

If SELinux is enabled and mcstrans is running, daemons are restarted on each
run. After further debugging, it turn out that ansible compare the untranslated
level 's0' with the translated level 'SystemLow' due to mcstrans being running,
which trigger a handler since this is considered as a change.
