### PR TITLE
Module rax_clb_nodes: Allow respecification of a node without requiring node_id. Fixes #5401

### DIFF
--- a/library/cloud/rax_clb_nodes
+++ b/library/cloud/rax_clb_nodes
@@ -137,19 +137,18 @@ def _activate_virtualenv(path):
 
 def _get_node(lb, node_id=None, address=None, port=None):
     """Return a matching node"""
-    searches = {
-        'id': node_id,
-        'address': address,
-        'port': port
-    }
-
     for node in getattr(lb, 'nodes', []):
-        try:
-            if all(getattr(node, attr) == value
-                   for (attr, value) in searches.items() if value is not None):
-                return node
-        except AttributeError:
-            continue
+        match_list = []
+        if node_id is not None:
+            match_list.append(getattr(node, 'id', None) == node_id)
+        if address is not None:
+            match_list.append(getattr(node, 'address', None) == address)
+        if port is not None:
+            match_list.append(getattr(node, 'port', None) == port)
+
+        if match_list and all(match_list):
+            return node
+
     return None
 
 

--- a/library/cloud/rax_clb_nodes
+++ b/library/cloud/rax_clb_nodes
@@ -135,11 +135,21 @@ def _activate_virtualenv(path):
     execfile(activate_this, dict(__file__=activate_this))
 
 
-def _get_node(lb, node_id):
-    """Return a node with the given `node_id`"""
-    for node in lb.nodes:
-        if node.id == node_id:
-            return node
+def _get_node(lb, node_id=None, address=None, port=None):
+    """Return a matching node"""
+    searches = {
+        'id': node_id,
+        'address': address,
+        'port': port
+    }
+
+    for node in getattr(lb, 'nodes', []):
+        try:
+            if all(getattr(node, attr) == value
+                   for (attr, value) in searches.items() if value is not None):
+                return node
+        except AttributeError:
+            continue
     return None
 
 
@@ -230,10 +240,7 @@ def main():
     except pyrax.exc.PyraxException, e:
         module.fail_json(msg='%s' % e.message)
 
-    if node_id:
-        node = _get_node(lb, node_id)
-    else:
-        node = None
+    node = _get_node(lb, node_id, address, port)
 
     result = _node_to_dict(node)
 
@@ -272,21 +279,11 @@ def main():
                 except pyrax.exc.PyraxException, e:
                     module.fail_json(msg='%s' % e.message)
         else:  # Updating an existing node
-            immutable = {
-                'address': address,
-                'port': port,
-            }
-
             mutable = {
                 'condition': condition,
                 'type': typ,
                 'weight': weight,
             }
-
-            for name, value in immutable.items():
-                if value:
-                    module.fail_json(
-                        msg='Attribute %s cannot be modified' % name)
 
             for name, value in mutable.items():
                 if value is None or value == getattr(node, name):


### PR DESCRIPTION
This pull request addresses #5401

Previously not specifying `node_id` would cause an error of "Duplicate nodes detected. One or more nodes already configured on load balancer."

This pull request allows node matching by any of node_id, address and port.

Test play:

```
- hosts: localhost
  gather_facts: False
  tasks:
    - name: Server build requests
      local_action:
        module: rax
        credentials: ~/.raxpub
        name: test
        flavor: performance1-1
        image: ubuntu-1204-lts-precise-pangolin
        region: ORD
        state: present
        wait: yes
      register: rax

    - name: Provision Load Balancer
      local_action:
        module: rax_clb
        credentials: ~/.raxpub
        name: my-lb
        port: 8080
        protocol: HTTP
        type: PUBLIC
        timeout: 30
        region: ORD
        wait: yes
        state: present
        meta:
          foo: baz
      register: clb

    - name: Add servers to Load balancer
      local_action:
        module: rax_clb_nodes
        credentials: ~/.raxpub
        load_balancer_id: "{{ clb.balancer.id }}"
        address: "{{ item.rax_networks.private|first }}"
        port: 80
        condition: enabled
        type: primary
        wait: yes
        region: ORD
      with_items: rax.instances
```
