### PR TITLE
minor doc correction

### DIFF
--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -101,7 +101,7 @@ Run commands in the background, killing the task after 'NUM' seconds.
 
 Poll a background job every 'NUM' seconds. Requires *-B*.
 
-*-u* 'USERNAME', *--remote-user=*'USERNAME'::
+*-u* 'USERNAME', *--user=*'USERNAME'::
 
 Use this remote 'USERNAME' instead of the current user.
 


### PR DESCRIPTION
--remote-user= does not work:
 ansible: error: no such option: --remote-user

--user= does. Updating docs
