### PR TITLE
ec2 modules: Move more responsibility to common EC2 module

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -294,15 +294,6 @@ local_action:
 import sys
 import time
 
-AWS_REGIONS = ['ap-northeast-1',
-               'ap-southeast-1',
-               'ap-southeast-2',
-               'eu-west-1',
-               'sa-east-1',
-               'us-east-1',
-               'us-west-1',
-               'us-west-2']
-
 try:
     import boto.ec2
     from boto.exception import EC2ResponseError
@@ -653,24 +644,7 @@ def main():
         )
     )
 
-    # def get_ec2_creds(module):
-    #   return ec2_url, ec2_access_key, ec2_secret_key, region
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
-
-    # If we have a region specified, connect to its endpoint.
-    if region:
-        try:
-            ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg = str(e))
-    # If we specified an ec2_url then try connecting to it
-    elif ec2_url:
-        try:
-            ec2 = boto.connect_ec2_endpoint(ec2_url, aws_access_key, aws_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg = str(e))
-    else:
-        module.fail_json(msg="Either region or ec2_url must be specified")
+    ec2 = ec2_connect(module)
 
     if module.params.get('state') == 'absent':
         instance_ids = module.params.get('instance_ids')

--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -156,15 +156,6 @@ EXAMPLES = '''
 import sys
 import time
 
-AWS_REGIONS = ['ap-northeast-1',
-               'ap-southeast-1',
-               'ap-southeast-2',
-               'eu-west-1',
-               'sa-east-1',
-               'us-east-1',
-               'us-west-1',
-               'us-west-2']
-
 try:
     import boto
     import boto.ec2
@@ -279,24 +270,7 @@ def main():
         )
     )
 
-    # def get_ec2_creds(module):
-    #   return ec2_url, ec2_access_key, ec2_secret_key, region
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
-
-    # If we have a region specified, connect to its endpoint.
-    if region:
-        try:
-            ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg = str(e))
-    # If we specified an ec2_url then try connecting to it
-    elif ec2_url:
-        try:
-            ec2 = boto.connect_ec2_endpoint(ec2_url, aws_access_key, aws_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg = str(e))
-    else:
-        module.fail_json(msg="Either region or ec2_url must be specified")
+    ec2 = ec2_connect(module)
 
     if module.params.get('state') == 'absent':
         if not module.params.get('image_id'):

--- a/library/cloud/ec2_eip
+++ b/library/cloud/ec2_eip
@@ -102,38 +102,6 @@ else:
     boto_found = True
 
 
-def connect(ec2_url, ec2_access_key, ec2_secret_key, region, module):
-
-    """ Return an ec2 connection"""
-    # allow environment variables to be used if ansible vars aren't set
-    if not ec2_url and 'EC2_URL' in os.environ:
-        ec2_url = os.environ['EC2_URL']
-    if not ec2_secret_key and 'EC2_SECRET_KEY' in os.environ:
-        ec2_secret_key = os.environ['EC2_SECRET_KEY']
-    if not ec2_access_key and 'EC2_ACCESS_KEY' in os.environ:
-        ec2_access_key = os.environ['EC2_ACCESS_KEY']
-
-    # If we have a region specified, connect to its endpoint.
-    if region:
-        try:
-            ec2 = boto.ec2.connect_to_region(region,
-                                        aws_access_key_id=ec2_access_key,
-                                        aws_secret_access_key=ec2_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg = str(" %s %s %s " % (region, ec2_access_key,
-                                                       ec2_secret_key)))
-    # Otherwise, no region so we fallback to the old connection method
-    else:
-        try:
-            if ec2_url: # if we have an URL set, connect to the specified endpoint
-                ec2 = boto.connect_ec2_endpoint(ec2_url, ec2_access_key, ec2_secret_key)
-            else: # otherwise it's Amazon.
-                ec2 = boto.connect_ec2(ec2_access_key, ec2_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg = str(e))
-    return ec2
-
-
 def associate_ip_and_instance(ec2, address, instance_id, module):
     if ip_is_associated_with_instance(ec2, address.public_ip, instance_id, module):
         module.exit_json(changed=False, public_ip=address.public_ip)
@@ -248,8 +216,8 @@ def main():
             state = dict(required=False, default='present',
                          choices=['present', 'absent']),
             ec2_url = dict(required=False, aliases=['EC2_URL']),
-            ec2_secret_key = dict(required=False, aliases=['EC2_SECRET_KEY'], no_log=True),
-            ec2_access_key = dict(required=False, aliases=['EC2_ACCESS_KEY']),
+            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
+            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
             region = dict(required=False, aliases=['ec2_region']),
             in_vpc = dict(required=False, choices=BOOLEANS, default=False),
         ),
@@ -259,13 +227,7 @@ def main():
     if not boto_found:
         module.fail_json(msg="boto is required")
 
-    ec2_url, ec2_access_key, ec2_secret_key, region = get_ec2_creds(module)
-
-    ec2 = connect(ec2_url,
-                  ec2_access_key,
-                  ec2_secret_key,
-                  region,
-                  module)
+    ec2 = ec2_connect(module)
 
     instance_id = module.params.get('instance_id')
     public_ip = module.params.get('public_ip')

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -102,15 +102,6 @@ import time
 import sys
 import os
 
-AWS_REGIONS = ['ap-northeast-1',
-               'ap-southeast-1',
-               'ap-southeast-2',
-               'eu-west-1',
-               'sa-east-1',
-               'us-east-1',
-               'us-west-1',
-               'us-west-2']
-
 try:
     import boto
     import boto.ec2

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -113,15 +113,11 @@ def main():
             ec2_url=dict(aliases=['EC2_URL']),
             ec2_secret_key=dict(aliases=['EC2_SECRET_KEY', 'aws_secret_key'], no_log=True),
             ec2_access_key=dict(aliases=['EC2_ACCESS_KEY', 'aws_access_key']),
-            region=dict(choices=['eu-west-1', 'sa-east-1', 'us-east-1', 'ap-northeast-1', 'us-west-2', 'us-west-1', 'ap-southeast-1', 'ap-southeast-2']),
+            region=dict(choices=AWS_REGIONS),
             state = dict(default='present', choices=['present', 'absent']),
         ),
         supports_check_mode=True,
     )
-
-    # def get_ec2_creds(module):
-    #   return ec2_url, ec2_access_key, ec2_secret_key, region
-    ec2_url, ec2_access_key, ec2_secret_key, region = get_ec2_creds(module)
 
     name = module.params['name']
     description = module.params['description']
@@ -131,21 +127,7 @@ def main():
 
     changed = False
 
-    # If we have a region specified, connect to its endpoint.
-    if region:
-        try:
-            ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=ec2_access_key, aws_secret_access_key=ec2_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg=str(e))
-    # Otherwise, no region so we fallback to the old connection method
-    else:
-        try:
-            if ec2_url:  # if we have an URL set, connect to the specified endpoint
-                ec2 = boto.connect_ec2_endpoint(ec2_url, ec2_access_key, ec2_secret_key)
-            else:  # otherwise it's Amazon.
-                ec2 = boto.connect_ec2(ec2_access_key, ec2_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg=str(e))
+    ec2 = ec2_connect(module)
 
     # find the group if present
     group = None

--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -101,15 +101,6 @@ except ImportError:
     print "failed=True msg='boto required for this module'"
     sys.exit(1)
 
-AWS_REGIONS = ['ap-northeast-1',
-               'ap-southeast-1',
-               'ap-southeast-2',
-               'eu-west-1',
-               'sa-east-1',
-               'us-east-1',
-               'us-west-1',
-               'us-west-2']
-
 def main():
     module = AnsibleModule(
         argument_spec = dict(
@@ -123,28 +114,11 @@ def main():
         )
     )
 
-    # def get_ec2_creds(module):
-    #   return ec2_url, ec2_access_key, ec2_secret_key, region
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
-
     resource = module.params.get('resource')
     tags = module.params['tags']
     state = module.params.get('state')
   
-    # If we have a region specified, connect to its endpoint.
-    if region: 
-        try:
-            ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg = str(e))
-    # Otherwise, no region so we fallback to the old connection method
-    elif ec2_url:
-        try:
-            ec2 = boto.connect_ec2_endpoint(ec2_url, aws_access_key, aws_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg = str(e))
-    else:
-        module.fail_json(msg="Either region or ec2_url must be specified")
+    ec2 = ec2_connect(module)
     
     # We need a comparison here so that we can accurately report back changed status.
     # Need to expand the gettags return format and compare with "tags" and then tag or detag as appropriate.

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -127,15 +127,6 @@ except ImportError:
     print "failed=True msg='boto required for this module'"
     sys.exit(1)
 
-AWS_REGIONS = ['ap-northeast-1',
-               'ap-southeast-1',
-               'ap-southeast-2',
-               'eu-west-1',
-               'sa-east-1',
-               'us-east-1',
-               'us-west-1',
-               'us-west-2']
-
 def main():
     module = AnsibleModule(
         argument_spec = dict(
@@ -151,30 +142,13 @@ def main():
         )
     )
 
-    # def get_ec2_creds(module):
-    #   return ec2_url, ec2_access_key, ec2_secret_key, region
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
-
     instance = module.params.get('instance')
     volume_size = module.params.get('volume_size')
     iops = module.params.get('iops')
     device_name = module.params.get('device_name')
     zone = module.params.get('zone')
    
-    # If we have a region specified, connect to its endpoint.
-    if region: 
-        try:
-            ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg = str(e))
-    # Otherwise, no region so we fallback to the old connection method
-    elif ec2_url:
-        try:
-            ec2 = boto.connect_ec2_endpoint(ec2_url, aws_access_key, aws_secret_key)
-        except boto.exception.NoAuthHandlerFound, e:
-            module.fail_json(msg = str(e))
-    else:
-        module.fail_json(msg="Either region or ec2_url must be specified")
+    ec2 = ec2_connect(module)
 
     # Here we need to get the zone info for the instance. This covers situation where 
     # instance is specified but zone isn't.

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -164,15 +164,6 @@ except ImportError:
     print "failed=True msg='boto required for this module'"
     sys.exit(1)
 
-AWS_REGIONS = ['ap-northeast-1',
-               'ap-southeast-1',
-               'ap-southeast-2',
-               'eu-west-1',
-               'sa-east-1',
-               'us-east-1',
-               'us-west-1',
-               'us-west-2']
-
 def get_vpc_info(vpc):
     """
     Retrieves vpc information from an instance

--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -137,15 +137,6 @@ import sys
 import os
 import time
 
-AWS_REGIONS = ['ap-northeast-1',
-               'ap-southeast-1',
-               'ap-southeast-2',
-               'eu-west-1',
-               'sa-east-1',
-               'us-east-1',
-               'us-west-1',
-               'us-west-2']
-
 try:
     import boto
     from boto.elasticache.layer1 import ElastiCacheConnection

--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -262,15 +262,6 @@ EXAMPLES = '''
 import sys
 import time
 
-AWS_REGIONS = ['ap-northeast-1',
-               'ap-southeast-1',
-               'ap-southeast-2',
-               'eu-west-1',
-               'sa-east-1',
-               'us-east-1',
-               'us-west-1',
-               'us-west-2']
-
 try:
     import boto.rds
 except ImportError:
@@ -346,25 +337,7 @@ def main():
     apply_immediately  = module.params.get('apply_immediately')
     new_instance_name  = module.params.get('new_instance_name')
 
-    # allow environment variables to be used if ansible vars aren't set
-    if not region:
-        if   'AWS_REGION' in os.environ:
-            region = os.environ['AWS_REGION']
-        elif   'EC2_REGION' in os.environ:
-            region = os.environ['EC2_REGION']
-
-    if not aws_secret_key:
-        if  'AWS_SECRET_KEY' in os.environ:
-            aws_secret_key = os.environ['AWS_SECRET_KEY']
-        elif 'EC2_SECRET_KEY' in os.environ:
-            aws_secret_key = os.environ['EC2_SECRET_KEY']
-
-    if not aws_access_key:
-        if 'AWS_ACCESS_KEY' in os.environ:
-            aws_access_key = os.environ['AWS_ACCESS_KEY']
-        elif 'EC2_ACCESS_KEY' in os.environ:
-            aws_access_key = os.environ['EC2_ACCESS_KEY']
-
+    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
     if not region:
         module.fail_json(msg = str("region not specified and unable to determine region from EC2_REGION."))
 
@@ -577,5 +550,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
 
 main()


### PR DESCRIPTION
Moved `AWS_REGIONS` into `ec2` module
Created `ec2_connect` method in `ec2` module
Updated modules able to use `ec2_connect` and `AWS_REGIONS`

As mentioned on ansible-devel.
So far I've tested `ec2`, `ec2_tag` and `ec2_vol` - and all works as expected. 
I'll add further comments as other tests are made but if anyone wishes to assist, let me know. 
