### PR TITLE
Modified library/system/user so that password change date is set on Sola...

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -1186,6 +1186,7 @@ class SunOS(User):
                             lines.append(line)
                             continue
                         fields[1] = self.password
+                        fields[2] = str(int(time.time() / 86400))
                         line = ':'.join(fields)
                         lines.append('%s\n' % line)
                     open(self.SHADOWFILE, 'w+').writelines(lines)
@@ -1272,6 +1273,7 @@ class SunOS(User):
                             lines.append(line)
                             continue
                         fields[1] = self.password
+                        fields[2] = str(int(time.time() / 86400))	
                         line = ':'.join(fields)
                         lines.append('%s\n' % line)
                     open(self.SHADOWFILE, 'w+').writelines(lines)


### PR DESCRIPTION
Modified library/system/user so that password change date is set on Solaris when updating password. Variable fields[2] now contains days since epoch before the join() and ultimate writing out of /etc/shadow on SunOS machines.
