### PR TITLE
Changed from /etc to /dev for unfrackpath test

### DIFF
--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -16,10 +16,13 @@ class TestUtils(unittest.TestCase):
     ### varReplace function tests
 
     def test_unfrackpath(self):
-        os.symlink("/etc", "/tmp/etc")
-        a = ansible.utils.unfrackpath('$HOME/../../tmp/etc/')
-        assert a == '/etc'
-        os.unlink('/tmp/etc')
+        path = '/dev'
+        symlink_err = "Looks like {0} is already symlink".format(path)
+        assert os.path.islink(path) is False, symlink_err
+        os.symlink(path, "/tmp/dev")
+        a = ansible.utils.unfrackpath('$HOME/../../tmp/dev/')
+        assert a == path
+        os.unlink('/tmp/dev')
 
     def test_varReplace_simple(self):
         template = 'hello $who'


### PR DESCRIPTION
On OS X `/etc` is symlinked to `/private/etc` which causes the test to
fail. I changed to use `/dev` which is not symlinked by default but
present on all other Unix and Unix like systems. I also added an
additional informative assert to check if `/dev` is for some reason
also a symlink and fail on that rather than the unfrackpath test.
