### PR TITLE
Fix issue #5621, rpm_key doesn't work for el5

### DIFF
--- a/library/packaging/rpm_key
+++ b/library/packaging/rpm_key
@@ -131,7 +131,9 @@ class RpmKey:
     def normalize_keyid(self, keyid):
         """Ensure a keyid doesn't have a leading 0x, has leading or trailing whitespace, and make sure is lowercase"""
         ret = keyid.strip().lower()
-        if ret.startswith(('0x', '0X')):
+        if ret.startswith('0x'):
+            return ret[2:]
+        elif ret.startswith('0X'):
             return ret[2:]
         else:
             return ret
@@ -141,9 +143,9 @@ class RpmKey:
         stdout, stderr = self.execute_command([gpg, '--no-tty', '--batch', '--with-colons', '--fixed-list-mode', '--list-packets', keyfile])
         for line in stdout.splitlines():
             line = line.strip()
-            if line.startswith('keyid:'):
+            if line.startswith(':signature packet:'):
                 # We want just the last 8 characters of the keyid
-                keyid = line.split(':')[1].strip()[8:]
+                keyid = line.split()[-1].strip()[8:]
                 return keyid
         self.json_fail(msg="Unexpected gpg output")
 


### PR DESCRIPTION
This small patch fixes issue #5621 and enables the rpm_key to work on Rhel 5 and derivative distros while still ensuring compatibility with more recent Red Hat ones.  The first part of the patch just adds Python 2.4 support and the second part grabs the keyid from the signature packet listing of the gpg command.
