### PR TITLE
Fixed -e "" on ansible-playbook.

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -103,7 +103,7 @@ def main(args):
         if extra_vars_opt.startswith("@"):
             # Argument is a YAML file (JSON is a subset of YAML)
             extra_vars = utils.combine_vars(extra_vars, utils.parse_yaml_from_file(extra_vars_opt[1:]))
-        elif extra_vars_opt[0] in '[{':
+        elif extra_vars_opt and extra_vars_opt[0] in '[{':
             # Arguments as YAML
             extra_vars = utils.combine_vars(extra_vars, utils.parse_yaml(extra_vars_opt))
         else:


### PR DESCRIPTION
Currently, _ansible-playbook_ fails when empty extra vars are passed (-e "").

```
Traceback (most recent call last):
  File "/home/alan/workspace/ansible/bin/ansible-playbook", line 268, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/home/alan/workspace/ansible/bin/ansible-playbook", line 106, in main
    elif extra_vars_opt[0] in '[{':
IndexError: string index out of range
```

The case of an empty string is not being accounted for. This commit fixes it.
