### PR TITLE
Fix illegal set operation in FreeBSD section of user module.

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -745,7 +745,7 @@ class FreeBsdUser(User):
                 cmd.append('-G')
                 new_groups = groups
                 if self.append:
-                    new_groups.extend(current_groups)
+                    new_groups = groups | set(current_groups)
                 cmd.append(','.join(new_groups))
 
         # modify the user if cmd will do anything


### PR DESCRIPTION
This fixes #4461. Cleaner patch than the previous. Thanks!
