### PR TITLE
Fix no kerberos

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -85,7 +85,7 @@ class Connection(object):
                                  "-o", "PubkeyAuthentication=no"]
         else:
             self.common_args += ["-o", "KbdInteractiveAuthentication=no",
-                                 "-o", "PreferredAuthentications=gssapi-with-mic,hostbased,publickey",
+                                 "-o", "PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey",
                                  "-o", "PasswordAuthentication=no"]
         if self.user != pwd.getpwuid(os.geteuid())[0]:
             self.common_args += ["-o", "User="+self.user]

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -85,7 +85,7 @@ class Connection(object):
                                  "-o", "PubkeyAuthentication=no"]
         else:
             self.common_args += ["-o", "KbdInteractiveAuthentication=no",
-                                 "-o", "PreferredAuthentications=hostbased,publickey",
+                                 "-o", "PreferredAuthentications=gssapi-with-mic,hostbased,publickey",
                                  "-o", "PasswordAuthentication=no"]
         if self.user != pwd.getpwuid(os.geteuid())[0]:
             self.common_args += ["-o", "User="+self.user]


### PR DESCRIPTION
It seems that 2bdba17 broke kerberos, theses 2 patch add it back. I tested it at work, using Fedora 19 to various RHEL servers.
