### PR TITLE
Use isinstance() rather than a check using type()

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -243,7 +243,7 @@ class Runner(object):
         """
         if complex_args is None:
             return module_args
-        if type(complex_args) != dict:
+        if not isinstance(complex_args, dict):
             raise errors.AnsibleError("complex arguments are not a dictionary: %s" % complex_args)
         for (k,v) in complex_args.iteritems():
             if isinstance(v, basestring):


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
(i think)
##### Ansible Version:

1.5
##### Environment:

N/A
##### Summary:

I'd like to see this as an isintance() check so that I can fake the datastructure being passed in with **instancecheck** for dict-like types that we need for our own projects.  I encountered this when calling the Runner API directly with a dict-like object that was not passing this check.
##### Steps To Reproduce:

N/A
##### Expected Results:

N/A
##### Actual Results:

N/A
