### PR TITLE
Ensure test_command tests are actually correct

### DIFF
--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -146,26 +146,26 @@ class TestRunner(unittest.TestCase):
 
         result = self._run('command', ["/usr/bin/this_does_not_exist", "splat"])
         assert 'msg' in result
-        assert 'failed' in result
+        assert result.get('failed')
 
         result = self._run('shell', ["/bin/echo", "$HOME"])
         assert 'failed' not in result
         assert result['rc'] == 0
 
         result = self._run('command', ["creates='/tmp/ansible command test'", "chdir=/tmp", "touch", "'ansible command test'"])
-        assert 'changed' in result
+        assert result.get('changed')
         assert result['rc'] == 0
 
         result = self._run('command', ["creates='/tmp/ansible command test'", "false"])
-        assert 'skipped' in result
+        assert result.get('skipped')
 
         result = self._run('shell', ["removes=/tmp/ansible\\ command\\ test", "chdir=/tmp", "rm -f 'ansible command test'; echo $?"])
-        assert 'changed' in result
+        assert result.get('changed')
         assert result['rc'] == 0
         assert result['stdout'] == '0'
 
         result = self._run('shell', ["removes=/tmp/ansible\\ command\\ test", "false"])
-        assert 'skipped' in result
+        assert result.get('skipped')
 
     def test_git(self):
         self._run('file', ['path=/tmp/gitdemo', 'state=absent'])


### PR DESCRIPTION
Using

```
assert 'changed' in result
```

doesn't actually check if something is changed if the result is

```
{ 'changed': False, ... }
```

which is presumably the reason for the assertion. What is actually needed is

```
assert result.get('changed')
```

which checks that changed is set and not False. Tests still pass after this change
