### PR TITLE
display_unmatched_hosts cfg option

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -579,7 +579,8 @@ class PlaybookCallbacks(object):
         call_callback_module('playbook_on_notify', host, handler)
 
     def on_no_hosts_matched(self):
-        display("skipping: no hosts matched", color='cyan')
+        if constants.DISPLAY_UNMATCHED_HOSTS:
+            display("skipping: no hosts matched", color='cyan')
         call_callback_module('playbook_on_no_hosts_matched')
 
     def on_no_hosts_remaining(self):
@@ -674,8 +675,9 @@ class PlaybookCallbacks(object):
         display(msg, color='cyan')
         call_callback_module('playbook_on_not_import_for_host', host, missing_file)
 
-    def on_play_start(self, pattern):
-        display(banner("PLAY [%s]" % pattern))
+    def on_play_start(self, pattern, matched):
+        if matched or constants.DISPLAY_UNMATCHED_HOSTS:
+            display(banner("PLAY [%s]" % pattern))
         call_callback_module('playbook_on_play_start', pattern)
 
     def on_stats(self, stats):

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -135,6 +135,7 @@ DEFAULT_LOG_PATH               = shell_expand_path(get_config(p, DEFAULTS, 'log_
 ANSIBLE_NOCOLOR                = get_config(p, DEFAULTS, 'nocolor', 'ANSIBLE_NOCOLOR', None, boolean=True)
 ANSIBLE_NOCOWS                 = get_config(p, DEFAULTS, 'nocows', 'ANSIBLE_NOCOWS', None, boolean=True)
 DISPLAY_SKIPPED_HOSTS          = get_config(p, DEFAULTS, 'display_skipped_hosts', 'DISPLAY_SKIPPED_HOSTS', True, boolean=True)
+DISPLAY_UNMATCHED_HOSTS        = get_config(p, DEFAULTS, 'display_unmatched_hosts', 'DISPLAY_UNMATCHED_HOSTS', True, boolean=True)
 DEFAULT_UNDEFINED_VAR_BEHAVIOR = get_config(p, DEFAULTS, 'error_on_undefined_vars', 'ANSIBLE_ERROR_ON_UNDEFINED_VARS', True, boolean=True)
 HOST_KEY_CHECKING              = get_config(p, DEFAULTS, 'host_key_checking',  'ANSIBLE_HOST_KEY_CHECKING',    True, boolean=True)
 DEPRECATION_WARNINGS           = get_config(p, DEFAULTS, 'deprecation_warnings', 'ANSIBLE_DEPRECATION_WARNINGS', True, boolean=True)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -502,9 +502,11 @@ class PlayBook(object):
     def _run_play(self, play):
         ''' run a list of tasks for a given pattern, in order '''
 
-        self.callbacks.on_play_start(play.name)
+        matched = self.inventory.list_hosts(play.hosts)
+
+        self.callbacks.on_play_start(play.name, matched)
         # if no hosts matches this play, drop out
-        if not self.inventory.list_hosts(play.hosts):
+        if not matched:
             self.callbacks.on_no_hosts_matched()
             return True
 


### PR DESCRIPTION
An option to suppress these logs when a playbook's hosts does not match anything.
Like display_skipped_hosts, default behavior is True.

```
PLAY [xyz] ****************************************** 
skipping: no hosts matched
```
