### PR TITLE
fixes 4365 - Mac with cisco vpn client, GenericBsdIfconfigNetwork get_default_interfaces fails with index out of range

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1576,7 +1576,7 @@ class GenericBsdIfconfigNetwork(Network):
             for line in lines:
                 words = line.split()
                 # Collect output from route command
-                if len(words) > 0:
+                if len(words) > 1:
                     if words[0] == 'interface:':
                         interface[v]['interface'] = words[1]
                     if words[0] == 'gateway:':


### PR DESCRIPTION
see #4365 issue :/
