### PR TITLE
Avoid a traceback when using accelerate

### DIFF
--- a/lib/ansible/runner/connection_plugins/accelerate.py
+++ b/lib/ansible/runner/connection_plugins/accelerate.py
@@ -86,7 +86,7 @@ class Connection(object):
     def _execute_accelerate_module(self):
         args = "password=%s port=%s debug=%d ipv6=%s" % (base64.b64encode(self.key.__str__()), str(self.accport), int(utils.VERBOSITY), self.runner.accelerate_ipv6)
         inject = dict(password=self.key)
-        if self.runner.accelerate_inventory_host:
+        if getattr(self.runner, 'accelerate_inventory_host', False):
             inject = utils.combine_vars(inject, self.runner.inventory.get_variables(self.runner.accelerate_inventory_host))
         else:
             inject = utils.combine_vars(inject, self.runner.inventory.get_variables(self.host))


### PR DESCRIPTION
This bit of code is attempting to access accelerate_inventory_host,
which may not have been set/created. This will cause a traceback.
Instead use getattr with a fallback to False.

This is related to issue #4244

This might be the wrong fix, the issue may be instead that this attribute isn't getting set nominally, but I figured I'd open the issue with code.
