### PR TITLE
Adds a new module, ec2_iam_role.

### DIFF
--- a/library/cloud/ec2_iam_role
+++ b/library/cloud/ec2_iam_role
@@ -74,6 +74,37 @@ EXAMPLES = '''
           policy: "{{ lookup('file', 'access_s3_file.json') }}"
         - name: policy_name2
           policy: "{{ lookup('file', 'access_policy2_file.json') }}"
+
+- ec2_iam_role:
+    state: present
+    name: some-role
+    instance_profile_name: some-role-permissions
+    trust_policy:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: "Allow"
+          Principal:
+            Service: "ec2.amazonaws.com"
+          Action: "sts:AssumeRole"
+    access_policies:
+        - name: s3
+          policy:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "s3:*"
+                Resource":
+                  - "*"
+        - name: ses
+          policy:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "ses:*"
+                Resource":
+                  - "*"
 '''
 
 import collections
@@ -166,6 +197,12 @@ def create_role(connection, module):
     if not trust_policy:
         module.fail_json(msg='trust_policy parameter is required for creating roles. %s' % module.params)
 
+    if isinstance(trust_policy, str):
+        try:
+            trust_policy = json.loads(trust_policy)
+        except:
+            module.fail_json(msg='trust_policy must be valid JSON.')
+
     access_policies = module.params['access_policies']
     if not access_policies:
         module.fail_json(msg='access_policies parameter is required for creating roles.')
@@ -199,6 +236,11 @@ def create_role(connection, module):
 
         # Upsert the policies that are listed
         for access_policy in access_policies:
+            if isinstance(access_policy, str):
+                try:
+                    access_policy = json.loads(access_policy)
+                except:
+                    module.fail_json(msg='access_policies must be valid JSON.')
             access_policy_name = access_policy['name']
             new_role_policy_names.append(access_policy_name)
 

--- a/library/cloud/ec2_iam_role
+++ b/library/cloud/ec2_iam_role
@@ -1,0 +1,299 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = """
+---
+module: ec2_asg
+short_description: Create or delete ec2 IAM instance roles
+description:
+  - Create or delete IAM instance roles
+version_added: "1.6"
+requirements: [ "boto" ]
+author: Scott Anderson
+options:
+  state:
+    description:
+      - Create or delete the role
+    required: true
+    choices: ['present', 'absent']
+  name:
+    description:
+      - Unique name for role to be created or deleted
+    required: true
+  trust_policy:
+    description:
+      - Trust policy for the role.
+    required: true
+  access_policies:
+    description:
+      - List of access policies, each of which is a dict with a name and policy key.
+    required: true
+  instance_profile_name:
+    description:
+      - Instance profile for the role. Defaults to the role name.
+    required: false
+  region:
+    description:
+      - AWS region for connection
+    required: true
+  aws_secret_key:
+    description:
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
+    required: false
+    default: None
+    aliases: ['ec2_secret_key', 'secret_key' ]
+  aws_access_key:
+    description:
+      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
+    required: false
+    default: None
+    aliases: ['ec2_access_key', 'access_key' ]
+"""
+
+EXAMPLES = '''
+- ec2_iam_role:
+    state: present
+    name: some-role
+    instance_profile_name: some-role-permissions
+    trust_policy: "{{ lookup('file', 'trust_policy_file.json') }}"
+    access_policies:
+        - name: s3
+          policy: "{{ lookup('file', 'access_s3_file.json') }}"
+        - name: policy_name2
+          policy: "{{ lookup('file', 'access_policy2_file.json') }}"
+'''
+
+import collections
+import pprint
+import sys
+import time
+import urllib
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+try:
+    import boto.iam
+    from boto.exception import BotoServerError
+except ImportError:
+    print "failed=True msg='boto required for this module'"
+    sys.exit(1)
+
+
+def get_role_info(role):
+    role_info = role['get_role_response']['get_role_result']['role']
+    role_info['assume_role_policy_document'] = urllib.unquote(role_info['assume_role_policy_document'])
+    return role_info
+
+
+def get_existing_role(module, connection, role_name):
+    try:
+        existing_role = connection.get_role(role_name)
+        existing_role = get_role_info(existing_role)
+    except BotoServerError, e:
+        if e.status == 404:
+            existing_role = None
+        else:
+            module.fail_json(msg=e)
+
+    return existing_role
+
+
+def get_policy_info(role):
+    policy_info = role['get_role_policy_response']['get_role_policy_result']
+    policy_info['policy_document'] = urllib.unquote(policy_info['policy_document'])
+    return policy_info
+
+
+def get_existing_policy(module, connection, role_name, access_policy_name):
+    try:
+        existing_policy = connection.get_role_policy(role_name, access_policy_name)
+        existing_policy = get_policy_info(existing_policy)
+    except BotoServerError, e:
+        if e.status == 404:
+            existing_policy = None
+        else:
+            module.fail_json(msg=e)
+
+    return existing_policy
+
+
+def get_profile_info(role):
+    profile_info = role['get_instance_profile_response']['get_instance_profile_result']['instance_profile']
+    return profile_info
+
+
+def get_existing_profile(module, connection, profile_name):
+    try:
+        existing_profile = connection.get_instance_profile(profile_name)
+        existing_profile = get_profile_info(existing_profile)
+    except BotoServerError, e:
+        if e.status == 404:
+            existing_profile = None
+        else:
+            module.fail_json(msg=e)
+
+    return existing_profile
+
+
+def get_existing_role_policy_names(module, connection, role_name):
+    try:
+        existing_role_policies = connection.list_role_policies(role_name)
+    except BotoServerError, e:
+        module.fail_json(msg='Cannot retrieve role policies for role: %s' %e)
+
+    return existing_role_policies['list_role_policies_response']['list_role_policies_result']['policy_names']
+
+def dicts_are_equal(dict1, dict2):
+    return pprint.pformat(dict1) == pprint.pformat(dict2)
+
+def create_role(connection, module):
+    role_name = module.params.get('name')
+    trust_policy = module.params['trust_policy']
+    if not trust_policy:
+        module.fail_json(msg='trust_policy parameter is required for creating roles. %s' % module.params)
+
+    access_policies = module.params['access_policies']
+    if not access_policies:
+        module.fail_json(msg='access_policies parameter is required for creating roles.')
+
+    instance_profile_name = module.params.get('instance_profile_name')
+    if not instance_profile_name:
+        instance_profile_name = role_name
+
+    existing_role = get_existing_role(module, connection, role_name)
+
+    try:
+        if not existing_role:
+            changed = True
+            connection.create_role(role_name, json.dumps(trust_policy))
+        else:
+            changed = False
+            normalized_policy_document = json.loads(existing_role['assume_role_policy_document'])
+            if not dicts_are_equal(trust_policy, normalized_policy_document):
+                changed = True
+                connection.update_assume_role_policy(role_name, json.dumps(trust_policy))
+
+    except BotoServerError, e:
+        module.fail_json(msg='Unable to create or update role: %s' % e)
+
+        
+    try:
+        # Get the existing policies for the role in case we need to delete some.
+        existing_role_policy_names = get_existing_role_policy_names(module, connection, role_name)
+
+        new_role_policy_names = []
+
+        # Upsert the policies that are listed
+        for access_policy in access_policies:
+            access_policy_name = access_policy['name']
+            new_role_policy_names.append(access_policy_name)
+
+            access_policy_document = access_policy['policy']
+            existing_policy = get_existing_policy(module, connection, role_name, access_policy_name)
+
+            if not existing_policy:
+                changed = True
+                connection.put_role_policy(role_name, access_policy_name, json.dumps(access_policy_document))
+            else:
+                normalized_access_policy_document = json.loads(existing_policy['policy_document'])
+                if not dicts_are_equal(access_policy_document, normalized_access_policy_document):
+                    changed = True
+                    connection.put_role_policy(role_name, access_policy_name, json.dumps(access_policy_document))
+
+        # Remove the existing policies that are no longer wanted
+        for existing_policy_name in existing_role_policy_names:
+            if existing_policy_name not in new_role_policy_names:
+                connection.delete_role_policy(role_name, existing_policy_name)
+
+    except BotoServerError, e:
+        module.fail_json(msg='Unable to create or update policy: %s (%s)' % (e, access_policy_name))
+
+
+    try:
+        existing_instance_profile = get_existing_profile(module, connection, instance_profile_name)
+        if not existing_instance_profile:
+            changed = True
+            connection.create_instance_profile(instance_profile_name)
+            connection.add_role_to_instance_profile(instance_profile_name, role_name)
+        else:
+            existing_profile_role = existing_instance_profile['roles'].get('member', None)
+            if not existing_profile_role or existing_profile_role['role_name'] <> role_name:
+                changed = True
+                connection.add_role_to_instance_profile(instance_profile_name, role_name)
+
+    except BotoServerError, e:
+        module.fail_json(msg='Unable to create or update instance profile: %s' % e)
+
+    existing_role = get_existing_role(module, connection, role_name)
+    module.exit_json(changed=changed, role=existing_role, ip=existing_instance_profile)
+
+
+def delete_role(connection, module):
+    role_name = module.params.get('name')
+    instance_profile_name = module.params.get('instance_profile_name')
+    if not instance_profile_name:
+        instance_profile_name = role_name
+
+    existing_role = get_existing_role(module, connection, role_name)
+
+    if existing_role:
+        try:
+            connection.remove_role_from_instance_profile(instance_profile_name, role_name)
+            connection.delete_instance_profile(instance_profile_name)
+
+            for policy_name in get_existing_role_policy_names(module, connection, role_name):
+                connection.delete_role_policy(role_name, policy_name)
+
+            connection.delete_role(role_name)
+
+        except BotoServerError, e:
+            module.fail_json(msg='Unable to delete role: %s' % e)
+
+        module.exit_json(changed=True)
+
+    else:
+        module.exit_json(changed=False)
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(required=True, type='str'),
+            trust_policy=dict(),
+            access_policies=dict(type='list'),
+            instance_profile_name=dict(type='str'),
+            region=dict(type='str'),
+            state=dict(default='present', choices=['present', 'absent']),
+        )
+    )
+    module = AnsibleModule(argument_spec=argument_spec)
+
+    state = module.params.get('state')
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
+    try:
+        connection = connect_to_aws(boto.iam, region, **aws_connect_params)
+    except boto.exception.NoAuthHandlerFound, e:
+        module.fail_json(msg=str(e))
+
+    if state == 'present':
+        create_role(connection, module)
+    elif state == 'absent':
+        delete_role(connection, module)
+
+main()


### PR DESCRIPTION
This module can create and delete IAM roles, policies, and instance profiles for association with an instance, either via instance creation or with a launch configuration.
