### PR TITLE
Create a common EC2 connection argument spec for EC2 modules

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -8,6 +8,15 @@ AWS_REGIONS = ['ap-northeast-1',
                'us-west-2']
 
 
+def ec2_argument_spec():
+    return dict(
+        region=dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
+        ec2_url=dict(),
+        ec2_secret_key=dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
+        ec2_access_key=dict(aliases=['aws_access_key', 'access_key']),
+    )
+
+
 def get_ec2_creds(module):
 
     # Check module args for credentials, then check environment vars

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -808,13 +808,12 @@ def startstop_instances(module, ec2, instance_ids):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             key_name = dict(aliases = ['keypair']),
             id = dict(),
             group = dict(type='list'),
             group_id = dict(type='list'),
-            region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
             zone = dict(aliases=['aws_zone', 'ec2_zone']),
             instance_type = dict(aliases=['type']),
             image = dict(),
@@ -824,9 +823,6 @@ def main():
             ramdisk = dict(),
             wait = dict(type='bool', default=False),
             wait_timeout = dict(default=300),
-            ec2_url = dict(),
-            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
-            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
             placement_group = dict(),
             user_data = dict(),
             instance_tags = dict(type='dict'),
@@ -839,6 +835,7 @@ def main():
             volumes = dict(type='list'),
         )
     )
+    module = AnsibleModule(argument_spec=argument_spec)
 
     ec2 = ec2_connect(module)
 

--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -252,11 +252,8 @@ def deregister_image(module, ec2):
     sys.exit(0)
 
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
-            ec2_url = dict(),
-            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
-            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             instance_id = dict(),
             image_id = dict(),
             delete_snapshot = dict(),
@@ -266,9 +263,9 @@ def main():
             description = dict(default=""),
             no_reboot = dict(default=False, type="bool"),
             state = dict(default='present'),
-            region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS)
         )
     )
+    module = AnsibleModule(argument_spec=argument_spec)
 
     ec2 = ec2_connect(module)
 

--- a/library/cloud/ec2_eip
+++ b/library/cloud/ec2_eip
@@ -209,18 +209,18 @@ def find_instance(ec2, instance_id, module):
     
 
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             instance_id = dict(required=False),
             public_ip = dict(required=False, aliases= ['ip']),
             state = dict(required=False, default='present',
                          choices=['present', 'absent']),
-            ec2_url = dict(required=False, aliases=['EC2_URL']),
-            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
-            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
-            region = dict(required=False, aliases=['ec2_region']),
             in_vpc = dict(required=False, choices=BOOLEANS, default=False),
-        ),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
         supports_check_mode=True
     )
 

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -107,18 +107,17 @@ def addRulesToLookup(rules, prefix, dict):
                                         grant.group_id, grant.cidr_ip)] = rule
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             name=dict(required=True),
             description=dict(required=True),
             vpc_id=dict(),
             rules=dict(),
-            ec2_url=dict(aliases=['EC2_URL']),
-            ec2_secret_key=dict(aliases=['EC2_SECRET_KEY', 'aws_secret_key'], no_log=True),
-            ec2_access_key=dict(aliases=['EC2_ACCESS_KEY', 'aws_access_key']),
-            region=dict(choices=AWS_REGIONS),
             state = dict(default='present', choices=['present', 'absent']),
-        ),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
         supports_check_mode=True,
     )
 

--- a/library/cloud/ec2_key
+++ b/library/cloud/ec2_key
@@ -97,16 +97,15 @@ except ImportError:
     sys.exit(1)
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             name=dict(required=True),
             key_material=dict(required=False),
-            ec2_url=dict(aliases=['EC2_URL']),
-            ec2_secret_key=dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
-            ec2_access_key=dict(aliases=['aws_access_key', 'access_key']),
-            region=dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
             state = dict(default='present', choices=['present', 'absent']),
-        ),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
         supports_check_mode=True,
     )
 

--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -103,17 +103,14 @@ except ImportError:
     sys.exit(1)
 
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             resource = dict(required=True),
             tags = dict(required=True),
-            region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
             state = dict(default='present', choices=['present', 'absent']),
-            ec2_url = dict(aliases=['EC2_URL']),
-            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
-            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
         )
     )
+    module = AnsibleModule(argument_spec=argument_spec)
 
     resource = module.params.get('resource')
     tags = module.params['tags']

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -139,20 +139,17 @@ except ImportError:
     sys.exit(1)
 
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             instance = dict(),
             volume_size = dict(required=True),
             iops = dict(),
             device_name = dict(),
-            region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
             zone = dict(aliases=['availability_zone', 'aws_zone', 'ec2_zone']),
-            ec2_url = dict(),
-            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
-            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
             snapshot = dict(),
         )
     )
+    module = AnsibleModule(argument_spec=argument_spec)
 
     instance = module.params.get('instance')
     volume_size = module.params.get('volume_size')


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

Based on:
ansible 1.5 (devel a0f91f2aaa) last updated 2014/02/05 20:43:12 (GMT +1000)
##### Environment:

N/A
##### Summary:

Refactor the currently well-factored ec2 modules (i.e. those that already use ec2_connect) to 
have a common argument spec. The idea is that new modules can use this spec without duplication
of code, and that new functionality can be added to the ec2 connection code (e.g. security 
token argument)
##### Steps To Reproduce:

N/A
##### Expected Results:

No actual change in functionality
##### Actual Results:

No apparent actual change in functionality of the modules I've tested
