### PR TITLE
Fix 'ansible-doc -l' runtime error following commit 4430d0f

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -161,7 +161,7 @@ def main():
                 continue
 
             filename = utils.plugins.module_finder.find_plugin(module)
-            if os.path.isdir(filename):
+            if filename is None:
                 continue
             try:
                 doc, plainexamples = module_docs.get_docstring(filename)


### PR DESCRIPTION
skip "module" not found as plugin, id est directory
