### PR TITLE
NPM install latest made more effecient

### DIFF
--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -209,7 +209,11 @@ def main():
             changed = True
             npm.install()
     elif state == 'latest':
-        npm.install()
+        installed, missing = npm.list()
+        outdated = npm.list_outdated()
+        if len(missing) or len(outdated):
+           changed = True
+           npm.install()
     else: #absent
         installed, missing = npm.list()
         if name in installed:

--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -212,8 +212,8 @@ def main():
         installed, missing = npm.list()
         outdated = npm.list_outdated()
         if len(missing) or len(outdated):
-           changed = True
-           npm.install()
+            changed = True
+            npm.install()
     else: #absent
         installed, missing = npm.list()
         if name in installed:

--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -209,12 +209,7 @@ def main():
             changed = True
             npm.install()
     elif state == 'latest':
-        installed, missing = npm.list()
-        outdated = npm.list_outdated()
-        if len(missing) or len(outdated):
-            changed = True
-            npm.install()
-            npm.update()
+        npm.install()
     else: #absent
         installed, missing = npm.list()
         if name in installed:


### PR DESCRIPTION
`npm install` is smart enough to only update updated modules. Checking for `outdated` and running `update` repeats the same process 2x.
