### PR TITLE
Remove stale references to 'latest' from docsite

### DIFF
--- a/docsite/README.md
+++ b/docsite/README.md
@@ -7,7 +7,7 @@ Contributions to the documentation are welcome.  To make changes, submit a pull 
 that changes the reStructuredText files in the "rst/" directory only, and Michael can
 do a docs build and push the static files. If you wish to verify output from the markup
 such as link references, you may [install Sphinx] and build the documentation by running
-`make viewdocs` from the `ansible/docsite/latest` directory.
+`make viewdocs` from the `ansible/docsite` directory.
 
 If you do not want to learn the reStructuredText format, you can also [file issues] about
 documentation problems on the Ansible GitHub project.


### PR DESCRIPTION
left over from 0cd09dd when 'latest' directory structure was removed
