### PR TITLE
BSD hardware address filtering

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -1732,7 +1732,9 @@ class GenericBsdIfconfigNetwork(Network):
             if line:
                 words = line.split()
 
-                if re.match('^\S', line) and len(words) > 3:
+                if words[0] == 'pass':
+                    continue
+                elif re.match('^\S', line) and len(words) > 3:
                     current_if = self.parse_interface_line(words)
                     interfaces[ current_if['device'] ] = current_if
                 elif words[0].startswith('options='):


### PR DESCRIPTION
Fixes #7093 
setup module tells about some "pas" interface, which does not exist.
using OpenBSD hardware address filtering, ifconfig output shows several 'pass [....]' rules.
