### PR TITLE
rax module: Don't set a default for disk_config

### DIFF
--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -645,7 +645,7 @@ def main():
             auto_increment=dict(choices=BOOLEANS, default=True, type='bool'),
             count=dict(default=1, type='int'),
             count_offset=dict(default=1, type='int'),
-            disk_config=dict(default='auto', choices=['auto', 'manual']),
+            disk_config=dict(choices=['auto', 'manual']),
             exact_count=dict(choices=BOOLEANS, default=False, type='bool'),
             files=dict(type='dict', default={}),
             flavor=dict(),
@@ -678,7 +678,9 @@ def main():
     auto_increment = module.params.get('auto_increment')
     count = module.params.get('count')
     count_offset = module.params.get('count_offset')
-    disk_config = module.params.get('disk_config').upper()
+    disk_config = module.params.get('disk_config')
+    if disk_config:
+        disk_config = disk_config.upper()
     exact_count = module.params.get('exact_count', False)
     files = module.params.get('files')
     flavor = module.params.get('flavor')


### PR DESCRIPTION
Don't set a default for disk_config. Defaulting to 'auto', causes issues with new images.

It has always been best practice to not send a disk_config option to the API unless specifically provided.  We are currently breaking best practices by defaulting the value to AUTO.

This should have no impact to anyone, as in all current cases where auto_disk_config is enabled, AUTO happens to be the default if no disk_config is specified.
