### PR TITLE
New lookup plugin csvreader

### DIFF
--- a/lib/ansible/runner/lookup_plugins/csvfile.py
+++ b/lib/ansible/runner/lookup_plugins/csvfile.py
@@ -1,0 +1,82 @@
+# (c) 2013, Jan-Piet Mens <jpmens(at)gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible import utils, errors
+import os
+import codecs
+import csv
+
+class LookupModule(object):
+
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
+
+    def read_csv(self, filename, key, delimiter, dflt=None, col=1):
+
+        try:
+            f = codecs.open(filename, 'r', encoding='utf-8')
+            creader = csv.reader(f, delimiter=delimiter)
+
+            for row in creader:
+                if row[0] == key:
+                    return row[int(col)]
+        except Exception, e:
+            raise errors.AnsibleError("csvfile: %s" % str(e))
+
+        return dflt
+
+    def run(self, terms, inject=None, **kwargs):
+
+        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
+
+        if isinstance(terms, basestring):
+            terms = [ terms ]
+
+        ret = []
+        for term in terms:
+            params = term.split()
+            key = params[0]
+
+            paramvals = {
+                'file' : 'ansible.csv',
+                'default' : None,
+                'delimiter' : "TAB",
+                'col' : "1",          # column to return
+            }
+
+            # parameters specified?
+            try:
+                for param in params[1:]:
+                    name, value = param.split('=')
+                    assert(name in paramvals)
+                    paramvals[name] = value
+            except (ValueError, AssertionError) as e:
+                raise errors.AnsibleError(e)
+
+            if paramvals['delimiter'] == 'TAB':
+                paramvals['delimiter'] = "\t"
+
+            path = utils.path_dwim(self.basedir, paramvals['file'])
+
+            var = self.read_csv(path, key, paramvals['delimiter'], paramvals['default'], paramvals['col'])
+            if var is not None:
+                if type(var) is list:
+                    for v in var:
+                        ret.append(v)
+                else:
+                    ret.append(var)
+        return ret


### PR DESCRIPTION
The `csvfile` lookup plugin results from a discussion on ansible-devel and supersedes #4846. This plugin reads CSV and TSV (default) data. (I chose to use TAB as default delimiter because that's a bit difficult to specify in a playbook. Even so, this delimiter can explicitly be specified as "TAB".)

`csvfile` is used as follows:

```
lookup('csvfile', 'key')
lookup('csvfile', 'key file=abc.csv')
lookup('csvfile', 'key delimiter=; file=abc.csv')
lookup('csvfile', 'key col=2')      # returns content of column 2 only (default: column 1; 0 is key)
```
- `key` is the key we want to look up in column 0 of the CSV file
- `file` is the CSV file to read (default: `ansible.csv`)
- `col` is the column number to be returned (0 is the key) and defaults to 1
- `delimiter` is a single character which specifies how fields in `file` are separated. Default is TAB. (As a special case, `delimiter=TAB`  can be used to mean `delimiter=\t`)
- `default` is the string to return if `key` isn't found and defaults to an empty string.
### input.csv (here with ; as delimiter)

``` txt
# bla bla bla
uno;This is number one;    col-1
dos;This is number two;col-2
bomb;tcp://192.168.1.2:328/
tres;El tercero!;col-3
jane;Jane Smith
alice;Alicia Ejemplo
joe;Joe's Acme Corp; and whatnot
```
### Playbook

``` yaml
- hosts:
  - 127.0.0.1
  gather_facts: False
  connection: local
  vars: 
  - conntype: "{{ lookup('csvfile', 'bomb file=input.csv delimiter=; col=1')  }}"
  - names: [ jane, notthere, alice ]
  tasks:
  - action: debug msg="conntype={{ conntype }}"
  - action: debug msg="host={{ lookup('csvfile', 'host file=input.txt col=1 delimiter=TAB')  }}"
  - action: template src=csv-template.in dest=/tmp/out.file
```
### Template

``` jinja2

{% for name in names -%}

{# Build param consisting of key and file= #}
{% 
    set param = ' '.join(( name, "file=input.csv", "default=OhNo!", "delimiter=;"))
-%}
{% set val = lookup('csvfile', param) -%}
{{ name }} is in fact "{{ val }}"
{% endfor %}
```
### run

```
PLAY [127.0.0.1] **************************************************************

TASK: [debug msg="conntype=tcp://192.168.1.2:328/"] ***************************
ok: [127.0.0.1] => {
    "msg": "conntype=tcp://192.168.1.2:328/"
}

TASK: [debug msg="host=-aaaaaaaaaaaaaaaaaaa-"] ********************************
ok: [127.0.0.1] => {
    "msg": "host=-aaaaaaaaaaaaaaaaaaa-"
}

TASK: [template src=csv-template.in dest=/tmp/out.file] ***********************
changed: [127.0.0.1]

PLAY RECAP ********************************************************************
127.0.0.1                  : ok=3    changed=1    unreachable=0    failed=0
```
### /tmp/out.file

```

jane is in fact "Jane Smith"
notthere is in fact "OhNo!"
alice is in fact "Alicia Ejemplo"
```
