### PR TITLE
Correcting the security group id lookup from the list of security group ...

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -392,9 +392,7 @@ def create_instances(module, ec2):
         if group_name:
             grp_details = ec2.get_all_security_groups()
             if type(group_name) == list:
-                # FIXME: this should be a nice list comprehension
-                # also not py 2.4 compliant
-                group_id = list(filter(lambda grp: str(grp.id) if str(tmp) in str(grp) else None, grp_details) for tmp in group_name)
+                group_id = [ str(grp.id) for grp in grp_details if str(grp.name) in group_name ]
             elif type(group_name) == str:
                 for grp in grp_details:
                     if str(group_name) in str(grp):


### PR DESCRIPTION
Corrects the lookup of Security Group IDs from Security Group Names in the EC2 module. This is needed for creating instances in a vpc subnet since you have to pass the ids to boto instead of the names.
