### PR TITLE
add_group module: strip trailing/leading whitespace from comma-separated group names

### DIFF
--- a/lib/ansible/runner/action_plugins/add_host.py
+++ b/lib/ansible/runner/action_plugins/add_host.py
@@ -79,6 +79,7 @@ class ActionModule(object):
         # add it to the group if that was specified
         if groupnames != '':
             for group_name in groupnames.split(","):
+                group_name = group_name.strip()
                 if not inventory.get_group(group_name):
                     new_group = Group(group_name)
                     inventory.add_group(new_group)


### PR DESCRIPTION
Something like this:

```
add_host: hostname=localhost groupname="mygroup, secondgroup"
```

...will result in a group being created with a leading space: 

```
ok: [localhost] => {"new_groups": ["mygroup", " secondgroup"], "new_host": "localhost"}
```

This patch strips trailing and leading whitespace from group names specified, which is probably almost always what the user means.
