### PR TITLE
Documentation update to yield example of "WITH GRANT OPTION" which is undocumented previous

### DIFF
--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -114,6 +114,9 @@ EXAMPLES = """
 # Create database user with name 'bob' and password '12345' with all database privileges
 - mysql_user: name=bob password=12345 priv=*.*:ALL state=present
 
+# Creates database user 'bob' and password '12345' with all database privileges and 'WITH GRANT OPTION'
+- mysql_user: name=bob password=12345 priv=*.*:ALL,GRANT state=present
+
 # Ensure no user named 'sally' exists, also passing in the auth credentials.
 - mysql_user: login_user=root login_password=123456 name=sally state=absent
 


### PR DESCRIPTION
Very minor addition of an example, which clarifies how to ensure the created user is created "WITH GRANT OPTION"
