### PR TITLE
Allow ec2 inventory to use a boto profile

### DIFF
--- a/docsite/rst/intro_dynamic_inventory.rst
+++ b/docsite/rst/intro_dynamic_inventory.rst
@@ -101,6 +101,20 @@ You can test the script by itself to make sure your config is correct::
 
 After a few moments, you should see your entire EC2 inventory across all regions in JSON.
 
+If you use boto profiles to manage multiple AWS accounts, you can pass ``--profile PROFILE`` name to the ``ec2.py`` script. An example profile might be::
+
+    [profile dev]
+    aws_access_key_id = <dev access key>
+    aws_secret_access_key = <dev secret key>
+
+    [profile prod]
+    aws_access_key_id = <prod access key>
+    aws_secret_access_key = <prod secret key>
+
+You can then run ``ec2.py --profile prod`` to get the inventory for the prod account, or run playbooks with: ``ansible-playbook -i 'ec2.py --profile prod' myplaybook.yml``.
+
+Alternatively, use the ``EC2_PROFILE`` variable - e.g. ``EC2_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml``
+
 Since each region requires its own API call, if you are only using a small set of regions, feel free to edit ``ec2.ini`` and list only the regions you are interested in. There are other config options in ``ec2.ini`` including cache control, and destination variables.
 
 At their heart, inventory files are simply a mapping from some name to a destination address. The default ``ec2.ini`` settings are configured for running Ansible from outside EC2 (from your laptop for example) -- and this is not the most efficient way to manage EC2.

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -67,10 +67,16 @@ class Inventory(object):
         self._also_restriction = None
         self._subset = None
 
+        args = []
         if isinstance(host_list, basestring):
             if "," in host_list:
                 host_list = host_list.split(",")
                 host_list = [ h for h in host_list if h and h.strip() ]
+            elif " " in host_list:
+                # presumably a script with arguments. Don't further parse lists though!
+                tokens = host_list.split()
+                self.host_list = host_list = tokens[0]
+                args = tokens[1:]
 
         if host_list is None:
             self.parser = None
@@ -115,7 +121,7 @@ class Inventory(object):
 
                 if utils.is_executable(host_list):
                     try:
-                        self.parser = InventoryScript(filename=host_list)
+                        self.parser = InventoryScript(filename=host_list, args=args)
                         self.groups = self.parser.groups.values()
                     except:
                         if not shebang_present:

--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -29,13 +29,14 @@ import sys
 class InventoryScript(object):
     ''' Host inventory parser for ansible using external inventory scripts. '''
 
-    def __init__(self, filename=C.DEFAULT_HOST_LIST):
+    def __init__(self, filename=C.DEFAULT_HOST_LIST, args=[]):
 
         # Support inventory scripts that are not prefixed with some
         # path information but happen to be in the current working
         # directory when '.' is not in PATH.
         self.filename = os.path.abspath(filename)
-        cmd = [ self.filename, "--list" ]
+        self.args = args
+        cmd = [ self.filename, "--list"] + self.args
         try:
             sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError, e:
@@ -116,8 +117,7 @@ class InventoryScript(object):
             got = self.host_vars_from_top.get(host.name, {})
             return got
 
-
-        cmd = [self.filename, "--host", host.name]
+        cmd = [self.filename, "--host", host.name] + self.args
         try:
             sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError, e:

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -22,6 +22,12 @@ you need to define:
 
     export EC2_URL=http://hostname_of_your_cc:port/services/Eucalyptus
 
+If you're using boto profiles (requires boto>=2.24.0) you can choose a profile 
+using the --profile command line argument (e.g. ec2.py --profile prod) or using
+the EC2_PROFILE variable:
+
+    EC2_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml
+
 For more details, see: http://docs.pythonboto.org/en/latest/boto_config_tut.html
 
 When run against a specific host, this script returns the following variables:
@@ -144,9 +150,20 @@ class Ec2Inventory(object):
         # Index of hostname (address) to instance ID
         self.index = {}
 
-        # Read settings and parse CLI arguments
-        self.read_settings()
+        # Parse CLI arguments and read settings
         self.parse_cli_args()
+        self.read_settings()
+
+        # boto profile to use (if any)
+        # Make sure that profile_name is not passed at all if not set
+        # as pre 2.24 boto will fall over otherwise
+        if self.args.profile:
+            if not hasattr(boto.ec2.EC2Connection, 'profile_name'):
+                sys.stderr.write("boto version must be >= 2.24 to use profile\n")
+                sys.exit(1)
+            self.profile = dict(profile_name=self.args.profile)
+        else:
+            self.profile = dict()
 
         # Cache
         if self.args.refresh_cache:
@@ -224,13 +241,14 @@ class Ec2Inventory(object):
 
         # Cache related
         cache_dir = os.path.expanduser(config.get('ec2', 'cache_path'))
+        if self.args.profile:
+            cache_dir = os.path.join(cache_dir, 'profile_' + self.args.profile)
         if not os.path.exists(cache_dir):
             os.makedirs(cache_dir)
 
         self.cache_path_cache = cache_dir + "/ansible-ec2.cache"
         self.cache_path_index = cache_dir + "/ansible-ec2.index"
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
-        
 
 
     def parse_cli_args(self):
@@ -243,6 +261,8 @@ class Ec2Inventory(object):
                            help='Get all the variables about a specific instance')
         parser.add_argument('--refresh-cache', action='store_true', default=False,
                            help='Force refresh of cache by making API requests to EC2 (default: False - use cache files)')
+        parser.add_argument('--profile', action='store', default=os.environ.get('EC2_PROFILE'),
+                           help='Use boto profile for connections to EC2')
         self.args = parser.parse_args()
 
 
@@ -260,6 +280,21 @@ class Ec2Inventory(object):
         self.write_to_cache(self.index, self.cache_path_index)
 
 
+    def boto_fix_security_token_in_profile(self, conn):
+        ''' monkey patch for boto issue boto/boto#2100 '''
+        profile = 'profile ' + self.profile.get('profile_name')
+        if boto.config.has_option(profile, 'aws_security_token'):
+            conn.provider.set_security_token(boto.config.get(profile, 'aws_security_token'))
+        return conn
+
+
+    def connect_to_aws(self, module, region):
+        conn = module.connect_to_region(region, **self.profile)
+        if 'profile_name' in self.profile:
+            conn = self.boto_fix_security_token_in_profile(conn)
+        return conn
+
+
     def get_instances_by_region(self, region):
         ''' Makes an AWS EC2 API call to the list of instances in a particular
         region '''
@@ -269,30 +304,31 @@ class Ec2Inventory(object):
                 conn = boto.connect_euca(host=self.eucalyptus_host)
                 conn.APIVersion = '2010-08-31'
             else:
-                conn = ec2.connect_to_region(region)
+                conn = self.connect_to_aws(ec2, region)
 
             # connect_to_region will fail "silently" by returning None if the region name is wrong or not supported
             if conn is None:
                 print("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
                 sys.exit(1)
- 
+
             reservations = conn.get_all_instances()
             for reservation in reservations:
                 for instance in reservation.instances:
                     self.add_instance(instance, region)
-        
+
         except boto.exception.BotoServerError, e:
             if  not self.eucalyptus:
                 print "Looks like AWS is down again:"
             print e
             sys.exit(1)
 
+
     def get_rds_instances_by_region(self, region):
-	''' Makes an AWS API call to the list of RDS instances in a particular
+        ''' Makes an AWS API call to the list of RDS instances in a particular
         region '''
 
         try:
-            conn = rds.connect_to_region(region)
+            conn = self.connect_to_aws(rds, region)
             if conn:
                 instances = conn.get_all_dbinstances()
                 for instance in instances:
@@ -309,7 +345,7 @@ class Ec2Inventory(object):
             conn = boto.connect_euca(self.eucalyptus_host)
             conn.APIVersion = '2010-08-31'
         else:
-            conn = ec2.connect_to_region(region)
+            conn = self.connect_to_aws(ec2, region)
 
         # connect_to_region will fail "silently" by returning None if the region name is wrong or not supported
         if conn is None:
@@ -358,7 +394,7 @@ class Ec2Inventory(object):
         # Inventory: Group by key pair
         if instance.key_name:
             self.push(self.inventory, self.to_safe('key_' + instance.key_name), dest)
-        
+
         # Inventory: Group by security group
         try:
             for group in instance.groups:
@@ -416,10 +452,10 @@ class Ec2Inventory(object):
 
         # Inventory: Group by availability zone
         self.push(self.inventory, instance.availability_zone, dest)
-        
+
         # Inventory: Group by instance type
         self.push(self.inventory, self.to_safe('type_' + instance.instance_class), dest)
-        
+
         # Inventory: Group by security group
         try:
             if instance.security_group:


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

Based on:
ansible 1.5 (devel 6f405c8970) last updated 2014/02/13 18:12:39 (GMT +1000)
##### Environment:

N/A
##### Summary:

This allows the EC2 inventory plugin to be used with
the same configuration against different EC2 accounts

Added documentation on profiles to EC2 dynamic inventory doc

Only tries to use profiles if --profile argument is given
to maintain compatibility will boto < 2.24.

Works around a minor bug in boto where if you try and use
a security token with a profile it fails (boto/boto#2100)
