### PR TITLE
Added ansible-vault to the installer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ setup(name='ansible',
          'bin/ansible-playbook',
          'bin/ansible-pull',
          'bin/ansible-doc',
-         'bin/ansible-galaxy'
+         'bin/ansible-galaxy',
+         'bin/ansible-vault',
       ],
       data_files=data_files
 )


### PR DESCRIPTION
The `ansible-vault` command is not installed. Fixed this in `setup.py`.
