### PR TITLE
rax_clb module: Ensure the id attribute is returned for a node

### DIFF
--- a/library/cloud/rax_clb
+++ b/library/cloud/rax_clb
@@ -118,7 +118,6 @@ EXAMPLES = '''
 '''
 
 import sys
-import os
 
 from types import NoneType
 
@@ -136,6 +135,12 @@ PROTOCOLS = ['DNS_TCP', 'DNS_UDP', 'FTP', 'HTTP', 'HTTPS', 'IMAPS', 'IMAPv4',
              'TCP_CLIENT_FIRST', 'UDP', 'UDP_STREAM', 'SFTP']
 
 
+def node_to_dict(obj):
+    node = obj.to_dict()
+    node['id'] = obj.id
+    return node
+
+
 def to_dict(obj):
     instance = {}
     for key in dir(obj):
@@ -151,7 +156,7 @@ def to_dict(obj):
         elif key == 'nodes':
             instance[key] = []
             for node in value:
-                instance[key].append(node.to_dict())
+                instance[key].append(node_to_dict(node))
         elif (isinstance(value, NON_CALLABLES) and
                 not key.startswith('_')):
             instance[key] = value


### PR DESCRIPTION
Currently, when rax_clb returns a list of nodes after an execution for use with register, the nodes are lacking the 'id' attribute.  This is due to the `to_dict` method of the node in pyrax, not including it.  This has been fixed in pyrax, but as a backwards compatible fix for ansible, this pull request ensures that the id attribute is returned.
