### PR TITLE
Add support for YAML lists to apt module.

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -363,7 +363,7 @@ def main():
             update_cache = dict(default=False, aliases=['update-cache'], type='bool'),
             cache_valid_time = dict(type='int'),
             purge = dict(default=False, type='bool'),
-            package = dict(default=None, aliases=['pkg', 'name']),
+            package = dict(default=None, aliases=['pkg', 'name'], type='list'),
             default_release = dict(default=None, aliases=['default-release']),
             install_recommends = dict(default='yes', aliases=['install-recommends'], type='bool'),
             force = dict(default='no', type='bool'),
@@ -444,7 +444,7 @@ def main():
         if p['upgrade']:
             upgrade(module, p['upgrade'], force_yes, dpkg_options)
 
-        packages = p['package'].split(',')
+        packages = p['package']
         latest = p['state'] == 'latest'
         for package in packages:
             if package.count('=') > 1:


### PR DESCRIPTION
This adds support for native YAML lists to the `package` parameter of the `apt` module.

For example, it becomes possible to use this:

```
- name: install Postfix
  apt:
    package:
      - postfix
      - postfix-cdb
      - postfix-mysql
      - postfix-ldap
    state: latest
```

Instead of this:

```
- name: install Postfix
  apt:
    package: postfix,postfix-cdb,postfix-mysql,postfix-ldap
    state: latest
```
