### PR TITLE
Document the `ec2` group.

### DIFF
--- a/docsite/rst/intro_dynamic_inventory.rst
+++ b/docsite/rst/intro_dynamic_inventory.rst
@@ -109,6 +109,9 @@ If you are running Ansible from within EC2, internal DNS names and IP addresses 
 
 The EC2 external inventory provides mappings to instances from several groups:
 
+Global
+  All instances are in group ``ec2``.
+
 Instance ID
   These are groups of one since instance IDs are unique.
   e.g.


### PR DESCRIPTION
This group is useful when using multiple inventory sources.
