### PR TITLE
Add an example to show all hostvars using debug

### DIFF
--- a/library/utilities/debug
+++ b/library/utilities/debug
@@ -50,6 +50,9 @@ EXAMPLES = '''
 
 - shell: /usr/bin/uptime
   register: result
+
 - debug: var=result
 
+- name: Display all variables/facts known for a host
+  debug: var=hostvars[inventory_hostname]
 '''


### PR DESCRIPTION
This is a useful example to help debug how facts and vars are being collated.
