### PR TITLE
Added ec2_cloudwatch module to create and destroy CloudWatch alarms

### DIFF
--- a/library/cloud/ec2_cloudwatch
+++ b/library/cloud/ec2_cloudwatch
@@ -1,0 +1,280 @@
+#!/usr/bin/python
+DOCUMENTATION = '''
+---
+module: ec2_cloudwatch
+short_description: create and destroy cloudwatch alarms.
+description:
+    - This module creates and destroys AWS CloudWatch alarms for AWS.
+version_added: 1.4
+options:
+  dimensions:
+    description:
+      - A dictionary of dimension key/values where the key is the dimension name and the value is either a scalar value or an iterator of values to be associated with that dimension.
+    required: false
+  name:
+    description:
+      - Name of alarm.
+    required: true
+  metric:
+    description:
+      - Name of alarm's associated metric.
+    required: true
+  namespace:
+    description:
+      - The namespace for the alarm's metric.
+    required: true
+    choices: ['AWS/AutoScaling','AWS/Billing','AWS/DynamoDB','AWS/ElastiCache','AWS/EBS','AWS/EC2','AWS/ELB','AWS/ElasticMapReduce','AWS/OpsWorks','AWS/Redshift','AWS/RDS','AWS/Route53','AWS/SNS','AWS/SQS','AWS/StorageGateway']
+  statistic:
+    description:
+      - The statistic to apply to the alarm's associated metric
+    required: true
+    choices: ["SampleCount", "Average", "Sum", "Minimum", "Maximum"]
+  comparison:
+    description:
+      - Comparison used to compare statistic with threshold
+    required: true
+    choices: [">=", ">", "<", "<="]
+  threshold:
+    description:
+      - The value against which the specified statistic is compared.
+    required: true
+  period:
+    description:
+      - The period in seconds over which teh specified statistic is applied.
+    required: true
+  evaluation_periods:
+    description:
+      - The number of periods over which data is compared to the specified threshold.
+    required: true
+  unit:
+    description:
+      - Metric unit.
+    required: false
+    choices: ["Seconds", "Microseconds", "Milliseconds", "Bytes", "Kilobytes", "Megabytes", "Gigabytes", "Terabytes", "Bits", "Kilobits", "Megabits", "Gigabits", "Terabits", "Percent", "Count", "Bytes/Second", "Kilobytes/Second", "Megabytes/Second", "Gigabytes/Second", "Terabytes/Second", "Bits/Second", "Kilobits/Second", "Megabits/Second", "Gigabits/Second", "Terabits/Second", "Count/Second", "None"]
+  description:
+    description:
+      - Description of MetricAlarm
+    required: false
+  alarm_actions:
+    description:
+      - A list of the ARNs of the actions to take in ALARM state.
+    required: false
+  insufficient_data_actions:
+    description:
+      - A list of the ARNs of the actions to take in INSUFFICIENT_DATA state.
+    required: false
+  ok_actions:
+    description:
+      - A list of the ARNs of the actions to take in OK state.
+    required: false
+  state:
+    description:
+      - If present, create an alarm.
+      - If absent, destroy the alarm with the specified name.
+    required: false
+    choices: ['present', 'absent']
+    default: present
+  ec2_url:
+    description:
+      - URL to use to connect to EC2-compatible cloud (by default the module will use EC2 endpoints)
+    required: false
+    default: null
+    aliases: [ EC2_URL ]
+  ec2_access_key:
+    description:
+      - EC2 access key. If not specified then the EC2_ACCESS_KEY environment variable is used.
+    required: false
+    default: null
+    aliases: [ EC2_ACCESS_KEY ]
+  ec2_secret_key:
+    description:
+      - EC2 secret key. If not specified then the EC2_SECRET_KEY environment variable is used.
+    required: false
+    default: null
+    aliases: [ EC2_SECRET_KEY ]
+  region:
+    description:
+      - the EC2 region to use
+    required: true
+    default: "us-east-1"
+    aliases: [ ec2_region ]
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
+  profile:
+    description:
+      - uses a boto profile. Only works with boto >= 2.24.0
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.6"
+  security_token:
+    description:
+      - security token to authenticate against AWS
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.6"
+  region:
+    description:
+      - the EC2 region to use
+    required: false
+    default: null
+    aliases: [ ec2_region ]
+
+requirements: [ "boto" ]
+author: Bernat Rafales <bernat@rafales-mulet.com>
+notes:
+   - This module will create, update or delete CloudWatch alarms.
+   - Alarms will be created by default with C(INSUFFICIENT_DATA) until
+     enough data has been generated for them.
+   - It is an interface to the I(boto) CloudWatch API
+     U(docs.pythonboto.org/en/latest/ref/cloudwatch.html)
+'''
+
+EXAMPLES = '''
+- name: create cpu alarm
+  ec2_cloudwatch:
+    region: "eu-west-1"
+    name: "CPU Alarm for box 1"
+    dimensions:
+      InstanceId: "id of the ec2 instance"
+    comparison: ">="
+    metric: "CPUUtilization"
+    period: 300
+    statistic: "Average"
+    threshold: 80.0
+    evaluation_periods: 3
+    state: "present"
+    alarm_actions: "ARN id"
+    namespace: "AWS/EC2"
+'''
+
+try:
+    import boto.ec2.cloudwatch
+except ImportError:
+    boto_found = False
+else:
+    boto_found = True
+
+def cw_connect(region, boto_params):
+
+    """ Return an ec2 cloudwatch connection"""
+
+    # If we have a region specified, connect to its endpoint.
+    if region:
+        try:
+            cw = boto.ec2.cloudwatch.connect_to_region(region, **boto_params)
+        except boto.exception.NoAuthHandlerFound, e:
+            module.fail_json(msg=str(e))
+    else:
+        module.fail_json(msg="Region must be specified")
+
+    return cw
+
+def create_alarm(cw, module):
+    #Check if alarm with that name already exists
+    dimensions = module.params.get('dimensions')
+    name = module.params.get('name')
+    metric = module.params.get('metric')
+    namespace = module.params.get('namespace')
+    statistic = module.params.get('statistic')
+    comparison = module.params.get('comparison')
+    threshold = module.params.get('threshold')
+    period = module.params.get('period')
+    evaluation_periods = module.params.get('evaluation_periods')
+    unit = module.params.get('unit')
+    description = module.params.get('description')
+    alarm_actions = module.params.get('alarm_actions')
+    insufficient_data_actions = module.params.get('insufficient_data_actions')
+    ok_actions = module.params.get('ok_actions')
+
+    current_alarms = cw.describe_alarms(alarm_names=[name])
+
+    alarm = boto.ec2.cloudwatch.alarm.MetricAlarm(name=name, metric=metric, namespace=namespace, statistic=statistic, comparison=comparison, threshold=threshold, period=period, evaluation_periods=evaluation_periods, unit=unit, description=description, dimensions=dimensions, alarm_actions=alarm_actions, insufficient_data_actions=insufficient_data_actions, ok_actions=ok_actions)
+
+    if len(current_alarms) > 0:
+        try:
+            cw_response = cw.update_alarm(alarm)
+        except boto.exception.EC2ResponseError, e:
+            module.fail_json(msg=str(e))
+    else:
+        try:
+            cw_response = cw.create_alarm(alarm)
+        except boto.exception.EC2ResponseError, e:
+            module.fail_json(msg=str(e))
+
+    if cw_response:
+        module.exit_json(changed=True)
+    else:
+        module.fail_json(msg="Alarm creation failed")
+
+def destroy_alarm(cw, module):
+    name = module.params.get('name')
+    current_alarms = cw.describe_alarms(alarm_names=[name])
+    print json.dumps(len(current_alarms))
+    if len(current_alarms) > 0:
+        cw_response = cw.delete_alarms([name])
+        if cw_response:
+            module.exit_json(changed=True)
+        else:
+            module.fail_json(msg="Alarm deletion failed")
+    else:
+        module.exit_json(changed=False)
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+            dimensions = dict(required=False, type='dict'),
+            name = dict(required=True),
+            metric = dict(required=True),
+            namespace = dict(required=False,
+                             choices=['AWS/AutoScaling','AWS/Billing','AWS/DynamoDB','AWS/ElastiCache','AWS/EBS','AWS/EC2','AWS/ELB','AWS/ElasticMapReduce','AWS/OpsWorks','AWS/Redshift','AWS/RDS','AWS/Route53','AWS/SNS','AWS/SQS','AWS/StorageGateway']),
+            statistic = dict(required=True,
+                             choices=['SampleCount', 'Average', 'Sum', 'Minimum', 'Maximum']),
+            comparison = dict(required=True,
+                              choices=['>=', '>', '<', '<=']),
+            threshold = dict(required=True, type='float'),
+            period = dict(required=True, type = 'int'),
+            evaluation_periods = dict(required=True, type='int'),
+            unit = dict(required=False,
+                        choices=['Seconds', 'Microseconds', 'Milliseconds', 'Bytes', 'Kilobytes', 'Megabytes', 'Gigabytes', 'Terabytes', 'Bits', 'Kilobits', 'Megabits', 'Gigabits', 'Terabits', 'Percent', 'Count', 'Bytes/Second', 'Kilobytes/Second', 'Megabytes/Second', 'Gigabytes/Second', 'Terabytes/Second', 'Bits/Second', 'Kilobits/Second', 'Megabits/Second', 'Gigabits/Second', 'Terabits/Second', 'Count/Second', 'None']),
+            description = dict(required=False),
+            alarm_actions = dict(required=False, type='list'),
+            insufficient_data_actions = dict(required=False, type='list'),
+            ok_actions = dict(required=False, type='list'),
+            state = dict(required=False, default='present',
+                         choices=['present', 'absent'])
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec = argument_spec
+    )
+
+    if not boto_found:
+        module.fail_json(msg="boto is required")
+
+    region, ec2_url, boto_params = get_aws_connection_info(module)
+    cw = cw_connect(region, boto_params)
+
+    state = module.params.get('state')
+
+    if state == 'present':
+        create_alarm(cw, module)
+    else:
+        destroy_alarm(cw, module)
+
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()

--- a/library/cloud/ec2_cloudwatch
+++ b/library/cloud/ec2_cloudwatch
@@ -1,4 +1,19 @@
 #!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
 DOCUMENTATION = '''
 ---
 module: ec2_cloudwatch

--- a/library/cloud/ec2_cloudwatch
+++ b/library/cloud/ec2_cloudwatch
@@ -135,12 +135,6 @@ options:
     default: null
     aliases: []
     version_added: "1.6"
-  region:
-    description:
-      - the EC2 region to use
-    required: false
-    default: null
-    aliases: [ ec2_region ]
 
 requirements: [ "boto" ]
 author: Bernat Rafales <bernat@rafales-mulet.com>


### PR DESCRIPTION
As discussed on the mailing list given that none of the current ec2 modules support it
