### PR TITLE
spelling correction for "separate"

### DIFF
--- a/docsite/rst/guide_aws.rst
+++ b/docsite/rst/guide_aws.rst
@@ -129,7 +129,7 @@ it will be automatically discoverable via a dynamic group like so::
        - ping
 
 Using this philosophy can be a great way to manage groups dynamically, without
-having to maintain seperate inventory.  
+having to maintain separate inventory.
 
 .. _aws_pull:
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -23,7 +23,7 @@ sudo_user      = root
 transport      = smart
 remote_port    = 22
 
-# additional paths to search for roles in, colon seperated
+# additional paths to search for roles in, colon separated
 #roles_path    = /etc/ansible/roles
 
 # uncomment this to disable SSH key host checking
@@ -82,7 +82,7 @@ ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid}
 # to revert the behavior to pre-1.3.
 #error_on_undefined_vars = False
 
-# set plugin path directories here, seperate with colons
+# set plugin path directories here, separate with colons
 action_plugins     = /usr/share/ansible_plugins/action_plugins
 callback_plugins   = /usr/share/ansible_plugins/callback_plugins
 connection_plugins = /usr/share/ansible_plugins/connection_plugins

--- a/library/files/assemble
+++ b/library/files/assemble
@@ -59,7 +59,7 @@ options:
     default: "no"
   delimiter:
     description:
-      - A delimiter to seperate the file contents.
+      - A delimiter to separate the file contents.
     version_added: "1.4"
     required: false
     default: null

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -39,7 +39,7 @@ vpc_destination_variable = ip_address
 route53 = False
 
 # Additionally, you can specify the list of zones to exclude looking up in
-# 'route53_excluded_zones' as a comma-seperated list.
+# 'route53_excluded_zones' as a comma-separated list.
 # route53_excluded_zones = samplezone1.com, samplezone2.com
 
 # API calls to EC2 are slow. For this reason, we cache the results of an API

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ integration
 
 Integration test layer, constructed using playbooks.
 
-Some tests may require cloud credentials, others will not, and destructive tests are seperated from non-destructive so a subset
+Some tests may require cloud credentials, others will not, and destructive tests are separated from non-destructive so a subset
 can be run on development machines.
 
 learn more


### PR DESCRIPTION
s/seperate/separate/

http://en.wiktionary.org/wiki/separate
