### PR TITLE
Allow 'make rpm' work from a release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,5 @@ include packaging/distutils/setup.py
 recursive-include docs *
 recursive-include library *
 include Makefile
+include VERSION
+include MANIFEST.in


### PR DESCRIPTION
`make rpm` cannot be run from a release tarball because the release tarball is missing the `VERSION` and `MANIFEST.in` files.

I am unsure if this is intended, but this is a somewhat simple pull request to have `MANIFEST.in` include `VERSION` and itself, so that `make rpm` will work.
