### PR TITLE
Fix exception being thrown for new instance registration with ELB

### DIFF
--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -202,7 +202,7 @@ class ElbManager:
             if instance_state.state == awaited_state:
                 # Check the current state agains the initial state, and only set
                 # changed if they are different.
-                if instance_state.state != initial_state.state:
+                if (initial_state is None) or (instance_state.state != initial_state.state):
                     self.changed = True
                 break
             elif self._is_instance_state_pending(instance_state):


### PR DESCRIPTION
Currently if we are trying to register an instance that has not yet
been registered with the elb an exception is thrown as follows:

Traceback (most recent call last):
  File "/home/ubuntu/.ansible/tmp/ansible-1388916053.26-72858643329411/ec2_elb", line 1412, in <module>
    main()
  File "/home/ubuntu/.ansible/tmp/ansible-1388916053.26-72858643329411/ec2_elb", line 335, in main
    elb_man.register(wait, enable_availability_zone)
  File "/home/ubuntu/.ansible/tmp/ansible-1388916053.26-72858643329411/ec2_elb", line 168, in register
    self._await_elb_instance_state(lb, 'InService', initial_state)
  File "/home/ubuntu/.ansible/tmp/ansible-1388916053.26-72858643329411/ec2_elb", line 213, in _await_elb_instance_state
    if instance_state.state != initial_state.state:
AttributeError: 'NoneType' object has no attribute 'state'

This is expected because the code is querying the elb for the state of the new instance and it responds with a "InvalidInstance" response (as its not been registered with the ELB yet) and the code sets the value of the initial_state to None. 

This code change checks if the initial_state is None. If it is, its safe to assume that its state has changed.
