### PR TITLE
supervisorctl module: adding support for custom supervisord installations

### DIFF
--- a/library/web_infrastructure/supervisorctl
+++ b/library/web_infrastructure/supervisorctl
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+import os
 
 DOCUMENTATION = '''
 ---
@@ -62,6 +63,14 @@ options:
     required: true
     default: null
     choices: [ "present", "started", "stopped", "restarted" ]
+  supervisorctl_path:
+    description:
+      - Path to supervisorctl executable to use
+    required: false
+    default: null
+    version_added: "1.4"
+requirements:
+  - supervisorctl
 requirements: [ ]
 author: Matt Wright
 '''
@@ -85,6 +94,7 @@ def main():
         server_url=dict(required=False),
         username=dict(required=False),
         password=dict(required=False),
+        supervisorctl_path=dict(required=False),
         state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped'])
     )
 
@@ -96,8 +106,16 @@ def main():
     server_url = module.params.get('server_url')
     username = module.params.get('username')
     password = module.params.get('password')
+    supervisorctl_path = module.params.get('supervisorctl_path')
 
-    supervisorctl_args = [ module.get_bin_path('supervisorctl', True) ]
+    if supervisorctl_path:
+        supervisorctl_path = os.path.expanduser(supervisorctl_path)
+        if os.path.exists(supervisorctl_path) and module.is_executable(supervisorctl_path):
+            supervisorctl_args = [ supervisorctl_path ]
+        else:
+            module.fail_json(msg="Provided path to supervisorctl does not exist or isn't executable: %s" % ctl_path)
+    else:
+        supervisorctl_args = [ module.get_bin_path('supervisorctl', True) ]
 
     if config:
         supervisorctl_args.extend(['-c', config])


### PR DESCRIPTION
Supervisord can be installed at the user level or system level.
Installing as a user is particularly useful for systems without root access.

Adds the ability to provide a custom supervisorctl executable path, supporting custom installations
