### PR TITLE
hostname module: add support for Amazon Linux

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -122,8 +122,11 @@ def get_distribution():
     if platform.system() == 'Linux':
         try:
             distribution = platform.linux_distribution()[0].capitalize()
-            if distribution == 'NA':
-                if os.path.is_file('/etc/system-release'):
+            if not distribution and os.path.is_file('/etc/system-release'):
+                distribution = platform.linux_distribution(supported_dists=['system'])[0].capitalize()
+                if 'Amazon' in distribution:
+                    distribution = 'Amazon'
+                else:
                     distribution = 'OtherLinux'
         except:
             # FIXME: MethodMissing, I assume?

--- a/library/system/hostname
+++ b/library/system/hostname
@@ -236,6 +236,11 @@ class CentOSHostname(Hostname):
     distribution = 'Centos'
     strategy_class = RedHatStrategy
 
+class AmazonLinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Amazon'
+    strategy_class = RedHatStrategy
+
 # ===========================================
 
 class FedoraStrategy(GenericStrategy):


### PR DESCRIPTION
I added support for Amazon Linux.

In order to add support for Amazon Linux, 
I modified "get_distribution" method of module_utils/basic.py to get "Amazon" distribution,
but I'm not too sure if this is correct.

I found a similar method "get_distribution_facts" on setup module,
but this implementation is very different from module_utils/basic.py's get_distribution.
