### PR TITLE
fetch_url: Avoid credential stripping for FTP-scheme URLs

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -204,7 +204,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
             ssl_handler = SSLValidationHandler(module, hostname, port)
             handlers.append(ssl_handler)
 
-    if '@' in parsed[1]:
+    if parsed[0] != 'ftp' and '@' in parsed[1]:
         credentials, netloc = parsed[1].split('@', 1)
         if ':' in credentials:
             username, password = credentials.split(':', 1)


### PR DESCRIPTION
This fixes the get_url module to work with FTP URLs that contain credentials.

The patch avoids entering logic that strips credentials to place into urllib2's HTTPPasswordMgr store if the URL scheme is FTP.
