### PR TITLE
Added region to nova client connection. 

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -249,6 +249,7 @@ def main():
                               module.params['login_password'],
                               module.params['login_tenant_name'],
                               module.params['auth_url'],
+                              region_name=module.params['region_name'],
                               service_type='compute')
     try:
         nova.authenticate()


### PR DESCRIPTION
Added the argument to nova client instantiation. Without it, it will fail if the cloud provider you are using uses multiple regions because the driver doesn't know how to disambiguate.

I made this pull request on an earlier branch. I'm re-doing so as to make it simple.
