### PR TITLE
added new play_hosts var

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -346,6 +346,8 @@ class PlayBook(object):
             run_hosts=hosts
         )
 
+        runner.module_vars.update({'play_hosts': hosts})
+
         if task.async_seconds == 0:
             results = runner.run()
         else:


### PR DESCRIPTION
this variable has the 'current host list' to be executed over in the
play. Useful when using --limit to not iterate over hosts not included
in play in templates or with_items.

Signed-off-by: Brian Coca <briancoca+dev@gmail.com>
