### PR TITLE
Fix ValueError when selection contains a colon

### DIFF
--- a/library/system/debconf
+++ b/library/system/debconf
@@ -96,7 +96,7 @@ def get_selections(module, pkg):
     selections = {}
 
     for line in out.splitlines():
-        (key, value) = line.split(':')
+        (key, value) = line.split(':', 1)
         selections[ key.strip('*').strip() ] = value.strip()
 
     return selections


### PR DESCRIPTION
For example ValueError exception occurs with `postfix/mynetworks` parameter because value contains colons:

```
$ debconf-show postfix |grep networks
  postfix/mynetworks: 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
```
