### PR TITLE
ec2 inventory: Make it possible to group instances via their tags using group names explicitly named as <tag>=<value>

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -52,3 +52,8 @@ cache_path = /tmp
 # The number of seconds a cache file is considered valid. After this many
 # seconds, a new API call will be made, and the cache file will be updated.
 cache_max_age = 300
+
+# You may want to have tags and their values appear explicitly as host groups
+# named '<tag>=<value>', rather than 'tag_<tag>_<value>'.  If you'd like to 
+# enable this behavior, than simply set 'bare_tag_value_groups' to True.
+bare_tag_value_groups = False


### PR DESCRIPTION
There are plenty of times where you'd like to do something like the following with ansible:

ansible -i ./ec2.py -a <some command> <tag>=<value>

-or-

ansible-playbook -i ./ec2_inventory/ playbooks/foo.yml  -l mytag=foo 
ansible-playbook -i ./ec2_inventory/ playbooks/baz.yml -l mytag=baz

Recent changes to the EC2 inventory plugin added this specifically as host variables, but this change does the same as explicit group names so that the above is possible.
