### PR TITLE
Expand environment vars in stat path

### DIFF
--- a/library/files/stat
+++ b/library/files/stat
@@ -79,6 +79,7 @@ def main():
 
     path = module.params.get('path')
     path = os.path.expanduser(path)
+    path = os.path.expandvars(path)
     follow = module.params.get('follow')
     get_md5 = module.params.get('get_md5')
 


### PR DESCRIPTION
Now it's possible to use environment variables in the `path` of stat module:

``` yml
- name: stat foo virtualenv
  stat: path=$WORKON_HOME/foo
```
