### PR TITLE
Coerce param types before checking

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -202,8 +202,8 @@ class AnsibleModule(object):
 
         if not bypass_checks:
             self._check_required_arguments()
-            self._check_argument_values()
             self._check_argument_types()
+            self._check_argument_values()
             self._check_mutually_exclusive(mutually_exclusive)
             self._check_required_together(required_together)
             self._check_required_one_of(required_one_of)

--- a/library/cloud/linode
+++ b/library/cloud/linode
@@ -440,7 +440,7 @@ def main():
             distribution = dict(type='int'),
             datacenter = dict(type='int'),
             linode_id = dict(type='int', aliases=['lid']),
-            payment_term = dict(default=1, choices=[1, 12, 24]),
+            payment_term = dict(type='int', default=1, choices=[1, 12, 24]),
             password = dict(type='str'),
             ssh_pub_key = dict(type='str'),
             swap = dict(type='int', default=512),


### PR DESCRIPTION
As explained in the message for the first commit, it seems to be better to first coerce module parameter types and then check their validity.

Included is a related Linode module param fix that initially led me to make this change.
