### PR TITLE
Added AIX Crontab support

### DIFF
--- a/library/system/cron
+++ b/library/system/cron
@@ -363,7 +363,7 @@ class CronTab(object):
         """
         user = ''
         if self.user:
-            if platform.system() == 'SunOS' od paltform.system() == 'AIX':
+            if platform.system() == 'SunOS' or platform.system() == 'AIX':
                 return "chown %s %s ; su '%s' -c '%s %s'" % (self.user, path, self.user, CRONCMD, path)
             else:
                 user = '-u %s' % self.user

--- a/library/system/cron
+++ b/library/system/cron
@@ -351,6 +351,8 @@ class CronTab(object):
         if self.user:
             if platform.system() == 'SunOS':
                 return "su '%s' -c '%s -l'" % (self.user, CRONCMD)
+            elif platform.system() == 'AIX':
+		return "%s -l %s" % (CRONCMD, self.user)
             else:
                 user = '-u %s' % self.user
         return "%s %s %s" % (CRONCMD , user, '-l')
@@ -361,7 +363,7 @@ class CronTab(object):
         """
         user = ''
         if self.user:
-            if platform.system() == 'SunOS':
+            if platform.system() == 'SunOS' od paltform.system() == 'AIX':
                 return "chown %s %s ; su '%s' -c '%s %s'" % (self.user, path, self.user, CRONCMD, path)
             else:
                 user = '-u %s' % self.user


### PR DESCRIPTION
On AIX the crontab command has the following format :-

crontab [ -e [UserName] | -l [UserName] | -r [UserName] | -v [UserName] | File ]

This is different from the Linux crontab [-u user] ... format.

While AIX could be added to the Solaris options (for both) it makes sense to me to use the native format for crontab -l user to grab the file.
