### PR TITLE
Allow templates in ansible_sudo_pass inventory var

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -689,7 +689,6 @@ class Runner(object):
         actual_user = template.template(self.basedir, actual_user, inject)
         actual_pass = template.template(self.basedir, actual_pass, inject)
         self.sudo_pass = template.template(self.basedir, self.sudo_pass, inject)
-        
 
         # make actual_user available as __magic__ ansible_ssh_user variable
         inject['ansible_ssh_user'] = actual_user

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -688,6 +688,8 @@ class Runner(object):
         # user/pass may still contain variables at this stage
         actual_user = template.template(self.basedir, actual_user, inject)
         actual_pass = template.template(self.basedir, actual_pass, inject)
+        self.sudo_pass = template.template(self.basedir, self.sudo_pass, inject)
+        
 
         # make actual_user available as __magic__ ansible_ssh_user variable
         inject['ansible_ssh_user'] = actual_user


### PR DESCRIPTION
Template ansible_sudo_pass the same way we template ansible_ssh_pass.

I don't like hard-coding passwords, but sometimes due to restrictions (like inability to use ssh-keys) dealing with raw passwords is necessary. I vastly prefer fetching these things from environment variables (transient) than hard-coding into an inventory.

Currently for ansible_ssh_pass I use a templated inventory var:

```
ansible_ssh_pass="{{ lookup('env', 'ANSIBLE_SSH_PASS') }}"
```

This works great, because of the template logic in `runner/__init__.py`.

This simple pull request just does the same for `ansible_sudo_pass`

Thanks
