### PR TITLE
Old FreeBSD compatibility (for service module)

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -764,15 +764,24 @@ class FreeBsdService(Service):
 
     platform = 'FreeBSD'
     distribution = None
+    use_service = True
 
     def get_service_tools(self):
-        self.svc_cmd = self.module.get_bin_path('service', True)
+        self.svc_cmd = self.module.get_bin_path('service')
 
         if not self.svc_cmd:
-            self.module.fail_json(msg='unable to find service binary')
+            self.use_service = False
+            self.svc_cmd = self.module.get_bin_path('/usr/local/etc/rc.d/%s' % self.name)
+            if not self.svc_cmd:
+                self.svc_cmd = self.module.get_bin_path('/etc/rc.d/%s' % self.name)
+                if not self.svc_cmd:
+                    self.module.fail_json(msg='unable to find service binary or rc.d script for %s' % self.name)
 
     def get_service_status(self):
-        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, 'onestatus', self.arguments))
+        if self.use_service:
+            rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, 'onestatus', self.arguments))
+        else:
+            rc, stdout, stderr = self.execute_command("%s %s %s" % (self.svc_cmd, 'onestatus', self.arguments))
         if rc == 1:
             self.running = False
         elif rc == 0:
@@ -789,7 +798,10 @@ class FreeBsdService(Service):
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
 
-        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, 'rcvar', self.arguments))
+        if self.use_service:
+            rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, 'rcvar', self.arguments))
+        else:
+            rc, stdout, stderr = self.execute_command("%s %s %s" % (self.svc_cmd, 'rcvar', self.arguments))
         cmd = "%s %s %s %s" % (self.svc_cmd, self.name, 'rcvar', self.arguments)
         rcvars = shlex.split(stdout, comments=True)
 
@@ -820,7 +832,10 @@ class FreeBsdService(Service):
         if self.action is "reload":
             self.action = "onereload"
 
-        return self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, self.action, self.arguments))
+        if self.use_service:
+            return self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, self.action, self.arguments))
+        else:
+            return self.execute_command("%s %s %s" % (self.svc_cmd, self.action, self.arguments))
 
 # ===========================================
 # Subclass: OpenBSD

--- a/library/system/setup
+++ b/library/system/setup
@@ -1007,13 +1007,13 @@ class FreeBSDHardware(Hardware):
         # Device          1M-blocks     Used    Avail Capacity
         # /dev/ada0p3        314368        0   314368     0%
         #
-        rc, out, err = module.run_command("/usr/sbin/swapinfo -m")
+        rc, out, err = module.run_command("/usr/sbin/swapinfo -k")
         lines = out.split('\n')
         if len(lines[-1]) == 0:
             lines.pop()
         data = lines[-1].split()
-        self.facts['swaptotal_mb'] = data[1]
-        self.facts['swapfree_mb'] = data[3]
+        self.facts['swaptotal_mb'] = int(data[1]) / 1024
+        self.facts['swapfree_mb'] = int(data[3]) / 1024
 
     def get_mount_facts(self):
         self.facts['mounts'] = []


### PR DESCRIPTION
This patch provides basic compatibility with FreeBSD 6.3+, at least as far as making the setup and ping modules run properly. Beyond that, file manipulation (lineinfile), service handling and user account creation seem to work.
