### PR TITLE
Allow equals sign in single-line ini variables

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -119,7 +119,7 @@ class InventoryParser(object):
                             if t.startswith('#'):
                                 break
                             try:
-                                (k,v) = t.split("=")
+                                (k,v) = t.split("=", 1)
                             except ValueError, e:
                                 raise errors.AnsibleError("Invalid ini entry: %s - %s" % (t, str(e)))
                             try:

--- a/test/TestInventory.py
+++ b/test/TestInventory.py
@@ -55,7 +55,7 @@ class TestInventory(unittest.TestCase):
             'thrudgelmir0', 'thrudgelmir1', 'thrudgelmir2',
             'thrudgelmir3', 'thrudgelmir4', 'thrudgelmir5',
             'Hotep-a', 'Hotep-b', 'Hotep-c',
-            'BastC', 'BastD', ]
+            'BastC', 'BastD', 'neptun', ]
 
     #####################################
     ### Empty inventory format tests
@@ -400,6 +400,11 @@ class TestInventory(unittest.TestCase):
         assert vars == {'inventory_hostname': 'zeus',
                         'inventory_hostname_short': 'zeus',
                         'group_names': ['greek', 'major-god']}
+
+    def test_allows_equals_sign_in_var(self):
+        inventory = self.simple_inventory()
+        auth = inventory.get_variables('neptun')['auth']
+        assert auth == 'YWRtaW46YWRtaW4='
 
     # test disabled as needs to be updated to model desired behavior
     #

--- a/test/simple_hosts
+++ b/test/simple_hosts
@@ -17,3 +17,6 @@ loki
 [egyptian]
 Hotep-[a:c]
 Bast[C:D]
+
+[auth]
+neptun auth="YWRtaW46YWRtaW4="


### PR DESCRIPTION
# Description/reproduce

Add a base64-encoded variable to the inventory hosts file (note the equals sign):

```
neptun auth="YWRtaW46YWRtaW4="
```

Running `ansible-playbook -i hosts` leads to an exception thrown.

```
Invalid ini entry: auth=YWRtaW46YWRtaW4= - too many values to unpack
```

PR fixes the issue.
