### PR TITLE
add fnmatch() support for apt remove too (just like install)

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -267,6 +267,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
 def remove(m, pkgspec, cache, purge=False,
            dpkg_options=expand_dpkg_options(DPKG_OPTIONS)):
     packages = ""
+    pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
     for package in pkgspec:
         name, version = package_split(package)
         installed, upgradable, has_files = package_status(m, name, version, cache, state='remove')


### PR DESCRIPTION
A user reported on irc today that:

```
 apt pkg=apache2* state=absent purge=yes force=yes
```

does not work.

I wrote the fnmatch support and had a quick look and the attached branch should fix the issue.

Bugreport at https://github.com/ansible/ansible/issues/5180
