### PR TITLE
quantum_* modules: Neutron name change, keeping backward compatibility

### DIFF
--- a/library/cloud/quantum_floating_ip
+++ b/library/cloud/quantum_floating_ip
@@ -67,13 +67,18 @@ options:
      default: present
    network_name:
      description:
-        - Name of the network from which IP has to be assigned to VM. Please make sure the network is an external network 
+        - Name of the network from which IP has to be assigned to VM. Please make sure the network is an external network
      required: true
      default: None
    instance_name:
      description:
         - The name of the instance to which the IP address should be assigned
      required: true
+     default: None
+   internal_network_name:
+     description:
+        - The name of the network of the port to associate with the floating ip. Necessary when VM multiple networks.
+     required: false
      default: None
 requirements: ["novaclient", "quantumclient", "neutronclient", "keystoneclient"]
 '''
@@ -82,7 +87,7 @@ EXAMPLES = '''
 # Assign a floating ip to the instance from an external network
 - quantum_floating_ip: state=present login_username=admin login_password=admin
                        login_tenant_name=admin network_name=external_network
-                       instance_name=vm1
+                       instance_name=vm1 internal_network_name=internal_network
 '''
 
 def _get_ksclient(module, kwargs):
@@ -135,7 +140,13 @@ def _get_server_state(module, nova):
         module.fail_json(msg = "Error in getting the server list: %s" % e.message)
     return server_info, server
 
-def _get_port_info(neutron, module, instance_id):
+def _get_port_info(neutron, module, instance_id, internal_network_name=None):
+    if internal_network_name:
+        kwargs = {
+            'name': internal_network_name,
+        }
+        networks = neutron.list_networks(**kwargs)
+        subnet_id = networks['networks'][0]['subnets'][0]
     kwargs = {
             'device_id': instance_id,
     }
@@ -143,9 +154,16 @@ def _get_port_info(neutron, module, instance_id):
         ports = neutron.list_ports(**kwargs)
     except Exception as e:
         module.fail_json( msg = "Error in listing ports: %s" % e.message)
+    if subnet_id:
+        port = next(port for port in ports['ports'] if port['fixed_ips'][0]['subnet_id'] == subnet_id)
+        port_id = port['id']
+        fixed_ip_address = port['fixed_ips'][0]['ip_address']
+    else:
+        port_id = ports['ports'][0]['id']
+        fixed_ip_address = ports['ports'][0]['fixed_ips'][0]['ip_address']
     if not ports['ports']:
         return None, None
-    return ports['ports'][0]['fixed_ips'][0]['ip_address'], ports['ports'][0]['id']
+    return fixed_ip_address, port_id
 
 def _get_floating_ip(module, neutron, fixed_ip_address):
     kwargs = {
@@ -204,7 +222,8 @@ def main():
             region_name                     = dict(default=None),
             network_name                    = dict(required=True),
             instance_name                   = dict(required=True),
-            state                           = dict(default='present', choices=['absent', 'present'])
+            state                           = dict(default='present', choices=['absent', 'present']),
+            internal_network_name           = dict(default=None),
         ),
     )
 
@@ -219,7 +238,7 @@ def main():
     if not server_info:
         module.fail_json(msg="The instance name provided cannot be found")
 
-    fixed_ip, port_id = _get_port_info(neutron, module, server_info['id'])
+    fixed_ip, port_id = _get_port_info(neutron, module, server_info['id'], module.params['internal_network_name'])
     if not port_id:
         module.fail_json(msg="Cannot find a port for this instance, maybe fixed ip is not assigned")
 

--- a/library/cloud/quantum_floating_ip
+++ b/library/cloud/quantum_floating_ip
@@ -18,11 +18,14 @@
 
 try:
     from novaclient.v1_1 import client as nova_client
-    from quantumclient.quantum import client
+    try:
+        from neutronclient.neutron import client
+    except ImportError:
+        from quantumclient.quantum import client
     from keystoneclient.v2_0 import client as ksclient
     import time
 except ImportError:
-    print("failed=True msg='glanceclient,keystoneclient and quantumclient client are required'")
+    print("failed=True msg='novaclient,keystoneclient and quantumclient (or neutronclient) are required'")
 
 DOCUMENTATION = '''
 ---
@@ -72,7 +75,7 @@ options:
         - The name of the instance to which the IP address should be assigned
      required: true
      default: None
-requirements: ["novaclient", "quantumclient", "keystoneclient"]
+requirements: ["novaclient", "quantumclient", "neutronclient", "keystoneclient"]
 '''
 
 EXAMPLES = '''
@@ -99,10 +102,10 @@ def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
     except Exception as e:
-        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+        module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
-def _get_quantum_client(module, kwargs):
+def _get_neutron_client(module, kwargs):
     _ksclient = _get_ksclient(module, kwargs)
     token = _ksclient.auth_token
     endpoint = _get_endpoint(module, _ksclient)
@@ -111,10 +114,10 @@ def _get_quantum_client(module, kwargs):
             'endpoint_url': endpoint
     }
     try:
-        quantum = client.Client('2.0', **kwargs)
+        neutron = client.Client('2.0', **kwargs)
     except Exception as e:
-        module.fail_json(msg = "Error in connecting to quantum: %s " % e.message)
-    return quantum       
+        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+    return neutron
 
 def _get_server_state(module, nova):
     server_info = None
@@ -130,68 +133,68 @@ def _get_server_state(module, nova):
                     break
     except Exception as e:
         module.fail_json(msg = "Error in getting the server list: %s" % e.message)
-    return server_info, server          
-                                 
-def _get_port_info(quantum, module, instance_id):
+    return server_info, server
+
+def _get_port_info(neutron, module, instance_id):
     kwargs = {
             'device_id': instance_id,
     }
     try:
-        ports = quantum.list_ports(**kwargs)
+        ports = neutron.list_ports(**kwargs)
     except Exception as e:
         module.fail_json( msg = "Error in listing ports: %s" % e.message)
     if not ports['ports']:
         return None, None
     return ports['ports'][0]['fixed_ips'][0]['ip_address'], ports['ports'][0]['id']
-        
-def _get_floating_ip(module, quantum, fixed_ip_address):
+
+def _get_floating_ip(module, neutron, fixed_ip_address):
     kwargs = {
             'fixed_ip_address': fixed_ip_address
     }
     try:
-        ips = quantum.list_floatingips(**kwargs)
+        ips = neutron.list_floatingips(**kwargs)
     except Exception as e:
         module.fail_json(msg = "error in fetching the floatingips's %s" % e.message)
     if not ips['floatingips']:
         return None, None
     return ips['floatingips'][0]['id'], ips['floatingips'][0]['floating_ip_address']
 
-def _create_floating_ip(quantum, module, port_id, net_id):
+def _create_floating_ip(neutron, module, port_id, net_id):
     kwargs = {
             'port_id': port_id,
             'floating_network_id': net_id
     }
     try:
-        result = quantum.create_floatingip({'floatingip': kwargs})
+        result = neutron.create_floatingip({'floatingip': kwargs})
     except Exception as e:
         module.fail_json(msg="There was an error in updating the floating ip address: %s" % e.message)
     module.exit_json(changed=True, result=result, public_ip=result['floatingip']['floating_ip_address'])
 
-def _get_net_id(quantum, module):
+def _get_net_id(neutron, module):
     kwargs = {
         'name': module.params['network_name'],
     }
     try:
-        networks = quantum.list_networks(**kwargs)
+        networks = neutron.list_networks(**kwargs)
     except Exception as e:
-        module.fail_json("Error in listing quantum networks: %s" % e.message)
+        module.fail_json("Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
         return None
     return networks['networks'][0]['id']
 
-def _update_floating_ip(quantum, module, port_id, floating_ip_id):
+def _update_floating_ip(neutron, module, port_id, floating_ip_id):
     kwargs = {
         'port_id': port_id
     }
     try:
-        result = quantum.update_floatingip(floating_ip_id, {'floatingip': kwargs})
+        result = neutron.update_floatingip(floating_ip_id, {'floatingip': kwargs})
     except Exception as e:
         module.fail_json(msg="There was an error in updating the floating ip address: %s" % e.message)
     module.exit_json(changed=True, result=result)
 
 
 def main():
-    
+
     module = AnsibleModule(
         argument_spec = dict(
             login_username                  = dict(default='admin'),
@@ -200,39 +203,39 @@ def main():
             auth_url                        = dict(default='http://127.0.0.1:35357/v2.0/'),
             region_name                     = dict(default=None),
             network_name                    = dict(required=True),
-            instance_name                   = dict(required=True), 
+            instance_name                   = dict(required=True),
             state                           = dict(default='present', choices=['absent', 'present'])
         ),
     )
-        
+
     try:
-        nova = nova_client.Client(module.params['login_username'], module.params['login_password'], 
+        nova = nova_client.Client(module.params['login_username'], module.params['login_password'],
             module.params['login_tenant_name'], module.params['auth_url'], service_type='compute')
-        quantum = _get_quantum_client(module, module.params)
+        neutron = _get_neutron_client(module, module.params)
     except Exception as e:
         module.fail_json(msg="Error in authenticating to nova: %s" % e.message)
-        
+
     server_info, server_obj = _get_server_state(module, nova)
     if not server_info:
         module.fail_json(msg="The instance name provided cannot be found")
 
-    fixed_ip, port_id = _get_port_info(quantum, module, server_info['id'])
+    fixed_ip, port_id = _get_port_info(neutron, module, server_info['id'])
     if not port_id:
         module.fail_json(msg="Cannot find a port for this instance, maybe fixed ip is not assigned")
 
-    floating_id, floating_ip = _get_floating_ip(module, quantum, fixed_ip)
+    floating_id, floating_ip = _get_floating_ip(module, neutron, fixed_ip)
 
     if module.params['state'] == 'present':
         if floating_ip:
             module.exit_json(changed = False, public_ip=floating_ip)
-        net_id = _get_net_id(quantum, module)   
+        net_id = _get_net_id(neutron, module)
         if not net_id:
             module.fail_json(msg = "cannot find the network specified, please check")
-        _create_floating_ip(quantum, module, port_id, net_id)
+        _create_floating_ip(neutron, module, port_id, net_id)
 
     if module.params['state'] == 'absent':
         if floating_ip:
-            _update_floating_ip(quantum, module, None, floating_id)
+            _update_floating_ip(neutron, module, None, floating_id)
         module.exit_json(changed=False)
 
 # this is magic, see lib/ansible/module.params['common.py

--- a/library/cloud/quantum_floating_ip_associate
+++ b/library/cloud/quantum_floating_ip_associate
@@ -18,11 +18,14 @@
 
 try:
     from novaclient.v1_1 import client as nova_client
-    from quantumclient.quantum import client
+    try:
+        from neutronclient.neutron import client
+    except ImportError:
+        from quantumclient.quantum import client
     from keystoneclient.v2_0 import client as ksclient
     import time
 except ImportError:
-    print "failed=True msg='glanceclient,novaclient and keystone client are required'"
+    print "failed=True msg='novaclient, keystone, and quantumclient (or neutronclient) client are required'"
 
 DOCUMENTATION = '''
 ---
@@ -72,7 +75,7 @@ options:
         - floating ip that should be assigned to the instance
      required: true
      default: None
-requirements: ["quantumclient", "keystoneclient"]
+requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 '''
 
 EXAMPLES = '''
@@ -103,10 +106,10 @@ def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
     except Exception as e:
-        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+        module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
-def _get_quantum_client(module, kwargs):
+def _get_neutron_client(module, kwargs):
     _ksclient = _get_ksclient(module, kwargs)
     token = _ksclient.auth_token
     endpoint = _get_endpoint(module, _ksclient)
@@ -115,10 +118,10 @@ def _get_quantum_client(module, kwargs):
             'endpoint_url': endpoint
     }
     try:
-        quantum = client.Client('2.0', **kwargs)
+        neutron = client.Client('2.0', **kwargs)
     except Exception as e:
-        module.fail_json(msg = "Error in connecting to quantum: %s " % e.message)
-    return quantum       
+        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+    return neutron
 
 def _get_server_state(module, nova):
     server_info = None
@@ -134,24 +137,24 @@ def _get_server_state(module, nova):
                     break
     except Exception as e:
             module.fail_json(msg = "Error in getting the server list: %s" % e.message)
-    return server_info, server          
-                                 
-def _get_port_id(quantum, module, instance_id):
+    return server_info, server
+
+def _get_port_id(neutron, module, instance_id):
     kwargs = dict(device_id = instance_id)
     try:
-        ports = quantum.list_ports(**kwargs)
+        ports = neutron.list_ports(**kwargs)
     except Exception as e:
         module.fail_json( msg = "Error in listing ports: %s" % e.message)
     if not ports['ports']:
         return None
     return ports['ports'][0]['id']
-        
-def _get_floating_ip_id(module, quantum):
+
+def _get_floating_ip_id(module, neutron):
     kwargs = {
         'floating_ip_address': module.params['ip_address']
     }
     try:
-        ips = quantum.list_floatingips(**kwargs)
+        ips = neutron.list_floatingips(**kwargs)
     except Exception as e:
         module.fail_json(msg = "error in fetching the floatingips's %s" % e.message)
     if not ips['floatingips']:
@@ -163,18 +166,18 @@ def _get_floating_ip_id(module, quantum):
         state = "attached"
     return state, ip
 
-def _update_floating_ip(quantum, module, port_id, floating_ip_id):
+def _update_floating_ip(neutron, module, port_id, floating_ip_id):
     kwargs = {
         'port_id': port_id
     }
     try:
-        result = quantum.update_floatingip(floating_ip_id, {'floatingip': kwargs})
+        result = neutron.update_floatingip(floating_ip_id, {'floatingip': kwargs})
     except Exception as e:
         module.fail_json(msg = "There was an error in updating the floating ip address: %s" % e.message)
     module.exit_json(changed = True, result = result, public_ip=module.params['ip_address'])
 
 def main():
-    
+
     module = AnsibleModule(
         argument_spec                   = dict(
             login_username                  = dict(default='admin'),
@@ -183,33 +186,34 @@ def main():
             auth_url                        = dict(default='http://127.0.0.1:35357/v2.0/'),
             region_name                     = dict(default=None),
             ip_address                      = dict(required=True),
-            instance_name                   = dict(required=True), 
+            instance_name                   = dict(required=True),
             state                           = dict(default='present', choices=['absent', 'present'])
         ),
     )
-        
+
     try:
-        nova = nova_client.Client(module.params['login_username'], module.params['login_password'],                                                                          module.params['login_tenant_name'], module.params['auth_url'], service_type='compute')
+        nova = nova_client.Client(module.params['login_username'], module.params['login_password'],
+                                 module.params['login_tenant_name'], module.params['auth_url'], service_type='compute')
     except Exception as e:
         module.fail_json( msg = " Error in authenticating to nova: %s" % e.message)
-    quantum = _get_quantum_client(module, module.params)
-    state, floating_ip_id = _get_floating_ip_id(module, quantum)        
+    neutron = _get_neutron_client(module, module.params)
+    state, floating_ip_id = _get_floating_ip_id(module, neutron)
     if module.params['state'] == 'present':
         if state == 'attached':
             module.exit_json(changed = False, result = 'attached', public_ip=module.params['ip_address'])
         server_info, server_obj = _get_server_state(module, nova)
         if not server_info:
             module.fail_json(msg = " The instance name provided cannot be found")
-        port_id = _get_port_id(quantum, module, server_info['id'])
+        port_id = _get_port_id(neutron, module, server_info['id'])
         if not port_id:
             module.fail_json(msg = "Cannot find a port for this instance, maybe fixed ip is not assigned")
-        _update_floating_ip(quantum, module, port_id, floating_ip_id)
+        _update_floating_ip(neutron, module, port_id, floating_ip_id)
 
     if module.params['state'] == 'absent':
         if state == 'detached':
             module.exit_json(changed = False, result = 'detached')
         if state == 'attached':
-            _update_floating_ip(quantum, module, None, floating_ip_id)
+            _update_floating_ip(neutron, module, None, floating_ip_id)
         module.exit_json(changed = True, result = "detached")
 
 # this is magic, see lib/ansible/module.params['common.py

--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -17,10 +17,13 @@
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
-    from quantumclient.quantum import client
+    try:
+        from neutronclient.neutron import client
+    except ImportError:
+        from quantumclient.quantum import client
     from keystoneclient.v2_0 import client as ksclient
 except ImportError:
-    print("failed=True msg='quantumclient and keystone client are required'")
+    print("failed=True msg='quantumclient (or neutronclient) and keystone client are required'")
 
 DOCUMENTATION = '''
 ---
@@ -67,7 +70,7 @@ options:
      default: present
    name:
      description:
-        - Name to be assigned to the nework 
+        - Name to be assigned to the nework
      required: true
      default: None
    provider_network_type:
@@ -100,7 +103,7 @@ options:
         - Whether the state should be marked as up or down
      required: false
      default: true
-requirements: ["quantumclient", "keystoneclient"]
+requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 
 '''
 
@@ -125,21 +128,21 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:   
+    except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
-    global _os_keystone 
+    global _os_keystone
     _os_keystone = kclient
-    return kclient 
- 
+    return kclient
+
 
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
     except Exception as e:
-        module.fail_json(msg = "Error getting endpoint for Quantum: %s " %e.message)
+        module.fail_json(msg = "Error getting network endpoint: %s " %e.message)
     return endpoint
 
-def _get_quantum_client(module, kwargs):
+def _get_neutron_client(module, kwargs):
     _ksclient = _get_ksclient(module, kwargs)
     token = _ksclient.auth_token
     endpoint = _get_endpoint(module, _ksclient)
@@ -148,10 +151,10 @@ def _get_quantum_client(module, kwargs):
             'endpoint_url': endpoint
     }
     try:
-        quantum = client.Client('2.0', **kwargs)
+        neutron = client.Client('2.0', **kwargs)
     except Exception as e:
-        module.fail_json(msg = " Error in connecting to quantum: %s " %e.message)
-    return quantum
+        module.fail_json(msg = " Error in connecting to neutron: %s " %e.message)
+    return neutron
 
 def _set_tenant_id(module):
     global _os_tenant_id
@@ -159,7 +162,7 @@ def _set_tenant_id(module):
         tenant_name = module.params['login_tenant_name']
     else:
         tenant_name = module.params['tenant_name']
-        
+
     for tenant in _os_keystone.tenants.list():
         if tenant.name == tenant_name:
             _os_tenant_id = tenant.id
@@ -168,22 +171,22 @@ def _set_tenant_id(module):
         module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
 
 
-def _get_net_id(quantum, module):
+def _get_net_id(neutron, module):
     kwargs = {
             'tenant_id': _os_tenant_id,
             'name': module.params['name'],
     }
     try:
-        networks = quantum.list_networks(**kwargs)
+        networks = neutron.list_networks(**kwargs)
     except Exception as e:
-        module.fail_json(msg = "Error in listing quantum networks: %s" % e.message)
-    if not networks['networks']:        
+        module.fail_json(msg = "Error in listing neutron networks: %s" % e.message)
+    if not networks['networks']:
         return None
     return networks['networks'][0]['id']
 
-def _create_network(module, quantum):
+def _create_network(module, neutron):
 
-    quantum.format = 'json'
+    neutron.format = 'json'
 
     network = {
         'name':                      module.params.get('name'),
@@ -212,21 +215,21 @@ def _create_network(module, quantum):
         network.pop('provider:segmentation_id', None)
 
     try:
-        net = quantum.create_network({'network':network})
+        net = neutron.create_network({'network':network})
     except Exception as e:
         module.fail_json(msg = "Error in creating network: %s" % e.message)
     return net['network']['id']
-                
-def _delete_network(module, net_id, quantum):
+
+def _delete_network(module, net_id, neutron):
 
     try:
-        id = quantum.delete_network(net_id)
-    except Exception as e: 
+        id = neutron.delete_network(net_id)
+    except Exception as e:
         module.fail_json(msg = "Error in deleting the network: %s" % e.message)
     return True
 
 def main():
-    
+
     module = AnsibleModule(
         argument_spec                   = dict(
             login_username                  = dict(default='admin'),
@@ -237,8 +240,8 @@ def main():
             name                            = dict(required=True),
             tenant_name                     = dict(default=None),
             provider_network_type           = dict(default=None, choices=['local', 'vlan', 'flat', 'gre']),
-            provider_physical_network       = dict(default=None), 
-            provider_segmentation_id        = dict(default=None), 
+            provider_physical_network       = dict(default=None),
+            provider_segmentation_id        = dict(default=None),
             router_external                 = dict(default=False, type='bool'),
             shared                          = dict(default=False, type='bool'),
             admin_state_up                  = dict(default=True, type='bool'),
@@ -254,24 +257,24 @@ def main():
             if not module.params['provider_segmentation_id']:
                 module.fail_json(msg = " for vlan & gre networks, variable provider_segmentation_id should be set.")
 
-    quantum = _get_quantum_client(module, module.params)
+    neutron = _get_neutron_client(module, module.params)
 
-    _set_tenant_id(module)      
+    _set_tenant_id(module)
 
-    if module.params['state'] == 'present':     
-        network_id = _get_net_id(quantum, module)
+    if module.params['state'] == 'present':
+        network_id = _get_net_id(neutron, module)
         if not network_id:
-            network_id = _create_network(module, quantum)
+            network_id = _create_network(module, neutron)
             module.exit_json(changed = True, result = "Created", id = network_id)
         else:
             module.exit_json(changed = False, result = "Success", id = network_id)
 
     if module.params['state'] == 'absent':
-        network_id = _get_net_id(quantum, module)
+        network_id = _get_net_id(neutron, module)
         if not network_id:
             module.exit_json(changed = False, result = "Success")
         else:
-            _delete_network(module, network_id, quantum)
+            _delete_network(module, network_id, neutron)
             module.exit_json(changed = True, result = "Deleted")
 
 # this is magic, see lib/ansible/module.params['common.py

--- a/library/cloud/quantum_router
+++ b/library/cloud/quantum_router
@@ -17,10 +17,13 @@
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
-    from quantumclient.quantum import client
+    try:
+        from neutronclient.neutron import client
+    except ImportError:
+        from quantumclient.quantum import client
     from keystoneclient.v2_0 import client as ksclient
 except ImportError:
-    print("failed=True msg='quantumclient and keystone client are required'")
+    print("failed=True msg='quantumclient (or neutronclient) and keystone client are required'")
 
 DOCUMENTATION = '''
 ---
@@ -75,7 +78,7 @@ options:
         - desired admin state of the created router .
      required: false
      default: true
-requirements: ["quantumclient", "keystoneclient"]
+requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 '''
 
 EXAMPLES = '''
@@ -96,21 +99,21 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:   
+    except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
-    global _os_keystone 
+    global _os_keystone
     _os_keystone = kclient
-    return kclient 
- 
+    return kclient
+
 
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
     except Exception as e:
-        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+        module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
-def _get_quantum_client(module, kwargs):
+def _get_neutron_client(module, kwargs):
     _ksclient = _get_ksclient(module, kwargs)
     token = _ksclient.auth_token
     endpoint = _get_endpoint(module, _ksclient)
@@ -119,10 +122,10 @@ def _get_quantum_client(module, kwargs):
             'endpoint_url': endpoint
     }
     try:
-        quantum = client.Client('2.0', **kwargs)
+        neutron = client.Client('2.0', **kwargs)
     except Exception as e:
-        module.fail_json(msg = "Error in connecting to quantum: %s " % e.message)
-    return quantum
+        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+    return neutron
 
 def _set_tenant_id(module):
     global _os_tenant_id
@@ -139,38 +142,38 @@ def _set_tenant_id(module):
             module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
 
 
-def _get_router_id(module, quantum):
+def _get_router_id(module, neutron):
     kwargs = {
             'name': module.params['name'],
             'tenant_id': _os_tenant_id,
     }
     try:
-        routers = quantum.list_routers(**kwargs)
+        routers = neutron.list_routers(**kwargs)
     except Exception as e:
         module.fail_json(msg = "Error in getting the router list: %s " % e.message)
     if not routers['routers']:
         return None
     return routers['routers'][0]['id']
 
-def _create_router(module, quantum):
+def _create_router(module, neutron):
     router = {
             'name': module.params['name'],
             'tenant_id': _os_tenant_id,
             'admin_state_up': module.params['admin_state_up'],
     }
     try:
-        new_router = quantum.create_router(dict(router=router))
+        new_router = neutron.create_router(dict(router=router))
     except Exception as e:
         module.fail_json( msg = "Error in creating router: %s" % e.message)
     return new_router['router']['id']
 
-def _delete_router(module, quantum, router_id):
+def _delete_router(module, neutron, router_id):
     try:
-        quantum.delete_router(router_id)
+        neutron.delete_router(router_id)
     except:
         module.fail_json("Error in deleting the router")
     return True
-                
+
 def main():
     module = AnsibleModule(
         argument_spec                   = dict(
@@ -185,26 +188,26 @@ def main():
         admin_state_up                  = dict(type='bool', default=True),
         ),
     )
-                
-    quantum = _get_quantum_client(module, module.params)
+
+    neutron = _get_neutron_client(module, module.params)
     _set_tenant_id(module)
 
     if module.params['state'] == 'present':
-        router_id = _get_router_id(module, quantum)
+        router_id = _get_router_id(module, neutron)
         if not router_id:
-            router_id = _create_router(module, quantum)
+            router_id = _create_router(module, neutron)
             module.exit_json(changed=True, result="Created", id=router_id)
         else:
             module.exit_json(changed=False, result="success" , id=router_id)
 
     else:
-        router_id = _get_router_id(module, quantum)
+        router_id = _get_router_id(module, neutron)
         if not router_id:
             module.exit_json(changed=False, result="success")
         else:
-            _delete_router(module, quantum, router_id)
+            _delete_router(module, neutron, router_id)
             module.exit_json(changed=True, result="deleted")
-                
+
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 main()

--- a/library/cloud/quantum_router_gateway
+++ b/library/cloud/quantum_router_gateway
@@ -17,10 +17,13 @@
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
-    from quantumclient.quantum import client
+    try:
+        from neutronclient.neutron import client
+    except ImportError:
+        from quantumclient.quantum import client
     from keystoneclient.v2_0 import client as ksclient
 except ImportError:
-    print("failed=True msg='quantumclient and keystone client are required'")
+    print("failed=True msg='quantumclient (or neutronclient) and keystone client are required'")
 DOCUMENTATION = '''
 ---
 module: quantum_router_gateway
@@ -69,7 +72,7 @@ options:
         - Name of the external network which should be attached to the router.
      required: true
      default: None
-requirements: ["quantumclient", "keystoneclient"]
+requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 '''
 
 EXAMPLES = '''
@@ -86,21 +89,21 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:   
+    except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
-    global _os_keystone 
+    global _os_keystone
     _os_keystone = kclient
-    return kclient 
- 
+    return kclient
+
 
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
     except Exception as e:
-        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+        module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
-def _get_quantum_client(module, kwargs):
+def _get_neutron_client(module, kwargs):
     _ksclient = _get_ksclient(module, kwargs)
     token = _ksclient.auth_token
     endpoint = _get_endpoint(module, _ksclient)
@@ -109,68 +112,68 @@ def _get_quantum_client(module, kwargs):
             'endpoint_url': endpoint
     }
     try:
-        quantum = client.Client('2.0', **kwargs)
+        neutron = client.Client('2.0', **kwargs)
     except Exception as e:
-        module.fail_json(msg = "Error in connecting to quantum: %s " % e.message)
-    return quantum
+        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+    return neutron
 
-def _get_router_id(module, quantum):
+def _get_router_id(module, neutron):
     kwargs = {
             'name': module.params['router_name'],
     }
     try:
-        routers = quantum.list_routers(**kwargs)
+        routers = neutron.list_routers(**kwargs)
     except Exception as e:
         module.fail_json(msg = "Error in getting the router list: %s " % e.message)
     if not routers['routers']:
             return None
     return routers['routers'][0]['id']
 
-def _get_net_id(quantum, module):
+def _get_net_id(neutron, module):
     kwargs = {
         'name':            module.params['network_name'],
         'router:external': True
     }
     try:
-        networks = quantum.list_networks(**kwargs)
+        networks = neutron.list_networks(**kwargs)
     except Exception as e:
-        module.fail_json("Error in listing quantum networks: %s" % e.message)
+        module.fail_json("Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
         return None
     return networks['networks'][0]['id']
 
-def _get_port_id(quantum, module, router_id, network_id):
+def _get_port_id(neutron, module, router_id, network_id):
     kwargs = {
         'device_id': router_id,
         'network_id': network_id,
     }
     try:
-        ports = quantum.list_ports(**kwargs)
+        ports = neutron.list_ports(**kwargs)
     except Exception as e:
         module.fail_json( msg = "Error in listing ports: %s" % e.message)
     if not ports['ports']:
         return None
     return ports['ports'][0]['id']
 
-def _add_gateway_router(quantum, module, router_id, network_id):
+def _add_gateway_router(neutron, module, router_id, network_id):
     kwargs = {
         'network_id': network_id
     }
     try:
-        quantum.add_gateway_router(router_id, kwargs)
+        neutron.add_gateway_router(router_id, kwargs)
     except Exception as e:
         module.fail_json(msg = "Error in adding gateway to router: %s" % e.message)
     return True
-                
-def  _remove_gateway_router(quantum, module, router_id):
+
+def  _remove_gateway_router(neutron, module, router_id):
     try:
-        quantum.remove_gateway_router(router_id)
+        neutron.remove_gateway_router(router_id)
     except Exception as e:
         module.fail_json(msg = "Error in removing gateway to router: %s" % e.message)
     return True
-        
+
 def main():
-    
+
     module = AnsibleModule(
         argument_spec          = dict(
             login_username     = dict(default='admin'),
@@ -183,29 +186,29 @@ def main():
             state              = dict(default='present', choices=['absent', 'present']),
         ),
     )
-                
-    quantum = _get_quantum_client(module, module.params)
-    router_id = _get_router_id(module, quantum)
+
+    neutron = _get_neutron_client(module, module.params)
+    router_id = _get_router_id(module, neutron)
 
     if not router_id:
         module.fail_json(msg="failed to get the router id, please check the router name")
 
-    network_id = _get_net_id(quantum, module)   
+    network_id = _get_net_id(neutron, module)
     if not network_id:
         module.fail_json(msg="failed to get the network id, please check the network name and make sure it is external")
-                
+
     if module.params['state'] == 'present':
-        port_id = _get_port_id(quantum, module, router_id, network_id)
+        port_id = _get_port_id(neutron, module, router_id, network_id)
         if not port_id:
-            _add_gateway_router(quantum, module, router_id, network_id)
+            _add_gateway_router(neutron, module, router_id, network_id)
             module.exit_json(changed=True, result="created")
         module.exit_json(changed=False, result="success")
 
     if module.params['state'] == 'absent':
-        port_id = _get_port_id(quantum, module, router_id, network_id)
+        port_id = _get_port_id(neutron, module, router_id, network_id)
         if not port_id:
             module.exit_json(changed=False, result="Success")
-        _remove_gateway_router(quantum, module, router_id)
+        _remove_gateway_router(neutron, module, router_id)
         module.exit_json(changed=True, result="Deleted")
 
 # this is magic, see lib/ansible/module.params['common.py

--- a/library/cloud/quantum_router_interface
+++ b/library/cloud/quantum_router_interface
@@ -17,10 +17,13 @@
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
-    from quantumclient.quantum import client
+    try:
+        from neutronclient.neutron import client
+    except ImportError:
+        from quantumclient.quantum import client
     from keystoneclient.v2_0 import client as ksclient
 except ImportError:
-    print("failed=True msg='quantumclient and keystone client are required'")
+    print("failed=True msg='quantumclient (or neutronclient) and keystone client are required'")
 DOCUMENTATION = '''
 ---
 module: quantum_router_interface
@@ -81,7 +84,7 @@ EXAMPLES = '''
 # Attach tenant1's subnet to the external router
 - quantum_router_interface: state=present login_username=admin
                             login_password=admin
-                            login_tenant_name=admin 
+                            login_tenant_name=admin
                             tenant_name=tenant1
                             router_name=external_route
                             subnet_name=t1subnet
@@ -97,21 +100,21 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:   
+    except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
-    global _os_keystone 
+    global _os_keystone
     _os_keystone = kclient
-    return kclient 
- 
+    return kclient
+
 
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
     except Exception as e:
-        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+        module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
-def _get_quantum_client(module, kwargs):
+def _get_neutron_client(module, kwargs):
     _ksclient = _get_ksclient(module, kwargs)
     token = _ksclient.auth_token
     endpoint = _get_endpoint(module, _ksclient)
@@ -120,10 +123,10 @@ def _get_quantum_client(module, kwargs):
             'endpoint_url': endpoint
     }
     try:
-        quantum = client.Client('2.0', **kwargs)
+        neutron = client.Client('2.0', **kwargs)
     except Exception as e:
-        module.fail_json(msg = "Error in connecting to quantum: %s " % e.message)
-    return quantum
+        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+    return neutron
 
 def _set_tenant_id(module):
     global _os_tenant_id
@@ -140,12 +143,12 @@ def _set_tenant_id(module):
         module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
 
 
-def _get_router_id(module, quantum):
+def _get_router_id(module, neutron):
     kwargs = {
         'name': module.params['router_name'],
     }
     try:
-        routers = quantum.list_routers(**kwargs)
+        routers = neutron.list_routers(**kwargs)
     except Exception as e:
         module.fail_json(msg = "Error in getting the router list: %s " % e.message)
     if not routers['routers']:
@@ -153,27 +156,27 @@ def _get_router_id(module, quantum):
     return routers['routers'][0]['id']
 
 
-def _get_subnet_id(module, quantum):
+def _get_subnet_id(module, neutron):
     subnet_id = None
     kwargs = {
             'tenant_id': _os_tenant_id,
             'name': module.params['subnet_name'],
     }
     try:
-        subnets = quantum.list_subnets(**kwargs)
+        subnets = neutron.list_subnets(**kwargs)
     except Exception as e:
         module.fail_json( msg = " Error in getting the subnet list:%s " % e.message)
     if not subnets['subnets']:
         return None
     return subnets['subnets'][0]['id']
-                
-def _get_port_id(quantum, module, router_id, subnet_id):
+
+def _get_port_id(neutron, module, router_id, subnet_id):
     kwargs = {
             'tenant_id': _os_tenant_id,
             'device_id': router_id,
     }
     try:
-        ports = quantum.list_ports(**kwargs)
+        ports = neutron.list_ports(**kwargs)
     except Exception as e:
         module.fail_json( msg = "Error in listing ports: %s" % e.message)
     if not ports['ports']:
@@ -184,26 +187,26 @@ def _get_port_id(quantum, module, router_id, subnet_id):
                 return port['id']
     return None
 
-def _add_interface_router(quantum, module, router_id, subnet_id):
+def _add_interface_router(neutron, module, router_id, subnet_id):
     kwargs = {
         'subnet_id': subnet_id
     }
     try:
-        quantum.add_interface_router(router_id, kwargs)
+        neutron.add_interface_router(router_id, kwargs)
     except Exception as e:
         module.fail_json(msg = "Error in adding interface to router: %s" % e.message)
     return True
-                
-def  _remove_interface_router(quantum, module, router_id, subnet_id):
+
+def  _remove_interface_router(neutron, module, router_id, subnet_id):
     kwargs = {
         'subnet_id': subnet_id
     }
     try:
-        quantum.remove_interface_router(router_id, kwargs)
+        neutron.remove_interface_router(router_id, kwargs)
     except Exception as e:
         module.fail_json(msg="Error in removing interface from router: %s" % e.message)
     return True
-        
+
 def main():
     module = AnsibleModule(
         argument_spec                   = dict(
@@ -218,32 +221,32 @@ def main():
             state                           = dict(default='present', choices=['absent', 'present']),
         ),
     )
-                
-    quantum = _get_quantum_client(module, module.params)
+
+    neutron = _get_neutron_client(module, module.params)
     _set_tenant_id(module)
 
-    router_id = _get_router_id(module, quantum)
+    router_id = _get_router_id(module, neutron)
     if not router_id:
         module.fail_json(msg="failed to get the router id, please check the router name")
 
-    subnet_id = _get_subnet_id(module, quantum) 
+    subnet_id = _get_subnet_id(module, neutron)
     if not subnet_id:
         module.fail_json(msg="failed to get the subnet id, please check the subnet name")
-                
+
     if module.params['state'] == 'present':
-        port_id = _get_port_id(quantum, module, router_id, subnet_id)
+        port_id = _get_port_id(neutron, module, router_id, subnet_id)
         if not port_id:
-            _add_interface_router(quantum, module, router_id, subnet_id)
+            _add_interface_router(neutron, module, router_id, subnet_id)
             module.exit_json(changed=True, result="created", id=port_id)
         module.exit_json(changed=False, result="success", id=port_id)
 
     if module.params['state'] == 'absent':
-        port_id = _get_port_id(quantum, module, router_id, subnet_id)
+        port_id = _get_port_id(neutron, module, router_id, subnet_id)
         if not port_id:
             module.exit_json(changed = False, result = "Success")
-        _remove_interface_router(quantum, module, router_id, subnet_id)
+        _remove_interface_router(neutron, module, router_id, subnet_id)
         module.exit_json(changed=True, result="Deleted")
-                        
+
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 main()

--- a/library/cloud/quantum_subnet
+++ b/library/cloud/quantum_subnet
@@ -17,10 +17,13 @@
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
-    from quantumclient.quantum import client
+    try:
+        from neutronclient.neutron import client
+    except ImportError:
+        from quantumclient.quantum import client
     from keystoneclient.v2_0 import client as ksclient
 except ImportError:
-    print("failed=True msg='quantum and keystone client are required'")
+    print("failed=True msg='quantumclient (or neutronclient) and keystoneclient are required'")
 
 DOCUMENTATION = '''
 ---
@@ -77,7 +80,7 @@ options:
      default: None
    ip_version:
      description:
-        - The IP version of the subnet 4 or 6 
+        - The IP version of the subnet 4 or 6
      required: false
      default: 4
    enable_dhcp:
@@ -105,7 +108,7 @@ options:
         - From the subnet pool the last IP that should be assigned to the virtual machines
      required: false
      default: None
-requirements: ["quantum", "keystoneclient"]
+requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 '''
 
 EXAMPLES = '''
@@ -125,21 +128,21 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:   
+    except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
-    global _os_keystone 
+    global _os_keystone
     _os_keystone = kclient
-    return kclient 
- 
+    return kclient
+
 
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
     except Exception as e:
-        module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
+        module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
-def _get_quantum_client(module, kwargs):
+def _get_neutron_client(module, kwargs):
     _ksclient = _get_ksclient(module, kwargs)
     token     = _ksclient.auth_token
     endpoint  = _get_endpoint(module, _ksclient)
@@ -148,10 +151,10 @@ def _get_quantum_client(module, kwargs):
             'endpoint_url': endpoint
     }
     try:
-        quantum = client.Client('2.0', **kwargs)
+        neutron = client.Client('2.0', **kwargs)
     except Exception as e:
-        module.fail_json(msg = " Error in connecting to quantum: %s" % e.message)
-    return quantum
+        module.fail_json(msg = " Error in connecting to neutron: %s" % e.message)
+    return neutron
 
 def _set_tenant_id(module):
     global _os_tenant_id
@@ -167,24 +170,24 @@ def _set_tenant_id(module):
     if not _os_tenant_id:
             module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
 
-def _get_net_id(quantum, module):
+def _get_net_id(neutron, module):
     kwargs = {
         'tenant_id': _os_tenant_id,
         'name': module.params['network_name'],
     }
     try:
-        networks = quantum.list_networks(**kwargs)
+        networks = neutron.list_networks(**kwargs)
     except Exception as e:
-        module.fail_json("Error in listing quantum networks: %s" % e.message)
+        module.fail_json("Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
             return None
     return networks['networks'][0]['id']
 
 
-def _get_subnet_id(module, quantum):
+def _get_subnet_id(module, neutron):
     global _os_network_id
     subnet_id = None
-    _os_network_id = _get_net_id(quantum, module)
+    _os_network_id = _get_net_id(neutron, module)
     if not _os_network_id:
         module.fail_json(msg = "network id of network not found.")
     else:
@@ -193,15 +196,15 @@ def _get_subnet_id(module, quantum):
             'name': module.params['name'],
         }
         try:
-            subnets = quantum.list_subnets(**kwargs)
+            subnets = neutron.list_subnets(**kwargs)
         except Exception as e:
             module.fail_json( msg = " Error in getting the subnet list:%s " % e.message)
         if not subnets['subnets']:
             return None
         return subnets['subnets'][0]['id']
 
-def _create_subnet(module, quantum):
-    quantum.format = 'json'
+def _create_subnet(module, neutron):
+    neutron.format = 'json'
     subnet = {
             'name':            module.params['name'],
             'ip_version':      module.params['ip_version'],
@@ -214,7 +217,7 @@ def _create_subnet(module, quantum):
     }
     if module.params['allocation_pool_start'] and module.params['allocation_pool_end']:
         allocation_pools = [
-            { 
+            {
                 'start' : module.params['allocation_pool_start'],
                 'end'   :  module.params['allocation_pool_end']
             }
@@ -227,22 +230,22 @@ def _create_subnet(module, quantum):
     else:
         subnet.pop('dns_nameservers')
     try:
-        new_subnet = quantum.create_subnet(dict(subnet=subnet))
+        new_subnet = neutron.create_subnet(dict(subnet=subnet))
     except Exception, e:
-        module.fail_json(msg = "Failure in creating subnet: %s" % e.message) 
+        module.fail_json(msg = "Failure in creating subnet: %s" % e.message)
     return new_subnet['subnet']['id']
-        
-                
-def _delete_subnet(module, quantum, subnet_id):
+
+
+def _delete_subnet(module, neutron, subnet_id):
     try:
-        quantum.delete_subnet(subnet_id)
+        neutron.delete_subnet(subnet_id)
     except Exception as e:
         module.fail_json( msg = "Error in deleting subnet: %s" % e.message)
     return True
-        
-                
+
+
 def main():
-    
+
     module = AnsibleModule(
         argument_spec = dict(
             login_username          = dict(default='admin'),
@@ -263,23 +266,23 @@ def main():
             allocation_pool_end     = dict(default=None),
         ),
     )
-    quantum = _get_quantum_client(module, module.params)
+    neutron = _get_neutron_client(module, module.params)
     _set_tenant_id(module)
     if module.params['state'] == 'present':
-        subnet_id = _get_subnet_id(module, quantum)
+        subnet_id = _get_subnet_id(module, neutron)
         if not subnet_id:
-            subnet_id = _create_subnet(module, quantum)
+            subnet_id = _create_subnet(module, neutron)
             module.exit_json(changed = True, result = "Created" , id = subnet_id)
         else:
             module.exit_json(changed = False, result = "success" , id = subnet_id)
     else:
-        subnet_id = _get_subnet_id(module, quantum)
+        subnet_id = _get_subnet_id(module, neutron)
         if not subnet_id:
             module.exit_json(changed = False, result = "success")
         else:
-            _delete_subnet(module, quantum, subnet_id)
+            _delete_subnet(module, neutron, subnet_id)
             module.exit_json(changed = True, result = "deleted")
-                
+
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 main()


### PR DESCRIPTION
This change makes the neutron client the default, with a fallback to the quantum client.
Also, adds an optional feature to quatum_floating_ip that allows for the specification
of an internal network name for the FIP to be assigned to, in the case of multiple NICs
on an instance.
