### PR TITLE
Introduce an ansible_version dict as runner variable

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -177,6 +177,8 @@ class PlayBook(object):
         ansible.callbacks.load_callback_plugins()
         ansible.callbacks.set_playbook(self.callbacks, self)
 
+        self._ansible_version = utils.version_info(gitinfo=True)
+
     # *****************************************************
 
     def _load_playbook_from_file(self, path, vars={}):
@@ -371,6 +373,7 @@ class PlayBook(object):
         )
 
         runner.module_vars.update({'play_hosts': hosts})
+        runner.module_vars.update({'ansible_version': self._ansible_version})
 
         if task.async_seconds == 0:
             results = runner.run()

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -578,6 +578,9 @@ class Runner(object):
         if self.inventory.src() is not None:
             inject['inventory_file'] = self.inventory.src()
 
+        # could be already set by playbook code
+        inject.setdefault('ansible_version', utils.version_info(gitinfo=False))
+
         # allow with_foo to work in playbooks...
         items = None
         items_plugin = self.module_vars.get('items_lookup_plugin', None)

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -647,6 +647,30 @@ def version(prog):
         result = result + " {0}".format(gitinfo)
     return result
 
+def version_info(gitinfo=False):
+    if gitinfo:
+        # expensive call, user with care
+        ansible_version_string = version('')
+    else:
+        ansible_version_string = __version__
+    ansible_version = ansible_version_string.split()[0]
+    ansible_versions = ansible_version.split('.')
+    for counter in range(len(ansible_versions)):
+        if ansible_versions[counter] == "":
+            ansible_versions[counter] = 0
+        try:
+            ansible_versions[counter] = int(ansible_versions[counter])
+        except:
+            pass
+    if len(ansible_versions) < 3:
+        for counter in range(len(ansible_versions), 3):
+            ansible_versions.append(0)
+    return {'string':      ansible_version_string.strip(),
+            'full':        ansible_version,
+            'major':       ansible_versions[0],
+            'minor':       ansible_versions[1],
+            'revision':    ansible_versions[2]}
+
 def getch():
     ''' read in a single character '''
     fd = sys.stdin.fileno()


### PR DESCRIPTION
  Given the version:
    "1.6 (ansible_version_var 14499e8bf3) last updated 2014/03/21 17:07:50 (GMT +200)"

  We get the special variable:
    "ansible_version": {
        "full": "1.6",
        "major": 1,
        "minor": 6,
        "revision": 0,
        "string": "1.6 (ansible_version_var 14499e8bf3) last updated 2014/03/21 17:07:50 (GMT +200)"
       }

  modified:   lib/ansible/runner/**init**.py

also in plain bin/ansible:
$ ansible -m debug -a var=ansible_version all
localhost | success >> {
    "ansible_version": {
        "full": "1.6", 
        "major": 1, 
        "minor": 6, 
        "revision": 0, 
        "string": "1.6 (ansible_version_var 69ee37f7a0) last updated 2014/03/21 18:12:46 (GMT +200)"
    }
}
