### PR TITLE
An attempt to allow role directories to be flatter

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -469,6 +469,10 @@ class Play(object):
                  os.path.join(basepath, 'main.yml'),
                  os.path.join(basepath, 'main.yaml'),
                  os.path.join(basepath, 'main.json'),
+                 basepath,
+                 basepath + '.yml',
+                 basepath + '.yaml',
+                 basepath + '.json',
                 )
         if sum([os.path.isfile(x) for x in mains]) > 1:
             raise errors.AnsibleError("found multiple main files at %s, only one allowed" % (basepath))


### PR DESCRIPTION
The amount of directory nesting inside the roles can be unconfortable when editing the files from the command line.  With a very small change it is possible to provide a choice when creating the role directory structure.
