### PR TITLE
Fix description of nova_compute:name option

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -61,7 +61,7 @@ options:
      default: present
    name:
      description:
-        - Name that has to be given to the image
+        - Name that has to be given to the instance
      required: true
      default: None
    image_id:


### PR DESCRIPTION
It's the name of the instance, not of an image.
