### PR TITLE
Fix accelerated mode listen ipv6 always true

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -457,6 +457,7 @@ class PlayBook(object):
             transport=play.transport, sudo_pass=self.sudo_pass, is_playbook=True, module_vars=play.vars,
             default_vars=play.default_vars, check=self.check, diff=self.diff,
             accelerate=play.accelerate, accelerate_port=play.accelerate_port,
+            accelerate_ipv6=play.accelerate_ipv6,
         ).run()
         self.stats.compute(setup_results, setup=True)
 

--- a/library/utilities/accelerate
+++ b/library/utilities/accelerate
@@ -441,7 +441,7 @@ def main():
     timeout   = int(module.params['timeout'])
     minutes   = int(module.params['minutes'])
     debug     = int(module.params['debug'])
-    ipv6      = bool(module.params['ipv6'])
+    ipv6      = json.loads(str(module.params['ipv6']).lower())
 
     if not HAS_KEYCZAR:
         module.fail_json(msg="keyczar is not installed (on the remote side)")


### PR DESCRIPTION
Should be able to take value from accelerate_ipv6 option, default false
