### PR TITLE
Fixes #3847: lineinfile without regex

### DIFF
--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -40,7 +40,7 @@ options:
     description:
       - The file to modify.
   regexp:
-    required: true
+    required: false
     description:
       - The regular expression to look for in every line of the file. For
         C(state=present), the pattern to replace if found; only the last line
@@ -169,7 +169,8 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
 
     msg = ""
 
-    mre = re.compile(regexp)
+    if regexp is not None:
+        mre = re.compile(regexp)
 
     if insertafter not in (None, 'BOF', 'EOF'):
         insre = re.compile(insertafter)
@@ -183,7 +184,10 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
     index = [-1, -1]
     m = None
     for lineno, cur_line in enumerate(lines):
-        match_found = mre.search(cur_line)
+        if regexp is not None:
+            match_found = mre.search(cur_line)
+        else:
+            match_found = line == cur_line.rstrip('\r\n')
         if match_found:
             index[0] = lineno
             m = match_found
@@ -243,7 +247,7 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
     module.exit_json(changed=changed, msg=msg)
 
 
-def absent(module, dest, regexp, backup):
+def absent(module, dest, regexp, line, backup):
 
     if not os.path.exists(dest):
         module.exit_json(changed=False, msg="file not present")
@@ -253,15 +257,18 @@ def absent(module, dest, regexp, backup):
     f = open(dest, 'rb')
     lines = f.readlines()
     f.close()
-    cre = re.compile(regexp)
+    if regexp is not None:
+        cre = re.compile(regexp)
     found = []
 
-    def matcher(line):
-        if cre.search(line):
-            found.append(line)
-            return False
+    def matcher(cur_line):
+        if regexp is not None:
+            match_found = cre.search(cur_line)
         else:
-            return True
+            match_found = line == cur_line.rstrip('\r\n')
+        if match_found:
+            found.append(cur_line)
+        return not match_found
 
     lines = filter(matcher, lines)
     changed = len(found) > 0
@@ -282,7 +289,7 @@ def main():
         argument_spec=dict(
             dest=dict(required=True, aliases=['name', 'destfile']),
             state=dict(default='present', choices=['absent', 'present']),
-            regexp=dict(required=True),
+            regexp=dict(default=None),
             line=dict(aliases=['value']),
             insertafter=dict(default=None),
             insertbefore=dict(default=None),
@@ -306,6 +313,9 @@ def main():
         module.fail_json(rc=256, msg='Destination %s is a directory !' % dest)
 
     if params['state'] == 'present':
+        if backrefs and params['regexp'] is None:
+            module.fail_json(msg='regexp= is required with backrefs=true')
+
         if params.get('line', None) is None:
             module.fail_json(msg='line= is required with state=present')
 
@@ -318,7 +328,10 @@ def main():
         present(module, dest, params['regexp'], params['line'],
                 ins_aft, ins_bef, create, backup, backrefs)
     else:
-        absent(module, dest, params['regexp'], backup)
+        if params['regexp'] is None and params.get('line', None) is None:
+            module.fail_json(msg='one of line= or regexp= is required with state=absent')
+
+        absent(module, dest, params['regexp'], params.get('line', None), backup)
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>


### PR DESCRIPTION
I also wanted to manage known_hosts with lineinfile, and this change Works For Me(tm).  I couldn't think of a decent change for the help text, so I didn't make a change there.  I can think about it more if you won't merge without it. :)

Description from #3847 ...

We'd like to use lineinfile to add entries into our ssh_known_hosts file.
Unfortunately we can't use the line itself as the regex value, because it contains non-escaped characters.
What would be great is you could omit the regex option, and then ansible would match only the insertion text verbatim.
