### PR TITLE
user module: reorder usermod options

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -389,9 +389,9 @@ class User(object):
             cmd.append(self.comment)
 
         if self.home is not None and info[5] != self.home:
-            cmd.append('-m')
             cmd.append('-d')
             cmd.append(self.home)
+            cmd.append('-m')
 
         if self.shell is not None and info[6] != self.shell:
             cmd.append('-s')


### PR DESCRIPTION
It appears the usermod command requires -m option to come after -d HOME_DIR.  Ansible fails and shows Usage in the user module

TASK: [../../shared/roles/rs-users | add users] ******************************\* 
failed: [removed] => 
...
msg: Usage: usermod [options] LOGIN 
