### PR TITLE
fix django_manage migrate command

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -164,7 +164,7 @@ def main():
         syncdb=('database', ),
         test=('failfast', 'testrunner', 'liveserver', 'apps', ),
         validate=(),
-        migrate=('apps', 'skip', 'database', 'merge'),
+        migrate=('apps', 'skip', 'merge'),
         collectstatic=('link', ),
         )
 


### PR DESCRIPTION
Fixes the bug described in #4405

The --database option is not documented for the South migrate command, and it appears it gets the database name into South when it shouldn't. The reason it shouldn't is that internally, the "database" variable is supposed to contain an alias ('default' instead of 'app_data' in the first example of https://docs.djangoproject.com/en/dev/topics/db/multi-db/), so it breaks when a real database name is passed.

Our solution is to remove "database" from the list of allowed params for the 'migrate' command on allowed_param_dict. Current patch makes the django_module error out and warn users when the database parameter is passed to the django_manage module in conjunction with the migrate command.
