### PR TITLE
fix issue #6932

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -393,6 +393,9 @@ def get_head_branch(git_path, module, dest, remote, bare=False):
 
 def fetch(git_path, module, repo, dest, version, remote, bare):
     ''' updates repo from remote sources '''
+    (rc, out0, err0) = module.run_command([git_path, 'remote', 'set-url', remote, repo], cwd=dest)
+    if rc != 0:
+        module.fail_json(msg="Failed to set a new url %s for %s: %s" % (repo, remote, out0 + err0))
     if bare:
         (rc, out1, err1) = module.run_command([git_path, 'fetch', remote, '+refs/heads/*:refs/heads/*'], cwd=dest)
     else:


### PR DESCRIPTION
add `git remote set-url` before fetch to set the remote repo to the new url, if provided
