### PR TITLE
Fixed crash when s3 bucket did not exist for put operation

### DIFF
--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -371,7 +371,8 @@ def main():
         
         # Lets check to see if bucket exists to get ground truth.
         bucketrtn = bucket_check(module, s3, bucket)
-        keyrtn = key_check(module, s3, bucket, obj)
+        if bucketrtn is True:
+            keyrtn = key_check(module, s3, bucket, obj)
 
         # Lets check key state. Does it exist and if it does, compute the etag md5sum.
         if bucketrtn is True and keyrtn is True:


### PR DESCRIPTION
As per the comment in https://github.com/ansible/ansible/pull/4426 please find attached a pull request that prevents a crash occuring when the s3 bucket does not exist for a put operation.
