### PR TITLE
Fix a bug in "hg" module so that `pull` is not set to a version.

### DIFF
--- a/library/source_control/hg
+++ b/library/source_control/hg
@@ -167,7 +167,7 @@ class Hg(object):
 
     def pull(self):
         return self._command(
-            ['pull', '-r', self.revision, '-R', self.dest, self.repo])
+            ['pull', '-R', self.dest, self.repo])
 
     def update(self):
         return self._command(['update', '-R', self.dest])


### PR DESCRIPTION
There is a bug in the `hg` module related to using a tag as a revision if that tag moves.

Basically if a tag is moved `hg` will incorrectly update to the previous commit the tag is set to, not the current commit.

To Reproduce:
- commit "1" is added to a mercurial repo
- commit "1" is tagged "LIVE", this creates commit "2" with the change to `.hgtags`.
- some more commits are added, bringing the number to 10.
- the tag "LIVE" is moved to commit "5", this creates a new commit, "11", when `.hgtags` is updated.
- ansible is run with this command: `hg: repo=my_repo dest=dest revision=LIVE`
  - this executes `hg pull -r LIVE -R dest my_repo`
  - because "LIVE" points to commit "5" only the commits "1" to "5" are pulled down
  - ansible then executes `hg update -r LIVE -R dest`
  - because "LIVE" in `.hgtags` points to commit "1" it will update the repository to commit "1" instead of the current version.

This change fixes the issue by always pulling every commit from the repository, which means the call to `switch_version` will always find the most versions for each tag.
