### PR TITLE
Respect DISPLAY_SKIPPED_HOSTS when play doesn't match any hosts

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -571,8 +571,9 @@ class PlaybookCallbacks(object):
         call_callback_module('playbook_on_notify', host, handler)
 
     def on_no_hosts_matched(self):
-        display("skipping: no hosts matched", color='cyan')
-        call_callback_module('playbook_on_no_hosts_matched')
+        if constants.DISPLAY_SKIPPED_HOSTS:
+            display("skipping: no hosts matched", color='cyan')
+            call_callback_module('playbook_on_no_hosts_matched')
 
     def on_no_hosts_remaining(self):
         display("\nFATAL: all hosts have already failed -- aborting", color='red')


### PR DESCRIPTION
When running a playbook where certain plays have no matching hosts, a 'skipped' message is displayed:

```
PLAY [deploy service] *************************************** 
skipping: no hosts matched

PLAY [deploy pres] *************************************************** 
skipping: no hosts matched
```

This patch makes this message respecting 'constants.DISPLAY_SKIPPED_HOSTS`:

```
PLAY [deploy service] *************************************** 

PLAY [deploy pres] *************************************************** 
```
