### PR TITLE
group_vars plugin: do not parse hidden files in subfolders

### DIFF
--- a/lib/ansible/inventory/vars_plugins/group_vars.py
+++ b/lib/ansible/inventory/vars_plugins/group_vars.py
@@ -123,7 +123,8 @@ def _load_vars_from_folder(folder_path, results):
     # filesystem lists them.
     names.sort() 
 
-    paths = [os.path.join(folder_path, name) for name in names]
+    # do not parse hidden files or dirs, e.g. .svn/
+    paths = [os.path.join(folder_path, name) for name in names if not name.startswith('.')]
     for path in paths:
         _found, results = _load_vars_from_path(path, results)
     return results


### PR DESCRIPTION
I recently reorganised my group_vars files as directories, that allow multiple vars files to be combined, which is an new functionality that was introduced, I'm not sure when.
The group_vars plugin will parse all files en subdirectories of group_vars/$groupname.

I believe previous version of the group_vars plugin used to ignore hidden files here, hower, 
As we however use svn as VCS, I noticed here that ansible tries to parse the .svn/ files...

This patch fixes that.
