### PR TITLE
Add 'remote_dest' argument to the assemble module

### DIFF
--- a/lib/ansible/runner/action_plugins/assemble.py
+++ b/lib/ansible/runner/action_plugins/assemble.py
@@ -66,6 +66,7 @@ class ActionModule(object):
 
         # Does all work assembling the file
         path = self._assemble_from_fragments(src, delimiter)
+        resultant = file(path).read()
 
         pathmd5 = utils.md5s(path)
         remote_md5 = self.runner._remote_md5(conn, tmp, dest)

--- a/lib/ansible/runner/action_plugins/assemble.py
+++ b/lib/ansible/runner/action_plugins/assemble.py
@@ -22,6 +22,7 @@ import pipes
 import shutil
 import tempfile
 from ansible import utils
+from ansible.runner.return_data import ReturnData
 
 class ActionModule(object):
 

--- a/library/files/assemble
+++ b/library/files/assemble
@@ -127,6 +127,7 @@ def main():
             dest = dict(required=True),
             backup=dict(default=False, type='bool'),
             remote_src=dict(default=False, type='bool'),
+            remote_dest=dict(default=False, type='bool'),
             regexp = dict(required=False),
         ),
         add_file_common_args=True


### PR DESCRIPTION
Following on from #5091 and #5119 I've updated the assemble module to have an extra argument, remote_dest. With this it shouldn't be necessary to have the combine module from #5119

I have had to cherry-pick a couple of commits from #5091, but I have only taken the ones that are needed to get this code path to complete without any issues (I believe that some work is still needed to get the assemble module fully working).
