### PR TITLE
[apt_repository] Correct check_mode conditional logic

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -353,9 +353,9 @@ def get_add_ppa_signing_key_callback(module):
         module.run_command(command, check_rc=True)
 
     if module.check_mode:
-        return _run_command 
-    else:
         return None
+    else:
+        return _run_command
 
 
 def main():


### PR DESCRIPTION
The desired behavior is to _not_ add the ppa signing key when check_mode is
enabled.  This fix corrects the conditional logic to comply with the stated
behavior.
