### PR TITLE
file module: Fixed missing prev_state == 'directory' in file

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -307,6 +307,10 @@ def main():
             if not force:
                 module.fail_json(dest=path, src=src, msg='Cannot link, file exists at destination')
             changed = True
+        elif prev_state == 'directory':
+            if not force:
+                module.fail_json(dest=path, src=src, msg='Cannot link, directory exists at destination')
+            changed = True
         else:
             module.fail_json(dest=path, src=src, msg='unexpected position reached')
 


### PR DESCRIPTION
In a previous pull request I had submitted a change that fixed an issue with using force == True on directories and symlinks. However, I had thought that the oversight was just in the if statement. After trying the same command on the latest version of ansible, I'm encountering a missing case in the confirmation of change. I've added the missing case below.
