### PR TITLE
fix get_db_info in postgresql_db

### DIFF
--- a/library/database/postgresql_db
+++ b/library/database/postgresql_db
@@ -130,10 +130,10 @@ def get_encoding_id(cursor, encoding):
 
 def get_db_info(cursor, db):
     query = """
-    SELECT usename AS owner,
+    SELECT rolname AS owner,
     pg_encoding_to_char(encoding) AS encoding, encoding AS encoding_id,
     datcollate AS lc_collate, datctype AS lc_ctype
-    FROM pg_database JOIN pg_user ON pg_user.usesysid = pg_database.datdba
+    FROM pg_database JOIN pg_roles ON pg_roles.oid = pg_database.datdba
     WHERE datname = %(db)s
     """
     cursor.execute(query, {'db':db})


### PR DESCRIPTION
using pg_roles instead of pg_user
if database owner is a role (not user) then it can not select form pg_user table.
