### PR TITLE
Add rax_dns module

### DIFF
--- a/library/cloud/rax_dns
+++ b/library/cloud/rax_dns
@@ -40,6 +40,11 @@ options:
   name:
     description:
       - Domain name to create
+  state:
+    description:
+      - Indicate desired state of the resource
+    choices: ['present', 'absent']
+    default: present
   ttl:
     description:
       - Time to live of domain in seconds

--- a/library/cloud/rax_dns
+++ b/library/cloud/rax_dns
@@ -152,7 +152,6 @@ def rax_dns(module, comment, email, name, state, ttl):
                 domain.delete()
                 changed = True
             except Exception, e:
-                raise
                 module.fail_json(msg='%s' % e.message)
 
     module.exit_json(changed=changed, domain=to_dict(domain))

--- a/library/cloud/rax_dns
+++ b/library/cloud/rax_dns
@@ -1,0 +1,189 @@
+#!/usr/bin/python -tt
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: rax_dns
+short_description: Manage domains on Rackspace Cloud DNS
+description:
+     - Manage domains on Rackspace Cloud DNS
+version_added: 1.5
+options:
+  api_key:
+    description:
+      - Rackspace API key (overrides C(credentials))
+  comment:
+    description:
+      - Brief description of the domain. Maximum length of 160 characters
+  credentials:
+    description:
+      - File to find the Rackspace credentials in (ignored if C(api_key) and
+        C(username) are provided)
+    default: null
+    aliases: ['creds_file']
+  email:
+    desctiption:
+      - Email address of the domain administrator
+  name:
+    description:
+      - Domain name to create
+  ttl:
+    description:
+      - Time to live of domain in seconds
+    default: 3600
+  username:
+    description:
+      - Rackspace username (overrides C(credentials))
+requirements: [ "pyrax" ]
+author: Matt Martz
+notes:
+  - The following environment variables can be used, C(RAX_USERNAME),
+    C(RAX_API_KEY), C(RAX_CREDS_FILE), C(RAX_CREDENTIALS), C(RAX_REGION).
+  - C(RAX_CREDENTIALS) and C(RAX_CREDS_FILE) points to a credentials file
+    appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
+  - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
+  - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+'''
+
+EXAMPLES = '''
+- name: Create domain
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: Domain create request
+      local_action:
+        module: rax_dns
+        credentials: ~/.raxpub
+        name: example.org
+        email: admin@example.org
+      register: rax_dns
+'''
+
+import sys
+import os
+
+from types import NoneType
+
+try:
+    import pyrax
+except ImportError:
+    print("failed=True msg='pyrax required for this module'")
+    sys.exit(1)
+
+NON_CALLABLES = (basestring, bool, dict, int, list, NoneType)
+
+
+def to_dict(obj):
+    instance = {}
+    for key in dir(obj):
+        value = getattr(obj, key)
+        if (isinstance(value, NON_CALLABLES) and not key.startswith('_')):
+            instance[key] = value
+    return instance
+
+
+def rax_dns(module, comment, email, name, state, ttl):
+    changed = False
+
+    dns = pyrax.cloud_dns
+
+    if state == 'present':
+        if not email:
+            module.fail_json(msg='An "email" attribute is required for '
+                                 'creating a domain')
+
+        try:
+            domain = dns.find(name=name)
+        except pyrax.exceptions.NoUniqueMatch, e:
+            module.fail_json(msg='%s' % e.message)
+        except pyrax.exceptions.NotFound:
+            try:
+                domain = dns.create(name=name, emailAddress=email, ttl=ttl,
+                                    comment=comment)
+                changed = True
+            except Exception, e:
+                module.fail_json(msg='%s' % e.message)
+
+        update = {}
+        if comment != getattr(domain, 'comment', None):
+            update['comment'] = comment
+        if ttl != getattr(domain, 'ttl', None):
+            update['ttl'] = ttl
+        if email != getattr(domain, 'emailAddress', None):
+            update['emailAddress'] = email
+
+        if update:
+            try:
+                domain.update(**update)
+                changed = True
+                domain.get()
+            except Exception, e:
+                module.fail_json('%s' % e.message)
+
+    elif state == 'absent':
+        try:
+            domain = dns.find(name=name)
+        except pyrax.exceptions.NotFound:
+            domain = {}
+            pass
+        except Exception, e:
+            module.fail_json(msg='%s' % e.message)
+
+        if domain:
+            try:
+                domain.delete()
+                changed = True
+            except Exception, e:
+                raise
+                module.fail_json(msg='%s' % e.message)
+
+    module.exit_json(changed=changed, domain=to_dict(domain))
+
+
+def main():
+    argument_spec = rax_argument_spec()
+    argument_spec.update(
+        dict(
+            comment=dict(),
+            email=dict(),
+            name=dict(),
+            state=dict(default='present', choices=['present', 'absent']),
+            ttl=dict(type='int', default=3600),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=rax_required_together(),
+    )
+
+    comment = module.params.get('comment')
+    email = module.params.get('email')
+    name = module.params.get('name')
+    state = module.params.get('state')
+    ttl = module.params.get('ttl')
+
+    setup_rax_module(module, pyrax)
+
+    rax_dns(module, comment, email, name, state, ttl)
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.rax import *
+
+### invoke the module
+main()


### PR DESCRIPTION
This module is designed for managing a domain (create, update, remove) on Rackspace Cloud DNS.

Additional modules for managing records and PTR records will come as additional pull requests.
