### PR TITLE
add regexp filter to assemble module

### DIFF
--- a/library/files/assemble
+++ b/library/files/assemble
@@ -22,6 +22,7 @@ import os
 import os.path
 import shutil
 import tempfile
+import re
 
 DOCUMENTATION = '''
 ---
@@ -62,6 +63,14 @@ options:
     version_added: "1.4"
     required: false
     default: null
+  regexp:
+    description:
+      - Assemble files only if C(regex) matches the filename. If not set,
+        all files are assembled. All "\" (backslash) must be escaped as
+        "\\\\" to comply yaml syntax. Uses Python regular expressions; see
+        U(http://docs.python.org/2/library/re.html).
+    required: false
+    default: null
   others:
     description:
       - all arguments accepted by the M(file) module also work here
@@ -80,12 +89,14 @@ EXAMPLES = '''
 # ===========================================
 # Support method
 
-def assemble_from_fragments(src_path, delimiter=None):
+def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None):
     ''' assemble a file from a directory of fragments '''
     tmpfd, temp_path = tempfile.mkstemp()
     tmp = os.fdopen(tmpfd,'w')
     delimit_me = False
     for f in sorted(os.listdir(src_path)):
+        if compiled_regexp and not compiled_regexp.search(f):
+            continue
         fragment = "%s/%s" % (src_path, f)
         if delimit_me and delimiter:
             tmp.write(delimiter)
@@ -107,6 +118,7 @@ def main():
             delimiter = dict(required=False),
             dest = dict(required=True),
             backup=dict(default=False, type='bool'),
+            regexp = dict(required=False),
         ),
         add_file_common_args=True
     )
@@ -118,6 +130,8 @@ def main():
     dest      = os.path.expanduser(module.params['dest'])
     backup    = module.params['backup']
     delimiter = module.params['delimiter']
+    regexp    = module.params['regexp']
+    compiled_regexp = None
 
     if not os.path.exists(src):
         module.fail_json(msg="Source (%s) does not exist" % src)
@@ -125,7 +139,13 @@ def main():
     if not os.path.isdir(src):
         module.fail_json(msg="Source (%s) is not a directory" % src)
 
-    path = assemble_from_fragments(src, delimiter)
+    if regexp != None:
+        try:
+            compiled_regexp = re.compile(regexp)
+        except re.error, e:
+            module.fail_json(msg="Invalid Regexp (%s) in \"%s\"" % (e, regexp))
+
+    path = assemble_from_fragments(src, delimiter, compiled_regexp)
     pathmd5 = module.md5(path)
 
     if os.path.exists(dest):
@@ -146,3 +166,4 @@ def main():
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 
 main()
+


### PR DESCRIPTION
add filename whitelisting to assemble module

Strict whitelisting may prevent accidental mixture of hidden, temporal, or automatically-created files.

```
regexp=^\\d\\d-.*\\.ya?ml$
```

will include `01-first.yaml` and `02-second.yml` but exclude `.gitignore`, `10-tmp.yml~` or`somefile.yml.rpmsave`.

in reply to https://github.com/ansible/ansible/pull/3929 , fileglob may do same thing for simple case, but its too fuzzy i think.
