### PR TITLE
ec2_tag module to tag resources (instances, volumes, sg's etc.)

### DIFF
--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -1,0 +1,215 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: ec2_tag 
+short_description: create and remove tag(s) to ec2 resources.
+description:
+    - Creates and removes tags from any EC2 resource.  The resource is referenced by its resource id (e.g. an instance being i-XXXXXXX). It is designed to be used with complex args (tags), see the examples.  This module has a dependency on python-boto.
+version_added: "1.3"
+options:
+  resource:
+    description:
+      - The EC2 resource id. 
+    required: true
+    default: null 
+    aliases: []
+  state:
+    description:
+      - Whether the tags should be present or absent on the resource.
+    required: true
+    default: null
+    aliases: []
+  region:
+    description:
+      - region in which the resource exists. 
+    required: false
+    default: null
+    aliases: ['aws_region', 'ec2_region']
+  aws_secret_key:
+    description:
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
+    required: false
+    default: None
+    aliases: ['ec2_secret_key', 'secret_key' ]
+  aws_access_key:
+    description:
+      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
+    required: false
+    default: None
+    aliases: ['ec2_access_key', 'access_key' ]
+  ec2_url:
+    description:
+      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints).  Must be specified if region is not used. If not set then the value of the EC2_URL environment variable, if any, is used.
+    required: false
+    default: null
+    aliases: []
+requirements: [ "boto" ]
+author: Lester Wade
+'''
+
+EXAMPLES = '''
+# Basic example of adding tag(s)
+tasks:
+- name: tag a resource
+  local_action: ec2_tag resource=vol-XXXXXX region=eu-west-1 state=present
+  args:
+    tags:
+      Name: ubervol
+      env: prod
+
+# Playbook example of adding tag(s) to spawned instances
+tasks:
+- name: launch some instances
+  local_action: ec2 keypair={{ keypair }} group={{ security_group }} instance_type={{ instance_type }} image={{ image_id }} wait=true region=eu-west-1
+  register: ec2
+
+- name: tag my launched instances
+  local_action: ec2_tag resource={{ item.id }} region=eu-west-1 state=present
+  with_items: ec2.instances
+  args:
+    tags:
+      Name: webserver
+      env: prod
+'''
+
+# Note: this module needs to be made idempotent. Possible solution is to use resource tags with the volumes.
+# if state=present and it doesn't exist, create, tag and attach. 
+# Check for state by looking for volume attachment with tag (and against block device mapping?).
+# Would personally like to revisit this in May when Eucalyptus also has tagging support (3.3).
+
+import sys
+import time
+
+try:
+    import boto.ec2
+except ImportError:
+    print "failed=True msg='boto required for this module'"
+    sys.exit(1)
+
+AWS_REGIONS = ['ap-northeast-1',
+               'ap-southeast-1',
+               'ap-southeast-2',
+               'eu-west-1',
+               'sa-east-1',
+               'us-east-1',
+               'us-west-1',
+               'us-west-2']
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            resource = dict(required=True),
+            tags = dict(required=True),
+            region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
+            state = dict(choices=['present', 'absent']),
+            ec2_url = dict(aliases=['EC2_URL']),
+            aws_secret_key = dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True),
+            aws_access_key = dict(aliases=['ec2_access_key', 'access_key']),
+        )
+    )
+
+    resource = module.params.get('resource')
+    tags = module.params['tags']
+    region = module.params.get('region')
+    state = module.params.get('state')
+    ec2_url = module.params.get('ec2_url')
+    aws_secret_key = module.params.get('aws_secret_key')
+    aws_access_key = module.params.get('aws_access_key')
+
+    # allow eucarc environment variables to be used if ansible vars aren't set
+    if not ec2_url and 'EC2_URL' in os.environ:
+        ec2_url = os.environ['EC2_URL']
+
+    if not aws_secret_key:
+        if  'AWS_SECRET_KEY' in os.environ:
+            aws_secret_key = os.environ['AWS_SECRET_KEY']
+        elif 'EC2_SECRET_KEY' in os.environ:
+            aws_secret_key = os.environ['EC2_SECRET_KEY']
+
+    if not aws_access_key:
+        if 'AWS_ACCESS_KEY' in os.environ:
+            aws_access_key = os.environ['AWS_ACCESS_KEY']
+        elif 'EC2_ACCESS_KEY' in os.environ:
+            aws_access_key = os.environ['EC2_ACCESS_KEY']
+
+    if not region:
+        if 'AWS_REGION' in os.environ:
+            region = os.environ['AWS_REGION']
+        elif 'EC2_REGION' in os.environ:
+            region = os.environ['EC2_REGION']
+    
+    # If we have a region specified, connect to its endpoint.
+    if region: 
+        try:
+            ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
+        except boto.exception.NoAuthHandlerFound, e:
+            module.fail_json(msg = str(e))
+    # Otherwise, no region so we fallback to the old connection method
+    elif ec2_url:
+        try:
+            ec2 = boto.connect_ec2_endpoint(ec2_url, aws_access_key, aws_secret_key)
+        except boto.exception.NoAuthHandlerFound, e:
+            module.fail_json(msg = str(e))
+    else:
+        module.fail_json(msg="Either region or ec2_url must be specified")
+    
+    # We need a comparison here so that we can accurately report back changed status.
+    # Need to expand the gettags return format and compare with "tags" and then tag or detag as appropriate.
+    filters = {'resource-id' : resource}
+    gettags = ec2.get_all_tags(filters=filters)
+   
+    dictadd = {}
+    dictremove = {}
+    baddict = {}
+    tagdict = {}
+    for tag in gettags:
+        tagdict[tag.name] = tag.value
+
+    if state == 'present':
+        if set(tags) == set(tagdict):
+            module.exit_json(msg="Tags already match for %s." %resource, changed=False)
+        else:
+            for (key, value) in set(tags.items()): 
+                if (key, value) not in set(tagdict.items()):
+                    dictadd[key] = value
+        tagger = ec2.create_tags(resource, dictadd)
+        gettags = ec2.get_all_tags(filters=filters)
+        module.exit_json(msg="Tags %s created for resource %s." % (dictadd,resource), changed=True)
+ 
+    if state == 'absent':
+        for (key, value) in set(tags.items()):
+            if (key, value) not in set(tagdict.items()):
+                    baddict[key] = value
+                    if set(baddict) == set(tags):
+                        module.exit_json(msg="Nothing to remove here. Move along.", changed=False)
+        for (key, value) in set(tags.items()):
+            if (key, value) in set(tagdict.items()):
+                    dictremove[key] = value
+        tagger = ec2.delete_tags(resource, dictremove)
+        gettags = ec2.get_all_tags(filters=filters)
+        module.exit_json(msg="Tags %s removed for resource %s." % (dictremove,resource), changed=True)
+    
+#    print json.dumps({
+#        "current_resource_tags": gettags,
+#    })
+    sys.exit(0)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+
+main()


### PR DESCRIPTION
This uses the complex args stuff like the cloudformation module to make it easy to supply a dict for tags.  It works with any ec2 resource.  It should provide a good basis for people to work on. 
