### PR TITLE
More module docs

### DIFF
--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -371,7 +371,7 @@ syntax highlighting before you include it in your Python file.
 Example
 +++++++
 
-See an example documentation string in the checkout under examples/DOCUMENTATION.yml
+See an example documentation string in the checkout under `examples/DOCUMENTATION.yml <https://github.com/ansible/ansible/blob/devel/examples/DOCUMENTATION.yml>`_.
 
 Include it in your module file like this::
 

--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -306,13 +306,17 @@ def main():
 
     category_list_path = os.path.join(options.output_dir, "modules_by_category.rst")
     category_list_file = open(category_list_path, "w")
-    category_list_file.write("Module Index\n")
-    category_list_file.write("============\n")
-    category_list_file.write("\n\n")
-    category_list_file.write(".. toctree::\n")
+    category_list_file.write("""\
+Module Index
+============
+
+.. toctree::
+   :maxdepth: 2
+
+""")
 
     for category in category_names:
-        category_list_file.write("    list_of_%s_modules\n" % category)
+        category_list_file.write("   list_of_%s_modules\n" % category)
         process_category(category, categories, options, env, template, outputname)
 
     category_list_file.close()

--- a/hacking/templates/rst.j2
+++ b/hacking/templates/rst.j2
@@ -1,7 +1,15 @@
 .. _@{ module }@:
 
-@{ module }@
-++++++++++++++++++++++++++++++++++++++
+{% if short_description %}
+{% set title = module + ' - ' + short_description|convert_symbols_to_format %}
+{% else %}
+{% set title = module %}
+{% endif %}
+{% set title_len = title|length %}
+
+@{ title }@
+@{ '+' * title_len }@
+
 {% if author %}
 :Author: @{ author }@
 {% endif %}

--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -17,9 +17,9 @@
 DOCUMENTATION = """
 ---
 module: elasticache
+short_description: Manage cache clusters in Amazon Elasticache.
 description:
   - Manage cache clusters in Amazon Elasticache.
-short_description: Manage cache clusters in Amazon Elasticache.
   - Returns information about the specified cache cluster.
 version_added: "1.4"
 requirements: [ "boto" ]


### PR DESCRIPTION
Most notable: module description page has short_description in it, which makes TOCs of module_index and list_of_*_modules to look more informative for a casual user.
