### PR TITLE
replace dashes to underscores in rc.conf keys (based on freebsd rc.d filenames)

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -103,6 +103,7 @@ import tempfile
 import shlex
 import select
 import time
+import string
 
 class Service(object):
     """
@@ -873,7 +874,7 @@ class NetBsdService(Service):
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
 
-        self.rcconf_key = "%s" % self.name
+        self.rcconf_key = "%s" % string.replace(self.name,"-","_");
 
         return self.service_enable_rcconf()
 


### PR DESCRIPTION
When using the service module, the rc.conf key should have its dashes replaced by underscores.

For example the service /usr/local/etc/rc.d/php-fpm should be enabled by placing php_fpm_enable="YES" in /etc/rc.conf
