### PR TITLE
Added shorthand regular expression test to filter stdout from command ex...

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -79,7 +79,7 @@ except ImportError:
 # Regex to test shorthand keyvalue syntax 
 # You can see how it works here : 
 #    - https://gist.github.com/llou/7335064#file-gistfile1-py
-keyvalue_regex = re.compile(r"^\s*\w+=(\w+|\"([^\"]|\\\")*\"|\'([^\']|\\\')*\')(\s+\w+=(\w+|\"([^\"]|\\\")*\"|\'([^\']|\\\')*\'))*\s*$")
+keyvalue_regex = re.compile(r"^\s*\w+=")
 
 
 ###############################################################

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -76,6 +76,12 @@ try:
 except ImportError:
     pass
 
+# Regex to test shorthand keyvalue syntax 
+# You can see how it works here : 
+#    - https://gist.github.com/llou/7335064#file-gistfile1-py
+keyvalue_regex = re.compile(r"^\s*\w+=(\w+|\"([^\"]|\\\")*\"|\'([^\']|\\\')*\')(\s+\w+=(\w+|\"([^\"]|\\\")*\"|\'([^\']|\\\')*\'))*\s*$")
+
+
 ###############################################################
 # Abstractions around keyczar
 ###############################################################
@@ -732,6 +738,9 @@ def last_non_blank_line(buf):
     # shouldn't occur unless there's no output
     return ""
 
+def check_keyvalue(line):
+    return True if keyvalue_regex.match(line) else False
+
 def filter_leading_non_json_lines(buf):
     '''
     used to avoid random output from SSH at the top of JSON output, like messages from
@@ -744,7 +753,7 @@ def filter_leading_non_json_lines(buf):
     filtered_lines = StringIO.StringIO()
     stop_filtering = False
     for line in buf.splitlines():
-        if stop_filtering or "=" in line or line.startswith('{') or line.startswith('['):
+        if stop_filtering or check_keyvalue(line) or line.startswith('{') or line.startswith('['):
             stop_filtering = True
             filtered_lines.write(line + '\n')
     return filtered_lines.getvalue()

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -196,6 +196,9 @@ class TestUtils(unittest.TestCase):
     #####################################
     ### key-value parsing
 
+    def test_check_keyvalue(self):
+        assert ansible.utils.check_keyvalue('a=simple b="with space" c="this=that"')
+
     def test_parse_kv_basic(self):
         assert (ansible.utils.parse_kv('a=simple b="with space" c="this=that"') ==
                 {'a': 'simple', 'b': 'with space', 'c': 'this=that'})


### PR DESCRIPTION
I was having trouble trying to run commands on a dd-wrt router as the motd included a lot of "="::

```
==========================================================

 ____  ___    __        ______ _____         ____  _  _ 
 | _ \| _ \   \ \      / /  _ \_   _| __   _|___ \| || | 
 || | || ||____\ \ /\ / /| |_) || |   \ \ / / __) | || |_ 
 ||_| ||_||_____\ V  V / |  _ < | |    \ V / / __/|__   _| 
 |___/|___/      \_/\_/  |_| \_\|_|     \_/ |_____|  |_| 

                       DD-WRT v24-sp2
                   http://www.dd-wrt.com

==========================================================
```

 so I implemented a regex filter to test shorthand key value expressions.

I have build a script for testing the expresion and is in gist: 

https://gist.github.com/llou/7335064#file-gistfile1-py

P.D. Sorry is my first pull request to any project, I am not sure if I have done it right. Don't be severe.
