### PR TITLE
Fix checking for existence of EC2 tags

### DIFF
--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -159,7 +159,7 @@ def main():
         tagdict[tag.name] = tag.value
 
     if state == 'present':
-        if set(tags).issubset(set(tagdict)):
+        if set(tags.items()).issubset(set(tagdict.items())):
             module.exit_json(msg="Tags already exists in %s." %resource, changed=False)
         else:
             for (key, value) in set(tags.items()): 


### PR DESCRIPTION
Without `.items()`, the comparison is:

```
tagdict=set([u'role', u'Name'])
tags=set([u'role'])
```

With `.items()`:

```
tagdict=[(u'role', u'new-app-server'), (u'Name', u'app-server-13-11-27-09-00')]
tags=[(u'role', u'old-app-server')]
```

See https://github.com/ansible/ansible/issues/5077 for history.
