### PR TITLE
Treat a False mandatory variable as defined.

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -76,9 +76,12 @@ def skipped(*a, **kw):
 
 def mandatory(a):
     ''' Make a variable mandatory '''
-    if not a:
+    try:
+        a
+    except NameError:
         raise errors.AnsibleFilterError('Mandatory variable not defined.')
-    return a
+    else:
+        return a
 
 def bool(a):
     ''' return a bool for the arg '''

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -58,7 +58,7 @@ def changed(*a, **kw):
     if not 'changed' in item:
         changed = False
         if ('results' in item    # some modules return a 'results' key
-                and type(item['results']) == list 
+                and type(item['results']) == list
                 and type(item['results'][0]) == dict):
             for result in item['results']:
                 changed = changed or result.get('changed', False)


### PR DESCRIPTION
When a variable is set to False, the "mandatory" filter returns False even if the variable is set. This is not expected behaviour. This patch will check if the variable exists and return True even if the value of the variable is False.

host_vars/vbox1.example.com

``` yaml
var_test: no
```

host_vars/vbox2.example.com

``` yaml
var_test: yes
```

tasks.yml

``` yaml
- debug: var=var_test

- name: Test var
  file:
    state: touch
    path: /root/var
  when: "{{ var_test | mandatory }}"
```

Output.

```
TASK: [test | debug var=var_test] *********************************************
ok: [vbox1.example.com] => {
    "item": "",
    "var_test": "False"
}
ok: [vbox2.example.com] => {
    "item": "",
    "var_test": "True"
}

TASK: [test | Test var] *******************************************************
fatal: [vbox1.example.com] => Mandatory variable not defined.
changed: [vbox2.example.com] => {"changed": true, "dest": "/root/var", "gid": 0, "group": "root", "item": "", "mode": "0644", "owner": "root", "size": 0, "state": "file", "uid": 0}
```
