### PR TITLE
Added support for parsing in the SLES patch level correctly

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -327,7 +327,7 @@ class Facts(object):
                         self.facts['distribution_release'] = ora_prefix + data
                     elif name == 'SuSE':
                         data = get_file_content(path).splitlines()
-                        self.facts['distribution_version'] = data.split[2].split('=')[1].strip()
+                        self.facts['distribution_version'] = data[2].split('=')[1].strip()
                     else:
                         self.facts['distribution'] = name
 

--- a/library/system/setup
+++ b/library/system/setup
@@ -327,7 +327,7 @@ class Facts(object):
                         self.facts['distribution_release'] = ora_prefix + data
                     elif name == 'SuSE':
                         data = get_file_content(path).splitlines()
-                        self.facts['distribution_version'] = data[2].split('=')[1].strip()
+                        self.facts['distribution_release'] = data[2].split('=')[1].strip()
                     else:
                         self.facts['distribution'] = name
 

--- a/library/system/setup
+++ b/library/system/setup
@@ -117,7 +117,8 @@ class Facts(object):
                     '/etc/system-release': 'OtherLinux',
                     '/etc/alpine-release': 'Alpine',
                     '/etc/release': 'Solaris',
-                    '/etc/arch-release': 'Archlinux' }
+                    '/etc/arch-release': 'Archlinux',
+                    '/etc/SuSE-release': 'SuSE' }
     SELINUX_MODE_DICT = { 1: 'enforcing', 0: 'permissive', -1: 'disabled' }
 
     # A list of dicts.  If there is a platform with more than one
@@ -324,6 +325,9 @@ class Facts(object):
                         self.facts['distribution'] = data.split()[0]
                         self.facts['distribution_version'] = data.split()[1]
                         self.facts['distribution_release'] = ora_prefix + data
+                    elif name == 'SuSE':
+                        data = get_file_content(path).splitlines()
+                        self.facts['distribution_version'] = data.split[2].split('=')[1].strip()
                     else:
                         self.facts['distribution'] = name
 


### PR DESCRIPTION
On SLES, the setup module was returning the architecture as the distribution version (i.e. platform.dist() didn't quite return the right thing). This change checks for /etc/SuSE-release and grabs the second column in the third line as distribution_version.
