### PR TITLE
Remove extra quote from the mysqldump password argument

### DIFF
--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -124,7 +124,7 @@ def db_delete(cursor, db):
 
 def db_dump(module, host, user, password, db_name, target, port, socket=None):
     cmd = module.get_bin_path('mysqldump', True)
-    cmd += " --quick --user=%s --password='%s'" % (pipes.quote(user), pipes.quote(password))
+    cmd += " --quick --user=%s --password=%s" % (pipes.quote(user), pipes.quote(password))
     if socket is not None:
         cmd += " --socket=%s" % pipes.quote(socket)
     else:
@@ -141,7 +141,7 @@ def db_dump(module, host, user, password, db_name, target, port, socket=None):
 
 def db_import(module, host, user, password, db_name, target, port, socket=None):
     cmd = module.get_bin_path('mysql', True)
-    cmd += " --user=%s --password='%s'" % (pipes.quote(user), pipes.quote(password))
+    cmd += " --user=%s --password=%s" % (pipes.quote(user), pipes.quote(password))
     if socket is not None:
         cmd += " --socket=%s" % pipes.quote(socket)
     else:


### PR DESCRIPTION
For complex passwords, the mysqldb Ansible module will fail for database imports or dumps with a '1045: Access Denied' mysql error even though the credentials work properly and the mysqldump command can be run manually.

This is caused by the extra quote around the '--password' argument to mysqldump, as pipes.quotes already quotes the password string.

> > > "--password='%s'" % pipes.quote('simple')
> > > "--password='simple'"
> > > 
> > > "--password='%s'" % pipes.quote('c0mplexp@ssword!')
> > > "--password=''c0mplexp@ssword!''"
> > > 
> > > "--password='%s'" % pipes.quote('password with space')
> > > "--password=''password with space''"
