### PR TITLE
When looking for double colon len(line) must be longer then 1.

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -375,7 +375,7 @@ It should be written as:
 """
         return msg
 
-    elif len(probline) and len(probline) >= column and probline[column] == ":" and probline.count(':') > 1:
+    elif len(probline) and len(probline) > 1 and len(probline) >= column and probline[column] == ":" and probline.count(':') > 1:
         msg = msg + """
 This one looks easy to fix.  There seems to be an extra unquoted colon in the line 
 and this is confusing the parser. It was only expecting to find one free 


### PR DESCRIPTION
Addresses GH-5116.

It comes up that when parsing json that if you are missing the last double quote on the last variable and the next line is just '}' we will get an out of range error. In this instance we will also then make sure that the line is long enough to have two colons.
