### PR TITLE
Adding regions_exclude parameter to be able to do subtractive region exc...

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -12,6 +12,7 @@
 # in AWS and merge the results together. Alternatively, set this to a comma
 # separated list of regions. E.g. 'us-east-1,us-west-1,us-west-2'
 regions = all
+regions_exclude = us-gov-west-1
 
 # When generating inventory, Ansible needs to know how to address a server.
 # Each EC2 instance has a lot of variables associated with it. Here is the list:

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -189,12 +189,14 @@ class Ec2Inventory(object):
         # Regions
         self.regions = []
         configRegions = config.get('ec2', 'regions')
+        configRegions_exclude = config.get('ec2', 'regions_exclude')
         if (configRegions == 'all'):
             if self.eucalyptus_host:
                 self.regions.append(boto.connect_euca(host=self.eucalyptus_host).region.name)
             else:
                 for regionInfo in ec2.regions():
-                    self.regions.append(regionInfo.name)
+                    if regionInfo.name not in configRegions_exclude:
+                        self.regions.append(regionInfo.name)
         else:
             self.regions = configRegions.split(",")
 


### PR DESCRIPTION
...lusion. 

Rationale:  boto 2.11.0 gives access to GovCloud, but GovCloud requires GovCloud credentials for api access.  This was breaking ec2.py because us-gov-west-1 now gets returned by ec2.regions(), so when ec2.py tried to scan that region, it would return a 401 Unavailable.

I set the default to us-gov-west-1 since that probably makes sense for most users, lest all of their things break when they upgrade boto.
