### PR TITLE
Enable YAML data as playbook, and ensure that modules use #!/usr/bin/env python as hashbang

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -161,7 +161,7 @@ class PlayBook(object):
         if self.inventory.src() is not None:
             vars['inventory_file'] = self.inventory.src()
 
-        self.filename = playbook
+        self.filename = (type(playbook) != list and os.path.exists(playbook)) or None
         (self.playbook, self.play_basedirs) = self._load_playbook(playbook, vars)
         ansible.callbacks.load_callback_plugins()
 
@@ -543,7 +543,7 @@ class PlayBook(object):
         for x in replay_hosts:
             buf.write("%s\n" % x)
         basedir = self.inventory.basedir()
-        filename = "%s.retry" % os.path.basename(self.filename)
+        filename = "%s.retry" % os.path.basename(self.filename or 'dynamic')
         filename = filename.replace(".yml","")
         filename = os.path.join(os.path.expandvars('$HOME/'), filename)
 

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -162,17 +162,21 @@ class PlayBook(object):
             vars['inventory_file'] = self.inventory.src()
 
         self.filename = playbook
-        (self.playbook, self.play_basedirs) = self._load_playbook_from_file(playbook, vars)
+        (self.playbook, self.play_basedirs) = self._load_playbook(playbook, vars)
         ansible.callbacks.load_callback_plugins()
 
     # *****************************************************
 
-    def _load_playbook_from_file(self, path, vars={}):
+    def _load_playbook(self, path, vars={}):
         '''
         run top level error checking on playbooks and allow them to include other playbooks.
         '''
 
-        playbook_data  = utils.parse_yaml_from_file(path)
+        if os.path.exists(path):
+            playbook_data  = utils.parse_yaml_from_file(path)
+        else:
+            playbook_data = path
+
         accumulated_plays = []
         play_basedirs = []
 
@@ -208,7 +212,7 @@ class PlayBook(object):
                     incvars[k] = template(basedir, v, incvars)
 
                 included_path = utils.path_dwim(basedir, template(basedir, tokens[0], incvars))
-                (plays, basedirs) = self._load_playbook_from_file(included_path, incvars)
+                (plays, basedirs) = self._load_playbook(included_path, incvars)
                 for p in plays:
                     # support for parameterized play includes works by passing
                     # those variables along to the subservient play

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -161,7 +161,7 @@ class PlayBook(object):
         if self.inventory.src() is not None:
             vars['inventory_file'] = self.inventory.src()
 
-        self.filename = (type(playbook) != list and os.path.exists(playbook)) or None
+        self.filename = (type(playbook) != list and os.path.exists(playbook)) and playbook or None
         (self.playbook, self.play_basedirs) = self._load_playbook(playbook, vars)
         ansible.callbacks.load_callback_plugins()
 

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -151,7 +151,7 @@ class PlayBook(object):
         if self.module_path is not None:
             utils.plugins.module_finder.add_directory(self.module_path)
 
-        self.basedir     = os.path.dirname(playbook) or '.'
+        self.basedir     = (type(playbook) != list and os.path.dirname(playbook)) or '.'
         utils.plugins.push_basedir(self.basedir)
         vars = extra_vars.copy()
         vars['playbook_dir'] = self.basedir
@@ -172,8 +172,8 @@ class PlayBook(object):
         run top level error checking on playbooks and allow them to include other playbooks.
         '''
 
-        if os.path.exists(path):
-            playbook_data  = utils.parse_yaml_from_file(path)
+        if type(path) != list and os.path.exists(path):
+            playbook_data = utils.parse_yaml_from_file(path)
         else:
             playbook_data = path
 
@@ -183,7 +183,7 @@ class PlayBook(object):
         if type(playbook_data) != list:
             raise errors.AnsibleError("parse error: playbooks must be formatted as a YAML list, got %s" % type(playbook_data))
 
-        basedir = os.path.dirname(path) or '.'
+        basedir = (type(path) != list and os.path.dirname(path)) or '.'
         utils.plugins.push_basedir(basedir)
         for play in playbook_data:
             if type(play) != dict:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -151,7 +151,7 @@ class PlayBook(object):
         if self.module_path is not None:
             utils.plugins.module_finder.add_directory(self.module_path)
 
-        self.basedir     = (type(playbook) != list and os.path.dirname(playbook)) or '.'
+        self.basedir     = (type(playbook) != list and os.path.dirname(playbook)) and os.path.dirname(playbook) or '.'
         utils.plugins.push_basedir(self.basedir)
         vars = extra_vars.copy()
         vars['playbook_dir'] = self.basedir
@@ -183,7 +183,7 @@ class PlayBook(object):
         if type(playbook_data) != list:
             raise errors.AnsibleError("parse error: playbooks must be formatted as a YAML list, got %s" % type(playbook_data))
 
-        basedir = (type(path) != list and os.path.dirname(path)) or '.'
+        basedir = (type(path) != list and os.path.dirname(path)) and os.path.dirname(path) or '.'
         utils.plugins.push_basedir(basedir)
         for play in playbook_data:
             if type(play) != dict:

--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2013, Cove Schneider
 #

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/ec2_eip
+++ b/library/cloud/ec2_eip
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 DOCUMENTATION = '''
 ---
 module: ec2_eip

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/ec2_facts
+++ b/library/cloud/ec2_facts
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 

--- a/library/cloud/ec2_key
+++ b/library/cloud/ec2_key
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 

--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/gc_storage
+++ b/library/cloud/gc_storage
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/gce
+++ b/library/cloud/gce
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/library/cloud/gce_lb
+++ b/library/cloud/gce_lb
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/library/cloud/gce_net
+++ b/library/cloud/gce_net
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/library/cloud/gce_pd
+++ b/library/cloud/gce_pd
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/library/cloud/glance_image
+++ b/library/cloud/glance_image
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/library/cloud/keystone_user
+++ b/library/cloud/keystone_user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Based on Jimmy Tang's implementation

--- a/library/cloud/linode
+++ b/library/cloud/linode
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/library/cloud/ovirt
+++ b/library/cloud/ovirt
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2013, Vincent Van der Kussen <vincent at vanderkussen.org>
 #

--- a/library/cloud/quantum_floating_ip
+++ b/library/cloud/quantum_floating_ip
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/library/cloud/quantum_floating_ip_associate
+++ b/library/cloud/quantum_floating_ip_associate
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/library/cloud/quantum_router
+++ b/library/cloud/quantum_router
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/library/cloud/quantum_router_gateway
+++ b/library/cloud/quantum_router_gateway
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/library/cloud/quantum_router_interface
+++ b/library/cloud/quantum_router_interface
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/library/cloud/quantum_subnet
+++ b/library/cloud/quantum_subnet
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/rax_clb
+++ b/library/cloud/rax_clb
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/rax_clb_nodes
+++ b/library/cloud/rax_clb_nodes
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/rax_dns
+++ b/library/cloud/rax_dns
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/rax_dns_record
+++ b/library/cloud/rax_dns_record
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/rax_facts
+++ b/library/cloud/rax_facts
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/rax_files
+++ b/library/cloud/rax_files
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 
 # (c) 2013, Paul Durivage <paul.durivage@rackspace.com>
 #

--- a/library/cloud/rax_files_objects
+++ b/library/cloud/rax_files_objects
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 
 # (c) 2013, Paul Durivage <paul.durivage@rackspace.com>
 #

--- a/library/cloud/rax_keypair
+++ b/library/cloud/rax_keypair
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/rax_network
+++ b/library/cloud/rax_network
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/rax_queue
+++ b/library/cloud/rax_queue
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/cloud/virt
+++ b/library/cloud/virt
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/library/commands/command
+++ b/library/commands/command
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Elliott Foster <elliott@fourkitchens.com>
 # Sponsored by Four Kitchens http://fourkitchens.com.

--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Mark Theunissen <mark.theunissen@gmail.com>

--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Mark Theunissen <mark.theunissen@gmail.com>
 # Sponsored by Four Kitchens http://fourkitchens.com.

--- a/library/database/mysql_variables
+++ b/library/database/mysql_variables
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/library/database/postgresql_db
+++ b/library/database/postgresql_db
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/database/postgresql_privs
+++ b/library/database/postgresql_privs
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/database/postgresql_user
+++ b/library/database/postgresql_user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/database/redis
+++ b/library/database/redis
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of Ansible

--- a/library/database/riak
+++ b/library/database/riak
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, James Martin <jmartin@basho.com>, Drew Kerrigan <dkerrigan@basho.com>

--- a/library/files/acl
+++ b/library/files/acl
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/files/assemble
+++ b/library/files/assemble
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>

--- a/library/files/copy
+++ b/library/files/copy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/files/file
+++ b/library/files/file
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Jan-Piet Mens <jpmens () gmail.com>

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Daniel Hokka Zakrisson <daniel@hozac.com>

--- a/library/files/stat
+++ b/library/files/stat
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012-2013, Timothy Appnel <tim@appnel.com>

--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/files/xattr
+++ b/library/files/xattr
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/internal/async_status
+++ b/library/internal/async_status
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others

--- a/library/internal/async_wrapper
+++ b/library/internal/async_wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others

--- a/library/messaging/rabbitmq_parameter
+++ b/library/messaging/rabbitmq_parameter
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>

--- a/library/messaging/rabbitmq_plugin
+++ b/library/messaging/rabbitmq_plugin
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>

--- a/library/messaging/rabbitmq_policy
+++ b/library/messaging/rabbitmq_policy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, John Dewey <john@dewey.ws>

--- a/library/messaging/rabbitmq_user
+++ b/library/messaging/rabbitmq_user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>

--- a/library/messaging/rabbitmq_vhost
+++ b/library/messaging/rabbitmq_vhost
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>

--- a/library/monitoring/airbrake_deployment
+++ b/library/monitoring/airbrake_deployment
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2013 Bruce Pennypacker <bruce@pennypacker.org>

--- a/library/monitoring/boundary_meter
+++ b/library/monitoring/boundary_meter
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/library/monitoring/datadog_event
+++ b/library/monitoring/datadog_event
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Author: Artūras 'arturaz' Šlajus <x11@arturaz.net>

--- a/library/monitoring/monit
+++ b/library/monitoring/monit
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Darryl Stoflet <stoflet@gmail.com>

--- a/library/monitoring/nagios
+++ b/library/monitoring/nagios
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # This file is largely copied from the Nagios module included in the

--- a/library/monitoring/newrelic_deployment
+++ b/library/monitoring/newrelic_deployment
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2013 Matt Coddington <coddington@gmail.com>

--- a/library/monitoring/pagerduty
+++ b/library/monitoring/pagerduty
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 DOCUMENTATION = '''
 

--- a/library/monitoring/pingdom
+++ b/library/monitoring/pingdom
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 DOCUMENTATION = '''
 

--- a/library/net_infrastructure/arista_interface
+++ b/library/net_infrastructure/arista_interface
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #    
 # Copyright (C) 2013, Arista Networks <netdevops@aristanetworks.com>

--- a/library/net_infrastructure/arista_l2interface
+++ b/library/net_infrastructure/arista_l2interface
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #    
 # Copyright (C) 2013, Arista Networks <netdevops@aristanetworks.com>

--- a/library/net_infrastructure/arista_lag
+++ b/library/net_infrastructure/arista_lag
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #    
 # Copyright (C) 2013, Arista Networks <netdevops@aristanetworks.com>

--- a/library/net_infrastructure/arista_vlan
+++ b/library/net_infrastructure/arista_vlan
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #    
 # Copyright (C) 2013, Arista Networks <netdevops@aristanetworks.com>

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, serge van Ginderachter <serge@vanginderachter.be>

--- a/library/net_infrastructure/bigip_monitor_tcp
+++ b/library/net_infrastructure/bigip_monitor_tcp
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, serge van Ginderachter <serge@vanginderachter.be>

--- a/library/net_infrastructure/bigip_node
+++ b/library/net_infrastructure/bigip_node
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Matt Hite <mhite@hotmail.com>

--- a/library/net_infrastructure/bigip_pool
+++ b/library/net_infrastructure/bigip_pool
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Matt Hite <mhite@hotmail.com>

--- a/library/net_infrastructure/bigip_pool_member
+++ b/library/net_infrastructure/bigip_pool_member
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Matt Hite <mhite@hotmail.com>

--- a/library/net_infrastructure/dnsmadeeasy
+++ b/library/net_infrastructure/dnsmadeeasy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/library/net_infrastructure/netscaler
+++ b/library/net_infrastructure/netscaler
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/library/net_infrastructure/openvswitch_bridge
+++ b/library/net_infrastructure/openvswitch_bridge
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # This module is free software: you can redistribute it and/or modify

--- a/library/net_infrastructure/openvswitch_port
+++ b/library/net_infrastructure/openvswitch_port
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # This module is free software: you can redistribute it and/or modify

--- a/library/network/get_url
+++ b/library/network/get_url
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Jan-Piet Mens <jpmens () gmail.com>

--- a/library/network/slurp
+++ b/library/network/slurp
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/network/uri
+++ b/library/network/uri
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Romeo Theriault <romeot () hawaii.edu>

--- a/library/notification/campfire
+++ b/library/notification/campfire
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 DOCUMENTATION = '''

--- a/library/notification/flowdock
+++ b/library/notification/flowdock
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2013 Matt Coddington <coddington@gmail.com>

--- a/library/notification/grove
+++ b/library/notification/grove
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 DOCUMENTATION = '''

--- a/library/notification/hipchat
+++ b/library/notification/hipchat
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 DOCUMENTATION = '''

--- a/library/notification/irc
+++ b/library/notification/irc
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Jan-Piet Mens <jpmens () gmail.com>

--- a/library/notification/jabber
+++ b/library/notification/jabber
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 DOCUMENTATION = '''

--- a/library/notification/mail
+++ b/library/notification/mail
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2012 Dag Wieers <dag@wieers.com>

--- a/library/notification/mqtt
+++ b/library/notification/mqtt
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Jan-Piet Mens <jpmens () gmail.com>

--- a/library/notification/osx_say
+++ b/library/notification/osx_say
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Michael DeHaan <michael@ansible.com>

--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Flowroute LLC

--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # encoding: utf-8
 
 # (c) 2012, Matt Wright <matt@nobien.net>

--- a/library/packaging/easy_install
+++ b/library/packaging/easy_install
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Matt Wright <matt@nobien.net>

--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Johan Wiren <johan.wiren.se@gmail.com>

--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Andrew Dunham <andrew@du.nham.ca>

--- a/library/packaging/macports
+++ b/library/packaging/macports
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Jimmy Tang <jcftang@gmail.com>

--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chris Hoffman <christopher.hoffman@gmail.com>

--- a/library/packaging/openbsd_pkg
+++ b/library/packaging/openbsd_pkg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Patrik Lundin <patrik.lundin.swe@gmail.com>

--- a/library/packaging/opkg
+++ b/library/packaging/opkg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Patrick Pelletier <pp.pelletier@gmail.com>

--- a/library/packaging/pacman
+++ b/library/packaging/pacman
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Afterburn

--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Matt Wright <matt@nobien.net>

--- a/library/packaging/pkgin
+++ b/library/packaging/pkgin
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Shaun Zinck

--- a/library/packaging/pkgng
+++ b/library/packaging/pkgng
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, bleader

--- a/library/packaging/pkgutil
+++ b/library/packaging/pkgutil
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Alexander Winkler <mail () winkler-alexander.de>

--- a/library/packaging/portinstall
+++ b/library/packaging/portinstall
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, berenddeboer

--- a/library/packaging/redhat_subscription
+++ b/library/packaging/redhat_subscription
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 DOCUMENTATION = '''
 ---

--- a/library/packaging/rhn_channel
+++ b/library/packaging/rhn_channel
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 DOCUMENTATION = '''
 ---

--- a/library/packaging/rhn_register
+++ b/library/packaging/rhn_register
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 DOCUMENTATION = '''
 ---

--- a/library/packaging/rpm_key
+++ b/library/packaging/rpm_key
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/library/packaging/svr4pkg
+++ b/library/packaging/svr4pkg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Boyd Adamson <boyd () boydadamson.com>

--- a/library/packaging/swdepot
+++ b/library/packaging/swdepot
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Raul Melo

--- a/library/packaging/urpmi
+++ b/library/packaging/urpmi
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Philippe Makowski

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Red Hat, Inc

--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/env python -tt
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Patrick Callahan <pmc@patrickcallahan.com>

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # encoding: utf-8
 
 # (c) 2013, Matthias Vogelgesang <matthias.vogelgesang@gmail.com>

--- a/library/source_control/bzr
+++ b/library/source_control/bzr
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, André Paramés <git@andreparames.com>

--- a/library/source_control/git
+++ b/library/source_control/git
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/source_control/github_hooks
+++ b/library/source_control/github_hooks
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Phillip Gentry <phillip@cx.com>

--- a/library/source_control/hg
+++ b/library/source_control/hg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #-*- coding: utf-8 -*-
 
 # (c) 2013, Yeukhon Wong <yeukhon@acm.org>

--- a/library/source_control/subversion
+++ b/library/source_control/subversion
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/at
+++ b/library/system/at
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2014, Richard Isaacson <richard.c.isaacson@gmail.com>

--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/library/system/cron
+++ b/library/system/cron
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2012, Dane Summers <dsummers@pinedesk.biz>

--- a/library/system/facter
+++ b/library/system/facter
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/filesystem
+++ b/library/system/filesystem
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Alexander Bulimov <lazywolf0@gmail.com>

--- a/library/system/firewalld
+++ b/library/system/firewalld
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Adam Miller (maxamillion@fedoraproject.org)

--- a/library/system/group
+++ b/library/system/group
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>

--- a/library/system/hostname
+++ b/library/system/hostname
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Hiroaki Nakamura <hnakamur@gmail.com>

--- a/library/system/kernel_blacklist
+++ b/library/system/kernel_blacklist
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # encoding: utf-8 -*-
 
 # (c) 2013, Matthias Vogelgesang <matthias.vogelgesang@gmail.com>

--- a/library/system/lvg
+++ b/library/system/lvg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Alexander Bulimov <lazywolf0@gmail.com>

--- a/library/system/lvol
+++ b/library/system/lvol
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Jeroen Hoekx <jeroen.hoekx@dsquare.be>, Alexander Bulimov <lazywolf0@gmail.com>

--- a/library/system/modprobe
+++ b/library/system/modprobe
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # This module is free software: you can redistribute it and/or modify

--- a/library/system/mount
+++ b/library/system/mount
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Red Hat, inc

--- a/library/system/ohai
+++ b/library/system/ohai
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/open_iscsi
+++ b/library/system/open_iscsi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Serge van Ginderachter <serge@vanginderachter.be>

--- a/library/system/ping
+++ b/library/system/ping
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/seboolean
+++ b/library/system/seboolean
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>
 #

--- a/library/system/selinux
+++ b/library/system/selinux
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Derek Carter<goozbach@friocorte.com>

--- a/library/system/service
+++ b/library/system/service
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/setup
+++ b/library/system/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, David "DaviXX" CHANIAL <david.chanial@gmail.com>

--- a/library/system/user
+++ b/library/system/user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Stephen Fromm <sfromm@gmail.com>

--- a/library/system/zfs
+++ b/library/system/zfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Johan Wiren <johan.wiren.se@gmail.com>

--- a/library/utilities/accelerate
+++ b/library/utilities/accelerate
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, James Cammarata <jcammarata@ansible.com>

--- a/library/utilities/debug
+++ b/library/utilities/debug
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2012 Dag Wieers <dag@wieers.com>

--- a/library/utilities/fail
+++ b/library/utilities/fail
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2012 Dag Wieers <dag@wieers.com>

--- a/library/utilities/fireball
+++ b/library/utilities/fireball
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>

--- a/library/utilities/set_fact
+++ b/library/utilities/set_fact
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2013 Dag Wieers <dag@wieers.com>

--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Jeroen Hoekx <jeroen@hoekx.be>

--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Scott Anderson <scottanderson42@gmail.com>

--- a/library/web_infrastructure/ejabberd_user
+++ b/library/web_infrastructure/ejabberd_user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2013, Peter Sprygada <sprygada@gmail.com>

--- a/library/web_infrastructure/htpasswd
+++ b/library/web_infrastructure/htpasswd
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Nimbis Services, Inc.

--- a/library/web_infrastructure/jboss
+++ b/library/web_infrastructure/jboss
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Jeroen Hoekx <jeroen.hoekx@dsquare.be>

--- a/library/web_infrastructure/supervisorctl
+++ b/library/web_infrastructure/supervisorctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Matt Wright <matt@nobien.net>


### PR DESCRIPTION
This is really two things rolled into a single pull request so feel free to reject it on that basis alone.

The first thing is allowing YAML data to be passed into playbook.Playbook() in addition to a file name.  this is handy for us in the tool we are building, it saves us, I think, from having to go all the way down to the Runner API to run play books programmatically.

The second thing is something that was discovered while trying to run Ansible inside a python Virtual Env-- the  use of   hardcoded /usr/bin/python path in the hash bang of module files was causing problems with some modules that rely on third-party libs (in our case it was boto-- installed in venv,  but not system-wide).
