### PR TITLE
Allow = symbols in variable values in host inventory

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -119,7 +119,7 @@ class InventoryParser(object):
                             if t.startswith('#'):
                                 break
                             try:
-                                (k,v) = t.split("=")
+                                (k,v) = t.split("=", 1)
                             except ValueError, e:
                                 raise errors.AnsibleError("Invalid ini entry: %s - %s" % (t, str(e)))
                             try:


### PR DESCRIPTION
Not sure why this merge [1] get reverted, but here is the patch again.

[1] https://github.com/ansible/ansible/pull/743
