### PR TITLE
Hipchat callback: Make "notify" flag optional (default off)

### DIFF
--- a/plugins/callbacks/hipchat.py
+++ b/plugins/callbacks/hipchat.py
@@ -54,7 +54,6 @@ class CallbackModule(object):
         self.room = os.getenv('HIPCHAT_ROOM', 'ansible')
         self.from_name = os.getenv('HIPCHAT_FROM', 'ansible')
         self.allow_notify = (os.getenv('HIPCHAT_NOTIFY') != 'false')
-        print(self.allow_notify)
 
         if self.token is None:
             self.disabled = True

--- a/plugins/callbacks/hipchat.py
+++ b/plugins/callbacks/hipchat.py
@@ -36,7 +36,7 @@ class CallbackModule(object):
         HIPCHAT_TOKEN (required): HipChat API token
         HIPCHAT_ROOM  (optional): HipChat room to post in. Default: ansible
         HIPCHAT_FROM  (optional): Name to post as. Default: ansible
-        HIPCHAT_NOTIFY (optional): Add notify flag to important messages ("true" or "false"). Default: false
+        HIPCHAT_NOTIFY (optional): Add notify flag to important messages ("true" or "false"). Default: true
 
     Requires:
         prettytable
@@ -53,7 +53,8 @@ class CallbackModule(object):
         self.token = os.getenv('HIPCHAT_TOKEN')
         self.room = os.getenv('HIPCHAT_ROOM', 'ansible')
         self.from_name = os.getenv('HIPCHAT_FROM', 'ansible')
-        self.allow_notify = (os.getenv('HIPCHAT_NOTIFY') == 'true')
+        self.allow_notify = (os.getenv('HIPCHAT_NOTIFY') != 'false')
+        print(self.allow_notify)
 
         if self.token is None:
             self.disabled = True

--- a/plugins/callbacks/hipchat.py
+++ b/plugins/callbacks/hipchat.py
@@ -36,6 +36,7 @@ class CallbackModule(object):
         HIPCHAT_TOKEN (required): HipChat API token
         HIPCHAT_ROOM  (optional): HipChat room to post in. Default: ansible
         HIPCHAT_FROM  (optional): Name to post as. Default: ansible
+        HIPCHAT_NOTIFY (optional): Add notify flag to important messages ("true" or "false"). Default: false
 
     Requires:
         prettytable
@@ -52,6 +53,7 @@ class CallbackModule(object):
         self.token = os.getenv('HIPCHAT_TOKEN')
         self.room = os.getenv('HIPCHAT_ROOM', 'ansible')
         self.from_name = os.getenv('HIPCHAT_FROM', 'ansible')
+        self.allow_notify = (os.getenv('HIPCHAT_NOTIFY') == 'true')
 
         if self.token is None:
             self.disabled = True
@@ -71,7 +73,7 @@ class CallbackModule(object):
         params['message'] = msg
         params['message_format'] = msg_format
         params['color'] = color
-        params['notify'] = int(notify)
+        params['notify'] = int(self.allow_notify and notify)
 
         url = ('%s?auth_token=%s' % (self.msg_uri, self.token))
         try:


### PR DESCRIPTION
The "notify" flag means everyone in the room sees the title change color and possible visual/audio alert, which I found too much for most situations, especially as it happens on start and end of the playbook run. This makes it optional by extending the environment variable configuration. It also defaults it to off.
