### PR TITLE
add param to note example for ssh-keyscan

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -123,7 +123,7 @@ notes:
     - "If the task seems to be hanging, first verify remote host is in C(known_hosts).
       SSH will prompt user to authorize the first contact with a remote host.  To avoid this prompt, 
       one solution is to add the remote host public key in C(/etc/ssh/ssh_known_hosts) before calling 
-      the git module, with the following command: ssh-keyscan remote_host.com >> /etc/ssh/ssh_known_hosts."
+      the git module, with the following command: ssh-keyscan -H remote_host.com >> /etc/ssh/ssh_known_hosts."
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
hostnames in the known hosts file are typically stored as Hashed values, calling 'ssh-keyscan' with '-H' changes to output to the Hashed format so that the known_hosts file looks more consistent
