### PR TITLE
Fix for #4992 - Add userdata to cloud/nova_compute

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -107,6 +107,11 @@ options:
         - The amount of time the module should wait for the VM to get into active state
      required: false
      default: 180
+   user_data:
+     description:
+        - Opaque blob of data which is made available to the instance
+     required: false
+     default: None
 requirements: ["novaclient"]
 '''
 
@@ -157,6 +162,8 @@ def _create_server(module, nova):
                 'meta' : module.params['meta'],
                 'key_name': module.params['key_name'],
                 'security_groups': module.params['security_groups'].split(','),
+                #userdata is unhyphenated in novaclient, but hyphenated here for consistency with the ec2 module:
+                'userdata': module.params['user_data'],
     }
     if not module.params['key_name']:
         del bootkwargs['key_name']
@@ -227,7 +234,8 @@ def main():
         meta                            = dict(default=None),
         wait                            = dict(default='yes', choices=['yes', 'no']),
         wait_for                        = dict(default=180),
-        state                           = dict(default='present', choices=['absent', 'present'])
+        state                           = dict(default='present', choices=['absent', 'present']),
+        user_data                       = dict(default=None)
         ),
     )
 


### PR DESCRIPTION
In common with the submitter of issue #4992 , I needed to create VMs on an OpenStack using the nova_compute module but it didn't have support for the userdata parameter.  Simple addition, only complication is that the underlying novaclient calls it 'userdata' but for consistency with the ec2 module, I've hyphenated the param to user_data.  I tested by adding this to my nova_compute task:

 user_data: "#!/bin/bash\necho Hello > /tmp/output\n"

The VM launched (edit: which had cloud-init installed) then had the expected text in the expected file.  

Note that a future improvement would be to allow a filename to be passed in and the contents of that file sent to novaclient - but this scratches my immediate itch :-)
