### PR TITLE
ec2 inventory: Fail EC2 inventory better with restricted EC2 users

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -295,9 +295,10 @@ class Ec2Inventory(object):
                 for instance in instances:
                     self.add_rds_instance(instance, region)
         except boto.exception.BotoServerError as e:
-            print "Looks like AWS RDS is down: "
-            print e
-            sys.exit(1)
+            if not e.reason == "Forbidden":
+                print "Looks like AWS RDS is down: "
+                print e
+                sys.exit(1)
 
     def get_instance(self, region, instance_id):
         ''' Gets details about a specific instance '''


### PR DESCRIPTION
If a user has full EC2 access but no RDS access, the user
should still be able to query the EC2 inventory, although
will not obtain any information about any RDS instances.
