### PR TITLE
Allow ec2_tag module to print the tags of an instance

### DIFF
--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -19,7 +19,7 @@ DOCUMENTATION = '''
 module: ec2_tag 
 short_description: create and remove tag(s) to ec2 resources.
 description:
-    - Creates and removes tags from any EC2 resource.  The resource is referenced by its resource id (e.g. an instance being i-XXXXXXX). It is designed to be used with complex args (tags), see the examples.  This module has a dependency on python-boto.
+    - Creates, removes and lists tags from any EC2 resource.  The resource is referenced by its resource id (e.g. an instance being i-XXXXXXX). It is designed to be used with complex args (tags), see the examples.  This module has a dependency on python-boto.
 version_added: "1.3"
 options:
   resource:
@@ -30,7 +30,7 @@ options:
     aliases: []
   state:
     description:
-      - Whether the tags should be present or absent on the resource.
+      - Whether the tags should be present or absent on the resource. Use list to interrogate the tags of an instance.
     required: false
     default: present
     choices: ['present', 'absent']
@@ -115,14 +115,14 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
             resource = dict(required=True),
-            tags = dict(required=True),
-            state = dict(default='present', choices=['present', 'absent']),
+            tags = dict(),
+            state = dict(default='present', choices=['present', 'absent', 'list']),
         )
     )
     module = AnsibleModule(argument_spec=argument_spec)
 
     resource = module.params.get('resource')
-    tags = module.params['tags']
+    tags = module.params.get('tags')
     state = module.params.get('state')
   
     ec2 = ec2_connect(module)
@@ -140,6 +140,8 @@ def main():
         tagdict[tag.name] = tag.value
 
     if state == 'present':
+        if not tags:
+            module.fail_json(msg="tags argument is required when state is present")
         if set(tags.items()).issubset(set(tagdict.items())):
             module.exit_json(msg="Tags already exists in %s." %resource, changed=False)
         else:
@@ -151,6 +153,8 @@ def main():
         module.exit_json(msg="Tags %s created for resource %s." % (dictadd,resource), changed=True)
  
     if state == 'absent':
+        if not tags:
+            module.fail_json(msg="tags argument is required when state is absent")
         for (key, value) in set(tags.items()):
             if (key, value) not in set(tagdict.items()):
                     baddict[key] = value
@@ -162,10 +166,9 @@ def main():
         tagger = ec2.delete_tags(resource, dictremove)
         gettags = ec2.get_all_tags(filters=filters)
         module.exit_json(msg="Tags %s removed for resource %s." % (dictremove,resource), changed=True)
-    
-#    print json.dumps({
-#        "current_resource_tags": gettags,
-#    })
+
+    if state == 'list':
+        module.exit_json(changed=False, **tagdict)
     sys.exit(0)
 
 # import module snippets


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

ansible 1.6 (devel 435104065e) last updated 2014/03/04 11:07:56 (GMT +1000)
##### Environment:

N/A
##### Summary:

Use the print argument to state to just collect the tags of a resource through the AWS API. This allows the extraction of tags information without connecting to the resource itself.

The intention is then to use this information in further tasks.
##### Steps To Reproduce:
##### Expected Results:
##### Actual Results:
