### PR TITLE
Automatically install apt_repository dependencies

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -366,10 +366,21 @@ def main():
     )
 
     if not HAVE_PYTHON_APT:
-        module.fail_json(msg='Could not import python modules: apt_pkg. Please install python-apt package.')
+        try:
+            module.run_command('apt-get update && apt-get install python-apt -y -q')
+            global apt, apt_pkg
+            import apt
+            import apt_pkg
+        except:
+            module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")
 
     if not HAVE_PYCURL:
-        module.fail_json(msg='Could not import python modules: pycurl. Please install python-pycurl package.')
+        try:
+            module.run_command('apt-get update && apt-get install python-pycurl -y -q')
+            global pycurl
+            import pycurl
+        except:
+            module.fail_json(msg='Could not import python modules: pycurl. Please install python-pycurl package.')
 
     repo = module.params['repo']
     state = module.params['state']


### PR DESCRIPTION
This follows the example of (and borrows code from) the apt module,
which will automatically install python-apt. This will make working with
repositories a bit easier just as the apt module is now easier.
