### PR TITLE
Update cloud/docker: if the image name containes a repository, strip it.

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -263,6 +263,8 @@ class DockerManager:
     
     
     def get_split_image_tag(self, image):
+        if '/' in image:
+            image = image.split('/')[1]
         tag = None
         if image.find(':') > 0:
             return image.split(':')


### PR DESCRIPTION
When using repositories other than the main one at docker.io, the image name contains the repo name (which itself contains ":" as a separator between domain and port). We don't really care about it here, so just get rid of it before looking at the image name.

This is a backport from https://github.com/cove/docker-ansible/ as per @cove's request in https://github.com/cove/docker-ansible/pull/19#issuecomment-28628426
