### PR TITLE
setting 0644 permissions on mkstemp file handles. Fixes issue #3857

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -182,6 +182,7 @@ class SourcesList(object):
             if sources:
                 d, fn = os.path.split(filename)
                 fd, tmp_path = tempfile.mkstemp(prefix=".%s-" % fn, dir=d)
+                os.chmod(os.path.join(fd, tmp_path), 0644)
 
                 with os.fdopen(fd, 'w') as f:
                     for n, valid, enabled, source, comment in sources:


### PR DESCRIPTION
New apt_repository files were being created with 0600 permissions, should be 0644 permissions.

tempfile.mkstemp() will only create files that are read/write by the owner. This patch sets 0644 permissions on the temporary filehandle, so that the atomic_move() retains them later. Putting a chmod elsewhere in the save() method resulted in existing repo files also getting chmodded, which may result in unexpected behavior, if an administrator has set permissions on their sources lists by hand for whatever reason.
