### PR TITLE
Fixed UnicodeDecodeError: 'utf8' codec can't decode byte 0xb7 ...

### DIFF
--- a/library/network/uri
+++ b/library/network/uri
@@ -280,7 +280,7 @@ def uri(module, url, dest, user, password, body, method, headers, redirects, soc
         r['redirected'] = redirected
         r.update(resp_redir)
         r.update(resp)
-        return r, content, dest
+        return r, content.decode('utf-8', 'ignore'), dest
     except httplib2.RedirectMissingLocation:
         module.fail_json(msg="A 3xx redirect response code was provided but no Location: header was provided to point to the new location.")
     except httplib2.RedirectLimit:


### PR DESCRIPTION
Without this fix I get an ugly traceback when using the uri module using return_content=yes on my own website. Have not tested beyond that.

```
[dag@moria ~]$ ansible localhost -m uri -a 'url=http://dag.wieers.com/ return_content=yes'
localhost | FAILED >> {
    "failed": true, 
    "msg": "Traceback (most recent call last):\n  File \"/home/dag/.ansible/tmp/ansible-1391523728.61-242369951155415/uri\", line 1450, in <module>\n    main()\n  File \"/home/dag/.ansible/tmp/ansible-1391523728.61-242369951155415/uri\", line 419, in main\n    module.exit_json(changed=changed, content=content, **uresp)\n  File \"/home/dag/.ansible/tmp/ansible-1391523728.61-242369951155415/uri\", line 1258, in exit_json\n    print self.jsonify(kwargs)\n  File \"/home/dag/.ansible/tmp/ansible-1391523728.61-242369951155415/uri\", line 1248, in jsonify\n    return json.dumps(data)\n  File \"/usr/lib64/python2.6/json/__init__.py\", line 230, in dumps\n    return _default_encoder.encode(obj)\n  File \"/usr/lib64/python2.6/json/encoder.py\", line 367, in encode\n    chunks = list(self.iterencode(o))\n  File \"/usr/lib64/python2.6/json/encoder.py\", line 309, in _iterencode\n    for chunk in self._iterencode_dict(o, markers):\n  File \"/usr/lib64/python2.6/json/encoder.py\", line 275, in _iterencode_dict\n    for chunk in self._iterencode(value, markers):\n  File \"/usr/lib64/python2.6/json/encoder.py\", line 294, in _iterencode\n    yield encoder(o)\nUnicodeDecodeError: 'utf8' codec can't decode byte 0xb7 in position 2804: invalid start byte\n", 
    "parsed": false
}
```

After adding that snippet:

```
[dag@moria ~]$ ansible localhost -m uri -a 'url=http://dag.wieers.com/ return_content=yes'
localhost | success >> {
    "_content_encoding": "gzip", 
    "cache_control": "no-cache; must-revalidate", 
    "changed": false, 
    "connection": "close", 
    "content": "<HTML lang=\"en\">\n\t<head>\n\t\t<title>DAG: Field Commander Wieers</title>....</body>\n</html>\n", 
    "content_length": "11293", 
    "content_location": "http://dag.wiee.rs/", 
    "content_type": "text/html; charset=iso-8859-15", 
    "date": "Tue, 04 Feb 2014 14:21:11 GMT", 
    "expires": "0", 
    "last_modified": "Sat, 23 Nov 2013 01:11:36 GMT", 
    "pragma": "no-cache, no-store", 
    "redirected": false, 
    "server": "Apache/2.2.15 (CentOS)", 
    "status": 200, 
    "vary": "Accept-Encoding", 
    "x_powered_by": "PHP/5.3.3"
}
```
