### PR TITLE
Fix documentation for accept_hostkey in GIT module

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -45,12 +45,13 @@ options:
               branch name, or a tag name.
     accept_hostkey:
         required: false
-        default: false
+        default: "no"
+        choices: [ "yes", "no" ]
         version_added: "1.5"
         description:
-            - Add the hostkey for the repo url if not already added.
-              If ssh_args contains "-o StrictHostKeyChecking=no", this
-              parameter is ignored.
+            - if C(yes), adds the hostkey for the repo url if not already 
+              added. If ssh_args contains "-o StrictHostKeyChecking=no", 
+              this parameter is ignored.
     ssh_opts:
         required: false
         default: None


### PR DESCRIPTION
Upon reading the documentation for the new `accept_hostkey` option in the `git` module, I could not determine what kind of values it expected. After pulling down the source I noticed it had the same argument spec `accept_hostkey=dict(default='no', type='bool'),` as the bare option which is a `yes` or `no` choice. 

So this PR adjusts the documentation so that the default is correctly labeled as `no` and adds the `yes, no` choices. 

This is my first time looking at python so please go easy if my assumptions are incorrect. If it does not accept a `yes, no` choice right now, it should be updated to match bare, force, and update options on the git module.
