### PR TITLE
Make sure droplet deletion works even when idempotency is achieved using 'name' and 'unique_name' rather than 'id'

### DIFF
--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -348,7 +348,7 @@ def core(module):
 
         elif state in ('absent', 'deleted'):
             # First, try to find a droplet by id.
-            droplet = Droplet.find(id=getkeyordie('id'))
+            droplet = Droplet.find(module.params['id'])
 
             # If we couldn't find the droplet and the user is allowing unique
             # hostnames, then check to see if a droplet with the specified


### PR DESCRIPTION
So this fixes a bug that makes it impossible to delete a droplet that is specified with just a combination of name and unique_names (for idempotency).

In particular, without the fix, this code: 

```
digital_ocean:
  image_id=1646467
  name=mydroplet
  ssh_key_ids=54036
  size_id=63
  region_id=4
  state=absent
  unique_name=yes
```

will always fail with:

```
TASK: [deploy droplets] *******************************************************
failed: [127.0.0.1] => (item=mydroplet) => {"failed": true, "item": "mydroplet"}
msg: Unable to load id

FATAL: all hosts have already failed -- aborting
```

because the module will fail, not finding 'id' (even though, according to the manual and to what I need to do, seems like a completely legit case)
