### PR TITLE
Cast the retrieved `retries` var to an int before incrementing as it may...

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -691,7 +691,7 @@ class Runner(object):
             if not utils.check_conditional(cond,  self.basedir, inject, fail_on_undefined=self.error_on_undefined_vars):
                 retries = self.module_vars.get('retries')
                 delay   = self.module_vars.get('delay')
-                for x in range(1, retries + 1):
+                for x in range(1, int(retries) + 1):
                     # template the delay, cast to float and sleep
                     delay = template.template(self.basedir, delay, inject, expand_lists=False)
                     delay = float(delay)


### PR DESCRIPTION
... be in string form.

For example, the following method of calculating the value will result in a type error:

```
appstatus_waitfor: 4  # Minutes
appstatus_delay: 5 # seconds
appstatus_retries: "{{ mins * 60 / delay }}"
```
