### PR TITLE
apt: pass child process stdout and stdout to m.fail_json() and m.exit_js...

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -237,9 +237,9 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None, install_reco
 
         rc, out, err = m.run_command(cmd)
         if rc:
-            m.fail_json(msg="'apt-get install %s' failed: %s" % (packages, err))
+            m.fail_json(msg="'apt-get install %s' failed: %s" % (packages, err), stdout=out, stderr=err)
         else:
-            m.exit_json(changed=True)
+            m.exit_json(changed=True, stdout=out, stderr=err)
     else:
         m.exit_json(changed=False)
 
@@ -265,8 +265,8 @@ def remove(m, pkgspec, cache, purge=False):
 
         rc, out, err = m.run_command(cmd)
         if rc:
-            m.fail_json(msg="'apt-get remove %s' failed: %s" % (packages, err))
-        m.exit_json(changed=True)
+            m.fail_json(msg="'apt-get remove %s' failed: %s" % (packages, err), stdout=out, stderr=err)
+        m.exit_json(changed=True, stdout=out, stderr=err)
 
 def upgrade(m, mode="yes", force=False):
     if m.check_mode:
@@ -298,10 +298,10 @@ def upgrade(m, mode="yes", force=False):
                                     force_yes, check_arg, upgrade_command)
     rc, out, err = m.run_command(cmd)
     if rc:
-        m.fail_json(msg="'%s %s' failed: %s" % (apt_cmd, upgrade_command, err))
+        m.fail_json(msg="'%s %s' failed: %s" % (apt_cmd, upgrade_command, err), stdout=out, stderr=err)
     if (apt_cmd == APT_GET_CMD and APT_GET_ZERO in out) or (apt_cmd == APTITUDE_CMD and APTITUDE_ZERO in out):
-        m.exit_json(changed=False, msg=out)
-    m.exit_json(changed=True, msg=out)
+        m.exit_json(changed=False, msg=out, stdout=out, stderr=err)
+    m.exit_json(changed=True, msg=out, stdout=out, stderr=err)
 
 def main():
     module = AnsibleModule(


### PR DESCRIPTION
...on().

Without this, this fails:

```
- name: apt-get dist-upgrade
  action: apt upgrade=dist
  register: apt_get_contents

- name: apt-get clean
  action: command apt-get clean
  when: apt_get_contents.stdout.find("0 upgraded") == -1
```

TASK: [apt-get clean] *********************************************************

fatal: [192.168.2.2] => error while evaluating conditional: {% if apt_get_contents.stdout.find("0 upgraded") == -1 %} True {% else %} False {% endif %}

FATAL: all hosts have already failed -- aborting
