### PR TITLE
A key_filter option to filter hosts by key_name

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -14,6 +14,10 @@
 regions = all
 regions_exclude = us-gov-west-1,cn-north-1
 
+# To restrict ansible to a subset of instances, specify the name of a Key Pair
+# here. Only instances created with this key pair will be available.
+# key_filter = AnsibleManagementKeyPair
+
 # When generating inventory, Ansible needs to know how to address a server.
 # Each EC2 instance has a lot of variables associated with it. Here is the list:
 #   http://docs.pythonboto.org/en/latest/ref/ec2.html#module-boto.ec2.instance

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -215,6 +215,11 @@ class Ec2Inventory(object):
         self.destination_variable = config.get('ec2', 'destination_variable')
         self.vpc_destination_variable = config.get('ec2', 'vpc_destination_variable')
 
+        # Key Filter
+        self.key_filter = False
+        if config.has_option('ec2', 'key_filter'):
+            self.key_filter = config.get('ec2', 'key_filter')
+
         # Route53
         self.route53_enabled = config.getboolean('ec2', 'route53')
         self.route53_excluded_zones = []
@@ -339,6 +344,12 @@ class Ec2Inventory(object):
         if not dest:
             # Skip instances we cannot address (e.g. private VPC subnet)
             return
+
+        if self.key_filter:
+            if not instance.key_name:
+                return
+            elif self.key_filter != instance.key_name:
+                return
 
         # Add to index
         self.index[dest] = [region, instance.id]


### PR DESCRIPTION
Useful for limiting ansible plays to a subset of ec2 hosts within a region.
