### PR TITLE
Prevent catching unrelated exceptions

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -436,7 +436,7 @@ def main():
             global apt, apt_pkg
             import apt
             import apt_pkg
-        except:
+        except ImportError:
             module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")
 
     global APTITUDE_CMD


### PR DESCRIPTION
There are many places in the code where ansible simply catches all exceptions, which is a bad practice also called [_Pokemon exception handling_](http://www.dodgycoder.net/2011/11/yoda-conditions-pokemon-exception.html).

I believe we can fine-grain most of them (as it's actually mentioned in [the coding guidelines](https://github.com/ansible/ansible/blob/devel/CODING_GUIDELINES.md#exceptions)) and this is the first place where it's actually already causing issues.

If the `module.run_command(...` will trigger `sys.exit()`, then [`SystemExit`](https://docs.python.org/2/library/exceptions.html#exceptions.SystemExit) will be catched by this statement too and if there was already a JSON output (`fail_json()` has been already called before exiting), it will end up in parse error on the output as two `fail_json()` calls will generate two unparsable concatenated JSON strings.

The erroneous situation can be simulated within #7094
