### PR TITLE
Add a clarifying heading to installation docs

### DIFF
--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -86,6 +86,11 @@ On the managed nodes, you only need Python 2.4 or later, but if you are are runn
    Unix systems.  If you need to bootstrap these remote systems by installing Python 2.X, 
    using the 'raw' module will be able to do it remotely.
 
+.. _installing_the_control_machine:
+
+Installing the Control Machine
+``````````````````````````````
+
 .. _from_source:
 
 Running From Source


### PR DESCRIPTION
Before this patch, the installation options for the control machine were nested underneath the "Managed Node Requirements" heading. This patch adds another heading, "Installing the Control Machine" which makes the header structure clearer.
