### PR TITLE
Allow multiple users to use ec2 inventory scripts

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -47,7 +47,7 @@ route53 = False
 # will be written to this directory:
 #   - ansible-ec2.cache
 #   - ansible-ec2.index
-cache_path = /tmp
+cache_path = ~/.ansible/tmp
 
 # The number of seconds a cache file is considered valid. After this many
 # seconds, a new API call will be made, and the cache file will be updated.

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -220,9 +220,12 @@ class Ec2Inventory(object):
                 config.get('ec2', 'route53_excluded_zones', '').split(','))
 
         # Cache related
-        cache_path = config.get('ec2', 'cache_path')
-        self.cache_path_cache = cache_path + "/ansible-ec2.cache"
-        self.cache_path_index = cache_path + "/ansible-ec2.index"
+        cache_dir = os.path.expanduser(config.get('ec2', 'cache_path'))
+        if not os.path.exists(cache_dir):
+            os.makedirs(cache_dir)
+
+        self.cache_path_cache = cache_dir + "/ansible-ec2.cache"
+        self.cache_path_index = cache_dir + "/ansible-ec2.index"
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
         
 


### PR DESCRIPTION
Move the ec2 cache files from a shared /tmp location to the
user's ansible tmp directory.
