### PR TITLE
add mongodb replicaset support

### DIFF
--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -46,6 +46,11 @@ options:
             - The port to connect to
         required: false
         default: 27017
+    replicaset:
+        description:
+            - Replicaset to connect to (automatically connects to primary for writes)
+        required: false
+        default: null
     database:
         description:
             - The name of the database to add/remove the user from
@@ -98,6 +103,7 @@ import ConfigParser
 try:
     from pymongo.errors import ConnectionFailure
     from pymongo.errors import OperationFailure
+    from pymongo.errors import PyMongoError
     from pymongo import MongoClient
 except ImportError:
     try:  # for older PyMongo 2.2
@@ -165,6 +171,7 @@ def main():
             login_password=dict(default=None),
             login_host=dict(default='localhost'),
             login_port=dict(default='27017'),
+            replicaset=dict(default=None),
             database=dict(required=True, aliases=['db']),
             user=dict(required=True, aliases=['name']),
             password=dict(aliases=['pass']),
@@ -180,6 +187,7 @@ def main():
     login_password = module.params['login_password']
     login_host = module.params['login_host']
     login_port = module.params['login_port']
+    replicaset = module.params['replicaset']
     db_name = module.params['database']
     user = module.params['user']
     password = module.params['password']
@@ -187,7 +195,11 @@ def main():
     state = module.params['state']
 
     try:
-        client = MongoClient(login_host, int(login_port))
+    	if replicaset:
+    	   client = MongoClient(login_host, int(login_port), replicaset=replicaset)
+    	else:
+    	   client = MongoClient(login_host, int(login_port))
+
         if login_user is None and login_password is None:
             mongocnf_creds = load_mongocnf()
             if mongocnf_creds is not False:

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -100,14 +100,16 @@ EXAMPLES = '''
 '''
 
 import ConfigParser
+from distutils.version import LooseVersion
 try:
     from pymongo.errors import ConnectionFailure
     from pymongo.errors import OperationFailure
-    from pymongo.errors import PyMongoError
     from pymongo import MongoClient
+    from pymongo import version as PyMongoVersion
 except ImportError:
     try:  # for older PyMongo 2.2
         from pymongo import Connection as MongoClient
+        from pymongo import version as PyMongoVersion
     except ImportError:
         pymongo_found = False
     else:
@@ -120,42 +122,33 @@ else:
 #
 
 def user_add(module, client, db_name, user, password, roles):
-    try:
-        db = client[db_name]
-        if roles is None:
-            db.add_user(user, password, False)
-        else:
-            try:
-                db.add_user(user, password, None, roles=roles)
-            except:
-                module.fail_json(msg='"problem adding user; you must be on mongodb 2.4+ and pymongo 2.5+ to use the roles param"')
-    except OperationFailure:
-        return False
-
-    return True
+    db = client[db_name]
+    if roles is None:
+        db.add_user(user, password, False)
+    else:
+        try:
+            db.add_user(user, password, None, roles=roles)
+        except OperationFailure, e:
+            err_msg = str(e)
+            if LooseVersion(PyMongoVersion) <= LooseVersion('2.5'):
+                err_msg = err_msg + ' (Note: you must be on mongodb 2.4+ and pymongo 2.5+ to use the roles param)'
+            module.fail_json(msg=err_msg)
 
 def user_remove(client, db_name, user):
-    try:
-        db = client[db_name]
-        db.remove_user(user)
-    except OperationFailure:
-        return False
-
-    return True
+    db = client[db_name]
+    db.remove_user(user)
 
 def load_mongocnf():
     config = ConfigParser.RawConfigParser()
     mongocnf = os.path.expanduser('~/.mongodb.cnf')
-    if not os.path.exists(mongocnf):
-        return False
 
     try:
         config.readfp(open(mongocnf))
         creds = dict(
-          user=config.get('client', 'user'),
-          password=config.get('client', 'pass')
+            user=config.get('client', 'user'),
+            password=config.get('client', 'pass')
         )
-    except (ConfigParser.NoOptionError, IOError):
+    except IOError:
         return False
 
     return creds
@@ -212,16 +205,22 @@ def main():
             client.admin.authenticate(login_user, login_password)
 
     except ConnectionFailure, e:
-        module.fail_json(msg='unable to connect to database, check login_user and login_password are correct')
+        module.fail_json(msg='unable to connect to database: %s' % str(e))
 
     if state == 'present':
         if password is None:
             module.fail_json(msg='password parameter required when adding a user')
-        if user_add(module, client, db_name, user, password, roles) is not True:
-            module.fail_json(msg='Unable to add or update user, check login_user and login_password are correct and that this user has access to the admin collection')
+
+        try:
+            user_add(module, client, db_name, user, password, roles)
+        except OperationFailure, e:
+            module.fail_json(msg='Unable to add or update user: %s' % str(e))
+
     elif state == 'absent':
-        if user_remove(client, db_name, user) is not True:
-            module.fail_json(msg='Unable to remove user, check login_user and login_password are correct and that this user has access to the admin collection')
+        try:
+            user_remove(client, db_name, user)
+        except OperationFailure, e:
+            module.fail_json(msg='Unable to remove user: %s' % str(e))
 
     module.exit_json(changed=True, user=user)
 

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -47,9 +47,9 @@ options:
             - The port to connect to
         required: false
         default: 27017
-    replicaset:
+    replica_set:
         description:
-            - Replicaset to connect to (automatically connects to primary for writes)
+            - Replica set to connect to (automatically connects to primary for writes)
         required: false
         default: null
     database:
@@ -98,6 +98,9 @@ EXAMPLES = '''
 - mongodb_user: database=burgers name=ben password=12345 roles='read' state=present
 - mongodb_user: database=burgers name=jim password=12345 roles='readWrite,dbAdmin,userAdmin' state=present
 - mongodb_user: database=burgers name=joe password=12345 roles='readWriteAnyDatabase' state=present
+
+# add a user to database in a replica set, the primary server is automatically discovered and written to
+- mongodb_user: database=burgers name=bob replica_set=blecher password=12345 roles='readWriteAnyDatabase' state=present
 '''
 
 import ConfigParser
@@ -165,7 +168,7 @@ def main():
             login_password=dict(default=None),
             login_host=dict(default='localhost'),
             login_port=dict(default='27017'),
-            replicaset=dict(default=None),
+            replica_set=dict(default=None),
             database=dict(required=True, aliases=['db']),
             user=dict(required=True, aliases=['name']),
             password=dict(aliases=['pass']),
@@ -181,7 +184,7 @@ def main():
     login_password = module.params['login_password']
     login_host = module.params['login_host']
     login_port = module.params['login_port']
-    replicaset = module.params['replicaset']
+    replica_set = module.params['replica_set']
     db_name = module.params['database']
     user = module.params['user']
     password = module.params['password']
@@ -189,8 +192,8 @@ def main():
     state = module.params['state']
 
     try:
-    	if replicaset:
-    	   client = MongoClient(login_host, int(login_port), replicaset=replicaset)
+    	if replica_set:
+    	   client = MongoClient(login_host, int(login_port), replicaset=replica_set)
     	else:
     	   client = MongoClient(login_host, int(login_port))
 

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+# (c) 2014, Epic Games, Inc.
 # (c) 2012, Elliott Foster <elliott@fourkitchens.com>
 # Sponsored by Four Kitchens http://fourkitchens.com.
 #

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -108,12 +108,11 @@ from distutils.version import LooseVersion
 try:
     from pymongo.errors import ConnectionFailure
     from pymongo.errors import OperationFailure
-    from pymongo import MongoClient
     from pymongo import version as PyMongoVersion
+    from pymongo import MongoClient
 except ImportError:
     try:  # for older PyMongo 2.2
         from pymongo import Connection as MongoClient
-        from pymongo import version as PyMongoVersion
     except ImportError:
         pymongo_found = False
     else:

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -146,10 +146,10 @@ def load_mongocnf():
     try:
         config.readfp(open(mongocnf))
         creds = dict(
-            user=config.get('client', 'user'),
-            password=config.get('client', 'pass')
+          user=config.get('client', 'user'),
+          password=config.get('client', 'pass')
         )
-    except IOError:
+    except (ConfigParser.NoOptionError, IOError):
         return False
 
     return creds

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 
-# (c) 2014, Epic Games, Inc.
 # (c) 2012, Elliott Foster <elliott@fourkitchens.com>
 # Sponsored by Four Kitchens http://fourkitchens.com.
+# (c) 2014, Epic Games, Inc.
 #
 # This file is part of Ansible
 #

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -28,6 +28,7 @@ import yum
 try:
     from yum.misc import find_unfinished_transactions, find_ts_remaining
     from rpmUtils.miscutils import splitFilename
+    from rpmUtils.miscutils import compareEVR
     transaction_helpers = True
 except:
     transaction_helpers = False
@@ -38,7 +39,7 @@ module: yum
 version_added: historical
 short_description: Manages packages with the I(yum) package manager
 description:
-     - Installs, upgrade, removes, and lists packages and groups with the I(yum) package manager.
+     - Installs, upgrades, downgrades, removes and lists packages and groups with the I(yum) package manager.
 options:
   name:
     description:
@@ -450,6 +451,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
     res['msg'] = ''
     res['rc'] = 0
     res['changed'] = False
+    downgrade = False
 
     for spec in items:
         pkg = None
@@ -524,12 +526,30 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                     
             if found:
                 continue
+
+            # downgrade - the yum install command will only install or upgrade to a spec version, it will
+            # not install an older version of an RPM even if specifed by the install spec. So we need to 
+            # determine if this is a downgrade, and then use the yum downgrade command to install the RPM.
+            pkg_name = splitFilename(spec)[0]
+            pkgs = is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True)
+            if pkgs:
+                (cur_name, cur_ver, cur_rel, cur_epoch, cur_arch) = splitFilename(pkgs[0])
+                (new_name, new_ver, new_rel, new_epoch, new_arch) = splitFilename(spec)
+
+                compare = compareEVR((cur_epoch, cur_ver, cur_rel), (new_epoch, new_ver, new_rel))
+                if compare > 0:
+                    downgrade = True
+
             # if not - then pass in the spec as what to install
             # we could get here if nothing provides it but that's not
             # the error we're catching here
             pkg = spec
 
-        cmd = yum_basecmd + ['install', pkg]
+        operation = 'install'
+        if downgrade:
+            operation = 'downgrade'
+
+        cmd = yum_basecmd + [operation, pkg]
 
         if module.check_mode:
             module.exit_json(changed=True)

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -28,7 +28,6 @@ import yum
 try:
     from yum.misc import find_unfinished_transactions, find_ts_remaining
     from rpmUtils.miscutils import splitFilename
-    from rpmUtils.miscutils import compareEVR
     transaction_helpers = True
 except:
     transaction_helpers = False
@@ -39,7 +38,7 @@ module: yum
 version_added: historical
 short_description: Manages packages with the I(yum) package manager
 description:
-     - Installs, upgrades, downgrades, removes and lists packages and groups with the I(yum) package manager.
+     - Installs, upgrade, removes, and lists packages and groups with the I(yum) package manager.
 options:
   name:
     description:
@@ -451,7 +450,6 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
     res['msg'] = ''
     res['rc'] = 0
     res['changed'] = False
-    downgrade = False
 
     for spec in items:
         pkg = None
@@ -526,30 +524,12 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                     
             if found:
                 continue
-
-            # downgrade - the yum install command will only install or upgrade to a spec version, it will
-            # not install an older version of an RPM even if specifed by the install spec. So we need to 
-            # determine if this is a downgrade, and then use the yum downgrade command to install the RPM.
-            pkg_name = splitFilename(spec)[0]
-            pkgs = is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True)
-            if pkgs:
-                (cur_name, cur_ver, cur_rel, cur_epoch, cur_arch) = splitFilename(pkgs[0])
-                (new_name, new_ver, new_rel, new_epoch, new_arch) = splitFilename(spec)
-
-                compare = compareEVR((cur_epoch, cur_ver, cur_rel), (new_epoch, new_ver, new_rel))
-                if compare > 0:
-                    downgrade = True
-
             # if not - then pass in the spec as what to install
             # we could get here if nothing provides it but that's not
             # the error we're catching here
             pkg = spec
 
-        operation = 'install'
-        if downgrade:
-            operation = 'downgrade'
-
-        cmd = yum_basecmd + [operation, pkg]
+        cmd = yum_basecmd + ['install', pkg]
 
         if module.check_mode:
             module.exit_json(changed=True)


### PR DESCRIPTION
user add will fail if you're not connected to the current primary (the primary can change), specifying the replicaset allows pymongo to automatically determine which host is the primary and add the user to the correct host.
