### PR TITLE
don't use EOF as default value for insertafter

### DIFF
--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -309,7 +309,7 @@ def main():
             module.fail_json(msg='line= is required with state=present')
 
         present(module, dest, params['regexp'], params['line'],
-                ins_aft, ins_bef, create, backup, backrefs)
+                params['insertafter'], params['insertbefore'], create, backup, backrefs)
     else:
         absent(module, dest, params['regexp'], backup)
 

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -76,7 +76,6 @@ options:
         the expanded line parameter.
   insertafter:
     required: false
-    default: EOF
     description:
       - Used with C(state=present). If specified, the line will be inserted
         after the specified regular expression. A special value is

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -309,12 +309,6 @@ def main():
         if params.get('line', None) is None:
             module.fail_json(msg='line= is required with state=present')
 
-        # Deal with the insertafter default value manually, to avoid errors
-        # because of the mutually_exclusive mechanism.
-        ins_bef, ins_aft = params['insertbefore'], params['insertafter']
-        if ins_bef is None and ins_aft is None:
-            ins_aft = 'EOF'
-
         present(module, dest, params['regexp'], params['line'],
                 ins_aft, ins_bef, create, backup, backrefs)
     else:


### PR DESCRIPTION
This patch fixes issue #4700.

```
- lineinfile: dest=/etc/libvirt/libvirtd.conf line="auth_unix_ro = \"none\"" regexp="\#auth_unix_ro = \"none\""
```

Using this task with every run a new line `auth_unix_ro = "none"` is attached at the EOF of /etc/libvirt/libvirtd.conf. That's not the expected behavior. The expected behavior is that the line `#auth_unix_ro = "none"` is replaced by `auth_unix_ro = "none"`.

Looks like the issue is that `insertafter = 'EOF'` is used when not setting insertafter and insertbefore.
