### PR TITLE
make cloudformation module accept template_parameters from command line

### DIFF
--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -159,7 +159,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             stack_name=dict(required=True),
-            template_parameters=dict(required=True),
+            template_parameters=dict(required=True, type='dict'),
             region=dict(aliases=['aws_region', 'ec2_region'], required=True, choices=AWS_REGIONS),
             state=dict(default='present', choices=['present', 'absent']),
             template=dict(default=None, required=True),


### PR DESCRIPTION
Passing cloudformation template_parameters on the command line
like so was failing:

```
ansible localhost -m cloudformation -a "...template_parameters=foo=5,bar=4..."
```
