### PR TITLE
Synchronize .deb package version with VERSION file

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,4 +1,4 @@
-ansible (1.5) unstable; urgency=low
+ansible (1.6) unstable; urgency=low
 
   * 1.6 release (PENDING)
  


### PR DESCRIPTION
`make deb` at the moment builds `ansible_1.5_all.deb` package which cannot be automatically installed using information from `VERSION` file ("1.6"). This patch fixes that issue.
