### PR TITLE
ec2 inventory plugin: Make it possible to group instances based off the expansion of the comma-seperated values of specified instance tags

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -45,5 +45,20 @@ cache_path = /tmp
 # seconds, a new API call will be made, and the cache file will be updated.
 cache_max_age = 300
 
-
-
+# For each instance tag name listed, if the value of the tag is a 
+# comma-delimited string, the string will be expanded and a new group will
+# be created for each sub-value in the expanded string.
+# Example:
+#   Say we have a tag that looks like:
+#     roles = "www, frontend"
+#
+#   If expanded_tag_names contains 'roles', then the instance will be added
+#   to the following groups:
+#
+#   tag_roles_www
+#   tag_roles_frontend
+#
+#  Expand values for tags named 'roles' and 'envs':
+#     expanded_tag_names = roles, envs
+#
+expanded_tag_names =

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -210,6 +210,11 @@ class Ec2Inventory(object):
         self.cache_path_index = cache_path + "/ansible-ec2.index"
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
         
+        # Tag value expansion
+        if config.has_option('ec2', 'expanded_tag_names'):
+            self.expanded_tag_names = map(str.strip, config.get('ec2', 'expanded_tag_names').split(','))
+        else:
+            self.expanded_tag_names = []
 
 
     def parse_cli_args(self):
@@ -346,8 +351,15 @@ class Ec2Inventory(object):
 
         # Inventory: Group by tag keys
         for k, v in instance.tags.iteritems():
-            key = self.to_safe("tag_" + k + "=" + v)
-            self.push(self.inventory, key, dest)
+            prefix = self.to_safe('tag_' + k)
+            if k in self.expanded_tag_names and v and len(v.split(',')) > 1:
+                values = map(lambda x: x.strip(), v.split(','))
+                for val in values:
+                    key = self.to_safe(prefix + '=' + val)
+                    self.push(self.inventory, key, dest)
+            else:  
+                key = self.to_safe(prefix + "=" + v)
+                self.push(self.inventory, key, dest)
 
 
     def add_rds_instance(self, instance, region):


### PR DESCRIPTION
In AWS, instance tags are unique and you cannot have multiple tags with the same name.

But there are situations where you'd like multiple values for a particular tag name, and as such, you'd end up setting the value to be a comma-seperated string.

This change adds the ability to group instances based off the expansion of comma-seperated lists for a set of tag names you specify.

For example, if you had 2 tags set like this on an instance:
roles = "www, db, frontend"
environments = "production, secure"

...and you set the 'expanded_tag_names'  setting to "roles, environments", then after this change, the ec2 inventory script would create 5 additional tag groups:

tag_roles_www
tag_roles_db
tag_roles_frontend
tag_environments_production
tag_environments_secure
