### PR TITLE
Do not fail if we try to generate a ssh key for a user without being root

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -336,8 +336,14 @@ class User(object):
 
     def _check_usermod_append(self):
         # check if this version of usermod can append groups
+        usermod_path = self.module.get_bin_path('usermod', True)
 
-        cmd = [self.module.get_bin_path('usermod', True)]
+        # for some reason, usermod --help cannot be used by non root
+        # on RH/Fedora, due to lack of execute bit for others
+        if not os.access(usermod_path, os.X_OK):
+            return False
+
+        cmd = [usermod_path]
         cmd.append('--help')
         rc, data1, data2 = self.execute_command(cmd)
         helpout = data1 + data2


### PR DESCRIPTION
If we try to use the user module without being root, it fail on RHEL/Fedora
because usermod --help cannot be run. The root cause is lack of permission
due to EAL4+ certification, as seen in shadow-utils changelo.

So if we cannot run it, assume there is no append. It doesn't matter
much since we will not be able to run usermod at all with or without the
option.
