### PR TITLE
The open_iscsi module fails if no active sessions.

### DIFF
--- a/library/system/open_iscsi
+++ b/library/system/open_iscsi
@@ -162,6 +162,8 @@ def target_loggedon(module, target):
     
     if rc == 0:
         return target in out
+    elif rc == 21 and err.find("No active sessions") != -1:
+        return False
     else:
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 


### PR DESCRIPTION
The open_iscsi module does a test for "logged on" status prior to logging in a configured target.  The target_loggedon test will always fail if there is not at least one existing iSCSI connection active, because in the absence of any sessions, iscsiadm returns error 21 and the module fails.  On newly-built machines, it is therefore impossible to connect to iSCSI targets because there aren't any sessions (a catch-22).
