### PR TITLE
Fix for accelerate when ansible_ssh_user is specified

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -571,6 +571,11 @@ class Runner(object):
         actual_private_key_file = inject.get('ansible_ssh_private_key_file', self.private_key_file)
 
         if self.accelerate and actual_transport != 'local':
+            #Fix to get the inventory name of the host to accelerate plugin
+            if inject.get('ansible_ssh_host', None):
+                self.accelerate_inventory_host = host
+            else:
+                self.accelerate_inventory_host = None
             # if we're using accelerated mode, force the
             # transport to accelerate
             actual_transport = "accelerate"

--- a/lib/ansible/runner/connection_plugins/accelerate.py
+++ b/lib/ansible/runner/connection_plugins/accelerate.py
@@ -86,7 +86,10 @@ class Connection(object):
     def _execute_accelerate_module(self):
         args = "password=%s port=%s" % (base64.b64encode(self.key.__str__()), str(self.accport))
         inject = dict(password=self.key)
-        inject = utils.combine_vars(inject, self.runner.inventory.get_variables(self.host))
+        if self.runner.accelerate_inventory_host:
+            inject = utils.combine_vars(inject, self.runner.inventory.get_variables(self.runner.accelerate_inventory_host))
+        else:
+            inject = utils.combine_vars(inject, self.runner.inventory.get_variables(self.host))
         self.ssh.connect()
         tmp_path = self.runner._make_tmp_path(self.ssh)
         return self.runner._execute_module(self.ssh, tmp_path, 'accelerate', args, inject=inject)


### PR DESCRIPTION
This PR fixes the issue where accelerate module fails is ansible_ssh_user is specified in inventory.
