### PR TITLE
Make vars plugins use `hash_behaviour` setting.

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -341,12 +341,12 @@ class Inventory(object):
             raise errors.AnsibleError("host not found: %s" % hostname)
 
         vars = {}
-        vars_results = [ plugin.run(host) for plugin in self._vars_plugins ] 
+        vars_results = [ plugin.run(host) for plugin in self._vars_plugins ]
         for updated in vars_results:
             if updated is not None:
-                vars.update(updated)
+                vars = utils.combine_vars(vars, updated)
 
-        vars.update(host.get_variables())
+        vars = utils.combine_vars(vars, host.get_variables())
         if self.parser is not None:
             vars = utils.combine_vars(vars, self.parser.get_host_variables(host))
         return vars


### PR DESCRIPTION
When applying precedence ordering of different classes of vars
(hostvars, groupvars, role-defaults, etc.), the hash_behaviour
setting controls whether duplicate hash keys are replaced in
entirety, or merged together.

The wording of the documentation suggests that this setting applies
to all levels of the precedence ordering, when it currently does not:

> Ansible by default will override variables in specific precedence orders,
> as described in Variables. When a variable of higher precedence wins,
> it will replace the other value. ... Some users prefer that variables that
> are hashes (aka ‘dictionaries’ in Python terms) are merged together. This
> setting is called ‘merge’.

This change causes the hash_behavior setting to extend to vars plugins.
