### PR TITLE
Check for ansible_facts in results for with_ tasks

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -361,8 +361,15 @@ class PlayBook(object):
 
         # add facts to the global setup cache
         for host, result in contacted.iteritems():
-            facts = result.get('ansible_facts', {})
-            self.SETUP_CACHE[host].update(facts)
+            if 'results' in result:
+                # task ran with_ lookup plugin, so facts are encapsulated in
+                # multiple list items in the results key
+                for res in result['results']:
+                    facts = res.get('ansible_facts', {})
+                    self.SETUP_CACHE[host].update(facts)
+            else:
+                facts = result.get('ansible_facts', {})
+                self.SETUP_CACHE[host].update(facts)
             # extra vars need to always trump - so update  again following the facts
             self.SETUP_CACHE[host].update(self.extra_vars)
             if task.register:


### PR DESCRIPTION
that loop over a lookup plugin. Fixes #3704 and #3735

Given the playbook

``` yaml
- hosts: localhost
  gather_facts: False
  tasks:
  - set_fact: specialvar={{item}}
    with_items:
    - a
    - b
    - c
    - d
  - debug: msg={{specialvar}}
```

gives:

``` yaml
TASK: [set_fact specialvar={{item}}] ****************************************** 
ok: [localhost] => (item=a)
ok: [localhost] => (item=b)
ok: [localhost] => (item=c)
ok: [localhost] => (item=d)

TASK: [debug msg={{specialvar}}] ********************************************** 
ok: [localhost] => {"msg": "{{specialvar}}"}
```

but with this patch this becomes:

``` yaml
TASK: [set_fact specialvar={{item}}] ****************************************** 
ok: [localhost] => (item=a)
ok: [localhost] => (item=b)
ok: [localhost] => (item=c)
ok: [localhost] => (item=d)

TASK: [debug msg={{specialvar}}] ********************************************** 
ok: [localhost] => {"msg": "d"}
```

Obviously there are more usefull examples (in my case using `with_random_choice`)
