### PR TITLE
Module lvol fails when decimal point is a colon

### DIFF
--- a/library/system/lvol
+++ b/library/system/lvol
@@ -72,7 +72,7 @@ EXAMPLES = '''
 '''
 
 import re
-decimal_point = pattern = re.compile(r"(\.|,)")
+decimal_point = re.compile(r"(\.|,)")
 
 def parse_lvs(data):
     lvs = []

--- a/library/system/lvol
+++ b/library/system/lvol
@@ -71,13 +71,16 @@ EXAMPLES = '''
 - lvol: vg=firefly lv=test state=absent
 '''
 
+import re
+decimal_point = pattern = re.compile(r"(\.|,)")
+
 def parse_lvs(data):
     lvs = []
     for line in data.splitlines():
         parts = line.strip().split(';')
         lvs.append({
             'name': parts[0],
-            'size': int(parts[1].split('.')[0]),
+            'size': int(decimal_point.split(parts[1])[0]),
         })
     return lvs
 


### PR DESCRIPTION
When decimal point is set to colon (LC_NUMERIC=pl_PL.UTF-8) module fails.
