### PR TITLE
Let merge hash_bahaviour work with dynamic inventory

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -351,7 +351,7 @@ class Inventory(object):
 
         vars.update(host.get_variables())
         if self.parser is not None:
-            vars.update(self.parser.get_host_variables(host))
+            vars = utils.combine_vars(vars, self.parser.get_host_variables(host))
         return vars
 
     def add_group(self, group):


### PR DESCRIPTION
When using a dynamic inventory script, 'hash_behaviour = merge' is not taken into account between group variables (returned by --list) and host variables (returned by --host $host).

This change makes it work (however I don't know ansible internals and potential side effects.)
Thanks for reviewing
