### PR TITLE
Adding support for detecting RHEV Hypervisor in ansible_virtualization_type

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -2080,6 +2080,11 @@ class LinuxVirtual(Virtual):
             self.facts['virtualization_role'] = 'guest'
             return
 
+        if product_name == 'RHEV Hypervisor':
+            self.facts['virtualization_type'] = 'RHEV'
+            self.facts['virtualization_role'] = 'guest'
+            return
+
         if product_name == 'VMware Virtual Platform':
             self.facts['virtualization_type'] = 'VMware'
             self.facts['virtualization_role'] = 'guest'


### PR DESCRIPTION
Adding support for detecting RHEV Hypervisor and thus marking a machine as a guest inside RHEV.

Before:

(ansible-1.4.3)ansible ~/ansible > ansible rhev_guestvm -m setup | grep virtualization
(ansible-1.4.3)ansible ~/ansible >

After:

(ansible-1.4.3_dieter)ansible ~/ansible > ansible rhev_guestvm -m setup | grep virtualization
"ansible_virtualization_role": "guest",
"ansible_virtualization_type": "RHEV"
(ansible-1.4.3_dieter)ansible ~/ansible >
