### PR TITLE
Add ansible.cache in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(name='ansible',
          'ansible.runner.connection_plugins',
          'ansible.runner.filter_plugins',
          'ansible.callback_plugins',
-         'ansible.module_utils'
+         'ansible.module_utils',
+         'ansible.cache'
       ],
       scripts=[
          'bin/ansible',


### PR DESCRIPTION
Without this, the cache module won't be installed, resulting each call to ansible to end with an ImportError.
