### PR TITLE
Change how the config file is loaded to support loading multiple config files

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -57,17 +57,14 @@ def _get_config(p, section, key, env_var, default):
 
 def load_config_file():
     p = ConfigParser.ConfigParser()
-    path1 = os.getcwd() + "/ansible.cfg"
-    path2 = os.path.expanduser(os.environ.get('ANSIBLE_CONFIG', "~/.ansible.cfg"))
-    path3 = "/etc/ansible/ansible.cfg"
+    read_files = p.read([
+        "/etc/ansible/ansible.cfg",
+        os.path.expanduser("~/.ansible.cfg"),
+        os.path.expanduser(os.environ.get('ANSIBLE_CONFIG', '')),
+        os.getcwd() + "/ansible.cfg"
+    ])
 
-    if os.path.exists(path1):
-        p.read(path1)
-    elif os.path.exists(path2):
-        p.read(path2)
-    elif os.path.exists(path3):
-        p.read(path3)
-    else:
+    if read_files == []:
         return None
     return p
 


### PR DESCRIPTION
Change how the config file is loaded to support loading multiple config files, starting with the most common (/etc) to the least (cwd), overwriting values as we go. This allows me to have development specific settings in my home directory and having system specific settings in /etc and having everything just work.
