### PR TITLE
Support ssh-ed25519 keys

### DIFF
--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -236,6 +236,7 @@ def parsekey(module, raw_key):
     '''
 
     VALID_SSH2_KEY_TYPES = [
+        'ssh-ed25519',
         'ecdsa-sha2-nistp256',
         'ecdsa-sha2-nistp384',
         'ecdsa-sha2-nistp521', 


### PR DESCRIPTION
The newest version of OpenSSH supports a new, wonderful key type. authorized_key incorrectly discards pubkeys of this type as busted because it doesn't recognize type signature.
