### PR TITLE
fix documentation examples for with_nested

### DIFF
--- a/docsite/latest/rst/playbooks2.rst
+++ b/docsite/latest/rst/playbooks2.rst
@@ -500,15 +500,15 @@ Nested Loops
 Loops can be nested as well::
 
     - name: give users access to multiple databases
-      mysql_user: name={{ item[0] }} priv={{ item[1] }}.*:*
+      mysql_user: name={{ item[0] }} priv={{ item[1] }}.*:ALL password=foo
       with_nested:
         - [ 'alice', 'bob', 'eve' ]
         - [ 'clientdb', 'employeedb', 'providerdb' ]
 
-As with the case of 'with_items' above, you can use previously defined variables. Just specify the variable'sname without templating it with '{{ }}'::
+As with the case of 'with_items' above, you can use previously defined variables. Just specify the variable's name without templating it with '{{ }}'::
 
     - name: here, 'users' contains the above list of employees
-      mysql_user: name={{ item[0] }} priv={{ item[1] }}.*:*
+      mysql_user: name={{ item[0] }} priv={{ item[1] }}.*:ALL password=foo
       with_nested:
         - users
         - [ 'clientdb', 'employeedb', 'providerdb' ]


### PR DESCRIPTION
In the mailing list, Edgars Mazurs commented that the docs' example for with_nested could be wrong: https://groups.google.com/forum/#!topic/ansible-project/PpRrBQv_T9s

This made me test the examples, and it turns out the example itself was almost good: there was an sql-related bug and I had missed the required password parameter. I've fixed the errors and tested the new examples before pushing. Sorry for that. From now on, I'll test the actual examples I add to the docs before pushing.

GATHERING FACTS ***************************************************************
ok: [testhost]

TASK: [give users access to multiple databases] *******************************
changed: [testhost] => (item=['alice', 'clientdb'])
changed: [testhost] => (item=['alice', 'employeedb'])
changed: [testhost] => (item=['alice', 'providerdb'])
changed: [testhost] => (item=['bob', 'clientdb'])
changed: [testhost] => (item=['bob', 'employeedb'])
changed: [testhost] => (item=['bob', 'providerdb'])
changed: [testhost] => (item=['eve', 'clientdb'])
changed: [testhost] => (item=['eve', 'employeedb'])
changed: [testhost] => (item=['eve', 'providerdb'])

PLAY RECAP ********************************************************************
testhost : ok=2    changed=1    unreachable=0    failed=0
