### PR TITLE
Improve Group.get_hosts() performance

### DIFF
--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -55,13 +55,10 @@ class Group(object):
 
         hosts = []
         for kid in self.child_groups:
-            kid_hosts = kid.get_hosts()
-            for kk in kid_hosts:
-               if kk not in hosts:
-                   hosts.append(kk)
-        for mine in self.hosts:
-            if mine not in hosts:
-                hosts.append(mine)
+            a = [h for h in kid.get_hosts() if h not in hosts]
+            hosts.extend(a)
+        a = [h for h in self.hosts if h not in hosts]
+        hosts.extend(a)
         return hosts
 
     def get_variables(self):


### PR DESCRIPTION
With my test case (a trivial playbook with an inventory with hundreds of groups and about a thousand hosts)
I see execution time dropping from ~3m down to ~20s.
