### PR TITLE
Fix proper defaulting/required of 'state' for gem module

### DIFF
--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -34,8 +34,9 @@ options:
   state:
     description: 
       - The desired state of the gem. C(latest) ensures that the latest version is installed.
-    required: true
+    required: false
     choices: [present, absent, latest]
+    default: present
   gem_source:
     description:
       - The path to a local gem used as installation source.
@@ -186,7 +187,7 @@ def main():
             include_dependencies = dict(required=False, default=True, type='bool'),
             name                 = dict(required=True, type='str'),
             repository           = dict(required=False, aliases=['source'], type='str'),
-            state                = dict(required=False, choices=['present','absent','latest'], type='str'),
+            state                = dict(required=False, default='present', choices=['present','absent','latest'], type='str'),
             user_install         = dict(required=False, default=True, type='bool'),
             version              = dict(required=False, type='str'),
         ),


### PR DESCRIPTION
The docs for 'gem' say state is required, but the actual code says it's not required.

If it's not included (and there's no default) then the if block falls through with no changes and no errors (it neither adds nor removes the gem).

This change synchronizes the docs with the code.  It also adds the sane default of state=present, which is consistent with all other modules with the 'state' field.
