### PR TITLE
Brings postgresql_db examples in line with documentation.

### DIFF
--- a/library/database/postgresql_db
+++ b/library/database/postgresql_db
@@ -90,12 +90,12 @@ author: Lorin Hochstein
 
 EXAMPLES = '''
 # Create a new database with name "acme"
-- postgresql_db: db=acme
+- postgresql_db: name=acme
 
 # Create a new database with name "acme" and specific encoding and locale
 # settings. If a template different from "template0" is specified, encoding
 # and locale settings must match those of the template.
-- postgresql_db: db=acme
+- postgresql_db: name=acme
                  encoding='UTF-8'
                  lc_collate='de_DE.UTF-8'
                  lc_ctype='de_DE.UTF-8'


### PR DESCRIPTION
As of now, the documentation lists a parameter as "name",
whereas the examples use a parameter called "db". This brings
them in line.
