### PR TITLE
Keep track of role dependencies across plays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Ansible Changes By Release
 Major features/changes:
 
 * The deprecated legacy variable templating system has been finally removed.  Use {{ foo }} always not $foo or ${foo}.
+* Role dependencies are now tracked across multiple plays, making common roles easier to include in dependencies without any special variable tricks.
 
 New Modules:
 

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -240,12 +240,19 @@ class PlayBook(object):
         plays = []
         matched_tags_all = set()
         unmatched_tags_all = set()
+        included_roles = []
 
         # loop through all patterns and run them
         self.callbacks.on_start()
         for (play_ds, play_basedir) in zip(self.playbook, self.play_basedirs):
-            play = Play(self, play_ds, play_basedir, vault_password=self.vault_password)
+            play = Play(self, play_ds, play_basedir, included_roles=included_roles, vault_password=self.vault_password)
             assert play is not None
+
+            # add any new roles brought in by this play to the 
+            # global list of roles we're tracking
+            for role in play.included_roles:
+                if role not in included_roles:
+                    included_roles.append(role)
 
             matched_tags, unmatched_tags = play.compare_tags(self.only_tags)
             matched_tags_all = matched_tags_all | matched_tags


### PR DESCRIPTION
Also fixes a bug in which tags specified on top-level roles were
not being passed down to dependent roles.

Fixes #4656
