### PR TITLE
Env facts added

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -737,7 +737,8 @@ class Runner(object):
             "(/usr/bin/digest -a md5 %s 2>/dev/null)" % path,   # Solaris 10+
             "(/sbin/md5 -q %s 2>/dev/null)" % path,     # Freebsd
             "(/usr/bin/md5 -n %s 2>/dev/null)" % path,  # Netbsd
-            "(/bin/md5 -q %s 2>/dev/null)" % path       # Openbsd
+            "(/bin/md5 -q %s 2>/dev/null)" % path,      # Openbsd
+            "(/usr/bin/csum -h MD5 %s 2>/dev/null)" % path # AIX
         ]
 
         cmd = " || ".join(md5s)

--- a/library/system/setup
+++ b/library/system/setup
@@ -147,6 +147,7 @@ class Facts(object):
         self.get_date_time_facts()
         self.get_user_facts()
         self.get_local_facts()
+        self.get_env_facts()
 
     def populate(self):
         return self.facts
@@ -457,6 +458,14 @@ class Facts(object):
     def get_user_facts(self):
         self.facts['user_id'] = getpass.getuser()
 
+    def get_env_facts(self):
+        self.facts['env'] = {}
+        for k in os.environ:
+            if len(k) > 0: # json encoder doesnt like empty keys
+                try:
+                    self.facts['env'][k] = os.environ[k]
+                except (KeyError,ValueError), e:
+                    pass # some stuff in environment breaks python dicts
 
 class Hardware(Facts):
     """


### PR DESCRIPTION
This should be used instead of #4051, it uses python instead of shell out also puts comments explaining why i filter 0 length keys and ignore errors 
