### PR TITLE
Add locked state for user module, beginnings of integration test

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -82,11 +82,12 @@ options:
     state:
         required: false
         default: "present"
-        choices: [ present, absent, locked ]
+        choices: [ present, absent, expired ]
         description:
-            - Whether the account should exist, and whether it is locked.
+            - Whether the account should exist, and whether it is expired.
               When C(absent), removes the user account.
-              Locked state is only implemented for Linux.
+              When C(expired), the user will not be able to login through any means.
+              Expired state is only implemented for Linux.
     createhome:
         required: false
         default: "yes"
@@ -314,7 +315,7 @@ class User(object):
             cmd.append('-s')
             cmd.append(self.shell)
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('--expiredate')
             cmd.append('1')
 
@@ -418,7 +419,7 @@ class User(object):
             cmd.append('-s')
             cmd.append(self.shell)
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('--expiredate')
             cmd.append('1')
 
@@ -689,7 +690,7 @@ class FreeBsdUser(User):
             cmd.append('-L')
             cmd.append(self.login_class)
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('-e')
             cmd.append('1970-01-01')
 
@@ -777,7 +778,7 @@ class FreeBsdUser(User):
                     new_groups = groups | set(current_groups)
                 cmd.append(','.join(new_groups))
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('-e')
             cmd.append('1970-01-01')
 
@@ -857,7 +858,7 @@ class OpenBSDUser(User):
             cmd.append('-L')
             cmd.append(self.login_class)
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('-e')
             cmd.append('1')
 
@@ -955,7 +956,7 @@ class OpenBSDUser(User):
                 cmd.append('-L')
                 cmd.append(self.login_class)
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('-e')
             cmd.append('1')
 
@@ -1032,7 +1033,7 @@ class NetBSDUser(User):
             cmd.append('-L')
             cmd.append(self.login_class)
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('-e')
             cmd.append('1')
 
@@ -1118,7 +1119,7 @@ class NetBSDUser(User):
             cmd.append('-L')
             cmd.append(self.login_class)
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('-e')
             cmd.append('1')
 
@@ -1199,7 +1200,7 @@ class SunOS(User):
         if self.createhome:
             cmd.append('-m')
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('-e')
             cmd.append('1/1/70')
 
@@ -1286,7 +1287,7 @@ class SunOS(User):
             cmd.append('-s')
             cmd.append(self.shell)
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('-e')
             cmd.append('1/1/70')
 
@@ -1378,7 +1379,7 @@ class AIX(User):
         if self.createhome:
             cmd.append('-m')
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('-e')
             cmd.append('0101000070')
 
@@ -1451,7 +1452,7 @@ class AIX(User):
             cmd.append('-s')
             cmd.append(self.shell)
 
-        if self.state == 'locked':
+        if self.state == 'expired':
             cmd.append('-e')
             cmd.append('0101000070')
 
@@ -1491,7 +1492,7 @@ def main():
     }
     module = AnsibleModule(
         argument_spec = dict(
-            state=dict(default='present', choices=['present', 'absent', 'locked'], type='str'),
+            state=dict(default='present', choices=['present', 'absent', 'expired'], type='str'),
             name=dict(required=True, aliases=['user'], type='str'),
             uid=dict(default=None, type='str'),
             non_unique=dict(default='no', type='bool'),
@@ -1546,10 +1547,10 @@ def main():
                 module.fail_json(name=user.name, msg=err, rc=rc)
             result['force'] = user.force
             result['remove'] = user.remove
-    elif user.state == 'locked' and user.platform != 'Generic':
+    elif user.state == 'expired' and user.platform != 'Generic':
                 module.fail_json(name=user.state,
-                        msg='locked state not yet support for {0} platform'.format(user.platform))
-    elif user.state == 'present' or user.state == 'locked':
+                        msg='expired state not yet support for {0} platform'.format(user.platform))
+    elif user.state == 'present' or user.state == 'expired':
         if not user.user_exists():
             if module.check_mode:
                 module.exit_json(changed=True)

--- a/library/system/user
+++ b/library/system/user
@@ -82,10 +82,10 @@ options:
     state:
         required: false
         default: "present"
-        choices: [ present, absent ]
+        choices: [ present, absent, locked ]
         description:
-            - Whether the account should exist.  When C(absent), removes
-              the user account.
+            - Whether the account should exist, and whether it is locked.
+              When C(absent), removes the user account. Only implemented for linux.
     createhome:
         required: false
         default: "yes"
@@ -313,6 +313,10 @@ class User(object):
             cmd.append('-s')
             cmd.append(self.shell)
 
+        if self.state == 'locked':
+            cmd.append('--expiredate')
+            cmd.append('1')
+
         if self.password is not None:
             cmd.append('-p')
             cmd.append(self.password)
@@ -412,6 +416,10 @@ class User(object):
         if self.shell is not None and info[6] != self.shell:
             cmd.append('-s')
             cmd.append(self.shell)
+
+        if self.state == 'locked':
+            cmd.append('--expiredate')
+            cmd.append('1')
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
             cmd.append('-p')
@@ -1444,7 +1452,7 @@ def main():
     }
     module = AnsibleModule(
         argument_spec = dict(
-            state=dict(default='present', choices=['present', 'absent'], type='str'),
+            state=dict(default='present', choices=['present', 'absent', 'locked'], type='str'),
             name=dict(required=True, aliases=['user'], type='str'),
             uid=dict(default=None, type='str'),
             non_unique=dict(default='no', type='bool'),
@@ -1499,7 +1507,10 @@ def main():
                 module.fail_json(name=user.name, msg=err, rc=rc)
             result['force'] = user.force
             result['remove'] = user.remove
-    elif user.state == 'present':
+    elif user.state == 'locked' and user.platform != 'Generic':
+                module.fail_json(name=user.state,
+                        msg='locked state not yet support for {0} platform'.format(user.platform))
+    elif user.state == 'present' or user.state == 'locked':
         if not user.user_exists():
             if module.check_mode:
                 module.exit_json(changed=True)

--- a/library/system/user
+++ b/library/system/user
@@ -85,7 +85,8 @@ options:
         choices: [ present, absent, locked ]
         description:
             - Whether the account should exist, and whether it is locked.
-              When C(absent), removes the user account. Only implemented for linux.
+              When C(absent), removes the user account.
+              Locked state is only implemented for Linux.
     createhome:
         required: false
         default: "yes"

--- a/library/system/user
+++ b/library/system/user
@@ -689,6 +689,10 @@ class FreeBsdUser(User):
             cmd.append('-L')
             cmd.append(self.login_class)
 
+        if self.state == 'locked':
+            cmd.append('-e')
+            cmd.append('1970-01-01')
+
         # system cannot be handled currently - should we error if its requested?
         # create the user
         (rc, out, err) = self.execute_command(cmd)
@@ -773,6 +777,10 @@ class FreeBsdUser(User):
                     new_groups = groups | set(current_groups)
                 cmd.append(','.join(new_groups))
 
+        if self.state == 'locked':
+            cmd.append('-e')
+            cmd.append('1970-01-01')
+
         # modify the user if cmd will do anything
         if cmd_len != len(cmd):
             (rc, out, err) = self.execute_command(cmd)
@@ -848,6 +856,10 @@ class OpenBSDUser(User):
         if self.login_class is not None:
             cmd.append('-L')
             cmd.append(self.login_class)
+
+        if self.state == 'locked':
+            cmd.append('-e')
+            cmd.append('1')
 
         if self.password is not None:
             cmd.append('-p')
@@ -943,6 +955,10 @@ class OpenBSDUser(User):
                 cmd.append('-L')
                 cmd.append(self.login_class)
 
+        if self.state == 'locked':
+            cmd.append('-e')
+            cmd.append('1')
+
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
             cmd.append('-p')
             cmd.append(self.password)
@@ -1015,6 +1031,10 @@ class NetBSDUser(User):
         if self.login_class is not None:
             cmd.append('-L')
             cmd.append(self.login_class)
+
+        if self.state == 'locked':
+            cmd.append('-e')
+            cmd.append('1')
 
         if self.password is not None:
             cmd.append('-p')
@@ -1098,6 +1118,10 @@ class NetBSDUser(User):
             cmd.append('-L')
             cmd.append(self.login_class)
 
+        if self.state == 'locked':
+            cmd.append('-e')
+            cmd.append('1')
+
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
             cmd.append('-p')
             cmd.append(self.password)
@@ -1174,6 +1198,10 @@ class SunOS(User):
 
         if self.createhome:
             cmd.append('-m')
+
+        if self.state == 'locked':
+            cmd.append('-e')
+            cmd.append('1/1/70')
 
         cmd.append(self.name)
 
@@ -1257,6 +1285,10 @@ class SunOS(User):
         if self.shell is not None and info[6] != self.shell:
             cmd.append('-s')
             cmd.append(self.shell)
+
+        if self.state == 'locked':
+            cmd.append('-e')
+            cmd.append('1/1/70')
 
         if self.module.check_mode:
             return (0, '', '')
@@ -1346,6 +1378,10 @@ class AIX(User):
         if self.createhome:
             cmd.append('-m')
 
+        if self.state == 'locked':
+            cmd.append('-e')
+            cmd.append('0101000070')
+
         cmd.append(self.name)
         (rc, out, err) = self.execute_command(cmd)
 
@@ -1415,6 +1451,9 @@ class AIX(User):
             cmd.append('-s')
             cmd.append(self.shell)
 
+        if self.state == 'locked':
+            cmd.append('-e')
+            cmd.append('0101000070')
 
         # skip if no changes to be made
         if len(cmd) == 1:

--- a/library/system/user
+++ b/library/system/user
@@ -93,7 +93,7 @@ options:
         description:
             - Unless set to C(no), a home directory will be made for the user
               when the account is created or if the home directory does not
-              exist. 
+              exist.
     move_home:
         required: false
         default: "no"
@@ -146,7 +146,7 @@ options:
         default: rsa
         version_added: "0.9"
         description:
-            - Optionally specify the type of SSH key to generate. 
+            - Optionally specify the type of SSH key to generate.
               Available SSH key types will depend on implementation
               present on target host.
     ssh_key_file:
@@ -291,8 +291,8 @@ class User(object):
             cmd.append(self.group)
         elif self.group_exists(self.name):
             # use the -N option (no user group) if a group already
-            # exists with the same name as the user to prevent 
-            # errors from useradd trying to create a group when 
+            # exists with the same name as the user to prevent
+            # errors from useradd trying to create a group when
             # USERGROUPS_ENAB is set in /etc/login.defs.
             cmd.append('-N')
 
@@ -523,7 +523,7 @@ class User(object):
         if not os.path.exists(info[5]):
             return (1, '', 'User %s home directory does not exist' % self.name)
         ssh_key_file = self.get_ssh_key_path()
-        ssh_dir = os.path.dirname(ssh_key_file) 
+        ssh_dir = os.path.dirname(ssh_key_file)
         if not os.path.exists(ssh_dir):
             try:
                 os.mkdir(ssh_dir, 0700)
@@ -612,7 +612,6 @@ class User(object):
                     os.chown(os.path.join(root, f), uid, gid)
         except OSError, e:
             self.module.exit_json(failed=True, msg="%s" % e)
-           
 
 # ===========================================
 
@@ -705,7 +704,7 @@ class FreeBsdUser(User):
                 self.module.get_bin_path('chpass', True),
                 '-p',
                 self.password,
-                self.name 
+                self.name
             ]
             return self.execute_command(cmd)
 
@@ -716,7 +715,7 @@ class FreeBsdUser(User):
             self.module.get_bin_path('pw', True),
             'usermod',
             '-n',
-            self.name 
+            self.name
         ]
         cmd_len = len(cmd)
         info = self.user_info()
@@ -795,7 +794,7 @@ class FreeBsdUser(User):
                 self.module.get_bin_path('chpass', True),
                 '-p',
                 self.password,
-                self.name 
+                self.name
             ]
             return self.execute_command(cmd)
 
@@ -1142,7 +1141,7 @@ class SunOS(User):
     """
     This is a SunOS User manipulation class - The main difference between
     this class and the generic user class is that Solaris-type distros
-    don't support the concept of a "system" account and we need to 
+    don't support the concept of a "system" account and we need to
     edit the /etc/shadow file manually to set a password. (Ugh)
 
     This overrides the following methods from the generic class:-
@@ -1212,7 +1211,7 @@ class SunOS(User):
             if rc is not None and rc != 0:
                 self.module.fail_json(name=self.name, msg=err, rc=rc)
 
-            # we have to set the password by editing the /etc/shadow file 
+            # we have to set the password by editing the /etc/shadow file
             if self.password is not None:
                 try:
                     lines = []
@@ -1302,7 +1301,7 @@ class SunOS(User):
             else:
                 (rc, out, err) = (None, '', '')
 
-            # we have to set the password by editing the /etc/shadow file 
+            # we have to set the password by editing the /etc/shadow file
             if self.update_password == 'always' and self.password is not None and info[1] != self.password:
                 try:
                     lines = []

--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -1,9 +1,9 @@
 - hosts: testhost
   gather_facts: True
-  roles: 
+  roles:
     - { role: test_service, tags: test_service }
     - { role: test_pip, tags: test_pip }
     - { role: test_gem, tags: test_gem }
     - { role: test_yum, tags: test_yum }
     - { role: test_apt, tags: test_apt }
-
+    - { role: test_user, tags: test_user }

--- a/test/integration/non_destructive.yml
+++ b/test/integration/non_destructive.yml
@@ -36,3 +36,4 @@
     - { role: test_command_shell, tags: test_command_shell }
     - { role: test_failed_when, tags: test_failed_when }
     - { role: test_script, tags: test_script }
+    - { role: test_user, tags: test_user }

--- a/test/integration/non_destructive.yml
+++ b/test/integration/non_destructive.yml
@@ -9,7 +9,7 @@
     vars_var: 123
 
   gather_facts: True
-  roles: 
+  roles:
     - { role: test_ping, tags: test_ping }
     - { role: test_copy, tags: test_copy }
     - { role: test_stat, tags: test_stat }
@@ -36,4 +36,3 @@
     - { role: test_command_shell, tags: test_command_shell }
     - { role: test_failed_when, tags: test_failed_when }
     - { role: test_script, tags: test_script }
-    - { role: test_user, tags: test_user }

--- a/test/integration/roles/test_user/tasks/main.yml
+++ b/test/integration/roles/test_user/tasks/main.yml
@@ -27,8 +27,8 @@
 - name: set password
   user: name={{ non_root_test_user }} password=test_pass
 
-- name: lock account
-  user: name={{ non_root_test_user }} state=locked
+- name: expire account
+  user: name={{ non_root_test_user }} state=expired
 
 - name: assert that account is expired
   shell: "chage -l {{ non_root_test_user }} | grep '^Account expires.*1970'"
@@ -47,11 +47,11 @@
   register: test_absence
   failed_when: test_absence.rc == 0
 
-- name: create and lock account
-  user: name={{ non_root_test_user }} state=locked
+- name: create and expire account
+  user: name={{ non_root_test_user }} state=expired
 
-- name: confirm that lock is idempotent
-  user: name={{ non_root_test_user }} state=locked
+- name: confirm that expire is idempotent
+  user: name={{ non_root_test_user }} state=expired
 
 - name: assert that account is expired
   shell: "chage -l {{ non_root_test_user }} | grep '^Account expires.*1970'"

--- a/test/integration/roles/test_user/tasks/main.yml
+++ b/test/integration/roles/test_user/tasks/main.yml
@@ -1,0 +1,32 @@
+# test code for the user module
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: create user account
+  user: name={{ non_root_test_user }} state=present
+  register: create_user
+  failed_when: not create_user|changed # let's not mess with existing users
+
+- name: assert that user exists
+  command: "grep {{ non_root_test_user }} /etc/passwd"
+
+- name: delete user account
+  user: name={{ non_root_test_user }} state=absent
+
+- name: assert that user does not exist
+  command: "grep {{ non_root_test_user }} /etc/passwd"
+  register: test_absence
+  failed_when: test_absence.rc == 0

--- a/test/integration/roles/test_user/tasks/main.yml
+++ b/test/integration/roles/test_user/tasks/main.yml
@@ -18,10 +18,26 @@
 - name: create user account
   user: name={{ non_root_test_user }} state=present
   register: create_user
-  failed_when: not create_user|changed # let's not mess with existing users
+  # let's not mess with the user if it already exists
+  failed_when: not create_user|changed
 
 - name: assert that user exists
   command: "grep {{ non_root_test_user }} /etc/passwd"
+
+- name: set password
+  user: name={{ non_root_test_user }} password=test_pass
+
+- name: lock account
+  user: name={{ non_root_test_user }} state=locked
+
+- name: assert that account is expired
+  shell: "chage -l {{ non_root_test_user }} | grep '^Account expires.*1970'"
+
+- name: assert that passwd is locked
+  command: "passwd -S {{ non_root_test_user }}"
+  register: passwd
+  failed_when: passwd.stdout.split()[1] != "L"
+  when: no # locking the password shouldn't be necessary after account expiry
 
 - name: delete user account
   user: name={{ non_root_test_user }} state=absent
@@ -30,3 +46,15 @@
   command: "grep {{ non_root_test_user }} /etc/passwd"
   register: test_absence
   failed_when: test_absence.rc == 0
+
+- name: create and lock account
+  user: name={{ non_root_test_user }} state=locked
+
+- name: confirm that lock is idempotent
+  user: name={{ non_root_test_user }} state=locked
+
+- name: assert that account is expired
+  shell: "chage -l {{ non_root_test_user }} | grep '^Account expires.*1970'"
+
+- name: delete user account
+  user: name={{ non_root_test_user }} state=absent


### PR DESCRIPTION
This branch adds implementations for locking user accounts across systems, but returns an error for all but Generic (Linux) systems, since I'm not able to test the others. Guided by #2211.

It also has basic tests for creating and deleting a user.

Lastly, there's a skipped test that would check for a locked password, but I'm unconvinced that that is necessary once you've expired the account.
