### PR TITLE
Returning 'NA' when no virtualization found

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -2185,6 +2185,13 @@ class LinuxVirtual(Virtual):
                 self.facts['virtualization_role'] = 'host'
                 return
 
+        # If none of the above matches, return 'NA' for virtualization_type
+        # and virtualization_role. This allows for proper grouping.
+        self.facts['virtualization_type'] = 'NA'
+        self.facts['virtualization_role'] = 'NA'
+        return
+
+
 class HPUXVirtual(Virtual):
     """
     This is a HP-UX specific subclass of Virtual. It defines


### PR DESCRIPTION
Patch to return 'NA' when no Linux virtualization found.
