### PR TITLE
Improve IRC module. Fixes #5186

### DIFF
--- a/library/notification/irc
+++ b/library/notification/irc
@@ -125,8 +125,7 @@ def send_msg(channel, msg, server='localhost', port='6667',
         if re.search('^:\S+ 00[1-4] %s :' % nick, motd, flags=re.M):
             break
         elif time.time() - start > timeout:
-            module.fail_json(msg='Timeout waiting for IRC server welcome '
-                                 'response')
+            raise Exception('Timeout waiting for IRC server welcome response')
         time.sleep(0.5)
 
     irc.send('JOIN %s\r\n' % channel)
@@ -137,7 +136,7 @@ def send_msg(channel, msg, server='localhost', port='6667',
         if re.search('^:\S+ 366 %s %s :' % (nick, channel), join, flags=re.M):
             break
         elif time.time() - start > timeout:
-            module.fail_json(msg='Timeout waiting for IRC JOIN response')
+            raise Exception('Timeout waiting for IRC JOIN response')
         time.sleep(0.5)
 
     irc.send('PRIVMSG %s :%s\r\n' % (channel, message))

--- a/library/notification/irc
+++ b/library/notification/irc
@@ -61,10 +61,16 @@ options:
     description:
       - Server password
     required: false
+  timeout:
+    description:
+      - Timeout to use while waiting for successful registration and join
+        messages, this is to prevent an endless loop
+    default: 30
+    version_added: 1.5
 
 # informational: requirements for nodes
 requirements: [ socket ]
-author: Jan-Piet Mens
+author: Jan-Piet Mens, Matt Martz
 '''
 
 EXAMPLES = '''
@@ -81,19 +87,22 @@ EXAMPLES = '''
 # IRC module support methods.
 #
 
-from time import sleep
+import re
 import socket
 
+from time import sleep
+
+
 def send_msg(channel, msg, server='localhost', port='6667',
-        nick="ansible", color='black', passwd=False):
+             nick="ansible", color='black', passwd=False, timeout=30):
     '''send message to IRC'''
 
     colornumbers = {
-        'black'  : "01",
-        'red'    : "04",
-        'green'  : "09",
-        'yellow' : "08",
-        'blue'   : "12",
+        'black': "01",
+        'red': "04",
+        'green': "09",
+        'yellow': "08",
+        'blue': "12",
     }
 
     try:
@@ -103,18 +112,38 @@ def send_msg(channel, msg, server='localhost', port='6667',
 
     message = "\x03" + colornumber + msg
 
-    irc = socket.socket( socket.AF_INET, socket.SOCK_STREAM )
-    irc.connect( ( server, int(port) ) )
+    irc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    irc.connect((server, int(port)))
     if passwd:
-        irc.send( 'PASS %s\r\n' % passwd )
-    irc.send( 'NICK %s\r\n' % nick )
-    irc.send( 'USER %s %s %s :ansible IRC\r\n' % (nick, nick, nick))
+        irc.send('PASS %s\r\n' % passwd)
+    irc.send('NICK %s\r\n' % nick)
+    irc.send('USER %s %s %s :ansible IRC\r\n' % (nick, nick, nick))
+    motd = ''
+    start = time.time()
+    while 1:
+        motd += irc.recv(1024)
+        if re.search('^:\S+ 00[1-4] %s :' % nick, motd, flags=re.M):
+            break
+        elif time.time() - start > timeout:
+            module.fail_json(msg='Timeout waiting for IRC server welcome '
+                                 'response')
+        time.sleep(0.5)
+
+    irc.send('JOIN %s\r\n' % channel)
+    join = ''
+    start = time.time()
+    while 1:
+        join += irc.recv(1024)
+        if re.search('^:\S+ 366 %s %s :' % (nick, channel), join, flags=re.M):
+            break
+        elif time.time() - start > timeout:
+            module.fail_json(msg='Timeout waiting for IRC JOIN response')
+        time.sleep(0.5)
+
+    irc.send('PRIVMSG %s :%s\r\n' % (channel, message))
     time.sleep(1)
-    irc.send( 'JOIN %s\r\n' % channel )
-    irc.send( 'PRIVMSG %s :%s\r\n' % (channel, message))
-    time.sleep(1)
-    irc.send( 'PART %s\r\n' % channel)
-    irc.send( 'QUIT\r\n' )
+    irc.send('PART %s\r\n' % channel)
+    irc.send('QUIT\r\n')
     time.sleep(1)
     irc.close()
 
@@ -122,32 +151,34 @@ def send_msg(channel, msg, server='localhost', port='6667',
 # Main
 #
 
-def main():
 
+def main():
     module = AnsibleModule(
         argument_spec=dict(
-            server = dict(default='localhost'),
-            port = dict(default = 6667),
-            nick = dict(default = 'ansible'),
-            msg = dict(required = True),
-            color = dict(default="black", choices=["yellow", "red", "green",
-                                                  "blue", "black"]),
-            channel = dict(required = True),
-            passwd = dict()
+            server=dict(default='localhost'),
+            port=dict(default=6667),
+            nick=dict(default='ansible'),
+            msg=dict(required=True),
+            color=dict(default="black", choices=["yellow", "red", "green",
+                                                 "blue", "black"]),
+            channel=dict(required=True),
+            passwd=dict(),
+            timeout=dict(type='int', default=30)
         ),
         supports_check_mode=True
     )
 
-    server  = module.params["server"]
-    port    = module.params["port"]
-    nick    = module.params["nick"]
-    msg     = module.params["msg"]
-    color   = module.params["color"]
+    server = module.params["server"]
+    port = module.params["port"]
+    nick = module.params["nick"]
+    msg = module.params["msg"]
+    color = module.params["color"]
     channel = module.params["channel"]
-    passwd  = module.params["passwd"]
+    passwd = module.params["passwd"]
+    timeout = module.params["timeout"]
 
     try:
-        send_msg(channel, msg, server, port, nick, color, passwd)
+        send_msg(channel, msg, server, port, nick, color, passwd, timeout)
     except Exception, e:
         module.fail_json(msg="unable to send to IRC: %s" % e)
 


### PR DESCRIPTION
See #5186

Currently, the IRC module, opens a connection to the server, and starts sending commands.  Some commands are separated with time.sleep() calls, but we should really be looking for responses from the IRC server to let us know when we can actually send commands.

As it is, on freenode, the "bot" never joins, and thus never sends the message.  This is due to a sleep that is too short.  Basically we need to connect, send NICK and USER, and wait for the server to respond with messages indicating success "registration" (not nick registration, but basically a response that you have successfully connected and can continue).

Additionally, we should wait after joining to ensure that we have actually joined a channel, before sending the string.

I did a bit of reading both on forums, existing IRC bots and RFC2812 and have something that currently works on the following IRC daemons:

ircd-seven (freenode)
InspIRCd

I haven't tested on many others due to lack of existing configurations.

The one problem with IRC servers is that while IRC has an RFC, the majority of the IRC servers do not follow it.  So most IRC clients start with RFCs and then write edge cases to make it work for all networks.

I'd rather not write a full blown IRC client for ansible, since we cannot add a new dependency on a module that could break backwards compatibility, but we can try to make it work better.

Perhaps we can create a module in the future that supports IRC using an existing IRC python module to alleviate the issues, and allow the ansible module to be more flexible, but that is not necessarily my goal with this pull request.

Here is a test for the module:

```
$ ansible localhost -i "localhost," -c local -m irc -a "server=irc.freenode.net channel=#ansible msg=test"
localhost | success >> {
    "changed": false,
    "channel": "#ansible",
    "msg": "test",
    "nick": "ansible"
}
```
