### PR TITLE
Correct documentation reference to SSH section.

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -507,7 +507,7 @@ instead.  Setting it to False will improve performance and is recommended when h
 OpenSSH Specific Settings
 -------------------------
 
-Under the [ssh] header, the following settings are tunable for SSH connections.  OpenSSH is the default connection type for Ansible
+Under the [ssh_connection] header, the following settings are tunable for SSH connections.  OpenSSH is the default connection type for Ansible
 on OSes that are new enough to support ControlPersist.  (This means basically all operating systems except Enterprise Linux 6 or earlier).
 
 .. _ssh_args:


### PR DESCRIPTION
The reference in the documentation indicates the section title is [ssh], however this doesn't work when set in the configuration file.  In lib/ansible/contants.py the section is referenced as [ssh_connection], therefore update documentation to match config.
