### PR TITLE
docsite/build-site.py should use full path to index.html

### DIFF
--- a/docsite/README.md
+++ b/docsite/README.md
@@ -7,7 +7,7 @@ Contributions to the documentation are welcome.  To make changes, submit a pull 
 that changes the reStructuredText files in the "rst/" directory only, and Michael can
 do a docs build and push the static files. If you wish to verify output from the markup
 such as link references, you may [install Sphinx] and build the documentation by running
-`make viewdocs` from the `ansible/docsite/latest` directory.
+`make viewdocs` from the `ansible/docsite` directory.
 
 If you do not want to learn the reStructuredText format, you can also [file issues] about
 documentation problems on the Ansible GitHub project.

--- a/docsite/build-site.py
+++ b/docsite/build-site.py
@@ -30,6 +30,8 @@ except ImportError:
     sys.exit(1)
 import os
 
+outdir = os.path.abspath(os.path.join(os.getcwd(), "htmlout"))
+
 
 class SphinxBuilder(object):
     """
@@ -45,7 +47,6 @@ class SphinxBuilder(object):
         try:
             buildername = 'html'
 
-            outdir = os.path.abspath(os.path.join(os.getcwd(), "htmlout"))
             # Create the output directory if it doesn't exist
             if not os.access(outdir, os.F_OK):
                 os.mkdir(outdir)
@@ -88,7 +89,7 @@ if __name__ == '__main__':
         print "    Run 'make viewdocs' to build and then preview in a web browser."
         sys.exit(0)
 
-    # The 'htmldocs' make target will call this scrip twith the 'rst'
+    # The 'htmldocs' make target will call this script with the 'rst'
     # parameter' We don't need to run the 'htmlman' target then.
     if "rst" in sys.argv:
         build_rst_docs()
@@ -99,5 +100,5 @@ if __name__ == '__main__':
 
     if "view" in sys.argv:
         import webbrowser
-        if not webbrowser.open('index.html'):
+        if not webbrowser.open(outdir + '/index.html'):
             print >> sys.stderr, "Could not open on your webbrowser."


### PR DESCRIPTION
## Before

```
foo@bar:~/ansible/mine/docsite$ ./build-site.py
~~snip~~
build succeeded, 1 warning.
gvfs-open: ~/ansible/mine/docsite/index.html: error opening location: Error when getting information for file '~ansible/mine/docsite/index.html': No such file or directory
foo@bar:~/ansible/mine/docsite$
```
## After

```
Webpage opens in browser
Also tested "make webdocs" from top level
```

Also fixed minor typo in comment. Apologies if you prefer that in a separate change, let me know, I though this would be pragmatic.
