### PR TITLE
Fix idempotence in mongodb_user module

### DIFF
--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -188,19 +188,28 @@ def main():
 
     try:
         client = MongoClient(login_host, int(login_port))
-        if login_user is None and login_password is None:
-            mongocnf_creds = load_mongocnf()
-            if mongocnf_creds is not False:
-                login_user = mongocnf_creds['user']
-                login_password = mongocnf_creds['password']
-        elif login_password is None and login_user is not None:
-            module.fail_json(msg='when supplying login arguments, both login_user and login_password must be provided')
-
-        if login_user is not None and login_password is not None:
-            client.admin.authenticate(login_user, login_password)
-
     except ConnectionFailure, e:
-        module.fail_json(msg='unable to connect to database, check login_user and login_password are correct')
+        module.fail_json(msg='unable to connect to database, check login_host and login_port are correct')
+
+    # try to authenticate as a target user to check if it already exists
+    try:
+        client[db_name].authenticate(user, password)
+        if state == 'present':
+            module.exit_json(changed=False, user=user)
+    except OperationFailure:
+        if state == 'absent':
+            module.exit_json(changed=False, user=user)
+
+    if login_user is None and login_password is None:
+        mongocnf_creds = load_mongocnf()
+        if mongocnf_creds is not False:
+            login_user = mongocnf_creds['user']
+            login_password = mongocnf_creds['password']
+    elif login_password is None and login_user is not None:
+        module.fail_json(msg='when supplying login arguments, both login_user and login_password must be provided')
+
+    if login_user is not None and login_password is not None:
+        client.admin.authenticate(login_user, login_password)
 
     if state == 'present':
         if password is None:


### PR DESCRIPTION
This patch adds an extra login attempt to find out if a given user already exists and exits early if `state` condition is met.

Before this patch, `mongodb_user` module always reported `changed=True` and tried to create a user, even if a given user was already present in the database.

Previous behaviour also creates sort of a chicken-and-egg problem when you want to create your first admin user:
- if you specify login_user and login_password, it will fail at the first time because no users exist in the database yet.
- if you don't specify login_user and login_password (and rely on MongoDB's [localhost exception](http://docs.mongodb.org/manual/tutorial/add-user-administrator/#localhost-exception)), then it will succeed on the first run, but will fail on any subsequent run, because there is already a user in the database, so localhost exception doesn't kick in and login_user/login_password are required.

I don't see any obvious backward incompatibilities, unless someone relied on this buggy behaviour - in that case we can hide it behind an extra `precheck_credentials` flag parameter or something like that.
