### PR TITLE
Add -I/--interpreter argument to test-module

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -56,6 +56,9 @@ def parse():
         help="module argument string")
     parser.add_option('-D', '--debugger', dest='debugger', 
         help="path to python debugger (e.g. /usr/bin/pdb)")
+    parser.add_option('-I', '--interpreter', dest='interpreter',
+        help="path to interpeter to use for this module (e.g. ansible_python_interpreter=/usr/bin/python)",
+        metavar='INTERPRETER_TYPE=INTERPRETER_PATH')
     options, args = parser.parse_args()
     if not options.module_path:
         parser.print_help()
@@ -74,7 +77,7 @@ def write_argsfile(argstring, json=False):
     argsfile.close()
     return argspath
 
-def boilerplate_module(modfile, args):
+def boilerplate_module(modfile, args, interpreter):
     """ simulate what ansible does with new style modules """
 
     #module_fh = open(modfile)
@@ -87,6 +90,16 @@ def boilerplate_module(modfile, args):
 
     complex_args = {}
     inject = {}
+    if interpreter:
+        if '=' not in interpreter:
+            print 'interpeter must by in the form of ansible_python_interpreter=/usr/bin/python'
+            sys.exit(1)
+        interpreter_type, interpreter_path = interpreter.split('=')
+        if not interpreter_type.startswith('ansible_'):
+            interpreter_type = 'ansible_%s' % interpreter_type
+        if not interpreter_type.endswith('_interpreter'):
+            interpreter_type = '%s_interpreter' % interpreter_type
+        inject[interpreter_type] = interpreter_path
     (module_data, module_style, shebang) = replacer.modify_module(
         modfile, 
         complex_args,
@@ -144,7 +157,7 @@ def rundebug(debugger, modfile, argspath):
 def main(): 
 
     options, args = parse()
-    (modfile, module_style) = boilerplate_module(options.module_path, options.module_args)
+    (modfile, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter)
 
     argspath=None
     if module_style != 'new':


### PR DESCRIPTION
When developing a module in a virtual environment, potentially with a python module dependency that is only installed in the virtual environment, test-module will fail to operate correctly.

This change adds a `-I` and `--interpeter` argument, to allow you to specify the interpreter that `module_common.ModuleReplacer.modify_module` will use when building the module.

The value is `key=value` formatted, where the key is the interpreter type, which can either be full or short form:
1. ansible_python_interpreter
2. python

And the value it the path to the interpreter.

Example:

`hacking/test-module -I ansible_python_interpreter=/usr/local/bin/python2.7 -m newmodule`

or using short form for the interpreter to save keystrokes:

`hacking/test-module -I python=/usr/local/bin/python2.7 -m newmodule`
