### PR TITLE
Reverting unarchive tests.

### DIFF
--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -410,21 +410,23 @@ class TestPlaybook(unittest.TestCase):
         assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
 
 
-    def test_unarchive(self):
-        pb = 'test/playbook-unarchive.yml'
-        actual = self._run(pb)
-
-        expected =  {
-            "localhost": {
-                "changed": 29,
-                "failures": 0,
-                "ok": 33,
-                "skipped": 12,
-                "unreachable": 0
-            }
-        }
-
-        assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
+    # Disabled for now as there are permissions issues that happen if you are not the owner that created files
+    # in the archive.
+    # def test_unarchive(self):
+    #     pb = 'test/playbook-unarchive.yml'
+    #     actual = self._run(pb)
+    #
+    #     expected =  {
+    #         "localhost": {
+    #             "changed": 29,
+    #             "failures": 0,
+    #             "ok": 33,
+    #             "skipped": 12,
+    #             "unreachable": 0
+    #         }
+    #     }
+    #
+    #     assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
 
 
     def _compare_file_output(self, filename, expected_lines):


### PR DESCRIPTION
We run into some problems because tar --diff will take into account the file ownership and fail if they don't match.

The real-world implication of this is that we could be doing more unarchives then we need to be doing.
