### PR TITLE
adding -K flag for ask-sudo-pass to ansible-pull

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -123,6 +123,8 @@ def main(args):
                       default=DEFAULT_REPO_TYPE,
                       help='Module name used to check out repository.  '
                       'Default is %s.' % DEFAULT_REPO_TYPE)
+    parser.add_option('-K', '--ask-sudo-pass', default=False, dest='ask_sudo_pass', action='store_true',
+                      help='ask for sudo password')
     options, args = parser.parse_args(args)
 
     hostname = socket.getfqdn()
@@ -180,6 +182,8 @@ def main(args):
     cmd = 'ansible-playbook %s %s' % (base_opts, playbook)
     if options.inventory:
         cmd += ' -i "%s"' % options.inventory
+    if options.ask_sudo_pass:
+        cmd += ' -K'
     os.chdir(options.dest)
 
     # RUN THE PLAYBOOK COMMAND


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

ansible 1.4.4
##### Environment:

Generic feature request, but I'm using Ubuntu 12.04
##### Summary:

Resubmission of pull request #4945.
I comfortably used ansible-playbook in my personal workflow with the -K flag. I recently tried ansible-pull but soon realized that it lacks the -K flag and many other flags found in ansible-playbook. This simple commit adds the -K flag to ansible-pull. Without it, I (and other users of the system) would need to run ansible-pull as a NOPASSWD user such as root, something I'd prefer not to do. Since ansible-pull simply calls ansible-playbook, might it make sense for most, if not all, of the flags available in ansible-playbook to be available in ansible-pull?
##### Steps To Reproduce:

ansible-pull -K ...
##### Expected Results:

ansible-pull -K asks for sudo password
##### Actual Results:

ansible-pull: error: no such option: -K
