### PR TITLE
Improve Group.get_hosts() performance.

### DIFF
--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -18,7 +18,7 @@
 class Group(object):
     ''' a group of ansible hosts '''
 
-    __slots__ = [ 'name', 'hosts', 'vars', 'child_groups', 'parent_groups', 'depth' ]
+    __slots__ = [ 'name', 'hosts', 'vars', 'child_groups', 'parent_groups', 'depth', '_hosts_cache' ]
 
     def __init__(self, name=None):
 
@@ -28,6 +28,7 @@ class Group(object):
         self.vars = {}
         self.child_groups = []
         self.parent_groups = []
+        self.clear_hosts_cache()
         if self.name is None:
             raise Exception("group name is required")
 
@@ -41,26 +42,44 @@ class Group(object):
             self.child_groups.append(group)
             group.depth = max([self.depth+1, group.depth])
             group.parent_groups.append(self)
+            self.clear_hosts_cache()
 
     def add_host(self, host):
 
         self.hosts.append(host)
         host.add_group(self)
+        self.clear_hosts_cache()
 
     def set_variable(self, key, value):
 
         self.vars[key] = value
 
+    def clear_hosts_cache(self):
+
+        self._hosts_cache = None
+        for g in self.parent_groups:
+            g.clear_hosts_cache()
+
     def get_hosts(self):
 
+        if self._hosts_cache is None:
+            self._hosts_cache = self._get_hosts()
+
+        return self._hosts_cache
+
+    def _get_hosts(self):
+
         hosts = []
+        seen = {}
         for kid in self.child_groups:
             kid_hosts = kid.get_hosts()
             for kk in kid_hosts:
-                if kk not in hosts:
+                if kk not in seen:
+                    seen[kk] = 1
                     hosts.append(kk)
         for mine in self.hosts:
-            if mine not in hosts:
+            if mine not in seen:
+                seen[mine] = 1
                 hosts.append(mine)
         return hosts
 


### PR DESCRIPTION
- reduce hosts group list to unique elements faster
- add a cache of already computed hosts group list

As an example I was using a trivial playbook with and inventory of 1122 hosts and 2850 groups: Group.get_hosts()
is called more and  3 000 000 times, accounting for 9 minutes of runtime on my test machine.
With the proposed hosts group list reduction to unique members implementation, execution time drops to about 30s.
And when adding the cache of the computed hosts group list, execution time drops to about 15s.
