### PR TITLE
work around environment problems in sudo mode

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -35,6 +35,9 @@ sudo_exe = sudo
 # what flags to pass to sudo
 #sudo_flags = -H
 
+# commands run before user commands while in sudo mode
+#sudo_preexec= source /etc/profile; source ~/.bash_profile;
+
 # SSH timeout
 timeout = 10
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -126,6 +126,7 @@ DEFAULT_KEEP_REMOTE_FILES = get_config(p, DEFAULTS, 'keep_remote_files', 'ANSIBL
 DEFAULT_SUDO              = get_config(p, DEFAULTS, 'sudo', 'ANSIBLE_SUDO', False, boolean=True)
 DEFAULT_SUDO_EXE          = get_config(p, DEFAULTS, 'sudo_exe', 'ANSIBLE_SUDO_EXE', 'sudo')
 DEFAULT_SUDO_FLAGS        = get_config(p, DEFAULTS, 'sudo_flags', 'ANSIBLE_SUDO_FLAGS', '-H')
+DEFAULT_SUDO_PREEXEC      = get_config(p, DEFAULTS, 'sudo_preexec', 'ANSIBLE_SUDO_PREEXEC', 'source /etc/profile; source ~/.bash_profile;')
 DEFAULT_HASH_BEHAVIOUR    = get_config(p, DEFAULTS, 'hash_behaviour', 'ANSIBLE_HASH_BEHAVIOUR', 'replace')
 DEFAULT_LEGACY_PLAYBOOK_VARIABLES = get_config(p, DEFAULTS, 'legacy_playbook_variables', 'ANSIBLE_LEGACY_PLAYBOOK_VARIABLES', True, boolean=True)
 DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBLE_JINJA2_EXTENSIONS', None)

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -882,7 +882,7 @@ def make_sudo_cmd(sudo_user, executable, cmd):
     success_key = 'SUDO-SUCCESS-%s' % randbits
     sudocmd = '%s -k && %s %s -S -p "%s" -u %s %s -c %s' % (
         C.DEFAULT_SUDO_EXE, C.DEFAULT_SUDO_EXE, C.DEFAULT_SUDO_FLAGS,
-        prompt, sudo_user, executable or '$SHELL', pipes.quote('echo %s; %s' % (success_key, cmd)))
+        prompt, sudo_user, executable or '$SHELL', pipes.quote('echo %s; %s %s' % (success_key, C.DEFAULT_SUDO_PREEXEC, cmd)))
     return ('/bin/sh -c ' + pipes.quote(sudocmd), prompt, success_key)
 
 


### PR DESCRIPTION
# this is repull of #6629

The problem can reproduce like this：
on some of my hosts(take 'fe08' as an example here), I have some tools
that _only_ can be used by user 'work'(for some security reason), so as
a result, I register it in work's .bashrc:

> [work@lg-com-xcache09 ~]$ which ipaddr
> <strong>~/bin/ipaddr</strong>
> [work@lg-com-xcache09 ~]$ cat .bashrc
> 
> ``` bash
> # .bashrc
> # ------ skip unrelated -----
> # User specific environment and startup programs
> export PATH=$HOME/bin:$PATH
> ```

But ansible seems can't find them at all:

> [bob@cs00 ~]$ ansible 'fe08' -m shell -a 'ipaddr' -s -U work
>    fe08 | FAILED | rc=127 >>
>    /bin/sh: ipaddr: command not found

Later I have found that ansibles sudo mode is in fact a non-login
terminal to run the command：

>    [bob@cs00 ~]$ ansible 'fe08' -m shell -a 'shopt login_shell' -s -U
> work
>    fe08 | FAILED | rc=1 >>
>    login_shell     off

But according to the [norms](http://linux.die.net/man/1/bash), even
non-login shell also need to source ~ /.bashrc, that's which we did not
do recently:

>    [bob@cs00 ~]$ ansible 'fe08' -m shell -a 'echo $PATH' -s -U work
> 
>    fe08 | success | rc=0 >>
>    /usr/lib64/qt-3.3/bin:/usr/local/bin:/bin:/usr/bin

In fact, we run a lot of programs in production environments which is
in need for environment variables like PYTHONPATH JAVA_HOME and so on.

there is a '-i' option in sudo can do these things, but when I add it
to sudo_flags(in ansible.cfg), ansible crashed:

>    [bob@cs00 ~]$ ansible 'fe08' -m shell -a 'whoami' -s -U work
>    fe08 | FAILED >> {
>        "failed": true,
>        "msg": "\r\n",
>        "parsed": false
>    }

To work around this problem, I add a shell hook, and run souce commands
in it
