### PR TITLE
Introduce Big-IP F5 http monitor module

### DIFF
--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -182,10 +182,11 @@ def create_monitor(api, monitor, template_attributes):
         api.LocalLB.Monitor.create_template(templates=[{'template_name': monitor, 'template_type': TEMPLATE_TYPE}], template_attributes=[template_attributes])
     except bigsuds.OperationFailed, e:
         if "already exists" in str(e):
-            pass
+            return False
         else:
             # genuine exception
             raise
+    return True
 
 
 def delete_monitor(api, monitor):
@@ -194,9 +195,12 @@ def delete_monitor(api, monitor):
         api.LocalLB.Monitor.delete_template(template_names=[monitor])
     except bigsuds.OperationFailed, e:
         # maybe it was deleted since we checked
-        if not "was not found" in str(e):
+        if "was not found" in str(e):
+            return False
+        else:
             # genuine exception
             raise
+    return True
 
 def check_string_property(api, monitor, str_property):
 
@@ -307,8 +311,11 @@ def main():
         if state == 'absent':
             if monitor_exists:
                 if not module.check_mode:
-                    delete_monitor(api, monitor)
-                result['changed'] = True
+                    # possible race condition if same task 
+                    # on other node deleted it first
+                    result['changed'] = delete_monitor(api, monitor)
+                else:
+                    result['changed'] = True
 
         else:
             ipport = {'address_type': address_type,
@@ -353,10 +360,13 @@ def main():
                     result['changed'] = True
 
             elif not module.check_mode:
-                create_monitor(api, monitor, template_attributes)
+                # possible race condition if same task 
+                # on other node deleted it first
+                result['changed'] = create_monitor(api, monitor, template_attributes)
                 for str_property in template_string_properties:
                     set_string_property(api, monitor, str_property)
-                result['changed'] = True
+                for int_property in template_integer_properties:
+                    set_integer_property(api, monitor, int_property)
             else: # monitor does not exist and check mode
                 result['changed'] = True
 

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -1,0 +1,260 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, serge van Ginderachter <serge@vanginderachter.be>
+# based on Matt Hite's bigip_pool module
+# (c) 2013, Matt Hite <mhite@hotmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: bigip_monitor_http
+short_description: "Manages F5 BIG-IP LTM http monitors"
+description:
+    - "Manages F5 BIG-IP LTM monitors via iControl SOAP API"
+version_added: "1.3"
+author: Serge van Ginderachter
+notes:
+    - "Requires BIG-IP software version >= 11"
+    - "F5 developed module 'bigsuds' required (see http://devcentral.f5.com)"
+    - "Best run as a local_action in your playbook"
+    - "Monitor API documentation: https://devcentral.f5.com/wiki/iControl.LocalLB__Monitor.ashx"
+requirements:
+    - bigsuds
+options:
+    server:
+        description:
+            - BIG-IP host
+        required: true
+        default: null
+        choices: []
+        aliases: []
+    user:
+        description:
+            - BIG-IP username
+        required: true
+        default: null
+        choices: []
+        aliases: []
+    password:
+        description:
+            - BIG-IP password
+        required: true
+        default: null
+        choices: []
+        aliases: []
+    state:
+        description:
+            - Monitor state
+        required: false
+        default: 'present'
+        choices: ['present', 'absent']
+        aliases: []
+    name:
+        description:
+            - Monitor name
+        required: true
+        default: null
+        choices: []
+        aliases: ['monitor']
+    partition:
+        description:
+            - Partition
+        required: false
+        default: 'Common'
+        choices: []
+        aliases: []
+    parent:
+        description:
+            - The parent template of this monitor template
+        required: false
+        default: 'http'
+        choices: []
+        aliases: []
+    send:
+        description:
+        required: true
+        default: null
+        choices: []
+        aliases: []
+    receive:
+        description:
+        required: true
+        default: null
+        choices: []
+        aliases: []
+'''
+
+EXAMPLES = '''
+
+'''
+
+try:
+    import bigsuds
+except ImportError:
+    bigsuds_found = False
+else:
+    bigsuds_found = True
+
+TEMPLATE_TYPE = 'TTYPE_HTTP'
+DEFAULT_PARENT_TYPE = 'http'
+
+
+# ===========================================
+# bigip_monitor module generic methods.
+# these should be re-useable for other monitor types
+#
+
+def bigip_api(bigip, user, password):
+
+    api = bigsuds.BIGIP(hostname=bigip, username=user, password=password)
+    return api
+
+
+def monitor_exists(module, api, monitor, parent):
+
+    # hack to determine if monitor exists
+    result = False
+    try:
+        ttype = api.LocalLB.Monitor.get_template_type(template_names=[monitor])[0]
+        parent2 = api.LocalLB.Monitor.get_parent_template(template_names=[monitor])[0]
+        if ttype == TEMPLATE_TYPE and parent == parent2:
+            result = True
+        else:
+            module.fail_json(msg='Monitor already exists, but has a different type (%s) or parent(%s)' % (ttype, parent))
+    except bigsuds.OperationFailed, e:
+        if "was not found" in str(e):
+            result = False
+        else:
+            # genuine exception
+            raise
+    return result
+
+
+def create_monitor(api, monitor, template_attributes):
+
+    api.LocalLB.Monitor.create_template(templates=[{'template_name': monitor, 'template_type': TEMPLATE_TYPE}], template_attributes=[template_attributes])
+
+
+def delete_monitor(api, monitor):
+
+    try:
+        api.LocalLB.Monitor.delete_template(template_names=[monitor])
+    except bigsuds.OperationFailed, e:
+        # maybe it was deleted since we checked
+        if not "was not found" in str(e):
+            # genuine exception
+            raise
+
+def check_string_property(api, monitor, str_property):
+
+    return str_property == api.LocalLB.Monitor.get_template_string_property([monitor], [str_property['type']])[0]
+
+
+def set_string_property(api, monitor, str_property):
+
+    api.LocalLB.Monitor.set_template_string_property(template_names=[monitor], values=[str_property])
+
+
+# ===========================================
+# main loop
+#
+def main():
+
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            server    = dict(required=True),
+            user      = dict(required=True),
+            password  = dict(required=True),
+            partition = dict(default='Common'),
+            state     = dict(default='present', choices=['present', 'absent']),
+            name      = dict(required=True),
+            parent    = dict(default=DEFAULT_PARENT_TYPE),
+            send      = dict(required=True),
+            receive   = dict(required=True)
+        ),
+        supports_check_mode=True
+    )
+
+    if not bigsuds_found:
+        module.fail_json(msg="the python bigsuds module is required")
+
+    server = module.params['server']
+    user = module.params['user']
+    password = module.params['password']
+    partition = module.params['partition']
+    state = module.params['state']
+    name = module.params['name']
+    parent = "/%s/%s" % (partition, module.params['parent'])
+    monitor = "/%s/%s" % (partition, name)
+    send = module.params['send']
+    receive = module.params['receive']
+
+    # sanity check user supplied values
+
+
+    # main logic 
+
+
+    try:
+        api = bigip_api(server, user, password)
+        result = {'changed': False}  # default
+
+
+        if state == 'absent':
+            if monitor_exists:
+                delete_monitor(api, monitor)
+                result['changed'] = True
+
+        else:
+            template_attributes = {'parent_template': parent,
+                                   'dest_ipport': {'address_type': 'ATYPE_STAR_ADDRESS_STAR_PORT',
+                                                   'ipport': {'address': '0.0.0.0', 
+                                                              'port': 0}
+                                                  },
+                                   'interval': 5,
+                                   'timeout': 16,
+                                   'is_read_only': False,
+                                   'is_directly_usable': True
+                                  }
+            template_string_properties = [{'type': 'STYPE_SEND',
+                                           'value': send},
+                                          {'type': 'STYPE_RECEIVE',
+                                           'value': receive}]
+            if monitor_exists(module, api, monitor, parent):
+                for str_property in template_string_properties:
+                    if not check_string_property(api, monitor, str_property):
+                        set_string_property(api, monitor, str_property)
+                        result['changed'] = True
+            else:
+                print (api, monitor, template_attributes)
+                create_monitor(api, monitor, template_attributes)
+                print "check"
+                for str_property in template_string_properties:
+                    set_string_property(api, monitor, str_property)
+                result['changed'] = True
+
+    except Exception, e:
+        module.fail_json(msg="received exception: %s" % e)
+
+    module.exit_json(**result)
+
+# include magic from lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()
+

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -41,71 +41,58 @@ options:
             - BIG-IP host
         required: true
         default: null
-        choices: []
-        aliases: []
     user:
         description:
             - BIG-IP username
         required: true
         default: null
-        choices: []
-        aliases: []
     password:
         description:
             - BIG-IP password
         required: true
         default: null
-        choices: []
-        aliases: []
     state:
         description:
             - Monitor state
         required: false
         default: 'present'
         choices: ['present', 'absent']
-        aliases: []
     name:
         description:
             - Monitor name
         required: true
         default: null
-        choices: []
         aliases: ['monitor']
     partition:
         description:
             - Partition for the monitor
         required: false
         default: 'Common'
-        choices: []
-        aliases: []
     parent:
         description:
             - The parent template of this monitor template
         required: false
         default: 'http'
-        choices: []
-        aliases: []
     parent_partition:
         description:
             - Partition for the parent monitor
         required: false
         default: 'Common'
-        choices: []
-        aliases: []
     send:
         description:
             - The send string for the monitor call
         required: true
-        default: null
-        choices: []
-        aliases: []
+        default: ''
     receive:
         description:
             - The receive string for the monitor call
         required: true
-        default: null
-        choices: []
-        aliases: []
+        default: ''
+    receive_disable:
+        description:
+            - The receive disable string for the monitor call
+        required: true
+        default: ''
     ip:
         description: 
             - IP address part of the ipport definition
@@ -131,8 +118,16 @@ options:
               the set time period, it is considered down. You can change this
               number to any number you want, however, it should be 3 times the
               interval number of seconds plus 1 second.
-        required: true
+        required: false
         default: 16
+    time_until_up:
+        description:
+            - Specifies the amount of time in seconds after the first successful
+              response before a node will be marked up. A value of 0 will cause a
+              node to be marked up immediately after a valid response is received
+              from the node. The default setting is 0.
+        required: false
+        default: 0
 '''
 
 EXAMPLES = '''
@@ -258,12 +253,14 @@ def main():
             name      = dict(required=True),
             parent    = dict(default=DEFAULT_PARENT_TYPE),
             parent_partition = dict(default='Common'),
-            send      = dict(required=True),
-            receive   = dict(required=True),
+            send      = dict(required=True, default=''),
+            receive   = dict(required=True, default=''),
+            receive_disable   = dict(required=True, default=''),
             ip        = dict(required=False, default='0.0.0.0'),
             port      = dict(required=False, type='int', default=0),
             interval  = dict(required=False, type='int', default=5),
             timeout   = dict(required=False, type='int', default=16)
+            time_until_up = dict(required=False, type='int', default=0)
         ),
         supports_check_mode=True
     )
@@ -282,10 +279,12 @@ def main():
     monitor = "/%s/%s" % (partition, name)
     send = module.params['send']
     receive = module.params['receive']
+    receive_disable = module.params['receive_disable']
     ip = module.params['ip']
     port = module.params['port']
     interval = module.params['interval']
     timeout = module.params['timeout']
+    time_until_up = module.params['time_until_up']
 
 
     if ip == '0.0.0.0' and port == 0:
@@ -307,7 +306,8 @@ def main():
 
         if state == 'absent':
             if monitor_exists:
-                delete_monitor(api, monitor)
+                if not module.check_mode:
+                    delete_monitor(api, monitor)
                 result['changed'] = True
 
         else:
@@ -325,11 +325,15 @@ def main():
             template_string_properties = [{'type': 'STYPE_SEND',
                                            'value': send},
                                           {'type': 'STYPE_RECEIVE',
-                                           'value': receive}]
+                                           'value': receive}
+                                          {'type': 'STYPE_RECEIVE_DRAIN',
+                                           'value': receive_disable}]
             template_integer_properties = [{'type': 'ITYPE_INTERVAL',
                                              'value': interval},
-                                            {'type': 'ITYPE_TIMEOUT',
-                                             'value': timeout}]
+                                           {'type': 'ITYPE_TIMEOUT',
+                                            'value': timeout},
+                                           {'type': 'ITYPE_TIME_UNTIL_UP',
+                                            'value': interval}]
             if monitor_exists(module, api, monitor, parent):
                 for str_property in template_string_properties:
                     if not check_string_property(api, monitor, str_property):

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -261,10 +261,6 @@ def update_monitor_properties(api, module, monitor, template_string_properties, 
     return changed
 
 
-# ===========================================
-# monitor specific function
-#
-
 def get_ipport(api, monitor):
 
     return api.LocalLB.Monitor.get_template_destination(template_names=[monitor])[0]
@@ -291,7 +287,7 @@ def set_ipport(api, monitor, ipport):
 
 def main():
 
-    # monitor specific stuff
+    # begin monitor specific stuff
 
     module = AnsibleModule(
         argument_spec = dict(
@@ -333,6 +329,7 @@ def main():
     timeout = module.params['timeout']
     time_until_up = module.params['time_until_up']
 
+    # end monitor specific stuff
 
     if not bigsuds_found:
         module.fail_json(msg="the python bigsuds module is required")
@@ -377,6 +374,7 @@ def main():
                            'is_read_only': False,
                            'is_directly_usable': True}
 
+    # monitor specific stuff
     template_string_properties = [{'type': 'STYPE_SEND',
                                    'value': send},
                                   {'type': 'STYPE_RECEIVE',
@@ -391,8 +389,7 @@ def main():
                                    {'type': 'ITYPE_TIME_UNTIL_UP',
                                     'value': interval}]
 
-    # monitor specific stuff END
-    # main logic, mostly monitor generic
+    # main logic, monitor generic
 
     try:
         result = {'changed': False}  # default
@@ -427,13 +424,11 @@ def main():
                                                                template_integer_properties)
             # else assume nothing changed
 
-# monitor specific stuff
             # we just have to update the ipport if monitor already exists and it's different
             if monitor_exists and cur_ipport != ipport:
                 set_ipport(api, monitor, ipport)    
                 result['changed'] |= True
             #else: monitor doesn't exist (check mode) or ipport is already ok
-# monitor specific stuff
 
 
     except Exception, e:

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -94,16 +94,45 @@ options:
         aliases: []
     send:
         description:
+            - The send string for the monitor call
         required: true
         default: null
         choices: []
         aliases: []
     receive:
         description:
+            - The receive string for the monitor call
         required: true
         default: null
         choices: []
         aliases: []
+    ip:
+        description: 
+            - IP address part of the ipport definition
+        required: false
+        default: '0.0.0.0'
+    port:
+        description: 
+            - port address part op the ipport definition
+        required: false
+        default: 0
+    interval:
+        description: 
+            - The interval specifying how frequently the monitor instance
+              of this template will run. By default, this interval is used for up and
+              down states
+        required: false
+        default: 5
+    timeout:
+        description:
+            - The number of seconds in which the node or service must respond to
+              the monitor request. If the target responds within the set time
+              period, it is considered up. If the target does not respond within
+              the set time period, it is considered down. You can change this
+              number to any number you want, however, it should be 3 times the
+              interval number of seconds plus 1 second.
+        required: true
+        default: 16
 '''
 
 EXAMPLES = '''
@@ -184,6 +213,32 @@ def set_string_property(api, monitor, str_property):
     api.LocalLB.Monitor.set_template_string_property(template_names=[monitor], values=[str_property])
 
 
+def check_integer_property(api, monitor, int_property):
+
+    return int_property == api.LocalLB.Monitor.get_template_integer_property([monitor], [int_property['type']])[0]
+
+
+def set_integer_property(api, monitor, int_property):
+
+    api.LocalLB.Monitor.set_template_int_property(template_names=[monitor], values=[int_property])
+
+def check_ipport(api, monitor, ipport):
+
+    return [ipport] == api.LocalLB.Monitor.get_template_destination(template_names=[monitor])
+
+def set_ipport(api, monitor, ipport):
+
+    try:
+        api.LocalLB.Monitor.set_template_destination(template_names=[monitor], destinations=[ipport])
+        return True, ""
+
+    except bigsuds.OperationFailed, e:
+        if "Cannot modify the address type of monitor" in str(e):
+            return False, "Cannot modify the address type of monitor if already assigned to a pool."
+        else:
+            # genuine exception
+            raise
+
 # ===========================================
 # main loop
 #
@@ -204,7 +259,11 @@ def main():
             parent    = dict(default=DEFAULT_PARENT_TYPE),
             parent_partition = dict(default='Common'),
             send      = dict(required=True),
-            receive   = dict(required=True)
+            receive   = dict(required=True),
+            ip        = dict(required=False, default='0.0.0.0'),
+            port      = dict(required=False, type='int', default=0),
+            interval  = dict(required=False, type='int', default=5),
+            timeout   = dict(required=False, type='int', default=16)
         ),
         supports_check_mode=True
     )
@@ -223,10 +282,23 @@ def main():
     monitor = "/%s/%s" % (partition, name)
     send = module.params['send']
     receive = module.params['receive']
+    ip = module.params['ip']
+    port = module.params['port']
+    interval = module.params['interval']
+    timeout = module.params['timeout']
+
+
+    if ip == '0.0.0.0' and port == 0:
+        address_type = 'ATYPE_STAR_ADDRESS_STAR_PORT'
+    elif ip == '0.0.0.0' and port != 0:
+        address_type = 'ATYPE_STAR_ADDRESS_EXPLICIT_PORT'
+    elif ip != '0.0.0.0' and port != 0:
+        address_type = 'ATYPE_EXPLICIT_ADDRESS_EXPLICIT_PORT'
+    else:
+        address_type = 'ATYPE_UNSET'
 
 
     # main logic 
-
 
     try:
         api = bigip_api(server, user, password)
@@ -239,13 +311,14 @@ def main():
                 result['changed'] = True
 
         else:
+            ipport = {'address_type': address_type,
+                      'ipport': {'address': ip,
+                                 'port': port}}
+
             template_attributes = {'parent_template': parent,
-                                   'dest_ipport': {'address_type': 'ATYPE_STAR_ADDRESS_STAR_PORT',
-                                                   'ipport': {'address': '0.0.0.0', 
-                                                              'port': 0}
-                                                  },
-                                   'interval': 5,
-                                   'timeout': 16,
+                                   'dest_ipport': ipport,
+                                   'interval': interval,
+                                   'timeout': timeout,
                                    'is_read_only': False,
                                    'is_directly_usable': True
                                   }
@@ -253,12 +326,28 @@ def main():
                                            'value': send},
                                           {'type': 'STYPE_RECEIVE',
                                            'value': receive}]
+            template_integer_properties = [{'type': 'ITYPE_INTERVAL',
+                                             'value': interval},
+                                            {'type': 'ITYPE_TIMEOUT',
+                                             'value': timeout}]
             if monitor_exists(module, api, monitor, parent):
                 for str_property in template_string_properties:
                     if not check_string_property(api, monitor, str_property):
                         if not module.check_mode:
                             set_string_property(api, monitor, str_property)
                         result['changed'] = True
+                for int_property in template_integer_properties:
+                    if not check_integer_property(api, monitor, int_property):
+                        if not module.check_mode:
+                            set_integer_property(api, monitor, int_property)
+                        result['changed'] = True
+                if not check_ipport(api, monitor, ipport):
+                    if not module.check_mode:
+                        res, msg = set_ipport(api, monitor, ipport)
+                        if not res:
+                            module.fail_json(msg=msg)
+                    result['changed'] = True
+
             elif not module.check_mode:
                 create_monitor(api, monitor, template_attributes)
                 for str_property in template_string_properties:

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -386,6 +386,7 @@ def main():
                     result['changed'] |= True
 
         else: # state present
+            ## check for monitor itself
             if not monitor_exists: # create it
                 if not module.check_mode: 
                     # again, check changed status here b/c race conditions
@@ -394,19 +395,22 @@ def main():
                 else: 
                     result['changed'] |= True
 
+            ## check for monitor parameters
             # whether it already existed, or was just created, now update
-            # attributes and properties
-            # the update functions need to check for check mode
-            result['changed'] |= update_monitor_properties(api, module, monitor,
-                                                           template_string_properties,
-                                                           template_integer_properties)
+            # the update functions need to check for check mode but
+            # cannot update settings if it doesn't exist which happens in check mode
+            if monitor_exists and not module.check_mode:
+                result['changed'] |= update_monitor_properties(api, module, monitor,
+                                                               template_string_properties,
+                                                               template_integer_properties)
+            # else assume nothing changed
 
 # monitor specific stuff
             # we just have to update the ipport if monitor already exists and it's different
             if monitor_exists and cur_ipport != ipport:
-                if not monitor_exists:
-                    set_ipport(api, monitor, ipport)    
+                set_ipport(api, monitor, ipport)    
                 result['changed'] |= True
+            #else: monitor doesn't exist (check mode) or ipport is already ok
 # monitor specific stuff
 
 

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -350,7 +350,7 @@ def main():
         if ip is None:              ip = '0.0.0.0'
         if port is None:            port = 0
         if send is None:            send = ''
-        if receive is None:         reveive = ''
+        if receive is None:         receive = ''
         if receive_disable is None: receive_disable = ''
 
     # define and set address type

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -26,7 +26,7 @@ module: bigip_monitor_http
 short_description: "Manages F5 BIG-IP LTM http monitors"
 description:
     - "Manages F5 BIG-IP LTM monitors via iControl SOAP API"
-version_added: "1.3"
+version_added: "1.4"
 author: Serge van Ginderachter
 notes:
     - "Requires BIG-IP software version >= 11"
@@ -134,7 +134,25 @@ options:
 '''
 
 EXAMPLES = '''
-
+- name: BIGIP F5 | Create HTTP Monitor
+  local_action:
+    module:             bigip_monitor_http
+    state:              present
+    server:             "{{ f5server }}"
+    user:               "{{ f5user }}"
+    password:           "{{ f5password }}"
+    name:               "{{ item.monitorname }}"
+    send:               "{{ item.send }}"
+    receive:            "{{ item.receive }}"
+  with_items: f5monitors
+- name: BIGIP F5 | Remove HTTP Monitor
+  local_action:
+    module:             bigip_monitor_http
+    state:              absent
+    server:             "{{ f5server }}"
+    user:               "{{ f5user }}"
+    password:           "{{ f5password }}"
+    name:               "{{ monitorname }}"
 '''
 
 try:

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -73,7 +73,7 @@ options:
         aliases: ['monitor']
     partition:
         description:
-            - Partition
+            - Partition for the monitor
         required: false
         default: 'Common'
         choices: []
@@ -83,6 +83,13 @@ options:
             - The parent template of this monitor template
         required: false
         default: 'http'
+        choices: []
+        aliases: []
+    parent_partition:
+        description:
+            - Partition for the parent monitor
+        required: false
+        default: 'Common'
         choices: []
         aliases: []
     send:
@@ -147,7 +154,14 @@ def monitor_exists(module, api, monitor, parent):
 
 def create_monitor(api, monitor, template_attributes):
 
-    api.LocalLB.Monitor.create_template(templates=[{'template_name': monitor, 'template_type': TEMPLATE_TYPE}], template_attributes=[template_attributes])
+    try: 
+        api.LocalLB.Monitor.create_template(templates=[{'template_name': monitor, 'template_type': TEMPLATE_TYPE}], template_attributes=[template_attributes])
+    except bigsuds.OperationFailed, e:
+        if "already exists" in str(e):
+            pass
+        else:
+            # genuine exception
+            raise
 
 
 def delete_monitor(api, monitor):
@@ -173,6 +187,9 @@ def set_string_property(api, monitor, str_property):
 # ===========================================
 # main loop
 #
+# writing a module for other monitor types should 
+# only need an updated main() 
+
 def main():
 
 
@@ -185,6 +202,7 @@ def main():
             state     = dict(default='present', choices=['present', 'absent']),
             name      = dict(required=True),
             parent    = dict(default=DEFAULT_PARENT_TYPE),
+            parent_partition = dict(default='Common'),
             send      = dict(required=True),
             receive   = dict(required=True)
         ),
@@ -198,14 +216,13 @@ def main():
     user = module.params['user']
     password = module.params['password']
     partition = module.params['partition']
+    parent_partition = module.params['parent_partition']
     state = module.params['state']
     name = module.params['name']
-    parent = "/%s/%s" % (partition, module.params['parent'])
+    parent = "/%s/%s" % (parent_partition, module.params['parent'])
     monitor = "/%s/%s" % (partition, name)
     send = module.params['send']
     receive = module.params['receive']
-
-    # sanity check user supplied values
 
 
     # main logic 
@@ -239,15 +256,17 @@ def main():
             if monitor_exists(module, api, monitor, parent):
                 for str_property in template_string_properties:
                     if not check_string_property(api, monitor, str_property):
-                        set_string_property(api, monitor, str_property)
+                        if not module.check_mode:
+                            set_string_property(api, monitor, str_property)
                         result['changed'] = True
-            else:
-                print (api, monitor, template_attributes)
+            elif not module.check_mode:
                 create_monitor(api, monitor, template_attributes)
-                print "check"
                 for str_property in template_string_properties:
                     set_string_property(api, monitor, str_property)
                 result['changed'] = True
+            else: # monitor does not exist and check mode
+                result['changed'] = True
+
 
     except Exception, e:
         module.fail_json(msg="received exception: %s" % e)

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -330,6 +330,8 @@ def main():
         if port is None:
             port = cur_ipport['ipport']['port']
     else: # use API defaults if not defined to create it
+        if interval is None:        interval = 5
+        if timeout is None:         timeout = 16
         if ip is None:              ip = '0.0.0.0'
         if port is None:            port = 0
         if send is None:            send = ''
@@ -351,6 +353,8 @@ def main():
                          'port': port}}
 
     template_attributes = {'parent_template': parent,
+                           'interval': interval,
+                           'timeout': timeout,
                            'dest_ipport': ipport,
                            'is_read_only': False,
                            'is_directly_usable': True}

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -82,34 +82,36 @@ options:
         description:
             - The send string for the monitor call
         required: true
-        default: ''
+        default: none
     receive:
         description:
             - The receive string for the monitor call
         required: true
-        default: ''
+        default: none
     receive_disable:
         description:
             - The receive disable string for the monitor call
         required: true
-        default: ''
+        default: none
     ip:
         description: 
-            - IP address part of the ipport definition
+            - IP address part of the ipport definition. The default API setting
+              is "0.0.0.0".
         required: false
-        default: '0.0.0.0'
+        default: none
     port:
         description: 
-            - port address part op the ipport definition
+            - port address part op the ipport definition. Tyhe default API
+              setting is 0.
         required: false
-        default: 0
+        default: none
     interval:
         description: 
             - The interval specifying how frequently the monitor instance
               of this template will run. By default, this interval is used for up and
-              down states
+              down states. The default API setting is 5.
         required: false
-        default: 5
+        default: none
     timeout:
         description:
             - The number of seconds in which the node or service must respond to
@@ -117,17 +119,18 @@ options:
               period, it is considered up. If the target does not respond within
               the set time period, it is considered down. You can change this
               number to any number you want, however, it should be 3 times the
-              interval number of seconds plus 1 second.
+              interval number of seconds plus 1 second. The default API setting
+              is 16.
         required: false
-        default: 16
+        default: none
     time_until_up:
         description:
             - Specifies the amount of time in seconds after the first successful
               response before a node will be marked up. A value of 0 will cause a
               node to be marked up immediately after a valid response is received
-              from the node. The default setting is 0.
+              from the node. The default API setting is 0.
         required: false
-        default: 0
+        default: none
 '''
 
 EXAMPLES = '''
@@ -156,7 +159,7 @@ def bigip_api(bigip, user, password):
     return api
 
 
-def monitor_exists(module, api, monitor, parent):
+def check_monitor_exists(module, api, monitor, parent):
 
     # hack to determine if monitor exists
     result = False
@@ -202,6 +205,7 @@ def delete_monitor(api, monitor):
             raise
     return True
 
+
 def check_string_property(api, monitor, str_property):
 
     return str_property == api.LocalLB.Monitor.get_template_string_property([monitor], [str_property['type']])[0]
@@ -221,9 +225,32 @@ def set_integer_property(api, monitor, int_property):
 
     api.LocalLB.Monitor.set_template_int_property(template_names=[monitor], values=[int_property])
 
-def check_ipport(api, monitor, ipport):
 
-    return [ipport] == api.LocalLB.Monitor.get_template_destination(template_names=[monitor])
+def update_monitor_properties(api, module, monitor, template_string_properties, template_integer_properties):
+
+    changed = False
+    for str_property in template_string_properties:
+        if str_property['value'] is not None and not check_string_property(api, monitor, str_property):
+            if not module.check_mode:
+                set_string_property(api, monitor, str_property)
+            changed = True
+    for int_property in template_integer_properties:
+        if int_property['value'] is not None and not check_integer_property(api, monitor, int_property):
+            if not module.check_mode:
+                set_integer_property(api, monitor, int_property)
+            changed = True
+
+    return changed
+
+
+# ===========================================
+# monitor specific function
+#
+
+def get_ipport(api, monitor):
+
+    return api.LocalLB.Monitor.get_template_destination(template_names=[monitor])[0]
+
 
 def set_ipport(api, monitor, ipport):
 
@@ -242,10 +269,11 @@ def set_ipport(api, monitor, ipport):
 # main loop
 #
 # writing a module for other monitor types should 
-# only need an updated main() 
+# only need an updated main() (and monitor specific functions)
 
 def main():
 
+    # monitor specific stuff
 
     module = AnsibleModule(
         argument_spec = dict(
@@ -257,20 +285,17 @@ def main():
             name      = dict(required=True),
             parent    = dict(default=DEFAULT_PARENT_TYPE),
             parent_partition = dict(default='Common'),
-            send      = dict(required=True, default=''),
-            receive   = dict(required=True, default=''),
-            receive_disable   = dict(required=True, default=''),
-            ip        = dict(required=False, default='0.0.0.0'),
-            port      = dict(required=False, type='int', default=0),
-            interval  = dict(required=False, type='int', default=5),
-            timeout   = dict(required=False, type='int', default=16)
+            send      = dict(required=False),
+            receive   = dict(required=False),
+            receive_disable   = dict(required=False),
+            ip        = dict(required=False),
+            port      = dict(required=False, type='int'),
+            interval  = dict(required=False, type='int'),
+            timeout   = dict(required=False, type='int'),
             time_until_up = dict(required=False, type='int', default=0)
         ),
         supports_check_mode=True
     )
-
-    if not bigsuds_found:
-        module.fail_json(msg="the python bigsuds module is required")
 
     server = module.params['server']
     user = module.params['user']
@@ -291,6 +316,27 @@ def main():
     time_until_up = module.params['time_until_up']
 
 
+    if not bigsuds_found:
+        module.fail_json(msg="the python bigsuds module is required")
+    api = bigip_api(server, user, password)
+    monitor_exists = check_monitor_exists(module, api, monitor, parent)
+
+
+    # ipport is a special setting
+    if monitor_exists: # make sure to not update current settings if not asked
+        cur_ipport = get_ipport(api, monitor)
+        if ip is None:
+            ip = cur_ipport['ipport']['address']
+        if port is None:
+            port = cur_ipport['ipport']['port']
+    else: # use API defaults if not defined to create it
+        if ip is None:              ip = '0.0.0.0'
+        if port is None:            port = 0
+        if send is None:            send = ''
+        if receive is None:         reveive = ''
+        if receive_disable is None: receive_disable = ''
+
+    # define and set address type
     if ip == '0.0.0.0' and port == 0:
         address_type = 'ATYPE_STAR_ADDRESS_STAR_PORT'
     elif ip == '0.0.0.0' and port != 0:
@@ -300,11 +346,33 @@ def main():
     else:
         address_type = 'ATYPE_UNSET'
 
+    ipport = {'address_type': address_type,
+              'ipport': {'address': ip,
+                         'port': port}}
 
-    # main logic 
+    template_attributes = {'parent_template': parent,
+                           'dest_ipport': ipport,
+                           'is_read_only': False,
+                           'is_directly_usable': True}
+
+    template_string_properties = [{'type': 'STYPE_SEND',
+                                   'value': send},
+                                  {'type': 'STYPE_RECEIVE',
+                                   'value': receive},
+                                  {'type': 'STYPE_RECEIVE_DRAIN',
+                                   'value': receive_disable}]
+
+    template_integer_properties = [{'type': 'ITYPE_INTERVAL',
+                                     'value': interval},
+                                   {'type': 'ITYPE_TIMEOUT',
+                                    'value': timeout},
+                                   {'type': 'ITYPE_TIME_UNTIL_UP',
+                                    'value': interval}]
+
+    # monitor specific stuff END
+    # main logic, mostly monitor generic
 
     try:
-        api = bigip_api(server, user, password)
         result = {'changed': False}  # default
 
 
@@ -313,62 +381,33 @@ def main():
                 if not module.check_mode:
                     # possible race condition if same task 
                     # on other node deleted it first
-                    result['changed'] = delete_monitor(api, monitor)
+                    result['changed'] |= delete_monitor(api, monitor)
                 else:
-                    result['changed'] = True
+                    result['changed'] |= True
 
-        else:
-            ipport = {'address_type': address_type,
-                      'ipport': {'address': ip,
-                                 'port': port}}
+        else: # state present
+            if not monitor_exists: # create it
+                if not module.check_mode: 
+                    # again, check changed status here b/c race conditions
+                    # if other task already created it
+                    result['changed'] |= create_monitor(api, monitor, template_attributes)
+                else: 
+                    result['changed'] |= True
 
-            template_attributes = {'parent_template': parent,
-                                   'dest_ipport': ipport,
-                                   'interval': interval,
-                                   'timeout': timeout,
-                                   'is_read_only': False,
-                                   'is_directly_usable': True
-                                  }
-            template_string_properties = [{'type': 'STYPE_SEND',
-                                           'value': send},
-                                          {'type': 'STYPE_RECEIVE',
-                                           'value': receive}
-                                          {'type': 'STYPE_RECEIVE_DRAIN',
-                                           'value': receive_disable}]
-            template_integer_properties = [{'type': 'ITYPE_INTERVAL',
-                                             'value': interval},
-                                           {'type': 'ITYPE_TIMEOUT',
-                                            'value': timeout},
-                                           {'type': 'ITYPE_TIME_UNTIL_UP',
-                                            'value': interval}]
-            if monitor_exists(module, api, monitor, parent):
-                for str_property in template_string_properties:
-                    if not check_string_property(api, monitor, str_property):
-                        if not module.check_mode:
-                            set_string_property(api, monitor, str_property)
-                        result['changed'] = True
-                for int_property in template_integer_properties:
-                    if not check_integer_property(api, monitor, int_property):
-                        if not module.check_mode:
-                            set_integer_property(api, monitor, int_property)
-                        result['changed'] = True
-                if not check_ipport(api, monitor, ipport):
-                    if not module.check_mode:
-                        res, msg = set_ipport(api, monitor, ipport)
-                        if not res:
-                            module.fail_json(msg=msg)
-                    result['changed'] = True
+            # whether it already existed, or was just created, now update
+            # attributes and properties
+            # the update functions need to check for check mode
+            result['changed'] |= update_monitor_properties(api, module, monitor,
+                                                           template_string_properties,
+                                                           template_integer_properties)
 
-            elif not module.check_mode:
-                # possible race condition if same task 
-                # on other node deleted it first
-                result['changed'] = create_monitor(api, monitor, template_attributes)
-                for str_property in template_string_properties:
-                    set_string_property(api, monitor, str_property)
-                for int_property in template_integer_properties:
-                    set_integer_property(api, monitor, int_property)
-            else: # monitor does not exist and check mode
-                result['changed'] = True
+# monitor specific stuff
+            # we just have to update the ipport if monitor already exists and it's different
+            if monitor_exists and cur_ipport != ipport:
+                if not monitor_exists:
+                    set_ipport(api, monitor, ipport)    
+                result['changed'] |= True
+# monitor specific stuff
 
 
     except Exception, e:


### PR DESCRIPTION
Based on the iControl API and and implemented by the bigsuds python library
- https://devcentral.f5.com/wiki/iControl.LocalLB__Monitor.ashx
- https://devcentral.f5.com/wiki/icontrol.Python-Bigsuds-Library.ashx

This module allows to create and configure a "monitor" which is used to check the availability of a pool (managed by the already included bigip_pool module.)

This specific modules handles 'http' monitors. The module was written to make it easy to base other monitor types on this module, by updating the needed parameters, and updating or adding a minimum of code.

Thanks to @mhite for reviewing big parts of this module.
