### PR TITLE
Implement a |changed filter plugin

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -34,7 +34,8 @@ def to_nice_json(*a, **kw):
     return json.dumps(*a, indent=4, sort_keys=True, **kw)
 
 def failed(*a, **kw):
-    item = a[0] 
+    ''' Test if task result yields failed '''
+    item = a[0]
     if type(item) != dict:
         raise errors.AnsibleFilterError("|failed expects a dictionary")
     rc = item.get('rc',0)
@@ -45,9 +46,18 @@ def failed(*a, **kw):
         return False
 
 def success(*a, **kw):
+    ''' Test if task result yields success '''
     return not failed(*a, **kw)
 
+def changed(*a, **kw):
+    ''' Test if task result yields changed '''
+    item = a[0]
+    if type(item) != dict:
+        raise errors.AnsibleFilterError("|changed expects a dictionary")
+    return item.get('changed', False)
+
 def skipped(*a, **kw):
+    ''' Test if task result yields skipped '''
     item = a[0]
     if type(item) != dict:
         raise errors.AnsibleFilterError("|skipped expects a dictionary")
@@ -105,6 +115,9 @@ class FilterModule(object):
             # failure testing
             'failed'  : failed,
             'success' : success,
+
+            # changed testing
+            'changed' : changed,
 
             # skip testing
             'skipped' : skipped,

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -54,7 +54,16 @@ def changed(*a, **kw):
     item = a[0]
     if type(item) != dict:
         raise errors.AnsibleFilterError("|changed expects a dictionary")
-    return item.get('changed', False)
+    if not 'changed' in item:
+        changed = False
+        if ('results' in item    # some modules return a 'results' key
+                and type(item['results']) == list 
+                and type(item['results'][0]) == dict):
+            for result in item['results']:
+                changed = changed or result.get('changed', False)
+    else:
+        changed = item.get('changed', False)
+    return changed
 
 def skipped(*a, **kw):
     ''' Test if task result yields skipped '''


### PR DESCRIPTION
As proposed on list at http://goo.gl/ECS4xm

I'm not sure what Michael meant with _The only difference is the filter understands lists when there is not a top level .changed element._ Is this about registered loop tasks (with_items) where different items yield changed or not? AIFACS, the main result already sets `changed: true' when at least one of the item subtasks had a`changed: true`.

Either way, I gave that a try in the next commit. Let me know what exactly is expected.
