### PR TITLE
rax module: Use regex start and end of string with name base filters

### DIFF
--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -576,7 +576,7 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                     names = [name] * count
             else:
                 search_opts = {
-                    'name': name,
+                    'name': '^%s$' % name,
                     'image': image,
                     'flavor': flavor
                 }
@@ -612,7 +612,7 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                     module.fail_json(msg='%s is required for the "rax" '
                                          'module' % arg)
             search_opts = {
-                'name': name,
+                'name': '^%s$' % name,
                 'image': image,
                 'flavor': flavor
             }

--- a/library/cloud/rax_facts
+++ b/library/cloud/rax_facts
@@ -112,7 +112,7 @@ def rax_facts(module, address, name, server_id):
 
     search_opts = {}
     if name:
-        search_opts = dict(name=name)
+        search_opts = dict(name='^%s$' % name)
         try:
             servers = cs.servers.list(search_opts=search_opts)
         except Exception, e:


### PR DESCRIPTION
When filtering via the API, the value of the name parameter is a regex match string.  Make sure to include beginning and end of string regex characters for exact matches.
