### PR TITLE
Fix broken behavior when removing all auxiliary groups from a user

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -443,7 +443,7 @@ class User(object):
         if self.groups is None:
             return None
         info = self.user_info()
-        groups = set(self.groups.split(','))
+        groups = set(filter(None, self.groups.split(',')))
         for g in set(groups):
             if not self.group_exists(g):
                 self.module.fail_json(msg="Group %s does not exist" % (g))


### PR DESCRIPTION
Fix broken behavior when removing all auxiliary groups from a user (e.g. 'groups=' in the user module). See #5933 for a tad more detail.
