### PR TITLE
Support mysql password hashes

### DIFF
--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -36,6 +36,11 @@ options:
       - set the user's password
     required: false
     default: null
+  password_hash:
+    description:
+      - set the user's password hash (used in place of plain text password)
+    required: false
+    default: null
   host:
     description:
       - the 'host' part of the MySQL username
@@ -138,6 +143,8 @@ password=n<_665{vS43y
 import ConfigParser
 import getpass
 import tempfile
+import string
+
 try:
     import MySQLdb
 except ImportError:
@@ -154,14 +161,32 @@ def user_exists(cursor, user, host):
     count = cursor.fetchone()
     return count[0] > 0
 
-def user_add(cursor, user, host, password, new_priv):
-    cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
+def user_add(cursor, user, host, password, password_hash, new_priv):
+    if password and not password_hash:
+        cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
+    elif password_hash:
+        cursor.execute("CREATE USER %s@%s IDENTIFIED BY PASSWORD %s", (user,host,password_hash))
+        print 'PASSWORD HASH!'
     if new_priv is not None:
         for db_table, priv in new_priv.iteritems():
             privileges_grant(cursor, user,host,db_table,priv)
     return True
 
-def user_mod(cursor, user, host, password, new_priv, append_privs):
+def is_hash(password):
+    ishash = False
+    if len(password) is 41 and password[0] is '*':
+        # in testing re.match completed in 0.00012s on average
+        # the following loop completed in  0.000006s on averagei
+        # Python 2.7.5, Fedora 19 x64, AMD FX(tm)-8350
+        ishash = True
+        for i in password[1:]:
+            if i not in string.hexdigits:
+                ishash = False
+                break 
+    return ishash
+          
+
+def user_mod(cursor, user, host, password, password_hash, new_priv, append_privs):
     changed = False
     grant_option = False
 
@@ -169,11 +194,20 @@ def user_mod(cursor, user, host, password, new_priv, append_privs):
     if password is not None:
         cursor.execute("SELECT password FROM user WHERE user = %s AND host = %s", (user,host))
         current_pass_hash = cursor.fetchone()
-        cursor.execute("SELECT PASSWORD(%s)", (password,))
-        new_pass_hash = cursor.fetchone()
-        if current_pass_hash[0] != new_pass_hash[0]:
-            cursor.execute("SET PASSWORD FOR %s@%s = PASSWORD(%s)", (user,host,password))
-            changed = True
+
+        if password:
+            cursor.execute("SELECT PASSWORD(%s)", (password,))
+            new_pass_hash = cursor.fetchone()
+            if current_pass_hash[0] != new_pass_hash[0]:
+                cursor.execute("SET PASSWORD FOR %s@%s = PASSWORD(%s)", (user,host,password))
+                changed = True
+        elif password_hash:
+            if is_hash(password_hash):
+                if current_pass_hash[0] != password:
+                    cursor.execute("SET PASSWORD FOR %s@%s = %s", (user, host, password))
+                    changed = True
+            else:
+                module.fail_json(msg="password_hash was specified however it does not appear to be a valid hash expecting: *SHA1(SHA1(your_password))")
 
     # Handle privileges.
     if new_priv is not None:
@@ -397,6 +431,7 @@ def main():
             login_unix_socket=dict(default=None),
             user=dict(required=True, aliases=['name']),
             password=dict(default=None),
+            password_hash=dict(default=None),
             host=dict(default="localhost"),
             state=dict(default="present", choices=["absent", "present"]),
             priv=dict(default=None),
@@ -406,6 +441,7 @@ def main():
     )
     user = module.params["user"]
     password = module.params["password"]
+    password_hash = module.params["password_hash"]
     host = module.params["host"]
     state = module.params["state"]
     priv = module.params["priv"]
@@ -452,11 +488,11 @@ def main():
 
     if state == "present":
         if user_exists(cursor, user, host):
-            changed = user_mod(cursor, user, host, password, priv, append_privs)
+            changed = user_mod(cursor, user, host, password, password_hash, priv, append_privs)
         else:
-            if password is None:
-                module.fail_json(msg="password parameter required when adding a user")
-            changed = user_add(cursor, user, host, password, priv)
+            if password is None and password_hash is None:
+                module.fail_json(msg="password or password_hash parameter required when adding a user")
+            changed = user_add(cursor, user, host, password, password_hash, priv)
     elif state == "absent":
         if user_exists(cursor, user, host):
             changed = user_delete(cursor, user, host)

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -166,7 +166,6 @@ def user_add(cursor, user, host, password, password_hash, new_priv):
         cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
     elif password_hash:
         cursor.execute("CREATE USER %s@%s IDENTIFIED BY PASSWORD %s", (user,host,password_hash))
-        print 'PASSWORD HASH!'
     if new_priv is not None:
         for db_table, priv in new_priv.iteritems():
             privileges_grant(cursor, user,host,db_table,priv)


### PR DESCRIPTION
To avoid having to use plaintext passwords in playbooks this adds support for instead passing the hash of the password which assuming the password is of sufficient complexity is far more secure than having the password in plaintext within the play books.

Tested with the following playbook:

```

---
- hosts: all
  tasks:
    - name: mysql_user test password hashed
      mysql_user: user=test password=*973D12C21B4F274E09461F56EEAB92AB7B6FC20A priv=*.*:ALL,GRANT
    - name: mysql_user test2 password not hashed
      mysql_user: user=test2 password=ansible priv=*.*:ALL,GRANT
```

resulting hash in both cases is identical.

A loop is used in place of a regect pattern as in testing the loop was 20x faster than re.match (assuming I got the math right of course).

Note this only works for 5.x MySQL hashes, the old password hashes are not support (and should not be used at all frankly); this does not work for pluggable authentication introduced in 5.6 i.e. the sha256 plugin at this time (can't pass the raw hash -> plain text will continue to function normally). 
