### PR TITLE
fix possible deadlock scenario (?)

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -935,10 +935,9 @@ class AnsibleModule(object):
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
             if data:
-                cmd.stdin.write(data)
                 if not binary_data:
-                    cmd.stdin.write('\\n')
-            out, err = cmd.communicate()
+                    data += '\\n'
+            out, err = cmd.communicate(input=data)
             rc = cmd.returncode
         except (OSError, IOError), e:
             self.fail_json(rc=e.errno, msg=str(e), cmd=args)


### PR DESCRIPTION
When collecting stdout/stderr _and_ feeding data into a Popen instance,
communicate() must be used to avoid a known deadlocking scenario
when data sizes cross PIPE_BUF (which can be as small as 512, although should
be much larger in practice on linux).

No point in leaving the potential issue in code since the fix is bloody simple, hence this quick patch to resolve it. :)
