### PR TITLE
Add functionality to unit test cloud modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ debian/
 # Vim swap files
 *.swp
 *.swo
+# Test related files
+.coverage

--- a/hacking/unit-test-module
+++ b/hacking/unit-test-module
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+# (c) 2014, Matt Martz <matt@sivel.net>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# this script is for testing modules without running through the
+# entire guts of ansible, and is very helpful for when developing
+# modules
+#
+# example:
+#    unit-test-module -m ../library/cloud/rax_facts
+#    unit-test-module -c -m ../library/cloud/rax_facts
+
+import os
+import re
+import sys
+import optparse
+import subprocess
+import ansible.module_common as module_common
+
+try:
+    import coverage
+    HAS_COVERAGE = True
+    del coverage
+except:
+    HAS_COVERAGE = False
+
+
+def parse():
+    """parse command line
+
+    :return : (options, args)"""
+    parser = optparse.OptionParser()
+
+    parser.usage = "%prog -[options] (-h for help)"
+
+    parser.add_option('-m', '--module-path', dest='module_path',
+        help='REQUIRED: full path of module source to execute')
+    parser.add_option('-c', '--coverage', dest='coverage',
+        help='Check test coverage', action='store_true')
+    parser.add_option('-v', '--verbose', dest='verbose',
+        help='Show verbose unit test output', action='store_const',
+        const=' -v', default='')
+    parser.add_option('-I', '--interpreter', dest='interpreter',
+        help="path to interpeter to use for this module (e.g. ansible_python_interpreter=/usr/bin/python)",
+        metavar='INTERPRETER_TYPE=INTERPRETER_PATH')
+    options, args = parser.parse_args()
+    if not options.module_path:
+        parser.print_help()
+        sys.exit(1)
+    else:
+        return options, args
+
+
+def boilerplate_module(modfile, interpreter):
+    """ simulate what ansible does with new style modules """
+
+    main_pattern = re.compile('^main\(\)', flags=re.M)
+
+    replacer = module_common.ModuleReplacer()
+
+    complex_args = {}
+    args = ''
+    inject = {}
+    if interpreter:
+        if '=' not in interpreter:
+            print 'interpeter must by in the form of ansible_python_interpreter=/usr/bin/python'
+            sys.exit(1)
+        interpreter_type, interpreter_path = interpreter.split('=')
+        if not interpreter_type.startswith('ansible_'):
+            interpreter_type = 'ansible_%s' % interpreter_type
+        if not interpreter_type.endswith('_interpreter'):
+            interpreter_type = '%s_interpreter' % interpreter_type
+        inject[interpreter_type] = interpreter_path
+
+    (module_data, module_style, shebang) = replacer.modify_module(
+        modfile,
+        complex_args,
+        args,
+        inject
+    )
+
+    mod_name = os.path.basename(modfile)
+
+    mockfile = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'test',
+                            'inject_module_unit_test', '%s_tests.py' % mod_name)
+
+    if not os.path.isfile(mockfile):
+        print "ERROR: Tests for this module do not exist"
+        sys.exit(1)
+    f_mock = open(mockfile)
+    mockdata = f_mock.read()
+    f_mock.close()
+
+    module_data = main_pattern.sub(mockdata, module_data)
+
+    modfile2_path = os.path.expanduser("~/.ansible_unit_test_%s" % mod_name)
+    print "* Including generated source, if any, saving to: %s" % modfile2_path
+    print "* This may offset any line numbers in tracebacks/debuggers!\n"
+    modfile2 = open(modfile2_path, 'w')
+    modfile2.write(module_data)
+    modfile2.close()
+    modfile = modfile2_path
+
+    return (modfile2_path, module_style)
+
+
+def runtest(modfile, coverage, verbose):
+    """Test run a module, piping it's output for reporting."""
+
+    os.system("chmod +x %s" % modfile)
+
+    if coverage and not HAS_COVERAGE:
+        print '* Unable to check and report on unit test coverage'
+        print '* Please install the "coverage" python module for this functionality'
+        coverage = False
+
+    if coverage:
+        invoke = "coverage erase; coverage run --source=%s %s%s; coverage report -m" % (modfile, modfile, verbose)
+    else:
+        invoke = "%s%s" % (modfile, verbose)
+
+    cmd = subprocess.Popen(invoke, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (out, err) = cmd.communicate()
+    print out
+    print err
+    sys.exit(cmd.returncode)
+
+
+def main():
+    options, args = parse()
+    (modfile, module_style) = boilerplate_module(options.module_path, options.interpreter)
+
+    runtest(modfile, options.coverage, options.verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/inject_module_unit_test/rax_facts_tests.py
+++ b/test/inject_module_unit_test/rax_facts_tests.py
@@ -1,0 +1,109 @@
+import StringIO
+import unittest
+
+try:
+    from novaclient.tests.v1_1 import fakes
+except:
+    raise SystemExit('"python-novaclient" module not installed')
+
+try:
+    import fixtures
+except ImportError:
+    raise SystemExit('"fixtures" module not installed')
+
+try:
+    import testtools
+except ImportError:
+    raise SystemExit('"testtools" module not installed')
+
+
+def setup_rax_module(module, rax_module):
+    rax_module.cloudservers = fakes.FakeClient()
+    return rax_module
+
+
+class RaxFactsTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(RaxFactsTest, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        self.sys_stdout = sys.stdout
+        self.sys_stderr = sys.stderr
+        sys.stdout = StringIO.StringIO()
+        sys.stderr = StringIO.StringIO()
+
+    def tearDown(self):
+        sys.stdout = self.sys_stdout
+        sys.stderr = self.sys_stderr
+
+    def run_main(self):
+        try:
+            main()
+        except SystemExit:
+            pass
+        return json.loads(sys.stdout.getvalue())
+
+    def test_correct_id(self):
+        global MODULE_ARGS
+        MODULE_ARGS = 'id=1234'
+        output = self.run_main()
+        self.assertTrue(isinstance(output, dict), 'Parsed JSON is not a dict')
+        self.assertNotEqual(output['ansible_facts'], {}, 'ansible_facts is empty')
+        self.assertEqual(output['ansible_facts'].get('rax_id'), 1234, 'The ID of the server does not match')
+
+    def test_incorrect_id(self):
+        global MODULE_ARGS
+        MODULE_ARGS = 'id=12345'
+        output = self.run_main()
+        self.assertTrue(isinstance(output, dict), 'Parsed JSON is not a dict')
+        self.assertEqual(output['ansible_facts'], {}, 'ansible_facts is not empty')
+
+    @unittest.skip('The FakeClient does not currently support filtered queries')
+    def test_correct_name(self):
+        global MODULE_ARGS
+        MODULE_ARGS = 'name=sample-server3'
+        output = self.run_main()
+        self.assertTrue(isinstance(output, dict), 'Parsed JSON is not a dict')
+        self.assertNotEqual(output['ansible_facts'], {}, 'ansible_facts is empty')
+        self.assertEqual(output['ansible_facts'].get('rax_name'), 'sample-server3', 'The name of the server does not match')
+
+    @unittest.skip('The FakeClient does not currently support filtered queries')
+    def test_incorrect_name(self):
+        global MODULE_ARGS
+        MODULE_ARGS = 'name=ansible'
+        output = self.run_main()
+        self.assertEqual(output['ansible_facts'], {}, 'ansible_facts is not empty')
+
+    @unittest.skip('The FakeClient does not currently support filtered queries')
+    def test_multi_name_match(self):
+        global MODULE_ARGS
+        MODULE_ARGS = 'name=sample-server'
+        output = self.run_main()
+        multi = {
+            'msg': 'Multiple servers found matching provided search parameters',
+            'failed': True
+        }
+        self.assertEqual(output.get('failed'), multi['failed'], 'Response did not indicate a failure')
+        self.assertEqual(output.get('msg'), multi['msg'], 'Response did not indicate multiple matches')
+
+    def test_correct_ip(self):
+        global MODULE_ARGS
+        MODULE_ARGS = 'address=1.2.3.4'
+        output = self.run_main()
+        self.assertEqual(output['ansible_facts'].get('rax_id'), 1234, 'The ID of the server does not match')
+
+    def test_incorrect_ip(self):
+        global MODULE_ARGS
+        MODULE_ARGS = 'address=11.22.33.44'
+        output = self.run_main()
+        self.assertEqual(output['ansible_facts'], {}, 'ansible_facts is not empty')
+
+    def test_mutually_exclusive(self):
+        global MODULE_ARGS
+        MODULE_ARGS = 'address=1.2.3.4 id=1.2.3.4'
+        output = self.run_main()
+        self.assertEqual(output.get('failed'), True, 'Response did not indicate a failure')
+        self.assertTrue('parameters are mutually exclusive' in output.get('msg'), 'No error indicating mutually exclusive argument failure')
+
+
+unittest.main()


### PR DESCRIPTION
@jctanner approached me about thinking of ways to unit test our cloud modules a day or so ago, and since then he and I have been chatting about ideas to make unit testing modules like rax and ec2 possible.  Currently they are not easily unit testable, and require integration testing.

Not everyone is going to have access to cloud environments that they will want to use for testing, and this could still help us catch issues with updates and such.  James pointed out that #5285 as a prime example of needing this functionality.

Thinking over the process, I couldn't really see a way in, other than taking the approach of how test-module works. For those that don't know, test-module basically uses ModuleReplacer to build out the module as it would appear during ansible execution, writes it to a file, and then subprocess.Popen()s it, and evaluates stdout.

I took this a little further, and after ModuleReplacer does it's thing, I strip out the `main()` call, and replace it with Mock, monkey patching, and test cases, from a file that would live in `test/inject_module_unit_test`.  The files in there would be named something like `MODULE_NAME_tests.py`, such as `test/inject_module_unit_test/rax_facts_tests.py`.

Then we run subprocess.Popen on the file, optionally running it via coverage.

I've only created tests for rax_facts right now, as it was simple and required minimal test cases an Mock/Monkey patching for testing.

A sample run looks like:

```
$ ./unit-test-module -c -v -m ../library/cloud/rax_facts
* including generated source, if any, saving to: /Users/matt/.ansible_unit_test_rax_facts
* this may offset any line numbers in tracebacks/debuggers!

Name                                       Stmts   Miss  Cover   Missing
------------------------------------------------------------------------
/Users/matt/.ansible_unit_test_rax_facts     886    546    38%   86-88, 115-119, 128-129, 138, 237-245, 250, 258-259, 263-264, 268, 290, 294-308, 316-332, 355-357, 392-417, 431-436, 439-449, 453-456, 467-469, 473-485, 488-503, 506-510, 513-516, 520-545, 548-567, 570-589, 592-630, 634-646, 649-661, 672-702, 714, 718, 723, 730-733, 738, 743, 745, 756, 764, 768, 772, 777-778, 786, 788, 798-803, 808-835, 852-895, 898, 920-921, 942, 953, 956-965, 978-996, 1000-1009, 1015, 1021, 1035, 1041-1053, 1057, 1061-1063, 1068-1075, 1078-1082, 1088-1130, 1146-1195, 1198-1211, 1237-1291, 1345-1350, 1355-1358, 1363-1371

test_correct_id (__main__.RaxFactsTest) ... ok
test_correct_ip (__main__.RaxFactsTest) ... ok
test_correct_name (__main__.RaxFactsTest) ... skipped 'The FakeClient does not currently support filtered queries'
test_incorrect_id (__main__.RaxFactsTest) ... ok
test_incorrect_ip (__main__.RaxFactsTest) ... ok
test_incorrect_name (__main__.RaxFactsTest) ... skipped 'The FakeClient does not currently support filtered queries'
test_multi_name_match (__main__.RaxFactsTest) ... skipped 'The FakeClient does not currently support filtered queries'
test_mutually_exclusive (__main__.RaxFactsTest) ... ok

----------------------------------------------------------------------
Ran 8 tests in 0.007s

OK (skipped=3)
```

For info, the actual module code extends to line 169, so a majority of that coverage is not pertinent, but can still be useful.

cc @willthames @claco @angstwad @j2sol @erjohnso 

For everyone CC'ed here, just trying to raise visibility.  I think @jctanner and I are ready to see this go in.
