### PR TITLE
Adding link to up-to-date ansible-examples GitHub repo. 

### DIFF
--- a/docsite/rst/playbooks_roles.rst
+++ b/docsite/rst/playbooks_roles.rst
@@ -28,7 +28,7 @@ more on the big picture and only dive down into the details when needed.
 We'll start with understanding includes so roles make more sense, but our ultimate goal should be understanding roles -- roles
 are great and you should use them every time you write playbooks.
 
-See the 'ansible-examples' repository on github for lots of examples of all of this
+See the `ansible-examples <https://github.com/ansible/ansible-examples>`_ repository on GitHub for lots of examples of all of this
 put together.  You may wish to have this open in a separate tab as you dive in.
 
 Task Include Files And Encouraging Reuse
@@ -338,8 +338,8 @@ The resulting order of execution would be as follows::
        Learn about available modules
    :doc:`developing_modules`
        Learn how to extend Ansible by writing your own modules
-   `Github examples directory <https://github.com/ansible/ansible/tree/devel/examples/playbooks>`_
-       Complete playbook files from the github project source
+   `GitHub Ansible examples <https://github.com/ansible/ansible-examples>`_
+       Complete playbook files from the GitHub project source
    `Mailing List <http://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
 


### PR DESCRIPTION
Adding a link near the top of the document to GitHub.

The GitHub link at the bottom is outdated, and in fact asks the reader to redirect to the corrected link.

Also using proper capitalization for "GitHub".
