### PR TITLE
Fix for RPM build on opensuse

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -26,7 +26,11 @@ Requires: python26-paramiko
 Requires: python26-jinja2
 Requires: python26-keyczar
 %else
+%if 0%{?suse_version}
+BuildRequires: python-devel
+%else
 BuildRequires: python2-devel
+%endif
 
 Requires: PyYAML
 Requires: python-paramiko


### PR DESCRIPTION
Opensuse (tested on 12.3) doesn't have package 'python2-devel', just
python-devel. This patch sort this and allow build RPM successfully
on OpenSuse 12.3.
