### PR TITLE
Add the ability to include yaml tasks from zip files

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -42,6 +42,7 @@ import traceback
 import getpass
 import sys
 import textwrap
+import zipfile
 
 VERBOSITY=0
 
@@ -483,6 +484,20 @@ Should be written as:
 
 
 def parse_yaml_from_file(path):
+    '''
+    Try to load a yaml file from a path that may contain a direct file path
+    or a path inside a zip archive
+    '''
+
+    if os.path.exists(path):
+        return parse_yaml_from_path(path)
+    else:
+        data = parse_yaml_from_zip(path)
+        if data is not None:
+            return data
+    raise errors.AnsibleError("file not found: %s" % path)
+
+def parse_yaml_from_path(path):
     ''' convert a yaml file to a data structure '''
 
     try:
@@ -490,6 +505,36 @@ def parse_yaml_from_file(path):
         return parse_yaml(data)
     except IOError:
         raise errors.AnsibleError("file not found: %s" % path)
+    except yaml.YAMLError, exc:
+        process_yaml_error(exc, data, path)
+
+def parse_yaml_from_zip(path):
+    ''' try to extract a yaml file from a zip or pex archive '''
+
+    (zip_path, yml_path) = os.path.split(path)
+    yml_path = [yml_path]
+
+    while len(zip_path) > 0:
+        if os.path.exists(zip_path):
+            break
+
+        (zip_path, prepend_path) = os.path.split(zip_path)
+        yml_path.insert(0, prepend_path)
+
+    yml_path = os.path.join(*yml_path)
+
+    if not os.path.exists(zip_path):
+        return None
+
+    if not zipfile.is_zipfile(zip_path):
+        return None
+
+    try:
+        zf = zipfile.ZipFile(zip_path, 'r')
+        print yml_path
+        data = zf.read(yml_path)
+        zf.close()
+        return parse_yaml(data)
     except yaml.YAMLError, exc:
         process_yaml_error(exc, data, path)
 


### PR DESCRIPTION
Zipfiles in python are considered a first class citizen. You can
bundle python scripts into zipfiles and execute them directly.

We use a similar method of deployment based on pants:
https://github.com/twitter/commons

This builds pex files that are basically self contained python
binaries. We need the ability to reference tasks bundled in the
pex files from playbooks external to the pex. This patch set
adds in the ability to do so. It would be fairly trivial to exapnd
it to also support loading directly from tar archives as well.

There should be no impact to any end user with this change.
