### PR TITLE
setup module: Partial fix for #4565, reporting Debian release version. Works only for Debian 7 and later

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -118,7 +118,8 @@ class Facts(object):
                     '/etc/alpine-release': 'Alpine',
                     '/etc/release': 'Solaris',
                     '/etc/arch-release': 'Archlinux',
-                    '/etc/SuSE-release': 'SuSE' }
+                    '/etc/SuSE-release': 'SuSE',
+                    '/etc/os-release': 'Debian' }
     SELINUX_MODE_DICT = { 1: 'enforcing', 0: 'permissive', -1: 'disabled' }
 
     # A list of dicts.  If there is a platform with more than one
@@ -328,6 +329,11 @@ class Facts(object):
                     elif name == 'SuSE':
                         data = get_file_content(path).splitlines()
                         self.facts['distribution_release'] = data[2].split('=')[1].strip()
+                    elif name == 'Debian':
+                        data = get_file_content(path).split('\n')[0]
+                        release = re.search("PRETTY_NAME.+ \(?([^ ]+?)\)?\"", data)
+                        if release:
+                            self.facts['distribution_release'] = release.groups()[0]
                     else:
                         self.facts['distribution'] = name
 


### PR DESCRIPTION
Determines the correct `ansible_distribution_release` for Debian 7 and later. It works for Debian stable/testing/sid.

I didn't find a clean solution for Debian versions <7 as `/etc/os-release` didn't exist there yet.

Maybe "hardcoding" a few codenames and comparing them to the first number in `ansible_distribution_version` is acceptable?
