### PR TITLE
2 fixes for ansible.spec

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -7,6 +7,11 @@
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 %endif
 
+%if 0%{?suse_version} && 0%{?suse_version} <= 1110
+%{!?python_sitelib: %global python_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+BuildRoot: %{_tmppath}/%{name}-%{version}
+%endif
+
 Name: ansible
 Release: 1%{?dist}
 Summary: SSH-based configuration management, deployment, and orchestration engine
@@ -26,9 +31,16 @@ Requires: python26-paramiko
 Requires: python26-jinja2
 Requires: python26-keyczar
 %else
+%if 0%{?suse_version}
+BuildRequires: python-devel
+%else
 BuildRequires: python2-devel
-
+%endif
+%if 0%{?suse_version}
+Requires: python-PyYAML
+%else
 Requires: PyYAML
+%endif
 Requires: python-paramiko
 Requires: python-jinja2
 Requires: python-keyczar
@@ -50,13 +62,12 @@ are transferred to managed machines automatically.
 %{__python} setup.py build
 
 %install
-%{__python} setup.py install -O1 --root=$RPM_BUILD_ROOT
+%{__python} setup.py install -O1 --root=$RPM_BUILD_ROOT --prefix=%{_prefix}
 mkdir -p $RPM_BUILD_ROOT/etc/ansible/
 cp examples/hosts $RPM_BUILD_ROOT/etc/ansible/
 cp examples/ansible.cfg $RPM_BUILD_ROOT/etc/ansible/
 mkdir -p $RPM_BUILD_ROOT/%{_mandir}/{man1,man3}/
 cp -v docs/man/man1/*.1 $RPM_BUILD_ROOT/%{_mandir}/man1/
-cp -v docs/man/man3/*.3 $RPM_BUILD_ROOT/%{_mandir}/man3/
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/ansible
 cp -rv library/* $RPM_BUILD_ROOT/%{_datadir}/ansible/
 
@@ -70,9 +81,8 @@ rm -rf $RPM_BUILD_ROOT
 %dir %{_datadir}/ansible
 %{_datadir}/ansible/*/*
 %config(noreplace) %{_sysconfdir}/ansible
-%doc README.md PKG-INFO COPYING
+%doc README.md COPYING
 %doc %{_mandir}/man1/ansible*
-%doc %{_mandir}/man3/ansible.*
 %doc examples/playbooks
 
 


### PR DESCRIPTION
Fix 1: SLES build:
- python_sitelib just like with RHEL
- BuildRequires: python-devel instead of python2-devel
- Requires: python-PyYAML instead of PyYAML

Fix 2: remove refs to absent man pages (man3):
- cp in %install
- %doc in %files
