### PR TITLE
allow ansible_ssh_private_key_file to be templated (thanks to benno)

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -611,6 +611,8 @@ class Runner(object):
         actual_pass = inject.get('ansible_ssh_pass', self.remote_pass)
         actual_transport = inject.get('ansible_connection', self.transport)
         actual_private_key_file = inject.get('ansible_ssh_private_key_file', self.private_key_file)
+        # allow ansible_ssh_private_key_file to be templated
+        actual_private_key_file = template.template(self.basedir, actual_private_key_file, inject, fail_on_undefined=True)
         self.sudo_pass = inject.get('ansible_sudo_pass', self.sudo_pass)
 
         if actual_private_key_file is not None:

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -441,7 +441,7 @@ class Runner(object):
 
         host_variables = self.inventory.get_variables(host)
         host_connection = host_variables.get('ansible_connection', self.transport)
-        if host_connection in [ 'paramiko', 'paramiko_old', 'ssh', 'ssh_old', 'accelerate' ]:
+        if host_connection in [ 'paramiko', 'paramiko_alt', 'ssh', 'ssh_old', 'accelerate' ]:
             port = host_variables.get('ansible_ssh_port', self.remote_port)
             if port is None:
                 port = C.DEFAULT_REMOTE_PORT
@@ -630,7 +630,7 @@ class Runner(object):
             if not self.accelerate_port:
                 self.accelerate_port = C.ACCELERATE_PORT
 
-        if actual_transport in [ 'paramiko', 'paramiko_old', 'ssh', 'ssh_old', 'accelerate' ]:
+        if actual_transport in [ 'paramiko', 'paramiko_alt', 'ssh', 'ssh_old', 'accelerate' ]:
             actual_port = inject.get('ansible_ssh_port', port)
 
         # the delegated host may have different SSH port configured, etc

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -121,7 +121,7 @@ class Connection(object):
         self.user = user
         self.password = password
         self.private_key_file = private_key_file
-        self.has_pipelining = True
+        self.has_pipelining = False
 
     def _cache_key(self):
         return "%s__%s__" % (self.host, self.user)
@@ -179,6 +179,9 @@ class Connection(object):
     def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False, executable='/bin/sh', in_data=None):
         ''' run a command on the remote host '''
 
+        if in_data:
+            raise errors.AnsibleError("Internal Error: this module does not support optimized module pipelining")
+
         bufsize = 4096
         try:
             chan = self.ssh.get_transport().open_session()
@@ -188,12 +191,12 @@ class Connection(object):
                 msg += ": %s" % str(e)
             raise errors.AnsibleConnectionFailed(msg)
 
-        if not self.runner.sudo or not sudoable or in_data:
+        if not self.runner.sudo or not sudoable:
             if executable:
                 quoted_command = executable + ' -c ' + pipes.quote(cmd)
             else:
                 quoted_command = cmd
-            vvv("EXEC ALT no-tty %s" % quoted_command, host=self.host)
+            vvv("EXEC %s" % quoted_command, host=self.host)
             chan.exec_command(quoted_command)
         else:
             # sudo usually requires a PTY (cf. requiretty option), therefore
@@ -224,17 +227,8 @@ class Connection(object):
             except socket.timeout:
                 raise errors.AnsibleError('ssh timed out waiting for sudo.\n' + sudo_output)
 
-        if in_data:
-            try:
-                stdin = chan.makefile('wb')
-                stdin.write(in_data)
-                chan.shutdown_write()
-            except Exception, e:
-                raise errors.AnsibleError('SSH Error: data could not be sent to the remote host. Make sure this host can be reached over ssh.')
-
         stdout = ''.join(chan.makefile('rb', bufsize))
         stderr = ''.join(chan.makefile_stderr('rb', bufsize))
-
         return (chan.recv_exit_status(), '', stdout, stderr)
 
     def put_file(self, in_path, out_path):


### PR DESCRIPTION
It can be very useful to select the SSH private key file based on inventory information (for example with Amazon EC2 where each host can have a different private key but it's always found in the inventory as ec2_key_name if using the EC2 dynamic inventory script). 

This allows one to do things like this e.g. in group variables:

```
ansible_ssh_private_key_file: "/home/ansible/.ssh/{{ ec2_key_name }}.pem"
```

This pull request implements that (thanks to benno).
