### PR TITLE
Fix localhost tasks with complex executables

### DIFF
--- a/lib/ansible/runner/connection_plugins/local.py
+++ b/lib/ansible/runner/connection_plugins/local.py
@@ -53,15 +53,16 @@ class Connection(object):
 
         if not self.runner.sudo or not sudoable:
             if executable:
-                local_cmd = [executable, '-c', cmd]
+                local_cmd = executable.split() + ['-c', cmd]
             else:
                 local_cmd = cmd
         else:
             local_cmd, prompt, success_key = utils.make_sudo_cmd(sudo_user, executable, cmd)
+        executable = executable.split()[0] if executable else None
 
         vvv("EXEC %s" % (local_cmd), host=self.host)
         p = subprocess.Popen(local_cmd, shell=isinstance(local_cmd, basestring),
-                             cwd=self.runner.basedir, executable=executable or None,
+                             cwd=self.runner.basedir, executable=executable,
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 


### PR DESCRIPTION
Enable the use of executable commands that use command line options with
the localhost command runner. These commands require parsing out the
base executable from the command string to pass to subprocess.
