### PR TITLE
apt: fixed pkg=<name>=<version> fails if package is not yet installed.

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -191,7 +191,7 @@ def package_status(m, pkgname, version, cache, state):
             # assume older version of python-apt is installed
             package_is_installed = pkg.isInstalled
 
-    if version:
+    if version and package_is_installed:
         try:
             installed_version = pkg.installed.version
         except AttributeError:


### PR DESCRIPTION
Reported and patch provided by https://github.com/msolo. Closes GH-5625.
