### PR TITLE
Pick up default EC2 region from boto.config

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -53,6 +53,9 @@ def get_ec2_creds(module):
             region = os.environ['EC2_REGION']
         elif 'AWS_REGION' in os.environ:
             region = os.environ['AWS_REGION']
+        else:
+            # boto.config.get returns None if config not found
+            region = boto.config.get('Boto', 'ec2_region_name')
 
     return ec2_url, ec2_access_key, ec2_secret_key, region
 


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

ansible-playbook 1.5 (devel 0bc0315171) last updated 2014/02/07 22:20:33 (GMT +1000)
##### Environment:

N/A
##### Summary:

Allows users to not set region parameter in EC2 modules when they
already have `ec2_region_name` set in their boto configuration file.

This doesn't account for boto configs where e.g. RDS has one
default region and EC2 another - all regions will default to `ec2_region_name`. 
However, this just changes the very last fallback for setting region rather than
having it be None.

However, this is just handy to allow an easy site wide default
region if existing configuration already relies on it.

Modules can be improved to mention this in the documentation and
turn off required=True where needed. But it works with `ec2`
and `ec2_vol` without change to those modules. 
##### Steps To Reproduce:

N/A
##### Expected Results:

No actual change in functionality
##### Actual Results:

No apparent actual change in functionality of the modules I've tested
