### PR TITLE
File fixes relsymlink fix

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -81,8 +81,8 @@ options:
     default: null
     choices: []
     description:
-      - path of the file to link to (applies only to C(state=link)). Will accept absolute,
-        relative and nonexisting paths. Relative paths are not expanded.
+      - path of the file to link to (applies only to C(state= link or hard)). Will accept absolute,
+        relative and nonexisting (with C(force)) paths. Relative paths are not expanded.
   seuser:
     required: false
     default: null
@@ -266,8 +266,12 @@ def main():
 
     elif state in ['link','hard']:
 
-        if not os.path.exists(src) and not force:
-            module.fail_json(path=path, src=src, msg='src file does not exist')
+        absrc = src
+        if not os.path.isabs(absrc):
+            absrc = os.path.normpath('%s/%s' % (os.path.dirname(path), absrc))
+
+        if not os.path.exists(absrc) and not force:
+            module.fail_json(path=path, src=src, msg='src file does not exist, use "force=yes" if you really want to create the link: %s' % absrc)
 
         if state == 'hard':
             if not os.path.isabs(src):

--- a/library/packaging/pkgng
+++ b/library/packaging/pkgng
@@ -142,9 +142,11 @@ def install_packages(module, pkgng_path, packages, cached, pkgsite):
     # as of pkg-1.1.4, PACKAGESITE is deprecated in favor of repository definitions
     # in /usr/local/etc/pkg/repos
     old_pkgng = pkgng_older_than(module, pkgng_path, [1, 1, 4])
-
-    if old_pkgng and (pkgsite != ""):
-        pkgsite = "PACKAGESITE=%s" % (pkgsite)
+    if pkgsite != "":
+        if old_pkgng:
+            pkgsite = "PACKAGESITE=%s" % (pkgsite)
+        else:
+            pkgsite = "-r %s" % (pkgsite)
 
     if not module.check_mode and cached == "no":
         if old_pkgng:
@@ -162,7 +164,7 @@ def install_packages(module, pkgng_path, packages, cached, pkgsite):
             if old_pkgng:
                 rc, out, err = module.run_command("%s %s install -g -U -y %s" % (pkgsite, pkgng_path, package))
             else:
-                rc, out, err = module.run_command("%s install -r %s -g -U -y %s" % (pkgng_path, pkgsite, package))
+                rc, out, err = module.run_command("%s install %s -g -U -y %s" % (pkgng_path, pkgsite, package))
 
         if not module.check_mode and not query_package(module, pkgng_path, package):
             module.fail_json(msg="failed to install %s: %s" % (package, out), stderr=err)


### PR DESCRIPTION
fixes issue with relative symlinks produced by my last PR.

they are now correctly detected as existing/missing sources when they are relative to path.

```
    - name: make relative link
      file: path=/tmp/www src=../var/www state=link
```
