### PR TITLE
Colon in example failure message causes a YAML compile error

### DIFF
--- a/docsite/rst/playbooks_conditionals.rst
+++ b/docsite/rst/playbooks_conditionals.rst
@@ -82,7 +82,7 @@ If a required variable has not been set, you can skip or fail using Jinja2's
         - shell: echo "I've got '{{ foo }}' and am not afraid to use it!"
           when: foo is defined
 
-        - fail: msg="Bailing out: this play requires 'bar'"
+        - fail: msg="Bailing out. this play requires 'bar'"
           when: bar is not defined
 
 This is especially useful in combination with the conditional import of vars


### PR DESCRIPTION
The example failure message was given as - fail: msg="Bailing out: this play requires 'bar'"

The colon in the example causes a YAML compile error, so I am replacing it with a '.'
