### PR TITLE
Remove debug print statement from rax_clb

### DIFF
--- a/library/cloud/rax_clb
+++ b/library/cloud/rax_clb
@@ -229,7 +229,6 @@ def cloud_load_balancer(module, state, name, meta, algorithm, port, protocol,
 
         if wait:
             attempts = wait_timeout / 5
-            print attempts
             pyrax.utils.wait_for_build(balancer, interval=5, attempts=attempts)
 
         balancer.get()


### PR DESCRIPTION
A debug print statement was left in rax_clb from development and testing.  This pull removes that print statement.

Sorry for the trouble!
