### PR TITLE
Fix documentation error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(name='ansible',
       packages=[
          'ansible',
          'ansible.utils',
+         'ansible.utils.module_docs_fragments',
          'ansible.inventory',
          'ansible.inventory.vars_plugins',
          'ansible.playbook',


### PR DESCRIPTION
The utility directory `module_docs_fragments` wasn't installed, resulting in a lot of `ansible-doc -l` errors.
This (tiny) patch fixes that.
