### PR TITLE
ec2 inventory: Verify that a security group exists before trying to use ...

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -384,8 +384,9 @@ class Ec2Inventory(object):
         
         # Inventory: Group by security group
         try:
-            key = self.to_safe("security_group_" + instance.security_group.name)
-            self.push(self.inventory, key, dest)
+            if instance.security_group:
+                key = self.to_safe("security_group_" + instance.security_group.name)
+                self.push(self.inventory, key, dest)
         except AttributeError:
             print 'Package boto seems a bit older.'
             print 'Please upgrade boto >= 2.3.0.'


### PR DESCRIPTION
...its name as a key in inventory.

The ec2 inventory plugin is automatically assuming that if an instance is missing the security_group attribute, that it must be using an older version of boto.  This is not always the case.
