### PR TITLE
docker: exclude 'entrypoint' from comparing 'command' param with containers

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -489,8 +489,7 @@ class DockerManager:
         return inspect
 
     def get_deployed_containers(self):
-        # determine which images/commands are running already
-        containers = self.client.containers(all=True)
+        """determine which images/commands are running already"""
         image = self.module.params.get('image')
         command = self.module.params.get('command')
         if command:
@@ -504,13 +503,18 @@ class DockerManager:
         # docker will give us back the full image name including a tag in the container list if one exists.
         image, tag = self.get_split_image_tag(image)
 
-        for i in containers:
+        for i in self.client.containers(all=True):
             running_image, running_tag = self.get_split_image_tag(i['Image'])
             running_command = i['Command'].strip()
 
-            if (name and name in i['Names']) or \
-                    (not name and running_image == image and (not tag or tag == running_tag) and
-                    (not command or running_command == command)):
+            name_matches = (name and name in i['Names'])
+            image_matches = (running_image == image)
+            tag_matches = (not tag or running_tag == tag)
+            # if a container has an entrypoint, `command` will actually equal
+            # '{} {}'.format(entrypoint, command)
+            command_matches = (not command or running_command.endswith(command))
+
+            if name_matches or (image_matches and tag_matches and command_matches):
                 details = self.client.inspect_container(i['Id'])
                 details = _docker_id_quirk(details)
                 deployed.append(details)
@@ -682,11 +686,11 @@ def main():
 
         # start/stop containers
         if state in [ "running", "present" ]:
-            
+
             # make sure a container with `name` exists, if not create and start it
             if name and "/" + name not in map(lambda x: x.get('Name'), deployed_containers):
                 containers = manager.create_containers(1)
-                if state == "present": #otherwise it get (re)started later anyways.. 
+                if state == "present": #otherwise it get (re)started later anyways..
                   manager.start_containers(containers)
                   running_containers = manager.get_running_containers()
                 deployed_containers = manager.get_deployed_containers()
@@ -695,18 +699,18 @@ def main():
                 # make sure a container with `name` is running
                 if name and "/" + name not in map(lambda x: x.get('Name'), running_containers):
                     manager.start_containers(deployed_containers)
-    
+
                 # start more containers if we don't have enough
                 elif delta > 0:
                     containers = manager.create_containers(delta)
                     manager.start_containers(containers)
-    
+
                 # stop containers if we have too many
                 elif delta < 0:
                     containers_to_stop = running_containers[0:abs(delta)]
                     containers = manager.stop_containers(containers_to_stop)
                     manager.remove_containers(containers_to_stop)
-    
+
                 facts = manager.get_running_containers()
             else:
                 acts = manager.get_deployed_containers()


### PR DESCRIPTION
The JSON the Docker API returns includes the container's entrypoint (if it has one) prepended to its `Command` value. So instead of checking if `container['Command'] == module.params['command']` – which will be wrong if the container has an entrypoint – we just check that `container['Command'].endswith(module.params['command'])` so the entrypoint won't affect a container being properly classified as matching the module params or not.

Also I refactored a super-long `if` statement into some temporary variables - I did it to help me figure out what was going wrong, and then it makes the code more readable so I kept it.

(Note that this won't work with the currently-released `docker-py` until #6991 is merged in, because the `docker` module is broken until that happens)
