### PR TITLE
Added add_info_message function, which will be shown on every exit.

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -212,6 +212,8 @@ class AnsibleModule(object):
         if not no_log:
             self._log_invocation()
 
+        self._info_msg = ''
+
     def load_file_common_arguments(self, params):
         '''
         many modules deal with files, this encapsulates common
@@ -773,6 +775,9 @@ class AnsibleModule(object):
         else:
             self.fail_json(msg='Boolean %s not in either boolean list' % arg)
 
+    def add_info_message(self, info_msg):
+        self._info_msg += info_msg + ' '
+
     def jsonify(self, data):
         return json.dumps(data)
 
@@ -784,6 +789,7 @@ class AnsibleModule(object):
         self.add_path_info(kwargs)
         if not kwargs.has_key('changed'):
             kwargs['changed'] = False
+        kwargs['msg'] = self._info_msg
         print self.jsonify(kwargs)
         sys.exit(0)
 
@@ -792,6 +798,7 @@ class AnsibleModule(object):
         self.add_path_info(kwargs)
         assert 'msg' in kwargs, "implementation error -- msg to explain the error is required"
         kwargs['failed'] = True
+        kwargs['msg'] = self._info_msg + kwargs['msg']
         print self.jsonify(kwargs)
         sys.exit(1)
 


### PR DESCRIPTION
In GH-4086, we have to add a info message in case of auto-installing python-apt.
IMHO this could be useful in more modules, so I implemented it in module_common.

Usage:

```
module = AnsibleModule
module.add_info_message('Module is deprecated. Use foobar instead.')
```

Or as it would be for GH-4086:

```
try:
    import apt
    import apt_pkg
except:
    try:
        module.run_command('apt-get install python-apt -y')
        import apt
        import apt_pkg
        module.add_info_message('python-apt was auto-installed to enable the future operation of this module.')
    except:
        module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")
```

Result installing foobar failed not having python-apt available:

```
TASK: [install default packages] ********************************************** 
failed: [web.example.com] => (item=foobar) => {"failed": true, "item": "foobar"}
msg: python-apt was auto-installed to enable the future operation of this module. No package matching 'foobar' is available.
```
