### PR TITLE
When name has digits in it, we may incorrectly determine package is already installed

### DIFF
--- a/library/packaging/portinstall
+++ b/library/packaging/portinstall
@@ -89,7 +89,7 @@ def query_package(module, name):
             if pkgng:
                 rc, out, err = module.run_command("%s %s" % (pkg_info_path, name_without_digits))
             else:
-                rc, out, err = module.run_command("%s `%s %s`" % (pkg_info_path, pkg_glob_path, name_without_digits))
+                rc, out, err = module.run_command("%s %s" % (pkg_info_path, name_without_digits))
 
         found = rc == 0
 


### PR DESCRIPTION
This fixes that issue. Only relevant for FreeBSD9.x and earlier.
