### PR TITLE
add module param to Network & sub-classes

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1413,7 +1413,8 @@ class Network(Facts):
                 subclass = sc
         return super(cls, subclass).__new__(subclass, *arguments, **keyword)
 
-    def __init__(self):
+    def __init__(self, module):
+        self.module = module
         Facts.__init__(self)
 
     def populate(self):
@@ -1430,11 +1431,10 @@ class LinuxNetwork(Network):
     platform = 'Linux'
 
     def __init__(self, module):
-        self.module = module
-        Network.__init__(self)
+        Network.__init__(self, module)
 
     def populate(self):
-        ip_path = module.get_bin_path('ip')
+        ip_path = self.module.get_bin_path('ip')
         if ip_path is None:
             return self.facts
         default_ipv4, default_ipv6 = self.get_default_interfaces(ip_path)
@@ -1650,8 +1650,8 @@ class GenericBsdIfconfigNetwork(Network):
     """
     platform = 'Generic_BSD_Ifconfig'
 
-    def __init__(self):
-        Network.__init__(self)
+    def __init__(self, module):
+        Network.__init__(self, module)
 
     def populate(self):
 


### PR DESCRIPTION
add module parameter to Network and sub-classes of Network, so that ansible 1.5.1 changes to LinuxNetwork apply to all Network classes. This fixes library/system/setup so it will run on non-Linux platforms (Mac, BSD, etc...).

fix #6382
