### PR TITLE
Fix for issue #4730 - stacktrace when deferenencing a non-existent group

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -541,6 +541,7 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
         except TypeError, te:
             if 'StrictUndefined' in str(te):
                 raise errors.AnsibleUndefinedVariable("unable to look up a name or access an attribute in template string")
+
         return res
     except (jinja2.exceptions.UndefinedError, errors.AnsibleUndefinedVariable):
         if fail_on_undefined:

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -533,12 +533,14 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
 
         t.globals['lookup'] = my_lookup
 
-        
-
         jvars =_jinja2_vars(basedir, vars, t.globals, fail_on_undefined)
         new_context = t.new_context(jvars, shared=True)
         rf = t.root_render_func(new_context)
-        res = jinja2.utils.concat(rf)
+        try:
+            res = jinja2.utils.concat(rf)
+        except TypeError, te:
+            if 'StrictUndefined' in str(te):
+                raise errors.AnsibleUndefinedVariable("unable to look up a name or access an attribute in template string")
         return res
     except (jinja2.exceptions.UndefinedError, errors.AnsibleUndefinedVariable):
         if fail_on_undefined:

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -536,13 +536,11 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
         jvars =_jinja2_vars(basedir, vars, t.globals, fail_on_undefined)
         new_context = t.new_context(jvars, shared=True)
         rf = t.root_render_func(new_context)
-
         try:
             res = jinja2.utils.concat(rf)
         except TypeError, te:
             if 'StrictUndefined' in str(te):
                 raise errors.AnsibleUndefinedVariable("unable to look up a name or access an attribute in template string")
-
         return res
     except (jinja2.exceptions.UndefinedError, errors.AnsibleUndefinedVariable):
         if fail_on_undefined:

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -536,6 +536,7 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
         jvars =_jinja2_vars(basedir, vars, t.globals, fail_on_undefined)
         new_context = t.new_context(jvars, shared=True)
         rf = t.root_render_func(new_context)
+
         try:
             res = jinja2.utils.concat(rf)
         except TypeError, te:


### PR DESCRIPTION
Added exception handling for bug reported in issue #4730. My first pull request so I apologize if it is a little messy.
