### PR TITLE
Allow raw and script to support su

### DIFF
--- a/lib/ansible/runner/action_plugins/raw.py
+++ b/lib/ansible/runner/action_plugins/raw.py
@@ -43,11 +43,12 @@ class ActionModule(object):
                 executable = v
         module_args = r.sub("", module_args)
 
-        result = self.runner._low_level_exec_command(conn, module_args, tmp, sudoable=True, executable=executable)
+        result = self.runner._low_level_exec_command(conn, module_args, tmp, sudoable=True, executable=executable,
+                                                     su=self.runner.su)
         # for some modules (script, raw), the sudo success key
         # may leak into the stdout due to the way the sudo/su
         # command is constructed, so we filter that out here
-        if result.get('stdout','').startswith('SUDO-SUCCESS-'):
-            result['stdout'] = re.sub(r'^SUDO-SUCCESS.*(\r)?\n', '', result['stdout'])
+        if result.get('stdout','').strip().startswith('SUDO-SUCCESS-'):
+            result['stdout'] = re.sub(r'^(\r)?\nSUDO-SUCCESS.*(\r)?\n', '', result['stdout'])
 
         return ReturnData(conn=conn, result=result)

--- a/lib/ansible/runner/action_plugins/script.py
+++ b/lib/ansible/runner/action_plugins/script.py
@@ -113,12 +113,13 @@ class ActionModule(object):
 
         sudoable = True
         # set file permissions, more permisive when the copy is done as a different user
-        if self.runner.sudo and self.runner.sudo_user != 'root':
+        if ((self.runner.sudo and self.runner.sudo_user != 'root') or
+                (self.runner.su and self.runner.su_user != 'root')):
             cmd_args_chmod = "chmod a+rx %s" % tmp_src
             sudoable = False
         else:
             cmd_args_chmod = "chmod +rx %s" % tmp_src
-        self.runner._low_level_exec_command(conn, cmd_args_chmod, tmp, sudoable=sudoable)
+        self.runner._low_level_exec_command(conn, cmd_args_chmod, tmp, sudoable=sudoable, su=self.runner.su)
 
         # add preparation steps to one ssh roundtrip executing the script
         env_string = self.runner._compute_environment_string(inject)


### PR DESCRIPTION
Currently, su support does not extend to `raw` and `script`.

`ansible 1.6 (devel ae1b183855) last updated 2014/03/28 16:45:19 (GMT -500)`
##### Current functionality:

```
ansible all -i test.sivel.net, --su --ask-su-pass -m raw -a whoami
test.sivel.net | success | rc=0 >>
matt
```

```
ansible all -i test.sivel.net, --su --ask-su-pass -m script -a ./whoami.sh
test.sivel.net | success | rc=0 >> {
    "changed": true,
    "rc": 0,
    "stderr": "",
    "stdout": "matt\r\n"
}
```
##### After:

```
ansible all -i test.sivel.net, --su --ask-su-pass -m raw -a whoami
test.sivel.net | success | rc=0 >>
root
```

```
ansible all -i test.sivel.net, --su --ask-su-pass -m script -a ./whoami.sh
test.sivel.net | success | rc=0 >> {
    "changed": true,
    "rc": 0,
    "stderr": "",
    "stdout": "root\r\n"
}
```

Additionally, I found a "bug" in logic of `raw.py` for stripping the `SUDO-SUCCESS-` string.  As such the string was not being removed from the output.  I've adjusted the logic and regular expression there as well to properly remove the string.  It seems stdout did not start with `SUDO-SUCCESS-` it was actually `\r\nSUDO-SUCCESS-`.
