### PR TITLE
Allow hash_behaviour=merge to be respected in core inventory

### DIFF
--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -16,6 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import ansible.constants as C
+from ansible import utils
 
 class Host(object):
     ''' a single ansible host '''
@@ -56,7 +57,7 @@ class Host(object):
         results = {}
         groups = self.get_groups()
         for group in sorted(groups, key=lambda g: g.depth):
-            results.update(group.get_variables())
+            results = utils.combine_vars(results, group.get_variables())
         results.update(self.vars)
         results['inventory_hostname'] = self.name
         results['inventory_hostname_short'] = self.name.split('.')[0]


### PR DESCRIPTION
Seems like no one bumped into this, but having hash_behaviour=merge, was not respected when using inventory scripts.

ATM, only inventory scripts go through group calculation in Host.get_variables() as the group_vars plugins handles this directly for yaml files.
