### PR TITLE
`env-setup` fix for zsh <= 4.3.10

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -5,7 +5,7 @@
 # When run using source as directed, $0 gets set to bash, so we must use $BASH_SOURCE
 if [ -n "$BASH_SOURCE" ] ; then
     HACKING_DIR=`dirname $BASH_SOURCE`
-elif [ ${0:(-9)} = "env-setup" ]; then
+elif [ $(basename $0) = "env-setup" ]; then
     HACKING_DIR=`dirname $0`
 else
     HACKING_DIR="$PWD/hacking"


### PR DESCRIPTION
This fixes issue #5026. It used to work. The regression was
introduced in 2b3381de7c6e0924b29123c33f0627a12418f2c8.
