### PR TITLE
Fix: absent state removing whole cron.d file instead of specific job

### DIFF
--- a/library/system/cron
+++ b/library/system/cron
@@ -455,6 +455,9 @@ def main():
     if job is None and do_install:
         module.fail_json(msg="You must specify 'job' to install a new cron job")
 
+    if job and name is None and not do_install:
+        module.fail_json(msg="You must specify 'name' to remove a cron job")
+
     if reboot:
         if special_time:
             module.fail_json(msg="reboot and special_time are mutually exclusive")

--- a/library/system/cron
+++ b/library/system/cron
@@ -466,7 +466,7 @@ def main():
         (backuph, backup_file) = tempfile.mkstemp(prefix='crontab')
         crontab.write(backup_file)
 
-    if crontab.cron_file and not do_install:
+    if crontab.cron_file and not name and not do_install:
         changed = crontab.remove_job_file()
         module.exit_json(changed=changed,cron_file=cron_file,state=state)
 


### PR DESCRIPTION
I've found a critical bug in cron module. If you try to remove some job from cron.d, the ansible will run crontab.remove_job_file() and delete the whole file which contains other jobs. I don't understand what the meaning of this function and commit 8f14ffe5, where this function was appeared, doesn't clarify at all. Furthermore, I think that removing files not a functional that cron module must to do. The file module is exists for this purpose.
