### PR TITLE
ec2_scaling_policy: Always return ARN when creating/updating a policy.

### DIFF
--- a/library/cloud/ec2_scaling_policy
+++ b/library/cloud/ec2_scaling_policy
@@ -90,8 +90,8 @@ def create_scaling_policy(connection, module):
             cooldown=cooldown)
 
         try:
-            connection.create_scaling_policy(sp)
-            module.exit_json(changed=True)
+            req = connection.create_scaling_policy(sp)
+            module.exit_json(changed=True, arn=req.PolicyARN)
         except BotoServerError, e:
             module.fail_json(msg=str(e))
     else:
@@ -116,9 +116,7 @@ def create_scaling_policy(connection, module):
         try:
             if changed:
                 connection.create_scaling_policy(policy)
-                policy = connection.get_all_policies(policy_names=[sp_name])[0]
-                module.exit_json(changed=changed, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment, cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
-            module.exit_json(changed=changed)
+            module.exit_json(changed=changed, arn=policy.policy_arn)
         except BotoServerError, e:
             module.fail_json(msg=str(e))
 
@@ -134,7 +132,7 @@ def delete_scaling_policy(connection, module):
             connection.delete_policy(sp_name, asg_name)
             module.exit_json(changed=True)
         except BotoServerError, e:
-            module.exit_json(changed=False, msg=str(e))
+            module.fail_json(msg=str(e))
     else:
         module.exit_json(changed=False)
 


### PR DESCRIPTION
This includes scenario where the policy remains unchanged, as the ARN could be
needed by subsequent tasks (e.g. putting metric alarm).

The other return values can be inferred by the caller, so I have removed them.

Also change to call `fail_json` when there is an error with policy delete.
