### PR TITLE
Added md5 as a jinja filter - returns hex digest of input

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -22,6 +22,7 @@ import yaml
 import types
 import pipes
 from ansible import errors
+from ansible.utils import md5s
 
 def to_nice_yaml(*a, **kw):
     '''Make verbose, human readable yaml'''
@@ -111,5 +112,8 @@ class FilterModule(object):
 
             # quote string for shell usage
             'quote': quote,
+
+            # md5 hex digest of string
+            'md5': md5s,
         }
     


### PR DESCRIPTION
As briefly discussed with mdehaan on IRC yesterday, here is a tiny patch to expose the existing MD5 (string - md5s() function) from ansible utils as a Jinja2 filter.

I cannot find documentation for the jinja2 filter extensions that ansible provides, so have not updated that.
However this sort of thing would be useful to document somewhere, but need to find the right niche.
