### PR TITLE
remove useless create/delete remote tmp dir roundtrip in copy module

### DIFF
--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -35,8 +35,6 @@ sys.setdefaultencoding("utf8")
 
 class ActionModule(object):
 
-    TRANSFERS_FILES = True
-
     def __init__(self, runner):
         self.runner = runner
 
@@ -125,9 +123,6 @@ class ActionModule(object):
         changed = False
         diffs = []
         module_result = {"changed": False}
-        # Remove tmp path since a new one is created below.  Should be empty.
-        if tmp.find("tmp") != -1:
-            self.runner._low_level_exec_command(conn, "rm -rf %s > /dev/null 2>&1" % tmp, tmp)
         for source_full, source_rel in source_files:
             # We need to get a new tmp path for each file, otherwise the copy module deletes the folder.
             tmp = self.runner._make_tmp_path(conn)


### PR DESCRIPTION
related to https://github.com/ansible/ansible/issues/5339
