### PR TITLE
get rid of newline chars when reading password file

### DIFF
--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -105,6 +105,8 @@ def _read_password(filename):
     f = open(filename, "rb")
     data = f.read()
     f.close
+    # get rid of newline chars
+    data = data.strip()
     return data
 
 def execute_create(args, options, parser):


### PR DESCRIPTION
To be consistent with: https://github.com/ansible/ansible/blob/devel/bin/ansible-playbook#L130-L131
