### PR TITLE
sysctl module: strip only when value exist

### DIFF
--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -120,7 +120,8 @@ class SysctlModule(object):
 
         # Whitespace is bad
         self.args['name'] = self.args['name'].strip()
-        self.args['value'] = self.args['value'].strip()
+        if self.args['value']:
+            self.args['value'] = self.args['value'].strip()
 
         thisname = self.args['name']
 


### PR DESCRIPTION
When I don't set "value" parameter to sysctl module, it fails.

```
Traceback (most recent call last):
  File "/home/dragon3/.ansible/tmp/ansible-tmp-1389943381.01-279224187992896/sysctl", line 1323, in <module>
    main()
  File "/home/dragon3/.ansible/tmp/ansible-tmp-1389943381.01-279224187992896/sysctl", line 283, in main
    result = SysctlModule(module)
  File "/home/dragon3/.ansible/tmp/ansible-tmp-1389943381.01-279224187992896/sysctl", line 113, in __init__
    self.process()
  File "/home/dragon3/.ansible/tmp/ansible-tmp-1389943381.01-279224187992896/sysctl", line 123, in process
    self.args['value'] = self.args['value'].strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```

"value" is not required parameter, however currently this parameter value is always striped.
I added checking this value exist.
