### PR TITLE
Adding aws_access_key and aws_secret_key aliases to ec2_group arguments

### DIFF
--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -42,13 +42,13 @@ options:
       - EC2 secret key
     required: false
     default: null
-    aliases: []
+    aliases: ['aws_secret_key']
   ec2_access_key:
     description:
       - EC2 access key
     required: false
     default: null
-    aliases: []
+    aliases: ['aws_access_key']
   state:
     version_added: "1.4"
     description:
@@ -110,8 +110,8 @@ def main():
             vpc_id=dict(),
             rules=dict(),
             ec2_url=dict(aliases=['EC2_URL']),
-            ec2_secret_key=dict(aliases=['EC2_SECRET_KEY'], no_log=True),
-            ec2_access_key=dict(aliases=['EC2_ACCESS_KEY']),
+            ec2_secret_key=dict(aliases=['EC2_SECRET_KEY', 'aws_secret_key'], no_log=True),
+            ec2_access_key=dict(aliases=['EC2_ACCESS_KEY', 'aws_access_key']),
             region=dict(choices=['eu-west-1', 'sa-east-1', 'us-east-1', 'ap-northeast-1', 'us-west-2', 'us-west-1', 'ap-southeast-1', 'ap-southeast-2']),
             state = dict(default='present', choices=['present', 'absent']),
         ),


### PR DESCRIPTION
There is inconsistency in the documents about using aws_ or ec2_ prefix for secret_key and access_key.  Realize this is water under the bridge, but think the safest course is to alias all of the ec2 modules both ways.  I had a case where I was assuming aws___key variables were being used when it was in fact pulling EC2___KEY from elsewhere.  

We may want to change the documentation to all read one way even if it is the preferred alias.  Probably ec2_*_key since not all EC2 implementations are Amazon.
