### PR TITLE
Fixed references to missing method in ec2 modules

### DIFF
--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -157,7 +157,7 @@ def commit(changes):
             time.sleep(500)
 
 def main():
-    argument_spec = ec2_argument_keys_spec()
+    argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
             command         = dict(choices=['get', 'create', 'delete'], required=True),
             zone            = dict(required=True),

--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -271,7 +271,7 @@ def is_walrus(s3_url):
         return False
 
 def main():
-    argument_spec = ec2_argument_keys_spec()
+    argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
             bucket         = dict(required=True),
             object         = dict(),


### PR DESCRIPTION
Change-Id: I9b89d433b545269d111b3c290b6411aabf58dd24

Tested the Route53 module successfully; went ahead and fixed s3 as well, but not tested.
