### PR TITLE
if hosts is localhost or 127.0.0.1 don't require it to be in inventory

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -20,6 +20,7 @@
 import fnmatch
 import os
 import re
+import sys
 
 import subprocess
 import ansible.constants as C
@@ -238,6 +239,8 @@ class Inventory(object):
     def implicit_localhost(self):
         if self._implicit_localhost is None:
             self._implicit_localhost = Host(name='localhost')
+            self._implicit_localhost.set_variable('ansible_connection', 'local')
+            self._implicit_localhost.set_variable('ansible_python_interpreter', sys.executable)
         return self._implicit_localhost
 
     def _host_match(self, host_name, pattern):

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -40,7 +40,7 @@ class Inventory(object):
 
     __slots__ = [ 'host_list', 'groups', '_restriction', '_also_restriction', '_subset', 
                   'parser', '_vars_per_host', '_vars_per_group', '_hosts_cache', '_groups_list',
-                  '_vars_plugins', '_playbook_basedir']
+                  '_vars_plugins', '_playbook_basedir', '_implicit_localhost']
 
     def __init__(self, host_list=C.DEFAULT_HOST_LIST):
 
@@ -66,6 +66,9 @@ class Inventory(object):
         self._restriction = None
         self._also_restriction = None
         self._subset = None
+
+        # to avoid having localhost explicitly in inventory (see #3129)
+        self._implicit_localhost = None
 
         if isinstance(host_list, basestring):
             if "," in host_list:
@@ -117,7 +120,7 @@ class Inventory(object):
         else:
             return any(fnmatch.fnmatch(str, pattern_str) for str in strs)
 
-    def get_hosts(self, pattern="all"):
+    def get_hosts(self, pattern='all', full=False):
         """ 
         find all host names matching a pattern string, taking into account any inventory restrictions or
         applied subsets.
@@ -127,11 +130,11 @@ class Inventory(object):
         if isinstance(pattern, list):
             pattern = ';'.join(pattern)
         patterns = pattern.replace(";",":").split(":")
-        hosts = self._get_hosts(patterns)
+        hosts = self._get_hosts(patterns, full)
 
         # exclude hosts not in a subset, if defined
         if self._subset:
-            subset = self._get_hosts(self._subset)
+            subset = self._get_hosts(self._subset, full)
             hosts.intersection_update(subset)
 
         # exclude hosts mentioned in any restriction (ex: failed hosts)
@@ -142,7 +145,7 @@ class Inventory(object):
 
         return sorted(hosts, key=lambda x: x.name)
 
-    def _get_hosts(self, patterns):
+    def _get_hosts(self, patterns, full=False):
         """
         finds hosts that match a list of patterns. Handles negative
         matches as well as intersection matches.
@@ -173,23 +176,23 @@ class Inventory(object):
         for p in patterns:
             if p.startswith("!"):
                 # Discard excluded hosts
-                hosts.difference_update(self.__get_hosts(p))
+                hosts.difference_update(self.__get_hosts(p, full))
             elif p.startswith("&"):
                 # Only leave the intersected hosts
-                hosts.intersection_update(self.__get_hosts(p))
+                hosts.intersection_update(self.__get_hosts(p, full))
             else:
                 # Get all hosts from both patterns
-                hosts.update(self.__get_hosts(p))
+                hosts.update(self.__get_hosts(p, full))
         return hosts
 
-    def __get_hosts(self, pattern):
+    def __get_hosts(self, pattern, full=False):
         """ 
         finds hosts that postively match a particular pattern.  Does not
         take into account negative matches.
         """
 
         (name, enumeration_details) = self._enumeration_info(pattern)
-        hpat = self._hosts_in_unenumerated_pattern(name)
+        hpat = self._hosts_in_unenumerated_pattern(name, full)
         hpat = sorted(hpat, key=lambda x: x.name)
 
         return set(self._apply_ranges(pattern, hpat))
@@ -232,6 +235,11 @@ class Inventory(object):
         enumerated = [ h for (i,h) in enumerated if i>=left and i<=right ]
         return enumerated
 
+    def implicit_localhost(self):
+        if self._implicit_localhost is None:
+            self._implicit_localhost = Host(name='localhost')
+        return self._implicit_localhost
+
     def _host_match(self, host_name, pattern):
         if host_name in LOCALHOST_ALIASES:
             return self._match(LOCALHOST_ALIASES, pattern)
@@ -239,7 +247,7 @@ class Inventory(object):
             return self._match([host_name], pattern)
 
     # TODO: cache this logic so if called a second time the result is not recalculated
-    def _hosts_in_unenumerated_pattern(self, pattern):
+    def _hosts_in_unenumerated_pattern(self, pattern, full=False):
         """ Get all host names matching the pattern """
 
         hosts = {}
@@ -251,6 +259,12 @@ class Inventory(object):
             for host in group.get_hosts():
                 if pattern == 'all' or self._host_match(group.name, pattern) or self._host_match(host.name, pattern):
                     hosts[host.name] = host
+
+        if pattern in LOCALHOST_ALIASES and not hosts:
+            hosts['localhost'] = self.implicit_localhost()
+        elif pattern == 'all' and full and 'localhost' not in hosts:
+            hosts['localhost'] = self.implicit_localhost()
+
         return sorted(hosts.values(), key=lambda x: x.name)
 
     def groups_for_host(self, host):
@@ -338,8 +352,8 @@ class Inventory(object):
         self.groups.append(group)
         self._groups_list = None  # invalidate internal cache 
 
-    def list_hosts(self, pattern="all"):
-        return [ h.name for h in self.get_hosts(pattern) ]
+    def list_hosts(self, pattern='all', full=False):
+        return [ h.name for h in self.get_hosts(pattern, full) ]
 
     def list_groups(self):
         return sorted([ g.name for g in self.groups ], key=lambda x: x)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -291,7 +291,7 @@ class PlayBook(object):
     def _list_available_hosts(self, *args):
         ''' returns a list of hosts that haven't failed and aren't dark '''
 
-        return [ h for h in self.inventory.list_hosts(*args) if (h not in self.stats.failures) and (h not in self.stats.dark)]
+        return [ h for h in self.inventory.list_hosts(*args, full=True) if (h not in self.stats.failures) and (h not in self.stats.dark)]
 
     # *****************************************************
 

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -16,6 +16,7 @@ class TestInventory(unittest.TestCase):
         self.complex_inventory_file     = os.path.join(self.test_dir, 'complex_hosts')
         self.inventory_script           = os.path.join(self.test_dir, 'inventory_api.py')
         self.inventory_dir              = os.path.join(self.test_dir, 'inventory_dir')
+        self.inventory_with_localhost   = os.path.join(self.test_dir, 'ansible_hosts')
 
         os.chmod(self.inventory_script, 0755)
 
@@ -44,6 +45,9 @@ class TestInventory(unittest.TestCase):
 
     def dir_inventory(self):
         return Inventory(self.inventory_dir)
+
+    def localhost_inventory(self):
+        return Inventory(self.inventory_with_localhost)
 
     all_simple_hosts=['jupiter', 'saturn', 'zeus', 'hera',
             'cerberus001','cerberus002','cerberus003',
@@ -102,6 +106,56 @@ class TestInventory(unittest.TestCase):
                         'cottus99','cottus100',
                         'thor', 'odin', 'loki']
         assert sorted(hosts) == sorted(expected_hosts)
+
+    def test_explicit_localhost(self):
+        inventory = self.localhost_inventory()
+        hosts = inventory.list_hosts("localhost")
+
+        self.assertEqual(hosts, ['localhost'])
+
+    def test_explicit_localhost_all(self):
+        inventory = self.localhost_inventory()
+        hosts = inventory.list_hosts("all")
+
+        self.assertEqual(hosts, ['localhost'])
+
+    def test_implicit_localhost(self):
+        inventory = self.simple_inventory()
+        hosts = inventory.list_hosts("localhost")
+
+        self.assertEqual(hosts, ['localhost'])
+
+    def test_implicit_localhost_instance(self):
+        inventory = self.simple_inventory()
+        host1 = inventory.get_hosts("localhost")[0]
+        host2 = inventory.get_hosts("localhost")[0]
+
+        assert host1 is host2
+
+    def test_implicit_localhost_all(self):
+        inventory = self.simple_inventory()
+        hosts = inventory.list_hosts("all")
+
+        assert 'localhost' not in hosts
+
+    def test_implicit_localhost_full(self):
+        inventory = self.simple_inventory()
+        # used in PlayBook._list_available_hosts
+        hosts = inventory.list_hosts("all", full=True)
+
+        assert 'localhost' in hosts
+
+    def test_implicit_localhost_ungrouped(self):
+        inventory = self.simple_inventory()
+        hosts = inventory.list_hosts("ungrouped")
+
+        assert 'localhost' not in hosts
+
+    def test_implicit_localhost_ungrouped_full(self):
+        inventory = self.simple_inventory()
+        hosts = inventory.list_hosts("ungrouped")
+
+        assert 'localhost' not in hosts
 
     def test_simple_restrict(self):
         inventory = self.simple_inventory()


### PR DESCRIPTION
This fixes issue #3129, which means ansible no longer requires explicit localhost in inventory files.

localhost and 127.0.0.1 should now always be one and the same host (an improvement upon 20bf5f130d67b5f75f925d9084c39d7f4882de28 as detailed in commit message).

Implicitly created localhost defaults to local connection using the same python executable as the currently running one, which is usually The Right Thing (e.g. uses the right virtualenv).
