### PR TITLE
lvg module bugfix on vg_options patch

### DIFF
--- a/library/system/lvg
+++ b/library/system/lvg
@@ -105,7 +105,7 @@ def main():
             vg=dict(required=True),
             pvs=dict(type='list'),
             pesize=dict(type='int', default=4),
-            vg_options=dict(),
+            vg_options=dict(default=''),
             state=dict(choices=["absent", "present"], default='present'),
             force=dict(type='bool', default='no'),
         ),
@@ -116,7 +116,7 @@ def main():
     state = module.params['state']
     force = module.boolean(module.params['force'])
     pesize = module.params['pesize']
-    vgoptions = module.params.get('vg_options', '').split()
+    vgoptions = module.params['vg_options'].split()
 
     if module.params['pvs']:
         dev_string = ' '.join(module.params['pvs'])


### PR DESCRIPTION
When no vg_options are passed to the module, 'vg_options' still exists
in the module.params dict with a value of None, so the default empty string in
the get method is never used. None cannot be "splitted", which backtraced.
