### PR TITLE
implemented 'inventory_file' variable. Closes GH-3789.

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -397,6 +397,12 @@ class Inventory(object):
             return cwd 
         return dname
 
+    def src(self):
+        """ if inventory came from a file, what's the directory and file name? """
+        if not self.is_file():
+            return None
+        return self.host_list
+
     def playbook_basedir(self):
         """ returns the directory of the current playbook """
         return self._playbook_basedir

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -140,6 +140,10 @@ class PlayBook(object):
         vars = extra_vars.copy()
         if self.inventory.basedir() is not None:
             vars['inventory_dir'] = self.inventory.basedir()
+
+        if self.inventory.src() is not None:
+            vars['inventory_file'] = self.inventory.src()
+
         self.filename = playbook
         (self.playbook, self.play_basedirs) = self._load_playbook_from_file(playbook, vars)
         ansible.callbacks.load_callback_plugins()

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -410,6 +410,9 @@ class Runner(object):
         if self.inventory.basedir() is not None:
             inject['inventory_dir'] = self.inventory.basedir()
 
+        if self.inventory.src() is not None:
+            inject['inventory_file'] = self.inventory.src()
+
         # late processing of parameterized sudo_user
         if self.sudo_user is not None:
             self.sudo_user = template.template(self.basedir, self.sudo_user, inject)


### PR DESCRIPTION
We use the hosts file like our "environment" like `hosts/production` has all production hosts and  `hosts/testing` has all testing hosts, but same groups. 

So testing becomes very natural:

```
ansible-playbook -i hosts/testing playbook.yml
```

if testing is ok, apply to production 

```
ansible-playbook -i hosts/production playbook.yml
```

But sometimes it makes sense to know in which "environment" (from which inventory_file) you apply the task.

e.g. this would be very nice:

```
action: foobar...
when: {{ inventory_file }} is "hosts/production"
```

Cheers 
René
