### PR TITLE
Fixes #5513. set is built-in since 2.4 and deprecated since 2.6

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -21,7 +21,6 @@ import fnmatch
 import os
 import re
 import subprocess
-from sets import Set
 
 import ansible.constants as C
 from ansible.inventory.ini import InventoryParser
@@ -252,7 +251,7 @@ class Inventory(object):
         """ Get all host names matching the pattern """
 
         hosts = []
-        hostnames = Set()
+        hostnames = set()
 
         # ignore any negative checks here, this is handled elsewhere
         pattern = pattern.replace("!","").replace("&", "")


### PR DESCRIPTION
Fixes the `set` related depreciation warning on python 2.6. Probably a simple oversight while developing on Python 2.7, which by [default](http://docs.python.org/dev/whatsnew/2.7.html#the-future-for-python-2-x) doesn't show depreciation warnings.

Maybe the `-Wd` flag or the `PYTHONWARNINGS` env variable should be used
