### PR TITLE
Lookup plugin for etcd

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -102,6 +102,9 @@ filter_plugins     = /usr/share/ansible_plugins/filter_plugins
 # set to 1 if you don't want colors, or export ANSIBLE_NOCOLOR=1
 #nocolor = 1
 
+# default URL for `etcd' lookup plugin
+etcd_url = 'http://127.0.0.1:4001'
+
 [paramiko_connection]
 
 # uncomment this line to cause the paramiko connection plugin to not record new host

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -148,6 +148,9 @@ ACCELERATE_TIMEOUT             = get_config(p, 'accelerate', 'accelerate_timeout
 ACCELERATE_CONNECT_TIMEOUT     = get_config(p, 'accelerate', 'accelerate_connect_timeout', 'ACCELERATE_CONNECT_TIMEOUT', 1.0, floating=True)
 PARAMIKO_PTY                   = get_config(p, 'paramiko_connection', 'pty', 'ANSIBLE_PARAMIKO_PTY', True, boolean=True)
 
+# LOOKUP PLUGIN RELATED
+ANSIBLE_ETCD_URL               = get_config(p, DEFAULTS, 'etcd_url', 'ANSIBLE_ETCD_URL', 'http://127.0.0.1:4001')
+
 
 # non-configurable things
 DEFAULT_SUDO_PASS         = None

--- a/lib/ansible/runner/lookup_plugins/etcd.py
+++ b/lib/ansible/runner/lookup_plugins/etcd.py
@@ -1,0 +1,73 @@
+# (c) 2013, Jan-Piet Mens <jpmens(at)gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible import utils, errors, constants
+import os
+import urllib2
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+class etcd():
+    def __init__(self, url='http://127.0.0.1:4001'):
+        self.url = url
+        self.baseurl = '%s/v1/keys' % (self.url)
+
+    def get(self, key):
+        url = "%s/%s" % (self.baseurl, key)
+
+        data = None
+        value = ""
+        try:
+            r = urllib2.urlopen(url)
+            data = r.read()
+        except:
+            return value
+
+        try:
+            # {"action":"get","key":"/name","value":"Jane Jolie","index":5}
+            item = json.loads(data)
+            if 'value' in item:
+                value = item['value']
+            if 'errorCode' in item:
+                value = "ENOENT"
+        except:
+            raise
+            pass
+
+        return value
+
+class LookupModule(object):
+
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
+        self.etcd = etcd(constants.ANSIBLE_ETCD_URL)
+
+    def run(self, terms, inject=None, **kwargs):
+
+        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
+
+        if isinstance(terms, basestring):
+            terms = [ terms ]
+
+        ret = []
+        for term in terms:
+            key = term.split()[0]
+            value = self.etcd.get(key)
+            ret.append(value)
+        return ret


### PR DESCRIPTION
This is a new lookup plugin for CoreOS' [etcd](https://github.com/coreos/etcd).

Example playbook (including deprecated `$ETCD()` invocation):

``` yaml

- hosts: localhost
  gather_facts: false
  vars:
  - myname: "{{ lookup('etcd', 'name') }}"
  - mynum: "{{ $ETCD(nr) }}"

  tasks:
  - action: debug msg="the value of name is {{ myname }} (and {{mynum}})"
```
