### PR TITLE
Fixed #3767 - mysql_user command fails with dots (and underscores) in database names.

### DIFF
--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -223,7 +223,7 @@ def privileges_get(cursor, user,host):
         privileges = [ pick(x) for x in privileges]
         if "WITH GRANT OPTION" in res.group(4):
             privileges.append('GRANT')
-        db = res.group(2).replace('`', '')
+        db = res.group(2)
         output[db] = privileges
     return output
 
@@ -241,7 +241,16 @@ def privileges_unpack(priv):
     output = {}
     for item in priv.split('/'):
         pieces = item.split(':')
+        if pieces[0].find('.') != -1:
+
+          pieces[0] = pieces[0].split('.')
+          for idx, piece in enumerate(pieces):
+            if pieces[0][idx] != "*":
+              pieces[0][idx] = "`" + pieces[0][idx] + "`"
+          pieces[0] = '.'.join(pieces[0])
+
         output[pieces[0]] = pieces[1].upper().split(',')
+
 
     if '*.*' not in output:
         output['*.*'] = ['USAGE']


### PR DESCRIPTION
Please excuse my code if it's not up to scratch - I'm not a very experienced python developer!

The problem that was causing #3767 was that the database names weren't being escaped properly. The solution is to further unserialize the privs argument for mysql_user, then surround all non-wildcard content with backticks.

The other thing causing #3767 was that the privileges_get() method was for some reason specifically removing all backticks. I can't think of a reason why this would ever be needed/useful? Removing that piece of code allowed the backticks to remain consistent throughout the script's execution.
