### PR TITLE
load tasks/vars includes in syntax-check mode as well

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -158,7 +158,7 @@ def main(args):
             diff=options.diff
         )
 
-        if options.listhosts or options.listtasks:
+        if options.listhosts or options.listtasks or options.syntax:
             print ''
             print 'playbook: %s' % playbook
             print ''


### PR DESCRIPTION
Hi,

it appears that the ansible-playbook --check-syntax site.yml does not check includes under the "tasks:" or "vars:" sections.

E.g.

```
$ cat site.yml
- hosts: all
  vars_files:
  - vars/no-file-here

$ ansible-playbook --syntax-check site.yml 
Playbook Syntax is fine
```

However:

```
$ ansible-playbook --list-tasks site.yml  
playbook: site.yml
ERROR: file not found: /tmp/vars/not-there
```

This branch will fix this and will error in the same way as --list-tasks when --syntax-check is used.

Thanks for your consideration,
Michael
