### PR TITLE
rax module: Support arbitrary extra args

### DIFF
--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -98,6 +98,17 @@ options:
         state=active/present
     default: no
     version_added: 1.4
+  extra_client_args:
+    description:
+      - A hash of key/value pairs to be used when creating the cloudservers
+        client. This is considered an advanced option, use it wisely and
+        with caution.
+    version_added: 1.6
+  extra_create_args:
+    description:
+      - A hash of key/value pairs to be used when creating a new server.
+        This is considered an advanced option, use it wisely and with caution.
+    version_added: 1.6
   files:
     description:
       - Files to insert into the instance. remotefilename:localcontent
@@ -246,7 +257,8 @@ def pyrax_object_to_dict(obj):
 
 
 def create(module, names, flavor, image, meta, key_name, files,
-           wait, wait_timeout, disk_config, group, nics):
+           wait, wait_timeout, disk_config, group, nics,
+           extra_create_args):
 
     cs = pyrax.cloudservers
     changed = False
@@ -266,7 +278,8 @@ def create(module, names, flavor, image, meta, key_name, files,
                                              flavor=flavor, meta=meta,
                                              key_name=key_name,
                                              files=files, nics=nics,
-                                             disk_config=disk_config))
+                                             disk_config=disk_config,
+                                             **extra_create_args))
     except Exception, e:
         module.fail_json(msg='%s' % e.message)
     else:
@@ -405,7 +418,7 @@ def delete(module, instance_ids, wait, wait_timeout):
 def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                  wait, wait_timeout, disk_config, count, group,
                  instance_ids, exact_count, networks, count_offset,
-                 auto_increment):
+                 auto_increment, extra_create_args):
     cs = pyrax.cloudservers
     cnw = pyrax.cloud_networks
     servers = []
@@ -602,7 +615,7 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                 names = [name] * (count - len(servers))
 
         create(module, names, flavor, image, meta, key_name, files,
-               wait, wait_timeout, disk_config, group, nics)
+               wait, wait_timeout, disk_config, group, nics, extra_create_args)
 
     elif state == 'absent':
         if instance_ids is None:
@@ -647,6 +660,8 @@ def main():
             count_offset=dict(default=1, type='int'),
             disk_config=dict(choices=['auto', 'manual']),
             exact_count=dict(default=False, type='bool'),
+            extra_client_args=dict(type='dict', default={}),
+            extra_create_args=dict(type='dict', default={}),
             files=dict(type='dict', default={}),
             flavor=dict(),
             group=dict(),
@@ -682,6 +697,8 @@ def main():
     if disk_config:
         disk_config = disk_config.upper()
     exact_count = module.params.get('exact_count', False)
+    extra_client_args = module.params.get('extra_client_args')
+    extra_create_args = module.params.get('extra_create_args')
     files = module.params.get('files')
     flavor = module.params.get('flavor')
     group = module.params.get('group')
@@ -697,10 +714,23 @@ def main():
 
     setup_rax_module(module, pyrax)
 
+    if pyrax.cloudservers is None:
+        module.fail_json(msg='Failed to instantiate client. This '
+                             'typically indicates an invalid region or an '
+                             'incorrectly capitalized region name.')
+
+    if extra_client_args:
+        pyrax.cloudservers = pyrax.connect_to_cloudservers(
+            region=pyrax.cloudservers.client.region_name,
+            **extra_client_args)
+        client = pyrax.cloudservers.client
+        if 'bypass_url' in extra_client_args:
+            client.management_url = extra_client_args['bypass_url']
+
     cloudservers(module, state, name, flavor, image, meta, key_name, files,
                  wait, wait_timeout, disk_config, count, group,
                  instance_ids, exact_count, networks, count_offset,
-                 auto_increment)
+                 auto_increment, extra_create_args)
 
 
 # import module snippets


### PR DESCRIPTION
Add `extra_create_args` and `extra_client_args` to rax module to support passing
advanced configuration options to client instantiation and server create calls.

This allows the module to be used a little more fully with other OpenStack clouds without exposing new individual attributes to users for options not necessarily supported in the Rackspace Public Cloud.
