### PR TITLE
assemble module: add newline between assembled files

### DIFF
--- a/library/files/assemble
+++ b/library/files/assemble
@@ -102,17 +102,22 @@ def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None):
     tmpfd, temp_path = tempfile.mkstemp()
     tmp = os.fdopen(tmpfd,'w')
     delimit_me = False
+    add_newline = False
 
     for f in sorted(os.listdir(src_path)):
         if compiled_regexp and not compiled_regexp.search(f):
             continue
         fragment = "%s/%s" % (src_path, f)
+        if not os.path.isfile(fragment):
+            continue
+        fragment_content = file(fragment).read()
+
+        # always put a newline between fragments if the previous fragment didn't end with a newline.
+        if add_newline:
+            tmp.write('\n')
 
         # delimiters should only appear between fragments
         if delimit_me:
-            # always put a newline between fragments
-            tmp.write('\n')
-
             if delimiter:
                 # un-escape anything like newlines
                 delimiter = delimiter.decode('unicode-escape')
@@ -122,9 +127,12 @@ def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None):
                 if delimiter[-1] != '\n':
                     tmp.write('\n')
 
-        if os.path.isfile(fragment):
-            tmp.write(file(fragment).read())
+        tmp.write(fragment_content)
         delimit_me = True
+        if fragment_content.endswith('\n'):
+            add_newline = False
+        else:
+            add_newline = True
 
     tmp.close()
     return temp_path

--- a/library/files/assemble
+++ b/library/files/assemble
@@ -102,21 +102,30 @@ def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None):
     tmpfd, temp_path = tempfile.mkstemp()
     tmp = os.fdopen(tmpfd,'w')
     delimit_me = False
+
     for f in sorted(os.listdir(src_path)):
         if compiled_regexp and not compiled_regexp.search(f):
             continue
         fragment = "%s/%s" % (src_path, f)
-        if delimit_me and delimiter:
-            # un-escape anything like newlines
-            delimiter = delimiter.decode('unicode-escape')
-            tmp.write(delimiter)
-            # always make sure there's a newline after the 
-            # delimiter, so lines don't run together
-            if delimiter[-1] != '\n':
-                tmp.write('\n')
+
+        # delimiters should only appear between fragments
+        if delimit_me:
+            # always put a newline between fragments
+            tmp.write('\n')
+
+            if delimiter:
+                # un-escape anything like newlines
+                delimiter = delimiter.decode('unicode-escape')
+                tmp.write(delimiter)
+                # always make sure there's a newline after the
+                # delimiter, so lines don't run together
+                if delimiter[-1] != '\n':
+                    tmp.write('\n')
+
         if os.path.isfile(fragment):
             tmp.write(file(fragment).read())
         delimit_me = True
+
     tmp.close()
     return temp_path
 


### PR DESCRIPTION
Closes GH-6353
Closes GH-6359

This work builds on GH-6359 which is a fix for GH-6353 by @pgehres and makes sure that a newline is only added if the previous file fragment does not end with a newline.

To demonstrate this I have tested against the following:
devel = ansible 1.6 (devel 9da26da335) last updated 2014/03/17 17:19:05 (GMT -500)
(pgehres/)6353-assemble = ansible 1.6 (6353-assemble f0a0c58d5c) last updated 2014/03/17 15:56:54 (GMT -500)
(risaacson/)pull_6359 = ansible 1.6 (pull_6359 c4fea9fe0c) last updated 2014/03/17 17:38:09 (GMT -500)

Files:

fragment0

```
0
```

fragment1

```
1

```

fragment2

```
2


```

fragment3

```
3
```

fragment4

```
4
```

fragment5

```
5

```

fragment6 is an empty directory.

Without delimiters:
devel

```
01
2

345

```

(pgehres/)6353-assemble

```
0
1

2


3
4
5

```

(risaacson/)pull_6359

```
0
1
2

3
4
5

```

With delimiters:
devel

```
0-=- Fragment Boundry -=-
1
-=- Fragment Boundry -=-
2

-=- Fragment Boundry -=-
3-=- Fragment Boundry -=-
4-=- Fragment Boundry -=-
5

```

(pgehres/)6353-assemble

```
0
-=- Fragment Boundry -=-
1

-=- Fragment Boundry -=-
2


-=- Fragment Boundry -=-
3
-=- Fragment Boundry -=-
4
-=- Fragment Boundry -=-
5

```

(risaacson/)pull_6359

```
0
-=- Fragment Boundry -=-
1
-=- Fragment Boundry -=-
2

-=- Fragment Boundry -=-
3
-=- Fragment Boundry -=-
4
-=- Fragment Boundry -=-
5

```
