### PR TITLE
file module: Added to the file module the functionality to force conversion hard link...

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -245,7 +245,7 @@ def main():
         module.exit_json(path=path, changed=True)
 
     if prev_state != 'absent' and prev_state != state:
-        if not (force and (prev_state == 'file' or prev_state == 'directory') and state == 'link') and state != 'touch':
+        if not (force and (prev_state == 'file' or prev_state == 'hard' or prev_state == 'directory') and state == 'link') and state != 'touch':
             module.fail_json(path=path, msg='refusing to convert between %s and %s for %s' % (prev_state, state, src))
 
     if prev_state == 'absent' and state == 'absent':


### PR DESCRIPTION
Dear Ansible Dev Team,

Recently, I've found that conversion between hard link and symbolic link with specified force=yes parameter doesn't work:

bash-4.1$ touch xxx
bash-4.1$ ln xxx yyy
bash-4.1$ ls -l xxx yyy
-rw-rw-r-- 2 mike mike 0 Dec 13 17:24 xxx
-rw-rw-r-- 2 mike mike 0 Dec 13 17:24 yyy
bash-4.1$ which ansible
/home/mike/dev/ansible/bin/ansible
bash-4.1$ ansible 127.0.0.1 --connection=local -m file -a 'path=yyy state=link src=xxx force='yes''
127.0.0.1 | FAILED >> {
    "failed": true, 
    "gid": x, 
    "group": "mike", 
    "mode": "0664", 
    "msg": "refusing to convert between hard and link for xxx", 
    "owner": "mike", 
    "path": "yyy", 
    "size": 0, 
    "state": "hard", 
    "uid": x
}

Therefore, I'd like to propose the following patch to fix this behavior. The following simple tests (including conversion from normal file to symlink) are:

bash-4.1$ git checkout hard_link_fix
Switched to branch 'hard_link_fix'
bash-4.1$ ansible 127.0.0.1 --connection=local -m file -a 'path=yyy state=link src=xxx force=yes'
127.0.0.1 | success >> {
    "changed": true, 
    "dest": "yyy", 
    "gid": x, 
    "group": "mike", 
    "mode": "0777", 
    "owner": "mike", 
    "size": 3, 
    "src": "xxx", 
    "state": "link", 
    "uid": x
}

bash-4.1$ ls -l xxx yyy
-rw-rw-r-- 1 mike mike 0 Dec 13 17:24 xxx
lrwxrwxrwx 1 mike mike 3 Dec 13 17:26 yyy -> xxx
bash-4.1$ unlink yyy
bash-4.1$ touch yyy
bash-4.1$ ansible 127.0.0.1 --connection=local -m file -a 'path=yyy state=link src=xxx force=yes'
127.0.0.1 | success >> {
    "changed": true, 
    "dest": "yyy", 
    "gid": x, 
    "group": "mike", 
    "mode": "0777", 
    "owner": "mike", 
    "size": 3, 
    "src": "xxx", 
    "state": "link", 
    "uid": x
}

Thank you in advance for your attention and have a good day!
