### PR TITLE
Fix for hostkey directory

### DIFF
--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -119,13 +119,21 @@ def add_host_key(module, fqdn, key_type="rsa"):
     result = False
     keyscan_cmd = module.get_bin_path('ssh-keyscan', True)
 
-    if not os.path.exists(os.path.expanduser("~/.ssh/")):
-        module.fail_json(msg="%s does not exist" % os.path.expanduser("~/.ssh/"))
+    if 'USER' in os.environ:
+        user_ssh_dir = os.path.expandvars("~${USER}/.ssh/")
+        user_host_file = os.path.expandvars("~${USER}/.ssh/known_hosts")
+    else:
+        user_ssh_dir = "~/.ssh/"
+        user_host_file = "~/.ssh/known_hosts"
+    user_ssh_dir = os.path.expanduser(user_ssh_dir)
+
+    if not os.path.exists(user_ssh_dir):
+        module.fail_json(msg="%s does not exist" % user_ssh_dir)
 
     this_cmd = "%s -t %s %s" % (keyscan_cmd, key_type, fqdn)
 
     rc, out, err = module.run_command(this_cmd)
-    module.append_to_file("~/.ssh/known_hosts", out)
+    module.append_to_file(user_host_file, out)
 
     return rc, out, err
 


### PR DESCRIPTION
I am using the new `accept_hostkey=yes` on the `git` module and I am getting the following error: `msg: /root/.ssh/ does not exist`. I tracked this down to the `add_host_key` method. 

The environment I am running this in looks like this:

```
        "SUDO_USER": "root",
        "USER": "vagrant",
        "USERNAME": "vagrant"
```

So it should not be looking into the `/root/.ssh` because I do not use `sudo` on the playbook or the play. I checked the `not_in_host_file` method and it looks within the `${USER}` known_hosts but when adding it, it does not. 

This solution will first check the USER environment variable or fallback to the old way, similar to the other methods. I have not been able to fully test this yet. Also, this could use some regression tests.
