### PR TITLE
service module: Properly disable Debian services

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -658,7 +658,8 @@ class LinuxService(Service):
 
                 return self.execute_command("%s %s enable" % (self.enable_cmd, self.name))
             else:
-                return self.execute_command("%s -f %s remove" % (self.enable_cmd, self.name))
+                return self.execute_command("%s %s disable" % (self.enable_cmd,
+                                                               self.name))
 
         # we change argument depending on real binary used:
         # - update-rc.d and systemctl wants enable/disable


### PR DESCRIPTION
Services on Debian need to be disabled with 'disable' instead of 'remove'
to avoid them being enabled again when 'update-rc.d $service defaults' is run,
e.g. as part of a postinst script.
