### PR TITLE
Initial creation of homebrew_tap for managing additional/third party rep...

### DIFF
--- a/library/packaging/homebrew_tap
+++ b/library/packaging/homebrew_tap
@@ -1,0 +1,132 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Jimmy Tang <jcftang@gmail.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: homebrew_tap
+author: Jimmy Tang
+short_description: Add or remove Taps for Homebrew
+description:
+    - Manages Homebrew Taps (additional and or third party repositories)
+version_added: "1.5"
+options:
+    repo:
+        description:
+            - A source string for the tap
+        required: true
+    state:
+        description:
+            - state of the tap
+        choices: [ 'present', 'absent' ]
+        required: false
+        default: present
+notes:  []
+'''
+EXAMPLES = '''
+- homebrew_tap: repo=phinze/cask state=present
+- homebrew_tap: repo=homebrew/version state=absent
+'''
+
+def query_repos(module, brew_path, repo, state="present"):
+    """ Returns whether a repo is installed or not. """
+
+    if state == "present":
+        rc, out, err = module.run_command("%s tap | grep -q '^%s$'" % (brew_path, repo))
+        if rc == 0:
+            return True
+
+        return False
+
+
+def remove_repos(module, brew_path, repos):
+    """ Uninstalls one or more repos if installed. """
+
+    removed_count = 0
+
+    # Using a for loop incase of error, we can report the repo that failed
+    for repo in repos:
+        # Query the repo first, to see if we even need to remove.
+        if not query_repos(module, brew_path, repo):
+            continue
+
+        if module.check_mode:
+            module.exit_json(changed=True)
+        rc, out, err = module.run_command([brew_path, 'untap', repo])
+
+        if query_repos(module, brew_path, repo):
+            module.fail_json(msg="failed to remove %s: %s" % (repo, out.strip()))
+
+        removed_count += 1
+
+    if removed_count > 0:
+        module.exit_json(changed=True, msg="removed %d repo(s)" % removed_count)
+
+    module.exit_json(changed=False, msg="repo(s) already absent")
+
+
+def install_repos(module, brew_path, repos):
+    """ Installs one or more repos if not already installed. """
+
+    installed_count = 0
+
+    for repo in repos:
+        if query_repos(module, brew_path, repo):
+            continue
+
+        if module.check_mode:
+            module.exit_json(changed=True)
+
+        cmd = [brew_path, 'tap', repo]
+        rc, out, err = module.run_command(cmd)
+
+        if not query_repos(module, brew_path, repo):
+            module.fail_json(msg="failed to install %s: '%s' %s" % (repo, cmd, out.strip()))
+
+        installed_count += 1
+
+    if installed_count > 0:
+        module.exit_json(changed=True, msg="installed %d repo(s)" % (installed_count,))
+
+    module.exit_json(changed=False, msg="repo(s) already present")
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            repo = dict(aliases=["name", "tap"], required=True),
+            state = dict(default="present", choices=["present", "installed", "tapped", "absent", "removed", "untapped"]),
+        ),
+        supports_check_mode=True
+    )
+
+    p = module.params
+
+    brew_path = module.get_bin_path('brew', True, ['/usr/local/bin'])
+
+    repos = p["repo"].split(",")
+
+    if p["state"] in ["present", "installed", "tapped"]:
+        install_repos(module, brew_path, repos)
+
+    elif p["state"] in ["absent", "removed", "untapped"]:
+        remove_repos(module, brew_path, repos)
+
+# import module snippets
+from ansible.module_utils.basic import *
+
+main()


### PR DESCRIPTION
...ositories for the home brew package manager

This module is makes managing homebrew taps a little more pleasant than just running brew from the command module and checking for existence of taps with the creates argument.
