### PR TITLE
Avoid breaking on unicode input when logging to syslog in modules

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -814,10 +814,10 @@ class AnsibleModule(object):
             except IOError, e:
                 # fall back to syslog since logging to journal failed
                 syslog.openlog(str(module), 0, syslog.LOG_USER)
-                syslog.syslog(syslog.LOG_NOTICE, msg.encode('utf8'))
+                syslog.syslog(syslog.LOG_NOTICE, msg.decode('utf8').encode('utf8'))
         else:
             syslog.openlog(str(module), 0, syslog.LOG_USER)
-            syslog.syslog(syslog.LOG_NOTICE, msg.encode('utf8'))
+            syslog.syslog(syslog.LOG_NOTICE, msg.decode('utf8').encode('utf8'))
 
     def get_bin_path(self, arg, required=False, opt_dirs=[]):
         '''

--- a/test/TestPlayBook.py
+++ b/test/TestPlayBook.py
@@ -409,6 +409,22 @@ class TestPlaybook(unittest.TestCase):
 
         assert utils.jsonify(expected, format=True) == utils.jsonify(actual,format=True)
 
+    def test_playbook_logging_non_ascii(self):
+        pb = 'test/playbook-logging-non-ascii.yml'
+        actual = self._run(pb)
+
+        expected = {
+            "localhost": {
+                "changed": 3,
+                "failures": 0,
+                "ok": 3,
+                "skipped": 0,
+                "unreachable": 0
+            }
+        }
+
+        assert utils.jsonify(expected, format=True) == utils.jsonify(actual, format=True)
+
 
     # Disabled for now as there are permissions issues that happen if you are not the owner that created files
     # in the archive.

--- a/test/playbook-logging-non-ascii.yml
+++ b/test/playbook-logging-non-ascii.yml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: False
+
+  tasks:
+  - name: Loggføring fungerer
+    command: echo "Feilsøking"
+    always_run: yes
+
+  - name: Die Süßigkeit
+    command: echo "Die Süßigkeit"
+    always_run: yes
+
+  - name: Logging works
+    command: echo "Debugging"
+    always_run: yes


### PR DESCRIPTION
After commit 254f87e, non-ascii input broke logging to syslog.
