### PR TITLE
gem module: support prerelease (--pre)

### DIFF
--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -66,6 +66,12 @@ options:
     description:
       - Version of the gem to be installed/removed.
     required: false
+  prerelease:
+    description:
+      - Allow installation of prerelease versions of the gem.
+    required: false
+    default: "no"
+    version_added: "1.6"
 author: Johan Wiren
 '''
 
@@ -172,6 +178,8 @@ def install(module):
         cmd.append('--user-install')
     else:
         cmd.append('--no-user-install')
+    if module.params['prerelease']:
+        cmd.append('--pre')
     cmd.append('--no-rdoc')
     cmd.append('--no-ri')
     cmd.append(module.params['gem_source'])
@@ -188,6 +196,7 @@ def main():
             repository           = dict(required=False, aliases=['source'], type='str'),
             state                = dict(required=False, choices=['present','absent','latest'], type='str'),
             user_install         = dict(required=False, default=True, type='bool'),
+            prerelease           = dict(required=False, default=False, type='bool'),
             version              = dict(required=False, type='str'),
         ),
         supports_check_mode = True,


### PR DESCRIPTION
Adds support for installing prerelease rubygems (--pre flag) to the gem module.  Didn't see preexisting tests but happy to modify one if you point me to it.  I tested this by running it:

ansible all -vvvv -i ../goodeggs-ansible/hosts/local -m gem -c local -a "name=scout prerelease=yes user_install=no state=present"
# gem list

[snip]
scout (5.8.0.pre)
[snip]

fixes https://github.com/ansible/ansible/issues/4393
