### PR TITLE
Tweak with_items error message to be more useful.

### DIFF
--- a/lib/ansible/runner/lookup_plugins/items.py
+++ b/lib/ansible/runner/lookup_plugins/items.py
@@ -37,7 +37,7 @@ class LookupModule(object):
         terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
 
         if not isinstance(terms, list):
-            raise errors.AnsibleError("with_items expects a list")
+            raise errors.AnsibleError("with_items expects a list; was given a %s: value %r" % (type(terms), terms,))
 
         return flatten(terms)
 


### PR DESCRIPTION
Being told "with_items only takes a list" is good; being told what
it was actually given that /was not a list/ is better since it makes debugging
variable flow in a playbook simpler (in particular, when ansible
skipped rendering of a target due to resolution failure).
