### PR TITLE
Implement ansible.module_utils.rax

### DIFF
--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -1,0 +1,46 @@
+import os
+
+
+def rax_argument_spec():
+    return dict(
+        api_key=dict(type='str'),
+        credentials=dict(type='str', aliases=['creds_file']),
+        region=dict(type='str'),
+        username=dict(type='str'),
+    )
+
+
+def rax_required_together():
+    return [['api_key', 'username']]
+
+
+def setup_rax_module(module, rax_module):
+    api_key = module.params.get('api_key')
+    credentials = module.params.get('credentials')
+    region = module.params.get('region')
+    username = module.params.get('username')
+
+    try:
+        username = username or os.environ.get('RAX_USERNAME')
+        api_key = api_key or os.environ.get('RAX_API_KEY')
+        credentials = (credentials or os.environ.get('RAX_CREDENTIALS') or
+                       os.environ.get('RAX_CREDS_FILE'))
+        region = region or os.environ.get('RAX_REGION')
+    except KeyError, e:
+        module.fail_json(msg='Unable to load %s' % e.message)
+
+    try:
+        rax_module.set_setting('identity_type', 'rackspace')
+
+        if api_key and username:
+            rax_module.set_credentials(username, api_key=api_key,
+                                       region=region)
+        elif credentials:
+            credentials = os.path.expanduser(credentials)
+            rax_module.set_credential_file(credentials, region=region)
+        else:
+            raise Exception('No credentials supplied!')
+    except Exception, e:
+        module.fail_json(msg='%s' % e.message)
+
+    return rax_module

--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -549,12 +549,11 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            api_key=dict(),
+    argument_spec = rax_argument_spec()
+    argument_spec.update(
+        dict(
             count=dict(default=1, type='int'),
             count_offset=dict(default=1, type='int'),
-            credentials=dict(aliases=['creds_file']),
             disk_config=dict(default='auto', choices=['auto', 'manual']),
             exact_count=dict(choices=BOOLEANS, default=False, type='bool'),
             files=dict(type='dict', default={}),
@@ -566,13 +565,16 @@ def main():
             meta=dict(type='dict', default={}),
             name=dict(),
             networks=dict(type='list', default=['public', 'private']),
-            region=dict(),
             service=dict(),
             state=dict(default='present', choices=['present', 'absent']),
-            username=dict(),
             wait=dict(choices=BOOLEANS, default=False, type='bool'),
             wait_timeout=dict(default=300),
-        ),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=rax_required_together(),
     )
 
     service = module.params.get('service')
@@ -582,10 +584,8 @@ def main():
                              'please remove "service: cloudservers" from your '
                              'playbook pertaining to the "rax" module')
 
-    api_key = module.params.get('api_key')
     count = module.params.get('count')
     count_offset = module.params.get('count_offset')
-    credentials = module.params.get('credentials')
     disk_config = module.params.get('disk_config').upper()
     exact_count = module.params.get('exact_count', False)
     files = module.params.get('files')
@@ -597,42 +597,20 @@ def main():
     meta = module.params.get('meta')
     name = module.params.get('name')
     networks = module.params.get('networks')
-    region = module.params.get('region')
     state = module.params.get('state')
-    username = module.params.get('username')
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
 
-    # Setup the credentials and region
-    try:
-        username = username or os.environ.get('RAX_USERNAME')
-        api_key = api_key or os.environ.get('RAX_API_KEY')
-        credentials = (credentials or os.environ.get('RAX_CREDENTIALS') or
-                       os.environ.get('RAX_CREDS_FILE'))
-        region = region or os.environ.get('RAX_REGION')
-
-    except KeyError, e:
-        module.fail_json(msg='Unable to load %s' % e.message)
-
-    # setup the auth
-    try:
-        pyrax.set_setting('identity_type', 'rackspace')
-        if api_key and username:
-            pyrax.set_credentials(username, api_key=api_key, region=region)
-        elif credentials:
-            credentials = os.path.expanduser(credentials)
-            pyrax.set_credential_file(credentials, region=region)
-        else:
-            raise Exception('No credentials supplied!')
-    except Exception, e:
-        module.fail_json(msg='%s' % e.message)
+    setup_rax_module(module, pyrax)
 
     cloudservers(module, state, name, flavor, image, meta, key_name, files,
                  wait, wait_timeout, disk_config, count, group,
                  instance_ids, exact_count, networks, count_offset)
 
 
+# import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.rax import *
 
 ### invoke the module
 main()

--- a/library/cloud/rax_clb
+++ b/library/cloud/rax_clb
@@ -268,64 +268,47 @@ def cloud_load_balancer(module, state, name, meta, algorithm, port, protocol,
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
+    argument_spec = rax_argument_spec()
+    argument_spec.update(
+        dict(
             algorithm=dict(choices=ALGORITHMS, default='LEAST_CONNECTIONS'),
-            api_key=dict(),
-            credentials=dict(aliases=['creds_file']),
             meta=dict(type='dict', default={}),
             name=dict(),
             port=dict(type='int', default=80),
             protocol=dict(choices=PROTOCOLS, default='HTTP'),
-            region=dict(),
             state=dict(default='present', choices=['present', 'absent']),
             timeout=dict(type='int', default=30),
             type=dict(choices=['PUBLIC', 'SERVICENET'], default='PUBLIC'),
-            username=dict(),
             wait=dict(type='bool'),
             wait_timeout=dict(default=300),
-        ),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=rax_required_together,
     )
 
     algorithm = module.params.get('algorithm')
-    api_key = module.params.get('api_key')
-    credentials = module.params.get('credentials')
     meta = module.params.get('meta')
     name = module.params.get('name')
     port = module.params.get('port')
     protocol = module.params.get('protocol')
-    region = module.params.get('region')
     state = module.params.get('state')
     timeout = int(module.params.get('timeout'))
-    username = module.params.get('username')
     vip_type = module.params.get('type')
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
 
-    try:
-        username = username or os.environ.get('RAX_USERNAME')
-        api_key = api_key or os.environ.get('RAX_API_KEY')
-        credentials = (credentials or os.environ.get('RAX_CREDENTIALS') or
-                       os.environ.get('RAX_CREDS_FILE'))
-        region = region or os.environ.get('RAX_REGION')
-    except KeyError, e:
-        module.fail_json(msg='Unable to load %s' % e.message)
-
-    try:
-        pyrax.set_setting('identity_type', 'rackspace')
-        if api_key and username:
-            pyrax.set_credentials(username, api_key=api_key, region=region)
-        elif credentials:
-            credentials = os.path.expanduser(credentials)
-            pyrax.set_credential_file(credentials, region=region)
-        else:
-            raise Exception('No credentials supplied!')
-    except Exception, e:
-        module.fail_json(msg='%s' % e.message)
+    setup_rax_module(module, pyrax)
 
     cloud_load_balancer(module, state, name, meta, algorithm, port, protocol,
                         vip_type, timeout, wait, wait_timeout)
 
-from ansible.module_utils.basic import *
 
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.rax import *
+
+### invoke the module
 main()

--- a/library/cloud/rax_clb_nodes
+++ b/library/cloud/rax_clb_nodes
@@ -136,6 +136,13 @@ EXAMPLES = '''
 '''
 
 import os
+import sys
+
+try:
+    import pyrax
+except ImportError:
+    print("failed=True msg='pyrax is required for this module'")
+    sys.exit(1)
 
 
 def _activate_virtualenv(path):
@@ -182,41 +189,36 @@ def _node_to_dict(node):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
+    argument_spec = rax_argument_spec()
+    argument_spec.update(
+        dict(
             address=dict(),
-            api_key=dict(),
             condition=dict(choices=['enabled', 'disabled', 'draining']),
-            credentials=dict(),
             load_balancer_id=dict(required=True, type='int'),
             node_id=dict(type='int'),
             port=dict(type='int'),
-            region=dict(),
             state=dict(default='present', choices=['present', 'absent']),
             type=dict(choices=['primary', 'secondary']),
-            username=dict(),
             virtualenv=dict(),
             wait=dict(default=False, type='bool'),
             wait_timeout=dict(default=30, type='int'),
             weight=dict(type='int'),
-        ),
-        required_together=[
-            ['api_key', 'username']
-        ],
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=rax_required_together(),
     )
 
     address = module.params['address']
-    api_key = module.params['api_key']
     condition = (module.params['condition'] and
                  module.params['condition'].upper())
-    credentials = module.params['credentials']
     load_balancer_id = module.params['load_balancer_id']
     node_id = module.params['node_id']
     port = module.params['port']
-    region = module.params['region']
     state = module.params['state']
     typ = module.params['type'] and module.params['type'].upper()
-    username = module.params['username']
     virtualenv = module.params['virtualenv']
     wait = module.params['wait']
     wait_timeout = module.params['wait_timeout'] or 1
@@ -229,28 +231,7 @@ def main():
             module.fail_json(msg='Failed to activate virtualenv %s (%s)' % (
                                  virtualenv, e))
 
-    try:
-        import pyrax
-    except ImportError:
-        module.fail_json(msg='pyrax is not installed')
-
-    username = username or os.environ.get('RAX_USERNAME')
-    api_key = api_key or os.environ.get('RAX_API_KEY')
-    credentials = credentials or os.environ.get('RAX_CREDENTIALS')
-    region = region or os.environ.get('RAX_REGION')
-
-    pyrax.set_setting("identity_type", "rackspace")
-
-    try:
-        if api_key and username:
-            pyrax.set_credentials(username, api_key=api_key, region=region)
-        elif credentials:
-            credentials = os.path.expanduser(credentials)
-            pyrax.set_credential_file(credentials, region=region)
-        else:
-            module.fail_json(msg='Credentials not set')
-    except pyrax.exc.PyraxException, e:
-        module.fail_json(msg='%s' % e.message)
+    setup_rax_module(module, pyrax)
 
     if not pyrax.cloud_loadbalancers:
         module.fail_json(msg='Failed to instantiate load balancer client '
@@ -345,6 +326,10 @@ def main():
     kwargs = {'node': result} if result else {}
     module.exit_json(changed=True, state=state, **kwargs)
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.rax import *
+
+### invoke the module
 main()

--- a/library/cloud/rax_facts
+++ b/library/cloud/rax_facts
@@ -144,51 +144,34 @@ def rax_facts(module, address, name, server_id):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
+    argument_spec = rax_argument_spec()
+    argument_spec.update(
+        dict(
             address=dict(),
-            api_key=dict(),
-            credentials=dict(aliases=['creds_file']),
             id=dict(),
             name=dict(),
-            region=dict(),
-            username=dict(),
-        ),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=rax_required_together(),
         mutually_exclusive=[['address', 'id', 'name']],
         required_one_of=[['address', 'id', 'name']],
     )
 
     address = module.params.get('address')
-    api_key = module.params.get('api_key')
-    credentials = module.params.get('credentials')
     server_id = module.params.get('id')
     name = module.params.get('name')
-    region = module.params.get('region')
-    username = module.params.get('username')
 
-    try:
-        username = username or os.environ.get('RAX_USERNAME')
-        api_key = api_key or os.environ.get('RAX_API_KEY')
-        credentials = (credentials or os.environ.get('RAX_CREDENTIALS') or
-                       os.environ.get('RAX_CREDS_FILE'))
-        region = region or os.environ.get('RAX_REGION')
-    except KeyError, e:
-        module.fail_json(msg='Unable to load %s' % e.message)
-
-    try:
-        pyrax.set_setting('identity_type', 'rackspace')
-        if api_key and username:
-            pyrax.set_credentials(username, api_key=api_key, region=region)
-        elif credentials:
-            credentials = os.path.expanduser(credentials)
-            pyrax.set_credential_file(credentials, region=region)
-        else:
-            raise Exception('No credentials supplied!')
-    except Exception, e:
-        module.fail_json(msg='%s' % e.message)
+    setup_rax_module(module, pyrax)
 
     rax_facts(module, address, name, server_id)
 
-from ansible.module_utils.basic import *
 
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.rax import *
+
+### invoke the module
 main()

--- a/library/cloud/rax_network
+++ b/library/cloud/rax_network
@@ -129,53 +129,33 @@ def cloud_network(module, state, label, cidr):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
+    argument_spec = rax_argument_spec()
+    argument_spec.update(
+        dict(
             state=dict(default='present',
                        choices=['present', 'absent']),
-            credentials=dict(aliases=['creds_file']),
-            api_key=dict(),
-            username=dict(),
-            region=dict(),
             label=dict(),
             cidr=dict()
         )
     )
 
-    credentials = module.params.get('credentials')
-    api_key = module.params.get('api_key')
-    username = module.params.get('username')
-    region = module.params.get('region')
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=rax_required_together(),
+    )
+
     state = module.params.get('state')
     label = module.params.get('label')
     cidr = module.params.get('cidr')
 
-    try:
-        username = username or os.environ.get('RAX_USERNAME')
-        api_key = api_key or os.environ.get('RAX_API_KEY')
-        credentials = (credentials or
-                       os.environ.get('RAX_CREDENTIALS') or
-                       os.environ.get('RAX_CREDS_FILE'))
-        region = region or os.environ.get('RAX_REGION')
-
-    except KeyError, e:
-        module.fail_json(msg='Unable to load %s' % e.message)
-
-    try:
-        pyrax.set_setting("identity_type", "rackspace")
-        if api_key and username:
-            pyrax.set_credentials(username, api_key=api_key, region=region)
-        elif credentials:
-            credentials = os.path.expanduser(credentials)
-            pyrax.set_credential_file(credentials, region=region)
-        else:
-            raise Exception('No credentials supplied!')
-    except Exception, e:
-        module.fail_json(msg='%s' % e.message)
+    setup_rax_module(module, pyrax)
 
     cloud_network(module, state, label, cidr)
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.rax import *
+
+### invoke the module
 main()


### PR DESCRIPTION
With the addition of a lot of rax modules, there is a lot of duplicate code currently.

Migrate some duplicate boilerplate code that usually shows up in main() into lib/ansible/module_utils/rax.py
