### PR TITLE
service_module: Fixed false positive on initctl as enable_cmd

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -431,10 +431,10 @@ class LinuxService(Service):
             if check_systemd(self.name):
                 # service is managed by systemd
                 self.enable_cmd = location['systemctl']
-            elif os.path.exists("/etc/init/%s.conf" % self.name):
+            elif os.path.exists("/etc/init/%s.conf" % self.name) and location['initctl']:
                 # service is managed by upstart
                 self.enable_cmd = location['initctl']
-            elif os.path.exists("/etc/init.d/%s" % self.name):
+            elif os.path.exists("/etc/init.d/%s" % self.name) and location['update-rc.d']:
                 # service is managed by with SysV init scripts, but with update-rc.d
                 self.enable_cmd = location['update-rc.d']
             else:
@@ -649,7 +649,7 @@ class LinuxService(Service):
                 return
 
             if self.enable:
-                # make sure the init.d symlinks are created 
+                # make sure the init.d symlinks are created
                 # otherwise enable might not work
                 (rc, out, err) = self.execute_command("%s %s defaults" \
                                                       % (self.enable_cmd, self.name))

--- a/library/system/service
+++ b/library/system/service
@@ -431,10 +431,10 @@ class LinuxService(Service):
             if check_systemd(self.name):
                 # service is managed by systemd
                 self.enable_cmd = location['systemctl']
-            elif os.path.exists("/etc/init/%s.conf" % self.name) and location['initctl']:
+            elif location['initctl'] and os.path.exists("/etc/init/%s.conf" % self.name):
                 # service is managed by upstart
                 self.enable_cmd = location['initctl']
-            elif os.path.exists("/etc/init.d/%s" % self.name) and location['update-rc.d']:
+            elif location['update-rc.d'] and os.path.exists("/etc/init.d/%s" % self.name):
                 # service is managed by with SysV init scripts, but with update-rc.d
                 self.enable_cmd = location['update-rc.d']
             else:


### PR DESCRIPTION
I have a clean Debian "wheezy" box, added the [dotdeb](http://www.dotdeb.org) repository, and installed `php5-fpm`.

I have the following task:

```
- service: "name=php5-fpm enabled=yes state=started"
```

which fails:

```
failed: [debian64.vagrant.malus] => {"failed": true, "item": ""}
msg: service name not recognized
```

After some debugging I realized the problem:

The install of `php5-fpm` created the script `/etc/init.d/php5-fpm` (as it should), and `/etc/init/php5-fpm.conf` (not sure why). The latter one causes the `service` module to assume `initctl` is used for enabling the service. But it's not on my box. It should use `update-rc.d`.

This PR fixes that :)

PS: My experience with Debian is very limited.
