### PR TITLE
Fix new new module_style determination. Fixes #5148

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -84,7 +84,7 @@ class ModuleReplacer(object):
         module_style = 'old'
         if REPLACER in module_data:
             module_style = 'new'
-        elif 'from ansible.snippets.' in module_data:
+        elif 'from ansible.module_utils.' in module_data:
             module_style = 'new'
         elif 'WANT_JSON' in module_data:
             module_style = 'non_native_want_json'


### PR DESCRIPTION
The `ansible.module_common._find_snippet_imports` method improperly detects the "new new" module_style as `old` because it is looking for `ansible.snippets` instead of `ansible.module_utils`

This causes `--check` mode to fail with:

```
demo | success >> {
    "msg": "cannot yet run check mode against old-style modules",
    "skippped": true
}
```
