### PR TITLE
Reports changed status from django_manage migrate

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -155,6 +155,9 @@ def loaddata_filter_output(line):
 def syncdb_filter_output(line):
     return ("Creating table " in line) or ("Installed" in line and "Installed 0 object" not in line)
 
+def migrate_filter_output(line):
+    return ("Migrating forwards " in line) or ("Installed" in line and "Installed 0 object" not in line)
+
 def main():
     command_allowed_param_map = dict(
         cleanup=(),


### PR DESCRIPTION
Please let me know if there's anything else I need to do to get this merged.  Thanks for all the hard work on Ansible, I'm using it with vagrant. 

The filter implementation is based on sample output from South 0.8.3. e.g.

With migrations to run:

```
Running migrations for my_app:
 - Migrating forwards to 0007_auto__add_field_stock_image_url.
 > my_app:0007_auto__add_field_stock_image_url
 - Loading initial data for my_app.
Installed 0 object(s) from 0 fixture(s)
```

Nothing to do (no changes):

```
Running migrations for my_app:
- Nothing to migrate.
 - Loading initial data for my_app.
Installed 0 object(s) from 0 fixture(s)
```
