### PR TITLE
Support multiple --extra-vars flags

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -61,8 +61,8 @@ def main(args):
         check_opts=True,
         diff_opts=True
     )
-    parser.add_option('-e', '--extra-vars', dest="extra_vars", default=None,
-        help="set additional key=value variables from the CLI")
+    parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append",
+        help="set additional variables as key=value or JSON", default=[])
     parser.add_option('-t', '--tags', dest='tags', default='all',
         help="only run plays and tasks tagged with these values")
     parser.add_option('--skip-tags', dest='skip_tags',
@@ -99,17 +99,17 @@ def main(args):
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
 
     extra_vars = {}
-    if options.extra_vars:
-        if options.extra_vars.startswith("@"):
+    for extra_vars_opt in options.extra_vars:
+        if extra_vars_opt.startswith("@"):
             # Argument is a JSON file
-            with open(options.extra_vars[1:]) as fd:
-                extra_vars = utils.json_loads(fd.read())
-        elif options.extra_vars[0] in '[{':
+            with open(extra_vars_opt[1:]) as fd:
+                extra_vars = utils.combine_vars(extra_vars, utils.json_loads(fd.read()))
+        elif extra_vars_opt[0] in '[{':
             # Arguments as JSON
-            extra_vars = utils.json_loads(options.extra_vars)
+            extra_vars = utils.combine_vars(extra_vars, utils.json_loads(extra_vars_opt))
         else:
             # Arguments as Key-value
-            extra_vars = utils.parse_kv(options.extra_vars)
+            extra_vars = utils.combine_vars(extra_vars, utils.parse_kv(extra_vars_opt))
 
     only_tags = options.tags.split(",")
     skip_tags = options.skip_tags


### PR DESCRIPTION
Allows passing flags to `ansible-playbook` like `--extra-flags "foo=bar" --extra-flags "baz=qux"`. Extremely useful when wrapping `ansible-playbook` in a shell script with contents like:

```
ansible-playbook -i "$1.inv" --extra-vars "ec2_stack_name=$2" "${@:2}"
```

Note that the above does magic things with the first two parameters, then passes the rest verbatim along to `ansible-playbook`. Without this patch, the first `--extra-vars` flag would get overwritten by a later one.

Rebased version of #3757.
