### PR TITLE
Mention shell module in command documentation

### DIFF
--- a/library/commands/command
+++ b/library/commands/command
@@ -34,7 +34,8 @@ description:
      - The M(command) module takes the command name followed by a list of space-delimited arguments.
      - The given command will be executed on all selected nodes. It will not be
        processed through the shell, so variables like C($HOME) and operations
-       like C("<"), C(">"), C("|"), and C("&") will not work.
+       like C("<"), C(">"), C("|"), and C("&") will not work (use the M(shell)
+       module if you need to use these features.
 options:
   free_form:
     description:


### PR DESCRIPTION
Users who use the command module for pretty much all shell commands may be stymied when they try using a command with <, >, $VAR, etc., and not know that they can use the `shell` module instead. This documentation fix clarifies this.
