### PR TITLE
fix distribution detection in apt_repository module, so it also work on mint as it work on Debian, partially fix #4587

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -349,7 +349,8 @@ def main():
     update_cache = module.params['update_cache']
     sourceslist = None
 
-    if isinstance(distro, aptsources.distro.DebianDistribution):
+    if isinstance(distro, aptsources.distro.DebianDistribution) or \
+            isinstance(distro, aptsources.distro.Distribution):
         sourceslist = SourcesList()
     elif isinstance(distro, aptsources.distro.UbuntuDistribution):
         sourceslist = UbuntuSourcesList(add_ppa_signing_keys_callback=get_add_ppa_signing_key_callback(module))


### PR DESCRIPTION
PPAs are not supported however, since that's a Ubuntu specific feature
and mint is detected as a generic distribution and use a different
codename than the Ubuntu release it is based on, which mean that apt_repository
cannot add detect and add the proper url without a better heuristic.
