### PR TITLE
debconf correctly quote strings

### DIFF
--- a/library/system/debconf
+++ b/library/system/debconf
@@ -107,7 +107,7 @@ def set_selection(module, pkg, question, vtype, value, unseen):
     data = ' '.join([ question, vtype, value ])
 
     setsel = module.get_bin_path('debconf-set-selections', True)
-    cmd = ["echo '%s %s' |" % (pipes.quote(pkg), pipes.quote(data)), setsel]
+    cmd = ["echo %s %s |" % (pipes.quote(pkg), pipes.quote(data)), setsel]
     if unseen:
         cmd.append('-u')
 


### PR DESCRIPTION
Fix https://github.com/ansible/ansible/issues/6819

Tested with:

value='foo2'
value="this shouldn't error"
value='foo2 ; foo3'

Looking at this code I also wonder if https://github.com/ansible/ansible/commit/4e8b97ddeb2fee56cd0a39f7ea1b7eac2c1ba519#diff-f4ae1d864fb6fcbee414ddfa4cfe9a38R355 might have issues double quoting strings?
