### PR TITLE
Enforce umask for cron module, so cron_file generated files are 0644.

### DIFF
--- a/library/system/cron
+++ b/library/system/cron
@@ -426,6 +426,8 @@ def main():
     changed      = False
     res_args     = dict()
 
+    # Ensure all files generated are only writable by the owning user.  Primarily relevant for the cron_file option.
+    os.umask(022)
     crontab = CronTab(module, user, cron_file)
 
     if crontab.syslogging:


### PR DESCRIPTION
Certain cron implementations get cranky if files in cron.\* are group
writable; thus enforce 022 umask to get 0644 for all generated content for this module.
