### PR TITLE
Fix for commented dmidecode output

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -629,7 +629,8 @@ class LinuxHardware(Hardware):
                 if dmi_bin is not None:
                     (rc, out, err) = module.run_command('%s -s %s' % (dmi_bin, v))
                     if rc == 0:
-                        self.facts[k] = out.rstrip()
+                        # Strip out commented lines (specific dmidecode output)
+                        self.facts[k] = ''.join([ line for line in out.split('\n') if not line.startswith('#') ])
                     else:
                         self.facts[k] = 'NA'
                 else:


### PR DESCRIPTION
This patch fixes the problem that on some system dmidecode prints out warning information as commented text. For example:

```
[user@system ~]# dmidecode -s system-manufacturer
# SMBIOS implementations newer than version 2.6 are not
# fully supported by this version of dmidecode.
HP
```

So we remove all commented lines from the output.
