### PR TITLE
Adding 'export' option to subversion module (to export instead of co)

### DIFF
--- a/library/source_control/subversion
+++ b/library/source_control/subversion
@@ -81,6 +81,9 @@ options:
 EXAMPLES = '''
 # Checkout subversion repository to specified folder.
 - subversion: repo=svn+ssh://an.example.org/path/to/repo dest=/src/checkout
+
+# Export subversion directory to folder
+- subversion: repo=svn+ssh://an.example.org/path/to/repo dest=/src/export export=True
 '''
 
 import re

--- a/library/source_control/subversion
+++ b/library/source_control/subversion
@@ -70,6 +70,12 @@ options:
     description:
       - Path to svn executable to use. If not supplied,
         the normal mechanism for resolving binary paths will be used.
+  export:
+    required: false
+    default: False
+    version_added: "1.5"
+    description:
+      - If True, do export instead of checkout/update.
 '''
 
 EXAMPLES = '''
@@ -110,6 +116,10 @@ class Subversion(object):
     def checkout(self):
         '''Creates new svn working directory if it does not already exist.'''
         self._exec("checkout -r %s '%s' '%s'" % (self.revision, self.repo, self.dest))
+		
+    def export(self, force=False):
+        '''Export svn repo to directory'''
+        self._exec("export -r %s '%s' '%s'" % (self.revision, self.repo, self.dest))
 
     def switch(self):
         '''Change working directory's repo.'''
@@ -163,6 +173,7 @@ def main():
             username=dict(required=False),
             password=dict(required=False),
             executable=dict(default=None),
+            export=dict(default=False, required=False),
         ),
         supports_check_mode=True
     )
@@ -174,6 +185,7 @@ def main():
     username = module.params['username']
     password = module.params['password']
     svn_path = module.params['executable'] or module.get_bin_path('svn', True)
+    export = module.params['export']
 
     svn = Subversion(module, dest, repo, revision, username, password, svn_path)
 
@@ -182,7 +194,10 @@ def main():
         local_mods = False
         if module.check_mode:
             module.exit_json(changed=True)
-        svn.checkout()
+        if not export:
+            svn.checkout()
+        else:
+            svn.export()
     elif os.path.exists("%s/.svn" % (dest, )):
         # Order matters. Need to get local mods before switch to avoid false
         # positives. Need to switch before revert to ensure we are reverting to


### PR DESCRIPTION
Our deploy process requires to export to a directory to have a full "static" version of each deployed version.
