### PR TITLE
minor correction

### DIFF
--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -105,7 +105,7 @@ Connection timeout to use when trying to talk to hosts, in 'SECONDS'.
 Force all plays to use sudo, even if not marked as such.
 
 
-*-u* 'USERNAME', *--remote-user=*'USERNAME'::
+*-u* 'USERNAME', *--user=*'USERNAME'::
 
 Use this remote user name on playbook steps that do not indicate a
 user name to run as.


### PR DESCRIPTION
Same doc-typo (confirmed) as https://github.com/ansible/ansible/pull/4759

--remote-user  _should be_  --user
