### PR TITLE
Fix #7057 missing False default for vars_prompt

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -643,7 +643,7 @@ class PlaybookCallbacks(object):
 
     def on_vars_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False, salt_size=None, salt=None, default=None):
 
-        if prompt and default:
+        if prompt and default is not None:
             msg = "%s [%s]: " % (prompt, default)
         elif prompt:
             msg = "%s: " % prompt


### PR DESCRIPTION
The test for default should be "is not None" since a boolean value of
False is a valid value.

See discussion at:
  [https://groups.google.com/forum/#!topic/ansible-project/oc1_zE-FnyI]
