### PR TITLE
wait_for module: Allow search_regex to be used with port

### DIFF
--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -76,9 +76,9 @@ options:
     version_added: "1.4"
     required: false
     description:
-      - with the path option can be used match a string in the file that must match before continuing.  Defaults to a multiline regex.
-   
-notes: []
+      - Can be used to match a string in either a file or a socket connection. Defaults to a multiline regex.
+notes:
+  - The ability to use search_regex with a port connection was added in 1.7.
 requirements: []
 author: Jeroen Hoekx, John Jarvis, Andrii Radyk
 '''
@@ -99,6 +99,9 @@ EXAMPLES = '''
 
 # wait until the process is finished and pid was destroyed
 - wait_for: path=/proc/3466/status state=absent
+
+# Wait 300 seconds for port 22 to become open and contain "OpenSSH", don't start checking for 10 seconds
+- local_action: wait_for port=22 host="{{ inventory_hostname }}" search_regex=OpenSSH delay=10
 
 '''
 
@@ -196,16 +199,32 @@ def main():
                 s.settimeout(connect_timeout)
                 try:
                     s.connect( (host, port) )
-                    s.shutdown(socket.SHUT_RDWR)
-                    s.close()
-                    break
+                    if search_regex:
+                        data = ''
+                        matched = False
+                        while 1:
+                            data += s.recv(1024)
+                            if re.search(search_regex, data, re.MULTILINE):
+                                matched = True
+                                break
+                        if matched:
+                            s.shutdown(socket.SHUT_RDWR)
+                            s.close()
+                            break
+                    else:
+                        s.shutdown(socket.SHUT_RDWR)
+                        s.close()
+                        break
                 except:
                     time.sleep(1)
                     pass
         else:
             elapsed = datetime.datetime.now() - start
             if port:
-                module.fail_json(msg="Timeout when waiting for %s:%s" % (host, port), elapsed=elapsed.seconds)
+                if search_regex:
+                    module.fail_json(msg="Timeout when waiting for search string %s in %s:%s" % (search_regex, host, port), elapsed=elapsed.seconds)
+                else:
+                    module.fail_json(msg="Timeout when waiting for %s:%s" % (host, port), elapsed=elapsed.seconds)
             elif path:
                 if search_regex:
                     module.fail_json(msg="Timeout when waiting for search string %s in %s" % (search_regex, path), elapsed=elapsed.seconds)


### PR DESCRIPTION
It is possible that someone may want to look for a string in a port connection with `wait_for` to validate that things are indeed ready and not just open.

For example the following could verify that "OpenSSH" is in the response on port 22:

```
$ ansible all -i localhost, -c local -m wait_for -a 'host=test.example.org port=22 search_regex=SSH'

localhost | success >> {
    "changed": false,
    "elapsed": 1,
    "path": null,
    "port": 22,
    "search_regex": "OpenSSH",
    "state": "started"
}
```
