### PR TITLE
Typo: assign not equal in boolean guard variable

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -658,7 +658,7 @@ class PlayBook(object):
                 # if no hosts remain, drop out
                 if not host_list:
                     if self.force_handlers:
-                        task_errors == True
+                        task_errors = True
                         break
                     else:
                         return False


### PR DESCRIPTION
Typo when variable controlling list of hosts left as available
