### PR TITLE
Clean up stray space at the end of a line after a period.

### DIFF
--- a/library/web_infrastructure/htpasswd
+++ b/library/web_infrastructure/htpasswd
@@ -39,7 +39,7 @@ options:
   password:
     required: false
     description:
-      - Password associated with user. 
+      - Password associated with user.
       - Must be specified if user does not exist yet.
   crypt_scheme:
     required: false


### PR DESCRIPTION
This was driving me nuts.
