### PR TITLE
Avoid duplicates of the 'all' group when using inventory script.

### DIFF
--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -72,7 +72,10 @@ class InventoryScript(object):
                     self.host_vars_from_top = data['hostvars']
                     continue
 
-            group = groups[group_name] = Group(group_name)
+            if group_name != all.name:
+                group = groups[group_name] = Group(group_name)
+            else:
+                group = all
             host = None
 
             if not isinstance(data, dict):


### PR DESCRIPTION
Do not recreate an 'all' group when it is in the inventory script's
output, but use the one created upfront.
