### PR TITLE
mysql_db: Adding target as a valid param for state=present.

### DIFF
--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -295,8 +295,8 @@ def main():
             else:
                 module.exit_json(changed=True, db=db, msg=stdout)
         elif state == "import":
-            rc, stdout, stderr = db_import(module, login_host, login_user, 
-                                        login_password, db, target, 
+            rc, stdout, stderr = db_import(module, login_host, login_user,
+                                        login_password, db, target,
                                         port=module.params['login_port'],
                                         socket=module.params['login_unix_socket'])
             if rc != 0:
@@ -306,6 +306,20 @@ def main():
     else:
         if state == "present":
             changed = db_create(cursor, db, encoding, collation)
+            if module.params['target']:
+                rc, stdout, stderr = db_import(module, login_host, login_user,
+                                               login_password, db, target,
+                                               port=module.params['login_port'],
+                                               socket=module.params['login_unix_socket'])
+                if rc != 0:
+                    # means we created a database but the import on the 
+                    # target failed, so we want to delete the empty database
+                    if changed:
+                        db_delete(cursor, db)
+
+                    module.fail_json(msg="%s" % stderr)
+                else:
+                    module.exit_json(changed=True, db=db, msg=stdout)
 
     module.exit_json(changed=changed, db=db)
 


### PR DESCRIPTION
Will import the file specified by "target" when using the state=present.

Use case : 
I want to create the basic schema for the database right after creating it. I don't want to run the .sql more than one time and only when creating the database the first time. 

Right now I had to check if 
- the database was already created and use "register" to save the output
- use state=present to create it
- use state=import + target=schema.sql when my_register=False

The overhead was a bit of a pain and changing the module was pretty easy.
Let me know what you think!

Note : the changes at line 298 and 299 are only removing the empty space at the end of the line.
