### PR TITLE
filesystem: Ignore blkid cache

### DIFF
--- a/library/system/filesystem
+++ b/library/system/filesystem
@@ -79,7 +79,7 @@ def main():
 
     cmd = module.get_bin_path('blkid', required=True)
 
-    rc,raw_fs,err = module.run_command("%s -o value -s TYPE %s" % (cmd, dev))
+    rc,raw_fs,err = module.run_command("%s -c /dev/null -o value -s TYPE %s" % (cmd, dev))
     fs = raw_fs.strip()
 
 


### PR DESCRIPTION
Sometimes, `blkid` will incorrectly return no information about a block
device, even if it exists and has a valid filesystem. This causes the
_filesystem_ module to fail if _force=no_. Instructing `blkid` to use
`/dev/null` as a cache file will force it to rescan the block device on
each run, making results more consistent.

Signed-off-by: Dustin C. Hatch admiralnemo@gmail.com
