### PR TITLE
Fix AWS credential params for ec2_ami, ec2_elb, ec2_tag, ec2_vpc, route53, and s3 modules

### DIFF
--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -264,8 +264,8 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             ec2_url = dict(),
-            aws_secret_key = dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True),
-            aws_access_key = dict(aliases=['ec2_access_key', 'access_key']),
+            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
+            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
             instance_id = dict(),
             image_id = dict(),
             delete_snapshot = dict(),

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -257,8 +257,8 @@ def main():
                     'choices': ['present', 'absent']},
             instance_id={'required': True},
             ec2_elbs={'default': None, 'required': False, 'type':'list'},
-            aws_secret_key={'default': None, 'aliases': ['ec2_secret_key', 'secret_key'], 'no_log': True},
-            aws_access_key={'default': None, 'aliases': ['ec2_access_key', 'access_key']},
+            ec2_secret_key={'default': None, 'aliases': ['aws_secret_key', 'secret_key'], 'no_log': True},
+            ec2_access_key={'default': None, 'aliases': ['aws_access_key', 'access_key']},
             region={'default': None, 'required': False, 'aliases':['aws_region', 'ec2_region'], 'choices':AWS_REGIONS},
             enable_availability_zone={'default': True, 'required': False, 'choices': BOOLEANS, 'type': 'bool'},
             wait={'required': False, 'choices': BOOLEANS, 'default': True, 'type': 'bool'}

--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -118,8 +118,8 @@ def main():
             region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
             state = dict(choices=['present', 'absent']),
             ec2_url = dict(aliases=['EC2_URL']),
-            aws_secret_key = dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True),
-            aws_access_key = dict(aliases=['ec2_access_key', 'access_key']),
+            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
+            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
         )
     )
 

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -489,8 +489,8 @@ def main():
             route_tables = dict(type='list'),
             region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
             state = dict(choices=['present', 'absent'], default='present'),
-            aws_secret_key = dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True),
-            aws_access_key = dict(aliases=['ec2_access_key', 'access_key']),
+            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
+            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
         )
     )
 

--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -153,8 +153,8 @@ def main():
             ttl             = dict(required=False, default=3600),
             type            = dict(choices=['A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS'], required=True),
             value           = dict(required=False), 
-            aws_secret_key  = dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True, required=False),
-            aws_access_key  = dict(aliases=['ec2_access_key', 'access_key'], required=False),
+            ec2_secret_key  = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True, required=False),
+            ec2_access_key  = dict(aliases=['aws_access_key', 'access_key'], required=False),
             overwrite       = dict(required=False, type='bool')
         )
     )

--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -258,8 +258,8 @@ def main():
             mode           = dict(choices=['get', 'put', 'delete', 'create', 'geturl', 'getstr'], required=True),
             expiry         = dict(default=600, aliases=['expiration']),
             s3_url         = dict(aliases=['S3_URL']),
-            aws_secret_key  = dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True, required=False),
-            aws_access_key  = dict(aliases=['ec2_access_key', 'access_key'], required=False),
+            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
+            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
             overwrite      = dict(aliases=['force'], default=True, type='bool'),
         ),
     )


### PR DESCRIPTION
The `ec2_ami`, `ec2_elb`, `ec2_tag`, `ec2_vpc`, `route53`, and `s3` modules
all canonicalize the AWS access and secret key params as
`aws_access_key` and `aws_secret_key`. However, following the fixes for #4540,
those modules now use `get_ec2_creds` from `lib/ansible/module_utils/ec2.py`,
which requires access/secret key params to be canonicalized as
`ec2_access_key` and `ec2_secret_key`. As a result, AWS credentials passed
to those six modules as parameters are ignored (they instead always use
the AWS credentials specified via environment variables, or nothing).

So this change fixes those six modules to canonicalize the
AWS access and secret key params as `ec2_access_key` and `ec2_secret_key`,
allowing them to again accept AWS credentials passed via module params.
