### PR TITLE
rax_facts and rax_keypair modules: update docs

### DIFF
--- a/library/cloud/rax_facts
+++ b/library/cloud/rax_facts
@@ -22,19 +22,56 @@ description:
      - Gather facts for Rackspace Cloud Servers.
 version_added: "1.4"
 options:
+  api_key:
+    description:
+      - Rackspace API key (overrides I(credentials))
+    aliases:
+      - password
+  auth_endpoint:
+    description:
+      - The URI of the authentication service
+    default: https://identity.api.rackspacecloud.com/v2.0/
+    version_added: 1.5
+  credentials:
+    description:
+      - File to find the Rackspace credentials in (ignored if I(api_key) and
+        I(username) are provided)
+    default: null
+    aliases:
+      - creds_file
+  env:
+    description:
+      - Environment as configured in ~/.pyrax.cfg,
+        see https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#pyrax-configuration
+    version_added: 1.5
+  identity_type:
+    description:
+      - Authentication machanism to use, such as rackspace or keystone
+    default: rackspace
+    version_added: 1.5
+  region:
+    description:
+      - Region to create an instance in
+    default: DFW
+  tenant_id:
+    description:
+      - The tenant ID used for authentication
+    version_added: 1.5
+  tenant_name:
+    description:
+      - The tenant name used for authentication
+    version_added: 1.5
+  username:
+    description:
+      - Rackspace username (overrides I(credentials))
+  verify_ssl:
+    description:
+      - Whether or not to require SSL validation of API endpoints
+    version_added: 1.5
   address:
     description:
       - Server IP address to retrieve facts for, will match any IP assigned to
         the server
-  api_key:
-    description:
-      - Rackspace API key (overrides C(credentials))
-  credentials:
-    description:
-      - File to find the Rackspace credentials in (ignored if C(api_key) and
-        C(username) are provided)
-    default: null
-    aliases: ['creds_file']
   id:
     description:
       - Server ID to retrieve facts for
@@ -42,13 +79,6 @@ options:
     description:
       - Server name to retrieve facts for
     default: null
-  region:
-    description:
-      - Region to retrieve facts for
-    default: DFW
-  username:
-    description:
-      - Rackspace username (overrides C(credentials))
 requirements: [ "pyrax" ]
 author: Matt Martz
 notes:

--- a/library/cloud/rax_keypair
+++ b/library/cloud/rax_keypair
@@ -24,13 +24,50 @@ version_added: 1.5
 options:
   api_key:
     description:
-      - Rackspace API key (overrides C(credentials))
+      - Rackspace API key (overrides I(credentials))
+    aliases:
+      - password
+  auth_endpoint:
+    description:
+      - The URI of the authentication service
+    default: https://identity.api.rackspacecloud.com/v2.0/
+    version_added: 1.5
   credentials:
     description:
-      - File to find the Rackspace credentials in (ignored if C(api_key) and
-        C(username) are provided)
+      - File to find the Rackspace credentials in (ignored if I(api_key) and
+        I(username) are provided)
     default: null
-    aliases: ['creds_file']
+    aliases:
+      - creds_file
+  env:
+    description:
+      - Environment as configured in ~/.pyrax.cfg,
+        see https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#pyrax-configuration
+    version_added: 1.5
+  identity_type:
+    description:
+      - Authentication machanism to use, such as rackspace or keystone
+    default: rackspace
+    version_added: 1.5
+  region:
+    description:
+      - Region to create an instance in
+    default: DFW
+  tenant_id:
+    description:
+      - The tenant ID used for authentication
+    version_added: 1.5
+  tenant_name:
+    description:
+      - The tenant name used for authentication
+    version_added: 1.5
+  username:
+    description:
+      - Rackspace username (overrides I(credentials))
+  verify_ssl:
+    description:
+      - Whether or not to require SSL validation of API endpoints
+    version_added: 1.5
   name:
     description:
       - Name of keypair
@@ -39,13 +76,6 @@ options:
     description:
       - Public Key string to upload
     default: null
-  region:
-    description:
-      - Region to create the key pair in
-    default: DFW
-  username:
-    description:
-      - Rackspace username (overrides C(credentials))
   state:
     description:
       - Indicate desired state of the resource


### PR DESCRIPTION
The rax_facts and rax_keypair modules also support the auth attributes added for other OpenStack clouds.

This pull request adds documentation for the new attributes.
