### PR TITLE
Update install documentation to include httplib2

### DIFF
--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -118,7 +118,7 @@ If you don't have pip installed in your version of Python, install pip::
 
 Ansible also uses the the following Python modules that need to be installed::
 
-    $ sudo pip install paramiko PyYAML jinja2
+    $ sudo pip install paramiko PyYAML jinja2 httplib2
 
 Once running the env-setup script you'll be running from checkout and the default inventory file
 will be /etc/ansible/hosts.  You can optionally specify an inventory file (see :doc:`intro_inventory`) 


### PR DESCRIPTION
With v1.4.2 setup.py requires httplib2 for install
