### PR TITLE
Add ansible_sudo_pass hostvar support. Fixes #4323

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -190,6 +190,8 @@ mentioned::
       The default ssh user name to use.
     ansible_ssh_pass
       The ssh password to use (this is insecure, we strongly recommend using --ask-pass or SSH keys)
+    ansible_sudo_pass
+      The sudo password to use (this is insecure, we strongly recommend using --ask-pass or SSH keys)
     ansible_connection
       Connection type of the host. Candidates are local, ssh or paramiko.  The default is paramiko before Ansible 1.2, and 'smart' afterwards which detects whether usage of 'ssh' would be feasible based on whether ControlPersist is supported.
     ansible_ssh_private_key_file

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -577,6 +577,7 @@ class Runner(object):
         actual_pass = inject.get('ansible_ssh_pass', self.remote_pass)
         actual_transport = inject.get('ansible_connection', self.transport)
         actual_private_key_file = inject.get('ansible_ssh_private_key_file', self.private_key_file)
+        self.sudo_pass = inject.get('ansible_sudo_pass', self.sudo_pass)
 
         if self.accelerate and actual_transport != 'local':
             #Fix to get the inventory name of the host to accelerate plugin
@@ -616,6 +617,7 @@ class Runner(object):
                 actual_pass = delegate_info.get('ansible_ssh_pass', actual_pass)
                 actual_private_key_file = delegate_info.get('ansible_ssh_private_key_file', self.private_key_file)
                 actual_transport = delegate_info.get('ansible_connection', self.transport)
+                self.sudo_pass = delegate_info.get('ansible_sudo_pass', self.sudo_pass)
                 for i in delegate_info:
                     if i.startswith("ansible_") and i.endswith("_interpreter"):
                         inject[i] = delegate_info[i]

--- a/lib/ansible/runner/connection_plugins/accelerate.py
+++ b/lib/ansible/runner/connection_plugins/accelerate.py
@@ -165,7 +165,7 @@ class Connection(object):
             executable = constants.DEFAULT_EXECUTABLE
 
         if self.runner.sudo and sudoable and sudo_user:
-            cmd, prompt = utils.make_sudo_cmd(sudo_user, executable, cmd)
+            cmd, prompt, success_key = utils.make_sudo_cmd(sudo_user, executable, cmd)
 
         vvv("EXEC COMMAND %s" % cmd)
 

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -844,10 +844,11 @@ def make_sudo_cmd(sudo_user, executable, cmd):
     # the -p option.
     randbits = ''.join(chr(random.randint(ord('a'), ord('z'))) for x in xrange(32))
     prompt = '[sudo via ansible, key=%s] password: ' % randbits
+    success_key = 'SUDO-SUCCESS-%s' % randbits
     sudocmd = '%s -k && %s %s -S -p "%s" -u %s %s -c %s' % (
         C.DEFAULT_SUDO_EXE, C.DEFAULT_SUDO_EXE, C.DEFAULT_SUDO_FLAGS,
-        prompt, sudo_user, executable or '$SHELL', pipes.quote(cmd))
-    return ('/bin/sh -c ' + pipes.quote(sudocmd), prompt)
+        prompt, sudo_user, executable or '$SHELL', pipes.quote('echo %s; %s' % (success_key, cmd)))
+    return ('/bin/sh -c ' + pipes.quote(sudocmd), prompt, success_key)
 
 _TO_UNICODE_TYPES = (unicode, type(None))
 


### PR DESCRIPTION
A few notes about this change.

I updated `make_sudo_cmd` to echo a "success" key as part of the sudo command.  This allows for the scenario where sudo may not require a password but one was given.

Additionally `make_sudo_cmd` now returns a 3 element tuple, now including the `success_key`.

Where applicable (local, paramiko, ssh), the sudo code, has been updated to make use of the new `success_key`.
