### PR TITLE
ansible-pull by default will look for local.yml and $fqdn.yml.

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -80,10 +80,12 @@ def select_playbook(path, args):
             return None
         return playbook
     else:
-        hostpb = "%s/%s.yml" % (path, socket.getfqdn())
+        fqdn = socket.getfqdn()
+        hostpb = "%s/%s.yml" % (path, fqdn)
+        shorthostpb = "%s/%s.yml" % (path, fqdn.split('.')[0])
         localpb = "%s/%s" % (path, DEFAULT_PLAYBOOK)
         errors = []
-        for pb in [hostpb, localpb]:
+        for pb in [hostpb, shorthostpb, localpb]:
             rc = try_playbook(pb)
             if rc == 0:
                 playbook = pb

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -32,8 +32,9 @@
 # for playbooks in the following order, stopping at the first match:
 #
 # 1. $workdir/path/playbook.yml, if specified
-# 2. $workdir/$hostname.yml
-# 3. $workdir/local.yml
+# 2. $workdir/$fqdn.yml
+# 3. $workdir/$hostname.yml
+# 4. $workdir/local.yml
 #
 # the source repo must contain at least one of these playbooks.
 

--- a/docs/man/man1/ansible-pull.1.asciidoc.in
+++ b/docs/man/man1/ansible-pull.1.asciidoc.in
@@ -43,8 +43,8 @@ OPTIONAL ARGUMENT
 
 The name of one the YAML format files to run as an ansible playbook.  This can
 be a relative path within the checkout.  If not provided, ansible-pull
-will look for a playbook based on the host's fully-qualified domain name and
-finally a playbook named *local.yml*.
+will look for a playbook based on the host's fully-qualified domain name, on the
+host hostname and finally a playbook named *local.yml*.
 
 
 OPTIONS


### PR DESCRIPTION
For a small network ( home, small company ), having to put the FQDN
in each file is a bit tedious, so this patch also add the shorthostname
as a 3rd default if the fqdn is not found.
