### PR TITLE
Decode before authentication to allow (encoded) special characters

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -359,7 +359,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
             passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
 
             # this creates a password manager
-            passman.add_password(None, netloc, username, password)
+            passman.add_password(None, netloc, urlparse.unquote(username), urlparse.unquote(password))
 
             # because we have put None at the start it will always
             # use this username/password combination for  urls


### PR DESCRIPTION
I had a problem with the get_url module and a url containing a password with a `[`. The url was not parsed correctly since it was thought to be an IPv6 url. 

I think the right way to solve this is to url-encode such a password manually when using the get_url module, and decode it in the library before passing it to the internal password manager to authenticate.
