### PR TITLE
Add rax_identity module

### DIFF
--- a/library/cloud/rax_identity
+++ b/library/cloud/rax_identity
@@ -1,0 +1,132 @@
+#!/usr/bin/python -tt
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: rax_identity
+short_description: Load Rackspace Cloud Identity
+description:
+     - Verifies Rackspace Cloud credentials and returns identity information
+version_added: "1.5"
+options:
+  api_key:
+    description:
+      - Rackspace API key (overrides C(credentials))
+  credentials:
+    description:
+      - File to find the Rackspace credentials in (ignored if C(api_key) and
+        C(username) are provided)
+    default: null
+    aliases: ['creds_file']
+  region:
+    description:
+      - Region to authenticate against
+    default: DFW
+  state:
+    description:
+      - Indicate desired state of the resource
+    choices: ['present', 'absent']
+    default: present
+  username:
+    description:
+      - Rackspace username (overrides C(credentials))
+requirements: [ "pyrax" ]
+author: Christopher H. Laco, Matt Martz
+notes:
+  - The following environment variables can be used, C(RAX_USERNAME),
+    C(RAX_API_KEY), C(RAX_CREDS_FILE), C(RAX_CREDENTIALS), C(RAX_REGION).
+  - C(RAX_CREDENTIALS) and C(RAX_CREDS_FILE) points to a credentials file
+    appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
+  - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
+  - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+'''
+
+EXAMPLES = '''
+- name: Load Rackspace Cloud Identity
+  gather_facts: False
+  hosts: local
+  connection: local
+  tasks:
+    - name: Load Identity
+      local_action:
+        module: rax_identity
+        credentials: ~/.raxpub
+        region: DFW
+      register: rackspace_identity
+'''
+
+import sys
+
+from types import NoneType
+
+try:
+    import pyrax
+except ImportError:
+    print("failed=True msg='pyrax required for this module'")
+    sys.exit(1)
+
+
+NON_CALLABLES = (basestring, bool, dict, int, list, NoneType)
+
+
+def cloud_identity(module, state, identity):
+    for arg in (state, identity):
+        if not arg:
+            module.fail_json(msg='%s is required for rax_identity' % arg)
+
+    instance = dict(
+        authenticated=identity.authenticated,
+        credentials=identity._creds_file
+    )
+    changed = False
+
+    for key, value in vars(identity).iteritems():
+        if (isinstance(value, NON_CALLABLES) and
+                not key.startswith('_')):
+            instance[key] = value
+
+    if state == 'present':
+        if not identity.authenticated:
+            module.fail_json(msg='Credentials could not be verified!')
+
+    module.exit_json(changed=changed, identity=instance)
+
+
+def main():
+    argument_spec = rax_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(default='present', choices=['present', 'absent'])
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=rax_required_together()
+    )
+
+    state = module.params.get('state')
+
+    setup_rax_module(module, pyrax)
+
+    cloud_identity(module, state, pyrax.identity)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.rax import *
+
+### invoke the module
+main()


### PR DESCRIPTION
For some tasks, I need to drop the username/api_key into configuration files.
Rather than rely on how I'm calling the rax modules, it seemed more
appropriate to authenticate against Rackspace and return the wealth of
information contained in the pyrax identity payload. Sharing that module for
others.
