### PR TITLE
Clean a bit more the ssh_args configuration

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -59,7 +59,8 @@ class Connection(object):
         self.common_args = []
         extra_args = C.ANSIBLE_SSH_ARGS
         if extra_args is not None:
-            self.common_args += shlex.split(extra_args)
+            # make sure there is no empty string added as this can produce weird errors
+            self.common_args += [x.strip() for x in shlex.split(extra_args) if x.strip()]
         else:
             self.common_args += ["-o", "ControlMaster=auto",
                                  "-o", "ControlPersist=60s",


### PR DESCRIPTION
If someone add ssh_args = " " to his .ansible.cfg, it will result into
strange failure later :

```
<server.example.org> ESTABLISH CONNECTION FOR USER: misc
<server.example.org> REMOTE_MODULE ping
<server.example.org> EXEC ['ssh', '-C', '-tt', '-q', ' ', '-o', 'KbdInteractiveAuthentication=no',
'-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no',
'-o', 'ConnectTimeout=10', 'server.example.org', "/bin/sh -c 'mkdir -p /tmp/ansible-tmp-1397947711.21-5932460998838
&& chmod a+rx /tmp/ansible-tmp-1397947711.21-5932460998838 && echo /tmp/ansible-tmp-1397947711.21-5932460998838'"]
server.example.org | FAILED => SSH encountered an unknown error during the connection. We recommend you re-run the
command using -vvvv, which will enable SSH debugging output to help diagnose the issue
```

The root cause is the empty string between -q and -o, who kinda break mkdir.
