### PR TITLE
Fix rpm_key on system with no gpg keys imported

### DIFF
--- a/library/packaging/rpm_key
+++ b/library/packaging/rpm_key
@@ -161,7 +161,7 @@ class RpmKey:
         return stdout, stderr
 
     def is_key_imported(self, keyid):
-        stdout, stderr = self.execute_command([self.rpm, '-q', 'gpg-pubkey'])
+        stdout, stderr = self.execute_command([self.rpm, '-qa', 'gpg-pubkey'])
         for line in stdout.splitlines():
             line = line.strip()
             if not line:


### PR DESCRIPTION
Without the -a option, rpm command will fail (exit code 1) and execute_command() will fail causing an initial key import to not work.

[root@test ~]# rpm -q gpg-pubkey
package gpg-pubkey is not installed
[root@test ~]# echo $?
1
[root@test ~]# rpm -qa gpg-pubkey
[root@test ~]# echo $?
0
