### PR TITLE
fix make tests to use the set of module from git checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ NOSETESTS := nosetests
 all: clean python
 
 tests:
-	PYTHONPATH=./lib $(NOSETESTS) -d -v
+	PYTHONPATH=./lib ANSIBLE_LIBRARY=./library  $(NOSETESTS) -d -v
 
 # To force a rebuild of the docs run 'touch VERSION && make docs'
 docs: $(MANPAGES) modulepages


### PR DESCRIPTION
If someone try to run the test suit with ansible already installed,
the mix between content in /usr/share and in the git checkout
can result in strange failure ( as I found out the hard way ). For example,
the test_copy module will call the action plugin for copy from git,
who will call the 'file' module from system, passing unsupported arguments.

To test, just take a git checkout of ansible, install ansible from rpm, and run make tests. On my Fedora 19, this fail on a few modules. After changing ANSIBLE_LIBRARY, it work fine.
