### PR TITLE
Support for setting hostname on Arch Linux; lsb fallback for get_distribution()

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -121,6 +121,7 @@ def get_platform():
 
 def get_distribution():
     ''' return the distribution name '''
+    distribution = None
     if platform.system() == 'Linux':
         try:
             distribution = platform.linux_distribution()[0].capitalize()
@@ -133,8 +134,17 @@ def get_distribution():
         except:
             # FIXME: MethodMissing, I assume?
             distribution = platform.dist()[0].capitalize()
-    else:
-        distribution = None
+        # Fall back to querying lsb_release
+        # TODO: share code w/ setup module (currently not modularized)
+        if not distribution:
+            try:
+                p = subprocess.Popen(['lsb_release', '-i', '-s'],
+                    stdout=subprocess.PIPE)
+                (distro_id, _) = p.communicate()
+                if p.returncode == 0:
+                    distribution = distro_id.strip().capitalize()
+            except OSError:
+                pass # lsb_release not installed
     return distribution
 
 def load_platform_subclass(cls, *args, **kwargs):

--- a/library/system/hostname
+++ b/library/system/hostname
@@ -27,7 +27,7 @@ short_description: Manage hostname
 requirements: [ hostname ]
 description:
     - Set system's hostname
-    - Currently implemented on only Debian, Ubuntu, RedHat and CentOS.
+    - Currently implemented on only Arch, Debian, Ubuntu, RedHat and CentOS.
 options:
     name:
         required: true
@@ -181,6 +181,11 @@ class DebianHostname(Hostname):
 class UbuntuHostname(Hostname):
     platform = 'Linux'
     distribution = 'Ubuntu'
+    strategy_class = DebianStrategy
+
+class ArchHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Arch'
     strategy_class = DebianStrategy
 
 # ===========================================


### PR DESCRIPTION
Python 2.x's platform module does not support detection of Arch Linux. For the hostname module to be able to correctly determine how to operate on this operating system, we add support in `get_distribution()` for falling back to detection based on the lsb-release tool.
