### PR TITLE
Treat 255 errors from raw as dark host

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -343,7 +343,7 @@ class Connection(object):
 
         if p.returncode != 0 and controlpersisterror:
             raise errors.AnsibleError('using -c ssh on certain older ssh versions may not support ControlPersist, set ANSIBLE_SSH_ARGS="" (or ansible_ssh_args in the config file) before running again')
-        if p.returncode == 255 and in_data:
+        if p.returncode == 255 and (in_data or self.runner.module_name == 'raw'):
             raise errors.AnsibleError('SSH Error: data could not be sent to the remote host. Make sure this host can be reached over ssh')
 
         return (p.returncode, '', stdout, stderr)


### PR DESCRIPTION
Any other module is able to detect a dark host, but raw was treating 255
as a return code from the module execution, rather from the connection
attempt. This change allows 255 to be treated as a connection failure
when using the raw module.
