### PR TITLE
Add key_file and accept_hostkey to ansible-pull

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -40,7 +40,6 @@
 
 import os
 import shutil
-import subprocess
 import sys
 import datetime
 import socket
@@ -137,6 +136,10 @@ def main(args):
                       help='ask for sudo password')
     parser.add_option('-t', '--tags', dest='tags', default=False,
                       help='only run plays and tasks tagged with these values')
+    parser.add_option('--accept-host-key', default=False, dest='accept_host_key', action='store_true',
+                      help='adds the hostkey for the repo url if not already added')
+    parser.add_option('--key-file', dest='key_file',
+                      help="Pass '-i <key_file>' to the SSH arguments used by git.")
     options, args = parser.parse_args(args)
 
     hostname = socket.getfqdn()
@@ -170,6 +173,15 @@ def main(args):
 
     if options.checkout:
         repo_opts += ' version=%s' % options.checkout
+
+    # Only git module is supported
+    if options.module_name == DEFAULT_REPO_TYPE:
+        if options.accept_host_key:
+            repo_opts += ' accept_hostkey=yes'
+
+        if options.key_file:
+            repo_opts += ' key_file=%s' % options.key_file
+
     path = utils.plugins.module_finder.find_plugin(options.module_name)
     if path is None:
         sys.stderr.write("module '%s' not found.\n" % options.module_name)


### PR DESCRIPTION
This commit implements a feature asked by @breerly in #6346, to add `key_file` and `accept_hostkey` to `ansible-pull` command to bootstrap easily.

Also I strictly pep8'ed and pyflaked this file and beautified possible options output. Not sure about options though.
