### PR TITLE
Clarify documentation for apt pkg, state, install_recommends

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -29,18 +29,18 @@ version_added: "0.0.2"
 options:
   pkg:
     description:
-      - A package name or package specifier with version, like C(foo) or C(foo=1.0). Shell like wildcards (fnmatch) like apt* are also supported.
+      - A package name, like C(foo), or package specifier with version, like C(foo=1.0). Wildcards (fnmatch) like apt* are also supported.
     required: false
     default: null
   state:
     description:
-      - Indicates the desired package state
+      - Indicates the desired package state. C(latest) ensures that the latest version is installed.
     required: false
     default: present
     choices: [ "latest", "absent", "present" ]
   update_cache:
     description:
-      - Run the equivalent of C(apt-get update) before the operation. Can be run as part of the package installation or as a separate step
+      - Run the equivalent of C(apt-get update) before the operation. Can be run as part of the package installation or as a separate step.
     required: false
     default: no
     choices: [ "yes", "no" ]
@@ -62,7 +62,7 @@ options:
     default: null
   install_recommends:
     description:
-      - Corresponds to the C(--no-install-recommends) option for I(apt), default behavior works as apt's default behavior, C(no) does not install recommended packages. Suggested packages are never installed.
+      - Corresponds to the C(--no-install-recommends) option for I(apt). Default behavior (C(yes)) replicates apt's default behavior; C(no) does not install recommended packages. Suggested packages are never installed.
     required: false
     default: yes
     choices: [ "yes", "no" ]


### PR DESCRIPTION
Minor changes to the apt packaging documentation to be clearer and better match other packaging modules.
