### PR TITLE
Added git disclaimer about dealing with ssh host checking

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -73,6 +73,12 @@ options:
             - If C(yes), repository will be updated using the supplied
               remote.  Otherwise the repo will be left untouched.
               Prior to 1.2, this was always 'yes' and could not be disabled.
+notes:
+    - If the task seems to be hanging, first verify remote host is in C(known_hosts).
+      SSH will prompt user to authorize the first contact with a remote host. One solution is to add
+      C(StrictHostKeyChecking no) in C(.ssh/config) which will accept and authorize the connection
+      on behalf of the user. However, if you run as a different user such as setting sudo to True),
+      for example, root will not look at the user .ssh/config setting.
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
This disclaimer already exists in library/source_control/hg but not here.  It affects both and was discussed awhile back on: https://groups.google.com/forum/#!msg/ansible-project/q9G9xIdsRxo/XJhQzuS-qSoJ  However no PR was ever sent to fix the doc.
