### PR TITLE
Fix determination of correct, possibly customized, 'easy_install' executable

### DIFF
--- a/library/packaging/easy_install
+++ b/library/packaging/easy_install
@@ -133,7 +133,6 @@ def main():
 
     name = module.params['name']
     env = module.params['virtualenv']
-    easy_install = module.get_bin_path(module.params['executable'], True, ['%s/bin' % env])
     executable = module.params['executable']
     easy_install = _get_easy_install(module, env, executable)
     site_packages = module.params['virtualenv_site_packages']
@@ -157,8 +156,6 @@ def main():
             rc += rc_venv
             out += out_venv
             err += err_venv
-
-    easy_install = module.get_bin_path('easy_install', True, ['%s/bin' % env])
 
     cmd = None
     changed = False


### PR DESCRIPTION
Obsolete attempts at determining the full path to the desired `easy_install` executable were still left behind and need to be removed for the customizable `executable` task argument to correctly work: `_get_easy_install` should take care of all the functionality related to determining the correct `easy_install` executable to use.
