### PR TITLE
Add missing info for the append option for user module

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -61,6 +61,8 @@ options:
               except the primary group.
     append:
         required: false
+        default: "no"
+        choices: [ "yes", "no" ]
         description:
             - If C(yes), will only add groups, not set them to just the list
               in I(groups).


### PR DESCRIPTION
Both 'default' and 'choices' options were missing at the documentation.
