### PR TITLE
Add use setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ from glob import glob
 
 sys.path.insert(0, os.path.abspath('lib'))
 from ansible import __version__, __author__
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 # find library modules
 from ansible.constants import DEFAULT_MODULE_PATH


### PR DESCRIPTION
When i install it. I see this:

```
/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'
```

In fact, you want to install dependencies are **not installed**. need to be using setuptools instead of distutils.
