### PR TITLE
add state absent/present to actions file, copy and template

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -118,6 +118,7 @@ FILE_COMMON_ARGUMENTS=dict(
     content = dict(),
     backup = dict(),
     force = dict(),
+    state = dict()
 )
 
 def get_platform():

--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -49,6 +49,9 @@ class ActionModule(object):
         if (source is None and 'first_available_file' not in inject) or dest is None:
             result = dict(failed=True, msg="src and dest are required")
             return ReturnData(conn=conn, comm_ok=False, result=result)
+          
+        if options.get('state', None) == 'absent':
+            return self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject, complex_args=complex_args)
 
         # if we have first_available_file in our vars
         # look up the files and use the first one we find as src

--- a/library/files/file
+++ b/library/files/file
@@ -142,7 +142,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-            state = dict(choices=['file','directory','link','hard','touch','absent'], default='file'),
+            state = dict(choices=['file','directory','link','hard','touch','absent','present'], default='file'),
             path  = dict(aliases=['dest', 'name'], required=True),
             recurse  = dict(default='no', type='bool'),
             force = dict(required=False,default=False,type='bool'),
@@ -154,6 +154,8 @@ def main():
     )
 
     params = module.params
+    if params['state'] == 'present':
+        params['state'] = 'file'
     state  = params['state']
     force = params['force']
     params['path'] = path = os.path.expanduser(params['path'])


### PR DESCRIPTION
another solution to adding arg state=absent to template and copy.
However this one adds a perhaps confusing state for a file as present.

Perhaps this can be reworked so a file marked as present can be a file/directory or link.
Currently I just 'alias' present as file.

template: src=bla dest=ba state=present|absent
copy: src=bla dest=ba state=present|absent
