### PR TITLE
Allow hacking/env-setup module path to use config file library path

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -21,7 +21,8 @@ PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 
 [[ $PYTHONPATH != ${PREFIX_PYTHONPATH}* ]] && export PYTHONPATH=$PREFIX_PYTHONPATH:$PYTHONPATH
 [[ $PATH != ${PREFIX_PATH}* ]] && export PATH=$PREFIX_PATH:$PATH
-export ANSIBLE_LIBRARY="$ANSIBLE_HOME/library"
+unset ANSIBLE_LIBRARY
+export ANSIBLE_LIBRARY="$ANSIBLE_HOME/library:`python $HACKING_DIR/get_library.py`"
 [[ $MANPATH != ${PREFIX_MANPATH}* ]] && export MANPATH=$PREFIX_MANPATH:$MANPATH
 
 # Print out values unless -q is set

--- a/hacking/get_library.py
+++ b/hacking/get_library.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# (c) 2014, Will Thames <will@thames.id.au>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import ansible.constants as C
+import sys
+
+def main():
+    print C.DEFAULT_MODULE_PATH
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
hacking/env-setup now adds the configured library path in ANSIBLE_CONFIG
to the ANSIBLE_LIBRARY environment variable in addition to the previous
default of ANSIBLE_HOME/library.

This replaces #5950.
