### PR TITLE
tests depend on the default encoding being utf8

### DIFF
--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -10,6 +10,10 @@ from nose.plugins.skip import SkipTest
 import ansible.utils
 import ansible.utils.template as template2
 
+import sys
+reload(sys)
+sys.setdefaultencoding("utf8") 
+
 class TestUtils(unittest.TestCase):
 
     #####################################


### PR DESCRIPTION
So we set the utils default encoding to be utf8

fixes bug #5224

Signed off by: Matthew Thode prometheanfire@gentoo.org
