### PR TITLE
Fix su bug where connecting as root would not allow su to another user

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -628,7 +628,7 @@ class Runner(object):
         actual_transport = inject.get('ansible_connection', self.transport)
         actual_private_key_file = inject.get('ansible_ssh_private_key_file', self.private_key_file)
         self.sudo_pass = inject.get('ansible_sudo_pass', self.sudo_pass)
-        self.su = inject.get('ansible_su', self.su_pass)
+        self.su = inject.get('ansible_su', self.su)
         self.su_user = inject.get('ansible_su_user', self.su_user)
         self.su_pass = inject.get('ansible_su_pass', self.su_pass)
 
@@ -843,7 +843,7 @@ class Runner(object):
 
         # compare connection user to sudo_user and disable if the same
         if hasattr(conn, 'user'):
-            if conn.user == sudo_user or conn.user == su_user:
+            if (conn.user == sudo_user and not su) or (conn.user == su_user and su):
                 sudoable = False
                 su = False
 


### PR DESCRIPTION
Hi guys,

This resolves the su issue as reported on the ansible-project mailing list.  The following playbook verifies the bug and the resolution with the patch.

```
- name: Test su connecting as root
  hosts: test
  gather_facts: no
  remote_user: root
  tasks:
    - name: Test connecting as root
      command: /usr/bin/whoami

    - name: Connect as root and su to testuser
      command: /usr/bin/whoami
      su: yes
      su_user: testuser
```

Tests are passing.

```
----------------------------------------------------------------------
Ran 96 tests in 27.138s

OK (SKIP=1)
```
