### PR TITLE
Allow leading ranges in the inventory host entries.

### DIFF
--- a/lib/ansible/inventory/expand_hosts.py
+++ b/lib/ansible/inventory/expand_hosts.py
@@ -41,8 +41,7 @@ def detect_range(line = None):
 
     Returnes True if the given line contains a pattern, else False.
     '''
-    if (not line.startswith("[") and
-        line.find("[") != -1 and
+    if (line.find("[") != -1 and
         line.find(":") != -1 and
         line.find("]") != -1 and
         line.index("[") < line.index(":") < line.index("]")):

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -65,8 +65,9 @@ class InventoryParser(object):
         active_group_name = 'ungrouped'
 
         for line in self.lines:
-            if line.startswith("[") and line.strip().endswith("]"):
-                active_group_name = line.split(" #")[0].replace("[","").replace("]","").strip()
+            line = line.split("#")[0].strip()
+            if line.startswith("[") and line.endswith("]"):
+                active_group_name = line.replace("[","").replace("]","")
                 if line.find(":vars") != -1 or line.find(":children") != -1:
                     active_group_name = active_group_name.rsplit(":", 1)[0]
                     if active_group_name not in self.groups:
@@ -76,10 +77,10 @@ class InventoryParser(object):
                 elif active_group_name not in self.groups:
                     new_group = self.groups[active_group_name] = Group(name=active_group_name)
                     all.add_child_group(new_group)
-            elif line.startswith("#") or line.startswith(";") or line == '':
+            elif line.startswith(";") or line == '':
                 pass
             elif active_group_name:
-                tokens = shlex.split(line.split(" #")[0])
+                tokens = shlex.split(line)
                 if len(tokens) == 0:
                     continue
                 hostname = tokens[0]

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -65,7 +65,7 @@ class InventoryParser(object):
         active_group_name = 'ungrouped'
 
         for line in self.lines:
-            if line.startswith("["):
+            if line.startswith("[") and line.strip().endswith("]"):
                 active_group_name = line.split(" #")[0].replace("[","").replace("]","").strip()
                 if line.find(":vars") != -1 or line.find(":children") != -1:
                     active_group_name = active_group_name.rsplit(":", 1)[0]

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -300,6 +300,10 @@ class TestInventory(unittest.TestCase):
         expected_hosts=['1.host','2.host','A.host','B.host']
         assert sorted(hosts) == sorted(expected_hosts)
 
+        hosts2 = i.list_hosts('test2')
+        expected_hosts2=['1.host','2.host','3.host']
+        assert sorted(hosts2) == sorted(expected_hosts2)
+
     ###################################################
     ### Inventory API tests
 

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -294,6 +294,12 @@ class TestInventory(unittest.TestCase):
         expected_hosts=['host1A','host2A','host1B','host2B']
         assert sorted(hosts) == sorted(expected_hosts)
 
+    def test_leading_range(self):
+        i = Inventory(os.path.join(self.test_dir, 'inventory','test_leading_range'))
+        hosts = i.list_hosts('test')
+        expected_hosts=['1.host','2.host','A.host','B.host']
+        assert sorted(hosts) == sorted(expected_hosts)
+
     ###################################################
     ### Inventory API tests
 

--- a/test/inventory/test_leading_range
+++ b/test/inventory/test_leading_range
@@ -1,3 +1,6 @@
 [test]
 [1:2].host
 [A:B].host
+
+[test2] # comment
+[1:3].host

--- a/test/inventory/test_leading_range
+++ b/test/inventory/test_leading_range
@@ -1,0 +1,3 @@
+[test]
+[1:2].host
+[A:B].host


### PR DESCRIPTION
This bugfix allows leading ranges in the inventory host entries such as:

```
[1:9].www.example.com
```

Added new test case to check exactly this situation. All other test cases pass.

```
Ran 116 tests in 17.796s

OK (SKIP=1)
```
