### PR TITLE
Add support for YAML lists to apt module.

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -411,7 +411,9 @@ def main():
         if p['upgrade']:
             upgrade(module, p['upgrade'], force_yes, dpkg_options)
 
-        packages = p['package'].split(',')
+        packages = p['package']
+        if hasattr(packages, 'split'):
+            packages = packages.split(',')
         latest = p['state'] == 'latest'
         for package in packages:
             if package.count('=') > 1:


### PR DESCRIPTION
This adds support for native YAML lists to the `package` parameter of the `apt` module.

For example, it becomes possible to use this:

```
- name: install Postfix
  apt:
    package:
      - postfix
      - postfix-cdb
      - postfix-mysql
      - postfix-ldap
    state: latest
```

Instead of this:

```
- name: install Postfix
  apt:
    package: postfix,postfix-cdb,postfix-mysql,postfix-ldap
    state: latest
```
