### PR TITLE
Re-add Synchronize (rsync) module (with improvements)

### DIFF
--- a/lib/ansible/runner/action_plugins/synchronize.py
+++ b/lib/ansible/runner/action_plugins/synchronize.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012-2013, Timothy Appnel <tim@appnel.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os.path
+
+from ansible import utils
+from ansible.runner.return_data import ReturnData
+
+class ActionModule(object):
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    def _process_origin(self, host, path, user):
+
+        if not host in ['127.0.0.1', 'localhost']:
+            return '%s@%s:%s' % (user, host, path)
+        else:
+            return path
+
+    def setup(self, module_name, inject):
+        ''' Always default to localhost as delegate if None defined '''
+        if inject.get('delegate_to') is None:
+            inject['delegate_to'] = '127.0.0.1'
+
+    def run(self, conn, tmp, module_name, module_args, 
+        inject, complex_args=None, **kwargs):
+
+        ''' generates params and passes them on to the rsync module '''
+
+        # load up options
+
+        options = {}
+        if complex_args:
+            options.update(complex_args)
+        options.update(utils.parse_kv(module_args))
+
+        src = options.get('src', None)
+        dest = options.get('dest', None)
+
+        try:
+            options['local_rsync_path'] = inject['ansible_rsync_path']
+        except KeyError:
+            pass
+
+        src_host = inject['delegate_to'] 
+        dest_host = inject.get('ansible_ssh_host', inject['inventory_hostname'])
+        if options.get('mode', 'push') == 'pull':
+            (dest_host, src_host) = (src_host, dest_host)
+        if not dest_host is src_host:
+            user = inject.get('ansible_ssh_user',
+                              self.runner.remote_user)
+            private_key = inject.get('ansible_ssh_private_key_file', self.runner.private_key_file)
+            if not private_key is None:
+                options['private_key'] = private_key
+            src = self._process_origin(src_host, src, user)
+            dest = self._process_origin(dest_host, dest, user)
+
+        options['src'] = src
+        options['dest'] = dest
+        if 'mode' in options:
+            del options['mode']
+
+        # run the synchronize module
+
+        self.runner.module_args = ' '.join(['%s=%s' % (k, v) for (k,
+                v) in options.items()])
+        return self.runner._execute_module(conn, tmp, 'synchronize',
+                self.runner.module_args, inject=inject)
+

--- a/lib/ansible/runner/action_plugins/synchronize.py
+++ b/lib/ansible/runner/action_plugins/synchronize.py
@@ -46,7 +46,7 @@ class ActionModule(object):
                 self.runner.sudo = False
                 self.sudo = True
         # Local action mode.
-        elif inject['delegate_to'] == '127.0.0.1':
+        elif inject['delegate_to'] in ['127.0.0.1', 'localhost']:
             self.mode = 'local'
         else:
             self.mode = 'other'
@@ -65,8 +65,6 @@ class ActionModule(object):
 
         src = options.get('src', None)
         dest = options.get('dest', None)
-        src_host = options.get('src_host', None)
-        dest_host = options.get('dest_host', None)
 
         try:
             options['local_rsync_path'] = inject['ansible_rsync_path']
@@ -74,20 +72,18 @@ class ActionModule(object):
             pass
 
         # Determine src_host
-        if src_host is None:
-            if self.mode in ['local', 'remote']:
-                src_host = '127.0.0.1'
-            else:
-                src_host = inject['delegate_to']
+        if self.mode in ['local', 'remote']:
+            src_host = '127.0.0.1'
+        else:
+            src_host = inject['delegate_to']
 
         # Determine dest_host
-        if dest_host is None:
-            if self.mode == 'local':
-                dest_host = '127.0.0.1'
-            elif self.mode == 'remote':
-                dest_host = inject.get('ansible_ssh_host', inject['inventory_hostname'])
-            else:
-                dest_host = inject['delegate_to']
+        if self.mode == 'local':
+            dest_host = '127.0.0.1'
+        elif self.mode == 'remote':
+            dest_host = inject.get('ansible_ssh_host', inject['inventory_hostname'])
+        else:
+            dest_host = inject['delegate_to']
 
         if options.get('mode', 'push') == 'pull':
             (dest_host, src_host) = (src_host, dest_host)
@@ -105,11 +101,6 @@ class ActionModule(object):
         options['dest'] = dest
         if 'mode' in options:
             del options['mode']
-
-        if 'src_host' in options:
-            del options['src_host']
-        if 'dest_host' in options:
-            del options['dest_host']
 
         rsync_path = options.get('rsync_path', None)
 

--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -1,0 +1,144 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012-2013, Timothy Appnel <tim@appnel.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+
+DOCUMENTATION = '''
+---
+module: synchronize
+version_added: "1.3"
+short_description: Uses rsync to make synchronizing file paths in your playbooks quick and easy.
+description:
+    - This is a wrapper around rsync. Of course you could just use the command action to call rsync yourself, but you also have to add a fair number of boilerplate options and host facts. You still may need to call rsync directly via C(command) or C(shell) depending on your use case. The synchronize action is meant to do common things with C(rsync) easily. It does not provide access to the full power of rsync, but does make most invocations easier to follow.
+options:
+  src:
+    description:
+      - Path on the source machine that will be synchronized to the destination; The path can be absolute or relative.
+    required: true
+  dest:
+    description:
+      - Path on the destination machine that will be synchronized from the source; The path can be absolute or relative.
+    required: true
+  mode:
+    description:
+      - Specify the direction of the synchroniztion. In push mode the localhost or delgate is the  source; In pull mode the remote host in context is the source.
+    required: false
+    choices: [ 'push', 'pull' ]
+    default: 'push'
+  verbosity:
+    description:
+      - An integer controlling the amount of information returned during processing. See the C(-v, --verbose) option of the rsync man page for details. If verbosity is not defined or a value of 0 is assumed, the C(--quiet) option is passed and information is supressed.
+    required: false
+    default: 0
+  delete:
+    description:
+      - Delete files that don't exist (after transfer, not before) in the C(src) path.
+    choices: [ 'yes', 'no' ]
+    default: 'no'
+    required: false
+  rsync_path:
+    description:
+      - Specify the rsync command to run on the remote machine. See C(--rsync-path) on the rsync man page.
+    required: false
+author: Timothy Appnel
+'''
+
+EXAMPLES = '''
+# Synchronization of src on the control machien to dest on the remote hosts
+synchronize: src=some/relative/path dest=/some/absolute/path
+
+# Synchronization of two paths both on the control machine
+local_action: synchronize src=some/relative/path dest=/some/absolute/path
+
+# Synchronization of src on the inventory host to the dest on the localhost in
+pull mode
+synchronize: mode=pull src=some/relative/path dest=/some/absolute/path
+
+# Synchronization of src on delegate host to dest on the current inventory host
+synchronize: >
+    src=some/relative/path dest=/some/absolute/path
+    delegate_to: delegate.host
+
+# Synchronize and delete files in dest on the remote host that are not found in src of localhost.
+synchronize: src=some/relative/path dest=/some/absolute/path delete=yes
+
+# Synchronize and return verbose information from the rsync transfer.
+synchronize: src=some/relative/path dest=/some/absolute/path verbosity=1
+
+# Synchronize using an alternate rsync command
+synchronize: src=some/relative/path dest=/some/absolute/path rsync_path="sudo rsync"
+'''
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            src = dict(required=True),
+            dest = dict(required=True),
+            verbosity = dict(default=0),
+            tmp_dir = dict(default=None),
+            delete = dict(default='no', type='bool'),
+            private_key = dict(default=None),
+            rsync_path = dict(default=None),
+        )
+    )
+
+    source = module.params['src']
+    dest = module.params['dest']
+    verbosity = module.params['verbosity']
+    delete = module.params['delete']
+    private_key = module.params['private_key']
+    rsync_path = module.params['rsync_path']
+    rsync = module.params.get('local_rsync_path', 'rsync')
+    temp = os.path.dirname(os.path.realpath(__file__))
+
+    cmd = '%s --archive --delay-updates --compress' % rsync
+    if verbosity:
+        cmd = '%s -%s' % (cmd, 'v' * int(verbosity))
+    else:
+        cmd = cmd + ' --quiet'
+    if temp:
+        cmd = cmd + ' --temp-dir ' + temp
+    if delete:
+        cmd = cmd + ' --delete-after'
+    if private_key is None:
+        private_key = ''
+    else:
+        private_key = '-i '+ private_key 
+    cmd = cmd + " --rsh '%s %s -o %s'" % ('ssh', private_key,
+                'StrictHostKeyChecking=no')  # need ssh param
+    if rsync_path:
+        cmd = cmd + ' --rsync-path ' + rsync_path
+
+    cmd = ' '.join([cmd, source, dest])
+    cmdstr = cmd
+    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                           stderr=subprocess.PIPE)
+    (out, err) = cmd.communicate()
+    if cmd.returncode:
+        return module.fail_json(msg=err, rc=cmd.returncode, cmd=cmdstr)
+    else:
+        return module.exit_json(changed=True, msg=out,
+                                rc=cmd.returncode, cmd=cmdstr)
+
+
+# include magic from lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+
+main()
+

--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -45,9 +45,57 @@ options:
       - An integer controlling the amount of information returned during processing. See the C(-v, --verbose) option of the rsync man page for details. If verbosity is not defined or a value of 0 is assumed, the C(--quiet) option is passed and information is supressed.
     required: false
     default: 0
+  recursive:
+    description:
+      - Recurse into directories.
+    choices: [ 'yes', 'no' ]
+    default: 'yes'
+    required: false
+  links:
+    description:
+      - Copy symlinks as symlinks.
+    choices: [ 'yes', 'no' ]
+    default: 'yes'
+    required: false
+  perms:
+    description:
+      - Preserve permissions.
+    choices: [ 'yes', 'no' ]
+    default: 'yes'
+    required: false
+  times:
+    description:
+      - Preserve modification times
+    choices: [ 'yes', 'no' ]
+    default: 'yes'
+    required: false
+  owner:
+    description:
+      - Preserve owner (super user only)
+    choices: [ 'yes', 'no' ]
+    default: 'no'
+    required: false
+  group:
+    description:
+      - Preserve group
+    choices: [ 'yes', 'no' ]
+    default: 'no'
+    required: false
+  archive:
+    description:
+      - Mirrors the rsync archive flag, enables recursive, links, perms, times, owner, group flags and -D.
+    choices: [ 'yes', 'no' ]
+    default: 'no'
+    required: false
   delete:
     description:
       - Delete files that don't exist (after transfer, not before) in the C(src) path.
+    choices: [ 'yes', 'no' ]
+    default: 'no'
+    required: false
+  dry_run:
+    description:
+      - Perform a trial run with no changes made.
     choices: [ 'yes', 'no' ]
     default: 'no'
     required: false
@@ -55,7 +103,7 @@ options:
     description:
       - Specify the rsync command to run on the remote machine. See C(--rsync-path) on the rsync man page.
     required: false
-author: Timothy Appnel
+author: Timothy Appnel / Ben Osman
 '''
 
 EXAMPLES = '''
@@ -92,6 +140,14 @@ def main():
             dest = dict(required=True),
             verbosity = dict(default=0),
             tmp_dir = dict(default=None),
+            recursive = dict(default='yes', type='bool'),
+            links = dict(default='yes', type='bool'),
+            perms = dict(default='yes', type='bool'),
+            times = dict(default='yes', type='bool'),
+            owner = dict(default='no', type='bool'),
+            group = dict(default='no', type='bool'),
+            archive = dict(default='no', type='bool'),
+            dry_run = dict(default='no', type='bool'),
             delete = dict(default='no', type='bool'),
             private_key = dict(default=None),
             rsync_path = dict(default=None),
@@ -101,40 +157,63 @@ def main():
     source = module.params['src']
     dest = module.params['dest']
     verbosity = module.params['verbosity']
+    recursive = module.params['recursive']
+    links = module.params['links']
+    perms = module.params['perms']
+    times = module.params['times']
+    owner = module.params['owner']
+    group = module.params['group']
+    archive = module.params['archive']
     delete = module.params['delete']
+    dry_run = module.params['dry_run']
     private_key = module.params['private_key']
     rsync_path = module.params['rsync_path']
     rsync = module.params.get('local_rsync_path', 'rsync')
-    temp = os.path.dirname(os.path.realpath(__file__))
+    temp =  module.params['tmp_dir']
 
-    cmd = '%s --archive --delay-updates --compress' % rsync
+    cmd = '%s --delay-updates --compress' % rsync
     if verbosity:
         cmd = '%s -%s' % (cmd, 'v' * int(verbosity))
-    else:
-        cmd = cmd + ' --quiet'
     if temp:
-        cmd = cmd + ' --temp-dir ' + temp
+        cmd += ' --temp-dir ' + temp
+    if archive:
+        cmd += ' --archive '
+    else:
+        if recursive:
+            cmd += ' -recursive'
+        if links:
+            cmd += ' --links'
+        if perms:
+            cmd += ' --perms'
+        if times:
+            cmd += ' --times'
+        if owner:
+            cmd += ' -owner'
+        if group:
+            cmd += ' -group'
     if delete:
-        cmd = cmd + ' --delete-after'
+        cmd +=  ' --delete-after'
+    if dry_run:
+        cmd +=  ' --dry-run'
     if private_key is None:
         private_key = ''
     else:
-        private_key = '-i '+ private_key 
-    cmd = cmd + " --rsh '%s %s -o %s'" % ('ssh', private_key,
+        private_key = '-i '+ private_key
+    cmd += " --rsh '%s %s -o %s'" % ('ssh', private_key,
                 'StrictHostKeyChecking=no')  # need ssh param
+    cmd += " --out-format='<changes>%i %n%L'"
     if rsync_path:
-        cmd = cmd + ' --rsync-path ' + rsync_path
+        cmd += " --rsync-path '%s'" %(rsync_path)
 
     cmd = ' '.join([cmd, source, dest])
     cmdstr = cmd
-    cmd = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE)
-    (out, err) = cmd.communicate()
-    if cmd.returncode:
-        return module.fail_json(msg=err, rc=cmd.returncode, cmd=cmdstr)
+    (rc, out, err) = module.run_command(cmd)
+    if rc:
+        return module.fail_json(msg=err, rc=rc, cmd=cmdstr)
     else:
-        return module.exit_json(changed=True, msg=out,
-                                rc=cmd.returncode, cmd=cmdstr)
+        changed =  '<changes>' in out
+        return module.exit_json(changed=changed, msg=out,
+                                rc=rc, cmd=cmdstr)
 
 
 # include magic from lib/ansible/module_common.py

--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -51,6 +51,12 @@ options:
     choices: [ 'yes', 'no' ]
     default: 'yes'
     required: false
+  dirs:
+    description:
+      - Transfer directories without recursing
+    choices: [ 'yes', 'no' ]
+    default: 'no'
+    required: false
   links:
     description:
       - Copy symlinks as symlinks.
@@ -90,12 +96,6 @@ options:
   delete:
     description:
       - Delete files that don't exist (after transfer, not before) in the C(src) path.
-    choices: [ 'yes', 'no' ]
-    default: 'no'
-    required: false
-  dry_run:
-    description:
-      - Perform a trial run with no changes made.
     choices: [ 'yes', 'no' ]
     default: 'no'
     required: false
@@ -139,25 +139,26 @@ def main():
             src = dict(required=True),
             dest = dict(required=True),
             verbosity = dict(default=0),
-            tmp_dir = dict(default=None),
             recursive = dict(default='yes', type='bool'),
+            dirs  = dict(default='no', type='bool'),
             links = dict(default='yes', type='bool'),
             perms = dict(default='yes', type='bool'),
             times = dict(default='yes', type='bool'),
             owner = dict(default='no', type='bool'),
             group = dict(default='no', type='bool'),
             archive = dict(default='no', type='bool'),
-            dry_run = dict(default='no', type='bool'),
             delete = dict(default='no', type='bool'),
             private_key = dict(default=None),
             rsync_path = dict(default=None),
-        )
+        ),
+        supports_check_mode=True
     )
 
     source = module.params['src']
     dest = module.params['dest']
     verbosity = module.params['verbosity']
     recursive = module.params['recursive']
+    dirs  = module.params['dirs']
     links = module.params['links']
     perms = module.params['perms']
     times = module.params['times']
@@ -165,22 +166,20 @@ def main():
     group = module.params['group']
     archive = module.params['archive']
     delete = module.params['delete']
-    dry_run = module.params['dry_run']
     private_key = module.params['private_key']
     rsync_path = module.params['rsync_path']
     rsync = module.params.get('local_rsync_path', 'rsync')
-    temp =  module.params['tmp_dir']
 
     cmd = '%s --delay-updates --compress' % rsync
     if verbosity:
         cmd = '%s -%s' % (cmd, 'v' * int(verbosity))
-    if temp:
-        cmd += ' --temp-dir ' + temp
     if archive:
         cmd += ' --archive '
     else:
         if recursive:
-            cmd += ' -recursive'
+            cmd += ' --recursive'
+        if dirs:
+            cmd += ' --dirs'
         if links:
             cmd += ' --links'
         if perms:
@@ -188,12 +187,15 @@ def main():
         if times:
             cmd += ' --times'
         if owner:
-            cmd += ' -owner'
+            cmd += ' --owner'
         if group:
-            cmd += ' -group'
+            cmd += ' --group'
     if delete:
-        cmd +=  ' --delete-after'
-    if dry_run:
+        if recursive or dirs or archive:
+            cmd +=  ' --delete-after'
+        else:
+            module.fail_json(msg='delete parameter requires one of recursive, dirs or archive parameters to be enabled.')
+    if module.check_mode:
         cmd +=  ' --dry-run'
     if private_key is None:
         private_key = ''
@@ -201,7 +203,8 @@ def main():
         private_key = '-i '+ private_key
     cmd += " --rsh '%s %s -o %s'" % ('ssh', private_key,
                 'StrictHostKeyChecking=no')  # need ssh param
-    cmd += " --out-format='<changes>%i %n%L'"
+    changed_marker = '<<changed>>'
+    cmd += " --out-format='" + changed_marker + "%i %n%L'"
     if rsync_path:
         cmd += " --rsync-path '%s'" %(rsync_path)
 
@@ -211,8 +214,8 @@ def main():
     if rc:
         return module.fail_json(msg=err, rc=rc, cmd=cmdstr)
     else:
-        changed =  '<changes>' in out
-        return module.exit_json(changed=changed, msg=out,
+        changed = changed_marker in out
+        return module.exit_json(changed=changed, msg=out.replace(changed_marker,''),
                                 rc=rc, cmd=cmdstr)
 
 


### PR DESCRIPTION
There has been a discussion of the ansible group about problems with the synchronize module which was removed.

https://groups.google.com/d/msg/ansible-project/DTIjx8aAo_4/wTVHAiOAwhYJ

The first commit restores the code from the initial pull request: https://github.com/ansible/ansible/pull/3173

The second commit includes my changes which:
- Attempt to fix the issues in the linked topic: Namely it doesn't work well on the localhost. The reason for this is that in the setup function it was force adding the delegate_to option but was not setting the transport method. This meant that ansible tried to ssh into localhost, which may work on some systems, but for many it doesn't. I used inject['ansible_connection'] = 'local'  to remedy this situation.
- Improved the src and dest handling, and introduced a mode variable for the class. This attempts to determine the mode that the action is being run in. It even takes care of using sudo.
  - The default is remote mode, and operates like copy action, where the src is a local filepath and dest is a remote filepath (if no hosts are specified).
  - If run using local_action or delegate_to is set to 127.0.0.1, then this is local mode. If no hosts are set in src and dest parameters then local filepaths are assumed.
  - If delegate_to is another host, then other mode is used, which uses filepaths on the specified host.
- Added a whole load of extra parameters based on rsync flags, and changed the default behaviour of using the -archive flag, which i found inconvenient as it keeps the owners of files the same as on the local system which if that user doesn't exist on the host then its not ideal. 
- Added change detection - now the response is parsed to determine whether there were any changes or not. Also added dry_run parameter which can be combined with change detection to test first whether there are changes.

I've been testing this for a few days, but would really welcome some further testing.
