### PR TITLE
More don't catch `SystemExit`

### DIFF
--- a/library/monitoring/nagios
+++ b/library/monitoring/nagios
@@ -214,7 +214,7 @@ def main():
             m = int(minutes)
             if not isinstance(m, types.IntType):
                 module.fail_json(msg='minutes must be a number')
-        except:
+        except Exception:
             module.fail_json(msg='invalid entry for minutes')
 
     ##################################################################

--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -138,7 +138,7 @@ def download_key(module, url):
             module.fail_json("error connecting to download key from url")
         data = connection.read()
         return data
-    except:
+    except Exception:
         module.fail_json(msg="error getting key id from url", traceback=format_exc())
 
 


### PR DESCRIPTION
This fixes issues similar to #5159. I skimmed through all occasions of `except:` in all modules (the `library` directory) and found two more cases.

I have _not_ tested these cases. If anyone could verify them, that would be great.

**Also:** There's plenty of `except:`s in the modules. I've only fixed the bugs that were apparent. These bugs will definitely be be popping up as more `module.fail_json(...)` calls will be added within the `try:`s for corner cases, errors etc. I think there's a systematic error going on here. Two proposed solutions:
- Change all `except:`s to `except Exception:` when they are valid. In most cases that's what you want to do.
- Add a comment about this in the module developer's documentation. Seems like most developer don't keep track of the difference.

Comment on this?
