### PR TITLE
apt_key module: Case insensitive presence checking

### DIFF
--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -124,7 +124,7 @@ def all_keys(module, keyring):
     return results
 
 def key_present(module, key_id):
-    (rc, out, err) = module.run_command("apt-key list | 2>&1 grep -q %s" % key_id)
+    (rc, out, err) = module.run_command("apt-key list | 2>&1 grep -i -q %s" % key_id)
     return rc == 0
 
 def download_key(module, url):


### PR DESCRIPTION
Right now `key_present()` in the apt_key module is case sensitive, only uppercase key IDs work. By using `grep -i`, lowercase IDs should work too.
