### PR TITLE
Identify Arch Linux as 'Arch' for consistency with Python 3 platform module

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -117,7 +117,7 @@ class Facts(object):
                     '/etc/system-release': 'OtherLinux',
                     '/etc/alpine-release': 'Alpine',
                     '/etc/release': 'Solaris',
-                    '/etc/arch-release': 'Archlinux',
+                    '/etc/arch-release': 'Arch',
                     '/etc/SuSE-release': 'SuSE',
                     '/etc/os-release': 'Debian' }
     SELINUX_MODE_DICT = { 1: 'enforcing', 0: 'permissive', -1: 'disabled' }


### PR DESCRIPTION
As of current Python 2.x, the platform module is not aware of Arch Linux. Appropriately, Ansible detects this distribution itself, mapping `/etc/arch-release` to a distribution identity of `Archlinux`.

In Python 3, the output of `platform.linux_distribution()` on Arch Linux is `('arch', 'Arch', 'Linux')`. Correspondingly, on this platform, the output of `lsb_release -s -i` (to get the distribution id in short form) is `Arch`.

For these reasons, the detection performed by the setup module should be normalized; otherwise, this will introduce an extra level of user-visible incompatibility (or need for mapping) on migration to Python 3.0.
