### PR TITLE
Fix wrong module name for exception in nova compute

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -238,9 +238,9 @@ def main():
                               service_type='compute')
     try:
         nova.authenticate()
-    except exc.Unauthorized, e:
+    except exceptions.Unauthorized, e:
         module.fail_json(msg = "Invalid OpenStack Nova credentials.: %s" % e.message)
-    except exc.AuthorizationFailure, e:
+    except exceptions.AuthorizationFailure, e:
         module.fail_json(msg = "Unable to authorize user: %s" % e.message)
 
     if module.params['state'] == 'present':


### PR DESCRIPTION
  failed: [127.0.0.1] => {"failed": true, "parsed": false}
  invalid output was: Traceback (most recent call last):
    File "/tmp/ansible-tmp-1393950384.39-102240090845592/nova_compute", line 1328, in <module>
      main()
    File "/tmp/ansible-tmp-1393950384.39-102240090845592/nova_compute", line 241, in main
      except exc.Unauthorized, e:
  NameError: global name 'exc' is not defined
