### PR TITLE
Fix various typos in markdown documentation

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -6,7 +6,7 @@ Hi!  Thanks for interest in contributing to Ansible.
 Here are some guidelines for contributing code.  The purpose of this document are to establish what we're looking for in code contributions, and to make sure
 new contributions know some of the conventions that we've been using.
 
-We don't think much of this should be too strange to readers familar with contributing to Python projects, though it helps if we all get on the same page.
+We don't think much of this should be too strange to readers familiar with contributing to Python projects, though it helps if we all get on the same page.
 
 Language
 ========
@@ -44,7 +44,7 @@ Shebang Lines
 =============
  
   * /usr/bin/scripts should start with '/usr/bin/env python'
-  * module code should still use '/usr/bin/python' as this is replaced automatically by 'ansible_python_interpeter', see the FAQ in the docs for more info.
+  * module code should still use '/usr/bin/python' as this is replaced automatically by 'ansible_python_interpreter', see the FAQ in the docs for more info.
 
 Comments
 ========
@@ -58,7 +58,7 @@ Comments
 Classes
 =======
 
-  * With the exception of module code (where inline is better), it is deseriable to see classes in their own files.
+  * With the exception of module code (where inline is better), it is desirable to see classes in their own files.
   * Classes should generally not cause side effects as soon as they are instantiated, move meaningful behavior to methods rather than constructors.
  
 Functions and Methods
@@ -262,7 +262,7 @@ To test if something is a string, consider that it may be unicode.
     if type(x) == str:
 
     # yes
-    if isintance(x, basestring):
+    if isinstance(x, basestring):
 
 Cleverness
 ==========

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ to see if the issue has already been reported.
 When filing a bug, the following information is always required:
 
 * A good name for the bug ("Foo module raises exception when xyz=glork is used", vs "foo doesn't work")
-* A succint description of the problem
+* A succinct description of the problem
 * What version of ansible you are using (ansible --version)
 * Steps to reproduce the problem, including commands or playbook snippets as relevant
 * Expected results

--- a/examples/issues/ISSUE_TEMPLATE.md
+++ b/examples/issues/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@ Please summarize your request in this space.  You will earn bonus points for bei
 
 ##### Steps To Reproduce:
 
-If this is a bug ticket, please enter the steps you use to reproduce the problem in the space below.  If this is a feature request, please enter the steps you would use to use the feature.  If an example playbook is useful, please include a short reproducer inline, indented by four spaces.  If a longer one is neccessary, please link one uploaded to gist.github.com. 
+If this is a bug ticket, please enter the steps you use to reproduce the problem in the space below.  If this is a feature request, please enter the steps you would use to use the feature.  If an example playbook is useful, please include a short reproducer inline, indented by four spaces.  If a longer one is necessary, please link one uploaded to gist.github.com. 
 
 ##### Expected Results:
 

--- a/packaging/macports/README.md
+++ b/packaging/macports/README.md
@@ -1,6 +1,6 @@
 This portfile installs ansible from the git repository, it will install the
 latest and greatest version of ansible. This portfile does not install the
-required dependancies to run in fireball mode.
+required dependencies to run in fireball mode.
 
 ## Installing the stable version of ansible via macports
 


### PR DESCRIPTION
Fix various typos in markdown documentation.

There are various other typos and spelling mistakes in other files. I assume you don't want a "big bang" PR. Would one PR for docsite/rst be OK?
