### PR TITLE
Use "brew list <name>" instead of grepping the output of "brew list". Fix for #5488

### DIFF
--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -71,7 +71,7 @@ def query_package(module, brew_path, name, state="present"):
     """ Returns whether a package is installed or not. """
 
     if state == "present":
-        rc, out, err = module.run_command("%s list -m1 | grep -q '^%s$'" % (brew_path, name))
+        rc, out, err = module.run_command("%s list %s" % (brew_path, name))
         if rc == 0:
             return True
 


### PR DESCRIPTION
`brew list <name>` fails with an error message and returns false when the package is not installed. Seems like a more robust way of querying for installed packages.
