### PR TITLE
Documentation updates

### DIFF
--- a/library/cloud/rax_files
+++ b/library/cloud/rax_files
@@ -59,6 +59,11 @@ options:
     description:
       - Region to create an instance in
     default: DFW
+  state:
+    description:
+      - Indicate desired state of the resource
+    choices: ['present', 'absent']
+    default: present
   ttl:
     description:
       - In seconds, set a container-wide TTL for all objects cached on CDN edge nodes.

--- a/library/cloud/rax_files_objects
+++ b/library/cloud/rax_files_objects
@@ -83,6 +83,11 @@ options:
         flat directory
     choices: ["yes", "no"]
     default: "yes"
+  state:
+    description:
+      - Indicate desired state of the resource
+    choices: ['present', 'absent']
+    default: present
   type:
     description:
       - Type of object to do work on


### PR DESCRIPTION
I forgot to document one of the module arguments in the documentation, and arguably a very important one.

`make webdocs` runs cleanly on my PR.
