### PR TITLE
Support using paramiko to set up accelerate connection

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -185,6 +185,7 @@ class Runner(object):
         self.accelerate       = accelerate
         self.accelerate_port  = accelerate_port
         self.callbacks.runner = self
+        self.original_transport = self.transport
 
         if self.accelerate:
             # if we're using accelerated mode, force the local

--- a/lib/ansible/runner/connection_plugins/accelerate.py
+++ b/lib/ansible/runner/connection_plugins/accelerate.py
@@ -23,6 +23,7 @@ import struct
 import time
 from ansible.callbacks import vvv
 from ansible.runner.connection_plugins.ssh import Connection as SSHConnection
+from ansible.runner.connection_plugins.paramiko_ssh import Connection as ParamikoConnection
 from ansible import utils
 from ansible import errors
 from ansible import constants
@@ -49,14 +50,24 @@ class Connection(object):
         self.fbport = port[1]
         self.is_connected = False
 
-        self.ssh = SSHConnection(
-            runner=self.runner,
-            host=self.host, 
-            port=self.port, 
-            user=self.user, 
-            password=password, 
-            private_key_file=private_key_file
-        )
+        if self.runner.original_transport == "paramiko":
+            self.ssh = ParamikoConnection(
+                runner=self.runner,
+                host=self.host,
+                port=self.port,
+                user=self.user,
+                password=password,
+                private_key_file=private_key_file
+            )
+        else:
+            self.ssh = SSHConnection(
+                runner=self.runner,
+                host=self.host,
+                port=self.port,
+                user=self.user,
+                password=password,
+                private_key_file=private_key_file
+            )
 
         # attempt to work around shared-memory funness
         if getattr(self.runner, 'aes_keys', None):


### PR DESCRIPTION
Adds original_transport attribute to Runner to track what the original
transport was before it is changed to 'accelerate'.
If using paramiko in original_transport, uses ParamikoConnection.  If
not, falls back to SSHConnection like before.

See issue #4022.
