### PR TITLE
Remove quotes aroung etcd_url value

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -103,7 +103,7 @@ filter_plugins     = /usr/share/ansible_plugins/filter_plugins
 #nocolor = 1
 
 # default URL for `etcd' lookup plugin
-etcd_url = 'http://127.0.0.1:4001'
+etcd_url = http://127.0.0.1:4001
 
 [paramiko_connection]
 


### PR DESCRIPTION
I get errors like this with etcd_url = 'http://127.0.0.1:4001':
`urllib2.URLError: <urlopen error unknown url type: 'http>`

Without quotes etcd lookup plugin works fine.
