### PR TITLE
Added the ability to assign networks by name in the Rackspace module

### DIFF
--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -82,6 +82,11 @@ options:
     description:
      - how long before wait gives up, in seconds
     default: 300
+  networks:
+    description:
+     - The network names to give to the instance (only used on instance creation). If specified, you must include ALL networks (including the public and private (ServiceNet) interfaces).
+    default: ["public", "private"]
+
 requirements: [ "pyrax" ]
 author: Jesse Keating
 notes:
@@ -111,6 +116,26 @@ EXAMPLES = '''
           /root/test.txt: /home/localuser/test.txt
         wait: yes
         state: present
+
+- name: Build a Cloud Server with ServiceNet and custom network interfaces but no public IP
+  gather_facts: False
+
+  tasks:
+    - name: Server build request
+      local_action:
+        module: rax
+        credentials: ~/.raxpub
+        service: cloudservers
+        name: rax-test1
+        flavor: 5
+        image: b11d9567-e412-4255-96b9-bd63ab23bcfe
+        files:
+          /root/.ssh/authorized_keys: /home/localuser/.ssh/id_rsa.pub
+          /root/test.txt: /home/localuser/test.txt
+        wait: yes
+        state: present
+        networks: ['private', 'My Custom Network']
+        
 '''
 
 import sys
@@ -130,7 +155,7 @@ except ImportError:
 SUPPORTEDSERVICES = ['cloudservers']
 
 def cloudservers(module, state, name, flavor, image, meta, key_name, files,
-                 wait, wait_timeout):
+                 wait, wait_timeout, networks):
     # Check our args (this could be done better)
     for arg in (state, name, flavor, image):
         if not arg:
@@ -164,12 +189,18 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                 except Exception, e:
                     module.fail_json(msg = 'Failed to load %s' % lpath)
             try:
+                # This is a slightly complicated invocation because the final result needs to be in a nova-compatible format, which is what
+                # get_server_networks() does (it returns a 1-element list).
+                nics = [network.get_server_networks()[0] for network in pyrax.cloud_networks.list() if network.label in networks]
+                
                 servers = [pyrax.cloudservers.servers.create(name=name,
                                                              image=image,
                                                              flavor=flavor,
                                                              key_name=key_name,
                                                              meta=meta,
-                                                             files=files)]
+                                                             files=files,
+                                                             nics=nics)]
+                                                                 
                 changed = True
             except Exception, e:
                 module.fail_json(msg = '%s' % e.message)
@@ -249,6 +280,7 @@ def main():
             region = dict(),
             wait = dict(type='bool', choices=BOOLEANS),
             wait_timeout = dict(default=300),
+            networks = dict(type='list')
         )
     )
 
@@ -266,7 +298,8 @@ def main():
     region = module.params.get('region')
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
-
+    networks = module.params.get('networks')
+    
     # Setup the credentials and region
     try:
         username = username or os.environ.get('RAX_USERNAME')
@@ -294,7 +327,7 @@ def main():
     # Act based on service
     if service == 'cloudservers':
         cloudservers(module, state, name, flavor, image, meta, key_name, files,
-                     wait, wait_timeout)
+                     wait, wait_timeout, networks)
     elif service in ['cloudfiles', 'cloud_blockstorage',
                      'cloud_databases', 'cloud_loadbalancers']:
         module.fail_json(msg = 'Service %s is not supported at this time' %

--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -189,9 +189,13 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                 except Exception, e:
                     module.fail_json(msg = 'Failed to load %s' % lpath)
             try:
-                # This is a slightly complicated invocation because the final result needs to be in a nova-compatible format, which is what
-                # get_server_networks() does (it returns a 1-element list).
-                nics = [network.get_server_networks()[0] for network in pyrax.cloud_networks.list() if network.label in networks]
+                nics = []
+                if networks:
+                    # Nics should be in the nova_client format so utilize pyrax to give it to us, filtering
+                    # by the network name that the user specified
+                    for remote_network in pyrax.cloud_networks.list():
+                        if remote_network.label in networks:
+                            nics.append(remote_network.get_server_networks()[0])
                 
                 servers = [pyrax.cloudservers.servers.create(name=name,
                                                              image=image,


### PR DESCRIPTION
This is a bit different than the rest of the Rackspace module where everything had to go by ID (like flavors and images). I personally find that a bit pedantic because I always have to go hunting for the IDs and in some cases view page sources (although I suppose I could just leverage the API). Instead, I simply allow networks to be referenced by name with special, reserved names for 'public' and 'private'.

It's pretty trivial to change to reference these by id instead so just let me know if I should update this. I also wasn't sure how to do tests for this, but I tested locally and it works ok on my end.
