### PR TITLE
Additional target states for virt module: "destroyed" and "paused"

### DIFF
--- a/library/cloud/virt
+++ b/library/cloud/virt
@@ -36,7 +36,7 @@ options:
         since these refer only to VM states. After starting a guest, it may not
         be immediately accessible.
     required: false
-    choices: [ "running", "shutdown" ]
+    choices: [ "running", "shutdown", "destroyed", "paused" ]
     default: "no"
   command:
     description:
@@ -414,13 +414,24 @@ def core(module):
 
         res['changed'] = False
         if state == 'running':
-            if v.status(guest) is not 'running':
+            if v.status(guest) is 'paused':
+                res['changed'] = True
+                res['msg'] = v.unpause(guest)
+            elif v.status(guest) is not 'running':
                 res['changed'] = True
                 res['msg'] = v.start(guest)
         elif state == 'shutdown':
             if v.status(guest) is not 'shutdown':
                 res['changed'] = True
                 res['msg'] = v.shutdown(guest)
+        elif state == 'destroyed':
+            if v.status(guest) is not 'shutdown':
+                res['changed'] = True
+                res['msg'] = v.destroy(guest)
+        elif state == 'paused':
+            if v.status(guest) is 'running':
+                res['changed'] = True
+                res['msg'] = v.pause(guest)
         else:
             module.fail_json(msg="unexpected state")
 
@@ -459,7 +470,7 @@ def main():
 
     module = AnsibleModule(argument_spec=dict(
         name = dict(aliases=['guest']),
-        state = dict(choices=['running', 'shutdown']),
+        state = dict(choices=['running', 'shutdown', 'destroyed', 'paused']),
         command = dict(choices=ALL_COMMANDS),
         uri = dict(default='qemu:///system'),
         xml = dict(),


### PR DESCRIPTION
It's more convenient to do:

```
virt: name=foo state=destroyed
```

than to first test the current state and then do:

```
virt: name=foo command=destroy
```
