### PR TITLE
Added .travis.yml for continuous integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+---
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+
+install:
+  - "pip install PyYAML --use-mirrors"
+  - "pip install jinja2 --use-mirrors"
+  - "pip install paramiko --use-mirrors"
+
+script: make tests


### PR DESCRIPTION
travis-ci.org is a nice little useful service. 

Once configured, It builds or tests all branches on change, and even pull requests. This service is for free for open source projects.

See http://about.travis-ci.org/docs/user/languages/python/ for more infos. 

To set up, login on travis-ci.org using oauth service of github and activate this project. travis-ci will set up the hook automatically. The file .travis.yml is used to configure, how travis-ci should build and test the project. 
