### PR TITLE
mention that the mount module will remove mount directories

### DIFF
--- a/library/system/mount
+++ b/library/system/mount
@@ -63,7 +63,9 @@ options:
     description:
       - If C(mounted) or C(unmounted), the device will be actively mounted or unmounted
         as well as just configured in I(fstab). C(absent) and C(present) only deal with
-        I(fstab).
+        I(fstab). C(mounted) will also automatically create the mount point
+        directory if it doesn't exist. If C(absent) changes anything, it will
+        remove the mount point directory.
     required: true
     choices: [ "present", "absent", "mounted", "unmounted" ]
     default: null


### PR DESCRIPTION
Mentioning the fact that mount point directories are created and
removed.

Background: I tried to unmount a mounted directory and it complained that it wasn't empty. I was surprised. Documentation did not give any hint. Reading source code proved to me that the module also was trying to remove the directory (which had content) after the unmount.
