### PR TITLE
gce: support virtualenv by detecting python via /usr/bin/env

### DIFF
--- a/library/cloud/gc_storage
+++ b/library/cloud/gc_storage
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/gce
+++ b/library/cloud/gce
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/library/cloud/gce_lb
+++ b/library/cloud/gce_lb
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/library/cloud/gce_net
+++ b/library/cloud/gce_net
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/library/cloud/gce_pd
+++ b/library/cloud/gce_pd
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/plugins/inventory/gce.ini
+++ b/plugins/inventory/gce.ini
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/plugins/inventory/gce.py
+++ b/plugins/inventory/gce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible


### PR DESCRIPTION
This is likely also required for anybody who needs to install a different python to that provided by their system.

There are almost 160 other similar shebangs in the project, if somebody thinks all of these need to be fixed:

```
git grep -E '^#!' |egrep -v 'make|env' | wc -l
```

FWIW as a non-python user it took me ~ 4h to figure out why the scripts failed and yet an interactive python session would succeed. Worth fixing!
