### PR TITLE
Added support for tagging subnets in ec2_vpc module

### DIFF
--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -277,7 +277,10 @@ def create_vpc(module, vpc_conn):
                 add_subnet = False
         if add_subnet:
             try:
-                vpc_conn.create_subnet(vpc.id, subnet['cidr'], subnet.get('az', None))
+                created_subnet = vpc_conn.create_subnet(vpc.id, subnet['cidr'], subnet.get('az', None))
+                subnet_tags = subnet.get('tags', None)
+                if subnet_tags:
+                    vpc_conn.create_tags(created_subnet.id, subnet_tags)
                 changed = True
             except EC2ResponseError, e:
                 module.fail_json(msg='Unable to create subnet {0}, error: {1}'.format(subnet['cidr'], e))

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -280,10 +280,18 @@ def create_vpc(module, vpc_conn):
                 add_subnet = False
         if add_subnet:
             try:
-                created_subnet = vpc_conn.create_subnet(vpc.id, subnet['cidr'], subnet.get('az', None))
-                subnet_tags = subnet.get('tags', None)
-                if subnet_tags:
-                    vpc_conn.create_tags(created_subnet.id, subnet_tags)
+                new_subnet = vpc_conn.create_subnet(vpc.id, subnet['cidr'], subnet.get('az', None))
+                new_subnet_tags = subnet.get('tags', None)
+                if new_subnet_tags:
+                    # Sometimes AWS takes its time to create a subnet and so using new subnets's id
+                    # to create tags results in exception.
+                    # boto doesn't seem to refresh 'state' of the newly created subnet, i.e.: it's always 'pending'
+                    # so i resorted to polling vpc_conn.get_all_subnets with the id of the newly added subnet
+                    while len(vpc_conn.get_all_subnets(filters={ 'subnet-id': new_subnet.id })) == 0:
+                        time.sleep(0.1)
+
+                    vpc_conn.create_tags(new_subnet.id, new_subnet_tags)
+
                 changed = True
             except EC2ResponseError, e:
                 module.fail_json(msg='Unable to create subnet {0}, error: {1}'.format(subnet['cidr'], e))
@@ -411,13 +419,14 @@ def create_vpc(module, vpc_conn):
     created_vpc_id = vpc.id
     returned_subnets = []
     current_subnets = vpc_conn.get_all_subnets(filters={ 'vpc_id': vpc.id })
+    
     for sn in current_subnets:
         returned_subnets.append({
+            'tags': dict((t.name, t.value) for t in vpc_conn.get_all_tags(filters={'resource-id': sn.id})),
             'cidr': sn.cidr_block, 
             'az': sn.availability_zone,
             'id': sn.id,
         })
-
 
     return (vpc_dict, created_vpc_id, returned_subnets, changed)
 

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -46,7 +46,7 @@ options:
     choices: [ "yes", "no" ]
   subnets:
     description:
-      - "A dictionary array of subnets to add of the form: { cidr: ..., az: ... }. Where az is the desired availability zone of the subnet, but it is not required. All VPC subnets not in this list will be removed."
+      - "A dictionary array of subnets to add of the form: { cidr: ..., az: ... , tags: ... }. Where az is the desired availability zone of the subnet, but it is not required. Tags (i.e.: tags) is also optional and use dictionary form: { "Environment":"Dev", "Tier":"Web", ...}. All VPC subnets not in this list will be removed."
     required: false
     default: null
     aliases: []
@@ -137,10 +137,13 @@ EXAMPLES = '''
         subnets: 
           - cidr: 172.22.1.0/24
             az: us-west-2c
+            tags: { "Environment":"Dev", "Tier" : "Web" }
           - cidr: 172.22.2.0/24
             az: us-west-2b
+            tags: { "Environment":"Dev", "Tier" : "App" }
           - cidr: 172.22.3.0/24
             az: us-west-2a
+            tags: { "Environment":"Dev", "Tier" : "DB" }
         internet_gateway: True
         route_tables:
           - subnets: 

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -46,7 +46,7 @@ options:
     choices: [ "yes", "no" ]
   subnets:
     description:
-      - "A dictionary array of subnets to add of the form: { cidr: ..., az: ... , tags: ... }. Where az is the desired availability zone of the subnet, but it is not required. Tags (i.e.: tags) is also optional and use dictionary form: { "Environment":"Dev", "Tier":"Web", ...}. All VPC subnets not in this list will be removed."
+      - "A dictionary array of subnets to add of the form: { cidr: ..., az: ... , instance_tags: ... }. Where az is the desired availability zone of the subnet, but it is not required. Tags (i.e.: instance_tags) is also optional and use dictionary form: { "Environment":"Dev", "Tier":"Web", ...}. All VPC subnets not in this list will be removed."
     required: false
     default: null
     aliases: []
@@ -137,13 +137,13 @@ EXAMPLES = '''
         subnets: 
           - cidr: 172.22.1.0/24
             az: us-west-2c
-            tags: { "Environment":"Dev", "Tier" : "Web" }
+            instance_tags: { "Environment":"Dev", "Tier" : "Web" }
           - cidr: 172.22.2.0/24
             az: us-west-2b
-            tags: { "Environment":"Dev", "Tier" : "App" }
+            instance_tags: { "Environment":"Dev", "Tier" : "App" }
           - cidr: 172.22.3.0/24
             az: us-west-2a
-            tags: { "Environment":"Dev", "Tier" : "DB" }
+            instance_tags: { "Environment":"Dev", "Tier" : "DB" }
         internet_gateway: True
         route_tables:
           - subnets: 
@@ -281,7 +281,7 @@ def create_vpc(module, vpc_conn):
         if add_subnet:
             try:
                 new_subnet = vpc_conn.create_subnet(vpc.id, subnet['cidr'], subnet.get('az', None))
-                new_subnet_tags = subnet.get('tags', None)
+                new_subnet_tags = subnet.get('instance_tags', None)
                 if new_subnet_tags:
                     # Sometimes AWS takes its time to create a subnet and so using new subnets's id
                     # to create tags results in exception.
@@ -422,7 +422,7 @@ def create_vpc(module, vpc_conn):
     
     for sn in current_subnets:
         returned_subnets.append({
-            'tags': dict((t.name, t.value) for t in vpc_conn.get_all_tags(filters={'resource-id': sn.id})),
+            'instance_tags': dict((t.name, t.value) for t in vpc_conn.get_all_tags(filters={'resource-id': sn.id})),
             'cidr': sn.cidr_block, 
             'az': sn.availability_zone,
             'id': sn.id,

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -46,7 +46,7 @@ options:
     choices: [ "yes", "no" ]
   subnets:
     description:
-      - "A dictionary array of subnets to add of the form: { cidr: ..., az: ... , instance_tags: ... }. Where az is the desired availability zone of the subnet, but it is not required. Tags (i.e.: instance_tags) is also optional and use dictionary form: { "Environment":"Dev", "Tier":"Web", ...}. All VPC subnets not in this list will be removed."
+      - "A dictionary array of subnets to add of the form: { cidr: ..., az: ... , resource_tags: ... }. Where az is the desired availability zone of the subnet, but it is not required. Tags (i.e.: resource_tags) is also optional and use dictionary form: { "Environment":"Dev", "Tier":"Web", ...}. All VPC subnets not in this list will be removed."
     required: false
     default: null
     aliases: []
@@ -137,13 +137,13 @@ EXAMPLES = '''
         subnets: 
           - cidr: 172.22.1.0/24
             az: us-west-2c
-            instance_tags: { "Environment":"Dev", "Tier" : "Web" }
+            resource_tags: { "Environment":"Dev", "Tier" : "Web" }
           - cidr: 172.22.2.0/24
             az: us-west-2b
-            instance_tags: { "Environment":"Dev", "Tier" : "App" }
+            resource_tags: { "Environment":"Dev", "Tier" : "App" }
           - cidr: 172.22.3.0/24
             az: us-west-2a
-            instance_tags: { "Environment":"Dev", "Tier" : "DB" }
+            resource_tags: { "Environment":"Dev", "Tier" : "DB" }
         internet_gateway: True
         route_tables:
           - subnets: 
@@ -281,7 +281,7 @@ def create_vpc(module, vpc_conn):
         if add_subnet:
             try:
                 new_subnet = vpc_conn.create_subnet(vpc.id, subnet['cidr'], subnet.get('az', None))
-                new_subnet_tags = subnet.get('instance_tags', None)
+                new_subnet_tags = subnet.get('resource_tags', None)
                 if new_subnet_tags:
                     # Sometimes AWS takes its time to create a subnet and so using new subnets's id
                     # to create tags results in exception.
@@ -422,7 +422,7 @@ def create_vpc(module, vpc_conn):
     
     for sn in current_subnets:
         returned_subnets.append({
-            'instance_tags': dict((t.name, t.value) for t in vpc_conn.get_all_tags(filters={'resource-id': sn.id})),
+            'resource_tags': dict((t.name, t.value) for t in vpc_conn.get_all_tags(filters={'resource-id': sn.id})),
             'cidr': sn.cidr_block, 
             'az': sn.availability_zone,
             'id': sn.id,


### PR DESCRIPTION
Tagging a subnet allows us to reference it later without using/knowing its id.  For example, if we tag subnets as tiers such as Web, App and DB we can later use this metadata to provision VMs into appropriate subnets:

``` YAML
# roles/ec2-provisioner/tasks/main.yml

---
- name: "Create Virtual Private Cloud (VPC)"
  local_action:
    module: ec2_vpc
    state: present
    cidr_block: 10.0.0.0/16
    subnets:
      - cidr: 10.0.1.0/24 
        az: us-east-1a   
        resource_tags: { "Environment":"DEV", "Tier" : "Web" }
      - cidr: 10.0.2.0/24
        az: us-east-1a       
        resource_tags: { "Environment":"DEV", "Tier" : "App" }
      - cidr: 10.0.3.0/24
        az: us-east-1a    
        resource_tags: { "Environment":"DEV", "Tier" : "DB" }
        ...
  register: env_vpc

```
