### PR TITLE
fixes #4954 plus updates for gcutil/v1beta16 tests

### DIFF
--- a/library/cloud/gce
+++ b/library/cloud/gce
@@ -121,13 +121,13 @@ EXAMPLES = '''
     zone: us-central1-a
   tasks:
     - name: Launch instances
-      local_action: gce instance_names=${names} machine_type=${machine_type}
-                    image=${image} zone=${zone}
+      local_action: gce instance_names={{names}} machine_type={{machine_type}}
+                    image={{image}} zone={{zone}}
       register: gce
     - name: Wait for SSH to come up
-      local_action: wait_for host=${item.public_ip} port=22 delay=10
+      local_action: wait_for host={{item.public_ip}} port=22 delay=10
                     timeout=60 state=started
-      with_items: ${gce.instance_data}
+      with_items: {{gce.instance_data}}
 
 - name: Configure instance(s)
   hosts: launched
@@ -144,7 +144,7 @@ EXAMPLES = '''
       local_action:
         module: gce
         state: 'absent'
-        instance_names: ${gce.instance_names}
+        instance_names: {{gce.instance_names}}
 
 '''
 
@@ -211,8 +211,8 @@ def get_instance_info(inst):
         'metadata': metadata,
         'name': inst.name,
         'network': netname,
-        'private_ip': inst.private_ip[0],
-        'public_ip': inst.public_ip[0],
+        'private_ip': inst.private_ips[0],
+        'public_ip': inst.public_ips[0],
         'status': ('status' in inst.extra) and inst.extra['status'] or None,
         'tags': ('tags' in inst.extra) and inst.extra['tags'] or [],
         'zone': ('zone' in inst.extra) and inst.extra['zone'].name or None,
@@ -344,7 +344,7 @@ def main():
             instance_names = dict(),
             machine_type = dict(default='n1-standard-1'),
             metadata = dict(),
-            name = dict(default='gce'),
+            name = dict(),
             network = dict(default='default'),
             persistent_boot_disk = dict(type='bool', choices=BOOLEANS, default=False),
             state = dict(choices=['active', 'present', 'absent', 'deleted'],

--- a/plugins/inventory/gce.py
+++ b/plugins/inventory/gce.py
@@ -114,8 +114,12 @@ class GceInventory(object):
     def get_gce_driver(self):
         '''Determine GCE authorization settings and return libcloud driver.'''
 
+        gce_ini_default_path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "gce.ini")
+        gce_ini_path = os.environ.get('GCE_INI_PATH', gce_ini_default_path)
+
         config = ConfigParser.SafeConfigParser()
-        config.read(os.path.dirname(os.path.realpath(__file__)) + '/gce.ini')
+        config.read(gce_ini_path)
 
         # the GCE params in 'secrets.py' will override these
         secrets_path = config.get('gce', 'libcloud_secrets')
@@ -180,8 +184,8 @@ class GceInventory(object):
             'gce_id': inst.id,
             'gce_image': inst.image,
             'gce_machine_type': inst.size,
-            'gce_private_ip': inst.private_ip[0],
-            'gce_public_ip': inst.public_ip[0],
+            'gce_private_ip': inst.private_ips[0],
+            'gce_public_ip': inst.public_ips[0],
             'gce_name': inst.name,
             'gce_description': inst.extra['description'],
             'gce_status': inst.extra['status'],


### PR DESCRIPTION
Fixed a couple of other issues while I was in here.
- Default 'gce' instance was being created
- Changed reference to private/public_ip
- Tested with latest gcutil/v1beta16
- Fixed inventory plugin path #4954
- Example/Comments cleaned up to use {{ var }} syntax
