### PR TITLE
Fix interpreter lines in a couple of modules

### DIFF
--- a/library/cloud/docker_image
+++ b/library/cloud/docker_image
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 
 # (c) 2014, Pavel Antonov <antonov@adwz.ru>

--- a/library/database/riak
+++ b/library/database/riak
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, James Martin <jmartin@basho.com>, Drew Kerrigan <dkerrigan@basho.com>


### PR DESCRIPTION
The `riak` and `docker_image` modules, both use `#!/usr/bin/env python` instead of `#!/usr/bin/python`

This pull request updates them to the proper values so that `ansible_python_interpreter` will work as expected
