### PR TITLE
playbook: permit the serial attribute to be a percentage string

### DIFF
--- a/docsite/rst/playbooks_delegation.rst
+++ b/docsite/rst/playbooks_delegation.rst
@@ -34,6 +34,18 @@ use case, you can define how many hosts Ansible should manage at a single time b
 In the above example, if we had 100 hosts, 3 hosts in the group 'webservers'
 would complete the play completely before moving on to the next 3 hosts.
 
+The ''serial'' keyword can also be specified as a percentage, which will be applied to the total number of hosts in a
+play, in order to determine the number of hosts per pass::
+
+    - name: test play
+      hosts: websevers
+      serial: "30%"
+
+If the number of hosts does not divide equally into the number of passes, the final pass will contain the remainder.
+
+.. note::
+     No matter how small the percentage, the number of hosts per pass will always be 1 or greater.
+
 .. _maximum_failure_percentage:
 
 Maximum Failure Percentage

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -516,14 +516,27 @@ class PlayBook(object):
         all_hosts = self._list_available_hosts(play.hosts)
         play.update_vars_files(all_hosts)
 
+        if play.serial.endswith("%"):
+
+            # This is a percentage, so calculate it based on the
+            # number of hosts
+            serial_pct = int(play.serial.replace("%",""))
+            serial = int((serial_pct)/100.0 * len(all_hosts))
+
+            # Ensure that no matter how small the percentage, serial
+            # can never fall below 1, so that things actually happen
+            serial = max(serial, 1)
+        else:
+            serial = int(play.serial)
+
         serialized_batch = []
-        if play.serial <= 0:
+        if serial <= 0:
             serialized_batch = [all_hosts]
         else:
             # do N forks all the way through before moving to next
             while len(all_hosts) > 0:
                 play_hosts = []
-                for x in range(play.serial):
+                for x in range(serial):
                     if len(all_hosts) > 0:
                         play_hosts.append(all_hosts.pop())
                 serialized_batch.append(play_hosts)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -521,7 +521,7 @@ class PlayBook(object):
             # This is a percentage, so calculate it based on the
             # number of hosts
             serial_pct = int(play.serial.replace("%",""))
-            serial = int((serial_pct)/100.0 * len(all_hosts))
+            serial = int((serial_pct/100.0) * len(all_hosts))
 
             # Ensure that no matter how small the percentage, serial
             # can never fall below 1, so that things actually happen

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -104,7 +104,7 @@ class Play(object):
             raise errors.AnsibleError('hosts declaration is required')
         elif isinstance(hosts, list):
             hosts = ';'.join(hosts)
-        self.serial           = int(ds.get('serial', 0))
+        self.serial           = str(ds.get('serial', 0))
         self.hosts            = hosts
         self.name             = ds.get('name', self.hosts)
         self._tasks           = ds.get('tasks', [])


### PR DESCRIPTION
Rolling updates with Ansible can suffer from unexpected side effects if the serial attribute is greater than the number of hosts, e.g. a generic deployment playbook used for differently-sized environments. Serial can now be specified as "x%", in which case 'x' will be used to calculate the actual number of hosts (which can never be < 1) for each pass, rounded down.

e.g.

10 hosts
serial: 30%

pass 1:
host01-03

pass 2:
host04-06

pass 3:
host07-09

pass 4:
host10

This PR was spawned from https://groups.google.com/d/topic/ansible-project/2T7kqVz5wzg/discussion 
