### PR TITLE
allow disabling module invocation logging

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -119,6 +119,7 @@ DEFAULT_TRANSPORT         = get_config(p, DEFAULTS, 'transport',        'ANSIBLE
 DEFAULT_SCP_IF_SSH        = get_config(p, 'ssh_connection', 'scp_if_ssh',       'ANSIBLE_SCP_IF_SSH',       False, boolean=True)
 DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')
 DEFAULT_SYSLOG_FACILITY   = get_config(p, DEFAULTS, 'syslog_facility',  'ANSIBLE_SYSLOG_FACILITY', 'LOG_USER')
+DEFAULT_DISABLE_INVOCATION_LOGGING = get_config(p, DEFAULTS, 'disable_invocation_logging',  'ANSIBLE_DISABLE_INVOCATION_LOGGING', False, boolean=True)
 DEFAULT_KEEP_REMOTE_FILES = get_config(p, DEFAULTS, 'keep_remote_files', 'ANSIBLE_KEEP_REMOTE_FILES', False, boolean=True)
 DEFAULT_SUDO              = get_config(p, DEFAULTS, 'sudo', 'ANSIBLE_SUDO', False, boolean=True)
 DEFAULT_SUDO_EXE          = get_config(p, DEFAULTS, 'sudo_exe', 'ANSIBLE_SUDO_EXE', 'sudo')

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -186,7 +186,9 @@ class AnsibleModule(object):
         os.environ['LANG'] = MODULE_LANG
         (self.params, self.args) = self._load_params()
 
-        self._legal_inputs = [ 'CHECKMODE' ]
+        disable_logging = self.boolean(self.params.pop('DISABLE_LOG_INVOCATION', False))
+
+        self._legal_inputs = [ 'CHECKMODE', ]
         
         self.aliases = self._handle_aliases()
 
@@ -205,7 +207,8 @@ class AnsibleModule(object):
             self._check_required_one_of(required_one_of)
 
         self._set_defaults(pre=False)
-        if not no_log:
+
+        if not no_log and not disable_logging:
             self._log_invocation()
 
     def load_file_common_arguments(self, params):

--- a/lib/ansible/runner/action_plugins/normal.py
+++ b/lib/ansible/runner/action_plugins/normal.py
@@ -50,6 +50,10 @@ class ActionModule(object):
             module_name = 'command'
             module_args += " #USE_SHELL"
 
+        # support log_invocation
+        if C.DEFAULT_DISABLE_INVOCATION_LOGGING:
+            module_args += " DISABLE_LOG_INVOCATION=%s" % C.DEFAULT_DISABLE_INVOCATION_LOGGING
+
         vv("REMOTE_MODULE %s %s" % (module_name, module_args), host=conn.host)
         return self.runner._execute_module(conn, tmp, module_name, module_args, inject=inject, complex_args=complex_args)
 


### PR DESCRIPTION
Add a new option "disable_invocation_logging" to the ansible.cfg
configuration that allows disabling the syslog logging of remote
module invocations.

This addresses bug #5525 - feedback very welcome.

One implementation question - it appears that the AnsibleModule.**init**(... no_log ...) parameter is not used and can be removed (checked via git grep). Of course for the paramters no_log is used and I won't touch that. If that sounds reasonable I will remove it. If its part of a exported API for 3rd party module I obviously will not change anything here.

Thanks for your consideration,
 Michael
