### PR TITLE
cloud/ec2_elb module - Deregister an instance even if its already OutOfService

### DIFF
--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -129,18 +129,20 @@ class ElbManager:
 
         for lb in self.lbs:
             initial_state = self._get_instance_health(lb) if wait else None
-
-            if initial_state and initial_state.state == 'InService':
-                lb.deregister_instances([self.instance_id])
-            else:
+            if initial_state is None:
+                # The instance isn't registered with this ELB so just 
+                # return unchanged
                 return
+
+            lb.deregister_instances([self.instance_id])
+
+            # The ELB is changing state in some way. Either an instance that's
+            # InService is moving to OutOfService, or an instance that's
+            # already OutOfService is being deregistered.
+            self.changed = True
 
             if wait:
                 self._await_elb_instance_state(lb, 'OutOfService', initial_state, timeout)
-            else:
-                # We cannot assume no change was made if we don't wait
-                # to find out
-                self.changed = True
 
     def register(self, wait, enable_availability_zone, timeout):
         """Register the instance for all ELBs and wait for the ELB

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -128,7 +128,7 @@ class ElbManager:
         to report it out-of-service"""
 
         for lb in self.lbs:
-            initial_state = self._get_instance_health(lb) if wait else None
+            initial_state = self._get_instance_health(lb) 
             if initial_state is None:
                 # The instance isn't registered with this ELB so just 
                 # return unchanged


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.6 (devel 2be8feebce) last updated 2014/04/22 18:45:33 (GMT +000)
##### Environment:

N/A
##### Summary:

The current behavior of the ec2_elb module does not match the documentation.  If an EC2 instance is registered with the ELB, but it's current state is OutOfService, then "state=absent" does nothing.  The instance remains registered with the ELB.
##### Steps To Reproduce:

Create an AWS EC2 instance.  Create an ELB instance and associate the EC2 instance with it.  Ensure the instance is listed as OutOfService in the ELB (no need for anything to be running on the EC2 instance).  Use the ec2_elb module as follows:

```
ec2_elbs=<name of ELB>
instance_id=<id of EC2 instance>
state=absent
```
##### Expected Results:

The instance should be removed from the ELB
##### Actual Results:

The instance is ignored because it is in the OutOfService state.  This pull request changes the behavior to be what is actually expected.  This change basically boils down to:
- If the instance is not found in the ELB then simply return with changed=false
- If the instance is found in the ELB, no matter the state (InService or OutOfService), deregister it from the ELB and return changed=true
