### PR TITLE
Fix TestInventory class by explicitly using /bin/bash

### DIFF
--- a/test/TestCallback.py
+++ b/test/TestCallback.py
@@ -41,7 +41,9 @@ class TestInventory(unittest.TestCase):
         os.chdir(self.cwd)
 
     def run_ansible_playbook(self):
-        subprocess.call('source ../../hacking/env-setup 2>&1 >/dev/null; ansible-playbook -i "127.0.0.1," test_playbook.yml 2>&1 >/dev/null', shell=True)
+        subprocess.call(('source ../../hacking/env-setup 2>&1 >/dev/null;'
+                         'ansible-playbook -i "127.0.0.1," test_playbook.yml 2>&1 >/dev/null'),
+                        shell=True, executable='/bin/bash')
 
     def test_callback(self):
         self.clean_file()


### PR DESCRIPTION
Here is the problem:

``` bash
$ make tests
PYTHONPATH=./lib nosetests -d -v
test_callback (TestCallback.TestInventory) ... /bin/sh: 1: source: not found
Traceback (most recent call last):
  File "/usr/bin/ansible-playbook", line 24, in <module>
    import ansible.playbook
ImportError: No module named ansible.playbook
FAIL
```

Note the `source: not found`

TestCallback.py:

``` python
subprocess.call('source ../../hacking/env-setup 2>&1 >/dev/null; ansible-playbook -i "127.0.0.1," test_playbook.yml 2>&1 >/dev/null', shell=True)
```

`source` is a builtin function of bash and not available in e.g. `/bin/sh`. For whatever reason my system is using /bin/sh instead of /bin/bash. I think if the subprocess call depends on bash functionality, it should force the usage with `executable='/bin/bash'`

FYI: I'm using a Debian sid with rxvt-unicode, /bin/bash for the login shell and virtualenv for the ansible project checkout.
