### PR TITLE
Fixed typo in example documentation

### DIFF
--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -81,7 +81,7 @@ EXAMPLES = '''
 # Set kernel.panic to 3 in /tmp/test_sysctl.conf, check if the sysctl key
 # seems writable, but do not reload sysctl, and do not check kernel value
 # after (not needed, because the real /etc/sysctl.conf was not updated)
-- sysctl: name=kernel.panic value=3 sysctl_file=/tmp/test_sysctl.conf check=before reload=no
+- sysctl: name=kernel.panic value=3 sysctl_file=/tmp/test_sysctl.conf checks=before reload=no
 '''
 
 # ==============================================================


### PR DESCRIPTION
Fixed a small typo in the example documentation
