### PR TITLE
added random sleep option to ansible-pull

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -44,6 +44,8 @@ import subprocess
 import sys
 import datetime
 import socket
+import random
+import time
 from ansible import utils
 from ansible.utils import cmd_functions
 
@@ -101,6 +103,8 @@ def main(args):
                       help='purge checkout after playbook run')
     parser.add_option('-o', '--only-if-changed', dest='ifchanged', default=False, action='store_true',
                       help='only run the playbook if the repository has been updated')
+    parser.add_option('-s', '--sleep', dest='sleep', default=None,
+                      help='sleep for random interval (between 0 and n number of seconds) before starting. this is a useful way to disperse git requests')
     parser.add_option('-f', '--force', dest='force', default=False,
                       action='store_true',
                       help='run the playbook even if the repository could '
@@ -159,7 +163,18 @@ def main(args):
             inv_opts, base_opts, options.module_name, repo_opts
             )
 
-    # RUN THE CHECKOUT COMMAND
+    if options.sleep:
+        try:
+            secs = random.randint(0,int(options.sleep));
+        except ValueError:
+            parser.error("%s is not a number." % options.sleep)
+            return 1
+
+        print >>sys.stderr, "Sleeping for %d seconds..." % secs
+        time.sleep(secs);
+
+
+    # RUN THe CHECKOUT COMMAND
     rc, out, err = cmd_functions.run_cmd(cmd, live=True)
 
     if rc != 0:


### PR DESCRIPTION
I think it's useful to have the script be able to sleep for a random amount of time before executing in order to prevent every node from hitting your git server at the same time. I was doing this using a separate sleep command before ansible-pull in a cron job but thought "why not just put it in the script"? 
