### PR TITLE
add cache_subnet_group_name param, cache_security_group can be None

### DIFF
--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -66,9 +66,13 @@ options:
     version_added: "1.6"
   cache_security_groups:
     description:
-      - A list of cache security group names to associate with this cache cluster
+      - A list of cache security group names to associate with this cache cluster. Only used if not inside a VPC.
     required: false
     default: ['default']
+  cache_subnet_group_name:
+    description:
+      - The subnet group that this cache cluster should be deployed into. Only used if inside a VPC.
+    version_added: "1.7"
   zone:
     description:
       - The EC2 Availability Zone in which the cache cluster will be created
@@ -158,7 +162,7 @@ class ElastiCacheManager(object):
     EXIST_STATUSES = ['available', 'creating', 'rebooting', 'modifying']
 
     def __init__(self, module, name, engine, cache_engine_version, node_type,
-                 num_nodes, cache_port, cache_security_groups, security_group_ids, zone, wait,
+                 num_nodes, cache_port, cache_security_groups, cache_subnet_group_name, security_group_ids, zone, wait,
                  hard_modify, aws_access_key, aws_secret_key, region):
         self.module = module
         self.name = name
@@ -168,6 +172,7 @@ class ElastiCacheManager(object):
         self.num_nodes = num_nodes
         self.cache_port = cache_port
         self.cache_security_groups = cache_security_groups
+        self.cache_subnet_group_name = cache_subnet_group_name
         self.security_group_ids = security_group_ids
         self.zone = zone
         self.wait = wait
@@ -224,6 +229,7 @@ class ElastiCacheManager(object):
                                                       engine=self.engine,
                                                       engine_version=self.cache_engine_version,
                                                       cache_security_group_names=self.cache_security_groups,
+						      cache_subnet_group_name=self.cache_subnet_group_name,
                                                       security_group_ids=self.security_group_ids,
                                                       preferred_availability_zone=self.zone,
                                                       port=self.cache_port)
@@ -485,8 +491,9 @@ def main():
             node_type={'required': False, 'default': 'cache.m1.small'},
             num_nodes={'required': False, 'default': None, 'type': 'int'},
             cache_port={'required': False, 'default': 11211, 'type': 'int'},
-            cache_security_groups={'required': False, 'default': ['default'],
+            cache_security_groups={'required': False, 'default': None,
                                    'type': 'list'},
+            cache_subnet_group_name={'required': False, 'default': None },
             security_group_ids={'required': False, 'default': [],
                                    'type': 'list'},
             zone={'required': False, 'default': None},
@@ -509,6 +516,7 @@ def main():
     num_nodes = module.params['num_nodes']
     cache_port = module.params['cache_port']
     cache_security_groups = module.params['cache_security_groups']
+    cache_subnet_group_name = module.params['cache_subnet_group_name']
     security_group_ids = module.params['security_group_ids']
     zone = module.params['zone']
     wait = module.params['wait']
@@ -520,10 +528,17 @@ def main():
     if not region:
         module.fail_json(msg=str("Either region or EC2_REGION environment variable must be set."))
 
+    if cache_security_groups and cache_subnet_group_name:
+        module.fail_json(msg=str("'cache_security_groups' and 'cache_subnet_group_name' are mutually exclusive."))
+
+    if not cache_security_groups and not cache_subnet_group_name:
+        cache_security_groups = 'default'
+
     elasticache_manager = ElastiCacheManager(module, name, engine,
                                              cache_engine_version, node_type,
                                              num_nodes, cache_port,
                                              cache_security_groups,
+                                             cache_subnet_group_name,
                                              security_group_ids, zone, wait,
                                              hard_modify, aws_access_key,
                                              aws_secret_key, region)


### PR DESCRIPTION
This PR adds the ability to set the cache_subnet-group_name that is required when deploying into a VPC. The current code sets it to 'default' which is probably erroneous for most people.

This also removes the default value for the cache_security_groups param (which is the value 'default') as it needs to be blank when deploying into a VPC.
