### PR TITLE
fix logic in module host to add aliases even if none exist already, fix #4563

### DIFF
--- a/library/system/host
+++ b/library/system/host
@@ -124,7 +124,7 @@ class Host(object):
                 break
 
     def full_entry_exists(self):
-        if self._has_aliases and not self._aliases_matches:
+        if self.aliases and not self._aliases_matches:
             return False
         return self._ip_matches and self._hostname_matches
 


### PR DESCRIPTION
self._has_aliases is used to know if a alias already exist, but
the test we want is to know if we need to add a new alias, which
is stored in self.aliases
