### PR TITLE
quantum_network should not default network provider type to local

### DIFF
--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -64,11 +64,11 @@ options:
         - Name to be assigned to the nework 
      required: true
      default: None
-   network_type:
+   provider_network_type:
      description:
-        - The type of the network to be created, gre, vlan, local.
+        - The type of the network to be created, gre, vlan, local. Available types depend on the plugin. The Quantum service decides if not specified.
      required: false
-     default: local
+     default: None
    provider_physical_network:
      description:
         - The physical network which would realize the virtual network for flat and vlan networks.
@@ -199,7 +199,12 @@ def _create_network(module, quantum):
 
     if module.params['provider_network_type'] == 'gre':
         network.pop('provider:physical_network', None)
-                
+
+    if module.params['provider_network_type'] is None:
+        network.pop('provider:network_type', None)
+        network.pop('provider:physical_network', None)
+        network.pop('provider:segmentation_id', None)
+
     try:
         net = quantum.create_network({'network':network})
     except Exception as e:
@@ -225,7 +230,7 @@ def main():
             region_name                     = dict(default=None),
             name                            = dict(required=True),
             tenant_name                     = dict(default=None),
-            provider_network_type           = dict(default='local', choices=['local', 'vlan', 'flat', 'gre']), 
+            provider_network_type           = dict(default=None, choices=['local', 'vlan', 'flat', 'gre']),
             provider_physical_network       = dict(default=None), 
             provider_segmentation_id        = dict(default=None), 
             router_external                 = dict(default=False, type='bool'),


### PR DESCRIPTION
It should allow the Quantum service to decide based on its configuration.

The quantum_network  module is not consistent with the Quantum CLI when provider network type is not specified. When you do:

$ quantum net-create net1

the Quantum service will pick the type and use the next available segmentation_id from the pool of gre or vlan ids. Eg. for the OpenvSwitch plugin this is whatever tenant_network_type is set to in ovs_quantum_plugin.ini. Also the types available depends on the plugin and how it is configured. Eg the LinuxBridge plugin does not have type gre, and the OVS plugin may not be configured for both gre and vlan. 

Also users without the admin role cannot see or set these attributes, but they can't use this module anyway - that's a different problem.

This pull request makes quantum_network work like the Quantum CLI when the provider type is not specified. 
