### PR TITLE
ec2: Adding type int for count (in line with other cloud modules)

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -1125,7 +1125,7 @@ def main():
             spot_price = dict(),
             image = dict(),
             kernel = dict(),
-            count = dict(default='1'),
+            count = dict(type='int', default='1'),
             monitoring = dict(type='bool', default=False),
             ramdisk = dict(),
             wait = dict(type='bool', default=False),


### PR DESCRIPTION
Was having some trouble writing a playbook that span up a specified count of spot instances. A simple fix to make count be an int seems to be a good idea (and is done in other cloud modules).
