### PR TITLE
pause plugin doesn't flush raw_input prompt

### DIFF
--- a/lib/ansible/runner/action_plugins/pause.py
+++ b/lib/ansible/runner/action_plugins/pause.py
@@ -77,11 +77,11 @@ class ActionModule(object):
         # Is 'prompt' a key in 'args'?
         elif 'prompt' in args:
             self.pause_type = 'prompt'
-            self.prompt = "[%s]\n%s: " % (hosts, args['prompt'])
+            self.prompt = "[%s]\n%s:\n" % (hosts, args['prompt'])
         # Is 'args' empty, then this is the default prompted pause
         elif len(args.keys()) == 0:
             self.pause_type = 'prompt'
-            self.prompt = "[%s]\nPress enter to continue: " % hosts
+            self.prompt = "[%s]\nPress enter to continue:\n" % hosts
         # I have no idea what you're trying to do. But it's so wrong.
         else:
             raise ae("invalid pause type given. must be one of: %s" % \


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.4.3
##### Environment:

N/A
##### Summary:

We are using a wrapper python script to run ansible-playbook. We use subprocess to execute and print the stdout as and when its written. Problem is when we use pause it doesn't display the prompt string as raw_input does not flush stdout before reading from stdin.

It looks like a dirty fix to add "\n" to the prompt string but i don't see any other way to over come this. If anyone else have a better fix please do propose/suggest.
##### Steps To Reproduce:

``` yaml
#File: test_play.yml
- name: Test
  hosts: $nodes
  gather_facts: false

  tasks:
    - name: Waiting for User
      local_action: pause prompt="Do you want to continue (yes/no)? "
```

``` python
#!/usr/bin/env python
#File: test.py
import shlex, subprocess

def run_process(process):
    process = process.encode("utf-8")
    command = shlex.split(process)
    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
    for line in iter(p.stdout.readline, b''):
        print line,

cmd = "/usr/bin/python -u /usr/bin/ansible-playbook -i hosts.txt test_play.yml -e 'nodes=local'"
run_process(cmd)
```

```
shell $ python test.py
```
##### Expected Results:

```
PLAY [Test] *******************************************************************

TASK: [Waiting for User] ******************************************************
[localhost]
Do you want to continue (yes/no)? :
```
##### Actual Results:

```
PLAY [Test] *******************************************************************

TASK: [Waiting for User] ******************************************************
[localhost]
```
