### PR TITLE
Add 'separate' list filter

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -135,6 +135,9 @@ def symmetric_difference(a, b):
 def union(a, b):
     return set(a).union(b)
 
+def separate(a, b):
+    return b.join(a)
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -195,5 +198,6 @@ class FilterModule(object):
             'difference': difference,
             'symmetric_difference': symmetric_difference,
             'union': union,
+            'separate': separate,
         }
 


### PR DESCRIPTION
'separate' filter allows you to convert a YAML list into a string with
each list member separated by a specified string.

Example usage:

```

---
- hosts: all
  vars:
    gpg_recipients: [ pubkey1, pubkey2, pubkey3 ]

  tasks:
    - name: Encrypt file to multiple recipients
      command: gpg --encrypt -r {{ gpg_recipients|separate(' -r ') }} -a /path/to/file creates=/path/to/file.asc
```
