### PR TITLE
Fix accelerate module on centos 5 by removing

### DIFF
--- a/library/utilities/accelerate
+++ b/library/utilities/accelerate
@@ -197,7 +197,7 @@ class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
 
     def recv_data(self):
         header_len = 8 # size of a packed unsigned long long
-        data = b""
+        data = ""
         vvvv("in recv_data(), waiting for the header")
         while len(data) < header_len:
             d = self.request.recv(header_len - len(data))


### PR DESCRIPTION
unsupported string prefix in 2.4

http://docs.python.org/release/2.4/ref/strings.html
This is also ignored on later version of python 2
and is present only for python 3 conversion, as seen
on http://docs.python.org/2/reference/lexical_analysis.html#string-literals

Also see http://stackoverflow.com/questions/6269765/what-does-the-b-character-do-in-front-of-a-string-literal
