### PR TITLE
Fixes templating of ansible_ssh_host for delegates

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -306,7 +306,7 @@ class Runner(object):
 
         delegate = {}
 
-        # allow ansible_ssh_host to be templated
+        # allow delegated host to be templated
         delegate['host'] = template.template(self.basedir, host, 
                                 remote_inject, fail_on_undefined=True)
 
@@ -331,7 +331,10 @@ class Runner(object):
             this_info = {}
 
         # get the real ssh_address for the delegate        
-        delegate['ssh_host'] = this_info.get('ansible_ssh_host', delegate['host'])
+        # and allow ansible_ssh_host to be templated
+        delegate['ssh_host'] = template.template(self.basedir,
+                            this_info.get('ansible_ssh_host', this_host),
+                            this_info, fail_on_undefined=True)
 
         delegate['port'] = this_info.get('ansible_ssh_port', port)
 


### PR DESCRIPTION
Follow up to some recent patches fro @jctanner (6035c0b1d5f286d906ad48b4165d33de4e6b02 and previous), to properly handle delegate_to: hosts. This patche re-enables the templating of ansible_ssh_host of delegates.
