### PR TITLE
remove "No hosts matched" from --list-hosts

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -94,7 +94,6 @@ class Cli(object):
             inventory_manager.subset(options.subset)
         hosts = inventory_manager.list_hosts(pattern)
         if len(hosts) == 0:
-            callbacks.display("No hosts matched")
             sys.exit(0)
 
         if options.listhosts:
@@ -141,7 +140,6 @@ class Cli(object):
             inventory_manager.subset(options.subset)
         hosts = inventory_manager.list_hosts(pattern)
         if len(hosts) == 0:
-            callbacks.display("No hosts matched")
             sys.exit(0)
 
         if options.listhosts:


### PR DESCRIPTION
Ansible --list-hosts says "No hosts matched" on stdout when it matches
no hosts.  Emitting "No hosts matched" on stdout interferes with a
script doing something useful with the lack of matching hosts.

```
% ansible -i hosts --list-hosts fred
No hosts matched
% ansible -i hosts --list-hosts fred >/dev/null
% for h in $( ansible -i hosts --list-hosts fred ) ; do echo $h ; done
No
hosts
matched
% ansible --version
ansible 1.5.3
```

My preference is to simply emit nothing in this case, not even on
stderr.  That no hosts were matched is evident from the lack of
hosts emitted.

Note that this behavior is new in 1.5.  It didn't do this in 1.4.3.
