### PR TITLE
Added -f/--force option to ansible-pull

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -103,6 +103,10 @@ def main(args):
                       help='purge checkout after playbook run')
     parser.add_option('-o', '--only-if-changed', dest='ifchanged', default=False, action='store_true',
                       help='only run the playbook if the repository has been updated')
+    parser.add_option('-f', '--force', dest='force', default=False,
+                      action='store_true',
+                      help='run the playbook even if the repository could '
+                           'not be updated')
     parser.add_option('-d', '--directory', dest='dest', default=None,
                       help='directory to checkout repository to')
     parser.add_option('-U', '--url', dest='url', default=None,
@@ -146,7 +150,11 @@ def main(args):
             )
     rc, out = _run(cmd)
     if rc != 0:
-        return rc
+        if options.force:
+            print("Unable to update repository.  Continuing with (forced) "
+                  "run of playbook.")
+        else:
+            return rc
     elif options.ifchanged and '"changed": true' not in out:
         print "Repository has not changed, quitting."
         return 0

--- a/docs/man/man1/ansible-pull.1.asciidoc.in
+++ b/docs/man/man1/ansible-pull.1.asciidoc.in
@@ -63,6 +63,12 @@ URL of the playbook repository to checkout.
 Branch/Tag/Commit to checkout.  If not provided, uses default behavior
 of module used to check out playbook repository.
 
+*-f*, *--force*::
+
+Force running of playbook even if unable to update playbook repository.  This
+can be useful, for example, to enforce run-time state when a network
+connection may not always be up or possible.
+
 *-i* 'PATH', *--inventory=*'PATH'::
 
 The 'PATH' to the inventory hosts file.  This can be a relative path within


### PR DESCRIPTION
I would like to use Ansible for semi-autonomous hosts which may have intermittent network connections.  These hosts are mostly stateless, except for their ansible-pull(ed) playbook repository which resides on a Flash card.  This adds a --force option to ansible-pull so that hosts such as these will run the playbook even if an update of the playbook is not possible.  Without such an option, the hosts may boot and do absolutely nothing useful.  With this option, they can continue doing what they did with their "last known" playbooks.
