### PR TITLE
Add tesing deps installation into hacking/README

### DIFF
--- a/hacking/README.md
+++ b/hacking/README.md
@@ -17,7 +17,7 @@ and do not wish to install them from your operating system package manager, you
 can install them from pip
 
     $ easy_install pip               # if pip is not already available
-    $ pip install pyyaml jinja2
+    $ pip install pyyaml jinja2 nose passlib pycrypto
 
 From there, follow ansible instructions on docs.ansible.com as normal.
 


### PR DESCRIPTION
Micro Pull Request. 

During the hacking on Ansible I tried to run `make tests` and test didn't execute properly until I installed `nose`, `passlib` and `pycrypto`. So, I think it's reasonable to add those deps into [hacking/README](/ansible/ansible/blob/devel/hacking/README.md).
