### PR TITLE
Pass through vault_password when parsing host/group vars as directories.

### DIFF
--- a/lib/ansible/inventory/vars_plugins/group_vars.py
+++ b/lib/ansible/inventory/vars_plugins/group_vars.py
@@ -86,7 +86,7 @@ def _load_vars_from_path(path, results, vault_password=None):
     if stat.S_ISDIR(pathstat.st_mode):
 
         # support organizing variables across multiple files in a directory
-        return True, _load_vars_from_folder(path, results)
+        return True, _load_vars_from_folder(path, results, vault_password=vault_password)
 
     # regular file
     elif stat.S_ISREG(pathstat.st_mode):
@@ -105,7 +105,7 @@ def _load_vars_from_path(path, results, vault_password=None):
         raise errors.AnsibleError("Expected a variable file or directory "
             "but found a non-file object at path %s" % (path, ))
 
-def _load_vars_from_folder(folder_path, results):
+def _load_vars_from_folder(folder_path, results, vault_password=None):
     """
     Load all variables within a folder recursively.
     """
@@ -126,7 +126,7 @@ def _load_vars_from_folder(folder_path, results):
     # do not parse hidden files or dirs, e.g. .svn/
     paths = [os.path.join(folder_path, name) for name in names if not name.startswith('.')]
     for path in paths:
-        _found, results = _load_vars_from_path(path, results)
+        _found, results = _load_vars_from_path(path, results, vault_password=vault_password)
     return results
 
             


### PR DESCRIPTION
Fixes a bug where vault_password parameter was not passed through in
`_load_vars_from_folder()`

Encrypted files in 
- group_vars/$groupname/some.yml
- host_vars/$hostname/other.yml
  could not be decrypted because of this missing parameter.

modified:   lib/ansible/inventory/vars_plugins/group_vars.py
