### PR TITLE
Added FILE_COMMON_DOCSTRINGS for common options.

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -119,6 +119,43 @@ FILE_COMMON_ARGUMENTS=dict(
     directory_mode = dict(), # used by copy
 )
 
+FILE_COMMON_DOCSTRINGS=dict(
+    # Prepend option name and append common attributes.
+    (key, '''{}:
+    {}
+    required: false
+    default: null
+    '''.format(key, value.strip())) for (key, value) in dict(
+    mode = '''
+    description:
+      - Change file mode bits.
+    ''',
+    owner = '''
+    description:
+      - Change file owner.
+    ''',
+    group = '''
+    description:
+      - Change file group.
+    ''',
+    seuser = '''
+    description:
+      - SELinux user.
+    ''',
+    serole = '''
+    description:
+      - SELinux role.
+    ''',
+    selevel = '''
+    description:
+      - SELinux level.
+    ''',
+    setype = '''
+    description:
+      - SELinux type.
+    ''',
+).iteritems())
+ 
 
 def get_platform():
     ''' what's the platform?  example: Linux is a platform. '''

--- a/library/files/assemble
+++ b/library/files/assemble
@@ -24,6 +24,8 @@ import shutil
 import tempfile
 import re
 
+from ansible.module_utils.basic import FILE_COMMON_DOCSTRINGS
+
 DOCUMENTATION = '''
 ---
 module: assemble
@@ -83,8 +85,11 @@ options:
     description:
       - all arguments accepted by the M(file) module also work here
     required: false
+  {owner}
+  {group}
+  {mode}
 author: Stephen Fromm
-'''
+'''.format(**FILE_COMMON_DOCSTRINGS)
 
 EXAMPLES = '''
 # Example from Ansible Playbooks

--- a/library/files/copy
+++ b/library/files/copy
@@ -21,6 +21,8 @@
 import os
 import time
 
+from ansible.module_utils.basic import FILE_COMMON_DOCSTRINGS
+
 DOCUMENTATION = '''
 ---
 module: copy
@@ -83,11 +85,14 @@ options:
         defaults.
     required: false
     version_added: "1.5"
+  {owner}
+  {group}
+  {mode}
 author: Michael DeHaan
 notes:
    - The "copy" module recursively copy facility does not scale to lots (>hundreds) of files.
      For alternative, see synchronize module, which is a wrapper around rsync.
-'''
+'''.format(**FILE_COMMON_DOCSTRINGS)
 
 EXAMPLES = '''
 # Example from Ansible Playbooks

--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from ansible.module_utils.basic import FILE_COMMON_DOCSTRINGS
 
 DOCUMENTATION = '''
 ---
@@ -64,6 +65,9 @@ options:
      description:
        - all arguments accepted by the M(file) module also work here
      required: false
+  {owner}
+  {group}
+  {mode}
 notes:
    - While it is possible to add an I(option) without specifying a I(value), this makes
      no sense.
@@ -73,7 +77,7 @@ notes:
      M(lineinfile) to add the missing line.
 requirements: [ ConfigParser ]
 author: Jan-Piet Mens
-'''
+'''.format(**FILE_COMMON_DOCSTRINGS)
 
 EXAMPLES = '''
 # Ensure "fav=lemonade is in section "[drinks]" in specified file

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -22,6 +22,8 @@ import re
 import os
 import tempfile
 
+from ansible.module_utils.basic import FILE_COMMON_DOCSTRINGS
+
 DOCUMENTATION = """
 ---
 module: lineinfile
@@ -119,7 +121,10 @@ options:
      description:
        - All arguments accepted by the M(file) module also work here.
      required: false
-"""
+  {owner}
+  {group}
+  {mode}
+""".format(**FILE_COMMON_DOCSTRINGS)
 
 EXAMPLES = r"""
 - lineinfile: dest=/etc/selinux/config regexp=^SELINUX= line=SELINUX=disabled

--- a/library/files/replace
+++ b/library/files/replace
@@ -22,6 +22,8 @@ import re
 import os
 import tempfile
 
+from ansible.module_utils.basic import FILE_COMMON_DOCSTRINGS
+
 DOCUMENTATION = """
 ---
 module: replace
@@ -70,7 +72,10 @@ options:
     description:
       - All arguments accepted by the M(file) module also work here.
     required: false
-"""
+  {owner}
+  {group}
+  {mode}
+""".format(**FILE_COMMON_DOCSTRINGS)
 
 EXAMPLES = r"""
 - replace: dest=/etc/hosts regexp='(\s+)old\.host\.name(\s+.*)?$' replace='\1new.host.name\2' backup=yes

--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+from ansible.module_utils.basic import FILE_COMMON_DOCSTRINGS
+
 DOCUMENTATION = '''
 ---
 module: unarchive
@@ -49,6 +51,9 @@ options:
     required: no
     default: null
     version_added: "1.6"
+  {owner}
+  {group}
+  {mode}
 author: Dylan Martin
 todo:
     - detect changed/unchanged for .zip files
@@ -64,7 +69,7 @@ notes:
       are not touched.  This is the same behavior as a normal archive extraction
     - existing files/directories in the destination which are not in the archive
       are ignored for purposes of deciding if the archive should be unpacked or not
-'''
+'''.format(**FILE_COMMON_DOCSTRINGS)
 
 EXAMPLES = '''
 # Example from Ansible Playbooks

--- a/library/network/get_url
+++ b/library/network/get_url
@@ -25,6 +25,8 @@ import datetime
 import re
 import tempfile
 
+from ansible.module_utils.basic import FILE_COMMON_DOCSTRINGS
+
 DOCUMENTATION = '''
 ---
 module: get_url
@@ -94,12 +96,15 @@ options:
     description:
       - all arguments accepted by the M(file) module also work here
     required: false
+  {owner}
+  {group}
+  {mode}
 notes:
     - This module doesn't yet support configuration for proxies.
 # informational: requirements for nodes
 requirements: [ urllib2, urlparse ]
 author: Jan-Piet Mens
-'''
+'''.format(**FILE_COMMON_DOCSTRINGS)
 
 EXAMPLES='''
 - name: download foo.conf

--- a/library/network/uri
+++ b/library/network/uri
@@ -29,6 +29,8 @@ try:
 except ImportError:
     import simplejson as json
 
+from ansible.module_utils.basic import FILE_COMMON_DOCSTRINGS
+
 DOCUMENTATION = '''
 ---
 module: uri
@@ -125,11 +127,14 @@ options:
     description:
       - all arguments accepted by the M(file) module also work here
     required: false
+  {owner}
+  {group}
+  {mode}
 
 # informational: requirements for nodes
 requirements: [ urlparse, httplib2 ]
 author: Romeo Theriault
-'''
+'''.format(**FILE_COMMON_DOCSTRINGS)
 
 EXAMPLES = '''
 # Check that you can connect (GET) to a page and it returns a status 200

--- a/library/web_infrastructure/htpasswd
+++ b/library/web_infrastructure/htpasswd
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from ansible.module_utils.basic import FILE_COMMON_DOCSTRINGS
+
 DOCUMENTATION = """
 module: htpasswd
 version_added: "1.3"
@@ -61,13 +63,16 @@ options:
       - Used with C(state=present). If specified, the file will be created
         if it does not already exist. If set to "no", will fail if the
         file does not exist
+  {owner}
+  {group}
+  {mode}
 notes:
   - "This module depends on the I(passlib) Python library, which needs to be installed on all target systems."
   - "On Debian, Ubuntu, or Fedora: install I(python-passlib)."
   - "On RHEL or CentOS: Enable EPEL, then install I(python-passlib)."
 requires: [ passlib>=1.6 ]
 author: Lorin Hochstein
-"""
+""".format(**FILE_COMMON_DOCSTRINGS)
 
 EXAMPLES = """
 # Add a user to a password file and ensure permissions are set


### PR DESCRIPTION
Multiple modules share the same common arguments that are expressed
in code by the add_file_common_args argument in the AnsibleModule
class. The modules that set this argument to True don't always update the
documentation accordingly though. For example, the owner is sometimes
assumed to exist only from the examples. This branch proposes a way to
share documentation across modules by using a FILE_COMMON_DOCSTRINGS
instead of copying and pasting the same documentation across modules.
