### PR TITLE
Adding daemontools module

### DIFF
--- a/library/system/svc
+++ b/library/system/svc
@@ -1,0 +1,257 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = '''
+---
+module: svc
+author: Brian Coca
+version_added:
+short_description:  Manage daemontools svcs.
+description:
+    - Controls daemontools svcs on remote hosts.
+options:
+    name:
+        required: true
+        description:
+        - Name of the svc.
+    state:
+        required: false
+        choices: [ started, stopped, restarted, reloaded, once ]
+        description:
+          C(Started)/C(stopped) are idempotent actions that will not run
+          commands unless necessary.  C(restarted) will always bounce the
+          svc (svc -t).  C(reloaded) will send a sigusr1 (svc -u).
+          C(once) will run a normally downed svc once (svc -o), not really
+          an idempotent operation.
+    downed:
+        required: false
+        choices: [ "yes", "no" ]
+        description:
+        - Should a 'down' file exist or not, if it exists it disables auto startup.
+        defaults to no. Downed does not imply stopped.
+    enabled:
+        required: false
+        choices: [ "yes", "no" ]
+        description:
+        - Wheater the service is enabled or not, if disabled it also implies stopped.
+        Make note that a service can be enabled and downed (no auto restart).
+    service_dir:
+        required: false
+        description:
+        - directory svscan watches for services, default is /service
+    service_src:
+        required: false
+        description:
+        - directory where services are defined, the source of symlinks to service_dir.
+examples:
+    - description: Example action to start svc dnscache, if not running
+      code: "svc: name=dnscache state=started"
+    - description: Example action to stop svc dnscache, if running
+      code: "svc: name=dnscache state=stopped"
+    - description: Example action to restart svc dnscache, in all cases
+      code: "svc : name=dnscache state=restarted"
+    - description: Example action to reload svc dnscache, in all cases
+      code: "svc: name=dnscache state=reloaded"
+    - description: Example using alt svc directory location
+      code: "svc: name=dnscache state=reloaded service_dir=/var/service"
+'''
+
+import platform
+import shlex
+
+def _load_dist_subclass(cls, *args, **kwargs):
+    '''
+    Used for derivative implementations
+    '''
+    subclass = None
+
+    distro = kwargs['module'].params['distro']
+
+    # get the most specific superclass for this platform
+    if distro is not None:
+        for sc in cls.__subclasses__():
+            if sc.distro is not None and sc.distro == distro:
+                subclass = sc
+    if subclass is None:
+        subclass = cls
+
+    return super(cls, subclass).__new__(subclass)
+
+class Svc(object):
+    """
+    Main class that handles daemontools, can be subclassed and overriden in case
+    we want to use a 'derivative' like encore, s6, etc
+    """
+
+
+    #def __new__(cls, *args, **kwargs):
+    #    return _load_dist_subclass(cls, args, kwargs)
+
+
+
+    def __init__(self, module):
+        self.extra_paths = [ '/command', '/usr/local/bin' ]
+        self.report_vars = ['state', 'enabled', 'downed', 'svc_full', 'src_full', 'pid', 'duration', 'full_state']
+
+        self.module         = module
+
+        self.name           = module.params['name']
+        self.service_dir    = module.params['service_dir']
+        self.service_src    = module.params['service_src']
+        self.enabled        = None
+        self.downed         = None
+        self.full_state     = None
+        self.state          = None
+        self.pid            = None
+        self.duration       = None
+
+        self.svc_cmd        = module.get_bin_path('svc', opt_dirs=self.extra_paths)
+        self.svstat_cmd     = module.get_bin_path('svstat', opt_dirs=self.extra_paths)
+        self.svc_full = '/'.join([ self.service_dir, self.name ])
+        self.src_full = '/'.join([ self.service_src, self.name ])
+
+        self.enabled = os.path.lexists(self.svc_full)
+        if self.enabled:
+            self.downed = os.path.lexists('%s/down' % self.svc_full)
+            self.get_status()
+        else:
+            self.downed = os.path.lexists('%s/down' % self.src_full)
+            self.state = 'stopped'
+
+
+    def enable(self):
+        if os.path.exists(self.src_full):
+            try:
+                os.symlink(self.src_full, self.svc_full)
+            except OSError, e:
+                self.module.fail_json(path=self.src_full, msg='Error while linking: %s' % str(e))
+        else:
+            self.module.fail_json(msg="Could not find source for service to enable (%s)." % self.src_full)
+
+    def disable(self):
+        try:
+            os.unlink(self.svc_full)
+        except OSError, e:
+            self.module.fail_json(path=self.svc_full, msg='Error while unlinking: %s' % str(e))
+        self.execute_command([self.svc_cmd,'-dx',self.src_full])
+
+        src_log = '%s/log' % self.src_full
+        if os.path.exists(src_log):
+            self.execute_command([self.svc_cmd,'-dx',src_log])
+
+    def get_status(self):
+        (rc, out, err) = self.execute_command([self.svstat_cmd, self.svc_full])
+
+        if err is not None and err:
+            self.full_state = self.state = err
+        else:
+            self.full_state = out
+
+            m = re.search('\(pid (\d+)\)', out)
+            if m:
+                self.pid = m.group(1)
+
+            m = re.search('(\d+) seconds', out)
+            if m:
+                self.duration = m.group(1)
+
+            if re.search(' up ', out):
+                self.state = 'start'
+            elif re.search(' down ', out):
+                self.state = 'stopp'
+            else:
+                self.state = 'unknown'
+                return
+
+            if re.search(' want ', out):
+                self.state += 'ing'
+            else:
+                self.state += 'ed'
+
+    def start(self):
+        return self.execute_command([self.svc_cmd, '-u', self.svc_full])
+
+    def stopp(self):
+        return self.stop()
+
+    def stop(self):
+        return self.execute_command([self.svc_cmd, '-d', self.svc_full])
+
+    def once(self):
+        return self.execute_command([self.svc_cmd, '-o', self.svc_full])
+
+    def reload(self):
+        return self.execute_command([self.svc_cmd, '-1', self.svc_full])
+
+    def execute_command(self, cmd):
+        try:
+            (rc, out, err) = self.module.run_command(' '.join(cmd))
+        except Exception, e:
+            self.module.fail_json(msg="failed to execute: %s" % str(e))
+        return (rc, out, err)
+
+
+    def report(self):
+        self.get_status()
+        return {k: self.__dict__[k] for k in self.report_vars}
+
+# ===========================================
+# Main control flow
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name = dict(required=True),
+            state = dict(choices=['started', 'stopped', 'restarted', 'reloaded', 'once']),
+            enabled = dict(required=False, type='bool', choices=BOOLEANS),
+            downed = dict(required=False, type='bool', choices=BOOLEANS),
+            dist = dict(required=False, default='daemontools'),
+            service_dir = dict(required=False, default='/service'),
+            service_src = dict(required=False, default='/etc/service'),
+        ),
+        supports_check_mode=True,
+    )
+
+    state = module.params['state']
+    enabled = module.params['enabled']
+    downed = module.params['downed']
+
+    svc = Svc(module)
+    changed = False
+    orig_state = svc.report()
+
+    if enabled is not None and enabled != svc.enabled:
+        changed = True
+        if not module.check_mode:
+            try:
+                if enabled:
+                    svc.enable()
+                else:
+                    svc.disable()
+            except (OSError, IOError) as e:
+                module.fail_json(msg="Could change service link: %s" % str(e))
+
+    if state is not None and state != svc.state:
+        changed = True
+        if not module.check_mode:
+            getattr(svc,state[:-2])()
+
+    if downed is not None and downed != svc.downed:
+        changed = True
+        if not module.check_mode:
+            d_file = "%s/down" % svc.svc_full
+            try:
+                if downed:
+                    open(d_file, "a").close()
+                else:
+                    os.unlink(d_file)
+            except (OSError, IOError) as e:
+                module.fail_json(msg="Could change downed file: %s "  % (str(e)))
+
+    module.exit_json(changed=changed, svc=svc.report())
+
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+
+main()


### PR DESCRIPTION
works with DJB version but can be subclassed to add features
for encore, s6, runit, etc. Then introduce the distro='classname'
parameter to switch between them.

Signed-off-by: Brian Coca <briancoca+dev@gmail.com>
