### PR TITLE
skipped callback in loop does not display 'item'.

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -884,7 +884,7 @@ class Runner(object):
                 # no callbacks
                 return result
             if 'skipped' in data:
-                self.callbacks.on_skipped(host)
+                self.callbacks.on_skipped(host, inject.get('item',None))
             elif not result.is_successful():
                 ignore_errors = self.module_vars.get('ignore_errors', False)
                 self.callbacks.on_failed(host, data, ignore_errors)


### PR DESCRIPTION
I noticed that when a module returns 'skipped':True while using a with_items loop, the skipped callback does not display the current item label like ok or changed does.

Investigating the code in runner/__init__.py, it seems that the item is not being passed through on line 887, but is on line 714. Note: There is another call to on_skipped on line 673, but that seems like it should never have 'item' set.

This patch brings consistency and fixes the issue for me. 

_Before_

```
TASK: [Skipping Test ] *********************************************** 
skipping: [192.168.66.10]
skipping: [192.168.66.10]
skipping: [192.168.66.10]
```

_After_

```
TASK: [Skipping Test ] *********************************************** 
skipping: [192.168.66.10] => (item=redis)
skipping: [192.168.66.10] => (item=varnish)
skipping: [192.168.66.10] => (item=nginx)
```
