### PR TITLE
be permissive with BSD with service enabled upper/lower/mixed cases

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -325,7 +325,7 @@ class Service(object):
             if len(rcarray) >= 1 and '=' in rcarray[0]:
                 (key, value) = rcarray[0].split("=", 1)
                 if key == self.rcconf_key:
-                    if value == self.rcconf_value:
+                    if value.upper() == self.rcconf_value:
                         # Since the proper entry already exists we can stop iterating.
                         changed = False
                         break


### PR DESCRIPTION
fixes #5802, this time w/o unintended pep8 breaking whitespace deletion

Signed-off-by: Brian Coca <briancoca+ansible@gmail.com>
