### PR TITLE
Fixed tiny bug with _meta handling in external inventory scripts

### DIFF
--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -110,7 +110,7 @@ class InventoryScript(object):
     def get_host_variables(self, host):
         """ Runs <script> --host <hostname> to determine additional host variables """
         if self.host_vars_from_top is not None:
-            got = self.host_vars_from_top.get(host, {})
+            got = self.host_vars_from_top.get(host.name, {})
             return got
 
 


### PR DESCRIPTION
This is a trivial fix for the bug I raised earlier today https://github.com/ansible/ansible/issues/3884 - ansible_ssh_host was not effective when returned in _meta from an external inventory script.  In fact I'm not sure _meta was working at all before this change!  First pull request (ever - let alone ansible) so please educate me if something's incorrect.  Thanks!
