### PR TITLE
Allow for reuse of allocated but unassociated Elastic IPs.

### DIFF
--- a/library/cloud/ec2_eip
+++ b/library/cloud/ec2_eip
@@ -53,6 +53,11 @@ options:
     required: false
     default: false
     version_added: "1.4"
+  reuse:
+    description:
+      - Reuse an EIP that is not associated to an instance (when available), instead of allocating a new one.
+    required: false
+    default: false
 requirements: [ "boto" ]
 author: Lorin Hochstein <lorin@nimbisservices.com>
 notes:
@@ -198,13 +203,27 @@ def ip_is_associated_with_instance(ec2, public_ip, instance_id, module):
         return False
 
 
-def allocate_address(ec2, domain, module):
-    """ Allocate a new elastic IP address and return it """
+def allocate_address(ec2, domain, module, reuse):
+    """ Allocate a new elastic IP address (when needed) and return it """
     # If we're in check mode, nothing else to do
     if module.check_mode:
         module.exit_json(change=True)
 
-    address = ec2.allocate_address(domain=domain)
+    if reuse:
+      if domain:
+        domain_filter = { 'domain' : domain }
+      else:
+        domain_filter = { 'domain' : 'standard' }
+      all_addresses = ec2.get_all_addresses(filters=domain_filter)
+
+      unassociated_addresses = filter(lambda a: a.instance_id is None, all_addresses)
+      if unassociated_addresses:
+        address = unassociated_addresses[0];
+      else:
+        address = ec2.allocate_address(domain=domain)
+    else:
+      address = ec2.allocate_address(domain=domain)
+
     return address
 
 
@@ -252,6 +271,7 @@ def main():
             ec2_access_key = dict(required=False, aliases=['EC2_ACCESS_KEY']),
             region = dict(required=False, aliases=['ec2_region']),
             in_vpc = dict(required=False, choices=BOOLEANS, default=False),
+            reuse = dict(required=False, choices=BOOLEANS, default=False),
         ),
         supports_check_mode=True
     )
@@ -272,18 +292,19 @@ def main():
     state = module.params.get('state')
     in_vpc = module.params.get('in_vpc')
     domain  = "vpc" if in_vpc else None
+    reuse = module.params.get('reuse');
 
     if state == 'present':
         if public_ip is None:
             if instance_id is None:
-                address = allocate_address(ec2, domain, module)
+                address = allocate_address(ec2, domain, module, reuse)
                 module.exit_json(changed=True, public_ip=address.public_ip)
             else:
                 # Determine if the instance is inside a VPC or not
                 instance = find_instance(ec2, instance_id, module)
                 if instance.vpc_id != None:
                     domain = "vpc"
-                address = allocate_address(ec2, domain, module)
+                address = allocate_address(ec2, domain, module, reuse)
         else:
             address = find_address(ec2, public_ip, module)
         associate_ip_and_instance(ec2, address, instance_id, module)


### PR DESCRIPTION
I've added a parameter `reuse` to the ec2_eip module describing if unassociated Elastic IPs can be reused. It's not always necessary to allocate a new one, hence this parameter. 

I'm aware that reuse can be dangerous too, since an unassociated Elastic IP might be parked to be used later, so it should be used with caution. When set to false, which is the default as well, the module behaves as it did. 
