### PR TITLE
Fail cloudformation operation when it is not completed successfully

### DIFF
--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -141,12 +141,12 @@ def stack_operation(cfn, stack_name, operation):
                           output = 'Stack %s complete' % operation)
             break
         if '%s_ROLLBACK_COMPLETE' % operation == stack.stack_status:
-            result = dict(changed=True,
+            result = dict(changed=True, failed=True,
                           events = map(str, list(stack.describe_events())),
                           output = 'Problem with %s. Rollback complete' % operation)
             break
         elif '%s_FAILED' % operation == stack.stack_status:
-            result = dict(changed=False,
+            result = dict(changed=True, failed=True,
                           events = map(str, list(stack.describe_events())),
                           output = 'Stack %s failed' % operation)
             break


### PR DESCRIPTION
When cloudformation operation is successfully submitted but some step
during stack creation or update fails, operation result should be
failed=True.

**What version of ansible you are using (ansible --version):**

ansible 1.4 (devel 9b5fb9ad6b) last updated 2013/09/30 15:44:30 (GMT +200)

**Steps to reproduce the problem:**

Use cloudformation module with template that can be successfully submitted bud fails during creation.

aws.yml:

``` yaml
- hosts: vpc
  gather_facts: no
  connection: local
  tasks:
    - name: create cloudformation stack
      cloudformation: >
        stack_name=TestStack
        template=cf_test.json
        region={{ region }}
        state=present
      args:
        template_parameters: {}
```

cf_test.json ("Tags" property is "key" instead of "Key"):

``` json
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Description": "Virtual Private Cloud",
  "Resources": {
    "VPC01": {
      "Type": "AWS::EC2::VPC",
      "Properties": {
        "CidrBlock": "10.1.0.0/16",
        "Tags": [
          { "key": "test", "Value": "xxx" }
        ]
      }
    }
  }
}
```

Run:

``` sh
ansible-playbook aws.yml -i vpc,
```

**Expected results:**

Task result is failed=True

**Actual results:**

Task result is changed=True (disable_rollback=no) or changed=False (disable_rollback=yes)
