### PR TITLE
Merge pull_6033.

### DIFF
--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -1,6 +1,7 @@
 #!/usr/bin/python -tt
 # -*- coding: utf-8 -*-
 
+# (c) 2014, Epic Games, Inc.
 # (c) 2012, Red Hat, Inc
 # Written by Seth Vidal <skvidal at fedoraproject.org>
 #

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -1,9 +1,9 @@
 #!/usr/bin/python -tt
 # -*- coding: utf-8 -*-
 
-# (c) 2014, Epic Games, Inc.
 # (c) 2012, Red Hat, Inc
 # Written by Seth Vidal <skvidal at fedoraproject.org>
+# (c) 2014, Epic Games, Inc.
 #
 # This file is part of Ansible
 #

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -543,15 +543,18 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
             # downgrade - the yum install command will only install or upgrade to a spec version, it will
             # not install an older version of an RPM even if specified by the install spec. So we need to
             # determine if this is a downgrade, and then use the yum downgrade command to install the RPM.
-            pkg_name = splitFilename(spec)[0]
-            pkgs = is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True)
-            if pkgs:
-                (cur_name, cur_ver, cur_rel, cur_epoch, cur_arch) = splitFilename(pkgs[0])
-                (new_name, new_ver, new_rel, new_epoch, new_arch) = splitFilename(spec)
+            split_pkg_name = splitFilename(spec)
+            # if the Name and Version match a version was not provided and this is not a downgrade.
+            if split_pkg_name[0] == split_pkg_name[1]:
+                pkg_name = split_pkg_name[0]
+                pkgs = is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True)
+                if pkgs:
+                    (cur_name, cur_ver, cur_rel, cur_epoch, cur_arch) = splitFilename(pkgs[0])
+                    (new_name, new_ver, new_rel, new_epoch, new_arch) = splitFilename(spec)
 
-                compare = compareEVR((cur_epoch, cur_ver, cur_rel), (new_epoch, new_ver, new_rel))
-                if compare > 0:
-                    downgrade = True
+                    compare = compareEVR((cur_epoch, cur_ver, cur_rel), (new_epoch, new_ver, new_rel))
+                    if compare > 0:
+                        downgrade = True
 
             # if not - then pass in the spec as what to install
             # we could get here if nothing provides it but that's not

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -110,7 +110,7 @@ EXAMPLES = '''
 - name: remove the Apache package
   yum: name=httpd state=removed
 
-- name: install the latest version of Apche from the testing repo
+- name: install the latest version of Apache from the testing repo
   yum: name=httpd enablerepo=testing state=installed
 
 - name: upgrade all packages
@@ -463,6 +463,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
     res['msg'] = ''
     res['rc'] = 0
     res['changed'] = False
+
     downgrade = False
 
     for spec in items:
@@ -540,7 +541,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                 continue
 
             # downgrade - the yum install command will only install or upgrade to a spec version, it will
-            # not install an older version of an RPM even if specifed by the install spec. So we need to 
+            # not install an older version of an RPM even if specified by the install spec. So we need to
             # determine if this is a downgrade, and then use the yum downgrade command to install the RPM.
             pkg_name = splitFilename(spec)[0]
             pkgs = is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True)

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -28,6 +28,7 @@ import yum
 try:
     from yum.misc import find_unfinished_transactions, find_ts_remaining
     from rpmUtils.miscutils import splitFilename
+    from rpmUtils.miscutils import compareEVR
     transaction_helpers = True
 except:
     transaction_helpers = False
@@ -38,7 +39,7 @@ module: yum
 version_added: historical
 short_description: Manages packages with the I(yum) package manager
 description:
-     - Installs, upgrade, removes, and lists packages and groups with the I(yum) package manager.
+     - Installs, upgrades, downgrades, removes and lists packages and groups with the I(yum) package manager.
 options:
   name:
     description:
@@ -461,6 +462,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
     res['msg'] = ''
     res['rc'] = 0
     res['changed'] = False
+    downgrade = False
 
     for spec in items:
         pkg = None
@@ -535,12 +537,30 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                     
             if found:
                 continue
+
+            # downgrade - the yum install command will only install or upgrade to a spec version, it will
+            # not install an older version of an RPM even if specifed by the install spec. So we need to 
+            # determine if this is a downgrade, and then use the yum downgrade command to install the RPM.
+            pkg_name = splitFilename(spec)[0]
+            pkgs = is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True)
+            if pkgs:
+                (cur_name, cur_ver, cur_rel, cur_epoch, cur_arch) = splitFilename(pkgs[0])
+                (new_name, new_ver, new_rel, new_epoch, new_arch) = splitFilename(spec)
+
+                compare = compareEVR((cur_epoch, cur_ver, cur_rel), (new_epoch, new_ver, new_rel))
+                if compare > 0:
+                    downgrade = True
+
             # if not - then pass in the spec as what to install
             # we could get here if nothing provides it but that's not
             # the error we're catching here
             pkg = spec
 
-        cmd = yum_basecmd + ['install', pkg]
+        operation = 'install'
+        if downgrade:
+            operation = 'downgrade'
+
+        cmd = yum_basecmd + [operation, pkg]
 
         if module.check_mode:
             module.exit_json(changed=True)


### PR DESCRIPTION
Closes GH-6033

Merges the ability to define a version of a rpm so that you can downgrade. Adds not running the extra code if a version is not defined.

Test playbook used at: https://gist.github.com/risaacson/99af626953ae2b76e2a0
