### PR TITLE
Adds groups example for user module

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -186,6 +186,11 @@ EXAMPLES = '''
 
 # Create a 2048-bit SSH key for user jsmith
 - user: name=jsmith generate_ssh_key=yes ssh_key_bits=2048
+
+# Add jsmith to the www-data group
+- user: >
+    name=jsmith
+    groups="jsmith, www-data"
 '''
 
 import os


### PR DESCRIPTION
The expected syntax for the groups argument was unclear to me. I found the answer on [serverfault](http://serverfault.com/questions/566756/how-can-i-add-a-user-to-multiple-groups-in-ansible) and thought folks would rather find it here.
