### PR TITLE
Give more information when a task is empty

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -505,7 +505,7 @@ class Play(object):
             included_additional_conditions = list(old_conditions)
 
             if not isinstance(x, dict):
-                raise errors.AnsibleError("expecting dict; got: %s" % x)
+                raise errors.AnsibleError("expecting dict; got: %s, error in %s" % (x, original_file))
 
             # evaluate sudo vars for current and child tasks 
             included_sudo_vars = {}


### PR DESCRIPTION
I made a typo in a playbook and was great by:

```
ERROR: expecting dict; got: None
```

The issue was a single - on the last line of a playbook.
With the name of the file, I was able to see right away where the
error was.
