### PR TITLE
Exit 0 with no matched hosts

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -81,8 +81,8 @@ class Cli(object):
             inventory_manager.subset(options.subset)
         hosts = inventory_manager.list_hosts(pattern)
         if len(hosts) == 0:
-            callbacks.display("No hosts matched", stderr=True)
-            sys.exit(1)
+            callbacks.display("No hosts matched")
+            sys.exit(0)
 
         if options.listhosts:
             for host in hosts:


### PR DESCRIPTION
This lines up with how ansible-playbook will exit. 0 in the case of no
matched hosts. This makes it easier to script ansible commands w/
variable iventory input which may or may not have an entry for the
specific ansible task being scripted. No matched hosts is acceptable,
but matched hosts w/ failures is not.
