### PR TITLE
Made load_balencers in ec2_lc non-required as not all ASGs require an ELB

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -159,7 +159,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             name = dict(required=True, type='str'),
-            load_balancers = dict(required=True, type='list'),
+            load_balancers = dict(required=False, type='list'),
             availability_zones = dict(required=True, type='list'),
             launch_config_name = dict(required=True, type='str'),
             min_size = dict(required=True, type='int'),


### PR DESCRIPTION
As per this discussion[1], I have made load_balcners non-required

[1] https://groups.google.com/forum/#!topic/ansible-project/V45bC1wWp88
