### PR TITLE
Additional test scenarios in roles/test_git

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -1,17 +1,20 @@
+INVENTORY ?= inventory
+VARS_FILE ?= integration_config.yml
+
 all: non_destructive destructive check_mode test_hash
 
 non_destructive:
-	ansible-playbook non_destructive.yml -i inventory -e @integration_config.yml -v $(TEST_FLAGS)
+	ansible-playbook non_destructive.yml -i $(INVENTORY) -e @$(VARS_FILE) -v $(TEST_FLAGS)
 
 destructive:
-	ansible-playbook destructive.yml -i inventory -e @integration_config.yml -v $(TEST_FLAGS)
+	ansible-playbook destructive.yml -i $(INVENTORY) -e @$(VARS_FILE) -v $(TEST_FLAGS)
 
 check_mode:
-	ansible-playbook check_mode.yml -i inventory -e @integration_config.yml -v --check $(TEST_FLAGS)
+	ansible-playbook check_mode.yml -i $(INVENTORY) -e @$(VARS_FILE) -v --check $(TEST_FLAGS)
 
 test_hash:
-	ANSIBLE_HASH_BEHAVIOUR=replace ansible-playbook test_hash.yml -i inventory -v -e '{"test_hash":{"extra_args":"this is an extra arg"}}'
-	ANSIBLE_HASH_BEHAVIOUR=merge ansible-playbook test_hash.yml -i inventory -v -e '{"test_hash":{"extra_args":"this is an extra arg"}}'
+	ANSIBLE_HASH_BEHAVIOUR=replace ansible-playbook test_hash.yml -i $(INVENTORY) -v -e '{"test_hash":{"extra_args":"this is an extra arg"}}'
+	ANSIBLE_HASH_BEHAVIOUR=merge ansible-playbook test_hash.yml -i $(INVENTORY) -v -e '{"test_hash":{"extra_args":"this is an extra arg"}}'
 
 cloud: amazon rackspace
 
@@ -25,17 +28,17 @@ rackspace_cleanup:
 	@#python cleanup_rax.py -y
 
 credentials.yml:
-	@echo "No credentials.yml file found.  A file named 'credentials.yml' is needed to provide credentials needed to run cloud tests."
+	@echo "No credentials.yml file found.  A file named 'credentials.yml' is needed to provide credentials needed to run cloud tests.  See sample 'credentials.template' file."
 	@exit 1
 
 amazon: credentials.yml
-	ansible-playbook amazon.yml -i inventory -e @integration_config.yml -e @credentials.yml -v $(TEST_FLAGS) ; \
+	ansible-playbook amazon.yml -i $(INVENTORY) -e @$(VARS_FILE) -e @credentials.yml -v $(TEST_FLAGS) ; \
     RC=$$? ; \
     make amazon_cleanup ; \
     exit $$RC;
 
 rackspace: credentials.yml
-	ansible-playbook rackspace.yml -i inventory -e @integration_config.yml -e @credentials.yml -v $(TEST_FLAGS) ; \
+	ansible-playbook rackspace.yml -i $(INVENTORY) -e @$(VARS_FILE) -e @credentials.yml -v $(TEST_FLAGS) ; \
     RC=$$? ; \
     make rackspace_cleanup ; \
     exit $$RC;

--- a/test/integration/credentials.template
+++ b/test/integration/credentials.template
@@ -1,0 +1,7 @@
+---
+# AWS Credentials
+ec2_access_key: FIXME
+ec2_secret_key: FIXME
+
+# GITHUB Credentials
+github_ssh_private_key: "{{ lookup('env','HOME') }}/.ssh/id_rsa"

--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -16,11 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: set where to extract the repo
-  set_fact: checkout_dir={{ output_dir }}/git
-
-- name: set what repo to use
-  set_fact: repo=https://github.com/jimi-c/test_role
+- name: set role facts
+  set_fact:
+    checkout_dir: '{{ output_dir }}/git'
+    repo_format1: 'https://github.com/jimi-c/test_role'
+    repo_format2: 'git@github.com:jimi-c/test_role.git'
+    repo_format3: 'ssh://git@github.com/jimi-c/test_role.git'
+    known_host_files:
+      - "{{ lookup('env','HOME') }}/.ssh/known_hosts"
+      - '/etc/ssh/ssh_known_hosts'
 
 - name: clean out the output_dir
   shell: rm -rf {{ output_dir }}/*
@@ -28,13 +32,13 @@
 - name: verify that git is installed so this test can continue
   shell: which git
 
+#
+# Test repo=https://github.com/...
+#
+
 - name: initial checkout
-  git: repo={{ repo }} dest={{ checkout_dir }}
+  git: repo={{ repo_format1 }} dest={{ checkout_dir }}
   register: git_result
-
-- debug: var=git_result
-
-- shell: ls ~/ansible_testing/git
 
 - name: verify information about the initial clone
   assert:
@@ -42,13 +46,11 @@
       - "'before' in git_result"
       - "'after' in git_result"
       - "not git_result.before"
-      - "git_result.changed"      
+      - "git_result.changed"
 
 - name: repeated checkout
-  git: repo={{ repo }} dest={{ checkout_dir }}
+  git: repo={{ repo_format1 }} dest={{ checkout_dir }}
   register: git_result2
-
-- debug: var=git_result2
 
 - name: check for tags
   stat: path={{ checkout_dir }}/.git/refs/tags
@@ -74,6 +76,61 @@
     that:
       - "not git_result2.changed"
 
+#
+# Test repo=git@github.com:/...
+# Requires variable: github_ssh_private_key
+#
 
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
 
+- name: remove known_host files
+  file: state=absent path={{ item }}
+  with_items: known_host_files
 
+- name: checkout ssh://git@github.com repo without accept_hostkey (expected fail)
+  git: repo={{ repo_format2 }} dest={{ checkout_dir }}
+  register: git_result
+  ignore_errors: true
+
+- assert:
+    that:
+      - 'git_result.failed'
+      - 'git_result.msg == "github.com has an unknown hostkey. Set accept_hostkey to True or manually add the hostkey prior to running the git module"'
+
+- name: checkout git@github.com repo with accept_hostkey (expected pass)
+  git:
+    repo: '{{ repo_format2 }}'
+    dest: '{{ checkout_dir }}'
+    accept_hostkey: true
+    key_file: '{{ github_ssh_private_key }}'
+  register: git_result
+  when: github_ssh_private_key is defined
+
+- assert:
+    that:
+      - 'git_result.changed'
+  when: not git_result|skipped
+
+#
+# Test repo=ssh://git@github.com/...
+# Requires variable: github_ssh_private_key
+#
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
+
+- name: checkout ssh://git@github.com repo with accept_hostkey (expected pass)
+  git:
+    repo: '{{ repo_format3 }}'
+    dest: '{{ checkout_dir }}'
+    version: 'master'
+    accept_hostkey: false # should already have been accepted
+    key_file: '{{ github_ssh_private_key }}'
+  register: git_result
+  when: github_ssh_private_key is defined
+
+- assert:
+    that:
+      - 'git_result.changed'
+  when: not git_result|skipped


### PR DESCRIPTION
In addition to more scenarios added to test_git, this pull-request adds support for specifying a custom inventory file by setting the variable `INVENTORY`.

The pull-request also creates a `credentials.template` file to guide users on the expected key/value pairs when running integration tests that require credentials (aka cloud).
