### PR TITLE
Allow vault encrypted vars as extra_vars

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -137,7 +137,7 @@ def main(args):
     for extra_vars_opt in options.extra_vars:
         if extra_vars_opt.startswith("@"):
             # Argument is a YAML file (JSON is a subset of YAML)
-            extra_vars = utils.combine_vars(extra_vars, utils.parse_yaml_from_file(extra_vars_opt[1:]))
+            extra_vars = utils.combine_vars(extra_vars, utils.parse_yaml_from_file(extra_vars_opt[1:], vault_password=vault_pass))
         elif extra_vars_opt and extra_vars_opt[0] in '[{':
             # Arguments as YAML
             extra_vars = utils.combine_vars(extra_vars, utils.parse_yaml(extra_vars_opt))


### PR DESCRIPTION
Forward the vault_password to the yaml file utility.
