### PR TITLE
Fix mistaken double backslash

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1039,7 +1039,7 @@ class AnsibleModule(object):
             
             if data:
                 if not binary_data:
-                    data += '\\n'
+                    data += '\n'
             out, err = cmd.communicate(input=data)
             rc = cmd.returncode
         except (OSError, IOError), e:


### PR DESCRIPTION
The module helper function run_command was appending a literal backslash
followed by 'n' to the stdin of a command it runs unless you called it
with binary_data=True (not the default).  I have changed it to what
I expect was the intent, to append an actual line feed to stdin.
