### PR TITLE
debconf may always reassert passwords

### DIFF
--- a/library/system/debconf
+++ b/library/system/debconf
@@ -34,6 +34,8 @@ notes:
     - A number of questions have to be answered (depending on the package).
       Use 'debconf-show <package>' on any Debian or derivative with the package
       installed to see questions/settings available.
+    - One some distros passwords will also be reasserted. This is due to
+      debconf-get-selections masking passwords.
 options:
   name:
     description:

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -34,8 +34,7 @@ notes:
     - A number of questions have to be answered (depending on the package).
       Use 'debconf-show <package>' on any Debian or derivative with the package
       installed to see questions/settings available.
-    - One some distros passwords will also be reasserted. This is due to
-      debconf-get-selections masking passwords.
+    - Some distros will always record tasks involving the setting of passwords as changed. This is due to debconf-get-selections masking passwords.
 options:
   name:
     description:


### PR DESCRIPTION
On some versions of Ubuntu debconf-get-selections hides the passwords, even when run as root. This means the debconf module believes the password isn't set correctly.

Make this clear in the documentation

@bcoca FYI as the original author
