### PR TITLE
Do not log the rax api_key argument in module invocation

### DIFF
--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -3,7 +3,7 @@ import os
 
 def rax_argument_spec():
     return dict(
-        api_key=dict(type='str'),
+        api_key=dict(type='str', no_log=True),
         credentials=dict(type='str', aliases=['creds_file']),
         region=dict(type='str'),
         username=dict(type='str'),


### PR DESCRIPTION
This pull request adds the no_log key to the api_key attribute of the argument spec, so that the api_key is not logged in module invocation.
