### PR TITLE
unified calls to fs function vs duplicate functions for file and dir

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -483,12 +483,6 @@ class AnsibleModule(object):
         )
         return changed
 
-    def set_directory_attributes_if_different(self, file_args, changed):
-        return self.set_fs_attributes_if_different(file_args, changed)
-
-    def set_file_attributes_if_different(self, file_args, changed):
-        return self.set_fs_attributes_if_different(file_args, changed)
-
     def add_path_info(self, kwargs):
         '''
         for results that are files, supplement the info about the file

--- a/library/files/assemble
+++ b/library/files/assemble
@@ -175,7 +175,7 @@ def main():
     os.remove(path)
 
     file_args = module.load_file_common_arguments(module.params)
-    changed = module.set_file_attributes_if_different(file_args, changed)
+    changed = module.set_fs_attributes_if_different(file_args, changed)
     # Mission complete
     module.exit_json(src=src, dest=dest, md5sum=pathmd5, changed=changed, msg="OK")
 

--- a/library/files/copy
+++ b/library/files/copy
@@ -126,7 +126,7 @@ def adjust_recursive_directory_permissions(pre_existing_dir, new_directory_list,
     if len(new_directory_list) > 0:
         working_dir = os.path.join(pre_existing_dir, new_directory_list.pop(0))
         directory_args['path'] = working_dir
-        changed = module.set_directory_attributes_if_different(directory_args, changed)
+        changed = module.set_fs_attributes_if_different(directory_args, changed)
         changed = adjust_recursive_directory_permissions(working_dir, new_directory_list, module, directory_args, changed)
     return changed
 
@@ -225,7 +225,7 @@ def main():
 
     module.params['dest'] = dest
     file_args = module.load_file_common_arguments(module.params)
-    res_args['changed'] = module.set_file_attributes_if_different(file_args, res_args['changed'])
+    res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
 
     module.exit_json(**res_args)
 

--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -179,7 +179,7 @@ def main():
     changed = do_ini(module, dest, section, option, value, state, backup)
 
     file_args = module.load_file_common_arguments(module.params)
-    changed = module.set_file_attributes_if_different(file_args, changed)
+    changed = module.set_fs_attributes_if_different(file_args, changed)
 
     # Mission complete
     module.exit_json(dest=dest, changed=changed, msg="OK")

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -164,7 +164,7 @@ def write_changes(module,lines,dest):
 def check_file_attrs(module, changed, message):
 
     file_args = module.load_file_common_arguments(module.params)
-    if module.set_file_attributes_if_different(file_args, False):
+    if module.set_fs_attributes_if_different(file_args, False):
 
         if changed:
             message += " and "

--- a/library/network/get_url
+++ b/library/network/get_url
@@ -280,7 +280,7 @@ def main():
     module.params['path'] = dest
     file_args = module.load_file_common_arguments(module.params)
     file_args['path'] = dest
-    changed = module.set_file_attributes_if_different(file_args, changed)
+    changed = module.set_fs_attributes_if_different(file_args, changed)
 
     # Mission complete
     module.exit_json(url=url, dest=dest, src=tmpsrc, md5sum=md5sum_src,

--- a/library/network/uri
+++ b/library/network/uri
@@ -409,7 +409,7 @@ def main():
             module.params['path'] = dest
             file_args = module.load_file_common_arguments(module.params)
             file_args['path'] = dest
-            changed = module.set_file_attributes_if_different(file_args, changed)
+            changed = module.set_fs_attributes_if_different(file_args, changed)
         resp['path'] = dest
     else:
         changed = False

--- a/library/web_infrastructure/htpasswd
+++ b/library/web_infrastructure/htpasswd
@@ -163,7 +163,7 @@ def absent(dest, username, check_mode):
 def check_file_attrs(module, changed, message):
 
     file_args = module.load_file_common_arguments(module.params)
-    if module.set_file_attributes_if_different(file_args, False):
+    if module.set_fs_attributes_if_different(file_args, False):
 
         if changed:
             message += " and "


### PR DESCRIPTION
The functions were identical and already merged in previous commit, now all modules that used them call the unified function so there is no need for the placeholders.
