### PR TITLE
Add check of return code for autoinstallation of python-apt

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -432,7 +432,7 @@ def main():
 
     if not HAS_PYTHON_APT:
         try:
-            module.run_command('apt-get update && apt-get install python-apt -y -q', use_unsafe_shell=True)
+            module.run_command('apt-get update && apt-get install python-apt -y -q', use_unsafe_shell=True, check_rc=True)
             global apt, apt_pkg
             import apt
             import apt_pkg


### PR DESCRIPTION
When you try to use `apt` role without having `python-apt` installed and **without passing `--sudo` as an option to `ansible-playbook`**, it will fail with quite vague error message:

```
msg: Could not import python modules: apt, apt_pkg. Please install python-apt package.
```

Requested change will pass the stderr from `apt-get install` command further to the user, so the message will be actually helpful:

```
install python-apt -y -q", "failed": true, "item": "git,git-svn", "rc": 100}
stderr: E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
E: Unable to lock directory /var/lib/apt/lists/
E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?

msg: E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
E: Unable to lock directory /var/lib/apt/lists/
E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?
```

In fact current message will look like this until #7095  will gets merged.

```
fatal: [localhost] => failed to parse: {"stdout": "", "cmd": "apt-get update && apt-get install python-apt -y -q", "failed": true, "stderr": "E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)\nE: Unable to lock directory /var/lib/apt/lists/\nE: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)\nE: Unable to lock the administration directory (/var/lib/dpkg/), are you root?\n", "rc": 100, "msg": "E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)\nE: Unable to lock directory /var/lib/apt/lists/\nE: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)\nE: Unable to lock the administration directory (/var/lib/dpkg/), are you root?"}
{"msg": "Could not import python modules: apt, apt_pkg. Please install python-apt package.", "failed": true}
```
