### PR TITLE
Fix handling of non-JSON lines in responses

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -884,10 +884,11 @@ def filter_leading_non_json_lines(buf):
     filter only leading lines since multiline JSON is valid.
     '''
 
+    kv_regex = re.compile(r'.*\w+=\w+.*')
     filtered_lines = StringIO.StringIO()
     stop_filtering = False
     for line in buf.splitlines():
-        if stop_filtering or "=" in line or line.startswith('{') or line.startswith('['):
+        if stop_filtering or kv_regex.match(line) or line.startswith('{') or line.startswith('['):
             stop_filtering = True
             filtered_lines.write(line + '\n')
     return filtered_lines.getvalue()


### PR DESCRIPTION
Garbage lines with ' = ' in them were causing parsing errors,
where key=val lines should not have spaces around the equals.

Fixes #6962
