### PR TITLE
now correctly checks absolute path for src= existance for links

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -81,8 +81,8 @@ options:
     default: null
     choices: []
     description:
-      - path of the file to link to (applies only to C(state=link)). Will accept absolute,
-        relative and nonexisting paths. Relative paths are not expanded.
+      - path of the file to link to (applies only to C(state= link or hard)). Will accept absolute,
+        relative and nonexisting (with C(force)) paths. Relative paths are not expanded.
   seuser:
     required: false
     default: null
@@ -266,8 +266,12 @@ def main():
 
     elif state in ['link','hard']:
 
-        if not os.path.exists(src) and not force:
-            module.fail_json(path=path, src=src, msg='src file does not exist')
+        absrc = src
+        if not os.path.isabs(absrc):
+            absrc = os.path.normpath('%s/%s' % (os.path.dirname(path), absrc))
+
+        if not os.path.exists(absrc) and not force:
+            module.fail_json(path=path, src=src, msg='src file does not exist, use "force=yes" if you really want to create the link: %s' % absrc)
 
         if state == 'hard':
             if not os.path.isabs(src):


### PR DESCRIPTION
also updated docs to be a bit clearer on symlink behaviour

```
   - name: make relative link
      file: path=/tmp/www src=../var/www state=link
```
