### PR TITLE
Update apt:deb with correct version

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -92,7 +92,7 @@ options:
      description:
        - Path to a local .deb package file to install.
      required: false
-     version_added: "1.5"
+     version_added: "1.6"
 requirements: [ python-apt, aptitude ]
 author: Matthew Williams
 notes:


### PR DESCRIPTION
The docs site says this option is available in 1.5, but it is not.  
#5910 added the deb option.  The PR was generated two months ago (before 1.5) but was not included until after 1.5 was released.  This fixes the docs.
