### PR TITLE
reword "except Error as e:" into "except Error, e:" to be compatible with Python 2.5

### DIFF
--- a/lib/ansible/runner/lookup_plugins/csvfile.py
+++ b/lib/ansible/runner/lookup_plugins/csvfile.py
@@ -64,7 +64,7 @@ class LookupModule(object):
                     name, value = param.split('=')
                     assert(name in paramvals)
                     paramvals[name] = value
-            except (ValueError, AssertionError) as e:
+            except (ValueError, AssertionError), e:
                 raise errors.AnsibleError(e)
 
             if paramvals['delimiter'] == 'TAB':

--- a/lib/ansible/runner/lookup_plugins/dnstxt.py
+++ b/lib/ansible/runner/lookup_plugins/dnstxt.py
@@ -61,7 +61,7 @@ class LookupModule(object):
                 string = 'NXDOMAIN'
             except dns.resolver.Timeout:
                 string = ''
-            except dns.exception.DNSException as e:
+            except dns.exception.DNSException, e:
                 raise errors.AnsibleError("dns.resolver unhandled exception", e)
 
             ret.append(''.join(string))

--- a/lib/ansible/runner/lookup_plugins/password.py
+++ b/lib/ansible/runner/lookup_plugins/password.py
@@ -68,7 +68,7 @@ class LookupModule(object):
                         paramvals['chars'] = use_chars
                     else:
                         paramvals[name] = value
-            except (ValueError, AssertionError) as e:
+            except (ValueError, AssertionError), e:
                 raise errors.AnsibleError(e)
 
             length  = paramvals['length']

--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -163,7 +163,7 @@ import time
 try:
     import dopy
     from dopy.manager import DoError, DoManager
-except ImportError as e:
+except ImportError, e:
     print "failed=True msg='dopy >= 0.2.2 required for this module'"
     sys.exit(1)
 
@@ -415,9 +415,9 @@ def main():
 
     try:
         core(module)
-    except TimeoutError as e:
+    except TimeoutError, e:
         module.fail_json(msg=str(e), id=e.id)
-    except (DoError, Exception) as e:
+    except (DoError, Exception), e:
         module.fail_json(msg=str(e))
 
 # import module snippets

--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -472,11 +472,11 @@ def main():
     
         module.exit_json(failed=failed, changed=changed, msg=msg, ansible_facts=_ansible_facts(facts))
 
-    except docker.client.APIError as e:
+    except docker.client.APIError, e:
         changed = manager.has_changed()
         module.exit_json(failed=True, changed=changed, msg="Docker API error: " + e.explanation)
 
-    except RequestException as e:
+    except RequestException, e:
         changed = manager.has_changed()
         module.exit_json(failed=True, changed=changed, msg=repr(e))
         

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -619,7 +619,7 @@ def create_instances(module, ec2):
             try:
                 res.connection.get_all_instances(instids)
                 break
-            except boto.exception.EC2ResponseError as e:
+            except boto.exception.EC2ResponseError, e:
                 if "<Code>InvalidInstanceID.NotFound</Code>" in str(e):
                     # there's a race between start and get an instance
                     continue
@@ -629,7 +629,7 @@ def create_instances(module, ec2):
         if instance_tags:
             try:
                 ec2.create_tags(instids, instance_tags)
-            except boto.exception.EC2ResponseError as e:
+            except boto.exception.EC2ResponseError, e:
                 module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
 
         # wait here until the instances are up
@@ -703,7 +703,7 @@ def terminate_instances(module, ec2, instance_ids):
                 instance_dict_array.append(get_instance_info(inst))
                 try:
                     ec2.terminate_instances([inst.id])
-                except EC2ResponseError as e:
+                except EC2ResponseError, e:
                     module.fail_json(msg='Unable to terminate instance {0}, error: {1}'.format(inst.id, e))
                 changed = True
 
@@ -773,7 +773,7 @@ def startstop_instances(module, ec2, instance_ids):
                        inst.start()
                    else:
                        inst.stop()
-               except EC2ResponseError as e:
+               except EC2ResponseError, e:
                    module.fail_json(msg='Unable to change state for instance {0}, error: {1}'.format(inst.id, e))
                changed = True
 

--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -195,7 +195,7 @@ def create_image(module, ec2):
         try:
             img = ec2.get_image(image_id)
             break
-        except boto.exception.EC2ResponseError as e:
+        except boto.exception.EC2ResponseError, e:
             if e.error_code == 'InvalidAMIID.NotFound':
                 time.sleep(1)
             else:

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -263,7 +263,7 @@ def create_vpc(module, vpc_conn):
             try:
                 vpc_conn.create_subnet(vpc.id, subnet['cidr'], subnet.get('az', None))
                 changed = True
-            except EC2ResponseError as e:
+            except EC2ResponseError, e:
                 module.fail_json(msg='Unable to create subnet {0}, error: {1}'.format(subnet['cidr'], e))
     # Now delete all absent subnets
     for csubnet in current_subnets:
@@ -275,7 +275,7 @@ def create_vpc(module, vpc_conn):
             try:
                 vpc_conn.delete_subnet(csubnet.id)
                 changed = True
-            except EC2ResponseError as e:
+            except EC2ResponseError, e:
                 module.fail_json(msg='Unable to delete subnet {0}, error: {1}'.format(csubnet.cidr_block, e))
 
     # Handle Internet gateway (create/delete igw)
@@ -289,7 +289,7 @@ def create_vpc(module, vpc_conn):
                 igw = vpc_conn.create_internet_gateway()
                 vpc_conn.attach_internet_gateway(igw.id, vpc.id)
                 changed = True
-            except EC2ResponseError as e:
+            except EC2ResponseError, e:
                 module.fail_json(msg='Unable to create Internet Gateway, error: {0}'.format(e))
         else:
             # Set igw variable to the current igw instance for use in route tables.
@@ -300,7 +300,7 @@ def create_vpc(module, vpc_conn):
                 vpc_conn.detach_internet_gateway(igws[0].id, vpc.id)
                 vpc_conn.delete_internet_gateway(igws[0].id)
                 changed = True
-            except EC2ResponseError as e:
+            except EC2ResponseError, e:
                 module.fail_json(msg='Unable to delete Internet Gateway, error: {0}'.format(e))
 
     # Handle route tables - this may be worth splitting into a
@@ -357,7 +357,7 @@ def create_vpc(module, vpc_conn):
                 vpc_conn.associate_route_table(new_rt.id, rsn.id)
 
             all_route_tables.append(new_rt)
-        except EC2ResponseError as e:
+        except EC2ResponseError, e:
             module.fail_json(
                 msg='Unable to create and associate route table {0}, error: ' \
                 '{1}'.format(rt, e)
@@ -382,7 +382,7 @@ def create_vpc(module, vpc_conn):
             try:
                 if not is_main:
                     vpc_conn.delete_route_table(rt.id)
-            except EC2ResponseError as e:
+            except EC2ResponseError, e:
                 module.fail_json(msg='Unable to delete old route table {0}, error: {1}'.format(rt.id, e))
 
     vpc_dict = get_vpc_info(vpc)
@@ -461,7 +461,7 @@ def terminate_vpc(module, vpc_conn, vpc_id=None, cidr=None):
                         vpc_conn.delete_route_table(rt.id)
 
                 vpc_conn.delete_vpc(vpc.id)
-            except EC2ResponseError as e:
+            except EC2ResponseError, e:
                 module.fail_json(
                     msg='Unable to delete VPC {0}, error: {1}'.format(vpc.id, e)
                 )

--- a/library/cloud/gce
+++ b/library/cloud/gce
@@ -259,10 +259,10 @@ def create_instances(module, gce, instance_names):
             md = literal_eval(metadata)
             if not isinstance(md, dict):
                 raise ValueError('metadata must be a dict')
-        except ValueError as e:
+        except ValueError, e:
             print("failed=True msg='bad metadata: %s'" % str(e))
             sys.exit(1)
-        except SyntaxError as e:
+        except SyntaxError, e:
             print("failed=True msg='bad metadata syntax'")
             sys.exit(1)
 
@@ -291,7 +291,7 @@ def create_instances(module, gce, instance_names):
             changed = True
         except ResourceExistsError:
             inst = gce.ex_get_node(name, lc_zone)
-        except GoogleBaseError as e:
+        except GoogleBaseError, e:
             module.fail_json(msg='Unexpected error attempting to create ' + \
                     'instance %s, error: %s' % (name, e.value))
 
@@ -327,7 +327,7 @@ def terminate_instances(module, gce, instance_names, zone_name):
             inst = gce.ex_get_node(name, zone_name)
         except ResourceNotFoundError:
             pass
-        except Exception as e:
+        except Exception, e:
             module.fail_json(msg=unexpected_error_msg(e), changed=False)
         if inst:
             gce.destroy_node(inst)
@@ -372,7 +372,7 @@ def main():
         gce = get_driver(Provider.GCE)(*ARGS, datacenter=zone, **KWARGS)
         gce.connection.user_agent_append("%s/%s" % (
             USER_AGENT_PRODUCT, USER_AGENT_VERSION))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
     inames = []

--- a/library/cloud/gce_lb
+++ b/library/cloud/gce_lb
@@ -211,7 +211,7 @@ def main():
         gcelb = get_driver_lb(Provider_lb.GCE)(gce_driver=gce)
         gcelb.connection.user_agent_append("%s/%s" % (
                 USER_AGENT_PRODUCT, USER_AGENT_VERSION))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
     changed = False
@@ -237,7 +237,7 @@ def main():
                 changed = True
             except ResourceExistsError:
                 hc = gce.ex_get_healthcheck(httphealthcheck_name)
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
             if hc is not None:
@@ -281,7 +281,7 @@ def main():
                 changed = True
             except ResourceExistsError:
                 lb = gcelb.get_balancer(name)
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
             if lb is not None:
@@ -307,7 +307,7 @@ def main():
                 changed = True
             except ResourceNotFoundError:
                 pass
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
         # destroy the health check if specified
@@ -319,7 +319,7 @@ def main():
                 changed = True
             except ResourceNotFoundError:
                 pass
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
 

--- a/library/cloud/gce_net
+++ b/library/cloud/gce_net
@@ -174,7 +174,7 @@ def main():
         gce = get_driver(Provider.GCE)(*ARGS, **KWARGS)
         gce.connection.user_agent_append("%s/%s" % (
                 USER_AGENT_PRODUCT, USER_AGENT_VERSION))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
     changed = False
@@ -188,7 +188,7 @@ def main():
             json_output['ipv4_range'] = network.cidr
         except ResourceNotFoundError:
             pass
-        except Exception as e:
+        except Exception, e:
             module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
         # user wants to create a new network that doesn't yet exist
@@ -202,7 +202,7 @@ def main():
                 json_output['name'] = name
                 json_output['ipv4_range'] = ipv4_range
                 changed = True
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
         if fwname:
@@ -224,7 +224,7 @@ def main():
                 changed = True
             except ResourceExistsError:
                 pass
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
             json_output['fwname'] = fwname
@@ -240,7 +240,7 @@ def main():
                 fw = gce.ex_get_firewall(fwname)
             except ResourceNotFoundError:
                 pass
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
             if fw:
                 gce.ex_destroy_firewall(fw)
@@ -254,7 +254,7 @@ def main():
             except ResourceNotFoundError:
 #                json_output['d2'] = 'not found network name %s' % name
                 pass
-            except Exception as e:
+            except Exception, e:
 #                json_output['d3'] = 'error with %s' % name
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
             if network:

--- a/library/cloud/gce_pd
+++ b/library/cloud/gce_pd
@@ -155,7 +155,7 @@ def main():
         gce = get_driver(Provider.GCE)(*ARGS, datacenter=zone, **KWARGS)
         gce.connection.user_agent_append("%s/%s" % (
                 USER_AGENT_PRODUCT, USER_AGENT_VERSION))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
     disk = inst = None
@@ -185,7 +185,7 @@ def main():
         json_output['size_gb'] = int(disk.size)
     except ResourceNotFoundError:
         pass
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
     # user wants a disk to exist.  If "instance_name" is supplied the user
@@ -214,14 +214,14 @@ def main():
             except QuotaExceededError:
                 module.fail_json(msg='Requested disk size exceeds quota',
                         changed=False)
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
             json_output['size_gb'] = size_gb
             changed = True
         if inst and not is_attached:
             try:
                 gce.attach_volume(inst, disk, device=name, ex_mode=mode)
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
             json_output['attached_to_instance'] = inst.name
             json_output['attached_mode'] = mode
@@ -233,15 +233,15 @@ def main():
         if inst and is_attached:
             try:
                 gce.detach_volume(disk, ex_node=inst)
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
             changed = True
         if not detach_only:
             try:
                 gce.destroy_volume(disk)
-            except ResourceInUseError as e:
+            except ResourceInUseError, e:
                 module.fail_json(msg=str(e.value), changed=False)
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
             changed = True
 

--- a/library/cloud/glance_image
+++ b/library/cloud/glance_image
@@ -133,7 +133,7 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:   
+    except Exception, e:   
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     return client 
  
@@ -141,7 +141,7 @@ def _get_ksclient(module, kwargs):
 def _get_endpoint(module, client):
     try:
         endpoint = client.service_catalog.url_for(service_type='image', endpoint_type='publicURL')
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error getting endpoint for glance: %s" % e.message)
     return endpoint
 
@@ -154,7 +154,7 @@ def _get_glance_client(module, kwargs):
     }
     try:
         client = glanceclient.Client('1', endpoint, **kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in connecting to glance: %s" %e.message)
     return client
 
@@ -164,7 +164,7 @@ def _glance_image_present(module, params, client):
             if image.name == params['name']:
                 return image.id 
         return None 
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in fetching image list: %s" %e.message)
 
 def _glance_image_create(module, params, client):
@@ -187,7 +187,7 @@ def _glance_image_create(module, params, client):
             if image.status == 'active':
                 break
             time.sleep(5)
-    except Exception as e:              
+    except Exception, e:              
         module.fail_json(msg = "Error in creating image: %s" %e.message)                
     if image.status == 'active':
         module.exit_json(changed = True, result = image.status, id=image.id)
@@ -199,7 +199,7 @@ def _glance_delete_image(module, params, client):
         for image in client.images.list():
             if image.name == params['name']:
                 client.images.delete(image)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in deleting image: %s" %e.message)
     module.exit_json(changed = True, result = "Deleted")
         

--- a/library/cloud/keystone_user
+++ b/library/cloud/keystone_user
@@ -332,7 +332,7 @@ def main():
         d = dispatch(keystone, user, password, tenant, tenant_description,
                      email, role, state, endpoint, token, login_user,
                      login_password, check_mode)
-    except Exception as e:
+    except Exception, e:
         if check_mode:
             # If we have a failure in check mode
             module.exit_json(changed=True,

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -137,7 +137,7 @@ def _delete_server(module, nova):
         if server_list:
             server = [x for x in server_list if x.name == module.params['name']]
             nova.servers.delete(server.pop())
-    except Exception as e:
+    except Exception, e:
         module.fail_json( msg = "Error in deleting vm: %s" % e.message)
     if module.params['wait'] == 'no':
         module.exit_json(changed = True, result = "deleted")
@@ -163,14 +163,14 @@ def _create_server(module, nova):
     try:
         server = nova.servers.create(*bootargs, **bootkwargs)
         server = nova.servers.get(server.id)
-    except Exception as e:
+    except Exception, e:
             module.fail_json( msg = "Error in creating instance: %s " % e.message)
     if module.params['wait'] == 'yes':
         expire = time.time() + int(module.params['wait_for'])
         while time.time() < expire:
             try:
                 server = nova.servers.get(server.id)
-            except Exception as e:
+            except Exception, e:
                     module.fail_json( msg = "Error in getting info from instance: %s " % e.message)
             if server.status == 'ACTIVE':
                 private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
@@ -194,7 +194,7 @@ def _get_server_state(module, nova):
         servers = nova.servers.list(True, {'name': module.params['name']})
         if servers:
             server = [x for x in servers if x.name == module.params['name']][0]
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in getting the server list: %s" % e.message)
     if server and module.params['state'] == 'present':
         if server.status != 'ACTIVE':
@@ -238,9 +238,9 @@ def main():
                               service_type='compute')
     try:
         nova.authenticate()
-    except exc.Unauthorized as e:
+    except exc.Unauthorized, e:
         module.fail_json(msg = "Invalid OpenStack Nova credentials.: %s" % e.message)
-    except exc.AuthorizationFailure as e:
+    except exc.AuthorizationFailure, e:
         module.fail_json(msg = "Unable to authorize user: %s" % e.message)
 
     if module.params['state'] == 'present':

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -107,9 +107,9 @@ def main():
                               service_type='compute')
     try:
         nova.authenticate()
-    except exc.Unauthorized as e:
+    except exc.Unauthorized, e:
         module.fail_json(msg = "Invalid OpenStack Nova credentials.: %s" % e.message)
-    except exc.AuthorizationFailure as e:
+    except exc.AuthorizationFailure, e:
         module.fail_json(msg = "Unable to authorize user: %s" % e.message)
 
     if module.params['state'] == 'present':
@@ -118,7 +118,7 @@ def main():
                 module.exit_json(changed = False, result = "Key present")
         try:
             key = nova.keypairs.create(module.params['name'], module.params['public_key'])
-        except Exception as e:
+        except Exception, e:
             module.exit_json(msg = "Error in creating the keypair: %s" % e.message)
         if not module.params['public_key']:
             module.exit_json(changed = True, key = key.private_key)
@@ -128,7 +128,7 @@ def main():
             if key.name == module.params['name']:
                 try:
                     nova.keypairs.delete(module.params['name'])
-                except Exception as e:
+                except Exception, e:
                     module.fail_json(msg = "The keypair deletion has failed: %s" % e.message)
                 module.exit_json( changed = True, result = "deleted")
         module.exit_json(changed = False, result = "not present")

--- a/library/cloud/quantum_floating_ip
+++ b/library/cloud/quantum_floating_ip
@@ -96,7 +96,7 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
     _os_keystone = kclient
@@ -106,7 +106,7 @@ def _get_ksclient(module, kwargs):
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
@@ -120,7 +120,7 @@ def _get_neutron_client(module, kwargs):
     }
     try:
         neutron = client.Client('2.0', **kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
     return neutron
 
@@ -136,7 +136,7 @@ def _get_server_state(module, nova):
                         module.fail_json( msg="The VM is available but not Active. state:" + info['status'])
                     server_info = info
                     break
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in getting the server list: %s" % e.message)
     return server_info, server
 
@@ -152,7 +152,7 @@ def _get_port_info(neutron, module, instance_id, internal_network_name=None):
     }
     try:
         ports = neutron.list_ports(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json( msg = "Error in listing ports: %s" % e.message)
     if subnet_id:
         port = next(port for port in ports['ports'] if port['fixed_ips'][0]['subnet_id'] == subnet_id)
@@ -171,7 +171,7 @@ def _get_floating_ip(module, neutron, fixed_ip_address):
     }
     try:
         ips = neutron.list_floatingips(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "error in fetching the floatingips's %s" % e.message)
     if not ips['floatingips']:
         return None, None
@@ -184,7 +184,7 @@ def _create_floating_ip(neutron, module, port_id, net_id):
     }
     try:
         result = neutron.create_floatingip({'floatingip': kwargs})
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg="There was an error in updating the floating ip address: %s" % e.message)
     module.exit_json(changed=True, result=result, public_ip=result['floatingip']['floating_ip_address'])
 
@@ -194,7 +194,7 @@ def _get_net_id(neutron, module):
     }
     try:
         networks = neutron.list_networks(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json("Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
         return None
@@ -206,7 +206,7 @@ def _update_floating_ip(neutron, module, port_id, floating_ip_id):
     }
     try:
         result = neutron.update_floatingip(floating_ip_id, {'floatingip': kwargs})
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg="There was an error in updating the floating ip address: %s" % e.message)
     module.exit_json(changed=True, result=result)
 
@@ -231,7 +231,7 @@ def main():
         nova = nova_client.Client(module.params['login_username'], module.params['login_password'],
             module.params['login_tenant_name'], module.params['auth_url'], service_type='compute')
         neutron = _get_neutron_client(module, module.params)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg="Error in authenticating to nova: %s" % e.message)
 
     server_info, server_obj = _get_server_state(module, nova)

--- a/library/cloud/quantum_floating_ip_associate
+++ b/library/cloud/quantum_floating_ip_associate
@@ -95,7 +95,7 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
     _os_keystone = kclient
@@ -105,7 +105,7 @@ def _get_ksclient(module, kwargs):
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
@@ -119,7 +119,7 @@ def _get_neutron_client(module, kwargs):
     }
     try:
         neutron = client.Client('2.0', **kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
     return neutron
 
@@ -135,7 +135,7 @@ def _get_server_state(module, nova):
                         module.fail_json(msg="The VM is available but not Active. state:" + info['status'])
                     server_info = info
                     break
-    except Exception as e:
+    except Exception, e:
             module.fail_json(msg = "Error in getting the server list: %s" % e.message)
     return server_info, server
 
@@ -143,7 +143,7 @@ def _get_port_id(neutron, module, instance_id):
     kwargs = dict(device_id = instance_id)
     try:
         ports = neutron.list_ports(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json( msg = "Error in listing ports: %s" % e.message)
     if not ports['ports']:
         return None
@@ -155,7 +155,7 @@ def _get_floating_ip_id(module, neutron):
     }
     try:
         ips = neutron.list_floatingips(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "error in fetching the floatingips's %s" % e.message)
     if not ips['floatingips']:
         module.fail_json(msg = "Could find the ip specified in parameter, Please check")
@@ -172,7 +172,7 @@ def _update_floating_ip(neutron, module, port_id, floating_ip_id):
     }
     try:
         result = neutron.update_floatingip(floating_ip_id, {'floatingip': kwargs})
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "There was an error in updating the floating ip address: %s" % e.message)
     module.exit_json(changed = True, result = result, public_ip=module.params['ip_address'])
 
@@ -194,7 +194,7 @@ def main():
     try:
         nova = nova_client.Client(module.params['login_username'], module.params['login_password'],
                                  module.params['login_tenant_name'], module.params['auth_url'], service_type='compute')
-    except Exception as e:
+    except Exception, e:
         module.fail_json( msg = " Error in authenticating to nova: %s" % e.message)
     neutron = _get_neutron_client(module, module.params)
     state, floating_ip_id = _get_floating_ip_id(module, neutron)

--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -128,7 +128,7 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
     _os_keystone = kclient
@@ -138,7 +138,7 @@ def _get_ksclient(module, kwargs):
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error getting network endpoint: %s " %e.message)
     return endpoint
 
@@ -152,7 +152,7 @@ def _get_neutron_client(module, kwargs):
     }
     try:
         neutron = client.Client('2.0', **kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = " Error in connecting to neutron: %s " %e.message)
     return neutron
 
@@ -178,7 +178,7 @@ def _get_net_id(neutron, module):
     }
     try:
         networks = neutron.list_networks(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
         return None
@@ -216,7 +216,7 @@ def _create_network(module, neutron):
 
     try:
         net = neutron.create_network({'network':network})
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in creating network: %s" % e.message)
     return net['network']['id']
 
@@ -224,7 +224,7 @@ def _delete_network(module, net_id, neutron):
 
     try:
         id = neutron.delete_network(net_id)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in deleting the network: %s" % e.message)
     return True
 

--- a/library/cloud/quantum_router
+++ b/library/cloud/quantum_router
@@ -99,7 +99,7 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
     _os_keystone = kclient
@@ -109,7 +109,7 @@ def _get_ksclient(module, kwargs):
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
@@ -123,7 +123,7 @@ def _get_neutron_client(module, kwargs):
     }
     try:
         neutron = client.Client('2.0', **kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
     return neutron
 
@@ -149,7 +149,7 @@ def _get_router_id(module, neutron):
     }
     try:
         routers = neutron.list_routers(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in getting the router list: %s " % e.message)
     if not routers['routers']:
         return None
@@ -163,7 +163,7 @@ def _create_router(module, neutron):
     }
     try:
         new_router = neutron.create_router(dict(router=router))
-    except Exception as e:
+    except Exception, e:
         module.fail_json( msg = "Error in creating router: %s" % e.message)
     return new_router['router']['id']
 

--- a/library/cloud/quantum_router_gateway
+++ b/library/cloud/quantum_router_gateway
@@ -89,7 +89,7 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
     _os_keystone = kclient
@@ -99,7 +99,7 @@ def _get_ksclient(module, kwargs):
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
@@ -113,7 +113,7 @@ def _get_neutron_client(module, kwargs):
     }
     try:
         neutron = client.Client('2.0', **kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
     return neutron
 
@@ -123,7 +123,7 @@ def _get_router_id(module, neutron):
     }
     try:
         routers = neutron.list_routers(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in getting the router list: %s " % e.message)
     if not routers['routers']:
             return None
@@ -136,7 +136,7 @@ def _get_net_id(neutron, module):
     }
     try:
         networks = neutron.list_networks(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json("Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
         return None
@@ -149,7 +149,7 @@ def _get_port_id(neutron, module, router_id, network_id):
     }
     try:
         ports = neutron.list_ports(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json( msg = "Error in listing ports: %s" % e.message)
     if not ports['ports']:
         return None
@@ -161,14 +161,14 @@ def _add_gateway_router(neutron, module, router_id, network_id):
     }
     try:
         neutron.add_gateway_router(router_id, kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in adding gateway to router: %s" % e.message)
     return True
 
 def  _remove_gateway_router(neutron, module, router_id):
     try:
         neutron.remove_gateway_router(router_id)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in removing gateway to router: %s" % e.message)
     return True
 

--- a/library/cloud/quantum_router_interface
+++ b/library/cloud/quantum_router_interface
@@ -100,7 +100,7 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
     _os_keystone = kclient
@@ -110,7 +110,7 @@ def _get_ksclient(module, kwargs):
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
@@ -124,7 +124,7 @@ def _get_neutron_client(module, kwargs):
     }
     try:
         neutron = client.Client('2.0', **kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
     return neutron
 
@@ -149,7 +149,7 @@ def _get_router_id(module, neutron):
     }
     try:
         routers = neutron.list_routers(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in getting the router list: %s " % e.message)
     if not routers['routers']:
         return None
@@ -164,7 +164,7 @@ def _get_subnet_id(module, neutron):
     }
     try:
         subnets = neutron.list_subnets(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json( msg = " Error in getting the subnet list:%s " % e.message)
     if not subnets['subnets']:
         return None
@@ -177,7 +177,7 @@ def _get_port_id(neutron, module, router_id, subnet_id):
     }
     try:
         ports = neutron.list_ports(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json( msg = "Error in listing ports: %s" % e.message)
     if not ports['ports']:
         return None
@@ -193,7 +193,7 @@ def _add_interface_router(neutron, module, router_id, subnet_id):
     }
     try:
         neutron.add_interface_router(router_id, kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error in adding interface to router: %s" % e.message)
     return True
 
@@ -203,7 +203,7 @@ def  _remove_interface_router(neutron, module, router_id, subnet_id):
     }
     try:
         neutron.remove_interface_router(router_id, kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg="Error in removing interface from router: %s" % e.message)
     return True
 

--- a/library/cloud/quantum_subnet
+++ b/library/cloud/quantum_subnet
@@ -128,7 +128,7 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'))
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
     _os_keystone = kclient
@@ -138,7 +138,7 @@ def _get_ksclient(module, kwargs):
 def _get_endpoint(module, ksclient):
     try:
         endpoint = ksclient.service_catalog.url_for(service_type='network', endpoint_type='publicURL')
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
@@ -152,7 +152,7 @@ def _get_neutron_client(module, kwargs):
     }
     try:
         neutron = client.Client('2.0', **kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg = " Error in connecting to neutron: %s" % e.message)
     return neutron
 
@@ -177,7 +177,7 @@ def _get_net_id(neutron, module):
     }
     try:
         networks = neutron.list_networks(**kwargs)
-    except Exception as e:
+    except Exception, e:
         module.fail_json("Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
             return None
@@ -197,7 +197,7 @@ def _get_subnet_id(module, neutron):
         }
         try:
             subnets = neutron.list_subnets(**kwargs)
-        except Exception as e:
+        except Exception, e:
             module.fail_json( msg = " Error in getting the subnet list:%s " % e.message)
         if not subnets['subnets']:
             return None
@@ -239,7 +239,7 @@ def _create_subnet(module, neutron):
 def _delete_subnet(module, neutron, subnet_id):
     try:
         neutron.delete_subnet(subnet_id)
-    except Exception as e:
+    except Exception, e:
         module.fail_json( msg = "Error in deleting subnet: %s" % e.message)
     return True
 

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -199,7 +199,7 @@ def main():
         if login_user is not None and login_password is not None:
             client.admin.authenticate(login_user, login_password)
 
-    except ConnectionFailure as e:
+    except ConnectionFailure, e:
         module.fail_json(msg='unable to connect to database, check login_user and login_password are correct')
 
     if state == 'present':

--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -205,7 +205,7 @@ class SourcesList(object):
 
                         try:
                             f.write(line)
-                        except IOError as err:
+                        except IOError, err:
                             module.fail_json(msg="Failed to write to file %s: %s" % (tmp_path, unicode(err)))
                 module.atomic_move(tmp_path, filename)
             else:
@@ -366,7 +366,7 @@ def main():
             sourceslist.add_source(repo)
         elif state == 'absent':
             sourceslist.remove_source(repo)
-    except InvalidSource as err:
+    except InvalidSource, err:
         module.fail_json(msg='Invalid repository string: %s' % unicode(err))
 
     sources_after = sourceslist.dump()
@@ -378,7 +378,7 @@ def main():
             if update_cache:
                 cache = apt.Cache()
                 cache.update()
-        except OSError as err:
+        except OSError, err:
             module.fail_json(msg=unicode(err))
 
     module.exit_json(changed=changed, repo=repo, state=state)

--- a/plugins/inventory/digital_ocean.py
+++ b/plugins/inventory/digital_ocean.py
@@ -139,7 +139,7 @@ except ImportError:
 
 try:
     from dopy.manager import DoError, DoManager
-except ImportError as e:
+except ImportError, e:
     print "failed=True msg='`dopy` library required for this script'"
     sys.exit(1)
 

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -281,7 +281,7 @@ class Ec2Inventory(object):
                 for instance in reservation.instances:
                     self.add_instance(instance, region)
         
-        except boto.exception.BotoServerError as e:
+        except boto.exception.BotoServerError, e:
             if  not self.eucalyptus:
                 print "Looks like AWS is down again:"
             print e
@@ -297,7 +297,7 @@ class Ec2Inventory(object):
                 instances = conn.get_all_dbinstances()
                 for instance in instances:
                     self.add_rds_instance(instance, region)
-        except boto.exception.BotoServerError as e:
+        except boto.exception.BotoServerError, e:
             if not e.reason == "Forbidden":
                 print "Looks like AWS RDS is down: "
                 print e


### PR DESCRIPTION
Fix for #5852

I've changed all occurences in a code base for that.

Although we probably need to discuss first if we need this everywhere or only in parts of the code run on remote server (i.e. `library/*` etc).
