### PR TITLE
Include database param if provided and valid in django_admin commands

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -186,7 +186,7 @@ def main():
     specific_params = ('apps', 'database', 'failfast', 'fixtures', 'liveserver', 'testrunner')
 
     # These params are automatically added to the command if present
-    general_params = ('settings', 'pythonpath', )
+    general_params = ('settings', 'pythonpath', 'database',)
     specific_boolean_params = ('failfast', 'skip', 'merge', 'link')
     end_of_command_params = ('apps', 'cache_table', 'fixtures')
 


### PR DESCRIPTION
The database param was being ignored in the django_admin commands that used it.
