### PR TITLE
allow per-host sudo operation

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -604,7 +604,15 @@ class Runner(object):
         actual_pass = inject.get('ansible_ssh_pass', self.remote_pass)
         actual_transport = inject.get('ansible_connection', self.transport)
         actual_private_key_file = inject.get('ansible_ssh_private_key_file', self.private_key_file)
+        self.sudo = utils.boolean(inject.get('ansible_sudo', self.sudo))
+        self.sudo_user = inject.get('ansible_sudo_user', self.sudo_user)
         self.sudo_pass = inject.get('ansible_sudo_pass', self.sudo_pass)
+
+        # select default root user in case self.sudo requested
+        # but no user specified; happens e.g. in host vars when
+        # just ansible_sudo=True is specified
+        if self.sudo and self.sudo_user is None:
+            self.sudo_user = 'root'
 
         if actual_private_key_file is not None:
             actual_private_key_file = os.path.expanduser(actual_private_key_file)


### PR DESCRIPTION
Hi,
I'd like to introduce two new per-host sudo configuration variables for inventory. Use case: Apply same tasks for Fedora EC2 instances and Fedora Physical hosts. Since Cloud-Init prevents direct root log-in, the easiest option is to introduce a EC2 group in inventory to apply proper sudo settings for hosts that need it.
Suggested variables:
- ansible_sudo
- ansible_sudo_user

See also Issue #2678.

Thanks,
milan
