### PR TITLE
debconf module

### DIFF
--- a/library/system/debconf
+++ b/library/system/debconf
@@ -76,7 +76,7 @@ debconf: name=locales setting='locales/default_environment_locale' value=fr_FR.U
 debconf: name=locales setting='locales/locales_to_be_generated  value='en_US.UTF-8 UTF-8, fr_FR.UTF-8 UTF-8'
 
 # Accept oracle license
-debconf: names='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
+debconf: name='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
 '''
 
 def get_selections(module, pkg):

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -26,9 +26,10 @@ DOCUMENTATION = '''
 module: debconf
 short_description: Configure a .deb package
 description:
-     - Configure a .deb package using debconf-set-selections
+     - Configure a .deb package using debconf-set-selections.
 version_added: "1.5"
 notes:
+    - This module requires the command line debconf tools.
     - A number of questions have to be answered (depending on the package).
       Use 'debconf-show <package>' on any Debian or derivative with the package
       installed to see questions/settings available.
@@ -39,12 +40,12 @@ options:
     required: true
     default: null
     aliases: ['pkg']
-  setting:
+  question:
     description:
       - A debconf configuration setting
     required: false
     default: null
-    aliases: ['question', 'selection']
+    aliases: ['setting', 'selection']
   vtype:
     description:
       - The type of the value supplied
@@ -70,10 +71,10 @@ author: Brian Coca
 
 EXAMPLES = '''
 # Set default locale to fr_FR.UTF-8
-debconf: name=locales setting='locales/default_environment_locale' value=fr_FR.UTF-8
+debconf: name=locales question='locales/default_environment_locale' value=fr_FR.UTF-8
 
 # set to generate locales:
-debconf: name=locales setting='locales/locales_to_be_generated  value='en_US.UTF-8 UTF-8, fr_FR.UTF-8 UTF-8'
+debconf: name=locales question='locales/locales_to_be_generated  value='en_US.UTF-8 UTF-8, fr_FR.UTF-8 UTF-8'
 
 # Accept oracle license
 debconf: name='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
@@ -118,7 +119,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
            name = dict(required=True, aliases=['pkg'], type='str'),
-           setting = dict(required=False, aliases=['question', 'selection'], type='str'),
+           question = dict(required=False, aliases=['setting', 'selection'], type='str'),
            vtype = dict(required=False, type='str', choices=['string', 'boolean', 'select',  'multiselect', 'note', 'text', 'password', 'title']),
            value= dict(required=False, type='str'),
            unseen = dict(required=False, type='bool'),
@@ -128,7 +129,7 @@ def main():
 
     #TODO: enable passing array of optionas and/or debconf file from get-selections dump
     pkg      = module.params["name"]
-    question = module.params["setting"]
+    question = module.params["question"]
     vtype     = module.params["vtype"]
     value    = module.params["value"]
     unseen   = module.params["unseen"]
@@ -138,6 +139,12 @@ def main():
 
     changed = False
     msg = ""
+
+    # Adjust value field if needed
+    if vtype == 'boolean':
+        value = boolean(value)
+    elif vtype == 'multiselect' and (isisntance(value, list) or isinstace(value, set)):
+        value = ','.join(value)
 
     if question is not None:
         if not question in prev or prev[question] != value:

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -1,0 +1,160 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+Ansible module to configure debian packages.
+(c) 2014, Brian Coca <briancoca+ansible@gmail.com>
+
+This file is part of Ansible
+
+Ansible is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Ansible is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+DOCUMENTATION = '''
+---
+module: debconf
+short_description: Configure a debian package
+description:
+     - Configure a Debian package using debconf-set-selections
+version_added: "1.5"
+notes:
+    - A number of questions have to be answered (depending on the package).
+      Use 'debconf-show <package>' on any debian/derivative with the package
+      installed to see questions/settings available.
+options:
+  name:
+    description:
+      - Name of package to configure.
+    required: true
+    default: null
+    aliases: ['pkg']
+  setting:
+    description:
+      - A debconf configuration setting
+    required: false
+    default: null
+    aliases: ['question', 'selection']
+  type:
+    description:
+      - The type of value supplied
+    required: false
+    default: null
+    choices: [string, boolean, select, multiselect, note, text, password, title]
+    aliases: []
+  value:
+    description:
+      -  Value to set the configuration to
+    required: false
+    default: null
+    aliases: ['awnser']
+  unseen:
+    description:
+      - Do not set 'seen' flag when preseeding
+    required: false
+    default: False
+    aliases: []
+author: Brian Coca
+
+'''
+
+EXAMPLES = '''
+# Set default locale to fr_FR.UTF-8
+debconf: name=locales setting='locales/default_environment_locale' value=fr_FR.UTF-8
+
+# set to generate locales:
+debconf: name=locales setting='locales/locales_to_be_generated  value='en_US.UTF-8 UTF-8, fr_FR.UTF-8 UTF-8'
+
+# Accept oracle license
+debconf: names='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' type='select'
+'''
+
+def get_selections(module, pkg):
+    cmd = [module.get_bin_path('debconf-show', True), pkg]
+    rc, out, err = module.run_command(' '.join(cmd))
+
+    if rc == 0:
+        selections = {}
+	for line in out.splitlines():
+            #if not line.startswith('*'): # only awnsered
+            #    continue
+            (key, value) = line.split(':')
+            selections[ key.strip('*').strip() ] = value.strip()
+        return selections
+    else:
+        module.fail_json(msg=err)
+
+
+def set_selection(module, pkg, question, type, value, unseen):
+
+    awnser = [ question ]
+    if 'type':
+        awnser.append(type)
+    awnser.append(value)
+
+    data = ' '.join(awnser)
+
+    setsel = module.get_bin_path('debconf-set-selections', True)
+    cmd = ["echo '%s %s' |" % (pkg, data), setsel]
+    if unseen:
+        cmd.append('-u')
+
+    return module.run_command(' '.join(cmd))
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+           name = dict(required=True, aliases=['pkg'], type='str'),
+           setting = dict(required=False, aliases=['question', 'selection'], type='str'),
+           type = dict(required=False, type='str', choices=['string', 'boolean', 'select',  'multiselect', 'note', 'text', 'password', 'title']),
+           value= dict(required=False, type='str'),
+           unseen = dict(required=False, type='bool'),
+        ),
+        supports_check_mode=True,
+    )
+
+    #TODO: enable passing array of optionas and/or debconf file from get-selections dump
+    pkg      = module.params["name"]
+    question = module.params["setting"]
+    type     = module.params["type"]
+    value    = module.params["value"]
+    unseen   = module.params["unseen"]
+
+    prev = get_selections(module, pkg)
+    diff = ''
+
+    changed = False
+    msg = ""
+
+    if question is not None:
+        if not question in prev or prev[question] != value:
+            changed = True
+
+    if changed:
+        if not module.check_mode:
+            rc, msg, e = set_selection(module, pkg, question, type, value, unseen)
+            if rc:
+                module.fail_json(msg=e)
+	curr = { question: value }
+	prev = (question, prev[question])
+
+        module.exit_json(changed=changed, msg=msg, current=curr, previous=prev)
+
+    module.exit_json(changed=changed, msg=msg, current=prev)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()
+
+

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -28,7 +28,7 @@ short_description: Configure a .deb package
 description:
      - Configure a .deb package using debconf-set-selections. Or just query
      existing selections.
-version_added: "1.5"
+version_added: "1.6"
 notes:
     - This module requires the command line debconf tools.
     - A number of questions have to be answered (depending on the package).

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -147,7 +147,7 @@ def main():
             if rc:
                 module.fail_json(msg=e)
 	curr = { question: value }
-	prev = (question: prev[question])
+	prev = {question: prev[question]}
 
         module.exit_json(changed=changed, msg=msg, current=curr, previous=prev)
 

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -47,7 +47,7 @@ options:
     aliases: ['question', 'selection']
   type:
     description:
-      - The type of value supplied
+      - The type of the value supplied
     required: false
     default: null
     choices: [string, boolean, select, multiselect, note, text, password, title]

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Ansible module to configure debian packages.
+Ansible module to configure .deb packages.
 (c) 2014, Brian Coca <briancoca+ansible@gmail.com>
 
 This file is part of Ansible
@@ -24,13 +24,13 @@ along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 DOCUMENTATION = '''
 ---
 module: debconf
-short_description: Configure a debian package
+short_description: Configure a .deb package
 description:
-     - Configure a Debian package using debconf-set-selections
+     - Configure a .deb package using debconf-set-selections
 version_added: "1.5"
 notes:
     - A number of questions have to be answered (depending on the package).
-      Use 'debconf-show <package>' on any debian/derivative with the package
+      Use 'debconf-show <package>' on any Debian or derivative with the package
       installed to see questions/settings available.
 options:
   name:
@@ -60,7 +60,7 @@ options:
     aliases: ['awnser']
   unseen:
     description:
-      - Do not set 'seen' flag when preseeding
+      - Do not set 'seen' flag when pre-seeding
     required: false
     default: False
     aliases: []

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -45,7 +45,7 @@ options:
     required: false
     default: null
     aliases: ['question', 'selection']
-  type:
+  vtype:
     description:
       - The type of the value supplied
     required: false
@@ -57,7 +57,7 @@ options:
       -  Value to set the configuration to
     required: false
     default: null
-    aliases: ['awnser']
+    aliases: ['answer']
   unseen:
     description:
       - Do not set 'seen' flag when pre-seeding
@@ -76,33 +76,33 @@ debconf: name=locales setting='locales/default_environment_locale' value=fr_FR.U
 debconf: name=locales setting='locales/locales_to_be_generated  value='en_US.UTF-8 UTF-8, fr_FR.UTF-8 UTF-8'
 
 # Accept oracle license
-debconf: names='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' type='select'
+debconf: names='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
 '''
 
 def get_selections(module, pkg):
     cmd = [module.get_bin_path('debconf-show', True), pkg]
     rc, out, err = module.run_command(' '.join(cmd))
 
-    if rc == 0:
-        selections = {}
-    for line in out.splitlines():
-            #if not line.startswith('*'): # only awnsered
-            #    continue
-            (key, value) = line.split(':')
-            selections[ key.strip('*').strip() ] = value.strip()
-        return selections
-    else:
+    if rc != 0:
         module.fail_json(msg=err)
 
+    selections = {}
 
-def set_selection(module, pkg, question, type, value, unseen):
+    for line in out.splitlines():
+        (key, value) = line.split(':')
+        selections[ key.strip('*').strip() ] = value.strip()
 
-    awnser = [ question ]
-    if 'type':
-        awnser.append(type)
-    awnser.append(value)
+    return selections
 
-    data = ' '.join(awnser)
+
+def set_selection(module, pkg, question, vtype, value, unseen):
+
+    answer = [ question ]
+    if 'vtype':
+        answer.append(vtype)
+    answer.append(value)
+
+    data = ' '.join(answer)
 
     setsel = module.get_bin_path('debconf-set-selections', True)
     cmd = ["echo '%s %s' |" % (pkg, data), setsel]
@@ -117,7 +117,7 @@ def main():
         argument_spec = dict(
            name = dict(required=True, aliases=['pkg'], type='str'),
            setting = dict(required=False, aliases=['question', 'selection'], type='str'),
-           type = dict(required=False, type='str', choices=['string', 'boolean', 'select',  'multiselect', 'note', 'text', 'password', 'title']),
+           vtype = dict(required=False, type='str', choices=['string', 'boolean', 'select',  'multiselect', 'note', 'text', 'password', 'title']),
            value= dict(required=False, type='str'),
            unseen = dict(required=False, type='bool'),
         ),
@@ -127,7 +127,7 @@ def main():
     #TODO: enable passing array of optionas and/or debconf file from get-selections dump
     pkg      = module.params["name"]
     question = module.params["setting"]
-    type     = module.params["type"]
+    vtype     = module.params["vtype"]
     value    = module.params["value"]
     unseen   = module.params["unseen"]
 
@@ -143,7 +143,7 @@ def main():
 
     if changed:
         if not module.check_mode:
-            rc, msg, e = set_selection(module, pkg, question, type, value, unseen)
+            rc, msg, e = set_selection(module, pkg, question, vtype, value, unseen)
             if rc:
                 module.fail_json(msg=e)
 
@@ -157,6 +157,5 @@ def main():
 
     module.exit_json(changed=changed, msg=msg, current=prev)
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+# import module snippets
+from ansible.module_utils.basic import *

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -146,8 +146,12 @@ def main():
             rc, msg, e = set_selection(module, pkg, question, type, value, unseen)
             if rc:
                 module.fail_json(msg=e)
-	curr = { question: value }
-	prev = {question: prev[question]}
+
+        curr = { question: value }
+        if question in prev:
+            prev = {question: prev[question]}
+        else:
+            prev[question] = ''
 
         module.exit_json(changed=changed, msg=msg, current=curr, previous=prev)
 

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -85,7 +85,7 @@ def get_selections(module, pkg):
 
     if rc == 0:
         selections = {}
-	for line in out.splitlines():
+    for line in out.splitlines():
             #if not line.startswith('*'): # only awnsered
             #    continue
             (key, value) = line.split(':')
@@ -160,5 +160,3 @@ def main():
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 main()
-
-

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -100,8 +100,10 @@ def set_selection(module, pkg, question, vtype, value, unseen):
     answer = [ question ]
     if 'vtype':
         answer.append(vtype)
-    answer.append(value)
 
+    if value is None:
+        value = ''
+    answer.append(value)
     data = ' '.join(answer)
 
     setsel = module.get_bin_path('debconf-set-selections', True)
@@ -159,3 +161,5 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+
+main()

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -147,7 +147,7 @@ def main():
             if rc:
                 module.fail_json(msg=e)
 	curr = { question: value }
-	prev = (question, prev[question])
+	prev = (question: prev[question])
 
         module.exit_json(changed=changed, msg=msg, current=curr, previous=prev)
 

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -26,7 +26,8 @@ DOCUMENTATION = '''
 module: debconf
 short_description: Configure a .deb package
 description:
-     - Configure a .deb package using debconf-set-selections.
+     - Configure a .deb package using debconf-set-selections. Or just query
+     existing selections.
 version_added: "1.5"
 notes:
     - This module requires the command line debconf tools.
@@ -78,6 +79,9 @@ debconf: name=locales question='locales/locales_to_be_generated  value='en_US.UT
 
 # Accept oracle license
 debconf: name='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
+
+# Specifying package you can register/return the list of questions and current values
+debconf: name='tzdata'
 '''
 
 def get_selections(module, pkg):
@@ -98,14 +102,7 @@ def get_selections(module, pkg):
 
 def set_selection(module, pkg, question, vtype, value, unseen):
 
-    answer = [ question ]
-    if 'vtype':
-        answer.append(vtype)
-
-    if value is None:
-        value = ''
-    answer.append(value)
-    data = ' '.join(answer)
+    data = ' '.join([ question, vtype, value ])
 
     setsel = module.get_bin_path('debconf-set-selections', True)
     cmd = ["echo '%s %s' |" % (pkg, data), setsel]
@@ -124,6 +121,7 @@ def main():
            value= dict(required=False, type='str'),
            unseen = dict(required=False, type='bool'),
         ),
+        required_together = ( ['question','vtype', 'value'],),
         supports_check_mode=True,
     )
 
@@ -140,13 +138,10 @@ def main():
     changed = False
     msg = ""
 
-    # Adjust value field if needed
-    if vtype == 'boolean':
-        value = boolean(value)
-    elif vtype == 'multiselect' and (isisntance(value, list) or isinstace(value, set)):
-        value = ','.join(value)
-
     if question is not None:
+        if vtype is None or value is None:
+            module.fail_json(msg="when supliying a question you must supply a valide vtype and value")
+
         if not question in prev or prev[question] != value:
             changed = True
 


### PR DESCRIPTION
Allows you to change or preseed debian debconf settings,  some packages won't allow installing non-interactively w/o this.

TODO: 
- add ability to take array and/or file to do mutliple operations at once
- allow for complex_args 

Signed-off-by: Brian Coca <briancoca+dev@gmail.com>
