### PR TITLE
Use realpath for plugin directories instead of abspath

### DIFF
--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -30,7 +30,7 @@ _basedirs = []
 
 def push_basedir(basedir):
     # avoid pushing the same absolute dir more than once
-    basedir = os.path.abspath(basedir)
+    basedir = os.path.realpath(basedir)
     if basedir not in _basedirs:
         _basedirs.insert(0, basedir)
 
@@ -99,7 +99,7 @@ class PluginLoader(object):
         ret = []
         ret += self._extra_dirs
         for basedir in _basedirs:
-            fullpath = os.path.abspath(os.path.join(basedir, self.subdir))
+            fullpath = os.path.realpath(os.path.join(basedir, self.subdir))
             if os.path.isdir(fullpath):
                 files = glob.glob("%s/*" % fullpath)
                 for file in files:
@@ -111,7 +111,7 @@ class PluginLoader(object):
         # look in any configured plugin paths, allow one level deep for subcategories 
         configured_paths = self.config.split(os.pathsep)
         for path in configured_paths:
-            path = os.path.abspath(os.path.expanduser(path))
+            path = os.path.realpath(os.path.expanduser(path))
             contents = glob.glob("%s/*" % path)
             for c in contents:
                 if os.path.isdir(c) and c not in ret:
@@ -131,7 +131,7 @@ class PluginLoader(object):
         ''' Adds an additional directory to the search path '''
 
         self._paths = None
-        directory = os.path.abspath(directory)
+        directory = os.path.realpath(directory)
 
         if directory is not None:
             if with_subdir:


### PR DESCRIPTION
Imagine the following "simplified" directory structure:

```
.
├── callback_plugins
│   └── someplugin.py
├── playbooks
│   ├── callback_plugins -> ../callback_plugins
│   └── someapp.yml
└── site.yml
```

We have a scenario where playbooks exist both in the root and inside of the playbooks directory.  We can either call site.yml which includes all playbooks inside of the playbooks directory, or an individual playbook in the playbooks directory.

Due to the possibility of running either site.yml or playbooks/someapp.yml we have our callback_plugins directory symlinked into playbooks.  Having just 1 or the other doesn't meet all use cases.

Currently the symlink works fine, however when running site.yml, the callback plugin is run twice, due to not deduping the realpath, but using abspath.

We can potentially get around the issue by defining a callback_plugins option in ansible.cfg, but since we do not use a centralized control machine, and our ansible.cfg files vary based on user names and such, enforcing the configuration is troublesome.

This change, simply changes the instances of abspath to realpath, which resolves the duplicate directory problems, and the callback plugins are only executed once.

I'm sure there are also other ways to tackle this, but this seems more simple in the end.
