### PR TITLE
self.su_user is done earlier in the code path, and is auto-vivified from

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -632,7 +632,6 @@ class Runner(object):
         actual_private_key_file = inject.get('ansible_ssh_private_key_file', self.private_key_file)
         self.sudo_pass = inject.get('ansible_sudo_pass', self.sudo_pass)
         self.su = inject.get('ansible_su', self.su)
-        self.su_user = inject.get('ansible_su_user', self.su_user)
         self.su_pass = inject.get('ansible_su_pass', self.su_pass)
 
         if actual_private_key_file is not None:


### PR DESCRIPTION
su_user_var.  My last PR was only half merged, and when the bug fix for
the su/su_pass typo was merged, the removed line in this commit was
mistakenly reintroduced.
