### PR TITLE
use ConfigObj instead of ConfigParser in ini_file

### DIFF
--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
+# (c) 2013, Christian Berendt <berendt@b1-systems.de>
 #
 # This file is part of Ansible
 #
@@ -24,9 +25,9 @@ DOCUMENTATION = '''
 module: ini_file
 short_description: Tweak settings in INI files
 description:
-     - Manage (add, remove, change) individual settings in an INI-style file without having
-       to manage the file as a whole with, say, M(template) or M(assemble). Adds missing
-       sections if they don't exist.
+  - Manage (add, remove, change) individual settings in an INI-style file without having
+    to manage the file as a whole with, say, M(template) or M(assemble). Adds missing
+    sections if they don't exist.
 version_added: "0.9"
 options:
   dest:
@@ -65,11 +66,7 @@ options:
 notes:
    - While it is possible to add an I(option) without specifying a I(value), this makes
      no sense.
-   - A section named C(default) cannot be added by the module, but if it exists, individual
-     options within the section can be updated. (This is a limitation of Python's I(ConfigParser).)
-     Either use M(template) to create a base INI file with a C([default]) section, or use
-     M(lineinfile) to add the missing line.
-requirements: [ ConfigParser ]
+requirements: [ configobj ]
 author: Jan-Piet Mens
 '''
 
@@ -84,72 +81,56 @@ EXAMPLES = '''
             backup=yes
 '''
 
-import ConfigParser
+from configobj import ConfigObj, ConfigObjError
 
-# ==============================================================
-# do_ini
-
-def do_ini(module, filename, section=None, option=None, value=None, state='present', backup=False):
+def do_ini(module):
 
     changed = False
-    cp = ConfigParser.ConfigParser()
 
     try:
-        f = open(filename)
-        cp.readfp(f)
-    except IOError:
-        pass
+        config = ConfigObj(module.params['dest'], encoding='UTF8')
+    except (IOError, ConfigObjError) as e:
+        module.fail_json(msg = " Error opening file %s: %s " % (module.params['dest'], str(e)))
 
-
-    if state == 'absent':
-        if option is None and value is None:
-            if cp.has_section(section):
-                cp.remove_section(section)
-                changed = True
-        else:
-            if option is not None:
-                try:
-                    if cp.get(section, option):
-                        cp.remove_option(section, option)
-                        changed = True
-                except:
-                    pass
-
-    if state == 'present':
-
-        # DEFAULT section is always there by DEFAULT, so never try to add it.
-        if cp.has_section(section) == False and section.upper() != 'DEFAULT':
-
-            cp.add_section(section)
+    if module.params['state'] == 'absent':
+        if (module.params['option'] is None and
+            module.params['value'] is None and
+            config.has_key(module.params['section'])):
+            del config[module.params['section']]
+            changed = True
+        elif (module.params['option'] is not None and
+              config.has_key(module.params['section']) and
+              config[module.params['section']].has_key(module.params['option'])):
+            del config[module.params['section']][module.params['option']]
             changed = True
 
-        if option is not None and value is not None:
-            try:
-                oldvalue = cp.get(section, option)
-                if str(value) != str(oldvalue):
-                    cp.set(section, option, value)
-                    changed = True
-            except ConfigParser.NoSectionError:
-                cp.set(section, option, value)
-                changed = True
-            except ConfigParser.NoOptionError:
-                cp.set(section, option, value)
+    if module.params['state'] == 'present':
+        if not config.has_key(module.params['section']):
+            config[module.params['section']] = {}
+            changed = True
+
+        if (module.params['option'] is not None and
+            not config[module.params['section']].has_key(module.params['option'])):
+            config[module.params['section']][module.params['option']] = None
+            changed = True
+
+        if (module.params['value'] is not None and
+            config[module.params['section']].has_key(module.params['option'])):
+            if (str(config[module.params['section']][module.params['option']]) != str(module.params['value'])):
+                config[module.params['section']][module.params['option']] = str(module.params['value'])
                 changed = True
 
     if changed:
-        if backup:
-            module.backup_local(filename)
+        if module.params['backup']:
+            module.backup_local(module.params['dest'])
 
         try:
-            f = open(filename, 'w')
-            cp.write(f)
-        except:
-            module.fail_json(msg="Can't creat %s" % filename)
+            config.write()
+        except (IOError, ConfigObjError) as e:
+            module.fail_json(msg = " Error writing file %s: %s " % (module.params['dest'], str(e)))
 
     return changed
 
-# ==============================================================
-# main
 
 def main():
 
@@ -165,22 +146,10 @@ def main():
         add_file_common_args = True
     )
 
-    info = dict()
-
-    dest = os.path.expanduser(module.params['dest'])
-    section = module.params['section']
-    option = module.params['option']
-    value = module.params['value']
-    state = module.params['state']
-    backup = module.params['backup']
-
-    changed = do_ini(module, dest, section, option, value, state, backup)
-
+    changed = do_ini(module)
     file_args = module.load_file_common_arguments(module.params)
     changed = module.set_file_attributes_if_different(file_args, changed)
-
-    # Mission complete
-    module.exit_json(dest=dest, changed=changed, msg="OK")
+    module.exit_json(dest=module.params['dest'], changed=changed, msg="OK")
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>


### PR DESCRIPTION
To make it possible to manage the DEFAULT section with ini_file
I changed the config file reader/writer from ConfigParser to
ConfigObj.

Details are available in issue #1682.
