### PR TITLE
implemented lookup_plugin with_hash_items

### DIFF
--- a/lib/ansible/runner/lookup_plugins/hash_items.py
+++ b/lib/ansible/runner/lookup_plugins/hash_items.py
@@ -1,0 +1,32 @@
+# (c) 2013, Ali-Akber Saifee <ali@indydevs.org>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import ansible.errors as errors
+from ansible.utils import safe_eval
+
+
+class LookupModule(object):
+
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
+
+    def run(self, terms, inject=None, **kwargs):
+        terms = safe_eval(terms)
+
+        if not isinstance(terms, dict):
+            raise errors.AnsibleError("with_hash_items expects a dict")
+        return [{"key": term[0], "value": term[1]} for term in terms.items()]

--- a/test/lookup_plugins.yml
+++ b/test/lookup_plugins.yml
@@ -4,6 +4,9 @@
   connection: local
   vars:
     empty_list: []
+    empty_hash: {}
+    test_hash:
+        hello: world
   tasks:
   - name: test with_items
     action: command true
@@ -18,6 +21,29 @@
   - name: test with_file and FILE
     action: command test "$item" = "$FILE(sample.j2)"
     with_file: sample.j2
+
+  - name: test with_hash_items and empty hash
+    action: command true
+    with_hash_items: $empty_hash
+
+  - name: test with_hash_items and plain hash
+    action: >
+      shell test "${item.key}" = "hello" && test "${item.value}" = "world"
+    with_hash_items: {"hello":"world"}
+
+  - name: test with_hash_items and nested hash
+    action: >
+      shell
+      test "${item.key}" = "hello" \
+            && test "${item.value.en}" = "world" \
+            && test "${item.value.sw}" = "duniya"
+    with_hash_items: {"hello":{"en":"world", "sw":"duniya"}}
+
+  - name: test with_hash_items with template
+    action: >
+      shell
+      test "${item.key}" = "hello" && test "${item.value}" = "world" \
+    with_hash_items: "{{ test_hash }}"
 
   - name: test with_pipe
     action: command test "$item" = "$PIPE(cat sample.j2)"


### PR DESCRIPTION
The plugin allows iterating over a hash using `with_hash_items`.
The key/values of the hash are made available to the action via ${item.key} &
${item.value}.

Some discussion here: https://groups.google.com/forum/#!topic/ansible-project/Jz_8dDrCYlQ
