### PR TITLE
Add check for virtual packages during install process. If package is virtual - raise an error.

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -169,6 +169,10 @@ def package_status(m, pkgname, version, cache, state):
         ll_pkg = cache._cache[pkgname] # the low-level package object
     except KeyError:
         if state == 'install':
+            # Lets check pkgname is virtual package, if True - raise an error
+            if cache.is_virtual_package(pkgname):
+                m.fail_json(msg="Package '%s' is virtual and not available for install, please choose not virtual package" % pkgname)
+                return False, False, False
             if cache.get_providing_packages(pkgname):
                 return False, True, False
             m.fail_json(msg="No package matching '%s' is available" % pkgname)


### PR DESCRIPTION
If apt module dont raise an error, then "provided by" package will be installed and on every ansible playbook run ther will be message that configuration was changed.
Also ansible will install provider package that not listed in playbook, without any information to playbook owner, so i add little check for virtual packages. 

As example, try to install php5-mhash package on Ubuntu 12.04:
ansible all -i production -m apt -a "pkg=php5-mhash state=latest" -k -K
