### PR TITLE
Properly handle DEFAULT section with ConfigParser in ini_file modules

### DIFF
--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -116,11 +116,11 @@ def do_ini(module, filename, section=None, option=None, value=None, state='prese
                     pass
 
     if state == 'present':
-        if cp.has_section(section) == False:
-            if section.upper() == 'DEFAULT':
-                module.fail_json(msg="[DEFAULT] is an illegal section name")
 
-            cp.add_section(section)
+        if cp.has_section(section) == False:
+
+            if section.upper() != 'DEFAULT':
+                cp.add_section(section)
             changed = True
 
         if option is not None and value is not None:

--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -117,10 +117,10 @@ def do_ini(module, filename, section=None, option=None, value=None, state='prese
 
     if state == 'present':
 
-        if cp.has_section(section) == False:
+        # DEFAULT section is always there by DEFAULT, so never try to add it.
+        if cp.has_section(section) == False and section.upper() != 'DEFAULT':
 
-            if section.upper() != 'DEFAULT':
-                cp.add_section(section)
+            cp.add_section(section)
             changed = True
 
         if option is not None and value is not None:


### PR DESCRIPTION
In ConfigParser, the DEFAULT section is treated as always there by default, and not as a named section. As such, it's a special case.

This patch moves the test for the DEFAULT section out so that sections are added only when the section named is not default. Options within the DEFAULT work as if it's already present, and it will be implicitly added if not.
