### PR TITLE
Ensure non-root users can read arguments file when using sudo_user and non-standard modules

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -320,6 +320,11 @@ class Runner(object):
             else:
                 argsfile = self._transfer_str(conn, tmp, 'arguments', args)
 
+            if self.sudo and self.sudo_user != 'root':
+                # deal with possible umask issues once sudo'ed to other user
+                cmd_args_chmod = "chmod a+r %s" % argsfile
+                self._low_level_exec_command(conn, cmd_args_chmod, tmp, sudoable=False)
+
             if async_jid is None:
                 cmd = "%s %s" % (remote_module_path, argsfile)
             else:


### PR DESCRIPTION
Non-standard modules must read in the arguments file in order to access their arguments, however, when this file is transfered to the remote host it may only have the permissions 600.  This means that using sudo and sudo_user will result in permission denied errors when attempting to read the arguments file.

This patch fixes #4438 by explicitly forcing the arguments file to be world readable before executing the module.
