### PR TITLE
Adding absent condition for to the wait_for module

### DIFF
--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -34,8 +34,8 @@ description:
        which is true of certain Java application servers. It is also 
        useful when starting guests with the M(virt) module and
        needing to pause until they are ready. This module can 
-       also be used to wait for a file to be available on the filesystem
-       or with a regex match a string to be present in a file.
+       also be used to wait for a file to be available or absent on the 
+       filesystem or with a regex match a string to be present in a file.
 version_added: "0.7"
 options:
   host:
@@ -60,10 +60,10 @@ options:
     required: false
   state:
     description:
-      - either C(present), C(started), or C(stopped) 
+      - either C(present), C(started), or C(stopped), C(absent)
       - When checking a port C(started) will ensure the port is open, C(stopped) will check that it is closed
-      - When checking for a file or a search string C(present) or C(started) will ensure that the file or string is present before continuing
-    choices: [ "present", "started", "stopped" ]
+      - When checking for a file or a search string C(present) or C(started) will ensure that the file or string is present before continuing, C(absent) will check that file is absent or removed
+    choices: [ "present", "started", "stopped", "absent" ]
     default: "started"
   path:
     version_added: "1.4"
@@ -78,7 +78,7 @@ options:
    
 notes: []
 requirements: []
-author: Jeroen Hoekx, John Jarvis
+author: Jeroen Hoekx, John Jarvis, Andrii Radyk
 '''
 
 EXAMPLES = '''
@@ -91,6 +91,12 @@ EXAMPLES = '''
 
 # wait until the string "completed" is in the file /tmp/foo before continuing
 - wait_for: path=/tmp/foo search_regex=completed
+
+# wait until the lock file is removed
+- wait_for: path=/var/lock/file.lock state=absent 
+
+# wait until the process is finished and pid was destroyed
+- wait_for: path=/proc/3466/status state=absent
 
 '''
 
@@ -105,7 +111,7 @@ def main():
             port=dict(default=None),
             path=dict(default=None),
             search_regex=dict(default=None),
-            state=dict(default='started', choices=['started', 'stopped', 'present']),
+            state=dict(default='started', choices=['started', 'stopped', 'present', 'absent']),
         ),
     )
 
@@ -133,23 +139,35 @@ def main():
     if delay:
         time.sleep(delay)
 
-    if state == 'stopped':
+    if state in [ 'stopped', 'absent' ]:
         ### first wait for the stop condition
         end = start + datetime.timedelta(seconds=timeout)
 
         while datetime.datetime.now() < end:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(connect_timeout)
-            try:
-                s.connect( (host, port) )
-                s.shutdown(socket.SHUT_RDWR)
-                s.close()
-                time.sleep(1)
-            except:
-                break
+            if path:
+                try:
+                    f = open(path)
+                    f.close()
+                    time.sleep(1)
+                    pass
+                except IOError:
+                    break
+            elif port:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.settimeout(connect_timeout)
+                try:
+                    s.connect( (host, port) )
+                    s.shutdown(socket.SHUT_RDWR)
+                    s.close()
+                    time.sleep(1)
+                except:
+                    break
         else:
             elapsed = datetime.datetime.now() - start
-            module.fail_json(msg="Timeout when waiting for %s:%s to stop." % (host, port), elapsed=elapsed.seconds)
+            if port:
+                module.fail_json(msg="Timeout when waiting for %s:%s to stop." % (host, port), elapsed=elapsed.seconds)
+            elif path:
+                module.fail_json(msg="Timeout when waiting for %s to be absent." % (path), elapsed=elapsed.seconds)
 
     elif state in ['started', 'present']:
         ### wait for start condition


### PR DESCRIPTION
Adds absent state to wait_for to wait for a file to be absent on the file 
system before continuing. This allows to wait until the lock file is removed 
or specific process is finished and its pid is destroyed
