### PR TITLE
Set default value for vg_options

### DIFF
--- a/library/system/lvg
+++ b/library/system/lvg
@@ -105,7 +105,7 @@ def main():
             vg=dict(required=True),
             pvs=dict(type='list'),
             pesize=dict(type='int', default=4),
-            vg_options=dict(),
+            vg_options=dict(default=''),
             state=dict(choices=["absent", "present"], default='present'),
             force=dict(type='bool', default='no'),
         ),


### PR DESCRIPTION
Fixes a bug when vg_options is not specified:
  File "/home/vagrant/.ansible/tmp/ansible-tmp-1397283690.67-233519411783834/lvg", line 119, in main
    vgoptions = module.params.get('vg_options', '').split()
AttributeError: 'NoneType' object has no attribute 'split'
