### PR TITLE
apt-key list only returns keys in uppercase

### DIFF
--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -210,6 +210,7 @@ def main():
             _ = int(key_id, 16)
             if key_id.startswith('0x'):
                 key_id = key_id[2:]
+            key_id.upper()
         except ValueError:
             module.fail_json(msg="Invalid key_id", id=key_id)
 


### PR DESCRIPTION
More user friendly if someone is silly enough to enter a lower case key.
