### PR TITLE
Rename private_key_file to private_key on example ansible.cfg

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -64,7 +64,7 @@ timeout = 10
 
 # if set, always use this private key file for authentication, same as 
 # if passing --private-key to ansible or ansible-playbook
-#private_key_file = /path/to/file
+#private_key = /path/to/file
 
 # format of string {{ ansible_managed }} available within Jinja2 
 # templates indicates to users editing templates files will be replaced.


### PR DESCRIPTION
Example configuration is wrong, it's private_key instead of private_key_file. This patch simply renames it.
