### PR TITLE
Fixes  #3352 Make default ANSIBLE_REMOTE_PORT None

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -36,9 +36,9 @@ def get_config(p, section, key, env_var, default, boolean=False, integer=False, 
     value = _get_config(p, section, key, env_var, default)
     if boolean:
         return mk_boolean(value)
-    if integer:
+    if value and integer:
         return int(value)
-    if floating:
+    if value and floating:
         return float(value)
     return value
 
@@ -114,7 +114,7 @@ DEFAULT_ASK_PASS          = get_config(p, DEFAULTS, 'ask_pass',  'ANSIBLE_ASK_PA
 DEFAULT_PRIVATE_KEY_FILE  = shell_expand_path(get_config(p, DEFAULTS, 'private_key_file', 'ANSIBLE_PRIVATE_KEY_FILE', None))
 DEFAULT_SUDO_USER         = get_config(p, DEFAULTS, 'sudo_user',        'ANSIBLE_SUDO_USER',        'root')
 DEFAULT_ASK_SUDO_PASS     = get_config(p, DEFAULTS, 'ask_sudo_pass',    'ANSIBLE_ASK_SUDO_PASS',    False, boolean=True)
-DEFAULT_REMOTE_PORT       = get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      22, integer=True)
+DEFAULT_REMOTE_PORT       = get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      None, integer=True)
 DEFAULT_TRANSPORT         = get_config(p, DEFAULTS, 'transport',        'ANSIBLE_TRANSPORT',        'smart')
 DEFAULT_SCP_IF_SSH        = get_config(p, 'ssh_connection', 'scp_if_ssh',       'ANSIBLE_SCP_IF_SSH',       False, boolean=True)
 DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')


### PR DESCRIPTION
The ansible remote port should be None, not 22. Having a default value
of 22 means that -o Port will be appended to the ssh connection all of
the time. This is incorrect when one would like to use something like
an ssh configuration file that calls out a port other than 22.

Part of this change requires that we check that the value is not None
before trying to coerce it into an integer or float.

This is related to https://github.com/ansible/ansible/issues/3352
