### PR TITLE
Allow to use '*test*' in enablerepo for yum action

### DIFF
--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -648,11 +648,16 @@ def ensure(module, state, pkgspec, conf_file, enablerepo, disablerepo,
             for r in dis_repos:
                 my.repos.disableRepo(r)
 
+            current_repos = my.repos.repos.keys()
             for r in en_repos:
                 try:
                     my.repos.enableRepo(r)
-                    rid = my.repos.getRepo(r)
-                    a = rid.repoXML.repoid
+                    new_repos = my.repos.repos.keys()
+                    for i in new_repos:
+                        if not i in current_repos:
+                            rid = my.repos.getRepo(i)
+                            a = rid.repoXML.repoid
+                    current_repos = new_repos
                 except yum.Errors.YumBaseError, e:
                     module.fail_json(msg="Error setting/accessing repo %s: %s" % (r, e))
         except yum.Errors.YumBaseError, e:


### PR DESCRIPTION
Yum commandline permit to use a wildcard to enable and disable
repositories in the --enablerepo switch, permitting to enable
a complete set of repository at once ( like all rpmfusion, all
update-testing, etc ).

However, this doesn't work in yum due to more stringent checks
that verify that a exact match is given for the name of the
repository , see commit 5c26805.

This commit enhance the check by permitting to test more than
1 repository at a time, thus permitting to use wildcards.
