### PR TITLE
gather_memory_facts on HP-UX without syslog

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1302,9 +1302,17 @@ class HPUX(Hardware):
         data = int(re.sub(' +',' ',out).split(' ')[5].strip())
         self.facts['memfree_mb'] = pagesize * data / 1024 / 1024
         if self.facts['architecture'] == '9000/800':
-            rc, out, err = module.run_command("grep Physical /var/adm/syslog/syslog.log")
-            data = re.search('.*Physical: ([0-9]*) Kbytes.*',out).groups()[0].strip()
-            self.facts['memtotal_mb'] = int(data) / 1024
+            try:
+                rc, out, err = module.run_command("grep Physical /var/adm/syslog/syslog.log")
+                data = re.search('.*Physical: ([0-9]*) Kbytes.*',out).groups()[0].strip()
+                self.facts['memtotal_mb'] = int(data) / 1024
+            except AttributeError:
+            	#For systems where memory details are not sent to syslog, use parsed adb output.
+            	rc, out, err = module.run_command(
+            	    "echo 'phys_mem_pages/D' | adb -k /stand/vmunix /dev/kmem | tail -1 | awk '{print $2}'"
+                )
+                data = out
+                self.facts['memtotal_mb'] = int(data) / 1024
         else:
             rc, out, err = module.run_command("/usr/contrib/bin/machinfo |grep Memory")
             data = re.search('Memory[\ :=]*([0-9]*).*MB.*',out).groups()[0].strip()


### PR DESCRIPTION
Depending on the system configuration of HP-UX systems, Memory information may not be delivered to syslog, causing the current setup module to return an AttributeError in the get_memofy_facts function.  In this case, use the absolute debugger to grab the information directly from the system.  (Closes Issue #5652)
