### PR TITLE
Fix: ec2_eip connect method references module var that is not passed in

### DIFF
--- a/library/cloud/ec2_eip
+++ b/library/cloud/ec2_eip
@@ -102,7 +102,7 @@ else:
     boto_found = True
 
 
-def connect(ec2_url, ec2_secret_key, ec2_access_key, region):
+def connect(ec2_url, ec2_secret_key, ec2_access_key, region, module):
     """ Return an ec2 connection"""
     # allow environment variables to be used if ansible vars aren't set
     if not ec2_url and 'EC2_URL' in os.environ:
@@ -258,14 +258,13 @@ def main():
     if not boto_found:
         module.fail_json(msg="boto is required")
 
-    # def get_ec2_creds(module):
-    #   return ec2_url, ec2_access_key, ec2_secret_key, region
     ec2_url, ec2_access_key, ec2_secret_key, region = get_ec2_creds(module)
 
-    ec2 = connect(ec2_url=ec2_url,
-                  ec2_access_key=ec2_access_key,
-                  ec2_secret_key=ec2_secret_key,
-                  region=region)
+    ec2 = connect(ec2_url,
+                  ec2_access_key,
+                  ec2_secret_key,
+                  region,
+                  module)
 
     instance_id = module.params.get('instance_id')
     public_ip = module.params.get('public_ip')


### PR DESCRIPTION
The connect method assumes that it has access to the module var although its not passed in. This results in an error that looks like the following when there is an exception thrown in the method, masking the actual error message.

fatal: [x.x.x.x] => failed to parse: Traceback (most recent call last):
  File "/home/ubuntu/.ansible/tmp/ansible-1383430459.64-34518968398797/ec2_eip", line 1346, in <module>
    main()
  File "/home/ubuntu/.ansible/tmp/ansible-1383430459.64-34518968398797/ec2_eip", line 268, in main
    region=region)
  File "/home/ubuntu/.ansible/tmp/ansible-1383430459.64-34518968398797/ec2_eip", line 132, in connect
    module.fail_json(msg = str(e))
NameError: global name 'module' is not defined

This diff fixes it by ensuring that connect call passes the module as well.
