### PR TITLE
Ensure async terminates when time limit is not divisible by 5

### DIFF
--- a/library/internal/async_wrapper
+++ b/library/internal/async_wrapper
@@ -180,7 +180,7 @@ try:
                 debug("%s still running (%s)"%(sub_pid, remaining))
                 time.sleep(5)
                 remaining = remaining - 5
-                if remaining == 0:
+                if remaining <= 0:
                     debug("Now killing %s"%(sub_pid))
                     os.killpg(sub_pid, signal.SIGKILL)
                     debug("Sent kill to group %s"%sub_pid)


### PR DESCRIPTION
Because async_wrapper subtracts 5 from time_limit and checks for
equality to zero, values not divisible by 5 will go negative and
continue forever.
