### PR TITLE
Revert "Include database param if provided and valid in django_admin commands"

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -186,7 +186,7 @@ def main():
     specific_params = ('apps', 'database', 'failfast', 'fixtures', 'liveserver', 'testrunner')
 
     # These params are automatically added to the command if present
-    general_params = ('settings', 'pythonpath', 'database',)
+    general_params = ('settings', 'pythonpath', )
     specific_boolean_params = ('failfast', 'skip', 'merge', 'link')
     end_of_command_params = ('apps', 'cache_table', 'fixtures')
 


### PR DESCRIPTION
Reverts commit bd446ef7, which is in devel branch but was made after release1.3.3, and which introduces a regression in the django_manage module.

The diff is:

```
     # These params are automatically added to the command if present
-    general_params = ('settings', 'pythonpath', )
+    general_params = ('settings', 'pythonpath', 'database',)
     specific_boolean_params = ('failfast', 'skip', 'merge', 'link')
     end_of_command_params = ('apps', 'cache_table', 'fixtures')
```

The result is that this line in my play, which works before the above commit:

```
  - name: run django syncdb and migrate
    django_manage:  command=$item settings='main.settings'
                    app_path=/home/artpro/enso-$customer-$role-$deploy
                    virtualenv=/home/artpro/.virtualenvs/$repo
                    database=enso_${customer}_${role}_${deploy}
    with_items:
      - syncdb
      - migrate
```

Gives after the following output:

TASK: [run django syncdb and migrate] ****************************************\* 
failed: [a.cms.customername.artpro.co] => (item=syncdb) => {"cmd": "python manage.py syncdb --noinput --settings=main.settings --database=enso_customername_cms_a", "failed": true, "item": "syncdb", "path": "/home/artpro/.virtualenvs/enso-core/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games", "state": "absent", "syspath": ["/home/artpro/.ansible/tmp/ansible-1381299121.18-255958505751459", "/usr/lib/python2.7", "/usr/lib/python2.7/plat-linux2", "/usr/lib/python2.7/lib-tk", "/usr/lib/python2.7/lib-old", "/usr/lib/python2.7/lib-dynload", "/usr/local/lib/python2.7/dist-packages", "/usr/lib/python2.7/dist-packages", "/usr/lib/python2.7/dist-packages/PIL", "/usr/lib/pymodules/python2.7"]}
msg: stdout: -----------------------------
ROOT_PATH: /home/artpro/enso-customername-cms-a
ENSO_ROOT: /home/artpro
STATIC_ROOT: /home/artpro/static
MEDIA_ROOT: /home/artpro/media
MEDIA_URL: /static/media/
STATIC_URL: /static/
UPLOAD_TO_PATH: /home/artpro/media/files
Syncing...

:stderr: Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/**init**.py", line 443, in execute_from_command_line
    utility.execute()
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/**init**.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(_args, *_options.**dict**)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(_args, *_options)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/base.py", line 371, in handle
    return self.handle_noargs(**options)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/south/management/commands/syncdb.py", line 90, in handle_noargs
    syncdb.Command().execute(**options)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(_args, *_options)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/base.py", line 371, in handle
    return self.handle_noargs(**options)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/commands/syncdb.py", line 56, in handle_noargs
    connection = connections[db]
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/db/utils.py", line 90, in **getitem**
    self.ensure_defaults(alias)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/db/utils.py", line 74, in ensure_defaults
    raise ConnectionDoesNotExist("The connection %s doesn't exist" % alias)
django.db.utils.ConnectionDoesNotExist: The connection enso_customername_cms_a doesn't exist

failed: [a.cms.customername.artpro.co] => (item=migrate) => {"cmd": "python manage.py migrate --noinput --settings=main.settings --database=enso_customername_cms_a", "failed": true, "item": "migrate", "path": "/home/artpro/.virtualenvs/enso-core/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games", "state": "absent", "syspath": ["/home/artpro/.ansible/tmp/ansible-1381299123.31-61401646153017", "/usr/lib/python2.7", "/usr/lib/python2.7/plat-linux2", "/usr/lib/python2.7/lib-tk", "/usr/lib/python2.7/lib-old", "/usr/lib/python2.7/lib-dynload", "/usr/local/lib/python2.7/dist-packages", "/usr/lib/python2.7/dist-packages", "/usr/lib/python2.7/dist-packages/PIL", "/usr/lib/pymodules/python2.7"]}
msg: stdout: -----------------------------
ROOT_PATH: /home/artpro/enso-customername-cms-a
ENSO_ROOT: /home/artpro
STATIC_ROOT: /home/artpro/static
MEDIA_ROOT: /home/artpro/media
MEDIA_URL: /static/media/
STATIC_URL: /static/
UPLOAD_TO_PATH: /home/artpro/media/files

:stderr: Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/**init**.py", line 443, in execute_from_command_line
    utility.execute()
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/**init**.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(_args, *_options.**dict**)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(_args, *_options)
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/south/management/commands/migrate.py", line 108, in handle
    ignore_ghosts = ignore_ghosts,
  File "/home/artpro/.virtualenvs/enso-core/local/lib/python2.7/site-packages/south/migration/**init**.py", line 171, in migrate_app
    south.db.db = south.db.dbs[database]
KeyError: 'enso_customername_cms_a'

FATAL: all hosts have already failed -- aborting

PLAY RECAP *******************************************************************\* 
           to retry, use: --limit @/home/kandinski/deploy.retry

a.cms.customername.artpro.co    : ok=9    changed=4    unreachable=0    failed=1   
