### PR TITLE
Clarify the port value always defaults to 3306

### DIFF
--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -131,7 +131,7 @@ options:
     aliases: []
   port:
     description:
-      - Port number that the DB instance uses for connections.  Defaults to 3306 for mysql, 1521 for Oracle, 1443 for SQL Server. Used only when command=create or command=replicate.
+      - Port number that the DB instance uses for connections.  Defaults to 3306 for mysql. Must be changed to 1521 for Oracle, 1443 for SQL Server, 5432 for PostgreSQL. Used only when command=create or command=replicate.
     required: false
     default: null
     aliases: []


### PR DESCRIPTION
While the [boto docs](https://github.com/boto/boto/blob/develop/boto/rds/__init__.py#L253) make it seem like the default value of `port` is changed depending on the engine chosen, AFAICT from looking at the code the default value is never changed from 3306.

I think the docs are intended to be read as "the default value used by [engine] is [port] so you should change `port` to that value".

If you don't specify the port value and chose the database engine as PostgreSQL you'll end up with a PostgreSQL instance running on port 3306.
