### PR TITLE
Add support for tags parameter to cloudformation module

### DIFF
--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -63,6 +63,7 @@ options:
   tags:
     description:
       - Dictionary of tags to associate with stack and it's resources during stack creation. Cannot be updated later.
+        Requires at least Boto version 2.6.0.
     required: false
     default: null
     aliases: []
@@ -93,6 +94,7 @@ import json
 import time
 
 try:
+    import boto
     import boto.cloudformation.connection
 except ImportError:
     print "failed=True msg='boto required for this module'"
@@ -124,6 +126,17 @@ def boto_exception(err):
         error = '%s: %s' % (Exception, err)
 
     return error
+
+
+def boto_version_required(version_tuple):
+    parts = boto.Version.split('.')
+    boto_version = []
+    try:
+        for part in parts:
+            boto_version.append(int(part))
+    except:
+        boto_version.append(-1)
+    return tuple(boto_version) >= tuple(version_tuple)
 
 
 def stack_operation(cfn, stack_name, operation):
@@ -190,6 +203,11 @@ def main():
         elif 'EC2_REGION' in os.environ:
             r = os.environ['EC2_REGION']
 
+    kwargs = dict()
+    if tags is not None:
+        if not boto_version_required((2,6,0)):
+            module.fail_json(msg='Module parameter "tags" requires at least Boto version 2.6.0')
+        kwargs['tags'] = tags
 
 
     # convert the template parameters ansible passes into a tuple for boto
@@ -214,7 +232,7 @@ def main():
                              template_body=template_body,
                              disable_rollback=disable_rollback,
                              capabilities=['CAPABILITY_IAM'],
-                             tags=tags)
+                             **kwargs)
             operation = 'CREATE'
         except Exception, err:
             error_msg = boto_exception(err)

--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -67,6 +67,7 @@ options:
     required: false
     default: null
     aliases: []
+    version_added: "1.4"
 
 requirements: [ "boto" ]
 author: James S. Martin

--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -60,6 +60,12 @@ options:
     required: true
     default: null
     aliases: []
+  tags:
+    description:
+      - Dictionary of tags to associate with stack and it's resources during stack creation. Cannot be updated later.
+    required: false
+    default: null
+    aliases: []
 
 requirements: [ "boto" ]
 author: James S. Martin
@@ -79,6 +85,8 @@ tasks:
       DiskType: ephemeral
       InstanceType: m1.small
       ClusterSize: 3
+    tags:
+      Stack: ansible-cloudformation
 '''
 
 import json
@@ -163,7 +171,8 @@ def main():
             region=dict(aliases=['aws_region', 'ec2_region'], required=True, choices=AWS_REGIONS),
             state=dict(default='present', choices=['present', 'absent']),
             template=dict(default=None, required=True),
-            disable_rollback=dict(default=False)
+            disable_rollback=dict(default=False),
+            tags=dict(default=None)
         )
     )
 
@@ -173,14 +182,15 @@ def main():
     template_body = open(module.params['template'], 'r').read()
     disable_rollback = module.params['disable_rollback']
     template_parameters = module.params['template_parameters']
+    tags = module.params['tags']
 
     if not r:
         if 'AWS_REGION' in os.environ:
             r = os.environ['AWS_REGION']
         elif 'EC2_REGION' in os.environ:
             r = os.environ['EC2_REGION']
-    
-    
+
+
 
     # convert the template parameters ansible passes into a tuple for boto
     template_parameters_tup = [(k, v) for k, v in template_parameters.items()]
@@ -203,7 +213,8 @@ def main():
             cfn.create_stack(stack_name, parameters=template_parameters_tup,
                              template_body=template_body,
                              disable_rollback=disable_rollback,
-                             capabilities=['CAPABILITY_IAM'])
+                             capabilities=['CAPABILITY_IAM'],
+                             tags=tags)
             operation = 'CREATE'
         except Exception, err:
             error_msg = boto_exception(err)


### PR DESCRIPTION
Expose boto.cloudformation.create_stack() tags parameter. Supplied tags
will be applied to stack and all it's resources on stack creation.
Cannot be updated later (not supported by UpdateStack CloudFormation
API).
