### PR TITLE
Added remote_user to plays

### DIFF
--- a/docsite/latest/rst/playbooks.rst
+++ b/docsite/latest/rst/playbooks.rst
@@ -51,7 +51,7 @@ For starters, here's a playbook that contains just one play::
       vars:
         http_port: 80
         max_clients: 200
-      user: root
+      remote_user: root
       tasks:
       - name: ensure apache is at the latest version
         yum: pkg=httpd state=latest
@@ -82,21 +82,21 @@ documentation.  The `user` is just the name of the user account::
 
     ---
     - hosts: webservers
-      user: root
+      remote_user: root
 
 
 Support for running things from sudo is also available::
 
     ---
     - hosts: webservers
-      user: yourname
+      remote_user: yourname
       sudo: yes
 
 You can also use sudo on a particular task instead of the whole play::
 
     ---
     - hosts: webservers
-      user: yourname
+      remote_user: yourname
       tasks:
         - service: name=nginx state=started
           sudo: yes
@@ -106,7 +106,7 @@ You can also login as you, and then sudo to different users than root::
 
     ---
     - hosts: webservers
-      user: yourname
+      remote_user: yourname
       sudo: yes
       sudo_user: postgres
 
@@ -134,7 +134,7 @@ The `vars` section contains a list of variables and values that can be used in t
 
     ---
     - hosts: webservers
-      user: root
+      remote_user: root
       vars:
          http_port: 80
          van_halen_port: 5150
@@ -387,7 +387,7 @@ which also supports structured variables::
 
       - include: wordpress.yml
         vars:
-            user: timmy
+            remote_user: timmy
             some_list_variable:
               - alpha
               - beta
@@ -424,7 +424,7 @@ For example::
 
     - name: this is a play at the top level of a file
       hosts: all
-      user: root
+      remote_user: root
       tasks:
       - name: say hi
         tags: foo

--- a/docsite/latest/rst/playbooks2.rst
+++ b/docsite/latest/rst/playbooks2.rst
@@ -163,7 +163,7 @@ You can do this by using an external variables file, or files, just like this::
 
     ---
     - hosts: all
-      remote_useq: root
+      remote_user: root
       vars:
         favcolor: blue
       vars_files:
@@ -197,7 +197,7 @@ in a push-script::
 
     ---
     - hosts: all
-      remote_useq: root
+      remote_user: root
       vars:
         from: "camelot"
       vars_prompt:
@@ -276,7 +276,7 @@ This is useful, for, among other things, setting the hosts group or the user for
 Example::
 
     ---
-    - remote_useq: '{{ user }}'
+    - remote_user: '{{ user }}'
       hosts: '{{ hosts }}'
       tasks:
          - ...
@@ -421,7 +421,7 @@ but it is easily handled with a minimum of syntax in an Ansible Playbook::
 
     ---
     - hosts: all
-      remote_useq: root
+      remote_user: root
       vars_files:
         - "vars/common.yml"
         - [ "vars/{{ ansible_os_family }}.yml", "vars/os_defaults.yml" ]
@@ -467,7 +467,7 @@ Loops
 To save some typing, repeated tasks can be written in short-hand like so::
 
     - name: add several users
-      remote_useq: name={{ item }} state=present groups=wheel
+      remote_user: name={{ item }} state=present groups=wheel
       with_items:
          - testuser1
          - testuser2
@@ -479,9 +479,9 @@ If you have defined a YAML list in a variables file, or the 'vars' section, you 
 The above would be the equivalent of::
 
     - name: add user testuser1
-      remote_useq: name=testuser1 state=present groups=wheel
+      remote_user: name=testuser1 state=present groups=wheel
     - name: add user testuser2
-      remote_useq: name=testuser2 state=present groups=wheel
+      remote_user: name=testuser2 state=present groups=wheel
 
 The yum and apt modules use with_items to execute fewer package manager transactions.
 
@@ -489,7 +489,7 @@ Note that the types of items you iterate over with 'with_items' do not have to b
 If you have a list of hashes, you can reference subkeys using things like::
 
     - name: add several users
-      remote_useq: name={{ item.name }} state=present groups={{ item.groups }}
+      remote_user: name={{ item.name }} state=present groups={{ item.groups }}
       with_items:
         - { name: 'testuser1', groups: 'wheel' }
         - { name: 'testuser2', groups: 'root' }
@@ -603,7 +603,7 @@ Negative numbers are not supported.  This works as follows::
         - group: name=odds state=present
 
         # create some test users
-        - remote_useq: name={{ item }} state=present groups=evens
+        - remote_user: name={{ item }} state=present groups=evens
           with_sequence: start=0 end=32 format=testuser%02x
 
         # create a series of directories with even numbers for some reason
@@ -649,7 +649,7 @@ This length can be changed by passing an extra parameter::
         (...)
 
         # create a user with a given password
-        - remote_useq: name=guestuser
+        - remote_user: name=guestuser
                 state=present
                 uid=5000
                 password={{ item }}
@@ -665,7 +665,7 @@ updates through a proxy and access other packages not through a proxy.  Ansible 
 to configure your environment by using the 'environment' keyword.  Here is an example::
 
     - hosts: all
-      remote_useq: root
+      remote_user: root
 
       tasks:
 
@@ -676,7 +676,7 @@ to configure your environment by using the 'environment' keyword.  Here is an ex
 The environment can also be stored in a variable, and accessed like so::
 
     - hosts: all
-      remote_useq: root
+      remote_user: root
 
       # here we make a variable named "env" that is a dictionary
       vars:
@@ -751,7 +751,7 @@ poll value is 10 seconds if you do not specify a value for `poll`::
 
     ---
     - hosts: all
-      remote_useq: root
+      remote_user: root
       tasks:
       - name: simulate long running op (15 sec), wait for up to 45, poll every 5
         command: /bin/sleep 15
@@ -768,7 +768,7 @@ Alternatively, if you do not need to wait on the task to complete, you may
 
     ---
     - hosts: all
-      remote_useq: root
+      remote_user: root
       tasks:
       - name: simulate long running op, allow to run for 45, fire and forget
         command: /bin/sleep 15

--- a/docsite/latest/rst/playbooks2.rst
+++ b/docsite/latest/rst/playbooks2.rst
@@ -163,7 +163,7 @@ You can do this by using an external variables file, or files, just like this::
 
     ---
     - hosts: all
-      user: root
+      remote_useq: root
       vars:
         favcolor: blue
       vars_files:
@@ -197,7 +197,7 @@ in a push-script::
 
     ---
     - hosts: all
-      user: root
+      remote_useq: root
       vars:
         from: "camelot"
       vars_prompt:
@@ -276,7 +276,7 @@ This is useful, for, among other things, setting the hosts group or the user for
 Example::
 
     ---
-    - user: '{{ user }}'
+    - remote_useq: '{{ user }}'
       hosts: '{{ hosts }}'
       tasks:
          - ...
@@ -421,7 +421,7 @@ but it is easily handled with a minimum of syntax in an Ansible Playbook::
 
     ---
     - hosts: all
-      user: root
+      remote_useq: root
       vars_files:
         - "vars/common.yml"
         - [ "vars/{{ ansible_os_family }}.yml", "vars/os_defaults.yml" ]
@@ -467,7 +467,7 @@ Loops
 To save some typing, repeated tasks can be written in short-hand like so::
 
     - name: add several users
-      user: name={{ item }} state=present groups=wheel
+      remote_useq: name={{ item }} state=present groups=wheel
       with_items:
          - testuser1
          - testuser2
@@ -479,9 +479,9 @@ If you have defined a YAML list in a variables file, or the 'vars' section, you 
 The above would be the equivalent of::
 
     - name: add user testuser1
-      user: name=testuser1 state=present groups=wheel
+      remote_useq: name=testuser1 state=present groups=wheel
     - name: add user testuser2
-      user: name=testuser2 state=present groups=wheel
+      remote_useq: name=testuser2 state=present groups=wheel
 
 The yum and apt modules use with_items to execute fewer package manager transactions.
 
@@ -489,7 +489,7 @@ Note that the types of items you iterate over with 'with_items' do not have to b
 If you have a list of hashes, you can reference subkeys using things like::
 
     - name: add several users
-      user: name={{ item.name }} state=present groups={{ item.groups }}
+      remote_useq: name={{ item.name }} state=present groups={{ item.groups }}
       with_items:
         - { name: 'testuser1', groups: 'wheel' }
         - { name: 'testuser2', groups: 'root' }
@@ -603,7 +603,7 @@ Negative numbers are not supported.  This works as follows::
         - group: name=odds state=present
 
         # create some test users
-        - user: name={{ item }} state=present groups=evens
+        - remote_useq: name={{ item }} state=present groups=evens
           with_sequence: start=0 end=32 format=testuser%02x
 
         # create a series of directories with even numbers for some reason
@@ -649,7 +649,7 @@ This length can be changed by passing an extra parameter::
         (...)
 
         # create a user with a given password
-        - user: name=guestuser
+        - remote_useq: name=guestuser
                 state=present
                 uid=5000
                 password={{ item }}
@@ -665,7 +665,7 @@ updates through a proxy and access other packages not through a proxy.  Ansible 
 to configure your environment by using the 'environment' keyword.  Here is an example::
 
     - hosts: all
-      user: root
+      remote_useq: root
 
       tasks:
 
@@ -676,7 +676,7 @@ to configure your environment by using the 'environment' keyword.  Here is an ex
 The environment can also be stored in a variable, and accessed like so::
 
     - hosts: all
-      user: root
+      remote_useq: root
 
       # here we make a variable named "env" that is a dictionary
       vars:
@@ -751,7 +751,7 @@ poll value is 10 seconds if you do not specify a value for `poll`::
 
     ---
     - hosts: all
-      user: root
+      remote_useq: root
       tasks:
       - name: simulate long running op (15 sec), wait for up to 45, poll every 5
         command: /bin/sleep 15
@@ -768,7 +768,7 @@ Alternatively, if you do not need to wait on the task to complete, you may
 
     ---
     - hosts: all
-      user: root
+      remote_useq: root
       tasks:
       - name: simulate long running op, allow to run for 45, fire and forget
         command: /bin/sleep 15

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -39,7 +39,7 @@ class Play(object):
     # and don't line up 1:1 with how they are stored
     VALID_KEYS = [
        'hosts', 'name', 'vars', 'vars_prompt', 'vars_files',
-       'tasks', 'handlers', 'user', 'port', 'include', 'accelerate', 'accelerate_port',
+       'tasks', 'handlers', 'remote_user', 'user', 'port', 'include', 'accelerate', 'accelerate_port',
        'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'serial',
        'any_errors_fatal', 'roles', 'pre_tasks', 'post_tasks', 'max_fail_percentage' 
     ]
@@ -104,7 +104,7 @@ class Play(object):
         self.name             = ds.get('name', self.hosts)
         self._tasks           = ds.get('tasks', [])
         self._handlers        = ds.get('handlers', [])
-        self.remote_user      = ds.get('user', self.playbook.remote_user)
+        self.remote_user      = ds.get('remote_user', ds.get('user', self.playbook.remote_user))
         self.remote_port      = ds.get('port', self.playbook.remote_port)
         self.sudo             = ds.get('sudo', self.playbook.sudo)
         self.sudo_user        = ds.get('sudo_user', self.playbook.sudo_user)

--- a/test/cron_test.yml
+++ b/test/cron_test.yml
@@ -1,7 +1,7 @@
 -
   hosts: all
   gather_facts: no
-  user:  root
+  remote_user:  root
   vars:
     color: brown
   tasks:


### PR DESCRIPTION
Still compatible with user: but deprecating it so we can have
a matching remote_user: in tasks, cannot be user: because of the
module of the same name. #3932

Signed-off-by: Brian Coca <briancoca+dev@gmail.com>
