### PR TITLE
Only remove leading '0x' from apt key ids, not all 0s

### DIFF
--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -191,7 +191,8 @@ def main():
     if key_id:
         try:
             _ = int(key_id, 16)
-            key_id = key_id.lstrip('0x')
+            if key_id.startswith('0x'):
+                key_id = key_id[2:]
         except ValueError:
             module.fail_json("Invalid key_id")
 


### PR DESCRIPTION
This fixes a bug introduced by #4544
