### PR TITLE
Fixes service update-rc.d functionality on debian

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -633,6 +633,12 @@ class LinuxService(Service):
                     self.changed = True
                     break
 
+            # Debian compatibility
+            for line in err.splitlines():
+                if self.enable and line.find('no runlevel symlinks to modify') != -1:
+                    self.changed = True
+                    break
+
             if self.module.check_mode:
                 self.module.exit_json(changed=self.changed)
 


### PR DESCRIPTION
As discussed in comments: https://github.com/ansible/ansible/commit/b2741f451e6d455a89f61d0248ffb32ea504e6fe#commitcomment-4224595
