### PR TITLE
Rax mod utils improvements

### DIFF
--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -10,6 +10,7 @@ def rax_argument_spec():
         identity_type=dict(type='str', default='rackspace'),
         region=dict(type='str'),
         tenant_id=dict(type='str'),
+        tenant_name=dict(type='str'),
         username=dict(type='str'),
         verify_ssl=dict(choices=BOOLEANS, type='bool'),
     )
@@ -27,6 +28,7 @@ def setup_rax_module(module, rax_module):
     identity_type = module.params.get('identity_type')
     region = module.params.get('region')
     tenant_id = module.params.get('tenant_id')
+    tenant_name = module.params.get('tenant_name')
     username = module.params.get('username')
     verify_ssl = module.params.get('verify_ssl')
 
@@ -40,6 +42,8 @@ def setup_rax_module(module, rax_module):
         rax_module.set_setting('auth_endpoint', auth_endpoint)
     if tenant_id is not None:
         rax_module.set_setting('tenant_id', tenant_id)
+    if tenant_name is not None:
+        rax_module.set_setting('tenant_name', tenant_name)
 
     try:
         username = username or os.environ.get('RAX_USERNAME')

--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -59,7 +59,7 @@ def setup_rax_module(module, rax_module):
     try:
         if api_key and username:
             if api_key == 'USE_KEYRING':
-                rax_module.keyring_auth(username)
+                rax_module.keyring_auth(username, region=region)
             else:
                 rax_module.set_credentials(username, api_key=api_key,
                                            region=region)

--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -45,8 +45,6 @@ def setup_rax_module(module, rax_module):
         module.fail_json(msg='Unable to load %s' % e.message)
 
     try:
-        rax_module.set_setting('identity_type', 'rackspace')
-
         if api_key and username:
             if api_key == 'USE_KEYRING':
                 rax_module.keyring_auth(username)

--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -2,16 +2,16 @@ import os
 
 
 def rax_argument_spec():
-    auth_endpoint = 'https://identity.api.rackspacecloud.com/v2.0/'
     return dict(
         api_key=dict(type='str', aliases=['password'], no_log=True),
-        auth_endpoint=dict(type='str', default=auth_endpoint),
+        auth_endpoint=dict(type='str'),
         credentials=dict(type='str', aliases=['creds_file']),
+        env=dict(type='str'),
         identity_type=dict(type='str', default='rackspace'),
         region=dict(type='str'),
         tenant_id=dict(type='str'),
         username=dict(type='str'),
-        verify_ssl=dict(choices=BOOLEANS, default=True, type='bool'),
+        verify_ssl=dict(choices=BOOLEANS, type='bool'),
     )
 
 
@@ -23,24 +23,35 @@ def setup_rax_module(module, rax_module):
     api_key = module.params.get('api_key')
     auth_endpoint = module.params.get('auth_endpoint')
     credentials = module.params.get('credentials')
+    env = module.params.get('env')
     identity_type = module.params.get('identity_type')
     region = module.params.get('region')
     tenant_id = module.params.get('tenant_id')
     username = module.params.get('username')
     verify_ssl = module.params.get('verify_ssl')
 
+    if env is not None:
+        rax_module.set_environment(env)
+
     rax_module.set_setting('identity_type', identity_type)
-    rax_module.set_setting('verify_ssl', verify_ssl)
-    rax_module.set_setting('auth_endpoint', auth_endpoint)
-    if tenant_id:
+    if verify_ssl is not None:
+        rax_module.set_setting('verify_ssl', verify_ssl)
+    if auth_endpoint is not None:
+        rax_module.set_setting('auth_endpoint', auth_endpoint)
+    if tenant_id is not None:
         rax_module.set_setting('tenant_id', tenant_id)
 
     try:
         username = username or os.environ.get('RAX_USERNAME')
-        api_key = api_key or os.environ.get('RAX_API_KEY')
+        if not username:
+            username = rax_module.get_setting('keyring_username')
+            api_key = 'USE_KEYRING'
+        if not api_key:
+            api_key = os.environ.get('RAX_API_KEY')
         credentials = (credentials or os.environ.get('RAX_CREDENTIALS') or
                        os.environ.get('RAX_CREDS_FILE'))
-        region = region or os.environ.get('RAX_REGION')
+        region = (region or os.environ.get('RAX_REGION') or
+                  rax_module.get_setting('region'))
     except KeyError, e:
         module.fail_json(msg='Unable to load %s' % e.message)
 

--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -33,8 +33,11 @@ def setup_rax_module(module, rax_module):
         rax_module.set_setting('identity_type', 'rackspace')
 
         if api_key and username:
-            rax_module.set_credentials(username, api_key=api_key,
-                                       region=region)
+            if api_key == 'USE_KEYRING':
+                rax_module.keyring_auth(username)
+            else:
+                rax_module.set_credentials(username, api_key=api_key,
+                                           region=region)
         elif credentials:
             credentials = os.path.expanduser(credentials)
             rax_module.set_credential_file(credentials, region=region)

--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -45,7 +45,8 @@ def setup_rax_module(module, rax_module):
         username = username or os.environ.get('RAX_USERNAME')
         if not username:
             username = rax_module.get_setting('keyring_username')
-            api_key = 'USE_KEYRING'
+            if username:
+                api_key = 'USE_KEYRING'
         if not api_key:
             api_key = os.environ.get('RAX_API_KEY')
         credentials = (credentials or os.environ.get('RAX_CREDENTIALS') or

--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -2,11 +2,16 @@ import os
 
 
 def rax_argument_spec():
+    auth_endpoint = 'https://identity.api.rackspacecloud.com/v2.0/'
     return dict(
-        api_key=dict(type='str', no_log=True),
+        api_key=dict(type='str', aliases=['password'], no_log=True),
+        auth_endpoint=dict(type='str', default=auth_endpoint),
         credentials=dict(type='str', aliases=['creds_file']),
+        identity_type=dict(type='str', default='rackspace'),
         region=dict(type='str'),
+        tenant_id=dict(type='str'),
         username=dict(type='str'),
+        verify_ssl=dict(choices=BOOLEANS, default=True, type='bool'),
     )
 
 
@@ -16,9 +21,19 @@ def rax_required_together():
 
 def setup_rax_module(module, rax_module):
     api_key = module.params.get('api_key')
+    auth_endpoint = module.params.get('auth_endpoint')
     credentials = module.params.get('credentials')
+    identity_type = module.params.get('identity_type')
     region = module.params.get('region')
+    tenant_id = module.params.get('tenant_id')
     username = module.params.get('username')
+    verify_ssl = module.params.get('verify_ssl')
+
+    rax_module.set_setting('identity_type', identity_type)
+    rax_module.set_setting('verify_ssl', verify_ssl)
+    rax_module.set_setting('auth_endpoint', auth_endpoint)
+    if tenant_id:
+        rax_module.set_setting('tenant_id', tenant_id)
 
     try:
         username = username or os.environ.get('RAX_USERNAME')

--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -26,6 +26,49 @@ options:
   api_key:
     description:
       - Rackspace API key (overrides I(credentials))
+    aliases:
+      - password
+  auth_endpoint:
+    description:
+      - The URI of the authentication service
+    default: https://identity.api.rackspacecloud.com/v2.0/
+    version_added: 1.5
+  credentials:
+    description:
+      - File to find the Rackspace credentials in (ignored if I(api_key) and
+        I(username) are provided)
+    default: null
+    aliases:
+      - creds_file
+  env:
+    description:
+      - Environment as configured in ~/.pyrax.cfg,
+        see U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#pyrax-configuration)
+    version_added: 1.5
+  identity_type:
+    description:
+      - Authentication machanism to use, such as rackspace or keystone
+    default: rackspace
+    version_added: 1.5
+  region:
+    description:
+      - Region to create an instance in
+    default: DFW
+  tenant_id:
+    description:
+      - The tenant ID used for authentication
+    version_added: 1.5
+  tenant_name:
+    description:
+      - The tenant name used for authentication
+    version_added: 1.5
+  username:
+    description:
+      - Rackspace username (overrides I(credentials))
+  verify_ssl:
+    description:
+      - Whether or not to require SSL validation of API endpoints
+    version_added: 1.5
   auto_increment:
     description:
       - Whether or not to increment a single number with the name of the
@@ -43,12 +86,6 @@ options:
       - number count to start at
     default: 1
     version_added: 1.4
-  credentials:
-    description:
-      - File to find the Rackspace credentials in (ignored if I(api_key) and
-        I(username) are provided)
-    default: null
-    aliases: ['creds_file']
   disk_config:
     description:
       - Disk partitioning strategy
@@ -103,18 +140,11 @@ options:
         or C(label).
     default: ['public', 'private']
     version_added: 1.4
-  region:
-    description:
-      - Region to create an instance in
-    default: DFW
   state:
     description:
       - Indicate desired state of the resource
     choices: ['present', 'absent']
     default: present
-  username:
-    description:
-      - Rackspace username (overrides I(credentials))
   wait:
     description:
       - wait for the instance to be in state 'running' before returning


### PR DESCRIPTION
This pull allows the following behaviors:

1) Support other OpenStack clouds with the rax module
2) Support pyrax environments via `~/.pyrax.cfg`
3) Support keyring based authentication when keyring_username is found in the environment from `~/.pyrax.cfg` or when the api_key is set to 'USE_KEYRING'
4) Update rax DOCUMENTATION with new auth related attributes
