### PR TITLE
Use host-pattern for inventory var resolution

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -751,7 +751,7 @@ class Play(object):
 
         if host is not None:
             inject = {}
-            inject.update(self.playbook.inventory.get_variables(host, vault_password=vault_password))
+            inject.update(self.playbook.inventory.get_variables(host, pattern=self.hosts, vault_password=vault_password))
             inject.update(self.playbook.SETUP_CACHE[host])
 
         for filename in self.vars_files:

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -533,7 +533,7 @@ class Runner(object):
     def _executor_internal(self, host, new_stdin):
         ''' executes any module one or more times '''
 
-        host_variables = self.inventory.get_variables(host, vault_password=self.vault_pass)
+        host_variables = self.inventory.get_variables(host, pattern=self.pattern, vault_password=self.vault_pass)
         host_connection = host_variables.get('ansible_connection', self.transport)
         if host_connection in [ 'paramiko', 'ssh', 'accelerate' ]:
             port = host_variables.get('ansible_ssh_port', self.remote_port)


### PR DESCRIPTION
Fixes unintuitive behavior described in https://github.com/ansible/ansible/issues/6538

Prior behavior was to flatten variables by hostname. This meant that if a var was declared in multiple groups on a single host you would not be able to know which value of the var ansible would use.

This pull request utilizes the host pattern to prioritize the vars in matching hostgroups over non-matching hostgroups. This reduces ambiguous/undefined behavior in favor of an intuitive resolution order.

Prior resolution order was:
1. flattened vars from host class
2. vars from plugins
3. host vars from parser

This commit changes the resolution order:
1. flattened vars from host class
2. group vars from hosts pattern :sparkles: **_new step_** :sparkles:
3. vars from plugins
4. host vars from parser

In my local tests everything is completely backwards compatible, and we are using this fix in production currently.  The use case in #6538 also works.

Thanks, let me know what I can do to help to get this merged,

Thomas Omans
Commission Junction
