### PR TITLE
Include all man pages in Arch Linux package.

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Michel Blanc <mblanc@erasme.org>
 
 pkgname=ansible-git
-pkgver=1.1.3403.g5cd97e8
+pkgver=1.1.4095.g3f2f5fe
 pkgrel=1
-pkgdesc='A radically simple IT automation'
+pkgdesc='Radically simple IT automation platform'
 arch=('any')
 url='http://www.ansible.com'
 license=('GPL3')
@@ -43,11 +43,8 @@ package() {
   install -D README.md "$pkgdir/usr/share/doc/ansible/README.md"
   install -D COPYING "$pkgdir/usr/share/doc/ansible/COPYING"
   install -D CHANGELOG.md "$pkgdir/usr/share/doc/ansible/CHANGELOG.md"
-  install -D CONTRIBUTING.md "$pkgdir/usr/share/doc/ansible/CONTRIBUTING.md"
-  install -D RELEASES.txt "$pkgdir/usr/share/doc/ansible/RELEASES.txt"
 
-  install -D docs/man/man1/ansible.1 "$pkgdir/usr/share/man/man1/ansible.1"
-  install -D docs/man/man1/ansible-playbook.1 "$pkgdir/usr/share/man/man1/ansible-playbook.1"
-  install -D docs/man/man1/ansible-pull.1 "$pkgdir/usr/share/man/man1/ansible-pull.1"
-  install -D docs/man/man1/ansible-doc.1 "$pkgdir/usr/share/man/man1/ansible-doc.1"
+  mkdir -p "$pkgdir/usr/share/man/man{1,3}"
+  cp -dpr --no-preserve=ownership docs/man/man1/*.1 "$pkgdir/usr/share/man/man1"
+  cp -dpr --no-preserve=ownership docs/man/man3/*.3 "$pkgdir/usr/share/man/man3"
 }


### PR DESCRIPTION
While we're on it, change $pkgdesc to follow its counterpart from
official repositories. Additionally don't install RELEASES.txt and
CONTRIBUTING.md; there is little use for them from the user's perspective.
