### PR TITLE
Do not use DEFAULT_MODULE_PATH in setup.py, since that's a constant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ from ansible import __version__, __author__
 from distutils.core import setup
 
 # find library modules
-from ansible.constants import DEFAULT_MODULE_PATH
+from ansible.constants import DIST_MODULE_PATH
 dirs=os.listdir("./library/")
 data_files = []
 for i in dirs:
-    data_files.append((os.path.join(DEFAULT_MODULE_PATH, i), glob('./library/' + i + '/*')))
+    data_files.append((os.path.join(DIST_MODULE_PATH, i), glob('./library/' + i + '/*')))
 
 setup(name='ansible',
       version=__version__,


### PR DESCRIPTION
that can be affected by configuration file, and therefor not act
as intended. For example, if the user running setup.py has more than 1
directory in his module path ( for example, having more than 1 checkout
with module ), setup.py will use a invalid path.
