### PR TITLE
Make apt module work with "apt-listchanges" and "apt-listbugs" installed

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -138,7 +138,7 @@ import datetime
 import fnmatch
 
 # APT related constants
-APT_ENVVARS = "DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical"
+APT_ENVVARS = "APT_LISTCHANGES_FRONTEND=none APT_LISTBUGS_FRONTEND=none DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical"
 DPKG_OPTIONS = 'force-confdef,force-confold'
 APT_GET_ZERO = "0 upgraded, 0 newly installed"
 APTITUDE_ZERO = "0 packages upgraded, 0 newly installed"


### PR DESCRIPTION
The problem basically looks like this:

```
failed: [foobar.local] => (item=virtualenvwrapper) => {"failed": true, "item": "virtualenvwrapper"}
msg: 'apt-get install 'virtualenvwrapper' ' failed: E: Sub-process /usr/sbin/apt-listbugs apt returned an error code (10)
E: Failure running script /usr/sbin/apt-listbugs apt
```

This is because a bug for the new _virtualenvwrapper_ version has been reported on the debian BTS (I'm running debian sid). A other case could be that the new package has exciting news in the **NEWS** file and _apt-listchanges_ tries to show you these news. I think we should explicitly disable the _apt-listchanges_ and _apt-listbugs_ hooks through the corresponding environment variables.
