### PR TITLE
Expose ansible_version to playbooks, add version_compare filter. Fixes #6583

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -208,6 +208,28 @@ To get the symmetric difference of 2 lists (items exclusive to each list)::
 
     {{ list1 | symmetric_difference(list2) }}
 
+.. _version_comparison_filters:
+
+Version Comparison Filters
+--------------------------
+
+.. versionadded:: 1.6
+
+To compare a version number, such as checking if the running Ansible version is greater than or equal to
+1.6, you can use the ``version_compare`` filter::
+
+    {{ ansible_version | version_compare(1.6, operator='ge') }}
+
+If ``ansible_version`` is 1.6 or greater, this filter will return True, otherwise it will return False.
+
+The ``version_compare`` filter can also be used to evaluate the ``ansible_distribution_version``::
+
+    {{ ansible_distribution_version | version_compare(12, '>') }}
+
+The ``version_compare`` filter accepts the following operators::
+
+    <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
+
 .. _other_useful_filters:
 
 Other Useful Filters
@@ -677,6 +699,8 @@ period, without the rest of the domain.
 Don't worry about any of this unless you think you need it.  You'll know when you do.
 
 Also available, *inventory_dir* is the pathname of the directory holding Ansible's inventory host file, *inventory_file* is the pathname and the filename pointing to the Ansible's inventory host file.
+
+The running version of Ansible is also available via the *ansible_version* variable.
 
 .. _variable_file_seperation_details:
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -34,6 +34,7 @@ import subprocess
 
 import ansible.constants as C
 import ansible.inventory
+from ansible import __version__
 from ansible import utils
 from ansible.utils import template
 from ansible.utils import check_conditional
@@ -549,13 +550,14 @@ class Runner(object):
         inject = utils.combine_vars(inject, self.module_vars)
         inject = utils.combine_vars(inject, self.setup_cache[host])
         inject.setdefault('ansible_ssh_user', self.remote_user)
-        inject['hostvars'] = HostVars(self.setup_cache, self.inventory)
-        inject['group_names'] = host_variables.get('group_names', [])
-        inject['groups']      = self.inventory.groups_list()
-        inject['vars']        = self.module_vars
-        inject['defaults']    = self.default_vars
-        inject['environment'] = self.environment
-        inject['playbook_dir'] = self.basedir
+        inject['hostvars']        = HostVars(self.setup_cache, self.inventory)
+        inject['group_names']     = host_variables.get('group_names', [])
+        inject['groups']          = self.inventory.groups_list()
+        inject['vars']            = self.module_vars
+        inject['defaults']        = self.default_vars
+        inject['environment']     = self.environment
+        inject['playbook_dir']    = self.basedir
+        inject['ansible_version'] = __version__
 
         if self.inventory.basedir() is not None:
             inject['inventory_dir'] = self.inventory.basedir()

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -23,8 +23,10 @@ import types
 import pipes
 import glob
 import re
+import operator as py_operator
 from ansible import errors
 from ansible.utils import md5s
+from distutils.version import LooseVersion
 
 def to_nice_yaml(*a, **kw):
     '''Make verbose, human readable yaml'''
@@ -142,6 +144,28 @@ def symmetric_difference(a, b):
 def union(a, b):
     return set(a).union(b)
 
+def version_compare(value, version, operator='eq'):
+    ''' Perform a version comparison on a value '''
+    op_map = {
+        '==': 'eq', '=':  'eq', 'eq': 'eq',
+        '<':  'lt', 'lt': 'lt',
+        '<=': 'le', 'le': 'le',
+        '>':  'gt', 'gt': 'gt',
+        '>=': 'ge', 'ge': 'ge',
+        '!=': 'ne', '<>': 'ne', 'ne': 'ne'
+    }
+
+    if operator in op_map:
+        operator = op_map[operator]
+    else:
+        raise errors.AnsibleFilterError('Invalid operator type')
+
+    try:
+        method = getattr(py_operator, operator)
+        return method(LooseVersion(str(value)), LooseVersion(str(version)))
+    except Exception, e:
+        raise errors.AnsibleFilterError('Version comparison: %s' % e)
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -203,5 +227,8 @@ class FilterModule(object):
             'difference': difference,
             'symmetric_difference': symmetric_difference,
             'union': union,
+
+            # version comparison
+            'version_compare': version_compare,
         }
 

--- a/test/units/TestFilters.py
+++ b/test/units/TestFilters.py
@@ -137,3 +137,25 @@ class TestFilters(unittest.TestCase):
         #out = open(dest).read()
         #self.assertEqual(DEST, out)
 
+    def test_version_compare(self):
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(0, 1.1, 'lt'))
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.1, 1.2, '<'))
+
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.2, 1.2, '=='))
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.2, 1.2, '='))
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.2, 1.2, 'eq'))
+
+
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.3, 1.2, 'gt'))
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.3, 1.2, '>'))
+
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.3, 1.2, 'ne'))
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.3, 1.2, '!='))
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.3, 1.2, '<>'))
+
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.1, 1.1, 'ge'))
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.2, 1.1, '>='))
+
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.1, 1.1, 'le'))
+        self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.0, 1.1, '<='))
+


### PR DESCRIPTION
A number of people have asked for the ansible version to be exposed to playbooks.

This pull request exposes it as `ansible_version`.

Additionally, on it's own, it is complicated to compare that version to another value.

This pull request additionally adds a `version_compare` filter for easy comparison of versions.

Unit tests have been added for the new filter, and here is an example playbook to see this in action:

```

---
- hosts: all
  tasks:
    - debug:
        var: ansible_version

    - debug:
        msg: "{{ ansible_version|version_compare(1.6) }}"

    - debug:
        msg: "{{ ansible_version|version_compare(1.4, 'gt') }}"

    - debug:
        msg: "{{ ansible_version|version_compare(1.7, 'lt') }}"

    - debug:
        msg: "{{ ansible_version|version_compare(1.6, '>=') }}"

    - debug:
        msg: "{{ ansible_version|version_compare(1.6, '<') }}"
```

The `version_compare` accepts an 'operator' argument, which supports: <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
