### PR TITLE
Add ok_rc module varirable. If rc is in ok_rc, then accept it is not an error.

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -189,7 +189,7 @@ class AggregateStats(object):
 
         for (host, value) in runner_results.get('contacted', {}).iteritems():
             if not ignore_errors and (('failed' in value and bool(value['failed'])) or
-                ('rc' in value and value['rc'] != 0)):
+                ('rc' in value and value['rc'] not in (value.get('ok_rc') or [0]))):
                 self._increment('failures', host)
             elif 'skipped' in value and bool(value['skipped']):
                 self._increment('skipped', host)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -29,7 +29,7 @@ class Task(object):
         'delegate_to', 'first_available_file', 'ignore_errors',
         'local_action', 'transport', 'sudo', 'sudo_user', 'sudo_pass',
         'items_lookup_plugin', 'items_lookup_terms', 'environment', 'args',
-        'any_errors_fatal', 'changed_when', 'always_run'
+        'any_errors_fatal', 'changed_when', 'always_run', 'ok_rc'
     ]
 
     # to prevent typos and such
@@ -38,7 +38,7 @@ class Task(object):
          'first_available_file', 'include', 'tags', 'register', 'ignore_errors',
          'delegate_to', 'local_action', 'transport', 'sudo', 'sudo_user',
          'sudo_pass', 'when', 'connection', 'environment', 'args',
-         'any_errors_fatal', 'changed_when', 'always_run'
+         'any_errors_fatal', 'changed_when', 'always_run', 'ok_rc'
     ]
 
     def __init__(self, play, ds, module_vars=None, default_vars=None, additional_conditions=None):
@@ -167,6 +167,8 @@ class Task(object):
         if self.changed_when is not None:
             self.changed_when = utils.compile_when_to_only_if(self.changed_when)
 
+        self.ok_rc = ds.get('ok_rc', None)
+
         self.async_seconds = int(ds.get('async', 0))  # not async by default
         self.async_poll_interval = int(ds.get('poll', 10))  # default poll = 10 seconds
         self.notify = ds.get('notify', [])
@@ -224,6 +226,7 @@ class Task(object):
         self.module_vars['register'] = self.register
         self.module_vars['changed_when'] = self.changed_when
         self.module_vars['always_run'] = self.always_run
+        self.module_vars['ok_rc'] = self.ok_rc
 
         # tags allow certain parts of a playbook to be run without running the whole playbook
         apply_tags = ds.get('tags', None)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -357,6 +357,8 @@ class Runner(object):
         data = utils.parse_json(res['stdout'])
         if 'parsed' in data and data['parsed'] == False:
             data['msg'] += res['stderr']
+        if 'ok_rc' in inject:
+            data['ok_rc'] = inject['ok_rc']
         return ReturnData(conn=conn, result=data)
 
     # *****************************************************
@@ -507,7 +509,7 @@ class Runner(object):
                 for x in results:
                     if x.get('changed') == True:
                         all_changed = True
-                    if (x.get('failed') == True) or (('rc' in x) and (x['rc'] != 0)):
+                    if (x.get('failed') == True) or (('rc' in x) and (x['rc'] not in (x.get('ok_rc') or [0]))):
                         all_failed = True
                         break
             msg = 'All items completed'

--- a/lib/ansible/runner/return_data.py
+++ b/lib/ansible/runner/return_data.py
@@ -59,5 +59,4 @@ class ReturnData(object):
         return self.comm_ok
 
     def is_successful(self):
-        return self.comm_ok and (self.result.get('failed', False) == False) and (self.result.get('rc',0) == 0)
-
+        return self.comm_ok and (self.result.get('failed', False) == False) and (self.result.get('rc', 0) in (self.result.get('ok_rc') or [0]))

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -149,7 +149,7 @@ def write_tree_file(tree, hostname, buf):
 def is_failed(result):
     ''' is a given JSON result a failed result? '''
 
-    return ((result.get('rc', 0) != 0) or (result.get('failed', False) in [ True, 'True', 'true']))
+    return ((result.get('rc', 0) not in (result('ok_rc') or [0])) or (result.get('failed', False) in [ True, 'True', 'true']))
 
 def is_changed(result):
     ''' is a given JSON result a changed result? '''

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -474,6 +474,34 @@ class TestPlaybook(unittest.TestCase):
 
        assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
 
+   def test_playbook_ok_rc(self):
+       test_callbacks = TestCallbacks()
+       playbook = ansible.playbook.PlayBook(
+           playbook=os.path.join(self.test_dir, 'playbook-ok_rc.yml'),
+           host_list='test/ansible_hosts',
+           stats=ans_callbacks.AggregateStats(),
+           callbacks=test_callbacks,
+           runner_callbacks=test_callbacks
+       )
+       actual = playbook.run()
+
+       # if different, this will output to screen
+       print "**ACTUAL**"
+       print utils.jsonify(actual, format=True)
+       expected =  {
+           "localhost": {
+               "changed": 1,
+               "failures": 0,
+               "ok": 1,
+               "skipped": 0,
+               "unreachable": 0
+           }
+       }
+       print "**EXPECTED**"
+       print utils.jsonify(expected, format=True)
+
+       assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
+
 
    def test_playbook_always_run(self):
       test_callbacks = TestCallbacks()

--- a/test/playbook-ok_rc.yml
+++ b/test/playbook-ok_rc.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  connection: local
+  gather_facts: False
+
+  tasks:
+  - action: shell exit 1
+    ok_rc: [0, 1]


### PR DESCRIPTION
Currently we can use ignore_errors, but we get a red failed log followed by the ignored message.
This is not so nice to our eyes.

Some commands like grep -q returns 0 or 1 as exit codes and we don't want to be treated to be an error,
especially when we run it to query the status.

Now I use a workaround like:

```
  shell: grep -q foo bar; echo $?
  register: result
```

And then at another task I use `when: result.stdout == '0'`.
But it is not good because we cannot treat codes other than 0 and 1 as errors.

So here is a pull request to add a `ok_rc` module variable, inspired by [ok_ret_codes in Fabric](http://docs.fabfile.org/en/1.7/usage/env.html#ok_ret_codes)
