### PR TITLE
KeyError: 'delegate_to' lookup in sync module needs to be checked to see if defined for ad hoc

### DIFF
--- a/lib/ansible/runner/action_plugins/synchronize.py
+++ b/lib/ansible/runner/action_plugins/synchronize.py
@@ -36,14 +36,14 @@ class ActionModule(object):
 
     def setup(self, module_name, inject):
         ''' Always default to localhost as delegate if None defined '''
-        if inject['delegate_to'] is None:
+        if inject.get('delegate_to') is None:
             inject['delegate_to'] = '127.0.0.1'
             inject['ansible_connection'] = 'local'
             # If sudo is active, disable from the connection set self.sudo to True.
             if self.runner.sudo:
                 self.runner.sudo = False
 
-    def run(self, conn, tmp, module_name, module_args, 
+    def run(self, conn, tmp, module_name, module_args,
         inject, complex_args=None, **kwargs):
 
         ''' generates params and passes them on to the rsync module '''


### PR DESCRIPTION
```
$ ansible skyl2 -m synchronize -a "src=./foo dest=~/bar/baz"
XX | FAILED => Traceback (most recent call last):
  File "ansible/lib/ansible/runner/__init__.py", line 394, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "ansible/lib/ansible/runner/__init__.py", line 485, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "ansible/lib/ansible/runner/__init__.py", line 578, in _executor_internal_inner
    handler.setup(module_name, inject)
  File "ansible/lib/ansible/runner/action_plugins/synchronize.py", line 39, in setup
    if inject['delegate_to'] is None:
KeyError: 'delegate_to'
```
