### PR TITLE
Fixed ufw module doc reset vs reseted

### DIFF
--- a/library/system/ufw
+++ b/library/system/ufw
@@ -38,9 +38,9 @@ options:
       - C(enabled) reloads firewall and enables firewall on boot.
       - C(disabled) unloads firewall and disables firewall on boot.
       - C(reloaded) reloads firewall.
-      - C(reseted) disables and resets firewall to installation defaults.
+      - C(reset) disables and resets firewall to installation defaults.
     required: false
-    choices: ['enabled', 'disabled', 'reloaded', 'reseted']
+    choices: ['enabled', 'disabled', 'reloaded', 'reset']
   policy:
     description:
       - Change the default policy for incoming or outgoing traffic.


### PR DESCRIPTION
As a result of closing https://github.com/ansible/ansible/pull/6719 without merge, here is a new PR that only fixes the "reset"/"reseted" issue (current code is internally expecting "reset" but generated doc states "reseted").

I'm not that fluent with American English but "reset" sounds more correct than "reseted" for past tense.

I didn't add my name to module authors tag but if it makes sense to record all contributors there, let me know, will adjust the PR.
