### PR TITLE
Insert newline when lineinfile is inserting at EOF, fixes #5825.

### DIFF
--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -248,7 +248,7 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
     # if insertafter=/insertbefore didn't match anything
     # (so default behaviour is to add at the end)
     elif insertafter == 'EOF':
-        lines.append(line + os.linesep)
+        lines.append(os.linesep + line + os.linesep)
         msg = 'line added'
         changed = True
     # Do nothing if insert* didn't match


### PR DESCRIPTION
In the case that the `regexp` is not found in the `dest` file, lineinfile defaults to adding the `line` at the EOF.  If this EOF is not a newline character already, the effect is that lineinfile appends `line` to the last line of the file, which is surprising behavior.  This (untested!) change should fix #5825, if you consider #5825 a bug, as I do.
