### PR TITLE
bug-fix: if name given ,not delete cron_file but cron entry

### DIFF
--- a/library/system/cron
+++ b/library/system/cron
@@ -462,7 +462,7 @@ def main():
         (backuph, backup_file) = tempfile.mkstemp(prefix='crontab')
         crontab.write(backup_file)
 
-    if crontab.cron_file and not do_install:
+    if crontab.cron_file and not do_install and not name:
         crontab.remove_job_file()
         changed = True
         module.exit_json(changed=changed,cron_file=cron_file,state=state)

--- a/library/system/cron
+++ b/library/system/cron
@@ -167,13 +167,8 @@ class CronTab(object):
         # select whether we dump additional debug info through syslog
         self.syslogging = False
 
-        # some cron file outside /etc/cron.d/ , like /etc/crontab
-        specific_cron_files = [ '/etc/crontab' ]
         if cron_file:
-            if cron_file in specific_cron_files:
-                self.cron_file = cron_file
-            else:
-                self.cron_file = '/etc/cron.d/%s' % cron_file
+            self.cron_file = '/etc/cron.d/%s' % cron_file
         else:
             self.cron_file = None
 

--- a/library/system/cron
+++ b/library/system/cron
@@ -167,8 +167,13 @@ class CronTab(object):
         # select whether we dump additional debug info through syslog
         self.syslogging = False
 
+        # some cron file outside /etc/cron.d/ , like /etc/crontab
+        specific_cron_files = [ '/etc/crontab' ]
         if cron_file:
-            self.cron_file = '/etc/cron.d/%s' % cron_file
+            if cron_file in specific_cron_files:
+                self.cron_file = cron_file
+            else:
+                self.cron_file = '/etc/cron.d/%s' % cron_file
         else:
             self.cron_file = None
 

--- a/library/system/cron
+++ b/library/system/cron
@@ -467,7 +467,7 @@ def main():
         (backuph, backup_file) = tempfile.mkstemp(prefix='crontab')
         crontab.write(backup_file)
 
-    if crontab.cron_file and not do_install:
+    if crontab.cron_file and not do_install and not name:
         crontab.remove_job_file()
         changed = True
         module.exit_json(changed=changed,cron_file=cron_file,state=state)

--- a/library/system/cron
+++ b/library/system/cron
@@ -467,7 +467,7 @@ def main():
         (backuph, backup_file) = tempfile.mkstemp(prefix='crontab')
         crontab.write(backup_file)
 
-    if crontab.cron_file and not do_install and not name:
+    if crontab.cron_file and not do_install:
         crontab.remove_job_file()
         changed = True
         module.exit_json(changed=changed,cron_file=cron_file,state=state)


### PR DESCRIPTION
<code>ansible -i hosts all -m cron -a "name=test minute='*/1' user=foo job='some job'  cron_file=/etc/crontab state=absent" </code>  I used the above command to delete a cron entry name test , but it seems to delete the whole cron file /etc/crontab. 
