### PR TITLE
Added Name Server Facts to the Setup Module

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1398,6 +1398,39 @@ class Network(Facts):
     def populate(self):
         return self.facts
 
+class ResolvConfHelper(object):
+    """
+    Providies a helper method to parse name server information from
+    /etc/resolv.conf
+    """
+    @staticmethod
+    def get_nameserver_info():
+        resolv_domain = None
+        default_nameserver = None
+        all_nameservers = []
+        try:
+            resolv_handle = open('/etc/resolv.conf', 'r')
+            for line in resolv_handle.readlines():
+                if len(line) < 1 or line[0] == "#":
+                    continue
+                words = line.split()
+                if len(words) < 2:
+                    continue
+                if words[0] == "nameserver":
+                    all_nameservers.append(words[1])
+                elif words[0] == "domain":
+                    resolv_domain = words[1]
+        except IOError:
+            # If we catch an error, all the data we've read so far is
+            # suspect, so return nothing, rather than partial data
+            resolv_domain = None
+            all_nameservers = []
+        else:
+            resolv_handle.close()
+        if len(all_nameservers) > 0:
+            default_nameserver = all_nameservers[0]
+        return resolv_domain, default_nameserver, all_nameservers
+
 class LinuxNetwork(Network):
     """
     This is a Linux-specific subclass of Network.  It defines
@@ -1417,6 +1450,10 @@ class LinuxNetwork(Network):
             return self.facts
         default_ipv4, default_ipv6 = self.get_default_interfaces(ip_path)
         interfaces, ips = self.get_interfaces_info(ip_path, default_ipv4, default_ipv6)
+        resolv_domain, default_nameserver, all_nameservers = ResolvConfHelper.get_nameserver_info()
+        self.facts['resolv_domain'] = resolv_domain
+        self.facts['default_nameserver'] = default_nameserver
+        self.facts['all_nameservers'] = all_nameservers
         self.facts['interfaces'] = interfaces.keys()
         for iface in interfaces:
             self.facts[iface] = interfaces[iface]
@@ -1641,6 +1678,12 @@ class GenericBsdIfconfigNetwork(Network):
         interfaces, ips = self.get_interfaces_info(ifconfig_path)
         self.merge_default_interface(default_ipv4, interfaces, 'ipv4')
         self.merge_default_interface(default_ipv6, interfaces, 'ipv6')
+        
+        resolv_domain, default_nameserver, all_nameservers = ResolvConfHelper.get_nameserver_info()
+        self.facts['resolv_domain'] = resolv_domain
+        self.facts['default_nameserver'] = default_nameserver
+        self.facts['all_nameservers'] = all_nameservers
+        
         self.facts['interfaces'] = interfaces.keys()
 
         for iface in interfaces:


### PR DESCRIPTION
# Added Name Server Facts to the Setup Module
## New Facts
-  all_nameservers: A list of IP addresses of all configured name servers.
-  default_nameserver: The first IP address in all_nameservers.
-  resolv_domain: The value of the 'domain' entry used for searching non-dot terminated domains.

All data are taken from /etc/resolv.conf using http://pic.dhe.ibm.com/infocenter/aix/v6r1/index.jsp?topic=%2Fcom.ibm.aix.files%2Fdoc%2Faixfiles%2Fresolv.conf.htm as a file format reference.
## Rationale For This Change
1. `resolv.conf` is common across systems and has a well defined format, so these changes are likely to result in useful facts on most systems.
2. It is certainly _possible_ to list resolvers in vars files related to each host. As the resolvers are facts about the host, it seems to make more sense to provide this information as setup facts.
3. These facts are notably missing from the wealth of facts which _are_ available about the networking subsystem as part of the setup module. As a result information about the system's networking setup is incomplete.
## Examples of Real World Usage
1. Several nginx modules (including `proxy` and `ocsp_staple`) require a DNS name server specified in the nginx configuration files. Providing these facts allows straightforward creation of compatible configuration files using only the template action.
2. These facts may be used to allow an Ansible script to test a host's DNS resolution capabilities by explicitly running DNS queries against the host's resolvers from both within and without the host.
3. These facts are useful in multi-machine deployments where Ansible manages gdnsd, or other DNS resolvers which need to be configured with upstream resolvers.
## Changes Since the Previous ver. of this Pull Request

Implements these facts using basic file I/O rather than running external commands. Added additional discussion as to the rational of this patch.
