### PR TITLE
Tell user to make inventory plugin executable

### DIFF
--- a/docsite/rst/guide_rax.rst
+++ b/docsite/rst/guide_rax.rst
@@ -171,8 +171,7 @@ directory and be sure the scripts are chmod +x, and the INI-based ones are not.
 rax.py
 ++++++
 
-To use the rackspace dynamic inventory script, copy ``rax.py`` from ``plugins/inventory`` into your inventory directory.  You can specify credentials 
-for ``rax.py`` utilizing the ``RAX_CREDS_FILE`` environment variable.
+To use the rackspace dynamic inventory script, copy ``rax.py`` from ``plugins/inventory`` into your inventory directory and make it executable. You can specify credentials for ``rax.py`` utilizing the ``RAX_CREDS_FILE`` environment variable.
 
 .. note:: Users of :doc:`tower` will note that dynamic inventory is natively supported by Tower, and all you have to do is associate a group with your Rackspace Cloud credentials, and it will easily synchronize without going through these steps::
 


### PR DESCRIPTION
The current version mentions nothing about chmod +x'ing the rax.py file, which means you get a really weird error message when you try to follow it:

```
raise ValueError, "No closing quotation"
```

... from deep inside shlex.py. I'm sure that makes sense if you realized that meant that it was trying to parse `rax.py` as an ini file...
