### PR TITLE
Bug fix for a crash, when any_errors_fatal is true

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -573,11 +573,11 @@ class PlayBook(object):
 
                 host_list = self._list_available_hosts(play.hosts)
 
-                if task.any_errors_fatal and len(host_list) < hosts_count:
-                    host_list = None
-
-                # If threshold for max nodes failed is exceeded , bail out.
-                if (hosts_count - len(host_list)) > int((play.max_fail_pct)/100.0 * hosts_count):
+                # If threshold for max nodes failed is exceeded or if any_errors_fatal is true, bail out.
+                if (
+                        (task.any_errors_fatal and len(host_list) < hosts_count) or
+                        ((hosts_count - len(host_list)) > int((play.max_fail_pct)/100.0 * hosts_count))
+                    ):
                     host_list = None
                     
                 # if no hosts remain, drop out

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -573,11 +573,12 @@ class PlayBook(object):
 
                 host_list = self._list_available_hosts(play.hosts)
 
-                # If threshold for max nodes failed is exceeded or if any_errors_fatal is true, bail out.
-                if (
-                        (task.any_errors_fatal and len(host_list) < hosts_count) or
-                        ((hosts_count - len(host_list)) > int((play.max_fail_pct)/100.0 * hosts_count))
-                    ):
+                # Set max_fail_pct to 0, So if any hosts fails, bail out
+                if task.any_errors_fatal and len(host_list) < hosts_count:
+                    play.max_fail_pct = 0
+
+                # If threshold for max nodes failed is exceeded , bail out.
+                if (hosts_count - len(host_list)) > int((play.max_fail_pct)/100.0 * hosts_count):
                     host_list = None
                     
                 # if no hosts remain, drop out


### PR DESCRIPTION
Reported by Rumen:

TASK: [fail FAIL] *************************************************************
skipping: [hostname.com]
failed: [hostname.com] => {"failed": true}
msg: Failed as requested from task
Traceback (most recent call last):
  File "/usr/local/bin/ansible-playbook", line 268, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/usr/local/bin/ansible-playbook", line 208, in main
    pb.run()
  File "/Library/Python/2.7/site-packages/ansible/playbook/**init**.py", line 262, in run
    if not self._run_play(play):
  File "/Library/Python/2.7/site-packages/ansible/playbook/__init__.py", line 580, in _run_play
    if (hosts_count - len(host_list)) > int((play.max_fail_pct)/100.0 \* hosts_count):
TypeError: object of type 'NoneType' has no len()
