### PR TITLE
file multiple new dirs permissoins

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -30,7 +30,7 @@ options:
   state:
     description:
       - If C(directory), all immediate subdirectories will be created if they
-        do not exist, since 1.6 they will be created with the supplied permissions.
+        do not exist, since 1.7 they will be created with the supplied permissions.
         If C(file), the file will NOT be created if it does not exist, see the M(copy)
         or M(template) module if you want that behavior.  If C(link), the symbolic
         link will be created or changed. Use C(hard) for hardlinks. If C(absent),

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -30,14 +30,14 @@ options:
   state:
     description:
       - If C(directory), all immediate subdirectories will be created if they
-        do not exist. If C(file), the file will NOT be created if it does not
-        exist, see the M(copy) or M(template) module if you want that behavior.
-        If C(link), the symbolic link will be created or changed. Use C(hard)
-        for hardlinks. If C(absent), directories will be recursively deleted,
-        and files or symlinks will be unlinked. If C(touch) (new in 1.4), an empty file will
-        be created if the c(path) does not exist, while an existing file or
-        directory will receive updated file access and modification times (similar
-        to the way `touch` works from the command line).
+        do not exist, since 1.6 they will be created with the supplied permissions.
+        If C(file), the file will NOT be created if it does not exist, see the M(copy)
+        or M(template) module if you want that behavior.  If C(link), the symbolic
+        link will be created or changed. Use C(hard) for hardlinks. If C(absent),
+        directories will be recursively deleted, and files or symlinks will be unlinked.
+        If C(touch) (new in 1.4), an empty file will be created if the c(path) does not
+        exist, while an existing file or directory will receive updated file access and
+        modification times (similar to the way `touch` works from the command line).
     required: false
     default: file
     choices: [ file, link, directory, hard, touch, absent ]

--- a/library/files/file
+++ b/library/files/file
@@ -165,8 +165,15 @@ def main():
         if prev_state == 'absent':
             if module.check_mode:
                 module.exit_json(changed=True)
-            os.makedirs(path)
             changed = True
+            curpath = ''
+            for dirname in path.split('/'):
+                curpath = '/'.join([curpath, dirname])
+                if not os.path.exists(curpath):
+                    os.mkdir(curpath)
+                    tmp_file_args = file_args.copy()
+                    tmp_file_args['path']=curpath
+                    changed = module.set_fs_attributes_if_different(tmp_file_args, changed)
 
         changed = module.set_fs_attributes_if_different(file_args, changed)
 


### PR DESCRIPTION
now when making multiple dirs in path to make directory, same permissions are assigned (but only for NEW dirs). Not that I think this is a good idea but its been asked for soo many times that I'm willing to do it just to remove the noise (fixes #7130)

Signed-off-by: Brian Coca <briancoca+ansible@gmail.com>
