### PR TITLE
using AIX 'csum' command for generating MD5 checksums

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -737,7 +737,8 @@ class Runner(object):
             "(/usr/bin/digest -a md5 %s 2>/dev/null)" % path,   # Solaris 10+
             "(/sbin/md5 -q %s 2>/dev/null)" % path,     # Freebsd
             "(/usr/bin/md5 -n %s 2>/dev/null)" % path,  # Netbsd
-            "(/bin/md5 -q %s 2>/dev/null)" % path       # Openbsd
+            "(/bin/md5 -q %s 2>/dev/null)" % path,      # Openbsd
+            "(/usr/bin/csum -h MD5 %s 2>/dev/null)" % path # AIX
         ]
 
         cmd = " || ".join(md5s)


### PR DESCRIPTION
md5 and md5sum are not available in AIX by default.

AIX provides csum for that purpose. Links to official technotes and documentation:
[How to get the MD5 checksum for a file: md5sum, digest, csum, fciv](http://www-01.ibm.com/support/docview.wss?uid=swg21496703)
[csum Command](http://pic.dhe.ibm.com/infocenter/aix/v7r1/topic/com.ibm.aix.cmds/doc/aixcmds1/csum.htm)
