### PR TITLE
Fix for connect method parameter order

### DIFF
--- a/library/cloud/ec2_eip
+++ b/library/cloud/ec2_eip
@@ -102,7 +102,8 @@ else:
     boto_found = True
 
 
-def connect(ec2_url, ec2_secret_key, ec2_access_key, region, module):
+def connect(ec2_url, ec2_access_key, ec2_secret_key, region, module):
+
     """ Return an ec2 connection"""
     # allow environment variables to be used if ansible vars aren't set
     if not ec2_url and 'EC2_URL' in os.environ:


### PR DESCRIPTION
Sorry - I made a mistake in my last pull request, the method params order was messed up. This corrects it. I have also tested it manually. 

I'll look into putting in some unittests to make sure this mistake does not happen again.
