### PR TITLE
Add '--list-groups' flag and support to ansible & ansible_playbook

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -61,6 +61,8 @@ class Cli(object):
         parser.add_option('-m', '--module-name', dest='module_name',
             help="module name to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
             default=C.DEFAULT_MODULE_NAME)
+        parser.add_option('--list-groups', dest='listgroups', action='store_true',
+            help='outputs a list of groups; does not execute anything else')
 
         options, args = parser.parse_args()
         self.callbacks.options = options
@@ -147,6 +149,11 @@ class Cli(object):
         if options.listhosts:
             for host in hosts:
                 callbacks.display('    %s' % host)
+            sys.exit(0)
+
+        if options.listgroups:
+            for group in inventory_manager.list_groups():
+                callbacks.display('    %s' % group)
             sys.exit(0)
 
         if ((options.module_name == 'command' or options.module_name == 'shell')

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -80,6 +80,9 @@ def main(args):
         help="start the playbook at the task matching this name")
     parser.add_option('--force-handlers', dest='force_handlers', action='store_true',
         help="run handlers even if a task fails")
+    parser.add_option('--list-all-groups', dest='listgroups', action='store_true',
+        help='outputs a list of groups available in the given inventory; does '
+             'not execute anything else')
 
     options, args = parser.parse_args(args)
 
@@ -101,6 +104,11 @@ def main(args):
     inventory.subset(options.subset)
     if len(inventory.list_hosts()) == 0:
         raise errors.AnsibleError("provided hosts list is empty")
+
+    if options.listgroups:
+        for group in inventory.list_groups():
+            callbacks.display('    %s' % group)
+        sys.exit(0)
 
     sshpass = None
     sudopass = None


### PR DESCRIPTION
We implemented this in our own scripts, turned out to be really useful for _our_ dynamic inventory scripts -- not so useful for really flat orgs, with maybe one/two groups, but, you know, it does what it says it does.  It lists groups.  :)
