### PR TITLE
Update wait_for documentation - remove extra quote

### DIFF
--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -84,7 +84,7 @@ author: Jeroen Hoekx, John Jarvis
 EXAMPLES = '''
 
 # wait 300 seconds for port 8000 to become open on the host, don't start checking for 10 seconds
-- wait_for: port=8000 delay=10"
+- wait_for: port=8000 delay=10
 
 # wait until the file /tmp/foo is present before continuing
 - wait_for: path=/tmp/foo


### PR DESCRIPTION
The timeout is in seconds (int), and the extra quote at the end could throw someone off if they're copying and pasting the example.
