### PR TITLE
Correct undefined aws_region to region

### DIFF
--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -349,12 +349,12 @@ def main():
         elif 'EC2_ACCESS_KEY' in os.environ:
             aws_access_key = os.environ['EC2_ACCESS_KEY']
 
-    if not aws_region:
+    if not region:
         module.fail_json(msg = str("region not specified and unable to determine region from EC2_REGION."))
 
     # connect to the rds endpoint
     try:
-        conn = boto.rds.connect_to_region(aws_region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
+        conn = boto.rds.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
     except boto.exception.BotoServerError, e:
         module.fail_json(msg = e.error_message)
 


### PR DESCRIPTION
I wasn't using EC2_REGION env var but 'region' in my play yml file, and it showed aws_region was undefined. It was a simple naming mismatch, and this corrects it.

(still can't create an RDS with the sample docs but at least this gets me beyond that hurdle; only 1.5 days with ansible so lots to learn)
