### PR TITLE
support i18n on sudo failure

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -25,6 +25,7 @@ import select
 import fcntl
 import hmac
 import pwd
+import gettext
 from hashlib import sha1
 import ansible.constants as C
 from ansible.callbacks import vvv
@@ -191,9 +192,11 @@ class Connection(object):
             rfd, wfd, efd = select.select([p.stdout, p.stderr], [], [p.stdout, p.stderr], 1)
 
             # fail early if the sudo password is wrong
-            if (self.runner.sudo and sudoable and self.runner.sudo_pass and
-                stdout.endswith("Sorry, try again.\r\n%s" % prompt)):
-                raise errors.AnsibleError('Incorrect sudo password')
+            if self.runner.sudo and sudoable and self.runner.sudo_pass:
+                incorrect_password = gettext.dgettext(
+                    "sudo", "Sorry, try again.")
+                if stdout.endswith("%s\r\n%s" % (incorrect_password, prompt)):
+                    raise errors.AnsibleError('Incorrect sudo password') 
 
             if p.stdout in rfd:
                 dat = os.read(p.stdout.fileno(), 9000)


### PR DESCRIPTION
A tiny addition to the bugfix/sudo-fail-on-wrong-password branch that will ensure the wrong password detection works in different locales. Sorry for not noticing this earlier, for some reason my ubuntu machine it seems like this prompt is not localized, but it seems to be for some other linux distros like arch linux.
