### PR TITLE
This oneliner change allows apt-key to inherit the http_proxy variable.

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -304,7 +304,7 @@ class UbuntuSourcesList(SourcesList):
 
             if self.add_ppa_signing_keys_callback is not None:
                 info = self._get_ppa_info(ppa_owner, ppa_name)
-                command = ['apt-key', 'adv', '--recv-keys', '--keyserver', 'keyserver.ubuntu.com', info['signing_key_fingerprint']]
+                command = ['apt-key', 'adv', '--recv-keys', '--keyserver', 'hkp://keyserver.ubuntu.com:80', info['signing_key_fingerprint']]
                 self.add_ppa_signing_keys_callback(command)
 
             file = file or self._suggest_filename('%s_%s' % (line, distro.codename))


### PR DESCRIPTION
Before this fix

  TASK: [apt_repository repo='ppa:vbernat/haproxy-1.5'] *************************
  failed: [134.226.115.202] => {"cmd": ["apt-key", "adv", "--recv-keys", "--keyserver", "keyserver.ubuntu.com", "CFFB779AADC995E4F350A060505D97A41C61B9CD"], "failed": true, "rc": 2}
  stderr: gpg: requesting key 1C61B9CD from hkp server keyserver.ubuntu.com
  gpg: no valid OpenPGP data found.
  gpg: Total number processed: 0

After the fix

  TASK: [apt_repository repo='ppa:vbernat/haproxy-1.5'] *************************
  changed: [134.226.115.202]
