### PR TITLE
Support for -a to accept a file with test-module

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -89,6 +89,11 @@ def boilerplate_module(modfile, args, interpreter):
     #included_boilerplate = module_data.find(module_common.REPLACER) != -1 or module_data.find("import ansible.module_utils") != -1
 
     complex_args = {}
+    if args.startswith("@"):
+        # Argument is a YAML file (JSON is a subset of YAML)
+        complex_args = utils.combine_vars(complex_args, utils.parse_yaml_from_file(args[1:]))
+        args=''
+
     inject = {}
     if interpreter:
         if '=' not in interpreter:


### PR DESCRIPTION
If the CLI value for -a starts with an @, treat it like a file, and dump the contents into complex_args

This supports yaml or json.

Tests:

args.json

``` json
{
    "filter": "ansible_hostname"
}
```

args.yaml

``` yaml

---
filter: ansible_hostname
```

```
$ ./test-module -m ../library/system/setup -a filter=ansible_hostname
* including generated source, if any, saving to: /path/to/.ansible_module_generated
* this may offset any line numbers in tracebacks/debuggers!
***********************************
RAW OUTPUT
{"verbose_override": true, "changed": false, "ansible_facts": {"ansible_hostname": "foobar"}}


***********************************
PARSED OUTPUT
{
    "ansible_facts": {
        "ansible_hostname": "foobar"
    },
    "changed": false,
    "verbose_override": true
}
```

```
$ ./test-module -m ../library/system/setup -a @args.yaml
* including generated source, if any, saving to: /path/to/.ansible_module_generated
* this may offset any line numbers in tracebacks/debuggers!
***********************************
RAW OUTPUT
{"verbose_override": true, "changed": false, "ansible_facts": {"ansible_hostname": "foobar"}}


***********************************
PARSED OUTPUT
{
    "ansible_facts": {
        "ansible_hostname": "foobar"
    },
    "changed": false,
    "verbose_override": true
}
```

```
$ ./test-module -m ../library/system/setup -a @args.json
* including generated source, if any, saving to: /path/to/.ansible_module_generated
* this may offset any line numbers in tracebacks/debuggers!
***********************************
RAW OUTPUT
{"verbose_override": true, "changed": false, "ansible_facts": {"ansible_hostname": "foobar"}}


***********************************
PARSED OUTPUT
{
    "ansible_facts": {
        "ansible_hostname": "foobar"
    },
    "changed": false,
    "verbose_override": true
}
```
