### PR TITLE
subversion: use LANG=C to prevent regex failures

### DIFF
--- a/library/source_control/subversion
+++ b/library/source_control/subversion
@@ -94,6 +94,7 @@ class Subversion(object):
 
     def _exec(self, args):
         bits = [
+            'LANG=C',
             self.svn_path,
             '--non-interactive',
             '--trust-server-cert',


### PR DESCRIPTION
Fixes bug GH-5549.
