### PR TITLE
Fix potential deadlocking usage of subprocess.Popen

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -929,10 +929,9 @@ class AnsibleModule(object):
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
             if data:
-                cmd.stdin.write(data)
                 if not binary_data:
-                    cmd.stdin.write('\\n')
-            out, err = cmd.communicate()
+                  data += '\\n'
+            out, err = cmd.communicate(input=data)
             rc = cmd.returncode
         except (OSError, IOError), e:
             self.fail_json(rc=e.errno, msg=str(e), cmd=args)


### PR DESCRIPTION
Documented, albeit subtle, gotcha of Popen objects is that you should
not feed input to the process if it's possible for the process to get
blocked waiting on stdout/stderr writing.  On linux this is only possible
if stdout/stderr wrote something like more than 64k without finishing consuming
stdin.

Either way, it's an obvious fix w/out any risks; thus sorting it.

See http://docs.python.org/2/library/subprocess.html#subprocess.Popen.kill ; the details are in the doc descriptions for stdin/stdout/stderr (that follow that anchor, specifically).
