### PR TITLE
corrections for Arch PKGBUILD

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -39,8 +39,6 @@ package() {
   python2 setup.py install -O1 --root="$pkgdir"
 
   install -Dm644 examples/ansible.cfg $pkgdir/etc/ansible/ansible.cfg
-  install -dm755 $pkgdir/etc/ansible/group_vars
-  install -dm755 $pkgdir/etc/ansible/host_vars
 
   install -Dm644 README.md $pkgdir/usr/share/doc/ansible/README.md
   install -Dm644 COPYING $pkgdir/usr/share/doc/ansible/COPYING

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -32,19 +32,21 @@ build() {
 package() {
   cd $pkgname
 
-  mkdir -p "$pkgdir/usr/share/ansible"
+  install -dm755 $pkgdir/usr/share/ansible
   cp -dpr --no-preserve=ownership ./library/* "$pkgdir/usr/share/ansible/"
   cp -dpr --no-preserve=ownership ./examples "$pkgdir/usr/share/ansible"
 
   python2 setup.py install -O1 --root="$pkgdir"
 
-  install -D examples/ansible.cfg "$pkgdir/etc/ansible/ansible.cfg"
+  install -Dm644 examples/ansible.cfg $pkgdir/etc/ansible/ansible.cfg
+  install -dm755 $pkgdir/etc/ansible/group_vars
+  install -dm755 $pkgdir/etc/ansible/host_vars
 
-  install -D README.md "$pkgdir/usr/share/doc/ansible/README.md"
-  install -D COPYING "$pkgdir/usr/share/doc/ansible/COPYING"
-  install -D CHANGELOG.md "$pkgdir/usr/share/doc/ansible/CHANGELOG.md"
+  install -Dm644 README.md $pkgdir/usr/share/doc/ansible/README.md
+  install -Dm644 COPYING $pkgdir/usr/share/doc/ansible/COPYING
+  install -Dm644 CHANGELOG.md $pkgdir/usr/share/doc/ansible/CHANGELOG.md
 
-  mkdir -p "$pkgdir/usr/share/man/man{1,3}"
+  install -dm755 ${pkgdir}/usr/share/man/man{1,3}
   cp -dpr --no-preserve=ownership docs/man/man1/*.1 "$pkgdir/usr/share/man/man1"
   cp -dpr --no-preserve=ownership docs/man/man3/*.3 "$pkgdir/usr/share/man/man3"
 }


### PR DESCRIPTION
Use correct permission mode when installing files and directories.  Also, create the group_vars and host_vars directories, since the ansible documentation states that these are best practice.

http://docs.ansible.com/intro_inventory.html#splitting-out-host-and-group-specific-data
