### PR TITLE
user module: force= and remove= should not be mutually exclusive

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -259,7 +259,7 @@ class User(object):
         cmd = [self.module.get_bin_path('userdel', True)]
         if self.force:
             cmd.append('-f')
-        elif self.remove:
+        if self.remove:
             cmd.append('-r')
         cmd.append(self.name)
 


### PR DESCRIPTION
There is a bug in the user module.
the force=yes and remove=yes should not be mutually exclusive.

currently

```
- name: suppress user user
  user: name={{ item.user }}
          force=yes remove=yes
          state=absent
  sudo: yes 
  sudo_user: root
```

does not remove the home dir

this PR fixes the issue
