### PR TITLE
new modules: zabbix_host, zabbix_group, zabbix_screen, zabbix_webcheck

### DIFF
--- a/library/monitoring/zabbix_group
+++ b/library/monitoring/zabbix_group
@@ -17,21 +17,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible. If not, see <http://www.gnu.org/licenses/>.
-# This is a port of the ruby zabbix api found here:
-# http://trac.red-tux.net/browser/ruby/api/zbx_api.rb
 #
 
 DOCUMENTATION = '''
 ---
 module: zabbix_group
-short_description: Zabbix host groups creates/deletes.
+short_description: Zabbix host groups creates/deletes
 description:
-   - Create Zabbix host groups if they don't exist.
-   - Delete the existing host groups in Zabbix.
+   - Create host groups if they don't exist.
+   - Delete existing host groups if they exist.
 version_added: "1.6"
 author: Tony Minfei Ding, Harrison Gu
 requirements:
-    - zabbix-api python module from https://github.com/gnetsman/zabbix_api (the 1.0 version in pip is too old unfortunately)
+    - zabbix-api python module
 options:
     server_url:
         description:
@@ -52,7 +50,7 @@ options:
         default: null
     state:
         description:
-            - create or delete host group.
+            - Create or delete host group.
             - Possible values are: present and absent.
         required: false
         default: "present"
@@ -60,11 +58,13 @@ options:
         description:
             - List of host groups to create or delete.
         required: true
+notes:
+    - Too many concurrent updates to the same group may cause Zabbix to return errors, see examples for a workaround if needed.
 '''
 
 EXAMPLES = '''
 # Base create host groups example
-- name: Create host groups in zabbix
+- name: Create host groups
   local_action:
     module: zabbix_group
     server_url: http://monitor.example.com
@@ -76,7 +76,7 @@ EXAMPLES = '''
       - Example group2
 
 # Limit the Zabbix group creations to one host since Zabbix can return an error when doing concurent updates
-- name: Create host groups in zabbix
+- name: Create host groups
   local_action:
     module: zabbix_group
     server_url: http://monitor.example.com
@@ -92,7 +92,7 @@ EXAMPLES = '''
 from ansible.module_utils.basic import *
 
 try:
-    from zabbix_api import ZabbixAPI
+    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
     from zabbix_api import Already_Exists
 
     HAS_ZABBIX_API = True
@@ -156,7 +156,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing requried zabbix-api module, see this module's requirements for which version to install")
+        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']
@@ -181,7 +181,7 @@ def main():
         group_ids, group_list = hostGroup.get_group_ids(host_groups)
 
     if state == "absent":
-   		# create host groups 	
+        # delete host groups
         if group_ids:
             delete_group_names = []
             hostGroup.delete_host_group(group_ids)
@@ -190,9 +190,9 @@ def main():
             module.exit_json(changed=True,
                              result="Successfully deleted host group(s): %s." % ",".join(delete_group_names))
         else:
-            module.exit_json(changed=False, result="Not found available host group(s) to delete.")
+            module.exit_json(changed=False, result="No host group(s) to delete.")
     else:
-    	# delete host groups
+        # create host groups
         group_add_list = hostGroup.create_host_group(host_groups)
         if len(group_add_list) > 0:
             module.exit_json(changed=True, result="Successfully created host group(s): %s" % group_add_list)

--- a/library/monitoring/zabbix_group
+++ b/library/monitoring/zabbix_group
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2013, Epic Games, Inc.
+# (c) 2013-2014, Epic Games, Inc.
 #
 # This file is part of Ansible
 #
@@ -54,6 +54,10 @@ options:
             - Possible values are: present and absent.
         required: false
         default: "present"
+    timeout:
+        description:
+            - The timeout of API request(seconds).
+        default: 10
     host_groups:
         description:
             - List of host groups to create or delete.
@@ -150,7 +154,8 @@ def main():
             login_user=dict(required=True),
             login_password=dict(required=True),
             host_groups=dict(required=True),
-            state=dict(default="present")
+            state=dict(default="present"),
+            timeout=dict(default=10)
         ),
         supports_check_mode=True
     )
@@ -163,12 +168,13 @@ def main():
     login_password = module.params['login_password']
     host_groups = module.params['host_groups']
     state = module.params['state']
+    timeout = module.params['timeout']
 
     zbx = None
 
     # login to zabbix
     try:
-        zbx = ZabbixAPI(server_url)
+        zbx = ZabbixAPI(server_url, timeout=timeout)
         zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/library/monitoring/zabbix_group
+++ b/library/monitoring/zabbix_group
@@ -26,7 +26,7 @@ short_description: Zabbix host groups creates/deletes
 description:
    - Create host groups if they don't exist.
    - Delete existing host groups if they exist.
-version_added: "1.6"
+version_added: "1.7"
 author: Tony Minfei Ding, Harrison Gu
 requirements:
     - zabbix-api python module

--- a/library/monitoring/zabbix_group
+++ b/library/monitoring/zabbix_group
@@ -24,13 +24,14 @@
 DOCUMENTATION = '''
 ---
 module: zabbix_group
-short_description: Creates Zabbix host groups.
+short_description: Zabbix host groups creates/deletes.
 description:
-   - Creates Zabbix host groups if they don't already exist.
+   - Create Zabbix host groups if they don't exist.
+   - Delete the existing host groups in Zabbix.
 version_added: "1.6"
-author: Tony Minfei Ding
+author: Tony Minfei Ding, Harrison Gu
 requirements:
-    - zabbix-api python module
+    - zabbix-api python module from https://github.com/gnetsman/zabbix_api (the 1.0 version in pip is too old unfortunately)
 options:
     server_url:
         description:
@@ -49,31 +50,51 @@ options:
             - Zabbix user password.
         required: true
         default: null
+    state:
+        description:
+            - create or delete host group.
+            - Possible values are: present and absent.
+        required: false
+        default: "present"
     host_groups:
         description:
-            - List of host groups to create.
+            - List of host groups to create or delete.
         required: true
 '''
 
 EXAMPLES = '''
+# Base create host groups example
 - name: Create host groups in zabbix
   local_action:
-    module: zabbix_host
+    module: zabbix_group
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
+    state: present
     host_groups:
       - Example group1
       - Example group2
+
+# Limit the Zabbix group creations to one host since Zabbix can return an error when doing concurent updates
+- name: Create host groups in zabbix
+  local_action:
+    module: zabbix_group
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    state: present
+    host_groups:
+      - Example group1
+      - Example group2
+  when: inventory_hostname==groups['group_name'][0]
 '''
 
-
-import random
-import time
 from ansible.module_utils.basic import *
+
 try:
     from zabbix_api import ZabbixAPI
     from zabbix_api import Already_Exists
+
     HAS_ZABBIX_API = True
 except ImportError:
     HAS_ZABBIX_API = False
@@ -84,19 +105,16 @@ class HostGroup(object):
         self._module = module
         self._zapi = zbx
 
-    # create host group if not exists
+    # create host group(s) if not exists
     def create_host_group(self, group_names):
         try:
             group_add_list = []
             for group_name in group_names:
                 result = self._zapi.hostgroup.exists({'name': group_name})
-                # sometimes will create some identical host groups in zabbix, maybe a bug in zabbix
-                for i in range(0, 3):
-                    if not result:
-                        time.sleep(random.randint(1, 5))
-                        result = self._zapi.hostgroup.exists({'name': group_name})
                 if not result:
                     try:
+                        if self._module.check_mode:
+                            self._module.exit_json(changed=True)
                         self._zapi.hostgroup.create({'name': group_name})
                         group_add_list.append(group_name)
                     except Already_Exists:
@@ -105,15 +123,24 @@ class HostGroup(object):
         except Exception, e:
             self._module.fail_json(msg="Failed to create host group(s): %s" % e)
 
-    def get_group_ids(self, group_names):
-        group_ids = []
-        group_name_list = group_names.split(",")
+    # delete host group(s)
+    def delete_host_group(self, group_ids):
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            self._zapi.hostgroup.delete(group_ids)
+        except Exception, e:
+            self._module.fail_json(msg="Failed to delete host group(s), Exception: %s" % e)
 
-        group_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': group_name_list}})
+    # get group ids by name
+    def get_group_ids(self, host_groups):
+        group_ids = []
+
+        group_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': host_groups}})
         for group in group_list:
             group_id = group['groupid']
             group_ids.append(group_id)
-        return group_ids
+        return group_ids, group_list
 
 
 def main():
@@ -122,33 +149,56 @@ def main():
             server_url=dict(required=True, default=None, aliases=['url']),
             login_user=dict(required=True),
             login_password=dict(required=True),
-            host_groups=dict(required=True)
+            host_groups=dict(required=True),
+            state=dict(default="present")
         ),
-        supports_check_mode=True,
+        supports_check_mode=True
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg="Missing requried zabbix-api module, see this module's requirements for which version to install")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']
     login_password = module.params['login_password']
     host_groups = module.params['host_groups']
+    state = module.params['state']
 
     zbx = None
+
     # login to zabbix
     try:
         zbx = ZabbixAPI(server_url)
         zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
-    hostGroup = HostGroup(module, zbx)
-    group_add_list = hostGroup.create_host_group(host_groups)
-    if len(group_add_list) > 0:
-        module.exit_json(changed=True, result="Successfully create host group(s): %s" % group_add_list)
-    else:
-        module.exit_json(changed=False)
 
-# include magic from lib/ansible/module_common.py
-# <<INCLUDE_ANSIBLE_MODULE_COMMON>>
+    hostGroup = HostGroup(module, zbx)
+
+    group_ids = []
+    group_list = []
+    if host_groups:
+        group_ids, group_list = hostGroup.get_group_ids(host_groups)
+
+    if state == "absent":
+   		# create host groups 	
+        if group_ids:
+            delete_group_names = []
+            hostGroup.delete_host_group(group_ids)
+            for group in group_list:
+                delete_group_names.append(group['name'])
+            module.exit_json(changed=True,
+                             result="Successfully deleted host group(s): %s." % ",".join(delete_group_names))
+        else:
+            module.exit_json(changed=False, result="Not found available host group(s) to delete.")
+    else:
+    	# delete host groups
+        group_add_list = hostGroup.create_host_group(host_groups)
+        if len(group_add_list) > 0:
+            module.exit_json(changed=True, result="Successfully created host group(s): %s" % group_add_list)
+        else:
+            module.exit_json(changed=False)
+
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 main()
+

--- a/library/monitoring/zabbix_group
+++ b/library/monitoring/zabbix_group
@@ -20,28 +20,6 @@
 # This is a port of the ruby zabbix api found here:
 # http://trac.red-tux.net/browser/ruby/api/zbx_api.rb
 #
-# The ZabbixAPI and ZabbixAPIObjectClass were based on:
-# https://github.com/gescheit/scripts/blob/master/zabbix/zabbix_api.py
-#
-# LGPL 2.1   http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-# Zabbix API Python Library.
-# Original Ruby Library is Copyright (C) 2009 Andrew Nelson nelsonab(at)red-tux(dot)net
-# Python Library is Copyright (C) 2009 Brett Lentz brett.lentz(at)gmail(dot)com
-#
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
-#
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-#
 
 DOCUMENTATION = '''
 ---
@@ -49,27 +27,29 @@ module: zabbix_group
 short_description: Creates Zabbix host groups.
 description:
    - Creates Zabbix host groups if they don't already exist.
-version_added: "1.5"
+version_added: "1.6"
 author: Tony Minfei Ding
+requirements:
+    - zabbix-api python module
 options:
-    zabbix_server:
+    server_url:
         description:
-            - Zabbix server to connect to.
+            - Url of Zabbix server, with protocol (http or https).
+              C(url) is an alias for C(server_url).
         required: true
-    zabbix_login_user:
+        default: null
+        aliases: [ "url" ]
+    login_user:
         description:
-            - Zabbix user to login with.
+            - Zabbix user name.
         required: true
-    zabbix_login_password:
+        default: null
+    login_password:
         description:
             - Zabbix user password.
         required: true
-    zabbix_access_protocol:
-        description:
-            - Protocol to use when connecting to Zabbix.
-        required: false
-        default: "http"
-    zabbix_host_groups:
+        default: null
+    host_groups:
         description:
             - List of host groups to create.
         required: true
@@ -79,185 +59,30 @@ EXAMPLES = '''
 - name: Create host groups in zabbix
   local_action:
     module: zabbix_host
-    zabbix_server: monitor.example.com
-    zabbix_login_user: username
-    zabbix_login_password: password
-    zabbix_access_protocol: http
-    zabbix_host_groups: 
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    host_groups:
       - Example group1
       - Example group2
 '''
 
-import json
-import base64
-import urllib2
+
 import random
 import time
-import re
-
 from ansible.module_utils.basic import *
+try:
+    from zabbix_api import ZabbixAPI
+    from zabbix_api import Already_Exists
+    HAS_ZABBIX_API = True
+except ImportError:
+    HAS_ZABBIX_API = False
 
-class ZabbixAPI(object):
-    def __init__(self, module):
-        self._module = module
-        self._request_url = None
-        self._protocol = None
-        self._server_address = None
-        self._username = None
-        self._password = None
-        self._auth = None
-
-        # the suffix of request url
-        self._request_url_suffix = '/api_jsonrpc.php'
-
-        # http request headers
-        self._headers = {'Content-Type': 'application/json-rpc', 'User-Agent': 'python/zabbix'}
-
-        # timeout for http request more than 10 secs
-        self._timeout = 20
-
-    # using a string object instead of an identifier to identify the attribute, e.g. ZabbixAPI.host
-    def __getattr__(self, name):
-        if not self.__dict__.has_key(name):
-            self.__dict__[name] = ZabbixAPIObjectClass(self, name, self._module)
-        return self.__dict__[name]
-
-    # logging to zabbix
-    def do_login(self, server_address, username, password, protocol):
-        self._username = username
-        self._password = password
-        self._server_address = server_address
-        self._protocol = protocol
-        self._request_url = self._protocol + "://" + self._server_address + self._request_url_suffix
-
-        params = {'user': self._username, 'password': self._password}
-        login_request = {'jsonrpc': '2.0',
-                         'method': 'user.login',
-                         'params': params,
-                         'id': 1
-        }
-
-        try:
-            response = self.do_request(json.dumps(login_request))
-            parse_response = self.parse_response(response)
-        except Exception, e:
-            self._module.fail_json(msg=e)
-
-        self._auth = parse_response['result']
-        if not self.check_auth():
-            self._module.fail_json(msg="Login failed")
-
-    # do request to zabbix and get response
-    def do_request(self, json_string):
-        base64string = base64.encodestring('%s:%s' % (self._username, self._password)).replace('\n', '')
-        self._headers['Authorization'] = "Basic %s" % base64string
-        request = urllib2.Request(url=self._request_url, headers=self._headers)
-        request.add_data(json_string.encode('utf-8'))
-        opener = self.get_build_opener()
-        urllib2.install_opener(opener)
-        try:
-            response = opener.open(request, timeout=self._timeout)
-        except Exception, e:
-            self._module.fail_json(msg=e)
-        return response
-
-    # return build opener by different http protocol
-    def get_build_opener(self):
-        if self._protocol == "https":
-            https_handler = urllib2.HTTPSHandler()
-            opener = urllib2.build_opener(https_handler)
-        elif self._protocol == "http":
-            http_handler = urllib2.HTTPHandler()
-            opener = urllib2.build_opener(http_handler)
-        else:
-            self._module.fail_json(msg="Unknown protocol: %s" % self._protocol)
-        return opener
-
-    # check and parse http response
-    def parse_response(self, response):
-        if response.code != 200:
-            self._module.fail_json(msg="Error status code %s: %s" % (response.status, response.reason))
-
-        reads = response.read()
-        if not len(reads):
-            self._module.fail_json(msg="Response is empty.")
-        try:
-            # load string to json obj
-            response_obj = json.loads(reads.decode('utf-8'))
-        except ValueError, e:
-           self._module.fail_json(msg="Unable to decode response: %s" % reads)
-
-        if 'error' in response_obj:
-            error_code = response_obj['error']['code']
-            error_msg = response_obj['error']['message']
-            error_data = response_obj['error']['data']
-            if re.search(".*already\sexists.*", error_data, re.I):  # already exists
-                raise Already_Exists(error_data, response_obj['error']['code'])
-                # self._module.fail_json(msg="Get an error, error code: %s, error message: %s, error data: %s" % (error_code, error_msg, error_data))
-
-        return response_obj
-
-    # check login status
-    def check_auth(self):
-        if not self._auth or self._auth == '':
-            return False
-        return True
-
-    def get_requst_json(self, method, params):
-        request = {'jsonrpc': '2.0',
-                   'method': method,
-                   'params': params,
-                   'auth': self._auth,
-                   'id': 1
-        }
-        return json.dumps(request)
-
-class ZabbixAPIException(Exception):
-    """ generic zabbix api exception
-    code list:
-         -32602 - Invalid params (eg already exists)
-         -32500 - no permissions
-    """
-    pass
-
-class Already_Exists(ZabbixAPIException):
-    pass
-
-class ZabbixAPIObjectClass(ZabbixAPI):
-    def __init__(self, zabbix_api, attr_name, module):
-        super(ZabbixAPIObjectClass, self).__init__(module)
-        self._zabbix_api = zabbix_api
-        self._attr_name = attr_name
-
-    def __getattr__(self, name):
-        def method(*opts):
-            if opts.__len__():
-                return self.do_call(method="%s.%s" % (self._attr_name, name), param=opts[0])
-        return method
-
-    # do call zabbix api
-    def do_call(self, **args):
-        if self._zabbix_api.check_auth():
-            json_string = self._zabbix_api.get_requst_json(args['method'], args['param'])
-            response = self._zabbix_api.do_request(json_string)
-            parse_response = self._zabbix_api.parse_response(response)
-            return parse_response['result']
-        else:
-            self._module.fail_json(msg="User %s not logged into %s" % (self._username, self._server_address))
 
 class HostGroup(object):
-    def __init__(self, module):
+    def __init__(self, module, zbx):
         self._module = module
-        self._zapi = None
-
-    def login(self, zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol):
-        try:
-            if not self._zapi:
-                self._zapi = ZabbixAPI(self._module)
-                if not self._zapi.check_auth():
-                    self._zapi.do_login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
-        except Exception, e:
-            self._module.fail_json(msg="Login to Zabbix server %s failed: %s" % (zabbix_server, e))
+        self._zapi = zbx
 
     # create host group if not exists
     def create_host_group(self, group_names):
@@ -290,27 +115,35 @@ class HostGroup(object):
             group_ids.append(group_id)
         return group_ids
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            zabbix_server=dict(required=True),
-            zabbix_login_user=dict(required=True),
-            zabbix_login_password=dict(required=True),
-            zabbix_access_protocol=dict(required=False, default="http"),
-            zabbix_host_groups=dict(required=True)
-        )
+            server_url=dict(required=True, default=None, aliases=['url']),
+            login_user=dict(required=True),
+            login_password=dict(required=True),
+            host_groups=dict(required=True)
+        ),
+        supports_check_mode=True,
     )
 
-    zabbix_server = module.params['zabbix_server']
-    zabbix_login_user = module.params['zabbix_login_user']
-    zabbix_login_password = module.params['zabbix_login_password']
-    zabbix_access_protocol = module.params['zabbix_access_protocol']
-    zabbix_host_groups = module.params['zabbix_host_groups']
+    if not HAS_ZABBIX_API:
+        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
 
-    hostGroup = HostGroup(module)
+    server_url = module.params['server_url']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    host_groups = module.params['host_groups']
+
+    zbx = None
     # login to zabbix
-    hostGroup.login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
-    group_add_list = hostGroup.create_host_group(zabbix_host_groups)
+    try:
+        zbx = ZabbixAPI(server_url)
+        zbx.login(login_user, login_password)
+    except Exception, e:
+        module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
+    hostGroup = HostGroup(module, zbx)
+    group_add_list = hostGroup.create_host_group(host_groups)
     if len(group_add_list) > 0:
         module.exit_json(changed=True, result="Successfully create host group(s): %s" % group_add_list)
     else:
@@ -319,4 +152,3 @@ def main():
 # include magic from lib/ansible/module_common.py
 # <<INCLUDE_ANSIBLE_MODULE_COMMON>>
 main()
-

--- a/library/monitoring/zabbix_group
+++ b/library/monitoring/zabbix_group
@@ -46,9 +46,9 @@
 DOCUMENTATION = '''
 ---
 module: zabbix_group
-short_description: Create host groups in Zabbix.
+short_description: Creates Zabbix host groups.
 description:
-   - Can create host groups in Zabbix if they don't exist.
+   - Creates Zabbix host groups if they don't already exist.
 version_added: "1.5"
 author: Tony Minfei Ding
 options:
@@ -71,7 +71,7 @@ options:
         default: "http"
     zabbix_host_groups:
         description:
-            - The host groups create.
+            - List of host groups to create.
         required: true
 '''
 
@@ -83,7 +83,9 @@ EXAMPLES = '''
     zabbix_login_user: username
     zabbix_login_password: password
     zabbix_access_protocol: http
-    zabbix_host_groups: Example group1,Example group2
+    zabbix_host_groups: 
+      - Example group1
+      - Example group2
 '''
 
 import json

--- a/library/monitoring/zabbix_group
+++ b/library/monitoring/zabbix_group
@@ -46,32 +46,32 @@
 DOCUMENTATION = '''
 ---
 module: zabbix_group
-short_description: Create host groups in zabbix.
+short_description: Create host groups in Zabbix.
 description:
-   - Can create host groups when not exist.
+   - Can create host groups in Zabbix if they don't exist.
 version_added: "1.5"
 author: Tony Minfei Ding
 options:
     zabbix_server:
         description:
-            - The website of zabbix server.
+            - Zabbix server to connect to.
         required: true
     zabbix_login_user:
         description:
-            - User of zabbix.
+            - Zabbix user to login with.
         required: true
     zabbix_login_password:
         description:
-            - Password of login user.
+            - Zabbix user password.
         required: true
     zabbix_access_protocol:
         description:
-            - Protocol of zabbix.
+            - Protocol to use when connecting to Zabbix.
         required: false
         default: "http"
     zabbix_host_groups:
         description:
-            - The host groups you want to create.
+            - The host groups create.
         required: true
 '''
 
@@ -143,7 +143,7 @@ class ZabbixAPI(object):
 
         self._auth = parse_response['result']
         if not self.check_auth():
-            self._module.fail_json(msg="Login failed, please check your configure.")
+            self._module.fail_json(msg="Login failed")
 
     # do request to zabbix and get response
     def do_request(self, json_string):
@@ -168,13 +168,13 @@ class ZabbixAPI(object):
             http_handler = urllib2.HTTPHandler()
             opener = urllib2.build_opener(http_handler)
         else:
-            self._module.fail_json(msg="Unknown protocol %s." % self._protocol)
+            self._module.fail_json(msg="Unknown protocol: %s" % self._protocol)
         return opener
 
     # check and parse http response
     def parse_response(self, response):
         if response.code != 200:
-            self._module.fail_json(msg="Get error status code %s, error reason: %s" % (response.status, response.reason))
+            self._module.fail_json(msg="Error status code %s: %s" % (response.status, response.reason))
 
         reads = response.read()
         if not len(reads):
@@ -183,7 +183,7 @@ class ZabbixAPI(object):
             # load string to json obj
             response_obj = json.loads(reads.decode('utf-8'))
         except ValueError, e:
-            self._module.fail_json(msg="Unable to decode. the response string: %s" % reads)
+           self._module.fail_json(msg="Unable to decode response: %s" % reads)
 
         if 'error' in response_obj:
             error_code = response_obj['error']['code']
@@ -241,7 +241,7 @@ class ZabbixAPIObjectClass(ZabbixAPI):
             parse_response = self._zabbix_api.parse_response(response)
             return parse_response['result']
         else:
-            self._module.fail_json(msg="The user %s not logged in %s." % (self._username, self._server_address))
+            self._module.fail_json(msg="User %s not logged into %s" % (self._username, self._server_address))
 
 class HostGroup(object):
     def __init__(self, module):
@@ -255,7 +255,7 @@ class HostGroup(object):
                 if not self._zapi.check_auth():
                     self._zapi.do_login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
         except Exception, e:
-            self._module.fail_json(msg="Login to Zabbix %s failed.%s" % (zabbix_server, e))
+            self._module.fail_json(msg="Login to Zabbix server %s failed: %s" % (zabbix_server, e))
 
     # create host group if not exists
     def create_host_group(self, group_names):
@@ -276,7 +276,7 @@ class HostGroup(object):
                         return group_add_list
             return group_add_list
         except Exception, e:
-            self._module.fail_json(msg="Create host groups failed. %s" % e)
+            self._module.fail_json(msg="Failed to create host group(s): %s" % e)
 
     def get_group_ids(self, group_names):
         group_ids = []
@@ -310,7 +310,7 @@ def main():
     hostGroup.login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
     group_add_list = hostGroup.create_host_group(zabbix_host_groups)
     if len(group_add_list) > 0:
-        module.exit_json(changed=True, result="Create host groups %s successful" % group_add_list)
+        module.exit_json(changed=True, result="Successfully create host group(s): %s" % group_add_list)
     else:
         module.exit_json(changed=False)
 

--- a/library/monitoring/zabbix_group
+++ b/library/monitoring/zabbix_group
@@ -1,0 +1,320 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Epic Games, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# This is a port of the ruby zabbix api found here:
+# http://trac.red-tux.net/browser/ruby/api/zbx_api.rb
+#
+# The ZabbixAPI and ZabbixAPIObjectClass were based on:
+# https://github.com/gescheit/scripts/blob/master/zabbix/zabbix_api.py
+#
+# LGPL 2.1   http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+# Zabbix API Python Library.
+# Original Ruby Library is Copyright (C) 2009 Andrew Nelson nelsonab(at)red-tux(dot)net
+# Python Library is Copyright (C) 2009 Brett Lentz brett.lentz(at)gmail(dot)com
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+DOCUMENTATION = '''
+---
+module: zabbix_group
+short_description: Create host groups in zabbix.
+description:
+   - Can create host groups when not exist.
+version_added: "1.5"
+author: Tony Minfei Ding
+options:
+    zabbix_server:
+        description:
+            - The website of zabbix server.
+        required: true
+    zabbix_login_user:
+        description:
+            - User of zabbix.
+        required: true
+    zabbix_login_password:
+        description:
+            - Password of login user.
+        required: true
+    zabbix_access_protocol:
+        description:
+            - Protocol of zabbix.
+        required: false
+        default: "http"
+    zabbix_host_groups:
+        description:
+            - The host groups you want to create.
+        required: true
+'''
+
+EXAMPLES = '''
+- name: Create host groups in zabbix
+  local_action:
+    module: zabbix_host
+    zabbix_server: monitor.example.com
+    zabbix_login_user: username
+    zabbix_login_password: password
+    zabbix_access_protocol: http
+    zabbix_host_groups: Example group1,Example group2
+'''
+
+import json
+import base64
+import urllib2
+import random
+import time
+import re
+
+from ansible.module_utils.basic import *
+
+class ZabbixAPI(object):
+    def __init__(self, module):
+        self._module = module
+        self._request_url = None
+        self._protocol = None
+        self._server_address = None
+        self._username = None
+        self._password = None
+        self._auth = None
+
+        # the suffix of request url
+        self._request_url_suffix = '/api_jsonrpc.php'
+
+        # http request headers
+        self._headers = {'Content-Type': 'application/json-rpc', 'User-Agent': 'python/zabbix'}
+
+        # timeout for http request more than 10 secs
+        self._timeout = 20
+
+    # using a string object instead of an identifier to identify the attribute, e.g. ZabbixAPI.host
+    def __getattr__(self, name):
+        if not self.__dict__.has_key(name):
+            self.__dict__[name] = ZabbixAPIObjectClass(self, name, self._module)
+        return self.__dict__[name]
+
+    # logging to zabbix
+    def do_login(self, server_address, username, password, protocol):
+        self._username = username
+        self._password = password
+        self._server_address = server_address
+        self._protocol = protocol
+        self._request_url = self._protocol + "://" + self._server_address + self._request_url_suffix
+
+        params = {'user': self._username, 'password': self._password}
+        login_request = {'jsonrpc': '2.0',
+                         'method': 'user.login',
+                         'params': params,
+                         'id': 1
+        }
+
+        try:
+            response = self.do_request(json.dumps(login_request))
+            parse_response = self.parse_response(response)
+        except Exception, e:
+            self._module.fail_json(msg=e)
+
+        self._auth = parse_response['result']
+        if not self.check_auth():
+            self._module.fail_json(msg="Login failed, please check your configure.")
+
+    # do request to zabbix and get response
+    def do_request(self, json_string):
+        base64string = base64.encodestring('%s:%s' % (self._username, self._password)).replace('\n', '')
+        self._headers['Authorization'] = "Basic %s" % base64string
+        request = urllib2.Request(url=self._request_url, headers=self._headers)
+        request.add_data(json_string.encode('utf-8'))
+        opener = self.get_build_opener()
+        urllib2.install_opener(opener)
+        try:
+            response = opener.open(request, timeout=self._timeout)
+        except Exception, e:
+            self._module.fail_json(msg=e)
+        return response
+
+    # return build opener by different http protocol
+    def get_build_opener(self):
+        if self._protocol == "https":
+            https_handler = urllib2.HTTPSHandler()
+            opener = urllib2.build_opener(https_handler)
+        elif self._protocol == "http":
+            http_handler = urllib2.HTTPHandler()
+            opener = urllib2.build_opener(http_handler)
+        else:
+            self._module.fail_json(msg="Unknown protocol %s." % self._protocol)
+        return opener
+
+    # check and parse http response
+    def parse_response(self, response):
+        if response.code != 200:
+            self._module.fail_json(msg="Get error status code %s, error reason: %s" % (response.status, response.reason))
+
+        reads = response.read()
+        if not len(reads):
+            self._module.fail_json(msg="Response is empty.")
+        try:
+            # load string to json obj
+            response_obj = json.loads(reads.decode('utf-8'))
+        except ValueError, e:
+            self._module.fail_json(msg="Unable to decode. the response string: %s" % reads)
+
+        if 'error' in response_obj:
+            error_code = response_obj['error']['code']
+            error_msg = response_obj['error']['message']
+            error_data = response_obj['error']['data']
+            if re.search(".*already\sexists.*", error_data, re.I):  # already exists
+                raise Already_Exists(error_data, response_obj['error']['code'])
+                # self._module.fail_json(msg="Get an error, error code: %s, error message: %s, error data: %s" % (error_code, error_msg, error_data))
+
+        return response_obj
+
+    # check login status
+    def check_auth(self):
+        if not self._auth or self._auth == '':
+            return False
+        return True
+
+    def get_requst_json(self, method, params):
+        request = {'jsonrpc': '2.0',
+                   'method': method,
+                   'params': params,
+                   'auth': self._auth,
+                   'id': 1
+        }
+        return json.dumps(request)
+
+class ZabbixAPIException(Exception):
+    """ generic zabbix api exception
+    code list:
+         -32602 - Invalid params (eg already exists)
+         -32500 - no permissions
+    """
+    pass
+
+class Already_Exists(ZabbixAPIException):
+    pass
+
+class ZabbixAPIObjectClass(ZabbixAPI):
+    def __init__(self, zabbix_api, attr_name, module):
+        super(ZabbixAPIObjectClass, self).__init__(module)
+        self._zabbix_api = zabbix_api
+        self._attr_name = attr_name
+
+    def __getattr__(self, name):
+        def method(*opts):
+            if opts.__len__():
+                return self.do_call(method="%s.%s" % (self._attr_name, name), param=opts[0])
+        return method
+
+    # do call zabbix api
+    def do_call(self, **args):
+        if self._zabbix_api.check_auth():
+            json_string = self._zabbix_api.get_requst_json(args['method'], args['param'])
+            response = self._zabbix_api.do_request(json_string)
+            parse_response = self._zabbix_api.parse_response(response)
+            return parse_response['result']
+        else:
+            self._module.fail_json(msg="The user %s not logged in %s." % (self._username, self._server_address))
+
+class HostGroup(object):
+    def __init__(self, module):
+        self._module = module
+        self._zapi = None
+
+    def login(self, zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol):
+        try:
+            if not self._zapi:
+                self._zapi = ZabbixAPI(self._module)
+                if not self._zapi.check_auth():
+                    self._zapi.do_login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
+        except Exception, e:
+            self._module.fail_json(msg="Login to Zabbix %s failed.%s" % (zabbix_server, e))
+
+    # create host group if not exists
+    def create_host_group(self, group_names):
+        try:
+            group_add_list = []
+            for group_name in group_names:
+                result = self._zapi.hostgroup.exists({'name': group_name})
+                # sometimes will create some identical host groups in zabbix, maybe a bug in zabbix
+                for i in range(0, 3):
+                    if not result:
+                        time.sleep(random.randint(1, 5))
+                        result = self._zapi.hostgroup.exists({'name': group_name})
+                if not result:
+                    try:
+                        self._zapi.hostgroup.create({'name': group_name})
+                        group_add_list.append(group_name)
+                    except Already_Exists:
+                        return group_add_list
+            return group_add_list
+        except Exception, e:
+            self._module.fail_json(msg="Create host groups failed. %s" % e)
+
+    def get_group_ids(self, group_names):
+        group_ids = []
+        group_name_list = group_names.split(",")
+
+        group_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': group_name_list}})
+        for group in group_list:
+            group_id = group['groupid']
+            group_ids.append(group_id)
+        return group_ids
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            zabbix_server=dict(required=True),
+            zabbix_login_user=dict(required=True),
+            zabbix_login_password=dict(required=True),
+            zabbix_access_protocol=dict(required=False, default="http"),
+            zabbix_host_groups=dict(required=True)
+        )
+    )
+
+    zabbix_server = module.params['zabbix_server']
+    zabbix_login_user = module.params['zabbix_login_user']
+    zabbix_login_password = module.params['zabbix_login_password']
+    zabbix_access_protocol = module.params['zabbix_access_protocol']
+    zabbix_host_groups = module.params['zabbix_host_groups']
+
+    hostGroup = HostGroup(module)
+    # login to zabbix
+    hostGroup.login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
+    group_add_list = hostGroup.create_host_group(zabbix_host_groups)
+    if len(group_add_list) > 0:
+        module.exit_json(changed=True, result="Create host groups %s successful" % group_add_list)
+    else:
+        module.exit_json(changed=False)
+
+# include magic from lib/ansible/module_common.py
+# <<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()
+

--- a/library/monitoring/zabbix_host
+++ b/library/monitoring/zabbix_host
@@ -27,7 +27,7 @@ description:
    - When the host does not exists, a new host will be created, added to any host groups and linked to any templates.
    - When the host already exists, the host group membership will be updated, along with the template links and interfaces.
    - Delete a host from Zabbix if the host exists.
-version_added: "1.6"
+version_added: "1.7"
 author: Tony Minfei Ding, Harrison Gu
 requirements:
     - zabbix-api python module
@@ -83,7 +83,8 @@ options:
         description:
             - List of interfaces to be created for the host (see example).
             - Available values are: dns, ip, main, port, type and useip.
-            - Please review the interface documentation for more information on the supported properties: https://www.zabbix.com/documentation/2.0/manual/appendix/api/hostinterface/definitions#host_interface
+            - Please review the interface documentation for more information on the supported properties:
+            - https://www.zabbix.com/documentation/2.0/manual/appendix/api/hostinterface/definitions#host_interface
         required: false
 '''
 
@@ -119,6 +120,7 @@ EXAMPLES = '''
 '''
 
 import logging
+import copy
 from ansible.module_utils.basic import *
 
 try:
@@ -130,7 +132,8 @@ except ImportError:
 
 
 # Extend the ZabbixAPI
-# Since the zabbix-api python module too old (version 1.0, no higher version so far), it does not support the 'hostinterface' api calls,
+# Since the zabbix-api python module too old (version 1.0, no higher version so far),
+# it does not support the 'hostinterface' api calls,
 # so we have to inherit the ZabbixAPI class to add 'hostinterface' support.
 class ZabbixAPIExtends(ZabbixAPI):
     hostinterface = None
@@ -138,6 +141,7 @@ class ZabbixAPIExtends(ZabbixAPI):
     def __init__(self, server, timeout, **kwargs):
         ZabbixAPI.__init__(self, server, timeout=timeout)
         self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
+
 
 class Host(object):
     def __init__(self, module, zbx):
@@ -220,37 +224,16 @@ class Host(object):
         except Exception, e:
             self._module.fail_json(msg="Failed to delete host %s: %s" % (host_name, e))
 
-    # link or clear template of the host
-    def link_or_clear_template(self, host_name, template_ids_list):
-
-        host_id = self.get_host_id(host_name)
-
-        # get host's exist templates
-        exist_template_ids_list = self.get_templates_by_host_id(host_id)
-        exist_templates_ids = set(exist_template_ids_list)
-        template_ids = set(template_ids_list)
-        # get unlink and clear templates
-        templates_clear = exist_templates_ids.difference(template_ids)
-        templates_clear_list = list(templates_clear)
-        request_str = {'hostid': host_id, 'templates': template_ids_list, 'templates_clear': templates_clear_list}
-        try:
-            if self._module.check_mode:
-                self._module.exit_json(changed=True)
-            self._zapi.host.update(request_str)
-        except Exception, e:
-            self._module.fail_json(msg="Failed to link template to host: %s" % e)
-
-    # get host id by hostname
-    def get_host_id(self, host_name):
+    # get host by host name
+    def get_host_by_host_name(self, host_name):
         host_list = self._zapi.host.get({'output': 'extend', 'filter': {'host': [host_name]}})
         if len(host_list) < 1:
             self._module.fail_json(msg="Host not found: %s" % host_name)
         else:
-            host_id = host_list[0]['hostid']
-            return host_id
+            return host_list[0]
 
-    # get group ids by names        
-    def get_group_ids(self, group_names):
+    # get group ids by group names
+    def get_group_ids_by_group_names(self, group_names):
         group_ids = []
         if self.check_host_group_exist(group_names):
             group_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': group_names}})
@@ -259,13 +242,97 @@ class Host(object):
                 group_ids.append({'groupid': group_id})
         return group_ids
 
-    # get host's templates
-    def get_templates_by_host_id(self, host_id):
+    # get host templates by host id
+    def get_host_templates_by_host_id(self, host_id):
         template_ids = []
         template_list = self._zapi.template.get({'output': 'extend', 'hostids': host_id})
         for template in template_list:
             template_ids.append(template['templateid'])
         return template_ids
+
+    # get host groups by host id
+    def get_host_groups_by_host_id(self, host_id):
+        exist_host_groups = []
+        host_groups_list = self._zapi.hostgroup.get({'output': 'extend', 'hostids': host_id})
+
+        if len(host_groups_list) >= 1:
+            for host_groups_name in host_groups_list:
+                exist_host_groups.append(host_groups_name['name'])
+        return exist_host_groups
+
+    # check the exist_interfaces whether it equals the interfaces or not
+    def check_interface_properties(self, exist_interface_list, interfaces):
+        interfaces_port_list = []
+        if len(interfaces) >= 1:
+            for interface in interfaces:
+                interfaces_port_list.append(int(interface['port']))
+
+        exist_interface_ports = []
+        if len(exist_interface_list) >= 1:
+            for exist_interface in exist_interface_list:
+                exist_interface_ports.append(int(exist_interface['port']))
+
+        if set(interfaces_port_list) != set(exist_interface_ports):
+            return True
+
+        for exist_interface in exist_interface_list:
+            exit_interface_port = int(exist_interface['port'])
+            for interface in interfaces:
+                interface_port = int(interface['port'])
+                if interface_port == exit_interface_port:
+                    for key in interface.keys():
+                        if str(exist_interface[key]) != str(interface[key]):
+                            return True
+
+        return False
+
+    # get the status of host by host
+    def get_host_status_by_host(self, host):
+        return host['status']
+
+    # check all the properties before link or clear template
+    def check_all_properties(self, host_id, host_groups, status, interfaces, template_ids,
+                             exist_interfaces, host):
+        # get the existing host's groups
+        exist_host_groups = self.get_host_groups_by_host_id(host_id)
+        if set(host_groups) != set(exist_host_groups):
+            return True
+
+        # get the existing status
+        exist_status = self.get_host_status_by_host(host)
+        if int(status) != int(exist_status):
+            return True
+
+        # check the exist_interfaces whether it equals the interfaces or not
+        if self.check_interface_properties(exist_interfaces, interfaces):
+            return True
+
+        # get the existing templates
+        exist_template_ids = self.get_host_templates_by_host_id(host_id)
+        if set(list(template_ids)) != set(exist_template_ids):
+            return True
+
+        return False
+
+    # link or clear template of the host
+    def link_or_clear_template(self, host_id, template_id_list):
+        # get host's exist template ids
+        exist_template_id_list = self.get_host_templates_by_host_id(host_id)
+
+        exist_template_ids = set(exist_template_id_list)
+        template_ids = set(template_id_list)
+        template_id_list = list(template_ids)
+
+        # get unlink and clear templates
+        templates_clear = exist_template_ids.difference(template_ids)
+        templates_clear_list = list(templates_clear)
+        request_str = {'hostid': host_id, 'templates': template_id_list, 'templates_clear': templates_clear_list}
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            self._zapi.host.update(request_str)
+        except Exception, e:
+            self._module.fail_json(msg="Failed to link template to host: %s" % e)
 
 
 def main():
@@ -317,8 +384,9 @@ def main():
         template_ids = host.get_template_ids(link_templates)
 
     group_ids = []
+
     if host_groups:
-        group_ids = host.get_group_ids(host_groups)
+        group_ids = host.get_group_ids_by_group_names(host_groups)
 
     ip = ""
     if interfaces:
@@ -327,33 +395,49 @@ def main():
                 ip = interface['ip']
 
     # check if host exist
-    isHostExist = host.is_host_exist(host_name)
+    is_host_exist = host.is_host_exist(host_name)
 
-    if isHostExist:
+    if is_host_exist:
         # get host id by host name
-        host_id = host.get_host_id(host_name)
+        zabbix_host_obj = host.get_host_by_host_name(host_name)
+        host_id = zabbix_host_obj['hostid']
 
         if state == "absent":
             # remove host
             host.delete_host(host_id, host_name)
-            module.exit_json(changed=True, result="Successfully deleted host %s" % host_name)
+            module.exit_json(changed=True, result="Successfully delete host %s" % host_name)
         else:
             if not group_ids:
                 module.fail_json(msg="Specify at least one group for updating host '%s'." % host_name)
 
-            # get exist interface
-            exist_interface_list = host._zapi.hostinterface.get({'output': 'extend', 'filter': {'hostid': host_id}})
+            # get exist host's interfaces
+            exist_interfaces = host._zapi.hostinterface.get({'output': 'extend', 'hostids': host_id})
+            exist_interfaces_copy = copy.deepcopy(exist_interfaces)
 
             # update host
             interfaces_len = len(interfaces) if interfaces else 0
-            if len(exist_interface_list) > interfaces_len:
-                host.link_or_clear_template(host_name, template_ids)
-                host.update_host(host_name, group_ids, status, host_id, interfaces, exist_interface_list)
+
+            if len(exist_interfaces) > interfaces_len:
+                if host.check_all_properties(host_id, host_groups, status, interfaces, template_ids,
+                                             exist_interfaces, zabbix_host_obj):
+                    host.link_or_clear_template(host_id, template_ids)
+                    host.update_host(host_name, group_ids, status, host_id,
+                                     interfaces, exist_interfaces)
+                    module.exit_json(changed=True,
+                                     result="Successfully update host %s (%s) and linked with template '%s'"
+                                     % (host_name, ip, link_templates))
+                else:
+                    module.exit_json(changed=False)
             else:
-                host.update_host(host_name, group_ids, status, host_id, interfaces, exist_interface_list)
-                host.link_or_clear_template(host_name, template_ids)
-            module.exit_json(changed=True, result="Successfully updated host %s (%s) and linked with template '%s'" % (
-                host_name, ip, link_templates))
+                if host.check_all_properties(host_id, host_groups, status, interfaces, template_ids,
+                                             exist_interfaces_copy, zabbix_host_obj):
+                    host.update_host(host_name, group_ids, status, host_id, interfaces, exist_interfaces)
+                    host.link_or_clear_template(host_id, template_ids)
+                    module.exit_json(changed=True,
+                                     result="Successfully update host %s (%s) and linked with template '%s'"
+                                     % (host_name, ip, link_templates))
+                else:
+                    module.exit_json(changed=False)
     else:
         if not group_ids:
             module.fail_json(msg="Specify at least one group for creating host '%s'." % host_name)

--- a/library/monitoring/zabbix_host
+++ b/library/monitoring/zabbix_host
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2013, Epic Games, Inc.
+# (c) 2013-2014, Epic Games, Inc.
 #
 # This file is part of Ansible
 #
@@ -75,6 +75,10 @@ options:
             - Possible values are: present and absent. If the host already exists, and the state is "present", just to update the host.
         required: false
         default: "present"
+    timeout:
+        description:
+            - The timeout of API request(seconds).
+        default: 10
     interfaces:
         description:
             - List of interfaces to be created for the host (see example).
@@ -131,8 +135,8 @@ except ImportError:
 class ZabbixAPIExtends(ZabbixAPI):
     hostinterface = None
 
-    def __init__(self, server, **kwargs):
-        ZabbixAPI.__init__(self, server)
+    def __init__(self, server, timeout, **kwargs):
+        ZabbixAPI.__init__(self, server, timeout=timeout)
         self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
 
 class Host(object):
@@ -275,6 +279,7 @@ def main():
             link_templates=dict(required=False),
             status=dict(default="enabled"),
             state=dict(default="present"),
+            timeout=dict(default=10),
             interfaces=dict(required=False)
         ),
         supports_check_mode=True
@@ -291,6 +296,7 @@ def main():
     link_templates = module.params['link_templates']
     status = module.params['status']
     state = module.params['state']
+    timeout = module.params['timeout']
     interfaces = module.params['interfaces']
 
     # convert enabled to 0; disabled to 1
@@ -299,7 +305,7 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url)
+        zbx = ZabbixAPIExtends(server_url, timeout=timeout)
         zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/library/monitoring/zabbix_host
+++ b/library/monitoring/zabbix_host
@@ -178,7 +178,9 @@ class Host(object):
         try:
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
-            self._zapi.host.create({'host': host_name, 'interfaces': interfaces, 'groups': group_ids, 'status': status})
+            host_list = self._zapi.host.create({'host': host_name, 'interfaces': interfaces, 'groups': group_ids, 'status': status})
+            if len(host_list) >= 1:
+                return host_list['hostids'][0]
         except Exception, e:
             self._module.fail_json(msg="Failed to create host %s: %s" % (host_name, e))
 
@@ -446,8 +448,8 @@ def main():
             module.fail_json(msg="Specify at least one interface for creating host '%s'." % host_name)
 
         # create host
-        host.add_host(host_name, group_ids, status, interfaces)
-        host.link_or_clear_template(host_name, template_ids)
+        host_id = host.add_host(host_name, group_ids, status, interfaces)
+        host.link_or_clear_template(host_id, template_ids)
         module.exit_json(changed=True, result="Successfully added host %s (%s) and linked with template '%s'" % (
             host_name, ip, link_templates))
 

--- a/library/monitoring/zabbix_host
+++ b/library/monitoring/zabbix_host
@@ -264,7 +264,7 @@ class Host(object):
         template_ids = []
         template_list = self._zapi.template.get({'output': 'extend', 'hostids': host_id})
         for template in template_list:
-            template_ids.append(template['hostid'])
+            template_ids.append(template['templateid'])
         return template_ids
 
 

--- a/library/monitoring/zabbix_host
+++ b/library/monitoring/zabbix_host
@@ -22,15 +22,15 @@
 DOCUMENTATION = '''
 ---
 module: zabbix_host
-short_description: Zabbix host creates/updates/deletes.
+short_description: Zabbix host creates/updates/deletes
 description:
-   - When the host does not exists, a new host will be created, added to any host groups, and link in any templates.
+   - When the host does not exists, a new host will be created, added to any host groups and linked to any templates.
    - When the host already exists, the host group membership will be updated, along with the template links and interfaces.
    - Delete a host from Zabbix if the host exists.
 version_added: "1.6"
 author: Tony Minfei Ding, Harrison Gu
 requirements:
-    - zabbix-api python module from https://github.com/gnetsman/zabbix_api (the 1.0 version in pip is too old unfortunately)
+    - zabbix-api python module
 options:
     server_url:
         description:
@@ -79,7 +79,7 @@ options:
         description:
             - List of interfaces to be created for the host (see example).
             - Available values are: dns, ip, main, port, type and useip.
-            - Please review at https://www.zabbix.com/documentation/2.0/manual/appendix/api/hostinterface/definitions#host_interface to get more details.
+            - Please review the interface documentation for more information on the supported properties: https://www.zabbix.com/documentation/2.0/manual/appendix/api/hostinterface/definitions#host_interface
         required: false
 '''
 
@@ -114,15 +114,26 @@ EXAMPLES = '''
         port: 12345
 '''
 
+import logging
 from ansible.module_utils.basic import *
 
 try:
-    from zabbix_api import ZabbixAPI
+    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
 
     HAS_ZABBIX_API = True
 except ImportError:
     HAS_ZABBIX_API = False
 
+
+# Extend the ZabbixAPI
+# Since the zabbix-api python module too old (version 1.0, no higher version so far), it does not support the 'hostinterface' api calls,
+# so we have to inherit the ZabbixAPI class to add 'hostinterface' support.
+class ZabbixAPIExtends(ZabbixAPI):
+    hostinterface = None
+
+    def __init__(self, server, **kwargs):
+        ZabbixAPI.__init__(self, server)
+        self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
 
 class Host(object):
     def __init__(self, module, zbx):
@@ -270,7 +281,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing requried zabbix-api module, see this module's requirements for which version to install")
+        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']
@@ -288,7 +299,7 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPI(server_url)
+        zbx = ZabbixAPIExtends(server_url)
         zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
@@ -320,9 +331,9 @@ def main():
             # remove host
             host.delete_host(host_id, host_name)
             module.exit_json(changed=True, result="Successfully deleted host %s" % host_name)
-        else:  
+        else:
             if not group_ids:
-                module.fail_json(msg="Need to specify at least one of groups for updating host '%s'." % host_name)
+                module.fail_json(msg="Specify at least one group for updating host '%s'." % host_name)
 
             # get exist interface
             exist_interface_list = host._zapi.hostinterface.get({'output': 'extend', 'filter': {'hostid': host_id}})
@@ -339,10 +350,10 @@ def main():
                 host_name, ip, link_templates))
     else:
         if not group_ids:
-            module.fail_json(msg="Need to specify at least one of groups for creating host '%s'." % host_name)
+            module.fail_json(msg="Specify at least one group for creating host '%s'." % host_name)
 
         if not interfaces or (interfaces and len(interfaces) == 0):
-            module.fail_json(msg="Need to specify at least one of interfaces for creating host '%s'." % host_name)
+            module.fail_json(msg="Specify at least one interface for creating host '%s'." % host_name)
 
         # create host
         host.add_host(host_name, group_ids, status, interfaces)

--- a/library/monitoring/zabbix_host
+++ b/library/monitoring/zabbix_host
@@ -22,14 +22,15 @@
 DOCUMENTATION = '''
 ---
 module: zabbix_host
-short_description: Creates a new host or updates and existing host in Zabbix.
+short_description: Zabbix host creates/updates/deletes.
 description:
    - When the host does not exists, a new host will be created, added to any host groups, and link in any templates.
    - When the host already exists, the host group membership will be updated, along with the template links and interfaces.
+   - Delete a host from Zabbix if the host exists.
 version_added: "1.6"
-author: Tony Minfei Ding
+author: Tony Minfei Ding, Harrison Gu
 requirements:
-    - zabbix-api python module
+    - zabbix-api python module from https://github.com/gnetsman/zabbix_api (the 1.0 version in pip is too old unfortunately)
 options:
     server_url:
         description:
@@ -48,7 +49,7 @@ options:
             - Zabbix user password.
         required: true
         default: null
-    host_names:
+    host_name:
         description:
             - Technical name of the host.
             - If the host has already been added, the host name won't be updated.
@@ -56,7 +57,7 @@ options:
     host_groups:
         description:
             - List of host groups to add the host to.
-        required: true
+        required: false
     link_templates:
         description:
             - List of templates to be linked to the host.
@@ -65,13 +66,21 @@ options:
     status:
         description:
             - Status and function of the host.
-            - Possible values are: 0 - (default) monitored host; 1 - unmonitored host.
+            - Possible values are: enabled and disabled
         required: false
-        default: "0"
+        default: "enabled"
+    state:
+        description:
+            - create/update or delete host.
+            - Possible values are: present and absent. If the host already exists, and the state is "present", just to update the host.
+        required: false
+        default: "present"
     interfaces:
         description:
             - List of interfaces to be created for the host (see example).
-        required: true
+            - Available values are: dns, ip, main, port, type and useip.
+            - Please review at https://www.zabbix.com/documentation/2.0/manual/appendix/api/hostinterface/definitions#host_interface to get more details.
+        required: false
 '''
 
 EXAMPLES = '''
@@ -88,7 +97,8 @@ EXAMPLES = '''
     link_templates:
       - Example template1
       - Example template2
-    status: 1
+    status: enabled
+    state: present
     interfaces:
       - type: 1
         main: 1
@@ -104,10 +114,11 @@ EXAMPLES = '''
         port: 12345
 '''
 
-
 from ansible.module_utils.basic import *
+
 try:
     from zabbix_api import ZabbixAPI
+
     HAS_ZABBIX_API = True
 except ImportError:
     HAS_ZABBIX_API = False
@@ -146,40 +157,53 @@ class Host(object):
 
     def add_host(self, host_name, group_ids, status, interfaces):
         try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
             self._zapi.host.create({'host': host_name, 'interfaces': interfaces, 'groups': group_ids, 'status': status})
         except Exception, e:
             self._module.fail_json(msg="Failed to create host %s: %s" % (host_name, e))
 
     def update_host(self, host_name, group_ids, status, host_id, interfaces, exist_interface_list):
         try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
             self._zapi.host.update({'hostid': host_id, 'groups': group_ids, 'status': status})
             interface_list_copy = exist_interface_list
-            for interface in interfaces:
-                flag = False
-                interface_str = interface
-                for exist_interface in exist_interface_list:
-                    interface_type = interface['type']
-                    exist_interface_type = int(exist_interface['type'])
-                    if interface_type == exist_interface_type:
-                        # update
-                        interface_str['interfaceid'] = exist_interface['interfaceid']
-                        self._zapi.hostinterface.update(interface_str)
-                        flag = True
-                        interface_list_copy.remove(exist_interface)
-                        break
-                if not flag:
-                    # add
-                    interface_str['hostid'] = host_id
-                    self._zapi.hostinterface.create(interface_str)
-            # remove
-            remove_interface_ids = []
-            for remove_interface in interface_list_copy:
-                interface_id = remove_interface['interfaceid']
-                remove_interface_ids.append(interface_id)
-            if len(remove_interface_ids) > 0:
-                self._zapi.hostinterface.delete(remove_interface_ids)
+            if interfaces:
+                for interface in interfaces:
+                    flag = False
+                    interface_str = interface
+                    for exist_interface in exist_interface_list:
+                        interface_type = interface['type']
+                        exist_interface_type = int(exist_interface['type'])
+                        if interface_type == exist_interface_type:
+                            # update
+                            interface_str['interfaceid'] = exist_interface['interfaceid']
+                            self._zapi.hostinterface.update(interface_str)
+                            flag = True
+                            interface_list_copy.remove(exist_interface)
+                            break
+                    if not flag:
+                        # add
+                        interface_str['hostid'] = host_id
+                        self._zapi.hostinterface.create(interface_str)
+                        # remove
+                remove_interface_ids = []
+                for remove_interface in interface_list_copy:
+                    interface_id = remove_interface['interfaceid']
+                    remove_interface_ids.append(interface_id)
+                if len(remove_interface_ids) > 0:
+                    self._zapi.hostinterface.delete(remove_interface_ids)
         except Exception, e:
             self._module.fail_json(msg="Failed to update host %s: %s" % (host_name, e))
+
+    def delete_host(self, host_id, host_name):
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            self._zapi.host.delete({'hostid': host_id})
+        except Exception, e:
+            self._module.fail_json(msg="Failed to delete host %s: %s" % (host_name, e))
 
     # link or clear template of the host
     def link_or_clear_template(self, host_name, template_ids_list):
@@ -195,6 +219,8 @@ class Host(object):
         templates_clear_list = list(templates_clear)
         request_str = {'hostid': host_id, 'templates': template_ids_list, 'templates_clear': templates_clear_list}
         try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
             self._zapi.host.update(request_str)
         except Exception, e:
             self._module.fail_json(msg="Failed to link template to host: %s" % e)
@@ -208,6 +234,7 @@ class Host(object):
             host_id = host_list[0]['hostid']
             return host_id
 
+    # get group ids by names        
     def get_group_ids(self, group_names):
         group_ids = []
         if self.check_host_group_exist(group_names):
@@ -233,16 +260,17 @@ def main():
             login_user=dict(required=True),
             login_password=dict(required=True),
             host_name=dict(required=True),
-            host_groups=dict(required=True),
+            host_groups=dict(required=False),
             link_templates=dict(required=False),
-            status=dict(required=False, default="0"),
-            interfaces=dict()
+            status=dict(default="enabled"),
+            state=dict(default="present"),
+            interfaces=dict(required=False)
         ),
-        supports_check_mode=True,
+        supports_check_mode=True
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg="Missing requried zabbix-api module, see this module's requirements for which version to install")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']
@@ -251,11 +279,11 @@ def main():
     host_groups = module.params['host_groups']
     link_templates = module.params['link_templates']
     status = module.params['status']
+    state = module.params['state']
     interfaces = module.params['interfaces']
-    ip = ""
-    for interface in interfaces:
-        if interface['type'] == 1:
-            ip = interface['ip']
+
+    # convert enabled to 0; disabled to 1
+    status = 1 if status == "disabled" else 0
 
     zbx = None
     # login to zabbix
@@ -266,30 +294,62 @@ def main():
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 
     host = Host(module, zbx)
-    template_ids = host.get_template_ids(link_templates)
-    group_ids = host.get_group_ids(host_groups)
+
+    template_ids = []
+    if link_templates:
+        template_ids = host.get_template_ids(link_templates)
+
+    group_ids = []
+    if host_groups:
+        group_ids = host.get_group_ids(host_groups)
+
+    ip = ""
+    if interfaces:
+        for interface in interfaces:
+            if interface['type'] == 1:
+                ip = interface['ip']
+
     # check if host exist
     isHostExist = host.is_host_exist(host_name)
 
     if isHostExist:
         # get host id by host name
         host_id = host.get_host_id(host_name)
-        # get exist interface
-        exist_interface_list = host._zapi.hostinterface.get({'output': 'extend', 'filter': {'hostid': host_id}})
-        # update host
-        if len(exist_interface_list) > len(interfaces):
-            host.link_or_clear_template(host_name, template_ids)
-            host.update_host(host_name, group_ids, status, host_id, interfaces, exist_interface_list)
-        else:
-            host.update_host(host_name, group_ids, status, host_id, interfaces, exist_interface_list)
-            host.link_or_clear_template(host_name, template_ids)
-        module.exit_json(changed=True, result="Successfully updated host %s (%s) and linked with template '%s'" % (host_name, ip, link_templates))
+
+        if state == "absent":
+            # remove host
+            host.delete_host(host_id, host_name)
+            module.exit_json(changed=True, result="Successfully deleted host %s" % host_name)
+        else:  
+            if not group_ids:
+                module.fail_json(msg="Need to specify at least one of groups for updating host '%s'." % host_name)
+
+            # get exist interface
+            exist_interface_list = host._zapi.hostinterface.get({'output': 'extend', 'filter': {'hostid': host_id}})
+
+            # update host
+            interfaces_len = len(interfaces) if interfaces else 0
+            if len(exist_interface_list) > interfaces_len:
+                host.link_or_clear_template(host_name, template_ids)
+                host.update_host(host_name, group_ids, status, host_id, interfaces, exist_interface_list)
+            else:
+                host.update_host(host_name, group_ids, status, host_id, interfaces, exist_interface_list)
+                host.link_or_clear_template(host_name, template_ids)
+            module.exit_json(changed=True, result="Successfully updated host %s (%s) and linked with template '%s'" % (
+                host_name, ip, link_templates))
     else:
+        if not group_ids:
+            module.fail_json(msg="Need to specify at least one of groups for creating host '%s'." % host_name)
+
+        if not interfaces or (interfaces and len(interfaces) == 0):
+            module.fail_json(msg="Need to specify at least one of interfaces for creating host '%s'." % host_name)
+
         # create host
         host.add_host(host_name, group_ids, status, interfaces)
         host.link_or_clear_template(host_name, template_ids)
-        module.exit_json(changed=True, result="Successfully added host %s (%s) and linked with template '%s'" % (host_name, ip, link_templates))
+        module.exit_json(changed=True, result="Successfully added host %s (%s) and linked with template '%s'" % (
+            host_name, ip, link_templates))
 
-# include magic from lib/ansible/module_common.py
-# <<INCLUDE_ANSIBLE_MODULE_COMMON>>
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 main()
+

--- a/library/monitoring/zabbix_host
+++ b/library/monitoring/zabbix_host
@@ -18,28 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible. If not, see <http://www.gnu.org/licenses/>.
 #
-# The ZabbixAPI and ZabbixAPIObjectClass were based on:
-# https://github.com/gescheit/scripts/blob/master/zabbix/zabbix_api.py
-#
-# LGPL 2.1   http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-# Zabbix API Python Library.
-# Original Ruby Library is Copyright (C) 2009 Andrew Nelson nelsonab(at)red-tux(dot)net
-# Python Library is Copyright (C) 2009 Brett Lentz brett.lentz(at)gmail(dot)com
-#
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
-#
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-#
 
 DOCUMENTATION = '''
 ---
@@ -48,36 +26,38 @@ short_description: Creates a new host or updates and existing host in Zabbix.
 description:
    - When the host does not exists, a new host will be created, added to any host groups, and link in any templates.
    - When the host already exists, the host group membership will be updated, along with the template links and interfaces.
-version_added: "1.5"
+version_added: "1.6"
 author: Tony Minfei Ding
+requirements:
+    - zabbix-api python module
 options:
-    zabbix_server:
+    server_url:
         description:
-            - Zabbix server to connect to.
+            - Url of Zabbix server, with protocol (http or https).
+              C(url) is an alias for C(server_url).
         required: true
-    zabbix_login_user:
+        default: null
+        aliases: [ "url" ]
+    login_user:
         description:
-            - Zabbix user to login with.
+            - Zabbix user name.
         required: true
-    zabbix_login_password:
+        default: null
+    login_password:
         description:
             - Zabbix user password.
         required: true
-    zabbix_access_protocol:
-        description:
-            - Protocol to use when connecting to Zabbix.
-        required: false
-        default: "http"
-    zabbix_host_name:
+        default: null
+    host_names:
         description:
             - Technical name of the host.
             - If the host has already been added, the host name won't be updated.
         required: true
-    zabbix_host_groups:
+    host_groups:
         description:
             - List of host groups to add the host to.
         required: true
-    zabbix_link_templates:
+    link_templates:
         description:
             - List of templates to be linked to the host.
         required: false
@@ -98,15 +78,14 @@ EXAMPLES = '''
 - name: Create a new host or update an existing host's info
   local_action:
     module: zabbix_host
-    zabbix_server: monitor.example.com
-    zabbix_login_user: username
-    zabbix_login_password: password
-    zabbix_access_protocol: http
-    zabbix_host_name: ExampleHost
-    zabbix_host_groups:
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    host_name: ExampleHost
+    host_groups:
       - Example group1
       - Example group2
-    zabbix_link_templates:
+    link_templates:
       - Example template1
       - Example template2
     status: 1
@@ -126,169 +105,22 @@ EXAMPLES = '''
 '''
 
 
-import json
-import base64
-import urllib2
-
 from ansible.module_utils.basic import *
-
-class ZabbixAPI(object):
-    def __init__(self, module):
-        self._module = module
-        self._request_url = None
-        self._protocol = None
-        self._server_address = None
-        self._username = None
-        self._password = None
-        self._auth = None
-
-        # the suffix of request url
-        self._request_url_suffix = '/api_jsonrpc.php'
-
-        # http request headers
-        self._headers = {'Content-Type': 'application/json-rpc', 'User-Agent': 'python/zabbix'}
-
-        # timeout for http request more than 10 secs
-        self._timeout = 20
-
-    # using a string object instead of an identifier to identify the attribute, e.g. ZabbixAPI.host
-    def __getattr__(self, name):
-        if not self.__dict__.has_key(name):
-            self.__dict__[name] = ZabbixAPIObjectClass(self, name, self._module)
-        return self.__dict__[name]
-
-    # logging to zabbix
-    def do_login(self, server_address, username, password, protocol):
-        self._username = username
-        self._password = password
-        self._server_address = server_address
-        self._protocol = protocol
-        self._request_url = self._protocol + "://" + self._server_address + self._request_url_suffix
-
-        params = {'user': self._username, 'password': self._password}
-        login_request = {'jsonrpc': '2.0',
-                         'method': 'user.login',
-                         'params': params,
-                         'id': 1
-        }
-
-        try:
-            response = self.do_request(json.dumps(login_request))
-            parse_response = self.parse_response(response)
-        except Exception, e:
-            self._module.fail_json(msg=e)
-
-        self._auth = parse_response['result']
-        if not self.check_auth():
-            self._module.fail_json(msg="Login failed")
-
-    # do request to zabbix and get response
-    def do_request(self, json_string):
-        base64string = base64.encodestring('%s:%s' % (self._username, self._password)).replace('\n', '')
-        self._headers['Authorization'] = "Basic %s" % base64string
-        request = urllib2.Request(url=self._request_url, headers=self._headers)
-        request.add_data(json_string.encode('utf-8'))
-        opener = self.get_build_opener()
-        urllib2.install_opener(opener)
-        try:
-            response = opener.open(request, timeout=self._timeout)
-        except Exception, e:
-            self._module.fail_json(msg=e)
-        return response
-
-    # return build opener by different http protocol
-    def get_build_opener(self):
-        if self._protocol == "https":
-            https_handler = urllib2.HTTPSHandler()
-            opener = urllib2.build_opener(https_handler)
-        elif self._protocol == "http":
-            http_handler = urllib2.HTTPHandler()
-            opener = urllib2.build_opener(http_handler)
-        else:
-            self._module.fail_json(msg="Unknown protocol: %s" % self._protocol)
-        return opener
-
-    # check and parse http response
-    def parse_response(self, response):
-        if response.code != 200:
-            self._module.fail_json(msg="Error status code %s: %s" % (response.status, response.reason))
-
-        reads = response.read()
-        if not len(reads):
-            self._module.fail_json(msg="Empty response from Zabbix server")
-        try:
-            # load string to json obj
-            response_obj = json.loads(reads.decode('utf-8'))
-        except ValueError as e:
-	    self._module.fail_json(msg="Unable to decode response: %s" % reads)
-
-        if 'error' in response_obj:
-            error_code = response_obj['error']['code']
-            error_msg = response_obj['error']['message']
-            error_data = response_obj['error']['data']
-	    self._module.fail_json(msg="Error status code %s: %s (%s)" % (error_code, error_msg, error_data))
-
-        return response_obj
-
-    # check login status
-    def check_auth(self):
-        if not self._auth or self._auth == '':
-            return False
-        return True
-
-    def get_requst_json(self, method, params):
-        request = {'jsonrpc': '2.0',
-                   'method': method,
-                   'params': params,
-                   'auth': self._auth,
-                   'id': 1
-        }
-        return json.dumps(request)
-
-
-class ZabbixAPIObjectClass(ZabbixAPI):
-    def __init__(self, zabbix_api, attr_name, module):
-        super(ZabbixAPIObjectClass, self).__init__(module)
-        self._zabbix_api = zabbix_api
-        self._attr_name = attr_name
-
-    def __getattr__(self, name):
-        def method(*opts):
-            if opts.__len__():
-                return self.do_call(method="%s.%s" % (self._attr_name, name), param=opts[0])
-        return method
-
-    # do call zabbix api
-    def do_call(self, **args):
-        if self._zabbix_api.check_auth():
-            json_string = self._zabbix_api.get_requst_json(args['method'], args['param'])
-            response = self._zabbix_api.do_request(json_string)
-            parse_response = self._zabbix_api.parse_response(response)
-            return parse_response['result']
-        else:
-            self._module.fail_json(msg="User %s not logged into %s" % (self._username, self._server_address))
+try:
+    from zabbix_api import ZabbixAPI
+    HAS_ZABBIX_API = True
+except ImportError:
+    HAS_ZABBIX_API = False
 
 
 class Host(object):
-    def __init__(self, module):
+    def __init__(self, module, zbx):
         self._module = module
-        self._zapi = None
-
-    def login(self, zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol):
-        try:
-            if not self._zapi:
-                self._zapi = ZabbixAPI(self._module)
-                if not self._zapi.check_auth():
-                    self._zapi.do_login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
-        except Exception, e:
-            self._module.fail_json(msg="Login to Zabbix server %s failed: %s" % (zabbix_server, e))
+        self._zapi = zbx
 
     # exist host
-    def is_host_exist(self, zabbix_host_name):
-        try:
-            result = self._zapi.host.exists({'host': zabbix_host_name})
-        except Exception, e:
-            self._module.fail_json(msg=e)
+    def is_host_exist(self, host_name):
+        result = self._zapi.host.exists({'host': host_name})
         return result
 
     # check if host group exists
@@ -296,7 +128,7 @@ class Host(object):
         for group_name in group_names:
             result = self._zapi.hostgroup.exists({'name': group_name})
             if not result:
-		self._module.fail_json(msg="Hostgroup not found: %s" % group_name)
+                self._module.fail_json(msg="Hostgroup not found: %s" % group_name)
         return True
 
     def get_template_ids(self, template_list):
@@ -312,13 +144,13 @@ class Host(object):
                 template_ids.append(template_id)
         return template_ids
 
-    def add_host(self, zabbix_host_name, group_ids, status, interfaces):
+    def add_host(self, host_name, group_ids, status, interfaces):
         try:
-            self._zapi.host.create({'host': zabbix_host_name, 'interfaces': interfaces, 'groups': group_ids, 'status': status})
+            self._zapi.host.create({'host': host_name, 'interfaces': interfaces, 'groups': group_ids, 'status': status})
         except Exception, e:
-            self._module.fail_json(msg="Failed to create host %s: %s" % (zabbix_host_name, e))
+            self._module.fail_json(msg="Failed to create host %s: %s" % (host_name, e))
 
-    def update_host(self, zabbix_host_name, group_ids, status, host_id, interfaces, exist_interface_list):
+    def update_host(self, host_name, group_ids, status, host_id, interfaces, exist_interface_list):
         try:
             self._zapi.host.update({'hostid': host_id, 'groups': group_ids, 'status': status})
             interface_list_copy = exist_interface_list
@@ -339,7 +171,7 @@ class Host(object):
                     # add
                     interface_str['hostid'] = host_id
                     self._zapi.hostinterface.create(interface_str)
-                # remove
+            # remove
             remove_interface_ids = []
             for remove_interface in interface_list_copy:
                 interface_id = remove_interface['interfaceid']
@@ -347,12 +179,12 @@ class Host(object):
             if len(remove_interface_ids) > 0:
                 self._zapi.hostinterface.delete(remove_interface_ids)
         except Exception, e:
-            self._module.fail_json(msg="Failed to update host %s: %s" % (zabbix_host_name, e))
+            self._module.fail_json(msg="Failed to update host %s: %s" % (host_name, e))
 
     # link or clear template of the host
-    def link_or_clear_template(self, zabbix_host_name, template_ids_list):
+    def link_or_clear_template(self, host_name, template_ids_list):
 
-        host_id = self.get_host_id(zabbix_host_name)
+        host_id = self.get_host_id(host_name)
 
         # get host's exist templates
         exist_template_ids_list = self.get_templates_by_host_id(host_id)
@@ -365,25 +197,24 @@ class Host(object):
         try:
             self._zapi.host.update(request_str)
         except Exception, e:
-		self._module.fail_json(msg="Failed to link template to host: %s" % e)
+            self._module.fail_json(msg="Failed to link template to host: %s" % e)
 
     # get host id by hostname
-    def get_host_id(self, zabbix_host_name):
-        host_list = self._zapi.host.get({'output': 'extend', 'filter': {'host': [zabbix_host_name]}})
+    def get_host_id(self, host_name):
+        host_list = self._zapi.host.get({'output': 'extend', 'filter': {'host': [host_name]}})
         if len(host_list) < 1:
-            self._module.fail_json(msg="Host not found: %s" % zabbix_host_name)
+            self._module.fail_json(msg="Host not found: %s" % host_name)
         else:
             host_id = host_list[0]['hostid']
             return host_id
 
     def get_group_ids(self, group_names):
         group_ids = []
-
         if self.check_host_group_exist(group_names):
             group_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': group_names}})
             for group in group_list:
                 group_id = group['groupid']
-                group_ids.append({'groupid':group_id})
+                group_ids.append({'groupid': group_id})
         return group_ids
 
     # get host's templates
@@ -398,25 +229,27 @@ class Host(object):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            zabbix_server=dict(required=True),
-            zabbix_login_user=dict(required=True),
-            zabbix_login_password=dict(required=True),
-            zabbix_access_protocol=dict(required=False, default="http"),
-            zabbix_host_name=dict(required=True),
-            zabbix_host_groups=dict(required=True),
-            zabbix_link_templates=dict(required=False),
+            server_url=dict(required=True, default=None, aliases=['url']),
+            login_user=dict(required=True),
+            login_password=dict(required=True),
+            host_name=dict(required=True),
+            host_groups=dict(required=True),
+            link_templates=dict(required=False),
             status=dict(required=False, default="0"),
             interfaces=dict()
-        )
+        ),
+        supports_check_mode=True,
     )
 
-    zabbix_server = module.params['zabbix_server']
-    zabbix_login_user = module.params['zabbix_login_user']
-    zabbix_login_password = module.params['zabbix_login_password']
-    zabbix_access_protocol = module.params['zabbix_access_protocol']
-    zabbix_host_name = module.params['zabbix_host_name']
-    zabbix_host_groups = module.params['zabbix_host_groups']
-    zabbix_link_templates = module.params['zabbix_link_templates']
+    if not HAS_ZABBIX_API:
+        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
+
+    server_url = module.params['server_url']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    host_name = module.params['host_name']
+    host_groups = module.params['host_groups']
+    link_templates = module.params['link_templates']
     status = module.params['status']
     interfaces = module.params['interfaces']
     ip = ""
@@ -424,34 +257,39 @@ def main():
         if interface['type'] == 1:
             ip = interface['ip']
 
-    host = Host(module)
+    zbx = None
     # login to zabbix
-    host.login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
-    template_ids = host.get_template_ids(zabbix_link_templates)
-    group_ids = host.get_group_ids(zabbix_host_groups)
+    try:
+        zbx = ZabbixAPI(server_url)
+        zbx.login(login_user, login_password)
+    except Exception, e:
+        module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
+
+    host = Host(module, zbx)
+    template_ids = host.get_template_ids(link_templates)
+    group_ids = host.get_group_ids(host_groups)
     # check if host exist
-    isHostExist = host.is_host_exist(zabbix_host_name)
+    isHostExist = host.is_host_exist(host_name)
 
     if isHostExist:
         # get host id by host name
-        host_id = host.get_host_id(zabbix_host_name)
+        host_id = host.get_host_id(host_name)
         # get exist interface
         exist_interface_list = host._zapi.hostinterface.get({'output': 'extend', 'filter': {'hostid': host_id}})
         # update host
         if len(exist_interface_list) > len(interfaces):
-            host.link_or_clear_template(zabbix_host_name, template_ids)
-            host.update_host(zabbix_host_name, group_ids, status, host_id, interfaces, exist_interface_list)
+            host.link_or_clear_template(host_name, template_ids)
+            host.update_host(host_name, group_ids, status, host_id, interfaces, exist_interface_list)
         else:
-            host.update_host(zabbix_host_name, group_ids, status, host_id, interfaces, exist_interface_list)
-            host.link_or_clear_template(zabbix_host_name, template_ids)
-        module.exit_json(changed=True, result="Successfully updated host %s (%s) and linked with template '%s'" % (zabbix_host_name, ip, zabbix_link_templates))
+            host.update_host(host_name, group_ids, status, host_id, interfaces, exist_interface_list)
+            host.link_or_clear_template(host_name, template_ids)
+        module.exit_json(changed=True, result="Successfully updated host %s (%s) and linked with template '%s'" % (host_name, ip, link_templates))
     else:
         # create host
-        host.add_host(zabbix_host_name, group_ids, status, interfaces)
-        host.link_or_clear_template(zabbix_host_name, template_ids)
-        module.exit_json(changed=True, result="Successfully added host %s (%s) and linked with template '%s'" % (zabbix_host_name, ip, zabbix_link_templates))
+        host.add_host(host_name, group_ids, status, interfaces)
+        host.link_or_clear_template(host_name, template_ids)
+        module.exit_json(changed=True, result="Successfully added host %s (%s) and linked with template '%s'" % (host_name, ip, link_templates))
 
 # include magic from lib/ansible/module_common.py
 # <<INCLUDE_ANSIBLE_MODULE_COMMON>>
 main()
-

--- a/library/monitoring/zabbix_host
+++ b/library/monitoring/zabbix_host
@@ -1,0 +1,453 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Epic Games, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+#
+# The ZabbixAPI and ZabbixAPIObjectClass were based on:
+# https://github.com/gescheit/scripts/blob/master/zabbix/zabbix_api.py
+#
+# LGPL 2.1   http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+# Zabbix API Python Library.
+# Original Ruby Library is Copyright (C) 2009 Andrew Nelson nelsonab(at)red-tux(dot)net
+# Python Library is Copyright (C) 2009 Brett Lentz brett.lentz(at)gmail(dot)com
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+DOCUMENTATION = '''
+---
+module: zabbix_host
+short_description: Create a new host or update host info in zabbix.
+description:
+   - When the host does not exists, a new host will be created, added to any host groups, and link in any templates.
+   - When the host already exists, the host group membership will be updated, along with the template links and interfaces.
+version_added: "1.5"
+author: Tony Minfei Ding
+options:
+    zabbix_server:
+        description:
+            - The website of zabbix server.
+        required: true
+    zabbix_login_user:
+        description:
+            - User of zabbix.
+        required: true
+    zabbix_login_password:
+        description:
+            - Password of login user.
+        required: true
+    zabbix_access_protocol:
+        description:
+            - Protocol of zabbix.
+        required: false
+        default: "http"
+    zabbix_host_name:
+        description:
+            - Technical name of the host.
+            - If the host has been added, the host name can't update in this script.
+        required: true
+    zabbix_host_groups:
+        description:
+            - Host groups to add the host to.
+        required: true
+    zabbix_link_templates:
+        description:
+            - Templates to be linked to the host.
+        required: false
+        default: None
+    status:
+        description:
+            - Status and function of the host.
+            - Possible values are: 0 - (default) monitored host; 1 - unmonitored host.
+        required: false
+        default: "0"
+    interfaces:
+        description:
+            - List of interfaces to be created for the host (see example).
+        required: true
+'''
+
+EXAMPLES = '''
+- name: Create a new host or update the host's info in zabbix
+  local_action:
+    module: zabbix_host
+    zabbix_server: monitor.example.com
+    zabbix_login_user: username
+    zabbix_login_password: password
+    zabbix_access_protocol: http
+    zabbix_host_name: ExampleHost
+    zabbix_host_groups: Example group1,Example group2
+    zabbix_link_templates: Example template1,Example template2
+    status: 1
+    interfaces:
+      - type: 1
+        main: 1
+        useip: 1
+        ip: 10.xx.xx.xx
+        dns: ""
+        port: 10050
+      - type: 4
+        main: 1
+        useip: 1
+        ip: 10.xx.xx.xx
+        dns: ""
+        port: 12345
+'''
+
+
+import json
+import base64
+import urllib2
+
+from ansible.module_utils.basic import *
+
+class ZabbixAPI(object):
+    def __init__(self, module):
+        self._module = module
+        self._request_url = None
+        self._protocol = None
+        self._server_address = None
+        self._username = None
+        self._password = None
+        self._auth = None
+
+        # the suffix of request url
+        self._request_url_suffix = '/api_jsonrpc.php'
+
+        # http request headers
+        self._headers = {'Content-Type': 'application/json-rpc', 'User-Agent': 'python/zabbix'}
+
+        # timeout for http request more than 10 secs
+        self._timeout = 20
+
+    # using a string object instead of an identifier to identify the attribute, e.g. ZabbixAPI.host
+    def __getattr__(self, name):
+        if not self.__dict__.has_key(name):
+            self.__dict__[name] = ZabbixAPIObjectClass(self, name, self._module)
+        return self.__dict__[name]
+
+    # logging to zabbix
+    def do_login(self, server_address, username, password, protocol):
+        self._username = username
+        self._password = password
+        self._server_address = server_address
+        self._protocol = protocol
+        self._request_url = self._protocol + "://" + self._server_address + self._request_url_suffix
+
+        params = {'user': self._username, 'password': self._password}
+        login_request = {'jsonrpc': '2.0',
+                         'method': 'user.login',
+                         'params': params,
+                         'id': 1
+        }
+
+        try:
+            response = self.do_request(json.dumps(login_request))
+            parse_response = self.parse_response(response)
+        except Exception, e:
+            self._module.fail_json(msg=e)
+
+        self._auth = parse_response['result']
+        if not self.check_auth():
+            self._module.fail_json(msg="Login failed, please check your configure.")
+
+    # do request to zabbix and get response
+    def do_request(self, json_string):
+        base64string = base64.encodestring('%s:%s' % (self._username, self._password)).replace('\n', '')
+        self._headers['Authorization'] = "Basic %s" % base64string
+        request = urllib2.Request(url=self._request_url, headers=self._headers)
+        request.add_data(json_string.encode('utf-8'))
+        opener = self.get_build_opener()
+        urllib2.install_opener(opener)
+        try:
+            response = opener.open(request, timeout=self._timeout)
+        except Exception, e:
+            self._module.fail_json(msg=e)
+        return response
+
+    # return build opener by different http protocol
+    def get_build_opener(self):
+        if self._protocol == "https":
+            https_handler = urllib2.HTTPSHandler()
+            opener = urllib2.build_opener(https_handler)
+        elif self._protocol == "http":
+            http_handler = urllib2.HTTPHandler()
+            opener = urllib2.build_opener(http_handler)
+        else:
+            self._module.fail_json(msg="Unknown protocol %s." % self._protocol)
+        return opener
+
+    # check and parse http response
+    def parse_response(self, response):
+        if response.code != 200:
+            self._module.fail_json(msg="Get error status code %s, error reason: %s" % (response.status, response.reason))
+
+        reads = response.read()
+        if not len(reads):
+            self._module.fail_json(msg="Response is empty.")
+        try:
+            # load string to json obj
+            response_obj = json.loads(reads.decode('utf-8'))
+        except ValueError as e:
+            self._module.fail_json(msg="Unable to decode. the response string: %s" % reads)
+
+        if 'error' in response_obj:
+            error_code = response_obj['error']['code']
+            error_msg = response_obj['error']['message']
+            error_data = response_obj['error']['data']
+            self._module.fail_json(msg="Get an error, error code: %s, error message: %s, error data: %s" % (error_code, error_msg, error_data))
+
+        return response_obj
+
+    # check login status
+    def check_auth(self):
+        if not self._auth or self._auth == '':
+            return False
+        return True
+
+    def get_requst_json(self, method, params):
+        request = {'jsonrpc': '2.0',
+                   'method': method,
+                   'params': params,
+                   'auth': self._auth,
+                   'id': 1
+        }
+        return json.dumps(request)
+
+
+class ZabbixAPIObjectClass(ZabbixAPI):
+    def __init__(self, zabbix_api, attr_name, module):
+        super(ZabbixAPIObjectClass, self).__init__(module)
+        self._zabbix_api = zabbix_api
+        self._attr_name = attr_name
+
+    def __getattr__(self, name):
+        def method(*opts):
+            if opts.__len__():
+                return self.do_call(method="%s.%s" % (self._attr_name, name), param=opts[0])
+        return method
+
+    # do call zabbix api
+    def do_call(self, **args):
+        if self._zabbix_api.check_auth():
+            json_string = self._zabbix_api.get_requst_json(args['method'], args['param'])
+            response = self._zabbix_api.do_request(json_string)
+            parse_response = self._zabbix_api.parse_response(response)
+            return parse_response['result']
+        else:
+            self._module.fail_json(msg="The user %s not logged in %s." % (self._username, self._server_address))
+
+
+class Host(object):
+    def __init__(self, module):
+        self._module = module
+        self._zapi = None
+
+    def login(self, zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol):
+        try:
+            if not self._zapi:
+                self._zapi = ZabbixAPI(self._module)
+                if not self._zapi.check_auth():
+                    self._zapi.do_login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
+        except Exception, e:
+            self._module.fail_json(msg="Login to Zabbix %s failed.%s" % (zabbix_server, e))
+
+    # exist host
+    def is_host_exist(self, zabbix_host_name):
+        try:
+            result = self._zapi.host.exists({'host': zabbix_host_name})
+        except Exception, e:
+            self._module.fail_json(msg=e)
+        return result
+
+    # check if host group exists
+    def check_host_group_exist(self, group_names):
+        for group_name in group_names:
+            result = self._zapi.hostgroup.exists({'name': group_name})
+            if not result:
+                self._module.fail_json(msg="The hostgroup %s not exist" % group_name)
+        return True
+
+    def get_template_ids(self, template_list):
+        template_ids = []
+        if template_list is None or len(template_list) == 0:
+            return template_ids
+        for template in template_list:
+            template_list = self._zapi.template.get({'output': 'extend', 'filter': {'host': template}})
+            if len(template_list) < 1:
+                self._module.fail_json(msg="Not found template %s." % template)
+            else:
+                template_id = template_list[0]['templateid']
+                template_ids.append(template_id)
+        return template_ids
+
+    def add_host(self, zabbix_host_name, group_ids, status, interfaces):
+        try:
+            self._zapi.host.create({'host': zabbix_host_name, 'interfaces': interfaces, 'groups': group_ids, 'status': status})
+        except Exception, e:
+            self._module.fail_json(msg="Failed to create %s.%s" % (zabbix_host_name, e))
+
+    def update_host(self, zabbix_host_name, group_ids, status, host_id, interfaces, exist_interface_list):
+        try:
+            self._zapi.host.update({'hostid': host_id, 'groups': group_ids, 'status': status})
+            interface_list_copy = exist_interface_list
+            for interface in interfaces:
+                flag = False
+                interface_str = interface
+                for exist_interface in exist_interface_list:
+                    interface_type = interface['type']
+                    exist_interface_type = int(exist_interface['type'])
+                    if interface_type == exist_interface_type:
+                        # update
+                        interface_str['interfaceid'] = exist_interface['interfaceid']
+                        self._zapi.hostinterface.update(interface_str)
+                        flag = True
+                        interface_list_copy.remove(exist_interface)
+                        break
+                if not flag:
+                    # add
+                    interface_str['hostid'] = host_id
+                    self._zapi.hostinterface.create(interface_str)
+                # remove
+            remove_interface_ids = []
+            for remove_interface in interface_list_copy:
+                interface_id = remove_interface['interfaceid']
+                remove_interface_ids.append(interface_id)
+            if len(remove_interface_ids) > 0:
+                self._zapi.hostinterface.delete(remove_interface_ids)
+        except Exception, e:
+            self._module.fail_json(msg="Failed to update %s.%s" % (zabbix_host_name, e))
+
+    # link or clear template of the host
+    def link_or_clear_template(self, zabbix_host_name, template_ids_list):
+
+        host_id = self.get_host_id(zabbix_host_name)
+
+        # get host's exist templates
+        exist_template_ids_list = self.get_templates_by_host_id(host_id)
+        exist_templates_ids = set(exist_template_ids_list)
+        template_ids = set(template_ids_list)
+        # get unlink and clear templates
+        templates_clear = exist_templates_ids.difference(template_ids)
+        templates_clear_list = list(templates_clear)
+        request_str = {'hostid': host_id, 'templates': template_ids_list, 'templates_clear': templates_clear_list}
+        try:
+            self._zapi.host.update(request_str)
+        except Exception, e:
+            self._module.fail_json(msg="Add templates failed.%s" % e)
+
+    # get host id by hostname
+    def get_host_id(self, zabbix_host_name):
+        host_list = self._zapi.host.get({'output': 'extend', 'filter': {'host': [zabbix_host_name]}})
+        if len(host_list) < 1:
+            self._module.fail_json(msg="Not found host %s." % zabbix_host_name)
+        else:
+            host_id = host_list[0]['hostid']
+            return host_id
+
+    def get_group_ids(self, group_names):
+        group_ids = []
+
+        if self.check_host_group_exist(group_names):
+            group_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': group_names}})
+            for group in group_list:
+                group_id = group['groupid']
+                group_ids.append({'groupid':group_id})
+        return group_ids
+
+    # get host's templates
+    def get_templates_by_host_id(self, host_id):
+        template_ids = []
+        template_list = self._zapi.template.get({'output': 'extend', 'hostids': host_id})
+        for template in template_list:
+            template_ids.append(template['hostid'])
+        return template_ids
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            zabbix_server=dict(required=True),
+            zabbix_login_user=dict(required=True),
+            zabbix_login_password=dict(required=True),
+            zabbix_access_protocol=dict(required=False, default="http"),
+            zabbix_host_name=dict(required=True),
+            zabbix_host_groups=dict(required=True),
+            zabbix_link_templates=dict(required=False),
+            status=dict(required=False, default="0"),
+            interfaces=dict()
+        )
+    )
+
+    zabbix_server = module.params['zabbix_server']
+    zabbix_login_user = module.params['zabbix_login_user']
+    zabbix_login_password = module.params['zabbix_login_password']
+    zabbix_access_protocol = module.params['zabbix_access_protocol']
+    zabbix_host_name = module.params['zabbix_host_name']
+    zabbix_host_groups = module.params['zabbix_host_groups']
+    zabbix_link_templates = module.params['zabbix_link_templates']
+    status = module.params['status']
+    interfaces = module.params['interfaces']
+    ip = ""
+    for interface in interfaces:
+        if interface['type'] == 1:
+            ip = interface['ip']
+
+    host = Host(module)
+    # login to zabbix
+    host.login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
+    template_ids = host.get_template_ids(zabbix_link_templates)
+    group_ids = host.get_group_ids(zabbix_host_groups)
+    # check if host exist
+    isHostExist = host.is_host_exist(zabbix_host_name)
+
+    if isHostExist:
+        # get host id by host name
+        host_id = host.get_host_id(zabbix_host_name)
+        # get exist interface
+        exist_interface_list = host._zapi.hostinterface.get({'output': 'extend', 'filter': {'hostid': host_id}})
+        # update host
+        if len(exist_interface_list) > len(interfaces):
+            host.link_or_clear_template(zabbix_host_name, template_ids)
+            host.update_host(zabbix_host_name, group_ids, status, host_id, interfaces, exist_interface_list)
+        else:
+            host.update_host(zabbix_host_name, group_ids, status, host_id, interfaces, exist_interface_list)
+            host.link_or_clear_template(zabbix_host_name, template_ids)
+        module.exit_json(changed=True, result="Update host %s(%s) successful and the template '%s' has linked to the host." % (zabbix_host_name, ip, zabbix_link_templates))
+    else:
+        # create host
+        host.add_host(zabbix_host_name, group_ids, status, interfaces)
+        host.link_or_clear_template(zabbix_host_name, template_ids)
+        module.exit_json(changed=True, result="Add host %s(%s) successful and the template '%s' has linked to the host." % (zabbix_host_name, ip, zabbix_link_templates))
+
+# include magic from lib/ansible/module_common.py
+# <<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()
+

--- a/library/monitoring/zabbix_host
+++ b/library/monitoring/zabbix_host
@@ -75,11 +75,11 @@ options:
         required: true
     zabbix_host_groups:
         description:
-            - Host groups to add the host to.
+            - List of host groups to add the host to.
         required: true
     zabbix_link_templates:
         description:
-            - Templates to be linked to the host.
+            - List of templates to be linked to the host.
         required: false
         default: None
     status:
@@ -103,8 +103,12 @@ EXAMPLES = '''
     zabbix_login_password: password
     zabbix_access_protocol: http
     zabbix_host_name: ExampleHost
-    zabbix_host_groups: Example group1,Example group2
-    zabbix_link_templates: Example template1,Example template2
+    zabbix_host_groups:
+      - Example group1
+      - Example group2
+    zabbix_link_templates:
+      - Example template1
+      - Example template2
     status: 1
     interfaces:
       - type: 1

--- a/library/monitoring/zabbix_host
+++ b/library/monitoring/zabbix_host
@@ -44,7 +44,7 @@
 DOCUMENTATION = '''
 ---
 module: zabbix_host
-short_description: Create a new host or update host info in zabbix.
+short_description: Creates a new host or updates and existing host in Zabbix.
 description:
    - When the host does not exists, a new host will be created, added to any host groups, and link in any templates.
    - When the host already exists, the host group membership will be updated, along with the template links and interfaces.
@@ -53,25 +53,25 @@ author: Tony Minfei Ding
 options:
     zabbix_server:
         description:
-            - The website of zabbix server.
+            - Zabbix server to connect to.
         required: true
     zabbix_login_user:
         description:
-            - User of zabbix.
+            - Zabbix user to login with.
         required: true
     zabbix_login_password:
         description:
-            - Password of login user.
+            - Zabbix user password.
         required: true
     zabbix_access_protocol:
         description:
-            - Protocol of zabbix.
+            - Protocol to use when connecting to Zabbix.
         required: false
         default: "http"
     zabbix_host_name:
         description:
             - Technical name of the host.
-            - If the host has been added, the host name can't update in this script.
+            - If the host has already been added, the host name won't be updated.
         required: true
     zabbix_host_groups:
         description:
@@ -95,7 +95,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: Create a new host or update the host's info in zabbix
+- name: Create a new host or update an existing host's info
   local_action:
     module: zabbix_host
     zabbix_server: monitor.example.com
@@ -176,7 +176,7 @@ class ZabbixAPI(object):
 
         self._auth = parse_response['result']
         if not self.check_auth():
-            self._module.fail_json(msg="Login failed, please check your configure.")
+            self._module.fail_json(msg="Login failed")
 
     # do request to zabbix and get response
     def do_request(self, json_string):
@@ -201,28 +201,28 @@ class ZabbixAPI(object):
             http_handler = urllib2.HTTPHandler()
             opener = urllib2.build_opener(http_handler)
         else:
-            self._module.fail_json(msg="Unknown protocol %s." % self._protocol)
+            self._module.fail_json(msg="Unknown protocol: %s" % self._protocol)
         return opener
 
     # check and parse http response
     def parse_response(self, response):
         if response.code != 200:
-            self._module.fail_json(msg="Get error status code %s, error reason: %s" % (response.status, response.reason))
+            self._module.fail_json(msg="Error status code %s: %s" % (response.status, response.reason))
 
         reads = response.read()
         if not len(reads):
-            self._module.fail_json(msg="Response is empty.")
+            self._module.fail_json(msg="Empty response from Zabbix server")
         try:
             # load string to json obj
             response_obj = json.loads(reads.decode('utf-8'))
         except ValueError as e:
-            self._module.fail_json(msg="Unable to decode. the response string: %s" % reads)
+	    self._module.fail_json(msg="Unable to decode response: %s" % reads)
 
         if 'error' in response_obj:
             error_code = response_obj['error']['code']
             error_msg = response_obj['error']['message']
             error_data = response_obj['error']['data']
-            self._module.fail_json(msg="Get an error, error code: %s, error message: %s, error data: %s" % (error_code, error_msg, error_data))
+	    self._module.fail_json(msg="Error status code %s: %s (%s)" % (error_code, error_msg, error_data))
 
         return response_obj
 
@@ -262,7 +262,7 @@ class ZabbixAPIObjectClass(ZabbixAPI):
             parse_response = self._zabbix_api.parse_response(response)
             return parse_response['result']
         else:
-            self._module.fail_json(msg="The user %s not logged in %s." % (self._username, self._server_address))
+            self._module.fail_json(msg="User %s not logged into %s" % (self._username, self._server_address))
 
 
 class Host(object):
@@ -277,7 +277,7 @@ class Host(object):
                 if not self._zapi.check_auth():
                     self._zapi.do_login(zabbix_server, zabbix_login_user, zabbix_login_password, zabbix_access_protocol)
         except Exception, e:
-            self._module.fail_json(msg="Login to Zabbix %s failed.%s" % (zabbix_server, e))
+            self._module.fail_json(msg="Login to Zabbix server %s failed: %s" % (zabbix_server, e))
 
     # exist host
     def is_host_exist(self, zabbix_host_name):
@@ -292,7 +292,7 @@ class Host(object):
         for group_name in group_names:
             result = self._zapi.hostgroup.exists({'name': group_name})
             if not result:
-                self._module.fail_json(msg="The hostgroup %s not exist" % group_name)
+		self._module.fail_json(msg="Hostgroup not found: %s" % group_name)
         return True
 
     def get_template_ids(self, template_list):
@@ -302,7 +302,7 @@ class Host(object):
         for template in template_list:
             template_list = self._zapi.template.get({'output': 'extend', 'filter': {'host': template}})
             if len(template_list) < 1:
-                self._module.fail_json(msg="Not found template %s." % template)
+                self._module.fail_json(msg="Template not found: %s" % template)
             else:
                 template_id = template_list[0]['templateid']
                 template_ids.append(template_id)
@@ -312,7 +312,7 @@ class Host(object):
         try:
             self._zapi.host.create({'host': zabbix_host_name, 'interfaces': interfaces, 'groups': group_ids, 'status': status})
         except Exception, e:
-            self._module.fail_json(msg="Failed to create %s.%s" % (zabbix_host_name, e))
+            self._module.fail_json(msg="Failed to create host %s: %s" % (zabbix_host_name, e))
 
     def update_host(self, zabbix_host_name, group_ids, status, host_id, interfaces, exist_interface_list):
         try:
@@ -343,7 +343,7 @@ class Host(object):
             if len(remove_interface_ids) > 0:
                 self._zapi.hostinterface.delete(remove_interface_ids)
         except Exception, e:
-            self._module.fail_json(msg="Failed to update %s.%s" % (zabbix_host_name, e))
+            self._module.fail_json(msg="Failed to update host %s: %s" % (zabbix_host_name, e))
 
     # link or clear template of the host
     def link_or_clear_template(self, zabbix_host_name, template_ids_list):
@@ -361,13 +361,13 @@ class Host(object):
         try:
             self._zapi.host.update(request_str)
         except Exception, e:
-            self._module.fail_json(msg="Add templates failed.%s" % e)
+		self._module.fail_json(msg="Failed to link template to host: %s" % e)
 
     # get host id by hostname
     def get_host_id(self, zabbix_host_name):
         host_list = self._zapi.host.get({'output': 'extend', 'filter': {'host': [zabbix_host_name]}})
         if len(host_list) < 1:
-            self._module.fail_json(msg="Not found host %s." % zabbix_host_name)
+            self._module.fail_json(msg="Host not found: %s" % zabbix_host_name)
         else:
             host_id = host_list[0]['hostid']
             return host_id
@@ -440,12 +440,12 @@ def main():
         else:
             host.update_host(zabbix_host_name, group_ids, status, host_id, interfaces, exist_interface_list)
             host.link_or_clear_template(zabbix_host_name, template_ids)
-        module.exit_json(changed=True, result="Update host %s(%s) successful and the template '%s' has linked to the host." % (zabbix_host_name, ip, zabbix_link_templates))
+        module.exit_json(changed=True, result="Successfully updated host %s (%s) and linked with template '%s'" % (zabbix_host_name, ip, zabbix_link_templates))
     else:
         # create host
         host.add_host(zabbix_host_name, group_ids, status, interfaces)
         host.link_or_clear_template(zabbix_host_name, template_ids)
-        module.exit_json(changed=True, result="Add host %s(%s) successful and the template '%s' has linked to the host." % (zabbix_host_name, ip, zabbix_link_templates))
+        module.exit_json(changed=True, result="Successfully added host %s (%s) and linked with template '%s'" % (zabbix_host_name, ip, zabbix_link_templates))
 
 # include magic from lib/ansible/module_common.py
 # <<INCLUDE_ANSIBLE_MODULE_COMMON>>

--- a/library/monitoring/zabbix_screen
+++ b/library/monitoring/zabbix_screen
@@ -19,18 +19,20 @@
 # along with Ansible. If not, see <http://www.gnu.org/licenses/>.
 #
 
+
 DOCUMENTATION = '''
 ---
 module: zabbix_screen
-short_description: Creates a new screen or updates existing screen in Zabbix.
+short_description: Zabbix screen creates/updates/deletes
 description:
-   - When the screen does not exists, a new screen will be created, along with the screen items.
+   - When the screen does not exists, a new screen will be created with any screen items specified.
    - When the screen already exists and the graphs have changed, the screen items will be updated.
    - When the graph IDs have not changed, the screen items won't be updated unless the graph_width and graph_height have changed.
+   - Delete screen(s) from Zabbix if the screen(s) exists.
 version_added: "1.6"
 author: Tony Minfei Ding, Harrison Gu
 requirements:
-    - zabbix-api python module from https://github.com/gnetsman/zabbix_api (the 1.0 version in pip is too old unfortunately)
+    - zabbix-api python module
 options:
     server_url:
         description:
@@ -51,11 +53,19 @@ options:
         default: null
     zabbix_screens:
         description:
-            - List of screens to be created(see example).
+            - List of screens to be created/updated/deleted(see example).
+            - If the screen(s) already been added, the screen(s) name won't be updated.
+            - When creating or updating screen(s), the screen_name, host_group are required.
+            - When deleting screen(s), the screen_name is required.
+            - The available states are: present(default) and absent. If the screen(s) already exists, and the state is not "absent", the screen(s) will just be updated.
         required: true
+        default: null
+notes:
+    - Too many concurrent updates to the same screen may cause Zabbix to return errors, see examples for a workaround if needed.
 '''
 
 EXAMPLES = '''
+# Create/update a screen.
 - name: Create a new screen or update an existing screen's items
   local_action:
     module: zabbix_screen
@@ -63,26 +73,80 @@ EXAMPLES = '''
     login_user: username
     login_password: password
     screens:
-      - screen_name: ExampleScreen
-        host_group: Example group
+      - screen_name: ExampleScreen1
+        host_group: Example group1
+        state: present
         graph_names:
           - Example graph1
           - Example graph2
         graph_width: 200
         graph_height: 100
+
+# Create/update multi-screen
+- name: Create two of new screens or update the existing screens' items
+  local_action:
+    module: zabbix_screen
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    screens:
+      - screen_name: ExampleScreen1
+        host_group: Example group1
+        state: present
+        graph_names:
+          - Example graph1
+          - Example graph2
+        graph_width: 200
+        graph_height: 100
+      - screen_name: ExampleScreen2
+        host_group: Example group2
+        state: present
+        graph_names:
+          - Example graph1
+          - Example graph2
+        graph_width: 200
+        graph_height: 100
+
+# Limit the Zabbix screen creations to one host since Zabbix can return an error when doing concurent updates
+- name: Create a new screen or update an existing screen's items
+  local_action:
+    module: zabbix_screen
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    state: present
+    screens:
+      - screen_name: ExampleScreen
+        host_group: Example group
+        state: present
+        graph_names:
+          - Example graph1
+          - Example graph2
+        graph_width: 200
+        graph_height: 100
+  when: inventory_hostname==groups['group_name'][0]
 '''
 
-
-import random
-import time
 from ansible.module_utils.basic import *
+
 try:
-    from zabbix_api import ZabbixAPI
+    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
     from zabbix_api import ZabbixAPIException
     from zabbix_api import Already_Exists
     HAS_ZABBIX_API = True
 except ImportError:
     HAS_ZABBIX_API = False
+
+
+# Extend the ZabbixAPI
+# Since the zabbix-api python module too old (version 1.0, and there's no higher version so far), it doesn't support the 'screenitem' api call,
+# we have to inherit the ZabbixAPI class to add 'screenitem' support.
+class ZabbixAPIExtends(ZabbixAPI):
+    screenitem = None
+
+    def __init__(self, server, **kwargs):
+        ZabbixAPI.__init__(self, server)
+        self.screenitem = ZabbixAPISubClass(self, dict({"prefix": "screenitem"}, **kwargs))
 
 
 class Screen(object):
@@ -91,7 +155,7 @@ class Screen(object):
         self._zapi = zbx
 
     # get group id by group name
-    def getHostGroupId(self, group_name):
+    def get_host_group_id(self, group_name):
         if group_name == "":
             self._module.fail_json(msg="group_name is required")
         hostGroup_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': group_name}})
@@ -102,7 +166,7 @@ class Screen(object):
             return hostGroup_id
 
     # get monitored host_id by host_group_id
-    def get_host_id_by_group_id(self, group_id):
+    def get_host_ids_by_group_id(self, group_id):
         host_list = self._zapi.host.get({'output': 'extend', 'groupids': group_id, 'monitored_hosts': 1})
         if len(host_list) < 1:
             self._module.fail_json(msg="No host in the group.")
@@ -119,20 +183,40 @@ class Screen(object):
             self._module.fail_json(msg="screen_name is required")
         try:
             screen_id_list = self._zapi.screen.get({'output': 'extend', 'search': {"name": screen_name}})
-            created = False
-            for i in range(0, 3):
-                if len(screen_id_list) < 1:
-                    time.sleep(random.randint(1, 5))
-                    screen_id_list = self._zapi.screen.get({'output': 'extend', 'search': {"name": screen_name}})
-            if len(screen_id_list) < 1:
-                screen = self._zapi.screen.create({'name': screen_name})
-                created = True
-                screen_id = screen['screenids'][0]
-            else:
+            if len(screen_id_list) >= 1:
                 screen_id = screen_id_list[0]['screenid']
-            return screen_id, created
-        except Already_Exists:
-            pass
+                return screen_id
+            return None
+        except Exception as e:
+            self._module.fail_json(msg="Failed to get screen %s from Zabbix: %s" % (screen_name, e))
+
+    # create screen
+    def create_screen(self, screen_name, h_size, v_size):
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            screen = self._zapi.screen.create({'name': screen_name, 'hsize': h_size, 'vsize': v_size})
+            return screen['screenids'][0]
+        except Exception as e:
+            self._module.fail_json(msg="Failed to create screen %s: %s" % (screen_name, e))
+
+    # update screen
+    def update_screen(self, screen_id, screen_name, h_size, v_size):
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            self._zapi.screen.update({'screenid': screen_id, 'hsize': h_size, 'vsize': v_size})
+        except Exception as e:
+            self._module.fail_json(msg="Failed to update screen %s: %s" % (screen_name, e))
+
+    # delete screen
+    def delete_screen(self, screen_id, screen_name):
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            self._zapi.screen.delete([screen_id])
+        except Exception as e:
+            self._module.fail_json(msg="Failed to delete screen %s: %s" % (screen_name, e))
 
     # get graph ids
     def get_graph_ids(self, hosts, graph_name_list):
@@ -172,11 +256,9 @@ class Screen(object):
             if len(screen_item_id_list) == 0:
                 return True
             screen_item_list = self.get_screen_items(screen_id)
-            for i in range(0, 3):
-                if len(screen_item_list) > 0:
-                    time.sleep(random.randint(1, 5))
-                    screen_item_list = self.get_screen_items(screen_id)
             if len(screen_item_list) > 0:
+                if self._module.check_mode:
+                    self._module.exit_json(changed=True)
                 self._zapi.screenitem.delete(screen_item_id_list)
                 return True
             return False
@@ -195,10 +277,6 @@ class Screen(object):
                 h_size = 3
             v_size = (v_size - 1) / h_size + 1
         return h_size, v_size
-
-    # update screen
-    def update_screen(self, screen_id, h_size, v_size):
-        self._zapi.screen.update({'screenid': screen_id, 'hsize': h_size, 'vsize': v_size})
 
     # create screen_items
     def create_screen_items(self, screen_id, hosts, graph_name_list, width, height, h_size):
@@ -242,12 +320,13 @@ def main():
             server_url=dict(required=True, default=None, aliases=['url']),
             login_user=dict(required=True),
             login_password=dict(required=True),
-            screens=dict()
-        )
+            screens=dict(required=True)
+        ),
+        supports_check_mode=True
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing requried zabbix-api module, see this module's requirements for which version to install")
+        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']
@@ -257,54 +336,82 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPI(server_url)
+        zbx = ZabbixAPIExtends(server_url)
         zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
+
     screen = Screen(module, zbx)
-    isChanged = 0
+    created_screens = []
+    changed_screens = []
+    deleted_screens = []
+
     for zabbix_screen in screens:
         screen_name = zabbix_screen['screen_name']
-        host_group = zabbix_screen['host_group']
-        graph_names = zabbix_screen['graph_names']
-        graph_width = None
-        if 'graph_width' in zabbix_screen:
-            graph_width = zabbix_screen['graph_width']
-        graph_height = None
-        if 'graph_height' in zabbix_screen:
-            graph_height = zabbix_screen['graph_height']
-        hostGroupId = screen.getHostGroupId(host_group)
-        hosts = screen.get_host_id_by_group_id(hostGroupId)
-        screen_id, created = screen.get_screen_id(screen_name)
-        screen_item_list = screen.get_screen_items(screen_id)
-        screen_item_id_list = []
-        resource_id_list = []
-        for screen_item in screen_item_list:
-            screen_item_id = screen_item['screenitemid']
-            resource_id = screen_item['resourceid']
-            screen_item_id_list.append(screen_item_id)
-            resource_id_list.append(resource_id)
-        graph_ids, v_size = screen.get_graph_ids(hosts, graph_names)
-        h_size, v_size = screen.get_hsize_vsize(hosts, v_size)
-        if created:
-            screen.update_screen(screen_id, h_size, v_size)
-            screen.create_screen_items(screen_id, hosts, graph_names, graph_width, graph_height, h_size)
-            isChanged += 1
+        screen_id = screen.get_screen_id(screen_name)
+        state = "absent" if "state" in zabbix_screen and zabbix_screen['state'] == "absent" else "present"
+
+        if state == "absent":
+            if screen_id:
+                screen_item_list = screen.get_screen_items(screen_id)
+                screen_item_id_list = []
+                for screen_item in screen_item_list:
+                    screen_item_id = screen_item['screenitemid']
+                    screen_item_id_list.append(screen_item_id)
+                screen.delete_screen_items(screen_id, screen_item_id_list)
+                screen.delete_screen(screen_id, screen_name)
+
+                deleted_screens.append(screen_name)
         else:
-            # when the screen items changed, then update
-            if graph_ids != resource_id_list:
-                deleted = screen.delete_screen_items(screen_id, screen_item_id_list)
-                if deleted:
-                    screen.update_screen(screen_id, h_size, v_size)
-                    screen.create_screen_items(screen_id, hosts, graph_names, graph_width, graph_height, h_size)
-                    isChanged += 1
-    if isChanged > 0:
-        module.exit_json(changed=True, result="Successfully updated screens")
+            host_group = zabbix_screen['host_group']
+            graph_names = zabbix_screen['graph_names']
+            graph_width = None
+            if 'graph_width' in zabbix_screen:
+                graph_width = zabbix_screen['graph_width']
+            graph_height = None
+            if 'graph_height' in zabbix_screen:
+                graph_height = zabbix_screen['graph_height']
+            host_group_id = screen.get_host_group_id(host_group)
+            hosts = screen.get_host_ids_by_group_id(host_group_id)
+
+            screen_item_id_list = []
+            resource_id_list = []
+
+            graph_ids, v_size = screen.get_graph_ids(hosts, graph_names)
+            h_size, v_size = screen.get_hsize_vsize(hosts, v_size)
+
+            if not screen_id:
+                # create screen
+                screen_id = screen.create_screen(screen_name, h_size, v_size)
+                screen.create_screen_items(screen_id, hosts, graph_names, graph_width, graph_height, h_size)
+                created_screens.append(screen_name)
+            else:
+                screen_item_list = screen.get_screen_items(screen_id)
+
+                for screen_item in screen_item_list:
+                    screen_item_id = screen_item['screenitemid']
+                    resource_id = screen_item['resourceid']
+                    screen_item_id_list.append(screen_item_id)
+                    resource_id_list.append(resource_id)
+
+                # when the screen items changed, then update
+                if graph_ids != resource_id_list:
+                    deleted = screen.delete_screen_items(screen_id, screen_item_id_list)
+                    if deleted:
+                        screen.update_screen(screen_id, screen_name, h_size, v_size)
+                        screen.create_screen_items(screen_id, hosts, graph_names, graph_width, graph_height, h_size)
+                        changed_screens.append(screen_name)
+
+    if created_screens and changed_screens:
+        module.exit_json(changed=True, result="Successfully created screen(s): %s, and updated screen(s): %s" % (",".join(created_screens), ",".join(changed_screens)))
+    elif created_screens:
+        module.exit_json(changed=True, result="Successfully created screen(s): %s" % ",".join(created_screens))
+    elif changed_screens:
+        module.exit_json(changed=True, result="Successfully updated screen(s): %s" % ",".join(changed_screens))
+    elif deleted_screens:
+        module.exit_json(changed=True, result="Successfully deleted screen(s): %s" % ",".join(deleted_screens))
     else:
         module.exit_json(changed=False)
 
-
-# include magic from lib/ansible/module_common.py
 # <<INCLUDE_ANSIBLE_MODULE_COMMON>>
 main()
-

--- a/library/monitoring/zabbix_screen
+++ b/library/monitoring/zabbix_screen
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2013, Epic Games, Inc.
+# (c) 2013-2014, Epic Games, Inc.
 #
 # This file is part of Ansible
 #
@@ -51,6 +51,10 @@ options:
             - Zabbix user password.
         required: true
         default: null
+    timeout:
+        description:
+            - The timeout of API request(seconds).
+        default: 10
     zabbix_screens:
         description:
             - List of screens to be created/updated/deleted(see example).
@@ -144,8 +148,8 @@ except ImportError:
 class ZabbixAPIExtends(ZabbixAPI):
     screenitem = None
 
-    def __init__(self, server, **kwargs):
-        ZabbixAPI.__init__(self, server)
+    def __init__(self, server, timeout, **kwargs):
+        ZabbixAPI.__init__(self, server, timeout=timeout)
         self.screenitem = ZabbixAPISubClass(self, dict({"prefix": "screenitem"}, **kwargs))
 
 
@@ -320,6 +324,7 @@ def main():
             server_url=dict(required=True, default=None, aliases=['url']),
             login_user=dict(required=True),
             login_password=dict(required=True),
+            timeout=dict(default=10),
             screens=dict(required=True)
         ),
         supports_check_mode=True
@@ -331,12 +336,13 @@ def main():
     server_url = module.params['server_url']
     login_user = module.params['login_user']
     login_password = module.params['login_password']
+    timeout = module.params['timeout']
     screens = module.params['screens']
 
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url)
+        zbx = ZabbixAPIExtends(server_url, timeout=timeout)
         zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/library/monitoring/zabbix_screen
+++ b/library/monitoring/zabbix_screen
@@ -29,7 +29,7 @@ description:
    - When the screen already exists and the graphs have changed, the screen items will be updated.
    - When the graph IDs have not changed, the screen items won't be updated unless the graph_width and graph_height have changed.
    - Delete screen(s) from Zabbix if the screen(s) exists.
-version_added: "1.6"
+version_added: "1.7"
 author: Tony Minfei Ding, Harrison Gu
 requirements:
     - zabbix-api python module

--- a/library/monitoring/zabbix_screen
+++ b/library/monitoring/zabbix_screen
@@ -24,13 +24,13 @@ DOCUMENTATION = '''
 module: zabbix_screen
 short_description: Creates a new screen or updates existing screen in Zabbix.
 description:
-   - When the screen does not exists, a new screen will be created, added to any screen items.
-   - When the screen already exists and graphs are changed, the screen items will be updated.
-   - When the graph ids not be changed, the screen items won't be updated if only change the graph_width and graph_height.
+   - When the screen does not exists, a new screen will be created, along with the screen items.
+   - When the screen already exists and the graphs have changed, the screen items will be updated.
+   - When the graph IDs have not changed, the screen items won't be updated unless the graph_width and graph_height have changed.
 version_added: "1.6"
-author: Tony Minfei Ding
+author: Tony Minfei Ding, Harrison Gu
 requirements:
-    - zabbix-api python module
+    - zabbix-api python module from https://github.com/gnetsman/zabbix_api (the 1.0 version in pip is too old unfortunately)
 options:
     server_url:
         description:
@@ -247,7 +247,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg="Missing requried zabbix-api module, see this module's requirements for which version to install")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']
@@ -307,3 +307,4 @@ def main():
 # include magic from lib/ansible/module_common.py
 # <<INCLUDE_ANSIBLE_MODULE_COMMON>>
 main()
+

--- a/library/monitoring/zabbix_screen
+++ b/library/monitoring/zabbix_screen
@@ -1,0 +1,309 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Epic Games, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = '''
+---
+module: zabbix_screen
+short_description: Creates a new screen or updates existing screen in Zabbix.
+description:
+   - When the screen does not exists, a new screen will be created, added to any screen items.
+   - When the screen already exists and graphs are changed, the screen items will be updated.
+   - When the graph ids not be changed, the screen items won't be updated if only change the graph_width and graph_height.
+version_added: "1.6"
+author: Tony Minfei Ding
+requirements:
+    - zabbix-api python module
+options:
+    server_url:
+        description:
+            - Url of Zabbix server, with protocol (http or https).
+              C(url) is an alias for C(server_url).
+        required: true
+        default: null
+        aliases: [ "url" ]
+    login_user:
+        description:
+            - Zabbix user name.
+        required: true
+        default: null
+    login_password:
+        description:
+            - Zabbix user password.
+        required: true
+        default: null
+    zabbix_screens:
+        description:
+            - List of screens to be created(see example).
+        required: true
+'''
+
+EXAMPLES = '''
+- name: Create a new screen or update an existing screen's items
+  local_action:
+    module: zabbix_screen
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    screens:
+      - screen_name: ExampleScreen
+        host_group: Example group
+        graph_names:
+          - Example graph1
+          - Example graph2
+        graph_width: 200
+        graph_height: 100
+'''
+
+
+import random
+import time
+from ansible.module_utils.basic import *
+try:
+    from zabbix_api import ZabbixAPI
+    from zabbix_api import ZabbixAPIException
+    from zabbix_api import Already_Exists
+    HAS_ZABBIX_API = True
+except ImportError:
+    HAS_ZABBIX_API = False
+
+
+class Screen(object):
+    def __init__(self, module, zbx):
+        self._module = module
+        self._zapi = zbx
+
+    # get group id by group name
+    def getHostGroupId(self, group_name):
+        if group_name == "":
+            self._module.fail_json(msg="group_name is required")
+        hostGroup_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': group_name}})
+        if len(hostGroup_list) < 1:
+            self._module.fail_json(msg="Host group not found: %s" % group_name)
+        else:
+            hostGroup_id = hostGroup_list[0]['groupid']
+            return hostGroup_id
+
+    # get monitored host_id by host_group_id
+    def get_host_id_by_group_id(self, group_id):
+        host_list = self._zapi.host.get({'output': 'extend', 'groupids': group_id, 'monitored_hosts': 1})
+        if len(host_list) < 1:
+            self._module.fail_json(msg="No host in the group.")
+        else:
+            host_ids = []
+            for i in host_list:
+                host_id = i['hostid']
+                host_ids.append(host_id)
+            return host_ids
+
+    # get screen
+    def get_screen_id(self, screen_name):
+        if screen_name == "":
+            self._module.fail_json(msg="screen_name is required")
+        try:
+            screen_id_list = self._zapi.screen.get({'output': 'extend', 'search': {"name": screen_name}})
+            created = False
+            for i in range(0, 3):
+                if len(screen_id_list) < 1:
+                    time.sleep(random.randint(1, 5))
+                    screen_id_list = self._zapi.screen.get({'output': 'extend', 'search': {"name": screen_name}})
+            if len(screen_id_list) < 1:
+                screen = self._zapi.screen.create({'name': screen_name})
+                created = True
+                screen_id = screen['screenids'][0]
+            else:
+                screen_id = screen_id_list[0]['screenid']
+            return screen_id, created
+        except Already_Exists:
+            pass
+
+    # get graph ids
+    def get_graph_ids(self, hosts, graph_name_list):
+        graph_id_lists = []
+        vsize = 1
+        for host in hosts:
+            graph_id_list = self.get_graphs_by_host_id(graph_name_list, host)
+            size = len(graph_id_list)
+            if size > 0:
+                graph_id_lists.extend(graph_id_list)
+                if vsize < size:
+                    vsize = size
+        return graph_id_lists, vsize
+
+    #  getGraphs
+    def get_graphs_by_host_id(self, graph_name_list, host_id):
+        graph_ids = []
+        for graph_name in graph_name_list:
+            graphs_list = self._zapi.graph.get({'output': 'extend', 'search': {'name': graph_name}, 'hostids': host_id})
+            graph_id_list = []
+            if len(graphs_list) > 0:
+                for graph in graphs_list:
+                    graph_id = graph['graphid']
+                    graph_id_list.append(graph_id)
+            if len(graph_id_list) > 0:
+                graph_ids.extend(graph_id_list)
+        return graph_ids
+
+    # get screen items
+    def get_screen_items(self, screen_id):
+        screen_item_list = self._zapi.screenitem.get({'output': 'extend', 'screenids': screen_id})
+        return screen_item_list
+
+    # delete screen items
+    def delete_screen_items(self, screen_id, screen_item_id_list):
+        try:
+            if len(screen_item_id_list) == 0:
+                return True
+            screen_item_list = self.get_screen_items(screen_id)
+            for i in range(0, 3):
+                if len(screen_item_list) > 0:
+                    time.sleep(random.randint(1, 5))
+                    screen_item_list = self.get_screen_items(screen_id)
+            if len(screen_item_list) > 0:
+                self._zapi.screenitem.delete(screen_item_id_list)
+                return True
+            return False
+        except ZabbixAPIException:
+            pass
+
+    # get screen's hsize and vsize
+    def get_hsize_vsize(self, hosts, v_size):
+        h_size = len(hosts)
+        if h_size == 1:
+            if v_size == 1:
+                h_size = 1
+            elif v_size in range(2, 9):
+                h_size = 2
+            else:
+                h_size = 3
+            v_size = (v_size - 1) / h_size + 1
+        return h_size, v_size
+
+    # update screen
+    def update_screen(self, screen_id, h_size, v_size):
+        self._zapi.screen.update({'screenid': screen_id, 'hsize': h_size, 'vsize': v_size})
+
+    # create screen_items
+    def create_screen_items(self, screen_id, hosts, graph_name_list, width, height, h_size):
+        if len(hosts) < 4:
+            if width is None or width < 0:
+                width = 500
+        else:
+            if width is None or width < 0:
+                width = 200
+        if height is None or height < 0:
+            height = 100
+
+        try:
+            # when there're only one host, only one row is not good.
+            if len(hosts) == 1:
+                graph_id_list = self.get_graphs_by_host_id(graph_name_list, hosts[0])
+                for i, graph_id in enumerate(graph_id_list):
+                    if graph_id is not None:
+                        self._zapi.screenitem.create({'screenid': screen_id, 'resourcetype': 0, 'resourceid': graph_id,
+                                                      'width': width, 'height': height,
+                                                      'x': i % h_size, 'y': i / h_size, 'colspan': 1, 'rowspan': 1,
+                                                      'elements': 0, 'valign': 0, 'halign': 0,
+                                                      'style': 0, 'dynamic': 0, 'sort_triggers': 0})
+            else:
+                for i, host in enumerate(hosts):
+                    graph_id_list = self.get_graphs_by_host_id(graph_name_list, host)
+                    for j, graph_id in enumerate(graph_id_list):
+                        if graph_id is not None:
+                            self._zapi.screenitem.create({'screenid': screen_id, 'resourcetype': 0, 'resourceid': graph_id,
+                                                          'width': width, 'height': height,
+                                                          'x': i, 'y': j, 'colspan': 1, 'rowspan': 1,
+                                                          'elements': 0, 'valign': 0, 'halign': 0,
+                                                          'style': 0, 'dynamic': 0, 'sort_triggers': 0})
+        except Already_Exists:
+            pass
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(required=True, default=None, aliases=['url']),
+            login_user=dict(required=True),
+            login_password=dict(required=True),
+            screens=dict()
+        )
+    )
+
+    if not HAS_ZABBIX_API:
+        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
+
+    server_url = module.params['server_url']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    screens = module.params['screens']
+
+    zbx = None
+    # login to zabbix
+    try:
+        zbx = ZabbixAPI(server_url)
+        zbx.login(login_user, login_password)
+    except Exception, e:
+        module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
+    screen = Screen(module, zbx)
+    isChanged = 0
+    for zabbix_screen in screens:
+        screen_name = zabbix_screen['screen_name']
+        host_group = zabbix_screen['host_group']
+        graph_names = zabbix_screen['graph_names']
+        graph_width = None
+        if 'graph_width' in zabbix_screen:
+            graph_width = zabbix_screen['graph_width']
+        graph_height = None
+        if 'graph_height' in zabbix_screen:
+            graph_height = zabbix_screen['graph_height']
+        hostGroupId = screen.getHostGroupId(host_group)
+        hosts = screen.get_host_id_by_group_id(hostGroupId)
+        screen_id, created = screen.get_screen_id(screen_name)
+        screen_item_list = screen.get_screen_items(screen_id)
+        screen_item_id_list = []
+        resource_id_list = []
+        for screen_item in screen_item_list:
+            screen_item_id = screen_item['screenitemid']
+            resource_id = screen_item['resourceid']
+            screen_item_id_list.append(screen_item_id)
+            resource_id_list.append(resource_id)
+        graph_ids, v_size = screen.get_graph_ids(hosts, graph_names)
+        h_size, v_size = screen.get_hsize_vsize(hosts, v_size)
+        if created:
+            screen.update_screen(screen_id, h_size, v_size)
+            screen.create_screen_items(screen_id, hosts, graph_names, graph_width, graph_height, h_size)
+            isChanged += 1
+        else:
+            # when the screen items changed, then update
+            if graph_ids != resource_id_list:
+                deleted = screen.delete_screen_items(screen_id, screen_item_id_list)
+                if deleted:
+                    screen.update_screen(screen_id, h_size, v_size)
+                    screen.create_screen_items(screen_id, hosts, graph_names, graph_width, graph_height, h_size)
+                    isChanged += 1
+    if isChanged > 0:
+        module.exit_json(changed=True, result="Successfully updated screens")
+    else:
+        module.exit_json(changed=False)
+
+
+# include magic from lib/ansible/module_common.py
+# <<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()

--- a/library/monitoring/zabbix_webcheck
+++ b/library/monitoring/zabbix_webcheck
@@ -240,7 +240,12 @@ class WebCheck(object):
         steps = self.get_steps(web_check_steps)
         if httptestid:
             if web_check_obj['steps']:
-                old_steps = list(web_check_obj['steps'].values())
+                if type(web_check_obj['steps']) is list:
+                    old_steps = web_check_obj['steps']
+                elif type(web_check_obj['steps']) is dict:
+                    old_steps = list(web_check_obj['steps'].values())
+                else:
+                    old_steps = None
                 steps = self.get_replace_steps(old_steps, steps, httptestid)
         web_check_params = {"name": web_check_name,
                             "applicationid": application_id,

--- a/library/monitoring/zabbix_webcheck
+++ b/library/monitoring/zabbix_webcheck
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2013, Epic Games, Inc.
+# (c) 2013-2014, Epic Games, Inc.
 #
 # This file is part of Ansible
 #
@@ -22,11 +22,13 @@
 DOCUMENTATION = '''
 ---
 module: zabbix_webcheck
-short_description: Zabbix web checks creates/deletes
+short_description: Zabbix web checks creates/updates/deletes
 description:
    - Creates a web check according to the host and application, the application will also be created if it does not exist.
+   - When the webcheck already exists and scenario steps are changed, the webcheck will be updated and the steps will be replaced.
+   - Delete webcheck from Zabbix if the webcheck exists.
 version_added: "1.6"
-author: Damon Chencheng Kong
+author: Damon Chencheng Kong, Harrison Gu
 requirements:
     - zabbix-api python module
 options:
@@ -47,23 +49,28 @@ options:
             - Zabbix user password.
         required: true
         default: null
+    timeout:
+        description:
+            - The timeout of API request(seconds).
+        default: 10
     web_check:
         description:
             - List of web check to be created/updated/deleted (see example).
-            - Available values: web_check_name,application_name,host_name,web_check_steps
-            - web_check_agent: User agent string that will be used by the web scenario
+            - If the webcheck has already been added, the web_check_name won't be updated.
+            - Available values: web_check_name(required), application_name(required), host_name(required), agent, authentication, delay, http_password, http_user, macros, nextcheck, status and web_check_steps(required)
+            - Available scenario step(web_check_steps) values are: name(required), number(required), url(required), posts, required, status_codes and timeout
             - Please review the web check documentation for more information on the supported web check properties: https://www.zabbix.com/documentation/2.0/manual/appendix/api/webcheck/definitions
         required: true
     state:
         description:
-            - Create or delete a web check.
+            - Create/update/delete a web check.
             - Possible values are: present, absent, default create web check.
         required: false
         default: "present"
 '''
 
 EXAMPLES = '''
-- name: add a web check
+- name: create or update(if exists) a web check
   local_action:
     module: zabbix_webcheck
     server_url: http://monitor.example.com
@@ -76,14 +83,14 @@ EXAMPLES = '''
       host_name: example host name
       web_check_agent: zabbix web check
       web_check_steps:
-        - step_name: WebSite Check1
-          step_url: http://www.example1.com
-          step_status_codes: 200
-          step_number: 1
-        - step_name: WebSite Check2
-          step_url: http://www.example2.com
-          step_status_codes: 200
-          step_number: 2
+        - name: WebSite Check1
+          url: http://www.example1.com
+          number: 1
+          status_codes: 200
+        - name: WebSite Check2
+          url: http://www.example2.com
+          number: 2
+          status_codes: 200
 
 - name: delete a web check
   local_action:
@@ -117,8 +124,8 @@ except ImportError:
 class ZabbixAPIExtends(ZabbixAPI):
     webcheck = None
 
-    def __init__(self, server, **kwargs):
-        ZabbixAPI.__init__(self, server, timeout=20)
+    def __init__(self, server, timeout, **kwargs):
+        ZabbixAPI.__init__(self, server, timeout=timeout)
         self.webcheck = ZabbixAPISubClass(self, dict({"prefix": "webcheck"}, **kwargs))
 
 
@@ -127,98 +134,171 @@ class WebCheck(object):
         self._module = module
         self._zapi = zbx
 
+        self._web_scenario_optional_properties_list = ['agent', 'authentication', 'delay', 'http_password',
+                                                       'http_user', 'macros', 'status']
+        self._scenario_step_optional_properties_list = ['posts', 'required', 'status_codes', 'timeout']
+
     # get host id by host name
-    def get_host_id(self, hostName):
+    def get_host_id(self, host_name):
         try:
-            hostObj = self._zapi.host.get({'output': 'extend', 'filter': {'host': hostName}})
-            hostId = hostObj[0]['hostid']
+            host_list = self._zapi.host.get({'output': 'extend', 'filter': {'host': host_name}})
+            if len(host_list) < 1:
+                self._module.fail_json(msg="Host not found: %s" % host_name)
+            else:
+                host_id = host_list[0]['hostid']
+                return host_id
         except Exception, e:
-            self._module.fail_json(msg="Failed to get the host %s id: %s." % (hostName, e))
-        return hostId
+            self._module.fail_json(msg="Failed to get the host %s id: %s." % (host_name, e))
 
     # get application id by application name, host id
-    def get_application_id(self, hostId, applicationName):
+    def get_application_id(self, host_id, application_name):
+        application_id = None
         try:
-            applicationObj = self._zapi.application.get(
-                {'output': 'extend', 'filter': {'hostid': hostId, "name": applicationName}})
-            applicationId = applicationObj[0]['applicationid']
-            if not applicationObj:
-                self.create_application(hostId, applicationName)
-                applicationObj = self._zapi.application.get(
-                    {'output': 'extend', 'filter': {'hostid': hostId, "name": applicationName}})
-                applicationId = applicationObj[0]['applicationid']
+            application_list = self._zapi.application.get(
+                {'output': 'extend', 'filter': {'hostid': host_id, "name": application_name}})
+            if len(application_list) < 1:
+                applicationids = self.create_application(host_id, application_name)
+                if len(applicationids) > 0:
+                    application_id = applicationids['applicationids'][0]
+            else:
+                application_id = application_list[0]['applicationid']
+            return application_id
         except Exception, e:
-            self._module.fail_json(msg="Failed to get the application %s id: %s." % (applicationName, e))
-        return applicationId
+            self._module.fail_json(msg="Failed to get the application '%s' id: %s." % (application_name, e))
 
     #get webcheck
-    def get_web_check(self, webCheckName):
+    def get_web_check(self, web_check_name, host_id):
         try:
-            webCheck = self._zapi.webcheck.get({'filter': {'name': webCheckName}})
+            web_check_list = self._zapi.webcheck.get(
+                {"output": "extend", "selectSteps": "extend", 'hostids': [host_id], 'filter': {'name': web_check_name}})
+            if len(web_check_list) > 0:
+                return web_check_list[0]
+            return None
         except Exception, e:
-            self._module.fail_json(msg="Failed to get WebCheck %s: %s" % (webCheckName, e))
-        return webCheck
+            self._module.fail_json(msg="Failed to get WebCheck %s: %s" % (web_check_name, e))
 
     # get steps
-    def get_steps(self, webCheckSteps):
+    def get_steps(self, web_check_steps):
         steps = []
-        for webCheckStep in webCheckSteps:
-            step = {"name": webCheckStep['step_name'],
-                    "url": webCheckStep['step_url'],
-                    "status_codes": webCheckStep['step_status_codes'],
-                    "no": webCheckStep['step_number']}
-            steps.append(step)
+        (name, url, no) = (None, None, None)
+        for web_check_step in web_check_steps:
+            if "name" in web_check_step and web_check_step["name"]:
+                name = web_check_step["name"]
+            else:
+                self._module.fail_json(msg="The \"name\" property in scenario steps is required and not null.")
+
+            if "url" in web_check_step and web_check_step["url"]:
+                url = web_check_step["url"]
+            else:
+                self._module.fail_json(msg="The \"url\" property in scenario steps is required and not null.")
+
+            if "number" in web_check_step and web_check_step["number"]:
+                no = web_check_step["number"]
+            else:
+                self._module.fail_json(msg="The \"no\" property in scenario steps is required and not null.")
+
+            optional_step_properties = dict()
+            for step_optional_property in self._scenario_step_optional_properties_list:
+                value = self.get_value_by_key(web_check_step, step_optional_property)
+                if value is not None:
+                    optional_step_properties[step_optional_property] = value
+
+            step = {"name": name,
+                    "url": url,
+                    "no": no}
+            steps.append(dict(step, **optional_step_properties))
         return steps
 
+    def get_replace_steps(self, old_webcheck_steps, new_webcheck_steps, httptestid):
+        relace_webcheck_steps = []
+
+        if new_webcheck_steps:
+            for new_webcheck_step in new_webcheck_steps:
+                flag = False
+                for old_webcheck_step in old_webcheck_steps:
+                    new_webcheck_step_url = new_webcheck_step['url']
+                    old_webcheck_step_url = old_webcheck_step['url']
+                    if new_webcheck_step_url == old_webcheck_step_url:
+                        # update
+                        new_webcheck_step['webstepid'] = old_webcheck_step['webstepid']
+                        new_webcheck_step['httptestid'] = httptestid
+                        relace_webcheck_steps.append(new_webcheck_step)
+                        flag = True
+                        break
+                if not flag:
+                    # add
+                    new_webcheck_step['httptestid'] = httptestid
+                    relace_webcheck_steps.append(new_webcheck_step)
+        return relace_webcheck_steps
+
     # get webcheck params
-    def get_web_check_params(self, hostId, applicationId, webCheckName, webCheckSteps, webCheckAgent):
-        steps = self.get_steps(webCheckSteps)
-        webCheckParams = {"name": webCheckName,
-                          "applicationid": applicationId,
-                          "agent": webCheckAgent,
-                          "hostid": hostId,
-                          "steps": steps}
-        return webCheckParams
+    def get_web_check_params(self, web_check_name, host_id, application_id, web_check_steps, optional_scenario_values,
+                             web_check_obj=None, httptestid=None):
+        steps = self.get_steps(web_check_steps)
+        if httptestid:
+            old_steps = list(web_check_obj['steps'].values())
+            steps = self.get_replace_steps(old_steps, steps, httptestid)
+
+        web_check_params = {"name": web_check_name,
+                            "applicationid": application_id,
+                            "hostid": host_id,
+                            "steps": steps}
+        if httptestid:
+            web_check_params['httptestid'] = httptestid
+        return dict(web_check_params, **optional_scenario_values)
 
     #create application by application name, host id
     def create_application(self, hostId, applicationName):
         try:
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
-            self._zapi.application.create({'hostid': hostId, 'name': applicationName})
+            return self._zapi.application.create({'hostid': hostId, 'name': applicationName})
         except Exception, e:
-            self._module.fail_json(msg="Failed to create Application %s: %s" % (applicationName, e))
+            self._module.fail_json(msg="Failed to create Application '%s': %s" % (applicationName, e))
 
     # create web check
-    def create_web_check(self, hostId, applicationId, webCheckName, webCheckSteps, webCheckAgent):
-        webCheck = self.get_web_check(webCheckName)
-        if not webCheck:
-            webCheckParams = self.get_web_check_params(hostId, applicationId, webCheckName, webCheckSteps,
-                                                       webCheckAgent)
-            try:
-                if self._module.check_mode:
-                    self._module.exit_json(changed=True)
-                self._zapi.webcheck.create(webCheckParams)
-                self._module.exit_json(changed=True, result="Successfully added WebCheck %s " % webCheckName)
-            except Exception, e:
-                self._module.fail_json(msg="Failed to create WebCheck %s: %s" % (webCheckName, e))
-        else:
-            self._module.exit_json(changed=True, result="WebCheck %s already exists" % webCheckName)
+    def create_web_check(self, web_check_name, host_id, application_id, web_check_steps, scenario_optional_properties):
+        web_check_params = self.get_web_check_params(web_check_name, host_id, application_id, web_check_steps,
+                                                     scenario_optional_properties)
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            self._zapi.webcheck.create(web_check_params)
+            self._module.exit_json(changed=True, result="Successfully added WebCheck %s " % web_check_name)
+        except Exception, e:
+            self._module.fail_json(msg="Failed to create WebCheck %s: %s" % (web_check_name, e))
+
+    # update web check
+    def update_web_check(self, web_check_obj, web_check_name, host_id, application_id, web_check_steps,
+                         scenario_optional_properties):
+        httptestid = web_check_obj['httptestid']
+        web_check_params = self.get_web_check_params(web_check_name, host_id, application_id, web_check_steps,
+                                                     scenario_optional_properties, web_check_obj, httptestid)
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            self._zapi.webcheck.update(web_check_params)
+            self._module.exit_json(changed=True, result="Successfully updated WebCheck %s " % web_check_params)
+        except Exception, e:
+            self._module.fail_json(msg="Failed to updated WebCheck %s: %s" % (web_check_params, e))
 
     # delete web check
-    def delete_web_check(self, webCheckName):
-        webCheck = self.get_web_check(webCheckName)
-        if not webCheck:
-            self._module.exit_json(changed=True, result="WebCheck %s does not exist" % webCheckName)
-        else:
-            webCheckId = webCheck[0]['httptestid'];
-            try:
-                if self._module.check_mode:
-                    self._module.exit_json(changed=True)
-                self._zapi.webcheck.delete([webCheckId])
-                self._module.exit_json(changed=True, result="Successfully deleted WebCheck %s " % webCheckName)
-            except Exception, e:
-                self._module.fail_json(msg="Failed to delete WebCheck %s: %s" % (webCheckName, e))
+    def delete_web_check(self, webCheckObj):
+        webCheckId = webCheckObj['httptestid']
+        webCheckName = webCheckObj['name']
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            self._zapi.webcheck.delete([webCheckId])
+            self._module.exit_json(changed=True, result="Successfully deleted WebCheck %s " % webCheckName)
+        except Exception, e:
+            self._module.fail_json(msg="Failed to delete WebCheck %s: %s" % (webCheckName, e))
+
+    def get_value_by_key(self, dict_obj, key):
+        if key in dict_obj:
+            value = dict_obj[key]
+            return value
+        return None
 
 
 def main():
@@ -228,44 +308,77 @@ def main():
             login_user=dict(required=True),
             login_password=dict(required=True),
             state=dict(default="present"),
+            timeout=dict(default=10),
             web_check=dict(required=True),
-        ),
+            ),
         supports_check_mode=True,
-    )
+        )
 
     if not HAS_ZABBIX_API:
         module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
 
-    zabbix_server_url = module.params['server_url']
-    zabbix_login_user = module.params['login_user']
-    zabbix_login_password = module.params['login_password']
+    server_url = module.params['server_url']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
     state = module.params['state']
-    zabbix_web_check = module.params['web_check']
-    zabbix_web_check_name = zabbix_web_check['web_check_name']
+    timeout = module.params['timeout']
+    web_check = module.params['web_check']
+
+    web_check_name = ''
+    if 'web_check_name' in web_check:
+        web_check_name = web_check['web_check_name']
+    else:
+        module.fail_json(msg="The \"web_check_name\" property is required and not null.")
 
     # login to zabbix
     zbx = None
     try:
-        zbx = ZabbixAPIExtends(zabbix_server_url, timeout=20)
-        zbx.login(zabbix_login_user, zabbix_login_password)
+        zbx = ZabbixAPIExtends(server_url, timeout=timeout)
+        zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 
-    web_check = WebCheck(module, zbx)
+    # new a WebCheck class object
+    web_check_class_obj = WebCheck(module, zbx)
 
-    # create web check
+    host_name = web_check_class_obj.get_value_by_key(web_check, "host_name")
+    if not host_name:
+        module.fail_json(msg="The \"host_name\" property is required.")
+    host_id = web_check_class_obj.get_host_id(host_name)
+
+    # get webcheck object by name
+    web_check_obj = web_check_class_obj.get_web_check(web_check_name, host_id)
+
     if state == 'absent':
-        web_check.delete_web_check(zabbix_web_check_name)
+        if not web_check_obj:
+            module.fail_json(changed=False, msg="WebCheck %s does not exist" % web_check_name)
+        else:
+            # delete a webcheck
+            web_check_class_obj.delete_web_check(web_check_obj)
     else:
-        zabbix_application_name = zabbix_web_check['application_name']
-        zabbix_web_check_steps = zabbix_web_check['web_check_steps']
-        zabbix_host_name = zabbix_web_check['host_name']
-        zabbix_web_check_agent = zabbix_web_check['web_check_agent']
-        hostId = web_check.get_host_id(zabbix_host_name)
-        applicationId = web_check.get_application_id(hostId, zabbix_application_name)
-        web_check.create_web_check(hostId, applicationId, zabbix_web_check_name, zabbix_web_check_steps,
-                                   zabbix_web_check_agent)
+        application_name = web_check_class_obj.get_value_by_key(web_check, "application_name")
+        if not application_name:
+            module.fail_json(msg="The \"application_name\" property is required.")
+
+        host_id = web_check_class_obj.get_host_id(host_name)
+        application_id = web_check_class_obj.get_application_id(host_id, application_name)
+
+        web_check_steps = web_check_class_obj.get_value_by_key(web_check, "web_check_steps")
+
+        scenario_optional_properties = dict()
+        for optional_property in web_check_class_obj._web_scenario_optional_properties_list:
+            value = web_check_class_obj.get_value_by_key(web_check, optional_property)
+            if value is not None:
+                scenario_optional_properties[optional_property] = value
+
+        if not web_check_obj:
+            # create webcheck
+            web_check_class_obj.create_web_check(web_check_name, host_id, application_id, web_check_steps,
+                                                 scenario_optional_properties)
+        else:
+            # update webcheck
+            web_check_class_obj.update_web_check(web_check_obj, web_check_name, host_id, application_id,
+                                                 web_check_steps, scenario_optional_properties)
 
 # <<INCLUDE_ANSIBLE_MODULE_COMMON>>
 main()
-

--- a/library/monitoring/zabbix_webcheck
+++ b/library/monitoring/zabbix_webcheck
@@ -181,33 +181,36 @@ class WebCheck(object):
     def get_steps(self, web_check_steps):
         steps = []
         (name, url, no) = (None, None, None)
-        for web_check_step in web_check_steps:
-            if "name" in web_check_step and web_check_step["name"]:
-                name = web_check_step["name"]
-            else:
-                self._module.fail_json(msg="The \"name\" property in scenario steps is required and not null.")
+        if web_check_steps:
+            for web_check_step in web_check_steps:
+                if "name" in web_check_step and web_check_step["name"]:
+                    name = web_check_step["name"]
+                else:
+                    self._module.fail_json(msg="The \"name\" property in scenario steps is required and not null.")
 
-            if "url" in web_check_step and web_check_step["url"]:
-                url = web_check_step["url"]
-            else:
-                self._module.fail_json(msg="The \"url\" property in scenario steps is required and not null.")
+                if "url" in web_check_step and web_check_step["url"]:
+                    url = web_check_step["url"]
+                else:
+                    self._module.fail_json(msg="The \"url\" property in scenario steps is required and not null.")
 
-            if "number" in web_check_step and web_check_step["number"]:
-                no = web_check_step["number"]
-            else:
-                self._module.fail_json(msg="The \"no\" property in scenario steps is required and not null.")
+                if "number" in web_check_step and web_check_step["number"]:
+                    no = web_check_step["number"]
+                else:
+                    self._module.fail_json(msg="The \"no\" property in scenario steps is required and not null.")
 
-            optional_step_properties = dict()
-            for step_optional_property in self._scenario_step_optional_properties_list:
-                value = self.get_value_by_key(web_check_step, step_optional_property)
-                if value is not None:
-                    optional_step_properties[step_optional_property] = value
+                optional_step_properties = dict()
+                for step_optional_property in self._scenario_step_optional_properties_list:
+                    value = self.get_value_by_key(web_check_step, step_optional_property)
+                    if value is not None:
+                        optional_step_properties[step_optional_property] = value
 
-            step = {"name": name,
-                    "url": url,
-                    "no": no}
-            steps.append(dict(step, **optional_step_properties))
-        return steps
+                step = {"name": name,
+                        "url": url,
+                        "no": no}
+                steps.append(dict(step, **optional_step_properties))
+            return steps
+        else:
+            self._module.fail_json(msg="The \"steps\" property in scenario is required and not null.")
 
     def get_replace_steps(self, old_webcheck_steps, new_webcheck_steps, httptestid):
         relace_webcheck_steps = []
@@ -236,9 +239,9 @@ class WebCheck(object):
                              web_check_obj=None, httptestid=None):
         steps = self.get_steps(web_check_steps)
         if httptestid:
-            old_steps = list(web_check_obj['steps'].values())
-            steps = self.get_replace_steps(old_steps, steps, httptestid)
-
+            if web_check_obj['steps']:
+                old_steps = list(web_check_obj['steps'].values())
+                steps = self.get_replace_steps(old_steps, steps, httptestid)
         web_check_params = {"name": web_check_name,
                             "applicationid": application_id,
                             "hostid": host_id,

--- a/library/monitoring/zabbix_webcheck
+++ b/library/monitoring/zabbix_webcheck
@@ -1,0 +1,271 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Epic Games, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = '''
+---
+module: zabbix_webcheck
+short_description: Zabbix web checks creates/deletes
+description:
+   - Creates a web check according to the host and application, the application will also be created if it does not exist.
+version_added: "1.6"
+author: Damon Chencheng Kong
+requirements:
+    - zabbix-api python module
+options:
+    server_url:
+        description:
+            - Url of Zabbix server, with protocol (http or https).
+              C(url) is an alias for C(server_url).
+        required: true
+        default: null
+        aliases: [ "url" ]
+    login_user:
+        description:
+            - Zabbix user name.
+        required: true
+        default: null
+    login_password:
+        description:
+            - Zabbix user password.
+        required: true
+        default: null
+    web_check:
+        description:
+            - List of web check to be created/updated/deleted (see example).
+            - Available values: web_check_name,application_name,host_name,web_check_steps
+            - web_check_agent: User agent string that will be used by the web scenario
+            - Please review the web check documentation for more information on the supported web check properties: https://www.zabbix.com/documentation/2.0/manual/appendix/api/webcheck/definitions
+        required: true
+    state:
+        description:
+            - Create or delete a web check.
+            - Possible values are: present, absent, default create web check.
+        required: false
+        default: "present"
+'''
+
+EXAMPLES = '''
+- name: add a web check
+  local_action:
+    module: zabbix_webcheck
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    state: present
+    web_check:
+      web_check_name: example Health Check
+      application_name: example app
+      host_name: example host name
+      web_check_agent: zabbix web check
+      web_check_steps:
+        - step_name: WebSite Check1
+          step_url: http://www.example1.com
+          step_status_codes: 200
+          step_number: 1
+        - step_name: WebSite Check2
+          step_url: http://www.example2.com
+          step_status_codes: 200
+          step_number: 2
+
+- name: delete a web check
+  local_action:
+    module: zabbix_webcheck
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    state: absent
+    web_check:
+      web_check_name: "example Health Check"
+'''
+
+import json
+import base64
+import urllib2
+import random
+import time
+
+from ansible.module_utils.basic import *
+
+try:
+    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
+    from zabbix_api import ZabbixAPIException
+    from zabbix_api import Already_Exists
+
+    HAS_ZABBIX_API = True
+except ImportError:
+    HAS_ZABBIX_API = False
+
+
+class ZabbixAPIExtends(ZabbixAPI):
+    webcheck = None
+
+    def __init__(self, server, **kwargs):
+        ZabbixAPI.__init__(self, server, timeout=20)
+        self.webcheck = ZabbixAPISubClass(self, dict({"prefix": "webcheck"}, **kwargs))
+
+
+class WebCheck(object):
+    def __init__(self, module, zbx):
+        self._module = module
+        self._zapi = zbx
+
+    # get host id by host name
+    def get_host_id(self, hostName):
+        try:
+            hostObj = self._zapi.host.get({'output': 'extend', 'filter': {'host': hostName}})
+            hostId = hostObj[0]['hostid']
+        except Exception, e:
+            self._module.fail_json(msg="Failed to get the host %s id: %s." % (hostName, e))
+        return hostId
+
+    # get application id by application name, host id
+    def get_application_id(self, hostId, applicationName):
+        try:
+            applicationObj = self._zapi.application.get(
+                {'output': 'extend', 'filter': {'hostid': hostId, "name": applicationName}})
+            applicationId = applicationObj[0]['applicationid']
+            if not applicationObj:
+                self.create_application(hostId, applicationName)
+                applicationObj = self._zapi.application.get(
+                    {'output': 'extend', 'filter': {'hostid': hostId, "name": applicationName}})
+                applicationId = applicationObj[0]['applicationid']
+        except Exception, e:
+            self._module.fail_json(msg="Failed to get the application %s id: %s." % (applicationName, e))
+        return applicationId
+
+    #get webcheck
+    def get_web_check(self, webCheckName):
+        try:
+            webCheck = self._zapi.webcheck.get({'filter': {'name': webCheckName}})
+        except Exception, e:
+            self._module.fail_json(msg="Failed to get WebCheck %s: %s" % (webCheckName, e))
+        return webCheck
+
+    # get steps
+    def get_steps(self, webCheckSteps):
+        steps = []
+        for webCheckStep in webCheckSteps:
+            step = {"name": webCheckStep['step_name'],
+                    "url": webCheckStep['step_url'],
+                    "status_codes": webCheckStep['step_status_codes'],
+                    "no": webCheckStep['step_number']}
+            steps.append(step)
+        return steps
+
+    # get webcheck params
+    def get_web_check_params(self, hostId, applicationId, webCheckName, webCheckSteps, webCheckAgent):
+        steps = self.get_steps(webCheckSteps)
+        webCheckParams = {"name": webCheckName,
+                          "applicationid": applicationId,
+                          "agent": webCheckAgent,
+                          "hostid": hostId,
+                          "steps": steps}
+        return webCheckParams
+
+    #create application by application name, host id
+    def create_application(self, hostId, applicationName):
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            self._zapi.application.create({'hostid': hostId, 'name': applicationName})
+        except Exception, e:
+            self._module.fail_json(msg="Failed to create Application %s: %s" % (applicationName, e))
+
+    # create web check
+    def create_web_check(self, hostId, applicationId, webCheckName, webCheckSteps, webCheckAgent):
+        webCheck = self.get_web_check(webCheckName)
+        if not webCheck:
+            webCheckParams = self.get_web_check_params(hostId, applicationId, webCheckName, webCheckSteps,
+                                                       webCheckAgent)
+            try:
+                if self._module.check_mode:
+                    self._module.exit_json(changed=True)
+                self._zapi.webcheck.create(webCheckParams)
+                self._module.exit_json(changed=True, result="Successfully added WebCheck %s " % webCheckName)
+            except Exception, e:
+                self._module.fail_json(msg="Failed to create WebCheck %s: %s" % (webCheckName, e))
+        else:
+            self._module.exit_json(changed=True, result="WebCheck %s already exists" % webCheckName)
+
+    # delete web check
+    def delete_web_check(self, webCheckName):
+        webCheck = self.get_web_check(webCheckName)
+        if not webCheck:
+            self._module.exit_json(changed=True, result="WebCheck %s does not exist" % webCheckName)
+        else:
+            webCheckId = webCheck[0]['httptestid'];
+            try:
+                if self._module.check_mode:
+                    self._module.exit_json(changed=True)
+                self._zapi.webcheck.delete([webCheckId])
+                self._module.exit_json(changed=True, result="Successfully deleted WebCheck %s " % webCheckName)
+            except Exception, e:
+                self._module.fail_json(msg="Failed to delete WebCheck %s: %s" % (webCheckName, e))
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(required=True),
+            login_user=dict(required=True),
+            login_password=dict(required=True),
+            state=dict(default="present"),
+            web_check=dict(required=True),
+        ),
+        supports_check_mode=True,
+    )
+
+    if not HAS_ZABBIX_API:
+        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
+
+    zabbix_server_url = module.params['server_url']
+    zabbix_login_user = module.params['login_user']
+    zabbix_login_password = module.params['login_password']
+    state = module.params['state']
+    zabbix_web_check = module.params['web_check']
+    zabbix_web_check_name = zabbix_web_check['web_check_name']
+
+    # login to zabbix
+    zbx = None
+    try:
+        zbx = ZabbixAPIExtends(zabbix_server_url, timeout=20)
+        zbx.login(zabbix_login_user, zabbix_login_password)
+    except Exception, e:
+        module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
+
+    web_check = WebCheck(module, zbx)
+
+    # create web check
+    if state == 'absent':
+        web_check.delete_web_check(zabbix_web_check_name)
+    else:
+        zabbix_application_name = zabbix_web_check['application_name']
+        zabbix_web_check_steps = zabbix_web_check['web_check_steps']
+        zabbix_host_name = zabbix_web_check['host_name']
+        zabbix_web_check_agent = zabbix_web_check['web_check_agent']
+        hostId = web_check.get_host_id(zabbix_host_name)
+        applicationId = web_check.get_application_id(hostId, zabbix_application_name)
+        web_check.create_web_check(hostId, applicationId, zabbix_web_check_name, zabbix_web_check_steps,
+                                   zabbix_web_check_agent)
+
+# <<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()
+

--- a/library/monitoring/zabbix_webcheck
+++ b/library/monitoring/zabbix_webcheck
@@ -58,7 +58,7 @@ options:
             - List of web check to be created/updated/deleted (see example).
             - If the webcheck has already been added, the web_check_name won't be updated.
             - Available values: web_check_name(required), application_name(required), host_name(required), agent, authentication, delay, http_password, http_user, macros, nextcheck, status and web_check_steps(required)
-            - Available scenario step(web_check_steps) values are: name(required), number(required), url(required), posts, required, status_codes and timeout
+            - Available scenario step(steps) values are: name(required), number(required), url(required), posts, required, status_codes and timeout
             - Please review the web check documentation for more information on the supported web check properties: https://www.zabbix.com/documentation/2.0/manual/appendix/api/webcheck/definitions
         required: true
     state:
@@ -81,8 +81,8 @@ EXAMPLES = '''
       web_check_name: example Health Check
       application_name: example app
       host_name: example host name
-      web_check_agent: zabbix web check
-      web_check_steps:
+      agent: zabbix web check
+      steps:
         - name: WebSite Check1
           url: http://www.example1.com
           number: 1
@@ -310,9 +310,9 @@ def main():
             state=dict(default="present"),
             timeout=dict(default=10),
             web_check=dict(required=True),
-            ),
+        ),
         supports_check_mode=True,
-        )
+    )
 
     if not HAS_ZABBIX_API:
         module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
@@ -351,7 +351,7 @@ def main():
 
     if state == 'absent':
         if not web_check_obj:
-            module.fail_json(changed=False, msg="WebCheck %s does not exist" % web_check_name)
+            module.exit_json(changed=False, msg="WebCheck %s does not exist" % web_check_name)
         else:
             # delete a webcheck
             web_check_class_obj.delete_web_check(web_check_obj)
@@ -363,7 +363,7 @@ def main():
         host_id = web_check_class_obj.get_host_id(host_name)
         application_id = web_check_class_obj.get_application_id(host_id, application_name)
 
-        web_check_steps = web_check_class_obj.get_value_by_key(web_check, "web_check_steps")
+        web_check_steps = web_check_class_obj.get_value_by_key(web_check, "steps")
 
         scenario_optional_properties = dict()
         for optional_property in web_check_class_obj._web_scenario_optional_properties_list:

--- a/library/monitoring/zabbix_webcheck
+++ b/library/monitoring/zabbix_webcheck
@@ -27,7 +27,7 @@ description:
    - Creates a web check according to the host and application, the application will also be created if it does not exist.
    - When the webcheck already exists and scenario steps are changed, the webcheck will be updated and the steps will be replaced.
    - Delete webcheck from Zabbix if the webcheck exists.
-version_added: "1.6"
+version_added: "1.7"
 author: Damon Chencheng Kong, Harrison Gu
 requirements:
     - zabbix-api python module


### PR DESCRIPTION
These modules allow you to add/update hosts, put them in the correct groups and link in the monitoring templates, the basic requirements for bring a new host online. Been in production use since late last year, appear to be working fine against Zabbix 2.0.
