### PR TITLE
mention that include works with addtional task files

### DIFF
--- a/docsite/rst/playbooks_roles.rst
+++ b/docsite/rst/playbooks_roles.rst
@@ -193,6 +193,7 @@ This designates the following behaviors, for each role 'x':
 - Any copy tasks can reference files in roles/x/files/ without having to path them relatively or absolutely
 - Any script tasks can reference scripts in roles/x/files/ without having to path them relatively or absolutely
 - Any template tasks can reference files in roles/x/templates/ without having to path them relatively or absolutely
+- Any include tasks can reference files in roles/x/tasks/ without having to path them relatively or absolutely
    
 In Ansible 1.4 and later you can configure a roles_path to search for roles.  Use this to check all of your common roles out to one location, and share
 them easily between multiple playbook projects.  See :doc:`intro_configuration` for details about how to set this up in ansible.cfg.


### PR DESCRIPTION
Mention we can include roles/x/tasks/anothertasks.yml with `include anothertasks.yml` within the role's `main.yml` as this is not obvious from the documentation
