### PR TITLE
Fix for Issue #2470 - gem version string processing

### DIFF
--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -104,7 +104,7 @@ def get_installed_versions(module, remote=False):
         if match:
             versions = match.group(1)
             for version in versions.split(', '):
-                installed_versions.append(version)
+                installed_versions.append(version.split()[0])
     return installed_versions
 
 def exists(module):


### PR DESCRIPTION
This fix assumes that no sane gem version has spaces in it, so when one like that is encountered, it will get truncated at the first space.
