### PR TITLE
Random filter

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -234,6 +234,27 @@ be used.  The default is ``False``, and if set as ``True`` will use more strict 
 
     {{ sample_version_var | version_compare('1.0', operator='lt', strict=True) }}
 
+.. _random_filter
+
+Random Number Filter
+--------------------------
+
+.. versionadded:: 1.6
+
+To get a random number from 0 to supplied end::
+
+    {{ 59 |random}} * * * * root /script/from/cron
+
+Get a random number from 0 to 100 but in steps of 10::
+
+    {{ 100 |random(step=10) }}  => 70
+
+Get a random number from 1 to 100 but in steps of 10::
+
+    {{ 100 |random(1, 10) }}    => 31
+    {{ 100 |random(start=1, step=10) }}    => 51
+
+
 .. _other_useful_filters:
 
 Other Useful Filters

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -162,7 +162,7 @@ class Connection(object):
                 if stdout.endswith("%s\r\n%s" % (incorrect_password, prompt)):
                     raise errors.AnsibleError('Incorrect sudo password')
 
-            if self.runner.su and su and self.runner.sudo_pass:
+            if self.runner.su and su and self.runner.su_pass:
                 incorrect_password = gettext.dgettext(
                     "su", "Sorry")
                 if stdout.endswith("%s\r\n%s" % (incorrect_password, prompt)):

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -27,6 +27,7 @@ import operator as py_operator
 from ansible import errors
 from ansible.utils import md5s
 from distutils.version import LooseVersion, StrictVersion
+from random import SystemRandom
 
 def to_nice_yaml(*a, **kw):
     '''Make verbose, human readable yaml'''
@@ -180,6 +181,10 @@ def version_compare(value, version, operator='eq', strict=False):
     except Exception, e:
         raise errors.AnsibleFilterError('Version comparison: %s' % e)
 
+def rand(end, start=0, step=1):
+    r = SystemRandom()
+    return r.randrange(start, end, step)
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -245,5 +250,8 @@ class FilterModule(object):
 
             # version comparison
             'version_compare': version_compare,
+
+            # random numbers
+            'random': rand,
         }
 


### PR DESCRIPTION
returns a random int using the filtered input as the top/end/stop.

```
{{ 59|random}} * * * * /cron/script
```

optionally it takes a start (0 is default) and a step (1 is default)

```
{{ 100|random(10, 2)
```

only even numbers from 10-100
