### PR TITLE
Mapping, filtering and overriding in ec2.py inventory script

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -45,5 +45,47 @@ cache_path = /tmp
 # seconds, a new API call will be made, and the cache file will be updated.
 cache_max_age = 300
 
+# Tags whose values are comma delimited lists that should be un-wrapped
+# and considered as multiple key=value entries
+#
+# Thus a tag such as:
+#
+#   role = webserver,dbserver
+#
+# Would result in the inventory groups tag_role_webserver
+# and tag_role_dbserver being created.
+#
+# This key is optional
+#
+# list_value_tags = role,type[,...]
 
+# Specifies how inventory group names should be created from a given
+# tag. The template can use the context variables key and value.
+# A different template to be specified for each tag thus treated.
+# Format:
+#
+#   <key>:<formatter>[;<key>:<formatter>...]
+#
+# e.g. the following would replicate existing formatting
+#
+#   tag_to_group = role:tag_{key}_{value}
+#
+# The only context variables available are key and value
+# This key is optional
+# tag_to_group = role:{value}
 
+# When working with multiple VPC you may wish to restrict the inventory
+# only to those hosts in the specified VPC. You may also want to restrict
+# on other grounds and the include_hosts_by_tag key allows you to
+# do this. Supply a tag key and a value and only those
+# hosts containing a tag with said key and matching value will be
+# included anywhere in the inventory file
+# Format:
+#
+#   <key>:<value>
+#
+# e.g.
+#
+#   include_hosts_by_tag = aws_cloudformation_stack-name:MyFirstStack
+#
+# This key is optional


### PR DESCRIPTION
Tag name mapping and host filtering capabilities added

This feature commit provides new configuration settings to do the following:
- Map a tag name/value to a different group name to the default tag_<key>_<value>
- Specify that the value for a given tag is a comma delimited list to be unwrapped such that it simulates having multiple tags with the same key but different values (example: Role:webserver,cacheserver)
- Specify that hosts in the resultant inventory should be limited to those that have a given tag set to a given value. Useful for limiting inventory only to those hosts in a given VPC, for example.

In addition it is now possible to override ec2.ini settings with environment variables, and the search path for ec2.ini has been enhanced:
- The ini file variables can be overridden by setting environment labels
- The location of the ini file can be specified in environment labels and will also be sought in the current working dir prior to falling back to the original behaviour which is to look in the directory in which the ec2.py script is located.

Documentation and examples in the updated ec2.ini file.
