### PR TITLE
Only update submodules when recursive is true

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -429,7 +429,7 @@ def submodule_update(git_path, module, dest):
         module.fail_json(msg="Failed to init/update submodules: %s" % out + err)
     return (rc, out, err)
 
-def switch_version(git_path, module, dest, remote, version):
+def switch_version(git_path, module, dest, remote, version, recursive):
     ''' once pulled, switch to a particular SHA, tag, or branch '''
     cmd = ''
     if version != 'HEAD':
@@ -455,8 +455,11 @@ def switch_version(git_path, module, dest, remote, version):
             module.fail_json(msg="Failed to checkout %s" % (version))
         else:
             module.fail_json(msg="Failed to checkout branch %s" % (branch))
-    (rc, out2, err2) = submodule_update(git_path, module, dest)
-    return (rc, out1 + out2, err1 + err2)
+    if recursive:
+        (rc, out2, err2) = submodule_update(git_path, module, dest)
+        out1 += out2
+        err1 += err1
+    return (rc, out1, err1)
 
 # ===========================================
 
@@ -565,7 +568,7 @@ def main():
     # switch to version specified regardless of whether
     # we cloned or pulled
     if not bare:
-        switch_version(git_path, module, dest, remote, version)
+        switch_version(git_path, module, dest, remote, version, recursive)
 
     # determine if we changed anything
     after = get_version(module, git_path, dest)


### PR DESCRIPTION
##### Issue Type:

“Bug Report” /  “Bugfix Pull Request”
##### Ansible Version:

ansible 1.6 (devel a5e7492c4f) last updated 2014/04/15 21:12:13 (GMT -400)
##### Environment:

Ubuntu 12.04
##### Summary:

Setting the git recursive parameter to no does not stop a repo with submodules from having all of the submodules cloned. While the `--recursive` flag is added to the clone command , the `main` function calls `switch_version` which automatically runs `submodule_update` without checking the recursive parameter.

This pull request adds that logic that only updates the submodules when the recursive parameter is set.
##### Steps To Reproduce:

With a git repo with submodules,  run 

`git: repo=reponame dest=place/to/put/it recursive=no`
##### Expected Results:

I expect my base module to be cloned / pulled, but for none of the submodules contents to be present. The path that the submodules point to should exist, but that should bot have the content from their repos
##### Actual Results:

_Before PR_:
All submodules are fully updated, with all contents present.

_After PR_
Expected Result
