### PR TITLE
Nova_compute wait_for fixes

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -220,7 +220,7 @@ def main():
         nics                            = dict(default=None),
         meta                            = dict(default=None),
         wait                            = dict(default='yes', choices=['yes', 'no']),
-        wait_for                        = dict(default=120),
+        wait_for                        = dict(default=180),
         state                           = dict(default='present', choices=['absent', 'present'])
         ),
     )

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -135,7 +135,7 @@ def _delete_server(module, nova):
         module.fail_json( msg = "Error in deleting vm: %s" % e.message)
     if module.params['wait'] == 'no':
         module.exit_json(changed = True, result = "deleted")
-    expire = time.time() + module.params['wait_for']
+    expire = time.time() + int(module.params['wait_for'])
     while time.time() < expire:
         name = nova.servers.list(True, {'name': module.params['name']})
         if not name:
@@ -160,7 +160,7 @@ def _create_server(module, nova):
     except Exception as e:
             module.fail_json( msg = "Error in creating instance: %s " % e.message)
     if module.params['wait'] == 'yes':
-        expire = time.time() + module.params['wait_for']
+        expire = time.time() + int(module.params['wait_for'])
         while time.time() < expire:
             try:
                 server = nova.servers.get(server.id)


### PR DESCRIPTION
There are 2 little bugs with the wait_for parameter in the nova_compute module :
- If you set wait_for, there is a conversion error between String to Float `TypeError: unsupported operand type(s) for +: 'float' and 'str'`
- The documentation says default value is 180 but in fact it is set to 120
