### PR TITLE
Group EC2 Inventory by AMI ID

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -346,6 +346,9 @@ class Ec2Inventory(object):
         # Inventory: Group by instance ID (always a group of 1)
         self.inventory[instance.id] = [dest]
 
+        # Inventory: Group by AMI ID
+        self.push(self.inventory, instance.image_id, dest)
+
         # Inventory: Group by region
         self.push(self.inventory, region, dest)
 


### PR DESCRIPTION
May need to run Ansible commands against an AMI ID. Updated the ec2.py to allow this to happen.
