### PR TITLE
Remove print statements

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -42,8 +42,6 @@ def failed(*a, **kw):
     ''' Test if task result yields failed '''
     item = a[0]
     if type(item) != dict:
-        print "DEBUG: GOT A"
-        print item
         raise errors.AnsibleFilterError("|failed expects a dictionary")
     rc = item.get('rc',0)
     failed = item.get('failed',False)


### PR DESCRIPTION
"print item" statement raises an exception when type of item is jinja2.runtime.StrictUndefined.
