### PR TITLE
Fix several changed tests in ec2 auto scaling related modules

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -157,11 +157,18 @@ def create_autoscaling_group(connection, module):
     else:
         as_group = as_groups[0]
         changed = False
-        for attr in ('launch_config_name', 'max_size', 'min_size', 'desired_capacity',
+        for attr in ('launch_config_name', 'max_size', 'min_size',
                      'vpc_zone_identifier'):
-            if getattr(as_group, attr) != module.params.get(attr):
+            if getattr(as_group, attr) != module.params[attr]:
                 changed = True
                 setattr(as_group, attr, module.params.get(attr))
+        # handle desired_capacity separately, so that we can leave the option
+        # unset, and thus do not disrupt the auto scaling group
+        desired_capacity = module.params.get('desired_capacity')
+        if desired_capacity is not None:
+            if as_group.desired_capacity != desired_capacity:
+                changed = True
+                as_group.desired_capacity = desired_capacity
         # handle availability zones separately as the orders can be different
         if sorted(as_group.availability_zones) != sorted(availability_zones):
             changed = True

--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -158,10 +158,14 @@ def create_autoscaling_group(connection, module):
         as_group = as_groups[0]
         changed = False
         for attr in ('launch_config_name', 'max_size', 'min_size', 'desired_capacity',
-                     'vpc_zone_identifier', 'availability_zones'):
+                     'vpc_zone_identifier'):
             if getattr(as_group, attr) != module.params.get(attr):
                 changed = True
                 setattr(as_group, attr, module.params.get(attr))
+        # handle availability zones separately as the orders can be different
+        if sorted(as_group.availability_zones) != sorted(availability_zones):
+            changed = True
+            as_group.availability_zones = availability_zones
         # handle loadbalancers separately because None != []
         load_balancers = module.params.get('load_balancers') or []
         if as_group.load_balancers != load_balancers:

--- a/library/cloud/ec2_metric_alarm
+++ b/library/cloud/ec2_metric_alarm
@@ -175,10 +175,16 @@ def create_metric_alarm(connection, module):
         alarm = alarms[0]
         changed = False
 
-        for attr in ('comparison','metric','namespace','statistic','threshold','period','evaluation_periods','unit','description'):
+        for attr in ('comparison','metric','namespace','statistic','threshold','period','evaluation_periods','unit'):
             if getattr(alarm, attr) != module.params.get(attr):
                 changed = True
                 setattr(alarm, attr, module.params.get(attr))
+        # If not set, description would be empty string instead of None
+        description = module.params.get('description') or ''
+        if alarm.description != description:
+            changed = True
+            alarm.description = description
+
         #this is to deal with a current bug where you cannot assign '<=>' to the comparator when modifying an existing alarm
         comparison = alarm.comparison
         comparisons = {'<=' : 'LessThanOrEqualToThreshold', '<' : 'LessThanThreshold', '>=' : 'GreaterThanOrEqualToThreshold', '>' : 'GreaterThanThreshold'}

--- a/library/cloud/ec2_metric_alarm
+++ b/library/cloud/ec2_metric_alarm
@@ -192,13 +192,21 @@ def create_metric_alarm(connection, module):
 
         dim1 = module.params.get('dimensions')
         dim2 = alarm.dimensions
-        
-        for keys in dim1:
-            if not isinstance(dim1[keys], list):
-                dim1[keys] = [dim1[keys]]
-            if dim1[keys] != dim2[keys]:
-                changed=True
-                setattr(alarm, 'dimensions', dim1)        
+        dim_changed = False
+
+        if dim1.keys() != dim2.keys():
+            dim_changed = True
+        else:
+            for key, value in dim1.items():
+                if not isinstance(value, list):
+                    dim1[key] = [value]
+                if dim1[key] != dim2[key]:
+                    dim_changed=True
+                    break
+
+        if dim_changed:
+            changed = True
+            alarm.dimensions = dim1
 
         for attr in ('alarm_actions','insufficient_data_actions','ok_actions'): 
             action = module.params.get(attr) or []


### PR DESCRIPTION
Currently, the ec2_asg and ec2_metric_alarm modules do not handle `"changed": true/false` correctly in certain situations:
- ec2_asg: the availability zones returned by AWS/boto can have different order than the availability zones passed in, e.g. `['ap-southeast-1b', 'ap-southeast-1a']` versus `['ap-southeast-1a', 'ap-southeast-1b']`
- ec2_metric_alarm: if not set, the description returned by AWS/boto would somehow be empty string instead of null
- ec2_metric_alarm: if the existing dimensions and the new dimensions have different keys, ansible can crash
- ec2_asg: if desired_capacity is not passed in, we shouldn't set changed to true
