### PR TITLE
use the current directory as a roles_path fallback

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -100,7 +100,7 @@ DEFAULTS='defaults'
 # configurable things
 DEFAULT_HOST_LIST         = shell_expand_path(get_config(p, DEFAULTS, 'hostfile', 'ANSIBLE_HOSTS', '/etc/ansible/hosts'))
 DEFAULT_MODULE_PATH       = get_config(p, DEFAULTS, 'library',          'ANSIBLE_LIBRARY',          DIST_MODULE_PATH)
-DEFAULT_ROLES_PATH        = get_config(p, DEFAULTS, 'roles_path',       'ANSIBLE_ROLES_PATH',       None)
+DEFAULT_ROLES_PATH        = get_config(p, DEFAULTS, 'roles_path',       'ANSIBLE_ROLES_PATH',       os.path.sep.join([os.getcwd(), "roles"]))
 DEFAULT_REMOTE_TMP        = shell_expand_path(get_config(p, DEFAULTS, 'remote_tmp',       'ANSIBLE_REMOTE_TEMP',      '$HOME/.ansible/tmp'))
 DEFAULT_MODULE_NAME       = get_config(p, DEFAULTS, 'module_name',      None,                       'command')
 DEFAULT_PATTERN           = get_config(p, DEFAULTS, 'pattern',          None,                       '*')


### PR DESCRIPTION
Currently roles_path searches in:

```
$REPO/playbook/roles/...
$REPO/playbook/[common|main|vars]
config.roles_path
```

We have a project where we have multiple playbooks sharing roles so we have a structure like this:

```
$REPO/hosts/production-hosts
$REPO/plays/a-play/[playbook.yaml&&files&&templates]
$REPO/plays/b-play/...
$REPO/plays/...
$REPO/roles/arole/
                common
                main
                templates
                vars
```

We want to set the roles_path dynamically to the top level $REPO directory, but that may be in different locations on different systems. We want to avoid using the $ANSIBLE_ROLES_PATH as using environment variables is considered legacy in favor of using ansible.cfg.

This pull request simply sets the 
`get_config()` default for roles_path to `os.path.sep.join([os.getcwd(), "roles"])` to accomplish this goal.

This also brings the roles_path search behavior more into line with [ansible.cfg location search behavior does](https://github.com/reedobrien/ansible/blob/72d295e16d36bfcaa9fdf8b8a3371cff451c46ba/lib/ansible/constants.py#L60). First try a couple default locations, then try the calling () directory.
