### PR TITLE
Docker: Add support for read-only volumes.

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -352,6 +352,9 @@ class DockerManager:
                 if len(parts) == 2:
                     self.volumes[parts[1]] = {}
                     self.binds[parts[0]] = parts[1]
+                elif len(parts) == 3:
+                    self.volumes[parts[1]] = {}
+                    self.binds[parts[0]] = parts[1] + ":" + parts[2]
                 # docker mount (e.g. /www, mounts a docker volume /www on the container at the same location)
                 else:
                     self.volumes[parts[0]] = {}


### PR DESCRIPTION
Allow specify volumes with access protection: "/var/cloud:/tmp/cloud:ro"

Mount /var/cloud with read-only access to /tmp/cloud. Try write file "echo" into write-protected directory.

```
    - name: "TEST"
      docker:
        image: ubuntu
        volumes:
          - "/var/cloud:/tmp/cloud:ro"
        command: /bin/bash -c 'echo 1 > /tmp/cloud/echo'
      tags:
        - deploy
```

Result:

```
docker ps -a
CONTAINER ID        IMAGE                  COMMAND                CREATED             STATUS              PORTS                                      NAMES
472c1e055df9        ubuntu:latest          /bin/bash -c echo 1    2 seconds ago       Exit 1

docker logs 472c1e055df9
/bin/bash: /tmp/cloud/echo: Read-only file system
```

Fix: #6884
Replace pull request: #6890
