### PR TITLE
Possible docs error: 'path' instead of 'src'

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -47,7 +47,7 @@ author: Michael DeHaan
 EXAMPLES = '''
 - file: path=/etc/foo.conf owner=foo group=foo mode=0644
 - file: src=/file/to/link/to dest=/path/to/symlink owner=foo group=foo state=link
-- file: path=/tmp/{{ item.path }} dest={{ item.dest }} state=link
+- file: src=/tmp/{{ item.path }} dest={{ item.dest }} state=link
   with_items:
     - { path: 'x', dest: 'y' }
     - { path: 'z', dest: 'k' }


### PR DESCRIPTION
I came to this example today (line 50), and when I tried it, I got an error:

`msg: src and dest are required for creating links`

So, I changed **path** to **src** and it worked fine. Looks like the example is wrong, since the docs say "dest" is already an alias for "path", in which case we would have 2 "path" definitions.
