### PR TITLE
Adding bold to service doc to call up state and enabled.

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -37,8 +37,8 @@ options:
         description:
           - C(started)/C(stopped) are idempotent actions that will not run
             commands unless necessary.  C(restarted) will always bounce the
-            service.  C(reloaded) will always reload. At least one of state
-            and enabled are required.
+            service.  C(reloaded) will always reload. B(At least one of state
+            and enabled are required.)
     sleep:
         required: false
         version_added: "1.3"
@@ -59,8 +59,8 @@ options:
         required: false
         choices: [ "yes", "no" ]
         description:
-        - Whether the service should start on boot. At least one of state and
-          enabled are required.
+        - Whether the service should start on boot. B(At least one of state and
+          enabled are required.)
 
     runlevel:
         required: false


### PR DESCRIPTION
The docs for the service module do not show state and enabled as being required. It is easy to miss that one or both are required in the docs. Making this bold to try to make it stand out more.
