### PR TITLE
Feature: Configurable role search path

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -12,6 +12,7 @@
 
 hostfile       = /etc/ansible/hosts
 library        = /usr/share/ansible
+#roles_path    = /etc/ansible/roles
 remote_tmp     = $HOME/.ansible/tmp
 pattern        = *
 forks          = 5

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -95,6 +95,7 @@ DEFAULTS='defaults'
 # configurable things
 DEFAULT_HOST_LIST         = shell_expand_path(get_config(p, DEFAULTS, 'hostfile', 'ANSIBLE_HOSTS', '/etc/ansible/hosts'))
 DEFAULT_MODULE_PATH       = get_config(p, DEFAULTS, 'library',          'ANSIBLE_LIBRARY',          DIST_MODULE_PATH)
+DEFAULT_ROLES_PATH        = get_config(p, DEFAULTS, 'roles_path',       'ANSIBLE_ROLES_PATH',       None)
 DEFAULT_REMOTE_TMP        = shell_expand_path(get_config(p, DEFAULTS, 'remote_tmp',       'ANSIBLE_REMOTE_TEMP',      '$HOME/.ansible/tmp'))
 DEFAULT_MODULE_NAME       = get_config(p, DEFAULTS, 'module_name',      None,                       'command')
 DEFAULT_PATTERN           = get_config(p, DEFAULTS, 'pattern',          None,                       '*')

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -21,6 +21,7 @@ from ansible.utils.template import template
 from ansible import utils
 from ansible import errors
 from ansible.playbook.task import Task
+import ansible.constants as C
 import pipes
 import shlex
 import os
@@ -148,16 +149,27 @@ class Play(object):
             role_vars = orig_path
             orig_path = role_name
 
-        path = utils.path_dwim(self.basedir, os.path.join('roles', orig_path))
-        if not os.path.isdir(path) and not orig_path.startswith(".") and not orig_path.startswith("/"):
-            path2 = utils.path_dwim(self.basedir, orig_path)
-            if not os.path.isdir(path2):
-                raise errors.AnsibleError("cannot find role in %s or %s" % (path, path2))
-            path = path2
-        elif not os.path.isdir(path):
-            raise errors.AnsibleError("cannot find role in %s" % (path))
+        role_path = None
 
-        return (path, role_vars)
+        possible_paths = [
+            utils.path_dwim(self.basedir, os.path.join('roles', orig_path)),
+            utils.path_dwim(self.basedir, orig_path)
+        ]
+
+        if C.DEFAULT_ROLES_PATH:
+            search_locations = C.DEFAULT_ROLES_PATH.split(os.pathsep)
+            for loc in search_locations:
+                possible_paths.append(utils.path_dwim(loc, orig_path))
+
+        for path_option in possible_paths:
+            if os.path.isdir(path_option):
+                role_path = path_option
+                break
+
+        if role_path is None:
+            raise errors.AnsibleError("cannot find role in %s" % " or ".join(possible_paths))
+
+        return (role_path, role_vars)
 
     def _build_role_dependencies(self, roles, dep_stack, passed_vars={}, level=0):
         # this number is arbitrary, but it seems sane


### PR DESCRIPTION
Feature discussed here: https://groups.google.com/forum/#!topic/ansible-devel/ITZJUnyzB1g

This adds an option to ansible.cfg: "roles_path" and the environment variable ANSIBLE_ROLES_PATH for extra locations to search for ansible roles to be made available to playbooks.

Existing behavior remains unchanged, new behavior is only around when the configuration option is set.

Tests all pass, let me know if I should change it up in any way.

Thanks,
Thomas Omans
