### PR TITLE
Add dns name support to ec2

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -607,16 +607,17 @@ def terminate_instances(module, ec2):
         except socket.gaierror:
             module.fail_json(msg='error while resolving domains from dns_name, aborting')
 
-    for res in ec2.get_all_instances(instance_ids):
-        for inst in res.instances:
-            if inst.state == 'running':
-                terminated_instance_ids.append(inst.id)
-                instance_dict_array.append(get_instance_info(inst))
-                try:
-                    ec2.terminate_instances([inst.id])
-                except EC2ResponseError as e:
-                    module.fail_json(msg='Unable to terminate instance {0}, error: {1}'.format(inst.id, e))
-                changed = True
+    if instance_ids:
+        for res in ec2.get_all_instances(instance_ids):
+            for inst in res.instances:
+                if inst.state == 'running':
+                    terminated_instance_ids.append(inst.id)
+                    instance_dict_array.append(get_instance_info(inst))
+                    try:
+                        ec2.terminate_instances([inst.id])
+                    except EC2ResponseError as e:
+                        module.fail_json(msg='Unable to terminate instance {0}, error: {1}'.format(inst.id, e))
+                    changed = True
 
     # wait here until the instances are 'terminated'
     if wait:

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -293,6 +293,7 @@ local_action:
 
 import sys
 import time
+import socket
 
 try:
     import boto.ec2
@@ -379,6 +380,7 @@ def create_instances(module, ec2):
 
     key_name = module.params.get('key_name')
     id = module.params.get('id')
+    dns_name = module.params.get('dns_name')
     group_name = module.params.get('group')
     group_id = module.params.get('group_id')
     zone = module.params.get('zone')
@@ -430,13 +432,25 @@ def create_instances(module, ec2):
     running_instances = []
     count_remaining = int(count)
 
-    if id != None:
+    if id:
         filter_dict = {'client-token':id, 'instance-state-name' : 'running'}
         previous_reservations = ec2.get_all_instances(None, filter_dict)
         for res in previous_reservations:
             for prev_instance in res.instances:
                 running_instances.append(prev_instance)
         count_remaining = count_remaining - len(running_instances)
+
+    if dns_name:
+        try:
+            (hostname, aliases, ips) = socket.gethostbyname_ex(dns_name)
+            filter_dict = {'dns-name':hostname, 'instance-state-name' : 'running'}
+            previous_reservations = ec2.get_all_instances(None, filter_dict)
+            for res in previous_reservations:
+                for prev_instance in res.instances:
+                    running_instances.append(prev_instance)
+            count_remaining = count_remaining - len(running_instances)
+        except socket.gaierror:
+            pass
 
     # Both min_count and max_count equal count parameter. This means the launch request is explicit (we want count, or fail) in how many instances we want.
 
@@ -521,7 +535,7 @@ def create_instances(module, ec2):
                 this_res = res_list[0]
                 num_running = len([ i for i in this_res.instances if i.state=='running' ])
             else:
-                # got a bad response of some sort, possibly due to 
+                # got a bad response of some sort, possibly due to
                 # stale/cached data. Wait a second and then try again
                 time.sleep(1)
                 continue
@@ -547,7 +561,7 @@ def create_instances(module, ec2):
     return (instance_dict_array, created_instance_ids, changed)
 
 
-def terminate_instances(module, ec2, instance_ids):
+def terminate_instances(module, ec2):
     """
     Terminates a list of instances
 
@@ -571,10 +585,28 @@ def terminate_instances(module, ec2, instance_ids):
     changed = False
     instance_dict_array = []
 
-    if not isinstance(instance_ids, list) or len(instance_ids) < 1:
-        module.fail_json(msg='instance_ids should be a list of instances, aborting')
+    dns_name = module.params.get('dns_name')
+    instance_ids = module.params.get('instance_ids')
+
+    if not dns_name and not isinstance(instance_ids, list):
+        module.fail_json(msg='instance_ids should be a list of instances or dns_name should be a list of domains, aborting')
 
     terminated_instance_ids = []
+
+    if dns_name:
+        try:
+            (hostname, aliases, ips) = socket.gethostbyname_ex(dns_name)
+            filter_dict = {'dns-name':hostname, 'instance-state-name' : 'running'}
+            domain_instance_ids = []
+            for inst in ec2.get_only_instances(None, filter_dict):
+                domain_instance_ids.append(inst.id)
+            if not isinstance(instance_ids, list):
+                instance_ids = domain_instance_ids
+            elif isinstance(instance_ids, list) and set(instance_ids) <> set(domain_instance_ids):
+                module.fail_json(msg='instance_ids and instance ids extracted from dns_name should be equal, aborting')
+        except socket.gaierror:
+            module.fail_json(msg='error while resolving domains from dns_name, aborting')
+
     for res in ec2.get_all_instances(instance_ids):
         for inst in res.instances:
             if inst.state == 'running':
@@ -609,7 +641,7 @@ def terminate_instances(module, ec2, instance_ids):
         if wait_timeout < time.time() and num_terminated < len(terminated_instance_ids):
             module.fail_json(msg = "wait for instance termination timeout on %s" % time.asctime())
 
-    return (changed, instance_dict_array, terminated_instance_ids)
+    return (instance_dict_array, terminated_instance_ids, changed)
 
 
 def main():
@@ -617,6 +649,7 @@ def main():
         argument_spec = dict(
             key_name = dict(aliases = ['keypair']),
             id = dict(),
+            dns_name = dict(),
             group = dict(type='list'),
             group_id = dict(type='list'),
             region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
@@ -648,10 +681,9 @@ def main():
 
     if module.params.get('state') == 'absent':
         instance_ids = module.params.get('instance_ids')
-        if not isinstance(instance_ids, list):
-            module.fail_json(msg='termination_list needs to be a list of instances to terminate')
-
-        (changed, instance_dict_array, new_instance_ids) = terminate_instances(module, ec2, instance_ids)
+        if not module.params.get('dns_name') and not isinstance(instance_ids, list):
+            module.fail_json(msg='termination_list needs to be a list of instances or domain names to terminate')
+        (instance_dict_array, new_instance_ids, changed) = terminate_instances(module, ec2)
 
     elif module.params.get('state') == 'present':
         # Changed is always set to true when provisioning new instances


### PR DESCRIPTION
Hello!

I would like to add dns_name feature to ec2 module.

For creation instances, dns_name parameter will work like id parameter, but in more convenient way. If instance with target dns_name exists, then the new instance with the same dns_name will not be created.

For termination instances, dns_name parameter will work like instance_ids parameter.

create:
    - name: Launch instance
      local_action: ec2
        dns_name={{ item.dns_name }}
        group={{ item.group }}
        ...
        aws_secret_key={{ aws_secret_key }}
        wait=true
      register: ec2

terminate:
tasks:
    - name: Terminate instance
      local_action: ec2
        dns_name={{ item.dns_name }}
        ...
        aws_secret_key={{ aws_secret_key }}
        state='absent'
      with_items:
          - dns_name: ec2-184-169-125-4.us-west-1.compute.amazonaws.com
          - dns_name: ec2-158-120-200-124.us-west-1.compute.amazonaws.com
