### PR TITLE
update npm-module to handle new node.js output

### DIFF
--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -163,7 +163,9 @@ class Npm(object):
         data = self._exec(['outdated'], True, False)
         for dep in data.splitlines():
             if dep:
-                pkg, other = dep.split('@', 1)
+                # node.js v0.10.22 changed the `npm outdated` module separator
+                # from "@" to " ". Split on both for backwards compatibility.
+                pkg, other = re.split('\s|@', dep, 1)
                 outdated.append(pkg)
 
         return outdated


### PR DESCRIPTION
The November 12 node.js release, [version 0.10.22](http://nodejs.org/changelog.html), changed the output format of `npm outdated`. This change breaks Ansible's npm module when invoked with `state=latest`.

**Expected:**  Node module works. 
**Actual:** `ValueError: need more than 1 value to unpack`
### Solution

The fix is very simple. Rather than sniffing versions, we can split the output of `npm outdated` on either whitespace or the `"@"` character. node.js modules can't have spaces in their names and in either case, Ansible's npm-module only uses the first item in npm's returned string.
### Node Changes

npm's output was modified in [commit 2f7fd62](https://github.com/isaacs/npm/commit/2f7fd625#diff-3d20499d58f14c6f1edfe93d8ba8a8a2L63), which removed the `"@"` from lines 64-65 of [lib/outdated.js](https://github.com/isaacs/npm/blob/master/lib/outdated.js).

That change to npm was finally integrated into node.js with [version 0.10.22](http://nodejs.org/changelog.html) on November 12, 2013. The code has been in npm since September 7, 2013.
### Test VM

I set up a simple Vagrant box to isolate the bug: [github.com/joemaller/ansible-npm-bug](https://github.com/joemaller/ansible-npm-bug)

_Thanks to @jctanner for helping point me in the right direction me on irc._
