### PR TITLE
ec2 inventory: Add the ability to group instances by their Route 53 domain names

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -36,11 +36,11 @@ vpc_destination_variable = ip_address
 
 # To tag instances on EC2 with the resource records that point to them from
 # Route53, uncomment and set 'route53' to True.
-#
-# Optionally, you can specify the list of zones to exclude looking up in
-# 'route53_excluded_zones' as a comma-seperated list.
 route53 = False
-route53_excluded_zones =
+
+# Additionally, you can specify the list of zones to exclude looking up in
+# 'route53_excluded_zones' as a comma-seperated list.
+# route53_excluded_zones = samplezone1.com, samplezone2.com
 
 # API calls to EC2 are slow. For this reason, we cache the results of an API
 # call. Set this to the path you want cache files to be written to. Two files

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -34,6 +34,14 @@ destination_variable = public_dns_name
 # be run from with EC2.
 vpc_destination_variable = ip_address
 
+# To tag instances on EC2 with the resource records that point to them from
+# Route53, uncomment and set 'route53' to True.
+#
+# Optionally, you can specify the list of zones to exclude looking up in
+# 'route53_excluded_zones' as a comma-seperated list.
+route53 = False
+route53_excluded_zones =
+
 # API calls to EC2 are slow. For this reason, we cache the results of an API
 # call. Set this to the path you want cache files to be written to. Two files
 # will be written to this directory:
@@ -44,6 +52,3 @@ cache_path = /tmp
 # The number of seconds a cache file is considered valid. After this many
 # seconds, a new API call will be made, and the cache file will be updated.
 cache_max_age = 300
-
-
-

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -207,7 +207,10 @@ class Ec2Inventory(object):
 
         # Route53
         self.route53_enabled = config.getboolean('ec2', 'route53')
-        self.route53_excluded_zones = config.get('ec2', 'route53_excluded_zones', '').split(',')
+        self.route53_excluded_zones = []
+        if config.has_option('ec2', 'route53_excluded_zones'):
+            self.route53_excluded_zones.extend(
+                config.get('ec2', 'route53_excluded_zones', '').split(','))
 
         # Cache related
         cache_path = config.get('ec2', 'cache_path')
@@ -422,9 +425,8 @@ class Ec2Inventory(object):
         r53_conn = route53.Route53Connection()
         all_zones = r53_conn.get_zones()
 
-        is_valid_zone = lambda zone: not zone.name in self.route53_excluded_zones
-
-        route53_zones = filter(is_valid_zone, all_zones)
+        route53_zones = [ zone for zone in all_zones if zone.name[:-1] 
+                          not in self.route53_excluded_zones ]
 
         self.route53_records = {}
 

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -337,7 +337,7 @@ class Ec2Inventory(object):
 
         # Inventory: Group by availability zone
         self.push(self.inventory, instance.placement, dest)
-        
+
         # Inventory: Group by instance type
         self.push(self.inventory, self.to_safe('type_' + instance.instance_type), dest)
 
@@ -425,7 +425,7 @@ class Ec2Inventory(object):
         r53_conn = route53.Route53Connection()
         all_zones = r53_conn.get_zones()
 
-        route53_zones = [ zone for zone in all_zones if zone.name[:-1] 
+        route53_zones = [ zone for zone in all_zones if zone.name[:-1]
                           not in self.route53_excluded_zones ]
 
         self.route53_records = {}


### PR DESCRIPTION
For users that use Route53 to reference their instances, it's much more convenient to be able to address instances by the domain names that point to it, rather than the instance's generated public domain name or IP address details.

This change adds extra groups by domain name for each instance, and can optionally ignore specific Route53 DNS zones that the user may specify.
