### PR TITLE
Use set_setting in rax.py inventory module

### DIFF
--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -70,9 +70,9 @@ notes:
 requirements: [ "pyrax" ]
 examples:
     - description: List server instances
-      code: RAX_CREDS=~/.raxpub RAX_REGION=ORD rax.py --list
+      code: RAX_CREDS_FILE=~/.raxpub RAX_REGION=ORD rax.py --list
     - description: List server instance properties
-      code: RAX_CREDS=~/.raxpub RAX_REGION=ORD rax.py --host <HOST_IP>
+      code: RAX_CREDS_FILE=~/.raxpub RAX_REGION=ORD rax.py --host <HOST_IP>
 '''
 
 import sys

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -112,6 +112,8 @@ except KeyError, e:
     sys.stderr.write('Unable to load %s\n' % e.message)
     sys.exit(1)
 
+pyrax.set_setting('identity_type', 'rackspace')
+
 try:
     pyrax.set_credential_file(os.path.expanduser(creds_file),
                               region=region)


### PR DESCRIPTION
Use `set_setting` in rax.py inventory plugin to set the `identity_type` to `rackspace`.  This will alleviate Pyrax's need to look for a `~/.pyrax.cfg` locally.

Oh, and a small correction to the documentation pointing out the need to use `RAX_CREDS_FILE` env var and not `RAX_CREDS`.
