### PR TITLE
Add register_as_list/hash

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -489,6 +489,18 @@ class PlayBook(object):
             # rather than the setup cache - vars should be transient between playbook executions
             if 'stdout' in result and 'stdout_lines' not in result:
                 result['stdout_lines'] = result['stdout'].splitlines()
+            if task.append_to_list:
+                if task.register not in self.VARS_CACHE[host]:
+                    self.VARS_CACHE[host][task.register] = []
+                result_list = self.VARS_CACHE[host][task.register]
+                result_list.append(result)
+                result = result_list
+            elif task.insert_into_hash:
+                if task.register not in self.VARS_CACHE[host]:
+                    self.VARS_CACHE[host][task.register] = {}
+                result_hash = self.VARS_CACHE[host][task.register]
+                result_hash[task.insert_into_hash] = result
+                result = result_hash
             utils.update_hash(self.VARS_CACHE, host, {task.register: result})
 
         # add facts to the global setup cache

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -27,8 +27,8 @@ class Task(object):
     __slots__ = [
         'name', 'meta', 'action', 'when', 'async_seconds', 'async_poll_interval',
         'notify', 'module_name', 'module_args', 'module_vars', 'default_vars',
-        'play', 'notified_by', 'tags', 'register', 'role_name',
-        'delegate_to', 'first_available_file', 'ignore_errors',
+        'play', 'notified_by', 'tags', 'register', 'append_to_list', 'insert_into_hash',
+        'role_name', 'delegate_to', 'first_available_file', 'ignore_errors',
         'local_action', 'transport', 'sudo', 'remote_user', 'sudo_user', 'sudo_pass',
         'items_lookup_plugin', 'items_lookup_terms', 'environment', 'args',
         'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until',
@@ -38,7 +38,8 @@ class Task(object):
     # to prevent typos and such
     VALID_KEYS = [
          'name', 'meta', 'action', 'when', 'async', 'poll', 'notify',
-         'first_available_file', 'include', 'tags', 'register', 'ignore_errors',
+         'first_available_file', 'include', 'tags', 'ignore_errors',
+         'append_to_list', 'insert_into_hash', 'register',
          'delegate_to', 'local_action', 'transport', 'remote_user', 'sudo', 'sudo_user',
          'sudo_pass', 'when', 'connection', 'environment', 'args',
          'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until',
@@ -118,6 +119,8 @@ class Task(object):
         self.name         = ds.get('name', None)
         self.tags         = [ 'all' ]
         self.register     = ds.get('register', None)
+        self.append_to_list = utils.boolean(ds.get('append_to_list', None))
+        self.insert_into_hash = ds.get('insert_into_hash', None)
         self.sudo         = utils.boolean(ds.get('sudo', play.sudo))
         self.su           = utils.boolean(ds.get('su', play.su))
         self.environment  = ds.get('environment', {})
@@ -125,7 +128,15 @@ class Task(object):
         self.no_log       = utils.boolean(ds.get('no_log', "false")) or self.play.no_log
         self.run_once     = utils.boolean(ds.get('run_once', 'false'))
 
-        #Code to allow do until feature in a Task 
+        if 'append_to_list' in ds or 'insert_into_hash' in ds:
+            # register is required
+            if not ds.get('register'):
+                raise errors.AnsibleError("register keyword is mandatory when using append_to_list/insert_into_hash feature")
+
+        if self.append_to_list and self.insert_into_hash:
+            raise errors.AnsibleError("append_to_list, and insert_into_hash are mutually incompatible in a single task")
+
+        #Code to allow do until feature in a Task
         if 'until' in ds:
             if not ds.get('register'):
                 raise errors.AnsibleError("register keyword is mandatory when using do until feature")
@@ -222,8 +233,7 @@ class Task(object):
         self.first_available_file = ds.get('first_available_file', None)
 
         self.items_lookup_plugin = ds.get('items_lookup_plugin', None)
-        self.items_lookup_terms  = ds.get('items_lookup_terms', None)
-     
+        self.items_lookup_terms = ds.get('items_lookup_terms', None)
 
         self.ignore_errors = ds.get('ignore_errors', False)
         self.any_errors_fatal = ds.get('any_errors_fatal', play.any_errors_fatal)
@@ -284,6 +294,8 @@ class Task(object):
         # make some task attributes accessible to Runner code
         self.module_vars['ignore_errors'] = self.ignore_errors
         self.module_vars['register'] = self.register
+        self.module_vars['append_to_list'] = self.append_to_list
+        self.module_vars['insert_into_hash'] = self.insert_into_hash
         self.module_vars['changed_when'] = self.changed_when
         self.module_vars['failed_when'] = self.failed_when
         self.module_vars['always_run'] = self.always_run


### PR DESCRIPTION
cleaner version of: https://github.com/ansible/ansible/pull/6488

Added 2 new keywords:

register_as_list: boolean
register_as_dict: hashkey
They both require the 'register' keyword to be present.
Its define the data structure,

register_as_list: yes => appends the result to a list
register_as_dict: key => adds the result to a hash[key]

exemple:

``` yaml
- name: Append result in a list
  template: src= a.conf.j2 dest=/root/a.conf backup=yes
  register: foo_list
  register_as_list: yes

- name: template1
  template: src=mytpl1.conf.j2 dest=/root/mytpl1.conf backup=yes
  register: bar_dict
  register_as_dict: key1

- name: template2
  template: src=mytpl2.conf.j2 dest=/root/mytpl2.conf backup=yes
  register: bar_dict
  register_as_dict: key2
```

use the registred results:

``` yaml
- name: display results (register_as_list)
  debug: msg={{item}}
  with_items: foo_list

- name: display result template1
  debug: msg={{bar_dict['key1']}}
```
