### PR TITLE
Allow async commands to run forever without watching

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -319,7 +319,7 @@ class PlayBook(object):
             error_on_undefined_vars=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR
         )
 
-        if task.async_seconds == 0:
+        if not task.async:
             results = runner.run()
         else:
             results, poller = runner.run_async(task.async_seconds)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -24,7 +24,8 @@ import sys
 class Task(object):
 
     __slots__ = [
-        'name', 'meta', 'action', 'only_if', 'when', 'async_seconds', 'async_poll_interval',
+        'name', 'meta', 'action', 'only_if', 'when', 
+        'async', 'async_seconds', 'async_poll_interval',
         'notify', 'module_name', 'module_args', 'module_vars', 'default_vars',
         'play', 'notified_by', 'tags', 'register', 'role_name',
         'delegate_to', 'first_available_file', 'ignore_errors',
@@ -204,6 +205,7 @@ class Task(object):
         if self.failed_when is not None:
             self.failed_when = utils.compile_when_to_only_if(self.failed_when)
 
+        self.async = 'async' in ds
         self.async_seconds = int(ds.get('async', 0))  # not async by default
         self.async_poll_interval = int(ds.get('poll', 10))  # default poll = 10 seconds
         self.notify = ds.get('notify', [])

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -119,6 +119,7 @@ class Runner(object):
         remote_port=None,                   # if SSH on different ports
         private_key_file=C.DEFAULT_PRIVATE_KEY_FILE, # if not using keys/passwords
         sudo_pass=C.DEFAULT_SUDO_PASS,      # ex: 'password123' or None
+        async=False,                        # whether to run the job asynchronously
         background=0,                       # async poll every X seconds, else 0 for non-async
         basedir=None,                       # directory of playbook, if applicable
         setup_cache=None,                   # used to share fact data w/ other tasks
@@ -174,6 +175,7 @@ class Runner(object):
         self.remote_port      = remote_port
         self.private_key_file = private_key_file
         self.background       = background
+        self.async            = async or background > 0
         self.sudo             = sudo
         self.sudo_user_var    = sudo_user
         self.sudo_user        = None
@@ -488,7 +490,7 @@ class Runner(object):
             # executing using with_items, so make multiple calls
             # TODO: refactor
 
-            if self.background > 0:
+            if self.async:
                 raise errors.AnsibleError("lookup plugins (with_*) cannot be used with async tasks")
 
             aggregrate = {}
@@ -556,10 +558,10 @@ class Runner(object):
         module_name  = template.template(self.basedir, module_name, inject)
 
         if module_name in utils.plugins.action_loader:
-            if self.background != 0:
+            if self.async:
                 raise errors.AnsibleError("async mode is not supported with the %s module" % module_name)
             handler = utils.plugins.action_loader.get(module_name, self)
-        elif self.background == 0:
+        elif not self.async:
             handler = utils.plugins.action_loader.get('normal', self)
         else:
             handler = utils.plugins.action_loader.get('async', self)
@@ -985,6 +987,7 @@ class Runner(object):
         ''' Run this module asynchronously and return a poller. '''
 
         self.background = time_limit
+        self.async = True
         results = self.run()
         return results, poller.AsyncPoller(results, self)
 

--- a/library/internal/async_wrapper
+++ b/library/internal/async_wrapper
@@ -170,6 +170,9 @@ try:
         if sub_pid:
             # the parent stops the process after the time limit
             remaining = int(time_limit)
+            if remaining == 0:
+                sys.exit(0)
+                os._exit(0)
 
             # set the child process group id to kill all children
             os.setpgid(sub_pid, sub_pid)

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -70,6 +70,7 @@ class TestRunner(unittest.TestCase):
         args = ' '.join(module_args)
         self.runner.module_args = args
         self.runner.background = background
+        self.runner.async = background > 0
         self.runner.check = check_mode
         results = self.runner.run()
         # when using nosetests this will only show up on failure


### PR DESCRIPTION
To make async: 0 actually work requires some logic changes because
currently a value of 0 for async_seconds means run synchronously.

The main change here is to not check whether to kill the child
process and let it live forever. The parent processes do remain in
place.

However, an alternative is daemonize in bash with a simple script
of the form and not run it asynchronously at all

```
setsid command args &
disown !$
```
