### PR TITLE
rds module: Fix: Cannot change security group of RDS instance in VPC

### DIFF
--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -119,7 +119,13 @@ options:
     aliases: []
   security_groups:
     description:
-      - Comma separated list of one or more security groups.  Used only when command=create or command=modify. If a subnet is specified then this is treated as a list of VPC security groups.
+      - Comma separated list of one or more security groups.  Used only when command=create or command=modify.
+    required: false
+    default: null
+    aliases: []
+  vpc_security_groups:
+    description:
+      - Comma separated list of one or more vpc security groups. Used only when command=create or command=modify.
     required: false
     default: null
     aliases: []
@@ -294,6 +300,7 @@ def main():
             multi_zone        = dict(type='bool', default=False),
             iops              = dict(required=False), 
             security_groups   = dict(required=False),
+            vpc_security_groups = dict(required=False),
             port              = dict(required=False),
             upgrade           = dict(type='bool', default=False),
             option_group      = dict(required=False),
@@ -328,6 +335,7 @@ def main():
     multi_zone         = module.params.get('multi_zone')
     iops               = module.params.get('iops')
     security_groups    = module.params.get('security_groups')
+    vpc_security_groups = module.params.get('vpc_security_groups')
     port               = module.params.get('port')
     upgrade            = module.params.get('upgrade')
     option_group       = module.params.get('option_group')
@@ -355,40 +363,46 @@ def main():
     except boto.exception.BotoServerError, e:
         module.fail_json(msg = e.error_message)
 
+    def invalid_security_group_type(subnet):
+        if subnet:
+            return 'security_groups'
+        else:
+            return 'vpc_security_groups'
+
     # Validate parameters for each command
     if command == 'create':
         required_vars = [ 'instance_name', 'db_engine', 'size', 'instance_type', 'username', 'password' ]
-        invalid_vars  = [ 'source_instance', 'snapshot', 'apply_immediately', 'new_instance_name' ]
+        invalid_vars  = [ 'source_instance', 'snapshot', 'apply_immediately', 'new_instance_name' ] + [invalid_security_group_type(subnet)]
 
     elif command == 'replicate':
         required_vars = [ 'instance_name', 'source_instance' ]
-        invalid_vars  = [ 'db_engine', 'size', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'security_groups', 'option_group', 'maint_window', 'backup_window', 'backup_retention', 'subnet', 'snapshot', 'apply_immediately', 'new_instance_name' ]
+        invalid_vars  = [ 'db_engine', 'size', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'vpc_security_groups', 'security_groups', 'option_group', 'maint_window', 'backup_window', 'backup_retention', 'subnet', 'snapshot', 'apply_immediately', 'new_instance_name' ]
 
     elif command == 'delete':
         required_vars = [ 'instance_name' ]
-        invalid_vars  = [ 'db_engine', 'size', 'instance_type', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'security_groups', 'option_group', 'maint_window', 'backup_window', 'backup_retention', 'port', 'upgrade', 'subnet', 'zone' , 'source_instance', 'apply_immediately', 'new_instance_name' ]
+        invalid_vars  = [ 'db_engine', 'size', 'instance_type', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'vpc_security_groups' ,'security_groups', 'option_group', 'maint_window', 'backup_window', 'backup_retention', 'port', 'upgrade', 'subnet', 'zone' , 'source_instance', 'apply_immediately', 'new_instance_name' ]
 
     elif command == 'facts':
         required_vars = [ 'instance_name' ]
-        invalid_vars  = [ 'db_engine', 'size', 'instance_type', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'security_groups', 'option_group', 'maint_window', 'backup_window', 'backup_retention', 'port', 'upgrade', 'subnet', 'zone', 'wait', 'source_instance' 'apply_immediately', 'new_instance_name' ]
+        invalid_vars  = [ 'db_engine', 'size', 'instance_type', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'vpc_security_groups', 'security_groups', 'option_group', 'maint_window', 'backup_window', 'backup_retention', 'port', 'upgrade', 'subnet', 'zone', 'wait', 'source_instance' 'apply_immediately', 'new_instance_name' ]
 
     elif command == 'modify':
         required_vars = [ 'instance_name' ]
         if password:
             params["master_password"] = password
-        invalid_vars = [ 'db_engine', 'username', 'db_name', 'engine_version',  'license_model', 'option_group', 'port', 'upgrade', 'subnet', 'zone', 'source_instance' ]
+        invalid_vars = [ 'db_engine', 'username', 'db_name', 'engine_version',  'license_model', 'option_group', 'port', 'upgrade', 'subnet', 'zone', 'source_instance']
 
     elif command == 'promote':
         required_vars = [ 'instance_name' ]
-        invalid_vars = [ 'db_engine', 'size', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'security_groups', 'option_group', 'maint_window', 'subnet', 'source_instance', 'snapshot', 'apply_immediately', 'new_instance_name' ]
+        invalid_vars = [ 'db_engine', 'size', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'vpc_security_groups', 'security_groups', 'option_group', 'maint_window', 'subnet', 'source_instance', 'snapshot', 'apply_immediately', 'new_instance_name' ]
     
     elif command == 'snapshot':
         required_vars = [ 'instance_name', 'snapshot']
-        invalid_vars = [ 'db_engine', 'size', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'security_groups', 'option_group', 'maint_window', 'subnet', 'source_instance', 'apply_immediately', 'new_instance_name' ]
+        invalid_vars = [ 'db_engine', 'size', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'vpc_security_groups', 'security_groups', 'option_group', 'maint_window', 'subnet', 'source_instance', 'apply_immediately', 'new_instance_name' ]
 
     elif command == 'restore':
         required_vars = [ 'instance_name', 'snapshot', 'instance_type' ]
-        invalid_vars = [ 'db_engine', 'db_name', 'usernmae', 'password', 'engine_version',  'option_group', 'source_instance', 'apply_immediately', 'new_instance_name' ]
+        invalid_vars = [ 'db_engine', 'db_name', 'username', 'password', 'engine_version',  'option_group', 'source_instance', 'apply_immediately', 'new_instance_name', 'vpc_security_groups', 'security_groups' ]
  
     for v in required_vars:
         if not module.params.get(v):
@@ -447,10 +461,10 @@ def main():
         params["iops"] = iops
 
     if security_groups:
-        if subnet:
-            params["vpc_security_groups"] = security_groups.split(',')
-        else:
-            params["security_groups"] = security_groups.split(',')
+        params["security_groups"] = security_groups.split(',')
+
+    if vpc_security_groups:
+        params["vpc_security_groups"] = vpc_security_groups.split(',')
 
     if new_instance_name:
         params["new_instance_id"] = new_instance_name


### PR DESCRIPTION
The code  relies on the "subnet" argument 
being set to determine if the RDS instance is within
a VPC. If it is it switches the "security_groups" argument (when provided) from
security_groups to vpc_security_groups. This works
fine for the command=create case.

However in the command=modify case, the "subnet"
argument is considered invalid (As the AWS API 
does not allow for subnet modification of a 
provisioned instance). This results in the 
security_groups parameter always being treated as 
a non-VPC security group, even when it is.

The underlying boto library uses two separate 
arguments for when the security group is part of a 
vpc (vpc_security_groups) and for when it is not
(security_groups). I feel replicating this
 separation is probably the simplest and most 
explicit way of solving this issue. 

This pull request implements the separation.
