### PR TITLE
Show argument dependency

### DIFF
--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -58,7 +58,7 @@ options:
     version_added: "1.5"
   delete:
     description:
-      - Delete files that don't exist (after transfer, not before) in the C(src) path.
+      - Delete files that don't exist (after transfer, not before) in the C(src) path. This option requires C(recursive=yes).
     choices: [ 'yes', 'no' ]
     default: 'no'
     required: false


### PR DESCRIPTION
failed: [192.168.1.2] => {"cmd": "rsync --delay-updates -FF --compress --timeout=10 --delete-after --rsh 'ssh -i /home/jjshoe/.vagrant.d/insecure_private_key -o StrictHostKeyChecking=no' --rsync-path 'sudo rsync' --out-format='<<CHANGED>>%i %n%L' /tmp/app vagrant@192.168.1.2:/home/ubuntu/app", "failed": true, "item": "", "rc": 1}
msg: rsync: --delete does not work without --recursive (-r) or --dirs (-d).
rsync error: syntax or usage error (code 1) at main.c(1453) [client=3.0.9]
