### PR TITLE
Add grant parameter to MySQL user module

### DIFF
--- a/docsite/latest/rst/playbooks_loops.rst
+++ b/docsite/latest/rst/playbooks_loops.rst
@@ -43,7 +43,7 @@ Nested Loops
 Loops can be nested as well::
 
     - name: give users access to multiple databases
-      mysql_user: name={{ item[0] }} priv={{ item[1] }}.*:ALL password=foo
+      mysql_user: name={{ item[0] }} priv={{ item[1] }}.*:ALL append_privs=yes password=foo
       with_nested:
         - [ 'alice', 'bob', 'eve' ]
         - [ 'clientdb', 'employeedb', 'providerdb' ]
@@ -51,7 +51,7 @@ Loops can be nested as well::
 As with the case of 'with_items' above, you can use previously defined variables. Just specify the variable's name without templating it with '{{ }}'::
 
     - name: here, 'users' contains the above list of employees
-      mysql_user: name={{ item[0] }} priv={{ item[1] }}.*:ALL password=foo
+      mysql_user: name={{ item[0] }} priv={{ item[1] }}.*:ALL append_privs=yes password=foo
       with_nested:
         - users
         - [ 'clientdb', 'employeedb', 'providerdb' ]

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -71,6 +71,14 @@ options:
       - "MySQL privileges string in the format: C(db.table:priv1,priv2)"
     required: false
     default: null
+  append_privs:
+    description:
+      - Append the privileges defined by priv to the existing ones for this
+        user instead of overwriting existing ones.
+    required: false
+    choices: [ "yes", "no" ]
+    default: "no"
+    version_added: "1.4"
   state:
     description:
       - Whether the user should exist.  When C(absent), removes
@@ -148,7 +156,7 @@ def user_add(cursor, user, host, password, new_priv):
             privileges_grant(cursor, user,host,db_table,priv)
     return True
 
-def user_mod(cursor, user, host, password, new_priv):
+def user_mod(cursor, user, host, password, new_priv, append_privs):
     changed = False
     grant_option = False
 
@@ -173,7 +181,7 @@ def user_mod(cursor, user, host, password, new_priv):
             if "GRANT" in priv:
                 grant_option = True
             if db_table not in new_priv:
-                if user != "root" and "PROXY" not in priv:
+                if user != "root" and "PROXY" not in priv and not append_privs:
                     privileges_revoke(cursor, user,host,db_table,grant_option)
                     changed = True
 
@@ -358,6 +366,7 @@ def main():
             host=dict(default="localhost"),
             state=dict(default="present", choices=["absent", "present"]),
             priv=dict(default=None),
+            append_privs=dict(type="bool", default="no"),
             check_implicit_admin=dict(default=False),
         )
     )
@@ -367,6 +376,7 @@ def main():
     state = module.params["state"]
     priv = module.params["priv"]
     check_implicit_admin = module.params['check_implicit_admin']
+    append_privs = module.boolean(module.params["append_privs"])
 
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")
@@ -408,7 +418,7 @@ def main():
 
     if state == "present":
         if user_exists(cursor, user, host):
-            changed = user_mod(cursor, user, host, password, priv)
+            changed = user_mod(cursor, user, host, password, priv, append_privs)
         else:
             if password is None:
                 module.fail_json(msg="password parameter required when adding a user")


### PR DESCRIPTION
The priv parameter sets the absolute privileges of a user. It can not be used to grant additional privileges to a user. The grant option added here allows exactly that.

The example in the documentation:

```
- name: give users access to multiple databases
  mysql_user: name={{ item[0] }} priv={{ item[1] }}.*:ALL password=foo
  with_nested:
    - [ 'alice', 'bob', 'eve' ]
    - [ 'clientdb', 'employeedb', 'providerdb' ]
```

Doesn't actually work. Instead it grants only permissions on providerdb. By changing `priv` to `grant` it does work.
