### PR TITLE
Create roles_file configurartion

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -181,7 +181,7 @@ def build_option_parser(action):
             '-n', '--no-deps', dest='no_deps', action='store_true', default=False,
             help='Don\'t download roles listed as dependencies')
         parser.add_option(
-            '-r', '--role-file', dest='role_file',
+            '-r', '--role-file', dest='role_file', default=C.DEFAULT_ROLES_FILE,
             help='A file containing a list of roles to be imported')
     elif action == "remove":
         parser.set_usage("usage: %prog remove role1 role2 ...")

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -102,6 +102,7 @@ DEFAULTS='defaults'
 # configurable things
 DEFAULT_HOST_LIST         = shell_expand_path(get_config(p, DEFAULTS, 'hostfile', 'ANSIBLE_HOSTS', '/etc/ansible/hosts'))
 DEFAULT_MODULE_PATH       = get_config(p, DEFAULTS, 'library',          'ANSIBLE_LIBRARY',          DIST_MODULE_PATH)
+DEFAULT_ROLES_FILE        = get_config(p, DEFAULTS, 'roles_file',       'ANSIBLE_ROLES_FILE',       None)
 DEFAULT_ROLES_PATH        = get_config(p, DEFAULTS, 'roles_path',       'ANSIBLE_ROLES_PATH',       '/etc/ansible/roles')
 DEFAULT_REMOTE_TMP        = shell_expand_path(get_config(p, DEFAULTS, 'remote_tmp',       'ANSIBLE_REMOTE_TEMP',      '$HOME/.ansible/tmp'))
 DEFAULT_MODULE_NAME       = get_config(p, DEFAULTS, 'module_name',      None,                       'command')

--- a/test/units/TestConstants.py
+++ b/test/units/TestConstants.py
@@ -10,7 +10,7 @@ import os
 
 
 def random_string(length):
-    return ''.join(random.choice(string.ascii_uppercase) for x in range(6))
+    return ''.join(random.choice(string.ascii_uppercase) for x in range(length))
 
 p = ConfigParser.ConfigParser()
 p.read(os.path.join(os.path.dirname(__file__), 'ansible.cfg'))


### PR DESCRIPTION
Create configuration roles_file to define the file used by ansible-galaxy to install roles. 

Example

```
# ansible.cfg
[defaults]
roles_file=ROLES_FILE
```

```
# ROLES_FILE
EHER.git
```

With that configurations into ansible.cfg and a [roles file](https://galaxy.ansible.com/intro) named ROLES_FILE, we are able to run `ansible-galaxy install` without parameters.

With that configuration we can create more flexible workflows into applications projects that holds ansible playbooks to configure environment.

That should not cause problems to other PR witch pretend make yml file available to configure roles.

---

It also fix random_string used into constants tests, that was ignoring length parameter and aways using 6. 
