### PR TITLE
BUGFIX: Fixes UnboundLocalError issue with the ec2 module

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -1045,6 +1045,8 @@ def main():
 
     ec2 = ec2_connect(module)
 
+    tagged_instances = []
+
     if module.params.get('state') == 'absent':
         instance_ids = module.params.get('instance_ids')
         if not isinstance(instance_ids, list):
@@ -1064,7 +1066,6 @@ def main():
         if not module.params.get('image'):
             module.fail_json(msg='image parameter is required for new instance')
    
-        tagged_instances = [] 
         if module.params.get('exact_count'):
             (tagged_instances, instance_dict_array, new_instance_ids, changed) = enforce_count(module, ec2)
         else:            


### PR DESCRIPTION
Fixes this issue:
    module.exit_json(changed=changed, instance_ids=new_instance_ids, instances=instance_dict_array, tagged_instances=tagged_instances\
)
UnboundLocalError: local variable 'tagged_instances' referenced before assignment

Which was introduced with this commit: https://github.com/ansible/ansible/commit/70ebb051907e1716c8ea62f4dacdea39a6071e55
