### PR TITLE
fix inventory.basedir is not absolute path when hostfile is startswith "./"

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -392,7 +392,7 @@ class Inventory(object):
         if not self.is_file():
             return None
         dname = os.path.dirname(self.host_list)
-        if dname is None or dname == '':
+        if dname is None or dname == '' or dname == '.':
             cwd = os.getcwd()
             return cwd 
         return dname


### PR DESCRIPTION
Fix a problem when 
ansible.cfg looks like 

```
[defaults]
hostfile = ./ansible_hosts
```

The inventory_dir is set to '.',  not the absolute path . 

That cause problem when I try to use lookup plugin like following:
some vars file 

```
somevar: "{{ lookup('file', inventory_dir + '/cred/server.crt') }}"
```

inventory_dir is resovled to '.',  the playbook will try to look for  `cred/server.crt` int the role dir , not in inventory_dir . 
