### PR TITLE
The cloudformation module argument spec should match the documentation.  

### DIFF
--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -159,7 +159,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             stack_name=dict(required=True),
-            template_parameters=dict(required=False),
+            template_parameters=dict(required=True),
             region=dict(aliases=['aws_region', 'ec2_region'], required=True, choices=AWS_REGIONS),
             state=dict(default='present', choices=['present', 'absent']),
             template=dict(default=None, required=True),


### PR DESCRIPTION
The cloudformation module argument spec should match the documentation so that template_parameters is a required argument.

The [documentation for the module](https://github.com/ansible/ansible/blob/devel/library/cloud/cloudformation#L41) states that `template_parameters` is required, but [the implementation](https://github.com/ansible/ansible/blob/devel/library/cloud/cloudformation#L162) says otherwise.  If a playbook uses the cloudformation module without the `template_parameters` argument, the following error may occur:

```
File ".../cloudformation", line 168, in main
template_parameters_tup = [(k, v) for k, v in template_parameters.items()]
AttributeError: 'NoneType' object has no attribute 'items'
```
