### PR TITLE
Added ['date_time']['tz_offset'] using %z to get the time offset rather ...

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -452,7 +452,7 @@ class Facts(object):
         self.facts['date_time']['iso8601_micro'] = now.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.facts['date_time']['iso8601'] = now.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
         self.facts['date_time']['tz'] = time.strftime("%Z")
-	self.facts['date_time']['tz_offset'] = time.strftime("%z")
+        self.facts['date_time']['tz_offset'] = time.strftime("%z")
 
 
     # User

--- a/library/system/setup
+++ b/library/system/setup
@@ -452,6 +452,7 @@ class Facts(object):
         self.facts['date_time']['iso8601_micro'] = now.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.facts['date_time']['iso8601'] = now.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
         self.facts['date_time']['tz'] = time.strftime("%Z")
+	self.facts['date_time']['tz_offset'] = time.strftime("%z")
 
 
     # User


### PR DESCRIPTION
...than time zone.

I desperately needed the GMT offset (what %z gives) for use in jinja templating, so I added it to the list of variables.

Accessible via {{ ansible_date_time.tz_offset }}.
