### PR TITLE
Added floating IP functionality to nova_compute

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -19,7 +19,9 @@
 
 try:
     from novaclient.v1_1 import client as nova_client
+    from novaclient.v1_1 import floating_ips 
     from novaclient import exceptions
+    from novaclient import utils
     import time
 except ImportError:
     print("failed=True msg='novaclient is required for this module'")
@@ -92,6 +94,11 @@ options:
         - A list of network id's to which the VM's interface should be attached
      required: false
      default: None
+   floating_ip:
+     description:
+        - list of key value pairs that determine how to assign, if specified, floating IPs. Either use an explicite list of valid floating IPs, list of floating IP pools to choose from, or auto-assign 
+     required: false
+     default: None
    meta:
      description:
         - A list of key value pairs that should be provided as a metadata to the new VM
@@ -133,7 +140,37 @@ EXAMPLES = '''
        meta:
          hostname: test1
          group: uge_master
+
+# Creates a new VM in HP Cloud AE1 region and automatically assigns a floating IP
+- name: launch a nova instance
+  hosts: localhost
+  tasks:
+  - name: launch an instance
+    nova_compute:
+      state: present
+      login_username: username 
+      login_password: Equality7-2521 
+      login_tenant_name: username-project1
+      name: vm1
+      auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
+      region_name: region-b.geo-1
+      image_id: 9302692b-b787-4b52-a3a6-daebb79cb498
+      key_name: test
+      wait_for: 200
+      flavor_id: 101
+      security_groups: default
+      floating_ip:
+        auto: True
+
+# If one wants to specify a floating ip to use:
+      <snip>
+      floating_ip:
+        ips: 
+          - 15.126.238.160
+
 '''
+
+
 
 def _delete_server(module, nova):
     name = None
@@ -157,6 +194,21 @@ def _delete_server(module, nova):
 
 
 def _create_server(module, nova):
+    # issue an error early on and not launch the instance
+    if module.params['floating_ip'] != None:
+        if module.params['floating_ip'].has_key('ips'):
+            # can't specify "ips" and "auto" both 
+            if module.params['floating_ip'].has_key('auto') and \
+            module.params['floating_ip']['auto'] is True:
+                err_msg = "For floating_ips - "
+                err_msg += "you cannot specify both 'auto' and 'ips'!"
+                module.fail_json(msg = err_msg)
+            # can't specify "ips" and "pools" both 
+            if module.params['floating_ip'].has_key('pools'):
+                err_msg = "For floating_ips - "
+                err_msg += "you cannot specify both 'ips' and 'pools'!"
+                module.fail_json(msg = err_msg)
+
     bootargs = [module.params['name'], module.params['image_id'], module.params['flavor_id']]
     bootkwargs = {
                 'nics' : module.params['nics'],
@@ -179,11 +231,92 @@ def _create_server(module, nova):
             try:
                 server = nova.servers.get(server.id)
             except Exception, e:
-                    module.fail_json( msg = "Error in getting info from instance: %s " % e.message)
+                    module.fail_json(msg = \
+                                     "Error in getting info from instance: %s"\
+                                     % e.message
+                                    )
             if server.status == 'ACTIVE':
+                # if floating_ip is specified, then attach 
+                if module.params['floating_ip'] != None:
+                    # instantiate FloatingIPManager object
+                    floating_ip_obj = floating_ips.FloatingIPManager(nova)
+                    # empty dict and list 
+                    usable_floating_ips = {} 
+                    pools = []
+
+                    # if floating_ip pools are defined, then make that
+                    # the list of pools
+                    if module.params['floating_ip'].has_key('pools'):
+                        # user specified
+                        pools = module.params['floating_ip']['pools']
+                    else:
+                        # otherwise all
+                        pools = ['']
+
+                    # if there is a list of IP addresses, make that the list 
+                    if module.params['floating_ip'].has_key('ips'):
+                        usable_floating_ips[''] = \
+                        module.params['floating_ip']['ips']
+
+                    # if 'auto', then assign automatically, no pool needed
+                    if module.params['floating_ip'].has_key('auto') and \
+                       module.params['floating_ip']['auto'] is True:        
+                        # get the list of all floating IPs. Mileage may 
+                        # vary according to Nova Compute configuration 
+                        # per cloud provider
+                        all_floating_ips = floating_ip_obj.list()
+
+                        # iterate through all pools of IP address. Empty
+                        # string means all and is the default value
+                        for pool in pools:
+                            # temporary list per pool
+                            pool_ips = []
+                            # loop through all floating IPs
+                            for f_ip in all_floating_ips:
+                                # if not reserved and the correct pool, add
+                                if f_ip.instance_id == None and \
+                                (f_ip.pool == pool or pool == ''):
+                                    pool_ips.append(f_ip.ip)
+                                    # one per pool
+                                    break
+                            # if the list is empty, add for this pool
+                            if len(pool_ips) == 0: 
+                                try:
+                                    new_ip = nova.floating_ips.create(pool)
+                                except Exception, e: 
+                                    module.fail_json(msg = \
+                                                     "Unable to create \
+                                                     floating ip")
+                                pool_ips.append(new_ip.ip)
+                            # Add to the main list
+                            usable_floating_ips[pool] = pool_ips
+
+                    # finally, add ip(s) to instance for each pool
+                    for pool in usable_floating_ips:
+                        for ip in usable_floating_ips[pool]:
+                            try:
+                                server.add_floating_ip(ip)
+                            except Exception, e:
+                                module.fail_json(msg = \
+                                                 "Error attaching IP %s to \
+                                                 instance %s: %s " % \
+                                                 (ip, server.id, e.message))
+
+                    # this may look redundant, but if there is now a 
+                    # floating IP, then it needs to be obtained from
+                    # a recent server object if the above code path exec'd 
+                    try:
+                        server = nova.servers.get(server.id)
+                    except Exception, e:
+                        module.fail_json(msg = \
+                                         "Error in getting info from \
+                                         instance: %s " % e.message)
+
                 private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
                 public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'floating']
+                # now exit with info 
                 module.exit_json(changed = True, id = server.id, private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
+
             if server.status == 'ERROR':
                 module.fail_json(msg = "Error in creating the server, please check logs")
             time.sleep(2)
@@ -193,6 +326,7 @@ def _create_server(module, nova):
             module.fail_json(msg = "Error in creating the server.. Please check manually")
     private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'fixed']
     public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'floating']
+
     module.exit_json(changed = True, id = info['id'], private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
 
 
@@ -241,7 +375,8 @@ def main():
         wait                            = dict(default='yes', choices=['yes', 'no']),
         wait_for                        = dict(default=180),
         state                           = dict(default='present', choices=['absent', 'present']),
-        user_data                       = dict(default=None)
+        user_data                       = dict(default=None),
+        floating_ip                     = dict(default=None)
         ),
     )
 


### PR DESCRIPTION
Hi!

I added the ability for a user to specify that they want a given IP, or to auto-assign a floating IP to a launched instance. Why? Well, some cloud providers, including HP Cloud and in fact, stock Nova (using devstack) with Grizzly, Havana, are set up such that when you launch an instance, you cannot get into that instance until a floating IP is assigned (Rackspace does assign btw).  This solves that issue.

I simply specify:

```
# Creates a new VM and attaches to a network and passes metadata to the instance
- name: launch a nova instance
  hosts: localhost
  tasks:
  - name: launch an instance
    nova_compute:
      state: present
      login_username: username_group
      login_password: redacted
      login_tenant_name: username-project1
      name: vm1
      auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
      region_name: region-b.geo-1
      image_id: 9302692b-b787-4b52-a3a6-daebb79cb498
      key_name: test
      wait_for: 200
      flavor_id: 101
      security_groups: default
      floating_ip:
        auto: True
```

and when I run this (verbose)

```
(python-dev)patg@ubuntu:~/code/cluster-install$ ansible-playbook -vvvv -i hosts compute.yml

PLAY [launch a nova instance] *************************************************

GATHERING FACTS ***************************************************************
<localhost> REMOTE_MODULE setup
<localhost> EXEC ['/bin/sh', '-c', 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1397237613.78-  137688590001215 && chmod a+rx $HOME/.ansible/tmp/ansible-tmp-1397237613.78-137688590001215 &&  echo $HOME/.ansible/tmp/ansible-tmp-1397237613.78-137688590001215']
<localhost> PUT /tmp/tmpKNZx2U TO /home/patg/.ansible/tmp/ansible-tmp-1397237613.78137688590001215/setup
<localhost> EXEC ['/bin/sh', '-c', '/usr/bin/python /home/patg/.ansible/tmp/ansible-tmp-1397237613.78-137688590001215/setup; rm -rf /home/patg/.ansible/tmp/ansible-tmp-1397237613.78-137688590001215/>/dev/null2>&1']
ok: [localhost]

TASK: [launch an instance] ****************************************************
<localhost> REMOTE_MODULE nova_compute region_name=region-b.geo-1 security_groups=default login_username=username_group login_password=VALUE_HIDDEN auth_url=https://region-b.geo1.identity.hpcloudsvc.com:35357/v2.0/ state=present image_id=9302692b-b787-4b52-a3a6-daebb79cb498 key_name=test login_tenant_name=advanced_technology_group-project1 name=vm1
<localhost> EXEC ['/bin/sh', '-c', 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1397237614.2-130455430804821 && chmod a+rx $HOME/.ansible/tmp/ansible-tmp-1397237614.2-130455430804821 && echo $HOME/.ansible/tmp/ansible-tmp-1397237614.2-130455430804821'] 
 <localhost> PUT /tmp/tmpbYIfYx TO /home/patg/.ansible/tmp/ansible-tmp-1397237614.2-130455430804821/nova_compute
<localhost> EXEC ['/bin/sh', '-c', '/usr/bin/python /home/patg/.ansible/tmp/ansible-tmp-1397237614.2-130455430804821/nova_compute; rm -rf /home/patg/.ansible/tmp/ansible-tmp-1397237614.2-130455430804821/ >/dev/null 2>&1'] changed: [localhost] => {"changed": true, "id": "7407b96f-2670-422e-b43d-c345e8ea7f11", "info": {"OS-EXT-AZ:availability_zone": "az2", "OS-EXT-STS:power_state": 1, "OS-EXT-STS:task_state": null, "OS-EXT-STS:vm_state": "active", "accessIPv4": "", "accessIPv6": "", "addresses":    {"username-network":
[{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:e7:95:ea", "OS-EXT-IPS:type": "fixed", "addr": "10.0.0.101",   "version": 4}, {"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:e7:95:ea", "OS-EXT-IPS:type": "floating", "addr":     "15.126.238.160", "version": 4}]}, "config_drive": "", "created": "2014-04-11T17:33:35Z", "flavor": {"id": "101", "links": [{"href": "http://region-b.geo-1.compute.hpcloudsvc.com/10966558279755/flavors/101", "rel":"bookmark"}]}, "hostId": "cb776184d50b8e0f6ad84c84b9529cfdf1cb5cd451877c3e8cb9ce34", "id":"7407b96f- 2670-422e-b43d-c345e8ea7f11", "image": {"id": "9302692b-b787-4b52-a3a6-daebb79cb498","links": [{"href": "http://region-b.geo-1.compute.hpcloudsvc.com/10966558279755/images/9302692b-b787-4b52-a3a6-daebb79cb498", "rel":"bookmark"}]}, "key_name": "test", "links": [{"href": "http://region-b.geo-1.compute.hpcloudsvc.com/v2/10966558279755/servers/7407b96f-2670-422e-b43d-c345e8ea7f11", "rel":"self"}, {"href": "http://region-b.geo-1.compute.hpcloudsvc.com/10966558279755/servers/7407b96f-2670-422e-b43d-c345e8ea7f11", "rel": "bookmark"}], "metadata": {}, "name": "vm1", "progress": 0, "security_groups":[{"name": "default"}], "status":"ACTIVE", "tenant_id": "11111111111", "updated": "2014-04-11T17:34:00Z","user_id": "10794113572441"}, "private_ip": "10.0.0.101", "public_ip": "15.126.238.160", "status": "ACTIVE"}

PLAY RECAP ********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```
