### PR TITLE
Add missing exception name

### DIFF
--- a/library/cloud/rax_network
+++ b/library/cloud/rax_network
@@ -106,7 +106,7 @@ def cloud_network(module, state, label, cidr):
                 changed = True
             except Exception, e:
                 module.fail_json(msg='%s' % e.message)
-        except Exception:
+        except Exception, e:
             module.fail_json(msg='%s' % e.message)
 
     elif state == 'absent':


### PR DESCRIPTION
Hitting this exception handler currently returns:

```
UnboundLocalError: local variable 'e' referenced before assignment
```
