### PR TITLE
Remove obsolete module development docs

### DIFF
--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -416,23 +416,6 @@ Put your completed module file into the 'library' directory and then
 run the command: ``make webdocs``. The new 'modules.html' file will be
 built and appear in the 'docsite/' directory.
 
-You can also test-build your docs one-by-one using the
-``module_formatter.py`` script:
-
-.. code-block:: bash
-
-   $ ./hacking/module_formatter.py -t man -M library/ -m git > ansible-git.1
-   $ man ./ansible-git.1
-
-This will build a manpage for the git module, and look in the
-'library/' directory for the module source. To see all the other
-output formats available:
-
-.. code-block:: bash
-
-   $ ./hacking/module_formatter.py -t --help
-
-
 .. tip::
 
    If you're having a problem with the syntax of your YAML you can

--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -146,7 +146,7 @@ def generate_parser():
     p.add_option("-A", "--ansible-version", action="store", dest="ansible_version", default="unknown", help="Ansible version number")
     p.add_option("-M", "--module-dir", action="store", dest="module_dir", default=MODULEDIR, help="Ansible library path")
     p.add_option("-T", "--template-dir", action="store", dest="template_dir", default="hacking/templates", help="directory containing Jinja2 templates")
-    p.add_option("-t", "--type", action='store', dest='type', choices=['html', 'latex', 'man', 'rst', 'json', 'markdown', 'js'], default='latex', help="Document type")
+    p.add_option("-t", "--type", action='store', dest='type', choices=['rst'], default='rst', help="Document type")
     p.add_option("-v", "--verbose", action='store_true', default=False, help="Verbose")
     p.add_option("-o", "--output-dir", action="store", dest="output_dir", default=None, help="Output directory for module files")
     p.add_option("-I", "--includes-file", action="store", dest="includes_file", default=None, help="Create a file containing list of processed modules")


### PR DESCRIPTION
As far as I can see, it's no longer possible to build the docs one-by-one, so there is no way to replace this. But `make webdocs` doesn't seem to work for me either (fails on some missing images), so maybe it's better to just mention something like this:

```
$ mkdir tmp_docs
$ ./hacking/module_formatter.py -t rst -M library/ -o tmp_docs
$ less tmp_docs/git_module.rst
```

Or possibly:

```
$ mkdir tmp_docs
$ ./hacking/module_formatter.py -t rst -M library/ -o tmp_docs
$ rst2man tmp_docs/git_module.rst > ansible-git.1
$ man ./ansible-git.1
```

This builds docs for all the modules, it still does less work than `make webdocs`.
