### PR TITLE
postgresql_user module: Gracefully handle ALTER ROLE on read-only postgres servers.

### DIFF
--- a/library/database/postgresql_user
+++ b/library/database/postgresql_user
@@ -173,7 +173,7 @@ def user_add(cursor, user, password, role_attr_flags,  encrypted, expires):
     cursor.execute(query)
     return True
 
-def user_alter(cursor, user, password, role_attr_flags, encrypted, expires):
+def user_alter(cursor, module, user, password, role_attr_flags, encrypted, expires):
     """Change user password and/or attributes. Return True if changed, False otherwise."""
     changed = False
 
@@ -203,7 +203,17 @@ def user_alter(cursor, user, password, role_attr_flags, encrypted, expires):
         if expires is not None:
             alter = alter + " VALID UNTIL '%(expires)s'" % { "exipres": expires }
 
-        cursor.execute(alter)
+        try:
+            cursor.execute(alter)
+        except psycopg2.InternalError, e:
+            if e.pgcode == '25006':
+                # Handle errors due to read-only transactions indicated by pgcode 25006
+                # ERROR:  cannot execute ALTER ROLE in a read-only transaction
+                changed = False
+                module.fail_json(msg=e.pgerror)
+                return changed
+            else:
+                raise psycopg2.InternalError, e
 
         # Grab new role attributes.
         cursor.execute(select, {"user": user})
@@ -455,7 +465,7 @@ def main():
 
     if state == "present":
         if user_exists(cursor, user):
-            changed = user_alter(cursor, user, password, role_attr_flags, encrypted, expires)
+            changed = user_alter(cursor, module, user, password, role_attr_flags, encrypted, expires)
         else:
             changed = user_add(cursor, user, password, role_attr_flags, encrypted, expires)
         changed = grant_privileges(cursor, user, privs) or changed


### PR DESCRIPTION
Re-request of https://github.com/ansible/ansible/pull/5202.

Currently this module will raise an unhandled exception if there's any type of error applying the ALTER ROLE.  Standby servers are in a read-only state, therefore they will return an error when trying to ALTER ROLE.

This patch catches the exception and reports the error.  It is then possible to allow the ansible run to continue if ignore_errors=True in the task.

This commit also fixes a bug that would have triggered an exception when user = PUBLIC and password is not None.
