### PR TITLE
Add capability to pass in a PATH prefix to run_command and allow pip module to utilize that to make virtualenv bin/ available in pip installs

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -900,7 +900,7 @@ class AnsibleModule(object):
             # rename might not preserve context
             self.set_context_if_different(dest, context, False)
 
-    def run_command(self, args, check_rc=False, close_fds=False, executable=None, data=None, binary_data=False):
+    def run_command(self, args, check_rc=False, close_fds=False, executable=None, data=None, binary_data=False, path_prefix=None):
         '''
         Execute a command, returns rc, stdout, and stderr.
         args is the command to run
@@ -924,6 +924,10 @@ class AnsibleModule(object):
         rc = 0
         msg = None
         st_in = None
+        env=os.environ
+        if path_prefix:
+            env['PATH']="%s:%s" % (path_prefix, env['PATH'])
+
         if data:
             st_in = subprocess.PIPE
         try:
@@ -933,7 +937,8 @@ class AnsibleModule(object):
                                    close_fds=close_fds,
                                    stdin=st_in,
                                    stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
+                                   stderr=subprocess.PIPE,
+                                   env=env)
             if data:
                 if not binary_data:
                     data += '\\n'

--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -234,6 +234,16 @@ def main():
     pip = _get_pip(module, env)
 
     cmd = '%s %s' % (pip, state_map[state])
+    
+    # If there's a virtualenv we want things we install to be able to use other
+    # installations that exist as binaries within this virtualenv. Example: we 
+    # install cython and then gevent -- gevent needs to use the cython binary, 
+    # not just a python package that will be found by calling the right python. 
+    # So if there's a virtualenv, we add that bin/ to the beginning of the PATH
+    # in run_command by setting path_prefix here.
+    path_prefix = None
+    if env:
+        path_prefix="/".join(pip.split('/')[:-1])
 
     if extra_args:
         cmd += ' %s' % extra_args
@@ -279,7 +289,7 @@ def main():
     os.chdir(tempfile.gettempdir())
     if chdir:
         os.chdir(chdir)
-    rc, out_pip, err_pip = module.run_command(cmd)
+    rc, out_pip, err_pip = module.run_command(cmd, path_prefix=path_prefix)
     out += out_pip
     err += err_pip
     if rc == 1 and state == 'absent' and 'not installed' in out_pip:


### PR DESCRIPTION
Add capability to pass in a PATH prefix to run_command and allow pip module to utilize that to make virtualenv bin/ available in pip installs.

As I said in the commit comments, currently if installing a program into a virtualenv via pip, anything previously installed into that virtualenv's bin/ directory isn't available on the PATH of the run_command environment.  This causes problems when, say, gevent wants to call cython during its install process.  I didn't see any other way to go about getting the PATH info into run_command (happy to be corrected), so I added that parameter. I can't imagine it won't be useful in other places to be able to pass-in an ad-hoc search path, so i figured it was a reasonable addition.
