### PR TITLE
Make sure ssh pipes are empty before moving on

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -237,9 +237,13 @@ class Connection(object):
                 stderr += dat
                 if dat == '':
                     rpipes.remove(p.stderr)
-            if not rpipes or p.poll() is not None:
-                p.wait()
+            # only break out if we've emptied the pipes, or there is nothing to
+            # read from and the process has finished.
+            if (not rpipes or not rfd) and p.poll() is not None:
                 break
+            # Calling wait while there are still pipes to read can cause a lock
+            elif not rpipes and p.poll() == None:
+                p.wait()
         stdin.close() # close stdin after we read from stdout (see also issue #848)
         
         if C.HOST_KEY_CHECKING and not_in_host_file:


### PR DESCRIPTION
Resolves issue #5082

Code as it was would hit a scenario where one of the FDs was not ready for
reading the first time through -- but p.poll() would show the process as
complete. This would cause ansible to continue on, while leaving some content
left in a pipe.

The other scenario -- the one that causes the unclosed quote, is if we go
through select.select() and we do get stdout in the ready for reading -- we
read from it (9000 bytes), but that's not all that is there. Again we'd get to
the p.poll() check and it would be indeed not none, but we would have left some
of stdout on the FD and thus the json blob would be malformed.

Tested with and without full ssh debugging.
Tested with and without ControlPersist
Tested with and without ControlPersist sockets already created
