### PR TITLE
add 'chars' parameter to password plugin to allow custom character set

### DIFF
--- a/lib/ansible/runner/lookup_plugins/password.py
+++ b/lib/ansible/runner/lookup_plugins/password.py
@@ -22,6 +22,7 @@ import os
 import errno
 import random
 from string import ascii_letters, digits
+import string
 
 
 class LookupModule(object):
@@ -52,6 +53,7 @@ class LookupModule(object):
             paramvals = {
                 'length': LookupModule.LENGTH,
                 'encrypt': None,
+                'chars': ['ascii_letters','digits',".,:-_"],
             }
 
             # get non-default parameters if specified
@@ -61,6 +63,11 @@ class LookupModule(object):
                     assert(name in paramvals)
                     if name == 'length':
                         paramvals[name] = int(value)
+                    elif name == 'chars':
+                        use_chars=[]
+                        if ",," in value: use_chars.append(',')
+                        use_chars.extend(value.replace(',,',',').replace('"','').replace("'",'').split(','))
+                        paramvals['chars'] = use_chars
                     else:
                         paramvals[name] = value
             except (ValueError, AssertionError) as e:
@@ -68,6 +75,7 @@ class LookupModule(object):
 
             length  = paramvals['length']
             encrypt = paramvals['encrypt']
+            use_chars = paramvals['chars']
 
             # get password or create it if file doesn't exist
             path = utils.path_dwim(self.basedir, relpath)
@@ -75,7 +83,7 @@ class LookupModule(object):
                 pathdir = os.path.dirname(path)
                 if not os.path.isdir(pathdir):
                     os.makedirs(pathdir)
-                chars = ascii_letters + digits + ".,:-_"
+                chars = "".join([getattr(string,c,c) for c in use_chars])
                 password = ''.join(random.choice(chars) for _ in range(length))
                 if encrypt is not None:
                     salt = self.random_salt()

--- a/lib/ansible/runner/lookup_plugins/password.py
+++ b/lib/ansible/runner/lookup_plugins/password.py
@@ -66,7 +66,7 @@ class LookupModule(object):
                     elif name == 'chars':
                         use_chars=[]
                         if ",," in value: use_chars.append(',')
-                        use_chars.extend(value.replace(',,',',').replace('"','').replace("'",'').split(','))
+                        use_chars.extend(value.replace(',,',',').split(','))
                         paramvals['chars'] = use_chars
                     else:
                         paramvals[name] = value
@@ -83,7 +83,7 @@ class LookupModule(object):
                 pathdir = os.path.dirname(path)
                 if not os.path.isdir(pathdir):
                     os.makedirs(pathdir)
-                chars = "".join([getattr(string,c,c) for c in use_chars])
+                chars = "".join([getattr(string,c,c) for c in use_chars]).replace('"','').replace("'",'')
                 password = ''.join(random.choice(chars) for _ in range(length))
                 if encrypt is not None:
                     salt = self.random_salt()


### PR DESCRIPTION
It accepts comma separated list of names that are
either string module attributes (ascii_letters,digits, etc)
or are used literally

To enter comma use two commas ',,' somewhere - preferably at the end
Qoutes and double qoutes are not supported
