### PR TITLE
Implement nesting lookup plugins

### DIFF
--- a/lib/ansible/runner/lookup_plugins/flattened.py
+++ b/lib/ansible/runner/lookup_plugins/flattened.py
@@ -69,6 +69,7 @@ class LookupModule(object):
 
         # see if the string represents a list and convert to list if so
         terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
+        terms = utils.resolve_nested_lookup_plugin_terms(terms, self.basedir, inject)
 
         if not isinstance(terms, list):
             raise errors.AnsibleError("with_flattened expects a list")

--- a/lib/ansible/runner/lookup_plugins/items.py
+++ b/lib/ansible/runner/lookup_plugins/items.py
@@ -35,6 +35,7 @@ class LookupModule(object):
 
     def run(self, terms, inject=None, **kwargs):
         terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
+        terms = utils.resolve_nested_lookup_plugin_terms(terms, self.basedir, inject)
 
         if not isinstance(terms, list) and not isinstance(terms,set):
             raise errors.AnsibleError("with_items expects a list or a set")

--- a/lib/ansible/runner/lookup_plugins/nested.py
+++ b/lib/ansible/runner/lookup_plugins/nested.py
@@ -54,6 +54,7 @@ class LookupModule(object):
         # this code is common with 'items.py' consider moving to utils if we need it again
 
         terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
+        terms = utils.resolve_nested_lookup_plugin_terms(terms, self.basedir, inject)
         terms = self.__lookup_injects(terms, inject)
 
         my_list = terms[:]

--- a/lib/ansible/runner/lookup_plugins/together.py
+++ b/lib/ansible/runner/lookup_plugins/together.py
@@ -54,6 +54,7 @@ class LookupModule(object):
         # this code is common with 'items.py' consider moving to utils if we need it again
 
         terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
+        terms = utils.resolve_nested_lookup_plugin_terms(terms, self.basedir, inject)
         terms = self.__lookup_injects(terms, inject)
 
         my_list = terms[:]


### PR DESCRIPTION
As proposed at #4060

This should allow to implement everything and more
than currently is possible in the not documented, not supported,
soon to be deprecated include: + with_items: construct

```
  - debug: msg="{{item}}"
    with_flattened:
    - lookup('first_found', ['/etc/network/interfaces', '/etc/sysconfig/network'])
    - lookup('fileglob', '/boot/*')
    - lookup('file', '/etc/hostname')
    - lookup('lines', 'ls /boot/grub/')
    - lookup('pipe', 'hostname --fqdn')
    - lookup('sequence', 'start=5 end=10 stride=5')
```

A test playbook and it's output can be found at https://gist.github.com/sergevanginderachter/7092035

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/4627)

<!-- Reviewable:end -->
