### PR TITLE
now bad ini entries will throw friendlier error

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -112,7 +112,10 @@ class InventoryParser(object):
                         for t in tokens[1:]:
                             if t.startswith('#'):
                                 break
-                            (k,v) = t.split("=")
+                            try:
+                                (k,v) = t.split("=")
+                            except ValueError, e:
+                                raise errors.AnsibleError("Invalid ini entry: %s - %s" % (t, str(e)))
                             host.set_variable(k,v)
                     self.groups[active_group_name].add_host(host)
 


### PR DESCRIPTION
many get hit by this traceback, specially when they leave an ansible.cfg in inventory dir

Signed-off-by: Brian Coca <briancoca+dev@gmail.com>
