### PR TITLE
Add env variables as default in the ConfigParser

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -58,7 +58,7 @@ def _get_config(p, section, key, env_var, default):
 def load_config_file():
     ''' Load Config File order(first found is used): ENV, CWD, HOME, /etc/ansible '''
 
-    p = ConfigParser.ConfigParser()
+    p = ConfigParser.ConfigParser(os.environ)
 
     path0 = os.getenv("ANSIBLE_CONFIG", None)
     if path0 is not None:


### PR DESCRIPTION
This allow to do substitution base on environment  variables. The change is so tiny that I did the PR directly but you may have some reason to refuse of exposing the env var in the ansible.cfg and I will be happy to discuss them on the mailing list.
#### Some Background about this change:

Our team is currently sharing generic roles between project via git submodule.
Loads of us are not familiar with git submodules so we've been talking about changing and keeping our role in a specific path to look at. But this create a problem as we are loosing the link between roles version and project version. 
I recently thought that I could simply make our roles installable via setuptools and then having a requirement file specific for our generic roles version. This will allow use to install our generic roles via `pip`.
But then I would like to able to set the role_path to $VIRTUAL_ENV/lib/python2.7/site-packages/ansible-roles/
so for being able to do so I would need access to the env variables from ansible.cfg 

Now my change is maybe redundant and you may have some better suggestions to handle role versioning other than `git submodule` or `subtree` .

R.
