### PR TITLE
Properly catch import errors in apt

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -153,7 +153,7 @@ HAS_PYTHON_APT = True
 try:
     import apt
     import apt_pkg
-except:
+except ImportError:
     HAS_PYTHON_APT = False
 
 def package_split(pkgspec):


### PR DESCRIPTION
When one accidentally tries to run this module as a user, he gets the error message that python-apt must be installed, no matter what. Because importing apt will trigger an exception as a regular user. Explicitly catching the ImportError will let the exception bubble. The exception clearly says Permission denied somewhere, and the user has a better idea, what he must fix.
