### PR TITLE
Hipchat module documentation error - param 'from' should be 'msg_from'

### DIFF
--- a/library/notification/hipchat
+++ b/library/notification/hipchat
@@ -17,7 +17,7 @@ options:
     description:
       - ID or name of the room.
     required: true
-  from:
+  msg_from:
     description:
       - Name the message will appear be sent from. max 15 characters.
         Over 15, will be shorten.


### PR DESCRIPTION
http://www.ansibleworks.com/docs/modules.html#hipchat

Using 'from' as param throws msg: unsupported parameter for module: from

Looked at module and param used is 'msg_from'

Cheers

--Bug report filed in #3853--
