### PR TITLE
Fixing bug where if both private_ip and assign_public_ip in ec2 are set ansible fails out

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -820,15 +820,13 @@ def create_instances(module, ec2, override_count=None):
                             private_ip_address=private_ip,
                             groups=group_id,
                             associate_public_ip_address=assign_public_ip)
-                        interfaces = boto.ec2.networkinterface.NetworkInterfaceCollection(interface)
-                        params['network_interfaces'] = interfaces
                     else:
                         interface = boto.ec2.networkinterface.NetworkInterfaceSpecification(
                             subnet_id=vpc_subnet_id,
                             groups=group_id,
                             associate_public_ip_address=assign_public_ip)
-                        interfaces = boto.ec2.networkinterface.NetworkInterfaceCollection(interface)
-                        params['network_interfaces'] = interfaces                   
+                    interfaces = boto.ec2.networkinterface.NetworkInterfaceCollection(interface)
+                    params['network_interfaces'] = interfaces                   
             else:
                 params['subnet_id'] = vpc_subnet_id
                 if vpc_subnet_id:

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -814,13 +814,21 @@ def create_instances(module, ec2, override_count=None):
                         msg="assign_public_ip only available with vpc_subnet_id")
 
                 else:
-                    interface = boto.ec2.networkinterface.NetworkInterfaceSpecification(
-                        subnet_id=vpc_subnet_id,
-                        groups=group_id,
-                        associate_public_ip_address=assign_public_ip)
-                    interfaces = boto.ec2.networkinterface.NetworkInterfaceCollection(interface)
-                    params['network_interfaces'] = interfaces
-
+                    if private_ip:
+                        interface = boto.ec2.networkinterface.NetworkInterfaceSpecification(
+                            subnet_id=vpc_subnet_id,
+                            private_ip_address=private_ip,
+                            groups=group_id,
+                            associate_public_ip_address=assign_public_ip)
+                        interfaces = boto.ec2.networkinterface.NetworkInterfaceCollection(interface)
+                        params['network_interfaces'] = interfaces
+                    else:
+                        interface = boto.ec2.networkinterface.NetworkInterfaceSpecification(
+                            subnet_id=vpc_subnet_id,
+                            groups=group_id,
+                            associate_public_ip_address=assign_public_ip)
+                        interfaces = boto.ec2.networkinterface.NetworkInterfaceCollection(interface)
+                        params['network_interfaces'] = interfaces                   
             else:
                 params['subnet_id'] = vpc_subnet_id
                 if vpc_subnet_id:
@@ -842,13 +850,22 @@ def create_instances(module, ec2, override_count=None):
 
             # check to see if we're using spot pricing first before starting instances
             if not spot_price:
-                params.update(dict(
-                    min_count          = count_remaining,
-                    max_count          = count_remaining,
-                    client_token       = id,
-                    placement_group    = placement_group,
-                    private_ip_address = private_ip,
-                ))
+                if assign_public_ip and private_ip:
+                    params.update(dict(
+                      min_count          = count_remaining,
+                      max_count          = count_remaining,
+                      client_token       = id,
+                      placement_group    = placement_group,
+                    ))
+                else:
+                    params.update(dict(
+                      min_count          = count_remaining,
+                      max_count          = count_remaining,
+                      client_token       = id,
+                      placement_group    = placement_group,
+                      private_ip_address = private_ip,
+                    ))
+
                 res = ec2.run_instances(**params)
                 instids = [ i.id for i in res.instances ]
                 while True:


### PR DESCRIPTION
Ansible fails out.

This fixes this bug:

https://github.com/ansible/ansible/issues/6987

I tested all 3 variations after creating this patch: Private_ip alone, assign_public_ip and both set. All work. It also passes the "make tests".

This is my first patch so let me know if I did something wrong.
