### PR TITLE
Fix get_url to support FTP URLs containing credentials

### DIFF
--- a/library/network/get_url
+++ b/library/network/get_url
@@ -151,7 +151,10 @@ def url_do_get(module, url, dest, use_proxy, last_mod_time, force):
             username = credentials
             password = ''
         parsed = list(parsed)
-        parsed[1] = netloc
+
+        # Skip credential stripping if URL scheme is ftp
+        if parsed[0] != 'ftp':
+            parsed[1] = netloc
 
         passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
         # this creates a password manager


### PR DESCRIPTION
I noticed get_url is stripping credentials from URLs to place into a urllib2 HTTPPasswordMgr.  This doesn't work for FTP URLs, so this is just a way to skip the replacement for the FTP scheme'd URLs.
