### PR TITLE
Add crypt scheme to htpasswd params

### DIFF
--- a/library/web_infrastructure/htpasswd
+++ b/library/web_infrastructure/htpasswd
@@ -40,6 +40,11 @@ options:
     description:
       - Password associated with user.
       - Must be specified if user does not exist yet
+  crypt_scheme:
+    required: false
+    default: "apr_md5_crypt"
+    description:
+      - Encryption scheme to be used. One of: "apr_md5_crypt", "des_crypt", "ldap_sha1" or "plaintext"
   state:
     required: false
     choices: [ present, absent ]
@@ -82,7 +87,7 @@ def create_missing_directories(dest):
         os.makedirs(destpath)
 
 
-def present(dest, username, password, create, check_mode):
+def present(dest, username, password, crypt_scheme, create, check_mode):
     """ Ensures user is present
 
     Returns (msg, changed) """
@@ -93,13 +98,13 @@ def present(dest, username, password, create, check_mode):
             return ("Create %s" % dest, True)
         create_missing_directories(dest)
         try:
-            ht = HtpasswdFile(dest, new=True)
+            ht = HtpasswdFile(dest, new=True, default_scheme=crypt_scheme)
         except:
             # library version doesn't take 'new', deal with it.
             fh = open(dest, 'w')
             fh.write('')
             fh.close()
-            ht = HtpasswdFile(dest)
+            ht = HtpasswdFile(dest, default_scheme=crypt_scheme)
         if getattr(ht, 'set_password', None):
             ht.set_password(username, password)
         else:
@@ -108,10 +113,10 @@ def present(dest, username, password, create, check_mode):
         return ("Created %s and added %s" % (dest, username), True)
     else:
         try:
-            ht = HtpasswdFile(dest, new=False)
+            ht = HtpasswdFile(dest, new=False, default_scheme=crypt_scheme)
         except:
-            ht = HtpasswdFile(dest)
- 
+            ht = HtpasswdFile(dest, default_scheme=crypt_scheme)
+
         found = None
         if getattr(ht, 'check_password', None):
             found = ht.check_password(username, password)
@@ -169,6 +174,7 @@ def main():
         path=dict(required=True, aliases=["dest", "destfile"]),
         name=dict(required=True, aliases=["username"]),
         password=dict(required=False, default=None),
+        crypt_scheme=dict(required=False, default=None),
         state=dict(required=False, default="present"),
         create=dict(type='bool', choices=BOOLEANS, default='yes'),
 
@@ -180,6 +186,7 @@ def main():
     path = module.params['path']
     username = module.params['name']
     password = module.params['password']
+    crypt_scheme = module.params['crypt_scheme']
     state = module.params['state']
     create = module.params['create']
     check_mode = module.check_mode
@@ -189,7 +196,7 @@ def main():
 
     try:
         if state == 'present':
-            (msg, changed) = present(path, username, password, create, check_mode)
+            (msg, changed) = present(path, username, password, crypt_scheme, create, check_mode)
         elif state == 'absent':
             (msg, changed) = absent(path, username, check_mode)
         else:


### PR DESCRIPTION
We're using htpasswd to generate a password file for VSFTPD which does not support md5 encryption.

So I've added a param to choose the encryption scheme to use.

This patch is backward compatible and fairly straightforward.
