### PR TITLE
Check parameter types before checking their values.

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -202,8 +202,8 @@ class AnsibleModule(object):
 
         if not bypass_checks:
             self._check_required_arguments()
-            self._check_argument_values()
             self._check_argument_types()
+            self._check_argument_values()
             self._check_mutually_exclusive(mutually_exclusive)
             self._check_required_together(required_together)
             self._check_required_one_of(required_one_of)


### PR DESCRIPTION
Checking types has a side effect of coercing types for parameters, which means
that an argument spec like this:

  argument_spec = dict(
    arg = dict(type='int', choices=[1, 2, 3]))

will work with -e arg=1. Otherwise it will fail, since the argument is a string
and the choices are all ints.
