### PR TITLE
rax_required_together is a function

### DIFF
--- a/library/cloud/rax_clb
+++ b/library/cloud/rax_clb
@@ -286,7 +286,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        required_together=rax_required_together,
+        required_together=rax_required_together(),
     )
 
     algorithm = module.params.get('algorithm')


### PR DESCRIPTION
When adding `ansible.module_utils.rax` I missed `()` following a function in the `rax_clb` module.
