### PR TITLE
Revamp of the rax.py inventory plugin

### DIFF
--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -57,22 +57,17 @@ options:
      - File to find the Rackspace Public Cloud credentials in
     required: true
     default: null
-  region_name:
-    description:
-      - Region name to use in request
-    required: false
-    default: DFW
-author: Jesse Keating
+authors:
+  - Jesse Keating <jesse.keating@rackspace.com>
+  - Paul Durivage <paul.durivage@rackspace.com>
 notes:
-  - Two environment variables need to be set, RAX_CREDS and RAX_REGION.
-  - RAX_CREDS points to a credentials file appropriate for pyrax
-  - RAX_REGION defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+  - One environment variable needs to be set: RAX_CREDS_FILE.
+  - RAX_CREDS_FILE points to a credentials file appropriate for pyrax.
+  - See https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating
 requirements: [ "pyrax" ]
 examples:
     - description: List server instances
-      code: RAX_CREDS_FILE=~/.raxpub RAX_REGION=ORD rax.py --list
-    - description: List server instance properties
-      code: RAX_CREDS_FILE=~/.raxpub RAX_REGION=ORD rax.py --host <HOST_IP>
+      code: RAX_CREDS_FILE=~/.raxpub rax.py --list
 '''
 
 import sys

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -86,6 +86,7 @@ examples:
 import sys
 import re
 import os
+
 import argparse
 import collections
 
@@ -192,6 +193,14 @@ def setup():
                              % (e.message, default_creds_file))
             sys.exit(1)
 
+    pyrax.set_setting('identity_type', 'rackspace')
+
+    try:
+        pyrax.set_credential_file(os.path.expanduser(creds_file))
+    except Exception, e:
+        sys.stderr.write("%s: %s\n" % (e, e.message))
+        sys.exit(1)
+
     regions = []
     for region in os.getenv('RAX_REGION', 'all').split(','):
         region = region.strip().upper()
@@ -203,14 +212,6 @@ def setup():
             sys.exit(1)
         elif region not in regions:
             regions.append(region)
-
-    pyrax.set_setting('identity_type', 'rackspace')
-
-    try:
-        pyrax.set_credential_file(os.path.expanduser(creds_file))
-    except Exception, e:
-        sys.stderr.write("%s: %s\n" % (e, e.message))
-        sys.exit(1)
 
     return regions
 

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -70,13 +70,15 @@ notes:
   - RAX_CREDS_FILE points to a credentials file appropriate for pyrax.
   - See https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating
   - RAX_REGION is an optional environment variable to narrow inventory search scope
-  - RAX_REGION, if used, needs a value like ORD, DFW, SYD (a Rackspace datacenter)
+  - RAX_REGION, if used, needs a value like ORD, DFW, SYD (a Rackspace datacenter) and optionally accepts a comma-separated list
 requirements: [ "pyrax" ]
 examples:
     - description: List server instances
       code: RAX_CREDS_FILE=~/.raxpub rax.py --list
     - description: List servers in ORD datacenter only
       code: RAX_CREDS_FILE=~/.raxpub RAX_REGION=ORD rax.py --list
+    - description: List servers in ORD and DFW datacenters
+      code: RAX_CREDS_FILE=~/.raxpub RAX_REGION=ORD,DFW rax.py --list
     - description: Get server details for server named "server.example.com"
       code: RAX_CREDS_FILE=~/.raxpub rax.py --host server.example.com
 '''
@@ -128,7 +130,8 @@ def _list(region):
     hostvars = collections.defaultdict(dict)
 
     if region and region.upper() in pyrax.regions:
-        pyrax.regions = (region,)
+        pyrax.regions = (region.upper() for region in region.split(','))
+
 
     # Go through all the regions looking for servers
     for region in pyrax.regions:

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -46,7 +46,7 @@ description:
         rax_name
         rax_created
         rax_tenant_id
-        rax__loaded
+        rax_loaded
 
     where some item can have nested structure.
   - credentials are set in a credentials file
@@ -57,6 +57,11 @@ options:
      - File to find the Rackspace Public Cloud credentials in
     required: true
     default: null
+  region:
+    description:
+     - An optional value to narrow inventory scope, i.e. DFW, ORD, IAD, LON
+     required: false
+     default: null
 authors:
   - Jesse Keating <jesse.keating@rackspace.com>
   - Paul Durivage <paul.durivage@rackspace.com>
@@ -64,10 +69,16 @@ notes:
   - One environment variable needs to be set: RAX_CREDS_FILE.
   - RAX_CREDS_FILE points to a credentials file appropriate for pyrax.
   - See https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating
+  - RAX_REGION is an optional environment variable to narrow inventory search scope
+  - RAX_REGION, if used, needs a value like ORD, DFW, SYD (a Rackspace datacenter)
 requirements: [ "pyrax" ]
 examples:
     - description: List server instances
       code: RAX_CREDS_FILE=~/.raxpub rax.py --list
+    - description: List servers in ORD datacenter only
+      code: RAX_CREDS_FILE=~/.raxpub RAX_REGION=ORD rax.py --list
+    - description: Get server details for server named "server.example.com"
+      code: RAX_CREDS_FILE=~/.raxpub rax.py --host server.example.com
 '''
 
 import sys

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -66,8 +66,8 @@ authors:
   - Jesse Keating <jesse.keating@rackspace.com>
   - Paul Durivage <paul.durivage@rackspace.com>
 notes:
-  - One environment variable needs to be set: RAX_CREDS_FILE.
-  - RAX_CREDS_FILE points to a credentials file appropriate for pyrax.
+  - RAX_CREDS_FILE is an optional environment variable that points to a pyrax-compatible credentials file.
+  - If RAX_CREDS_FILE is not supplied, rax.py will look for a credentials file at ~/.rackspace_cloud_credentials.
   - See https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating
   - RAX_REGION is an optional environment variable to narrow inventory search scope
   - RAX_REGION, if used, needs a value like ORD, DFW, SYD (a Rackspace datacenter) and optionally accepts a comma-separated list
@@ -181,14 +181,22 @@ def parse_args():
 
 
 def setup():
+    default_creds_file = os.path.expanduser('~/.rackspace_cloud_credentials')
+
+    # Attempt to grab credentials from environment first
     try:
         creds_file = os.environ['RAX_CREDS_FILE']
-        region = os.getenv('RAX_REGION')
     except KeyError, e:
-        sys.stderr.write('Unable to load environment '
-                         'variable %s\n' % e.message)
-        sys.exit(1)
+        # But if that fails, use the default location of ~/.rackspace_cloud_credentials
+        if os.path.isfile(default_creds_file):
+            creds_file = default_creds_file
+        else:
+            sys.stderr.write('No value in environment variable %s and/or no '
+                             'credentials file at %s\n'
+                             % (e.message, default_creds_file))
+            sys.exit(1)
 
+    region = os.getenv('RAX_REGION')
     pyrax.set_setting('identity_type', 'rackspace')
 
     try:

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -141,16 +141,6 @@ def _list(region):
             # Create a group on region
             groups[region].append(server.name)
 
-            # Anything we can discern from the hostname?
-            try:
-                subdom = server.name.split('.')[0]
-            except IndexError:
-                pass
-            else:
-                for name in ('web', 'db', 'sql', 'lb', 'app'):
-                    if name in subdom:
-                        groups[name].append(server.name)
-
             # Check if group metadata key in servers' metadata
             try:
                 group = server.metadata['group']


### PR DESCRIPTION
Eliminate the RAX_REGION environment variable; iterate through all regions available to an account and present servers in region groups; default to using server name to identify servers in groups; set ansible_ssh_host key for each server; utilize the _meta key to provide all the hostvars for each server; all grouping by web, db, sql, lb, app based on server name; pretty print JSON output for some human-readable inventory action

The only special consideration here is that we're no longer referencing instances by IP address -- before, it looked like this:
{'undefined': ['192.168.1.5', '192.168.1.2']}

Now, we reference by the server name:
{'DFW': ['myhost.example.com', otherhost.example.com', 'myserver'] }
