### PR TITLE
Fix a typo in the subversion module documentation

### DIFF
--- a/library/source_control/subversion
+++ b/library/source_control/subversion
@@ -27,7 +27,7 @@ description:
 version_added: "0.7"
 author: Dane Summers, njharman@gmail.com
 notes:
-   - Requres I(svn) to be installed on the client.
+   - Requires I(svn) to be installed on the client.
 requirements: []
 options:
   repo:


### PR DESCRIPTION
Just added a missing letter
