### PR TITLE
Fix inconsistency in hostvars access.

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -81,15 +81,13 @@ def _executor_hook(job_queue, result_queue, new_stdin):
         except:
             traceback.print_exc()
 
-class HostVars(dict):
+class HostVars(collections.Mapping):
     ''' A special view of setup_cache that adds values from the inventory when needed. '''
 
     def __init__(self, setup_cache, inventory):
         self.setup_cache = setup_cache
         self.inventory = inventory
         self.lookup = {}
-
-        self.update(setup_cache)
 
     def __getitem__(self, host):
         if not host in self.lookup:
@@ -98,8 +96,12 @@ class HostVars(dict):
             self.lookup[host] = result
         return self.lookup[host]
 
-    def __contains__(self, host):
-        return host in self.lookup or host in self.setup_cache or self.inventory.get_host(host)
+    def __iter__(self):
+        return (host.name for host in self.inventory.get_group('all').hosts)
+
+    def __len__(self):
+        return len(self.inventory.get_group('all').hosts)
+
 
 class Runner(object):
     ''' core API interface to ansible '''


### PR DESCRIPTION
Previously, hostvars would only expose a keys() list of hosts that had
been seen yet- however you could explicitly access the host if you knew
the name, and get the content that way.  This precludes template code
from being able to safely access information about other hosts if any
limiters/tags were in use.

Additionally, the object was inconsistent for hostvars['myhost'] access
and [x[1] for x in hostvars.items() if x[0] == 'myhost'] access; this is
due to the original derivation from the dict object.  .items() would be
handled by dict.items(), using the passed in setup_cache values without
using the actual lookup content.

This patch rebases the class implementation to a py2.6 dictmixin, fixing
those issues and restoring behaviour to match what the docs claim.
