### PR TITLE
debconf to support 'error' vtype

### DIFF
--- a/library/system/debconf
+++ b/library/system/debconf
@@ -52,7 +52,7 @@ options:
       - The type of the value supplied
     required: false
     default: null
-    choices: [string, boolean, select, multiselect, note, text, password, title]
+    choices: [string, boolean, select, multiselect, note, text, password, title, error]
     aliases: []
   value:
     description:
@@ -119,7 +119,7 @@ def main():
         argument_spec = dict(
            name = dict(required=True, aliases=['pkg'], type='str'),
            question = dict(required=False, aliases=['setting', 'selection'], type='str'),
-           vtype = dict(required=False, type='str', choices=['string', 'boolean', 'select',  'multiselect', 'note', 'text', 'password', 'title']),
+           vtype = dict(required=False, type='str', choices=['string', 'boolean', 'select',  'multiselect', 'note', 'text', 'password', 'title', 'error']),
            value= dict(required=False, type='str'),
            unseen = dict(required=False, type='bool'),
         ),


### PR DESCRIPTION
http://manpages.ubuntu.com/manpages/quantal/man7/debconf-devel.7.html defines the 'error' type, which I've needed. Not sure why it isn't defined at http://www.debian.org/doc/packaging-manuals/debconf_specification.html

@bcoca FYI, as you are the original author.
