### PR TITLE
Allow creating empty inventory

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -70,7 +70,9 @@ class Inventory(object):
                 host_list = host_list.split(",")
                 host_list = [ h for h in host_list if h and h.strip() ]
 
-        if isinstance(host_list, list):
+        if host_list is None:
+            self.parser = None
+        elif isinstance(host_list, list):
             self.parser = None
             all = Group('all')
             self.groups = [ all ]

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -30,6 +30,9 @@ class TestInventory(unittest.TestCase):
         print right
         assert left == right
 
+    def empty_inventory(self):
+        return Inventory(None)
+
     def simple_inventory(self):
         return Inventory(self.inventory_file)
 
@@ -53,6 +56,14 @@ class TestInventory(unittest.TestCase):
             'thrudgelmir3', 'thrudgelmir4', 'thrudgelmir5',
             'Hotep-a', 'Hotep-b', 'Hotep-c',
             'BastC', 'BastD', ]
+
+    #####################################
+    ### Empty inventory format tests
+
+    def test_empty(self):
+        inventory = self.empty_inventory()
+        hosts = inventory.list_hosts()
+        self.assertEqual(hosts, [])
 
     #####################################
     ### Simple inventory format tests


### PR DESCRIPTION
Instantiating the Inventory class with host_list=None now results in an
empty inventory instead of an error.
