### PR TITLE
automatically include all variables in roles/foo/vars/

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -26,6 +26,7 @@ import pipes
 import shlex
 import os
 import sys
+import glob
 
 class Play(object):
 
@@ -375,6 +376,10 @@ class Play(object):
                 new_handlers.append(nt)
             if os.path.isfile(vars_file):
                 new_vars_files.append(vars_file)
+            # add the extra vars, see RFC-2958
+            new_vars_files.extend(sorted(
+                [f for f in glob.glob(vars_basepath+"/*.yml")
+                 if os.path.isfile(f) and not os.path.basename(f) == "main.yml"]))
             if os.path.isfile(defaults_file):
                 defaults_files.append(defaults_file)
             if os.path.isdir(library):


### PR DESCRIPTION
This patch implements RFE 2958. Additional vars/ files in the
roles/foo/vars/ will be automatically added.

To test you can simply rename any roles/foo/vars/main.yml into roles/foo/vars/a.yml and b.yml and observe that the vars are still available for the role.

I'm happy to 
- cleanup/improve of the code in any way required
- provide a test project for easy manual testing
- provide a proper integreation test 
  if there is a chance that this feature gets in :)

I find it quite useful and natural to organize variables this way.

Thanks for your consideration,
 Michael
