### PR TITLE
allow ansible_ssh_private_key_file to be templated (thanks to benno)

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -708,6 +708,8 @@ class Runner(object):
         actual_pass = inject.get('ansible_ssh_pass', self.remote_pass)
         actual_transport = inject.get('ansible_connection', self.transport)
         actual_private_key_file = inject.get('ansible_ssh_private_key_file', self.private_key_file)
+        # allow ansible_ssh_private_key_file to be templated
+        actual_private_key_file = template.template(self.basedir, actual_private_key_file, inject, fail_on_undefined=True)
         self.sudo_pass = inject.get('ansible_sudo_pass', self.sudo_pass)
         self.su = inject.get('ansible_su', self.su)
         self.su_pass = inject.get('ansible_su_pass', self.su_pass)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -708,7 +708,6 @@ class Runner(object):
         actual_pass = inject.get('ansible_ssh_pass', self.remote_pass)
         actual_transport = inject.get('ansible_connection', self.transport)
         actual_private_key_file = inject.get('ansible_ssh_private_key_file', self.private_key_file)
-        # allow ansible_ssh_private_key_file to be templated
         actual_private_key_file = template.template(self.basedir, actual_private_key_file, inject, fail_on_undefined=True)
         self.sudo_pass = inject.get('ansible_sudo_pass', self.sudo_pass)
         self.su = inject.get('ansible_su', self.su)

--- a/lib/ansible/runner/action_plugins/synchronize.py
+++ b/lib/ansible/runner/action_plugins/synchronize.py
@@ -135,6 +135,8 @@ class ActionModule(object):
             else:
                 private_key = inject.get('ansible_ssh_private_key_file', self.runner.private_key_file)
 
+            private_key = template.template(self.runner.basedir, private_key, inject, fail_on_undefined=True)
+
             if not private_key is None:
                 private_key = os.path.expanduser(private_key)
                 options['private_key'] = private_key


### PR DESCRIPTION
It can be very useful to select the SSH private key file based on inventory information (for example with Amazon EC2 where each host can have a different private key but it's always found in the inventory as ec2_key_name if using the EC2 dynamic inventory script).

This allows one to do things like this e.g. in group variables:

```
ansible_ssh_private_key_file: "/home/ansible/.ssh/{{ ec2_key_name }}.pem"
```

This pull request implements that (thanks to benno).
