### PR TITLE
Expose the playbook to callback plugins

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -108,6 +108,12 @@ def log_unflock(runner):
         except OSError:
             pass
 
+def set_playbook(callback, playbook):
+    ''' used to notify callback plugins of playbook context '''
+    callback.playbook = playbook
+    for callback_plugin in callback_plugins:
+        callback_plugin.playbook = playbook
+
 def set_play(callback, play):
     ''' used to notify callback plugins of context '''
     callback.play = play

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -148,6 +148,7 @@ class PlayBook(object):
         self.filename = playbook
         (self.playbook, self.play_basedirs) = self._load_playbook_from_file(playbook, vars)
         ansible.callbacks.load_callback_plugins()
+        ansible.callbacks.set_playbook(self.callbacks, self)
 
     # *****************************************************
 


### PR DESCRIPTION
This is a second attempt at adding this functionality through different means...

Having just implemented a callback plugin to send notifications when ansible is being run, I found that not having the playbook filename available to playbook_on_start was potentially confusing, as you wouldn't really know what playbook was being run.

This pull request, adds a `set_playbook()` function to ansible/callbacks.py to match that of `set_play()` and `set_task()`.  It will set a `playbook` attribute in each callback plugin, with a value of the `Playbook` instance.

`ansible.callbacks.set_playbook` is called from the `__init__` method of the `Playbook` class.
