### PR TITLE
Sosreport module

### DIFF
--- a/library/system/sosreport
+++ b/library/system/sosreport
@@ -1,0 +1,152 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2014, Richard Isaacson <richard.c.isaacson@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: sosreport
+short_description: Execute sosreport and make the archive available.
+description:
+ - sosreport is a tool for collecting current system state information into an archive.
+ - The sosreport module will always be executed in batch mode.
+ - The sosreport module is restricted to RHEL based distributions for availability reasons.
+version_added: "0.0"
+options:
+    archive_name:
+        description:
+             - Specify the archive name that will be created.
+        required: false
+        default: null
+    ticket_number:
+        description:
+             - Put in a ticket number.
+        required: false
+        default: null
+    skip_plugins:
+        description:
+             - Disable the specified plugin(s). Multiple plug-ins may be specified as a comma-separated list.
+        required: false
+        default: null
+    enable_plugins:
+        description:
+             - Enable the specified plugin(s). Multiple plug-ins may be specified as a comma-separated list.
+        required: false
+        default: null
+    only_plugins:
+        description:
+             - Only enable the specified plugin(s). Multiple plug-ins may be specified as a comma-separated list.
+        required: false
+        default: null
+    config_file:
+        description:
+             - Specify an alternate configuration file.
+        required: false
+        default: null
+    temp_dir
+        description:
+             - Specify an alternate temporary directory.
+        required: false
+        default: null
+requirements:
+ - sosreport
+author: Richard Isaacson
+'''
+
+EXAMPLES = '''
+# Execute sosreport creating an archive with a provided name.
+- sosreport: archive_name="server"
+'''
+
+import os
+import tempfile
+
+SOSCMD = "/usr/bin/sosreport"
+
+#================================================
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            archive_name=dict(required=False),
+            ticket_number=dict(required=False),
+            skip_plugins=dict(required=False),
+            enable_plugins=dict(required=True)
+            only_plugins=dict(required=True)
+            config_file=dict(required=True)
+            tmp_dir=dict(required=True)
+        ),
+        supports_check_mode = False,
+    )
+
+    archive_name   = module.params['archive_name']
+    ticket_number  = module.params['ticket_nuber']
+    skip_plugins   = module.params['skip_plugins']
+    enable_plugins = module.params['enable_plugins']
+    only_plugins   = module.params['only_plugins']
+    config_file    = module.params['config_file']
+    tmp_dir        = module.params['tmp_dir']
+
+#TODO: if this is not a RHEL based distro fail.
+
+    if (skip plugins or enable_plugins) and only_plugins:
+        module.fail_json(msg="skip_plugins or enable_plugins and only_plugins are mutually exclusive")
+
+    result = {}
+
+    sosreport_command = "%s --batch" % (SOSCMD)
+    rc, out, err = module.run_command(sosreport_command)
+    if rc != 0:
+        module.fail_json(msg=err)
+
+
+    # result['unit_count'] = unit_count
+    # result['unit_type'] = unit_type
+
+    # if command:
+    #     filed, path = tempfile.mkstemp(prefix='at')
+    #     result['script_file'] = path
+    #     fileh = os.fdopen(filed, 'w')
+    #     fileh.write(command)
+    #     fileh.close()
+    #     at_command = "%s now + %s %s -f %s" % (ATCMD, unit_count, unit_type, path)
+    #     if user:
+    #         at_command = "chown %s %s; su '%s' -c '%s'" % (user, path, user, at_command)
+    #     rc, out, err = module.run_command(at_command)
+    #     if rc != 0:
+    #         module.fail_json(msg=err)
+    #     os.unlink(path)
+    #     result['changed'] = 'true'
+    # elif script_file:
+    #     result['script_file'] = script_file
+    #     at_command = "%s now + %s %s -f %s" % (ATCMD, unit_count, unit_type, script_file)
+    #     if user:
+    #     	# We expect that if this is an installed the permissions are already correct for the user to execute it.
+    #         at_command = "su '%s' -c '%s'" % (user, at_command)
+    #     rc, out, err = module.run_command(at_command)
+    #     if rc != 0:
+    #         module.fail_json(msg=err)
+    #     result['changed'] = 'true'
+    # else:
+    #     module.fail_json(msg="command or script_file not specified")
+
+    module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()

--- a/library/system/sosreport
+++ b/library/system/sosreport
@@ -26,11 +26,11 @@ description:
  - sosreport is a tool for collecting current system state information into an archive.
  - The sosreport module will always be executed in batch mode.
  - The sosreport module is restricted to RHEL based distributions for availability reasons.
-version_added: "0.0"
+version_added: "1.5"
 options:
-    archive_name:
+    name:
         description:
-             - Specify the archive name that will be created.
+             - Specify a name to be included in the archive name.
         required: false
         default: null
     ticket_number:
@@ -70,80 +70,73 @@ author: Richard Isaacson
 
 EXAMPLES = '''
 # Execute sosreport creating an archive with a provided name.
-- sosreport: archive_name="server"
+- sosreport: name="server"
 '''
 
+from cStringIO import StringIO
 import os
 import tempfile
 
-SOSCMD = "/usr/bin/sosreport"
-
 #================================================
+
 
 def main():
     module = AnsibleModule(
-        argument_spec = dict(
-            archive_name=dict(required=False),
-            ticket_number=dict(required=False),
-            skip_plugins=dict(required=False),
-            enable_plugins=dict(required=True)
-            only_plugins=dict(required=True)
-            config_file=dict(required=True)
-            tmp_dir=dict(required=True)
+        argument_spec=dict(
+            name=dict(required=False, type='str'),
+            ticket_number=dict(required=False, type='int'),
+            skip_plugins=dict(required=False, type='str'),
+            enable_plugins=dict(required=False, type='str'),
+            only_plugins=dict(required=False, type='str'),
+            config_file=dict(required=False, type='str'),
+            tmp_dir=dict(required=False, type='str')
         ),
-        supports_check_mode = False,
+        supports_check_mode=False
     )
 
-    archive_name   = module.params['archive_name']
-    ticket_number  = module.params['ticket_nuber']
+    sosreport_path = module.get_bin_path('sosreport', True)
+
+    name           = module.params['name']
+    ticket_number  = module.params['ticket_number']
     skip_plugins   = module.params['skip_plugins']
     enable_plugins = module.params['enable_plugins']
     only_plugins   = module.params['only_plugins']
     config_file    = module.params['config_file']
     tmp_dir        = module.params['tmp_dir']
 
-#TODO: if this is not a RHEL based distro fail.
+# TODO: if this is not a RHEL based distro fail.
 
-    if (skip plugins or enable_plugins) and only_plugins:
+    if (skip_plugins or enable_plugins) and only_plugins:
         module.fail_json(msg="skip_plugins or enable_plugins and only_plugins are mutually exclusive")
 
-    result = {}
+    result = {'changed': False}
 
-    sosreport_command = "%s --batch" % (SOSCMD)
-    rc, out, err = module.run_command(sosreport_command)
-    if rc != 0:
-        module.fail_json(msg=err)
+    sosreport_command = "%s --batch" % sosreport_path
+    if skip_plugins:
+        sosreport_command = "%s --skip-plugins %s" % (sosreport_command, skip_plugins)
+    if enable_plugins:
+        sosreport_command = "%s --enable-plugins %s" % (sosreport_command, enable_plugins)
+    if only_plugins:
+        sosreport_command = "%s --only-plugins %s" % (sosreport_command, only_plugins)
+    if config_file:
+        sosreport_command = "%s --config-file %s" % (sosreport_command, config_file)
+    if name:
+        sosreport_command = "%s --name %s" % (sosreport_command, name)
+    if ticket_number:
+        sosreport_command = "%s --ticket-number %s" % (sosreport_command, ticket_number)
+    if tmp_dir:
+        sosreport_command = "%s --tmp-dir %s" % (sosreport_command, tmp_dir)
 
+    result['command'] = sosreport_command
 
-    # result['unit_count'] = unit_count
-    # result['unit_type'] = unit_type
-
-    # if command:
-    #     filed, path = tempfile.mkstemp(prefix='at')
-    #     result['script_file'] = path
-    #     fileh = os.fdopen(filed, 'w')
-    #     fileh.write(command)
-    #     fileh.close()
-    #     at_command = "%s now + %s %s -f %s" % (ATCMD, unit_count, unit_type, path)
-    #     if user:
-    #         at_command = "chown %s %s; su '%s' -c '%s'" % (user, path, user, at_command)
-    #     rc, out, err = module.run_command(at_command)
-    #     if rc != 0:
-    #         module.fail_json(msg=err)
-    #     os.unlink(path)
-    #     result['changed'] = 'true'
-    # elif script_file:
-    #     result['script_file'] = script_file
-    #     at_command = "%s now + %s %s -f %s" % (ATCMD, unit_count, unit_type, script_file)
-    #     if user:
-    #     	# We expect that if this is an installed the permissions are already correct for the user to execute it.
-    #         at_command = "su '%s' -c '%s'" % (user, at_command)
-    #     rc, out, err = module.run_command(at_command)
-    #     if rc != 0:
-    #         module.fail_json(msg=err)
-    #     result['changed'] = 'true'
-    # else:
-    #     module.fail_json(msg="command or script_file not specified")
+    rc, out, err = module.run_command(sosreport_command, check_rc=True)
+    result['changed'] = True
+    in_string = StringIO(out)
+    while True:
+        in_line = in_string.readline()
+        if in_line == '': break
+        if 'Your sosreport has been generated and saved in:' in in_line:
+            result['file'] = in_string.readline().strip()
 
     module.exit_json(**result)
 

--- a/library/system/sosreport
+++ b/library/system/sosreport
@@ -21,11 +21,9 @@
 DOCUMENTATION = '''
 ---
 module: sosreport
-short_description: Execute sosreport and make the archive available.
+short_description: Gather system state data into an archive.
 description:
- - sosreport is a tool for collecting current system state information into an archive.
- - The sosreport module will always be executed in batch mode.
- - The sosreport module is restricted to RHEL based distributions for availability reasons.
+ - Allows you to gather the current system state information into an archive returning the path to the archive and MD5 file.
 version_added: "1.5"
 options:
     name:
@@ -64,18 +62,19 @@ options:
         required: false
         default: null
 requirements:
- - sosreport
+ - sos
 author: Richard Isaacson
 '''
 
 EXAMPLES = '''
-# Execute sosreport creating an archive with a provided name.
-- sosreport: name="server"
+# Basic execution creating an archive.
+- sosreport:
+
+# Execution skippint the system plugin.
+- sosreport: skip_plugins:system
 '''
 
 from cStringIO import StringIO
-import os
-import tempfile
 
 #================================================
 
@@ -104,8 +103,6 @@ def main():
     config_file    = module.params['config_file']
     tmp_dir        = module.params['tmp_dir']
 
-# TODO: if this is not a RHEL based distro fail.
-
     if (skip_plugins or enable_plugins) and only_plugins:
         module.fail_json(msg="skip_plugins or enable_plugins and only_plugins are mutually exclusive")
 
@@ -127,7 +124,7 @@ def main():
     if tmp_dir:
         sosreport_command = "%s --tmp-dir %s" % (sosreport_command, tmp_dir)
 
-    result['command'] = sosreport_command
+    # result['command'] = sosreport_command
 
     rc, out, err = module.run_command(sosreport_command, check_rc=True)
     result['changed'] = True
@@ -136,7 +133,8 @@ def main():
         in_line = in_string.readline()
         if in_line == '': break
         if 'Your sosreport has been generated and saved in:' in in_line:
-            result['file'] = in_string.readline().strip()
+            result['sosreport_archive'] = in_string.readline().strip()
+            result['sosreport_md5'] = "%s.md5" % result['sosreport_archive']
 
     module.exit_json(**result)
 


### PR DESCRIPTION
sosreport is a tool that is a part of the sos package used for "gathering system logs and other debug information"(https://github.com/sosreport/sosreport). It is included with a number of RHEL based repositories and has been ported to be useful with Ubuntu. sosreport is also easily extendable by creating custom plugins to copy data not captured by the built-in plugins.

This module runs sosreport on the remote host and returns the archive and md5 path in the result so they can be copied local and removed from the remote host. An example playbook can be found here:  https://github.com/risaacson/ansible-examples/tree/master/sosreport

This module should strongly appeal to anyone running large clusters in need of pulling system information for debugging or a support case.
