### PR TITLE
Added a new check to the setup module that retrieves whether a net interface is on promiscuous mode

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1440,7 +1440,7 @@ class LinuxNetwork(Network):
                     path = os.path.join(path, 'bonding', 'all_slaves_active')
                     if os.path.exists(path):
                         interfaces[device]['all_slaves_active'] = open(path).read() == '1'
-            #Check whether a interface is in promiscuous mode
+            # Check whether a interface is in promiscuous mode
             if os.path.exists(os.path.join(path,'flags')):
                 promisc_mode = False
                 # The second byte indicates whether the interface is in promiscuous mode.

--- a/library/system/setup
+++ b/library/system/setup
@@ -1440,6 +1440,15 @@ class LinuxNetwork(Network):
                     path = os.path.join(path, 'bonding', 'all_slaves_active')
                     if os.path.exists(path):
                         interfaces[device]['all_slaves_active'] = open(path).read() == '1'
+            #Check whether a interface is in promiscuous mode
+            if os.path.exists(os.path.join(path,'flags')):
+                promisc_mode = False
+                # The second byte indicates whether the interface is in promiscuous mode.
+                # 1 = promisc
+                # 0 = no promisc
+                data = int(open(os.path.join(path, 'flags')).read().strip(),16)
+                promisc_mode = (data & 0x0100 > 0)
+                interfaces[device]['promisc'] = promisc_mode
             ip_path = module.get_bin_path("ip")
             output = subprocess.Popen([ip_path, 'addr', 'show', device], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
             for line in output.split('\n'):


### PR DESCRIPTION
I have tested it against a Debian, an ubuntu and a Fedora system. I haven't tested it against a BSD like system. I think maybe on a BSD-like system the ethernet card information is located in a different place.

Systems in which it has been tested:
Linux ubuntu 3.8.0-29-generic #42~precise1-Ubuntu SMP Wed Aug 14 16:19:23 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux

Linux devel 3.9-1-amd64 #1 SMP Debian 3.9.6-1 x86_64 GNU/Linux

Fedora 18: Linux localhost.localdomain 3.6.10-4.fc18.i686 #1 SMP Tue Dec 11 18:24:49 UTC 2012 i686 i686 i386 GNU/Linux
