### PR TITLE
Support hosts without private ip without errors

### DIFF
--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -279,7 +279,11 @@ class LinodeInventory(object):
 
         node_vars["datacenter_city"] = self.get_datacenter_city(node)
         node_vars["public_ip"] = [addr.address for addr in node.ipaddresses if addr.is_public][0]
-        node_vars["private_ip"] = [addr.address for addr in node.ipaddresses if not addr.is_public][0]
+
+        private_ips = [addr.address for addr in node.ipaddresses if not addr.is_public]
+
+        if private_ips:
+            node_vars["private_ip"] = private_ips[0]
 
         return self.json_format_dict(node_vars, True)
 


### PR DESCRIPTION
Not all Linode hosts have a private ip. This fixes an actual error that was happening because the generated list of private ips is empty when there isn't one.
