### PR TITLE
Fix Linode inventory plugin causing a Chube exception when attempting to obtain information on a specific Linode host

### DIFF
--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -132,7 +132,7 @@ class LinodeInventory(object):
                 if os.path.isfile(self.cache_path_index):
                     return True
         return False
- 
+
     def read_settings(self):
         """Reads the settings from the .ini file."""
         config = ConfigParser.SafeConfigParser()
@@ -204,7 +204,7 @@ class LinodeInventory(object):
         dest = node.label
 
         # Add to index
-        self.index[dest] = [node.api_id]
+        self.index[dest] = node.api_id
 
         # Inventory: Group by node ID (always a group of 1)
         self.inventory[node.api_id] = [dest]


### PR DESCRIPTION
Running Ansible 1.5, I see the following error when attempting to run the inventory plugin with the "--host" option to retrieve info on a specific host:

/note: I've replaced real API values with dummy data to protect my Linode account/

```
$ ansible/plugins/inventory/linode.py --host host1
Traceback (most recent call last):
  File "ansible/plugins/inventory/linode.py", line 306, in <module>
    LinodeInventory()
  File "ansible/plugins/inventory/linode.py", line 116, in __init__
    data_to_print = self.get_host_info()
  File "ansible/plugins/inventory/linode.py", line 234, in get_host_info
    node = self.get_node(node_id)
  File "ansible/plugins/inventory/linode.py", line 178, in get_node
    return Linode.find(api_id=linode_id)
  File "<<base path obfuscated>>/env/lib/python2.7/site-packages/chube/util.py", line 29, in f_new
    return f(*f_args, **f_kwargs)
  File "<<base path obfuscated>>/env/lib/python2.7/site-packages/chube/linode_obj.py", line 139, in find
    if len(a) < 1: raise RuntimeError("No Linode found with the given criteria (%s)" % (kwargs,))
RuntimeError: No Linode found with the given criteria ({'api_id': [0001]})
```

According to an earlier API call, this host does exist with the expected api_key:

```
$ ansible/plugins/inventory/linode.py
{
  "0001": [
    "host1"
  ],
  "0002": [
    "host2"
  ],
  "": [
    "host1",
    "host2"
  ]
}
```

It looks like the cause is the api_id is being passed as a list to Chube as it is stored as one in the file index. I have altered to script to add api IDs to the index as an int.

cc original author, @danslimmon
