### PR TITLE
Funny grammar fixed plus added detail

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -45,7 +45,7 @@ options:
             - A source string state.
     update_cache:
         description:
-            - Run the equivalent of C(apt-get update) if has changed.
+            - Run the equivalent of C(apt-get update). If your state is present the cache is updated after adding the repository. If your state is absent the repository is removed and the cache is updated.
         required: false
         default: "yes"
         choices: [ "yes", "no" ]


### PR DESCRIPTION
Found funny grammar while trying to find out if the cache update happens before or after you add the repo. I believe lines 377 and 378 confirm that the source is added before a cache update.
