### PR TITLE
Fix inventory parsing so that FQDN can be parsed without throwing ssh port error

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -89,10 +89,10 @@ class InventoryParser(object):
                 # 0. A hostname that contains a range pesudo-code and a port
                 # 1. A hostname that contains just a port
                 if hostname.count(":") > 1:
-                    # probably an IPv6 addresss, so check for the format
-                    # XXX:XXX::XXX.port, otherwise we'll just assume no
-                    # port is set 
-                    if hostname.find(".") != -1:
+                    # Possible an IPv6 address, or maybe a host line with multiple ranges
+                    # IPv6 with Port  XXX:XXX::XXX.port
+                    # FQDN            foo.example.com
+                    if hostname.count(".") == 1:
                         (hostname, port) = hostname.rsplit(".", 1)
                 elif (hostname.find("[") != -1 and
                     hostname.find("]") != -1 and

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -163,6 +163,21 @@ class TestInventory(unittest.TestCase):
         var = inventory.get_variables('FE80:EF45::12:1')
         self.assertEqual(var['ansible_ssh_port'], 2222)
 
+    def test_simple_string_fqdn(self):
+        inventory = Inventory('foo.example.com,bar.example.com')
+        hosts = inventory.list_hosts()
+        self.assertEqual(sorted(hosts), sorted(['foo.example.com','bar.example.com']))
+
+    def test_simple_string_fqdn_port(self):
+        inventory = Inventory('foo.example.com:2222,bar.example.com')
+        hosts = inventory.list_hosts()
+        self.assertEqual(sorted(hosts), sorted(['foo.example.com','bar.example.com']))
+
+    def test_simple_string_fqdn_vars(self):
+        inventory = Inventory('foo.example.com:2222,bar.example.com')
+        var = inventory.get_variables('foo.example.com')
+        self.assertEqual(var['ansible_ssh_port'], 2222)
+
     def test_simple_vars(self):
         inventory = self.simple_inventory()
         vars = inventory.get_variables('thor')
@@ -254,6 +269,7 @@ class TestInventory(unittest.TestCase):
         expected2 = ['rtp_a', 'rtp_b']
         expected3 = ['rtp_a', 'rtp_b', 'rtp_c', 'tri_a', 'tri_b', 'tri_c']
         expected4 = ['rtp_b', 'orlando' ]
+        expected5 = ['blade-a-1']
 
         inventory = self.complex_inventory()
         hosts = inventory.list_hosts("nc[1]")
@@ -264,6 +280,8 @@ class TestInventory(unittest.TestCase):
         self.compare(hosts, expected3, sort=False)
         hosts = inventory.list_hosts("nc[1-2]:florida[0-1]")
         self.compare(hosts, expected4, sort=False)
+        hosts = inventory.list_hosts("blade-a-1")
+        self.compare(hosts, expected5, sort=False)
 
     def test_complex_intersect(self):
         inventory = self.complex_inventory()

--- a/test/complex_hosts
+++ b/test/complex_hosts
@@ -87,3 +87,9 @@ host[2:3]
 
 [role3]
 host[1:3:2]
+
+[role4]
+blade-[a:c]-[1:16]
+blade-[d:z]-[01:16].example.com
+blade-[1:10]-[1:16]
+host-e-[10:16].example.net:1234


### PR DESCRIPTION
We use two ranges to define our hosts, first for the bladecenter, then the blade slot, so we have hosts defined like this:

```
[servers]
host-[1:6]-[1:16].example.com
```

gives (Line numbers might be slightly out due to due to extra debugging I've added)

``` python
File "/mnt/data/home/johnb/development/ansible/mine/lib/ansible/inventory/host.py", line 31, in __init__
    self.set_variable('ansible_ssh_port', int(port))
ValueError: invalid literal for int() with base 10: 'com:2222'
```

I believe this is a regression over 1.3.4, possibly caused by https://github.com/ansible/ansible/commit/948d019fef8781b22960859caaa93485a074e339

Added unit tests for FQDN. I couldn't see any existing ones. They could be extended further, but at least this particular issues is fixed and defended
