### PR TITLE
apt_key: fix key lookup for 64 bit key ids

### DIFF
--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -120,11 +120,11 @@ def check_missing_binaries(module):
     if len(missing):
         module.fail_json(msg="binaries are missing", names=missing)
 
-def all_keys(module, keyring):
+def all_keys(module, keyring, short_format):
     if keyring:
-        cmd = "apt-key --keyring %s list" % keyring
+        cmd = "apt-key --keyring %s adv --list-public-keys --keyid-format=long" % keyring
     else:
-        cmd = "apt-key list"
+        cmd = "apt-key adv --list-public-keys --keyid-format=long"
     (rc, out, err) = module.run_command(cmd)
     results = []
     lines = out.split('\n')
@@ -134,11 +134,19 @@ def all_keys(module, keyring):
             code = tokens[1]
             (len_type, real_code) = code.split("/")
             results.append(real_code)
+    if short_format:
+        results = shorten_key_ids(results)
     return results
 
-def key_present(module, key_id):
-    (rc, out, err) = module.run_command("apt-key list | 2>&1 grep -i -q %s" % pipes.quote(key_id), use_unsafe_shell=True)
-    return rc == 0
+def shorten_key_ids(key_id_list):
+    """
+    Takes a list of key ids, and converts them to the 'short' format,
+    by reducing them to their last 8 characters.
+    """
+    short = []
+    for key in key_id_list:
+        short.append(key[-8:])
+    return short
 
 def download_key(module, url):
     # FIXME: move get_url code to common, allow for in-memory D/L, support proxies
@@ -210,13 +218,15 @@ def main():
             _ = int(key_id, 16)
             if key_id.startswith('0x'):
                 key_id = key_id[2:]
+            key_id = key_id.upper()
         except ValueError:
             module.fail_json(msg="Invalid key_id", id=key_id)
 
     # FIXME: I think we have a common facility for this, if not, want
     check_missing_binaries(module)
 
-    keys = all_keys(module, keyring)
+    short_format = (key_id is not None and len(key_id) == 8)
+    keys = all_keys(module, keyring, short_format)
     return_values = {}
 
     if state == 'present':
@@ -237,7 +247,7 @@ def main():
                 else:
                     add_key(module, "-", keyring, data)
                 changed=False
-                keys2 = all_keys(module, keyring)
+                keys2 = all_keys(module, keyring, short_format)
                 if len(keys) != len(keys2):
                     changed=True
                 if key_id and not key_id in keys2:


### PR DESCRIPTION
Fixes #7018 by extending `all_keys` to work with either short or long keys.

Also removes the ununsed method `key_present`.
