### PR TITLE
Accerate mode: Vulnerability fix/allowed finer grain configuration

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -157,6 +157,9 @@ ZEROMQ_PORT                    = get_config(p, 'fireball_connection', 'zeromq_po
 ACCELERATE_PORT                = get_config(p, 'accelerate', 'accelerate_port', 'ACCELERATE_PORT', 5099, integer=True)
 ACCELERATE_TIMEOUT             = get_config(p, 'accelerate', 'accelerate_timeout', 'ACCELERATE_TIMEOUT', 30, integer=True)
 ACCELERATE_CONNECT_TIMEOUT     = get_config(p, 'accelerate', 'accelerate_connect_timeout', 'ACCELERATE_CONNECT_TIMEOUT', 1.0, floating=True)
+ACCELERATE_KEYS_DIR            = get_config(p, 'accelerate', 'accelerate_keys_dir', 'ACCELERATE_KEYS_DIR', '~/.fireball.keys')
+ACCELERATE_KEYS_DIR_PERMS      = get_config(p, 'accelerate', 'accelerate_keys_dir_perms', 'ACCELERATE_KEYS_DIR_PERMS', '700')
+ACCELERATE_KEYS_FILE_PERMS     = get_config(p, 'accelerate', 'accelerate_keys_file_perms', 'ACCELERATE_KEYS_FILE_PERMS', '600')
 PARAMIKO_PTY                   = get_config(p, 'paramiko_connection', 'pty', 'ANSIBLE_PARAMIKO_PTY', True, boolean=True)
 
 # characters included in auto-generated passwords

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -87,15 +87,19 @@ def key_for_hostname(hostname):
     if not KEYCZAR_AVAILABLE:
         raise errors.AnsibleError("python-keyczar must be installed on the control machine to use accelerated modes")
 
-    key_path = os.path.expanduser("~/.fireball.keys")
+    key_path = os.path.expanduser(C.ACCELERATE_KEYS_DIR)
     if not os.path.exists(key_path):
         os.makedirs(key_path)
-    key_path = os.path.expanduser("~/.fireball.keys/%s" % hostname)
+    elif not os.path.isdir(key_path):
+        raise errors.AnsibleError('ACCELERATE_KEYS_DIR is not a directory.')
+    os.chmod(key_path, int(C.ACCELERATE_KEYS_DIR_PERMS, 8))
+    key_path = os.path.join(key_path, hostname)
 
     # use new AES keys every 2 hours, which means fireball must not allow running for longer either
     if not os.path.exists(key_path) or (time.time() - os.path.getmtime(key_path) > 60*60*2):
         key = AesKey.Generate()
-        fh = open(key_path, "w")
+        fd = os.open(key_path, os.O_WRONLY | os.O_CREAT, int(C.ACCELERATE_KEYS_FILE_PERMS, 8))
+        fh = os.fdopen(fd, 'w')
         fh.write(str(key))
         fh.close()
         return key

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -94,7 +94,7 @@ def key_for_hostname(hostname):
     elif not os.path.isdir(key_path):
         raise errors.AnsibleError('ACCELERATE_KEYS_DIR is not a directory.')
 
-    if stat.S_IMODE(os.stat(key_path).st_mode) != C.ACCELERATE_KEYS_DIR_PERMS:
+    if stat.S_IMODE(os.stat(key_path).st_mode) != int(C.ACCELERATE_KEYS_DIR_PERMS, 8):
         raise errors.AnsibleError('Incorrect permissions on ACCELERATE_KEYS_DIR (%s)' % (C.ACCELERATE_KEYS_DIR,))
 
     key_path = os.path.join(key_path, hostname)
@@ -108,7 +108,7 @@ def key_for_hostname(hostname):
         fh.close()
         return key
     else:
-        if stat.S_IMODE(os.stat(key_path).st_mode) != C.ACCELERATE_KEYS_FILE_PERMS:
+        if stat.S_IMODE(os.stat(key_path).st_mode) != int(C.ACCELERATE_KEYS_FILE_PERMS, 8):
             raise errors.AnsibleError('Incorrect permissions on ACCELERATE_KEYS_FILE (%s)' % (key_path,))
         fh = open(key_path)
         key = AesKey.Read(fh.read())


### PR DESCRIPTION
Accelerate mode saves the key files to ~/.fireball.keys/<hostname> with world readable permissions by default. This is clearly not acceptable as an attacker can then trivially access the accelerated daemon by having a cronjob which checks for these keys in all user home directories.

In addition, if multiple users want to be able to use the same ansible script, they have to wait for the previous user's daemon to timeout before they will be able to run the script - as the previous user's daemon is hogging the fireball port but the new user does not have the correct keys. Hence, I have allowed the fireball keys directory and files to have their location and permissions configured so that they may be in one global place and given group access to everyone in some group associated with ansible deployment.
