### PR TITLE
Need to compare on server object not list

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -190,7 +190,7 @@ def _get_server_state(module, nova):
     try:
         servers = nova.servers.list(True, {'name': module.params['name']})
         if servers:
-            server = [x for x in servers if x.name == module.params['name']]
+            server = [x for x in servers if x.name == module.params['name']][0]
     except Exception as e:
         module.fail_json(msg = "Error in getting the server list: %s" % e.message)
     if server and module.params['state'] == 'present':


### PR DESCRIPTION
```
TASK: [create test controller 0] **********************************************
failed: [127.0.0.1] => {"failed": true, "parsed": false}
invalid output was: Traceback (most recent call last):
  File "/Users/jdewey/.ansible/tmp/ansible-1383197329.62-262790004573235/nova_compute", line 1203, in <module>
    main()
  File "/Users/jdewey/.ansible/tmp/ansible-1383197329.62-262790004573235/nova_compute", line 261, in main
    _get_server_state(module, nova)
  File "/Users/jdewey/.ansible/tmp/ansible-1383197329.62-262790004573235/nova_compute", line 197, in _get_server_state
    if server.status != 'ACTIVE':
AttributeError: 'list' object has no attribute 'status'
```
