### PR TITLE
add a default value for the -d option of ansible-pull

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -122,9 +122,10 @@ def main(args):
                       'Default is %s.' % DEFAULT_REPO_TYPE)
     options, args = parser.parse_args(args)
 
+    hostname = socket.getfqdn()
     if not options.dest:
-        parser.error("Missing required directory argument")
-        return 1
+        # use a hostname dependent directory, in case of $HOME on nfs
+        options.dest = utils.prepare_writeable_dir('~/.ansible/pull/%s' % hostname)
 
     options.dest = os.path.abspath(options.dest)
 
@@ -136,7 +137,7 @@ def main(args):
     print >>sys.stderr, now.strftime("Starting ansible-pull at %F %T")
 
     inv_opts = 'localhost,'
-    limit_opts = 'localhost:%s:127.0.0.1' % socket.getfqdn()
+    limit_opts = 'localhost:%s:127.0.0.1' % hostname
     base_opts = '-c local --limit "%s"' % limit_opts
     repo_opts = "name=%s dest=%s" % (options.url, options.dest)
     if options.checkout:

--- a/docs/man/man1/ansible-pull.1.asciidoc.in
+++ b/docs/man/man1/ansible-pull.1.asciidoc.in
@@ -52,7 +52,8 @@ OPTIONS
 
 *-d* 'DEST', *--directory=*'DEST'::
 
-Directory to checkout repository into.
+Directory to checkout repository into. If not provided, a subdirectory of
+~/.ansible/pull/ will be used.
 
 *-U* 'URL', *--url=*'URL'::
 


### PR DESCRIPTION
Thi permit to simplify the command line to use by using a sensible default, and so reduce the number of incorrect possible choices and setup needed. Among potential incorrect choices is using a fixed directory in /tmp, which could be problematic with a setup whose access is not properly restricted.
