### PR TITLE
Exit with status 3 if no failures but unreachable.

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -159,7 +159,7 @@ if __name__ == '__main__':
             if 'failed' in result or result.get('rc', 0) != 0:
                 sys.exit(2)
         if results['dark']:
-            sys.exit(2)
+            sys.exit(3)
     except errors.AnsibleError, e:
         # Generic handler for ansible specific errors
         callbacks.display("ERROR: %s" % str(e), stderr=True, color='red')

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -202,6 +202,7 @@ def main(args):
             return 0
 
         failed_hosts = []
+        unreachable_hosts = []
 
         try:
 
@@ -213,11 +214,15 @@ def main(args):
 
             for h in hosts:
                 t = pb.stats.summarize(h)
-                if t['unreachable'] > 0 or t['failures'] > 0:
+                if t['failures'] > 0:
                     failed_hosts.append(h)
+                if t['unreachable'] > 0:
+                    unreachable_hosts.append(h)
 
-            if len(failed_hosts) > 0:
-                filename = pb.generate_retry_inventory(failed_hosts)
+            retries = failed_hosts + unreachable_hosts
+
+            if len(retries) > 0:
+                filename = pb.generate_retry_inventory(retries)
                 if filename:
                     display("           to retry, use: --limit @%s\n" % filename)
 
@@ -246,6 +251,8 @@ def main(args):
             print ""
             if len(failed_hosts) > 0:
                 return 2
+            if len(unreachable_hosts) > 0:
+                return 3
 
         except errors.AnsibleError, e:
             display("ERROR: %s" % e, color='red')


### PR DESCRIPTION
Provide hints to playbook callers that a playbook execution had
unreachable vs failures. 2 == failures, 3 == no failures, but
unreachable hosts. 0 continues to be all good.

I couldn't find any tests that would test this functionality (and I didn't create one, shame on me). Also I don't know whether this is documented anywhere or not, so I didn't add any.
