### PR TITLE
Add note about su support in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Major features/changes:
 * Start of new integration test infrastructure (WIP, more details TBD)
 * if repoquery is unavailble, the yum module will automatically attempt to install yum-utils
 * ansible-vault: a framework for encrypting your playbooks and variable files 
+* added support for privilege escalation via 'su' into bin/ansible and bin/ansible-playbook and associated keywords 'su', 'su_user', 'su_pass' for tasks/plays
 
 New modules:
 


### PR DESCRIPTION
##### Issue Type:

Docs Pull Request
##### Ansible Version:

1.5
##### Environment:

N/A
##### Summary:

Add note about su support.  I figured this change was big enough to merit being in the changelog, at least for posterity.
##### Steps To Reproduce:

N/A
##### Expected Results:

N/A
##### Actual Results:

N/A
