### PR TITLE
Add a nocolor setting to ansible.cfg

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -88,6 +88,10 @@ filter_plugins     = /usr/share/ansible_plugins/filter_plugins
 # set to 1 if you don't want cowsay support or export ANSIBLE_NOCOWS=1 
 #nocows = 1
 
+# don't like colors either?
+# set to 1 if you don't want colors, or export ANSIBLE_NOCOLOR=1
+#nocolor = 1
+
 [paramiko_connection]
 
 # uncomment this line to cause the paramiko connection plugin to not record new host

--- a/lib/ansible/color.py
+++ b/lib/ansible/color.py
@@ -17,9 +17,10 @@
 
 import os
 import sys
+import constants
 
 ANSIBLE_COLOR=True
-if os.getenv("ANSIBLE_NOCOLOR") is not None:
+if constants.ANSIBLE_NOCOLOR is not None:
     ANSIBLE_COLOR=False
 elif not hasattr(sys.stdout, 'isatty') or not sys.stdout.isatty():
     ANSIBLE_COLOR=False

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -125,6 +125,7 @@ DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       '
 DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '/usr/share/ansible_plugins/filter_plugins')
 DEFAULT_LOG_PATH               = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
 
+ANSIBLE_NOCOLOR                = get_config(p, DEFAULTS, 'nocolor', 'ANSIBLE_NOCOLOR', None)
 ANSIBLE_NOCOWS                 = get_config(p, DEFAULTS, 'nocows', 'ANSIBLE_NOCOWS', None)
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)


### PR DESCRIPTION
This works exactly like nocows/ANSIBLE_NOCOWS for me, and doesn't break any tests.

Speaking of cows, a minor consideration: the code tests that "constants.ANSIBLE_NOCOWS is not None", which means that setting "nocows = 0" in ansible.cfg still disables cowsay. Is that worth fixing?
