### PR TITLE
Fix slow ssh

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -303,6 +303,9 @@ class Connection(object):
             # Calling wait while there are still pipes to read can cause a lock
             elif not rpipes and p.poll() == None:
                 p.wait()
+                # the process has finished and the pipes are empty,
+                # if we loop and do the select it waits all the timeout
+                break
         stdin.close() # close stdin after we read from stdout (see also issue #848)
         
         if C.HOST_KEY_CHECKING and not_in_host_file:

--- a/lib/ansible/runner/connection_plugins/ssh_old.py
+++ b/lib/ansible/runner/connection_plugins/ssh_old.py
@@ -261,6 +261,9 @@ class Connection(object):
             # Calling wait while there are still pipes to read can cause a lock
             elif not rpipes and p.poll() == None:
                 p.wait()
+                # the process has finished and the pipes are empty,
+                # if we loop and do the select it waits all the timeout
+                break
         stdin.close() # close stdin after we read from stdout (see also issue #848)
         
         if C.HOST_KEY_CHECKING and not_in_host_file:


### PR DESCRIPTION
We break the read while loop after waiting "the end of the process" and
the pipes are empty, otherwise we do another select that waits all the
timeout.
See #5570. Replace pull #5839.

This patch passes @jctanner's test:
`for i in {1..100}; do rm test/*.pyc ; nosetests --tests=test/TestSSH.py; done`

@lukyanov, can you please test this? 
