### PR TITLE
Fix issue#6430 by instantiating Network() with expected arguments

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -2297,7 +2297,7 @@ def ansible_facts(module):
     facts = {}
     facts.update(Facts().populate())
     facts.update(Hardware().populate())
-    facts.update(Network(module).populate())
+    facts.update(Network().populate())
     facts.update(Virtual().populate())
     return facts
 


### PR DESCRIPTION
This resolves the problem reported in issue #6430
