### PR TITLE
Proposing fix for Issue #4324; adding support for su

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -96,31 +96,46 @@ class Cli(object):
 
         sshpass = None
         sudopass = None
+        su_pass = None
         options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
         # Never ask for an SSH password when we run with local connection
         if options.connection == "local":
             options.ask_pass = False
         options.ask_sudo_pass = options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
-        (sshpass, sudopass) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass)
-        if options.sudo_user or options.ask_sudo_pass:
+        options.ask_su_pass = options.ask_su_pass or C.DEFAULT_ASK_SU_PASS
+        (sshpass, sudopass, su_pass) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass, ask_su_pass=options.ask_su_pass)
+        if options.su_user or options.ask_su_pass:
+            options.su = True
+        elif options.sudo_user or options.ask_sudo_pass:
             options.sudo = True
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
+        options.su_user = options.su_user or C.DEFAULT_SU_USER
         if options.tree:
             utils.prepare_writeable_dir(options.tree)
 
+
         runner = Runner(
-            module_name=options.module_name, module_path=options.module_path,
+            module_name=options.module_name,
+            module_path=options.module_path,
             module_args=options.module_args,
-            remote_user=options.remote_user, remote_pass=sshpass,
-            inventory=inventory_manager, timeout=options.timeout,
+            remote_user=options.remote_user,
+            remote_pass=sshpass,
+            inventory=inventory_manager,
+            timeout=options.timeout,
             private_key_file=options.private_key_file,
             forks=options.forks,
             pattern=pattern,
-            callbacks=self.callbacks, sudo=options.sudo,
-            sudo_pass=sudopass,sudo_user=options.sudo_user,
-            transport=options.connection, subset=options.subset,
+            callbacks=self.callbacks,
+            sudo=options.sudo,
+            sudo_pass=sudopass,
+            sudo_user=options.sudo_user,
+            transport=options.connection,
+            subset=options.subset,
             check=options.check,
-            diff=options.check
+            diff=options.check,
+            su=options.su,
+            su_pass=su_pass,
+            su_user=options.su_user
         )
 
         if options.seconds:

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -90,14 +90,18 @@ def main(args):
 
     sshpass = None
     sudopass = None
+    su_pass = None
     if not options.listhosts and not options.syntax and not options.listtasks:
         options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
         # Never ask for an SSH password when we run with local connection
         if options.connection == "local":
             options.ask_pass = False
         options.ask_sudo_pass = options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
-        (sshpass, sudopass) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass)
+        options.ask_su_pass = options.ask_su_pass or C.DEFAULT_ASK_SU_PASS
+        (sshpass, sudopass, su_pass) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass, ask_su_pass=options.ask_su_pass)
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
+        options.su_user = options.su_user or C.DEFAULT_SU_USER
+
 
     extra_vars = {}
     for extra_vars_opt in options.extra_vars:
@@ -156,7 +160,10 @@ def main(args):
             only_tags=only_tags,
             skip_tags=skip_tags,
             check=options.check,
-            diff=options.diff
+            diff=options.diff,
+            su=options.su,
+            su_pass=su_pass,
+            su_user=options.su_user
         )
 
         if options.listhosts or options.listtasks or options.syntax:

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -127,6 +127,11 @@ DEFAULT_HASH_BEHAVIOUR    = get_config(p, DEFAULTS, 'hash_behaviour', 'ANSIBLE_H
 DEFAULT_LEGACY_PLAYBOOK_VARIABLES = get_config(p, DEFAULTS, 'legacy_playbook_variables', 'ANSIBLE_LEGACY_PLAYBOOK_VARIABLES', True, boolean=True)
 DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBLE_JINJA2_EXTENSIONS', None)
 DEFAULT_EXECUTABLE        = get_config(p, DEFAULTS, 'executable', 'ANSIBLE_EXECUTABLE', '/bin/sh')
+DEFAULT_SU_EXE = get_config(p, DEFAULTS, 'su_exe', 'ANSIBLE_SU_EXE', 'su')
+DEFAULT_SU = get_config(p, DEFAULTS, 'su', 'ANSIBLE_SU', False, boolean=True)
+DEFAULT_SU_FLAGS = get_config(p, DEFAULTS, 'su_flags', 'ANSIBLE_SU_FLAGS', '')
+DEFAULT_SU_USER = get_config(p, DEFAULTS, 'su_user', 'ANSIBLE_SU_USER', 'root')
+DEFAULT_ASK_SU_PASS = get_config(p, DEFAULTS, 'ask_su_pass', 'ANSIBLE_ASK_SU_PASS', False, boolean=True)
 
 DEFAULT_ACTION_PLUGIN_PATH     = get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '/usr/share/ansible_plugins/action_plugins')
 DEFAULT_CALLBACK_PLUGIN_PATH   = get_config(p, DEFAULTS, 'callback_plugins',   'ANSIBLE_CALLBACK_PLUGINS', '/usr/share/ansible_plugins/callback_plugins')
@@ -163,4 +168,5 @@ ANSIBLE_ETCD_URL               = get_config(p, DEFAULTS, 'etcd_url', 'ANSIBLE_ET
 DEFAULT_SUDO_PASS         = None
 DEFAULT_REMOTE_PASS       = None
 DEFAULT_SUBSET            = None
+DEFAULT_SU_PASS           = None
 

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -68,7 +68,11 @@ class PlayBook(object):
         inventory        = None,
         check            = False,
         diff             = False,
-        any_errors_fatal = False):
+        any_errors_fatal = False,
+        su               = False,
+        su_user          = False,
+        su_pass          = False,
+    ):
 
         """
         playbook:         path to a playbook file
@@ -122,6 +126,9 @@ class PlayBook(object):
         self.only_tags        = only_tags
         self.skip_tags        = skip_tags
         self.any_errors_fatal = any_errors_fatal
+        self.su               = su
+        self.su_user          = su_user
+        self.su_pass          = su_pass
 
         self.callbacks.playbook = self
         self.runner_callbacks.playbook = self
@@ -303,20 +310,39 @@ class PlayBook(object):
         self.inventory.restrict_to(hosts)
 
         runner = ansible.runner.Runner(
-            pattern=task.play.hosts, inventory=self.inventory, module_name=task.module_name,
-            module_args=task.module_args, forks=self.forks,
-            remote_pass=self.remote_pass, module_path=self.module_path,
-            timeout=self.timeout, remote_user=task.remote_user,
-            remote_port=task.play.remote_port, module_vars=task.module_vars,
-            default_vars=task.default_vars, private_key_file=self.private_key_file,
-            setup_cache=self.SETUP_CACHE, basedir=task.play.basedir,
-            conditional=task.only_if, callbacks=self.runner_callbacks,
-            sudo=task.sudo, sudo_user=task.sudo_user,
-            transport=task.transport, sudo_pass=task.sudo_pass, is_playbook=True,
-            check=self.check, diff=self.diff, environment=task.environment, complex_args=task.args,
-            accelerate=task.play.accelerate, accelerate_port=task.play.accelerate_port,
+            pattern=task.play.hosts,
+            inventory=self.inventory,
+            module_name=task.module_name,
+            module_args=task.module_args,
+            forks=self.forks,
+            remote_pass=self.remote_pass,
+            module_path=self.module_path,
+            timeout=self.timeout,
+            remote_user=task.remote_user,
+            remote_port=task.play.remote_port,
+            module_vars=task.module_vars,
+            default_vars=task.default_vars,
+            private_key_file=self.private_key_file,
+            setup_cache=self.SETUP_CACHE,
+            basedir=task.play.basedir,
+            conditional=task.only_if,
+            callbacks=self.runner_callbacks,
+            sudo=task.sudo,
+            sudo_user=task.sudo_user,
+            transport=task.transport,
+            sudo_pass=task.sudo_pass,
+            is_playbook=True,
+            check=self.check,
+            diff=self.diff,
+            environment=task.environment,
+            complex_args=task.args,
+            accelerate=task.play.accelerate,
+            accelerate_port=task.play.accelerate_port,
             accelerate_ipv6=task.play.accelerate_ipv6,
-            error_on_undefined_vars=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR
+            error_on_undefined_vars=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR,
+            su=task.su,
+            su_user=task.su_user,
+            su_pass=task.su_pass
         )
 
         if task.async_seconds == 0:
@@ -450,13 +476,30 @@ class PlayBook(object):
 
         # push any variables down to the system
         setup_results = ansible.runner.Runner(
-            pattern=play.hosts, module_name='setup', module_args={}, inventory=self.inventory,
-            forks=self.forks, module_path=self.module_path, timeout=self.timeout, remote_user=play.remote_user,
-            remote_pass=self.remote_pass, remote_port=play.remote_port, private_key_file=self.private_key_file,
-            setup_cache=self.SETUP_CACHE, callbacks=self.runner_callbacks, sudo=play.sudo, sudo_user=play.sudo_user,
-            transport=play.transport, sudo_pass=self.sudo_pass, is_playbook=True, module_vars=play.vars,
-            default_vars=play.default_vars, check=self.check, diff=self.diff,
-            accelerate=play.accelerate, accelerate_port=play.accelerate_port,
+            pattern=play.hosts,
+            module_name='setup',
+            module_args={},
+            inventory=self.inventory,
+            forks=self.forks,
+            module_path=self.module_path,
+            timeout=self.timeout,
+            remote_user=play.remote_user,
+            remote_pass=self.remote_pass,
+            remote_port=play.remote_port,
+            private_key_file=self.private_key_file,
+            setup_cache=self.SETUP_CACHE,
+            callbacks=self.runner_callbacks,
+            sudo=play.sudo,
+            sudo_user=play.sudo_user,
+            transport=play.transport,
+            sudo_pass=self.sudo_pass,
+            is_playbook=True,
+            module_vars=play.vars,
+            default_vars=play.default_vars,
+            check=self.check,
+            diff=self.diff,
+            accelerate=play.accelerate,
+            accelerate_port=play.accelerate_port,
         ).run()
         self.stats.compute(setup_results, setup=True)
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -34,7 +34,7 @@ class Play(object):
        'handlers', 'remote_user', 'remote_port', 'included_roles', 'accelerate',
        'accelerate_port', 'accelerate_ipv6', 'sudo', 'sudo_user', 'transport', 'playbook',
        'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
-       'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct'
+       'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', 'su', 'su_user'
     ]
 
     # to catch typos and so forth -- these are userland names
@@ -121,6 +121,8 @@ class Play(object):
         self.accelerate_port  = ds.get('accelerate_port', None)
         self.accelerate_ipv6  = ds.get('accelerate_ipv6', False)
         self.max_fail_pct     = int(ds.get('max_fail_percentage', 100))
+        self.su               = ds.get('su', self.playbook.su)
+        self.su_user          = ds.get('su_user', self.playbook.su_user)
 
         load_vars = {}
         load_vars['playbook_dir'] = self.basedir
@@ -427,7 +429,8 @@ class Play(object):
 
     # *************************************************
 
-    def _load_tasks(self, tasks, vars=None, default_vars=None, sudo_vars=None, additional_conditions=None, original_file=None, role_name=None):
+    def _load_tasks(self, tasks, vars=None, default_vars=None, sudo_vars=None,
+                    additional_conditions=None, original_file=None, role_name=None):
         ''' handle task and handler include statements '''
 
         results = []
@@ -464,7 +467,7 @@ class Play(object):
 
             if 'meta' in x:
                 if x['meta'] == 'flush_handlers':
-                    results.append(Task(self,x))
+                    results.append(Task(self, x))
                     continue
 
             task_vars = self.vars.copy()
@@ -537,7 +540,13 @@ class Play(object):
                     loaded = self._load_tasks(data, mv, default_vars, included_sudo_vars, list(included_additional_conditions), original_file=include_filename, role_name=new_role)
                     results += loaded
             elif type(x) == dict:
-                task = Task(self,x,module_vars=task_vars,default_vars=default_vars,additional_conditions=list(additional_conditions),role_name=role_name)
+                task = Task(
+                    self, x,
+                    module_vars=task_vars,
+                    default_vars=default_vars,
+                    additional_conditions=list(additional_conditions),
+                    role_name=role_name
+                )
                 results.append(task)
             else:
                 raise Exception("unexpected task type")

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -30,7 +30,8 @@ class Task(object):
         'delegate_to', 'first_available_file', 'ignore_errors',
         'local_action', 'transport', 'sudo', 'remote_user', 'sudo_user', 'sudo_pass',
         'items_lookup_plugin', 'items_lookup_terms', 'environment', 'args',
-        'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until'
+        'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until',
+        'su', 'su_user', 'su_pass'
     ]
 
     # to prevent typos and such
@@ -118,6 +119,7 @@ class Task(object):
         self.tags         = [ 'all' ]
         self.register     = ds.get('register', None)
         self.sudo         = utils.boolean(ds.get('sudo', play.sudo))
+        self.su           = utils.boolean(ds.get('sudo', play.su))
         self.environment  = ds.get('environment', {})
         self.role_name    = role_name
         
@@ -143,13 +145,18 @@ class Task(object):
         else:
             self.remote_user      = ds.get('remote_user', play.playbook.remote_user)
 
+        self.sudo_user    = None
+        self.sudo_pass    = None
+        self.su_user      = None
+        self.su_pass      = None
+
         if self.sudo:
             self.sudo_user    = ds.get('sudo_user', play.sudo_user)
             self.sudo_pass    = ds.get('sudo_pass', play.playbook.sudo_pass)
-        else:
-            self.sudo_user    = None
-            self.sudo_pass    = None
-        
+        elif self.su:
+            self.su_user      = ds.get('su_user', play.su_user)
+            self.su_pass      = ds.get('su_pass', play.playbook.su_pass)
+
         # Both are defined
         if ('action' in ds) and ('local_action' in ds):
             raise errors.AnsibleError("the 'action' and 'local_action' attributes can not be used together")

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -446,8 +446,6 @@ class Runner(object):
         inject['environment'] = self.environment
         inject['playbook_dir'] = self.basedir
 
-        #raise errors.AnsibleError(repr(inject))
-
         if self.inventory.basedir() is not None:
             inject['inventory_dir'] = self.inventory.basedir()
 

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -144,7 +144,7 @@ class Connection(object):
                     return False
         return True
 
-    def exec_command(self, cmd, tmp_path, sudo_user,sudoable=False, executable='/bin/sh'):
+    def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False, su_user=None, su=False, executable='/bin/sh'):
         ''' run a command on the remote host '''
 
         ssh_cmd = self._password_cmd()
@@ -159,7 +159,10 @@ class Connection(object):
             ssh_cmd += ['-6']
         ssh_cmd += [self.host]
 
-        if not self.runner.sudo or not sudoable:
+        if su and su_user:
+            sudocmd, prompt, success_key = utils.make_su_cmd(su_user, executable, cmd)
+            ssh_cmd.append(sudocmd)
+        elif not self.runner.sudo or not sudoable:
             if executable:
                 ssh_cmd.append(executable + ' -c ' + pipes.quote(cmd))
             else:
@@ -194,7 +197,8 @@ class Connection(object):
 
         self._send_password()
 
-        if self.runner.sudo and sudoable and self.runner.sudo_pass:
+        if (self.runner.sudo and sudoable and self.runner.sudo_pass) or \
+                (self.runner.su and su and self.runner.su_pass):
             fcntl.fcntl(p.stdout, fcntl.F_SETFL,
                         fcntl.fcntl(p.stdout, fcntl.F_GETFL) | os.O_NONBLOCK)
             sudo_output = ''
@@ -204,13 +208,16 @@ class Connection(object):
                 if p.stdout in rfd:
                     chunk = p.stdout.read()
                     if not chunk:
-                        raise errors.AnsibleError('ssh connection closed waiting for sudo password prompt')
+                        raise errors.AnsibleError('ssh connection closed waiting for sudo or su password prompt')
                     sudo_output += chunk
                 else:
                     stdout = p.communicate()
-                    raise errors.AnsibleError('ssh connection error waiting for sudo password prompt')
+                    raise errors.AnsibleError('ssh connection error waiting for sudo or su password prompt')
             if success_key not in sudo_output:
-                stdin.write(self.runner.sudo_pass + '\n')
+                if sudoable:
+                    stdin.write(self.runner.sudo_pass + '\n')
+                elif su:
+                    stdin.write(self.runner.su_pass + '\n')
             fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
 
         # We can't use p.communicate here because the ControlMaster may have stdout open as well
@@ -220,12 +227,18 @@ class Connection(object):
         while True:
             rfd, wfd, efd = select.select(rpipes, [], rpipes, 1)
 
-            # fail early if the sudo password is wrong
+            # fail early if the sudo/su password is wrong
             if self.runner.sudo and sudoable and self.runner.sudo_pass:
                 incorrect_password = gettext.dgettext(
                     "sudo", "Sorry, try again.")
                 if stdout.endswith("%s\r\n%s" % (incorrect_password, prompt)):
-                    raise errors.AnsibleError('Incorrect sudo password') 
+                    raise errors.AnsibleError('Incorrect sudo password')
+
+            if self.runner.su and su and self.runner.sudo_pass:
+                incorrect_password = gettext.dgettext(
+                    "su", "Sorry")
+                if stdout.endswith("%s\r\n%s" % (incorrect_password, prompt)):
+                    raise errors.AnsibleError('Incorrect su password')
 
             if p.stdout in rfd:
                 dat = os.read(p.stdout.fileno(), 9000)

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -634,6 +634,8 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
         help='use this file to authenticate the connection')
     parser.add_option('-K', '--ask-sudo-pass', default=False, dest='ask_sudo_pass', action='store_true',
         help='ask for sudo password')
+    parser.add_option('--ask-su-pass', default=False, dest='ask_su_pass',
+                      action='store_true', help='ask for su password')
     parser.add_option('--list-hosts', dest='listhosts', action='store_true',
         help='outputs a list of matching hosts; does not execute anything else')
     parser.add_option('-M', '--module-path', dest='module_path',
@@ -657,11 +659,15 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
     if runas_opts:
         parser.add_option("-s", "--sudo", default=constants.DEFAULT_SUDO, action="store_true",
             dest='sudo', help="run operations with sudo (nopasswd)")
-        parser.add_option('-U', '--sudo-user', dest='sudo_user', help='desired sudo user (default=root)',
-            default=None)   # Can't default to root because we need to detect when this option was given
+        parser.add_option('-U', '--sudo-user', dest='sudo_user', default=None,
+                          help='desired sudo user (default=root)')  # Can't default to root because we need to detect when this option was given
         parser.add_option('-u', '--user', default=constants.DEFAULT_REMOTE_USER,
-            dest='remote_user',
-            help='connect as this user (default=%s)' % constants.DEFAULT_REMOTE_USER)
+            dest='remote_user', help='connect as this user (default=%s)' % constants.DEFAULT_REMOTE_USER)
+
+        parser.add_option('-S', '--su', default=constants.DEFAULT_SU,
+                          action='store_true', help='run operations with su')
+        parser.add_option('-R', '--su-user', help='run operations with su as this '
+                                                  'user (default=%s)' % constants.DEFAULT_SU_USER)
 
     if connect_opts:
         parser.add_option('-c', '--connection', dest='connection',
@@ -688,10 +694,12 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
 
     return parser
 
-def ask_passwords(ask_pass=False, ask_sudo_pass=False):
+def ask_passwords(ask_pass=False, ask_sudo_pass=False, ask_su_pass=False):
     sshpass = None
     sudopass = None
+    su_pass = None
     sudo_prompt = "sudo password: "
+    su_prompt = "su password: "
 
     if ask_pass:
         sshpass = getpass.getpass(prompt="SSH password: ")
@@ -702,7 +710,10 @@ def ask_passwords(ask_pass=False, ask_sudo_pass=False):
         if ask_pass and sudopass == '':
             sudopass = sshpass
 
-    return (sshpass, sudopass)
+    if ask_su_pass:
+        su_pass = getpass.getpass(prompt=su_prompt)
+
+    return (sshpass, sudopass, su_pass)
 
 def do_encrypt(result, encrypt, salt_size=None, salt=None):
     if PASSLIB_AVAILABLE:
@@ -853,6 +864,21 @@ def make_sudo_cmd(sudo_user, executable, cmd):
     sudocmd = '%s -k && %s %s -S -p "%s" -u %s %s -c %s' % (
         C.DEFAULT_SUDO_EXE, C.DEFAULT_SUDO_EXE, C.DEFAULT_SUDO_FLAGS,
         prompt, sudo_user, executable or '$SHELL', pipes.quote('echo %s; %s' % (success_key, cmd)))
+    return ('/bin/sh -c ' + pipes.quote(sudocmd), prompt, success_key)
+
+
+def make_su_cmd(su_user, executable, cmd):
+    """
+    Helper function for connection plugins to create direct su commands
+    """
+    # TODO: work on this function
+    randbits = ''.join(chr(random.randint(ord('a'), ord('z'))) for x in xrange(32))
+    prompt = 'assword: '
+    success_key = 'SUDO-SUCCESS-%s' % randbits
+    sudocmd = '%s %s %s %s -c %s' % (
+        C.DEFAULT_SU_EXE, C.DEFAULT_SU_FLAGS, su_user, executable or '$SHELL',
+        pipes.quote('echo %s; %s' % (success_key, cmd))
+    )
     return ('/bin/sh -c ' + pipes.quote(sudocmd), prompt, success_key)
 
 _TO_UNICODE_TYPES = (unicode, type(None))


### PR DESCRIPTION
For Issue #4324, this adds support for `su`.
- add su support to `bin/ansible`
- su support added into the `runner.Runner` class
- ssh conn plugin updated to allow su-able commands
- necessary helper functions added into ansible.utils module
- add su support to `bin/ansible-playbook` and
- add relevant su support to playbook code in lib
- resolve issues where remote /tmp dir has improper permissions; ensure chmod issues are handled in situations where the su user is not root

Tests ran ok:

```
Ran 93 tests in 41.325s

OK (SKIP=1)
```

**The glaring omission here is lack of hostvars support**.  This does not incorporate su-ing via hostvars.  Basically, I'm soliciting feedback on this -- like, should we implement this support and how...or is this even the right direction to take for adding su support in Ansible.   Perhaps you know what I mean.

Hey, did you guys know that the Ansible codebase is complex and has tons of stuff going on?  Of course you did!  But I didn't, not until I worked on su, so here's hoping my proposed PR here is good enough.  ;)  Thanks, dudes.
