### PR TITLE
New module to get a machine's external IP address

### DIFF
--- a/library/network/external_ip
+++ b/library/network/external_ip
@@ -1,0 +1,98 @@
+#!/usr/bin/python
+
+# (c) 2013, Boosh
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>. 
+
+DOCUMENTATION = '''
+---
+module: external_ip
+short_description: discover a machine's external IP address
+description:
+     - Connects to one of several external web sites that returns the external IP address of the machine. This can be useful when you need to dynamically add the IP address of the local machine to a firewall for example.
+options:
+  timeout:
+    description:
+      - timeout to use when connecting to the external web sites before trying the next one.
+    required: false
+    default: 30
+
+author: Ally Boosh
+'''
+
+EXAMPLES = '''
+# Remote example
+- name: get the external IP address of the remote machine
+  action: external_ip
+
+# Local example
+- local_action: external_ip
+  register: my_ip
+- debug: msg="My IP is {{my_ip.ip}}"
+'''
+
+import re
+
+try:
+    import urllib2
+    HAS_URLLIB2 = True
+except ImportError:
+    HAS_URLLIB2 = False
+
+# sites we can use to check our external IP address
+ip_sources = [
+    'http://icanhazip.com/',
+    'http://api.externalip.net/ip/',
+    'http://wgetip.com/'
+]
+
+# ==============================================================
+# main
+
+def main():
+    if not HAS_URLLIB2:
+        module.fail_json(msg="urllib2 is not installed")
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            timeout = dict(default=30)
+        )
+    )
+
+    ip = None
+    ip_regex = re.compile('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
+
+    for source in ip_sources:
+        try:
+            response = urllib2.urlopen(source, timeout=module.params['timeout'])
+        except urllib2.HTTPError:
+            continue
+
+        if response.getcode() != 200:
+            continue
+
+        ip = response.read().strip()
+        if ip_regex.match(ip):
+            break
+
+    if ip is None:
+        module.fail_json(msg="Unable to retrieve external IP address")
+    else:
+        module.exit_json(changed=True, ip=ip)
+
+# include magic from lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()

--- a/library/network/external_ip
+++ b/library/network/external_ip
@@ -96,3 +96,4 @@ def main():
 # include magic from lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 main()
+

--- a/library/network/external_ip
+++ b/library/network/external_ip
@@ -22,7 +22,7 @@ DOCUMENTATION = '''
 module: external_ip
 short_description: discover a machine's external IP address
 description:
-     - Connects to one of several external web sites that returns the external IP address of the machine. This can be useful when you need to dynamically add the IP address of the local machine to a firewall for example.
+  - Connects to one of several external web sites that returns the external IP address of the machine. This can be useful when you need to dynamically add the IP address of the local machine to a firewall for example.
 options:
   timeout:
     description:
@@ -30,7 +30,7 @@ options:
     required: false
     default: 30
 
-author: Ally Boosh
+author: Boosh
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
I've created a new module that connects to a web service that returns the machine's external IP address. This can be useful to add your own IP address to firewalls of new cloud instances that are brought up so only you can connect to them.
