### PR TITLE
If a executable is defined but not found the module should fail.

### DIFF
--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -175,7 +175,8 @@ def _get_pip(module, env=None, executable=None):
         if os.path.isabs(executable):
             pip = executable
         else:
-            candidate_pip_basenames.insert(0, executable)
+            # If you define your own executable that executable should be the only candidate.
+            candidate_pip_basenames = [executable]
     if pip is None:
         if env is None:
             opt_dirs = []


### PR DESCRIPTION
Address https://github.com/ansible/ansible/issues/5781.

What we are doing is changing the candidate_pip_basenames to just include the defined executable. If that executable is not found we fail.
