### PR TITLE
Fix typo for ANSIBLE_FORCE_COLOR in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -765,7 +765,7 @@ Other Core Changes:
 * ability to access inventory variables via 'hostvars' for hosts not yet included in any play, using on demand lookups
 * merged ansible-plugins, ansible-resources, and ansible-docs into the main project
 * you can set ANSIBLE_NOCOWS=1 if you want to disable cowsay if it is installed.  Though no one should ever want to do this!  Cows are great!
-* you can set ANSIBLE_FORCECOLOR=1 to force color mode even when running without a TTY
+* you can set ANSIBLE_FORCE_COLOR=1 to force color mode even when running without a TTY
 * fatal errors are now properly colored red.
 * skipped messages are now cyan, to differentiate them from unchanged messages.
 * extensive documentation upgrades


### PR DESCRIPTION
In https://github.com/ansible/ansible/blob/devel/lib/ansible/color.py it is:

``` PYTHON
if os.getenv("ANSIBLE_FORCE_COLOR") is not None:
        ANSIBLE_COLOR=True
```

In the Changelog it's `ANSIBLE_FORCECOLOR=1`
This feature is not documented elsewhere, and I spent 10 minutes figuring out why it's not working.

Maybe it can help someone else too.
