### PR TITLE
Feature/multi version import

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -18,6 +18,9 @@
 
 #######################################################
 
+__requires__ = ['ansible']
+import pkg_resources
+
 import sys
 import os
 import stat

--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -20,6 +20,9 @@
 # example playbook to bootstrap this script in the examples/ dir which
 # installs ansible and sets it up to run on cron.
 
+__requires__ = ['ansible']
+import pkg_resources
+
 import os
 import sys
 import traceback

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -25,6 +25,12 @@ Requires: python26-paramiko
 Requires: python26-jinja2
 Requires: python26-keyczar
 Requires: python26-httplib2
+Requires: python26-setuptools
+%endif
+
+# RHEL == 6
+%if 0%{?rhel} == 6
+Requires: python-crypto2.6
 %endif
 
 # RHEL > 5
@@ -35,6 +41,7 @@ Requires: python-paramiko
 Requires: python-jinja2
 Requires: python-keyczar
 Requires: python-httplib2
+Requires: python-setuptools
 %endif
 
 # FEDORA > 17
@@ -45,6 +52,7 @@ Requires: python-paramiko
 Requires: python-jinja2
 Requires: python-keyczar
 Requires: python-httplib2
+Requires: python-setuptools
 %endif
 
 # SuSE/openSuSE
@@ -56,6 +64,7 @@ Requires: python-jinja2
 Requires: python-keyczar
 Requires: python-yaml
 Requires: python-httplib2
+Requires: python-setuptools
 %endif
 
 Requires: sshpass

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='ansible',
       author_email='michael@ansible.com',
       url='http://ansible.com/',
       license='GPLv3',
-      install_requires=['paramiko', 'jinja2', "PyYAML"],
+      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
       package_dir={ 'ansible': 'lib/ansible' },
       packages=[
          'ansible',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,17 @@ from glob import glob
 
 sys.path.insert(0, os.path.abspath('lib'))
 from ansible import __version__, __author__
-from setuptools import setup
+try:
+    from setuptools import setup
+    raise ImportError
+except ImportError:
+    print('''
+ansible now needs setuptools in order to build.
+
+Some scripts now need setuptools installed in order to run.
+          ''')
+    raise
+
 
 # find library modules
 from ansible.constants import DEFAULT_MODULE_PATH

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from glob import glob
 
 sys.path.insert(0, os.path.abspath('lib'))
 from ansible import __version__, __author__
-from distutils.core import setup
+from setuptools import setup
 
 # find library modules
 from ansible.constants import DEFAULT_MODULE_PATH


### PR DESCRIPTION
multi-version import that lets us use a newer-than-the-default pycrypto package.

This implementation replaces the distutils setup function in setup.py with the one from setuptools.  The advantage is that we're then able to specify which version of pycrypto we need in setup.py and that information is then pushed out to the egg-info in a manner that setuptools can read.  This means that we can then set each script to require ansible and setuptools' (its pkg_rsources module) will look up the deps for ansible and make sure that those are installed and the correct version.

If desired, this implementation could be further enhanced so that different scripts could require different dependencies: http://pythonhosted.org/setuptools/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
