### PR TITLE
ec2 inventory script: Add a global group for both EC2 and RDS instances when listing inventory using the EC2 plugin

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -349,6 +349,9 @@ class Ec2Inventory(object):
             key = self.to_safe("tag_" + k + "=" + v)
             self.push(self.inventory, key, dest)
 
+        # Global Tag: tag all EC2 instances
+        self.push(self.inventory, 'ec2', dest)
+
 
     def add_rds_instance(self, instance, region):
         ''' Adds an RDS instance to the inventory and index, as long as it is
@@ -399,6 +402,9 @@ class Ec2Inventory(object):
 
         # Inventory: Group by parameter group
         self.push(self.inventory, self.to_safe("rds_parameter_group_" + instance.parameter_group.name), dest)
+
+        # Global Tag: all RDS instances
+        self.push(self.inventory, 'rds', dest)
 
 
     def get_host_info(self):


### PR DESCRIPTION
When using the EC2 inventory plugin in an inventory that is fed by multiple sources (plugins, host file, etc.), it's hard to identify which hosts come from the EC2 inventory because there is no unified grouping that identifies EC2 or RDS instances; they are only tagged based off the attributes that each instance possesses (ie., security group, instance tags, region, etc.)

This change adds 2 global groups: 
- all EC2 instances will appear in an 'ec2' group
- all RDS instances in an 'rds' group.

In this way, it's much easier to identify and perform actions to only EC2 or RDS instances because there is now a consistent tag for all hosts of that type.
