### PR TITLE
pip module: fix unexpected behavior when creating virtualenvs

### DIFF
--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -247,7 +247,7 @@ def main():
             if module.params['virtualenv_site_packages']:
                 cmd = '%s --system-site-packages %s' % (virtualenv, env)
             else:
-                cmd = '%s %s' % (virtualenv, env)
+                cmd = '%s --no-site-packages %s' % (virtualenv, env)
             os.chdir(tempfile.gettempdir())
             if chdir:
                 os.chdir(chdir)


### PR DESCRIPTION
This module supports `virtualenv_site_packages` as an option to control whether or not to include system packages when installing pip packages into a virtual environment. 

The default is no, and when you say yes it explicitly it includes a flag to include site packages, otherwise it doesn't provide a flag. 

Some versions of virtualenv by default include site packages and other versions by default do not. 

This patch just makes both branches explicit, so `virtualenv_site_packages=no` really means no.
