### PR TITLE
remove check for version string

### DIFF
--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -196,13 +196,6 @@ def main():
     result['name'] = name
     result['state'] = state
 
-    # Decide if the name contains a version number.
-    match = re.search("-[0-9]", name)
-    if match:
-        specific_version = True
-    else:
-        specific_version = False
-
     # Get package state
     installed_state = get_package_state(module, name)
 


### PR DESCRIPTION
this check does not get used anywhere and is not needed as zypper/rpm can handle version information directly
