### PR TITLE
Allow storing input from user in a pause prompt

### DIFF
--- a/lib/ansible/runner/action_plugins/pause.py
+++ b/lib/ansible/runner/action_plugins/pause.py
@@ -101,7 +101,7 @@ class ActionModule(object):
                 # Clear out any unflushed buffered input which would
                 # otherwise be consumed by raw_input() prematurely.
                 tcflush(sys.stdin, TCIFLUSH)
-                raw_input(self.prompt)
+                self.result['user_input'] = raw_input(self.prompt)
         except KeyboardInterrupt:
             while True:
                 print '\nAction? (a)bort/(c)ontinue: '


### PR DESCRIPTION
It came up a few times in #ansible today that there are some situations where you might want to capture the users input inline (one example was confirming that a user did indeed want to delete a database, or other destructive operations). This simply sets the user_input var in the result dict that allows you to use register on a pause to use it down the road for something else.

//cc @drybjed @candeira
