### PR TITLE
EC2 inventory toggle to exclude/include RDS instances.

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -38,8 +38,8 @@ vpc_destination_variable = ip_address
 # Route53, uncomment and set 'route53' to True.
 route53 = False
 
-# To include RDS instances in inventory, set to True.
-rds = False
+# To exclude RDS instances from the inventory, uncomment and set to False.
+#rds = False
 
 # Additionally, you can specify the list of zones to exclude looking up in
 # 'route53_excluded_zones' as a comma-separated list.

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -38,6 +38,9 @@ vpc_destination_variable = ip_address
 # Route53, uncomment and set 'route53' to True.
 route53 = False
 
+# To include RDS instances in inventory, set to True.
+rds = False
+
 # Additionally, you can specify the list of zones to exclude looking up in
 # 'route53_excluded_zones' as a comma-separated list.
 # route53_excluded_zones = samplezone1.com, samplezone2.com

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -222,6 +222,9 @@ class Ec2Inventory(object):
             self.route53_excluded_zones.extend(
                 config.get('ec2', 'route53_excluded_zones', '').split(','))
 
+        # RDS
+        self.rds_enabled = config.getboolean('ec2', 'rds')
+
         # Cache related
         cache_dir = os.path.expanduser(config.get('ec2', 'cache_path'))
         if not os.path.exists(cache_dir):
@@ -254,7 +257,8 @@ class Ec2Inventory(object):
 
         for region in self.regions:
             self.get_instances_by_region(region)
-            self.get_rds_instances_by_region(region)
+            if self.rds_enabled:
+                self.get_rds_instances_by_region(region)
 
         self.write_to_cache(self.inventory, self.cache_path_cache)
         self.write_to_cache(self.index, self.cache_path_index)

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -223,7 +223,9 @@ class Ec2Inventory(object):
                 config.get('ec2', 'route53_excluded_zones', '').split(','))
 
         # RDS
-        self.rds_enabled = config.getboolean('ec2', 'rds')
+        self.rds_enabled = True
+        if config.has_option('ec2', 'rds'):
+            self.rds_enabled = config.getboolean('ec2', 'rds')
 
         # Cache related
         cache_dir = os.path.expanduser(config.get('ec2', 'cache_path'))


### PR DESCRIPTION
This simply adds a toggle to choose inclusion of RDS instances in the EC2 dynamic inventory or not. This is because these instances are not SSH manageable and therefore may not be desirable to be included in the **all** hosts selection.
