### PR TITLE
Never ask for SSH password when using local connection.

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -97,6 +97,9 @@ class Cli(object):
         sshpass = None
         sudopass = None
         options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
+        # Never ask for an SSH password when we run with local connection
+        if options.connection == "local":
+          options.ask_pass = False
         options.ask_sudo_pass= options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
         ( sshpass, sudopass ) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass)
         if options.sudo_user or options.ask_sudo_pass:

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -91,6 +91,9 @@ def main(args):
     sudopass = None
     if not options.listhosts and not options.syntax and not options.listtasks:
         options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
+        # Never ask for an SSH password when we run with local connection
+        if options.connection == "local":
+          options.ask_pass = False
         options.ask_sudo_pass = options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
         ( sshpass, sudopass ) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass)
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER


### PR DESCRIPTION
With the command line option "-c local", ansible and ansible-playbook
should never ask for a SSH password even if this is set in the config.

Fixes #3720
