### PR TITLE
Pass playbook filename to CallbackModule.playbook_on_start

### DIFF
--- a/lib/ansible/callback_plugins/noop.py
+++ b/lib/ansible/callback_plugins/noop.py
@@ -62,7 +62,7 @@ class CallbackModule(object):
     def runner_on_async_failed(self, host, res, jid):
         pass
 
-    def playbook_on_start(self):
+    def playbook_on_start(self, name):
         pass
 
     def playbook_on_notify(self, host, handler):

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -578,8 +578,8 @@ class PlaybookCallbacks(object):
 
         self.verbose = verbose
 
-    def on_start(self):
-        call_callback_module('playbook_on_start')
+    def on_start(self, name):
+        call_callback_module('playbook_on_start', name)
 
     def on_notify(self, host, handler):
         call_callback_module('playbook_on_notify', host, handler)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -224,7 +224,7 @@ class PlayBook(object):
         unmatched_tags_all = set()
 
         # loop through all patterns and run them
-        self.callbacks.on_start()
+        self.callbacks.on_start(self.filename)
         for (play_ds, play_basedir) in zip(self.playbook, self.play_basedirs):
             play = Play(self, play_ds, play_basedir)
             assert play is not None

--- a/plugins/callbacks/log_plays.py
+++ b/plugins/callbacks/log_plays.py
@@ -84,7 +84,7 @@ class CallbackModule(object):
     def runner_on_async_failed(self, host, res, jid):
         log(host, 'ASYNC_FAILED', res)
 
-    def playbook_on_start(self):
+    def playbook_on_start(self, name):
         pass
 
     def playbook_on_notify(self, host, handler):

--- a/plugins/callbacks/osx_say.py
+++ b/plugins/callbacks/osx_say.py
@@ -70,8 +70,8 @@ class CallbackModule(object):
     def runner_on_async_failed(self, host, res, jid):
         say("Failure on host %s" % host, FAILED_VOICE)
 
-    def playbook_on_start(self):
-        say("Running Playbook", REGULAR_VOICE)
+    def playbook_on_start(self, name):
+        say("Running Playbook: %s" % name, REGULAR_VOICE)
 
     def playbook_on_notify(self, host, handler):
         say("pew", LASER_VOICE)


### PR DESCRIPTION
Having just implemented a callback plugin to send notifications when ansible is being run, I found that not having the playbook filename available to playbook_on_start was potentially confusing, as you wouldn't really know what playbook was being run.

This pull request adds a play argument to playbook_on_start which contains the playbook filename.

My only "concern" here is that adding this will cause ansible to send a 2nd argument to the method, and those that already have a callback plugin implemented, will run into issues unless they update.
