### PR TITLE
return failed if a package couldn't be installed

### DIFF
--- a/library/packaging/urpmi
+++ b/library/packaging/urpmi
@@ -158,7 +158,14 @@ def install_packages(module, pkgspec, force=True, no_suggests=True):
         cmd = ("%s --auto %s --quiet %s %s > /dev/null" % (URPMI_PATH, force_yes, no_suggests_yes, packages))
 
         rc, out, err = module.run_command(cmd)
-        if rc:
+
+        installed = True
+        for packages in pkgspec:
+            if not query_package_provides(module, package):
+                installed = False
+
+        # urpmi always have 0 for exit code if --force is used
+        if rc or not installed:
             module.fail_json(msg="'urpmi %s' failed: %s" % (packages, err))
         else:
             module.exit_json(changed=True, msg="%s present(s)" % packages)


### PR DESCRIPTION
For some reason, on my test mandriva, urpmi --force return 0
even when it cannot install a rpm. So we have to explicitely check
if the package was properly installed with a loop.
