### PR TITLE
Use /etc/rc.conf.local for sevice configuration on FreeBSD

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -784,7 +784,7 @@ class FreeBsdService(Service):
         else:
             self.rcconf_value = "NO"
 
-        rcfiles = [ '/etc/rc.conf','/usr/local/etc/rc.conf' ]
+        rcfiles = [ '/etc/rc.conf','/etc/rc.conf.local' ] # prefer /etc/rc.conf.local if it exists
         for rcfile in rcfiles:
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile

--- a/library/system/service
+++ b/library/system/service
@@ -784,7 +784,7 @@ class FreeBsdService(Service):
         else:
             self.rcconf_value = "NO"
 
-        rcfiles = [ '/etc/rc.conf','/etc/rc.conf.local' ] # prefer /etc/rc.conf.local if it exists
+        rcfiles = [ '/etc/rc.conf','/etc/rc.conf.local', '/usr/local/etc/rc.conf' ]
         for rcfile in rcfiles:
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile


### PR DESCRIPTION
/etc/rc.conf.local is the preferred location for system-specific
startup configuration, and /usr/local/etc/rc.conf generally isn’t used.

see:
http://www.freebsd.org/doc/handbook/configtuning-core-configuration.html
