### PR TITLE
Fix typos in ansible-playbook man page source

### DIFF
--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -76,11 +76,11 @@ access, if any.
 
 Desired sudo user (default=root).
 
-*-t*, 'TAGS', *'--tags=*'TAGS'::
+*-t*, 'TAGS', *--tags=*'TAGS'::
 
 Only run plays and tasks tagged with these values.
 
-*'--skip-tags=*'SKIP_TAGS'::
+*--skip-tags=*'SKIP_TAGS'::
 
 Only run plays and tasks whose tags do not match these values.
 


### PR DESCRIPTION
Note: the man page needs to be rebuilt.
