### PR TITLE
Fix: Notify only the right hosts

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -592,6 +592,7 @@ class PlayBook(object):
                         fired_names = {}
                         for handler in play.handlers():
                             if len(handler.notified_by) > 0:
+                                play._play_hosts = handler.notified_by
                                 self.inventory.restrict_to(handler.notified_by)
 
                                 # Resolve the variables first


### PR DESCRIPTION
After e8ad36c8, notification are always runned on all hosts of play:

```
PLAY [all] ********************************************************************
TASK: [change deb7] ***********************************************************
changed: [deb7.inter.nos]
ok: [deb6.inter.nos]
NOTIFIED: [deb7] **************************************************************
changed: [deb6.inter.nos]
changed: [deb7.inter.nos]
```

This pull should fix
