### PR TITLE
Handle missing symlink tempfile 

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -305,7 +305,8 @@ def main():
                         os.symlink(src, tmppath)
                     os.rename(tmppath, path)
                 except OSError, e:
-                    os.unlink(tmppath)
+                    if os.path.exists(tmppath):
+                        os.unlink(tmppath)
                     module.fail_json(path=path, msg='Error while replacing: %s' % str(e))
             try:
                 if state == 'hard':


### PR DESCRIPTION
Only unlink the symlink tempfile on error if it was created in the previous operation.
