### PR TITLE
improve error on invalid vars file (if its a list instead of a dict)

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -188,6 +188,8 @@ class Play(object):
             if os.path.isfile(vars):
                 vars_data = utils.parse_yaml_from_file(vars)
                 if vars_data:
+                    if not isinstance(vars_data, dict):
+                        raise errors.AnsibleError("vars from '%s' are not a dict" % vars)
                     role_vars = utils.combine_vars(vars_data, role_vars)
             defaults = self._resolve_main(utils.path_dwim(self.basedir, os.path.join(role_path, 'defaults')))
             defaults_data = {}


### PR DESCRIPTION
This branch improves the error message when a roles var file is in the wrong format (in my case, list instead of dict).

I made a mistake in my vars file and it was a list instead of a dict. This caused a somewhat cryptic error message:

```
$ cat vars/main.yml
- include: zimk_ntp.yml
$ ansible-playbook --list-tasks site.yml
[...]
AttributeError: 'list' object has no attribute 'items'
```

and it took me a bit to figure out what I did wrong. This branch should make it more obvious to users like me where to look:

```
$ ansible-playbook --list-tasks site.yml
ERROR: vars from '/home/mvo/src/ansible-config/roles/base-server/vars/main.yml' are not a dict
```

I'm happy to change the exact message if you prefer a different wording and/or provide better instructions how to reproduce. Just let me know what you need :)

Cheers,
 Michael
