### PR TITLE
ec2 module: Ephemeral devices can now be specified at instance creation time.

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -306,6 +306,8 @@ AWS_REGIONS = ['ap-northeast-1',
 try:
     import boto.ec2
     from boto.exception import EC2ResponseError
+    from boto.ec2.blockdevicemapping import BlockDeviceType
+    from boto.ec2.blockdevicemapping import BlockDeviceMapping
 except ImportError:
     print "failed=True msg='boto required for this module'"
     sys.exit(1)
@@ -406,6 +408,7 @@ def create_instances(module, ec2):
     assign_public_ip = module.boolean(module.params.get('assign_public_ip'))
     private_ip = module.params.get('private_ip')
     instance_profile_name = module.params.get('instance_profile_name')
+    ephemeral = int(module.params.get('ephemeral'))
 
     # group_id and group_name are exclusive of each other
     if group_id and group_name:
@@ -497,6 +500,15 @@ def create_instances(module, ec2):
                     params['security_group_ids'] = group_id
                 else:
                     params['security_groups'] = group_name
+
+            if ephemeral > 0:
+                mapping = BlockDeviceMapping()
+                for cnt in range(ephemeral):
+                    eph = BlockDeviceType()
+                    eph.ephemeral_name = 'ephemeral%s' % cnt
+                    device_name = '/dev/xvd%s' % chr(ord('b') + cnt)
+                    mapping[device_name] = eph
+                params['block_device_map'] = mapping
 
             res = ec2.run_instances(**params)
         except boto.exception.BotoServerError, e:
@@ -650,6 +662,7 @@ def main():
             instance_profile_name = dict(),
             instance_ids = dict(type='list'),
             state = dict(default='present'),
+            ephemeral = dict(default=0),
         )
     )
 


### PR DESCRIPTION
For EC2 instances that use EBS for the root device there is not instance store available at boot time.  These instance store volumes can't be added after the instance has been launched.  This adds the ability to specify the number of instance stores to attach to the instance during provisioning.  This is the equivalent to specifying the command line option(s) '-b "/dev/xvdb=ephemeral0" -b "/dev/xvdc=ephemeral1"'.

Example provisioning play:

```
- name: Provision and launch a new AWS EC2 Instance
  local_action: >
    ec2
    keypair='MyKeyPair'
    group='default'
    instance_type='m1.large'
    image='ami-a73264ce'
    ephemeral=2
    wait=true
    region='us-east-1'
    zone='us-east-1b'
  register: ec2
```
