### PR TITLE
Allow custom nosetest parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ifeq ($(OFFICIAL),)
 endif
 RPMNVR = "$(NAME)-$(VERSION)-$(RPMRELEASE)$(RPMDIST)"
 
-NOSETESTS := nosetests
+NOSETESTS ?= nosetests
 
 ########################################################
 


### PR DESCRIPTION
The NOSETESTS variable can be used to support customizing the nosetests
parameters.  This allows providing custom nose parameters such as
--with-coverage.
