### PR TITLE
Fix documentation example for the fail module

### DIFF
--- a/library/utilities/fail
+++ b/library/utilities/fail
@@ -40,5 +40,5 @@ author: Dag Wieers
 EXAMPLES = '''
 # Example playbook using fail and when together
 - fail: msg="The system may not be provisioned according to the CMDB status."
-  when: "{{ cmdb_status }} != 'to-be-staged'"
+  when: cmdb_status != "to-be-staged"
 '''


### PR DESCRIPTION
The example for the fail module doesn't work:
  http://www.ansibleworks.com/docs/modules.html#fail

The current text shows:
    - fail: msg="The system may not be provisioned according to the CMDB status."
      when: "{{ cmdb_status }} != 'to-be-staged'"

The "when" documentation indicates that the argument is already a Jinja2
expression:
  http://www.ansibleworks.com/docs/playbooks_conditionals.html#the-when-statement

Thus, the following is
      when: cmdb_status != "to-be-staged"

is preferred even though the following could work but generates a
deprecation warning:
      when: {{cmdb_status != "to-be-staged"}}
