### PR TITLE
Normalise the module name when comparing against the module names in /proc/modules

### DIFF
--- a/library/system/modprobe
+++ b/library/system/modprobe
@@ -60,8 +60,9 @@ def main():
     try:
         modules = open('/proc/modules')
         present = False
+        module_name = args['name'].replace('-', '_') + ' '
         for line in modules:
-            if line.startswith(args['name'] + ' '):
+            if line.startswith(module_name):
                 present = True
                 break
         modules.close()


### PR DESCRIPTION
When using the modprobe command , '_' and '-' in the name of the module are interchangeable. However, in /proc/module they are always listed with '_' in the name. When 'modprobe' Ansible module if the name is given with a '-' the module is enabled regardless of whether it was enabled previously or not, thus marking the task as changed. 

eg. 

``` yaml
- modprobe: name=snd-aloop state=present
```

Will always be marked as changed. The work-around is to use name=snd_aloop. 
