### PR TITLE
Pass host to runner_on_file_diff callback

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -341,7 +341,7 @@ class DefaultRunnerCallbacks(object):
         call_callback_module('runner_on_async_failed', host, res, jid)
 
     def on_file_diff(self, host, diff):
-        call_callback_module('runner_on_file_diff', diff)
+        call_callback_module('runner_on_file_diff', host, diff)
 
 ########################################################################
 


### PR DESCRIPTION
When registering file changes, along with diff, I want host name to appear in log.
