### PR TITLE
Set use_mirrors default to "no" for the pip module

### DIFF
--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -287,8 +287,6 @@ def main():
     if env:
         path_prefix="/".join(pip.split('/')[:-1])
 
-    if extra_args:
-        cmd += ' %s' % extra_args
     if name:
         # pip can accept a path to a local project or a VCS url beginning
         # with svn+, git+, hg+, or bz+ and these sources usually do not qualify
@@ -326,6 +324,10 @@ def main():
 
         if not is_package and state != 'absent' and use_mirrors and '--use-mirrors' in cmd_opts:
             cmd += ' --use-mirrors'
+
+    if extra_args:
+        cmd += ' %s' % extra_args
+    if name:
         cmd += ' %s' % _get_full_name(name, version)
     elif requirements:
         cmd += ' -r %s' % requirements

--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -70,15 +70,6 @@ options:
         C(virtualenv2), C(~/bin/virtualenv), C(/usr/local/bin/virtualenv).
     required: false
     default: virtualenv
-  use_mirrors:
-    description:
-      - Whether to use mirrors when installing python libraries.  If using
-        an older version of pip (< 1.0), you should set this to no because
-        older versions of pip do not support I(--use-mirrors).
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-    version_added: "1.0"
   state:
     description:
       - The state of module
@@ -119,7 +110,7 @@ EXAMPLES = '''
 # Install (Bottle) python package on version 0.11.
 - pip: name=bottle version=0.11
 
-# Install (MyApp) using one of the remote protocols (bzr+,hg+,git+,svn+) or tarballs (zip, gz, bz2) (pip) supports. You do not have to supply '-e' option in extra_args. For these source names, (use_mirrors) is ignored and not applicable.
+# Install (MyApp) using one of the remote protocols (bzr+,hg+,git+,svn+). You do not have to supply '-e' option in extra_args.
 - pip: name='svn+http://myrepo/svn/MyApp#egg=MyApp'
 
 # Install (Bottle) into the specified (virtualenv), inheriting none of the globally installed modules
@@ -234,7 +225,6 @@ def main():
     name = module.params['name']
     version = module.params['version']
     requirements = module.params['requirements']
-    use_mirrors = module.params['use_mirrors']
     extra_args = module.params['extra_args']
     chdir = module.params['chdir']
 
@@ -275,7 +265,6 @@ def main():
     pip = _get_pip(module, env, module.params['executable'])
 
     cmd = '%s %s' % (pip, state_map[state])
-    cmd_opts = None
     
     # If there's a virtualenv we want things we install to be able to use other
     # installations that exist as binaries within this virtualenv. Example: we 
@@ -287,25 +276,11 @@ def main():
     if env:
         path_prefix="/".join(pip.split('/')[:-1])
 
+    # Automatically apply -e option to extra_args when source is a VCS url. VCS
+    # includes those beginning with svn+, git+, hg+ or bzr+
     if name:
-        # pip can accept a path to a local project or a VCS url beginning
-        # with svn+, git+, hg+, or bz+ and these sources usually do not qualify
-        # --use-mirrors. Furthermore, the -e option is applied only when
-        # source is a VCS url. Therefore, we will have branch cases for each
-        # type of sources.
-        #
-        # is_vcs includes those begin with svn+, git+, hg+ or bzr+
-        # is_tar ends with .zip, .tar.gz, or .tar.bz2
-        is_vcs = False
-        is_tar = False
-        is_local_path = False
-        if name.endswith('.tar.gz') or name.endswith('.tar.bz2') or name.endswith('.zip'):
-            is_tar = True
-        elif name.startswith('svn+') or name.startswith('git+') or \
+        if name.startswith('svn+') or name.startswith('git+') or \
                 name.startswith('hg+') or name.startswith('bzr+'):
-            is_vcs = True
-        # If is_vcs=True, we must add -e option (we assume users won't add that to extra_args).
-        if is_vcs:
             args_list = []  # used if extra_args is not used at all
             if extra_args:
                 args_list = extra_args.split(' ')
@@ -313,17 +288,6 @@ def main():
                 args_list.append('-e')
                 # Ok, we will reconstruct the option string
                 extra_args = ' '.join(args_list)
-
-        if name.startswith('.') or name.startswith('/'):
-            is_local_path = True
-        # for tarball or vcs source, applying --use-mirrors doesn't really make sense
-        is_package = is_vcs or is_tar or is_local_path       # just a shortcut for bool
-
-        if cmd_opts is None:
-            cmd_opts = _get_cmd_options(module, '%s %s' % (pip, state_map[state]))
-
-        if not is_package and state != 'absent' and use_mirrors and '--use-mirrors' in cmd_opts:
-            cmd += ' --use-mirrors'
 
     if extra_args:
         cmd += ' %s' % extra_args


### PR DESCRIPTION
Also deprecate `use_mirrors`, if that's ok! I hope I'm not overstepping my bounds; it just seems like a good idea.

Anyway, PyPI moved to a CDN on 2013-05-26, so mirrors are now largely unnecessary and pip removed the functionality in 1.5. More importantly (and why I wrote this request): on 2014-02-15 the mirror directory was taken offline, so mirrors may not work anymore even for pip versions that support them. Somehow one of my machines was able to install things anyway (using pip 1.0), but another one of my machines hung indefinitely when trying to install a new version of a package.
