### PR TITLE
Prevents UnicodeEncodeError

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -128,9 +128,15 @@ def display(msg, color=None, stderr=False, screen_only=False, log_only=False, ru
         msg2 = stringc(msg, color)
     if not log_only:
         if not stderr:
-            print msg2
+            try:
+                print msg2
+            except UnicodeEncodeError:
+                print msg2.encode('utf-8')
         else:
-            print >>sys.stderr, msg2
+            try:
+                print >>sys.stderr, msg2
+            except UnicodeEncodeError:
+                print >>sys.stderr, msg2.encode('utf-8')
     if constants.DEFAULT_LOG_PATH != '':
         while msg.startswith("\n"):
             msg = msg.replace("\n","")

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -136,7 +136,10 @@ class ModuleReplacer(object):
             complex_args_json = utils.jsonify(complex_args)
             # We force conversion of module_args to str because module_common calls shlex.split,
             # a standard library function that incorrectly handles Unicode input before Python 2.7.3.
-            encoded_args = repr(module_args.encode('utf-8'))
+            try:
+                encoded_args = repr(module_args.encode('utf-8'))
+            except UnicodeDecodeError:
+                encoded_args = repr(module_args)
             encoded_lang = repr(C.DEFAULT_MODULE_LANG)
             encoded_complex = repr(complex_args_json)
 


### PR DESCRIPTION
Prevents UnicodeEncodeError: 'ascii' codec can't encode character, while printing shell commands output
This fixed a problem to print a user name called "José" from a system with unicode locale.
