### PR TITLE
Add detail to copy module validate argument

### DIFF
--- a/library/files/copy
+++ b/library/files/copy
@@ -65,7 +65,8 @@ options:
     aliases: [ "thirsty" ]
   validate:
     description:
-      - validation to run before copying into place
+      - The validation command to run before copying into place.  The path to the file to
+        validate is passed in via '%s' which must be present as in the visudo example below.
     required: false
     default: ""
     version_added: "1.2"


### PR DESCRIPTION
This clarifies the validate command argument and makes it clear that if
it is present, it must include the '%s' argument for the path to the
temporary file to validate.
