### PR TITLE
user module: add support for specifying skel_dir

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -92,6 +92,13 @@ options:
         description:
             - Unless set to C(no), a home directory will be made for the user
               when the account is created.
+    skeleton_directory:
+        required: false
+        version_added: "1.3"
+        description:
+            - The skeleton directory from where files used to populate the
+              new user's home directory are copied from. If no skeleton
+              directory is provided the system default will be used.
     system:
         required: false
         default: "no"
@@ -229,6 +236,7 @@ class User(object):
         self.force      = module.params['force']
         self.remove     = module.params['remove']
         self.createhome = module.params['createhome']
+        self.skeleton_directory = module.params['skeleton_directory']
         self.system     = module.params['system']
         self.login_class = module.params['login_class']
         self.append     = module.params['append']
@@ -302,6 +310,9 @@ class User(object):
 
         if self.createhome:
             cmd.append('-m')
+            if self.skeleton_directory is not None:
+                cmd.append('-k')
+                cmd.append(self.skeleton_directory)
         else:
             cmd.append('-M')
 
@@ -602,6 +613,9 @@ class FreeBsdUser(User):
 
         if self.createhome:
             cmd.append('-m')
+            if self.skeleton_directory is not None:
+                cmd.append('-k')
+                cmd.append(self.skeleton_directory)
 
         if self.shell is not None:
             cmd.append('-s')
@@ -775,6 +789,9 @@ class OpenBSDUser(User):
 
         if self.createhome:
             cmd.append('-m')
+            if self.skeleton_directory is not None:
+                cmd.append('-k')
+                cmd.append(self.skeleton_directory)
 
         cmd.append(self.name)
         return self.execute_command(cmd)
@@ -927,6 +944,9 @@ class NetBSDUser(User):
 
         if self.createhome:
             cmd.append('-m')
+            if self.skeleton_directory is not None:
+                cmd.append('-k')
+                cmd.append(self.skeleton_directory)
 
         cmd.append(self.name)
         return self.execute_command(cmd)
@@ -1077,6 +1097,9 @@ class SunOS(User):
 
         if self.createhome:
             cmd.append('-m')
+            if self.skeleton_directory is not None:
+                cmd.append('-k')
+                cmd.append(self.skeleton_directory)
 
         cmd.append(self.name)
 
@@ -1240,6 +1263,9 @@ class AIX(User):
 
         if self.createhome:
             cmd.append('-m')
+            if self.skeleton_directory is not None:
+                cmd.append('-k')
+                cmd.append(self.skeleton_directory)
 
         cmd.append(self.name)
         (rc, out, err) = self.execute_command(cmd)
@@ -1357,6 +1383,7 @@ def main():
             remove=dict(default='no', type='bool'),
             # following options are specific to useradd
             createhome=dict(default='yes', type='bool'),
+            skeleton_directory=dict(default=None, type='str'),
             system=dict(default='no', type='bool'),
             # following options are specific to usermod
             append=dict(default='no', type='bool'),
@@ -1402,6 +1429,8 @@ def main():
             (rc, out, err) = user.create_user()
             result['system'] = user.system
             result['createhome'] = user.createhome
+            if user.skeleton_directory is not None:
+                result['skeleton_directory'] = user.skeleton_directory
         else:
             # modify user (note: this function is check mode aware)
             (rc, out, err) = user.modify_user()


### PR DESCRIPTION
All supported plattforms of the user module can take a `-k` option
to specify a different skeleton directory than the system default
(/etc/skel).

Man page references:

Linux: http://man7.org/linux/man-pages/man8/useradd.8.html
FreeBSD: http://www.freebsd.org/cgi/man.cgi?query=pw&section=8
OpenBSD: http://www.openbsd.org/cgi-bin/man.cgi?query=useradd&sektion=8
NetBSD: http://netbsd.gw.com/cgi-bin/man-cgi?useradd++NetBSD-current
Solaris: http://illumos.org/man/useradd
AIX: http://pic.dhe.ibm.com/infocenter/aix/v7r1/index.jsp?topic=/com.ibm.aix.cmds/doc/aixcmds5/useradd.htm
