### PR TITLE
supervisorctl: user expansion on config filepath

### DIFF
--- a/library/web_infrastructure/supervisorctl
+++ b/library/web_infrastructure/supervisorctl
@@ -118,7 +118,7 @@ def main():
         supervisorctl_args = [ module.get_bin_path('supervisorctl', True) ]
 
     if config:
-        supervisorctl_args.extend(['-c', config])
+        supervisorctl_args.extend(['-c', os.path.expanduser(config)])
     if server_url:
         supervisorctl_args.extend(['-s', server_url])
     if username:


### PR DESCRIPTION
simple pull, fixes some undesirable behavior when you try to use ~/ in config path.

Thanks,
Thomas Omans
