### PR TITLE
Add option to specify the MySQL server port

### DIFF
--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -48,6 +48,11 @@ options:
       - Host running the database
     required: false
     default: localhost
+  login_port:
+    description:
+      - Port of the MySQL server
+    required: false
+    default: 3306
   login_unix_socket:
     description:
       - The path to a Unix domain socket for local connections
@@ -197,6 +202,7 @@ def main():
             login_user=dict(default=None),
             login_password=dict(default=None),
             login_host=dict(default="localhost"),
+            login_port=dict(default="3306"),
             login_unix_socket=dict(default=None),
             db=dict(required=True, aliases=['name']),
             encoding=dict(default=""),
@@ -242,7 +248,7 @@ def main():
         if module.params["login_unix_socket"]:
             db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db=connect_to_db)
         else:
-            db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db=connect_to_db)
+            db_connection = MySQLdb.connect(host=module.params["login_host"], port=int(module.params["login_port"]), user=login_user, passwd=login_password, db=connect_to_db)
         cursor = db_connection.cursor()
     except Exception, e:
         module.fail_json(msg="unable to connect, check login_user and login_password are correct, or alternatively check ~/.my.cnf contains credentials")

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -56,6 +56,11 @@ options:
       - Host running the database
     required: false
     default: localhost
+  login_port:
+    description:
+      - Port of the MySQL server
+    required: false
+    default: 3306
   login_unix_socket:
     description:
       - The path to a Unix domain socket for local connections
@@ -326,7 +331,7 @@ def connect(module, login_user, login_password):
     if module.params["login_unix_socket"]:
         db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db="mysql")
     else:
-        db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
+        db_connection = MySQLdb.connect(host=module.params["login_host"], port=int(module.params["login_port"]), user=login_user, passwd=login_password, db="mysql")
     return db_connection.cursor()
 
 # ===========================================
@@ -339,6 +344,7 @@ def main():
             login_user=dict(default=None),
             login_password=dict(default=None),
             login_host=dict(default="localhost"),
+            login_port=dict(default="3306"),
             login_unix_socket=dict(default=None),
             user=dict(required=True, aliases=['name']),
             password=dict(default=None),


### PR DESCRIPTION
This is useful if you are running multiple instances of MySQL on the same server listening on different ports. 
