### PR TITLE
Allow for dynamic accelerate_port: and port: in plays

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -624,7 +624,7 @@ class Runner(object):
                 # calls just to accomodate this one case
                 actual_port = [actual_port, self.accelerate_port]
             elif actual_port is not None:
-                actual_port = int(actual_port)
+                actual_port = int(template.template(self.basedir, actual_port, inject))
         except ValueError, e:
             result = dict(failed=True, msg="FAILED: Configured port \"%s\" is not a valid port, expected integer" % actual_port)
             return ReturnData(host=host, comm_ok=False, result=result)


### PR DESCRIPTION
ansible-playbook run from different terminal session or by colleage doesn't break fireball or accelerate connection anymore with individual port taken from script. Use with port: $LOOKUP(pipe,id -u) or similar.
