### PR TITLE
service: use `systemctl list-units` in addition to `list-unit-files`

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -406,6 +406,9 @@ class LinuxService(Service):
                 name = "%s.service" % name
 
             rc, out, err = self.execute_command("%s list-unit-files" % (location['systemctl']))
+            # LSB services are only listed in `systemctl list-units`
+            rc_, out_, err_ = self.execute_command("%s list-units --all --full" % (location['systemctl']))
+            out += out_
 
             # adjust the service name to account for template service unit files
             index = name.find('@')


### PR DESCRIPTION
The service module checks for the presence of a service before issuing
a command on it, e.g. before starting the service. On systemd systems, the list
of available services is currently retrieved with `systemctl list-unit-files`.
Because LSB-defined services in /etc/init.d don't have unit files, they are not
part of this list. This commit adds an additional call to `systemctl
list-units`, to add support for LSB services.
