### PR TITLE
Set keepalive to 5 seconds in paramiko_ssh.py

### DIFF
--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -185,6 +185,7 @@ class Connection(object):
         bufsize = 4096
         try:
             chan = self.ssh.get_transport().open_session()
+            self.ssh.get_transport().set_keepalive(5)
         except Exception, e:
             msg = "Failed to open session"
             if len(str(e)) > 0:


### PR DESCRIPTION
This update resolves https://github.com/ansible/ansible/issues/6476.
