### PR TITLE
Add missing sha1 import on known_hosts.py

### DIFF
--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -27,6 +27,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import hmac
+from hashlib import sha1
 HASHED_KEY_MAGIC = "|1|"
 
 def add_git_host_key(module, url, accept_hostkey=True):


### PR DESCRIPTION
Due to a missing import of the `sha1` module in the `known_hosts.py` file coupled with a catch all `except` (line 105), the git module silently failed to validate hashed fingerprints in the `.ssh/known_hosts`.
This makes it quite hard to use a pre-made `known_hosts` file without using `accept_hostkey`, since the module always complains that the hostkey is unknown even though it is in the `known_hosts` file.
