### PR TITLE
Add progress output to batched playbook execution

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -681,4 +681,10 @@ class PlaybookCallbacks(object):
     def on_stats(self, stats):
         call_callback_module('playbook_on_stats', stats)
 
+    def on_batch_completed(self, completed_hosts, total_hosts):
+        if (completed_hosts != total_hosts and total_hosts > 0):
+            display(banner("STATUS"))
+            msg = "%d hosts processed of %d total (%.2f%%)" % (completed_hosts, total_hosts, (completed_hosts/float(total_hosts)) * 100)
+            display(msg, color='cyan')
+        call_callback_module('playbook_on_batch_completed', completed_hosts, total_hosts)
 

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -528,6 +528,7 @@ class PlayBook(object):
                         play_hosts.append(all_hosts.pop())
                 serialized_batch.append(play_hosts)
 
+        completed_count = 0
         for on_hosts in serialized_batch:
 
             self.inventory.also_restrict_to(on_hosts)
@@ -611,6 +612,9 @@ class PlayBook(object):
                     return False
 
             self.inventory.lift_also_restriction()
+            
+            completed_count += len(on_hosts)
+            self.callbacks.on_batch_completed(completed_count, len(self._list_available_hosts(play.hosts)))
 
         return True
 


### PR DESCRIPTION
One issue I have found with long playbook runs for rolling deployments is that it is not possible, viewing Ansible's output, to easily tell how far along the process is.  This is particularly bad when deploying to hundreds of machines--with a conservative enough rate of serial execution, such a run can take hours.  It would be a great help for me to see how many hosts have been processed.

This small change adds a simple additional output during playbook runs.  It prints between playbook batches, excluding the last batch.  Output looks as follows:

```
STATUS ************************************************************************ 
2 hosts processed of 3 total (66.67%)
```

In addition, this surfaces a potentially interesting new callback for plugin authors to take advantage of.  

Let me know if this needs anything else to be considered for merging, or if I can make any changes to improve it.
