### PR TITLE
Add new cloud/rds DB instance types (db.m3 and db.cr1 families)

### DIFF
--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -60,7 +60,7 @@ options:
     required: false
     default: null
     aliases: []
-    choices: [ 'db.t1.micro', 'db.m1.small', 'db.m1.medium', 'db.m1.large', 'db.m1.xlarge', 'db.m2.xlarge', 'db.m2.2xlarge', 'db.m2.4xlarge' ]
+    choices: [ 'db.t1.micro', 'db.m1.small', 'db.m1.medium', 'db.m1.large', 'db.m1.xlarge', 'db.m2.xlarge', 'db.m2.2xlarge', 'db.m2.4xlarge', 'db.m3.medium', 'db.m3.large', 'db.m3.xlarge', 'db.m3.2xlarge', 'db.cr1.8xlarge' ]
   username:
     description:
       - Master database username. Used only when command=create.
@@ -290,7 +290,7 @@ def main():
             source_instance   = dict(required=False),
             db_engine         = dict(choices=['MySQL', 'oracle-se1', 'oracle-se', 'oracle-ee', 'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex', 'sqlserver-web', 'postgres'], required=False),
             size              = dict(required=False), 
-            instance_type     = dict(aliases=['type'], choices=['db.t1.micro', 'db.m1.small', 'db.m1.medium', 'db.m1.large', 'db.m1.xlarge', 'db.m2.xlarge', 'db.m2.2xlarge', 'db.m2.4xlarge'], required=False),
+            instance_type     = dict(aliases=['type'], choices=['db.t1.micro', 'db.m1.small', 'db.m1.medium', 'db.m1.large', 'db.m1.xlarge', 'db.m2.xlarge', 'db.m2.2xlarge', 'db.m2.4xlarge', 'db.m3.medium', 'db.m3.large', 'db.m3.xlarge', 'db.m3.2xlarge', 'db.cr1.8xlarge'], required=False),
             username          = dict(required=False),
             password          = dict(no_log=True, required=False),
             db_name           = dict(required=False),


### PR DESCRIPTION
This PR adds the new AWS RDS DB instance types (the db.m3 and db.cr1 families). The list now matches that on http://aws.amazon.com/rds/details/.

These new DB instance types were relesed on 2014 Feb 20: http://aws.amazon.com/about-aws/whats-new/2014/02/20/amazon-rds-now-offers-new-faster-and-cheaper-db-instances/.

Incidentally, it would be nice if this list were not hardcoded. Would you accept a PR to that effect?
