### PR TITLE
stat module: mode is now returned as an octal and md5 call can be skipped.

### DIFF
--- a/library/files/stat
+++ b/library/files/stat
@@ -34,6 +34,12 @@ options:
     required: false
     default: no
     aliases: []
+  get_md5:
+    description:
+      - Whether to return the md5 sum o fthe file
+    required: false
+    default: yes
+    aliases: []
 author: Bruce Pennypacker
 '''
 
@@ -51,6 +57,9 @@ EXAMPLES = '''
   register: p
 - debug: msg="Path exists and is a directory"
   when: p.stat.isdir is defined and p.stat.isdir == true
+
+# Don't do md5 checksum
+- stat: path=/path/to/myhugefile get_md5=no
 '''
 
 import os
@@ -62,7 +71,8 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             path = dict(required=True),
-            follow = dict(default='no', type='bool')
+            follow = dict(default='no', type='bool'),
+            get_md5 = dict(default='yes', type='bool')
         ),
         supports_check_mode = True
     )
@@ -70,6 +80,7 @@ def main():
     path = module.params.get('path')
     path = os.path.expanduser(path)
     follow = module.params.get('follow')
+    get_md5 = module.params.get('get_md5')
 
     try:
         if follow:
@@ -80,7 +91,7 @@ def main():
         if e.errno == errno.ENOENT:
             d = { 'exists' : False }
             module.exit_json(changed=False, stat=d)
-       
+
         module.fail_json(msg = e.strerror)
 
     mode = st.st_mode
@@ -89,6 +100,7 @@ def main():
     d = {
         'exists'   : True,
         'mode'     : S_IMODE(mode),
+        'octal'    : "%04o" % S_IMODE(mode),
         'isdir'    : S_ISDIR(mode),
         'ischr'    : S_ISCHR(mode),
         'isblk'    : S_ISBLK(mode),
@@ -121,7 +133,7 @@ def main():
     if S_ISLNK(mode):
         d['lnk_source'] = os.path.realpath(path)
 
-    if S_ISREG(mode):
+    if S_ISREG(mode) and get_md5:
         d['md5']        = module.md5(path)
 
     try:
@@ -130,7 +142,7 @@ def main():
         d['pw_name']   = pw.pw_name
     except:
         pass
-        
+
 
     module.exit_json(changed=False, stat=d)
 

--- a/library/files/stat
+++ b/library/files/stat
@@ -99,8 +99,7 @@ def main():
     # back to ansible
     d = {
         'exists'   : True,
-        'mode'     : S_IMODE(mode),
-        'octal'    : "%04o" % S_IMODE(mode),
+        'mode'    : "%04o" % S_IMODE(mode),
         'isdir'    : S_ISDIR(mode),
         'ischr'    : S_ISCHR(mode),
         'isblk'    : S_ISBLK(mode),

--- a/library/files/stat
+++ b/library/files/stat
@@ -36,7 +36,7 @@ options:
     aliases: []
   get_md5:
     description:
-      - Whether to return the md5 sum o fthe file
+      - Whether to return the md5 sum of the file
     required: false
     default: yes
     aliases: []


### PR DESCRIPTION
Closes GH-6176

The only changed beyond GH-6176 are that we want mode to be octal rather then a new variable.

Tested with: https://gist.github.com/risaacson/bbce046e1b2f9b7d6435
