### PR TITLE
Add a better error message for service

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -565,7 +565,7 @@ class LinuxService(Service):
     def service_enable(self):
 
         if self.enable_cmd is None:
-            self.module.fail_json(msg='unknown init system, cannot enable service')
+            self.module.fail_json(msg='cannot detect command to enable service %s, typo or init system potentially unknown' % self.name)
 
         # FIXME: we use chkconfig or systemctl
         # to decide whether to run the command here but need something


### PR DESCRIPTION
While migrating my playbook to a newer ansible version, I faced
the error message "unknown init system, cannot enable service". It turned
out to be caused by a wrong service name that was not expanded anymore.

So by giving the name of the service that cannot be enabled and a more precise
reason, i think people will be able to diagnose their issue more easily.
