### PR TITLE
Fix incorrect use of .join on list causing a traceback

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -275,7 +275,7 @@ class Play(object):
                                     if type(passed_vars['when']) is str:
                                         tmpcond.append(passed_vars['when'])
                                     elif type(passed_vars['when']) is list:
-                                        tmpcond.join(passed_vars['when'])
+                                        tmpcond += passed_vars['when']
 
                                     if type(dep_vars['when']) is str:
                                         tmpcond.append(dep_vars['when'])


### PR DESCRIPTION
tmpcond is a list, so .join won't work.

While investigating this behavior I also noticed that a role is evaluated several times (and so its `when' condition added to tmpcond several times) during parsing - is this ok?
