### PR TITLE
Correctly handle option user_install in gem module

### DIFF
--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -157,7 +157,9 @@ def install(module):
     else:
         if major and major < 2:
             cmd.append('--include-dependencies')
-    if not module.params['user_install']:
+    if module.params['user_install']:
+        cmd.append('--user-install')
+    else:
         cmd.append('--no-user-install')            
     cmd.append('--no-rdoc')
     cmd.append('--no-ri')


### PR DESCRIPTION
With latest versions of gem, --no-user-install is the default value. This means that if we specify user_install: yes in a task, we must propagate this option to gem call, by adding --user-install.
