### PR TITLE
Module "file": Fix link to "path" in documentation

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -52,7 +52,7 @@ options:
         If C(link), the symbolic link will be created or changed. Use C(hard)
         for hardlinks. If C(absent), directories will be recursively deleted,
         and files or symlinks will be unlinked. If C(touch) (new in 1.4), an empty file will 
-        be created if the c(dest) does not exist, while an existing file or
+        be created if the c(path) does not exist, while an existing file or
         directory will receive updated file access and modification times (similar
         to the way `touch` works from the command line).
     required: false


### PR DESCRIPTION
c(dest) -> c(path)

dest is just an alias to path so the linking fails.
