### PR TITLE
Allow async commands to run forever without watching

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -318,7 +318,7 @@ class PlayBook(object):
             error_on_undefined_vars=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR
         )
 
-        if task.async_seconds == 0:
+        if not task.async:
             results = runner.run()
         else:
             results, poller = runner.run_async(task.async_seconds)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -24,7 +24,8 @@ import sys
 class Task(object):
 
     __slots__ = [
-        'name', 'meta', 'action', 'only_if', 'when', 'async_seconds', 'async_poll_interval',
+        'name', 'meta', 'action', 'only_if', 'when', 
+        'async', 'async_seconds', 'async_poll_interval',
         'notify', 'module_name', 'module_args', 'module_vars', 'default_vars',
         'play', 'notified_by', 'tags', 'register', 'role_name',
         'delegate_to', 'first_available_file', 'ignore_errors',
@@ -204,6 +205,7 @@ class Task(object):
         if self.failed_when is not None:
             self.failed_when = utils.compile_when_to_only_if(self.failed_when)
 
+        self.async = 'async' in ds
         self.async_seconds = int(ds.get('async', 0))  # not async by default
         self.async_poll_interval = int(ds.get('poll', 10))  # default poll = 10 seconds
         self.notify = ds.get('notify', [])

--- a/library/internal/async_wrapper
+++ b/library/internal/async_wrapper
@@ -170,6 +170,9 @@ try:
         if sub_pid:
             # the parent stops the process after the time limit
             remaining = int(time_limit)
+            if remaining == 0:
+                sys.exit(0)
+                os._exit(0)
 
             # set the child process group id to kill all children
             os.setpgid(sub_pid, sub_pid)
@@ -180,7 +183,7 @@ try:
                 debug("%s still running (%s)"%(sub_pid, remaining))
                 time.sleep(5)
                 remaining = remaining - 5
-                if remaining == 0:
+                if remaining <= 0:
                     debug("Now killing %s"%(sub_pid))
                     os.killpg(sub_pid, signal.SIGKILL)
                     debug("Sent kill to group %s"%sub_pid)

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -70,6 +70,7 @@ class TestRunner(unittest.TestCase):
         args = ' '.join(module_args)
         self.runner.module_args = args
         self.runner.background = background
+        self.runner.async = background > 0
         self.runner.check = check_mode
         results = self.runner.run()
         # when using nosetests this will only show up on failure


### PR DESCRIPTION
There is a bug fix in here that should be accepted either way,
that remaining <= 0 rather than remaining == 0 (as otherwise
any async value not divisible by 5 never terminates)

The remainder of this commit relates to issue #4778

To make async: 0 actually work requires some logic changes because
currently a value of 0 for async_seconds means run synchronously.

The main change here is to not check whether to kill the child
process and let it live forever. The parent processes do remain in
place.

However, an alternative is daemonize in bash with a simple script
of the form and not run it asynchronously at all

```
setsid command args &
disown !$
```
