### PR TITLE
Fix bug in sysctl module for multivalue values

### DIFF
--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -178,7 +178,7 @@ class SysctlModule(object):
     def set_token_value(self, token, value):
         if len(value.split()) > 0:
             value = '"' + value + '"'
-        thiscmd = "%s -w %s=%s" % (self.sysctl_cmd, token, value)
+        thiscmd = '%s -w %s="%s"' % (self.sysctl_cmd, token, value)
         rc,out,err = self.module.run_command(thiscmd)
         if rc != 0:
             self.module.fail_json(msg='setting %s failed: %s' (token, out + err))


### PR DESCRIPTION
sysctl failed with the following test case due to the str formatting not
quoting the value.

```
- sysctl: name=net.ipv4.tcp_wmem value="4096 65536 16777216" state=present
```

For reference this should produce something like this.

```
sysctl -w net.ipv4.tcp_wmem="4096 65536 16777216"
```
