### PR TITLE
Fix "manual" ansible-playbook example in guide_vagrant.rst

### DIFF
--- a/docsite/rst/guide_vagrant.rst
+++ b/docsite/rst/guide_vagrant.rst
@@ -117,7 +117,7 @@ Here is an example:
 
 .. code-block:: bash
    
-    $ ansible-playbook -i insecure_private_key --private-key=~/.vagrant.d/insecure_private_key -u vagrant playbook.yml
+    $ ansible-playbook -i vagrant_ansible_inventory_machinename --private-key=~/.vagrant.d/insecure_private_key -u vagrant playbook.yml
 
 .. seealso::
 


### PR DESCRIPTION
The given example is trying to load an inventory file with the `-i` option, but somehow the key file name ended up in there instead of the inventory file name. 

I contemplated using `-i vagrant_ansible_inventory_default` instead (which is what my Vagrant demo actually creates) but `-i vagrant_ansible_inventory_machinename` is more consistent with the existing example in the docs.
