### PR TITLE
Answer yes for pkgin list command to update package database if requeste...

### DIFF
--- a/library/packaging/pkgin
+++ b/library/packaging/pkgin
@@ -64,7 +64,7 @@ def query_package(module, pkgin_path, name, state="present"):
 
     if state == "present":
 
-        rc, out, err = module.run_command("%s list | grep ^%s" % (pkgin_path, name))
+        rc, out, err = module.run_command("%s -y list | grep ^%s" % (pkgin_path, name))
 
         if rc == 0:
             # At least one package with a package name that starts with ``name``


### PR DESCRIPTION
...d.

If the pkgin database is outdated the pkgin list command will prompt the user asking if the package database should be updated.  This behavior causes Ansible to hang as well.  Adding the "-y" option to pkgin list will answer yes when prompted and bypass this message.  The "-y" option is already included in the other pkgin commands so this change follows right along with those.
