### PR TITLE
Fix authorized keys

### DIFF
--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -185,6 +185,9 @@ def parseoptions(options):
     if options:
         options_list = options.strip().split(",")
         for option in options_list:
+            # happen when there is comma at the end
+            if option == '':
+                continue
             if option.find("=") != -1:
                 (arg,val) = option.split("=", 1)
             else:

--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -254,7 +254,7 @@ def writekeys(module, filename, keys):
                 option_str = ""
                 if options:
                     option_strings = []
-                    for option_key in options.keys():
+                    for option_key in sorted(options.keys()):
                         if options[option_key]:
                             option_strings.append("%s=%s" % (option_key, options[option_key]))
                         else:

--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -256,7 +256,7 @@ def writekeys(module, filename, keys):
                     option_strings = []
                     for option_key in sorted(options.keys()):
                         if options[option_key]:
-                            option_strings.append("%s=%s" % (option_key, options[option_key]))
+                            option_strings.append("%s=\"%s\"" % (option_key, options[option_key]))
                         else:
                             option_strings.append("%s " % option_key)
 


### PR DESCRIPTION
The module autorized_keys didn't work when I tried with the new key_options parameters.
First, the line created was using space as separator, not commas. Then, fixing this one, i found out that finishing the option with a single comma confused the options parser. Finally, for reproducibility and to avoid trigger tools like AIDE, it would be better to have a consistent order of option, since the module rewrite completely the file each time.
