### PR TITLE
Adding os realpath filter.

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -120,6 +120,7 @@ class FilterModule(object):
             # path
             'basename': os.path.basename,
             'dirname': os.path.dirname,
+            'realpath': os.path.realpath,
 
             # failure testing
             'failed'  : failed,


### PR DESCRIPTION
This is particularly useful when wanting to get the absolute path of filepaths found by the 'fileglob' filter.

This also lets you provide absolute paths to roles, which search for files in different areas unless absolutely pathed.
