### PR TITLE
Fix for documentation playbook loops

### DIFF
--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -128,7 +128,7 @@ It might happen like so::
     - user: name={{ item.name }} state=present generate_ssh_key=yes
       with_items: users
 
-    - authorized_key: user={{ item.0.name }} key="{{ lookup('file', item.1) }}"
+    - authorized_key: "user={{ item.0.name }} key='{{ lookup('file', item.1) }}'"
       with_subelements:
          - users
          - authorized

--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -128,7 +128,7 @@ It might happen like so::
     - user: name={{ item.name }} state=present generate_ssh_key=yes
       with_items: users
 
-    - authorized_key: user={{ item.0.name }} key={{ lookup('file', item.1) }}
+    - authorized_key: user={{ item.0.name }} key="{{ lookup('file', item.1) }}"
       with_subelements:
          - users
          - authorized


### PR DESCRIPTION
if key is used with lookup parameter that needs to be in quotes as
otherwise it will load "ssh-rsa" "<the key>" "<the comment>" as separate
values and fail with "this module requires key=value arguments"
