### PR TITLE
Allow sudo to another user from root with the ansible command

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -933,13 +933,13 @@ class Runner(object):
 
         # compare connection user to (su|sudo)_user and disable if the same
         if hasattr(conn, 'user'):
-            if conn.user == sudo_user or conn.user == su_user:
+            if (not su and conn.user == sudo_user) or (su and conn.user == su_user):
                 sudoable = False
                 su = False
         else:
             # assume connection type is local if no user attribute
             this_user = getpass.getuser()
-            if this_user == sudo_user or this_user == su_user:
+            if (not su and this_user == sudo_user) or (su and this_user == su_user):
                 sudoable = False
                 su = False
 


### PR DESCRIPTION
##### Issue Type:

Bug Report
##### Ansible Version:

```
ansible 1.6 (devel d88ac5e24d) last updated 2014/04/22 11:14:36 (GMT -500)
```

Issue introduced in f72f5a20df22c9231191d15502a606cef7f2f287
##### Environment:

Control: N/A

Target: N/A
##### Summary:

When using the `ansible` command, with a remote user of `root`, specifying to sudo to another user, will still run the module as `root`.

`ansible-playbook` does not appear to be affected

The issue appears to be some invalid logic in a couple of if statements.
##### Steps To Reproduce:
1. `ansible all -i test.example.com, -u root -k -s -U foobar -a id`
##### Expected Results:

```
uid=1001(foobar) gid=1001(foobar) groups=1001(foobar)
```
##### Actual Results:

```
uid=0(root) gid=0(root) groups=0(root)
```
