### PR TITLE
Disallow su and sudo params in same play/task

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -125,6 +125,11 @@ class Play(object):
         self.su               = ds.get('su', self.playbook.su)
         self.su_user          = ds.get('su_user', self.playbook.su_user)
 
+        # Fail out if user specifies a sudo param with a su param in a given play
+        if (ds.get('sudo') or ds.get('sudo_user')) and (ds.get('su') or ds.get('su_user')):
+            raise errors.AnsibleError('sudo params ("sudo", "sudo_user") and su params '
+                                      '("su", "su_user") cannot be used together')
+
         load_vars = {}
         load_vars['playbook_dir'] = self.basedir
         if self.playbook.inventory.basedir() is not None:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -157,6 +157,13 @@ class Task(object):
             self.su_user      = ds.get('su_user', play.su_user)
             self.su_pass      = ds.get('su_pass', play.playbook.su_pass)
 
+        # Fail out if user specifies a sudo param with a su param in a given play
+        if (ds.get('sudo') or ds.get('sudo_user') or ds.get('sudo_pass')) and \
+                (ds.get('su') or ds.get('su_user') or ds.get('su_pass')):
+            raise errors.AnsibleError('sudo params ("sudo", "sudo_user", "sudo_pass") '
+                                      'and su params "su", "su_user", "su_pass") '
+                                      'cannot be used together')
+
         # Both are defined
         if ('action' in ds) and ('local_action' in ds):
             raise errors.AnsibleError("the 'action' and 'local_action' attributes can not be used together")


### PR DESCRIPTION
```

---
- name: Test the ansible-playbook command's su support
  hosts: etcd
  su: yes
  sudo_user: testuser
  gather_facts: no

  tasks:
    - name: "Running /usr/bin/whoami"
      command: /usr/bin/whoami
```

```
14:19 $ ansible-playbook -i staging test-su-play.yml
sudo password:
ERROR: sudo params ("sudo", "sudo_user") and su params ("su", "su_user") cannot be used together
```
