### PR TITLE
apt: update index before trying to autoinstall python-apt

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -350,7 +350,7 @@ def main():
 
     if not HAS_PYTHON_APT:
         try:
-            module.run_command('apt-get install python-apt -y -q')
+            module.run_command('apt-get update && apt-get install python-apt -y -q')
             global apt, apt_pkg
             import apt
             import apt_pkg


### PR DESCRIPTION
Minor fix to make sure index is updated.
