### PR TITLE
Make sure requested version tag gets downloaded

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -280,6 +280,17 @@ def get_branches(git_path, module, dest):
         branches.append(line.strip())
     return branches
 
+def get_tags(git_path, module, dest):
+    os.chdir(dest)
+    tags = []
+    cmd = '%s tag' % (git_path,)
+    (rc, out, err) = module.run_command(cmd)
+    if rc != 0:
+        module.fail_json(msg="Could not determine tag data - received %s" % out)
+    for line in out.split('\n'):
+        tags.append(line.strip())
+    return tags
+
 def is_remote_branch(git_path, module, dest, remote, version):
     cmd = '%s ls-remote %s -h refs/heads/%s' % (git_path, remote, version)
     (rc, out, err) = module.run_command(cmd, check_rc=True)
@@ -492,6 +503,10 @@ def main():
             if local_mods:
                 module.exit_json(changed=True, before=before, after=remote_head,
                     msg="Local modifications exist")
+            elif is_remote_tag(git_path, module, dest, repo, version):
+                # if the remote is a tag and we have the tag locally, exit early
+                if version in get_tags(git_path, module, dest):
+                    module.exit_json(changed=False, before=before, after=remote_head)
             else:
                 module.exit_json(changed=False, before=before, after=remote_head)
         if module.check_mode:


### PR DESCRIPTION
There is a subtle bug in how the git module currently works. If the
version you request is a tag name, and you've already got the repo
cloned, and the tag name is a new tag, but refers to the already checked
out working copy, the git module would exit early without change. This
is bad as it means the new tag ref was not fetched and could not be used
in later tasks.

This change will check if the version is a remote tag, and if the tag
doesn't exist locally. If that is true, it'll do a fetch.

The activity could still be seen as not a change, because the working
copy won't be updated, if the new tag refers to the already checked out
copy, but that's not different than before and can be fixed as a more
comprehensive overhaul of tracking change in the git module.
