### PR TITLE
Add option 'lz4' for compression in zfs module

### DIFF
--- a/library/system/zfs
+++ b/library/system/zfs
@@ -70,7 +70,7 @@ options:
     description:
       - The compression property.
     required: False
-    choices: ['on','off',lzjb,gzip,gzip-1,gzip-2,gzip-3,gzip-4,gzip-5,gzip-6,gzip-7,gzip-8,gzip-9]
+    choices: ['on','off',lzjb,gzip,gzip-1,gzip-2,gzip-3,gzip-4,gzip-5,gzip-6,gzip-7,gzip-8,gzip-9,lz4]
   copies:
     description:
       - The copies property.
@@ -338,7 +338,7 @@ def main():
             'canmount':        {'required': False, 'choices':['on', 'off', 'noauto']},
             'casesensitivity': {'required': False, 'choices':['sensitive', 'insensitive', 'mixed']},
             'checksum':        {'required': False, 'choices':['on', 'off', 'fletcher2', 'fletcher4', 'sha256']},
-            'compression':     {'required': False, 'choices':['on', 'off', 'lzjb', 'gzip', 'gzip-1', 'gzip-2', 'gzip-3', 'gzip-4', 'gzip-5', 'gzip-6', 'gzip-7', 'gzip-8', 'gzip-9']},
+            'compression':     {'required': False, 'choices':['on', 'off', 'lzjb', 'gzip', 'gzip-1', 'gzip-2', 'gzip-3', 'gzip-4', 'gzip-5', 'gzip-6', 'gzip-7', 'gzip-8', 'gzip-9', 'lz4']},
             'copies':          {'required': False, 'choices':['1', '2', '3']},
             'dedup':           {'required': False, 'choices':['on', 'off']},
             'devices':         {'required': False, 'choices':['on', 'off']},


### PR DESCRIPTION
The feature 'lz4_compress' is now available on 'ZFS on Linux' and on the upcoming FreeBSD 9.2 among others. This patch adds support for 'lz4' in the ZFS module.
