### PR TITLE
Locate easy_install path after (optionally) creating virtualenv.

### DIFF
--- a/library/packaging/easy_install
+++ b/library/packaging/easy_install
@@ -94,7 +94,6 @@ def main():
 
     name = module.params['name']
     env = module.params['virtualenv']
-    easy_install = module.get_bin_path('easy_install', True, ['%s/bin' % env])
     site_packages = module.params['virtualenv_site_packages']
     virtualenv_command = module.params['virtualenv_command']
 
@@ -116,6 +115,8 @@ def main():
             rc += rc_venv
             out += out_venv
             err += err_venv
+
+    easy_install = module.get_bin_path('easy_install', True, ['%s/bin' % env])
 
     cmd = None
     changed = False


### PR DESCRIPTION
Without this, the first call to the easy_install module with a new virtualenv
will only create the virtualenv without installing the intended package, since
the `_is_package_installed` check will succeed as running /usr/bin/easy_install
as non-root user will return permission denied error with empty stdout.

Before:

```
$ ansible -i hosts local -m easy_install -a "name=Mako virtualenv=/home/sayap/virtualenv/test1"
localhost | success >> {
    "binary": "/usr/bin/easy_install", 
    "changed": false, 
    "name": "Mako", 
    "virtualenv": "/home/sayap/virtualenv/test1"
}

$ ls ~/virtualenv/test1/lib/python2.7/site-packages/
easy_install.py  easy_install.pyc  _markerlib  pip  pip-1.4.1-py2.7.egg-info  pkg_resources.py  pkg_resources.pyc  setuptools  setuptools-0.9.8-py2.7.egg-info
```

After:

```
$ ansible -i hosts local -m easy_install -a "name=Mako virtualenv=/home/sayap/virtualenv/test2"
localhost | success >> {
    "binary": "/home/sayap/virtualenv/test2/bin/easy_install", 
    "changed": true, 
    "name": "Mako", 
    "virtualenv": "/home/sayap/virtualenv/test2"
}

$ ls ~/virtualenv/test2/lib/python2.7/site-packages/
easy-install.pth  easy_install.pyc      _markerlib                              pip                       pkg_resources.py   setuptools
easy_install.py   Mako-0.9.0-py2.7.egg  MarkupSafe-0.18-py2.7-linux-x86_64.egg  pip-1.4.1-py2.7.egg-info  pkg_resources.pyc  setuptools-0.9.8-py2.7.egg-info
```
