### PR TITLE
Changed parameter from 'user' to 'name' in the examples to coincide with...

### DIFF
--- a/library/database/postgresql_user
+++ b/library/database/postgresql_user
@@ -108,16 +108,16 @@ author: Lorin Hochstein
 
 EXAMPLES = '''
 # Create django user and grant access to database and products table
-- postgresql_user: db=acme user=django password=ceec4eif7ya priv=CONNECT/products:ALL
+- postgresql_user: db=acme name=django password=ceec4eif7ya priv=CONNECT/products:ALL
 
 # Create rails user, grant privilege to create other databases and demote rails from super user status
-- postgresql_user: user=rails password=secret role_attr_flags=CREATEDB,NOSUPERUSER
+- postgresql_user: name=rails password=secret role_attr_flags=CREATEDB,NOSUPERUSER
 
 # Remove test user privileges from acme
-- postgresql_user: db=acme user=test priv=ALL/products:ALL state=absent fail_on_user=no
+- postgresql_user: db=acme name=test priv=ALL/products:ALL state=absent fail_on_user=no
 
 # Remove test user from test database and the cluster
-- postgresql_user: db=test user=test priv=ALL state=absent
+- postgresql_user: db=test name=test priv=ALL state=absent
 
 # Example privileges string format
 INSERT,UPDATE/table:SELECT/anothertable:ALL


### PR DESCRIPTION
... the specs.

Regarding the parameter 'name' in module postgresql_user, the specs on the website (http://www.ansibleworks.com/docs/modules.html#postgresql-user) differ from the examples below it.
