### PR TITLE
Make `vpc_security_group` docs more accurate

### DIFF
--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -125,7 +125,7 @@ options:
     aliases: []
   vpc_security_groups:
     description:
-      - Comma separated list of one or more vpc security groups. Used only when command=create or command=modify.
+      - Comma separated list of one or more vpc security group ids. Also requires `subnet` to be specified. Used only when command=create or command=modify.
     required: false
     default: null
     aliases: []


### PR DESCRIPTION
Without the `subnet` parameter supplied there's an error `msg: Parameter vpc_security_groups invalid for create command`. (This might be a bug?)

If the VPC security group name rather than ID is supplied there's an error: `msg: Invalid security group , groupId= <some group name>, groupName=.` (Accepting a group name might be a feature enhancement.)

In my case I set the subnet as `default` and used `register` to get the result of the security group creation section and just referred to its `group_id` property.
