### PR TITLE
Add support for loading JSON from shell commands

### DIFF
--- a/library/commands/command
+++ b/library/commands/command
@@ -94,6 +94,7 @@ def main():
     args  = module.params['args']
     creates  = module.params['creates']
     removes  = module.params['removes']
+    load_json = module.params['json']
 
     if args.strip() == '':
         module.fail_json(rc=256, msg="no command given")
@@ -145,6 +146,10 @@ def main():
     if err is None:
         err = ''
 
+    json_arg = {}
+    if out and load_json:
+        json_arg['json'] = module.from_json(out)
+
     module.exit_json(
         cmd     = args,
         stdout  = out.rstrip("\r\n"),
@@ -153,7 +158,8 @@ def main():
         start   = str(startd),
         end     = str(endd),
         delta   = str(delta),
-        changed = True
+        changed = True,
+        **json_arg
     )
 
 # import module snippets
@@ -179,11 +185,12 @@ class CommandModule(AnsibleModule):
         params['removes'] = None
         params['shell'] = False
         params['executable'] = None
+        params['json'] = False
         if args.find("#USE_SHELL") != -1:
             args = args.replace("#USE_SHELL", "")
             params['shell'] = True
 
-        r = re.compile(r'(^|\s)(creates|removes|chdir|executable)=(?P<quote>[\'"])?(.*?)(?(quote)(?<!\\)(?P=quote))((?<!\\)(?=\s)|$)')
+        r = re.compile(r'(^|\s)(creates|removes|chdir|executable|json)=(?P<quote>[\'"])?(.*?)(?(quote)(?<!\\)(?P=quote))((?<!\\)(?=\s)|$)')
         for m in r.finditer(args):
             v = m.group(4).replace("\\", "")
             if m.group(2) == "creates":
@@ -202,6 +209,8 @@ class CommandModule(AnsibleModule):
                 if not (os.path.exists(v)):
                     self.fail_json(rc=258, msg="cannot use executable '%s': file does not exist" % v)
                 params['executable'] = v
+            elif m.group(2) == "json":
+                params['json'] = self.boolean(v)
         args = r.sub("", args)
         params['args'] = args
         return (params, params['args'])

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -159,6 +159,9 @@ class TestRunner(unittest.TestCase):
         result = self._run('command', ["creates='/tmp/ansible command test'", "false"])
         assert result.get('skipped')
 
+        result = self._run('command', ["json=yes", "echo '{\"foo\":true}'"])
+        assert result.get('json') == {'foo': True}
+
         result = self._run('shell', ["removes=/tmp/ansible\\ command\\ test", "chdir=/tmp", "rm -f 'ansible command test'; echo $?"])
         assert result.get('changed')
         assert result['rc'] == 0
@@ -166,6 +169,10 @@ class TestRunner(unittest.TestCase):
 
         result = self._run('shell', ["removes=/tmp/ansible\\ command\\ test", "false"])
         assert result.get('skipped')
+
+        result = self._run('command', ["json=yes", "echo '{\"bar\":false}'"])
+        assert result.get('json') == {'bar': False}
+
 
     def test_git(self):
         self._run('file', ['path=/tmp/gitdemo', 'state=absent'])

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -162,6 +162,9 @@ class TestRunner(unittest.TestCase):
         result = self._run('command', ["json=yes", "echo '{\"foo\":true}'"])
         assert result.get('json') == {'foo': True}
 
+        result = self._run('command', ["json=yes", "echo '{'"])
+        assert result.get('failed')
+
         result = self._run('shell', ["removes=/tmp/ansible\\ command\\ test", "chdir=/tmp", "rm -f 'ansible command test'; echo $?"])
         assert result.get('changed')
         assert result['rc'] == 0
@@ -170,9 +173,11 @@ class TestRunner(unittest.TestCase):
         result = self._run('shell', ["removes=/tmp/ansible\\ command\\ test", "false"])
         assert result.get('skipped')
 
-        result = self._run('command', ["json=yes", "echo '{\"bar\":false}'"])
+        result = self._run('shell', ["json=yes", "echo '{\"bar\":false}'"])
         assert result.get('json') == {'bar': False}
 
+        result = self._run('shell', ["json=yes", "echo '{'"])
+        assert result.get('failed')
 
     def test_git(self):
         self._run('file', ['path=/tmp/gitdemo', 'state=absent'])


### PR DESCRIPTION
My particular use case is to load JSON from a curl against CouchDB that uses a non-standard `-X COPY` method.  This could have been added to the `uri` module, sure, but I'd prefer to have the flexibility to load JSON from arbitrary commands.  I realize this introduces _yet another_ place where vars can come from, so I'm totally ready to get shot down.  Thanks either way!
