### PR TITLE
zypper_repository: claims to support check_mode, but does not.

### DIFF
--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -120,7 +120,7 @@ def main():
             description=dict(required=False),
             disable_gpg_check = dict(required=False, default='no', type='bool'),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     repo = module.params['repo']


### PR DESCRIPTION
 Fixes GH-5614
