### PR TITLE
Add support for Scientific Linux for hostname module

### DIFF
--- a/library/system/hostname
+++ b/library/system/hostname
@@ -256,6 +256,11 @@ class AmazonLinuxHostname(Hostname):
     distribution = 'Amazon'
     strategy_class = RedHatStrategy
 
+class ScientificLinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Scientific'
+    strategy_class = RedHatStrategy
+    
 # ===========================================
 
 class FedoraStrategy(GenericStrategy):


### PR DESCRIPTION
hostname module was lacking support for Scientific Linux, this commit adds it.
