### PR TITLE
Use home path expansion for virtualenv param in django_manage module

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -101,9 +101,9 @@ EXAMPLES = """
 
 #Run syncdb on the application
 - django_manage: >
-      command=syncdb 
+      command=syncdb
       app_path={{ django_dir }}
-      settings={{ settings_app_name }} 
+      settings={{ settings_app_name }}
       pythonpath={{ settings_dir }}
       virtualenv={{ virtualenv_dir }}
 
@@ -131,7 +131,7 @@ def _ensure_virtualenv(module):
 
     virtualenv = module.get_bin_path('virtualenv', True)
 
-    vbin = os.path.join(venv_param, 'bin')
+    vbin = os.path.join(os.path.expanduser(venv_param), 'bin')
     activate = os.path.join(vbin, 'activate')
 
     if not os.path.exists(activate):


### PR DESCRIPTION
Minor issue, but caused me some confusion since I store my virtualenvs in `~/.virtualenvs/`.

Fixes #3817
