### PR TITLE
Ensure duplicate roles are not loaded in the case of a missing meta/main.yml file

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -194,6 +194,8 @@ class Play(object):
                                         continue
                                     else:
                                         self.included_roles.append(dep)
+                        else:
+                            continue
                         dep_vars = utils.combine_vars(passed_vars, dep_vars)
                         dep_vars = utils.combine_vars(role_vars, dep_vars)
                         vars = self._resolve_main(utils.path_dwim(self.basedir, os.path.join(dep_path, 'vars')))


### PR DESCRIPTION
Pull request for https://github.com/ansible/ansible/issues/4017

> I was running into issues with a dependency being included multiple times when i thought the default was to onlyinclude once.
> 
> I had been trying allow_duplicates: false in the top level role but that had no effect. After stepping through the code in a debugger i noticed that it was looking in the dependency role itself for a meta.yml file which was not present. So now for my situation I can get it working.
> 
> However, I wanted to post this issue to see if this is how it is intended.
> 
> It seems to work like the following:
> 
> Top role depends on Base role.
> 
> Base role contains no meta/main.yml => Role can be included many times
> Base role contains empty meta/main.yml => Role only included once.
> Base role contains meta/main.yml with allow_duplicates set => works as expected
