### PR TITLE
Fix case where there is a ~/.ssh/known_hosts file and the host key is only in /etc/ssh/ssh_known_hosts

### DIFF
--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -40,8 +40,7 @@ def check_hostkey(module, fqdn):
     this_cmd = keygen_cmd + " -H -F " + fqdn
     rc, out, err = module.run_command(this_cmd)
 
-    if rc == 0:
-        if out != "":
+    if rc == 0 and out != "":
             result = True
     else:
         # Check the main system location


### PR DESCRIPTION
When not finding a host in ~/.ssh/known_hosts, the return value is 0 if the host just is not found. We then never check the system host file in /etc. This fixes the code to check /etc on any failure, not just a bad return code.
