### PR TITLE
Added ability to start and stop existing EC2 instances.

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -17,9 +17,9 @@
 DOCUMENTATION = '''
 ---
 module: ec2
-short_description: create or terminate an instance in ec2, return instanceid
+short_description: create, terminate, start or stop an instance in ec2, return instanceid
 description:
-     - Creates or terminates ec2 instances. When created optionally waits for it to be 'running'. This module has a dependency on python-boto >= 2.5
+     - Creates, terminates, starts or stops ec2 instances. When created or started optionally waits for it to be 'running'. This module has a dependency on python-boto >= 2.5
 version_added: "0.9"
 options:
   key_name:
@@ -156,13 +156,6 @@ options:
     required: false
     default: null
     aliases: []
-  assign_public_ip:
-    version_added: "1.4"
-    description:
-      - when provisioning within vpc, assign a public IP address. Boto library must be 2.13.0+
-    required: false
-    default: null
-    aliases: []
   private_ip:
     version_added: "1.2"
     description:
@@ -245,7 +238,7 @@ local_action:
     image: ami-6e649707
     wait: yes
     vpc_subnet_id: subnet-29e63245
-    assign_public_ip: yes
+
 
 # Launch instances, runs some tasks
 # and then terminate them
@@ -289,6 +282,50 @@ local_action:
         state: 'absent'
         instance_ids: {{ec2.instance_ids}}
 
+
+# Start a few existing instances, run some tasks
+# and stop the instances
+
+- name: Start sandbox instances
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    instance_ids:
+    - 'i-xxxxxx'
+    - 'i-xxxxxx'
+    - 'i-xxxxxx'
+    region: us-east-1
+  tasks:
+    - name: Start the sandbox instances
+      local_action:
+	    module: ec2
+	    instance_ids: '{{ instance_ids }}'
+	    region: '{{ region }}'
+	    state: running
+	    wait: True
+  role:
+    - do_neat_stuff
+    - do_more_neat_stuff
+
+- name: Stop sandbox instances
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    instance_ids:
+    - 'i-xxxxxx'
+    - 'i-xxxxxx'
+    - 'i-xxxxxx'
+    region: us-east-1
+  tasks:
+    - name: Stop the sanbox instances
+      local_action:
+	   module: e2
+  	   instance_ids: '{{ instance_ids }}'
+	   region: {'{ region }}'
+	   state: stopped
+       wait: True
 '''
 
 import sys
@@ -343,24 +380,6 @@ def get_instance_info(inst):
 
     return instance_info
 
-def boto_supports_associate_public_ip_address(ec2):
-    """
-    Check if Boto library has associate_public_ip_address in the NetworkInterfaceSpecification
-    class. Added in Boto 2.13.0
-
-    ec2: authenticated ec2 connection object
-
-    Returns:
-        True if Boto library accepts associate_public_ip_address argument, else false
-    """
-
-    try:
-        network_interface = boto.ec2.networkinterface.NetworkInterfaceSpecification()
-        getattr(network_interface, "associate_public_ip_address")
-        return True
-    except AttributeError:
-        return False
-
 def boto_supports_profile_name_arg(ec2):
     """
     Check if Boto library has instance_profile_name argument. instance_profile_name has been added in Boto 2.5.0
@@ -403,9 +422,9 @@ def create_instances(module, ec2):
     user_data = module.params.get('user_data')
     instance_tags = module.params.get('instance_tags')
     vpc_subnet_id = module.params.get('vpc_subnet_id')
-    assign_public_ip = module.boolean(module.params.get('assign_public_ip'))
     private_ip = module.params.get('private_ip')
     instance_profile_name = module.params.get('instance_profile_name')
+
 
     # group_id and group_name are exclusive of each other
     if group_id and group_name:
@@ -465,6 +484,7 @@ def create_instances(module, ec2):
                       'instance_type': instance_type,
                       'kernel_id': kernel,
                       'ramdisk_id': ramdisk,
+                      'subnet_id': vpc_subnet_id,
                       'private_ip_address': private_ip,
                       'user_data': user_data}
 
@@ -475,28 +495,10 @@ def create_instances(module, ec2):
                     module.fail_json(
                         msg="instance_profile_name parameter requires Boto version 2.5.0 or higher")
 
-            if assign_public_ip:
-                if not boto_supports_associate_public_ip_address(ec2):
-                    module.fail_json(
-                        msg="assign_public_ip parameter requires Boto version 2.13.0 or higher.")
-                elif not vpc_subnet_id:
-                    module.fail_json(
-                        msg="assign_public_ip only available with vpc_subnet_id")
-
-                else:
-                    interface = boto.ec2.networkinterface.NetworkInterfaceSpecification(
-                        subnet_id=vpc_subnet_id,
-                        groups=group_id,
-                        associate_public_ip_address=assign_public_ip)
-                    interfaces = boto.ec2.networkinterface.NetworkInterfaceCollection(interface)
-                    params['network_interfaces'] = interfaces
-
+            if vpc_subnet_id:
+                params['security_group_ids'] = group_id
             else:
-                params['subnet_id'] = vpc_subnet_id
-                if vpc_subnet_id:
-                    params['security_group_ids'] = group_id
-                else:
-                    params['security_groups'] = group_name
+                params['security_groups'] = group_name
 
             res = ec2.run_instances(**params)
         except boto.exception.BotoServerError, e:
@@ -620,6 +622,78 @@ def terminate_instances(module, ec2, instance_ids):
 
     return (changed, instance_dict_array, terminated_instance_ids)
 
+def startstop_instances(module, ec2, instance_ids):
+    """
+    Starts or stops a list of existing instances
+
+    module: Ansible module object
+    ec2: authenticated ec2 connection object
+    instance_ids: The list of instances to start in the form of
+      [ {id: <inst-id>}, ..]
+
+    Returns a dictionary of instance information
+    about the instances started.
+
+    If the instance was not able to change state,
+    "changed" will be set to False.
+
+    """
+    
+    wait = module.params.get('wait')
+    wait_timeout = int(module.params.get('wait_timeout'))
+    changed = False
+    instance_dict_array = []
+    
+    if not isinstance(instance_ids, list) or len(instance_ids) < 1:
+        module.fail_json(msg='instance_ids should be a list of instances, aborting')
+
+    dest_state = module.params.get('state')
+    dest_state_ec2 = 'stop' if dest_state == 'stopped' else 'running'
+
+    # Check that our instances are not running, and sart them
+    running_instances_array = []
+    for res in ec2.get_all_instances(instance_ids):
+        for inst in res.instances:
+           if not inst.state == dest_state_ec2
+               instance_dict_array.append(get_instance_info(inst))
+               try:
+                   if dest_state == 'running':
+                       inst.start()
+                   else:
+                       inst.stop()
+               except EC2ResponseError as e:
+                   module.fail_json(msg='Unable to change state for instance {0}, error: {1}'.format(inst.id, e))
+               changed = True
+
+    ## Wait for all the instances to finish starting or stopping
+    instids = [ i.id for i in res.instances ]
+    this_res = []
+    num_running = 0
+    wait_timeout = time.time() + wait_timeout
+    while wait_timeout > time.time() and num_running < len(instids):
+        res_list = res.connection.get_all_instances(instids)
+        if len(res_list) > 0:
+            this_res = res_list[0]
+            num_running = len([ i for i in this_res.instances if i.state == dest_state_ec2 ])
+        else:
+            # got a bad response of some sort, possibly due to 
+            # stale/cached data. Wait a second and then try again
+            time.sleep(1)
+            continue
+        if wait and num_running < len(instids):
+            time.sleep(5)
+        else:
+            break
+
+    if wait and wait_timeout <= time.time():
+        # waiting took too long
+        module.fail_json(msg = "wait for instances running timeout on %s" % time.asctime())
+
+    for inst in this_res.instances:
+        running_instances_array.append(inst.id)
+
+    return (changed, instance_dict_array, running_instances_array)
+
 
 def main():
     module = AnsibleModule(
@@ -639,13 +713,12 @@ def main():
             wait = dict(type='bool', default=False),
             wait_timeout = dict(default=300),
             ec2_url = dict(),
-            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
-            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
+            aws_secret_key = dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True),
+            aws_access_key = dict(aliases=['ec2_access_key', 'access_key']),
             placement_group = dict(),
             user_data = dict(),
             instance_tags = dict(type='dict'),
             vpc_subnet_id = dict(),
-            assign_public_ip = dict(type='bool', default=False),
             private_ip = dict(),
             instance_profile_name = dict(),
             instance_ids = dict(type='list'),
@@ -653,9 +726,33 @@ def main():
         )
     )
 
-    # def get_ec2_creds(module):
-    #   return ec2_url, ec2_access_key, ec2_secret_key, region
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    ec2_url = module.params.get('ec2_url')
+    aws_secret_key = module.params.get('aws_secret_key')
+    aws_access_key = module.params.get('aws_access_key')
+    region = module.params.get('region')
+
+
+    # allow eucarc environment variables to be used if ansible vars aren't set
+    if not ec2_url and 'EC2_URL' in os.environ:
+        ec2_url = os.environ['EC2_URL']
+
+    if not aws_secret_key:
+        if  'AWS_SECRET_KEY' in os.environ:
+            aws_secret_key = os.environ['AWS_SECRET_KEY']
+        elif 'EC2_SECRET_KEY' in os.environ:
+            aws_secret_key = os.environ['EC2_SECRET_KEY']
+
+    if not aws_access_key:
+        if 'AWS_ACCESS_KEY' in os.environ:
+            aws_access_key = os.environ['AWS_ACCESS_KEY']
+        elif 'EC2_ACCESS_KEY' in os.environ:
+            aws_access_key = os.environ['EC2_ACCESS_KEY']
+
+    if not region:
+        if 'AWS_REGION' in os.environ:
+            region = os.environ['AWS_REGION']
+        elif 'EC2_REGION' in os.environ:
+            region = os.environ['EC2_REGION']
 
     # If we have a region specified, connect to its endpoint.
     if region:
@@ -679,6 +776,13 @@ def main():
 
         (changed, instance_dict_array, new_instance_ids) = terminate_instances(module, ec2, instance_ids)
 
+    elif module.params.get('state') == 'running' or module.params.get('state') == 'stopped':
+        instance_ids = module.params.get('instance_ids')
+        if not isinstance(instance_ids, list):
+            module.fail_json(msg='running list needs to be a list of instances to run: %s' % instance_ids)
+
+        (changed, instance_dict_array, new_instance_ids) = startstop_instances(module, ec2, instance_ids)
+
     elif module.params.get('state') == 'present':
         # Changed is always set to true when provisioning new instances
         if not module.params.get('key_name'):
@@ -689,8 +793,8 @@ def main():
 
     module.exit_json(changed=changed, instance_ids=new_instance_ids, instances=instance_dict_array)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 
 main()


### PR DESCRIPTION
This adds the ability to set the state of an existing instance to 'started' or 'stopped' in the ec2 module.

Example usage to start an instance:

```
- name: Start an EC2 instance
  local_action:
    module: ec2
    instance_ids: '{{ instance_ids }}'
    region: '{{ region }}'
    state: running
    wait: True
```

Since I had this in my main fork I rebased and reset my fork and created a branch to properly put this change in to.  So this is the same changes from my original pull #4805.
