### PR TITLE
Added region name to client connection as it is needed for some cloud pr...

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -249,6 +249,7 @@ def main():
                               module.params['login_password'],
                               module.params['login_tenant_name'],
                               module.params['auth_url'],
+                              region_name=module.params['region_name'],
                               service_type='compute')
     try:
         nova.authenticate()


### PR DESCRIPTION
I could not get this to work with HP Cloud because there are two endpoints and if you don't specify the region, you will get this error:

"Found more than one valid endpoint. Use a more restrictive filter"

This would happen in any setup with multiple regions.
