### PR TITLE
fixed/extended module package/zypper

### DIFF
--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -33,9 +33,9 @@ DOCUMENTATION = '''
 module: zypper
 author: Patrick Callahan
 version_added: "1.2"
-short_description: Manage packages on SuSE and openSuSE
+short_description: Manage packages on SUSE and openSUSE
 description:
-    - Manage packages on SuSE and openSuSE using the zypper and rpm tools.
+    - Manage packages on SUSE and openSUSE using the zypper and rpm tools.
 options:
     name:
         description:
@@ -59,6 +59,14 @@ options:
         default: "no"
         choices: [ "yes", "no" ]
         aliases: []
+    recommends:
+        description:
+          - Whether to install recommend packages.
+        required: false
+        default: "yes"
+        choices: [ "yes", "no" ]
+        aliases: []
+
 
 notes: []
 # informational: requirements for nodes
@@ -72,6 +80,9 @@ EXAMPLES = '''
 
 # Remove the "nmap" package
 - zypper: name=nmap state=absent
+
+# Install "nmap" package without recommend packages
+- zypper: name=nmap recommends=no state=present
 '''
 
 # Function used for getting the name of a currently installed package.
@@ -102,7 +113,7 @@ def get_package_state(m, name):
         return False
 
 # Function used to make sure a package is present.
-def package_present(m, name, installed_state, disable_gpg_check):
+def package_present(m, name, installed_state, disable_gpg_check, recommends):
     if installed_state is False:
         cmd = ['/usr/bin/zypper', '--non-interactive']
         # add global options before zypper command
@@ -110,6 +121,12 @@ def package_present(m, name, installed_state, disable_gpg_check):
             cmd.append('--no-gpg-check')
 
         cmd.extend(['install', '--auto-agree-with-licenses'])
+
+        if recommends:
+            cmd.append('--recommends')
+        else:
+            cmd.append('--no-recommends')
+
         cmd.append(name)
         rc, stdout, stderr = m.run_command(cmd, check_rc=False)
 
@@ -126,10 +143,24 @@ def package_present(m, name, installed_state, disable_gpg_check):
     return (rc, stdout, stderr, changed)
 
 # Function used to make sure a package is the latest available version.
-def package_latest(m, name, installed_state, disable_gpg_check):
+def package_latest(m, name, installed_state, disable_gpg_check, recommends):
 
     if installed_state is True:
-        cmd = ['/usr/bin/zypper', '--non-interactive', 'update', '--auto-agree-with-licenses', name]
+        cmd = ['/usr/bin/zypper', '--non-interactive']
+
+        # add global options before zypper command
+        if disable_gpg_check:
+            cmd.append('--no-gpg-check')
+
+        cmd.extend(['update', '--auto-agree-with-licenses'])
+
+        if recommends:
+            cmd.append('--recommends')
+        else:
+            cmd.append('--no-recommends')
+
+        cmd.append(name)
+
         pre_upgrade_name = ''
         post_upgrade_name = ''
 
@@ -149,7 +180,7 @@ def package_latest(m, name, installed_state, disable_gpg_check):
 
     else:
         # If package was not installed at all just make it present.
-        return package_present(m, name, installed_state, disable_gpg_check)
+        return package_present(m, name, installed_state, disable_gpg_check, recommends)
 
 # Function used to make sure a package is not installed.
 def package_absent(m, name, installed_state):
@@ -178,6 +209,7 @@ def main():
             name = dict(required=True, aliases=['pkg']),
             state = dict(required=False, default='present', choices=['absent', 'installed', 'latest', 'present', 'removed']),
             disable_gpg_check = dict(required=False, default='no', type='bool'),
+            recommends = dict(required=False, default='yes', type='bool'),
         ),
         supports_check_mode = False
     )
@@ -188,6 +220,7 @@ def main():
     name  = params['name']
     state = params['state']
     disable_gpg_check = params['disable_gpg_check']
+    recommends = params['recommends']
 
     rc = 0
     stdout = ''
@@ -201,11 +234,11 @@ def main():
 
     # Perform requested action
     if state in ['installed', 'present']:
-        (rc, stdout, stderr, changed) = package_present(module, name, installed_state, disable_gpg_check)
+        (rc, stdout, stderr, changed) = package_present(module, name, installed_state, disable_gpg_check, recommends)
     elif state in ['absent', 'removed']:
         (rc, stdout, stderr, changed) = package_absent(module, name, installed_state)
     elif state == 'latest':
-        (rc, stdout, stderr, changed) = package_latest(module, name, installed_state, disable_gpg_check)
+        (rc, stdout, stderr, changed) = package_latest(module, name, installed_state, disable_gpg_check, recommends)
 
     if rc != 0:
         if stderr:

--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -60,6 +60,7 @@ options:
         choices: [ "yes", "no" ]
         aliases: []
     recommends:
+        version_added: "1.6"
         description:
           - Whether to install recommend packages.
         required: false


### PR DESCRIPTION
- Introduced new parameter recommends to be able to install
  and updated packages without installing recommend packages.
- Made disable_gpg_check usable with updating packages.
- Changed SuSE to SUSE in the description, because that's the
  correct name of the company. Have a look at
  http://en.wikipedia.org/wiki/SUSE for verification.
