### PR TITLE
fix json typo in documentation

### DIFF
--- a/docsite/rst/developing_inventory.rst
+++ b/docsite/rst/developing_inventory.rst
@@ -31,7 +31,7 @@ When the external node script is called with the single argument ``--list``, the
             "vars"    : {
                 "b"   : false
             },
-            "children": [ "marietta", "5points" ],
+            "children": [ "marietta", "5points" ]
         },
         "marietta"    : [ "host6.example.com" ],
         "5points"     : [ "host7.example.com" ]


### PR DESCRIPTION
Example JSON in Developing Dynamic Inventory Sources has an extra comma.

In []:

```
utils.parse_json("""{
    "databases"   : {
        "hosts"   : [ "host1.example.com", "host2.example.com" ],
        "vars"    : {
            "a"   : true
        }
    },
    "webservers"  : [ "host2.example.com", "host3.example.com" ],
    "atlanta"     : {
        "hosts"   : [ "host1.example.com", "host4.example.com", "host5.example.com" ],
        "vars"    : {
            "b"   : false
        },
        "children": [ "marietta", "5points" ],
    },
    "marietta"    : [ "host6.example.com" ],
    "5points"     : [ "host7.example.com" ]
}
""")
```

---

```
AnsibleError                              Traceback (most recent call last)
<ipython-input-78-3ec7f25b2040> in <module>()
     17     "5points"     : [ "host7.example.com" ]
     18 }
---> 19 """)

/ansible/lib/ansible/utils/__init__.pyc in parse_json(raw_data)
    300         for t in tokens:
    301             if t.find("=") == -1:
--> 302                 raise errors.AnsibleError("failed to parse: %s" % orig_data)
    303             (key,value) = t.split("=", 1)
    304             if key == 'changed' or 'failed':

AnsibleError: failed to parse: {
    "databases"   : {
        "hosts"   : [ "host1.example.com", "host2.example.com" ],
        "vars"    : {
            "a"   : true
        }
    },
    "webservers"  : [ "host2.example.com", "host3.example.com" ],
    "atlanta"     : {
        "hosts"   : [ "host1.example.com", "host4.example.com", "host5.example.com" ],
        "vars"    : {
            "b"   : false
        },
        "children": [ "marietta", "5points" ],
    },
    "marietta"    : [ "host6.example.com" ],
    "5points"     : [ "host7.example.com" ]
}
```
