### PR TITLE
Add option remote_user to task level, to specify the ssh login user

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -305,7 +305,7 @@ class PlayBook(object):
             pattern=task.play.hosts, inventory=self.inventory, module_name=task.module_name,
             module_args=task.module_args, forks=self.forks,
             remote_pass=self.remote_pass, module_path=self.module_path,
-            timeout=self.timeout, remote_user=task.play.remote_user,
+            timeout=self.timeout, remote_user=task.remote_user,
             remote_port=task.play.remote_port, module_vars=task.module_vars,
             private_key_file=self.private_key_file,
             setup_cache=self.SETUP_CACHE, basedir=task.play.basedir,

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -27,7 +27,7 @@ class Task(object):
         'notify', 'module_name', 'module_args', 'module_vars',
         'play', 'notified_by', 'tags', 'register',
         'delegate_to', 'first_available_file', 'ignore_errors',
-        'local_action', 'transport', 'sudo', 'sudo_user', 'sudo_pass',
+        'local_action', 'transport', 'sudo', 'remote_user', 'sudo_user', 'sudo_pass',
         'items_lookup_plugin', 'items_lookup_terms', 'environment', 'args',
         'any_errors_fatal', 'changed_when', 'always_run'
     ]
@@ -36,7 +36,7 @@ class Task(object):
     VALID_KEYS = [
          'name', 'meta', 'action', 'only_if', 'async', 'poll', 'notify',
          'first_available_file', 'include', 'tags', 'register', 'ignore_errors',
-         'delegate_to', 'local_action', 'transport', 'sudo', 'sudo_user',
+         'delegate_to', 'local_action', 'transport', 'remote_user', 'sudo', 'sudo_user',
          'sudo_pass', 'when', 'connection', 'environment', 'args',
          'any_errors_fatal', 'changed_when', 'always_run'
     ]
@@ -113,6 +113,8 @@ class Task(object):
         # rather than simple key=value args on the options line, these represent structured data and the values
         # can be hashes and lists, not just scalars
         self.args         = ds.get('args', {})
+
+        self.remote_user      = ds.get('remote_user', play.playbook.remote_user)
 
         if self.sudo:
             self.sudo_user    = ds.get('sudo_user', play.sudo_user)


### PR DESCRIPTION
This commit adds an option remote_user: to tasks, to specify the user to use on ssh login. I would have used used: as in plays, but it is already used by a module.

A better option might by to add a remote_user: option in addition to user: in plays, so that options are aligned. Do you think it is worth the change ?
