### PR TITLE
ec2 module fails when state is not absent

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -1045,6 +1045,7 @@ def main():
 
     ec2 = ec2_connect(module)
 
+    tagged_instances = [] 
     if module.params.get('state') == 'absent':
         instance_ids = module.params.get('instance_ids')
         if not isinstance(instance_ids, list):
@@ -1064,7 +1065,6 @@ def main():
         if not module.params.get('image'):
             module.fail_json(msg='image parameter is required for new instance')
    
-        tagged_instances = [] 
         if module.params.get('exact_count'):
             (tagged_instances, instance_dict_array, new_instance_ids, changed) = enforce_count(module, ec2)
         else:            


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.5 (devel 6f405c8970) last updated 2014/02/13 18:12:39 (GMT +1000)
##### Environment:

N/A
##### Summary:

tagged_instances is initialised in a scope not visible
when state is not absent.
##### Steps To Reproduce:

run ec2 module against an instance with state=absent
##### Expected Results:

instance should be terminated
##### Actual Results:

```
[will@cheetah ansible]$ ansible-playbook -i ~/src/ansible/plugins/inventory/ec2.py ec2_destroy.yml 

PLAY [tag_Name_newbobbins] **************************************************** 

TASK: [ec2 ] ****************************************************************** 
failed: [54.206.23.206] => {"failed": true, "parsed": false}
invalid output was: Traceback (most recent call last):
  File "/Users/will/.ansible/tmp/ansible-tmp-1392285420.29-67669935799855/ec2", line 2210, in <module>
    main()
  File "/Users/will/.ansible/tmp/ansible-tmp-1392285420.29-67669935799855/ec2", line 1073, in main
    module.exit_json(changed=changed, instance_ids=new_instance_ids, instances=instance_dict_array, tagged_instances=tagged_instances)
UnboundLocalError: local variable 'tagged_instances' referenced before assignment
```
