### PR TITLE
synchronize module: override sudo settings.

### DIFF
--- a/lib/ansible/runner/action_plugins/synchronize.py
+++ b/lib/ansible/runner/action_plugins/synchronize.py
@@ -39,9 +39,6 @@ class ActionModule(object):
         if inject.get('delegate_to') is None:
             inject['delegate_to'] = '127.0.0.1'
             inject['ansible_connection'] = 'local'
-            # If sudo is active, disable from the connection set self.sudo to True.
-            if self.runner.sudo:
-                self.runner.sudo = False
 
     def run(self, conn, tmp, module_name, module_args,
         inject, complex_args=None, **kwargs):


### PR DESCRIPTION
Not sure what was a logic here, but it's definitely a bug:

<pre>
$ ls -la /tmp/
drwx------   3 root           wheel   102 11 дек 18:31 3
</pre>


Before patch:

<pre>
$ ansible -i localhost localhost -s -m synchronize -a 'src=/tmp/3/only_root_can_see_me dest=/tmp/ archive=no' -vvv
<127.0.0.1> EXEC ['/bin/sh', '-c', 'mkdir -p /tmp/ansible-1386779541.35-27956844187075 && chmod a+rx /tmp/ansible-1386779541.35-27956844187075 && echo /tmp/ansible-1386779541.35-27956844187075']
<127.0.0.1> PUT /var/folders/12/q4kqxh314sd_yvs2j74djwgr0000gn/T/tmptR5Puv TO /tmp/ansible-1386779541.35-27956844187075/synchronize
<127.0.0.1> EXEC ['/bin/sh', '-c', '/usr/bin/python /tmp/ansible-1386779541.35-27956844187075/synchronize; rm -rf /tmp/ansible-1386779541.35-27956844187075/ >/dev/null 2>&1']
127.0.0.1 | FAILED >> {
    "cmd": "rsync --delay-updates --compress --timeout=10 --rsh 'ssh  -o StrictHostKeyChecking=no' --out-format='<<CHANGED>>%i %n%L' /tmp/3/only_root_can_see_me /tmp/",
    "failed": true,
    "msg": "rsync: change_dir \"/tmp/3\" failed: Permission denied (13)\nrsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1122) [sender=3.0.9]\n",
    "rc": 23
}
</pre>


After:

<pre>
$ ansible -i localhost localhost -m synchronize -a 'src=/tmp/3/only_root_can_see_me dest=/tmp/ archive=no' -vvv
<127.0.0.1> EXEC ['/bin/sh', '-c', 'mkdir -p /tmp/ansible-1386780260.79-48898061431143 && chmod a+rx /tmp/ansible-1386780260.79-48898061431143 && echo /tmp/ansible-1386780260.79-48898061431143']
<127.0.0.1> PUT /var/folders/12/q4kqxh314sd_yvs2j74djwgr0000gn/T/tmp3597pf TO /tmp/ansible-1386780260.79-48898061431143/synchronize
<127.0.0.1> EXEC ['/bin/sh', '-c', '/usr/bin/python /tmp/ansible-1386780260.79-48898061431143/synchronize; rm -rf /tmp/ansible-1386780260.79-48898061431143/ >/dev/null 2>&1']
127.0.0.1 | FAILED >> {
    "cmd": "rsync --delay-updates --compress --timeout=10 --rsh 'ssh  -o StrictHostKeyChecking=no' --out-format='<<CHANGED>>%i %n%L' /tmp/3/only_root_can_see_me /tmp/",
    "failed": true,
    "msg": "rsync: change_dir \"/tmp/3\" failed: Permission denied (13)\nrsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1122) [sender=3.0.9]\n",
    "rc": 23
}

$ ansible -i localhost localhost -s -m synchronize -a 'src=/tmp/3/only_root_can_see_me dest=/tmp/ archive=no' -vvv
<127.0.0.1> EXEC ['/bin/sh', '-c', 'mkdir -p /tmp/ansible-1386780268.01-198016953500339 && chmod a+rx /tmp/ansible-1386780268.01-198016953500339 && echo /tmp/ansible-1386780268.01-198016953500339']
<127.0.0.1> PUT /var/folders/12/q4kqxh314sd_yvs2j74djwgr0000gn/T/tmpsXHNYY TO /tmp/ansible-1386780268.01-198016953500339/synchronize
<127.0.0.1> EXEC /bin/sh -c 'sudo -k && sudo -H -S -p "[sudo via ansible, key=isboirorpjyaxqnsqyazgcjuvxlhetvf] password: " -u root /bin/sh -c '"'"'echo SUDO-SUCCESS-isboirorpjyaxqnsqyazgcjuvxlhetvf; /usr/bin/python /tmp/ansible-1386780268.01-198016953500339/synchronize; rm -rf /tmp/ansible-1386780268.01-198016953500339/ >/dev/null 2>&1'"'"''
127.0.0.1 | success >> {
    "changed": true,
    "cmd": "rsync --delay-updates --compress --timeout=10 --rsh 'ssh  -o StrictHostKeyChecking=no' --rsync-path 'sudo rsync' --out-format='<<CHANGED>>%i %n%L' /tmp/3/only_root_can_see_me /tmp/",
    "msg": ">f++++++++++ only_root_can_see_me\n",
    "rc": 0
}
</pre>
