### PR TITLE
This PR would enable variable files to be added during a play run.

### DIFF
--- a/lib/ansible/runner/action_plugins/include_files.py
+++ b/lib/ansible/runner/action_plugins/include_files.py
@@ -1,0 +1,66 @@
+# (c) 2013, Benno Joy <benno@ansibleworks.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from ansible.utils import template
+from ansible import utils
+from ansible import errors
+from ansible.runner.return_data import ReturnData
+
+class ActionModule(object):
+
+    NEEDS_TMPPATH = False
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
+        if not module_args and not 'first_available_file' in inject:
+            result = dict(failed=True, msg="No Source file Given.")
+            return ReturnData(conn=conn, comm_ok=True, result=result)
+        if 'first_available_file' in inject:
+            found = False
+            for fn in self.runner.module_vars.get('first_available_file'):
+                fn_orig = fn
+                fnt = template.template(self.runner.basedir, fn, inject)
+                fnd = utils.path_dwim(self.runner.basedir, fnt)
+                if not os.path.exists(fnd) and '_original_file' in inject:
+                    fnd = utils.path_dwim_relative(inject['_original_file'], 'templates', fnt, self.runner.basedir, check=False)
+                if os.path.exists(fnd):
+                    source = fnd
+                    found = True
+                    break
+            if not found:
+                result = dict(failed=True, msg="could not find src in first_available_file list")
+                return ReturnData(conn=conn, comm_ok=False, result=result)
+        if not found:
+            source = module_args
+        source = template.template(self.runner.basedir, source, inject)
+        if '_original_file' in inject:
+            source = utils.path_dwim_relative(inject['_original_file'], 'files', source, self.runner.basedir)
+        else:
+            source = utils.path_dwim(self.runner.basedir, source)
+        if os.path.exists(source):
+            data = utils.parse_yaml_from_file(source)
+            if type(data) != dict:
+                raise errors.AnsibleError("%s must be stored as a dictionary/hash" % source)
+            result = dict(ansible_facts=data)
+            return ReturnData(conn=conn, comm_ok=True, result=result)
+        else:
+            result = dict(failed=True, msg="Source file not found.", file=source)
+            return ReturnData(conn=conn, comm_ok=True, result=result)
+

--- a/library/utilities/include_files
+++ b/library/utilities/include_files
@@ -1,0 +1,44 @@
+# -*- mode: python -*-
+
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+author: Benno Joy
+module: include_files
+short_description: Load variables in a file from a task 
+description:
+     - This module allows loading variables from a yaml file similar to vars_files but from a task.
+        it would be specially useful for conditionally loading vars file from a role. 
+     - These variables will survive between plays.
+options:
+  free-form:
+    description:
+       - Add the file name from which variables should be loaded, if called from a role it will look for 
+         the file in files directory else the path would be relative to playbook. An absolute path can 
+         also be provided.
+    required: false
+version_added: "1.4"
+'''
+
+EXAMPLES = '''
+# Example loading variable conditionally based on os distribution
+- include_files: "{{ ansible_os_distribution }}.yml"
+
+# Example loading multiple variable files
+- include_files: "{{ item }}"
+  with_fileglob: "*.yml"
+
+#Example loading the first available file
+- include_files: 
+  first_available_file: 
+   - "foo.yml"
+   - "bar.yml"
+ 
+'''


### PR DESCRIPTION
The module included with this PR allows loading variables from a yaml file similar to vars_files but from a task. this would be specially useful for conditionally loading vars file from within a role. This would be similar to any other tasks so you can add vars files via with_\* for first_available_file or just plain - include_files: a.yml, and conditionally load vars file via - include_files: "{{ ansible_os_distribution }}.yml"
