### PR TITLE
module docker - add docker version comment

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -184,7 +184,7 @@ options:
     aliases: []
     version_added: "1.6"
 author: Cove Schneider, Joshua Conner, Pavel Antonov
-requirements: [ "docker-py >= 0.3.0" ]
+requirements: [ "docker-py >= 0.3.0", "docker >= 0.10.0" ]
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
Default docker version 0.9.1 from Ubuntu 14.04 LTS don't report APIVersion.
