### PR TITLE
Properly revert changes introduced in #6579 

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -128,7 +128,7 @@ class Cli(object):
             this_path = os.path.expanduser(options.vault_password_file)
             try:
                 f = open(this_path, "rb")
-                tmp_vault_pass=f.read()
+                tmp_vault_pass=f.read().strip()
                 f.close()
             except (OSError, IOError), e:
                 raise errors.AnsibleError("Could not read %s: %s" % (this_path, e))

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -122,7 +122,7 @@ def main(args):
             this_path = os.path.expanduser(options.vault_password_file)
             try:
                 f = open(this_path, "rb")
-                tmp_vault_pass=f.read()
+                tmp_vault_pass=f.read().strip()
                 f.close()
             except (OSError, IOError), e:
                 raise errors.AnsibleError("Could not read %s: %s" % (this_path, e))


### PR DESCRIPTION
While reverting changes @jctanner forgot to revert strip() removal which made ansible-vault and ansible{,-playbook} incompatible. This fixes it. 
