### PR TITLE
bugfix: support path separators in module path during install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,11 @@ from distutils.core import setup
 
 # find library modules
 from ansible.constants import DEFAULT_MODULE_PATH
+install_path = DEFAULT_MODULE_PATH.split(os.pathsep)[0]
 dirs=os.listdir("./library/")
 data_files = []
 for i in dirs:
-    data_files.append((os.path.join(DEFAULT_MODULE_PATH, i), glob('./library/' + i + '/*')))
+    data_files.append((os.path.join(install_path, i), glob('./library/' + i + '/*')))
 
 setup(name='ansible',
       version=__version__,


### PR DESCRIPTION
As described by http://docs.ansible.com/intro_configuration.html#library the library supports multiple paths to load modules from. 

Currently `setup.py` treats something like `/usr/share/ansible:/my/custom/modules` as a single directory name and results in the installed modules not being on the module path. (instead they are in a directory named `/usr/share/ansible:/my/custom/modules`) 

This commit simply takes the first listed directory as the install directory for the core modules.
