### PR TITLE
Return early from setup step when possible

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -433,11 +433,11 @@ class PlayBook(object):
     def _do_setup_step(self, play):
         ''' get facts from the remote system '''
 
-        host_list = self._list_available_hosts(play.hosts)
-
         if play.gather_facts is False:
             return {}
-        elif play.gather_facts is None:
+
+        host_list = self._list_available_hosts(play.hosts)
+        if play.gather_facts is None:
             host_list = [h for h in host_list if h not in self.SETUP_CACHE or 'module_setup' not in self.SETUP_CACHE[h]]
             if len(host_list) == 0:
                 return {}


### PR DESCRIPTION
The _list_available_hosts call can be lengthy, and in the case where
gather_facts is disabled the call is pointless. So re-arrange the logic
to return early from _do_setup_step when gather_facts is false.
