### PR TITLE
bigip_monitor_http: two small bug fixes

### DIFF
--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -94,19 +94,19 @@ options:
         required: true
         default: none
     ip:
-        description: 
+        description:
             - IP address part of the ipport definition. The default API setting
               is "0.0.0.0".
         required: false
         default: none
     port:
-        description: 
+        description:
             - port address part op the ipport definition. Tyhe default API
               setting is 0.
         required: false
         default: none
     interval:
-        description: 
+        description:
             - The interval specifying how frequently the monitor instance
               of this template will run. By default, this interval is used for up and
               down states. The default API setting is 5.
@@ -199,7 +199,7 @@ def check_monitor_exists(module, api, monitor, parent):
 
 def create_monitor(api, monitor, template_attributes):
 
-    try: 
+    try:
         api.LocalLB.Monitor.create_template(templates=[{'template_name': monitor, 'template_type': TEMPLATE_TYPE}], template_attributes=[template_attributes])
     except bigsuds.OperationFailed, e:
         if "already exists" in str(e):
@@ -282,7 +282,7 @@ def set_ipport(api, monitor, ipport):
 # ===========================================
 # main loop
 #
-# writing a module for other monitor types should 
+# writing a module for other monitor types should
 # only need an updated main() (and monitor specific functions)
 
 def main():
@@ -345,19 +345,19 @@ def main():
         if port is None:
             port = cur_ipport['ipport']['port']
     else: # use API defaults if not defined to create it
-        if interval is None:        
+        if interval is None:
             interval = 5
-        if timeout is None:         
+        if timeout is None:
             timeout = 16
-        if ip is None:              
+        if ip is None:
             ip = '0.0.0.0'
-        if port is None:            
+        if port is None:
             port = 0
-        if send is None:            
+        if send is None:
             send = ''
-        if receive is None:         
+        if receive is None:
             receive = ''
-        if receive_disable is None: 
+        if receive_disable is None:
             receive_disable = ''
 
     # define and set address type
@@ -394,7 +394,7 @@ def main():
                                    {'type': 'ITYPE_TIMEOUT',
                                     'value': timeout},
                                    {'type': 'ITYPE_TIME_UNTIL_UP',
-                                    'value': interval}]
+                                    'value': time_until_up}]
 
     # main logic, monitor generic
 
@@ -405,7 +405,7 @@ def main():
         if state == 'absent':
             if monitor_exists:
                 if not module.check_mode:
-                    # possible race condition if same task 
+                    # possible race condition if same task
                     # on other node deleted it first
                     result['changed'] |= delete_monitor(api, monitor)
                 else:
@@ -414,26 +414,24 @@ def main():
         else: # state present
             ## check for monitor itself
             if not monitor_exists: # create it
-                if not module.check_mode: 
+                if not module.check_mode:
                     # again, check changed status here b/c race conditions
                     # if other task already created it
                     result['changed'] |= create_monitor(api, monitor, template_attributes)
-                else: 
+                else:
                     result['changed'] |= True
 
             ## check for monitor parameters
             # whether it already existed, or was just created, now update
             # the update functions need to check for check mode but
             # cannot update settings if it doesn't exist which happens in check mode
-            if monitor_exists and not module.check_mode:
-                result['changed'] |= update_monitor_properties(api, module, monitor,
-                                                               template_string_properties,
-                                                               template_integer_properties)
-            # else assume nothing changed
+            result['changed'] |= update_monitor_properties(api, module, monitor,
+                                                    template_string_properties,
+                                                    template_integer_properties)
 
             # we just have to update the ipport if monitor already exists and it's different
             if monitor_exists and cur_ipport != ipport:
-                set_ipport(api, monitor, ipport)    
+                set_ipport(api, monitor, ipport)
                 result['changed'] |= True
             #else: monitor doesn't exist (check mode) or ipport is already ok
 


### PR DESCRIPTION
- extra properties were not set at creation, only when updating
  which can be overlooked when running the module from more than 1 node, as the second would to the update
- fix parameter var as time_until_up didn't get used
