### PR TITLE
Fix how module_common handles selevel (issue #4142)

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -233,7 +233,7 @@ class AnsibleModule(object):
         seuser    = params.get('seuser', None)
         serole    = params.get('serole', None)
         setype    = params.get('setype', None)
-        selevel   = params.get('serange', 's0')
+        selevel   = params.get('selevel', None)
         secontext = [seuser, serole, setype]
 
         if self.selinux_mls_enabled():
@@ -309,7 +309,9 @@ class AnsibleModule(object):
             return context
         if ret[0] == -1:
             return context
-        context = ret[1].split(':')
+        # Limit split to 4 because the selevel, the last in the list,
+        # may contain ':' characters
+        context = ret[1].split(':', 3)
         return context
 
     def selinux_context(self, path):
@@ -325,7 +327,9 @@ class AnsibleModule(object):
                 self.fail_json(path=path, msg='failed to retrieve selinux context')
         if ret[0] == -1:
             return context
-        context = ret[1].split(':')
+        # Limit split to 4 because the selevel, the last in the list,
+        # may contain ':' characters
+        context = ret[1].split(':', 3)
         return context
 
     def user_and_group(self, filename):


### PR DESCRIPTION
Two fixes:
- parameter name is selevel, not serange.
- Fix split on selinux context to limit to max of 4 since the selevel
  may contain ':' characters.  This was fixed in
  selinux_default_context() and selinux_context().

See issue #4142.
