### PR TITLE
netctl service support

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1006,9 +1006,8 @@ class AnsibleModule(object):
         - executable (string) See documentation for subprocess.Popen().
                               Default is None.
         '''
-
         shell = False
-        if isinstance(args, list):
+        if isinstance(args, list) or isinstance(args, tuple):
             if use_unsafe_shell:
                 args = " ".join([pipes.quote(x) for x in args])
                 shell = True

--- a/library/system/service
+++ b/library/system/service
@@ -685,8 +685,9 @@ class LinuxService(Service):
         elif self.enable_cmd.endswith("systemctl"):
             check_rc = True
             is_netctl = self.__systemd_unit.startswith('netctl@') and self.__locations.get('netctl')
+            name = self.name[len('netctl@'):] if is_netctl else self.__systemd_unit
             enable_cmd = self.__locations['netctl'] if is_netctl else self.enable_cmd
-            args = (enable_cmd, enable_disable, self.name[len('netctl@'):])
+            args = (enable_cmd, enable_disable, name)
         else:
             args = (self.enable_cmd, self.name, on_off)
 

--- a/library/system/service
+++ b/library/system/service
@@ -384,9 +384,11 @@ class LinuxService(Service):
     def get_service_tools(self):
 
         paths = [ '/sbin', '/usr/sbin', '/bin', '/usr/bin' ]
-        binaries = [ 'service', 'chkconfig', 'update-rc.d', 'rc-service', 'rc-update', 'initctl', 'systemctl', 'start', 'stop', 'restart' ]
+        binaries = [ 'service', 'chkconfig', 'update-rc.d', 'rc-service', 'rc-update', 'initctl', 'netctl', 'systemctl', 'start', 'stop', 'restart' ]
         initpaths = [ '/etc/init.d' ]
         location = dict()
+
+        self.__locations = location
 
         for binary in binaries:
             location[binary] = None
@@ -535,6 +537,8 @@ class LinuxService(Service):
 
     def service_enable(self):
 
+        check_rc = False # to avoid breaking backends that we can't test
+
         if self.enable_cmd is None:
             self.module.fail_json(msg='service name not recognized')
 
@@ -679,7 +683,10 @@ class LinuxService(Service):
         if self.enable_cmd.endswith("rc-update"):
             args = (self.enable_cmd, add_delete, self.name + " " + self.runlevel)
         elif self.enable_cmd.endswith("systemctl"):
-            args = (self.enable_cmd, enable_disable, self.__systemd_unit)
+            check_rc = True
+            is_netctl = self.__systemd_unit.startswith('netctl@') and self.__locations.get('netctl')
+            enable_cmd = self.__locations['netctl'] if is_netctl else self.enable_cmd
+            args = (enable_cmd, enable_disable, self.name[len('netctl@'):])
         else:
             args = (self.enable_cmd, self.name, on_off)
 
@@ -688,7 +695,7 @@ class LinuxService(Service):
         if self.module.check_mode and self.changed:
             self.module.exit_json(changed=True)
 
-        return self.execute_command("%s %s %s" % args)
+        return self.execute_command(args, check_rc=check_rc)
 
 
     def service_control(self):

--- a/library/system/service
+++ b/library/system/service
@@ -168,14 +168,14 @@ class Service(object):
     # ===========================================
     # Generic methods that should be used on all platforms.
 
-    def execute_command(self, cmd, daemonize=False):
+    def execute_command(self, cmd, daemonize=False, **kwargs):
         if self.syslogging:
             syslog.openlog('ansible-%s' % os.path.basename(__file__))
             syslog.syslog(syslog.LOG_NOTICE, 'Command %s, daemonize %r' % (cmd, daemonize))
 
         # Most things don't need to be daemonized
         if not daemonize:
-            return self.module.run_command(cmd)
+            return self.module.run_command(cmd, **kwargs)
 
         # This is complex because daemonization is hard for people.
         # What we do is daemonize a part of this module, the daemon runs the


### PR DESCRIPTION
Arch Linux's neworking support uses a wrapper for systemctl services called netctl. netctl services need to be enabled via a wrapper to systemd rather than invoked directly.

Some other enhancements are made in the course of supporting this robustly: run_command() is given to accept tuples as well as the already-supported lists and strings, and Service.execute_command() is granted the ability to pass keyword arguments through to run_command(), which is used to pass `check_rc=True` through for systemd services. (This is kept off for other service backends due to inability to test, though it probably should be turned on in at least some subset of them if not on-by-default).
