### PR TITLE
Remove superfluous/invalid quote

### DIFF
--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -111,7 +111,7 @@ EXAMPLES = '''
 # Add an AAAA record.  Note that because there are colons in the value
 # that the entire parameter list must be quoted:
 - route53: >
-      "command=create
+      command=create
       zone=foo.com
       record=localhost.foo.com
       type=AAAA


### PR DESCRIPTION
Allow the example to be copy-pasted with minimal confusion about the error.
