### PR TITLE
Rackspace Guide Example Fix

### DIFF
--- a/docsite/rst/guide_rax.rst
+++ b/docsite/rst/guide_rax.rst
@@ -542,7 +542,7 @@ Build a complete webserver environment with servers, custom networks and load ba
             module: rax_clb_nodes
             credentials: ~/.raxpub
             load_balancer_id: "{{ clb.balancer.id }}"
-            address: "{{ item.networks.private|first }}"
+            address: "{{ item.rax_networks.private|first }}"
             port: 80
             condition: enabled
             type: primary


### PR DESCRIPTION
In example 2, we refer to `item.networks`, however the attributes are namespace prefixed with `rax_`, and that should have been referenced as `item.rax_networks`

This pull request addresses the invalid reference.
