### PR TITLE
Add 'postgres' RDS database engine type

### DIFF
--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -269,7 +269,7 @@ def main():
             command           = dict(choices=['create', 'replicate', 'delete', 'facts', 'modify'], required=True),
             instance_name     = dict(required=True),
             source_instance   = dict(required=False),
-            db_engine         = dict(choices=['MySQL', 'oracle-se1', 'oracle-se', 'oracle-ee', 'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex', 'sqlserver-web'], required=False),
+            db_engine         = dict(choices=['MySQL', 'postgres', 'oracle-se1', 'oracle-se', 'oracle-ee', 'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex', 'sqlserver-web'], required=False),
             size              = dict(required=False), 
             instance_type     = dict(aliases=['type'], choices=['db.t1.micro', 'db.m1.small', 'db.m1.medium', 'db.m1.large', 'db.m1.xlarge', 'db.m2.xlarge', 'db.m2.2xlarge', 'db.m2.4xlarge'], required=False),
             username          = dict(required=False),

--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -47,7 +47,7 @@ options:
     required: false
     default: null
     aliases: []
-    choices: [ 'MySQL', 'oracle-se1', 'oracle-se', 'oracle-ee', 'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex', 'sqlserver-web' ]
+    choices: [ 'MySQL', 'postgres', 'oracle-se1', 'oracle-se', 'oracle-ee', 'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex', 'sqlserver-web' ]
   size:
     description:
       - Size in gigabytes of the initial storage for the DB instance. Used only when command=create or command=modify.


### PR DESCRIPTION
Amazon recently added PostgreSQL support to RDS: http://aws.amazon.com/rds/postgresql/

This adds it as a permitted db_engine so we can provision Postgres RDS instances with Ansible.
