### PR TITLE
added optional ignore_md5_mismatch parameter

### DIFF
--- a/lib/ansible/runner/action_plugins/fetch.py
+++ b/lib/ansible/runner/action_plugins/fetch.py
@@ -50,6 +50,8 @@ class ActionModule(object):
         flat = utils.boolean(flat)
         fail_on_missing = options.get('fail_on_missing', False)
         fail_on_missing = utils.boolean(fail_on_missing)
+        ignore_md5_mismatch = options.get('ignore_md5_mismatch', False)
+        ignore_md5_mismatch = utils.boolean(ignore_md5_mismatch)
         if source is None or dest is None:
             results = dict(failed=True, msg="src and dest are required")
             return ReturnData(conn=conn, result=results)
@@ -112,10 +114,10 @@ class ActionModule(object):
                 f.write(remote_data)
                 f.close()
             new_md5 = utils.md5(dest)
-            if new_md5 != remote_md5:
-                result = dict(failed=True, md5sum=new_md5, msg="md5 mismatch", file=source, dest=dest)
+            if not ignore_md5_mismatch and new_md5 != remote_md5:
+                result = dict(failed=True, md5sum=new_md5, msg="md5 mismatch", file=source, dest=dest, remote_md5sum=remote_md5)
                 return ReturnData(conn=conn, result=result)
-            result = dict(changed=True, md5sum=new_md5, dest=dest)
+            result = dict(changed=True, md5sum=new_md5, dest=dest, remote_md5sum=remote_md5)
             return ReturnData(conn=conn, result=result)
         else:
             result = dict(changed=False, md5sum=local_md5, file=source, dest=dest)

--- a/lib/ansible/runner/action_plugins/fetch.py
+++ b/lib/ansible/runner/action_plugins/fetch.py
@@ -50,8 +50,8 @@ class ActionModule(object):
         flat = utils.boolean(flat)
         fail_on_missing = options.get('fail_on_missing', False)
         fail_on_missing = utils.boolean(fail_on_missing)
-        ignore_md5_mismatch = options.get('ignore_md5_mismatch', False)
-        ignore_md5_mismatch = utils.boolean(ignore_md5_mismatch)
+        validate_md5 = options.get('validate_md5', True)
+        validate_md5 = utils.boolean(validate_md5)
         if source is None or dest is None:
             results = dict(failed=True, msg="src and dest are required")
             return ReturnData(conn=conn, result=results)
@@ -114,7 +114,7 @@ class ActionModule(object):
                 f.write(remote_data)
                 f.close()
             new_md5 = utils.md5(dest)
-            if not ignore_md5_mismatch and new_md5 != remote_md5:
+            if validate_md5 and new_md5 != remote_md5:
                 result = dict(failed=True, md5sum=new_md5, msg="md5 mismatch", file=source, dest=dest, remote_md5sum=remote_md5)
                 return ReturnData(conn=conn, result=result)
             result = dict(changed=True, md5sum=new_md5, dest=dest, remote_md5sum=remote_md5)

--- a/library/files/fetch
+++ b/library/files/fetch
@@ -34,13 +34,13 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "no"
-  ignore_md5_mismatch:
+  validate_md5:
     version_added: "1.3"
     description:
-      - Do not check the md5sum of the destination file. Useful if transferring files that may change during the transfer, such as log files.
+      - Verify that the source and destination md5sums match after the files are fetched.
     required: false
     choices: [ "yes", "no" ]
-    default: "no"
+    default: "yes"
   flat:
     version_added: "1.2"
     description:

--- a/library/files/fetch
+++ b/library/files/fetch
@@ -34,6 +34,13 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "no"
+  ignore_md5_mismatch:
+    version_added: "1.3"
+    description:
+      - Do not check the md5sum of the destination file. Useful if transferring files that may change during the transfer, such as log files.
+    required: false
+    choices: [ "yes", "no" ]
+    default: "no"
   flat:
     version_added: "1.2"
     description:


### PR DESCRIPTION
As I mentioned in my post to the Ansible group - an optional parameter to skip the md5 check in case you're doing something like fetching a snapshot of a log that's currently being written to.
