### PR TITLE
Add config option to allow sudo to the same user

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -74,6 +74,18 @@ different locations::
 
 Most users will not need to use this feature.  See :doc:`developing_plugins` for more details.
 
+.. _allow_sudo_same_user:
+
+allow_sudo_same_user
+====================
+
+Most of the time, using *sudo* to run a command as the same user who is running
+*sudo* itself is unnecessary overhead, so Ansible does not allow it. However,
+depending on the *sudo* configuration, it may be necessary to run a command as
+the same user through *sudo*, such as to switch SELinux contexts. For this
+reason, you can set ``allow_sudo_same_user`` to ``True`` and disable this
+optimization.
+
 .. _ansible_managed:
 
 ansible_managed

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -151,6 +151,7 @@ DISPLAY_SKIPPED_HOSTS          = get_config(p, DEFAULTS, 'display_skipped_hosts'
 DEFAULT_UNDEFINED_VAR_BEHAVIOR = get_config(p, DEFAULTS, 'error_on_undefined_vars', 'ANSIBLE_ERROR_ON_UNDEFINED_VARS', True, boolean=True)
 HOST_KEY_CHECKING              = get_config(p, DEFAULTS, 'host_key_checking',  'ANSIBLE_HOST_KEY_CHECKING',    True, boolean=True)
 DEPRECATION_WARNINGS           = get_config(p, DEFAULTS, 'deprecation_warnings', 'ANSIBLE_DEPRECATION_WARNINGS', True, boolean=True)
+ALLOW_SUDO_SAME_USER           = get_config(p, DEFAULTS, 'allow_sudo_same_user', 'ANSIBLE_ALLOW_SUDO_SAME_USER', False, boolean=True)
 
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -934,7 +934,8 @@ class Runner(object):
         # compare connection user to (su|sudo)_user and disable if the same
         if hasattr(conn, 'user'):
             if (not su and conn.user == sudo_user) or (su and conn.user == su_user):
-                sudoable = False
+                if not C.ALLOW_SUDO_SAME_USER:
+                    sudoable = False
                 su = False
         else:
             # assume connection type is local if no user attribute


### PR DESCRIPTION
This patch adds a configuration setting to allow running commands through sudo to the same user. This is useful when sudo does more than change the effective uid of the process, such as switching SELinux contexts.
