### PR TITLE
Configure retry file usage and location

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -221,7 +221,7 @@ def main(args):
 
             retries = failed_hosts + unreachable_hosts
 
-            if len(retries) > 0:
+            if C.RETRY_FILES_ENABLED and len(retries) > 0:
                 filename = pb.generate_retry_inventory(retries)
                 if filename:
                     display("           to retry, use: --limit @%s\n" % filename)

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -102,6 +102,17 @@ filter_plugins     = /usr/share/ansible_plugins/filter_plugins
 # set to 1 if you don't want colors, or export ANSIBLE_NOCOLOR=1
 #nocolor = 1
 
+# by default, when a playbook fails for some hosts, Ansible will create a
+# special inventory file containing those failed hosts. Uncomment the
+# following line to disable this behaviour
+# retry_files_enabled = False
+
+# by default, retry files are placed in the .ansible-retry directory under
+# your home directory. Uncomment and edit the following to change the
+# directory. NOTE: if you change this, you will have to create the directory
+# yourself.
+# retry_files_save_path = '$HOME/.ansible-retry'
+
 [paramiko_connection]
 
 # uncomment this line to cause the paramiko connection plugin to not record new host

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -143,6 +143,9 @@ DEFAULT_UNDEFINED_VAR_BEHAVIOR = get_config(p, DEFAULTS, 'error_on_undefined_var
 HOST_KEY_CHECKING              = get_config(p, DEFAULTS, 'host_key_checking',  'ANSIBLE_HOST_KEY_CHECKING',    True, boolean=True)
 DEPRECATION_WARNINGS           = get_config(p, DEFAULTS, 'deprecation_warnings', 'ANSIBLE_DEPRECATION_WARNINGS', True, boolean=True)
 
+RETRY_FILES_ENABLED    = get_config(p, DEFAULTS, 'retry_files_enabled',    'ANSIBLE_RETRY_FILES_ENABLED', True, boolean=True)
+RETRY_FILES_SAVE_PATH  = get_config(p, DEFAULTS, 'retry_files_save_path', 'ANSIBLE_RETRY_FILES_SAVE_PATH', '$HOME/.ansible-retry')
+
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -479,19 +479,29 @@ class PlayBook(object):
         buf = StringIO.StringIO()
         for x in replay_hosts:
             buf.write("%s\n" % x)
-        basedir = self.inventory.basedir()
         filename = "%s.retry" % os.path.basename(self.filename)
         filename = filename.replace(".yml","")
-        filename = os.path.join(os.path.expandvars('$HOME/'), filename)
+
+        basedir = os.path.expandvars(C.RETRY_FILES_SAVE_PATH)
+        target = os.path.join(basedir, filename)
 
         try:
-            fd = open(filename, 'w')
+            if C.RETRY_FILES_SAVE_PATH == '$HOME/.ansible-retry' and not os.path.exists(basedir):
+                os.makedirs(basedir)
+
+            fd = open(target, 'w')
             fd.write(buf.getvalue())
             fd.close()
-            return filename
         except:
-            pass
-        return None
+            ansible.callbacks.display(
+                "\nERROR: could not create retry file. Check the value of \n"
+                + "the configuration variable 'retry_files_save_path' or set \n" 
+                + "'retry_files_enabled' to False to avoid this message.\n",
+                color='red'
+            )
+            return None
+
+        return target
 
     # *****************************************************
 

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -392,6 +392,33 @@ class TestPlaybook(unittest.TestCase):
 
       assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
 
+   def test_playbook_retry_files(self):
+       '''
+       This test is not particularly deep. It simply asserts some behaviour
+       following a regression and some discussion on the mailing list.
+       '''
+
+       test_callbacks = TestCallbacks()
+       playbook = ansible.playbook.PlayBook(
+           playbook=os.path.join(self.test_dir, 'playbook-always-fail.yml'),
+           host_list='test/ansible_hosts',
+           stats=ans_callbacks.AggregateStats(),
+           callbacks=test_callbacks,
+           runner_callbacks=test_callbacks
+       )
+
+       filename = playbook.generate_retry_inventory('localhost')
+       expected = os.path.join(
+             os.path.expandvars(C.RETRY_FILES_SAVE_PATH), 'playbook-always-fail.retry'
+       )
+
+       print "**ACTUAL**"
+       print filename
+       print "**EXPECTED**"
+       print expected
+
+       assert filename == expected
+
 
    def test_recursive_copy(self):
        pb = 'test/playbook-recursive-copy.yml'

--- a/test/playbook-always-fail.yml
+++ b/test/playbook-always-fail.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  connection: local
+  gather_facts: False
+  tasks:
+  - action: fail


### PR DESCRIPTION
New configuration settings: 

retry_files_enabled = True
retry_files_save_path = '$HOME/.ansible-retry'
