### PR TITLE
Add a package to missing list if npm list reported it as invalid

### DIFF
--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -142,6 +142,8 @@ class Npm(object):
             for dep in data['dependencies']:
                 if 'missing' in data['dependencies'][dep] and data['dependencies'][dep]['missing']:
                     missing.append(dep)
+                elif 'invalid' in data['dependencies'][dep] and data['dependencies'][dep]['invalid']:
+                    missing.append(dep)
                 else:
                     installed.append(dep)
         #Named dependency not installed


### PR DESCRIPTION
When bumping a dependency's version in packge.json npm list will list it as "invalid" and not "missing", causing the npm module to not mark it for installation.
