### PR TITLE
Add documentation for usage of encrypted postgresql passwords.

### DIFF
--- a/docsite/README.md
+++ b/docsite/README.md
@@ -7,7 +7,10 @@ Contributions to the documentation are welcome.  To make changes, submit a pull 
 that changes the reStructuredText files in the "rst/" directory only, and Michael can
 do a docs build and push the static files. If you wish to verify output from the markup
 such as link references, you may [install Sphinx] and build the documentation by running
-`make viewdocs` from the `ansible/docsite` directory.
+`make viewdocs` from the `ansible/docsite` directory.  To include module documentation
+you'll need to run `make webdocs` at the top level of the repository.  The generated
+html files are in docsite/htmlout/ and will require Wordpress to render correctly.
+
 
 If you do not want to learn the reStructuredText format, you can also [file issues] about
 documentation problems on the Ansible GitHub project.

--- a/library/database/postgresql_user
+++ b/library/database/postgresql_user
@@ -44,6 +44,7 @@ options:
   password:
     description:
       - set the user's password, before 1.4 this was required.
+      - "When passing an encrypted password it must be generated with the format C('str(\"md5\") + md5( password + username )'), resulting in a total of 35 characters.  An easy way to do this is: C(echo \"md5$(echo -n \"verysecretpasswordJOE\" | md5)\")."
     required: false
     default: null
   db:

--- a/library/database/postgresql_user
+++ b/library/database/postgresql_user
@@ -44,7 +44,7 @@ options:
   password:
     description:
       - set the user's password, before 1.4 this was required.
-      - "When passing an encrypted password it must be generated with the format C('str(\"md5\") + md5( password + username )'), resulting in a total of 35 characters.  An easy way to do this is: C(echo \"md5$(echo -n \"verysecretpasswordJOE\" | md5)\")."
+      - "When passing an encrypted password it must be generated with the format C('str[\\"md5\\"] + md5[ password + username ]'), resulting in a total of 35 characters.  An easy way to do this is: C(echo \\"md5`echo -n \\"verysecretpasswordJOE\\" | md5`\\")."
     required: false
     default: null
   db:


### PR DESCRIPTION
PostgreSQL requires the encrypted password is generated correctly.  Document how to generate this.
