### PR TITLE
Add "virtio" and "private_networking" options for DigitalOcean droplets

### DIFF
--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -63,6 +63,18 @@ options:
   ssh_key_ids:
     description:
      - Optional, comma separated list of ssh_key_ids that you would like to be added to the server
+  virtio:
+    description:
+     - "Bool, turn on virtio driver in droplet for improved network and storage I/O"
+    version_added: "1.4"
+    default: "yes"
+    choices: [ "yes", "no" ]
+  private_networking:
+    description:
+     - "Bool, add an additional, private network interface to droplet for inter-droplet communication"
+    version_added: "1.4"
+    default: "no"
+    choices: [ "yes", "no" ]
   wait:
     description:
      - Wait for the droplet to be in state 'running' before returning.  If wait is "no" an ip_address may not be returned.
@@ -211,8 +223,8 @@ class Droplet(JsonfyMixIn):
         cls.manager = DoManager(client_id, api_key)
 
     @classmethod
-    def add(cls, name, size_id, image_id, region_id, ssh_key_ids=None):
-        json = cls.manager.new_droplet(name, size_id, image_id, region_id, ssh_key_ids)
+    def add(cls, name, size_id, image_id, region_id, ssh_key_ids=None, virtio=True, private_networking=False):
+        json = cls.manager.new_droplet(name, size_id, image_id, region_id, ssh_key_ids, virtio, private_networking)
         droplet = cls(json)
         return droplet
 
@@ -313,7 +325,9 @@ def core(module):
                     size_id=getkeyordie('size_id'),
                     image_id=getkeyordie('image_id'),
                     region_id=getkeyordie('region_id'),
-                    ssh_key_ids=module.params['ssh_key_ids']
+                    ssh_key_ids=module.params['ssh_key_ids'],
+                    virtio=module.params['virtio'],
+                    private_networking=module.params['private_networking']
                 )
 
             if droplet.is_powered_on():
@@ -372,6 +386,8 @@ def main():
             image_id = dict(type='int'),
             region_id = dict(type='int'),
             ssh_key_ids = dict(default=''),
+            virtio = dict(type='bool', choices=BOOLEANS, default='yes'),
+            private_networking = dict(type='bool', choices=BOOLEANS, default='no'),
             id = dict(aliases=['droplet_id'], type='int'),
             unique_name = dict(type='bool', choices=BOOLEANS, default='no'),
             wait = dict(type='bool', choices=BOOLEANS, default='yes'),

--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -160,9 +160,14 @@ import os
 import time
 
 try:
+    import dopy
     from dopy.manager import DoError, DoManager
 except ImportError as e:
-    print "failed=True msg='dopy required for this module'"
+    print "failed=True msg='dopy >= 0.2.2 required for this module'"
+    sys.exit(1)
+
+if dopy.__version__ < '0.2.2':
+    print "failed=True msg='dopy >= 0.2.2 required for this module'"
     sys.exit(1)
 
 class TimeoutError(DoError):


### PR DESCRIPTION
The dopy manager defaults to False for virtio, but the DigitalOcean web interface defaults to True, which is a pretty safe default and sensible considering the performance gains.

Private networks are a new feature currently available only in the NYC2 region as of Oct 2, 2013.

NOTE: dopy >= 0.2.2 is required for these options to work.
