### PR TITLE
Allow for dynamic accelerate_port: and port: in plays

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -624,7 +624,7 @@ class Runner(object):
                 # calls just to accomodate this one case
                 actual_port = [actual_port, self.accelerate_port]
             elif actual_port is not None:
-                actual_port = int(actual_port)
+                actual_port = int(template.template(self.basedir, actual_port, inject))
         except ValueError, e:
             result = dict(failed=True, msg="FAILED: Configured port \"%s\" is not a valid port, expected integer" % actual_port)
             return ReturnData(host=host, comm_ok=False, result=result)

--- a/library/utilities/accelerate
+++ b/library/utilities/accelerate
@@ -347,7 +347,8 @@ def main():
             port=dict(required=False, default=5099),
             password=dict(required=True),
             minutes=dict(required=False, default=30),
-        )
+        ),
+        supports_check_mode=True
     )
 
     password  = base64.b64decode(module.params['password'])

--- a/library/utilities/fireball
+++ b/library/utilities/fireball
@@ -259,7 +259,8 @@ def main():
             port=dict(required=False, default=5099),
             password=dict(required=True),
             minutes=dict(required=False, default=30),
-        )
+        ),
+        supports_check_mode=True
     )
 
     password  = base64.b64decode(module.params['password'])


### PR DESCRIPTION
ansible-playbook run from different terminal session or by colleage doesn't break fireball or accelerate connection anymore with individual port taken from script. Use with port: $LOOKUP(pipe,id -u) or similar.
