### PR TITLE
Fix for #6397 and potentially more: call run_command with "use_unsafe_shell = True" where needed.

### DIFF
--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -135,7 +135,7 @@ def db_dump(module, host, user, password, db_name, target, port, socket=None):
         cmd = cmd + ' | bzip2 > ' + target
     else:
         cmd += " > %s" % target
-    rc, stdout, stderr = module.run_command(cmd)
+    rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
     return rc, stdout, stderr
 
 def db_import(module, host, user, password, db_name, target, port, socket=None):
@@ -152,7 +152,7 @@ def db_import(module, host, user, password, db_name, target, port, socket=None):
         cmd = 'bunzip2 < ' + target + ' | ' + cmd
     else:
         cmd += " < %s" % target
-    rc, stdout, stderr = module.run_command(cmd)
+    rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
     return rc, stdout, stderr
 
 def db_create(cursor, db, encoding, collation):

--- a/library/database/riak
+++ b/library/database/riak
@@ -106,7 +106,7 @@ except ImportError:
 
 def ring_check(module, riak_admin_bin):
     cmd = '%s ringready 2> /dev/null' % riak_admin_bin
-    rc, out, err = module.run_command(cmd)
+    rc, out, err = module.run_command(cmd, use_unsafe_shell = True)
     if rc == 0 and 'TRUE All nodes agree on the ring' in out:
         return True
     else:

--- a/library/monitoring/monit
+++ b/library/monitoring/monit
@@ -67,7 +67,7 @@ def main():
         rc, out, err = module.run_command('%s reload' % MONIT)
         module.exit_json(changed=True, name=name, state=state)
     
-    rc, out, err = module.run_command('%s summary | grep "Process \'%s\'"' % (MONIT, name))
+    rc, out, err = module.run_command('%s summary | grep "Process \'%s\'"' % (MONIT, name), use_unsafe_shell=True)
     present = name in out
 
     if not present and not state == 'present':
@@ -78,7 +78,7 @@ def main():
             if module.check_mode:
                 module.exit_json(changed=True)
             module.run_command('%s reload' % MONIT, check_rc=True)
-            rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name))
+            rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name), use_unsafe_shell=True)
             if name in out:
                 module.exit_json(changed=True, name=name, state=state)
             else:
@@ -86,7 +86,7 @@ def main():
 
         module.exit_json(changed=False, name=name, state=state)
 
-    rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name))
+    rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name), use_unsafe_shell=True)
     running = 'running' in out.lower()
 
     if running and (state == 'started' or state == 'monitored'):
@@ -99,7 +99,7 @@ def main():
         if module.check_mode:
             module.exit_json(changed=True)
         module.run_command('%s stop %s' % (MONIT, name))
-        rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name))
+        rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name), use_unsafe_shell=True)
         if 'not monitored' in out.lower() or 'stop pending' in out.lower():
             module.exit_json(changed=True, name=name, state=state)
         module.fail_json(msg=out)
@@ -108,7 +108,7 @@ def main():
         if module.check_mode:
             module.exit_json(changed=True)
         module.run_command('%s unmonitor %s' % (MONIT, name))
-        rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name))
+        rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name), use_unsafe_shell=True)
         if 'not monitored' in out.lower():
             module.exit_json(changed=True, name=name, state=state)
         module.fail_json(msg=out)
@@ -117,7 +117,7 @@ def main():
         if module.check_mode:
             module.exit_json(changed=True)
         module.run_command('%s restart %s' % (MONIT, name))
-        rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name))
+        rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name), use_unsafe_shell=True)
         if 'initializing' in out.lower() or 'restart pending' in out.lower():
             module.exit_json(changed=True, name=name, state=state)
         module.fail_json(msg=out)
@@ -126,7 +126,7 @@ def main():
         if module.check_mode:
             module.exit_json(changed=True)
         module.run_command('%s start %s' % (MONIT, name))
-        rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name))
+        rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name), use_unsafe_shell=True)
         if 'initializing' in out.lower() or 'start pending' in out.lower():
             module.exit_json(changed=True, name=name, state=state)
         module.fail_json(msg=out)
@@ -135,7 +135,7 @@ def main():
         if module.check_mode:
             module.exit_json(changed=True)
         module.run_command('%s monitor %s' % (MONIT, name))
-        rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name))
+        rc, out, err = module.run_command('%s summary | grep %s' % (MONIT, name), use_unsafe_shell=True)
         if 'initializing' in out.lower() or 'start pending' in out.lower():
             module.exit_json(changed=True, name=name, state=state)
         module.fail_json(msg=out)

--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -131,7 +131,7 @@ def all_keys(module, keyring):
     return results
 
 def key_present(module, key_id):
-    (rc, out, err) = module.run_command("apt-key list | 2>&1 grep -i -q %s" % key_id)
+    (rc, out, err) = module.run_command("apt-key list | 2>&1 grep -i -q %s" % key_id, use_unsafe_shell=True)
     return rc == 0
 
 def download_key(module, url):

--- a/library/packaging/macports
+++ b/library/packaging/macports
@@ -68,7 +68,7 @@ def query_package(module, port_path, name, state="present"):
 
     if state == "present":
 
-        rc, out, err = module.run_command("%s installed | grep -q ^.*%s" % (port_path, name))
+        rc, out, err = module.run_command("%s installed | grep -q ^.*%s" % (port_path, name), use_unsafe_shell=True)
         if rc == 0:
             return True
 
@@ -76,7 +76,7 @@ def query_package(module, port_path, name, state="present"):
 
     elif state == "active":
 
-        rc, out, err = module.run_command("%s installed %s | grep -q active" % (port_path, name))
+        rc, out, err = module.run_command("%s installed %s | grep -q active" % (port_path, name), use_unsafe_shell=True)
         if rc == 0:
             return True
 

--- a/library/packaging/opkg
+++ b/library/packaging/opkg
@@ -66,7 +66,7 @@ def query_package(module, opkg_path, name, state="present"):
 
     if state == "present":
 
-        rc, out, err = module.run_command("%s list-installed | grep -q ^%s" % (opkg_path, name))
+        rc, out, err = module.run_command("%s list-installed | grep -q ^%s" % (opkg_path, name), use_unsafe_shell=True)
         if rc == 0:
             return True
 

--- a/library/packaging/pacman
+++ b/library/packaging/pacman
@@ -101,7 +101,7 @@ def query_package(module, name, state="installed"):
 
 def update_package_db(module):
     cmd = "pacman -Syy > /dev/null"
-    rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+    rc, stdout, stderr = module.run_command(cmd, check_rc=False, use_unsafe_shell=True)
 
     if rc != 0:
         module.fail_json(msg="could not update package db")
@@ -121,7 +121,7 @@ def remove_packages(module, packages):
             continue
 
         cmd = "pacman -%s %s --noconfirm > /dev/null" % (args, package)
-        rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+        rc, stdout, stderr = module.run_command(cmd, check_rc=False, use_unsafe_shell=True)
 
         if rc != 0:
             module.fail_json(msg="failed to remove %s" % (package))
@@ -149,7 +149,7 @@ def install_packages(module, packages, package_files):
             params = '-S %s' % package
 
         cmd = "pacman %s --noconfirm > /dev/null" % (params)
-        rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+        rc, stdout, stderr = module.run_command(cmd, check_rc=False, use_unsafe_shell=True)
 
         if rc != 0:
             module.fail_json(msg="failed to install %s" % (package))

--- a/library/packaging/pkgin
+++ b/library/packaging/pkgin
@@ -64,7 +64,7 @@ def query_package(module, pkgin_path, name, state="present"):
 
     if state == "present":
 
-        rc, out, err = module.run_command("%s -y list | grep ^%s" % (pkgin_path, name))
+        rc, out, err = module.run_command("%s -y list | grep ^%s" % (pkgin_path, name), use_unsafe_shell=True)
 
         if rc == 0:
             # At least one package with a package name that starts with ``name``

--- a/library/packaging/pkgutil
+++ b/library/packaging/pkgutil
@@ -78,7 +78,7 @@ def package_latest(module, name, site):
         cmd += [ '-t', site ]
     cmd.append(name)
     cmd += [ '| tail -1 | grep -v SAME' ]
-    rc, out, err = module.run_command(' '.join(cmd))
+    rc, out, err = module.run_command(' '.join(cmd), use_unsafe_shell=True)
     if rc == 1:
         return True
     else:

--- a/library/packaging/portinstall
+++ b/library/packaging/portinstall
@@ -99,13 +99,13 @@ def query_package(module, name):
 def matching_packages(module, name):
 
     ports_glob_path = module.get_bin_path('ports_glob', True)
-    rc, out, err = module.run_command("%s %s | wc" % (ports_glob_path, name))
+    rc, out, err = module.run_command("%s %s | wc" % (ports_glob_path, name), use_unsafe_shell=True)
     parts = out.split()
     occurrences = int(parts[0])
     if occurrences == 0:
         name_without_digits = re.sub('[0-9]', '', name)
         if name != name_without_digits:
-            rc, out, err = module.run_command("%s %s | wc" % (ports_glob_path, name_without_digits))
+            rc, out, err = module.run_command("%s %s | wc" % (ports_glob_path, name_without_digits), use_unsafe_shell=True)
             parts = out.split()
             occurrences = int(parts[0])
     return occurrences

--- a/library/packaging/swdepot
+++ b/library/packaging/swdepot
@@ -78,9 +78,9 @@ def query_package(module, name, depot=None):
 
     cmd_list = '/usr/sbin/swlist -a revision -l product'
     if depot:
-        rc, stdout, stderr = module.run_command("%s -s %s %s | grep %s" % (cmd_list, depot, name, name))
+        rc, stdout, stderr = module.run_command("%s -s %s %s | grep %s" % (cmd_list, depot, name, name), use_unsafe_shell=True)
     else:
-        rc, stdout, stderr = module.run_command("%s %s | grep %s" % (cmd_list, name, name))
+        rc, stdout, stderr = module.run_command("%s %s | grep %s" % (cmd_list, name, name), use_unsafe_shell=True)
     if rc == 0:
         version = re.sub("\s\s+|\t" , " ", stdout).strip().split()[1]
     else:

--- a/library/packaging/urpmi
+++ b/library/packaging/urpmi
@@ -105,7 +105,7 @@ def query_package_provides(module, name):
     # rpm -q returns 0 if the package is installed,
     # 1 if it is not installed
     cmd = "rpm -q --provides %s >/dev/null" % (name)
-    rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+    rc, stdout, stderr = module.run_command(cmd, check_rc=False, use_unsafe_shell=True)
     return rc == 0
 
 
@@ -126,7 +126,7 @@ def remove_packages(module, packages):
             continue
 
         cmd = "%s --auto %s > /dev/null" % (URPME_PATH, package)
-        rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+        rc, stdout, stderr = module.run_command(cmd, check_rc=False, use_unsafe_shell=True)
 
         if rc != 0:
             module.fail_json(msg="failed to remove %s" % (package))
@@ -160,7 +160,7 @@ def install_packages(module, pkgspec, force=True, no_suggests=True):
 
         cmd = ("%s --auto %s --quiet %s %s > /dev/null" % (URPMI_PATH, force_yes, no_suggests_yes, packages))
 
-        rc, out, err = module.run_command(cmd)
+        rc, out, err = module.run_command(cmd, use_unsafe_shell=True)
 
         installed = True
         for packages in pkgspec:

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -109,7 +109,7 @@ def set_selection(module, pkg, question, vtype, value, unseen):
     if unseen:
         cmd.append('-u')
 
-    return module.run_command(' '.join(cmd))
+    return module.run_command(' '.join(cmd), use_unsafe_shell=True)
 
 def main():
 

--- a/library/system/hostname
+++ b/library/system/hostname
@@ -286,7 +286,7 @@ class FedoraStrategy(GenericStrategy):
 
     def get_permanent_hostname(self):
         cmd = 'hostnamectl status | awk \'/^ *Static hostname:/{printf("%s", $3)}\''
-        rc, out, err = self.module.run_command(cmd)
+        rc, out, err = self.module.run_command(cmd, use_unsafe_shell=True)
         if rc != 0:
             self.module.fail_json(msg="Command failed rc=%d, out=%s, err=%s" %
                 (rc, out, err))

--- a/library/system/user
+++ b/library/system/user
@@ -257,12 +257,12 @@ class User(object):
         # select whether we dump additional debug info through syslog
         self.syslogging = False
 
-    def execute_command(self, cmd):
+    def execute_command(self, cmd, use_unsafe_shell=False):
         if self.syslogging:
             syslog.openlog('ansible-%s' % os.path.basename(__file__))
             syslog.syslog(syslog.LOG_NOTICE, 'Command %s' % '|'.join(cmd))
 
-        return self.module.run_command(cmd)
+        return self.module.run_command(cmd, use_unsafe_shell)
 
     def remove_user_userdel(self):
         cmd = [self.module.get_bin_path('userdel', True)]
@@ -1348,7 +1348,7 @@ class AIX(User):
             cmd.append(self.module.get_bin_path('chpasswd', True))
             cmd.append('-e')
             cmd.append('-c')
-            self.execute_command(' '.join(cmd))
+            self.execute_command(' '.join(cmd), use_unsafe_shell=True)
 
         return (rc, out, err)
 


### PR DESCRIPTION
Since commit ba0fec4, run_command() requires use_unsafe_shell=True for shell pipelines to work.
This fixes it for hopefully all modules, including mysql_db (issue #6397)
