### PR TITLE
don't parse empty stream chunks

### DIFF
--- a/library/cloud/docker_image
+++ b/library/cloud/docker_image
@@ -137,6 +137,9 @@ class DockerImageManager:
         self.changed = True
 
         for chunk in stream:
+            if not chunk:
+                continue
+
             chunk_json = json.loads(chunk)
 
             if 'error' in chunk_json:


### PR DESCRIPTION
docker-py (tested against >=0.3.0) currently outputs empty chunks in the stream result from `docker.Client.build()`.  This causes `json.load()` to throw an error in docker_image (see below, debug output included).

Will submit a patch to docker-py (assuming filtering empty lines is desired), but in the meantime, it seems sensible to guard against this case here regardless.

This is using the latest docker-py from git:

```
pip install -e git+https://github.com/dotcloud/docker-py#egg=docker-py-git
```

```
$ ansible --version
ansible 1.5.3
```

```
$ docker -v
Docker version 0.9.1, build 3600720
```

Error:

```
TASK: [containers/mway/base-dev | Build mway/base-dev] ************************
<127.0.0.1> ESTABLISH CONNECTION FOR USER: root
<127.0.0.1> REMOTE_MODULE docker_image name="mway/base-dev" tag="latest" path="/opt/docker/containers/mway/base-dev" state=present
<127.0.0.1> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'Port=22', '-o', 'KbdInteractiveAuthentication=n
o', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no', '-o', 'ConnectTimeout=10', '127.0.0.1', "/bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1
396205439.7-267945287365133 && echo $HOME/.ansible/tmp/ansible-tmp-1396205439.7-267945287365133'"]
<127.0.0.1> PUT /tmp/tmpKVB3eG TO /root/.ansible/tmp/ansible-tmp-1396205439.7-267945287365133/docker_image
<127.0.0.1> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'Port=22', '-o', 'KbdInteractiveAuthentication=n
o', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no', '-o', 'ConnectTimeout=10', '127.0.0.1', "/bin/sh -c '/usr/bin/env python /root/.ansible/tmp/an
sible-tmp-1396205439.7-267945287365133/docker_image; rm -rf /root/.ansible/tmp/ansible-tmp-1396205439.7-267945287365133/ >/dev/null 2>&1'"]
fatal: [dockerctl] => failed to parse: mway/base-dev:latest
chunk: {"stream":"Step 0 : FROM ubuntu:precise\n"}
chunk: {"stream":" ---\u003e 9cd978db300e\n"}
chunk: {"stream":"Step 1 : MAINTAINER Matt Way \u003cxx@xxxx.xx\u003e\n"}
chunk: {"stream":" ---\u003e Running in 1546acbdde64\n"}
chunk: {"stream":" ---\u003e 18657cc5b14d\n"}
chunk: {"stream":"Step 2 : RUN locale-gen en_US.UTF-8\n"}
chunk: {"stream":" ---\u003e Running in 39675f4e0408\n"}
chunk: {"stream":"Generating locales...\n"}
chunk:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1396205439.7-267945287365133/docker_image", line 1329, in <module>
    main()
  File "/root/.ansible/tmp/ansible-tmp-1396205439.7-267945287365133/docker_image", line 219, in main
    image_id = manager.build()
  File "/root/.ansible/tmp/ansible-tmp-1396205439.7-267945287365133/docker_image", line 142, in build
    chunk_json = json.loads(chunk)
  File "/usr/lib/python2.7/json/__init__.py", line 326, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```
