### PR TITLE
workaround for no stderr of yum errors in RHEL5 and state=present/state=latest

### DIFF
--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -207,7 +207,7 @@ def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_
             
         if rc == 0 and rc2 == 0:
             out += out2
-            return [ p for p in out.split('\n') if p.strip() ]
+            return [ p for p in out.split('\n') if pkgspec in p.strip() ]
         else:
             module.fail_json(msg='Error from repoquery: %s: %s' % (cmd, err + err2))
             
@@ -345,7 +345,7 @@ def what_provides(module, repoq, req_spec, conf_file,  qf=def_qf, en_repos=[], d
         rc2,out2,err2 = module.run_command(cmd)
         if rc == 0 and rc2 == 0:
             out += out2
-            pkgs = set([ p for p in out.split('\n') if p.strip() ])
+            pkgs = set([ p for p in out.split('\n') if req_spec in p.strip() ])
             if not pkgs:
                 pkgs = is_installed(module, repoq, req_spec, conf_file, qf=qf)
             return pkgs


### PR DESCRIPTION
Yum in RHEL5 doesn't output errors to stderr but to stdout (RHEL6 works correctly). 
This gives some issues for functions that check if stdout is empty or not to determine if a package is available or not.
This simple patch fixes this issue in RHEL5 by checking if the stdout result contains the package name itself and not some random error.

Tested on RHEL5.10 and RHEL6.5
Apparently this sending errors/'info' to stdout will also be in RHEL7: 
https://bugzilla.redhat.com/show_bug.cgi?id=1017354

To reproduce the issue, e.g an error where we have duplicate yum repos:
RHEL5 #; /usr/bin/repoquery --show-duplicates --plugins --quiet -q --disablerepo=\* --pkgnarrow=installed --qf %{name}-%{version}-%{release}.%{arch} --whatprovides httpd > /tmp/abc
RHEL5 #; cat /tmp/abc
Repository epel is listed more than once in the configuration
httpd-2.2.3-85.el5_10.x86_64
RHEL6 #

RHEL6 # /usr/bin/repoquery --show-duplicates --plugins --quiet -q --disablerepo=\* --pkgnarrow=installed --qf %{name}-%{version}-%{release}.%{arch} --whatprovides httpd > /tmp/abc
Repository epel is listed more than once in the configuration
RHEL6 # cat /tmp/abc
httpd-2.2.15-30.el6_5.x86_64
RHEL6 #
