### PR TITLE
apt: do not consider not-removed and not-upgraded packages as changes.

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -131,8 +131,8 @@ import fnmatch
 # APT related constants
 APT_ENVVARS = "DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical"
 DPKG_OPTIONS = '-o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"'
-APT_GET_ZERO = "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded."
-APTITUDE_ZERO = "0 packages upgraded, 0 newly installed, 0 to remove and 0 not upgraded."
+APT_GET_ZERO = "0 upgraded, 0 newly installed"
+APTITUDE_ZERO = "0 packages upgraded, 0 newly installed"
 APT_LISTS_PATH = "/var/lib/apt/lists"
 APT_UPDATE_SUCCESS_STAMP_PATH = "/var/lib/apt/periodic/update-success-stamp"
 


### PR DESCRIPTION
If one pins a package and does a 'apt-get dist-upgrade' then the
output looks like:

```
# apt-get dist-upgrade
Reading package lists... Done
Building dependency tree
Reading state information... Done
Calculating upgrade... Done
The following packages have been kept back:
  cassandra
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
```

The check for any changes made should only be on the 'upgraded' and
'newly installed' values and not include the 'to remove' and 'not
upgraded' values.
