### PR TITLE
Add --remote to git submodule_update

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -310,7 +310,7 @@ def submodule_update(git_path, module, dest):
         return (0, '', '')
     cmd = [ git_path, 'submodule', 'sync' ]
     (rc, out, err) = module.run_command(cmd, check_rc=True)
-    cmd = [ git_path, 'submodule', 'update', '--init', '--recursive' ]
+    cmd = [ git_path, 'submodule', 'update', '--init', '--recursive' ,'--remote' ]
     (rc, out, err) = module.run_command(cmd)
     if rc != 0:
         module.fail_json(msg="Failed to init/update submodules")


### PR DESCRIPTION
This simply adds --remote to the git submodule update command.
This means that if a branch is defined in .gitmodules then we should track said branch when updating.
