### PR TITLE
Supports to the playbook of Process Substitution

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -20,6 +20,7 @@
 
 import sys
 import os
+import stat
 
 import ansible.playbook
 import ansible.constants as C
@@ -118,7 +119,7 @@ def main(args):
     for playbook in args:
         if not os.path.exists(playbook):
             raise errors.AnsibleError("the playbook: %s could not be found" % playbook)
-        if not os.path.isfile(playbook):
+        if not ( os.path.isfile(playbook) or stat.S_ISFIFO(os.stat(playbook).st_mode) ):
             raise errors.AnsibleError("the playbook: %s does not appear to be a file" % playbook)
 
     # run all playbooks specified on the command line

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -119,7 +119,7 @@ def main(args):
     for playbook in args:
         if not os.path.exists(playbook):
             raise errors.AnsibleError("the playbook: %s could not be found" % playbook)
-        if not ( os.path.isfile(playbook) or stat.S_ISFIFO(os.stat(playbook).st_mode) ):
+        if not (os.path.isfile(playbook) or stat.S_ISFIFO(os.stat(playbook).st_mode)):
             raise errors.AnsibleError("the playbook: %s does not appear to be a file" % playbook)
 
     # run all playbooks specified on the command line


### PR DESCRIPTION
It was an error to specify the playbook of [bash process substitution](http://tldp.org/LDP/abs/html/process-sub.html) as follows.

```
$ ansible-playbook -i stage <(curl -s https://URL_REDACTED_THIS_IS_TOTALLY_UNSAFE/masahide/playbook-sample/master/sample.yml)
ERROR: the playbook: / dev/fd/63 does not appear to be a file
```

If using the bash process substitution, this error seems to occur to become a named pipe file.
