### PR TITLE
Fix package dependencies for SuSE/openSuSE

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -47,11 +47,10 @@ Requires: python-keyczar
 # SuSE/openSuSE
 %if 0%{?suse_version} 
 BuildRequires: python-devel
-BuildRequires: python-setuptools
 Requires: python-paramiko
-Requires: python-jinja2
+Requires: python-Jinja2
 Requires: python-keyczar
-Requires: python-yaml
+Requires: python-PyYAML
 %endif
 
 Requires: sshpass


### PR DESCRIPTION
- Official package name of PyYAML is "python-PyYAML" on openSUSE, not "python-yaml" (see http://software.opensuse.org/package/python-PyYAML)
- Official package name of Jinja2 is "python-Jinja2" on openSUSE, not "python-jinja2" (see http://software.opensuse.org/package/python-Jinja2)
- python-setuptools is not necessary to build ansible on SUSE/openSUSE (distutils in the Python Standard Library is sufficient)
