### PR TITLE
Enforce alphanumeric ordering for plugins grabbed via glob.

### DIFF
--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -176,7 +176,9 @@ class PluginLoader(object):
         ''' instantiates all plugins with the same arguments '''       
 
         for i in self._get_paths():
-            for path in glob.glob(os.path.join(i, "*.py")):
+            matches = glob.glob(os.path.join(i, "*.py"))
+            matches.sort()
+            for path in matches:
                 name, ext = os.path.splitext(os.path.basename(path))
                 if name.startswith("_"):
                     continue


### PR DESCRIPTION
If this isn't done, it's left to directory ordering which can result
in indeterminent behaviour.
