### PR TITLE
Fix regression causing setup to run for every play

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -475,10 +475,13 @@ class PlayBook(object):
     def _do_setup_step(self, play):
         ''' get facts from the remote system '''
 
+        host_list = self._trim_unavailable_hosts(play._play_hosts)
         if play.gather_facts is False:
             return {}
-
-        host_list = self._trim_unavailable_hosts(play._play_hosts)
+        elif play.gather_facts is None:
+            host_list = [h for h in host_list if h not in self.SETUP_CACHE or 'module_setup' not in self.SETUP_CACHE[h]]
+            if len(host_list) == 0:
+                return {}
 
         self.callbacks.on_setup()
         self.inventory.restrict_to(host_list)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -117,7 +117,7 @@ class Play(object):
         self.sudo             = ds.get('sudo', self.playbook.sudo)
         self.sudo_user        = ds.get('sudo_user', self.playbook.sudo_user)
         self.transport        = ds.get('connection', self.playbook.transport)
-        self.gather_facts     = ds.get('gather_facts', True)
+        self.gather_facts     = ds.get('gather_facts', None)
         self.remote_port      = self.remote_port
         self.any_errors_fatal = utils.boolean(ds.get('any_errors_fatal', 'false'))
         self.accelerate       = utils.boolean(ds.get('accelerate', 'false'))


### PR DESCRIPTION
This patch makes sure setup only runs once, unless it is enforced on a play.
