### PR TITLE
Fix package_dir to properly reference lib. Remove extraneous include.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@ include README.md packaging/rpm/ansible.spec COPYING
 include examples/hosts
 include examples/ansible.cfg
 graft examples/playbooks
-include packaging/distutils/setup.py
 recursive-include docs *
 recursive-include library *
 include Makefile

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='ansible',
       url='http://ansibleworks.com/',
       license='GPLv3',
       install_requires=['paramiko', 'jinja2', "PyYAML"],
-      package_dir={ 'ansible': 'lib/ansible' },
+      package_dir={ '': 'lib' },
       packages=[
          'ansible',
          'ansible.utils',


### PR DESCRIPTION
This pull request fixes some of the package details in setup.py and allows for ansible to be installed in develop mode (a.k.a. `pip install -e https://github.com/ansible/ansible.git`).

It fixes #558 (which was closed pending a proposed fix, which this pull request is).

The problem boiled down to a slightly incorrect construction of the `package_dir` argument to `setup()`.

Proper usage of this setting is described [here in the disutils docs](http://docs.python.org/2/distutils/setupscript.html#listing-whole-packages). Those docs actually perfectly describe the ansible set up, where source code lives under a `lib` subdirectory. They suggest using `{ '': 'lib' }` and then explicitly listing out the packages that live there. This is what my pull request accomplishes.

That's the easy explanation, and if you read those docs I linked to above my change aligns with the recommendation there.

The more confusing bit is the fact that this _should_ apparently play nicely with `pip install -e` / `python setup.py develop` as it is written now. Why it doesn't play nicely is apparently an issue that the distribute folks are contending with, see here: https://bitbucket.org/tarek/distribute/issue/177/setuppy-develop-doesnt-support-package_dir

In short, this change should not alter behavior for normal `python setup.py install` usage but should allow developers to install in editable mode via pip if they choose to.

(The change to MANIFEST.in removes an include that references a non existent file and throws a warning during pip install process.)
