### PR TITLE
fix get_selections to support urls and other values with ':' in them...

### DIFF
--- a/library/system/debconf
+++ b/library/system/debconf
@@ -96,7 +96,7 @@ def get_selections(module, pkg):
     selections = {}
 
     for line in out.splitlines():
-        (key, value) = line.split(':')
+        (key, value) = line.split(':', 1)
         selections[ key.strip('*').strip() ] = value.strip()
 
     return selections


### PR DESCRIPTION
get_selections should only split value returned by debconf-show on first value,

so that values can have :s in them (e.g., URLs)
