### PR TITLE
apt_key: Fix traceback when key_id format is invalid

### DIFF
--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -199,7 +199,7 @@ def main():
             if key_id.startswith('0x'):
                 key_id = key_id[2:]
         except ValueError:
-            module.fail_json("Invalid key_id")
+            module.fail_json(msg="Invalid key_id", id=key_id)
 
     # FIXME: I think we have a common facility for this, if not, want
     check_missing_binaries(module)


### PR DESCRIPTION
fail_json() take a mandatory msg parameter:

```
% ansible all -m apt_key -a 'id=invalid'
docker0 | FAILED >> {
    "failed": true, 
    "msg": "Traceback (most recent call last):\n  File \"<stdin>\", line 1588, in <module>\n  File \"<stdin>\", line 202, in main\nTypeError: fail_json() takes exactly 1 argument (2 given)\n", 
    "parsed": false
}
```

And with this fix:

```
% ansible all -m apt_key -a 'id=invalid'
docker0 | FAILED >> {
    "failed": true, 
    "id": "invalid", 
    "msg": "Invalid key_id"
}
```
