### PR TITLE
Add ansible.cfg setting for ANSIBLE_FORCE_COLOR

### DIFF
--- a/lib/ansible/color.py
+++ b/lib/ansible/color.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import sys
 import constants
 
@@ -37,7 +36,7 @@ else:
         # curses returns an error (e.g. could not find terminal)
         ANSIBLE_COLOR=False
 
-if os.getenv("ANSIBLE_FORCE_COLOR") is not None:
+if constants.ANSIBLE_FORCE_COLOR:
         ANSIBLE_COLOR=True
 
 # --- begin "pretty"

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -136,6 +136,7 @@ DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       '
 DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '/usr/share/ansible_plugins/filter_plugins')
 DEFAULT_LOG_PATH               = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
 
+ANSIBLE_FORCE_COLOR            = get_config(p, DEFAULTS, 'force_color', 'ANSIBLE_FORCE_COLOR', None, boolean=True)
 ANSIBLE_NOCOLOR                = get_config(p, DEFAULTS, 'nocolor', 'ANSIBLE_NOCOLOR', None, boolean=True)
 ANSIBLE_NOCOWS                 = get_config(p, DEFAULTS, 'nocows', 'ANSIBLE_NOCOWS', None, boolean=True)
 DISPLAY_SKIPPED_HOSTS          = get_config(p, DEFAULTS, 'display_skipped_hosts', 'DISPLAY_SKIPPED_HOSTS', True, boolean=True)


### PR DESCRIPTION
Continuation of #5243

I added a `constants.py` variable, and changed the logic in `color.py` to check that instead of the Env. Variable.

I also updated the documentation and the example ansible.cfg. Should I push those here too, or make a separate pull request?
