### PR TITLE
file: state=hard only works for initial setup of hardlink

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -204,7 +204,12 @@ def main():
         elif os.path.isdir(path):
             prev_state = 'directory'
         else:
-            prev_state = 'file'
+            old_src_ino = os.fstat(os.open(path, os.O_RDWR|os.O_CREAT )).st_ino
+            new_src_ino = os.fstat(os.open(src, os.O_RDWR|os.O_CREAT )).st_ino
+            if old_src_ino == new_src_ino:
+                prev_state = 'hard'
+            else:
+                prev_state = 'file'
 
     if prev_state != 'absent' and state == 'absent':
         try:
@@ -229,7 +234,7 @@ def main():
         module.exit_json(path=path, changed=True)
 
     if prev_state != 'absent' and prev_state != state:
-        if force and prev_state == 'file' and state == 'link':
+        if force and prev_state == 'file' and state in ('link', 'hard'):
             pass
         else:
             module.fail_json(path=path, msg='refusing to convert between %s and %s for %s' % (prev_state, state, src))
@@ -293,6 +298,8 @@ def main():
                 os.unlink(path)
                 dolink(src, path, state, module)
                 changed = True
+        elif prev_state == 'hard':
+            pass
         elif prev_state == 'file':
             if not force:
                 module.fail_json(dest=path, src=src, msg='Cannot link, file exists at destination')


### PR DESCRIPTION
The new state=hard (indicating a hardlink rather than symlink) only works the first time around.
Every time this action is run after that it will fail because it thinks that the hardlink is just a file.
I think the problem lies with the os.readlink(path) part in the below snippet.

Snippet

<pre>
        elif prev_state == 'link':
             old_src = os.readlink(path)
             if not os.path.isabs(old_src):
                 old_src = os.path.join(os.path.dirname(path), old_src)
             if old_src != src:
                 if module.check_mode:
                     module.exit_json(changed=True)
                 os.unlink(path)
                 dolink(src, path, state, module)
                 changed = True
</pre>


This snippet is from library/files/file on current devel branch (3e32654f9d67a1a7b5109fe9c543f89401f71746 at writing)

Running this I get 

<pre>
OSError: [Errno 22] Invalid argument: '/path/to/file'
</pre>
