### PR TITLE
added gathering control to ansible, 

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -24,6 +24,11 @@ transport      = smart
 remote_port    = 22
 module_lang    = C
 
+# controls implicit fact gathering (always, never or smart).
+# smart gathers only if not currently in memory.
+# does NOT affect explicit 'gather_facts' entries.
+gathering = smart
+
 # additional paths to search for roles in, colon separated
 #roles_path    = /etc/ansible/roles
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -24,9 +24,11 @@ transport      = smart
 remote_port    = 22
 module_lang    = C
 
-# controls implicit fact gathering (always, never or smart).
-# smart gathers only if not currently in memory.
-# does NOT affect explicit 'gather_facts' entries.
+# This setting controls implicit fact gathering, valid values are
+# implicit, explicit or smart (default).
+# smart gathers only if facts for that host are not currently in memory.
+# implicit set the default of gather_facts to True, explicit sets it
+# to False. This does NOT affect explicit 'gather_facts' entries.
 gathering = smart
 
 # additional paths to search for roles in, colon separated

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -134,6 +134,7 @@ DEFAULT_SU = get_config(p, DEFAULTS, 'su', 'ANSIBLE_SU', False, boolean=True)
 DEFAULT_SU_FLAGS = get_config(p, DEFAULTS, 'su_flags', 'ANSIBLE_SU_FLAGS', '')
 DEFAULT_SU_USER = get_config(p, DEFAULTS, 'su_user', 'ANSIBLE_SU_USER', 'root')
 DEFAULT_ASK_SU_PASS = get_config(p, DEFAULTS, 'ask_su_pass', 'ANSIBLE_ASK_SU_PASS', False, boolean=True)
+DEFAULT_GATHERING = get_config(p, DEFAULTS, 'gathering', 'ANSIBLE_GATHERING', 'smart').lower()
 
 DEFAULT_ACTION_PLUGIN_PATH     = get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '/usr/share/ansible_plugins/action_plugins')
 DEFAULT_CALLBACK_PLUGIN_PATH   = get_config(p, DEFAULTS, 'callback_plugins',   'ANSIBLE_CALLBACK_PLUGINS', '/usr/share/ansible_plugins/callback_plugins')

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -481,7 +481,7 @@ class PlayBook(object):
             host_list = [h for h in host_list if h not in self.SETUP_CACHE or 'module_setup' not in self.SETUP_CACHE[h]]
             if len(host_list) == 0:
                 return {}
-        elif play.gather_facts is False or (play.gather_facts is None and C.DEFAULT_GATHERING == 'never'):
+        elif play.gather_facts is False or (play.gather_facts is None and C.DEFAULT_GATHERING == 'explicit'):
             return {}
 
         self.callbacks.on_setup()

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -475,10 +475,14 @@ class PlayBook(object):
     def _do_setup_step(self, play):
         ''' get facts from the remote system '''
 
-        if play.gather_facts is False:
-            return {}
-
         host_list = self._trim_unavailable_hosts(play._play_hosts)
+
+        if play.gather_facts is None and C.DEFAULT_GATHERING == 'smart':
+            host_list = [h for h in host_list if h not in self.SETUP_CACHE or 'module_setup' not in self.SETUP_CACHE[h]]
+            if len(host_list) == 0:
+                return {}
+        elif play.gather_facts is False or (play.gather_facts is None and C.DEFAULT_GATHERING == 'never'):
+            return {}
 
         self.callbacks.on_setup()
         self.inventory.restrict_to(host_list)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -117,7 +117,7 @@ class Play(object):
         self.sudo             = ds.get('sudo', self.playbook.sudo)
         self.sudo_user        = ds.get('sudo_user', self.playbook.sudo_user)
         self.transport        = ds.get('connection', self.playbook.transport)
-        self.gather_facts     = ds.get('gather_facts', True)
+        self.gather_facts     = ds.get('gather_facts', None)
         self.remote_port      = self.remote_port
         self.any_errors_fatal = utils.boolean(ds.get('any_errors_fatal', 'false'))
         self.accelerate       = utils.boolean(ds.get('accelerate', 'false'))


### PR DESCRIPTION
As talked here:
https://groups.google.com/forum/#!msg/ansible-project/lGrvGwKuENU/-MNfmPBUHY4J

Before 1.5 fact gathering was 'magically smart' if you had gathered facts and you did not explicitly force fact gathering ansible would reuse the cache and avoid running fact gathering again. Striving for correctness and 'less magic' and unintended consequences, this was removed in 1.5.

This adds it back making it more visible and controllable by users through configuration.
