### PR TITLE
Adding the region to the output of the ec2 module's creation of a new in...

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -549,6 +549,7 @@ def get_instance_info(inst):
                      'image_id': inst.image_id,
                      'key_name': inst.key_name,
                      'placement': inst.placement,
+                     'region': inst.placement[:-1],
                      'kernel': inst.kernel,
                      'ramdisk': inst.ramdisk,
                      'launch_time': inst.launch_time,


### PR DESCRIPTION
...stance.

Details: For our ec2 cloud, we require SSH to go through a bastion host.  When spinning up new instances we need to delegate the wait_for ssh to the bastion host since port 22 is blocked from the internet. There is a bastion host for each region and thus we need to know an instance's region to vary between bastion hosts. The result of the spinup does include the placement, but that also include the AZ for the instance, which makes it unhelpful. Further, it does not appear to be simple to do a [:-1] operation in a jinja2 filter. Thusly, I do that very simply in the module output and make it available.  Once you can run ec2_facts (after the instance has come up), this problem takes care of itself. 
