### PR TITLE
Document env dependency for test-module

### DIFF
--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -61,6 +61,7 @@ Testing Modules
 There's a useful test script in the source checkout for ansible::
 
     git clone git@github.com:ansible/ansible.git
+    source ansible/hacking/env-setup
     chmod +x ansible/hacking/test-module
 
 Let's run the script you just wrote with that::


### PR DESCRIPTION
You need to source hacking/env-setup before running hacking/test-module; otherwise you get an error like this:

```
ImportError: No module named ansible.utils
```
