### PR TITLE
Minor change to cron core module, to unlink cron file if empty.

### DIFF
--- a/library/system/cron
+++ b/library/system/cron
@@ -507,6 +507,10 @@ def main():
 
     if cron_file:
         res_args['cron_file'] = cron_file
+        
+        # unlink cron file if empty
+        if len(crontab.lines) == 0:
+            crontab.remove_job_file()
 
     module.exit_json(**res_args)
 


### PR DESCRIPTION
Currently the cron module will leave an empty file in /etc/cron.d/ if you remove all the cron jobs added to it via ansible. This is sort of confusing and messy if you are adding and removing cron.d/ files alot. May be slightly less efficient in edge case where you remove all cron entries then add some in the same play.

Minor change, but I think it is the more correct behavior to remove the file if it is empty. Note the file is still not removed if it contains non ansible managed cron stuff like env settings.
