### PR TITLE
Correct the invocation of ‘_assemble_from_fragments’

### DIFF
--- a/lib/ansible/runner/action_plugins/assemble.py
+++ b/lib/ansible/runner/action_plugins/assemble.py
@@ -28,7 +28,7 @@ class ActionModule(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def _assemble_from_fragments(src_path, delimiter=None):
+    def _assemble_from_fragments(self, src_path, delimiter=None):
         ''' assemble a file from a directory of fragments '''
         tmpfd, temp_path = tempfile.mkstemp()
         tmp = os.fdopen(tmpfd,'w')
@@ -64,7 +64,7 @@ class ActionModule(object):
             return self.runner._execute_module(conn, tmp, 'assemble', module_args, inject=inject, complex_args=complex_args)
 
         # Does all work assembling the file
-        path = _assemble_from_fragments(src, delimiter)
+        path = self._assemble_from_fragments(src, delimiter)
 
         pathmd5 = utils.md5s(path)
         remote_md5 = self.runner._remote_md5(conn, tmp, dest)


### PR DESCRIPTION
The previous commit (82c9f5) didn't work for me.

```
  File "/usr/local/Cellar/ansible/HEAD/lib/python2.7/site-packages/ansible/runner/__init__.py", line 394, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/usr/local/Cellar/ansible/HEAD/lib/python2.7/site-packages/ansible/runner/__init__.py", line 485, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/usr/local/Cellar/ansible/HEAD/lib/python2.7/site-packages/ansible/runner/__init__.py", line 685, in _executor_internal_inner
    result = handler.run(conn, tmp, module_name, module_args, inject, complex_args)
  File "/usr/local/Cellar/ansible/HEAD/lib/python2.7/site-packages/ansible/runner/action_plugins/assemble.py", line 67, in run
    path = _assemble_from_fragments(src, delimiter)
NameError: global name '_assemble_from_fragments' is not defined
```

This PR got rid of that error though. I'm not sure if this is the correct way to fix it though.
