### PR TITLE
New files inaccessible (0600)

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1056,6 +1056,11 @@ class AnsibleModule(object):
         if creating and os.getenv("SUDO_USER"):
             os.chown(dest, os.getuid(), os.getgid())
 
+        if creating:
+            umask = os.umask(0)
+            os.umask(umask)
+            os.chmod(dest, 0666 ^ umask)
+
         if self.selinux_enabled():
             # rename might not preserve context
             self.set_context_if_different(dest, context, False)


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.5.4
##### Environment:

Ubuntu 12.04, all
##### Summary:

Following 898a38b074f2561d19059315030b2b5da68a4f34, all newly created files are 0600 but should be 0644 as before (i.e. by umask)
##### Steps To Reproduce:

```
echo HOSTNAME >/tmp/hosts
ansible HOSTNAME -i /tmp/hosts -m copy -a 'content=hello dest=/tmp/1'
```
##### Expected Results:

```
"mode": "0644"
```

usually and driven by umask. This was in Ansible before the commit.
##### Actual Results:

```
 "mode": "0600"
```

driven by the `tempfile.NamedTemporaryFile` behavior: making a temporary file private for the creator. This behavior after the commit did and will break previous playbooks for many users.
