### PR TITLE
basic AIX network facts

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1785,6 +1785,61 @@ class FreeBSDNetwork(GenericBsdIfconfigNetwork, Network):
     """
     platform = 'FreeBSD'
 
+class AIXNetwork(GenericBsdIfconfigNetwork, Network):
+    """
+    This is the FreeBSD Network Class.
+    It uses the GenericBsdIfconfigNetwork unchanged.
+    """
+    platform = 'AIX'
+
+    # AIX 'ifconfig -a' does not have three words in the interface line
+    def get_interfaces_info(self, ifconfig_path):
+        interfaces = {}
+        current_if = {}
+        ips = dict(
+            all_ipv4_addresses = [],
+            all_ipv6_addresses = [],
+        )
+        rc, out, err = module.run_command([ifconfig_path, '-a'])
+
+        for line in out.split('\n'):
+
+            if line:
+                words = line.split()
+
+		# only this condition differs from GenericBsdIfconfigNetwork
+                if re.match('^\w*\d*:', line):
+                    current_if = self.parse_interface_line(words)
+                    interfaces[ current_if['device'] ] = current_if
+                elif words[0].startswith('options='):
+                    self.parse_options_line(words, current_if, ips)
+                elif words[0] == 'nd6':
+                    self.parse_nd6_line(words, current_if, ips)
+                elif words[0] == 'ether':
+                    self.parse_ether_line(words, current_if, ips)
+                elif words[0] == 'media:':
+                    self.parse_media_line(words, current_if, ips)
+                elif words[0] == 'status:':
+                    self.parse_status_line(words, current_if, ips)
+                elif words[0] == 'lladdr':
+                    self.parse_lladdr_line(words, current_if, ips)
+                elif words[0] == 'inet':
+                    self.parse_inet_line(words, current_if, ips)
+                elif words[0] == 'inet6':
+                    self.parse_inet6_line(words, current_if, ips)
+                else:
+                    self.parse_unknown_line(words, current_if, ips)
+
+        return interfaces, ips
+
+    # AIX 'ifconfig -a' does not inform about MTU, so remove current_if['mtu'] here
+    def parse_interface_line(self, words):
+        device = words[0][0:-1]
+        current_if = {'device': device, 'ipv4': [], 'ipv6': [], 'type': 'unknown'}
+        current_if['flags'] = self.get_options(words[1])
+        current_if['macaddress'] = 'unknown'    # will be overwritten later
+        return current_if
+
 class OpenBSDNetwork(GenericBsdIfconfigNetwork, Network):
     """
     This is the OpenBSD Network Class.

--- a/library/system/setup
+++ b/library/system/setup
@@ -1787,7 +1787,7 @@ class FreeBSDNetwork(GenericBsdIfconfigNetwork, Network):
 
 class AIXNetwork(GenericBsdIfconfigNetwork, Network):
     """
-    This is the FreeBSD Network Class.
+    This is the AIX Network Class.
     It uses the GenericBsdIfconfigNetwork unchanged.
     """
     platform = 'AIX'


### PR DESCRIPTION
just some minor changes to get AIX network facts
- the AIXNetwork overload class itself
- with adopted regexp in get_interfaces_info for parse_interface_line to match AIX's ifconfig output
- and removed MTU detection in parse_interface_line
