### PR TITLE
Fix acl doc and error

### DIFF
--- a/library/files/acl
+++ b/library/files/acl
@@ -221,7 +221,7 @@ def main():
             module.fail_json(msg="%s requires either etype and permissions or just entry be set" % state)
 
     if entry:
-        if etype  or entity  or permissions:
+        if etype or entity or permissions:
             module.fail_json(msg="entry and another incompatible field (entity, etype or permissions) are also set")
         if entry.count(":") not in [2,3]:
             module.fail_json(msg="Invalid entry: '%s', it requires 3 or 4 sections divided by ':'" % entry)

--- a/library/files/acl
+++ b/library/files/acl
@@ -95,7 +95,7 @@ EXAMPLES = '''
 - acl: name=/etc/foo.d entity=joe etype=user permissions=rw default=yes state=present
 
 # Same as previous but using entry shorthand
-- acl: name=/etc/foo.d entrty="default:user:joe:rw-" state=present
+- acl: name=/etc/foo.d entry="default:user:joe:rw-" state=present
 
 # Obtain the acl for a specific file
 - acl: name=/etc/foo.conf
@@ -218,7 +218,7 @@ def main():
 
     if state in ['present','absent']:
         if  not entry and not etype:
-            module.fail_json(msg="%s requries to have ither either etype and permissions or entry to be set" % state)
+            module.fail_json(msg="%s requires either etype and permissions or just entry be set" % state)
 
     if entry:
         if etype  or entity  or permissions:


### PR DESCRIPTION
Small doc and error message fixes in acl module:
- Fix typo in docstring
- Correct error message displayed when entry and etype are both set
- Remove extra whitespace in check to determine if etype or entity or 
  permissions are set when entry is set.
