### PR TITLE
Avoid range selection on empty groups

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -227,6 +227,12 @@ class Inventory(object):
         given a pattern like foo[0:5], where foo matches hosts, return the first 6 hosts
         """ 
 
+        # If there are no hosts to select from, just return the
+        # empty set. This prevents trying to do selections on an empty set.
+        # issue#6258
+        if not hosts:
+            return hosts
+
         (loose_pattern, limits) = self._enumeration_info(pat)
         if not limits:
             return hosts

--- a/test/units/TestInventory.py
+++ b/test/units/TestInventory.py
@@ -212,6 +212,11 @@ class TestInventory(unittest.TestCase):
         inventory.subset('greek[0-2];norse[0]')
         self.assertEqual(sorted(inventory.list_hosts()),  sorted(['zeus','hera','thor']))
 
+    def test_subet_range_empty_group(self):
+        inventory = self.simple_inventory()
+        inventory.subset('missing[0]')
+        self.assertEqual(sorted(inventory.list_hosts()), sorted([]))
+
     def test_subset_filename(self):
         inventory = self.simple_inventory()
         inventory.subset('@' + os.path.join(self.test_dir, 'restrict_pattern'))


### PR DESCRIPTION
This prevents a traceback when the group is empty.
Fixes #6258
