### PR TITLE
Touch up documentation strings for DigitalOcean.

### DIFF
--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -20,7 +20,7 @@ DOCUMENTATION = '''
 module: digital_ocean
 short_description: Create/delete a droplet/SSH_key in DigitalOcean
 description:
-     - Create/delete a droplet in DigitalOcean and optionally waits for it to be 'running', or deploy an SSH key.
+     - Create/delete a droplet in DigitalOcean and optionally wait for it to be 'running', or deploy an SSH key.
 version_added: "1.3"
 options:
   command:
@@ -35,10 +35,10 @@ options:
     choices: ['present', 'active', 'absent', 'deleted']
   client_id:
      description:
-     - Digital Ocean manager id.
+     - DigitalOcean manager id.
   api_key:
     description:
-     - Digital Ocean api key.
+     - DigitalOcean api key.
   id:
     description:
      - Numeric, the droplet id you want to operate on.
@@ -47,31 +47,31 @@ options:
      - String, this is the name of the droplet - must be formatted by hostname rules, or the name of a SSH key.
   unique_name:
     description:
-     - Bool, require unique hostnames.  By default, digital ocean allows multiple hosts with the same name.  Setting this to "yes" allows only one host per name.  Useful for idempotence.
+     - Bool, require unique hostnames.  By default, DigitalOcean allows multiple hosts with the same name.  Setting this to "yes" allows only one host per name.  Useful for idempotence.
     version_added: "1.4"
     default: "no"
     choices: [ "yes", "no" ]
   size_id:
     description:
-     - Numeric, this is the id of the size you would like the droplet created at.
+     - Numeric, this is the id of the size you would like the droplet created with.
   image_id:
     description:
      - Numeric, this is the id of the image you would like the droplet created with.
   region_id:
     description:
-     - "Numeric, this is the id of the region you would like your server"
+     - "Numeric, this is the id of the region you would like your server to be created in."
   ssh_key_ids:
     description:
-     - Optional, comma separated list of ssh_key_ids that you would like to be added to the server
+     - Optional, comma separated list of ssh_key_ids that you would like to be added to the server.
   virtio:
     description:
-     - "Bool, turn on virtio driver in droplet for improved network and storage I/O"
+     - "Bool, turn on virtio driver in droplet for improved network and storage I/O."
     version_added: "1.4"
     default: "yes"
     choices: [ "yes", "no" ]
   private_networking:
     description:
-     - "Bool, add an additional, private network interface to droplet for inter-droplet communication"
+     - "Bool, add an additional, private network interface to droplet for inter-droplet communication."
     version_added: "1.4"
     default: "no"
     choices: [ "yes", "no" ]


### PR DESCRIPTION
This will fix a few of the documentation strings in the DigitalOcean module. I were initially just to fix `Numeric, this is the id of the region you would like your server` being cut off at the end, but added a few more things:
- Consistent spelling of "DigitalOcean".
- Add some periods to those sentences missing them.
- Tiny corrections in wording.
  See the change set itself for details.
