### PR TITLE
Don't use keyword `error` in encode

### DIFF
--- a/library/database/postgresql_privs
+++ b/library/database/postgresql_privs
@@ -597,7 +597,8 @@ def main():
     except psycopg2.Error, e:
         conn.rollback()
         # psycopg2 errors come in connection encoding, reencode
-        msg = e.message.decode(conn.encoding).encode(errors='replace')
+        msg = e.message.decode(conn.encoding).encode(sys.getdefaultencoding(),
+                                                     'replace')
         module.fail_json(msg=msg)
 
     if module.check_mode:


### PR DESCRIPTION
This is not supported in Python 2.6. Just use positional arguments.
