### PR TITLE
Module zabbix_maintenance to create maintenance windows in zabbix

### DIFF
--- a/library/monitoring/zabbix_maintenance
+++ b/library/monitoring/zabbix_maintenance
@@ -1,0 +1,352 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Alexander Bulimov <lazywolf0@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+
+module: zabbix_maintenance
+short_description: Create Zabbix maintenance windows
+description:
+    - This module will let you create Zabbix maintenance windows.
+version_added: "1.5"
+author: Alexander Bulimov
+requirements:
+    - zabbix-api python module
+options:
+    state:
+        description:
+            - Create or remove a maintenance window.
+        required: true
+        default: null
+        choices: [ "present", "absent" ]
+    server:
+        description:
+            - Url of Zabbix server, with schema (http or https).
+        required: true
+        default: null
+        aliases: [ "url" ]
+    user:
+        description:
+            - Zabbix user name.
+        required: true
+        default: null
+    passwd:
+        description:
+            - Zabbix user password.
+        required: true
+        default: null
+    hosts:
+        description:
+            - Hosts to manage maintenance window for. Separate multiple hosts with commas.
+              C(host) is an alias for C(hosts).
+              B(Required) option when C(state) is I(present) and no C(groups) specified.
+        required: false
+        default: null
+        aliases: [ "host" ]
+    groups:
+        description:
+            - Host groups to manage maintenance window for. Separate multiple groups with commas.
+              C(group) is an alias for C(groups).
+              B(Required) option when C(state) is I(present) and no C(hosts) specified.
+        required: false
+        default: null
+        aliases: [ "group" ]
+    minutes:
+        description:
+            - Length of maintenance window in minutes.
+        required: false
+        default: 10
+    name:
+        description:
+            - Unique name of maintenance window.
+        required: true
+        default: null
+    desc:
+        description:
+            - Short description of maintenance window.
+        required: true
+        default: Created by Ansible
+    collect_data:
+        description:
+            - Type of maintenance. With data collection, or without.
+        required: false
+        default: "true"
+notes:
+    - Useful for setting hosts in maintenance mode before big update,
+      and removing maintenance window after update.
+    - Module creates maintenance window from now() to now() + minutes,
+      so if Zabbix server's time and host's time are not synchronized,
+      you will get strange results.
+    - Install required module with 'pip install zabbix-api' command.
+    - Checks existance only by maintenance name.
+'''
+
+EXAMPLES = '''
+# Create maintenance window named "Update of www1"
+# for host www1.example.com for 90 minutes
+- zabbix_maintenance: name="Update of www1" 
+                      host=www1.example.com 
+                      state=present
+                      minutes=90
+                      server=https://monitoring.example.com
+                      user=ansible
+                      passwd=pAsSwOrD
+
+# Create maintenance window named "Mass update"
+# for host www1.example.com and host groups Office and Dev
+- zabbix_maintenance: name="Update of www1" 
+                      host=www1.example.com 
+                      group=Office,Dev
+                      state=present
+                      server=https://monitoring.example.com
+                      user=ansible
+                      passwd=pAsSwOrD
+
+# Remove maintenance window named "Test1"
+- zabbix_maintenance: name=Test1" 
+                      state=absent
+                      server=https://monitoring.example.com
+                      user=ansible
+                      passwd=pAsSwOrD
+'''
+
+import datetime, time
+
+try:
+    from zabbix_api import ZabbixAPI
+    HAS_ZABBIX_API = True
+except ImportError:
+    HAS_ZABBIX_API = False
+
+def create_maintenance(zbx, group_ids, host_ids, start_time, maintenance_type, period, name, desc):
+    end_time = start_time + period
+    try:
+        zbx.maintenance.create(
+            {
+                "groupids": group_ids,
+                "hostids": host_ids,
+                "name": name,
+                "maintenance_type": maintenance_type,
+                "active_since": str(start_time),
+                "active_till": str(end_time),
+                "description": desc,
+                "timeperiods":  [{
+                    "timeperiod_type": "0",
+                    "start_date": str(start_time),
+                    "period": str(period),
+                }]
+            }
+        )
+    except BaseException as e:
+        return 1, None, str(e)
+    return 0, None, None
+
+def get_maintenance_id(zbx, name):
+    try:
+        result = zbx.maintenance.get(
+            {
+                "filter":
+                {
+                    "name": name,
+                }
+            }
+        )
+    except BaseException as e:
+        return 1, None, str(e)
+
+    maintenance_ids = []
+    for res in result:
+        maintenance_ids.append(res["maintenanceid"])
+
+    return 0, maintenance_ids, None
+
+def delete_maintenance(zbx, maintenance_id):
+    try:
+        result = zbx.maintenance.delete(maintenance_id)
+    except BaseException as e:
+        return 1, None, str(e)
+    return 0, None, None
+
+def check_maintenance(zbx, name):
+    try:
+        result = zbx.maintenance.exists(
+            {
+                "name": name
+            }
+        )
+    except BaseException as e:
+        return 1, None, str(e)
+    return 0, result, None
+
+def get_group_ids(zbx, group_names):
+    group_ids = []
+    for group in group_names:
+        try:
+            result = zbx.hostgroup.get(
+                {
+                    "output": "extend",
+                    "filter":
+                    {
+                        "name": group
+                    }
+                }
+            )
+        except BaseException as e:
+            return 1, None, str(e)
+
+        if not result:
+            return 1, None, "Group id for group %s not found"%group
+
+        group_ids.append(result[0]["groupid"])
+
+    return 0, group_ids, None
+
+def get_host_ids(zbx, host_names):
+    host_ids = []
+    for host in host_names:
+        try:
+            result = zbx.host.get(
+                {
+                    "output": "extend",
+                    "filter":
+                    {
+                        "name": host
+                    }
+                }
+            )
+        except BaseException as e:
+            return 1, None, str(e)
+
+        if not result:
+            return 1, None, "Host id for host %s not found"%host
+
+        host_ids.append(result[0]["hostid"])
+
+    return 0, host_ids, None
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            state=dict(required=True, default=None, choices=['present', 'absent']),
+            server=dict(required=True, default=None, aliases=['url']),
+            hosts=dict(type='list', required=False, default=None, aliases=['host']),
+            minutes=dict(type='int', required=False, default=10),
+            groups=dict(type='list', required=False, default=None, aliases=['group']),
+            user=dict(required=True, default=None),
+            passwd=dict(required=True, default=None),
+            name=dict(required=True, default=None),
+            desc=dict(required=False, default="Created by Ansible"),
+            collect_data=dict(type='bool', required=False, default=True),
+        ),
+        supports_check_mode=True,
+    )
+
+    if not HAS_ZABBIX_API:
+        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
+
+    hosts = module.params['hosts']
+    groups = module.params['groups']
+    state = module.params['state']
+    user = module.params['user']
+    passwd = module.params['passwd']
+    minutes = module.params['minutes']
+    name = module.params['name']
+    desc = module.params['desc']
+    server = module.params['server']
+    collect_data = module.params['collect_data']
+    if collect_data:
+        maintenance_type = 0
+    else:
+        maintenance_type = 1
+
+
+    try:
+        zbx = ZabbixAPI(server)
+        zbx.login(user, passwd)
+    except BaseException as e:
+        module.fail_json(msg="Failed to connect to Zabbix server: %s"%e)
+
+    changed = False
+
+    if state == "present":
+
+        now = datetime.datetime.now()
+        start_time = time.mktime(now.timetuple())
+        period = 60 * int(minutes) #N * 60 seconds
+
+        if groups:
+            (rc, group_ids, error) = get_group_ids(zbx, groups)
+            if rc != 0:
+                module.fail_json(msg="Failed to get group_ids: %s"%error)
+        else:
+            group_ids = []
+
+        if hosts:
+            (rc, host_ids, error) = get_host_ids(zbx, hosts)
+            if rc != 0:
+                module.fail_json(msg="Failed to get host_ids: %s"%error)
+        else:
+            host_ids = []
+
+        (rc, exists, error) = check_maintenance(zbx, name)
+        if rc != 0:
+            module.fail_json(msg="Failed to check maintenance %s existance: %s"%(name, error))
+
+        if not exists:
+            if not hosts and not groups:
+                module.fail_json(msg="At least one host or host group must be defined for each created maintenance.")
+
+            if module.check_mode:
+                changed = True
+            else:
+                (rc, _, error) = create_maintenance(zbx, group_ids, host_ids, start_time, maintenance_type, period, name, desc)
+                if rc == 0:
+                    changed = True
+                else:
+                    module.fail_json(msg="Failed to create maintenance: %s"%error)
+
+    if state == "absent":
+
+        (rc, exists, error) = check_maintenance(zbx, name)
+        if rc != 0:
+            module.fail_json(msg="Failed to check maintenance %s existance: %s"%(name, error))
+
+        if exists:
+            (rc, maintenance, error) = get_maintenance_id(zbx, name)
+            if rc != 0:
+                module.fail_json(msg="Failed to get maintenance id: %s"%error)
+
+            if maintenance:
+                if module.check_mode:
+                    changed = True
+                else:
+                    (rc, _, error) = delete_maintenance(zbx, maintenance)
+                    if rc == 0:
+                        changed = True
+                    else:
+                        module.fail_json(msg="Failed to remove maintenance: %s"%error)
+
+
+    module.exit_json(changed=changed)
+
+# include magic from lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()

--- a/library/monitoring/zabbix_maintenance
+++ b/library/monitoring/zabbix_maintenance
@@ -25,7 +25,7 @@ module: zabbix_maintenance
 short_description: Create Zabbix maintenance windows
 description:
     - This module will let you create Zabbix maintenance windows.
-version_added: "1.5"
+version_added: "1.6"
 author: Alexander Bulimov
 requirements:
     - zabbix-api python module
@@ -36,38 +36,39 @@ options:
         required: true
         default: null
         choices: [ "present", "absent" ]
-    server:
+    server_url:
         description:
-            - Url of Zabbix server, with schema (http or https).
+            - Url of Zabbix server, with protocol (http or https).
+              C(url) is an alias for C(server_url).
         required: true
         default: null
         aliases: [ "url" ]
-    user:
+    login_user:
         description:
             - Zabbix user name.
         required: true
         default: null
-    passwd:
+    login_password:
         description:
             - Zabbix user password.
         required: true
         default: null
-    hosts:
+    host_names:
         description:
             - Hosts to manage maintenance window for. Separate multiple hosts with commas.
-              C(host) is an alias for C(hosts).
-              B(Required) option when C(state) is I(present) and no C(groups) specified.
+              C(host_name) is an alias for C(host_names).
+              B(Required) option when C(state) is I(present) and no C(host_groups) specified.
         required: false
         default: null
-        aliases: [ "host" ]
-    groups:
+        aliases: [ "host_name" ]
+    host_groups:
         description:
             - Host groups to manage maintenance window for. Separate multiple groups with commas.
-              C(group) is an alias for C(groups).
-              B(Required) option when C(state) is I(present) and no C(hosts) specified.
+              C(host_group) is an alias for C(host_groups).
+              B(Required) option when C(state) is I(present) and no C(host_names) specified.
         required: false
         default: null
-        aliases: [ "group" ]
+        aliases: [ "host_group" ]
     minutes:
         description:
             - Length of maintenance window in minutes.
@@ -102,39 +103,39 @@ EXAMPLES = '''
 # Create maintenance window named "Update of www1"
 # for host www1.example.com for 90 minutes
 - zabbix_maintenance: name="Update of www1" 
-                      host=www1.example.com
+                      host_name=www1.example.com
                       state=present
                       minutes=90
-                      server=https://monitoring.example.com
-                      user=ansible
-                      passwd=pAsSwOrD
+                      server_url=https://monitoring.example.com
+                      login_user=ansible
+                      login_password=pAsSwOrD
 
 # Create maintenance window named "Mass update"
 # for host www1.example.com and host groups Office and Dev
 - zabbix_maintenance: name="Update of www1"
-                      host=www1.example.com
-                      group=Office,Dev
+                      host_name=www1.example.com
+                      host_groups=Office,Dev
                       state=present
-                      server=https://monitoring.example.com
-                      user=ansible
-                      passwd=pAsSwOrD
+                      server_url=https://monitoring.example.com
+                      login_user=ansible
+                      login_password=pAsSwOrD
 
 # Create maintenance window named "update"
-# for host www1.example.com and without data collection.
+# for hosts www1.example.com and db1.example.com and without data collection.
 - zabbix_maintenance: name=update
-                      host=www1.example.com
+                      host_names=www1.example.com,db1.example.com
                       state=present
                       collect_data=false
-                      server=https://monitoring.example.com
-                      user=ansible
-                      passwd=pAsSwOrD
+                      server_url=https://monitoring.example.com
+                      login_user=ansible
+                      login_password=pAsSwOrD
 
 # Remove maintenance window named "Test1"
 - zabbix_maintenance: name=Test1
                       state=absent
-                      server=https://monitoring.example.com
-                      user=ansible
-                      passwd=pAsSwOrD
+                      server_url=https://monitoring.example.com
+                      login_user=ansible
+                      login_password=pAsSwOrD
 '''
 
 import datetime, time
@@ -205,9 +206,9 @@ def check_maintenance(zbx, name):
         return 1, None, str(e)
     return 0, result, None
 
-def get_group_ids(zbx, group_names):
+def get_group_ids(zbx, host_groups):
     group_ids = []
-    for group in group_names:
+    for group in host_groups:
         try:
             result = zbx.hostgroup.get(
                 {
@@ -256,12 +257,12 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(required=True, default=None, choices=['present', 'absent']),
-            server=dict(required=True, default=None, aliases=['url']),
-            hosts=dict(type='list', required=False, default=None, aliases=['host']),
+            server_url=dict(required=True, default=None, aliases=['url']),
+            host_names=dict(type='list', required=False, default=None, aliases=['host_name']),
             minutes=dict(type='int', required=False, default=10),
-            groups=dict(type='list', required=False, default=None, aliases=['group']),
-            user=dict(required=True, default=None),
-            passwd=dict(required=True, default=None),
+            host_groups=dict(type='list', required=False, default=None, aliases=['host_group']),
+            login_user=dict(required=True, default=None),
+            login_password=dict(required=True, default=None),
             name=dict(required=True, default=None),
             desc=dict(required=False, default="Created by Ansible"),
             collect_data=dict(type='bool', required=False, default=True),
@@ -272,15 +273,15 @@ def main():
     if not HAS_ZABBIX_API:
         module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
 
-    hosts = module.params['hosts']
-    groups = module.params['groups']
+    host_names = module.params['host_names']
+    host_groups = module.params['host_groups']
     state = module.params['state']
-    user = module.params['user']
-    passwd = module.params['passwd']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
     minutes = module.params['minutes']
     name = module.params['name']
     desc = module.params['desc']
-    server = module.params['server']
+    server_url = module.params['server_url']
     collect_data = module.params['collect_data']
     if collect_data:
         maintenance_type = 0
@@ -289,8 +290,8 @@ def main():
 
 
     try:
-        zbx = ZabbixAPI(server)
-        zbx.login(user, passwd)
+        zbx = ZabbixAPI(server_url)
+        zbx.login(login_user, login_password)
     except BaseException as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s"%e)
 
@@ -302,15 +303,15 @@ def main():
         start_time = time.mktime(now.timetuple())
         period = 60 * int(minutes) #N * 60 seconds
 
-        if groups:
-            (rc, group_ids, error) = get_group_ids(zbx, groups)
+        if host_groups:
+            (rc, group_ids, error) = get_group_ids(zbx, host_groups)
             if rc != 0:
                 module.fail_json(msg="Failed to get group_ids: %s"%error)
         else:
             group_ids = []
 
-        if hosts:
-            (rc, host_ids, error) = get_host_ids(zbx, hosts)
+        if host_names:
+            (rc, host_ids, error) = get_host_ids(zbx, host_names)
             if rc != 0:
                 module.fail_json(msg="Failed to get host_ids: %s"%error)
         else:
@@ -321,8 +322,8 @@ def main():
             module.fail_json(msg="Failed to check maintenance %s existance: %s"%(name, error))
 
         if not exists:
-            if not hosts and not groups:
-                module.fail_json(msg="At least one host or host group must be defined for each created maintenance.")
+            if not host_names and not host_groups:
+                module.fail_json(msg="At least one host_name or host_group must be defined for each created maintenance.")
 
             if module.check_mode:
                 changed = True

--- a/library/monitoring/zabbix_maintenance
+++ b/library/monitoring/zabbix_maintenance
@@ -25,7 +25,7 @@ module: zabbix_maintenance
 short_description: Create Zabbix maintenance windows
 description:
     - This module will let you create Zabbix maintenance windows.
-version_added: "1.6"
+version_added: "1.7"
 author: Alexander Bulimov
 requirements:
     - zabbix-api python module
@@ -55,17 +55,21 @@ options:
         default: null
     host_names:
         description:
-            - Hosts to manage maintenance window for. Separate multiple hosts with commas.
+            - Hosts to manage maintenance window for.
+              Separate multiple hosts with commas.
               C(host_name) is an alias for C(host_names).
-              B(Required) option when C(state) is I(present) and no C(host_groups) specified.
+              B(Required) option when C(state) is I(present)
+              and no C(host_groups) specified.
         required: false
         default: null
         aliases: [ "host_name" ]
     host_groups:
         description:
-            - Host groups to manage maintenance window for. Separate multiple groups with commas.
+            - Host groups to manage maintenance window for.
+              Separate multiple groups with commas.
               C(host_group) is an alias for C(host_groups).
-              B(Required) option when C(state) is I(present) and no C(host_names) specified.
+              B(Required) option when C(state) is I(present)
+              and no C(host_names) specified.
         required: false
         default: null
         aliases: [ "host_group" ]
@@ -102,7 +106,7 @@ notes:
 EXAMPLES = '''
 # Create maintenance window named "Update of www1"
 # for host www1.example.com for 90 minutes
-- zabbix_maintenance: name="Update of www1" 
+- zabbix_maintenance: name="Update of www1"
                       host_name=www1.example.com
                       state=present
                       minutes=90
@@ -138,13 +142,15 @@ EXAMPLES = '''
                       login_password=pAsSwOrD
 '''
 
-import datetime, time
+import datetime
+import time
 
 try:
     from zabbix_api import ZabbixAPI
     HAS_ZABBIX_API = True
 except ImportError:
     HAS_ZABBIX_API = False
+
 
 def create_maintenance(zbx, group_ids, host_ids, start_time, maintenance_type, period, name, desc):
     end_time = start_time + period
@@ -169,6 +175,7 @@ def create_maintenance(zbx, group_ids, host_ids, start_time, maintenance_type, p
         return 1, None, str(e)
     return 0, None, None
 
+
 def get_maintenance_id(zbx, name):
     try:
         result = zbx.maintenance.get(
@@ -188,12 +195,14 @@ def get_maintenance_id(zbx, name):
 
     return 0, maintenance_ids, None
 
+
 def delete_maintenance(zbx, maintenance_id):
     try:
-        result = zbx.maintenance.delete(maintenance_id)
+        zbx.maintenance.delete(maintenance_id)
     except BaseException as e:
         return 1, None, str(e)
     return 0, None, None
+
 
 def check_maintenance(zbx, name):
     try:
@@ -205,6 +214,7 @@ def check_maintenance(zbx, name):
     except BaseException as e:
         return 1, None, str(e)
     return 0, result, None
+
 
 def get_group_ids(zbx, host_groups):
     group_ids = []
@@ -223,11 +233,12 @@ def get_group_ids(zbx, host_groups):
             return 1, None, str(e)
 
         if not result:
-            return 1, None, "Group id for group %s not found"%group
+            return 1, None, "Group id for group %s not found" % group
 
         group_ids.append(result[0]["groupid"])
 
     return 0, group_ids, None
+
 
 def get_host_ids(zbx, host_names):
     host_ids = []
@@ -246,7 +257,7 @@ def get_host_ids(zbx, host_names):
             return 1, None, str(e)
 
         if not result:
-            return 1, None, "Host id for host %s not found"%host
+            return 1, None, "Host id for host %s not found" % host
 
         host_ids.append(result[0]["hostid"])
 
@@ -288,12 +299,11 @@ def main():
     else:
         maintenance_type = 1
 
-
     try:
         zbx = ZabbixAPI(server_url)
         zbx.login(login_user, login_password)
     except BaseException as e:
-        module.fail_json(msg="Failed to connect to Zabbix server: %s"%e)
+        module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 
     changed = False
 
@@ -301,25 +311,25 @@ def main():
 
         now = datetime.datetime.now()
         start_time = time.mktime(now.timetuple())
-        period = 60 * int(minutes) #N * 60 seconds
+        period = 60 * int(minutes)  # N * 60 seconds
 
         if host_groups:
             (rc, group_ids, error) = get_group_ids(zbx, host_groups)
             if rc != 0:
-                module.fail_json(msg="Failed to get group_ids: %s"%error)
+                module.fail_json(msg="Failed to get group_ids: %s" % error)
         else:
             group_ids = []
 
         if host_names:
             (rc, host_ids, error) = get_host_ids(zbx, host_names)
             if rc != 0:
-                module.fail_json(msg="Failed to get host_ids: %s"%error)
+                module.fail_json(msg="Failed to get host_ids: %s" % error)
         else:
             host_ids = []
 
         (rc, exists, error) = check_maintenance(zbx, name)
         if rc != 0:
-            module.fail_json(msg="Failed to check maintenance %s existance: %s"%(name, error))
+            module.fail_json(msg="Failed to check maintenance %s existance: %s" % (name, error))
 
         if not exists:
             if not host_names and not host_groups:
@@ -332,18 +342,18 @@ def main():
                 if rc == 0:
                     changed = True
                 else:
-                    module.fail_json(msg="Failed to create maintenance: %s"%error)
+                    module.fail_json(msg="Failed to create maintenance: %s" % error)
 
     if state == "absent":
 
         (rc, exists, error) = check_maintenance(zbx, name)
         if rc != 0:
-            module.fail_json(msg="Failed to check maintenance %s existance: %s"%(name, error))
+            module.fail_json(msg="Failed to check maintenance %s existance: %s" % (name, error))
 
         if exists:
             (rc, maintenance, error) = get_maintenance_id(zbx, name)
             if rc != 0:
-                module.fail_json(msg="Failed to get maintenance id: %s"%error)
+                module.fail_json(msg="Failed to get maintenance id: %s" % error)
 
             if maintenance:
                 if module.check_mode:
@@ -353,8 +363,7 @@ def main():
                     if rc == 0:
                         changed = True
                     else:
-                        module.fail_json(msg="Failed to remove maintenance: %s"%error)
-
+                        module.fail_json(msg="Failed to remove maintenance: %s" % error)
 
     module.exit_json(changed=changed)
 

--- a/library/monitoring/zabbix_maintenance
+++ b/library/monitoring/zabbix_maintenance
@@ -102,7 +102,7 @@ EXAMPLES = '''
 # Create maintenance window named "Update of www1"
 # for host www1.example.com for 90 minutes
 - zabbix_maintenance: name="Update of www1" 
-                      host=www1.example.com 
+                      host=www1.example.com
                       state=present
                       minutes=90
                       server=https://monitoring.example.com
@@ -111,16 +111,26 @@ EXAMPLES = '''
 
 # Create maintenance window named "Mass update"
 # for host www1.example.com and host groups Office and Dev
-- zabbix_maintenance: name="Update of www1" 
-                      host=www1.example.com 
+- zabbix_maintenance: name="Update of www1"
+                      host=www1.example.com
                       group=Office,Dev
                       state=present
                       server=https://monitoring.example.com
                       user=ansible
                       passwd=pAsSwOrD
 
+# Create maintenance window named "update"
+# for host www1.example.com and without data collection.
+- zabbix_maintenance: name=update
+                      host=www1.example.com
+                      state=present
+                      collect_data=false
+                      server=https://monitoring.example.com
+                      user=ansible
+                      passwd=pAsSwOrD
+
 # Remove maintenance window named "Test1"
-- zabbix_maintenance: name=Test1" 
+- zabbix_maintenance: name=Test1
                       state=absent
                       server=https://monitoring.example.com
                       user=ansible


### PR DESCRIPTION
Hello. I've wrote simple module to create and remove maintenance windows in Zabbix. It uses zabbix-api python module.

With this module you can, for example, set your hosts to maintenance mode before rolling update, and delete maintenance window after update.
