### PR TITLE
Fixed hostname module for RHEL6 Workstation

### DIFF
--- a/library/system/hostname
+++ b/library/system/hostname
@@ -226,9 +226,14 @@ class RedHat5Hostname(Hostname):
     distribution = 'Redhat'
     strategy_class = RedHatStrategy
 
-class RedHatHostname(Hostname):
+class RedHatServerHostname(Hostname):
     platform = 'Linux'
     distribution = 'Red hat enterprise linux server'
+    strategy_class = RedHatStrategy
+
+class RedHatWorkstationHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Red hat enterprise linux workstation'
     strategy_class = RedHatStrategy
 
 class CentOSHostname(Hostname):


### PR DESCRIPTION
RHEL6 has two variants, server and workstation. Hopefully this can be added to the next 1.4 bug-fix release.
