### PR TITLE
redhat_subscription calls AnsibleModule() without argument_spec

### DIFF
--- a/library/packaging/redhat_subscription
+++ b/library/packaging/redhat_subscription
@@ -327,7 +327,7 @@ class RhsmPools(object):
 def main():
 
     # Load RHSM configuration from file
-    rhn = Rhsm(AnsibleModule())
+    rhn = Rhsm(None)
 
     module = AnsibleModule(
                 argument_spec = dict(


### PR DESCRIPTION
The Rhsm object requires an AnsibleModule but it isn't created with an argument_spec and fails.  Since the rhn.module is set directly after, setting None for the required argument of Rhsm fixes the module.
