### PR TITLE
homebrew: state=head includes --HEAD

### DIFF
--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -756,8 +756,10 @@ def main():
         path = ['/usr/local/bin']
 
     state = p['state']
-    if state in ('present', 'installed', 'head'):
+    if state in ('present', 'installed'):
         state = 'installed'
+    if state in ('head'):
+        state = 'head'
     if state in ('latest', 'upgraded'):
         state = 'upgraded'
     if state == 'linked':


### PR DESCRIPTION
allows for `--HEAD` option to be included in `brew install` command when `state=head`
