### PR TITLE
Populate module_setup from the setup module rather than special code elsewhere

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -525,7 +525,6 @@ class PlayBook(object):
         # let runner template out future commands
         setup_ok = setup_results.get('contacted', {})
         for (host, result) in setup_ok.iteritems():
-            self.SETUP_CACHE[host].update({'module_setup': True})
             self.SETUP_CACHE[host].update(result.get('ansible_facts', {}))
         return setup_results
 

--- a/library/system/setup
+++ b/library/system/setup
@@ -2293,7 +2293,7 @@ def ansible_facts():
 
 def run_setup(module):
 
-    setup_options = {}
+    setup_options = dict(module_setup=True)
     facts = ansible_facts()
 
     for (k, v) in facts.items():


### PR DESCRIPTION
This small change allows for individual setup actions to populate the SETUP_CACHE and not cause a subsequent facts-gathering when not needed. This follows the standard of other facts modules as laid out in #1206 and implemented in fedfd187749654105a22be20c27e0050bc722d0a. It allows to test of the setup module has already been run even when gather_facts was explicitely disabled.
