### PR TITLE
Allow pacman's update_cache to be run by itself

### DIFF
--- a/library/packaging/pacman
+++ b/library/packaging/pacman
@@ -1,80 +1,81 @@
 #!/usr/bin/python -tt
 # -*- coding: utf-8 -*-
 
-# (c) 2012, Afterburn
-# Written by Afterburn <http://github.com/afterburn> 
-# Based on apt module written by Matthew Williams <matthew@flowroute.com>
+# (c) 2012, Afterburn <http://github.com/afterburn>
+# (c) 2013, Aaron Bull Schaefer <aaron@elasticdog.com>
 #
-# This module is free software: you can redistribute it and/or modify
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# This software is distributed in the hope that it will be useful,
+# Ansible is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
-
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 DOCUMENTATION = '''
 ---
 module: pacman
-short_description: Package manager for Archlinux
+short_description: Manage packages with I(pacman)
 description:
-    - Manages Archlinux packages
-
+    - Manage packages with the I(pacman) package manager, which is used by
+      Arch Linux and its variants.
 version_added: "1.0"
+author: Afterburn
+notes: []
+requirements: []
 options:
     name:
         description:
-            - name of package to install, upgrade or remove.
-        required: true
+            - Name of the package to install, upgrade, or remove.
+        required: false
+        default: null
 
     state:
         description:
-            - state of the package (installed or absent).
+            - Desired state of the package.
         required: false
-
-    update_cache:
-        description:
-            - update the package database first (pacman -Syy).
-        required: false
-        default: "no"
-        choices: [ "yes", "no" ]
+        default: "present"
+        choices: ["present", "absent"]
 
     recurse:
         description:
-            - remove all not explicitly installed dependencies not required
-              by other packages of the package to remove
+            - When removing a package, also remove its dependencies, provided
+              that they are not required by other packages and were not
+              explicitly installed by a user.
         required: false
         default: "no"
-        choices: [ "yes", "no" ]
+        choices: ["yes", "no"]
         version_added: "1.3"
 
-author: Afterburn
-notes:  []
+    update_cache:
+        description:
+            - Whether or not to refresh the master package lists. This can be
+              run as part of a package installation or as a separate step.
+        required: false
+        default: "no"
+        choices: ["yes", "no"]
 '''
 
 EXAMPLES = '''
 # Install package foo
-- pacman: name=foo state=installed
+- pacman: name=foo state=present
 
-# Remove package foo
-- pacman: name=foo state=absent
-
-# Remove packages foo and bar 
+# Remove packages foo and bar
 - pacman: name=foo,bar state=absent
 
 # Recursively remove package baz
 - pacman: name=baz state=absent recurse=yes
 
-# Update the package database (pacman -Syy) and install bar (bar will be the updated if a newer version exists) 
-- pacman: name=bar, state=installed, update_cache=yes
+# Run the equivalent of "pacman -Syy" as a separate step
+- pacman: update_cache=yes
 '''
-
 
 import json
 import shlex
@@ -84,11 +85,10 @@ import sys
 
 PACMAN_PATH = "/usr/bin/pacman"
 
-def query_package(module, name, state="installed"):
-
+def query_package(module, name, state="present"):
     # pacman -Q returns 0 if the package is installed,
     # 1 if it is not installed
-    if state == "installed":
+    if state == "present":
         rc = os.system("pacman -Q %s" % (name))
 
         if rc == 0:
@@ -100,16 +100,18 @@ def query_package(module, name, state="installed"):
 def update_package_db(module):
     rc = os.system("pacman -Syy > /dev/null")
 
-    if rc != 0:
+    if rc == 0:
+        return True
+    else:
         module.fail_json(msg="could not update package db")
-         
+
 
 def remove_packages(module, packages):
     if module.params["recurse"]:
         args = "Rs"
     else:
         args = "R"
-    
+
     remove_c = 0
     # Using a for loop incase of error, we can report the package that failed
     for package in packages:
@@ -121,7 +123,7 @@ def remove_packages(module, packages):
 
         if rc != 0:
             module.fail_json(msg="failed to remove %s" % (package))
-    
+
         remove_c += 1
 
     if remove_c > 0:
@@ -132,7 +134,6 @@ def remove_packages(module, packages):
 
 
 def install_packages(module, packages, package_files):
-
     install_c = 0
 
     for i, package in enumerate(packages):
@@ -150,7 +151,7 @@ def install_packages(module, packages, package_files):
             module.fail_json(msg="failed to install %s" % (package))
 
         install_c += 1
-    
+
     if install_c > 0:
         module.exit_json(changed=True, msg="installed %s package(s)" % (install_c))
 
@@ -161,7 +162,7 @@ def check_packages(module, packages, state):
     would_be_changed = []
     for package in packages:
         installed = query_package(module, package)
-        if ((state == "installed" and not installed) or
+        if ((state == "present" and not installed) or
                 (state == "absent" and installed)):
             would_be_changed.append(package)
     if would_be_changed:
@@ -175,44 +176,52 @@ def check_packages(module, packages, state):
 
 def main():
     module = AnsibleModule(
-            argument_spec    = dict(
-                state        = dict(default="installed", choices=["installed","absent"]),
-                update_cache = dict(default="no", aliases=["update-cache"], type='bool'),
-                recurse      = dict(default="no", type='bool'),
-                name         = dict(aliases=["pkg"], required=True)),
-            supports_check_mode = True)
-                
+        argument_spec    = dict(
+            name         = dict(aliases=['pkg']),
+            state        = dict(default='present', choices=['present', 'installed', 'absent', 'removed']),
+            recurse      = dict(default='no', choices=BOOLEANS, type='bool'),
+            update_cache = dict(default='no', aliases=['update-cache'], choices=BOOLEANS, type='bool')),
+        required_one_of = [['name', 'update_cache']],
+        supports_check_mode = True)
 
     if not os.path.exists(PACMAN_PATH):
         module.fail_json(msg="cannot find pacman, looking for %s" % (PACMAN_PATH))
 
     p = module.params
 
+    # normalize the state parameter
+    if p['state'] in ['present', 'installed']:
+        p['state'] = 'present'
+    elif p['state'] in ['absent', 'removed']:
+        p['state'] = 'absent'
+
     if p["update_cache"] and not module.check_mode:
         update_package_db(module)
+        if not p['name']:
+            module.exit_json(changed=True, msg='updated the package master lists')
 
-    pkgs = p["name"].split(",")
+    if p['name']:
+        pkgs = p['name'].split(',')
 
-    pkg_files = []
-    for i, pkg in enumerate(pkgs):
-        if pkg.endswith('.pkg.tar.xz'):
-            # The package given is a filename, extract the raw pkg name from
-            # it and store the filename
-            pkg_files.append(pkg)
-            pkgs[i] = re.sub('-[0-9].*$', '', pkgs[i].split('/')[-1])
-        else:
-            pkg_files.append(None)
+        pkg_files = []
+        for i, pkg in enumerate(pkgs):
+            if pkg.endswith('.pkg.tar.xz'):
+                # The package given is a filename, extract the raw pkg name from
+                # it and store the filename
+                pkg_files.append(pkg)
+                pkgs[i] = re.sub('-[0-9].*$', '', pkgs[i].split('/')[-1])
+            else:
+                pkg_files.append(None)
 
-    if module.check_mode:
-        check_packages(module, pkgs, p['state'])
+        if module.check_mode:
+            check_packages(module, pkgs, p['state'])
 
-    if p["state"] == "installed":
-        install_packages(module, pkgs, pkg_files)
-
-    elif p["state"] == "absent":
-        remove_packages(module, pkgs)
+        if p['state'] == 'present':
+            install_packages(module, pkgs, pkg_files)
+        elif p['state'] == 'absent':
+            remove_packages(module, pkgs)
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-    
-main()        
+
+main()


### PR DESCRIPTION
The module was also cleaned up to conform with the more standard terms 'present' and 'absent' (although 'installed' and 'removed' still work), as well as rewording and making the documentation more consistent. I did remove trailing whitespace on a few lines, but I was touching most of the file for this update anyway.

`git diff --patience` makes this much easier to read, but _all changes are backward compatible_.
