### PR TITLE
Fixes various typos, fetch_url now working, changed command composure for wait_for_service

### DIFF
--- a/library/database/riak
+++ b/library/database/riak
@@ -124,9 +124,8 @@ def main():
         wait_for_handoffs=dict(default=False, type='int'),
         wait_for_ring=dict(default=False, type='int'),
         wait_for_service=dict(
-            required=False, default=None, choices=['kv'])
-        ),
-        validate_certs = dict(default='yes', type='bool'),
+            required=False, default=None, choices=['kv']),
+        validate_certs = dict(default='yes', type='bool'))
     )
 
 
@@ -137,6 +136,7 @@ def main():
     wait_for_handoffs = module.params.get('wait_for_handoffs')
     wait_for_ring = module.params.get('wait_for_ring')
     wait_for_service = module.params.get('wait_for_service')
+    validate_certs =  module.params.get('validate_certs')
 
 
     #make sure riak commands are on the path
@@ -231,7 +231,7 @@ def main():
                 module.fail_json(msg='Timeout waiting for handoffs.')
 
     if wait_for_service:
-        cmd = '%s wait_for_service riak_%s %s' % ( riak_admin_bin, wait_for_service, node_name)
+        cmd = [riak_admin_bin, 'wait_for_service', 'riak_%s' % wait_for_service, node_name ]
         rc, out, err = module.run_command(cmd)
         result['service'] = out
 
@@ -250,5 +250,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.urls import *
 
 main()


### PR DESCRIPTION
So there was a few things wrong with the module that seemed to crop up with 1.5.x:

some typographical errors related to validate_certs when defining the module parameters, as well as forgetting to set the variable itself.

fetch_url was not being imported.

Additionally, something odd became of the wait_for_service command it was continuously resulting in:

```
10.42.0.6 | FAILED >> {
    "cmd": "'/\u0000\u0000\u0000u\u0000\u0000\u0000s\u0000\u0000\u0000r\u0000\u0000\u0000/\u0000\u0000\u0000s\u0000\u0000\u0000b\u0000\u0000\u0000i\u0000\u0000\u0000n\u0000\u0000\u0000/\u0000\u0000\u0000r\u0000\u0000\u0000i\u0000\u0000\u0000a\u0000\u0000\u0000k\u0000\u0000\u0000-\u0000\u0000\u0000a\u0000\u0000\u0000d\u0000\u0000\u0000m\u0000\u0000\u0000i\u0000\u0000\u0000n\u0000\u0000\u0000' '\u0000\u0000\u0000w\u0000\u0000\u0000a\u0000\u0000\u0000i\u0000\u0000\u0000t\u0000\u0000\u0000_\u0000\u0000\u0000f\u0000\u0000\u0000o\u0000\u0000\u0000r\u0000\u0000\u0000_\u0000\u0000\u0000s\u0000\u0000\u0000e\u0000\u0000\u0000r\u0000\u0000\u0000v\u0000\u0000\u0000i\u0000\u0000\u0000c\u0000\u0000\u0000e\u0000\u0000\u0000' '\u0000\u0000\u0000r\u0000\u0000\u0000i\u0000\u0000\u0000a\u0000\u0000\u0000k\u0000\u0000\u0000_\u0000\u0000\u0000k\u0000\u0000\u0000v\u0000\u0000\u0000' '\u0000\u0000\u0000r\u0000\u0000\u0000i\u0000\u0000\u0000a\u0000\u0000\u0000k\u0000\u0000\u0000@\u0000\u0000\u00001\u0000\u0000\u00000\u0000\u0000\u0000.\u0000\u0000\u00004\u0000\u0000\u00002\u0000\u0000\u0000.\u0000\u0000\u00000\u0000\u0000\u0000.\u0000\u0000\u00006\u0000\u0000\u0000'", 
    "failed": true, 
    "msg": "Traceback (most recent call last):\n  File \"/home/vagrant/.ansible/tmp/ansible-tmp-1394673303.65-75463125268691/riak\", line 1332, in run_command\n    cmd = subprocess.Popen(args, **kwargs)\n  File \"/usr/lib64/python2.6/subprocess.py\", line 642, in __init__\n    errread, errwrite)\n  File \"/usr/lib64/python2.6/subprocess.py\", line 1234, in _execute_child\n    raise child_exception\nTypeError: execv() argument 1 must be encoded string without NULL bytes, not str\n", 
    "rc": 257
}
```

The only way I was able to fix it was to compose the command as a list instead of a string.  While debugging I did notice that if I hardcoded the command, it would work fine -- but using the %s string formatting would cause the exception.

To make a long story short, when the following was evaluated:

```
cmd = '%s wait_for_service riak_%s %s' % ( riak_admin_bin, wait_for_service, node_name)
```

it would return, for example:

```
/usr/sbin/riak-admin wait_for_service riak_kv riak@10.42.0.6
```

Which is perfectly valid, but would cause the above error.
