### PR TITLE
Fix ec2_ami no_reboot setting (currently it will not reboot instances to...

### DIFF
--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -273,7 +273,7 @@ def main():
             wait = dict(type="bool", default=False),
             wait_timeout = dict(default=900),
             description = dict(default=""),
-            no_reboot = dict(default=True, type="bool"),
+            no_reboot = dict(default=False, type="bool"),
             state = dict(default='present'),
             region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS)
         )


### PR DESCRIPTION
... create the AMI)

Line 276: no_reboot = dict(default=True, type="bool"),

This should really default to False (When AMIs are created the machine will reboot before copying the disk).

"When enabled, Amazon EC2 does not shut down the instance before creating the image. When this option is used, file system integrity on the created image cannot be guaranteed."
