### PR TITLE
Added support for VPC subnets

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/aws.py
+++ b/lib/ansible/utils/module_docs_fragments/aws.py
@@ -1,0 +1,76 @@
+# (c) 2014, Will Thames <will@thames.id.au>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # AWS only documentation fragment
+    DOCUMENTATION = """
+options:
+  ec2_url:
+    description:
+      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints).  Must be specified if region is not used. If not set then the value of the EC2_URL environment variable, if any, is used
+    required: false
+    default: null
+    aliases: []
+  aws_secret_key:
+    description:
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
+    required: false
+    default: null
+    aliases: [ 'ec2_secret_key', 'secret_key' ]
+  aws_access_key:
+    description:
+      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
+    required: false
+    default: null
+    aliases: [ 'ec2_access_key', 'access_key' ]
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
+  profile:
+    description:
+      - uses a boto profile. Only works with boto >= 2.24.0
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.6"
+  security_token:
+    description:
+      - security token to authenticate against AWS
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.6"
+requirements:
+  - boto
+notes:
+  - The following environment variables can be used C(AWS_ACCESS_KEY) or 
+    C(EC2_ACCESS_KEY) or C(AWS_ACCESS_KEY_ID),
+    C(AWS_SECRET_KEY) or C(EC2_SECRET_KEY) or C(AWS_SECRET_ACCESS_KEY), 
+    C(AWS_REGION) or C(EC2_REGION), C(AWS_SECURITY_TOKEN)
+  - Ansible uses the boto configuration file (typically ~/.boto) if no
+    credentials are provided. See http://boto.readthedocs.org/en/latest/boto_config_tut.html 
+  - C(AWS_REGION) or C(EC2_REGION) can be typically be used to specify the 
+    AWS region, when required, but
+    this can also be configured in the boto config file
+"""

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -110,24 +110,6 @@ options:
       - how long to wait for the spot instance request to be fulfilled
     default: 600
     aliases: []
-  ec2_url:
-    description:
-      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints).  Must be specified if region is not used. If not set then the value of the EC2_URL environment variable, if any, is used
-    required: false
-    default: null
-    aliases: []
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
-    required: false
-    default: null
-    aliases: [ 'ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ 'ec2_access_key', 'access_key' ]
   count:
     description:
       - number of instances to launch
@@ -237,31 +219,9 @@ options:
     required: false
     default: null
     aliases: []
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
-  profile:
-    description:
-      - uses a boto profile. Only works with boto >= 2.24.0
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
-  security_token:
-    description:
-      - security token to authenticate against AWS
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
 
-requirements: [ "boto" ]
 author: Seth Vidal, Tim Gerla, Lester Wade
+extends_documentation_fragment: aws
 '''
 
 EXAMPLES = '''

--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -22,24 +22,6 @@ short_description: create or destroy an image in ec2, return imageid
 description:
      - Creates or deletes ec2 images. This module has a dependency on python-boto >= 2.5
 options:
-  ec2_url:
-    description:
-      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints).  Must be specified if region is not used. If not set then the value of the EC2_URL environment variable, if any, is used
-    required: false
-    default: null
-    aliases: []
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
-    required: false
-    default: null
-    aliases: [ 'ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: ['ec2_access_key', 'access_key' ]
   instance_id:
     description:
       - instance id of the image to create
@@ -101,31 +83,9 @@ options:
     required: false
     default: null
     aliases: []
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
-  profile:
-    description:
-      - uses a boto profile. Only works with boto >= 2.24.0
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
-  security_token:
-    description:
-      - security token to authenticate against AWS
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
 
-requirements: [ "boto" ]
 author: Evan Duffield <eduffield@iacquire.com>
+extends_documentation_fragment: aws
 '''
 
 # Thank you to iAcquire for sponsoring development of this module.

--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -22,7 +22,6 @@ description:
   - Can create or delete AWS Autoscaling Groups
   - Works with the ec2_lc module to manage Launch Configurations
 version_added: "1.6"
-requirements: [ "boto" ]
 author: Gareth Rushgrove
 options:
   state:
@@ -58,18 +57,6 @@ options:
     description:
       - Desired number of instances in group
     required: false
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
-    required: false
-    default: None
-    aliases: ['ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: None
-    aliases: ['ec2_access_key', 'access_key' ]
   region:
     description:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
@@ -80,6 +67,7 @@ options:
       - List of VPC subnets to use
     required: false
     default: None
+extends_documentation_fragment: aws
 """
 
 EXAMPLES = '''

--- a/library/cloud/ec2_eip
+++ b/library/cloud/ec2_eip
@@ -23,24 +23,6 @@ options:
     required: false
     choices: ['present', 'absent']
     default: present
-  ec2_url:
-    description:
-      - URL to use to connect to EC2-compatible cloud (by default the module will use EC2 endpoints)
-    required: false
-    default: null
-    aliases: [ EC2_URL ]
-  ec2_access_key:
-    description:
-      - EC2 access key. If not specified then the EC2_ACCESS_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ EC2_ACCESS_KEY ]
-  ec2_secret_key:
-    description:
-      - EC2 secret key. If not specified then the EC2_SECRET_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ EC2_SECRET_KEY ]
   region:
     description:
       - the EC2 region to use
@@ -53,28 +35,6 @@ options:
     required: false
     default: false
     version_added: "1.4"
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
-  profile:
-    description:
-      - uses a boto profile. Only works with boto >= 2.24.0
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
-  security_token:
-    description:
-      - security token to authenticate against AWS
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
   reuse_existing_ip_allowed:
     description:
       - Reuse an EIP that is not associated to an instance (when available), instead of allocating a new one.
@@ -82,7 +42,7 @@ options:
     default: false
     version_added: "1.6"
 
-requirements: [ "boto" ]
+extends_documentation_fragment: aws
 author: Lorin Hochstein <lorin@nimbisservices.com>
 notes:
    - This module will return C(public_ip) on success, which will contain the

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -25,7 +25,6 @@ description:
     if state=absent is passed as an argument.
   - Will be marked changed when called only if there are ELBs found to operate on.
 version_added: "1.2"
-requirements: [ "boto" ]
 author: John Jarvis
 options:
   state:
@@ -33,29 +32,15 @@ options:
       - register or deregister the instance
     required: true
     choices: ['present', 'absent']
-
   instance_id:
     description:
       - EC2 Instance ID
     required: true
-
   ec2_elbs:
     description:
       - List of ELB names, required for registration. The ec2_elbs fact should be used if there was a previous de-register.
     required: false
     default: None
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
-    required: false
-    default: None
-    aliases: ['ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: None
-    aliases: ['ec2_access_key', 'access_key' ]
   region:
     description:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
@@ -88,7 +73,7 @@ options:
     required: false
     default: 0
     version_added: "1.6"
-
+extends_documentation_fragment: aws
 """
 
 EXAMPLES = """
@@ -130,12 +115,11 @@ class ElbManager:
     """Handles EC2 instance ELB registration and de-registration"""
 
     def __init__(self, module, instance_id=None, ec2_elbs=None,
-                 aws_access_key=None, aws_secret_key=None, region=None):
-        self.aws_access_key = aws_access_key
-        self.aws_secret_key = aws_secret_key
+                 region=None, **aws_connect_params):
         self.module = module
         self.instance_id = instance_id
         self.region = region
+        self.aws_connect_params = aws_connect_params
         self.lbs = self._get_instance_lbs(ec2_elbs)
         self.changed = False
 
@@ -270,9 +254,8 @@ class ElbManager:
                   are attached to self.instance_id"""
 
         try:
-            endpoint="elasticloadbalancing.%s.amazonaws.com" % self.region
-            connect_region = RegionInfo(name=self.region, endpoint=endpoint)
-            elb = boto.ec2.elb.ELBConnection(self.aws_access_key, self.aws_secret_key, region=connect_region)
+            elb = connect_to_aws(boto.ec2.elb, self.region, 
+                                 **self.aws_connect_params)
         except boto.exception.NoAuthHandlerFound, e:
             self.module.fail_json(msg=str(e))
 
@@ -291,12 +274,11 @@ class ElbManager:
     def _get_instance(self):
         """Returns a boto.ec2.InstanceObject for self.instance_id"""
         try:
-            endpoint = "ec2.%s.amazonaws.com" % self.region
-            connect_region = RegionInfo(name=self.region, endpoint=endpoint)
-            ec2_conn = boto.ec2.EC2Connection(self.aws_access_key, self.aws_secret_key, region=connect_region)
+            ec2 = connect_to_aws(boto.ec2, self.region, 
+                                 **self.aws_connect_params)
         except boto.exception.NoAuthHandlerFound, e:
             self.module.fail_json(msg=str(e))
-        return ec2_conn.get_only_instances(instance_ids=[self.instance_id])[0]
+        return ec2.get_only_instances(instance_ids=[self.instance_id])[0]
 
 
 def main():
@@ -315,12 +297,12 @@ def main():
         argument_spec=argument_spec,
     )
 
-    # def get_ec2_creds(module):
-    #   return ec2_url, ec2_access_key, ec2_secret_key, region
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
+
+    if not region: 
+        module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
 
     ec2_elbs = module.params['ec2_elbs']
-    region = module.params['region']
     wait = module.params['wait']
     enable_availability_zone = module.params['enable_availability_zone']
     timeout = module.params['wait_timeout']
@@ -329,8 +311,8 @@ def main():
         module.fail_json(msg="ELBs are required for registration")
 
     instance_id = module.params['instance_id']
-    elb_man = ElbManager(module, instance_id, ec2_elbs, aws_access_key,
-                         aws_secret_key, region=region)
+    elb_man = ElbManager(module, instance_id, ec2_elbs, 
+                         region=region, **aws_connect_params)
 
     if ec2_elbs is not None:
         for elb in ec2_elbs:

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -22,7 +22,6 @@ short_description: Creates or destroys Amazon ELB.
   - Returns information about the load balancer.
   - Will be marked changed when called only if state is changed.
 version_added: "1.5"
-requirements: [ "boto" ]
 author: Jim Dalton
 options:
   state:
@@ -62,32 +61,12 @@ options:
       - An associative array of health check configuration settigs (see example)
     require: false
     default: None
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
-    required: false
-    default: None
-    aliases: ['ec2_secret_key', 'secret_key']
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: None
-    aliases: ['ec2_access_key', 'access_key']
   region:
     description:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
     required: false
     aliases: ['aws_region', 'ec2_region']
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
-
+extends_documentation_fragment: aws
 """
 
 EXAMPLES = """
@@ -190,7 +169,7 @@ class ElbManager(object):
 
     def __init__(self, module, name, listeners=None, purge_listeners=None,
                  zones=None, purge_zones=None, security_group_ids=None, health_check=None,
-                 aws_access_key=None, aws_secret_key=None, region=None):
+                 region=None, **aws_connect_params):
         self.module = module
         self.name = name
         self.listeners = listeners
@@ -200,8 +179,7 @@ class ElbManager(object):
         self.security_group_ids = security_group_ids
         self.health_check = health_check
 
-        self.aws_access_key = aws_access_key
-        self.aws_secret_key = aws_secret_key
+        self.aws_connect_params = aws_connect_params
         self.region = region
 
         self.changed = False
@@ -271,11 +249,8 @@ class ElbManager(object):
 
     def _get_elb_connection(self):
         try:
-            endpoint = "elasticloadbalancing.%s.amazonaws.com" % self.region
-            connect_region = RegionInfo(name=self.region, endpoint=endpoint)
-            return boto.ec2.elb.ELBConnection(self.aws_access_key,
-                                              self.aws_secret_key,
-                                              region=connect_region)
+            return connect_to_aws(boto.ec2.elb, self.region, 
+                                  **self.aws_connect_params)
         except boto.exception.NoAuthHandlerFound, e:
             self.module.fail_json(msg=str(e))
 
@@ -479,9 +454,9 @@ def main():
         argument_spec=argument_spec,
     )
 
-    # def get_ec2_creds(module):
-    #   return ec2_url, ec2_access_key, ec2_secret_key, region
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
+    if not region:
+        module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
 
     name = module.params['name']
     state = module.params['state']
@@ -499,8 +474,8 @@ def main():
         module.fail_json(msg="At least one availability zone is required for ELB creation")
 
     elb_man = ElbManager(module, name, listeners, purge_listeners, zones,
-                         purge_zones, security_group_ids, health_check, aws_access_key,
-                         aws_secret_key, region=region)
+                         purge_zones, security_group_ids, health_check, 
+                         region=region, **aws_connect_params)
 
     if state == 'present':
         elb_man.ensure_ok()

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -66,6 +66,22 @@ options:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
     required: false
     aliases: ['aws_region', 'ec2_region']
+  subnets:
+    description:
+      - A list of VPC subnets to use when creating ELB. Zones should be empty if using this. 
+    required: false
+    default: None
+    aliases: []
+    version_added: "1.6"    
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
+
 extends_documentation_fragment: aws
 """
 
@@ -91,6 +107,21 @@ EXAMPLES = """
         instance_port: 80
         # ssl certificate required for https or ssl
         ssl_certificate_id: "arn:aws:iam::123456789012:server-certificate/company/servercerts/ProdServerCert"
+
+
+# Basic VPC provisioning example
+- local_action:
+    module: ec2_elb_lb
+    name: "test-vpc"
+    state: present
+    subnets: 
+    zones:
+      - subnet-abcd1234
+      - subnet-1a2b3c4d
+    listeners:
+      - protocol: http # options are http, https, ssl, tcp
+        load_balancer_port: 80
+        instance_port: 80
 
 # Configure a health check
 - local_action:
@@ -149,6 +180,19 @@ EXAMPLES = """
         load_balancer_port: 80
         instance_port: 80
     purge_zones: yes
+
+# Creates a ELB and assigns a list of subnets to it. 
+- local_action:
+    module: ec2_elb_lb
+    state: present
+    name: 'New ELB'
+    security_group_ids: 'sg-123456, sg-67890'
+    region: us-west-2
+    subnets: 'subnet-123456, subnet-67890'
+    listeners:
+      - protocol: http
+        load_balancer_port: 80
+        instance_port: 80
 """
 
 import sys
@@ -168,8 +212,10 @@ class ElbManager(object):
     """Handles ELB creation and destruction"""
 
     def __init__(self, module, name, listeners=None, purge_listeners=None,
-                 zones=None, purge_zones=None, security_group_ids=None, health_check=None,
+                 zones=None, purge_zones=None, security_group_ids=None, 
+                 health_check=None, subnets=None,
                  region=None, **aws_connect_params):
+
         self.module = module
         self.name = name
         self.listeners = listeners
@@ -178,6 +224,7 @@ class ElbManager(object):
         self.purge_zones = purge_zones
         self.security_group_ids = security_group_ids
         self.health_check = health_check
+        self.subnets = subnets
 
         self.aws_connect_params = aws_connect_params
         self.region = region
@@ -196,6 +243,7 @@ class ElbManager(object):
             self._set_zones()
             self._set_security_groups()
             self._set_elb_listeners()
+            self._set_subnets()
         self._set_health_check()
 
     def ensure_gone(self):
@@ -215,7 +263,8 @@ class ElbManager(object):
                 'dns_name': self.elb.dns_name,
                 'zones': self.elb.availability_zones,
                 'security_group_ids': self.elb.security_groups,
-                'status': self.status
+                'status': self.status,
+                'subnets': self.subnets
             }
 
             if self.elb.health_check:
@@ -266,7 +315,8 @@ class ElbManager(object):
         self.elb = self.elb_conn.create_load_balancer(name=self.name,
                                                       zones=self.zones,
                                                       security_groups=self.security_group_ids,
-                                                      complex_listeners=listeners)
+                                                      complex_listeners=listeners,
+                                                      subnets=self.subnets)
         if self.elb:
             self.changed = True
             self.status = 'created'
@@ -373,22 +423,42 @@ class ElbManager(object):
         self.elb_conn.disable_availability_zones(self.name, zones)
         self.changed = True
 
+    def _attach_subnets(self, subnets):
+        self.elb_conn.attach_lb_to_subnets(self.name, subnets)
+        self.changed = True
+
+    def _detach_subnets(self, subnets):
+        self.elb_conn.detach_lb_from_subnets(self.name, subnets)
+        self.changed = True
+
+    def _set_subnets(self):
+        """Determine which subnets need to be attached or detached on the ELB"""
+        if self.subnets:
+            subnets_to_detach = list(set(self.elb.subnets) - set(self.subnets))
+            subnets_to_attach = list(set(self.subnets) - set(self.elb.subnets))
+
+            if subnets_to_attach:
+                self._attach_subnets(subnets_to_attach)
+            if subnets_to_detach:
+                self._detach_subnets(subnets_to_detach)
+                
     def _set_zones(self):
         """Determine which zones need to be enabled or disabled on the ELB"""
-        if self.purge_zones:
-            zones_to_disable = list(set(self.elb.availability_zones) -
+        if self.zones:
+            if self.purge_zones:
+                zones_to_disable = list(set(self.elb.availability_zones) -
                                     set(self.zones))
-            zones_to_enable = list(set(self.zones) -
-                                   set(self.elb.availability_zones))
-        else:
-            zones_to_disable = None
-            zones_to_enable = list(set(self.zones) -
-                                   set(self.elb.availability_zones))
-        if zones_to_enable:
-            self._enable_zones(zones_to_enable)
-        # N.B. This must come second, in case it would have removed all zones
-        if zones_to_disable:
-            self._disable_zones(zones_to_disable)
+                zones_to_enable = list(set(self.zones) -
+                                    set(self.elb.availability_zones))
+            else:
+                zones_to_disable = None
+                zones_to_enable = list(set(self.zones) -
+                                    set(self.elb.availability_zones))
+            if zones_to_enable:
+                self._enable_zones(zones_to_enable)
+            # N.B. This must come second, in case it would have removed all zones
+            if zones_to_disable:
+                self._disable_zones(zones_to_disable)
 
     def _set_security_groups(self):
         if self.security_group_ids != None and set(self.elb.security_groups) != set(self.security_group_ids):
@@ -447,6 +517,7 @@ def main():
             purge_zones={'default': False, 'required': False, 'type': 'bool'},
             security_group_ids={'default': None, 'required': False, 'type': 'list'},
             health_check={'default': None, 'required': False, 'type': 'dict'},
+            subnets={'default': None, 'required': False, 'type': 'list'}
         )
     )
 
@@ -466,15 +537,16 @@ def main():
     purge_zones = module.params['purge_zones']
     security_group_ids = module.params['security_group_ids']
     health_check = module.params['health_check']
+    subnets = module.params['subnets']
 
     if state == 'present' and not listeners:
         module.fail_json(msg="At least one port is required for ELB creation")
 
-    if state == 'present' and not zones:
-        module.fail_json(msg="At least one availability zone is required for ELB creation")
+    if state == 'present' and not (zones or subnets):
+        module.fail_json(msg="At least one availability zone or subnet is required for ELB creation")
 
-    elb_man = ElbManager(module, name, listeners, purge_listeners, zones,
-                         purge_zones, security_group_ids, health_check, 
+    elb_man = ElbManager(module, name, listeners, purge_listeners, zones, 
+                         purge_zones, security_group_ids, health_check, subnets, 
                          region=region, **aws_connect_params)
 
     if state == 'present':

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -79,6 +79,13 @@ options:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
     required: false
     aliases: ['aws_region', 'ec2_region']
+  subnets:
+    description:
+      - A list of VPC subnets to use when creating ELB. Zones should be empty if using this. 
+    required: false
+    default: None
+    aliases: []
+    version_added: "1.6"    
   validate_certs:
     description:
       - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
@@ -112,6 +119,21 @@ EXAMPLES = """
         instance_port: 80
         # ssl certificate required for https or ssl
         ssl_certificate_id: "arn:aws:iam::123456789012:server-certificate/company/servercerts/ProdServerCert"
+
+
+# Basic VPC provisioning example
+- local_action:
+    module: ec2_elb_lb
+    name: "test-vpc"
+    state: present
+    subnets: 
+    zones:
+      - subnet-abcd1234
+      - subnet-1a2b3c4d
+    listeners:
+      - protocol: http # options are http, https, ssl, tcp
+        load_balancer_port: 80
+        instance_port: 80
 
 # Configure a health check
 - local_action:
@@ -189,8 +211,9 @@ class ElbManager(object):
     """Handles ELB creation and destruction"""
 
     def __init__(self, module, name, listeners=None, purge_listeners=None,
-                 zones=None, purge_zones=None, security_group_ids=None, health_check=None,
-                 aws_access_key=None, aws_secret_key=None, region=None):
+                 zones=None, purge_zones=None, security_group_ids=None, 
+                 health_check=None, subnets=None,
+                 aws_access_key=None, aws_secret_key=None, region=None ):
         self.module = module
         self.name = name
         self.listeners = listeners
@@ -199,6 +222,7 @@ class ElbManager(object):
         self.purge_zones = purge_zones
         self.security_group_ids = security_group_ids
         self.health_check = health_check
+        self.subnets = subnets
 
         self.aws_access_key = aws_access_key
         self.aws_secret_key = aws_secret_key
@@ -218,6 +242,7 @@ class ElbManager(object):
             self._set_zones()
             self._set_security_groups()
             self._set_elb_listeners()
+            self._set_subnets()
         self._set_health_check()
 
     def ensure_gone(self):
@@ -237,7 +262,8 @@ class ElbManager(object):
                 'dns_name': self.elb.dns_name,
                 'zones': self.elb.availability_zones,
                 'security_group_ids': self.elb.security_groups,
-                'status': self.status
+                'status': self.status,
+                'subnets': self.subnets
             }
 
             if self.elb.health_check:
@@ -291,7 +317,8 @@ class ElbManager(object):
         self.elb = self.elb_conn.create_load_balancer(name=self.name,
                                                       zones=self.zones,
                                                       security_groups=self.security_group_ids,
-                                                      complex_listeners=listeners)
+                                                      complex_listeners=listeners,
+                                                      subnets=self.subnets)
         if self.elb:
             self.changed = True
             self.status = 'created'
@@ -398,22 +425,42 @@ class ElbManager(object):
         self.elb_conn.disable_availability_zones(self.name, zones)
         self.changed = True
 
+    def _attach_subnets(self, subnets):
+        self.elb_conn.attach_lb_to_subnets(self.name, subnets)
+        self.changed = True
+
+    def _detach_subnets(self, subnets):
+        self.elb_conn.detach_lb_from_subnets(self.name, subnets)
+        self.changed = True
+
+    def _set_subnets(self):
+        """Determine which subnets need to be attached or detached on the ELB"""
+        if self.subnets:
+            subnets_to_detach = list(set(self.elb.subnets) - set(self.subnets))
+            subnets_to_attach = list(set(self.subnets) - set(self.elb.subnets))
+
+            if subnets_to_attach:
+                self._attach_subnets(subnets_to_attach)
+            if subnets_to_detach:
+                self._detach_subnets(subnets_to_detach)
+                
     def _set_zones(self):
         """Determine which zones need to be enabled or disabled on the ELB"""
-        if self.purge_zones:
-            zones_to_disable = list(set(self.elb.availability_zones) -
+        if self.zones:
+            if self.purge_zones:
+                zones_to_disable = list(set(self.elb.availability_zones) -
                                     set(self.zones))
-            zones_to_enable = list(set(self.zones) -
-                                   set(self.elb.availability_zones))
-        else:
-            zones_to_disable = None
-            zones_to_enable = list(set(self.zones) -
-                                   set(self.elb.availability_zones))
-        if zones_to_enable:
-            self._enable_zones(zones_to_enable)
-        # N.B. This must come second, in case it would have removed all zones
-        if zones_to_disable:
-            self._disable_zones(zones_to_disable)
+                zones_to_enable = list(set(self.zones) -
+                                    set(self.elb.availability_zones))
+            else:
+                zones_to_disable = None
+                zones_to_enable = list(set(self.zones) -
+                                    set(self.elb.availability_zones))
+            if zones_to_enable:
+                self._enable_zones(zones_to_enable)
+            # N.B. This must come second, in case it would have removed all zones
+            if zones_to_disable:
+                self._disable_zones(zones_to_disable)
 
     def _set_security_groups(self):
         if self.security_group_ids != None and set(self.elb.security_groups) != set(self.security_group_ids):
@@ -472,6 +519,7 @@ def main():
             purge_zones={'default': False, 'required': False, 'type': 'bool'},
             security_group_ids={'default': None, 'required': False, 'type': 'list'},
             health_check={'default': None, 'required': False, 'type': 'dict'},
+            subnets={'default': None, 'required': False, 'type': 'list'}
         )
     )
 
@@ -491,16 +539,17 @@ def main():
     purge_zones = module.params['purge_zones']
     security_group_ids = module.params['security_group_ids']
     health_check = module.params['health_check']
+    subnets = module.params['subnets']
 
     if state == 'present' and not listeners:
         module.fail_json(msg="At least one port is required for ELB creation")
 
-    if state == 'present' and not zones:
-        module.fail_json(msg="At least one availability zone is required for ELB creation")
+    if state == 'present' and not (zones or subnets):
+        module.fail_json(msg="At least one availability zone or subnet is required for ELB creation")
 
-    elb_man = ElbManager(module, name, listeners, purge_listeners, zones,
-                         purge_zones, security_group_ids, health_check, aws_access_key,
-                         aws_secret_key, region=region)
+    elb_man = ElbManager(module, name, listeners, purge_listeners, zones, 
+                         purge_zones, security_group_ids, health_check, subnets, 
+                         aws_access_key, aws_secret_key, region=region)
 
     if state == 'present':
         elb_man.ensure_ok()

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -37,24 +37,6 @@ options:
     required: false
     default: null
     aliases: []
-  ec2_url:
-    description:
-      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints)
-    required: false
-    default: null
-    aliases: []
-  ec2_secret_key:
-    description:
-      - EC2 secret key
-    required: false
-    default: null
-    aliases: ['aws_secret_key']
-  ec2_access_key:
-    description:
-      - EC2 access key
-    required: false
-    default: null
-    aliases: ['aws_access_key']
   state:
     version_added: "1.4"
     description:
@@ -62,30 +44,8 @@ options:
     required: false
     default: 'present'
     aliases: []
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
-  profile:
-    description:
-      - uses a boto profile. Only works with boto >= 2.24.0
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
-  security_token:
-    description:
-      - security token to authenticate against AWS
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
 
-requirements: [ "boto" ]
+extends_documentation_fragment: aws
 
 notes:
   - If a rule declares a group_name and that group doesn't exist, it will be

--- a/library/cloud/ec2_key
+++ b/library/cloud/ec2_key
@@ -24,52 +24,12 @@ options:
     required: false
     default: null
     aliases: []
-  ec2_url:
-    description:
-      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints)
-    required: false
-    default: null
-    aliases: []
-  ec2_secret_key:
-    description:
-      - EC2 secret key
-    required: false
-    default: null
-    aliases: ['aws_secret_key', 'secret_key']
-  ec2_access_key:
-    description:
-      - EC2 access key
-    required: false
-    default: null
-    aliases: ['aws_access_key', 'access_key']
   state:
     description:
       - create or delete keypair
     required: false
     default: 'present'
     aliases: []
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
-  profile:
-    description:
-      - uses a boto profile. Only works with boto >= 2.24.0
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
-  security_token:
-    description:
-      - security token to authenticate against AWS
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
   wait:
     description:
       - Wait for the specified action to complete before returning.
@@ -85,7 +45,7 @@ options:
     aliases: []
     version_added: "1.6"
 
-requirements: [ "boto" ]
+extends_documentation_fragment: aws
 author: Vincent Viallet
 '''
 

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -22,7 +22,6 @@ description:
   - Can create or delete AwS Autoscaling Configurations
   - Works with the ec2_asg module to manage Autoscaling Groups
 version_added: "1.6"
-requirements: [ "boto" ]
 author: Gareth Rushgrove
 options:
   state:
@@ -46,18 +45,6 @@ options:
     description:
       - A list of security groups into which instances should be found
     required: false
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
-    required: false
-    default: None
-    aliases: ['ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: None
-    aliases: ['ec2_access_key', 'access_key' ]
   region:
     description:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
@@ -75,6 +62,7 @@ options:
     required: false
     default: null
     aliases: []
+extends_documentation_fragment: aws
 """
 
 EXAMPLES = '''

--- a/library/cloud/ec2_metric_alarm
+++ b/library/cloud/ec2_metric_alarm
@@ -21,7 +21,6 @@ description:
  - Can create or delete AWS metric alarms
  - Metrics you wish to alarm on must already exist
 version_added: "1.6"
-requirements: [ "boto" ]
 author: Zacharie Eakin
 options:
     state:
@@ -91,6 +90,7 @@ options:
         description:
           - A list of the names of action(s) to take when the alarm is in the 'ok' status
         required: false
+extends_documentation_fragment: aws
 """
 
 EXAMPLES = '''

--- a/library/cloud/ec2_scaling_policy
+++ b/library/cloud/ec2_scaling_policy
@@ -7,7 +7,6 @@ description:
   - Can create or delete scaling policies for autoscaling groups
   - Referenced autoscaling groups must already exist
 version_added: "1.6"
-requirements: [ "boto" ]
 author: Zacharie Eakin
 options:
   state:
@@ -40,6 +39,7 @@ options:
     description:
       - The minimum period of time between which autoscaling actions can take place
     required: false
+extends_documentation_fragment: aws
 """
 
 EXAMPLES = '''

--- a/library/cloud/ec2_snapshot
+++ b/library/cloud/ec2_snapshot
@@ -22,24 +22,6 @@ description:
     - creates an EC2 snapshot from an existing EBS volume
 version_added: "1.5"
 options:
-  ec2_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
-    required: false
-    default: None
-    aliases: ['aws_secret_key', 'secret_key' ]
-  ec2_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: None
-    aliases: ['aws_access_key', 'access_key' ]
-  ec2_url:
-    description:
-      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints).  Must be specified if region is not used. If not set then the value of the EC2_URL environment variable, if any, is used
-    required: false
-    default: null
-    aliases: []
   region:
     description:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
@@ -70,23 +52,9 @@ options:
     required: false
     default: null
     aliases: []
-  profile:
-    description:
-      - uses a boto profile. Only works with boto >= 2.24.0
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
-  security_token:
-    description:
-      - security token to authenticate against AWS
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
 
-requirements: [ "boto" ]
 author: Will Thames
+extends_documentation_fragment: aws
 '''
 
 EXAMPLES = '''

--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -41,49 +41,9 @@ options:
     required: false
     default: null
     aliases: ['aws_region', 'ec2_region']
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
-    required: false
-    default: None
-    aliases: ['ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: None
-    aliases: ['ec2_access_key', 'access_key' ]
-  ec2_url:
-    description:
-      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints).  Must be specified if region is not used. If not set then the value of the EC2_URL environment variable, if any, is used.
-    required: false
-    default: null
-    aliases: []
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
-  profile:
-    description:
-      - uses a boto profile. Only works with boto >= 2.24.0
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
-  security_token:
-    description:
-      - security token to authenticate against AWS
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
 
-requirements: [ "boto" ]
 author: Lester Wade
+extends_documentation_fragment: aws
 '''
 
 EXAMPLES = '''

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -22,24 +22,6 @@ description:
     - creates an EBS volume and optionally attaches it to an instance.  If both an instance ID and a device name is given and the instance has a device at the device name, then no volume is created and no attachment is made.  This module has a dependency on python-boto.
 version_added: "1.1"
 options:
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
-    required: false
-    default: None
-    aliases: ['ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: None
-    aliases: ['ec2_access_key', 'access_key' ]
-  ec2_url:
-    description:
-      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints).  Must be specified if region is not used. If not set then the value of the EC2_URL environment variable, if any, is used
-    required: false
-    default: null
-    aliases: []
   instance:
     description:
       - instance ID if you wish to attach the volume. 
@@ -105,20 +87,6 @@ options:
     choices: ["yes", "no"]
     aliases: []
     version_added: "1.5"
-  profile:
-    description:
-      - uses a boto profile. Only works with boto >= 2.24.0
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
-  security_token:
-    description:
-      - security token to authenticate against AWS
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
   state:
     description: 
       - whether to ensure the volume is present or absent
@@ -126,8 +94,8 @@ options:
     default: present
     choices: ['absent', 'present']
     version_added: "1.6"
-requirements: [ "boto" ]
 author: Lester Wade
+extends_documentation_fragment: aws
 '''
 
 EXAMPLES = '''

--- a/library/files/copy
+++ b/library/files/copy
@@ -84,7 +84,6 @@ options:
     required: false
     version_added: "1.5"
 author: Michael DeHaan
-extends_documentation_fragment: files.DOCUMENTATION
 notes:
    - The "copy" module recursively copy facility does not scale to lots (>hundreds) of files.
      For alternative, see synchronize module, which is a wrapper around rsync.

--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -124,6 +124,10 @@ options:
       - put user@ for the remote paths. If you have a custom ssh config to define the remote user for a host
         that does not match the inventory user, you should set this parameter to "no".
     default: yes
+  rsync_opts:
+    description:
+      - Specify additional rsync options by passing in an array. (added in Ansible 1.6)
+    default:
     required: false
 notes:
    - Inspect the verbose output to validate the destination user/host/path
@@ -173,6 +177,9 @@ synchronize: src=some/relative/path dest=/some/absolute/path rsync_path="sudo rs
 - var       # exclude any path whose last part is 'var'
 - /var      # exclude any path starting with 'var' starting at the source directory
 + /var/conf # include /var/conf even though it was previously excluded
+
+# Synchronize passing in extra rsync options
+synchronize: src=/tmp/helloworld dest=/var/www/helloword rsync_opts=--no-motd,--exclude=.git 
 '''
 
 
@@ -196,7 +203,8 @@ def main():
             owner = dict(type='bool'),
             group = dict(type='bool'),
             set_remote_user = dict(default='yes', type='bool'),
-            rsync_timeout = dict(type='int', default=10)
+            rsync_timeout = dict(type='int', default=10),
+            rsync_opts = dict(type='list')
         ),
         supports_check_mode = True
     )
@@ -220,6 +228,7 @@ def main():
     times = module.params['times']
     owner = module.params['owner']
     group = module.params['group']
+    rsync_opts = module.params['rsync_opts']
 
     cmd = '%s --delay-updates -FF --compress --timeout=%s' % (rsync, rsync_timeout)
     if module.check_mode:
@@ -275,6 +284,8 @@ def main():
 
     if rsync_path:
         cmd = cmd + " --rsync-path '%s'" %(rsync_path)
+    if rsync_opts:
+        cmd = cmd + " " +  " ".join(rsync_opts)
     changed_marker = '<<CHANGED>>'
     cmd = cmd + " --out-format='" + changed_marker + "%i %n%L'"
 

--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -133,7 +133,7 @@ options:
     default: yes
   rsync_opts:
     description:
-      - Specify additional rsync options by passing in an array. (added in Ansible 1.6)
+      - Specify additional rsync options by passing in an array.
     default:
     required: false
     version_added: "1.6"

--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -136,6 +136,7 @@ options:
       - Specify additional rsync options by passing in an array. (added in Ansible 1.6)
     default:
     required: false
+    version_added: "1.6"
 notes:
    - Inspect the verbose output to validate the destination user/host/path
      are what was expected.

--- a/library/files/template
+++ b/library/files/template
@@ -55,7 +55,6 @@ notes:
   which changes the variable interpolation markers to  [% var %] instead of  {{ var }}. This is the best way to prevent evaluation of things that look like, but should not be Jinja2.  raw/endraw in Jinja2 will not work as you expect because templates in Ansible are recursively evaluated."
 
 requirements: []
-extends_documentation_fragment: files.DOCUMENTATION
 author: Michael DeHaan
 '''
 

--- a/test/units/TestPlayVarsFiles.py
+++ b/test/units/TestPlayVarsFiles.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python
+
+import os
+import shutil
+from tempfile import mkstemp
+from tempfile import mkdtemp
+from ansible.playbook.play import Play
+import ansible
+
+import unittest
+from nose.plugins.skip import SkipTest
+
+
+class FakeCallBacks(object):
+    def __init__(self):
+        pass
+    def on_vars_prompt(self):
+        pass
+    def on_import_for_host(self, host, filename):
+        pass
+
+class FakeInventory(object):
+    def __init__(self):
+        self.hosts = {}
+    def basedir(self):
+        return "."        
+    def get_variables(self, host, vault_password=None):
+        if host in self.hosts:
+            return self.hosts[host]        
+        else:
+            return {}            
+
+class FakePlayBook(object):
+    def __init__(self):
+        self.extra_vars = {}
+        self.remote_user = None
+        self.remote_port = None
+        self.sudo = None
+        self.sudo_user = None
+        self.su = None
+        self.su_user = None
+        self.transport = None
+        self.only_tags = None
+        self.skip_tags = None
+        self.VARS_CACHE = {}
+        self.SETUP_CACHE = {}
+        self.inventory = FakeInventory()
+        self.callbacks = FakeCallBacks()
+
+        self.VARS_CACHE['localhost'] = {}
+
+
+class TestMe(unittest.TestCase):
+
+    ########################################
+    # BASIC FILE LOADING BEHAVIOR TESTS
+    ########################################
+
+    def test_play_constructor(self):
+        # __init__(self, playbook, ds, basedir, vault_password=None)
+        playbook = FakePlayBook()
+        ds = { "hosts": "localhost"}
+        basedir = "."
+        play = Play(playbook, ds, basedir)
+
+    def test_vars_file(self):
+
+        # make a vars file
+        fd, temp_path = mkstemp()
+        f = open(temp_path, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # create a play with a vars_file
+        playbook = FakePlayBook()
+        ds = { "hosts": "localhost",
+               "vars_files": [temp_path]}
+        basedir = "."
+        play = Play(playbook, ds, basedir)
+        os.remove(temp_path)
+
+        # make sure the variable was loaded
+        assert 'foo' in play.vars, "vars_file was not loaded into play.vars"
+        assert play.vars['foo'] == 'bar', "foo was not set to bar in play.vars"
+
+    def test_vars_file_nonlist_error(self):
+
+        # make a vars file
+        fd, temp_path = mkstemp()
+        f = open(temp_path, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # create a play with a string for vars_files
+        playbook = FakePlayBook()
+        ds = { "hosts": "localhost",
+               "vars_files": temp_path}
+        basedir = "."
+        error_hit = False
+        try:
+            play = Play(playbook, ds, basedir)
+        except:
+            error_hit = True
+        os.remove(temp_path)
+
+        assert error_hit == True, "no error was thrown when vars_files was not a list"
+
+
+    def test_multiple_vars_files(self):
+
+        # make a vars file
+        fd, temp_path = mkstemp()
+        f = open(temp_path, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # make a second vars file
+        fd, temp_path2 = mkstemp()
+        f = open(temp_path2, "wb")
+        f.write("baz: bang\n")
+        f.close()
+
+
+        # create a play with two vars_files
+        playbook = FakePlayBook()
+        ds = { "hosts": "localhost",
+               "vars_files": [temp_path, temp_path2]}
+        basedir = "."
+        play = Play(playbook, ds, basedir)
+        os.remove(temp_path)
+        os.remove(temp_path2)
+
+        # make sure the variables were loaded
+        assert 'foo' in play.vars, "vars_file was not loaded into play.vars"
+        assert play.vars['foo'] == 'bar', "foo was not set to bar in play.vars"
+        assert 'baz' in play.vars, "vars_file2 was not loaded into play.vars"
+        assert play.vars['baz'] == 'bang', "baz was not set to bang in play.vars"
+
+    def test_vars_files_first_found(self):
+
+        # make a vars file
+        fd, temp_path = mkstemp()
+        f = open(temp_path, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # get a random file path        
+        fd, temp_path2 = mkstemp()
+        # make sure this file doesn't exist
+        os.remove(temp_path2)
+
+        # create a play
+        playbook = FakePlayBook()
+        ds = { "hosts": "localhost",
+               "vars_files": [[temp_path2, temp_path]]}
+        basedir = "."
+        play = Play(playbook, ds, basedir)
+        os.remove(temp_path)
+
+        # make sure the variable was loaded
+        assert 'foo' in play.vars, "vars_file was not loaded into play.vars"
+        assert play.vars['foo'] == 'bar', "foo was not set to bar in play.vars"
+
+    def test_vars_files_multiple_found(self):
+
+        # make a vars file
+        fd, temp_path = mkstemp()
+        f = open(temp_path, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # make a second vars file
+        fd, temp_path2 = mkstemp()
+        f = open(temp_path2, "wb")
+        f.write("baz: bang\n")
+        f.close()
+
+        # create a play
+        playbook = FakePlayBook()
+        ds = { "hosts": "localhost",
+               "vars_files": [[temp_path, temp_path2]]}
+        basedir = "."
+        play = Play(playbook, ds, basedir)
+        os.remove(temp_path)
+        os.remove(temp_path2)
+
+        # make sure the variables were loaded
+        assert 'foo' in play.vars, "vars_file was not loaded into play.vars"
+        assert play.vars['foo'] == 'bar', "foo was not set to bar in play.vars"
+        assert 'baz' not in play.vars, "vars_file2 was loaded after vars_file1 was loaded"
+
+    def test_vars_files_assert_all_found(self):
+
+        # make a vars file
+        fd, temp_path = mkstemp()
+        f = open(temp_path, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # make a second vars file
+        fd, temp_path2 = mkstemp()
+        # make sure it doesn't exist
+        os.remove(temp_path2)
+
+        # create a play
+        playbook = FakePlayBook()
+        ds = { "hosts": "localhost",
+               "vars_files": [temp_path, temp_path2]}
+        basedir = "."
+
+        error_hit = False
+        error_msg = None
+
+        try:
+            play = Play(playbook, ds, basedir)
+        except ansible.errors.AnsibleError, e:
+            error_hit = True
+            error_msg = e
+
+        os.remove(temp_path)
+        assert error_hit == True, "no error was thrown for missing vars_file"
+
+
+    ########################################
+    # VARIABLE PRECEDENCE TESTS
+    ########################################
+
+    # On the first run vars_files are loaded into play.vars by host == None
+    #   * only files with vars from host==None will work here
+    # On the secondary run(s), a host is given and the vars_files are loaded into VARS_CACHE
+    #   * this only occurs if host is not None, filename2 has vars in the name, and filename3 does not
+
+    # filename  -- the original string
+    # filename2 -- filename templated with play vars
+    # filename3 -- filename2 template with inject (hostvars + setup_cache + vars_cache)
+    # filename4 -- path_dwim(filename3)
+
+    def test_vars_files_for_host(self):
+
+        # host != None
+        # vars in filename2
+        # no vars in filename3
+
+        # make a vars file
+        fd, temp_path = mkstemp()
+        f = open(temp_path, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # build play attributes
+        playbook = FakePlayBook()
+        ds = { "hosts": "localhost",
+               "vars_files": ["{{ temp_path }}"]}
+        basedir = "."
+        playbook.VARS_CACHE['localhost']['temp_path'] = temp_path
+
+        # create play and do first run        
+        play = Play(playbook, ds, basedir)
+
+        # the second run is started by calling update_vars_files        
+        play.update_vars_files(['localhost'])
+        os.remove(temp_path)
+
+        assert 'foo' in play.playbook.VARS_CACHE['localhost'], "vars_file vars were not loaded into vars_cache"
+        assert play.playbook.VARS_CACHE['localhost']['foo'] == 'bar', "foo does not equal bar"
+
+    def test_vars_files_for_host_with_extra_vars(self):
+
+        # host != None
+        # vars in filename2
+        # no vars in filename3
+
+        # make a vars file
+        fd, temp_path = mkstemp()
+        f = open(temp_path, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # build play attributes
+        playbook = FakePlayBook()
+        ds = { "hosts": "localhost",
+               "vars_files": ["{{ temp_path }}"]}
+        basedir = "."
+        playbook.VARS_CACHE['localhost']['temp_path'] = temp_path
+        playbook.extra_vars = {"foo": "extra"}
+
+        # create play and do first run        
+        play = Play(playbook, ds, basedir)
+
+        # the second run is started by calling update_vars_files        
+        play.update_vars_files(['localhost'])
+        os.remove(temp_path)
+
+        assert 'foo' in play.vars, "extra vars were not set in play.vars"
+        assert 'foo' in play.playbook.VARS_CACHE['localhost'], "vars_file vars were not loaded into vars_cache"
+        assert play.playbook.VARS_CACHE['localhost']['foo'] == 'extra', "extra vars did not overwrite vars_files vars"
+
+
+    ########################################
+    # COMPLEX FILENAME TEMPLATING TESTS
+    ########################################
+
+    def test_vars_files_two_vars_in_name(self):
+
+        # self.vars = ds['vars']
+        # self.vars += _get_vars() ... aka extra_vars
+
+        # make a temp dir
+        temp_dir = mkdtemp()
+
+        # make a temp file
+        fd, temp_file = mkstemp(dir=temp_dir)
+        f = open(temp_file, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # build play attributes
+        playbook = FakePlayBook()
+        ds = { "hosts": "localhost",
+               "vars": { "temp_dir": os.path.dirname(temp_file),
+                         "temp_file": os.path.basename(temp_file) },
+               "vars_files": ["{{ temp_dir + '/' + temp_file }}"]}
+        basedir = "."
+
+        # create play and do first run        
+        play = Play(playbook, ds, basedir)
+
+        # cleanup
+        shutil.rmtree(temp_dir)
+
+        assert 'foo' in play.vars, "double var templated vars_files filename not loaded"
+    
+    def test_vars_files_two_vars_different_scope(self):
+
+        #
+        # Use a play var and an inventory var to create the filename
+        #
+
+        # self.playbook.inventory.get_variables(host)
+        #   {'group_names': ['ungrouped'], 'inventory_hostname': 'localhost', 
+        #   'ansible_ssh_user': 'root', 'inventory_hostname_short': 'localhost'}
+
+        # make a temp dir
+        temp_dir = mkdtemp()
+
+        # make a temp file
+        fd, temp_file = mkstemp(dir=temp_dir)
+        f = open(temp_file, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # build play attributes
+        playbook = FakePlayBook()
+        playbook.inventory.hosts['localhost'] = {'inventory_hostname': os.path.basename(temp_file)}
+        ds = { "hosts": "localhost",
+               "vars": { "temp_dir": os.path.dirname(temp_file)},
+               "vars_files": ["{{ temp_dir + '/' + inventory_hostname }}"]}
+        basedir = "."
+
+        # create play and do first run        
+        play = Play(playbook, ds, basedir)
+
+        # do the host run        
+        play.update_vars_files(['localhost'])
+
+        # cleanup
+        shutil.rmtree(temp_dir)
+
+        assert 'foo' not in play.vars, \
+            "mixed scope vars_file loaded into play vars"
+        assert 'foo' in play.playbook.VARS_CACHE['localhost'], \
+            "differently scoped templated vars_files filename not loaded"
+        assert play.playbook.VARS_CACHE['localhost']['foo'] == 'bar', \
+            "foo is not bar"    
+
+    def test_vars_files_two_vars_different_scope_first_found(self):
+
+        #
+        # Use a play var and an inventory var to create the filename
+        #
+
+        # make a temp dir
+        temp_dir = mkdtemp()
+
+        # make a temp file
+        fd, temp_file = mkstemp(dir=temp_dir)
+        f = open(temp_file, "wb")
+        f.write("foo: bar\n")
+        f.close()
+
+        # build play attributes
+        playbook = FakePlayBook()
+        playbook.inventory.hosts['localhost'] = {'inventory_hostname': os.path.basename(temp_file)}
+        ds = { "hosts": "localhost",
+               "vars": { "temp_dir": os.path.dirname(temp_file)},
+               "vars_files": [["{{ temp_dir + '/' + inventory_hostname }}"]]}
+        basedir = "."
+
+        # create play and do first run        
+        play = Play(playbook, ds, basedir)
+
+        # do the host run        
+        play.update_vars_files(['localhost'])
+
+        # cleanup
+        shutil.rmtree(temp_dir)
+
+        assert 'foo' not in play.vars, \
+            "mixed scope vars_file loaded into play vars"
+        assert 'foo' in play.playbook.VARS_CACHE['localhost'], \
+            "differently scoped templated vars_files filename not loaded"
+        assert play.playbook.VARS_CACHE['localhost']['foo'] == 'bar', \
+            "foo is not bar"    
+    
+


### PR DESCRIPTION
Adds support through boto for VPC subnets. 

```
- name: Create ELB    
  local_action:
    module: ec2_elb_lb
    state: present
    name: 'New ELB'
    security_group_ids: 'sg-123456, sg-67890'
    region: us-west-2
    subnets: 'subnet-123456, subnet-67890'
    listeners:
      - protocol: http
        load_balancer_port: 80
        instance_port: 80
```

Or of you have created the through ec2-vpc and register a vpc variable 

```
 - name: Create ELB  
  local_action:
    module: ec2_elb_lb
    state: present
    name: 'New ELB'
    security_group_ids: 'sg-123456, sg-67890'
    region: us-west-2
    subnets: "{{ vpc.subnets | join(',',  attribute='id') }}"       
    listeners:
      - protocol: http
        load_balancer_port: 80
        instance_port: 80
```
