### PR TITLE
Fix an issue where ansbile-pull fails with AttributeError

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -272,6 +272,10 @@ class Inventory(object):
             new_host.set_variable("ansible_python_interpreter", sys.executable)
             new_host.set_variable("ansible_connection", "local")
             ungrouped = self.get_group("ungrouped")
+            if ungrouped is None:
+                self.add_group(Group('ungrouped'))
+                ungrouped = self.get_group('ungrouped')
+
             ungrouped.add_host(new_host)
             results.append(new_host)
         return results


### PR DESCRIPTION
As part of 94f3b9bfab69feefa37bb006bf75f4a1b8acb19f the code was changed to support dynamically adding localhost to the inventory. This change introduced an crash when run via ansible-pull

```
Starting ansible-pull at 2014-01-20 23:09:57
Traceback (most recent call last):
  File "/tmp/ansible/bin/ansible", line 157, in <module>
    (runner, results) = cli.run(options, args)
  File "/tmp/ansible/bin/ansible", line 82, in run
    hosts = inventory_manager.list_hosts(pattern)
  File "/tmp/ansible/lib/ansible/inventory/__init__.py", line 372, in list_hosts
    result = [ h.name for h in self.get_hosts(pattern) ]
  File "/tmp/ansible/lib/ansible/inventory/__init__.py", line 136, in get_hosts
    subset = self._get_hosts(self._subset)
  File "/tmp/ansible/lib/ansible/inventory/__init__.py", line 177, in _get_hosts
    that = self.__get_hosts(p)
  File "/tmp/ansible/lib/ansible/inventory/__init__.py", line 198, in __get_hosts
    hpat = self._hosts_in_unenumerated_pattern(name)
  File "/tmp/ansible/lib/ansible/inventory/__init__.py", line 275, in _hosts_in_unenumerated_pattern
    ungrouped.add_host(new_host)
AttributeError: 'NoneType' object has no attribute 'add_host'
```

The root cause is there is no group for the host to be added to. I fixed this case by creating the ungrouped group when it doesn't exist and then adding the host to the newly added group. This fixes the regression for me.
