### PR TITLE
Add ability to specify a VirtualIP ID for sharing a VIP with another LB

### DIFF
--- a/library/cloud/rax_clb
+++ b/library/cloud/rax_clb
@@ -74,6 +74,10 @@ options:
   username:
     description:
       - Rackspace username (overrides C(credentials))
+  vip_id:
+    description:
+      - Virtual IP ID to use when creating the load balancer for purposes of
+        sharing an IP with another load balancer of another protocol
   wait:
     description:
       - wait for the balancer to be in state 'running' before returning
@@ -160,7 +164,7 @@ def to_dict(obj):
 
 
 def cloud_load_balancer(module, state, name, meta, algorithm, port, protocol,
-                        vip_type, timeout, wait, wait_timeout):
+                        vip_type, timeout, wait, wait_timeout, vip_id):
     for arg in (state, name, port, protocol, vip_type):
         if not arg:
             module.fail_json(msg='%s is required for rax_clb' % arg)
@@ -189,7 +193,7 @@ def cloud_load_balancer(module, state, name, meta, algorithm, port, protocol,
 
         if not balancers:
             try:
-                virtual_ips = [clb.VirtualIP(type=vip_type)]
+                virtual_ips = [clb.VirtualIP(type=vip_type, id=vip_id)]
                 balancer = clb.create(name, metadata=metadata, port=port,
                                       algorithm=algorithm, protocol=protocol,
                                       timeout=timeout, virtual_ips=virtual_ips)
@@ -279,6 +283,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent']),
             timeout=dict(type='int', default=30),
             type=dict(choices=['PUBLIC', 'SERVICENET'], default='PUBLIC'),
+            vip_id=dict(),
             wait=dict(type='bool'),
             wait_timeout=dict(default=300),
         )
@@ -296,6 +301,7 @@ def main():
     protocol = module.params.get('protocol')
     state = module.params.get('state')
     timeout = int(module.params.get('timeout'))
+    vip_id = module.params.get('vip_id')
     vip_type = module.params.get('type')
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
@@ -303,7 +309,7 @@ def main():
     setup_rax_module(module, pyrax)
 
     cloud_load_balancer(module, state, name, meta, algorithm, port, protocol,
-                        vip_type, timeout, wait, wait_timeout)
+                        vip_type, timeout, wait, wait_timeout, vip_id)
 
 
 # import module snippets

--- a/library/cloud/rax_clb
+++ b/library/cloud/rax_clb
@@ -78,6 +78,7 @@ options:
     description:
       - Virtual IP ID to use when creating the load balancer for purposes of
         sharing an IP with another load balancer of another protocol
+    version_added: 1.5
   wait:
     description:
       - wait for the balancer to be in state 'running' before returning


### PR DESCRIPTION
This pull adds a vip_id attribute to the rax_clb module, for creating a LB with a previously created Virtual IP so you can share IPs between load balancers of different protocols.
