### PR TITLE
Fix various warning on accelerate module, found by pyflakes

### DIFF
--- a/library/utilities/accelerate
+++ b/library/utilities/accelerate
@@ -250,7 +250,7 @@ class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
                     vv("bad decrypt, skipping...")
                     data2 = json.dumps(dict(rc=1))
                     data2 = self.server.key.Encrypt(data2)
-                    send_data(client, data2)
+                    self.send_data(data2)
                     return
 
                 vvvv("loading json from the data")

--- a/library/utilities/accelerate
+++ b/library/utilities/accelerate
@@ -72,9 +72,9 @@ EXAMPLES = '''
 
 import base64
 import getpass
+import json
 import os
 import os.path
-import shutil
 import signal
 import socket
 import struct

--- a/library/utilities/accelerate
+++ b/library/utilities/accelerate
@@ -360,13 +360,11 @@ class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
             return dict(failed=True, msg='internal error: out_path is required')
 
         final_path = None
-        final_user = None
         if 'user' in data and data.get('user') != getpass.getuser():
             vv("the target user doesn't match this user, we'll move the file into place via sudo")
             (fd,out_path) = tempfile.mkstemp(prefix='ansible.', dir=os.path.expanduser('~/.ansible/tmp/'))
             out_fd = os.fdopen(fd, 'w', 0)
             final_path = data['out_path']
-            final_user = data['user']
         else:
             out_path = data['out_path']
             out_fd = open(out_path, 'w')


### PR DESCRIPTION
Running pyflakes on accelerate module, i stumbled accross various warning. Most of them are harmless ( missing import, too much import ), but in order to reduce the noise, I fixed them. There is however 1 real bug in a code path executed in case of error, so likely almost never exercised.
