### PR TITLE
Change ssh header to ssh_connection header

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -507,7 +507,7 @@ instead.  Setting it to False will improve performance and is recommended when h
 OpenSSH Specific Settings
 -------------------------
 
-Under the [ssh] header, the following settings are tunable for SSH connections.  OpenSSH is the default connection type for Ansible
+Under the [ssh_connection] header, the following settings are tunable for SSH connections.  OpenSSH is the default connection type for Ansible
 on OSes that are new enough to support ControlPersist.  (This means basically all operating systems except Enterprise Linux 6 or earlier).
 
 .. _ssh_args:


### PR DESCRIPTION
Pretty self explanatory. Just a minor typo in the OpenSSH section of the ansible.cfg documentation.
