### PR TITLE
[GH-6449] Apply --limit to localhost and 127.0.0.1

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -97,7 +97,7 @@ def main(args):
 
     inventory = ansible.inventory.Inventory(options.inventory)
     inventory.subset(options.subset)
-    if len(inventory.list_hosts()) == 0:
+    if len(inventory.list_hosts('all:localhost:127.0.0.1')) == 0:
         raise errors.AnsibleError("provided hosts list is empty")
 
     sshpass = None

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -384,8 +384,6 @@ class Inventory(object):
         """ return a list of hostnames for a pattern """
 
         result = [ h.name for h in self.get_hosts(pattern) ]
-        if len(result) == 0 and pattern in ["localhost", "127.0.0.1"]:
-            result = [pattern]
         return result
 
     def list_groups(self):


### PR DESCRIPTION
This is a first proposal to fix #6449. It was still a work in progress, but I think it is worth to start the discussion on this base.

Note that I am currently not fully satisfied with the proposed fix, because `!localhost`will also skip `127.0.0.1`. Many thanks in advance for your review!

I use following playbook for my tests (e.g. `--limit=localhost`, `--limit='group1:!127.0.0.1'`, etc)

```
- name: mix local and remote
  hosts: 'localhost:all'
  gather_facts: no

  tasks:
    - name: 'remote AND localhost task, but not 127.0.0.1'
      command: echo 'localhost and remote'

- name: 127.0.0.1

  hosts: 127.0.0.1
  gather_facts: no

  tasks:
    - name: 127.0.0.1 task 1
      command: echo 'local task 1'

    - name: 127.0.0.1 task 2
      command: echo 'local task 2'

- name: localhost

  hosts: localhost
  gather_facts: no

  tasks:
    - name: localhost task 1
      command: echo 'local task 1'

    - name: localhost task 2
      command: echo 'local task 2'

- name: group1

  hosts: group1
  gather_facts: no

  tasks:
    - name: remote task 1
      command: echo 'remote task 1'
    - name: local action
      local_action: command echo 'local action'

- name: group2

  hosts: group2
  gather_facts: no

  tasks:
    - name: remote task 2
      command: echo 'remote task 2'
```
