### PR TITLE
add limiting Inventory to a list of 1 or more VPCs

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -42,6 +42,10 @@ route53 = False
 # 'route53_excluded_zones' as a comma-separated list.
 # route53_excluded_zones = samplezone1.com, samplezone2.com
 
+# You can also specify a list of VPCs you want to limit your instance lookup to
+# If you switch between VPCs then you'll need to refresh your cache too
+# vpcs = vpc-<id>
+
 # API calls to EC2 are slow. For this reason, we cache the results of an API
 # call. Set this to the path you want cache files to be written to. Two files
 # will be written to this directory:

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -222,6 +222,11 @@ class Ec2Inventory(object):
             self.route53_excluded_zones.extend(
                 config.get('ec2', 'route53_excluded_zones', '').split(','))
 
+        if config.has_option('ec2', 'vpcs'):
+            self.vpcs = config.get('ec2', 'vpcs')
+        else:
+            self.vpcs = [];
+
         # Cache related
         cache_dir = os.path.expanduser(config.get('ec2', 'cache_path'))
         if not os.path.exists(cache_dir):

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -279,7 +279,11 @@ class Ec2Inventory(object):
             reservations = conn.get_all_instances()
             for reservation in reservations:
                 for instance in reservation.instances:
-                    self.add_instance(instance, region)
+                    if (len(self.vpcs) != 0):
+                        if(instance.vpc_id in self.vpcs):
+                            self.add_instance(instance, region)
+                    else:
+                        self.add_instance(instance, region)
         
         except boto.exception.BotoServerError, e:
             if  not self.eucalyptus:


### PR DESCRIPTION
Due to limitations in the EC2 API you can't limit DescribeInstance

However, with the addition of VPCs you may want to limit yourself
to a particular VPC for a particular environment

This allows you to specify which VPC(s) you want to describe

My Python skills aren't great so there may be easier ways to do what I've done.
