### PR TITLE
Make sure action plugin copy cleans up tmp dir

### DIFF
--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -125,6 +125,9 @@ class ActionModule(object):
         changed = False
         diffs = []
         module_result = {"changed": False}
+        # Remove tmp path since a new one is created below.  Should be empty.
+        if tmp.find("tmp") != -1:
+            self.runner._low_level_exec_command(conn, "rm -rf %s > /dev/null 2>&1" % tmp, tmp)
         for source_full, source_rel in source_files:
             # We need to get a new tmp path for each file, otherwise the copy module deletes the folder.
             tmp = self.runner._make_tmp_path(conn)


### PR DESCRIPTION
The copy action plugin creates its own tmp dir for each file that it
copies to the target machine.  However, it does not clean up the
original tmp path it was given when run() is called.  This cleans up the
tmp path before it begins looping on source files.

Here's an example of what get's left behind in /root/.ansible/tmp/ during a copy task:

```
524301  128 drwxr-xr-x  14 root     root       126976 Dec 20 15:00 /root/.ansible/tmp
655362    4 drwxr-xr-x   2 root     root         4096 Dec 20 15:00 /root/.ansible/tmp/ansible-1387580405.01-67575964197913
655364    4 drwxr-xr-x   2 root     root         4096 Dec 20 15:00 /root/.ansible/tmp/ansible-1387580405.05-192672143251266
655365   52 -rw-------   1 root     root        51922 Dec 20 15:00 /root/.ansible/tmp/ansible-1387580405.05-192672143251266/file
```

And after the copy task:

```
524301  128 drwxr-xr-x  13 root     root       126976 Dec 20 15:00 /root/.ansible/tmp
655362    4 drwxr-xr-x   2 root     root         4096 Dec 20 15:00 /root/.ansible/tmp/ansible-1387580405.01-67575964197913
```

This bug got introduced with commit 33242cacf3c4b12381bf0f79f58c8d3227bd340d.  Please let me know if this PR should be tweaked in any way.
