### PR TITLE
Use ansible_private_key_file for delegated hosts

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -346,6 +346,12 @@ class Runner(object):
         delegate['transport'] = this_info.get('ansible_connection', self.transport)
         delegate['sudo_pass'] = this_info.get('ansible_sudo_pass', self.sudo_pass)
 
+        # Last chance to get private_key_file from global variables.
+        # this is usefull if delegated host is not defined in the inventory
+        if delegate['private_key_file'] is None:
+            delegate['private_key_file'] = remote_inject.get(
+                'ansible_ssh_private_key_file', None)
+
         if delegate['private_key_file'] is not None:
             delegate['private_key_file'] = os.path.expanduser(delegate['private_key_file'])
 


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

All
##### Environment:

N/A
##### Summary:

When running playbooks in an inventory-less environment
ansible_private_key_file is not honored for delegated hosts. This
patch fixed that issue.
##### Steps To Reproduce:

Simple playbook:

```
- hosts: "all"
  user: ansible
  sudo: yes
  sudo_user: root

  vars:
    - ansible_ssh_private_key_file: ../.ssh/ansible

  tasks:
    - name: test delegated
      ping: ""
      delegate_to: delegated-host.example.com
```

`ansible-playbook -i target.example.com, test.yml -vvvvv` will produce:
##### Expected Results:

With the patch:

```
TASK: [test delegated] ********************************************************
<delegated-host.example.com> ESTABLISH CONNECTION FOR USER: ansible
<delegated-host.example.com> REMOTE_MODULE ping
<delegated-host.example.com> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'IdentityFile=../.ssh/ansible', '-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no', '-o', 'User=ansible', '-o', 'ConnectTimeout=10', 'delegated-host.example.com', "/bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1397779436.94-6033870923105 && chmod a+rx $HOME/.ansible/tmp/ansible-tmp-1397779436.94-6033870923105 && echo $HOME/.ansible/tmp/ansible-tmp-1397779436.94-6033870923105'"]
<delegated-host.example.com> PUT /tmp/tmpTF1ZSn TO /var/lib/ansible/.ansible/tmp/ansible-tmp-1397779436.94-6033870923105/ping
<delegated-host.example.com> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'IdentityFile=../.ssh/ansible', '-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no', '-o', 'User=ansible', '-o', 'ConnectTimeout=10', 'delegated-host.example.com', '/bin/sh -c \'sudo -k && sudo -H -S -p "[sudo via ansible, key=bioohyqkycfxhtrpgdosyaoyveusieag] password: " -u root /bin/sh -c \'"\'"\'echo SUDO-SUCCESS-bioohyqkycfxhtrpgdosyaoyveusieag; /usr/bin/python /var/lib/ansible/.ansible/tmp/ansible-tmp-1397779436.94-6033870923105/ping; rm -rf /var/lib/ansible/.ansible/tmp/ansible-tmp-1397779436.94-6033870923105/ >/dev/null 2>&1\'"\'"\'\'']
ok: [target.example.com] => {"changed": false, "ping": "pong"}
```
##### Actual Results:

Without the patch

```
GATHERING FACTS ***************************************************************
<target.example.com> ESTABLISH CONNECTION FOR USER: ansible
<target.example.com> REMOTE_MODULE setup
<target.example.com> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'IdentityFile=../.ssh/ansible', '-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no', '-o', 'User=ansible', '-o', 'ConnectTimeout=10', 'target.example.com', "/bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1397779303.75-87764599171703 && chmod a+rx $HOME/.ansible/tmp/ansible-tmp-1397779303.75-87764599171703 && echo $HOME/.ansible/tmp/ansible-tmp-1397779303.75-87764599171703'"]
<target.example.com> PUT /tmp/tmpMstUct TO /var/lib/ansible/.ansible/tmp/ansible-tmp-1397779303.75-87764599171703/setup
<target.example.com> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'IdentityFile=../.ssh/ansible', '-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no', '-o', 'User=ansible', '-o', 'ConnectTimeout=10', 'target.example.com', '/bin/sh -c \'sudo -k && sudo -H -S -p "[sudo via ansible, key=baqrymoikypfmsraluxihemembjubbrg] password: " -u root /bin/sh -c \'"\'"\'echo SUDO-SUCCESS-baqrymoikypfmsraluxihemembjubbrg; /usr/bin/python /var/lib/ansible/.ansible/tmp/ansible-tmp-1397779303.75-87764599171703/setup; rm -rf /var/lib/ansible/.ansible/tmp/ansible-tmp-1397779303.75-87764599171703/ >/dev/null 2>&1\'"\'"\'\'']
ok: [target.example.com]

TASK: [test delegated] ********************************************************
<delegated-host.example.com> ESTABLISH CONNECTION FOR USER: ansible
<delegated-host.example.com> REMOTE_MODULE ping
<delegated-host.example.com> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no', '-o', 'User=ansible', '-o', 'ConnectTimeout=10', 'delegated-host.example.com', "/bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1397779307.22-52434613811698 && chmod a+rx $HOME/.ansible/tmp/ansible-tmp-1397779307.22-52434613811698 && echo $HOME/.ansible/tmp/ansible-tmp-1397779307.22-52434613811698'"]
```

The delegated host does not have the `'-o', 'IdentityFile=../.ssh/ansible'` ssh option set.
### Commit log

If a delegated host is not found in the inventory specified
private_key_file for primary host was not used.

This allows running playbooks without having to define any inventory at
all and to use the same ssh private key for both primary host and
delegated one.
