### PR TITLE
Adding 'validate_certs' option to EC2 modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Major features/changes:
 * acl module now handles 'default' and allows for either shorthand entry or specific fields per entry section
 * play_hosts is a new magic variable to provide a list of hosts in scope for the current play.
 * ec2 module now accepts 'exact_count' and 'count_tag' as a way to enforce a running number of nodes by tags.
+* all ec2 modules that work with Eucalyptus also now support a 'validate_certs' option, which can be set to 'off' for installations using self-signed certs.
 
 
 New modules:

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -1,3 +1,9 @@
+try:
+    from distutils.version import LooseVersion
+    HAS_LOOSE_VERSION = True
+except:
+    HAS_LOOSE_VERSION = False
+
 AWS_REGIONS = ['ap-northeast-1',
                'ap-southeast-1',
                'ap-southeast-2',
@@ -14,6 +20,7 @@ def ec2_argument_spec():
         ec2_url=dict(),
         ec2_secret_key=dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
         ec2_access_key=dict(aliases=['aws_access_key', 'access_key']),
+        validate_certs=dict(default=True, type='bool'),
     )
 
 
@@ -62,17 +69,24 @@ def ec2_connect(module):
     """ Return an ec2 connection"""
 
     ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    validate_certs = module.get('validate_certs', True)
 
     # If we have a region specified, connect to its endpoint.
     if region:
         try:
-            ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
+            if HAS_LOOSE_VERSION and LooseVersion(boto.Version) >= LooseVersion("2.6.0"):
+                ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key, validate_certs=validate_certs)
+            else:
+                ec2 = boto.ec2.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
     # Otherwise, no region so we fallback to the old connection method
     elif ec2_url:
         try:
-            ec2 = boto.connect_ec2_endpoint(ec2_url, aws_access_key, aws_secret_key)
+            if HAS_LOOSE_VERSION and LooseVersion(boto.Version) >= LooseVersion("2.6.0"):
+                ec2 = boto.connect_ec2_endpoint(ec2_url, aws_access_key, aws_secret_key, validate_certs=validate_certs)
+            else:
+                ec2 = boto.connect_ec2_endpoint(ec2_url, aws_access_key, aws_secret_key)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
     else:

--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -88,14 +88,6 @@ options:
     required: false
     aliases: ['aws_region', 'ec2_region']
     version_added: "1.5"
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
 
 requirements: [ "boto" ]
 author: James S. Martin

--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -88,6 +88,14 @@ options:
     required: false
     aliases: ['aws_region', 'ec2_region']
     version_added: "1.5"
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
 
 requirements: [ "boto" ]
 author: James S. Martin

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -212,7 +212,14 @@ options:
     required: false
     default: null
     aliases: []
-       
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
 
 requirements: [ "boto" ]
 author: Seth Vidal, Tim Gerla, Lester Wade

--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -101,6 +101,14 @@ options:
     required: false
     default: null
     aliases: []
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
 
 requirements: [ "boto" ]
 author: Evan Duffield <eduffield@iacquire.com>

--- a/library/cloud/ec2_eip
+++ b/library/cloud/ec2_eip
@@ -53,6 +53,15 @@ options:
     required: false
     default: false
     version_added: "1.4"
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
+
 requirements: [ "boto" ]
 author: Lorin Hochstein <lorin@nimbisservices.com>
 notes:

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -74,6 +74,14 @@ options:
     required: false
     default: yes
     choices: [ "yes", "no" ] 
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
 
 """
 

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -73,6 +73,14 @@ options:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
     required: false
     aliases: ['aws_region', 'ec2_region']
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
 
 """
 

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -57,6 +57,14 @@ options:
     required: false
     default: 'present'
     aliases: []
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
 
 requirements: [ "boto" ]
 '''

--- a/library/cloud/ec2_key
+++ b/library/cloud/ec2_key
@@ -48,6 +48,14 @@ options:
     required: false
     default: 'present'
     aliases: []
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
 
 requirements: [ "boto" ]
 author: Vincent Viallet

--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -59,6 +59,15 @@ options:
     required: false
     default: null
     aliases: []
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
+
 requirements: [ "boto" ]
 author: Lester Wade
 '''

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -82,6 +82,15 @@ options:
       - snapshot ID on which to base the volume
     required: false
     default: null
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
+
 requirements: [ "boto" ]
 author: Lester Wade
 '''

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -99,6 +99,15 @@ options:
     required: false
     default: None
     aliases: ['ec2_access_key', 'access_key' ]
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
+
 requirements: [ "boto" ]
 author: Carson Gee
 '''


### PR DESCRIPTION
When disabled, the boto connection will be instantiated without validating
the SSL certificate from the target endpoint. This allows the modules to connect
to Eucalyptus instances running with self-signed certs without errors.

Fixes #3978
