### PR TITLE
allow pkgin packages to be specifed with versions

### DIFF
--- a/library/packaging/pkgin
+++ b/library/packaging/pkgin
@@ -93,7 +93,7 @@ def query_package(module, pkgin_path, name, state="present"):
                 # (results in sth like 'gcc47-libs')
                 pkgname_without_version = '-'.join(pkgname_with_version.split('-')[:-1])
 
-                if name == pkgname_without_version:
+                if name == pkgname_without_version or name == pkgname_with_version:
                     return True
 
         return False


### PR DESCRIPTION
The pkgin module does not allow one to specify a specific package version. This is a big problem if you want to install a package that exists as multiple versions like erlang, which has both "erlang-16.1", "erlang-15.1.3.1" on my Joyent SmartOS distribution.

A fix is provided.
