### PR TITLE
Honor wait on ec2 instance termination

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -533,6 +533,10 @@ def terminate_instances(module, ec2, instance_ids):
 
     """
 
+    # Whether to wait for termination to complete before returning
+    wait = module.params.get('wait')
+    wait_timeout = int(module.params.get('wait_timeout'))
+
     changed = False
     instance_dict_array = []
 
@@ -551,8 +555,30 @@ def terminate_instances(module, ec2, instance_ids):
                     module.fail_json(msg='Unable to terminate instance {0}, error: {1}'.format(inst.id, e))
                 changed = True
 
-    return (changed, instance_dict_array, terminated_instance_ids)
+    # wait here until the instances are 'terminated'
+    if wait:
+        num_terminated = 0
+        wait_timeout = time.time() + wait_timeout
+        while wait_timeout > time.time() and num_terminated < len(terminated_instance_ids):
+            response = ec2.get_all_instances( \
+                instance_ids=terminated_instance_ids, \
+                filters={'instance-state-name':'terminated'})
+            try:
+                num_terminated = len(response.pop().instances)
+            except Exception, e:
+                # got a bad response of some sort, possibly due to
+                # stale/cached data. Wait a second and then try again
+                time.sleep(1)
+                continue
 
+            if num_terminated < len(terminated_instance_ids):
+                time.sleep(5)
+
+        # waiting took too long
+        if wait_timeout < time.time() and num_terminated < len(terminated_instance_ids):
+            module.fail_json(msg = "wait for instance termination timeout on %s" % time.asctime())
+
+    return (changed, instance_dict_array, terminated_instance_ids)
 
 
 def main():


### PR DESCRIPTION
Similar to pull-request #4185, the ec2 module does not honor the `wait` and `wait_timeout` parameters on instance termination.  This pull request allows the ec2 module to honor those parameters.  When `wait` evaluates to `True`, the ec2 module will poll until terminated instances have a `instance-state-name` of `terminated`.  If instances have not terminated by the time specified by `wait_timeout` the module calls `module.fail_json(...)`

I have tested and confirmed expected results with the following parameters:
1. `wait: false`
2. `wait: true`  (test instances terminate using the default value for `wait_timeout`)
3. `wait: true` and `wait_timeout: 5`  (test that the module fails because instances haven't terminated by `wait_timeout`)
4. `wait: true` and `wait_timeout: 1000`  (test that instances terminate when a long `wait_timeout` is provided)
