### PR TITLE
Fix notes section of template module

### DIFF
--- a/library/files/template
+++ b/library/files/template
@@ -51,7 +51,7 @@ notes:
 
   - "Also, you can override jinja2 settings by adding a special header to template file.
   i.e. C(#jinja2:variable_start_string:'[%' , variable_end_string:'%]')
-  which changes the variable interpolation markers to  [% var %] instead of  {{ var }}."  This is the best way to prevent evaluation of things that look like, but should not be Jinja2.  raw/endraw in Jinja2 will not work as you expect because templates in Ansible are recursively evaluated.
+  which changes the variable interpolation markers to  [% var %] instead of  {{ var }}.  This is the best way to prevent evaluation of things that look like, but should not be Jinja2.  raw/endraw in Jinja2 will not work as you expect because templates in Ansible are recursively evaluated."
 
 requirements: []
 author: Michael DeHaan


### PR DESCRIPTION
The notes section in DOCUMENTATION for the template module, is causing doc builds to fail for me.

The changes in this pull (moving the end quote to the end of the line) fix the issue.

The error I am getting is:

```
Traceback (most recent call last):
  File "/path/to/ansible/lib/ansible/utils/module_docs.py", line 48, in get_docstring
    doc = yaml.safe_load(child.value.s)
  File "/path/to/lib/python2.7/site-packages/yaml/__init__.py", line 93, in safe_load
    return load(stream, SafeLoader)
  File "/path/to/lib/python2.7/site-packages/yaml/__init__.py", line 71, in load
    return loader.get_single_data()
  File "/path/to/lib/python2.7/site-packages/yaml/constructor.py", line 37, in get_single_data
    node = self.get_single_node()
  File "/path/to/lib/python2.7/site-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/path/to/lib/python2.7/site-packages/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "/path/to/lib/python2.7/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/path/to/lib/python2.7/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/path/to/lib/python2.7/site-packages/yaml/composer.py", line 82, in compose_node
    node = self.compose_sequence_node(anchor)
  File "/path/to/lib/python2.7/site-packages/yaml/composer.py", line 110, in compose_sequence_node
    while not self.check_event(SequenceEndEvent):
  File "/path/to/lib/python2.7/site-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/path/to/lib/python2.7/site-packages/yaml/parser.py", line 393, in parse_block_sequence_entry
    "expected <block end>, but found %r" % token.id, token.start_mark)
ParserError: while parsing a block collection
  in "<string>", line 48, column 3:
      - Since Ansible version 0.9, tem ...
      ^
expected <block end>, but found '<scalar>'
  in "<string>", line 52, column 91:
     ... var %] instead of  {{ var }}."  This is the best way to prevent  ...
                                         ^
*** ERROR: CORE MODULE MISSING DOCUMENTATION: ../library/files/template, template ***
make[1]: *** [modules] Error 1
make: *** [webdocs] Error 2
```
