### PR TITLE
Add option to disable creating a PTY during a paramiko connection

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -98,8 +98,11 @@ filter_plugins     = /usr/share/ansible_plugins/filter_plugins
 # uncomment this line to cause the paramiko connection plugin to not record new host
 # keys encountered.  Increases performance on new host additions.  Setting works independently of the
 # host key checking setting above.
-
 #record_host_keys=False
+
+# by default, Ansible request a pseudo-terminal for commands execuded under sudo. Uncomment this
+# line for override this behaviour.
+#pty=False
 
 [ssh_connection]
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -133,6 +133,7 @@ ANSIBLE_NOCOWS                 = get_config(p, DEFAULTS, 'nocows', 'ANSIBLE_NOCO
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
+PARAMIKO_PTY                   = get_config(p, 'paramiko_connection', 'pty', 'ANSIBLE_PARAMIKO_PTY', True, boolean=True)
 ZEROMQ_PORT                    = int(get_config(p, 'fireball_connection', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099))
 ACCELERATE_PORT                = int(get_config(p, 'accelerate', 'accelerate_port', 'ACCELERATE_PORT', 5099))
 

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -196,11 +196,12 @@ class Connection(object):
             chan.exec_command(quoted_command)
         else:
             # sudo usually requires a PTY (cf. requiretty option), therefore
-            # we give it one, and we try to initialise from the calling
-            # environment
-            chan.get_pty(term=os.getenv('TERM', 'vt100'),
-                         width=int(os.getenv('COLUMNS', 0)),
-                         height=int(os.getenv('LINES', 0)))
+            # we give it one by default (pty=True in ansble.cfg), and we try
+            # to initialise from the calling environment
+            if C.PARAMIKO_PTY:
+                chan.get_pty(term=os.getenv('TERM', 'vt100'),
+                             width=int(os.getenv('COLUMNS', 0)),
+                             height=int(os.getenv('LINES', 0)))
             shcmd, prompt = utils.make_sudo_cmd(sudo_user, executable, cmd)
             vvv("EXEC %s" % shcmd, host=self.host)
             sudo_output = ''


### PR DESCRIPTION
Probable fix for #4227 by adding boolean pty option in ansible.cfg
I still think that any type of program crash is the issue. Even if some option helps avoid this.
Maybe the best solution is try to call get_pty() function and, if it fails, worked without them. But I couldn't figure out some neat exception.
