### PR TITLE
Fix traceback when openstack do not have OS-EXT-IPS:type attached to add...

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -167,8 +167,8 @@ def _create_server(module, nova):
             except Exception as e:
                     module.fail_json( msg = "Error in getting info from instance: %s " % e.message)
             if server.status == 'ACTIVE':
-                private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'fixed']
-                public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'floating']
+                private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
+                public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'floating']
                 module.exit_json(changed = True, id = server.id, private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
             if server.status == 'ERROR':
                 module.fail_json(msg = "Error in creating the server, please check logs")
@@ -193,8 +193,8 @@ def _get_server_state(module, nova):
     if server and module.params['state'] == 'present':
         if server.status != 'ACTIVE':
             module.fail_json( msg="The VM is available but not Active. state:" + server.status)
-        private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'fixed']
-        public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'floating']
+        private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
+        public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'floating']
         module.exit_json(changed = False, id = server.id, public_ip = ''.join(public), private_ip = ''.join(private), info = server._info)      
     if server and module.params['state'] == 'absent':
         return True


### PR DESCRIPTION
...ress

failed: [127.0.0.1] => {"failed": true, "parsed": false}
    invalid output was: Traceback (most recent call last):
      File "/tmp/ansible-1376083321.99-111209413777779/nova_compute", line 1176, in <module>
        main()
      File "/tmp/ansible-1376083321.99-111209413777779/nova_compute", line 239, in main
        _get_server_state(module, nova)
      File "/tmp/ansible-1376083321.99-111209413777779/nova_compute", line 198, in _get_server_state
        private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'fixed']
    KeyError: 'OS-EXT-IPS:type'

This extension was added less than 6 month ago, and so cannot be used on a release
older than Grizzly ( like Folsom ).

Commit of the extension : https://review.openstack.org/#/c/21453/

See https://wiki.openstack.org/wiki/ReleaseNotes/Grizzly#Key_New_Features_2
