### PR TITLE
yum module downgrade support

### DIFF
--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -46,6 +46,11 @@ options:
             - The port to connect to
         required: false
         default: 27017
+    replicaset:
+        description:
+            - Replicaset to connect to (automatically connects to primary for writes)
+        required: false
+        default: null
     database:
         description:
             - The name of the database to add/remove the user from
@@ -98,6 +103,7 @@ import ConfigParser
 try:
     from pymongo.errors import ConnectionFailure
     from pymongo.errors import OperationFailure
+    from pymongo.errors import PyMongoError
     from pymongo import MongoClient
 except ImportError:
     try:  # for older PyMongo 2.2
@@ -165,6 +171,7 @@ def main():
             login_password=dict(default=None),
             login_host=dict(default='localhost'),
             login_port=dict(default='27017'),
+            replicaset=dict(default=None),
             database=dict(required=True, aliases=['db']),
             user=dict(required=True, aliases=['name']),
             password=dict(aliases=['pass']),
@@ -180,6 +187,7 @@ def main():
     login_password = module.params['login_password']
     login_host = module.params['login_host']
     login_port = module.params['login_port']
+    replicaset = module.params['replicaset']
     db_name = module.params['database']
     user = module.params['user']
     password = module.params['password']
@@ -187,7 +195,11 @@ def main():
     state = module.params['state']
 
     try:
-        client = MongoClient(login_host, int(login_port))
+    	if replicaset:
+    	   client = MongoClient(login_host, int(login_port), replicaset=replicaset)
+    	else:
+    	   client = MongoClient(login_host, int(login_port))
+
         if login_user is None and login_password is None:
             mongocnf_creds = load_mongocnf()
             if mongocnf_creds is not False:

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -100,14 +100,16 @@ EXAMPLES = '''
 '''
 
 import ConfigParser
+from distutils.version import LooseVersion
 try:
     from pymongo.errors import ConnectionFailure
     from pymongo.errors import OperationFailure
-    from pymongo.errors import PyMongoError
     from pymongo import MongoClient
+    from pymongo import version as PyMongoVersion
 except ImportError:
     try:  # for older PyMongo 2.2
         from pymongo import Connection as MongoClient
+        from pymongo import version as PyMongoVersion
     except ImportError:
         pymongo_found = False
     else:
@@ -120,42 +122,33 @@ else:
 #
 
 def user_add(module, client, db_name, user, password, roles):
-    try:
-        db = client[db_name]
-        if roles is None:
-            db.add_user(user, password, False)
-        else:
-            try:
-                db.add_user(user, password, None, roles=roles)
-            except:
-                module.fail_json(msg='"problem adding user; you must be on mongodb 2.4+ and pymongo 2.5+ to use the roles param"')
-    except OperationFailure:
-        return False
-
-    return True
+    db = client[db_name]
+    if roles is None:
+        db.add_user(user, password, False)
+    else:
+        try:
+            db.add_user(user, password, None, roles=roles)
+        except OperationFailure, e:
+            err_msg = str(e)
+            if LooseVersion(PyMongoVersion) <= LooseVersion('2.5'):
+                err_msg = err_msg + ' (Note: you must be on mongodb 2.4+ and pymongo 2.5+ to use the roles param)'
+            module.fail_json(msg=err_msg)
 
 def user_remove(client, db_name, user):
-    try:
-        db = client[db_name]
-        db.remove_user(user)
-    except OperationFailure:
-        return False
-
-    return True
+    db = client[db_name]
+    db.remove_user(user)
 
 def load_mongocnf():
     config = ConfigParser.RawConfigParser()
     mongocnf = os.path.expanduser('~/.mongodb.cnf')
-    if not os.path.exists(mongocnf):
-        return False
 
     try:
         config.readfp(open(mongocnf))
         creds = dict(
-          user=config.get('client', 'user'),
-          password=config.get('client', 'pass')
+            user=config.get('client', 'user'),
+            password=config.get('client', 'pass')
         )
-    except (ConfigParser.NoOptionError, IOError):
+    except IOError:
         return False
 
     return creds
@@ -212,16 +205,22 @@ def main():
             client.admin.authenticate(login_user, login_password)
 
     except ConnectionFailure, e:
-        module.fail_json(msg='unable to connect to database, check login_user and login_password are correct')
+        module.fail_json(msg='unable to connect to database: %s' % str(e))
 
     if state == 'present':
         if password is None:
             module.fail_json(msg='password parameter required when adding a user')
-        if user_add(module, client, db_name, user, password, roles) is not True:
-            module.fail_json(msg='Unable to add or update user, check login_user and login_password are correct and that this user has access to the admin collection')
+
+        try:
+            user_add(module, client, db_name, user, password, roles)
+        except OperationFailure, e:
+            module.fail_json(msg='Unable to add or update user: %s' % str(e))
+
     elif state == 'absent':
-        if user_remove(client, db_name, user) is not True:
-            module.fail_json(msg='Unable to remove user, check login_user and login_password are correct and that this user has access to the admin collection')
+        try:
+            user_remove(client, db_name, user)
+        except OperationFailure, e:
+            module.fail_json(msg='Unable to remove user: %s' % str(e))
 
     module.exit_json(changed=True, user=user)
 

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -46,11 +46,6 @@ options:
             - The port to connect to
         required: false
         default: 27017
-    replicaset:
-        description:
-            - Replicaset to connect to (automatically connects to primary for writes)
-        required: false
-        default: null
     database:
         description:
             - The name of the database to add/remove the user from
@@ -103,7 +98,6 @@ import ConfigParser
 try:
     from pymongo.errors import ConnectionFailure
     from pymongo.errors import OperationFailure
-    from pymongo.errors import PyMongoError
     from pymongo import MongoClient
 except ImportError:
     try:  # for older PyMongo 2.2
@@ -171,7 +165,6 @@ def main():
             login_password=dict(default=None),
             login_host=dict(default='localhost'),
             login_port=dict(default='27017'),
-            replicaset=dict(default=None),
             database=dict(required=True, aliases=['db']),
             user=dict(required=True, aliases=['name']),
             password=dict(aliases=['pass']),
@@ -187,7 +180,6 @@ def main():
     login_password = module.params['login_password']
     login_host = module.params['login_host']
     login_port = module.params['login_port']
-    replicaset = module.params['replicaset']
     db_name = module.params['database']
     user = module.params['user']
     password = module.params['password']
@@ -195,11 +187,7 @@ def main():
     state = module.params['state']
 
     try:
-    	if replicaset:
-    	   client = MongoClient(login_host, int(login_port), replicaset=replicaset)
-    	else:
-    	   client = MongoClient(login_host, int(login_port))
-
+        client = MongoClient(login_host, int(login_port))
         if login_user is None and login_password is None:
             mongocnf_creds = load_mongocnf()
             if mongocnf_creds is not False:

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -100,16 +100,14 @@ EXAMPLES = '''
 '''
 
 import ConfigParser
-from distutils.version import LooseVersion
 try:
     from pymongo.errors import ConnectionFailure
     from pymongo.errors import OperationFailure
+    from pymongo.errors import PyMongoError
     from pymongo import MongoClient
-    from pymongo import version as PyMongoVersion
 except ImportError:
     try:  # for older PyMongo 2.2
         from pymongo import Connection as MongoClient
-        from pymongo import version as PyMongoVersion
     except ImportError:
         pymongo_found = False
     else:
@@ -122,33 +120,42 @@ else:
 #
 
 def user_add(module, client, db_name, user, password, roles):
-    db = client[db_name]
-    if roles is None:
-        db.add_user(user, password, False)
-    else:
-        try:
-            db.add_user(user, password, None, roles=roles)
-        except OperationFailure, e:
-            err_msg = str(e)
-            if LooseVersion(PyMongoVersion) <= LooseVersion('2.5'):
-                err_msg = err_msg + ' (Note: you must be on mongodb 2.4+ and pymongo 2.5+ to use the roles param)'
-            module.fail_json(msg=err_msg)
+    try:
+        db = client[db_name]
+        if roles is None:
+            db.add_user(user, password, False)
+        else:
+            try:
+                db.add_user(user, password, None, roles=roles)
+            except:
+                module.fail_json(msg='"problem adding user; you must be on mongodb 2.4+ and pymongo 2.5+ to use the roles param"')
+    except OperationFailure:
+        return False
+
+    return True
 
 def user_remove(client, db_name, user):
-    db = client[db_name]
-    db.remove_user(user)
+    try:
+        db = client[db_name]
+        db.remove_user(user)
+    except OperationFailure:
+        return False
+
+    return True
 
 def load_mongocnf():
     config = ConfigParser.RawConfigParser()
     mongocnf = os.path.expanduser('~/.mongodb.cnf')
+    if not os.path.exists(mongocnf):
+        return False
 
     try:
         config.readfp(open(mongocnf))
         creds = dict(
-            user=config.get('client', 'user'),
-            password=config.get('client', 'pass')
+          user=config.get('client', 'user'),
+          password=config.get('client', 'pass')
         )
-    except IOError:
+    except (ConfigParser.NoOptionError, IOError):
         return False
 
     return creds
@@ -205,22 +212,16 @@ def main():
             client.admin.authenticate(login_user, login_password)
 
     except ConnectionFailure, e:
-        module.fail_json(msg='unable to connect to database: %s' % str(e))
+        module.fail_json(msg='unable to connect to database, check login_user and login_password are correct')
 
     if state == 'present':
         if password is None:
             module.fail_json(msg='password parameter required when adding a user')
-
-        try:
-            user_add(module, client, db_name, user, password, roles)
-        except OperationFailure, e:
-            module.fail_json(msg='Unable to add or update user: %s' % str(e))
-
+        if user_add(module, client, db_name, user, password, roles) is not True:
+            module.fail_json(msg='Unable to add or update user, check login_user and login_password are correct and that this user has access to the admin collection')
     elif state == 'absent':
-        try:
-            user_remove(client, db_name, user)
-        except OperationFailure, e:
-            module.fail_json(msg='Unable to remove user: %s' % str(e))
+        if user_remove(client, db_name, user) is not True:
+            module.fail_json(msg='Unable to remove user, check login_user and login_password are correct and that this user has access to the admin collection')
 
     module.exit_json(changed=True, user=user)
 

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -28,6 +28,7 @@ import yum
 try:
     from yum.misc import find_unfinished_transactions, find_ts_remaining
     from rpmUtils.miscutils import splitFilename
+    from rpmUtils.miscutils import compareEVR
     transaction_helpers = True
 except:
     transaction_helpers = False
@@ -38,7 +39,7 @@ module: yum
 version_added: historical
 short_description: Manages packages with the I(yum) package manager
 description:
-     - Installs, upgrade, removes, and lists packages and groups with the I(yum) package manager.
+     - Installs, upgrades, downgrades, removes and lists packages and groups with the I(yum) package manager.
 options:
   name:
     description:
@@ -450,6 +451,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
     res['msg'] = ''
     res['rc'] = 0
     res['changed'] = False
+    downgrade = False
 
     for spec in items:
         pkg = None
@@ -524,12 +526,30 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                     
             if found:
                 continue
+
+            # downgrade - the yum install command will only install or upgrade to a spec version, it will
+            # not install an older version of an RPM even if specifed by the install spec. So we need to 
+            # determine if this is a downgrade, and then use the yum downgrade command to install the RPM.
+            pkg_name = splitFilename(spec)[0]
+            pkgs = is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True)
+            if pkgs:
+                (cur_name, cur_ver, cur_rel, cur_epoch, cur_arch) = splitFilename(pkgs[0])
+                (new_name, new_ver, new_rel, new_epoch, new_arch) = splitFilename(spec)
+
+                compare = compareEVR((cur_epoch, cur_ver, cur_rel), (new_epoch, new_ver, new_rel))
+                if compare > 0:
+                    downgrade = True
+
             # if not - then pass in the spec as what to install
             # we could get here if nothing provides it but that's not
             # the error we're catching here
             pkg = spec
 
-        cmd = yum_basecmd + ['install', pkg]
+        operation = 'install'
+        if downgrade:
+            operation = 'downgrade'
+
+        cmd = yum_basecmd + [operation, pkg]
 
         if module.check_mode:
             module.exit_json(changed=True)

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -28,7 +28,6 @@ import yum
 try:
     from yum.misc import find_unfinished_transactions, find_ts_remaining
     from rpmUtils.miscutils import splitFilename
-    from rpmUtils.miscutils import compareEVR
     transaction_helpers = True
 except:
     transaction_helpers = False
@@ -39,7 +38,7 @@ module: yum
 version_added: historical
 short_description: Manages packages with the I(yum) package manager
 description:
-     - Installs, upgrades, downgrades, removes and lists packages and groups with the I(yum) package manager.
+     - Installs, upgrade, removes, and lists packages and groups with the I(yum) package manager.
 options:
   name:
     description:
@@ -451,7 +450,6 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
     res['msg'] = ''
     res['rc'] = 0
     res['changed'] = False
-    downgrade = False
 
     for spec in items:
         pkg = None
@@ -526,30 +524,12 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                     
             if found:
                 continue
-
-            # downgrade - the yum install command will only install or upgrade to a spec version, it will
-            # not install an older version of an RPM even if specifed by the install spec. So we need to 
-            # determine if this is a downgrade, and then use the yum downgrade command to install the RPM.
-            pkg_name = splitFilename(spec)[0]
-            pkgs = is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True)
-            if pkgs:
-                (cur_name, cur_ver, cur_rel, cur_epoch, cur_arch) = splitFilename(pkgs[0])
-                (new_name, new_ver, new_rel, new_epoch, new_arch) = splitFilename(spec)
-
-                compare = compareEVR((cur_epoch, cur_ver, cur_rel), (new_epoch, new_ver, new_rel))
-                if compare > 0:
-                    downgrade = True
-
             # if not - then pass in the spec as what to install
             # we could get here if nothing provides it but that's not
             # the error we're catching here
             pkg = spec
 
-        operation = 'install'
-        if downgrade:
-            operation = 'downgrade'
-
-        cmd = yum_basecmd + [operation, pkg]
+        cmd = yum_basecmd + ['install', pkg]
 
         if module.check_mode:
             module.exit_json(changed=True)


### PR DESCRIPTION
Allows the yum module to downgrade an RPM if it's older than the currently installed version. 

From the ref thread below, we discuses adding an optional version= param and mentioning that you can specify the version in the name. I didn't end up doing it that way because version is a bit ambiguous due to RPM's complex notion of version (i.e. epoch, rel, ver). Using the regular spec notation (it's an expression actually) would be more intuitive I believe, and there's examples in the module already. But am happy to adjust as needed. This is prob more of a bug fix than a feature add. 

Ref thread:
https://groups.google.com/forum/#!searchin/ansible-project/yum$20downgrade/ansible-project/P_Rp4fVJYHk/ZettkjxKBlcJ
