### PR TITLE
allow for ssh-specific arguments

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -152,6 +152,7 @@ DEPRECATION_WARNINGS           = get_config(p, DEFAULTS, 'deprecation_warnings',
 
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
+ANSIBLE_SSH_SPECIFIC_ARGS      = get_config(p, 'ssh_connection', 'ssh_specific_args', 'ANSIBLE_SSH_SPECIFIC_ARGS', None)
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -65,6 +65,10 @@ class Connection(object):
                                  "-o", "ControlPersist=60s",
                                  "-o", "ControlPath=%s" % (C.ANSIBLE_SSH_CONTROL_PATH % dict(directory=self.cp_dir))]
 
+        self.ssh_specific_args = []
+        if C.ANSIBLE_SSH_SPECIFIC_ARGS:
+            self.ssh_specific_args += shlex.split(C.ANSIBLE_SSH_SPECIFIC_ARGS)
+
         cp_in_use = False
         cp_path_set = False
         for arg in self.common_args:
@@ -164,6 +168,8 @@ class Connection(object):
         else:
             ssh_cmd += ["-q"]
         ssh_cmd += self.common_args
+
+        ssh_cmd += self.ssh_specific_args
 
         if self.ipv6:
             ssh_cmd += ['-6']


### PR DESCRIPTION
Hi,

scp and scp are not necessarily argument compatible. For example, the -R switch (which allows you to create a reverse tunnel) is usable on SSH only and not SCP. I am trying to use this in an ansible script but unfortunately there is no configuration option to pass arguments to just the ssh command and not scp/sftp.

This code allows you to specify commands that will only be passed to ssh via ssh_specific_args in ansible.cfg. 
