### PR TITLE
Fixed broken force=yes on files for directories

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -226,7 +226,7 @@ def main():
         module.exit_json(path=path, changed=True)
 
     if prev_state != 'absent' and prev_state != state:
-        if not (force and prev_state == 'file' and state == 'link') and state != 'touch':
+        if not (force and (prev_state == 'file' or prev_state == 'directory') and state == 'link') and state != 'touch':
             module.fail_json(path=path, msg='refusing to convert between %s and %s for %s' % (prev_state, state, src))
 
     if prev_state == 'absent' and state == 'absent':


### PR DESCRIPTION
If you try to overwrite a directory with a symlink using file and force=yes, you are presented with the error: "msg: refusing to convert between directory and link for...". This is not the expected behavior according to the documentation.

This fix simply adds a check for whether the previous state is a directory, restoring full functionality for the force option.
