### PR TITLE
Add support to using list variables in the notify: keyword

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -538,7 +538,8 @@ class PlayBook(object):
             for host, results in results.get('contacted',{}).iteritems():
                 if results.get('changed', False):
                     for handler_name in task.notify:
-                        handler_name = template(play.basedir, handler_name, task.module_vars)
+                        all_vars = task.combine_all_vars()
+                        handler_name = template(play.basedir, handler_name, all_vars)
                         if not isinstance(handler_name, basestring):
                             for item in handler_name:
                                 self._flag_handler(play, item, host)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -541,9 +541,9 @@ class PlayBook(object):
                         handler_name = template(play.basedir, handler_name, task.module_vars)
                         if not isinstance(handler_name, basestring):
                             for item in handler_name:
-                                self._flag_handler(play, template(play.basedir, item, task.module_vars), host)
+                                self._flag_handler(play, item, host)
                         else:
-                            self._flag_handler(play, template(play.basedir, handler_name, task.module_vars), host)
+                            self._flag_handler(play, handler_name, host)
 
         ansible.callbacks.set_task(self.callbacks, None)
         ansible.callbacks.set_task(self.runner_callbacks, None)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -538,7 +538,12 @@ class PlayBook(object):
             for host, results in results.get('contacted',{}).iteritems():
                 if results.get('changed', False):
                     for handler_name in task.notify:
-                        self._flag_handler(play, template(play.basedir, handler_name, task.module_vars), host)
+                        handler_name = template(play.basedir, handler_name, task.module_vars)
+                        if not isinstance(handler_name, basestring):
+                            for item in handler_name:
+                                self._flag_handler(play, template(play.basedir, item, task.module_vars), host)
+                        else:
+                            self._flag_handler(play, template(play.basedir, handler_name, task.module_vars), host)
 
         ansible.callbacks.set_task(self.callbacks, None)
         ansible.callbacks.set_task(self.runner_callbacks, None)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -456,6 +456,19 @@ class PlayBook(object):
         if len(contacted.keys()) == 0 and len(dark.keys()) == 0:
             return None
 
+        # flag which notify handlers need to be run
+        if len(task.notify) > 0:
+            for host, results in results.get('contacted',{}).iteritems():
+                if results.get('changed', False):
+                    combined_vars = runner.get_inject_vars(host)
+                    for handler_name in task.notify:
+                        handler_name = template(task.play.basedir, handler_name, combined_vars)
+                        if not isinstance(handler_name, basestring):
+                            for item in handler_name:
+                                self._flag_handler(task.play, item, host)
+                        else:
+                            self._flag_handler(task.play, handler_name, host)
+
         return results
 
     # *****************************************************
@@ -532,19 +545,6 @@ class PlayBook(object):
             failed = results.get('failed', {})
             for host, result in failed.iteritems():
                 _register_play_vars(host, result)
-
-        # flag which notify handlers need to be run
-        if len(task.notify) > 0:
-            for host, results in results.get('contacted',{}).iteritems():
-                if results.get('changed', False):
-                    for handler_name in task.notify:
-                        all_vars = task.combine_all_vars()
-                        handler_name = template(play.basedir, handler_name, all_vars)
-                        if not isinstance(handler_name, basestring):
-                            for item in handler_name:
-                                self._flag_handler(play, item, host)
-                        else:
-                            self._flag_handler(play, handler_name, host)
 
         ansible.callbacks.set_task(self.callbacks, None)
         ansible.callbacks.set_task(self.runner_callbacks, None)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -222,7 +222,12 @@ class Task(object):
         self.failed_when = ds.get('failed_when', None)
 
         # combine the default and module vars here for use in templating
-        all_vars = self.combine_all_vars()
+        all_vars = self.default_vars.copy()
+        all_vars = utils.combine_vars(all_vars, self.play_vars)
+        all_vars = utils.combine_vars(all_vars, self.play_file_vars)
+        all_vars = utils.combine_vars(all_vars, self.role_vars)
+        all_vars = utils.combine_vars(all_vars, self.module_vars)
+        all_vars = utils.combine_vars(all_vars, self.role_params)
 
         self.async_seconds = ds.get('async', 0)  # not async by default
         self.async_seconds = template.template_from_string(play.basedir, self.async_seconds, all_vars)
@@ -316,11 +321,3 @@ class Task(object):
             if self.when:
                 new_conditions.append(self.when)
             self.when = new_conditions
-
-    def combine_all_vars(self):
-        all_vars = self.default_vars.copy()
-        all_vars = utils.combine_vars(all_vars, self.play_vars)
-        all_vars = utils.combine_vars(all_vars, self.play_file_vars)
-        all_vars = utils.combine_vars(all_vars, self.role_vars)
-        all_vars = utils.combine_vars(all_vars, self.module_vars)
-        return all_vars

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -222,12 +222,7 @@ class Task(object):
         self.failed_when = ds.get('failed_when', None)
 
         # combine the default and module vars here for use in templating
-        all_vars = self.default_vars.copy()
-        all_vars = utils.combine_vars(all_vars, self.play_vars)
-        all_vars = utils.combine_vars(all_vars, self.play_file_vars)
-        all_vars = utils.combine_vars(all_vars, self.role_vars)
-        all_vars = utils.combine_vars(all_vars, self.module_vars)
-        all_vars = utils.combine_vars(all_vars, self.role_params)
+        all_vars = self.combine_all_vars()
 
         self.async_seconds = ds.get('async', 0)  # not async by default
         self.async_seconds = template.template_from_string(play.basedir, self.async_seconds, all_vars)
@@ -321,3 +316,11 @@ class Task(object):
             if self.when:
                 new_conditions.append(self.when)
             self.when = new_conditions
+
+    def combine_all_vars(self):
+        all_vars = self.default_vars.copy()
+        all_vars = utils.combine_vars(all_vars, self.play_vars)
+        all_vars = utils.combine_vars(all_vars, self.play_file_vars)
+        all_vars = utils.combine_vars(all_vars, self.role_vars)
+        all_vars = utils.combine_vars(all_vars, self.module_vars)
+        return all_vars

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -55,6 +55,9 @@ test_group_by:
 test_handlers:
 	ansible-playbook test_handlers.yml -i inventory.handlers -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
+test_notify:
+	ansible-playbook test_notify.yml -i inventory.notify -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+
 test_hash:
 	ANSIBLE_HASH_BEHAVIOUR=replace ansible-playbook test_hash.yml -i $(INVENTORY) $(CREDENTIALS_ARG) -v -e '{"test_hash":{"extra_args":"this is an extra arg"}}'
 	ANSIBLE_HASH_BEHAVIOUR=merge ansible-playbook test_hash.yml -i $(INVENTORY) $(CREDENTIALS_ARG) -v -e '{"test_hash":{"extra_args":"this is an extra arg"}}'

--- a/test/integration/inventory.notify
+++ b/test/integration/inventory.notify
@@ -1,0 +1,5 @@
+A handlers_list='["foo", "bar"]'
+B handlers_list=scalar
+C handlers_list=notify_host_c
+D
+E

--- a/test/integration/roles/test_notify/defaults/main.yml
+++ b/test/integration/roles/test_notify/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+handlers_list:
+  - default_foo

--- a/test/integration/roles/test_notify/handlers/main.yml
+++ b/test/integration/roles/test_notify/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: default_foo
+  command: echo

--- a/test/integration/roles/test_notify/tasks/main.yml
+++ b/test/integration/roles/test_notify/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: notify with role default vars
+  command: echo
+  notify: '{{handlers_list}}'

--- a/test/integration/test_notify.yml
+++ b/test/integration/test_notify.yml
@@ -1,0 +1,54 @@
+---
+- name: run notify with host vars
+  hosts: A:B
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: notify with host vars
+      command: echo
+      notify: '{{handlers_list}}'
+  handlers:
+    - name: foo
+      command: echo
+    - name: bar
+      command: echo
+    - name: scalar
+      command: echo
+
+- name: run notify with play vars
+  hosts: A:B
+  vars:
+    handlers_list:
+      - play_foo
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: notify with play vars
+      command: echo
+      notify: '{{handlers_list}}'
+  handlers:
+    - name: play_foo
+      command: echo
+
+- name: run notify with included vars
+  hosts: A:B
+  gather_facts: False
+  connection: local
+  tasks:
+    - include_vars: vars/test_notify_vars.yml
+    - name: notify with included vars
+      command: echo
+      notify: '{{handlers_list}}'
+  handlers:
+    - name: included_foo
+      command: echo
+
+- name: run notify with role default vars
+  hosts: C:D:E
+  gather_facts: False
+  connection: local
+  roles:
+    - role: test_notify
+  handlers:
+    - name: notify_host_c
+      command: echo

--- a/test/integration/vars/test_notify_vars.yml
+++ b/test/integration/vars/test_notify_vars.yml
@@ -1,0 +1,3 @@
+---
+handlers_list:
+  - included_foo


### PR DESCRIPTION
```
vars:
    handlers_list:
      - foo
      - bar
tasks:
    - name: template configuration file
      template: src=template.j2 dest=/etc/foo.conf
      notify: '{{handlers_list}}'
```

Expected:
TASK: [template configuration file]

---

changed: [deb7.inter.nos]

NOTIFIED: [foo]

---

changed: [deb7.inter.nos]

NOTIFIED: [bar]

---

changed: [deb7.inter.nos]

Without this:
TASK: [template configuration file]

---

changed: [deb7.inter.nos]
ERROR: change handler (['foo', 'bar']) is not defined
