### PR TITLE
Use setuptools to get a recent enough version of python-crypto2.6

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -18,6 +18,9 @@
 
 #######################################################
 
+__requires__ = ['pycrypto >= 2.6']
+import pkg_resources
+
 import sys
 import os
 import stat

--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -20,6 +20,9 @@
 # example playbook to bootstrap this script in the examples/ dir which
 # installs ansible and sets it up to run on cron.
 
+__requires__ = ['pycrypto >= 2.6']
+import pkg_resources
+
 import os
 import sys
 import traceback

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='ansible',
       author_email='michael@ansible.com',
       url='http://ansible.com/',
       license='GPLv3',
-      install_requires=['paramiko', 'jinja2', "PyYAML"],
+      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
       package_dir={ 'ansible': 'lib/ansible' },
       packages=[
          'ansible',


### PR DESCRIPTION
This is an alternative means of doing multi-versions to what's in pull request https://github.com/ansible/ansible/pull/6497

This implementation does not require changing from distutils setup to setuptools setup in the setup.py file.  The tradeoff is that in this implementation, any script that ansible ships that needs a non-default version will need to have those dependencies listed in the `__requires__` in the script (instead of being able to specify a package-wise "ansible" dep as in PR:6497)
