### PR TITLE
Fix compatibility issue with passlib version < 1.6 (as encountered on eg...

### DIFF
--- a/library/web_infrastructure/htpasswd
+++ b/library/web_infrastructure/htpasswd
@@ -76,9 +76,11 @@ EXAMPLES = """
 
 
 import os
+from distutils.version import StrictVersion
 
 try:
     from passlib.apache import HtpasswdFile
+    import passlib
 except ImportError:
     passlib_installed = False
 else:
@@ -101,14 +103,10 @@ def present(dest, username, password, crypt_scheme, create, check_mode):
         if check_mode:
             return ("Create %s" % dest, True)
         create_missing_directories(dest)
-        try:
+        if StrictVersion(passlib.__version__) >= StrictVersion('1.6'):
             ht = HtpasswdFile(dest, new=True, default_scheme=crypt_scheme)
-        except:
-            # library version doesn't take 'new', deal with it.
-            fh = open(dest, 'w')
-            fh.write('')
-            fh.close()
-            ht = HtpasswdFile(dest, default_scheme=crypt_scheme)
+        else:
+            ht = HtpasswdFile(dest, autoload=False, default=crypt_scheme)
         if getattr(ht, 'set_password', None):
             ht.set_password(username, password)
         else:
@@ -116,10 +114,10 @@ def present(dest, username, password, crypt_scheme, create, check_mode):
         ht.save()
         return ("Created %s and added %s" % (dest, username), True)
     else:
-        try:
+        if StrictVersion(passlib.__version__) >= StrictVersion('1.6'):
             ht = HtpasswdFile(dest, new=False, default_scheme=crypt_scheme)
-        except:
-            ht = HtpasswdFile(dest, default_scheme=crypt_scheme)
+        else:
+            ht = HtpasswdFile(dest, default=crypt_scheme)
 
         found = None
         if getattr(ht, 'check_password', None):
@@ -146,9 +144,9 @@ def absent(dest, username, check_mode):
     if not os.path.exists(dest):
         raise ValueError("%s does not exists" % dest)
 
-    try:
+    if StrictVersion(passlib.__version__) >= StrictVersion('1.6'):
         ht = HtpasswdFile(dest, new=False)
-    except:
+    else:
         ht = HtpasswdFile(dest)
 
     if username not in ht.users():


### PR DESCRIPTION
... EL6 systems)
- passlib.apache.HtpasswdFile's 'default_scheme' was called 'default'
  before passlib version 1.6
- while here also deal with passlib.apache.HtpasswdFile's older
  'autoload' paramter vs the newer 'new' one.
