### PR TITLE
Filter out messages that match the pattern username:password@host

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -179,6 +179,7 @@ def vvvv(msg, host=None):
     return verbose(msg, host=host, caplevel=3)
 
 def verbose(msg, host=None, caplevel=2):
+    msg = utils.sanitize_output(msg)
     if utils.VERBOSITY > caplevel:
         if host is None:
             display(msg, color='blue')


### PR DESCRIPTION
This filtering is done in both the module invocation logging and in
the regular verbose() logging output.

Fixes #4087
