### PR TITLE
changed deprecated channel_label attribute

### DIFF
--- a/library/packaging/rhn_channel
+++ b/library/packaging/rhn_channel
@@ -89,7 +89,10 @@ def unsubscribe_channels(channels, client, session, sysname, sys_id):
 
 def base_channels(client, session, sys_id):
     basechan = client.channel.software.listSystemChannels(session, sys_id)
-    chans = [item['channel_label'] for item in basechan]
+    try:
+        chans = [item['label'] for item in basechan]
+    except KeyError:
+        chans = [item['channel_label'] for item in basechan]
     return chans
 
 # ------------------------------------------------------- #


### PR DESCRIPTION
Since RHN Satellite 5.3 "channel_label" attribute is removed from the api (deprecated in RHN Satellite 5.2), it is replaced by "label" attribute.
https://access.redhat.com/site/documentation/en-US/Red_Hat_Network_Satellite/5.2/html/API_Overview/files/handlers/ChannelSoftwareHandler.html#listSystemChannels
