### PR TITLE
Enable use of droplet name as inventory hostname

### DIFF
--- a/plugins/inventory/digital_ocean.ini
+++ b/plugins/inventory/digital_ocean.ini
@@ -23,3 +23,10 @@ cache_path = /tmp
 # seconds, a new API call will be made, and the cache file will be updated.
 #
 cache_max_age = 300
+
+
+# The droplet attribute to use as the Ansible hostname. Use 'ip_address' or
+# 'name'. Note that Droplet names are not guaranteed to be unique. (Default is
+# 'ip_address'.)
+#
+#host_key = name


### PR DESCRIPTION
Although Digital Ocean droplet names are not guaranteed to be unique,
they are routinely set to the VM hostname. This change gives the option to
use the droplet name as the Ansible hostname instead of a group name.

The inventory script will exit with an error exit code if multiple hosts
share the same name.
