### PR TITLE
Update callbacks used for async tasks

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -277,7 +277,7 @@ class PlayBook(object):
         # since these likely got killed by async_wrapper
         for host in poller.hosts_to_poll:
             reason = { 'failed' : 1, 'rc' : None, 'msg' : 'timed out' }
-            self.runner_callbacks.on_failed(host, reason)
+            self.runner_callbacks.on_async_failed(host, reason, poller.jid)
             results['contacted'][host] = reason
 
         return results
@@ -319,6 +319,9 @@ class PlayBook(object):
             if task.async_poll_interval > 0:
                 # if not polling, playbook requested fire and forget, so don't poll
                 results = self._async_poll(poller, task.async_seconds, task.async_poll_interval)
+            else:
+                for (host, res) in results.get('contacted', {}).iteritems():
+                    self.runner_callbacks.on_async_ok(host, res, poller.jid)
 
         contacted = results.get('contacted',{})
         dark      = results.get('dark', {})

--- a/lib/ansible/runner/poller.py
+++ b/lib/ansible/runner/poller.py
@@ -73,7 +73,7 @@ class AsyncPoller(object):
             else:
                 self.results['contacted'][host] = res
                 poll_results['contacted'][host] = res
-                if 'failed' in res:
+                if res.get('failed', False) or res.get('rc', 0) != 0:
                     self.runner.callbacks.on_async_failed(host, res, self.jid)
                 else:
                     self.runner.callbacks.on_async_ok(host, res, self.jid)


### PR DESCRIPTION
(In lib/ansible/runner/poller.py) It's possible to have an async task fail with rc != 0, call the runner_on_failed callback, then followed by a runner_on_async_ok callback.  Correctly check for failed status from an async task so that the runner_on_async_failed callback is used whenever the task fails.

(In lib/ansible/playbook/**init**.py) A task that times out calls the runner_on_failed callback.  I think it makes more sense to use the runner_on_async_failed callback instead.

(In lib/ansible/playbook/**init**.py) When an async task is started in fire and forget mode, the only callback called is runner_on_ok (from launching the task via async_wrapper), and no runner_on_async_\* callbacks are called. I'm proposing adding a call to the runner_on_async_ok callback in this case, so that every async task will result in at least one runner_on_async_\* callback.
