### PR TITLE
path_dwim: fix when basedir not set

### DIFF
--- a/lib/ansible/runner/action_plugins/debug.py
+++ b/lib/ansible/runner/action_plugins/debug.py
@@ -28,6 +28,7 @@ class ActionModule(object):
 
     def __init__(self, runner):
         self.runner = runner
+        self.basedir = runner.basedir
 
     def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
         args = {}
@@ -50,7 +51,7 @@ class ActionModule(object):
             else:
                 result = dict(msg=args['msg'])
         elif 'var' in args:
-            results = template.template(None, "{{ %s }}" % args['var'], inject)
+            results = template.template(self.basedir, "{{ %s }}" % args['var'], inject)
             result[args['var']] = results
 
         # force flag to make debug output module always verbose

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -250,6 +250,8 @@ def path_dwim(basedir, given):
     elif given.startswith("~"):
         return os.path.abspath(os.path.expanduser(given))
     else:
+        if basedir is None:
+            basedir = "."
         return os.path.abspath(os.path.join(basedir, given))
 
 def path_dwim_relative(original, dirname, source, playbook_base, check=True):


### PR DESCRIPTION
I bumped into a small bug. Easily patched, but I'm not 100% sure what I did is the best way here.

Can be reproduced with this basic playbook

```
- hosts: localhost                                                              
  gather_facts: false                                                           
  connection: local                                                             

  vars:                                                                         
      my: "{{ lookup('password','tmppwfile') }}"                                
  tasks:                                                                        
      - debug: var=my  
```

Which yields this traceback:

```
fatal: [localhost] => Traceback (most recent call last):
  File "/home/serge/src/ansible/lib/ansible/runner/__init__.py", line 426, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/home/serge/src/ansible/lib/ansible/runner/__init__.py", line 517, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/home/serge/src/ansible/lib/ansible/runner/__init__.py", line 717, in _executor_internal_inner
    result = handler.run(conn, tmp, module_name, module_args, inject, complex_args)
  File "/home/serge/src/ansible/lib/ansible/runner/action_plugins/debug.py", line 53, in run
    results = template.template(None, "{{ %s }}" % args['var'], inject)
  File "/home/serge/src/ansible/lib/ansible/utils/template.py", line 319, in template
    varname = template_from_string(basedir, varname, vars, fail_on_undefined)
  File "/home/serge/src/ansible/lib/ansible/utils/template.py", line 546, in template_from_string
    res = jinja2.utils.concat(rf)
  File "<template>", line 6, in root
  File "/usr/lib/python2.7/dist-packages/jinja2/runtime.py", line 153, in resolve
    return self.parent[key]
  File "/home/serge/src/ansible/lib/ansible/utils/template.py", line 400, in __getitem__
    return template(self.basedir, var, self.vars, fail_on_undefined=self.fail_on_undefined)
  File "/home/serge/src/ansible/lib/ansible/utils/template.py", line 319, in template
    varname = template_from_string(basedir, varname, vars, fail_on_undefined)
  File "/home/serge/src/ansible/lib/ansible/utils/template.py", line 546, in template_from_string
    res = jinja2.utils.concat(rf)
  File "<template>", line 8, in root
  File "/usr/lib/python2.7/dist-packages/jinja2/runtime.py", line 193, in call
    return __obj(*args, **kwargs)
  File "/home/serge/src/ansible/lib/ansible/utils/template.py", line 539, in my_lookup
    return lookup(*args, basedir=basedir, **kwargs)
  File "/home/serge/src/ansible/lib/ansible/utils/template.py", line 89, in lookup
    ran = instance.run(*args, inject=vars, **kwargs)
  File "/home/serge/src/ansible/lib/ansible/runner/lookup_plugins/password.py", line 79, in run
    path = utils.path_dwim(self.basedir, relpath)
  File "/home/serge/src/ansible/lib/ansible/utils/__init__.py", line 253, in path_dwim
    return os.path.abspath(os.path.join(basedir, given))
  File "/usr/lib/python2.7/posixpath.py", line 77, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```

The cause and solution is  believe in two places:
- The debug plugin wit a var param calls a template function setting basedir explicit to None
- The path_dwimd oes a os.path.join(basedir, given) without checking basedir is not None
  I'm not sure why the the debug plugin didn't set a basedir here, whether that was an explicit choice or not.

Fixing either of those two items solves the bug. I feel though both fixes might both be implemented, to avoid this bug being repeated elsewhere, but not sure.
