### PR TITLE
Added -FF flag to rsync invocation in synchronize

### DIFF
--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -183,7 +183,7 @@ def main():
     owner = module.params['owner']
     group = module.params['group']
 
-    cmd = '%s --delay-updates --compress --timeout=%s' % (rsync, rsync_timeout)
+    cmd = '%s --delay-updates -FF --compress --timeout=%s' % (rsync, rsync_timeout)
     if module.check_mode:
         cmd = cmd + ' --dry-run'
     if delete:

--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -109,6 +109,10 @@ notes:
    - The remote user for the dest path will always be the remote_user, not
      the sudo_user. 
    - Expect that dest=~/x will be ~<remote_user>/x even if using sudo.
+   - To exclude files and directories from being synchronized, you may add 
+     C(.rsync-filter) files to the source directory.
+     
+     
 author: Timothy Appnel
 '''
 
@@ -142,6 +146,11 @@ synchronize: src=some/relative/path dest=/some/absolute/path delete=yes
 
 # Synchronize using an alternate rsync command
 synchronize: src=some/relative/path dest=/some/absolute/path rsync_path="sudo rsync"
+
+# Example .rsync-filter file in the source directory
+- var       # exclude any path whose last part is 'var'
+- /var      # exclude any path starting with 'var' starting at the source directory
++ /var/conf # include /var/conf even though it was previously excluded
 '''
 
 


### PR DESCRIPTION
The `-FF` flag causes rsync to look for files in the source directory named `.rsync-filter` and uses them to filter directories underneath them. If no `.rsync-filter` files are found, the behavior is identical to the command run without the -FF option. This flag does not sync the .rsync-filter files themselves.

This change should be backwards compatible and not produce surprising behavior for users, since they are unlikely to create `.rsync-filter` files unintentionally.
