### PR TITLE
Don't fail if ec2_access_key/ec2_secret_key not specified to use IAM rol...

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -18,16 +18,12 @@ def get_ec2_creds(module):
             ec2_access_key = os.environ['EC2_ACCESS_KEY']
         elif 'AWS_ACCESS_KEY' in os.environ:
             ec2_access_key = os.environ['AWS_ACCESS_KEY']
-        else:
-            module.fail_json(msg="Please specify an ec2_access_key")
 
     if not ec2_secret_key:
         if 'EC2_SECRET_KEY' in os.environ:
             ec2_secret_key = os.environ['EC2_SECRET_KEY']
         elif 'AWS_SECRET_KEY' in os.environ:
             ec2_secret_key = os.environ['AWS_SECRET_KEY']
-        else:
-            module.fail_json(msg="Please specify an ec2_secret_key")
 
     if not region:
         if 'EC2_REGION' in os.environ:


### PR DESCRIPTION
boto supports IAM roles.
When a user use IAM role to connect AWS API, these params are empty.
