### PR TITLE
nova_compute: fix for partial match b/w params['name'] and an existing name

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -197,7 +197,8 @@ def _get_server_state(module, nova):
             # with names that partially match the server name, so we have to
             # strictly filter here
             servers = [x for x in servers if x.name == module.params['name']]
-            server = servers[0] if servers else None
+            if servers:
+                server = servers[0]
     except Exception, e:
         module.fail_json(msg = "Error in getting the server list: %s" % e.message)
     if server and module.params['state'] == 'present':

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -193,7 +193,11 @@ def _get_server_state(module, nova):
     try:
         servers = nova.servers.list(True, {'name': module.params['name']})
         if servers:
-            server = [x for x in servers if x.name == module.params['name']][0]
+            # the {'name': module.params['name']} will also return servers
+            # with names that partially match the server name, so we have to
+            # strictly filter here
+            servers = [x for x in servers if x.name == module.params['name']]
+            server = servers[0] if servers else None
     except Exception, e:
         module.fail_json(msg = "Error in getting the server list: %s" % e.message)
     if server and module.params['state'] == 'present':


### PR DESCRIPTION
When there is an Openstack instance that has a name that's a partial match for module.params['name'], but a server with name module.params['name'] doesn't yet exist*, this module would fail with a list index out of bounds error. This fixes that by filtering by exact name and only **then** getting the server from the list if the list is still not empty.

\* For example, a server with name 'nginx-prod' exists, and module.params['name'] = 'nginx'.
