### PR TITLE
Make SSL verification on Mac OS X work out of the box

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -137,8 +137,9 @@ class SSLValidationHandler(urllib2.BaseHandler):
 
         tmp_fd, tmp_path = tempfile.mkstemp()
 
-        # Write the dummy ca cert
-        os.write(tmp_fd, DUMMY_CA_CERT)
+        # Write the dummy ca cert if we are running on Mac OS X
+        if platform == 'Darwin':
+            os.write(tmp_fd, DUMMY_CA_CERT)
 
         # for all of the paths, find any  .crt or .pem files
         # and compile them into single temp file for use

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -52,6 +52,31 @@ except:
 
 import tempfile
 
+
+# This is a dummy cacert provided for Mac OS since you need at least 1
+# ca cert, regardless of validity, for Python on Mac OS to use the
+# keychain functionality in OpenSSL for validating SSL certificates.
+# See: http://mercurial.selenic.com/wiki/CACertificates#Mac_OS_X_10.6_and_higher
+DUMMY_CA_CERT = """-----BEGIN CERTIFICATE-----
+MIICvDCCAiWgAwIBAgIJAO8E12S7/qEpMA0GCSqGSIb3DQEBBQUAMEkxCzAJBgNV
+BAYTAlVTMRcwFQYDVQQIEw5Ob3J0aCBDYXJvbGluYTEPMA0GA1UEBxMGRHVyaGFt
+MRAwDgYDVQQKEwdBbnNpYmxlMB4XDTE0MDMxODIyMDAyMloXDTI0MDMxNTIyMDAy
+MlowSTELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMQ8wDQYD
+VQQHEwZEdXJoYW0xEDAOBgNVBAoTB0Fuc2libGUwgZ8wDQYJKoZIhvcNAQEBBQAD
+gY0AMIGJAoGBANtvpPq3IlNlRbCHhZAcP6WCzhc5RbsDqyh1zrkmLi0GwcQ3z/r9
+gaWfQBYhHpobK2Tiq11TfraHeNB3/VfNImjZcGpN8Fl3MWwu7LfVkJy3gNNnxkA1
+4Go0/LmIvRFHhbzgfuo9NFgjPmmab9eqXJceqZIlz2C8xA7EeG7ku0+vAgMBAAGj
+gaswgagwHQYDVR0OBBYEFPnN1nPRqNDXGlCqCvdZchRNi/FaMHkGA1UdIwRyMHCA
+FPnN1nPRqNDXGlCqCvdZchRNi/FaoU2kSzBJMQswCQYDVQQGEwJVUzEXMBUGA1UE
+CBMOTm9ydGggQ2Fyb2xpbmExDzANBgNVBAcTBkR1cmhhbTEQMA4GA1UEChMHQW5z
+aWJsZYIJAO8E12S7/qEpMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEA
+MUB80IR6knq9K/tY+hvPsZer6eFMzO3JGkRFBh2kn6JdMDnhYGX7AXVHGflrwNQH
+qFy+aenWXsC0ZvrikFxbQnX8GVtDADtVznxOi7XzFw7JOxdsVrpXgSN0eh0aMzvV
+zKPZsZ2miVGclicJHzm5q080b1p/sZtuKIEZk6vZqEg=
+-----END CERTIFICATE-----
+"""
+
+
 class RequestWithMethod(urllib2.Request):
     '''
     Workaround for using DELETE/PUT/etc with urllib2
@@ -111,6 +136,9 @@ class SSLValidationHandler(urllib2.BaseHandler):
         paths_checked.append('/etc/ansible')
 
         tmp_fd, tmp_path = tempfile.mkstemp()
+
+        # Write the dummy ca cert
+        os.write(tmp_fd, DUMMY_CA_CERT)
 
         # for all of the paths, find any  .crt or .pem files
         # and compile them into single temp file for use


### PR DESCRIPTION
In `module_utils/urls.py` we build a temp file with ca certs discovered from common locations.  On OS X, there is no ca bundle file provided by default.

A bit of reading let me to http://mercurial.selenic.com/wiki/CACertificates#Mac_OS_X_10.6_and_higher which mentions, that if you have at least 1 cert, python on OS X will utilize OpenSSL which has hooks into keychain where the SSL certificates live on OS X.

I've generated a dummy cert per those instructions and included it in `urls.py`.  It will always be the first cert in the list, and on OS X will be the only cert in that file.

Here are the tests that I ran (stripped of a little bit of data):
### Current

```
$ ansible --version
ansible 1.6 (devel 750d9e2d59) last updated 2014/03/18 09:36:42 (GMT -500)

$ /test-module -m ../library/network/get_url -a 'url=https://cacert.org/ dest=/tmp/fail'

***********************************
RAW OUTPUT
{"msg": "Failed to validate the SSL certificate for cacert.org:443. Use validate_certs=no or make sure your managed systems have a valid CA certificate installed. Paths checked for this platform: /etc/ssl/certs, /etc/ansible", "failed": true}

$ ./test-module -m ../library/network/get_url -a 'url=https://ansible.com/ dest=/tmp/success'

***********************************
RAW OUTPUT
{"msg": "Failed to validate the SSL certificate for ansible.com:443. Use validate_certs=no or make sure your managed systems have a valid CA certificate installed. Paths checked for this platform: /etc/ssl/certs, /etc/ansible", "failed": true}
```
### After

```
$ ansible --version
ansible 1.6 (ssl-cert-validation-osx 3b5aa8bd30) last updated 2014/03/18 17:16:44 (GMT -500)

$ ./test-module -m ../library/network/get_url -a 'url=https://cacert.org/ dest=/tmp/fail'

***********************************
RAW OUTPUT
{"msg": "Failed to validate the SSL certificate for cacert.org:443. Use validate_certs=no or make sure your managed systems have a valid CA certificate installed. Paths checked for this platform: /etc/ssl/certs, /etc/ansible", "failed": true}

$ ./test-module -m ../library/network/get_url -a 'url=https://ansible.com/ dest=/tmp/success'

***********************************
RAW OUTPUT
{"src": "/var/folders/p3/b_15nft95md8kpmv32twplhr0000gn/T/tmpDqPZds", "changed": true, "group": "wheel", "uid": 501, "url": "https://ansible.com/", "md5sum": "c99593df81253a41ba279861b3ec6aea", "owner": "matt", "sha256sum": "", "dest": "/tmp/success", "state": "file", "gid": 0, "mode": "0644", "msg": "OK (unknown bytes)", "size": 57523}
```

I did test with other modules as well, such as the `nexmo` module which worked equally well.

For anyone interested here is the data used to generate the dummy cert:

Organization: Ansible
Locality: Durham
State: North Carolina
Country: US
Valid From: March 18, 2014
Valid To: March 15, 2024
Issuer: Ansible
Key Size: 1024 bit
Serial Number: ef04d764bbfea129
