### PR TITLE
Filter hosts based on ec2 variables in inventory script

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -14,6 +14,10 @@
 regions = all
 regions_exclude = us-gov-west-1,cn-north-1
 
+# Use only hosts that pass though this filter, based on ec2 variables (including tags).
+# Can be variable name or var=value.
+#host_filter = ec2_tag_env=
+
 # When generating inventory, Ansible needs to know how to address a server.
 # Each EC2 instance has a lot of variables associated with it. Here is the list:
 #   http://docs.pythonboto.org/en/latest/ref/ec2.html#module-boto.ec2.instance

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -16,7 +16,8 @@ regions_exclude = us-gov-west-1,cn-north-1
 
 # Use only hosts that pass though this filter, based on ec2 variables (including tags).
 # Can be variable name or var=value.
-#host_filter = ec2_tag_env=
+#host_filter = ec2_tag_prod_
+#host_filter = ec2_tag_role=webserver
 
 # When generating inventory, Ansible needs to know how to address a server.
 # Each EC2 instance has a lot of variables associated with it. Here is the list:

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -26,7 +26,7 @@ For more details, see: http://docs.pythonboto.org/en/latest/boto_config_tut.html
 
 When run against a specific host, this script returns the following variables:
  - ec2_ami_launch_index
-- ec2_architecture
+ - ec2_architecture
  - ec2_association
  - ec2_attachTime
  - ec2_attachment
@@ -344,8 +344,9 @@ class Ec2Inventory(object):
         if instance.state != 'running':
             return
 
-        # Filter instances based on hostvars
         instance_vars = self.get_host_info_dict_from_instance(instance)
+
+        # Filter instances based on hostvars
         if self.host_filter:
             var, value = self.host_filter
             if var not in instance_vars:


### PR DESCRIPTION
This adds a host_filter option to ec2.ini that adds only hosts that pass the filter to the inventory. Can be used to separate stage and prod envs in the same region via tags, for example.
