### PR TITLE
Expand templates inside of notify

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -451,21 +451,27 @@ class PlayBook(object):
 
     # *****************************************************
 
-    def _flag_handler(self, play, handler_name, host):
+    def _flag_handler(self, play, handlers_or_handler, host):
         '''
         if a task has any notify elements, flag handlers for run
         at end of execution cycle for hosts that have indicated
         changes have been made
         '''
 
-        found = False
-        for x in play.handlers():
-            if handler_name == template(play.basedir, x.name, x.module_vars):
-                found = True
-                self.callbacks.on_notify(host, x.name)
-                x.notified_by.append(host)
-        if not found:
-            raise errors.AnsibleError("change handler (%s) is not defined" % handler_name)
+        if isinstance(handlers_or_handler, basestring):
+          handlers = [ handlers_or_handler ]
+        else:
+          handlers = handlers_or_handler
+
+        for handler in handlers:
+          found = False
+          for x in play.handlers():
+              if handler == template(play.basedir, x.name, x.module_vars):
+                  found = True
+                  self.callbacks.on_notify(host, x.name)
+                  x.notified_by.append(host)
+          if not found:
+              raise errors.AnsibleError("change handler (%s) is not defined" % handler )
 
     # *****************************************************
 


### PR DESCRIPTION
This patch expands templates inside of the notify block, to allow for implementing 'hooks' in roles.

Example:
roles/hooked/main.yml:

```

---
- debug: Frobbing "{{thing}}"
  notify: $onUpdate
```

main.yml:

```

---
hosts: all
roles:
  - role: hooked
    thing: "Something"
    onUpdate:
      - reload
  - role: hooked
    thing: "Something Else"
    onUpdate:
      - reload
      - cleanup
handlers:
  - name: reload
    action: debug Reloaded
  - name: cleanup
    action: debug Cleaned up!
```

This results in the reload handler being executed once for each task, and the cleanup handler executing once for the second application of the hooked role.
