### PR TITLE
fixed shebang in openshift inventory

### DIFF
--- a/plugins/inventory/openshift.py
+++ b/plugins/inventory/openshift.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 
 # (c) 2013, Michael Scherer <misc@zarb.org>
 #


### PR DESCRIPTION
Changed `#!/bin/python` to `#!/usr/bin/python` but IMHO we should consider using `#!/usr/bin/env python` to be more open for non-standard setups. 
