### PR TITLE
npm module: Fix a bug installing local packages globally with npm

### DIFF
--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -122,11 +122,12 @@ class Npm(object):
         else:
             self.name_version = self.name
 
-    def _exec(self, args, run_in_check_mode=False, check_rc=True):
+    def _exec(self, args, run_in_check_mode=False, check_rc=True,
+            skip_global=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
             cmd = [self.executable] + args
 
-            if self.glbl:
+            if self.glbl and not skip_global:
                 cmd.append('--global')
             if self.production:
                 cmd.append('--production')
@@ -162,6 +163,18 @@ class Npm(object):
         #Named dependency not installed
         else:
             missing.append(self.name)
+
+        # If we are installing a package from the local system globally, the
+        # check above will not work since it checks what is missing globally.
+        # In order to see whether our local package is installed or missing,
+        # npm list without the --global flag to get the local package name,
+        # then add it to the list of (global) missing packages.
+        if self.path and self.glbl and not self.name:
+            cmd = ['list', '--json']
+            data = json.loads(self._exec(cmd, True, False, skip_global=True))
+            package_name = data.get('name')
+            if package_name and package_name not in installed:
+                missing.append(package_name)
 
         return installed, missing
 


### PR DESCRIPTION
When specifying a local package with `path` and `global`, the check for
whether that package was missing would always return false. Because the `npm
list` command was run with the `--global` switch, the missing packages would
never contain the local package since there is no way for npm to know about it.

 In order to see whether a local package is or isn't installed locally, we must
do an `npm list` _without_ the global flag inside the local package, then
explicity add it to the list of globally missing packages.

This fixes #5204
