### PR TITLE
Fix/Re-enable broken tests from 8d0487

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -68,7 +68,8 @@ class PlayBook(object):
         inventory        = None,
         check            = False,
         diff             = False,
-        any_errors_fatal = False):
+        any_errors_fatal = False,
+        fail_on_undefined= C.DEFAULT_UNDEFINED_VAR_BEHAVIOR):
 
         """
         playbook:         path to a playbook file
@@ -122,6 +123,7 @@ class PlayBook(object):
         self.only_tags        = only_tags
         self.skip_tags        = skip_tags
         self.any_errors_fatal = any_errors_fatal
+        self.fail_on_undefined= fail_on_undefined
 
         self.callbacks.playbook = self
         self.runner_callbacks.playbook = self
@@ -314,7 +316,7 @@ class PlayBook(object):
             transport=task.transport, sudo_pass=task.sudo_pass, is_playbook=True,
             check=self.check, diff=self.diff, environment=task.environment, complex_args=task.args, 
             accelerate=task.play.accelerate, accelerate_port=task.play.accelerate_port,
-            error_on_undefined_vars=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR
+            error_on_undefined_vars=self.fail_on_undefined
         )
 
         if task.async_seconds == 0:

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -268,20 +268,16 @@ class TestPlaybook(unittest.TestCase):
 
    def _test_playbook_undefined_vars(self, playbook, fail_on_undefined):
        # save DEFAULT_UNDEFINED_VAR_BEHAVIOR so we can restore it in the end of the test
-       saved_undefined_var_behavior = C.DEFAULT_UNDEFINED_VAR_BEHAVIOR
-       C.DEFAULT_UNDEFINED_VAR_BEHAVIOR = fail_on_undefined
-
        test_callbacks = TestCallbacks()
        playbook = ansible.playbook.PlayBook(
            playbook=os.path.join(self.test_dir, 'test_playbook_undefined_vars', playbook),
            host_list='test/test_playbook_undefined_vars/hosts',
            stats=ans_callbacks.AggregateStats(),
            callbacks=test_callbacks,
-           runner_callbacks=test_callbacks
+           runner_callbacks=test_callbacks,
+           fail_on_undefined=fail_on_undefined
        )
        actual = playbook.run()
-
-       C.DEFAULT_UNDEFINED_VAR_BEHAVIOR = saved_undefined_var_behavior
 
        # if different, this will output to screen
        print "**ACTUAL**"
@@ -300,17 +296,17 @@ class TestPlaybook(unittest.TestCase):
 
        assert utils.jsonify(expected, format=True) == utils.jsonify(actual, format=True)
 
-   #def test_playbook_undefined_vars1_ignore(self):
-   #    self._test_playbook_undefined_vars('playbook1.yml', False)
+   def test_playbook_undefined_vars1_ignore(self):
+       self._test_playbook_undefined_vars('playbook1.yml', False)
 
-   #def test_playbook_undefined_vars1_fail(self):
-   #    self._test_playbook_undefined_vars('playbook1.yml', True)
+   def test_playbook_undefined_vars1_fail(self):
+       self._test_playbook_undefined_vars('playbook1.yml', True)
 
-   #def test_playbook_undefined_vars2_ignore(self):
-   #    self._test_playbook_undefined_vars('playbook2.yml', False)
+   def test_playbook_undefined_vars2_ignore(self):
+       self._test_playbook_undefined_vars('playbook2.yml', False)
 
-   #def test_playbook_undefined_vars2_fail(self):
-   #    self._test_playbook_undefined_vars('playbook2.yml', True)
+   def test_playbook_undefined_vars2_fail(self):
+       self._test_playbook_undefined_vars('playbook2.yml', True)
 
    def test_yaml_hosts_list(self):
        # Make sure playbooks support hosts: [host1, host2]


### PR DESCRIPTION
This re-enables coverage some basic undefined var tests that were previously
flakey (fixed via this CL and via d0ad6c5).

This is a necessary dep for the next fixes I have that turn on missing filter failures (they use these tests), similar for exposing syntax errors up the stack.
