### PR TITLE
Explicit executable for running 'easy_install' and 'pip'.

### DIFF
--- a/library/packaging/easy_install
+++ b/library/packaging/easy_install
@@ -19,6 +19,8 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import os.path
+
 DOCUMENTATION = '''
 ---
 module: easy_install
@@ -92,21 +94,47 @@ def _is_package_installed(module, name, easy_install):
     return not ('Reading' in status_stdout or 'Downloading' in status_stdout)
 
 
+def _get_easy_install(module, env=None, executable=None):
+    candidate_easy_inst_basenames = ['easy_install']
+    easy_install = None
+    if executable is not None:
+        if os.path.isabs(executable):
+            easy_install = executable
+        else:
+            candidate_easy_inst_basenames.insert(0, executable)
+    if easy_install is None:
+        if env is None:
+            opt_dirs = []
+        else:
+            # Try easy_install with the virtualenv directory first.
+            opt_dirs = ['%s/bin' % env]
+        for basename in candidate_easy_inst_basenames:
+            easy_install = module.get_bin_path(basename, False, opt_dirs)
+            if easy_install is not None:
+                break
+    # easy_install should have been found by now.  The final call to
+    # get_bin_path will trigger fail_json.
+    if easy_install is None:
+        basename = candidate_easy_inst_basenames[0]
+        easy_install = module.get_bin_path(basename, True, opt_dirs)
+    return easy_install
+
+
 def main():
     arg_spec = dict(
         name=dict(required=True),
         virtualenv=dict(default=None, required=False),
         virtualenv_site_packages=dict(default='no', type='bool'),
         virtualenv_command=dict(default='virtualenv', required=False),
-        executable=dict(default='easy_install', required=False),
+        executable=dict(default=None, required=False),
     )
 
     module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
 
     name = module.params['name']
     env = module.params['virtualenv']
-    easy_install = module.get_bin_path(module.params['executable'], True,
-                                       ['%s/bin' % env])
+    executable = module.params['executable']
+    easy_install = _get_easy_install(module, env, executable)
     site_packages = module.params['virtualenv_site_packages']
     virtualenv_command = module.params['virtualenv_command']
 

--- a/library/packaging/easy_install
+++ b/library/packaging/easy_install
@@ -57,6 +57,16 @@ options:
         C(pyvenv), C(virtualenv), C(virtualenv2).
     required: false
     default: virtualenv
+  executable:
+    description:
+      - The explicit executable or a pathname to the executable to be used to
+        run easy_install for a specific version of Python installed in the
+        system. For example C(easy_install-3.3), if there are both Python 2.7
+        and 3.3 installations in the system and you want to run easy_install
+        for the Python 3.3 installation.
+version_added: "1.3"
+    required: false
+    default: null
 notes:
     - Please note that the M(easy_install) module can only install Python
       libraries. Thus this module is not able to remove libraries. It is
@@ -88,13 +98,15 @@ def main():
         virtualenv=dict(default=None, required=False),
         virtualenv_site_packages=dict(default='no', type='bool'),
         virtualenv_command=dict(default='virtualenv', required=False),
+        executable=dict(default='easy_install', required=False),
     )
 
     module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
 
     name = module.params['name']
     env = module.params['virtualenv']
-    easy_install = module.get_bin_path('easy_install', True, ['%s/bin' % env])
+    easy_install = module.get_bin_path(module.params['executable'], True,
+                                       ['%s/bin' % env])
     site_packages = module.params['virtualenv_site_packages']
     virtualenv_command = module.params['virtualenv_command']
 

--- a/library/packaging/easy_install
+++ b/library/packaging/easy_install
@@ -125,11 +125,11 @@ def main():
         if module.check_mode:
             module.exit_json(changed=True)
         cmd = '%s %s' % (easy_install, name)
-        rc_pip, out_pip, err_pip = module.run_command(cmd)
+        rc_easy_inst, out_easy_inst, err_easy_inst = module.run_command(cmd)
 
-        rc += rc_pip
-        out += out_pip
-        err += err_pip
+        rc += rc_easy_inst
+        out += out_easy_inst
+        err += err_easy_inst
 
         changed = True
 

--- a/library/packaging/easy_install
+++ b/library/packaging/easy_install
@@ -72,8 +72,8 @@ EXAMPLES = '''
 # Examples from Ansible Playbooks
 - easy_install: name=pip
 
-# Install Flast into the specified virtualenv.
-- easy_install: name=flask virtualenv=/webapps/myapp/venv
+# Install Bottle into the specified virtualenv.
+- easy_install: name=bottle virtualenv=/webapps/myapp/venv
 '''
 
 def _is_package_installed(module, name, easy_install):

--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -97,6 +97,15 @@ options:
     version_added: "1.3"
     required: false
     default: null
+  executable:
+    description:
+      - The explicit executable or a pathname to the executable to be used to
+        run pip for a specific version of Python installed in the system. For
+        example C(pip-3.3), if there are both Python 2.7 and 3.3 installations
+        in the system and you want to run pip for the Python 3.3 installation.
+    version_added: "1.3"
+    required: false
+    default: null
 notes:
    - Please note that virtualenv (U(http://www.virtualenv.org/)) must be installed on the remote host if the virtualenv parameter is specified.
 requirements: [ "virtualenv", "pip" ]
@@ -130,6 +139,9 @@ EXAMPLES = '''
 
 # Install specified python requirements and custom Index URL.
 - pip: requirements=/my_app/requirements.txt extra_args='-i https://example.com/pypi/simple'
+
+# Install (Bottle) for Python 3.3 specifically,using the 'pip-3.3' executable.
+- pip: name=bottle executable=pip-3.3
 '''
 
 
@@ -141,21 +153,26 @@ def _get_full_name(name, version=None):
     return resp
 
 
-def _get_pip(module, env):
-    # On Debian and Ubuntu, pip is pip.
-    # On Fedora18 and up, pip is python-pip.
-    # On Fedora17 and below, CentOS and RedHat 6 and 5, pip is pip-python.
-    # On Fedora, CentOS, and RedHat, the exception is in the virtualenv.
-    # There, pip is just pip.
-    # Try pip with the virtualenv directory first.
-    pip = module.get_bin_path('pip', False, ['%s/bin' % env])
-    for p in ['python-pip', 'pip-python']:
+def _get_pip(module, env, executable=None):
+    if executable is None:
+        # Default pip executables.
+        # On Debian and Ubuntu, pip is pip.
+        # On Fedora18 and up, pip is python-pip.
+        # On Fedora17 and below, CentOS and RedHat 6 and 5, pip is pip-python.
+        # On Fedora, CentOS, and RedHat, the exception is in the virtualenv.
+        # There, pip is just pip.
+        # Try pip with the virtualenv directory first.
+        pip = module.get_bin_path('pip', False, ['%s/bin' % env])
+        for p in ['python-pip', 'pip-python']:
+            if not pip:
+                pip = module.get_bin_path(p, False, ['%s/bin' % env])
+        # pip should have been found by now.  The final call to get_bin_path
+        # will trigger fail_json.
         if not pip:
-            pip = module.get_bin_path(p, False, ['%s/bin' % env])
-    # pip should have been found by now.  The final call to get_bin_path
-    # will trigger fail_json.
-    if not pip:
-        pip = module.get_bin_path('pip', True, ['%s/bin' % env])
+            pip = module.get_bin_path('pip', True, ['%s/bin' % env])
+    else:
+        # Explicit pip executable.
+        pip = module.get_bin_path(executable, True)
     return pip
 
 
@@ -187,6 +204,7 @@ def main():
             use_mirrors=dict(default='yes', type='bool'),
             extra_args=dict(default=None, required=False),
             chdir=dict(default=None, required=False),
+            executable=dict(default=None, required=False),
         ),
         required_one_of=[['name', 'requirements']],
         mutually_exclusive=[['name', 'requirements']],
@@ -231,7 +249,7 @@ def main():
             if rc != 0:
                 _fail(module, cmd, out, err)
 
-    pip = _get_pip(module, env)
+    pip = _get_pip(module, env, module.params['executable'])
 
     cmd = '%s %s' % (pip, state_map[state])
 

--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -104,23 +104,23 @@ author: Matt Wright
 '''
 
 EXAMPLES = '''
-# Install (flask) python package.
-- pip: name=flask
+# Install (Bottle) python package.
+- pip: name=bottle
 
-# Install (flask) python package on version 0.8.
-- pip: name=flask version=0.8
+# Install (Bottle) python package on version 0.11.
+- pip: name=bottle version=0.11
 
 # Install (MyApp) using one of the remote protocols (bzr+,hg+,git+,svn+) or tarballs (zip, gz, bz2) (pip) supports. You do not have to supply '-e' option in extra_args. For these source names, (use_mirrors) is ignored and not applicable.
 - pip: name='svn+http://myrepo/svn/MyApp#egg=MyApp'
 
-# Install (Flask) into the specified (virtualenv), inheriting none of the globally installed modules
-- pip: name=flask virtualenv=/my_app/venv
+# Install (Bottle) into the specified (virtualenv), inheriting none of the globally installed modules
+- pip: name=bottle virtualenv=/my_app/venv
 
-# Install (Flask) into the specified (virtualenv), inheriting globally installed modules
-- pip: name=flask virtualenv=/my_app/venv virtualenv_site_packages=yes
+# Install (Bottle) into the specified (virtualenv), inheriting globally installed modules
+- pip: name=bottle virtualenv=/my_app/venv virtualenv_site_packages=yes
 
-# Install (Flask) into the specified (virtualenv), using Python 2.7
-- pip: name=flask virtualenv=/my_app/venv virtualenv_command=virtualenv-2.7
+# Install (Bottle) into the specified (virtualenv), using Python 2.7
+- pip: name=bottle virtualenv=/my_app/venv virtualenv_command=virtualenv-2.7
 
 # Install specified python requirements.
 - pip: requirements=/my_app/requirements.txt

--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -153,26 +153,34 @@ def _get_full_name(name, version=None):
     return resp
 
 
-def _get_pip(module, env, executable=None):
-    if executable is None:
-        # Default pip executables.
-        # On Debian and Ubuntu, pip is pip.
-        # On Fedora18 and up, pip is python-pip.
-        # On Fedora17 and below, CentOS and RedHat 6 and 5, pip is pip-python.
-        # On Fedora, CentOS, and RedHat, the exception is in the virtualenv.
-        # There, pip is just pip.
-        # Try pip with the virtualenv directory first.
-        pip = module.get_bin_path('pip', False, ['%s/bin' % env])
-        for p in ['python-pip', 'pip-python']:
-            if not pip:
-                pip = module.get_bin_path(p, False, ['%s/bin' % env])
-        # pip should have been found by now.  The final call to get_bin_path
-        # will trigger fail_json.
-        if not pip:
-            pip = module.get_bin_path('pip', True, ['%s/bin' % env])
-    else:
-        # Explicit pip executable.
-        pip = module.get_bin_path(executable, True)
+def _get_pip(module, env=None, executable=None):
+    # On Debian and Ubuntu, pip is pip.
+    # On Fedora18 and up, pip is python-pip.
+    # On Fedora17 and below, CentOS and RedHat 6 and 5, pip is pip-python.
+    # On Fedora, CentOS, and RedHat, the exception is in the virtualenv.
+    # There, pip is just pip.
+    candidate_pip_basenames = ['pip', 'python-pip', 'pip-python']
+    pip = None
+    if executable is not None:
+        if os.path.isabs(executable):
+            pip = executable
+        else:
+            candidate_pip_basenames.insert(0, executable)
+    if pip is None:
+        if env is None:
+            opt_dirs = []
+        else:
+            # Try pip with the virtualenv directory first.
+            opt_dirs = ['%s/bin' % env]
+        for basename in candidate_pip_basenames:
+            pip = module.get_bin_path(basename, False, opt_dirs)
+            if pip is not None:
+                break
+    # pip should have been found by now.  The final call to get_bin_path will
+    # trigger fail_json.
+    if pip is None:
+        basename = candidate_pip_basenames[0]
+        pip = module.get_bin_path(basename, True, opt_dirs)
     return pip
 
 


### PR DESCRIPTION
New `executable` module argument for `easy_install` and `pip` packaging modules, that allows specifying explicitly the executable to use for running `easy_install` and `pip`, allowing for example, the system installation of packages for a specific version of _Python_ when there are multiple versions of _Python_ installed in the system.
