### PR TITLE
Added version check for pip and fails if use_mirrors is being used and p...

### DIFF
--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -274,6 +274,16 @@ def main():
 
     pip = _get_pip(module, env, module.params['executable'])
 
+    # get pip version. pip 1.5 doesn't support --use-mirrors, so we have to detect the version
+    pipv_cmd = '%s --version' % (pip)
+    rc_pipv, out_pipv, err_pipv = module.run_command(pipv_cmd)
+    out += out_pipv
+    err += err_pipv
+    pip_version = out_pipv.split(' ')[1]
+
+    if use_mirrors and (pip_version < "1.0" or pip_version >= "1.5"):
+        module.fail_json(msg='pip version %s does not support --use-mirrors, set use_mirrors=no or use a different pip version' % pip_version)
+
     cmd = '%s %s' % (pip, state_map[state])
     
     # If there's a virtualenv we want things we install to be able to use other


### PR DESCRIPTION
...ip doesn't support it

Pip 1.5 doesn't support --use-mirrors: http://www.pip-installer.org/en/latest/news.html
