### PR TITLE
Have paramiko use /etc/ssh_known_hosts

### DIFF
--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -147,6 +147,7 @@ class Connection(object):
         self.keyfile = os.path.expanduser("~/.ssh/known_hosts")
 
         if C.HOST_KEY_CHECKING:
+            ssh.load_system_host_keys("/etc/ssh/ssh_known_hosts")
             ssh.load_system_host_keys()
         ssh.set_missing_host_key_policy(MyAddPolicy(self.runner))
 

--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -85,6 +85,10 @@ options:
      - Will create links to the files instead of copying them, you can only use this parameter with 'collectstatic' command
     required: false
     version_added: "1.3"
+  async:
+    description:
+     - Will run the command asyncronously, in "fire and forget" mode.  Use this to start daemon processes.
+    required: false
 notes:
    - I(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the virtualenv parameter is specified.
    - This module will create a virtualenv if the virtualenv parameter is specified and a virtualenv does not already exist at the given location.
@@ -213,6 +217,7 @@ def main():
             skip        = dict(default=None, required=False, type='bool'),
             merge       = dict(default=None, required=False, type='bool'),
             link        = dict(default=None, required=False, type='bool'),
+            async       = dict(default='no', required=False, type='bool'),
         ),
     )
 
@@ -253,6 +258,18 @@ def main():
         if module.params[param]:
             cmd = '%s %s' % (cmd, module.params[param])
 
+    # If we're async, fire and forget...
+    if module.params['async']:
+        rc, stdout, stderr = module.run_command(cmd, cwd=app_path, close_fds=True)
+        if stdout is None:
+            stdout = ''
+        if stderr is None:
+            stderr = ''
+
+        module.exit_json(changed=False, out=stdout, cmd=cmd, app_path=app_path, virtualenv=virtualenv,
+                     settings=module.params['settings'], pythonpath=module.params['pythonpath'])
+
+    # Otherwise validate the output, based on the command
     rc, out, err = module.run_command(cmd, cwd=app_path)
     if rc != 0:
         if command == 'createcachetable' and 'table' in err and 'already exists' in err:


### PR DESCRIPTION
Fixes an issue with a confusing error: "paramiko: The authenticity of host '[host]' can't be established" when ssh on the command line doesn't complain
