### PR TITLE
Correct/update debconf examples - need to specify vtype.

### DIFF
--- a/library/system/debconf
+++ b/library/system/debconf
@@ -73,10 +73,10 @@ author: Brian Coca
 
 EXAMPLES = '''
 # Set default locale to fr_FR.UTF-8
-debconf: name=locales question='locales/default_environment_locale' value=fr_FR.UTF-8
+debconf: name=locales question='locales/default_environment_locale' value=fr_FR.UTF-8 vtype='select'
 
 # set to generate locales:
-debconf: name=locales question='locales/locales_to_be_generated'  value='en_US.UTF-8 UTF-8, fr_FR.UTF-8 UTF-8'
+debconf: name=locales question='locales/locales_to_be_generated'  value='en_US.UTF-8 UTF-8, fr_FR.UTF-8 UTF-8' vtype='multiselect'
 
 # Accept oracle license
 debconf: name='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'


### PR DESCRIPTION
Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
