### PR TITLE
Add Archlinux "distribution" fact

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -115,7 +115,8 @@ class Facts(object):
                     '/etc/openwrt_release': 'OpenWrt',
                     '/etc/system-release': 'OtherLinux',
                     '/etc/alpine-release': 'Alpine',
-                    '/etc/release': 'Solaris' }
+                    '/etc/release': 'Solaris',
+                    '/etc/arch-release': 'Archlinux' }
     SELINUX_MODE_DICT = { 1: 'enforcing', 0: 'permissive', -1: 'disabled' }
 
     # A list of dicts.  If there is a platform with more than one


### PR DESCRIPTION
This is a really simple change that allows the `setup` module to detect Arch Linux by checking for `/etc/arch-release` (part of the `core/filesystem` package).
