### PR TITLE
cloud/rds : renaming an rds instance always fails

### DIFF
--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -540,6 +540,12 @@ def main():
                             found = 1
                     if found == 0:
                         time.sleep(5)
+
+                # The name of the database has now changed, so we have
+                # to force result to contain the new instance, otherwise
+                # the call below to get_current_resource will fail since it
+                # will be looking for the old instance name.
+                result.id = new_instance_name
             else:
                 # Wait for a few seconds since it takes a while for AWS
                 # to change the instance from 'available' to 'modifying'


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.6 (rds_modify 632eb18) last updated 2014/04/18 17:39:06 (GMT +000)
##### Environment:

N/A
##### Summary:

Using the RDS module with command=modify and apply_immediately=yes to rename an instance (setting new_instance_name) will currently always fail. When this module was modified recently it wasn't tested with renaming an instance. A call to get_current_resource fails simply because it's trying to look up details of the old instance name, not the new name that the instance was just renamed to.
##### Steps To Reproduce:

An rds task with the following properites set:

```
command=modify
apply_immediately=yes
new_instance_name=some_new_instance_name
```
##### Expected Results:

No error should be thrown.  The instance is actually renamed but Ansible throws an error.
##### Actual Results:

```
failed: [test_host] => {"failed": true}
msg: DBInstance starting_test_instance not found.
```
