### PR TITLE
tests: added travis.yml to run unit test of pull requests on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+---
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq ruby-json facter
+ - git config --global user.name "Travis CI"
+ - git config --global user.email "travis@example.com"
+
+install:
+  - "pip install PyYAML --use-mirrors"
+  - "pip install jinja2 --use-mirrors"
+  - "pip install paramiko --use-mirrors"
+
+script: make tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![PyPI version](https://badge.fury.io/py/ansible.png)](http://badge.fury.io/py/ansible)
+[![Build Status](https://travis-ci.org/ansible/ansible.png?branch=devel)](https://travis-ci.org/ansible/ansible)
 
 Ansible
 =======


### PR DESCRIPTION
I would like to do another try to integrate the free for open source projects unit test service travis-ci.org into ansible.
## Why?
- It makes people more sensible implementing unit test, if they see, each and every pull request will be tested against regression errors.
- does not cost a dime.
- transparency as travis is well integrated into github.
- easy and simple, like ansible.
## How?
1. sign in on travis-ci.org using your github account (oauth)
2. go to https://travis-ci.org/profile.
3. activate the ansible/ansible repo.
4. merge this PR.
## Preview how it would look:

https://github.com/resmo/ansible/pull/1
