### PR TITLE
django_manage module: need not require virtualenv in PATH

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -129,12 +129,11 @@ def _ensure_virtualenv(module):
     if venv_param is None:
         return
 
-    virtualenv = module.get_bin_path('virtualenv', True)
-
     vbin = os.path.join(os.path.expanduser(venv_param), 'bin')
     activate = os.path.join(vbin, 'activate')
 
     if not os.path.exists(activate):
+        virtualenv = module.get_bin_path('virtualenv', True)
         vcmd = '%s %s' % (virtualenv, venv_param)
         vcmd = [virtualenv, venv_param]
         rc, out_venv, err_venv = module.run_command(vcmd)


### PR DESCRIPTION
The virtualenv parameter to the django_manage command is used to locate
the virtualenv and build it if necessary.  Access to the virtualenv
executable is only needed if the virtualenv directory doesn't exist and
needs to be built.  This patch allows for the situation where a
virtualenv that is not in the PATH was used to create a virtualenv prior
to running the django_manage module.
