### PR TITLE
Add paramiko ssh agent forwarding (optional)

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -131,6 +131,8 @@ ANSIBLE_NOCOLOR                = get_config(p, DEFAULTS, 'nocolor', 'ANSIBLE_NOC
 ANSIBLE_NOCOWS                 = get_config(p, DEFAULTS, 'nocows', 'ANSIBLE_NOCOWS', None, boolean=True)
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
+# agent forwarding can be configured at 4 progressive levels: 'none', 'user', 'sudo', 'sudo_user'
+PARAMIKO_AGENT_FORWARDING      = get_config(p, 'paramiko_connection', 'agent_forwarding', 'ANSIBLE_PARAMIKO_AGENT_FORWARDING', 'none')
 ZEROMQ_PORT                    = int(get_config(p, 'fireball_connection', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099))
 ACCELERATE_PORT                = int(get_config(p, 'accelerate', 'accelerate_port', 'ACCELERATE_PORT', 5099))
 


### PR DESCRIPTION
Hello,

After our discussion on the ML, this patch improves the paramiko ssh transport in order to allow for agent forwarding.

option name : paramiko_connection.agent_forwarding
env option name : ANSIBLE_PARAMIKO_AGENT_FORWARDING

This option can take 4 progressive values :
- none (default): no agent forwarding
- user : allow agent forwarding for the ansible ssh user
- sudo : allow agent forwarding for the ansible ssh user & root via sudo or sudo_user
- sudo_user : allow agent forwarding for the ansible ssh user & root & any sudo_user

please note that for security reasons, the sudo_user != root case is only available when setfacl is available on the remote host

this implementation raise explicit errors when:
- paramiko version does not support agent forwarding
- setfacl is not present on the remote host

I hope this helps
