### PR TITLE
Add space after full stop in ansible-galaxy help

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -170,7 +170,7 @@ def build_option_parser(action):
         parser.set_usage("usage: %prog init [options] role_name")
         parser.add_option(
             '-p', '--init-path', dest='init_path', default="./",
-            help='The path in which the skeleton role will be created.'
+            help='The path in which the skeleton role will be created. '
                  'The default is the current working directory.')
     elif action == "install":
         parser.set_usage("usage: %prog install [options] [-r FILE | role_name(s)[,version] | tar_file(s)]")
@@ -181,7 +181,7 @@ def build_option_parser(action):
             '-n', '--no-deps', dest='no_deps', action='store_true', default=False,
             help='Don\'t download roles listed as dependencies')
         parser.add_option(
-            '-r', '--role-file', dest='role_file', 
+            '-r', '--role-file', dest='role_file',
             help='A file containing a list of roles to be imported')
     elif action == "remove":
         parser.set_usage("usage: %prog remove role1 role2 ...")
@@ -192,7 +192,7 @@ def build_option_parser(action):
     if action != "init":
         parser.add_option(
             '-p', '--roles-path', dest='roles_path', default=C.DEFAULT_ROLES_PATH,
-            help='The path to the directory containing your roles.'
+            help='The path to the directory containing your roles. '
                  'The default is the roles_path configured in your '
                  'ansible.cfg file (/etc/ansible/roles if not configured)')
 


### PR DESCRIPTION
Space between full stop and next word missing in a few places.
Before

```

  -p ROLES_PATH, --roles-path=ROLES_PATH
                        The path to the directory containing your roles.The
                        default is the roles_path configured in your
                        ansible.cfg file (/etc/ansible/roles if not
                        configured)
```

After

```
p ROLES_PATH, --roles-path=ROLES_PATH
                        The path to the directory containing your roles. The
                        default is the roles_path configured in your
                        ansible.cfg file (/etc/ansible/roles if not
                        configured)
```
