### PR TITLE
conditional that is just an integer (??) causes traceback, 9ea54fcaaf

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -171,11 +171,11 @@ def check_conditional(conditional, basedir, inject, fail_on_undefined=False, jin
 
     if conditional.startswith("jinja2_compare"):
         conditional = conditional.replace("jinja2_compare ","")
+        original = conditional
         # allow variable names
         if conditional in inject and str(inject[conditional]).find('-') == -1:
             conditional = inject[conditional]
         conditional = template.template(basedir, conditional, inject, fail_on_undefined=fail_on_undefined)
-        original = conditional.replace("jinja2_compare ","")
         # a Jinja2 evaluation that results in something Python can eval!
         presented = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % conditional
         conditional = template.template(basedir, presented, inject)


### PR DESCRIPTION
## ERROR: test_check_conditional_jinja2_variable_literals (TestUtils.TestUtils)

Traceback (most recent call last):
  File "/home/misc/checkout/git/ansible/test/TestUtils.py", line 151, in test_check_conditional_jinja2_variable_literals
    'jinja2_compare var', '/', {'var': 1}) == True)
  File "/home/misc/checkout/git/ansible/lib/ansible/utils/**init**.py", line 178, in check_conditional
    original = conditional.replace("jinja2_compare ","")
AttributeError: 'int' object has no attribute 'replace'
