### PR TITLE
Make `write_ssh_wrapper` work for Python 2.4

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -142,8 +142,8 @@ import re
 import tempfile
 
 def write_ssh_wrapper():
-    fh = tempfile.NamedTemporaryFile(delete=False)
-    wrapper_path = fh.name
+    fd, wrapper_path = tempfile.mkstemp()
+    fh = os.fdopen(fd, 'w+b')
     template = """#!/bin/sh
 if [ -z "$GIT_SSH_OPTS" ]; then
     BASEOPTS=""


### PR DESCRIPTION
The `delete` parameter wasn't added until Python 2.6, and Ansible has a requirement of Python 2.4 for managed nodes (for #5822) 
