### PR TITLE
Changed to use sudopass in one liner

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -122,8 +122,8 @@ def main(args):
             # Arguments as Key-value
             extra_vars = utils.combine_vars(extra_vars, utils.parse_kv(extra_vars_opt))
 
-	if 'sudopass' in extra_vars:
-		sudopass = extra_vars['sudopass']
+    if 'sudopass' in extra_vars:
+        sudopass = extra_vars['sudopass']
 
     only_tags = options.tags.split(",")
     skip_tags = options.skip_tags

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -124,6 +124,8 @@ def main(args):
 
     if 'sudopass' in extra_vars:
         sudopass = extra_vars['sudopass']
+    elif sudopass:
+        extra_vars['sudopass'] = sudopass
 
     only_tags = options.tags.split(",")
     skip_tags = options.skip_tags

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -122,6 +122,9 @@ def main(args):
             # Arguments as Key-value
             extra_vars = utils.combine_vars(extra_vars, utils.parse_kv(extra_vars_opt))
 
+	if 'sudopass' in extra_vars:
+		sudopass = extra_vars['sudopass']
+
     only_tags = options.tags.split(",")
     skip_tags = options.skip_tags
     if options.skip_tags is not None:


### PR DESCRIPTION
We can use sudopass in one liner like a following example.

```
$ ansible-playbook -i inventory site.yml -e '{"sudopass":"******"}'
```
