### PR TITLE
apt_key module: support for apt-key keyserver parameter

### DIFF
--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -58,6 +58,11 @@ options:
         default: none
         description:
             - url to retrieve key from.
+    keyserver:
+        required: false
+        default: none
+        description:
+            - keyserver to retrieve key from.
     state:
         required: false
         choices: [ absent, present ]
@@ -141,6 +146,10 @@ def download_key(module, url):
     except:
         module.fail_json(msg="error getting key id from url", traceback=format_exc())
 
+def import_key(module, keyserver, key_id):
+    cmd = "apt-key adv --keyserver %s --recv %s" % (keyserver, key_id)
+    (rc, out, err) = module.run_command(cmd, check_rc=True)
+    return True
 
 def add_key(module, keyfile, keyring, data=None):
     if data is not None:
@@ -175,6 +184,7 @@ def main():
             file=dict(required=False),
             key=dict(required=False),
             keyring=dict(required=False),
+            keyserver=dict(required=False),
             state=dict(required=False, choices=['present', 'absent'], default='present')
         ),
         supports_check_mode=True
@@ -186,6 +196,7 @@ def main():
     filename        = module.params['file']
     keyring         = module.params['keyring']
     state           = module.params['state']
+    keyserver       = module.params['keyserver']
     changed         = False
 
     if key_id:
@@ -206,7 +217,7 @@ def main():
         if key_id and key_id in keys:
             module.exit_json(changed=False)
         else:
-            if not filename and not data:
+            if not filename and not data and not keyserver:
                 data = download_key(module, url)
             if key_id and key_id in keys:
                 module.exit_json(changed=False)
@@ -215,6 +226,8 @@ def main():
                     module.exit_json(changed=True)
                 if filename:
                     add_key(module, filename, keyring)
+                elif keyserver:
+                    import_key(module, keyserver, key_id)
                 else:
                     add_key(module, "-", keyring, data)
                 changed=False


### PR DESCRIPTION
I needed to import a key for apt repository from keyserver. As apt-key module didn't support this, I've modified it a bit, adding this feature. I've started using ansible just yesterday, so don't be too harsh on me ;)
