### PR TITLE
Fix ansible-doc option output.

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -149,7 +149,12 @@ def get_snippet_text(doc):
     for o in sorted(doc['options'].keys()):
         opt = doc['options'][o]
         desc = tty_ify("".join(opt['description']))
-        s = o + "="
+
+        if opt.get('required', False):
+            s = o + "="
+        else:
+            s = o
+
         text.append("      %-20s   # %s" % (s, desc))
     text.append('')
 

--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -98,7 +98,7 @@ def get_man_text(doc):
     if 'option_keys' in doc and len(doc['option_keys']) > 0:
         text.append("Options (= is mandatory):\n")
 
-    for o in doc['option_keys']:
+    for o in sorted(doc['option_keys']):
         opt = doc['options'][o]
 
         if opt.get('required', False):
@@ -146,7 +146,7 @@ def get_snippet_text(doc):
     text.append("- name: %s" % (desc))
     text.append("  action: %s" % (doc['module']))
 
-    for o in doc['options']:
+    for o in sorted(doc['options'].keys()):
         opt = doc['options'][o]
         desc = tty_ify("".join(opt['description']))
         s = o + "="


### PR DESCRIPTION
This PR will sort options before displaying them to the user, it will also only display the equals sign in summary mode for required options.

``` bash
$ ansible-doc s3 -s
- name: idempotent S3 module putting a file into S3.
  action: s3
      aws_access_key         # AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is
      aws_secret_key         # AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is
      bucket=                # Bucket name.
      dest                   # The destination file path when downloading an object/key with a GET operation.
      expiration             # Time limit (in seconds) for the URL generated and returned by S3/Walrus when performing
      mode=                  # Switches the module behaviour between put (upload), get (download), geturl (return downl
      object                 # Keyname of the object inside the bucket. Can be used to create "virtual directories", se
      overwrite              # Force overwrite either locally on the filesystem or remotely with the object/key. Used w
      s3_url                 # S3 URL endpoint. If not specified then the S3_URL environment variable is used, if that
      src                    # The source file path when performing a PUT operation.
```

Previously:

``` bash
$ ansible-doc s3 -s
- name: idempotent S3 module putting a file into S3.
  action: s3
      aws_secret_key=        # AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is
      src=                   # The source file path when performing a PUT operation.
      aws_access_key=        # AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is
      dest=                  # The destination file path when downloading an object/key with a GET operation.
      object=                # Keyname of the object inside the bucket. Can be used to create "virtual directories", se
      bucket=                # Bucket name.
      mode=                  # Switches the module behaviour between put (upload), get (download), geturl (return downl
      s3_url=                # S3 URL endpoint. If not specified then the S3_URL environment variable is used, if that
      overwrite=             # Force overwrite either locally on the filesystem or remotely with the object/key. Used w
      expiration=            # Time limit (in seconds) for the URL generated and returned by S3/Walrus when performing
```
