### PR TITLE
Fix TypeError when using old simplejson lib.

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -884,6 +884,9 @@ class AnsibleModule(object):
         for encoding in ("utf-8", "latin-1", "unicode_escape"):
             try:
                 return json.dumps(data, encoding=encoding)
+            # Old systems using simplejson module does not support encoding keyword.
+            except TypeError, e:
+                return json.dumps(data)
             except UnicodeDecodeError, e:
                 continue
         self.fail_json(msg='Invalid unicode encoding encountered')


### PR DESCRIPTION
##### Issue Type:

 Bugfix Pull Request
##### Ansible Version:

All since #a023cbce.
##### Environment:

Old client using `simplejson` module that does not support `encoding` keyword.
##### Summary:

Here is the traceback:

```
fatal: [host.example.com] => failed to parse: Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1395747065.86-65473690515679/ping", line 1183, in ?
    main()
  File "/root/.ansible/tmp/ansible-tmp-1395747065.86-65473690515679/ping", line 50, in main
    module.exit_json(**result)
  File "/root/.ansible/tmp/ansible-tmp-1395747065.86-65473690515679/ping", line 935, in exit_json
    print self.jsonify(kwargs)
  File "/root/.ansible/tmp/ansible-tmp-1395747065.86-65473690515679/ping", line 922, in jsonify
    return json.dumps(data, encoding=encoding)
  File "/var/lib/python-support/python2.4/simplejson/__init__.py", line 151, in dumps
    check_circular=check_circular, allow_nan=allow_nan, **kw).encode(obj)
TypeError: __init__() got an unexpected keyword argument 'encoding'
```
##### Steps To Reproduce:

On a host having old `simplejson` module  (tested with `simplejson` 1.3, got no issue with `simplejson` 1.9, I don't have intermediate version of `simplejson`).

```
ansible all -i old-host.example.com, -m ping
```
##### Expected Results:

```
old-host.example.com | success >> {
    "changed": false,
    "ping": "pong"
}
```
##### Actual Results:

See previous backtrace.
