### PR TITLE
git: Execute git commands in `dest` directory

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -263,7 +263,7 @@ def get_remote_head(git_path, module, dest, version, remote, bare):
 
 def is_remote_tag(git_path, module, dest, remote, version):
     cmd = '%s ls-remote %s -t refs/tags/%s' % (git_path, remote, version)
-    (rc, out, err) = module.run_command(cmd, check_rc=True)
+    (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
     if version in out:
         return True
     else:
@@ -291,7 +291,7 @@ def get_tags(git_path, module, dest):
 
 def is_remote_branch(git_path, module, dest, remote, version):
     cmd = '%s ls-remote %s -h refs/heads/%s' % (git_path, remote, version)
-    (rc, out, err) = module.run_command(cmd, check_rc=True)
+    (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
     if version in out:
         return True
     else:


### PR DESCRIPTION
Fixes bug reported in https://github.com/ansible/ansible/issues/6431.

If a `version` other than "HEAD" is supplied to the git command, ansible will check to see if it is a git branch or git tag. Both of these commands were failing because they were not run in the correct directory (the destination directory), with output like:

```
failed: [localhost] => {"cmd": ["/usr/bin/git", "ls-remote", "origin", "-t", "refs/tags/v1.0.0"], "failed": true, "item": "", "rc": 128}
stderr: fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

msg: fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

FATAL: all hosts have already failed -- aborting
```

I've tested this locally and this allows me to properly clone a git repo with a specified version, like:

```
- name: Checkout repo from git
  sudo_user: our_user
  git: repo=git@bitbucket.org:{{ org }}/{{ repo }}.git
       version=v1.0.0
       dest={{ dest_code_dir }}
```
