### PR TITLE
Don't disable GSSAPIAuthentication or PubkeyAuthentication when using --ask-pass

### DIFF
--- a/v1/ansible/runner/connection_plugins/ssh.py
+++ b/v1/ansible/runner/connection_plugins/ssh.py
@@ -91,10 +91,7 @@ class Connection(object):
             self.common_args += ["-o", "IdentityFile=\"%s\"" % os.path.expanduser(self.private_key_file)]
         elif self.runner.private_key_file is not None:
             self.common_args += ["-o", "IdentityFile=\"%s\"" % os.path.expanduser(self.runner.private_key_file)]
-        if self.password:
-            self.common_args += ["-o", "GSSAPIAuthentication=no",
-                                 "-o", "PubkeyAuthentication=no"]
-        else:
+        if not self.password:
             self.common_args += ["-o", "KbdInteractiveAuthentication=no",
                                  "-o", "PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey",
                                  "-o", "PasswordAuthentication=no"]


### PR DESCRIPTION
As requested on irc, here's the output of ansible-playbook -vvvv with one echo on a delegate_to host and one on the main host.  The password on the delegated host is different from the one I provided on the command line, so it had to use the pubkey, and the main host doesn't have a pubkey on it yet, so it had to use the password.

TASK: [createvm | echo on delegated host] ****************************************
<delegate.example.net> ESTABLISH CONNECTION FOR USER: ansible
<delegate.example.net> REMOTE_MODULE command echo "This is on the delegated host"
<delegate.example.net> EXEC ['sshpass', '-d14', 'ssh', '-C', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ForwardAgent=yes', '-o', 'ControlPath=/home/jon/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'User=ansible', '-o', 'ConnectTimeout=10', u'delegate.example.net', '/bin/sh -c /usr/bin/python']
changed: [main.example.net] => {"changed": true, "cmd": ["echo", "This is on the delegated host"], "delta": "0:00:00.001584", "end": "2014-04-03 13:19:35.184026", "item": "", "rc": 0, "start": "2014-04-03 13:19:35.182442", "stderr": "", "stdout": "This is on the delegated host"}

TASK: [bootstrap | echo on main host] *****************************************
<main.example.net> ESTABLISH CONNECTION FOR USER: root
<main.example.net> REMOTE_MODULE command echo "This is on the main host"
<main.example.net> EXEC ['sshpass', '-d9', 'ssh', '-C', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ForwardAgent=yes', '-o', 'ControlPath=/home/jon/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'User=root', '-o', 'ConnectTimeout=10', u'main.example.net', '/bin/sh -c /usr/bin/python']
changed: [main.example.net] => {"changed": true, "cmd": ["echo", "This is on the main host"], "delta": "0:00:00.001749", "end": "2014-04-03 13:19:42.459113", "item": "", "rc": 0, "start": "2014-04-03 13:19:42.457364", "stderr": "", "stdout": "This is on the main host"}
