### PR TITLE
Fix the install destination

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from ansible.constants import DEFAULT_MODULE_PATH
 dirs=os.listdir("./library/")
 data_files = []
 for i in dirs:
-    data_files.append((DEFAULT_MODULE_PATH + '/' + i, glob('./library/' + i + '/*')))
+    data_files.append((os.path.join(DEFAULT_MODULE_PATH, i), glob('./library/' + i + '/*')))
 
 setup(name='ansible',
       version=__version__,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from ansible.constants import DEFAULT_MODULE_PATH
 dirs=os.listdir("./library/")
 data_files = []
 for i in dirs:
-    data_files.append((DEFAULT_MODULE_PATH + i, glob('./library/' + i + '/*')))
+    data_files.append((DEFAULT_MODULE_PATH + '/' + i, glob('./library/' + i + '/*')))
 
 setup(name='ansible',
       version=__version__,


### PR DESCRIPTION
When installing the destination directory is wrong.

Things end up in the `/usr/share/ansible<name>/` directory and _not_ where they should (`/usr/share/ansible/<name>`)
