### PR TITLE
More descriptive error message if init system is unknown

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -565,7 +565,7 @@ class LinuxService(Service):
     def service_enable(self):
 
         if self.enable_cmd is None:
-            self.module.fail_json(msg='service name not recognized')
+            self.module.fail_json(msg='unknown init system, cannot enable service')
 
         # FIXME: we use chkconfig or systemctl
         # to decide whether to run the command here but need something


### PR DESCRIPTION
I just spent a long time debugging a problem where I thought Ansible could not find an initscript to start a service, but it turned out the problem was that Ansible did not know about the init system on my target machine.  I was mislead by an inaccurate error message, so I would like to submit this trivial patch to change the error message to be more helpful.
