### PR TITLE
Fix bug where playbook tasks do not escalate privs with 'su'

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -119,7 +119,7 @@ class Task(object):
         self.tags         = [ 'all' ]
         self.register     = ds.get('register', None)
         self.sudo         = utils.boolean(ds.get('sudo', play.sudo))
-        self.su           = utils.boolean(ds.get('sudo', play.su))
+        self.su           = utils.boolean(ds.get('su', play.su))
         self.environment  = ds.get('environment', {})
         self.role_name    = role_name
         


### PR DESCRIPTION
Hey guys, caught my own bug here in my recently merged su support.

This was causing a problem were su was being set at the task level and not the play level in playbooks, causing su-marked tasks to never escalate privs.  This will fix the problem.

Use this play before and after to confirm:

```

---
- name: Test 
  hosts: etcd
  gather_facts: no
  tasks:
    - name: "No sudo or su"
      command: /usr/bin/whoami

    - name: "su to root"
      command: /usr/bin/whoami
      su: yes

    - name: "su to testuser"
      command: /usr/bin/whoami
      su: yes
      su_user: testuser
      su_pass: notMyREALpassword

    - name: "sudo to root"
      command: /usr/bin/whoami
      sudo: yes
      sudo_pass: notMyREALpassword
```

![screen shot 2014-01-22 at 11 09 41 am](https://f.cloud.github.com/assets/1240740/1976286/51745b8e-8388-11e3-9455-38451bd3f143.png)

Tests are passing:

```
Ran 96 tests in 27.259s

OK (SKIP=1)
```
