### PR TITLE
fix debian release version

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,4 +1,4 @@
-ansible (1.3.1) unstable; urgency=low
+ansible (1.3) unstable; urgency=low
 
   * 1.3 release (PENDING)
  


### PR DESCRIPTION
The version for the Debian package is 1.3.1, prolly a typo.
