### PR TITLE
autodetect ANSIBLE_LIBRARY and PYTHONPATH if missing #6185 v1

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -22,7 +22,13 @@
 import os
 import sys
 
-from ansible.runner import Runner
+# find own sources if PYTHONPATH is not set
+try:
+    from ansible.runner import Runner
+except:
+    sys.path.append(os.path.abspath(os.path.realpath(__file__)+'/../../lib'))
+    from ansible.runner import Runner
+
 import ansible.constants as C
 from ansible import utils
 from ansible import errors

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -22,7 +22,13 @@ import sys
 import os
 import stat
 
-import ansible.playbook
+# find own sources if PYTHONPATH is not set
+try:
+    import ansible.playbook
+except:
+    sys.path.append(os.path.abspath(os.path.realpath(__file__)+'/../../lib'))
+    import ansible.playbook
+
 import ansible.constants as C
 import ansible.utils.template
 from ansible import errors

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -90,7 +90,10 @@ if getattr(sys, "real_prefix", None):
     # in a virtualenv
     DIST_MODULE_PATH = os.path.join(sys.prefix, 'share/ansible/')
 else:
-    DIST_MODULE_PATH = '/usr/share/ansible/'
+    if os.path.isdir('/usr/share/ansible'):
+        DIST_MODULE_PATH = '/usr/share/ansible/'
+    else:
+        DIST_MODULE_PATH = os.path.abspath(__file__ + '/../../../library')
 
 # check all of these extensions when looking for yaml files for things like
 # group variables


### PR DESCRIPTION
ansible and ansible-playbook can now be run directly from the git clone, without setting any environmental variables.
Works with symlinked files.
Original behavior takes precedence.
Tries to resolve #6185 .
