### PR TITLE
Improved EC2 multiple account support

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -3,6 +3,11 @@
 
 [ec2]
 
+# If you insist on not using environment variables for AWS access credentials,
+# you can specify the access key and secret key by uncommenting the lines below
+#aws_access_key_id = YOUR_ACCESS_KEY_ID
+#aws_secret_access_key = YOUR_SECRET_ACCESS_KEY
+
 # to talk to a private eucalyptus instance uncomment these lines
 # and edit edit eucalyptus_host to be the host name of your cloud controller
 #eucalyptus = True

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -569,6 +569,11 @@ class Ec2Inventory(object):
     def write_to_cache(self, data, filename):
         ''' Writes data in JSON format to a file '''
 
+        # Create the directory if it doesn't exist
+        directory = os.path.dirname(filename)
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
         json_data = self.json_format_dict(data, True)
         cache = open(filename, 'w')
         cache.write(json_data)


### PR DESCRIPTION
These changes allow a user to define a simple shell wrapper script that they can symlink to define different accounts for different environments. I'm not entirely convinced this is the best way to do this, but it seems the simplest without modifying the way dynamic inventory works. I'd love feedback if anyone thinks there's a better way.

For reference, here is the wrapper script I use:

``` bash
#!/bin/sh

EC2_INI_PATH=../inventory/$(basename "$0").ini
export EC2_INI_PATH
exec ../inventory/ec2.py "$@"
```

I then create a symlink to this file for each config file representing an environment. For example, if I have a `production.ini` config file, I create a symlink named `production`.

**NOTE**: The path to the config and ec2.py scripts should be adjusted for your setup.
