### PR TITLE
Updated authorized_key module documentation regarding manage_dir

### DIFF
--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -48,7 +48,7 @@ options:
     version_added: "1.2"
   manage_dir:
     description:
-      - Whether this module should manage the directory of the authorized_keys file
+      - Whether this module should manage the directory of the authorized_keys file. Make sure to set C(manage_dir=no) if you are using an alternate directory for authorized_keys set with C(path), since you could lock yourself out of SSH access. See the example below.
     required: false
     choices: [ "yes", "no" ]
     default: "yes"


### PR DESCRIPTION
Added a warning in the documentation about manage_dir when selecting an alternate directory for authorized_keys as discussed in #5796
