### PR TITLE
Retrieve EC2 state when using newer versions of Boto

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -496,7 +496,14 @@ class Ec2Inventory(object):
             key = self.to_safe('ec2_' + key)
 
             # Handle complex types
-            if type(value) in [int, bool]:
+            # state/previous_state changed to properties in boto in https://github.com/boto/boto/commit/a23c379837f698212252720d2af8dec0325c9518
+            if key == 'ec2__state':
+                instance_vars['ec2_state'] = instance.state or ''
+                instance_vars['ec2_state_code'] = instance.state_code
+            elif key == 'ec2__previous_state':
+                instance_vars['ec2_previous_state'] = instance.previous_state or ''
+                instance_vars['ec2_previous_state_code'] = instance.previous_state_code
+            elif type(value) in [int, bool]:
                 instance_vars[key] = value
             elif type(value) in [str, unicode]:
                 instance_vars[key] = value.strip()


### PR DESCRIPTION
In https://github.com/boto/boto/commit/a23c379837f698212252720d2af8dec0325c9518, Boto changed how it stores state/state_code from attributes on an instance to properties, which aren't automatically picked up as host vars by the inventory script.

This change adds support for state, state_code, previous_state, and previous_state_code host vars when using newer versions of Boto, and should still work for older versions as before.
