### PR TITLE
make sure ssh do not ask password

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -73,6 +73,7 @@ class Connection(object):
                                  "-o", "PubkeyAuthentication=no"]
         else:
             self.common_args += ["-o", "KbdInteractiveAuthentication=no",
+                                 "-o", "PreferredAuthentications=hostbased,publickey",
                                  "-o", "PasswordAuthentication=no"]
         if self.user != pwd.getpwuid(os.geteuid())[0]:
             self.common_args += ["-o", "User="+self.user]


### PR DESCRIPTION
For some reason, ssh seems to ask for password even when
PasswordAuthentication is set to no, adding PreferredAuthentications
with the 2 options removed do the trick.

To verify that, just take a server where you do not have ssh key: 

ssh -v  -o 'KbdInteractiveAuthentication=no' '-o' 'PasswordAuthentication=no' '-o' 'PreferredAuthentications=hostbased,publickey'  test.example.org 

=> no password asked

ssh -v  -o 'KbdInteractiveAuthentication=no' '-o' 'PasswordAuthentication=no'   test.example.org 
=> ask password

Tested from a F19 and RHEL 6 to a Centos 6 server.
