### PR TITLE
This adds a associate_public_ip parameter (to the ec2 module)

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -19,7 +19,7 @@ DOCUMENTATION = '''
 module: ec2
 short_description: create or terminate an instance in ec2, return instanceid
 description:
-     - Creates or terminates ec2 instances. When created optionally waits for it to be 'running'. This module has a dependency on python-boto >= 2.5
+     - Creates or terminates ec2 instances. When created optionally waits for it to be 'running'. This module has a dependency on python-boto >= 2.13
 version_added: "0.9"
 options:
   key_name:
@@ -163,6 +163,13 @@ options:
     required: false
     defualt: null
     aliases: []
+  associate_public_ip:
+    version_added: "1.4"
+    description:
+      - Boolean value as to whether a public IP address should be associated with the instance(s)
+    required: false
+    default: yes
+    aliases: []
   instance_profile_name:
     version_added: "1.3"
     description:
@@ -238,6 +245,7 @@ local_action:
     image: ami-6e649707
     wait: yes
     vpc_subnet_id: subnet-29e63245
+    associate_public_ip: no
 
 
 # Launch instances, runs some tasks
@@ -286,6 +294,7 @@ local_action:
 
 import sys
 import time
+from distutils.version import LooseVersion
 
 AWS_REGIONS = ['ap-northeast-1',
                'ap-southeast-1',
@@ -297,7 +306,10 @@ AWS_REGIONS = ['ap-northeast-1',
                'us-west-2']
 
 try:
+    import boto
     import boto.ec2
+    from boto.ec2.networkinterface import NetworkInterfaceSpecification
+    from boto.ec2.networkinterface import NetworkInterfaceCollection
     from boto.exception import EC2ResponseError
 except ImportError:
     print "failed=True msg='boto required for this module'"
@@ -379,6 +391,7 @@ def create_instances(module, ec2):
     instance_tags = module.params.get('instance_tags')
     vpc_subnet_id = module.params.get('vpc_subnet_id')
     private_ip = module.params.get('private_ip')
+    associate_public_ip = module.params.get('associate_public_ip')
     instance_profile_name = module.params.get('instance_profile_name')
 
 
@@ -442,8 +455,7 @@ def create_instances(module, ec2):
                       'instance_type': instance_type,
                       'kernel_id': kernel,
                       'ramdisk_id': ramdisk,
-                      'subnet_id': vpc_subnet_id,
-                      'private_ip_address': private_ip,
+                      'network_interfaces': None,
                       'user_data': user_data}
 
             if boto_supports_profile_name_arg(ec2):
@@ -454,11 +466,25 @@ def create_instances(module, ec2):
                         msg="instance_profile_name parameter requires Boto version 2.5.0 or higher")
 
             if vpc_subnet_id:
-                params['security_group_ids'] = group_id
+                if LooseVersion(boto.__version__) < LooseVersion('2.13'):
+                    module.fail_json(msg = "boto > 2.13 required for VPC instances")
+
+                network_interfaces = NetworkInterfaceCollection()
+                network_interfaces.append(
+                    NetworkInterfaceSpecification(
+                        device_index=0,
+                        private_ip_address=private_ip, 
+                        associate_public_ip_address = associate_public_ip,
+                        subnet_id = vpc_subnet_id,
+                        groups = group_id,
+                    )
+                )
+                params['network_interfaces'] = network_interfaces
             else:
                 params['security_groups'] = group_name
 
             res = ec2.run_instances(**params)
+
         except boto.exception.BotoServerError, e:
             module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
 
@@ -580,6 +606,7 @@ def main():
             instance_tags = dict(type='dict'),
             vpc_subnet_id = dict(),
             private_ip = dict(),
+            associate_public_ip = dict(choices=BOOLEANS, default=True),
             instance_profile_name = dict(),
             instance_ids = dict(type='list'),
             state = dict(default='present'),


### PR DESCRIPTION
The parameter defaults to true and sets things up so that VPC type instances
can get public IP addresses in non-default subnets.  The snag is that it
requires boto >= 2.13 which may be an issue for some deployments.
