### PR TITLE
create install_options parameter for homebrew module

### DIFF
--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -24,7 +24,7 @@ author: Andrew Dunham
 short_description: Package manager for Homebrew
 description:
     - Manages Homebrew packages
-version_added: "1.1"
+version_added: "1.4"
 options:
     name:
         description:

--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -42,6 +42,11 @@ options:
         required: false
         default: "no"
         choices: [ "yes", "no" ]
+    install_options:
+        description:
+            - options flags to install a package
+        required: false
+        default: ""
 notes:  []
 '''
 EXAMPLES = '''
@@ -49,6 +54,7 @@ EXAMPLES = '''
 - homebrew: name=foo state=present update_homebrew=yes
 - homebrew: name=foo state=absent
 - homebrew: name=foo,bar state=absent
+- homebrew: name=foo state=present install_options=with-baz,enable-debug
 '''
 
 
@@ -98,7 +104,7 @@ def remove_packages(module, brew_path, packages):
     module.exit_json(changed=False, msg="package(s) already absent")
 
 
-def install_packages(module, brew_path, packages):
+def install_packages(module, brew_path, packages, options):
     """ Installs one or more packages if not already installed. """
 
     installed_count = 0
@@ -109,7 +115,8 @@ def install_packages(module, brew_path, packages):
 
         if module.check_mode:
             module.exit_json(changed=True)
-        rc, out, err = module.run_command([brew_path, 'install', package])
+
+        rc, out, err = module.run_command([brew_path, 'install', package, options])
 
         if not query_package(module, brew_path, package):
             module.fail_json(msg="failed to install %s: %s" % (package, out.strip()))
@@ -121,13 +128,22 @@ def install_packages(module, brew_path, packages):
 
     module.exit_json(changed=False, msg="package(s) already present")
 
+def generate_options_string(install_options):
+    options_str =  ''
+
+    for option in install_options:
+        options_str += ' --%s' % option
+
+    return options_str.strip()
+
 
 def main():
     module = AnsibleModule(
         argument_spec = dict(
             name = dict(aliases=["pkg"], required=True),
             state = dict(default="present", choices=["present", "installed", "absent", "removed"]),
-            update_homebrew = dict(default="no", aliases=["update-brew"], type='bool')
+            update_homebrew = dict(default="no", aliases=["update-brew"], type='bool'),
+            install_options = dict(default="", aliases=["options"], type='list')
         ),
         supports_check_mode=True
     )
@@ -142,7 +158,8 @@ def main():
     pkgs = p["name"].split(",")
 
     if p["state"] in ["present", "installed"]:
-        install_packages(module, brew_path, pkgs)
+        opt = generate_options_string(p["install_options"])
+        install_packages(module, brew_path, pkgs, opt)
 
     elif p["state"] in ["absent", "removed"]:
         remove_packages(module, brew_path, pkgs)

--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -46,7 +46,7 @@ options:
         description:
             - options flags to install a package
         required: false
-        default: ""
+        default: null
 notes:  []
 '''
 EXAMPLES = '''
@@ -116,7 +116,10 @@ def install_packages(module, brew_path, packages, options):
         if module.check_mode:
             module.exit_json(changed=True)
 
-        rc, out, err = module.run_command([brew_path, 'install', package, options])
+        if options:
+            rc, out, err = module.run_command([brew_path, 'install', package, options])
+        else:
+            rc, out, err = module.run_command([brew_path, 'install', package])
 
         if not query_package(module, brew_path, package):
             module.fail_json(msg="failed to install %s: %s" % (package, out.strip()))
@@ -129,6 +132,9 @@ def install_packages(module, brew_path, packages, options):
     module.exit_json(changed=False, msg="package(s) already present")
 
 def generate_options_string(install_options):
+    if install_options is None:
+        return ''
+
     options_str =  ''
 
     for option in install_options:
@@ -143,7 +149,7 @@ def main():
             name = dict(aliases=["pkg"], required=True),
             state = dict(default="present", choices=["present", "installed", "absent", "removed"]),
             update_homebrew = dict(default="no", aliases=["update-brew"], type='bool'),
-            install_options = dict(default="", aliases=["options"], type='list')
+            install_options = dict(default=None, aliases=["options"], type='list')
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
This parameter enable homebrew option flags. Ex:

``` yml
- name: install wget
  homebrew: name=wget state=present install_options=enable-debug,enable-iri
```

It executes:

``` bash
brew install wget --enable-debug --enable-iri
```
