### PR TITLE
Fix .ssh/known_hosts path expansion.

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -117,7 +117,11 @@ class Connection(object):
             os.close(self.wfd)
 
     def not_in_host_file(self, host):
-        host_file = os.path.expanduser(os.path.expandvars("~${USER}/.ssh/known_hosts"))
+        if 'USER' in os.environ:
+            host_file = os.path.expandvars("~${USER}/.ssh/known_hosts")
+        else:
+            host_file = "~/.ssh/known_hosts"
+        host_file = os.path.expanduser(host_file)
         if not os.path.exists(host_file):
             print "previous known host file not found"
             return True


### PR DESCRIPTION
In particular, do not rely on the $USER environment variable always existing.
tmux for example seems to clear it, causing lots of invalid messages:
"previous known host file not found"

This broke in commit 80fd22dc, but instead of reverting that commit, we now
fall back to expanding just ~ when $USER is not set.
