### PR TITLE
Expand user home path in stat module

### DIFF
--- a/library/files/stat
+++ b/library/files/stat
@@ -67,6 +67,7 @@ def main():
     )
 
     path = module.params.get('path')
+    path = os.path.expanduser(path)
     follow = module.params.get('follow')
 
     try:


### PR DESCRIPTION
This now works:

```
- name: stat Music dir
  stat: path=~/Music
  register: st
```

Whereas before it wouldn't be able to find the ~/Music directory, as it wasn't expanding the ~.
