### PR TITLE
Don't remove ControlPersist defaults when custom SSH arguments are provided

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -57,13 +57,14 @@ class Connection(object):
         vvv("ESTABLISH CONNECTION FOR USER: %s" % self.user, host=self.host)
 
         self.common_args = []
+
         extra_args = C.ANSIBLE_SSH_ARGS
         if extra_args is not None:
             self.common_args += shlex.split(extra_args)
-        else:
-            self.common_args += ["-o", "ControlMaster=auto",
-                                 "-o", "ControlPersist=60s",
-                                 "-o", "ControlPath=%s" % (C.ANSIBLE_SSH_CONTROL_PATH % dict(directory=self.cp_dir))]
+
+        self.common_args += ["-o", "ControlMaster=auto",
+                             "-o", "ControlPersist=60s",
+                             "-o", "ControlPath=%s" % (C.ANSIBLE_SSH_CONTROL_PATH % dict(directory=self.cp_dir))]
 
         cp_in_use = False
         cp_path_set = False


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:
- ansible 1.5
- ansible 1.6 (devel 9a06292a52) last updated 2014/03/07 21:17:55 (GMT +200)
##### Environment:

N/A
##### Summary:

Use `ANSIBLE_SSH_ARGS` environment variable (or `ssh_args` under `[ssh_connection]` header of an `ansible.cfg` configuration file) to pass a specific set of options to Ansible, _but without removing ControlPersist default settings_.
##### Steps To Reproduce:

Let's take an example where we want to additionally enable SSH-agent forwarding (this could be any kind of SSH customization), while keeping Ansible ControlMaster/ControlPersist default settings.
- `$ export ANSIBLE_SSH_ARGS='-o ForwardAgent=yes'`
- `$ ansible-playbook -i ... testplaybook.yml`
##### Expected Results:

Custom ssh_args **should be prepended** to SSH options set by Ansible (`-o ControlMaster=auto -o ControlPersist=60s -o ControlPath=... -o Port=...`)

```
TASK: [Do something] **********************************************************
<127.0.0.1> ESTABLISH CONNECTION FOR USER: vagrant
<127.0.0.1> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ForwardAgent=yes', '-o', 'ControlMaster=auto', 
'-o', 'ControlPersist=60s', '-o', 'ControlPath=/Users/gilles/.ansible/cp/ansible-ssh-%h-%p-%r', 
'-o', 'Port=2200', '-o', 'IdentityFile=/Users/gilles/.vagrant.d/insecure_private_key', 
'-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no', '-o', 'User=vagrant', '-o', 'ConnectTimeout=10', '127.0.0.1', "/bin/sh -c 'mkdir -p /tmp/ansible-tmp-1394230023.77-247682811037099 && chmod a+rx /tmp/ansible-tmp-1394230023.77-247682811037099 && echo /tmp/ansible-tmp-1394230023.77-247682811037099'"]
```

Note: output partially wrapped in multiple lines for better readability
##### Actual Results:

Ansible Defaults (`-o ControlMaster=auto -o ControlPersist=60s -o ControlPath=...`) have been replaced by the custom ssh_args.

```
TASK: [Do something] **********************************************************
<127.0.0.1> ESTABLISH CONNECTION FOR USER: vagrant
<127.0.0.1> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ForwardAgent=yes', '-o', 'Port=2200', 
'-o', 'IdentityFile=/Users/gilles/.vagrant.d/insecure_private_key', 
'-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no', '-o', 'User=vagrant', '-o', 'ConnectTimeout=10', '127.0.0.1', "/bin/sh -c 'mkdir -p /tmp/ansible-tmp-1394230252.89-11219683818974 && chmod a+rx /tmp/ansible-tmp-1394230252.89-11219683818974 && echo /tmp/ansible-tmp-1394230252.89-11219683818974'"]
```

Note: output partially wrapped in multiple lines for better readability
##### Additional Notes:
- Overriding or Disabling all Ansible default settings is _explicitly_ possible via ANSIBLE_SSH_ARGS/ansible.cfg, since the first obtained value for each SSH parameter will be used.
- This pull request does not include yet any documentation update. Of course, I'm willing to provide it as part of this feature branch, if this change is accepted (and if you're not too afraid of my english).
- Motivated by mitchellh/vagrant#2952 use cases.
