### PR TITLE
Filter to convert size for human readable usage

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -138,6 +138,39 @@ def symmetric_difference(a, b):
 def union(a, b):
     return set(a).union(b)
 
+def to_KiB(a):
+    # 1024^1
+    return int(a)/1024.0
+
+def to_KB(a):
+    # 1000^1
+    return int(a)/1000.0
+
+def to_MiB(a):
+    # 1024^2
+    return int(a)/1048576.0
+
+def to_MB(a):
+    # 1000^2
+    return int(a)/1000000.0
+
+def to_GiB(a):
+    # 1024^3
+    return int(a)/1073741824.0
+
+def to_GB(a):
+    # 1000^3
+    return int(a)/1000000000.0
+
+def to_TiB(a):
+    # 1024^4
+    return int(a)/1099511627776.0
+
+def to_TB(a):
+    # 1000^4
+    return int(a)/1000000000000.0
+
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -198,5 +231,15 @@ class FilterModule(object):
             'difference': difference,
             'symmetric_difference': symmetric_difference,
             'union': union,
+
+            # size to human readable
+            'to_KiB': to_KiB,
+            'to_KB': to_KB,
+            'to_MiB': to_MiB,
+            'to_MB': to_MB,
+            'to_GiB': to_GiB,
+            'to_GB': to_GB,
+            'to_TiB': to_TiB,
+            'to_TB': to_TB,
         }
 


### PR DESCRIPTION
Size such as disk or memory can now be converted to human readable
values in filters.

For example:

Variable is defined as:

  sda_size: "{{ ansible_devices['sda'].sectors|int  \*  ansible_devices['sda'].sectorsize|int }}"

This can be used:
- name: between 8Gb and 16Gb
  command: echo "{{ sda_size }}"
  when: sda_size|to_GiB <= 16 and sda_size|to_GiB > 8

New filters:
- to_KiB (binary unit 1024^1), to_KB (SI unit 1000^1)
- to_MiB (binary unit 1024^2), to_MB (SI unit 1000^2)
- to_GiB (binary unit 1024^3), to_GB (SI unit 1000^3)
- to_TiB (binary unit 1024^4), to_TB (SI unit 1000^4)
