### PR TITLE
Allow keystring passed to authorized_key to contain blank lines and comments

### DIFF
--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -341,7 +341,9 @@ def enforce_state(module, params):
     state       = params.get("state", "present")
     key_options = params.get("key_options", None)
 
-    key = key.split('\n')
+    # extract indivial keys into an array, skipping blank lines and comments
+    key = [s for s in key.splitlines() if s and not s.startswith('#')]
+
 
     # check current state -- just get the filename, don't create file
     do_write = False


### PR DESCRIPTION
Openssh allows "authorized_keys" files to contain blank lines and comments (lines starting with a "#" character).

Ansible's authorized_key module should also tolerate and ignore blank lines and comments in the key string passed to it - instead of failing with an "invalid key" error.
