### PR TITLE
pkgng module: declare BATCH mode before installing packages.

### DIFF
--- a/library/packaging/pkgng
+++ b/library/packaging/pkgng
@@ -112,7 +112,7 @@ def install_packages(module, pkgin_path, packages, cached, pkgsite):
         pkgsite="PACKAGESITE=%s" % (pkgsite)
 
     if not module.check_mode and cached == "no":
-        rc, out, err = module.run_command("%s %s update" % (pkgsite, pkgin_path))
+        rc, out, err = module.run_command("BATCH=yes %s %s update" % (pkgsite, pkgin_path))
         if rc != 0:
             module.fail_json(msg="Could not update catalogue")
 

--- a/library/packaging/pkgng
+++ b/library/packaging/pkgng
@@ -116,6 +116,7 @@ def install_packages(module, pkgin_path, packages, cached, pkgsite):
         if rc != 0:
             module.fail_json(msg="Could not update catalogue")
 
+    module.run_command("set BATCH=yes")
     for package in packages:
         if query_package(module, pkgin_path, package):
             continue

--- a/library/packaging/pkgng
+++ b/library/packaging/pkgng
@@ -116,13 +116,12 @@ def install_packages(module, pkgin_path, packages, cached, pkgsite):
         if rc != 0:
             module.fail_json(msg="Could not update catalogue")
 
-    module.run_command("set BATCH=yes")
     for package in packages:
         if query_package(module, pkgin_path, package):
             continue
 
         if not module.check_mode:
-            rc, out, err = module.run_command("%s %s install -g -U -y %s" % (pkgsite, pkgin_path, package))
+            rc, out, err = module.run_command("BATCH=yes %s %s install -g -U -y %s" % (pkgsite, pkgin_path, package))
 
         if not module.check_mode and not query_package(module, pkgin_path, package):
             module.fail_json(msg="failed to install %s: %s" % (package, out), stderr=err)


### PR DESCRIPTION
setting BATCH=yes means that the package will not ask any questions during the install process.  Case in point: mail/postfix
# /usr/sbin/pkg install -g -U -y mail/postfix

The following 1 packages will be installed:

```
    Installing postfix: 2.10.2,1
```

The installation will require 14 MB more space

0 B to be downloaded
Checking integrity... done
[1/1] Installing postfix-2.10.2,1...===> Creating users and/or groups.
Using existing group 'mail'.
Using existing group 'maildrop'.
Using existing group 'postfix'.
Using existing user 'postfix'.
Would you like to activate Postfix in /etc/mail/mailer.conf [n]?
