### PR TITLE
Fix zfs create command for properties with spaces

### DIFF
--- a/library/system/zfs
+++ b/library/system/zfs
@@ -264,7 +264,7 @@ class Zfs(object):
             cmd.append('-b %s' % volblocksize)
         if properties:
             for prop, value in properties.iteritems():
-                cmd.append('-o %s=%s' % (prop, value))
+                cmd.append('-o %s="%s"' % (prop, value))
         if volsize:
             cmd.append('-V')
             cmd.append(volsize)


### PR DESCRIPTION
If a property value contains one or more spaces, the zfs command will fail.
With value quoted this behavior is fixed.

The problem occurrs while creating a new ZFS dataset, e.g.:

```
zfs: name=tank/test state=present sharenfs="-ro 10.0.0.0/13"
```
