### PR TITLE
Fix bug in uri where redirect check fails.

### DIFF
--- a/library/network/uri
+++ b/library/network/uri
@@ -261,7 +261,7 @@ def uri(module, url, dest, user, password, body, method, headers, redirects, soc
                 # and update dest with the new url filename
             except:
                 pass
-            if resp_redir['status'] in ["301", "302", "303", "307"]:
+            if 'status' in resp_redir and resp_redir['status'] in ["301", "302", "303", "307"]:
                 url = resp_redir['location']
                 redirected = True
             dest = os.path.join(dest, url_filename(url))


### PR DESCRIPTION
When the redirect check fails, the 'status' key might not be set in
resp_redir, so we need to check for this.
