### PR TITLE
fix: bug in apt module when python-apt is not available

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -377,7 +377,7 @@ def main():
 
     if not HAS_PYTHON_APT:
         try:
-            module.run_command('apt-get update && apt-get install python-apt -y -q')
+            module.run_command('apt-get update && apt-get install python-apt -y -q', use_unsafe_shell=True)
             global apt, apt_pkg
             import apt
             import apt_pkg


### PR DESCRIPTION
##### Issue Type: Bug Fix Pull request
##### Ansible Version: devel >= 1.5.3
##### Environment: from Debian 7 managing Debian 7
##### Summary:

When python-apt is not installed the apt module tries to use apt-get, update apt-cache and install python-apt. But due to pull request #5222 modifications and use of the unsafe string '&&' the proper command was never executed.

This fix is minimal and uses the use_unsafe_shell=True parameter to make it finally work.
Any input appreciated, 

Regards, 

@Spiroid & @Ssaboum
