### PR TITLE
BUGFIX: fixes a bug introduced by the use of get_ec2_creds in the rds module

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -8,13 +8,22 @@ AWS_REGIONS = ['ap-northeast-1',
                'us-west-2']
 
 
-def ec2_argument_spec():
+def ec2_argument_keys_spec():
     return dict(
-        region=dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
-        ec2_url=dict(),
-        ec2_secret_key=dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
-        ec2_access_key=dict(aliases=['aws_access_key', 'access_key']),
+        aws_secret_key=dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True),
+        aws_access_key=dict(aliases=['ec2_access_key', 'access_key']),
     )
+
+
+def ec2_argument_spec():
+    spec = ec2_argument_keys_spec()
+    spec.update(
+        dict(
+            region=dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
+            ec2_url=dict(),
+        )
+    )
+    return spec
 
 
 def get_ec2_creds(module):
@@ -22,8 +31,8 @@ def get_ec2_creds(module):
     # Check module args for credentials, then check environment vars
 
     ec2_url = module.params.get('ec2_url')
-    ec2_secret_key = module.params.get('ec2_secret_key')
-    ec2_access_key = module.params.get('ec2_access_key')
+    ec2_secret_key = module.params.get('aws_secret_key')
+    ec2_access_key = module.params.get('aws_access_key')
     region = module.params.get('region')
 
     if not ec2_url:

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -1045,6 +1045,8 @@ def main():
 
     ec2 = ec2_connect(module)
 
+    tagged_instances = [] 
+
     if module.params.get('state') == 'absent':
         instance_ids = module.params.get('instance_ids')
         if not isinstance(instance_ids, list):
@@ -1064,7 +1066,6 @@ def main():
         if not module.params.get('image'):
             module.fail_json(msg='image parameter is required for new instance')
    
-        tagged_instances = [] 
         if module.params.get('exact_count'):
             (tagged_instances, instance_dict_array, new_instance_ids, changed) = enforce_count(module, ec2)
         else:            

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -284,19 +284,19 @@ class ElbManager:
 
 
 def main():
-
-    module = AnsibleModule(
-        argument_spec=dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             state={'required': True,
                     'choices': ['present', 'absent']},
             instance_id={'required': True},
             ec2_elbs={'default': None, 'required': False, 'type':'list'},
-            ec2_secret_key={'default': None, 'aliases': ['aws_secret_key', 'secret_key'], 'no_log': True},
-            ec2_access_key={'default': None, 'aliases': ['aws_access_key', 'access_key']},
-            region={'default': None, 'required': False, 'aliases':['aws_region', 'ec2_region'], 'choices':AWS_REGIONS},
             enable_availability_zone={'default': True, 'required': False, 'choices': BOOLEANS, 'type': 'bool'},
             wait={'required': False, 'choices': BOOLEANS, 'default': True, 'type': 'bool'}
         )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
     )
 
     # def get_ec2_creds(module):

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -439,8 +439,8 @@ class ElbManager(object):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             state={'required': True, 'choices': ['present', 'absent']},
             name={'required': True},
             listeners={'default': None, 'required': False, 'type': 'list'},
@@ -450,15 +450,11 @@ def main():
             purge_zones={'default': False, 'required': False,
                          'choices': BOOLEANS, 'type': 'bool'},
             health_check={'default': None, 'required': False, 'type': 'dict'},
-            ec2_secret_key={'default': None,
-                            'aliases': ['aws_secret_key', 'secret_key'],
-                            'no_log': True},
-            ec2_access_key={'default': None,
-                            'aliases': ['aws_access_key', 'access_key']},
-            region={'default': None, 'required': False,
-                    'aliases': ['aws_region', 'ec2_region'],
-                    'choices': AWS_REGIONS},
         )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
     )
 
     # def get_ec2_creds(module):

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -471,8 +471,8 @@ def terminate_vpc(module, vpc_conn, vpc_id=None, cidr=None):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             cidr_block = dict(),
             wait = dict(choices=BOOLEANS, default=False),
             wait_timeout = dict(default=300),
@@ -482,11 +482,12 @@ def main():
             vpc_id = dict(),
             internet_gateway = dict(choices=BOOLEANS, default=False),
             route_tables = dict(type='list'),
-            region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
             state = dict(choices=['present', 'absent'], default='present'),
-            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
-            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
         )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
     )
 
     state = module.params.get('state')

--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -458,8 +458,8 @@ class ElastiCacheManager(object):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             state={'required': True, 'choices': ['present', 'absent', 'rebooted']},
             name={'required': True},
             engine={'required': False, 'default': 'memcached'},
@@ -470,17 +470,13 @@ def main():
             cache_security_groups={'required': False, 'default': ['default'],
                                    'type': 'list'},
             zone={'required': False, 'default': None},
-            ec2_secret_key={'default': None,
-                            'aliases': ['aws_secret_key', 'secret_key'],
-                            'no_log': True},
-            ec2_access_key={'default': None,
-                            'aliases': ['aws_access_key', 'access_key']},
-            region={'default': None, 'required': False,
-                    'aliases': ['aws_region', 'ec2_region'],
-                    'choices': AWS_REGIONS},
             wait={'required': False, 'choices': BOOLEANS, 'default': True},
             hard_modify={'required': False, 'choices': BOOLEANS, 'default': False}
         )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
     )
 
     ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)

--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -277,8 +277,8 @@ def get_current_resource(conn, resource, command):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
             command           = dict(choices=['create', 'replicate', 'delete', 'facts', 'modify', 'promote', 'snapshot', 'restore'], required=True),
             instance_name     = dict(required=True),
             source_instance   = dict(required=False),
@@ -300,17 +300,18 @@ def main():
             maint_window      = dict(required=False),
             backup_window     = dict(required=False),
             backup_retention  = dict(required=False), 
-            region            = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS, required=False),
             zone              = dict(aliases=['aws_zone', 'ec2_zone'], required=False),
             subnet            = dict(required=False),
-            aws_secret_key    = dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True, required=False),
-            aws_access_key    = dict(aliases=['ec2_access_key', 'access_key'], required=False),
             wait              = dict(type='bool', default=False),
             wait_timeout      = dict(default=300),
             snapshot          = dict(required=False),
             apply_immediately = dict(type='bool', default=False),
             new_instance_name = dict(required=False),
         )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
     )
 
     command            = module.params.get('command')

--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -145,19 +145,18 @@ def commit(changes):
             time.sleep(500)
 
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
+    argument_spec = ec2_argument_keys_spec()
+    argument_spec.update(dict(
             command         = dict(choices=['get', 'create', 'delete'], required=True),
             zone            = dict(required=True),
             record          = dict(required=True),
             ttl             = dict(required=False, default=3600),
             type            = dict(choices=['A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS'], required=True),
             value           = dict(required=False), 
-            ec2_secret_key  = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True, required=False),
-            ec2_access_key  = dict(aliases=['aws_access_key', 'access_key'], required=False),
             overwrite       = dict(required=False, type='bool')
         )
     )
+    module = AnsibleModule(argument_spec=argument_spec)
 
     command_in            = module.params.get('command')
     zone_in               = module.params.get('zone')

--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -249,8 +249,8 @@ def is_walrus(s3_url):
         return False
 
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
+    argument_spec = ec2_argument_keys_spec()
+    argument_spec.update(dict(
             bucket         = dict(required=True),
             object         = dict(),
             src            = dict(),
@@ -258,11 +258,10 @@ def main():
             mode           = dict(choices=['get', 'put', 'delete', 'create', 'geturl', 'getstr'], required=True),
             expiry         = dict(default=600, aliases=['expiration']),
             s3_url         = dict(aliases=['S3_URL']),
-            ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
-            ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
             overwrite      = dict(aliases=['force'], default=True, type='bool'),
-        ),
+        )
     )
+    module = AnsibleModule(argument_spec=argument_spec)
 
     bucket = module.params.get('bucket')
     obj = module.params.get('object')


### PR DESCRIPTION
Commit 12005a1 modified the rds module to use get_ec2_creds. Most of the ec2 modules use the ec2_access_key and ec2_secret_key nomenclature and get_ec2_creds extracts those module parameters. However, rds uses aws_access_key and aws_secret_key instead with an alias for ec2_*.

As a result, the rds module will not authenticate properly if aws___key are used, and will instead use only the AWS__ environment variables if they are defined.

This fix standardizes the AWS cloud module access and secret key naming convention on aws_access_key and aws_secret_key as more encompassing names.
