### PR TITLE
Fix apt module to be able to install package by giving just a provides a...

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -169,6 +169,8 @@ def package_status(m, pkgname, version, cache, state):
         ll_pkg = cache._cache[pkgname] # the low-level package object
     except KeyError:
         if state == 'install':
+            if cache.get_providing_packages(pkgname):
+                return False, True, False
             m.fail_json(msg="No package matching '%s' is available" % pkgname)
         else:
             return False, False, False


### PR DESCRIPTION
...nd not the full name

The apt module check if a packag eis valid by loking in the cache, checking only for
full name, while it should also check that the name is not just provided.
Fix https://github.com/ansible/ansible/issues/5177
