### PR TITLE
add NoneType check.

### DIFF
--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -300,10 +300,11 @@ def main():
     elb_man = ElbManager(module, instance_id, ec2_elbs, aws_access_key,
                          aws_secret_key, region=region)
 
-    for elb in ec2_elbs:
-        if not elb_man.exists(elb):
-            msg="ELB %s does not exist" % elb
-            module.fail_json(msg=msg)
+    if ec2_elbs is not None:
+        for elb in ec2_elbs:
+            if not elb_man.exists(elb):
+                msg="ELB %s does not exist" % elb
+                module.fail_json(msg=msg)
 
     if module.params['state'] == 'present':
         elb_man.register(wait, enable_availability_zone)


### PR DESCRIPTION
Version 1.2.3 or earlier, ec2_elb module allows deregistering instance without 'ec2_elbs' parameter.But 1.3.0 or later, it raises 'TypeError: 'NoneType' object is not iterable'.
