### PR TITLE
Fix timeout bug in firewalld module

### DIFF
--- a/library/system/firewalld
+++ b/library/system/firewalld
@@ -163,7 +163,7 @@ def main():
             zone=dict(required=False,default=None),
             permanent=dict(type='bool',required=True),
             state=dict(choices=['enabled', 'disabled'], required=True),
-            timeout=dict(required=False,default=0),
+            timeout=dict(type='int',required=False,default=0),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
stack trace from the error:

```
fatal: [192.168.100.168] => failed to parse: ERROR:dbus.connection:Unable to set arguments ('public', 'https', '10') according to signature u'ssi': <type 'exceptions.TypeError'>: an integer is required
Traceback (most recent call last):
  File "/home/ansible/.ansible/tmp/ansible-1381387583.17-274005383929762/firewalld", line 1325, in <module>
    main()
  File "/home/ansible/.ansible/tmp/ansible-1381387583.17-274005383929762/firewalld", line 288, in main
    set_service_enabled(zone, service, timeout)
  File "/home/ansible/.ansible/tmp/ansible-1381387583.17-274005383929762/firewalld", line 137, in set_service_enabled
    fw.addService(zone, service, timeout)
  File "<string>", line 2, in addService
  File "/usr/lib/python2.7/site-packages/slip/dbus/polkit.py", line 103, in _enable_proxy
    return func(*p, **k)
  File "<string>", line 2, in addService
  File "/usr/lib/python2.7/site-packages/firewall/client.py", line 46, in handle_exceptions
    return func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/firewall/client.py", line 1212, in addService
    return dbus_to_python(self.fw_zone.addService(zone, service, timeout))
  File "/usr/lib/python2.7/site-packages/slip/dbus/proxies.py", line 50, in __call__
    return dbus.proxies._ProxyMethod.__call__(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/dbus/proxies.py", line 145, in __call__
    **keywords)
  File "/usr/lib/python2.7/site-packages/dbus/connection.py", line 641, in call_blocking
    message.append(signature=signature, *args)
TypeError: an integer is required
```
