### PR TITLE
Makes regions_exclude optional in ec2.ini

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -197,7 +197,9 @@ class Ec2Inventory(object):
         # Regions
         self.regions = []
         configRegions = config.get('ec2', 'regions')
-        configRegions_exclude = config.get('ec2', 'regions_exclude')
+        configRegions_exclude = []
+        if config.has_option('ec2', 'regions_excluse'):
+            configRegions_exclude = config.get('ec2', 'regions_exclude')
         if (configRegions == 'all'):
             if self.eucalyptus_host:
                 self.regions.append(boto.connect_euca(host=self.eucalyptus_host).region.name)


### PR DESCRIPTION
A micro fix. I just got annoyed when commenting out the regions_exclude and had ec2.py fail on me :)
