### PR TITLE
 #4869 compatibility with older versions of apt

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -177,20 +177,29 @@ def package_status(m, pkgname, version, cache, state):
     except AttributeError:
         has_files = False  # older python-apt cannot be used to determine non-purged
 
+    try:
+        package_is_installed = ll_pkg.current_state == apt_pkg.CURSTATE_INSTALLED 
+    except AttributeError: # python-apt 0.7.X has very weak low-level object
+        try:
+            # might not be necessary as python-apt post-0.7.X should have current_state property
+            package_is_installed = pkg.is_installed
+        except AttributeError:
+            # assume older version of python-apt is installed
+            package_is_installed = pkg.isInstalled
+
     if version:
-        try :
-            return ll_pkg.current_state == apt_pkg.CURSTATE_INSTALLED and \
-                   fnmatch.fnmatch(pkg.installed.version, version), False, has_files
+        try:
+            installed_version = pkg.installed.version
         except AttributeError:
-            #assume older version of python-apt is installed
-            return ll_pkg.current_state == apt_pkg.CURSTATE_INSTALLED and \
-                   fnmatch.fnmatch(pkg.installedVersion, version), False, has_files
+            installed_version = pkg.installedVersion
+        return package_is_installed and fnmatch.fnmatch(installed_version, version), False, has_files
     else:
-        try :
-            return ll_pkg.current_state == apt_pkg.CURSTATE_INSTALLED, pkg.is_upgradable, has_files
+        try:
+            package_is_upgradable = pkg.is_upgradable
         except AttributeError:
-            #assume older version of python-apt is installed
-            return ll_pkg.current_state == apt_pkg.CURSTATE_INSTALLED, pkg.isUpgradable, has_files
+            # assume older version of python-apt is installed
+            package_is_upgradable = pkg.isUpgradable
+        return package_is_installed, package_is_upgradable, has_files
 
 def expand_dpkg_options(dpkg_options_compressed):
     options_list = dpkg_options_compressed.split(',')


### PR DESCRIPTION
A fix for #4869.

This should preserve the current behaviour for modern low-level apt cache object while sticking to pre-https://github.com/ansible/ansible/commit/0d408ff29565d7c9814b5fc70ecea82db37c8e00 behaviour otherwise.

I could not find the tests for the module so I've just done fluent test on my boxes (including Lenny, Squeeze and Wheezy) to do some basic install/remove operations.

You might also want to check if regressions for https://github.com/ansible/ansible/issues/3421 are introduced — I don't know how to check that so I didn't do that.
