### PR TITLE
Print a useful tip about sourcing env-setup if ansible.utils can not be found

### DIFF
--- a/docsite/README.md
+++ b/docsite/README.md
@@ -25,5 +25,5 @@ Michael DeHaan -- michael.dehaan@gmail.com
 
 [install Sphinx]: http://sphinx-doc.org/install.html
 [file issues]: https://github.com/ansible/ansible/issues
-[module-docs]: http://www.ansibleworks.com/docs/moduledev.html#documenting-your-module
+[module-docs]: http://www.ansibleworks.com/docs/developing_modules.html#documenting-your-module
 

--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -31,7 +31,12 @@ import time
 import datetime
 import subprocess
 import cgi
-import ansible.utils
+try:
+    import ansible.util
+except ImportError, e:
+    print "Can not find 'ansible.utils', as per CONTRIBUTING.md, you may need to do:"
+    print "    source ./hacking/env-setup"
+    exit (1)
 import ansible.utils.module_docs as module_docs
 
 # Get parent directory of the directory this script lives in

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -33,7 +33,12 @@ import os
 import subprocess
 import traceback
 import optparse
-import ansible.utils as utils
+try:
+    import ansible.utils as utils
+except ImportError, e:
+    print "Can not find 'ansible.utils', as per CONTRIBUTING.md, you may need to do:"
+    print "    source ./hacking/env-setup"
+    exit (1)
 import ansible.module_common as module_common
 import ansible.constants as C
 


### PR DESCRIPTION
Helpful hit to avoid issues like https://github.com/ansible/ansible/issues/5105

Before

```
Traceback (most recent call last):
  File "ansible/hacking/test-module", line 36, in <module>
    import ansible.utils as utils
ImportError: No module named ansible.utils
```

After

```
Can not find 'ansible.utils', as per CONTRIBUTING.md, you need to do:
    source ./hacking/env-setup
```
