### PR TITLE
generalize package_dir to fix setuptools' develop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='ansible',
       url='http://ansible.com/',
       license='GPLv3',
       install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
-      package_dir={ 'ansible': 'lib/ansible' },
+      package_dir={ '': 'lib' },
       packages=[
          'ansible',
          'ansible.utils',


### PR DESCRIPTION
Running setuptools' develop target (as well as, by extension, `pip
install -e`) on an ansible checkout does not work.  This is a
limitation of the develop target, but it can be made to work if
install_dir is generalized to say that _all_ packages are in lib.
(cf. https://github.com/pypa/pip/issues/126#issuecomment-874855)

Note that this does not address the modules in library.  Setting
the ANSIBLE_LIBRARY environment variable appropriately will, though.
These two items are sufficient to use a source checkout in a
virtualenv without using the env-setup script.
