### PR TITLE
Digital ocean idempotence

### DIFF
--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -19,8 +19,9 @@ DOCUMENTATION = '''
 ---
 module: digital_ocean
 short_description: Create/delete a droplet/SSH_key in DigitalOcean
-description:
-     - Create/delete a droplet in DigitalOcean and optionally waits for it to be 'running', or deploy an SSH key.
+description: >
+  Create/delete a droplet in DigitalOcean and optionally waits for
+  it to be 'running', or deploy an SSH key.
 version_added: "1.3"
 options:
   command:
@@ -43,23 +44,28 @@ options:
     description:
      - Numeric, the droplet id you want to operate on.
   name:
-    description:
-     - String, this is the name of the droplet - must be formatted by hostname rules, or the name of a SSH key.
+    description: >
+      String, this is the name of the droplet - must be formatted by hostname
+      rules, or the name of a SSH key.
   size_id:
-    description:
-     - Numeric, this is the id of the size you would like the droplet created at.
+    description: >
+      Numeric, this is the id of the size you would like the droplet created
+      at.
   image_id:
-    description:
-     - Numeric, this is the id of the image you would like the droplet created with.
+    description: >
+      Numeric, this is the id of the image you would like the droplet
+      created with.
   region_id:
     description:
      - "Numeric, this is the id of the region you would like your server"
   ssh_key_ids:
-    description:
-     - Optional, comma separated list of ssh_key_ids that you would like to be added to the server
+    description: >
+      Optional, comma separated list of ssh_key_ids that you would like to be
+      added to the server
   wait:
-    description:
-     - Wait for the droplet to be in state 'running' before returning.  If wait is "no" an ip_address may not be returned.
+    description: >
+      Wait for the droplet to be in state 'running' before returning.  If
+      wait is "no" an ip_address may not be returned.
     default: "yes"
     choices: [ "yes", "no" ]
   wait_timeout:
@@ -76,9 +82,10 @@ notes:
 
 
 EXAMPLES = '''
-# Ensure a SSH key is present
+# Ensure a SSH key is present.
 # If a key matches this name, will return the ssh key id and changed = False
-# If no existing key matches this name, a new key is created, the ssh key id is returned and changed = False
+# If no existing key matches this name, a new key is created, the ssh key id
+# is returned and changed = False
 
 - digital_ocean: >
       state=present
@@ -89,7 +96,8 @@ EXAMPLES = '''
       api_key=XXX
 
 # Create a new Droplet
-# Will return the droplet details including the droplet id (used for idempotence)
+# Will return the droplet details including the droplet id (used for
+# idempotence)
 
 - digital_ocean: >
       state=present
@@ -105,8 +113,10 @@ EXAMPLES = '''
 - debug: msg="ID: {{ my_droplet.droplet.id }} IP: {{ my_droplet.droplet.ip_address }}"
 
 # Ensure a droplet is present
-# If droplet id already exist, will return the droplet details and changed = False
-# If no droplet matches the id, a new droplet will be created and the droplet details (including the new id) are returned, changed = True.
+# If droplet id already exist, will return the droplet details and
+# changed = False
+# If no droplet matches the id, a new droplet will be created and the droplet
+# details (including the new id) are returned, changed = True.
 
 - digital_ocean: >
       state=present
@@ -121,7 +131,8 @@ EXAMPLES = '''
       wait_timeout=500
 
 # Create a droplet with ssh key
-# The ssh key id can be passed as argument at the creation of a droplet (see ssh_key_ids).
+# The ssh key id can be passed as argument at the creation of a droplet
+# (see ssh_key_ids).
 # Several keys can be added to ssh_key_ids as id1,id2,id3
 # The keys are used to connect as root to the droplet.
 
@@ -146,14 +157,17 @@ except ImportError as e:
     print "failed=True msg='dopy required for this module'"
     sys.exit(1)
 
+
 class TimeoutError(DoError):
     def __init__(self, msg, id):
         super(TimeoutError, self).__init__(msg)
         self.id = id
 
+
 class JsonfyMixIn(object):
     def to_json(self):
         return self.__dict__
+
 
 class Droplet(JsonfyMixIn):
     manager = None
@@ -205,7 +219,13 @@ class Droplet(JsonfyMixIn):
 
     @classmethod
     def add(cls, name, size_id, image_id, region_id, ssh_key_ids=None):
-        json = cls.manager.new_droplet(name, size_id, image_id, region_id, ssh_key_ids)
+        json = cls.manager.new_droplet(
+            name,
+            size_id,
+            image_id,
+            region_id,
+            ssh_key_ids,
+        )
         droplet = cls(json)
         return droplet
 
@@ -223,6 +243,7 @@ class Droplet(JsonfyMixIn):
     def list_all(cls):
         json = cls.manager.all_active_droplets()
         return map(cls, json)
+
 
 class SSH(JsonfyMixIn):
     manager = None
@@ -259,6 +280,7 @@ class SSH(JsonfyMixIn):
         json = cls.manager.new_ssh_key(name, key_pub)
         return cls(json)
 
+
 def core(module):
     def getkeyordie(k):
         v = module.params[k]
@@ -283,24 +305,29 @@ def core(module):
             droplet = Droplet.find(module.params['id'])
             if not droplet:
                 droplet = Droplet.add(
-                        name=getkeyordie('name'),
-                        size_id=getkeyordie('size_id'),
-                        image_id=getkeyordie('image_id'),
-                        region_id=getkeyordie('region_id'),
-                        ssh_key_ids=module.params['ssh_key_ids']
-                    )
+                    name=getkeyordie('name'),
+                    size_id=getkeyordie('size_id'),
+                    image_id=getkeyordie('image_id'),
+                    region_id=getkeyordie('region_id'),
+                    ssh_key_ids=module.params['ssh_key_ids']
+                )
+
             if droplet.is_powered_on():
                 changed = False
+
             droplet.ensure_powered_on(
-                        wait=getkeyordie('wait'),
-                        wait_timeout=getkeyordie('wait_timeout')
-                    )
+                wait=getkeyordie('wait'),
+                wait_timeout=getkeyordie('wait_timeout')
+            )
+
             module.exit_json(changed=changed, droplet=droplet.to_json())
 
         elif state in ('absent', 'deleted'):
             droplet = Droplet.find(getkeyordie('id'))
+
             if not droplet:
-                module.exit_json(changed=False, msg='The droplet is not found.')
+                module.exit_json(changed=False, msg='The droplet not found.')
+
             event_json = droplet.destroy()
             module.exit_json(changed=True, event_id=event_json['event_id'])
 
@@ -316,38 +343,44 @@ def core(module):
 
         elif state in ('absent', 'deleted'):
             key = SSH.find(name)
+
             if not key:
-                module.exit_json(changed=False, msg='SSH key with the name of %s is not found.' % name)
+                module.exit_json(
+                    changed=False,
+                    msg='SSH key with the name of %s is not found.' % name)
+
             key.destroy()
             module.exit_json(changed=True)
 
 
 def main():
     module = AnsibleModule(
-        argument_spec = dict(
-            command = dict(choices=['droplet', 'ssh'], default='droplet'),
-            state = dict(choices=['active', 'present', 'absent', 'deleted'], default='present'),
-            client_id = dict(aliases=['CLIENT_ID'], no_log=True),
-            api_key = dict(aliases=['API_KEY'], no_log=True),
-            name = dict(type='str'),
-            size_id = dict(type='int'),
-            image_id = dict(type='int'),
-            region_id = dict(type='int'),
-            ssh_key_ids = dict(default=''),
-            id = dict(aliases=['droplet_id'], type='int'),
-            wait = dict(type='bool', choices=BOOLEANS, default='yes'),
-            wait_timeout = dict(default=300, type='int'),
-            ssh_pub_key = dict(type='str'),
+        argument_spec=dict(
+            command=dict(choices=['droplet', 'ssh'], default='droplet'),
+            state=dict(
+                choices=['active', 'present', 'absent', 'deleted'],
+                default='present'),
+            client_id=dict(aliases=['CLIENT_ID'], no_log=True),
+            api_key=dict(aliases=['API_KEY'], no_log=True),
+            name=dict(type='str'),
+            size_id=dict(type='int'),
+            image_id=dict(type='int'),
+            region_id=dict(type='int'),
+            ssh_key_ids=dict(default=''),
+            id=dict(aliases=['droplet_id'], type='int'),
+            wait=dict(type='bool', choices=BOOLEANS, default='yes'),
+            wait_timeout=dict(default=300, type='int'),
+            ssh_pub_key=dict(type='str'),
         ),
-        required_together = (
+        required_together=(
             ['size_id', 'image_id', 'region_id'],
         ),
-        mutually_exclusive = (
+        mutually_exclusive=(
             ['size_id', 'ssh_pub_key'],
             ['image_id', 'ssh_pub_key'],
             ['region_id', 'ssh_pub_key'],
         ),
-        required_one_of = (
+        required_one_of=(
             ['id', 'name'],
         ),
     )

--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -208,9 +208,9 @@ class Droplet(JsonfyMixIn):
             self.power_on()
 
         if wait:
-            end_time = time.time()+wait_timeout
+            end_time = time.time() + wait_timeout
             while time.time() < end_time:
-                time.sleep(min(20, end_time-time.time()))
+                time.sleep(min(20, end_time - time.time()))
                 self.update_attr()
                 if self.is_powered_on():
                     if not self.ip_address:

--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -110,7 +110,8 @@ EXAMPLES = '''
       image_id=3
       wait_timeout=500
   register: my_droplet
-- debug: msg="ID: {{ my_droplet.droplet.id }} IP: {{ my_droplet.droplet.ip_address }}"
+- debug: msg="ID is {{ my_droplet.droplet.id }}"
+- debug: msg="IP is {{ my_droplet.droplet.ip_address }}"
 
 # Ensure a droplet is present
 # If droplet id already exist, will return the droplet details and

--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -47,6 +47,13 @@ options:
     description: >
       String, this is the name of the droplet - must be formatted by hostname
       rules, or the name of a SSH key.
+  unique_name:
+    description: >
+      Bool, require unique hostnames.  By default, digital ocean allows
+      multiple hosts with the same name.  Setting this to "yes" allows only one
+      host per name.  Useful for idempotence.
+    default: "no"
+    choices: [ "yes", "no" ]
   size_id:
     description: >
       Numeric, this is the id of the size you would like the droplet created
@@ -231,13 +238,22 @@ class Droplet(JsonfyMixIn):
         return droplet
 
     @classmethod
-    def find(cls, id):
-        if not id:
+    def find(cls, id=None, name=None):
+        if not id and not name:
             return False
+
         droplets = cls.list_all()
+
+        # Check first by id.  digital ocean requires that it be unique
         for droplet in droplets:
             if droplet.id == id:
                 return droplet
+
+        # Failing that, check by hostname.
+        for droplet in droplets:
+            if droplet.name == name:
+                return droplet
+
         return False
 
     @classmethod
@@ -303,7 +319,17 @@ def core(module):
     if command == 'droplet':
         Droplet.setup(client_id, api_key)
         if state in ('active', 'present'):
-            droplet = Droplet.find(module.params['id'])
+
+            # First, try to find a droplet by id.
+            droplet = Droplet.find(id=module.params['id'])
+
+            # If we couldn't find the droplet and the user is allowing unique
+            # hostnames, then check to see if a droplet with the specified
+            # hostname already exists.
+            if not droplet and module.params['unique_name']:
+                droplet = Droplet.find(name=getkeyordie('name'))
+
+            # If both of those attempts failed, then create a new droplet.
             if not droplet:
                 droplet = Droplet.add(
                     name=getkeyordie('name'),
@@ -324,7 +350,14 @@ def core(module):
             module.exit_json(changed=changed, droplet=droplet.to_json())
 
         elif state in ('absent', 'deleted'):
+            # First, try to find a droplet by id.
             droplet = Droplet.find(getkeyordie('id'))
+
+            # If we couldn't find the droplet and the user is allowing unique
+            # hostnames, then check to see if a droplet with the specified
+            # hostname already exists.
+            if not droplet and module.params['unique_name']:
+                droplet = Droplet.find(name=getkeyordie('name'))
 
             if not droplet:
                 module.exit_json(changed=False, msg='The droplet not found.')
@@ -369,6 +402,7 @@ def main():
             region_id=dict(type='int'),
             ssh_key_ids=dict(default=''),
             id=dict(aliases=['droplet_id'], type='int'),
+            unique_name=dict(type='bool', choices=BOOLEANS, default='no'),
             wait=dict(type='bool', choices=BOOLEANS, default='yes'),
             wait_timeout=dict(default=300, type='int'),
             ssh_pub_key=dict(type='str'),


### PR DESCRIPTION
Commit f20229d is cosmetic but invasive.
Commit fa20a10 fixes a broken example.
Commit 351d8e3 actually changes functionality.

As it stands now, it is difficult to write idempotent tasks for digital
ocean droplets.  Digital ocean assigns new nodes a random id when they
are provisioned and that id is the only key that can be used to identify
it in subsequent runs of that play.

The workflow up until now involved manual intervention:
- write a play defining a new node with no specified id
- run it, collect the randomly assigned id by hand
- modify the play to add the id by hand so future runs don't create
  duplicate nodes
- perform future re-runs that check if the node exists (by its id)
  - if it does exist then do nothing.
  - if it does not exist, then create it and return a _new random id_
  - collect the new random id by hand, modify the playbook file, and
    start all over.

Its a huge pain.

The modifications in this commit allow you to use the 'hostname' as a
primary key for idempotence with digital ocean.  By default, digital
ocean will let you create as many hosts with the same hostname as you
like.  Here, we provide an option to constrain the user to using only
unique hostnames.

The workflow will now look like:
- write a play defining a new node with a specified hostname and
  "unique_name: true""
- run it, create the new node and move on.
- re-run it, notice that a node with that hostname is already created
  and move on.
