### PR TITLE
Don't lstrip data to be parsed by parse_yaml. Fixes #6384

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -354,9 +354,9 @@ def smush_ds(data):
 def parse_yaml(data, path_hint=None):
     ''' convert a yaml string to a data structure.  Also supports JSON, ssssssh!!!'''
 
-    data = data.lstrip()
+    stripped_data = data.lstrip()
     loaded = None
-    if data.startswith("{") or data.startswith("["):
+    if stripped_data.startswith("{") or stripped_data.startswith("["):
         # since the line starts with { or [ we can infer this is a JSON document.
         try:
             loaded = json.loads(data)


### PR DESCRIPTION
Only used stripped data for testing if the file is json, still use unstripped data when actually parsing. Fixes #6348

This prevents indented yaml on the first line, from being unindented and breaking YAML formatting resulting in a parser error.
