### PR TITLE
Allow 'PATCH' method in 'uri' module

### DIFF
--- a/library/network/uri
+++ b/library/network/uri
@@ -68,7 +68,7 @@ options:
     description:
       - The HTTP method of the request or response.
     required: false
-    choices: [ "GET", "POST", "PUT", "HEAD", "DELETE", "OPTIONS" ]
+    choices: [ "GET", "POST", "PUT", "HEAD", "DELETE", "OPTIONS", "PATCH" ]
     default: "GET"
   return_content:
     description:
@@ -309,7 +309,7 @@ def main():
             user = dict(required=False, default=None),
             password = dict(required=False, default=None),
             body = dict(required=False, default=None),
-            method = dict(required=False, default='GET', choices=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS']),
+            method = dict(required=False, default='GET', choices=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'PATCH']),
             return_content = dict(required=False, default='no', type='bool'),
             force_basic_auth = dict(required=False, default='no', type='bool'),
             follow_redirects = dict(required=False, default='no', type='bool'),


### PR DESCRIPTION
`httplib2` allows any HTTP method. Some APIs (e.g. GitHub) have some endpoint that expect the `PATCH` HTTP method, so add it to list of allowed `method` argument choices.
