### PR TITLE
Check for AWS keys using boto names

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -16,6 +16,8 @@ def get_ec2_creds(module):
     if not ec2_access_key:
         if 'EC2_ACCESS_KEY' in os.environ:
             ec2_access_key = os.environ['EC2_ACCESS_KEY']
+        elif 'AWS_ACCESS_KEY_ID' in os.environ:
+            ec2_access_key = os.environ['AWS_ACCESS_KEY_ID']
         elif 'AWS_ACCESS_KEY' in os.environ:
             ec2_access_key = os.environ['AWS_ACCESS_KEY']
         else:
@@ -24,6 +26,8 @@ def get_ec2_creds(module):
     if not ec2_secret_key:
         if 'EC2_SECRET_KEY' in os.environ:
             ec2_secret_key = os.environ['EC2_SECRET_KEY']
+        elif 'AWS_SECRET_ACCESS_KEY' in os.environ:
+            ec2_secret_key = os.environ['AWS_SECRET_ACCESS_KEY']
         elif 'AWS_SECRET_KEY' in os.environ:
             ec2_secret_key = os.environ['AWS_SECRET_KEY']
         else:


### PR DESCRIPTION
- see https://github.com/boto/boto#getting-started-with-boto

I haven't deep-dived into all the AWS code, but it seems like most (all?) ec2 modules use boto behind the scenes. If this is true, we might want to use the [boto.core.get_credentials()](https://github.com/boto/boto/blob/develop/boto/core/credentials.py#L147) method since they have a substantial search path for the keys.

I'm not sure how such a change would affect eucalyptus users though.
