### PR TITLE
Symlink to relative paths in target directory (documentaion update); fix of incorrect usage of the force parameter in case of hard links

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -123,8 +123,7 @@ options:
     default: "no"
     choices: [ "yes", "no" ]
     description:
-      - 'force the creation of the symlinks in two cases: the source file does 
-        not exist (but will appear later); the destination exists and is a file (so, we need to unlink the
+      - 'force the creation of the symlinks when the destination exists and is a file (so, we need to unlink the
         "path" file and create symlink to the "src" file in place of it).'
 notes:
     - See also M(copy), M(template), M(assemble)
@@ -135,6 +134,10 @@ author: Michael DeHaan
 EXAMPLES = '''
 - file: path=/etc/foo.conf owner=foo group=foo mode=0644
 - file: src=/file/to/link/to dest=/path/to/symlink owner=foo group=foo state=link
+- file: path=/tmp/{{ item.path }} dest={{ item.dest }} state=link
+  with_items:
+    - { path: 'x', dest: 'y' }
+    - { path: 'z', dest: 'k' }
 '''
 
 def main():

--- a/library/files/file
+++ b/library/files/file
@@ -149,7 +149,6 @@ def main():
             original_basename = dict(required=False), # Internal use only, for recursive ops
             recurse  = dict(default='no', type='bool'),
             force = dict(required=False,default=False,type='bool'),
-            chdir = dict(required=False,default=False),
             diff_peek = dict(default=None),
             validate = dict(required=False, default=None),
         ),
@@ -161,14 +160,7 @@ def main():
     state  = params['state']
     force = params['force']
 
-    params['chdir'] = chdir = os.path.expanduser(params['chdir'])
     params['path'] = path = os.path.expanduser(params['path'])
-
-    if state == 'link' and chdir is not None and os.isdir(chdir):
-        os.chdir(chdir)
-        # catch exception permission deny, no directory, etc
-        # save current working directory, chdir to it at the end of the module
-        # or before any escape
 
     # short-circuit for diff_peek
     if params.get('diff_peek', None) is not None:
@@ -298,7 +290,7 @@ def main():
             else:
                 module.fail_json(msg="absolute paths are required")
 
-            if not os.path.exists(abs_src) and not force:
+            if not os.path.exists(abs_src):
                 module.fail_json(path=path, src=src, msg='src file does not exist')
 
         if prev_state == 'absent':

--- a/library/files/file
+++ b/library/files/file
@@ -149,6 +149,7 @@ def main():
             original_basename = dict(required=False), # Internal use only, for recursive ops
             recurse  = dict(default='no', type='bool'),
             force = dict(required=False,default=False,type='bool'),
+            chdir = dict(required=False,default=False),
             diff_peek = dict(default=None),
             validate = dict(required=False, default=None),
         ),
@@ -159,7 +160,15 @@ def main():
     params = module.params
     state  = params['state']
     force = params['force']
+
+    params['chdir'] = chdir = os.path.expanduser(params['chdir'])
     params['path'] = path = os.path.expanduser(params['path'])
+
+    if state == 'link' and chdir is not None and os.isdir(chdir):
+        os.chdir(chdir)
+        # catch exception permission deny, no directory, etc
+        # save current working directory, chdir to it at the end of the module
+        # or before any escape
 
     # short-circuit for diff_peek
     if params.get('diff_peek', None) is not None:


### PR DESCRIPTION
Dear Ansible Dev Team,

Here is the brief description of my small work:
- Update of the description of the 'force' parameter (file module now allows to create symlinks to non-existent desctinations)
- The addition of one example of creation the symlink pointing to non-absolute paths of type `x -> y` in target directory
- fixed incorrect usage of force parameter in case of hard links: src must always exists, otherwise non-correct error message is produced. For example, non-correct message (/tmp/yyy does not exist):

```
[root] # ansible 127.0.0.1 --connection=local -m file -a "path=/tmp/xxx src=/tmp/yyy state=hard force=yes"
127.0.0.1 | FAILED >> {
    "failed": true, 
    "msg": "Error while linking: [Errno 2] No such file or directory", 
    "path": "/tmp/xxx", 
    "state": "absent"
}
```

Patched version (/tmp/yyy does not exist):

```
[root@abpc11619] /var/lib/ansible # ansible 127.0.0.1 --connection=local -m file -a "path=/tmp/xxx src=/tmp/yyy state=hard force=yes"
127.0.0.1 | FAILED >> {
    "failed": true, 
    "msg": "src file does not exist", 
    "path": "/tmp/xxx", 
    "src": "/tmp/yyy", 
    "state": "absent"
}
```
