### PR TITLE
Mark stat module as supporting check_mode

### DIFF
--- a/library/files/stat
+++ b/library/files/stat
@@ -63,7 +63,8 @@ def main():
         argument_spec = dict(
             path = dict(required=True),
             follow = dict(default='no', type='bool')
-        )
+        ),
+        supports_check_mode = True
     )
 
     path = module.params.get('path')


### PR DESCRIPTION
Since the "stat" module doesn't change the filesystem, it's safe to add the supports_check_mode flag to it.
