### PR TITLE
apt: autoinstall python-apt if apt or apt_pkg is not available

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -322,7 +322,13 @@ def main():
     )
 
     if not HAS_PYTHON_APT:
-        module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")
+        try:
+            module.run_command('apt-get install python-apt -y -q')
+            global apt, apt_pkg
+            import apt
+            import apt_pkg
+        except:
+            module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")
 
     global APTITUDE_CMD
     APTITUDE_CMD = module.get_bin_path("aptitude", False)


### PR DESCRIPTION
This PR fixes #4079. 
