### PR TITLE
Make irc module accept the nick being shortened by the server.

### DIFF
--- a/library/notification/irc
+++ b/library/notification/irc
@@ -39,7 +39,7 @@ options:
     default: 6667
   nick:
     description:
-      - Nickname
+      - Nickname. May be shortened, depending on server's NICKLEN setting.
     required: false
     default: ansible
   msg:
@@ -122,7 +122,11 @@ def send_msg(channel, msg, server='localhost', port='6667',
     start = time.time()
     while 1:
         motd += irc.recv(1024)
-        if re.search('^:\S+ 00[1-4] %s :' % nick, motd, flags=re.M):
+		# The server might send back a shorter nick than we specified (due to NICKLEN),
+		#  so grab that and use it from now on (assuming we find the 00[1-4] response).
+        match = re.search('^:\S+ 00[1-4] (?P<nick>\S+) :', motd, flags=re.M)
+        if match:
+            nick = match.group('nick')
             break
         elif time.time() - start > timeout:
             raise Exception('Timeout waiting for IRC server welcome response')

--- a/library/notification/irc
+++ b/library/notification/irc
@@ -122,8 +122,8 @@ def send_msg(channel, msg, server='localhost', port='6667',
     start = time.time()
     while 1:
         motd += irc.recv(1024)
-		# The server might send back a shorter nick than we specified (due to NICKLEN),
-		#  so grab that and use it from now on (assuming we find the 00[1-4] response).
+        # The server might send back a shorter nick than we specified (due to NICKLEN),
+        #  so grab that and use it from now on (assuming we find the 00[1-4] response).
         match = re.search('^:\S+ 00[1-4] (?P<nick>\S+) :', motd, flags=re.M)
         if match:
             nick = match.group('nick')


### PR DESCRIPTION
This can happen if the server has a NICKLEN setting which is less
than the length of the specified nick. With this patch we now grab
that nick and use it moving forward, instead of failing because we
didn't get back the one we specified, in the connection response.
