### PR TITLE
Egress rules for ec2 security groups

### DIFF
--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -91,6 +91,12 @@ EXAMPLES = '''
       - proto: all
         # the containing group name may be specified here
         group_name: example
+      - proto: tcp
+        from_port: 0
+        to_port: 65535
+        cidr_ip: 0.0.0.0/0
+        # egress means that the rule will be assigned to outbound traffic
+        egress: yes
 '''
 
 try:
@@ -184,12 +190,14 @@ def main():
     if group:
         groupRules = {}
         addRulesToLookup(group.rules, 'in', groupRules)
+        addRulesToLookup(group.rules_egress, 'out', groupRules)
 
         # Now, go through all provided rules and ensure they are there.
         if rules:
             for rule in rules:
                 group_id = None
                 group_name = None
+                egress = 'egress' in rule and rule['egress']
                 ip = None
                 if 'group_id' in rule and 'cidr_ip' in rule:
                     module.fail_json(msg="Specify group_id OR cidr_ip, not both")
@@ -216,7 +224,8 @@ def main():
                     rule['to_port'] = None
 
                 # If rule already exists, don't later delete it
-                ruleId = "%s-%s-%s-%s-%s-%s" % ('in', rule['proto'], rule['from_port'], rule['to_port'], group_id, ip)
+                prefix = 'in' if not egress else 'out'
+                ruleId = "%s-%s-%s-%s-%s-%s" % (prefix, rule['proto'], rule['from_port'], rule['to_port'], group_id, ip)
                 if ruleId in groupRules:
                     del groupRules[ruleId]
                 # Otherwise, add new rule
@@ -226,17 +235,24 @@ def main():
                         grantGroup = groups[group_id]
 
                     if not module.check_mode:
-                        group.authorize(rule['proto'], rule['from_port'], rule['to_port'], ip, grantGroup)
+                        if egress:
+                            ec2.authorize_security_group_egress(group.id, rule['proto'], rule['from_port'], rule['to_port'], group_id, ip)
+                        else:
+                            group.authorize(rule['proto'], rule['from_port'], rule['to_port'], ip, grantGroup)
                     changed = True
 
         # Finally, remove anything left in the groupRules -- these will be defunct rules
-        for rule in groupRules.itervalues():
+        for (ruleKey, rule) in groupRules.iteritems():
             for grant in rule.grants:
                 grantGroup = None
                 if grant.group_id:
                     grantGroup = groups[grant.group_id]
                 if not module.check_mode:
-                    group.revoke(rule.ip_protocol, rule.from_port, rule.to_port, grant.cidr_ip, grantGroup)
+                    egress = ruleKey.startswith('out-')
+                    if egress:
+                        ec2.revoke_security_group_egress(group.id, rule.ip_protocol, rule.from_port, rule.to_port, grant.group_id, grant.cidr_ip)
+                    else:
+                        group.revoke(rule.ip_protocol, rule.from_port, rule.to_port, grant.cidr_ip, grantGroup)
                 changed = True
 
     if group:

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -193,11 +193,14 @@ def main():
         addRulesToLookup(group.rules_egress, 'out', groupRules)
 
         # Now, go through all provided rules and ensure they are there.
+        egressRulesExist = False
         if rules:
             for rule in rules:
                 group_id = None
                 group_name = None
                 egress = 'egress' in rule and rule['egress']
+                if egress:
+                    egressRulesExist = True
                 ip = None
                 if 'group_id' in rule and 'cidr_ip' in rule:
                     module.fail_json(msg="Specify group_id OR cidr_ip, not both")
@@ -215,6 +218,8 @@ def main():
                         group_id = group.id
                         groups[group_id] = group
                         groups[group_name] = group
+                    else:
+                        module.fail_json(msg="Group name '%s' doesn't exist" % group_name)
                 elif 'cidr_ip' in rule:
                     ip = rule['cidr_ip']
 
@@ -241,6 +246,12 @@ def main():
                             group.authorize(rule['proto'], rule['from_port'], rule['to_port'], ip, grantGroup)
                     changed = True
 
+            # If there is any egress rules, the default rule needs to be removed first. The default rule will not appear on the rules_egress
+            # list of the group as it is not returned when creating a new group. This is one sulotion to the problem, another could be getting
+            # the group again but I think that this is better because it's faster.
+            if egressRulesExist:
+                ec2.revoke_security_group_egress(group.id, -1, None, None, None, "0.0.0.0/0")
+
         # Finally, remove anything left in the groupRules -- these will be defunct rules
         for (ruleKey, rule) in groupRules.iteritems():
             for grant in rule.grants:
@@ -249,7 +260,7 @@ def main():
                     grantGroup = groups[grant.group_id]
                 if not module.check_mode:
                     egress = ruleKey.startswith('out-')
-                    if egress:
+                    if egress and egressRulesExist:
                         ec2.revoke_security_group_egress(group.id, rule.ip_protocol, rule.from_port, rule.to_port, grant.group_id, grant.cidr_ip)
                     else:
                         group.revoke(rule.ip_protocol, rule.from_port, rule.to_port, grant.cidr_ip, grantGroup)

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -262,7 +262,7 @@ def main():
                     egress = ruleKey.startswith('out-')
                     if egress and egressRulesExist:
                         ec2.revoke_security_group_egress(group.id, rule.ip_protocol, rule.from_port, rule.to_port, grant.group_id, grant.cidr_ip)
-                    else:
+                    elif not egress:
                         group.revoke(rule.ip_protocol, rule.from_port, rule.to_port, grant.cidr_ip, grantGroup)
                 changed = True
 


### PR DESCRIPTION
This will have the ability of adding egress rules, here is an example:

```
 - name: example ec2 group
   local_action:
     module: ec2_group
     name: example
     description: an example EC2 group
     vpc_id: 12345
     region: eu-west-1a
     ec2_secret_key: SECRET
     ec2_access_key: ACCESS
     rules:
       - proto: tcp
         from_port: 80
         to_port: 80
         cidr_ip: 0.0.0.0/0
         egress: yes <------------------ this will mark it as egress
       - proto: tcp
         from_port: 22
         to_port: 22
         cidr_ip: 10.0.0.0/8
```

When creating a security group on EC2, a default egress rule is always created, this rule gives unrestricted access to all protocols and all ports. This is unrelated to Ansible nor Boto.
When creating a security group using my changes, if no egress rules are configured then it will not change any egress rules that already exist on the group. If there are rules configured then similar to ingress rules it will remove the ones that are not configured.
I'm not sure if this is behavior is better for most users, but after contemplating I thought it is more reasonable.
