### PR TITLE
fix for uri module following redirects

### DIFF
--- a/library/network/uri
+++ b/library/network/uri
@@ -87,10 +87,15 @@ options:
     default: "no"
   follow_redirects:
     description:
-      - Whether or not the URI module should follow all redirects.
+      - Whether or not the URI module should follow redirects. C(all) will follow all redirects.
+        C(safe) will follow only "safe" redirects, where "safe" means that the client is only 
+        doing a GET or HEAD on the URI to which it is being redirected. C(none) will not follow
+        any redirects. Note that C(yes) and C(no) choices are accepted for backwards compatibility, 
+        where C(yes) is the equivalent of C(all) and C(no) is the equivalent of C(safe). C(yes) and C(no)
+        are deprecated and will be removed in some future version of Ansible.
     required: false
-    choices: [ "yes", "no" ]
-    default: "no"
+    choices: [ "all", "safe", "none" ]
+    default: "safe"
   creates:
     description:
       - a filename, when it already exists, this step will not be run.
@@ -231,9 +236,21 @@ def uri(module, url, dest, user, password, body, method, headers, redirects, soc
     # To debug
     #httplib2.debug = 4
 
+    # Handle Redirects         
+    if redirects == "all" or redirects == "yes":
+        follow_redirects = True
+        follow_all_redirects = True
+    elif redirects == "none":
+        follow_redirects = False
+        follow_all_redirects = False
+    else:
+        follow_redirects = True
+        follow_all_redirects = False
+
     # Create a Http object and set some default options.
     h = httplib2.Http(disable_ssl_certificate_validation=True, timeout=socket_timeout)
-    h.follow_all_redirects = redirects
+    h.follow_all_redirects = follow_all_redirects
+    h.follow_redirects = follow_redirects
     h.forward_authorization_headers = True
 
     # If they have a username or password verify they have both, then add them to the request
@@ -272,7 +289,7 @@ def uri(module, url, dest, user, password, body, method, headers, redirects, soc
             headers['If-Modified-Since'] = tstamp
 
     # do safe redirects now, including 307
-    h.follow_redirects=True
+    h.follow_redirects=follow_redirects
 
     # Make the request, or try to :)
     try: 
@@ -312,7 +329,7 @@ def main():
             method = dict(required=False, default='GET', choices=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS']),
             return_content = dict(required=False, default='no', type='bool'),
             force_basic_auth = dict(required=False, default='no', type='bool'),
-            follow_redirects = dict(required=False, default='no', type='bool'),
+            follow_redirects = dict(required=False, default='safe', choices=['all', 'safe', 'none', 'yes', 'no']),
             creates = dict(required=False, default=None),
             removes = dict(required=False, default=None),
             status_code = dict(required=False, default=200, type='int'),
@@ -335,7 +352,7 @@ def main():
     dest = module.params['dest']
     return_content = module.params['return_content']
     force_basic_auth = module.params['force_basic_auth']
-    follow_redirects = module.params['follow_redirects']
+    redirects = module.params['follow_redirects']
     creates = module.params['creates']
     removes = module.params['removes']
     status_code = int(module.params['status_code'])
@@ -372,11 +389,6 @@ def main():
     if force_basic_auth:
         dict_headers["Authorization"] = "Basic {0}".format(base64.b64encode("{0}:{1}".format(user, password))) 
 
-    # Redirects         
-    if follow_redirects:
-        redirects = True        
-    else:
-        redirects = False
 
     # Make the request
     resp, content, dest = uri(module, url, dest, user, password, body, method, dict_headers, redirects, socket_timeout)


### PR DESCRIPTION
This is a fix for Issue #5742 where the uri module was following redirects even when 'no' was set on the 'follow_redirects' option. The commit adds the following choices to the follow_redirects option: all, safe, none, while still supporting yes and no for backwards compatibility. It also makes note of this in the description of the option.
