### PR TITLE
get_url: Enabled downloading of password protected FTP files

### DIFF
--- a/library/network/get_url
+++ b/library/network/get_url
@@ -143,7 +143,7 @@ def url_do_get(module, url, dest, use_proxy, last_mod_time):
 
     parsed = urlparse.urlparse(url)
 
-    if '@' in parsed[1]:
+    if '@' in parsed[1] and parsed.scheme in ['http','https']:
         credentials, netloc = parsed[1].split('@', 1)
         if ':' in credentials:
             username, password = credentials.split(':', 1)


### PR DESCRIPTION
After stripping username and password from FTP URL, the urllib module wasn't able to download FTP URLs with username and password.
