### PR TITLE
Introduce neutron modules

### DIFF
--- a/library/cloud/neutron_floating_ip
+++ b/library/cloud/neutron_floating_ip
@@ -1,0 +1,260 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# (c) 2013, Benno Joy <benno@ansibleworks.com>
+# (c) 2013, Brad P. Crochet <brad@redhat.com>
+#           Change to neutron
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    from novaclient.v1_1 import client as nova_client
+    from neutronclient.neutron import client
+    from keystoneclient.v2_0 import client as ksclient
+    import time
+except ImportError:
+    print("failed=True msg='glanceclient,keystoneclient and neutronclient client are required'")
+
+DOCUMENTATION = '''
+---
+module: neutron_floating_ip
+short_description: Add/Remove floating IP from an instance
+description:
+   - Add or Remove a floating IP to an instance
+options:
+   login_username:
+     description:
+        - login username to authenticate to keystone
+     required: true
+     default: admin
+   login_password:
+     description:
+        - Password of login user
+     required: true
+     default: 'yes'
+   login_tenant_name:
+     description:
+        - The tenant name of the login user
+     required: true
+     default: 'yes'
+   auth_url:
+     description:
+        - The keystone url for authentication
+     required: false
+     default: 'http://127.0.0.1:35357/v2.0/'
+   region_name:
+     description:
+        - Name of the region
+     required: false
+     default: None
+   state:
+     description:
+        - Indicate desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+   network_name:
+     description:
+        - Name of the network from which IP has to be assigned to VM. Please make sure the network is an external network
+     required: true
+     default: None
+   instance_name:
+     description:
+        - The name of the instance to which the IP address should be assigned
+     required: true
+     default: None
+   internal_network_name:
+     description:
+        - The name of the network of the port to associate with the floating ip. Necessary when VM has multiple networks.
+     required: false
+     default: None
+requirements: ["novaclient", "neutronclient", "keystoneclient"]
+'''
+
+EXAMPLES = '''
+# Assign a floating ip to the instance from an external network
+- neutron_floating_ip: state=present login_username=admin login_password=admin
+                       login_tenant_name=admin network_name=external_network
+                       instance_name=vm1 internal_network_name=internal_network
+'''
+
+def _get_ksclient(module, kwargs):
+    try:
+        kclient = ksclient.Client(username=kwargs.get('login_username'),
+                                 password=kwargs.get('login_password'),
+                                 tenant_name=kwargs.get('login_tenant_name'),
+                                 auth_url=kwargs.get('auth_url'))
+    except Exception as e:
+        module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
+    global _os_keystone
+    _os_keystone = kclient
+    return kclient
+
+
+def _get_endpoint(module, ksclient):
+    try:
+        endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
+    except Exception as e:
+        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+    return endpoint
+
+def _get_neutron_client(module, kwargs):
+    _ksclient = _get_ksclient(module, kwargs)
+    token = _ksclient.auth_token
+    endpoint = _get_endpoint(module, _ksclient)
+    kwargs = {
+            'token': token,
+            'endpoint_url': endpoint
+    }
+    try:
+        neutron = client.Client('2.0', **kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+    return neutron
+
+def _get_server_state(module, nova):
+    server_info = None
+    server = None
+    try:
+        for server in nova.servers.list():
+            if server:
+                info = server._info
+                if info['name'] == module.params['instance_name']:
+                    if info['status'] != 'ACTIVE' and module.params['state'] == 'present':
+                        module.fail_json( msg="The VM is available but not Active. state:" + info['status'])
+                    server_info = info
+                    break
+    except Exception as e:
+        module.fail_json(msg = "Error in getting the server list: %s" % e.message)
+    return server_info, server
+
+def _get_port_info(neutron, module, instance_id, internal_network_name=None):
+    if internal_network_name:
+        kwargs = {
+            'name': internal_network_name,
+        }
+        networks = neutron.list_networks(**kwargs)
+        subnet_id = networks['networks'][0]['subnets'][0]
+    kwargs = {
+            'device_id': instance_id,
+    }
+    try:
+        ports = neutron.list_ports(**kwargs)
+    except Exception as e:
+        module.fail_json( msg = "Error in listing ports: %s" % e.message)
+    if subnet_id:
+        port = next(port for port in ports['ports'] if port['fixed_ips'][0]['subnet_id'] == subnet_id)
+        port_id = port['id']
+        fixed_ip_address = port['fixed_ips'][0]['ip_address']
+    else:
+        port_id = ports['ports'][0]['id']
+        fixed_ip_address = ports['ports'][0]['fixed_ips'][0]['ip_address']
+    if not ports['ports']:
+        return None, None
+    return fixed_ip_address, port_id
+
+def _get_floating_ip(module, neutron, fixed_ip_address):
+    kwargs = {
+            'fixed_ip_address': fixed_ip_address
+    }
+    try:
+        ips = neutron.list_floatingips(**kwargs)
+    except Exception as e:
+        module.fail_json(msg = "error in fetching the floatingips's %s" % e.message)
+    if not ips['floatingips']:
+        return None, None
+    return ips['floatingips'][0]['id'], ips['floatingips'][0]['floating_ip_address']
+
+def _create_floating_ip(neutron, module, port_id, net_id):
+    kwargs = {
+            'port_id': port_id,
+            'floating_network_id': net_id
+    }
+    try:
+        result = neutron.create_floatingip({'floatingip': kwargs})
+    except Exception as e:
+        module.fail_json(msg="There was an error in updating the floating ip address: %s" % e.message)
+    module.exit_json(changed=True, result=result, public_ip=result['floatingip']['floating_ip_address'])
+
+def _get_net_id(neutron, module):
+    kwargs = {
+        'name': module.params['network_name'],
+    }
+    try:
+        networks = neutron.list_networks(**kwargs)
+    except Exception as e:
+        module.fail_json("Error in listing neutron networks: %s" % e.message)
+    if not networks['networks']:
+        return None
+    return networks['networks'][0]['id']
+
+def _update_floating_ip(neutron, module, port_id, floating_ip_id):
+    kwargs = {
+        'port_id': port_id
+    }
+    try:
+        result = neutron.update_floatingip(floating_ip_id, {'floatingip': kwargs})
+    except Exception as e:
+        module.fail_json(msg="There was an error in updating the floating ip address: %s" % e.message)
+    module.exit_json(changed=True, result=result)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            login_username                  = dict(default='admin'),
+            login_password                  = dict(required=True),
+            login_tenant_name               = dict(required='True'),
+            auth_url                        = dict(default='http://127.0.0.1:5000/v2.0/'),
+            region_name                     = dict(default=None),
+            network_name                    = dict(required=True),
+            instance_name                   = dict(required=True),
+            state                           = dict(default='present', choices=['absent', 'present']),
+            internal_network_name           = dict(default=None),
+        ),
+    )
+
+    try:
+        nova = nova_client.Client(module.params['login_username'], module.params['login_password'],
+            module.params['login_tenant_name'], module.params['auth_url'], service_type='compute')
+        neutron = _get_neutron_client(module, module.params)
+    except Exception as e:
+        module.fail_json(msg="Error in authenticating to nova: %s" % e.message)
+
+    server_info, server_obj = _get_server_state(module, nova)
+    if not server_info:
+        module.fail_json(msg="The instance name provided cannot be found")
+
+    fixed_ip, port_id = _get_port_info(neutron, module, server_info['id'], module.params['internal_network_name'])
+    if not port_id:
+        module.fail_json(msg="Cannot find a port for this instance, maybe fixed ip is not assigned")
+
+    floating_id, floating_ip = _get_floating_ip(module, neutron, fixed_ip)
+
+    if module.params['state'] == 'present':
+        if floating_ip:
+            module.exit_json(changed = False, public_ip=floating_ip)
+        net_id = _get_net_id(neutron, module)
+        if not net_id:
+            module.fail_json(msg = "cannot find the network specified, please check")
+        _create_floating_ip(neutron, module, port_id, net_id)
+
+    if module.params['state'] == 'absent':
+        if floating_ip:
+            _update_floating_ip(neutron, module, None, floating_id)
+        module.exit_json(changed=False)
+
+# this is magic, see lib/ansible/module.params['common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()

--- a/library/cloud/neutron_floating_ip_associate
+++ b/library/cloud/neutron_floating_ip_associate
@@ -1,0 +1,220 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# (c) 2013, Benno Joy <benno@ansibleworks.com>
+# (c) 2013, Brad P. Crochet <brad@redhat.com>
+#           Change to neutron
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    from novaclient.v1_1 import client as nova_client
+    from neutronclient.neutron import client
+    from keystoneclient.v2_0 import client as ksclient
+    import time
+except ImportError:
+    print "failed=True msg='glanceclient,novaclient and keystone client are required'"
+
+DOCUMENTATION = '''
+---
+module: neutron_floating_ip_associate
+version_added: "1.2"
+short_description: Associate or disassociate a particular floating IP with an instance
+description:
+   - Associates or disassociates a specific floating IP with a particular instance
+options:
+   login_username:
+     description:
+        - login username to authenticate to keystone
+     required: true
+     default: admin
+   login_password:
+     description:
+        - password of login user
+     required: true
+     default: 'yes'
+   login_tenant_name:
+     description:
+        - the tenant name of the login user
+     required: true
+     default: true
+   auth_url:
+     description:
+        - the keystone url for authentication
+     required: false
+     default: 'http://127.0.0.1:35357/v2.0/'
+   region_name:
+     description:
+        - name of the region
+     required: false
+     default: None
+   state:
+     description:
+        - indicates the desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+   instance_name:
+     description:
+        - name of the instance to which the public IP should be assigned
+     required: true
+     default: None
+   ip_address:
+     description:
+        - floating ip that should be assigned to the instance
+     required: true
+     default: None
+requirements: ["neutronclient", "keystoneclient"]
+'''
+
+EXAMPLES = '''
+# Associate a specific floating IP with an Instance
+- neutron_floating_ip_associate:
+           state=present
+           login_username=admin
+           login_password=admin
+           login_tenant_name=admin
+           ip_address=1.1.1.1
+           instance_name=vm1
+'''
+
+def _get_ksclient(module, kwargs):
+    try:
+        kclient = ksclient.Client(username=kwargs.get('login_username'),
+                                 password=kwargs.get('login_password'),
+                                 tenant_name=kwargs.get('login_tenant_name'),
+                                 auth_url=kwargs.get('auth_url'))
+    except Exception as e:
+        module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
+    global _os_keystone
+    _os_keystone = kclient
+    return kclient
+
+
+def _get_endpoint(module, ksclient):
+    try:
+        endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
+    except Exception as e:
+        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+    return endpoint
+
+def _get_neutron_client(module, kwargs):
+    _ksclient = _get_ksclient(module, kwargs)
+    token = _ksclient.auth_token
+    endpoint = _get_endpoint(module, _ksclient)
+    kwargs = {
+            'token': token,
+            'endpoint_url': endpoint
+    }
+    try:
+        neutron = client.Client('2.0', **kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+    return neutron       
+
+def _get_server_state(module, nova):
+    server_info = None
+    server = None
+    try:
+        for server in nova.servers.list():
+            if server:
+                info = server._info
+                if info['name'] == module.params['instance_name']:
+                    if info['status'] != 'ACTIVE' and module.params['state'] == 'present':
+                        module.fail_json(msg="The VM is available but not Active. state:" + info['status'])
+                    server_info = info
+                    break
+    except Exception as e:
+            module.fail_json(msg = "Error in getting the server list: %s" % e.message)
+    return server_info, server          
+                                 
+def _get_port_id(neutron, module, instance_id):
+    kwargs = dict(device_id = instance_id)
+    try:
+        ports = neutron.list_ports(**kwargs)
+    except Exception as e:
+        module.fail_json( msg = "Error in listing ports: %s" % e.message)
+    if not ports['ports']:
+        return None
+    return ports['ports'][0]['id']
+        
+def _get_floating_ip_id(module, neutron):
+    kwargs = {
+        'floating_ip_address': module.params['ip_address']
+    }
+    try:
+        ips = neutron.list_floatingips(**kwargs)
+    except Exception as e:
+        module.fail_json(msg = "error in fetching the floatingips's %s" % e.message)
+    if not ips['floatingips']:
+        module.fail_json(msg = "Could find the ip specified in parameter, Please check")
+    ip = ips['floatingips'][0]['id']
+    if not ips['floatingips'][0]['port_id']:
+        state = "detached"
+    else:
+        state = "attached"
+    return state, ip
+
+def _update_floating_ip(neutron, module, port_id, floating_ip_id):
+    kwargs = {
+        'port_id': port_id
+    }
+    try:
+        result = neutron.update_floatingip(floating_ip_id, {'floatingip': kwargs})
+    except Exception as e:
+        module.fail_json(msg = "There was an error in updating the floating ip address: %s" % e.message)
+    module.exit_json(changed = True, result = result, public_ip=module.params['ip_address'])
+
+def main():
+    
+    module = AnsibleModule(
+        argument_spec                   = dict(
+            login_username                  = dict(default='admin'),
+            login_password                  = dict(required=True),
+            login_tenant_name               = dict(required='True'),
+            auth_url                        = dict(default='http://127.0.0.1:35357/v2.0/'),
+            region_name                     = dict(default=None),
+            ip_address                      = dict(required=True),
+            instance_name                   = dict(required=True), 
+            state                           = dict(default='present', choices=['absent', 'present'])
+        ),
+    )
+        
+    try:
+        nova = nova_client.Client(module.params['login_username'], module.params['login_password'],                                                                          module.params['login_tenant_name'], module.params['auth_url'], service_type='compute')
+    except Exception as e:
+        module.fail_json( msg = " Error in authenticating to nova: %s" % e.message)
+    neutron = _get_neutron_client(module, module.params)
+    state, floating_ip_id = _get_floating_ip_id(module, neutron)        
+    if module.params['state'] == 'present':
+        if state == 'attached':
+            module.exit_json(changed = False, result = 'attached', public_ip=module.params['ip_address'])
+        server_info, server_obj = _get_server_state(module, nova)
+        if not server_info:
+            module.fail_json(msg = " The instance name provided cannot be found")
+        port_id = _get_port_id(neutron, module, server_info['id'])
+        if not port_id:
+            module.fail_json(msg = "Cannot find a port for this instance, maybe fixed ip is not assigned")
+        _update_floating_ip(neutron, module, port_id, floating_ip_id)
+
+    if module.params['state'] == 'absent':
+        if state == 'detached':
+            module.exit_json(changed = False, result = 'detached')
+        if state == 'attached':
+            _update_floating_ip(neutron, module, None, floating_ip_id)
+        module.exit_json(changed = True, result = "detached")
+
+# this is magic, see lib/ansible/module.params['common.py
+from ansible.module_utils.basic import *
+main()
+

--- a/library/cloud/neutron_network
+++ b/library/cloud/neutron_network
@@ -1,0 +1,282 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# (c) 2013, Benno Joy <benno@ansibleworks.com>
+# (c) 2013, Brad P. Crochet <brad@redhat.com>
+#           Change to neutron
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    from neutronclient.neutron import client
+    from keystoneclient.v2_0 import client as ksclient
+except ImportError:
+    print("failed=True msg='neutronclient and keystone client are required'")
+
+DOCUMENTATION = '''
+---
+module: neutron_network
+version_added: "1.4"
+short_description: Creates/Removes networks from OpenStack
+description:
+   - Add or Remove network from OpenStack.
+options:
+   login_username:
+     description:
+        - login username to authenticate to keystone
+     required: true
+     default: admin
+   login_password:
+     description:
+        - Password of login user
+     required: true
+     default: 'yes'
+   login_tenant_name:
+     description:
+        - The tenant name of the login user
+     required: true
+     default: 'yes'
+   tenant_name:
+     description:
+        - The name of the tenant for whom the network is created
+     required: false
+     default: None
+   auth_url:
+     description:
+        - The keystone url for authentication
+     required: false
+     default: 'http://127.0.0.1:35357/v2.0/'
+   region_name:
+     description:
+        - Name of the region
+     required: false
+     default: None
+   state:
+     description:
+        - Indicate desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+   name:
+     description:
+        - Name to be assigned to the nework 
+     required: true
+     default: None
+   provider_network_type:
+     description:
+        - The type of the network to be created, gre, vlan, local. Available types depend on the plugin. The Quantum service decides if not specified.
+     required: false
+     default: None
+   provider_physical_network:
+     description:
+        - The physical network which would realize the virtual network for flat and vlan networks.
+     required: false
+     default: None
+   provider_segmentation_id:
+     description:
+        - The id that has to be assigned to the network, in case of vlan networks that would be vlan id and for gre the tunnel id
+     required: false
+     default: None
+   router_external:
+     description:
+        - If 'yes', specifies that the virtual network is a external network (public).
+     required: false
+     default: false
+   shared:
+     description:
+        - Whether this network is shared or not
+     required: false
+     default: false
+   admin_state_up:
+     description:
+        - Whether the state should be marked as up or down
+     required: false
+     default: true
+requirements: ["neutronclient", "keystoneclient"]
+
+'''
+
+EXAMPLES = '''
+# Create a GRE backed Quantum network with tunnel id 1 for tenant1
+- neutron_network: name=t1network tenant_name=tenant1 state=present
+                   provider_network_type=gre provider_segmentation_id=1
+                   login_username=admin login_password=admin login_tenant_name=admin
+
+# Create an external network
+- neutron_network: name=external_network state=present
+                   provider_network_type=local router_external=yes
+                   login_username=admin login_password=admin login_tenant_name=admin
+'''
+
+_os_keystone = None
+_os_tenant_id = None
+
+def _get_ksclient(module, kwargs):
+    try:
+        kclient = ksclient.Client(username=kwargs.get('login_username'),
+                                 password=kwargs.get('login_password'),
+                                 tenant_name=kwargs.get('login_tenant_name'),
+                                 auth_url=kwargs.get('auth_url'))
+    except Exception as e:   
+        module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
+    global _os_keystone 
+    _os_keystone = kclient
+    return kclient 
+ 
+
+def _get_endpoint(module, ksclient):
+    try:
+        endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
+    except Exception as e:
+        module.fail_json(msg = "Error getting endpoint for Quantum: %s " %e.message)
+    return endpoint
+
+def _get_neutron_client(module, kwargs):
+    _ksclient = _get_ksclient(module, kwargs)
+    token = _ksclient.auth_token
+    endpoint = _get_endpoint(module, _ksclient)
+    kwargs = {
+            'token': token,
+            'endpoint_url': endpoint
+    }
+    try:
+        neutron = client.Client('2.0', **kwargs)
+    except Exception as e:
+        module.fail_json(msg = " Error in connecting to neutron: %s " %e.message)
+    return neutron
+
+def _set_tenant_id(module):
+    global _os_tenant_id
+    if not module.params['tenant_name']:
+        tenant_name = module.params['login_tenant_name']
+    else:
+        tenant_name = module.params['tenant_name']
+        
+    for tenant in _os_keystone.tenants.list():
+        if tenant.name == tenant_name:
+            _os_tenant_id = tenant.id
+            break
+    if not _os_tenant_id:
+        module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
+
+
+def _get_net_id(neutron, module):
+    kwargs = {
+            'tenant_id': _os_tenant_id,
+            'name': module.params['name'],
+    }
+    try:
+        networks = neutron.list_networks(**kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in listing neutron networks: %s" % e.message)
+    if not networks['networks']:        
+        return None
+    return networks['networks'][0]['id']
+
+def _create_network(module, neutron):
+
+    neutron.format = 'json'
+
+    network = {
+        'name':                      module.params.get('name'),
+        'tenant_id':                 _os_tenant_id,
+        'provider:network_type':     module.params.get('provider_network_type'),
+        'provider:physical_network': module.params.get('provider_physical_network'),
+        'provider:segmentation_id':  module.params.get('provider_segmentation_id'),
+        'router:external':           module.params.get('router_external'),
+        'shared':                    module.params.get('shared'),
+        'admin_state_up':            module.params.get('admin_state_up'),
+    }
+
+    if module.params['provider_network_type'] == 'local':
+        network.pop('provider:physical_network', None)
+        network.pop('provider:segmentation_id', None)
+
+    if module.params['provider_network_type'] == 'flat':
+        network.pop('provider:segmentation_id', None)
+
+    if module.params['provider_network_type'] == 'gre':
+        network.pop('provider:physical_network', None)
+
+    if module.params['provider_network_type'] is None:
+        network.pop('provider:network_type', None)
+        network.pop('provider:physical_network', None)
+        network.pop('provider:segmentation_id', None)
+
+    try:
+        net = neutron.create_network({'network':network})
+    except Exception as e:
+        module.fail_json(msg = "Error in creating network: %s" % e.message)
+    return net['network']['id']
+                
+def _delete_network(module, net_id, neutron):
+
+    try:
+        id = neutron.delete_network(net_id)
+    except Exception as e: 
+        module.fail_json(msg = "Error in deleting the network: %s" % e.message)
+    return True
+
+def main():
+    
+    module = AnsibleModule(
+        argument_spec                   = dict(
+            login_username                  = dict(default='admin'),
+            login_password                  = dict(required=True),
+            login_tenant_name               = dict(required='True'),
+            auth_url                        = dict(default='http://127.0.0.1:35357/v2.0/'),
+            region_name                     = dict(default=None),
+            name                            = dict(required=True),
+            tenant_name                     = dict(default=None),
+            provider_network_type           = dict(default=None, choices=['local', 'vlan', 'flat', 'gre']),
+            provider_physical_network       = dict(default=None), 
+            provider_segmentation_id        = dict(default=None), 
+            router_external                 = dict(default=False, type='bool'),
+            shared                          = dict(default=False, type='bool'),
+            admin_state_up                  = dict(default=True, type='bool'),
+            state                           = dict(default='present', choices=['absent', 'present'])
+        ),
+    )
+
+    if module.params['provider_network_type'] in ['vlan' , 'flat']:
+            if not module.params['provider_physical_network']:
+                module.fail_json(msg = " for vlan and flat networks, variable provider_physical_network should be set.")
+
+    if module.params['provider_network_type']  in ['vlan', 'gre']:
+            if not module.params['provider_segmentation_id']:
+                module.fail_json(msg = " for vlan & gre networks, variable provider_segmentation_id should be set.")
+
+    neutron = _get_neutron_client(module, module.params)
+
+    _set_tenant_id(module)      
+
+    if module.params['state'] == 'present':     
+        network_id = _get_net_id(neutron, module)
+        if not network_id:
+            network_id = _create_network(module, neutron)
+            module.exit_json(changed = True, result = "Created", id = network_id)
+        else:
+            module.exit_json(changed = False, result = "Success", id = network_id)
+
+    if module.params['state'] == 'absent':
+        network_id = _get_net_id(neutron, module)
+        if not network_id:
+            module.exit_json(changed = False, result = "Success")
+        else:
+            _delete_network(module, network_id, neutron)
+            module.exit_json(changed = True, result = "Deleted")
+
+# this is magic, see lib/ansible/module.params['common.py
+from ansible.module_utils.basic import *
+main()
+

--- a/library/cloud/neutron_router
+++ b/library/cloud/neutron_router
@@ -1,0 +1,213 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# (c) 2013, Benno Joy <benno@ansibleworks.com>
+# (c) 2013, Brad P. Crochet <brad@redhat.com>
+#           Change to neutron
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    from neutronclient.neutron import client
+    from keystoneclient.v2_0 import client as ksclient
+except ImportError:
+    print("failed=True msg='neutronclient and keystone client are required'")
+
+DOCUMENTATION = '''
+---
+module: neutron_router
+version_added: "1.2"
+short_description: Create or Remove router from openstack
+description:
+   - Create or Delete routers from OpenStack
+options:
+   login_username:
+     description:
+        - login username to authenticate to keystone
+     required: true
+     default: admin
+   login_password:
+     description:
+        - Password of login user
+     required: true
+     default: 'yes'
+   login_tenant_name:
+     description:
+        - The tenant name of the login user
+     required: true
+     default: 'yes'
+   auth_url:
+     description:
+        - The keystone url for authentication
+     required: false
+     default: 'http://127.0.0.1:35357/v2.0/'
+   region_name:
+     description:
+        - Name of the region
+     required: false
+     default: None
+   state:
+     description:
+        - Indicate desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+   name:
+     description:
+        - Name to be give to the router
+     required: true
+     default: None
+   tenant_name:
+     description:
+        - Name of the tenant for which the router has to be created, if none router would be created for the login tenant.
+     required: false
+     default: None
+   admin_state_up:
+     description:
+        - desired admin state of the created router .
+     required: false
+     default: true
+requirements: ["neutronclient", "keystoneclient"]
+'''
+
+EXAMPLES = '''
+# Creates a router for tenant admin
+- neutron_router: state=present
+                login_username=admin
+                login_password=admin
+                login_tenant_name=admin
+                name=router1"
+'''
+
+_os_keystone = None
+_os_tenant_id = None
+
+def _get_ksclient(module, kwargs):
+    try:
+        kclient = ksclient.Client(username=kwargs.get('login_username'),
+                                 password=kwargs.get('login_password'),
+                                 tenant_name=kwargs.get('login_tenant_name'),
+                                 auth_url=kwargs.get('auth_url'))
+    except Exception as e:   
+        module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
+    global _os_keystone 
+    _os_keystone = kclient
+    return kclient 
+ 
+
+def _get_endpoint(module, ksclient):
+    try:
+        endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
+    except Exception as e:
+        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+    return endpoint
+
+def _get_neutron_client(module, kwargs):
+    _ksclient = _get_ksclient(module, kwargs)
+    token = _ksclient.auth_token
+    endpoint = _get_endpoint(module, _ksclient)
+    kwargs = {
+            'token': token,
+            'endpoint_url': endpoint
+    }
+    try:
+        neutron = client.Client('2.0', **kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+    return neutron
+
+def _set_tenant_id(module):
+    global _os_tenant_id
+    if not module.params['tenant_name']:
+        login_tenant_name = module.params['login_tenant_name']
+    else:
+        login_tenant_name = module.params['tenant_name']
+
+    for tenant in _os_keystone.tenants.list():
+        if tenant.name == login_tenant_name:
+            _os_tenant_id = tenant.id
+            break
+    if not _os_tenant_id:
+            module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
+
+
+def _get_router_id(module, neutron):
+    kwargs = {
+            'name': module.params['name'],
+            'tenant_id': _os_tenant_id,
+    }
+    try:
+        routers = neutron.list_routers(**kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in getting the router list: %s " % e.message)
+    if not routers['routers']:
+        return None
+    return routers['routers'][0]['id']
+
+def _create_router(module, neutron):
+    router = {
+            'name': module.params['name'],
+            'tenant_id': _os_tenant_id,
+            'admin_state_up': module.params['admin_state_up'],
+    }
+    try:
+        new_router = neutron.create_router(dict(router=router))
+    except Exception as e:
+        module.fail_json( msg = "Error in creating router: %s" % e.message)
+    return new_router['router']['id']
+
+def _delete_router(module, neutron, router_id):
+    try:
+        neutron.delete_router(router_id)
+    except:
+        module.fail_json("Error in deleting the router")
+    return True
+                
+def main():
+    module = AnsibleModule(
+        argument_spec                   = dict(
+        login_username                  = dict(default='admin'),
+        login_password                  = dict(required=True),
+        login_tenant_name               = dict(required='True'),
+        auth_url                        = dict(default='http://127.0.0.1:35357/v2.0/'),
+        region_name                     = dict(default=None),
+        name                            = dict(required=True),
+        tenant_name                     = dict(default=None),
+        state                           = dict(default='present', choices=['absent', 'present']),
+        admin_state_up                  = dict(type='bool', default=True),
+        ),
+    )
+                
+    neutron = _get_neutron_client(module, module.params)
+    _set_tenant_id(module)
+
+    if module.params['state'] == 'present':
+        router_id = _get_router_id(module, neutron)
+        if not router_id:
+            router_id = _create_router(module, neutron)
+            module.exit_json(changed=True, result="Created", id=router_id)
+        else:
+            module.exit_json(changed=False, result="success" , id=router_id)
+
+    else:
+        router_id = _get_router_id(module, neutron)
+        if not router_id:
+            module.exit_json(changed=False, result="success")
+        else:
+            _delete_router(module, neutron, router_id)
+            module.exit_json(changed=True, result="deleted")
+                
+# this is magic, see lib/ansible/module.params['common.py
+from ansible.module_utils.basic import *
+main()
+

--- a/library/cloud/neutron_router_gateway
+++ b/library/cloud/neutron_router_gateway
@@ -1,0 +1,216 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# (c) 2013, Benno Joy <benno@ansibleworks.com>
+# (c) 2013, Brad P. Crochet <brad@redhat.com>
+#           Change to neutron
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    from neutronclient.neutron import client
+    from keystoneclient.v2_0 import client as ksclient
+except ImportError:
+    print("failed=True msg='neutronclient and keystone client are required'")
+DOCUMENTATION = '''
+---
+module: neutron_router_gateway
+version_added: "1.2"
+short_description: set/unset a gateway interface for the router with the specified external network
+description:
+   - Creates/Removes a gateway interface from the router, used to associate a external network with a router to route external traffic.
+options:
+   login_username:
+     description:
+        - login username to authenticate to keystone
+     required: true
+     default: admin
+   login_password:
+     description:
+        - Password of login user
+     required: true
+     default: 'yes'
+   login_tenant_name:
+     description:
+        - The tenant name of the login user
+     required: true
+     default: 'yes'
+   auth_url:
+     description:
+        - The keystone URL for authentication
+     required: false
+     default: 'http://127.0.0.1:35357/v2.0/'
+   region_name:
+     description:
+        - Name of the region
+     required: false
+     default: None
+   state:
+     description:
+        - Indicate desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+   router_name:
+     description:
+        - Name of the router to which the gateway should be attached.
+     required: true
+     default: None
+   network_name:
+     description:
+        - Name of the external network which should be attached to the router.
+     required: true
+     default: None
+requirements: ["neutronclient", "keystoneclient"]
+'''
+
+EXAMPLES = '''
+# Attach an external network with a router to allow flow of external traffic
+- neutron_router_gateway: state=present login_username=admin login_password=admin
+                          login_tenant_name=admin router_name=external_router
+                          network_name=external_network
+'''
+
+_os_keystone = None
+def _get_ksclient(module, kwargs):
+    try:
+        kclient = ksclient.Client(username=kwargs.get('login_username'),
+                                 password=kwargs.get('login_password'),
+                                 tenant_name=kwargs.get('login_tenant_name'),
+                                 auth_url=kwargs.get('auth_url'))
+    except Exception as e:   
+        module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
+    global _os_keystone 
+    _os_keystone = kclient
+    return kclient 
+ 
+
+def _get_endpoint(module, ksclient):
+    try:
+        endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
+    except Exception as e:
+        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+    return endpoint
+
+def _get_neutron_client(module, kwargs):
+    _ksclient = _get_ksclient(module, kwargs)
+    token = _ksclient.auth_token
+    endpoint = _get_endpoint(module, _ksclient)
+    kwargs = {
+            'token': token,
+            'endpoint_url': endpoint
+    }
+    try:
+        neutron = client.Client('2.0', **kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+    return neutron
+
+def _get_router_id(module, neutron):
+    kwargs = {
+            'name': module.params['router_name'],
+    }
+    try:
+        routers = neutron.list_routers(**kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in getting the router list: %s " % e.message)
+    if not routers['routers']:
+            return None
+    return routers['routers'][0]['id']
+
+def _get_net_id(neutron, module):
+    kwargs = {
+        'name':            module.params['network_name'],
+        'router:external': True
+    }
+    try:
+        networks = neutron.list_networks(**kwargs)
+    except Exception as e:
+        module.fail_json("Error in listing neutron networks: %s" % e.message)
+    if not networks['networks']:
+        return None
+    return networks['networks'][0]['id']
+
+def _get_port_id(neutron, module, router_id, network_id):
+    kwargs = {
+        'device_id': router_id,
+        'network_id': network_id,
+    }
+    try:
+        ports = neutron.list_ports(**kwargs)
+    except Exception as e:
+        module.fail_json( msg = "Error in listing ports: %s" % e.message)
+    if not ports['ports']:
+        return None
+    return ports['ports'][0]['id']
+
+def _add_gateway_router(neutron, module, router_id, network_id):
+    kwargs = {
+        'network_id': network_id
+    }
+    try:
+        neutron.add_gateway_router(router_id, kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in adding gateway to router: %s" % e.message)
+    return True
+                
+def  _remove_gateway_router(neutron, module, router_id):
+    try:
+        neutron.remove_gateway_router(router_id)
+    except Exception as e:
+        module.fail_json(msg = "Error in removing gateway to router: %s" % e.message)
+    return True
+        
+def main():
+    
+    module = AnsibleModule(
+        argument_spec          = dict(
+            login_username     = dict(default='admin'),
+            login_password     = dict(required=True),
+            login_tenant_name  = dict(required='True'),
+            auth_url           = dict(default='http://127.0.0.1:35357/v2.0/'),
+            region_name        = dict(default=None),
+            router_name        = dict(required=True),
+            network_name       = dict(required=True),
+            state              = dict(default='present', choices=['absent', 'present']),
+        ),
+    )
+                
+    neutron = _get_neutron_client(module, module.params)
+    router_id = _get_router_id(module, neutron)
+
+    if not router_id:
+        module.fail_json(msg="failed to get the router id, please check the router name")
+
+    network_id = _get_net_id(neutron, module)   
+    if not network_id:
+        module.fail_json(msg="failed to get the network id, please check the network name and make sure it is external")
+                
+    if module.params['state'] == 'present':
+        port_id = _get_port_id(neutron, module, router_id, network_id)
+        if not port_id:
+            _add_gateway_router(neutron, module, router_id, network_id)
+            module.exit_json(changed=True, result="created")
+        module.exit_json(changed=False, result="success")
+
+    if module.params['state'] == 'absent':
+        port_id = _get_port_id(neutron, module, router_id, network_id)
+        if not port_id:
+            module.exit_json(changed=False, result="Success")
+        _remove_gateway_router(neutron, module, router_id)
+        module.exit_json(changed=True, result="Deleted")
+
+# this is magic, see lib/ansible/module.params['common.py
+from ansible.module_utils.basic import *
+main()
+

--- a/library/cloud/neutron_router_interface
+++ b/library/cloud/neutron_router_interface
@@ -1,0 +1,252 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# (c) 2013, Benno Joy <benno@ansibleworks.com>
+# (c) 2013, Brad P. Crochet <brad@redhat.com>
+#           Change to neutron
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    from neutronclient.neutron import client
+    from keystoneclient.v2_0 import client as ksclient
+except ImportError:
+    print("failed=True msg='neutronclient and keystone client are required'")
+DOCUMENTATION = '''
+---
+module: neutron_router_interface
+version_added: "1.2"
+short_description: Attach/Dettach a subnet's interface to a router
+description:
+   - Attach/Dettach a subnet interface to a router, to provide a gateway for the subnet.
+options:
+   login_username:
+     description:
+        - login username to authenticate to keystone
+     required: true
+     default: admin
+   login_password:
+     description:
+        - Password of login user
+     required: true
+     default: 'yes'
+   login_tenant_name:
+     description:
+        - The tenant name of the login user
+     required: true
+     default: 'yes'
+   auth_url:
+     description:
+        - The keystone URL for authentication
+     required: false
+     default: 'http://127.0.0.1:35357/v2.0/'
+   region_name:
+     description:
+        - Name of the region
+     required: false
+     default: None
+   state:
+     description:
+        - Indicate desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+   router_name:
+     description:
+        - Name of the router to which the subnet's interface should be attached.
+     required: true
+     default: None
+   subnet_name:
+     description:
+        - Name of the subnet to whose interface should be attached to the router.
+     required: true
+     default: None
+   tenant_name:
+     description:
+        - Name of the tenant whose subnet has to be attached.
+     required: false
+     default: None
+requirements: ["neutronclient", "keystoneclient"]
+'''
+
+EXAMPLES = '''
+# Attach tenant1's subnet to the external router
+- neutron_router_interface: state=present login_username=admin
+                            login_password=admin
+                            login_tenant_name=admin 
+                            tenant_name=tenant1
+                            router_name=external_route
+                            subnet_name=t1subnet
+'''
+
+
+_os_keystone = None
+_os_tenant_id = None
+
+def _get_ksclient(module, kwargs):
+    try:
+        kclient = ksclient.Client(username=kwargs.get('login_username'),
+                                 password=kwargs.get('login_password'),
+                                 tenant_name=kwargs.get('login_tenant_name'),
+                                 auth_url=kwargs.get('auth_url'))
+    except Exception as e:   
+        module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
+    global _os_keystone 
+    _os_keystone = kclient
+    return kclient 
+ 
+
+def _get_endpoint(module, ksclient):
+    try:
+        endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
+    except Exception as e:
+        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+    return endpoint
+
+def _get_neutron_client(module, kwargs):
+    _ksclient = _get_ksclient(module, kwargs)
+    token = _ksclient.auth_token
+    endpoint = _get_endpoint(module, _ksclient)
+    kwargs = {
+            'token': token,
+            'endpoint_url': endpoint
+    }
+    try:
+        neutron = client.Client('2.0', **kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+    return neutron
+
+def _set_tenant_id(module):
+    global _os_tenant_id
+    if not module.params['tenant_name']:
+        login_tenant_name = module.params['login_tenant_name']
+    else:
+        login_tenant_name = module.params['tenant_name']
+
+    for tenant in _os_keystone.tenants.list():
+        if tenant.name == login_tenant_name:
+            _os_tenant_id = tenant.id
+            break
+    if not _os_tenant_id:
+        module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
+
+
+def _get_router_id(module, neutron):
+    kwargs = {
+        'name': module.params['router_name'],
+    }
+    try:
+        routers = neutron.list_routers(**kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in getting the router list: %s " % e.message)
+    if not routers['routers']:
+        return None
+    return routers['routers'][0]['id']
+
+
+def _get_subnet_id(module, neutron):
+    subnet_id = None
+    kwargs = {
+            'tenant_id': _os_tenant_id,
+            'name': module.params['subnet_name'],
+    }
+    try:
+        subnets = neutron.list_subnets(**kwargs)
+    except Exception as e:
+        module.fail_json( msg = " Error in getting the subnet list:%s " % e.message)
+    if not subnets['subnets']:
+        return None
+    return subnets['subnets'][0]['id']
+                
+def _get_port_id(neutron, module, router_id, subnet_id):
+    kwargs = {
+            'tenant_id': _os_tenant_id,
+            'device_id': router_id,
+    }
+    try:
+        ports = neutron.list_ports(**kwargs)
+    except Exception as e:
+        module.fail_json( msg = "Error in listing ports: %s" % e.message)
+    if not ports['ports']:
+        return None
+    for port in  ports['ports']:
+        for subnet in port['fixed_ips']:
+            if subnet['subnet_id'] == subnet_id:
+                return port['id']
+    return None
+
+def _add_interface_router(neutron, module, router_id, subnet_id):
+    kwargs = {
+        'subnet_id': subnet_id
+    }
+    try:
+        neutron.add_interface_router(router_id, kwargs)
+    except Exception as e:
+        module.fail_json(msg = "Error in adding interface to router: %s" % e.message)
+    return True
+                
+def  _remove_interface_router(neutron, module, router_id, subnet_id):
+    kwargs = {
+        'subnet_id': subnet_id
+    }
+    try:
+        neutron.remove_interface_router(router_id, kwargs)
+    except Exception as e:
+        module.fail_json(msg="Error in removing interface from router: %s" % e.message)
+    return True
+        
+def main():
+    module = AnsibleModule(
+        argument_spec                   = dict(
+            login_username                  = dict(default='admin'),
+            login_password                  = dict(required=True),
+            login_tenant_name               = dict(required='True'),
+            auth_url                        = dict(default='http://127.0.0.1:35357/v2.0/'),
+            region_name                     = dict(default=None),
+            router_name                     = dict(required=True),
+            subnet_name                     = dict(required=True),
+            tenant_name                     = dict(default=None),
+            state                           = dict(default='present', choices=['absent', 'present']),
+        ),
+    )
+                
+    neutron = _get_neutron_client(module, module.params)
+    _set_tenant_id(module)
+
+    router_id = _get_router_id(module, neutron)
+    if not router_id:
+        module.fail_json(msg="failed to get the router id, please check the router name")
+
+    subnet_id = _get_subnet_id(module, neutron) 
+    if not subnet_id:
+        module.fail_json(msg="failed to get the subnet id, please check the subnet name")
+                
+    if module.params['state'] == 'present':
+        port_id = _get_port_id(neutron, module, router_id, subnet_id)
+        if not port_id:
+            _add_interface_router(neutron, module, router_id, subnet_id)
+            module.exit_json(changed=True, result="created", id=port_id)
+        module.exit_json(changed=False, result="success", id=port_id)
+
+    if module.params['state'] == 'absent':
+        port_id = _get_port_id(neutron, module, router_id, subnet_id)
+        if not port_id:
+            module.exit_json(changed = False, result = "Success")
+        _remove_interface_router(neutron, module, router_id, subnet_id)
+        module.exit_json(changed=True, result="Deleted")
+                        
+# this is magic, see lib/ansible/module.params['common.py
+from ansible.module_utils.basic import *
+main()
+

--- a/library/cloud/neutron_subnet
+++ b/library/cloud/neutron_subnet
@@ -1,0 +1,288 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# (c) 2013, Benno Joy <benno@ansibleworks.com>
+# (c) 2013, Brad P. Crochet <brad@redhat.com>
+#           Change to neutron
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    from neutronclient.neutron import client
+    from keystoneclient.v2_0 import client as ksclient
+except ImportError:
+    print("failed=True msg='neutron and keystone client are required'")
+
+DOCUMENTATION = '''
+---
+module: neutron_subnet
+version_added: "1.2"
+short_description: Add/Remove floating IP from an instance
+description:
+   - Add or Remove a floating IP to an instance
+options:
+   login_username:
+     description:
+        - login username to authenticate to keystone
+     required: true
+     default: admin
+   login_password:
+     description:
+        - Password of login user
+     required: true
+     default: True
+   login_tenant_name:
+     description:
+        - The tenant name of the login user
+     required: true
+     default: True
+   auth_url:
+     description:
+        - The keystone URL for authentication
+     required: false
+     default: 'http://127.0.0.1:35357/v2.0/'
+   region_name:
+     description:
+        - Name of the region
+     required: false
+     default: None
+   state:
+     description:
+        - Indicate desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+   network_name:
+     description:
+        - Name of the network to which the subnet should be attached
+     required: true
+     default: None
+   cidr:
+     description:
+        - The CIDR representation of the subnet that should be assigned to the subnet
+     required: true
+     default: None
+   tenant_name:
+     description:
+        - The name of the tenant for whom the subnet should be created
+     required: false
+     default: None
+   ip_version:
+     description:
+        - The IP version of the subnet 4 or 6 
+     required: false
+     default: 4
+   enable_dhcp:
+     description:
+        - Whether DHCP should be enabled for this subnet.
+     required: false
+     default: true
+   gateway_ip:
+     description:
+        - The ip that would be assigned to the gateway for this subnet
+     required: false
+     default: None
+   dns_nameservers:
+     description:
+        - DNS nameservers for this subnet, comma-separated
+     required: false
+     default: None
+   allocation_pool_start:
+     description:
+        - From the subnet pool the starting address from which the IP should be allocated
+     required: false
+     default: None
+   allocation_pool_end:
+     description:
+        - From the subnet pool the last IP that should be assigned to the virtual machines
+     required: false
+     default: None
+requirements: ["neutron", "keystoneclient"]
+'''
+
+EXAMPLES = '''
+# Create a subnet for a tenant with the specified subnet
+- neutron_subnet: state=present login_username=admin login_password=admin
+                  login_tenant_name=admin tenant_name=tenant1
+                  network_name=network1 name=net1subnet cidr=192.168.0.0/24"
+'''
+
+_os_keystone   = None
+_os_tenant_id  = None
+_os_network_id = None
+
+def _get_ksclient(module, kwargs):
+    try:
+        kclient = ksclient.Client(username=kwargs.get('login_username'),
+                                 password=kwargs.get('login_password'),
+                                 tenant_name=kwargs.get('login_tenant_name'),
+                                 auth_url=kwargs.get('auth_url'))
+    except Exception as e:   
+        module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
+    global _os_keystone 
+    _os_keystone = kclient
+    return kclient 
+ 
+
+def _get_endpoint(module, ksclient):
+    try:
+        endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
+    except Exception as e:
+        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+    return endpoint
+
+def _get_neutron_client(module, kwargs):
+    _ksclient = _get_ksclient(module, kwargs)
+    token     = _ksclient.auth_token
+    endpoint  = _get_endpoint(module, _ksclient)
+    kwargs = {
+            'token':        token,
+            'endpoint_url': endpoint
+    }
+    try:
+        neutron = client.Client('2.0', **kwargs)
+    except Exception as e:
+        module.fail_json(msg = " Error in connecting to neutron: %s" % e.message)
+    return neutron
+
+def _set_tenant_id(module):
+    global _os_tenant_id
+    if not module.params['tenant_name']:
+        tenant_name = module.params['login_tenant_name']
+    else:
+        tenant_name = module.params['tenant_name']
+
+    for tenant in _os_keystone.tenants.list():
+        if tenant.name == tenant_name:
+            _os_tenant_id = tenant.id
+            break
+    if not _os_tenant_id:
+            module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
+
+def _get_net_id(neutron, module):
+    kwargs = {
+        'tenant_id': _os_tenant_id,
+        'name': module.params['network_name'],
+    }
+    try:
+        networks = neutron.list_networks(**kwargs)
+    except Exception as e:
+        module.fail_json("Error in listing neutron networks: %s" % e.message)
+    if not networks['networks']:
+            return None
+    return networks['networks'][0]['id']
+
+
+def _get_subnet_id(module, neutron):
+    global _os_network_id
+    subnet_id = None
+    _os_network_id = _get_net_id(neutron, module)
+    if not _os_network_id:
+        module.fail_json(msg = "network id of network not found.")
+    else:
+        kwargs = {
+            'tenant_id': _os_tenant_id,
+            'name': module.params['name'],
+        }
+        try:
+            subnets = neutron.list_subnets(**kwargs)
+        except Exception as e:
+            module.fail_json( msg = " Error in getting the subnet list:%s " % e.message)
+        if not subnets['subnets']:
+            return None
+        return subnets['subnets'][0]['id']
+
+def _create_subnet(module, neutron):
+    neutron.format = 'json'
+    subnet = {
+            'name':            module.params['name'],
+            'ip_version':      module.params['ip_version'],
+            'enable_dhcp':     module.params['enable_dhcp'],
+            'tenant_id':       _os_tenant_id,
+            'gateway_ip':      module.params['gateway_ip'],
+            'dns_nameservers': module.params['dns_nameservers'],
+            'network_id':      _os_network_id,
+            'cidr':            module.params['cidr'],
+    }
+    if module.params['allocation_pool_start'] and module.params['allocation_pool_end']:
+        allocation_pools = [
+            { 
+                'start' : module.params['allocation_pool_start'],
+                'end'   :  module.params['allocation_pool_end']
+            }
+        ]
+        subnet.update({'allocation_pools': allocation_pools})
+    if not module.params['gateway_ip']:
+        subnet.pop('gateway_ip')
+    if module.params['dns_nameservers']:
+        subnet['dns_nameservers'] = module.params['dns_nameservers'].split(',')
+    else:
+        subnet.pop('dns_nameservers')
+    try:
+        new_subnet = neutron.create_subnet(dict(subnet=subnet))
+    except Exception, e:
+        module.fail_json(msg = "Failure in creating subnet: %s" % e.message) 
+    return new_subnet['subnet']['id']
+        
+                
+def _delete_subnet(module, neutron, subnet_id):
+    try:
+        neutron.delete_subnet(subnet_id)
+    except Exception as e:
+        module.fail_json( msg = "Error in deleting subnet: %s" % e.message)
+    return True
+        
+                
+def main():
+    
+    module = AnsibleModule(
+        argument_spec = dict(
+            login_username          = dict(default='admin'),
+            login_password          = dict(required=True),
+            login_tenant_name       = dict(required='True'),
+            auth_url                = dict(default='http://127.0.0.1:35357/v2.0/'),
+            region_name             = dict(default=None),
+            name                    = dict(required=True),
+            network_name            = dict(required=True),
+            cidr                    = dict(required=True),
+            tenant_name             = dict(default=None),
+            state                   = dict(default='present', choices=['absent', 'present']),
+            ip_version              = dict(default='4', choices=['4', '6']),
+            enable_dhcp             = dict(default='true', choices=BOOLEANS),
+            gateway_ip              = dict(default=None),
+            dns_nameservers         = dict(default=None),
+            allocation_pool_start   = dict(default=None),
+            allocation_pool_end     = dict(default=None),
+        ),
+    )
+    neutron = _get_neutron_client(module, module.params)
+    _set_tenant_id(module)
+    if module.params['state'] == 'present':
+        subnet_id = _get_subnet_id(module, neutron)
+        if not subnet_id:
+            subnet_id = _create_subnet(module, neutron)
+            module.exit_json(changed = True, result = "Created" , id = subnet_id)
+        else:
+            module.exit_json(changed = False, result = "success" , id = subnet_id)
+    else:
+        subnet_id = _get_subnet_id(module, neutron)
+        if not subnet_id:
+            module.exit_json(changed = False, result = "success")
+        else:
+            _delete_subnet(module, neutron, subnet_id)
+            module.exit_json(changed = True, result = "deleted")
+                
+# this is magic, see lib/ansible/module.params['common.py
+from ansible.module_utils.basic import *
+main()
+


### PR DESCRIPTION
Neutron is the new Quantum. Changes the library name to nuetronclient.
The only other change is in neutron_floating_ip, which allows for
the specification of which internal port to assign the floating IP
to, which is necessary when the instance has multiple NICs. The old
behaviour was to just select the first in the list returned from
neutron, but this was not always the correct network.
