### PR TITLE
Show a friendly error if you use the validate option but forget: %s

### DIFF
--- a/library/files/copy
+++ b/library/files/copy
@@ -204,6 +204,8 @@ def main():
                 os.unlink(dest)
                 open(dest, 'w').close()
             if validate:
+                if "%s" not in validate:
+                    module.fail_json(msg="validate must contain %%s: %s" % (validate))
                 (rc,out,err) = module.run_command(validate % src)
                 if rc != 0:
                     module.fail_json(msg="failed to validate: rc:%s error:%s" % (rc,err))

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -154,6 +154,8 @@ def write_changes(module,lines,dest):
     validate = module.params.get('validate', None)
     valid = not validate
     if validate:
+        if "%s" not in validate:
+            module.fail_json(msg="validate must contain %%s: %s" % (validate))
         (rc, out, err) = module.run_command(validate % tmpfile)
         valid = rc == 0
         if rc != 0:

--- a/library/files/replace
+++ b/library/files/replace
@@ -90,6 +90,8 @@ def write_changes(module,contents,dest):
     validate = module.params.get('validate', None)
     valid = not validate
     if validate:
+        if "%s" not in validate:
+            module.fail_json(msg="validate must contain %%s: %s" % (validate))
         (rc, out, err) = module.run_command(validate % tmpfile)
         valid = rc == 0
         if rc != 0:


### PR DESCRIPTION
before:

```
fatal: [192.168.33.10] => failed to parse: Traceback (most recent call last):
  File "/home/vagrant/.ansible/tmp/ansible-tmp-1397870557.51-203219450016801/copy", line 1326, in <module>
    main()
  File "/home/vagrant/.ansible/tmp/ansible-tmp-1397870557.51-203219450016801/copy", line 210, in main
    (rc,out,err) = module.run_command(validate % src)
TypeError: not all arguments converted during string formatting
```

after:

```
failed: [192.168.33.10] => {"failed": true, "item": "", "md5sum": "cb9915cece456389db174d2e69311f57"}
msg: validate must contain %s: /bin/true
```
