### PR TITLE
Adding better failure output for chkconfig failures 

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -577,7 +577,7 @@ class LinuxService(Service):
                 self.execute_command("%s --add %s" % (self.enable_cmd, self.name))
                 (rc, out, err) = self.execute_command("%s --list %s" % (self.enable_cmd, self.name))
             if not self.name in out:
-                self.module.fail_json(msg="unknown service name")
+                self.module.fail_json(msg="service %s does not support chkconfig" % self.name)
             state = out.split()[-1]
             if self.enable and ( "3:on" in out and "5:on" in out ):
                 return


### PR DESCRIPTION
I spent a couple of hours trying to debug why a new init script worked great on the box but didn't work when I used Ansible.  The output of the failure led me in the wrong direction:

FAILED >> {
    "failed": true,
    "msg": "unknown service name"
}

It turned out enabled=true was what what breaking this because the init script didn't have any chkconfig settings. Hopefully this message will save people from the same hair pulling in the future.
