### PR TITLE
Fix cron module and memtotal_mb fact on HP-UX

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1257,8 +1257,9 @@ class HPUX(Hardware):
                 #adb output. Unfortunatley /dev/kmem doesn't have world-read, so this only works as root.
                 if os.access("/dev/kmem", os.R_OK):
                     rc, out, err = module.run_command("echo 'phys_mem_pages/D' | adb -k /stand/vmunix /dev/kmem | tail -1 | awk '{print $2}'", use_unsafe_shell=True)
-                    data = out
-                    self.facts['memtotal_mb'] = int(data) / 256
+                    if not err:
+                      data = out
+                      self.facts['memtotal_mb'] = int(data) / 256
         else:
             rc, out, err = module.run_command("/usr/contrib/bin/machinfo | grep Memory", use_unsafe_shell=True)
             data = re.search('Memory[\ :=]*([0-9]*).*MB.*',out).groups()[0].strip()

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1248,9 +1248,17 @@ class HPUX(Hardware):
         data = int(re.sub(' +',' ',out).split(' ')[5].strip())
         self.facts['memfree_mb'] = pagesize * data / 1024 / 1024
         if self.facts['architecture'] == '9000/800':
-            rc, out, err = module.run_command("grep Physical /var/adm/syslog/syslog.log")
-            data = re.search('.*Physical: ([0-9]*) Kbytes.*',out).groups()[0].strip()
-            self.facts['memtotal_mb'] = int(data) / 1024
+            try:
+                rc, out, err = module.run_command("grep Physical /var/adm/syslog/syslog.log")
+                data = re.search('.*Physical: ([0-9]*) Kbytes.*',out).groups()[0].strip()
+                self.facts['memtotal_mb'] = int(data) / 1024
+            except AttributeError:
+                #For systems where memory details aren't sent to syslog or the log has rotated, use parsed
+                #adb output. Unfortunatley /dev/kmem doesn't have world-read, so this only works as root.
+                if os.access("/dev/kmem", os.R_OK):
+                    rc, out, err = module.run_command("echo 'phys_mem_pages/D' | adb -k /stand/vmunix /dev/kmem | tail -1 | awk '{print $2}'", use_unsafe_shell=True)
+                    data = out
+                    self.facts['memtotal_mb'] = int(data) / 256
         else:
             rc, out, err = module.run_command("/usr/contrib/bin/machinfo | grep Memory", use_unsafe_shell=True)
             data = re.search('Memory[\ :=]*([0-9]*).*MB.*',out).groups()[0].strip()

--- a/library/system/cron
+++ b/library/system/cron
@@ -353,6 +353,8 @@ class CronTab(object):
         if self.user:
             if platform.system() == 'SunOS':
                 return "su %s -c '%s -l'" % (pipes.quote(self.user), pipes.quote(CRONCMD))
+            elif platform.system() == 'HP-UX':
+                return "%s %s %s" % (CRONCMD , '-l', pipes.quote(self.user))
             else:
                 user = '-u %s' % pipes.quote(self.user)
         return "%s %s %s" % (CRONCMD , user, '-l')
@@ -363,7 +365,7 @@ class CronTab(object):
         """
         user = ''
         if self.user:
-            if platform.system() == 'SunOS':
+            if platform.system() in ['SunOS', 'HP-UX']:
                 return "chown %s %s ; su '%s' -c '%s %s'" % (pipes.quote(self.user), pipes.quote(path), pipes.quote(self.user), CRONCMD, pipes.quote(path))
             else:
                 user = '-u %s' % pipes.quote(self.user)


### PR DESCRIPTION
On HP-UX, the crontab command works like this, because there is no "-u" it's picky about the order of the arguments:

```
 crontab(1)                                                       crontab(1)
 NAME
      crontab - user job file scheduler
 SYNOPSIS
      crontab [file]
      crontab -e [username]
      crontab -l [username]
      crontab -r [username]
```

The first patch ensures "crontab -l [username]" for reading, and "crontab [file]" for writing (same as SunOS).

The second patch attempts to address Michael's recommendations in pull request #6018 .

This was something we have been manually fixing each release of Ansible (we rotate syslog.log on HP-UX).  This will ensure setup gets the **memtotal_mb** fact when running witih --sudo.
