### PR TITLE
Adding support for yaml inventory scripts

### DIFF
--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -49,15 +49,15 @@ class InventoryScript(object):
     def _parse(self, err):
 
         all_hosts = {}
-        self.raw  = utils.parse_json(self.data)
         all       = Group('all')
         groups    = dict(all=all)
         group     = None
 
-
-        if 'failed' in self.raw:
+        try:
+            self.raw = utils.parse_yaml(self.data)
+        except Exception, e:
             sys.stderr.write(err + "\n")
-            raise errors.AnsibleError("failed to parse executable inventory script results: %s" % self.raw)
+            raise errors.AnsibleError("failed to parse executable inventory script results: %s" % e)
 
         for (group_name, data) in self.raw.items():
  


### PR DESCRIPTION
Since all valid JSON is valid YAML, using the yaml parser for inventory scripts instead of the json parser.

Thanks,
Thomas Omans
