### PR TITLE
Bypass warning to allow MySQL replication through SSH tunnel or VPN.

### DIFF
--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -161,7 +161,13 @@ def start_slave(cursor):
 
 def changemaster(cursor, chm):
     SQLPARAM = ",".join(chm)
-    cursor.execute("CHANGE MASTER TO " + SQLPARAM)
+    with warnings.catch_warnings(record=True):
+        # If master_password is set but SSL parameters are not,
+        # MySQL 5.6 throws a security warning.  If you are using
+        # an SSH tunnel or VPN rather than MySQL SSL, you can 
+        # ignore this warning
+        warnings.filterwarnings('default', category = MySQLdb.Warning)
+        cursor.execute("CHANGE MASTER TO " + SQLPARAM)
 
 
 def strip_quotes(s):


### PR DESCRIPTION
The mysql_replication module is set to fail on warnings.  If MASTER_PASSWORD is set without enabling MySQL SSL, a security warning is printed which will cause the module to fail, but this warning can be safely ignored if an SSH tunnel or VPN is used for replication.  This change allows the playbook to continue to run when this warning is given.
