### PR TITLE
mysql_replication switch to DictCursor for compatibility with more mysql server versions

### DIFF
--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -305,15 +305,15 @@ def main():
         masterstatus = get_master_status(cursor)
         try:
             module.exit_json( **masterstatus )
-        except TypeError, e:
-            module.fail_json(msg="Server is not configured as mysql master: %s" % e)
+        except TypeError:
+            module.fail_json(msg="Server is not configured as mysql master")
 
     elif mode in "getslave":
         slavestatus = get_slave_status(cursor)
         try:
             module.exit_json( **slavestatus )
-        except TypeError, e:
-            module.fail_json(msg="Server is not configured as mysql slave: %s" % e)
+        except TypeError:
+            module.fail_json(msg="Server is not configured as mysql slave")
 
     elif mode in "changemaster":
         print "Change master"

--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -294,69 +294,26 @@ def main():
             db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db="mysql")
         else:
             db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
-        cursor = db_connection.cursor()
     except Exception, e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials")
+    try:
+        cursor = db_connection.cursor(cursorclass=MySQLdb.cursors.DictCursor)
+    except Exception, e:
+        module.fail_json(msg="Trouble getting DictCursor from db_connection: %s" % e)
 
     if mode in "getmaster":
         masterstatus = get_master_status(cursor)
         try:
-            module.exit_json(
-                File=masterstatus[0],
-                Position=masterstatus[1],
-                Binlog_Do_DB=masterstatus[2],
-                Binlog_Ignore_DB=masterstatus[3]
-            )
-        except TypeError:
-            module.fail_json(msg="Server is not configured as mysql master")
+            module.exit_json( **masterstatus )
+        except TypeError, e:
+            module.fail_json(msg="Server is not configured as mysql master: %s" % e)
 
     elif mode in "getslave":
         slavestatus = get_slave_status(cursor)
         try:
-            module.exit_json(
-                Slave_IO_State=slavestatus[0],
-                Master_Host=slavestatus[1],
-                Master_User=slavestatus[2],
-                Master_Port=slavestatus[3],
-                Connect_Retry=slavestatus[4],
-                Master_Log_File=slavestatus[5],
-                Read_Master_Log_Pos=slavestatus[6],
-                Relay_Log_File=slavestatus[7],
-                Relay_Log_Pos=slavestatus[8],
-                Relay_Master_Log_File=slavestatus[9],
-                Slave_IO_Running=slavestatus[10],
-                Slave_SQL_Running=slavestatus[11],
-                Replicate_Do_DB=slavestatus[12],
-                Replicate_Ignore_DB=slavestatus[13],
-                Replicate_Do_Table=slavestatus[14],
-                Replicate_Ignore_Table=slavestatus[15],
-                Replicate_Wild_Do_Table=slavestatus[16],
-                Replicate_Wild_Ignore_Table=slavestatus[17],
-                Last_Errno=slavestatus[18],
-                Last_Error=slavestatus[19],
-                Skip_Counter=slavestatus[20],
-                Exec_Master_Log_Pos=slavestatus[21],
-                Relay_Log_Space=slavestatus[22],
-                Until_Condition=slavestatus[23],
-                Until_Log_File=slavestatus[24],
-                Until_Log_Pos=slavestatus[25],
-                Master_SSL_Allowed=slavestatus[26],
-                Master_SSL_CA_File=slavestatus[27],
-                Master_SSL_CA_Path=slavestatus[28],
-                Master_SSL_Cert=slavestatus[29],
-                Master_SSL_Cipher=slavestatus[30],
-                Master_SSL_Key=slavestatus[31],
-                Seconds_Behind_Master=slavestatus[32],
-                Master_SSL_Verify_Server_Cert=slavestatus[33],
-                Last_IO_Errno=slavestatus[34],
-                Last_IO_Error=slavestatus[35],
-                Last_SQL_Errno=slavestatus[36],
-                Last_SQL_Error=slavestatus[37],
-                Replicate_Ignore_Server_Ids=slavestatus[38],
-                Master_Server_Id=slavestatus[39]
-            )
-        except TypeError:
-            module.fail_json(msg="Server is not configured as mysql slave")
+            module.exit_json( **slavestatus )
+        except TypeError, e:
+            module.fail_json(msg="Server is not configured as mysql slave: %s" % e)
 
     elif mode in "changemaster":
         print "Change master"


### PR DESCRIPTION
Hi, this is my first pull request.  It's a small change to the mysql_replication module to make it work on more versions of mysql server.

mysql_replication's getslave and getmaster actions failed on my version of mysql because the fields returned by my version of mysql did not match those coded into mysql_replication.  

The standard cursor object in python MySQLdb returns rows as arrays, while DictCursor returns them as dicts with the field name as the key in the dict.  DictCursor is part of MySQLdb, so nothing funny there.

By using a DictCursor instead of the standard cursor, we get a mysql_replication that can be used across versions and is safe from any future changes because the field names are no longer hard coded but instead used from the output of the database.  Also, the code is shorter, which is kind of nice.

The hard-coded field names from the original mysql_replication appear to be the same as the field names output my mysql, so this change does not break current setups that work with the current mysql_replication.

I'm pretty inexperienced at python, so it's entirely possible that I've just done something stupid and there was a very good reason for doing it with the standard cursor object instead of the DictCursor object.  

Thanks for creating and maintaining ansible!  It makes my brain hurt a lot less.

-Dylan
