### PR TITLE
Added instance_type to  ec2_lc variable list

### DIFF
--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -77,6 +77,7 @@ EXAMPLES = '''
     image_id: ami-XXX
     key_name: default
     security_groups: 'group,group2'
+    instance_type: t1.micro
 
 '''
 

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -33,6 +33,12 @@ options:
     description:
       - Unique name for configuration
     required: true
+  instance_type:
+    description:
+      - instance type to use for the instance
+    required: true
+    default: null
+    aliases: []
   image_id:
     description:
       - The AMI unique identifier to be used for the group


### PR DESCRIPTION
This is missing from the documentation 
