### PR TITLE
Elasticache vpc security groups

### DIFF
--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -51,6 +51,11 @@ options:
       - Purge existing availability zones on ELB that are not found in zones
     required: false
     default: false
+  security_group_ids:
+    description:
+      - A list of security groups to apply to the elb
+    require: false
+    default: None
   health_check:
     description:
       - An associative array of health check configuration settigs (see example)
@@ -175,7 +180,7 @@ class ElbManager(object):
     """Handles ELB creation and destruction"""
 
     def __init__(self, module, name, listeners=None, purge_listeners=None,
-                 zones=None, purge_zones=None, health_check=None,
+                 zones=None, purge_zones=None, security_group_ids=None, health_check=None,
                  aws_access_key=None, aws_secret_key=None, region=None):
         self.module = module
         self.name = name
@@ -183,6 +188,7 @@ class ElbManager(object):
         self.purge_listeners = purge_listeners
         self.zones = zones
         self.purge_zones = purge_zones
+        self.security_group_ids = security_group_ids
         self.health_check = health_check
 
         self.aws_access_key = aws_access_key
@@ -201,6 +207,7 @@ class ElbManager(object):
             self._create_elb()
         else:
             self._set_zones()
+            self._set_security_groups()
             self._set_elb_listeners()
         self._set_health_check()
 
@@ -220,6 +227,7 @@ class ElbManager(object):
                 'name': self.elb.name,
                 'dns_name': self.elb.dns_name,
                 'zones': self.elb.availability_zones,
+                'security_group_ids': self.elb.security_groups,
                 'status': self.status
             }
 
@@ -273,6 +281,7 @@ class ElbManager(object):
         listeners = [self._listener_as_tuple(l) for l in self.listeners]
         self.elb = self.elb_conn.create_load_balancer(name=self.name,
                                                       zones=self.zones,
+                                                      security_groups=self.security_group_ids,
                                                       complex_listeners=listeners)
         if self.elb:
             self.changed = True
@@ -397,6 +406,11 @@ class ElbManager(object):
         if zones_to_disable:
             self._disable_zones(zones_to_disable)
 
+    def _set_security_groups(self):
+        if self.security_group_ids != None and set(self.elb.security_groups) != set(self.security_group_ids):
+            self.elb_conn.apply_security_groups_to_lb(self.name, self.security_group_ids)
+            self.Changed = True
+
     def _set_health_check(self):
         """Set health check values on ELB as needed"""
         if self.health_check:
@@ -449,6 +463,7 @@ def main():
             zones={'default': None, 'required': False, 'type': 'list'},
             purge_zones={'default': False, 'required': False,
                          'choices': BOOLEANS, 'type': 'bool'},
+            security_group_ids={'default': None, 'required': False, 'type': 'list'},
             health_check={'default': None, 'required': False, 'type': 'dict'},
             ec2_secret_key={'default': None,
                             'aliases': ['aws_secret_key', 'secret_key'],
@@ -471,6 +486,7 @@ def main():
     purge_listeners = module.params['purge_listeners']
     zones = module.params['zones']
     purge_zones = module.params['purge_zones']
+    security_group_ids = module.params['security_group_ids']
     health_check = module.params['health_check']
 
     if state == 'present' and not listeners:
@@ -480,7 +496,7 @@ def main():
         module.fail_json(msg="At least one availability zone is required for ELB creation")
 
     elb_man = ElbManager(module, name, listeners, purge_listeners, zones,
-                         purge_zones, health_check, aws_access_key,
+                         purge_zones, security_group_ids, health_check, aws_access_key,
                          aws_secret_key, region=region)
 
     if state == 'present':

--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -58,6 +58,11 @@ options:
       - The port number on which each of the cache nodes will accept connections
     required: false
     default: 11211
+  security_group_ids:
+    description:
+      - A list of vpc security group names to associate with this cache cluster. Only use if inside a vpc
+    required: false
+    default: ['default']
   cache_security_groups:
     description:
       - A list of cache security group names to associate with this cache cluster
@@ -152,7 +157,7 @@ class ElastiCacheManager(object):
     EXIST_STATUSES = ['available', 'creating', 'rebooting', 'modifying']
 
     def __init__(self, module, name, engine, cache_engine_version, node_type,
-                 num_nodes, cache_port, cache_security_groups, zone, wait,
+                 num_nodes, cache_port, cache_security_groups, security_group_ids, zone, wait,
                  hard_modify, aws_access_key, aws_secret_key, region):
         self.module = module
         self.name = name
@@ -162,6 +167,7 @@ class ElastiCacheManager(object):
         self.num_nodes = num_nodes
         self.cache_port = cache_port
         self.cache_security_groups = cache_security_groups
+        self.security_group_ids = security_group_ids
         self.zone = zone
         self.wait = wait
         self.hard_modify = hard_modify
@@ -217,6 +223,7 @@ class ElastiCacheManager(object):
                                                       engine=self.engine,
                                                       engine_version=self.cache_engine_version,
                                                       cache_security_group_names=self.cache_security_groups,
+                                                      security_group_ids=self.security_group_ids,
                                                       preferred_availability_zone=self.zone,
                                                       port=self.cache_port)
         except boto.exception.BotoServerError, e:
@@ -291,6 +298,7 @@ class ElastiCacheManager(object):
                                                   num_cache_nodes=self.num_nodes,
                                                   cache_node_ids_to_remove=nodes_to_remove,
                                                   cache_security_group_names=self.cache_security_groups,
+                                                  security_group_ids=self.security_group_ids,
                                                   apply_immediately=True,
                                                   engine_version=self.cache_engine_version)
         except boto.exception.BotoServerError, e:
@@ -377,12 +385,20 @@ class ElastiCacheManager(object):
             if self.data[key] != value:
                 return True
 
-        # Check security groups
+        # Check cache security groups
         cache_security_groups = []
         for sg in self.data['CacheSecurityGroups']:
             cache_security_groups.append(sg['CacheSecurityGroupName'])
             if set(cache_security_groups) - set(self.cache_security_groups):
                 return True
+
+        # check vpc security groups
+        vpc_security_groups = []
+        for sg in self.data['SecurityGroups']:
+            vpc_security_groups.append(sg['SecurityGroupId'])
+            if set(vpc_security_groups) - set(self.security_group_ids):
+                return True
+
         return False
 
     def _requires_destroy_and_create(self):
@@ -469,6 +485,8 @@ def main():
             cache_port={'required': False, 'default': 11211, 'type': 'int'},
             cache_security_groups={'required': False, 'default': ['default'],
                                    'type': 'list'},
+            security_group_ids={'required': False, 'default': [],
+                                   'type': 'list'},
             zone={'required': False, 'default': None},
             ec2_secret_key={'default': None,
                             'aliases': ['aws_secret_key', 'secret_key'],
@@ -493,6 +511,7 @@ def main():
     num_nodes = module.params['num_nodes']
     cache_port = module.params['cache_port']
     cache_security_groups = module.params['cache_security_groups']
+    security_group_ids = module.params['security_group_ids']
     zone = module.params['zone']
     wait = module.params['wait']
     hard_modify = module.params['hard_modify']
@@ -506,7 +525,8 @@ def main():
     elasticache_manager = ElastiCacheManager(module, name, engine,
                                              cache_engine_version, node_type,
                                              num_nodes, cache_port,
-                                             cache_security_groups, zone, wait,
+                                             cache_security_groups,
+                                             security_group_ids, zone, wait,
                                              hard_modify, aws_access_key,
                                              aws_secret_key, region)
 


### PR DESCRIPTION
A couple of changes to `ec2_elb_lb` and `elasticache` to add better ec2 security group support.

For `elasticache`, only cache security groups which allow public access to elasticache instances.  I added a `security_group_ids` option to allow for internal ec2 applications access to elasticache (like inside a vpc).

For `ec2_elb_lb`, I added a `security_group_ids` options to allow for optionally setting one or more security groups to your elb.
