### PR TITLE
Make test-module interpret --args='{...' as yaml.

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -93,6 +93,10 @@ def boilerplate_module(modfile, args, interpreter):
         # Argument is a YAML file (JSON is a subset of YAML)
         complex_args = utils.combine_vars(complex_args, utils.parse_yaml_from_file(args[1:]))
         args=''
+    elif args.startswith("{"):
+        # Argument is a YAML document (not a file)
+        complex_args = utils.combine_vars(complex_args, utils.parse_yaml(args))
+        args=''
 
     inject = {}
     if interpreter:


### PR DESCRIPTION
I found this pretty useful when testing modules with complex args.

Of course reusing --args for this is somewhat hacky. But then
there is already --args='@...' which loads a YAML file, so...
