### PR TITLE
dest in s3 module does not work with ~username expansion for home directories

### DIFF
--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -261,7 +261,7 @@ def main():
     bucket = module.params.get('bucket')
     obj = module.params.get('object')
     src = module.params.get('src')
-    dest = module.params.get('dest')
+    dest = os.path.expanduser(module.params.get('dest'))
     mode = module.params.get('mode')
     expiry = int(module.params['expiry'])
     s3_url = module.params.get('s3_url')


### PR DESCRIPTION
Since the s3 module uses boto's get_contents_to_filename which just calls an open() which, apparently, doesn't do tilde expansion, I wrapped the "dest" definition in os.path.expanduser() which will return the expanded path in case of successful tilde expansion and otherwise the original value
