### PR TITLE
Correct default for update_cache parameter in apt_repository module

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -335,7 +335,7 @@ def main():
         argument_spec=dict(
             repo=dict(required=True),
             state=dict(choices=['present', 'absent'], default='present'),
-            update_cache = dict(aliases=['update-cache'], type='bool'),
+            update_cache = dict(aliases=['update-cache'], type='bool', default=True),
         ),
         supports_check_mode=True,
     )


### PR DESCRIPTION
In the Python code for the apt_repository module, add a default value for update_cache parameter to match the documented default value (yes).
