### PR TITLE
rpm packaging: Fixed and cleaned spec

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -1,10 +1,4 @@
-%define name ansible
-
-%if 0%{?rhel} == 5
-%define __python /usr/bin/python26
-%endif
-
-Name:      %{name}
+Name:      ansible
 Version:   1.5
 Release:   1%{?dist}
 Url:       http://www.ansibleworks.com
@@ -16,52 +10,17 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 
 BuildArch: noarch
-
-# RHEL <=5
-%if 0%{?rhel} && 0%{?rhel} <= 5
-BuildRequires: python26-devel
-Requires: python26-PyYAML
-Requires: python26-paramiko
-Requires: python26-jinja2
-Requires: python26-keyczar
-Requires: python26-httplib2
-%endif
-
-# RHEL > 5
-%if 0%{?rhel} && 0%{?rhel} > 5
-BuildRequires: python2-devel
-Requires: PyYAML
-Requires: python-paramiko
-Requires: python-jinja2
-Requires: python-keyczar
-Requires: python-httplib2
-%endif
-
-# FEDORA > 17
-%if 0%{?fedora} >= 18
-BuildRequires: python-devel
-Requires: PyYAML
-Requires: python-paramiko
-Requires: python-jinja2
-Requires: python-keyczar
-Requires: python-httplib2
-%endif
-
-# SuSE/openSuSE
-%if 0%{?suse_version} 
 BuildRequires: python-devel
 BuildRequires: python-setuptools
+Requires: PyYAML
 Requires: python-paramiko
 Requires: python-jinja2
 Requires: python-keyczar
 Requires: python-yaml
 Requires: python-httplib2
-%endif
-
 Requires: sshpass
 
 %description
-
 Ansible is a radically simple model-driven configuration management,
 multi-node deployment, and orchestration engine. Ansible works
 over SSH and does not require any software or daemons to be installed
@@ -79,9 +38,8 @@ are transferred to managed machines automatically.
 mkdir -p %{buildroot}/etc/ansible/
 cp examples/hosts %{buildroot}/etc/ansible/
 cp examples/ansible.cfg %{buildroot}/etc/ansible/
-mkdir -p %{buildroot}/%{_mandir}/{man1,man3}/
-cp -v docs/man/man1/*.1 %{buildroot}/%{_mandir}/man1/
-cp -v docs/man/man3/*.3 %{buildroot}/%{_mandir}/man3/
+mkdir -p %{buildroot}/%{_mandir}
+cp -rv docs/man/man1 docs/man/man3 %{buildroot}/%{_mandir}
 mkdir -p %{buildroot}/%{_datadir}/ansible
 cp -rv library/* %{buildroot}/%{_datadir}/ansible/
 
@@ -90,17 +48,14 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root)
+%doc README.md COPYING
+%doc %{_mandir}/man1
+%doc %{_mandir}/man3
+%doc examples/playbooks
 %{python_sitelib}/ansible*
 %{_bindir}/ansible*
-%dir %{_datadir}/ansible
-%dir %{_datadir}/ansible/*
-%{_datadir}/ansible/*/*
+%{_datadir}/ansible
 %config(noreplace) %{_sysconfdir}/ansible
-%doc README.md PKG-INFO COPYING
-%doc %{_mandir}/man1/ansible*
-%doc %{_mandir}/man3/ansible.*
-%doc examples/playbooks
-
 
 %changelog
 


### PR DESCRIPTION
The build is fixed by removing empty doc dir and missing doc file.
Plus I cleaned BuildRequires and Requires, there's no need for OS specific requirement.

See https://build.opensuse.org/package/show/home:rgarrigue/ansible-devel to confirm the rpmbuild are working for most distro.
