### PR TITLE
Clean up temp file left behind by assemble module

### DIFF
--- a/library/files/assemble
+++ b/library/files/assemble
@@ -137,6 +137,8 @@ def main():
         shutil.copy(path, dest)
         changed = True
 
+    os.remove(path)
+
     file_args = module.load_file_common_arguments(module.params)
     changed = module.set_file_attributes_if_different(file_args, changed)
     # Mission complete


### PR DESCRIPTION
The assemble module was leaving behind temp files after assembling fragments into a file.
