### PR TITLE
DEFAULT_MODULE_PATH in setup.py

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -82,9 +82,12 @@ active_user   = pwd.getpwuid(os.geteuid())[0]
 # Needed so the RPM can call setup.py and have modules land in the
 # correct location. See #1277 for discussion
 if getattr(sys, "real_prefix", None):
+    # in a virtualenv
     DIST_MODULE_PATH = os.path.join(sys.prefix, 'share/ansible/')
 else:
     DIST_MODULE_PATH = '/usr/share/ansible/'
+# custom ansible location without a virtualenv
+DIST_MODULE_PATH = os.environ.get("ANSIBLE_DIST_MODULE_PATH", DIST_MODULE_PATH)
 
 # sections in config file
 DEFAULTS='defaults'

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -86,8 +86,6 @@ if getattr(sys, "real_prefix", None):
     DIST_MODULE_PATH = os.path.join(sys.prefix, 'share/ansible/')
 else:
     DIST_MODULE_PATH = '/usr/share/ansible/'
-# custom ansible location without a virtualenv
-DIST_MODULE_PATH = os.environ.get("ANSIBLE_DIST_MODULE_PATH", DIST_MODULE_PATH)
 
 # sections in config file
 DEFAULTS='defaults'

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ from ansible import __version__, __author__
 from distutils.core import setup
 
 # find library modules
-from ansible.constants import DIST_MODULE_PATH
+from ansible.constants import DEFAULT_MODULE_PATH
 dirs=os.listdir("./library/")
 data_files = []
 for i in dirs:
-    data_files.append((DIST_MODULE_PATH + i, glob('./library/' + i + '/*')))
+    data_files.append((DEFAULT_MODULE_PATH + i, glob('./library/' + i + '/*')))
 
 setup(name='ansible',
       version=__version__,


### PR DESCRIPTION
Using `DEFAULT_MODULE_PATH` in setup.py allows for the use of `ANSIBLE_LIBRARY` environment variable to set the location of the install.
