### PR TITLE
Update playbooks.rst

### DIFF
--- a/docsite/rst/playbooks.rst
+++ b/docsite/rst/playbooks.rst
@@ -62,7 +62,7 @@ For starters, here's a playbook that contains just one play::
       vars:
         http_port: 80
         max_clients: 200
-      remote_user: root
+      user: root
       tasks:
       - name: ensure apache is at the latest version
         yum: pkg=httpd state=latest


### PR DESCRIPTION
Updating documentation.  

I believe remote_user has been changed to user for playbooks.  On my current ansible version (1.3), using remote_user I get the following error: ERROR: remote_user is not a legal parameter in an Ansible Playbook
