### PR TITLE
Modules for managing Rackspace Cloud Databases instances, databases and users.

### DIFF
--- a/library/cloud/rax_cdb
+++ b/library/cloud/rax_cdb
@@ -1,0 +1,293 @@
+#!/usr/bin/python -tt
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: rax_cdb
+short_description: create / delete or resize a Rackspace Cloud Databases instance
+description:
+  - creates / deletes or resize a Rackspace Cloud Databases instance
+    and optionally waits for it to be 'running'. The name option needs to be unique since
+    it's used to identify the instance.
+version_added: "1.6"
+options:
+  api_key:
+    description:
+      - Rackspace API key (overrides I(credentials))
+    aliases:
+      - password
+  credentials:
+    description:
+      - File to find the Rackspace credentials in (ignored if I(api_key) and
+        I(username) are provided)
+    default: null
+    aliases:
+      - creds_file
+  region:
+    description:
+      - Region to create an instance in
+    default: DFW
+  username:
+    description:
+      - Rackspace username (overrides I(credentials))
+  name:
+    description:
+      - Name of the databases server instance
+    default: null
+  flavor:
+    description:
+      - flavor to use for the instance 1 to 6 (i.e. 512MB to 16GB)
+    default: 1
+  volume:
+    description:
+      - Volume size of the database 1-150GB
+    default: 2
+  state:
+    description:
+      - Indicate desired state of the resource
+    choices: ['present', 'absent']
+    default: present
+  wait:
+    description:
+      - wait for the instance to be in state 'running' before returning
+    default: "no"
+    choices: [ "yes", "no" ]
+  wait_timeout:
+    description:
+      - how long before wait gives up, in seconds
+    default: 300
+requirements: [ "pyrax" ]
+author: Simon JAILLET
+notes:
+  - The following environment variables can be used, C(RAX_USERNAME),
+    C(RAX_API_KEY), C(RAX_CREDS_FILE), C(RAX_CREDENTIALS), C(RAX_REGION).
+  - C(RAX_CREDENTIALS) and C(RAX_CREDS_FILE) points to a credentials file
+    appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
+  - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
+  - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+'''
+
+EXAMPLES = '''
+- name: Build a Cloud Databases
+  gather_facts: False
+  tasks:
+    - name: Server build request
+      local_action:
+        module: rax_cdb
+        credentials: ~/.raxpub
+        region: IAD
+        name: db-server1
+        flavor: 1
+        volume: 2
+        wait: yes
+        state: present
+      register: rax_db_server
+'''
+
+import sys
+from types import NoneType
+
+try:
+    import pyrax
+except ImportError:
+    print("failed=True msg='pyrax is required for this module'")
+    sys.exit(1)
+
+NON_CALLABLES = (basestring, bool, dict, int, list, NoneType)
+
+
+def to_dict(obj):
+    instance = {}
+    for key in dir(obj):
+        value = getattr(obj, key)
+        if (isinstance(value, NON_CALLABLES) and not key.startswith('_')):
+            instance[key] = value
+    return instance
+
+
+def find_instance(name):
+
+    cdb = pyrax.cloud_databases
+    instances = cdb.list()
+    if instances:
+        for instance in instances:
+            if instance.name == name:
+                return instance
+    return False
+
+
+def save_instance(module, name, flavor, volume, wait, wait_timeout):
+
+    for arg, value in dict(name=name, flavor=flavor,
+                           volume=volume).iteritems():
+        if not value:
+            module.fail_json(msg='%s is required for the "rax_cdb"'
+                                 ' module' % arg)
+
+    if not (volume >= 1 and volume <= 150):
+        module.fail_json(msg='volume is required to be between 1 and 150')
+
+    cdb = pyrax.cloud_databases
+
+    flavors = []
+    for item in cdb.list_flavors():
+        flavors.append(item.id)
+
+    if not (flavor in flavors):
+        module.fail_json(msg='unexisting flavor reference "%s"' % str(flavor))
+
+    changed = False
+
+    instance = find_instance(name)
+
+    if not instance:
+        action = 'create'
+        try:
+            instance = cdb.create(name=name, flavor=flavor, volume=volume)
+        except Exception, e:
+            module.fail_json(msg='%s' % e.message)
+        else:
+            changed = True
+
+    else:
+        action = None
+
+        if instance.volume.size != volume:
+            action = 'resize'
+            if instance.volume.size > volume:
+                module.fail_json(
+                    changed=False,
+                    action=action,
+                    msg='The new volume size must be larger than the'
+                        ' current volume size',
+                    cdb=to_dict(instance)
+                )
+            instance.resize_volume(volume)
+            changed = True
+
+        if int(instance.flavor.id) != flavor:
+            action = 'resize'
+            pyrax.utils.wait_until(
+                instance,
+                'status',
+                'ACTIVE',
+                attempts=wait_timeout
+            )
+            instance.resize(flavor)
+            changed = True
+
+    if wait:
+        pyrax.utils.wait_until(
+            instance,
+            'status',
+            'ACTIVE',
+            attempts=wait_timeout
+        )
+
+    if wait and instance.status != 'ACTIVE':
+        module.fail_json(
+          changed=changed,
+          action=action,
+          cdb=to_dict(instance),
+          msg='Timeout waiting for "%s" databases instance to be '
+              'created' % name
+        )
+
+    module.exit_json(changed=changed, action=action, cdb=to_dict(instance))
+
+
+def delete_instance(module, name, wait, wait_timeout):
+
+    if not name:
+        module.fail_json(msg='name is required for the "rax_cdb" module')
+
+    changed = False
+
+    instance = find_instance(name)
+    if not instance:
+        module.exit_json(changed=False, action='delete')
+
+    try:
+        instance.delete()
+    except Exception, e:
+        module.fail_json(msg='%s' % e.message)
+    else:
+        changed = True
+
+    if wait:
+        pyrax.utils.wait_until(
+            instance,
+            'status',
+            'SHUTDOWN',
+            attempts=wait_timeout
+        )
+
+    if wait and instance.status != 'SHUTDOWN':
+        module.fail_json(
+          changed=changed,
+          action='delete',
+          cdb=to_dict(instance),
+          msg='Timeout waiting for "%s" databases instance to be '
+              'deleted' % name
+        )
+
+    module.exit_json(changed=changed, action='delete', cdb=to_dict(instance))
+
+
+def rax_cdb(module, state, name, flavor, volume, wait, wait_timeout):
+
+    # act on the state
+    if state == 'present':
+        save_instance(module, name, flavor, volume, wait, wait_timeout)
+    elif state == 'absent':
+        delete_instance(module, name, wait, wait_timeout)
+
+
+def main():
+    argument_spec = rax_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(type='str', required=True),
+            flavor=dict(type='int', default=1),
+            volume=dict(type='int', default=2),
+            state=dict(default='present', choices=['present', 'absent']),
+            wait=dict(type='bool', default=False),
+            wait_timeout=dict(type='int', default=300),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=rax_required_together(),
+    )
+
+    name = module.params.get('name')
+    flavor = module.params.get('flavor')
+    volume = module.params.get('volume')
+    state = module.params.get('state')
+    wait = module.params.get('wait')
+    wait_timeout = module.params.get('wait_timeout')
+
+    setup_rax_module(module, pyrax)
+    rax_cdb(module, state, name, flavor, volume, wait, wait_timeout)
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.rax import *
+
+### invoke the module
+main()

--- a/library/cloud/rax_cdb_database
+++ b/library/cloud/rax_cdb_database
@@ -1,0 +1,225 @@
+#!/usr/bin/python -tt
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: rax_cdb_database
+short_description: create / delete a database in the Cloud Databases
+description:
+  - create / delete a database in the Cloud Databases.
+version_added: "1.6"
+options:
+  api_key:
+    description:
+      - Rackspace API key (overrides I(credentials))
+    aliases:
+      - password
+  credentials:
+    description:
+      - File to find the Rackspace credentials in (ignored if I(api_key) and
+        I(username) are provided)
+    default: null
+    aliases:
+      - creds_file
+  region:
+    description:
+      - Region to create an instance in
+    default: DFW
+  username:
+    description:
+      - Rackspace username (overrides I(credentials))
+  cdb_id:
+    description:
+      - The databases server UUID
+    default: null
+  name:
+    description:
+      - Name to give to the database
+    default: null
+  character_set:
+    description:
+      - Set of symbols and encodings
+    default: 'utf8'
+  collate:
+    description:
+      - Set of rules for comparing characters in a character set
+    default: 'utf8_general_ci'
+  state:
+    description:
+      - Indicate desired state of the resource
+    choices: ['present', 'absent']
+    default: present
+requirements: [ "pyrax" ]
+author: Simon JAILLET
+notes:
+  - The following environment variables can be used, C(RAX_USERNAME),
+    C(RAX_API_KEY), C(RAX_CREDS_FILE), C(RAX_CREDENTIALS), C(RAX_REGION).
+  - C(RAX_CREDENTIALS) and C(RAX_CREDS_FILE) points to a credentials file
+    appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
+  - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
+  - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+'''
+
+EXAMPLES = '''
+- name: Build a database in Cloud Databases
+  tasks:
+    - name: Database build request
+      local_action:
+        module: rax_cdb_database
+        credentials: ~/.raxpub
+        region: IAD
+        cdb_id: 323e7ce0-9cb0-11e3-a5e2-0800200c9a66
+        name: db1
+        state: present
+      register: rax_db_database
+'''
+
+import sys
+from types import NoneType
+
+try:
+    import pyrax
+except ImportError:
+    print("failed=True msg='pyrax is required for this module'")
+    sys.exit(1)
+
+NON_CALLABLES = (basestring, bool, dict, int, list, NoneType)
+
+
+def to_dict(obj):
+    instance = {}
+    for key in dir(obj):
+        value = getattr(obj, key)
+        if (isinstance(value, NON_CALLABLES) and not key.startswith('_')):
+            instance[key] = value
+    return instance
+
+
+def find_database(instance, name):
+    try:
+        database = instance.get_database(name)
+    except Exception:
+        return False
+
+    return database
+
+
+def save_database(module, cdb_id, name, character_set, collate):
+
+    for arg, value in dict(cdb_id=cdb_id, name=name).iteritems():
+        if not value:
+            module.fail_json(msg='%s is required for the "rax_cdb_database" '
+                                 'module' % arg)
+
+    cdb = pyrax.cloud_databases
+
+    try:
+        instance = cdb.get(cdb_id)
+    except Exception, e:
+        module.fail_json(msg='%s' % e.message)
+
+    changed = False
+
+    database = find_database(instance, name)
+
+    if not database:
+        try:
+            database = instance.create_database(name=name,
+                                                character_set=character_set,
+                                                collate=collate)
+        except Exception, e:
+            module.fail_json(msg='%s' % e.message)
+        else:
+            changed = True
+
+    module.exit_json(
+      changed=changed,
+      action='create',
+      database=to_dict(database)
+    )
+
+
+def delete_database(module, cdb_id, name):
+
+    for arg, value in dict(cdb_id=cdb_id, name=name).iteritems():
+        if not value:
+            module.fail_json(msg='%s is required for the "rax_cdb_database" '
+                                 'module' % arg)
+
+    cdb = pyrax.cloud_databases
+
+    try:
+        instance = cdb.get(cdb_id)
+    except Exception, e:
+        module.fail_json(msg='%s' % e.message)
+
+    changed = False
+
+    database = find_database(instance, name)
+
+    if database:
+        try:
+            database.delete()
+        except Exception, e:
+            module.fail_json(msg='%s' % e.message)
+        else:
+            changed = True
+
+    module.exit_json(changed=changed, action='delete')
+
+
+def rax_cdb_database(module, state, cdb_id, name, character_set, collate):
+
+    # act on the state
+    if state == 'present':
+        save_database(module, cdb_id, name, character_set, collate)
+    elif state == 'absent':
+        delete_database(module, cdb_id, name)
+
+
+def main():
+    argument_spec = rax_argument_spec()
+    argument_spec.update(
+        dict(
+            cdb_id=dict(type='str', required=True),
+            name=dict(type='str', required=True),
+            character_set=dict(type='str', default='utf8'),
+            collate=dict(type='str', default='utf8_general_ci'),
+            state=dict(default='present', choices=['present', 'absent'])
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=rax_required_together(),
+    )
+
+    cdb_id = module.params.get('cdb_id')
+    name = module.params.get('name')
+    character_set = module.params.get('character_set')
+    collate = module.params.get('collate')
+    state = module.params.get('state')
+
+    setup_rax_module(module, pyrax)
+    rax_cdb_database(module, state, cdb_id, name, character_set, collate)
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.rax import *
+
+### invoke the module
+main()

--- a/library/cloud/rax_cdb_user
+++ b/library/cloud/rax_cdb_user
@@ -1,0 +1,255 @@
+#!/usr/bin/python -tt
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: rax_cdb_user
+short_description: create / delete a database in the Cloud Databases
+description:
+  - create / delete a database in the Cloud Databases.
+version_added: "1.6"
+options:
+  api_key:
+    description:
+      - Rackspace API key (overrides I(credentials))
+    aliases:
+      - password
+  credentials:
+    description:
+      - File to find the Rackspace credentials in (ignored if I(api_key) and
+        I(username) are provided)
+    default: null
+    aliases:
+      - creds_file
+  region:
+    description:
+      - Region to create an instance in
+    default: DFW
+  username:
+    description:
+      - Rackspace username (overrides I(credentials))
+  cdb_id:
+    description:
+      - The databases server UUID
+    default: null
+  db_username:
+    description:
+      - Name of the database user
+    default: null
+  db_password:
+    description:
+      - Database user password
+    default: null
+  databases:
+    description:
+      - Name of the databases that the user can access
+    default: []
+  host:
+    description:
+      - Specifies the host from which a user is allowed to connect to
+        the database. Possible values are a string containing an IPv4 address
+        or "%" to allow connecting from any host
+    default: '%'
+  state:
+    description:
+      - Indicate desired state of the resource
+    choices: ['present', 'absent']
+    default: present
+requirements: [ "pyrax" ]
+author: Simon JAILLET
+notes:
+  - The following environment variables can be used, C(RAX_USERNAME),
+    C(RAX_API_KEY), C(RAX_CREDS_FILE), C(RAX_CREDENTIALS), C(RAX_REGION).
+  - C(RAX_CREDENTIALS) and C(RAX_CREDS_FILE) points to a credentials file
+    appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
+  - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
+  - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+'''
+
+EXAMPLES = '''
+- name: Build a user in Cloud Databases
+  tasks:
+    - name: User build request
+      local_action:
+        module: rax_cdb_user
+        credentials: ~/.raxpub
+        region: IAD
+        cdb_id: 323e7ce0-9cb0-11e3-a5e2-0800200c9a66
+        db_username: user1
+        db_password: user1
+        databases: ['db1']
+        state: present
+      register: rax_db_user
+'''
+
+import sys
+from types import NoneType
+
+try:
+    import pyrax
+except ImportError:
+    print("failed=True msg='pyrax is required for this module'")
+    sys.exit(1)
+
+NON_CALLABLES = (basestring, bool, dict, int, list, NoneType)
+
+
+def to_dict(obj):
+    instance = {}
+    for key in dir(obj):
+        value = getattr(obj, key)
+        if (isinstance(value, NON_CALLABLES) and not key.startswith('_')):
+            instance[key] = value
+    return instance
+
+
+def find_user(instance, name):
+    try:
+        user = instance.get_user(name)
+    except Exception:
+        return False
+
+    return user
+
+
+def save_user(module, cdb_id, name, password, databases, host):
+
+    for arg, value in dict(cdb_id=cdb_id, name=name).iteritems():
+        if not value:
+            module.fail_json(msg='%s is required for the "rax_cdb_user" '
+                                 'module' % arg)
+
+    cdb = pyrax.cloud_databases
+
+    try:
+        instance = cdb.get(cdb_id)
+    except Exception, e:
+        module.fail_json(msg='%s' % e.message)
+
+    changed = False
+
+    user = find_user(instance, name)
+
+    if not user:
+        action = 'create'
+        try:
+            user = instance.create_user(name=name,
+                                        password=password,
+                                        database_names=databases,
+                                        host=host)
+        except Exception, e:
+            module.fail_json(msg='%s' % e.message)
+        else:
+            changed = True
+    else:
+        action = 'update'
+
+        if user.host != host:
+            changed = True
+
+        user.update(password=password, host=host)
+
+        former_dbs = set([item.name for item in user.list_user_access()])
+        databases = set(databases)
+
+        if databases != former_dbs:
+            try:
+                revoke_dbs = [db for db in former_dbs if db not in databases]
+                user.revoke_user_access(db_names=revoke_dbs)
+
+                new_dbs = [db for db in databases if db not in former_dbs]
+                user.grant_user_access(db_names=new_dbs)
+            except Exception, e:
+                module.fail_json(msg='%s' % e.message)
+            else:
+                changed = True
+
+    module.exit_json(changed=changed, action=action, user=to_dict(user))
+
+
+def delete_user(module, cdb_id, name):
+
+    for arg, value in dict(cdb_id=cdb_id, name=name).iteritems():
+        if not value:
+            module.fail_json(msg='%s is required for the "rax_cdb_user"'
+                                 ' module' % arg)
+
+    cdb = pyrax.cloud_databases
+
+    try:
+        instance = cdb.get(cdb_id)
+    except Exception, e:
+        module.fail_json(msg='%s' % e.message)
+
+    changed = False
+
+    user = find_user(instance, name)
+
+    if user:
+        try:
+            user.delete()
+        except Exception, e:
+            module.fail_json(msg='%s' % e.message)
+        else:
+            changed = True
+
+    module.exit_json(changed=changed, action='delete')
+
+
+def rax_cdb_user(module, state, cdb_id, name, password, databases, host):
+
+    # act on the state
+    if state == 'present':
+        save_user(module, cdb_id, name, password, databases, host)
+    elif state == 'absent':
+        delete_user(module, cdb_id, name)
+
+
+def main():
+    argument_spec = rax_argument_spec()
+    argument_spec.update(
+        dict(
+            cdb_id=dict(type='str', required=True),
+            db_username=dict(type='str', required=True),
+            db_password=dict(type='str', required=True, no_log=True),
+            databases=dict(type='list', default=[]),
+            host=dict(type='str', default='%'),
+            state=dict(default='present', choices=['present', 'absent'])
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=rax_required_together(),
+    )
+
+    cdb_id = module.params.get('cdb_id')
+    name = module.params.get('db_username')
+    password = module.params.get('db_password')
+    databases = module.params.get('databases')
+    host = unicode(module.params.get('host'))
+    state = module.params.get('state')
+
+    setup_rax_module(module, pyrax)
+    rax_cdb_user(module, state, cdb_id, name, password, databases, host)
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.rax import *
+
+### invoke the module
+main()


### PR DESCRIPTION
Theses modules allow to manage Rackspace Cloud Databases instances , databases and users.
### rax_cdb

Supported operations are:
- creation (when state == present)
- deletion (when state == absent)
- resizing (when flavor is modified)
- resizing the db volume (when the volume is increased, i.e. increase only)
### rax_cdb_database

Supported operations are:
- creation (when state == present)
- deletion (when state == absent)
### rax_cdb_user

Supported operations are:
- creation (when state == present)
- deletion (when state == absent)
- grant/revoke privileges (according the the databases option)
- always update password according the db_password option (this action doesn't generate a "change event" since the previous state can't be known).
- Note: do not use an host option != '%'. It make the user "invisible" from the API (maybe a bug in pyrax)

Example of configuration

``` yaml
  tasks:
  - name: build webserver
    local_action:
      module: rax_cdb
      credentials: ../.rax.conf
      region: IAD
      name: db_server
      flavor: 1
      volume: 1
      state: present
      wait: yes
    register: rax_db_server

  - name: build database
    local_action:
      module: rax_cdb_database
      credentials: ../.rax.conf
      region: IAD
      cdb_id: "{{ rax_db_server.cdb.id }}"
      name: db
      state: present
    register: rax_db_database

  - name: build database user
    local_action:
      module: rax_cdb_user
      credentials: ../.rax.conf
      region: IAD
      cdb_id: "{{ rax_db_server.cdb.id }}"
      db_username: user
      db_password: user
      databases: ['db']
      state: present
    register: rax_db_user
```
