### PR TITLE
Allow tilde path expansion in lineinfile module

### DIFF
--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -298,7 +298,8 @@ def main():
     create = module.params['create']
     backup = module.params['backup']
     backrefs = module.params['backrefs']
-    dest = os.path.expanduser(params['dest'])
+    # fix module.params['dest'] otherwise the call to file module will not work
+    dest = module.params['dest'] = os.path.expanduser(params['dest'])
 
 
     if os.path.isdir(dest):


### PR DESCRIPTION
Although the setup of lineinfile expands the path before using it,
the expansion wasn't being passed through to the later call to the
file module. This fixes that.
