### PR TITLE
Use pkgng glob (-g) feature to allow installation of packages by wildcard

### DIFF
--- a/library/packaging/pkgng
+++ b/library/packaging/pkgng
@@ -72,7 +72,7 @@ import sys
 
 def query_package(module, pkgin_path, name):
 
-    rc, out, err = module.run_command("%s info -e %s" % (pkgin_path, name))
+    rc, out, err = module.run_command("%s info -g -e %s" % (pkgin_path, name))
 
     if rc == 0:
         return True
@@ -121,7 +121,7 @@ def install_packages(module, pkgin_path, packages, cached, pkgsite):
             continue
 
         if not module.check_mode:
-            rc, out, err = module.run_command("%s %s install -U -y %s" % (pkgsite, pkgin_path, package))
+            rc, out, err = module.run_command("%s %s install -g -U -y %s" % (pkgsite, pkgin_path, package))
 
         if not module.check_mode and not query_package(module, pkgin_path, package):
             module.fail_json(msg="failed to install %s: %s" % (package, out), stderr=err)


### PR DESCRIPTION
Also solves the particular problem of installing packages that have multiple versions in the repo, but specifying the exact version would be troublesome:

$ pkg install -n dovecot
The following 2 packages will be installed:

```
Installing dovecot: 1.2.17
Reinstalling dovecot-2.2.6 (options changed)
```

$ pkg install -n dovecot-2.2.6
The following 1 packages will be installed:

```
Reinstalling dovecot-2.2.6 (options changed)
```

$ pkg install -n -g dovecot-2*
The following 1 packages will be installed:

```
Reinstalling dovecot-2.2.6 (options changed)
```
