### PR TITLE
Spelling correction

### DIFF
--- a/library/cloud/rax_dns_record
+++ b/library/cloud/rax_dns_record
@@ -45,7 +45,7 @@ options:
     required: True
   name:
     description:
-      - FWQN record name to create
+      - FQDN record name to create
     required: True
   priority:
     description:


### PR DESCRIPTION
##### Issue Type:

Docs Pull Request
##### Ansible Version:

ansible 1.5 (docfix 0dbd5d3e18) last updated 2014/02/14 10:47:27 (GMT -500)
##### Environment:

N/A
##### Summary:

Spelling correction, replacing FWQN (**F**ully **W**orking **Q**uincy **N**ovel) with FQDN, which makes a lot more sense, given the purpose of this module.  Thanks, guys.
##### Steps To Reproduce:

N/A
##### Expected Results:

N/A
##### Actual Results:

N/A
