### PR TITLE
backreferences should be double escaped

### DIFF
--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -138,7 +138,7 @@ EXAMPLES = r"""
 # Fully quoted because of the ': ' on the line. See the Gotchas in the YAML docs.
 - lineinfile: "dest=/etc/sudoers state=present regexp='^%wheel' line='%wheel ALL=(ALL) NOPASSWD: ALL'"
 
-- lineinfile: dest=/opt/jboss-as/bin/standalone.conf regexp='^(.*)Xms(\d+)m(.*)$' line='\1Xms${xms}m\3' backrefs=yes
+- lineinfile: dest=/opt/jboss-as/bin/standalone.conf regexp='^(.*)Xms(\d+)m(.*)$' line='\\1Xms${xms}m\\3' backrefs=yes
 
 # Validate a the sudoers file before saving
 - lineinfile: dest=/etc/sudoers state=present regexp='^%ADMIN ALL\=' line='%ADMIN ALL=(ALL) NOPASSWD:ALL' validate='visudo -cf %s'


### PR DESCRIPTION
The **DOCUMENTATION** string mentions that the line parameter should have backreferences double escaped, but the **EXAMPLES** string contains an example where it is not.
