### PR TITLE
Make sure initial_state is initialized

### DIFF
--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -138,8 +138,7 @@ class ElbManager:
         to report it out-of-service"""
 
         for lb in self.lbs:
-            if wait:
-                initial_state = self._get_instance_health(lb)
+            initial_state = self._get_instance_health(lb) if wait else None
 
             if initial_state and initial_state.state == 'InService':
                 lb.deregister_instances([self.instance_id])


### PR DESCRIPTION
This fixes a small (but critical) bug that was brought up in the comments on pull request #5232.

> Getting an error here: If wait isn't set, initial_state is not declared before it's used:
> 
> invalid output was: Traceback (most recent call last):
> File "/home/rawr/.ansible/tmp/ansible-1386807871.34-9619501383113/ec2_elb", line 1411, in 
> main()
> File "/home/rawr/.ansible/tmp/ansible-1386807871.34-9619501383113/ec2_elb", line 336, in main
> elb_man.deregister(wait)
> File "/home/rawr/.ansible/tmp/ansible-1386807871.34-9619501383113/ec2_elb", line 144, in deregister
> if initial_state and initial_state.state == 'InService':
> UnboundLocalError: local variable 'initial_state' referenced before assignment
