### PR TITLE
Make missing known hosts file message a verbose message

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -157,7 +157,8 @@ class Connection(object):
                         return False
 
         if (hfiles_not_found == len(host_file_list)):
-            print "previous known host file not found"
+            if utils.VERBOSITY > 0:
+                print "INFO: No previous known host file found"
         return True
 
     def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False, executable='/bin/sh', in_data=None, su_user=None, su=False):


### PR DESCRIPTION
Since ansible does not completely implement a OpenSSH option parser it
does not really know which known hosts file needs to be used. Therefore
a faulty message appears if eg a GlobalKnownHosts file is used or a
non-standard UserKnownHosts file as specified by ~/.ssh/config or eg
/etc/ssh/ssh_config. Therefore the message a about the known hosts files
not being found should be only shown if VERBOSITY is at least 1.
