### PR TITLE
fixed ETIME issue on FreeBSD 8 through 10, which broke fact gather

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -49,7 +49,7 @@ except ImportError:
 class TimeoutError(Exception):
     pass
 
-def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
+def timeout(seconds=10, error_message="Timer expired"):
     def decorator(func):
         def _handle_timeout(signum, frame):
             raise TimeoutError(error_message)


### PR DESCRIPTION
As reported here:

https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/ansible-project/fkEqPHf0nH4/glUqeCuDIDsJ

fact gathering on FreeBSD breaks with the following error:

```
Had a working setup using the dev branch from a week or two ago.. today I did an update and after that I am getting an error:
GATHERING FACTS *************************************************************** 
<107.170.122.172> REMOTE_MODULE setup
<10.1.1.191> REMOTE_MODULE setup
fatal: [fat.natserv.net] => failed to parse: Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1397944758.52-275089191503778/setup", line 1391, in <module>
    def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
AttributeError: 'module' object has no attribute 'ETIME'
```

This patch fixes it, ETIME is not a valid constant in errno module in python 2.7 on FreeBSD
