### PR TITLE
hg module: Don't modify hgrc when running purge

### DIFF
--- a/library/source_control/hg
+++ b/library/source_control/hg
@@ -59,9 +59,7 @@ options:
         choices: [ "yes", "no" ]
     purge:
         description:
-            - Deletes untracked files. Runs C(hg purge). Note this requires C(purge) extension to
-              be enabled if C(purge=yes). This module will modify hgrc file on behalf of the user
-              and undo the changes before exiting the task.
+            - Deletes untracked files. Runs C(hg purge).
         required: false
         default: "no"
         choices: [ "yes", "no" ]
@@ -85,36 +83,6 @@ EXAMPLES = '''
 - hg: repo=https://bitbucket.org/user/repo1 dest=/home/user/repo1 revision=stable purge=yes
 '''
 
-def _set_hgrc(hgrc, vals):
-    parser = ConfigParser.SafeConfigParser()
-    parser.read(hgrc)
-
-    # val is a list of triple-tuple of the form [(section, option, value),...]
-    for each in vals:
-        (section, option, value) = each
-        if not parser.has_section(section):
-            parser.add_section(section)
-        parser.set(section, option, value)
-
-    f = open(hgrc, 'w')
-    parser.write(f)
-    f.close()
-
-
-def _undo_hgrc(hgrc, vals):
-    parser = ConfigParser.SafeConfigParser()
-    parser.read(hgrc)
-
-    for each in vals:
-        (section, option, value) = each
-        if parser.has_section(section):
-            parser.remove_option(section, option)
-
-    f = open(hgrc, 'w')
-    parser.write(f)
-    f.close()
-
-
 class Hg(object):
 
     def __init__(self, module, dest, repo, revision, hg_path):
@@ -129,7 +97,8 @@ class Hg(object):
         return (rc, out, err)
 
     def _list_untracked(self):
-        return self._command(['purge', '-R', self.dest, '--print'])
+        args = ['purge', '--config', 'extensions.purge=', '-R', self.dest, '--print']
+        return self._command(args)
 
     def get_revision(self):
         """
@@ -168,10 +137,6 @@ class Hg(object):
             return True
 
     def purge(self):
-        hgrc = os.path.join(self.dest, '.hg/hgrc')
-        purge_option = [('extensions', 'purge', '')]
-        _set_hgrc(hgrc, purge_option)   # enable purge extension
-
         # before purge, find out if there are any untracked files
         (rc1, out1, err1) = self._list_untracked()
         if rc1 != 0:
@@ -179,10 +144,9 @@ class Hg(object):
 
         # there are some untrackd files
         if out1 != '':
-            (rc2, out2, err2) = self._command(['purge', '-R', self.dest])
-            if rc2 == 0:
-                _undo_hgrc(hgrc, purge_option)
-            else:
+            args = ['purge', '--config', 'extensions.purge=', '-R', self.dest]
+            (rc2, out2, err2) = self._command(args)
+            if rc2 != 0:
                 self.module.fail_json(msg=err2)
             return True
         else:


### PR DESCRIPTION
Mercurial extensions can be enabled via command-line flags.
