### PR TITLE
Various fix for the urpmi module

### DIFF
--- a/library/packaging/urpmi
+++ b/library/packaging/urpmi
@@ -90,6 +90,13 @@ def query_package(module, name):
     else:
         return False
 
+def query_package_provides(module, name):
+
+    # rpm -q returns 0 if the package is installed,
+    # 1 if it is not installed
+    rc = os.system("rpm -q --provides %s >/dev/null" % (name))
+    return rc == 0
+
 
 def update_package_db(module):
     rc = os.system("urpmi.update -a -q")
@@ -125,7 +132,8 @@ def install_packages(module, pkgspec, force=True, no_suggests=True):
 
     packages = ""
     for package in pkgspec:
-        packages += "'%s' " % package
+        if not query_package_provides(module, package):
+            packages += "'%s' " % package
 
     if len(packages) != 0:
         if no_suggests:

--- a/library/packaging/urpmi
+++ b/library/packaging/urpmi
@@ -76,11 +76,18 @@ import json
 import shlex
 import os
 import sys
+try:
+    import rpm
+    USE_PYTHON = True
+except ImportError:
+    USE_PYTHON = False
 
 URPMI_PATH = '/usr/sbin/urpmi'
 URPME_PATH = '/usr/sbin/urpme'
 
 def query_package(module, name):
+    if USE_PYTHON:
+        return rpm.TransactionSet().dbMatch(rpm.RPMTAG_NAME, name).count() != 0
 
     # rpm -q returns 0 if the package is installed,
     # 1 if it is not installed
@@ -91,6 +98,8 @@ def query_package(module, name):
         return False
 
 def query_package_provides(module, name):
+    if USE_PYTHON:
+        return rpm.TransactionSet().dbMatch(rpm.RPMTAG_PROVIDES, name).count() != 0
 
     # rpm -q returns 0 if the package is installed,
     # 1 if it is not installed


### PR DESCRIPTION
Testing the urpmi module yesterday, I noticed a few bug.
The first one is that urpmi will always return 0 even when there is nothing to install, thus always flagging 'changed' to True, even when there was nothing. This is inconsistent with others modules behavior.

I also added a small optimisation, by using rpm python module directly rather than calling rpm, this avoid the cost of fork and exec which would help if you need to install and verify lots of package. Since python-rpm is not installed by default ( unlike on yum based distribution ), the code will fallback to fork/exec if this doesn't work.

I may push others fix later:
- urpmi --force always return 0, so urpmi do not detect if we give a wrong rpm name, and always return success
- urpmi module do not support 'latest' like zypper, but could be added
