### PR TITLE
Bug fix: Digital Ocean cannot delete server with unique_name

### DIFF
--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -348,7 +348,7 @@ def core(module):
 
         elif state in ('absent', 'deleted'):
             # First, try to find a droplet by id.
-            droplet = Droplet.find(id=getkeyordie('id'))
+            droplet = Droplet.find(id=module.params['id'])
 
             # If we couldn't find the droplet and the user is allowing unique
             # hostnames, then check to see if a droplet with the specified


### PR DESCRIPTION
The unique_name parameter works great for state=present, but the call to `getkeyordie` causes it to fail when state=absent.
