### PR TITLE
rax module: Fix regex match

### DIFF
--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -464,7 +464,7 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                         else:
                             module.fail_json(msg=e.message)
 
-                    pattern = re.sub(r'%\d+[sd]', r'(\d+)', name)
+                    pattern = re.sub(r'%\d*[sd]', r'(\d+)', name)
                     for server in cs.servers.list():
                         if server.metadata.get('group') == group:
                             servers.append(server)
@@ -525,7 +525,7 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                         else:
                             module.fail_json(msg=e.message)
 
-                    pattern = re.sub(r'%\d+[sd]', r'(\d+)', name)
+                    pattern = re.sub(r'%\d*[sd]', r'(\d+)', name)
                     for server in cs.servers.list():
                         if server.metadata.get('group') == group:
                             servers.append(server)


### PR DESCRIPTION
The printf regex match should work with 0 or more numeric padding characters, not 1 or more.

The is currently causing the host increment to not work properly with more simplistic printf formatting or no formatting supplied for the name parameter.

When using something such as:

``` yaml
- name: Create a server
  hosts: localhost
  gather_facts: False
  tasks:
    - name: Server build requests
      local_action:
        module: rax
        credentials: ~/.raxpub
        name: test
        flavor: performance1-1
        image: ubuntu-1204-lts-precise-pangolin
        region: IAD
        state: present
        wait: yes
        meta:
          group: test
      register: rax
```

The server name created will always be 'test1' instead of incrementing the the host number to be test2, test3, etc...on successive runs.
