### PR TITLE
Feature: ignore_errors: silently /  RPM spec fixes

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -470,20 +470,22 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
             msg = "failed: [%s] => (item=%s) => %s" % (host, item, utils.jsonify(results2))
         else:
             msg = "failed: [%s] => %s" % (host, utils.jsonify(results2))
-        display(msg, color='red', runner=self.runner)
-
-        if stderr:
-            display("stderr: %s" % stderr, color='red', runner=self.runner)
-        if stdout:
-            display("stdout: %s" % stdout, color='red', runner=self.runner)
-        if returned_msg:
-            display("msg: %s" % returned_msg, color='red', runner=self.runner)
-        if not parsed and module_msg:
-            display("invalid output was: %s" % module_msg, color='red', runner=self.runner)
-        if ignore_errors:
-            display("...ignoring", color='cyan', runner=self.runner)
-        super(PlaybookRunnerCallbacks, self).on_failed(host, results, ignore_errors=ignore_errors)
-
+        if ignore_errors == "silently":
+            display(msg + " ...ignoring", color='cyan', runner=self.runner)
+        else:
+            display(msg, color='red', runner=self.runner)
+            if stderr:
+                display("stderr: %s" % stderr, color='red', runner=self.runner)
+            if stdout:
+                display("stdout: %s" % stdout, color='red', runner=self.runner)
+            if returned_msg:
+                display("msg: %s" % returned_msg, color='red', runner=self.runner)
+            if not parsed and module_msg:
+                display("invalid output was: %s" % module_msg, color='red', runner=self.runner)
+            if ignore_errors:
+                display("...ignoring", color='cyan', runner=self.runner)
+            super(PlaybookRunnerCallbacks, self).on_failed(host, results, ignore_errors=ignore_errors)
+  
     def on_ok(self, host, host_result):
 
         item = host_result.get('item', None)

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -17,6 +17,12 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 
 BuildArch: noarch
 
+# make rpm
+BuildRequires: asciidoc
+BuildRequires: rpm-build
+# make tests
+BuildRequires: python-nose
+
 # RHEL <=5
 %if 0%{?rhel} && 0%{?rhel} <= 5
 BuildRequires: python26-devel
@@ -28,7 +34,7 @@ Requires: python26-keyczar
 
 # RHEL > 5
 %if 0%{?rhel} && 0%{?rhel} > 5
-BuildRequires: python2-devel
+BuildRequires: python-devel
 Requires: PyYAML
 Requires: python-paramiko
 Requires: python-jinja2


### PR DESCRIPTION
Following #5249, here is a ignore_errors: silently feature. Nothing deep, I made it simply, no doc or additional test or whatever.
make tests is ok, make rpm too. I added some missing BuildRequires in ansible.spec.
