### PR TITLE
Make ssh_config paramiko 1.12/1.13 compatible

### DIFF
--- a/plugins/inventory/ssh_config.py
+++ b/plugins/inventory/ssh_config.py
@@ -63,7 +63,8 @@ def get_config():
         for d in cfg._config:
             _copy = dict(d)
             del _copy['host']
-            ret_dict[d['host']] = _copy
+            for host in d['host']:
+                ret_dict[host] = _copy['config']
         return ret_dict
 
 


### PR DESCRIPTION
`ssh_config.py` tries to make a hash of hostnames like this:

```
ret_dict[d['host']] = _copy
```

This fails, because d['host'] is a list, which you cannot hash. It's been a list since at least 2012 in the Paramiko codebase.

This also searches the `_copy` dictionary for various keys- user, hostname, etc. This is not going to work with Paramiko 1.12/1.13, where those keys are actually inside another dictionary, kept inside of the 'config' key.
