### PR TITLE
Fix traceback in service module when svc_cmd is None (2nd fix)

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -667,7 +667,7 @@ class LinuxService(Service):
             else:
                 # SysV
                 rc_state, stdout, stderr = self.execute_command("%s %s %s" % (self.action, self.name, arguments), daemonize=True)
-        elif self.svc_cmd.endswith('rc-service'):
+        elif self.svc_cmd and self.svc_cmd.endswith('rc-service'):
             # All services in OpenRC support restart.
             rc_state, stdout, stderr = self.execute_command("%s %s %s" % (svc_cmd, self.action, arguments), daemonize=True)
         else:


### PR DESCRIPTION
When service module is used on unsupported Linux system where init script is used directly, LinuxService.svc_cmd is None so .endswith() fails.

This extends fix from e2f20db53481128553d876109d5fbdab9f43dd5b also for state=restarted.

Fixes issue #3533

Running against Debian Lenny server:

```
$ ansible webserver.local -i webserver.local, -u root -m service -a 'name=apache2 state=restarted'
webserver.local | FAILED => failed to parse: Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-1379082596.06-63995244988034/service", line 2080, in <module>
    main()
  File "/root/.ansible/tmp/ansible-1379082596.06-63995244988034/service", line 1112, in main
    (rc, out, err) = service.modify_service_state()
  File "/root/.ansible/tmp/ansible-1379082596.06-63995244988034/service", line 299, in modify_service_state
    return self.service_control()
  File "/root/.ansible/tmp/ansible-1379082596.06-63995244988034/service", line 670, in service_control
    elif self.svc_cmd.endswith('rc-service'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```
