### PR TITLE
Add check mode support for non-python modules

### DIFF
--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -296,10 +296,12 @@ mode, your module will simply be skipped.
 To support check mode in non-python modules, insert a '#SUPPORTS_CHECK_MODE=True' in your source.
 The module argument CHECKMODE will be 'True' when check mode is enabled. For example::
 
+    #!/bin/bash
     #SUPPORTS_CHECK_MODE=True
-    #INCLUDE_BASH_HELPER --args 'somearg1 somearg2 CHECKMODE'
+    ... Parse args file, will contain 'CHECKMODE=True' if in check mode ...
     if [ "$CHECKMODE" = 'True' ]; then
-        ...
+       # Test and flag if changes are needed, but *don't* modify anything!
+       echo "ok=true changed=true"
 
 .. _module_dev_pitfalls:
 

--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -291,6 +291,16 @@ system state is altered when the user enables check mode.
 If your module does not support check mode, when the user runs Ansible in check
 mode, your module will simply be skipped.
 
+.. versionadded:: 1.6
+
+To support check mode in non-python modules, insert a '#SUPPORTS_CHECK_MODE=True' in your source.
+The module argument CHECKMODE will be 'True' when check mode is enabled. For example::
+
+    #SUPPORTS_CHECK_MODE=True
+    #INCLUDE_BASH_HELPER --args 'somearg1 somearg2 CHECKMODE'
+    if [ "$CHECKMODE" = 'True' ]; then
+        ...
+
 .. _module_dev_pitfalls:
 
 Common Pitfalls

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -105,7 +105,7 @@ def boilerplate_module(modfile, args, interpreter):
         if not interpreter_type.endswith('_interpreter'):
             interpreter_type = '%s_interpreter' % interpreter_type
         inject[interpreter_type] = interpreter_path
-    (module_data, module_style, shebang) = replacer.modify_module(
+    (module_data, module_style, shebang, module_checkable) = replacer.modify_module(
         modfile, 
         complex_args,
         args,

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -20,6 +20,7 @@ from cStringIO import StringIO
 import inspect
 import os
 import shlex
+import collections
 
 # from Ansible
 from ansible import errors
@@ -170,5 +171,5 @@ class ModuleReplacer(object):
                     lines[0] = shebang = "#!%s %s" % (inject[interpreter_config], " ".join(args[1:]))
                     module_data = "\n".join(lines)
 
-            return (module_data, module_style, shebang, module_checkable)
+            return (collections.namedtuple('ModuleInfo', ('data', 'style', 'shebang', 'checkable'))(module_data, module_style, shebang, module_checkable))
 

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -30,6 +30,7 @@ REPLACER = "#<<INCLUDE_ANSIBLE_MODULE_COMMON>>"
 REPLACER_ARGS = "\"<<INCLUDE_ANSIBLE_MODULE_ARGS>>\""
 REPLACER_LANG = "\"<<INCLUDE_ANSIBLE_MODULE_LANG>>\""
 REPLACER_COMPLEX = "\"<<INCLUDE_ANSIBLE_MODULE_COMPLEX_ARGS>>\""
+REPLACER_MODULE_CHECKABLE = '\n#SUPPORTS_CHECK_MODE=True'
 
 class ModuleReplacer(object):
 
@@ -88,6 +89,8 @@ class ModuleReplacer(object):
             module_style = 'new'
         elif 'WANT_JSON' in module_data:
             module_style = 'non_native_want_json'
+
+        module_checkable = REPLACER_MODULE_CHECKABLE in module_data
       
         output = StringIO()
         lines = module_data.split('\n')
@@ -120,7 +123,7 @@ class ModuleReplacer(object):
         if len(snippet_names) > 0 and not 'basic' in snippet_names:
             raise errors.AnsibleError("missing required import in %s: from ansible.module_utils.basic import *" % module_path) 
 
-        return (output.getvalue(), module_style)
+        return (output.getvalue(), module_style, module_checkable)
 
     # ******************************************************************************
 
@@ -131,7 +134,7 @@ class ModuleReplacer(object):
             # read in the module source
             module_data = f.read()
 
-            (module_data, module_style) = self._find_snippet_imports(module_data, module_path)
+            (module_data, module_style, module_checkable) = self._find_snippet_imports(module_data, module_path)
 
             complex_args_json = utils.jsonify(complex_args)
             # We force conversion of module_args to str because module_common calls shlex.split,
@@ -167,5 +170,5 @@ class ModuleReplacer(object):
                     lines[0] = shebang = "#!%s %s" % (inject[interpreter_config], " ".join(args[1:]))
                     module_data = "\n".join(lines)
 
-            return (module_data, module_style, shebang)
+            return (module_data, module_style, shebang, module_checkable)
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -395,7 +395,8 @@ class Runner(object):
         (
         module_style,
         shebang,
-        module_data
+        module_data,
+        module_checkable
         ) = self._configure_module(conn, module_name, args, inject, complex_args)
 
         # a remote tmp path may be necessary and not already created
@@ -422,7 +423,7 @@ class Runner(object):
         cmd = ""
         in_data = None
         if module_style != 'new':
-            if 'CHECKMODE=True' in args:
+            if 'CHECKMODE=True' in args and not module_checkable:
                 # if module isn't using AnsibleModuleCommon infrastructure we can't be certain it knows how to
                 # do --check mode, so to be safe we will not run it.
                 return ReturnData(conn=conn, result=dict(skipped=True, msg="cannot yet run check mode against old-style modules"))
@@ -1053,7 +1054,8 @@ class Runner(object):
         (
         module_style,
         module_shebang,
-        module_data
+        module_data,
+        module_checkable
         ) = self._configure_module(conn, module_name, module_args, inject, complex_args)
         module_remote_path = os.path.join(tmp, module_name)
         
@@ -1073,11 +1075,11 @@ class Runner(object):
 
 
         # insert shared code and arguments into the module
-        (module_data, module_style, module_shebang) = module_replacer.modify_module(
+        (module_data, module_style, module_shebang, module_checkable) = module_replacer.modify_module(
             module_path, complex_args, module_args, inject
         )
 
-        return (module_style, module_shebang, module_data)
+        return (module_style, module_shebang, module_data, module_checkable)
 
 
     # *****************************************************

--- a/test/units/TestModuleUtilsBasic.py
+++ b/test/units/TestModuleUtilsBasic.py
@@ -44,10 +44,10 @@ class TestModuleUtilsBasic(unittest.TestCase):
         os.write(self.tmp_fd, TEST_MODULE_DATA)
 
         # template the module code and eval it
-        module_data, module_style, shebang = ModuleReplacer().modify_module(self.tmp_path, {}, "", {})
+        module_info = ModuleReplacer().modify_module(self.tmp_path, {}, "", {})
 
         d = {}
-        exec(module_data, d, d)
+        exec(module_info.data, d, d)
         self.module = d['get_module']()
 
         # module_utils/basic.py screws with CWD, let's save it and reset


### PR DESCRIPTION
Allows non-python modules to run in check mode.

If a module contains '#SUPPORTS_CHECK_MODE' and check mode is enabled, ansible will call the module even if it's not new-style python. The module will then receive the argument CHECKMODE=True.

Please note this pull request was developed at the same time as my next pull request 'Helper for bash modules'. There's a small reference in the doc to the helper module, so if the two pull requests are not merged at more or less the same time, please ask me to remove the reference. Thanks!
