### PR TITLE
Test hosts defined in multiple groups in different files

### DIFF
--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -413,3 +413,11 @@ class TestInventory(unittest.TestCase):
     #                    'inventory_hostname_short': 'zeus',
     #                    'group_names': ['greek', 'major-god', 'ungrouped'],
     #                    'var_a': '1#2'}
+
+    def test_dir_inventory_multiple_groups(self):
+         inventory = self.dir_inventory()
+         group_greek = inventory.get_group('greek')
+         group_major_god = inventory.get_group('major-god')
+         actual_host_names = [host.name for host in group_greek.get_hosts()];
+         print "%s : %s " % (group_greek.name, actual_host_names)
+         assert actual_host_names == ['zeus','morpheus'] 

--- a/test/inventory_dir/3comments
+++ b/test/inventory_dir/3comments
@@ -1,8 +1,8 @@
-[major-god] # group with inline comments
-zeus var_a="1#2" # host with inline comments and "#" in the var string
-# A comment
-thor
+#[major-god] # group with inline comments
+#zeus var_a="1#2" # host with inline comments and "#" in the var string
+## A comment
+#thor
 
-[minor-god] # group with inline comment and unbalanced quotes: ' "
-morpheus # host with inline comments and unbalanced quotes: ' "
-# A comment with unbalanced quotes: ' "
+#[minor-god] # group with inline comment and unbalanced quotes: ' "
+#morpheus # host with inline comments and unbalanced quotes: ' "
+## A comment with unbalanced quotes: ' "


### PR DESCRIPTION
add test for #5749

not fixed yet in devel 00b3f627ebb2b8e9cf743671a9ddd2d8d8c9fe45

since inventory_dir was not parseable I had to comment out the content of test/inventory_dir/3comments
