### PR TITLE
Add generated test files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ debian/
 *.swp
 *.swo
 credentials.yml
+# test output
+.coverage
+results.xml
+coverage.xml
+/test/units/cover-html


### PR DESCRIPTION
When running 'make tests', with custom parameters to enable 'coverage' and 'xunit' output, files are generated by nosetests.  These files have no business in version control and should be ignored.
