### PR TITLE
Fix for #6365: cloudformation module fails to update if stack exists

### DIFF
--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -250,7 +250,7 @@ def main():
             operation = 'CREATE'
         except Exception, err:
             error_msg = boto_exception(err)
-            if 'AlreadyExistsException' in error_msg:
+            if 'AlreadyExistsException' in error_msg or 'already exists' in error_msg:
                 update = True
             else:
                 module.fail_json(msg=error_msg)


### PR DESCRIPTION
It looks like the error message returned by the AWS API has changed, this pull request updated the code that checks whether the stack already exists.

See #6365
