### PR TITLE
Fix logic in process_common_errors for unbalanced quotes

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -424,7 +424,7 @@ Or:
                 match = True
             elif middle.startswith('"') and not middle.endswith('"'):
                 match = True
-            if len(middle) > 0 and middle[0] in [ '"', "'" ] and middle[-1] in [ '"', "'" ] and probline.count("'") > 2 or probline.count("'") > 2:
+            if len(middle) > 0 and middle[0] in [ '"', "'" ] and middle[-1] in [ '"', "'" ] and probline.count("'") > 2 or probline.count('"') > 2:
                 unbalanced = True
             if match:
                 msg = msg + """

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -301,8 +301,7 @@ class TestUtils(unittest.TestCase):
         self.assertTrue('same kind of quote' in ansible.utils.process_common_errors('', "foo: '{{bar}}'baz", 6))
 
         # unbalanced
-        # The first test fails and is commented out for now, logic is wrong and the test fails
-        #self.assertTrue('We could be wrong' in ansible.utils.process_common_errors('', 'foo: "bad" "wolf"', 6))
+        self.assertTrue('We could be wrong' in ansible.utils.process_common_errors('', 'foo: "bad" "wolf"', 6))
         self.assertTrue('We could be wrong' in ansible.utils.process_common_errors('', "foo: 'bad' 'wolf'", 6))
 
 


### PR DESCRIPTION
This pull addresses a logic issue in `process_common_errors` where we were always only looking for unbalanced single quotes instead of unbalanced single and double quotes.

The matching unit test has been uncommented now as well.
