### PR TITLE
Fixed SQL syntax error when running mysql_replication module

### DIFF
--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -325,7 +325,7 @@ def main():
         if master_password:
             chm.append("MASTER_PASSWORD='" + master_password + "'")
         if master_port:
-            chm.append("MASTER_PORT='" + master_port + "'")
+            chm.append("MASTER_PORT=" + master_port)
         if master_connect_retry:
             chm.append("MASTER_CONNECT_RETRY='" + master_connect_retry + "'")
         if master_log_file:


### PR DESCRIPTION
Based on MySQL documentation, `MASTER_PORT` can only accept integer value. Running current `mysql_replication` will result in syntax error due to the generated SQL with single quote around `MASTER_PORT` value.

Current module will generate something that looks like this:

```
CHANGE MASTER TO MASTER_HOST='10.1.1.1',MASTER_USER='user',MASTER_PASSWORD='password',MASTER_PORT='1234',MASTER_LOG_FILE='mysql-bin.000011',MASTER_LOG_POS=22
```

It should have generated something like this (pay attention to `MASTER_PORT` value):

```
CHANGE MASTER TO MASTER_HOST='10.1.1.1',MASTER_USER='user',MASTER_PASSWORD='password',MASTER_PORT=1234,MASTER_LOG_FILE='mysql-bin.000011',MASTER_LOG_POS=22
```

MySQL Documentation 5.6 for reference (pretty much the same for all versions):

```
CHANGE MASTER TO option [, option] ...

option:
    MASTER_BIND = 'interface_name'
  | MASTER_HOST = 'host_name'
  | MASTER_USER = 'user_name'
  | MASTER_PASSWORD = 'password'
  | MASTER_PORT = port_num
  | MASTER_CONNECT_RETRY = interval
  | MASTER_HEARTBEAT_PERIOD = interval
  | MASTER_LOG_FILE = 'master_log_name'
  | MASTER_LOG_POS = master_log_pos
  | RELAY_LOG_FILE = 'relay_log_name'
  | RELAY_LOG_POS = relay_log_pos
  | MASTER_SSL = {0|1}
  | MASTER_SSL_CA = 'ca_file_name'
  | MASTER_SSL_CAPATH = 'ca_directory_name'
  | MASTER_SSL_CERT = 'cert_file_name'
  | MASTER_SSL_KEY = 'key_file_name'
  | MASTER_SSL_CIPHER = 'cipher_list'
  | MASTER_SSL_VERIFY_SERVER_CERT = {0|1}
  | IGNORE_SERVER_IDS = (server_id_list)

server_id_list:
    [server_id [, server_id] ... ]
```

Source: https://dev.mysql.com/doc/refman/5.5/en/change-master-to.html
