### PR TITLE
ec2: specify by start/stop by tag

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -405,11 +405,25 @@ local_action:
   tasks:
     - name: Stop the sanbox instances
       local_action:
-      module: ec2
-      instance_ids: '{{ instance_ids }}'
-      region: '{{ region }}'
-      state: stopped
-      wait: True
+        module: ec2
+        instance_ids: '{{ instance_ids }}'
+        region: '{{ region }}'
+        state: stopped
+        wait: True
+
+#
+# Start stopped instances specified by tag
+#
+- name: Start up extra power instances
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Start instances named "ExtraPower"
+      local_action:
+        module: ec2
+        instance_tags:
+          Name: ExtraPower
+        state: running
 
 #
 # Enforce that 5 instances with a tag "foo" are running

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -133,7 +133,8 @@ options:
   instance_tags:
     version_added: "1.0"
     description:
-      - a hash/dictionary of tags to add to the new instance; '{"key":"value"}' and '{"key":"value","key":"value"}'
+      - a hash/dictionary of tags '{"key":"value"}' and '{"key":"value","key":"value"}'
+      - used for attaching to new instances and for starting/stopping instance by tag
     required: false
     default: null
     aliases: []
@@ -1025,7 +1026,7 @@ def terminate_instances(module, ec2, instance_ids):
     return (changed, instance_dict_array, terminated_instance_ids)
 
 
-def startstop_instances(module, ec2, instance_ids):
+def startstop_instances(module, ec2, instance_ids, instance_tags):
     """
     Starts or stops a list of existing instances
 
@@ -1033,6 +1034,11 @@ def startstop_instances(module, ec2, instance_ids):
     ec2: authenticated ec2 connection object
     instance_ids: The list of instances to start in the form of
       [ {id: <inst-id>}, ..]
+    instance_tags: A dict of tag keys and values in the form of
+      {key: value, ... }
+
+    Note that if instance_ids and instance_tags are both non-empty,
+    this method will process the intersection of the two
 
     Returns a dictionary of instance information
     about the instances started.
@@ -1041,22 +1047,32 @@ def startstop_instances(module, ec2, instance_ids):
     "changed" will be set to False.
 
     """
-    
+
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
     changed = False
     instance_dict_array = []
-    
+
     if not isinstance(instance_ids, list) or len(instance_ids) < 1:
-        module.fail_json(msg='instance_ids should be a list of instances, aborting')
+        # Fail unless the user defined instance tags
+        if not instance_tags:
+            module.fail_json(msg='instance_ids should be a list of instances, aborting')
 
     dest_state = module.params.get('state')
     dest_state_ec2 = 'stopped' if dest_state == 'stopped' else 'running'
 
+    # To make an EC2 tag filter, we need to prepend 'tag:' to each key.
+    # An empty filter does no filtering, so it's safe to pass it to the
+    # get_all_instances method even if the user did not specify instance_tags
+    filters = {}
+    if instance_tags:
+        for key, value in instance_tags.items():
+            filters["tag:" + key] = value
+
     # Check that our instances are not in the state we want to take them to
     # and change them to our desired state
     running_instances_array = []
-    for res in ec2.get_all_instances(instance_ids):
+    for res in ec2.get_all_instances(instance_ids, filters=filters):
         for inst in res.instances:
            if not inst.state == dest_state_ec2:
                instance_dict_array.append(get_instance_info(inst))
@@ -1155,11 +1171,12 @@ def main():
         (changed, instance_dict_array, new_instance_ids) = terminate_instances(module, ec2, instance_ids)
 
     elif module.params.get('state') == 'running' or module.params.get('state') == 'stopped':
+        instance_tags = module.params.get('instance_tags')
         instance_ids = module.params.get('instance_ids')
-        if not isinstance(instance_ids, list):
-            module.fail_json(msg='running list needs to be a list of instances to run: %s' % instance_ids)
+        if not (isinstance(instance_ids, list) or isinstance(instance_tags, dict)):
+            module.fail_json(msg='running list needs to be a list of instances or set of tags to run: %s' % instance_ids)
 
-        (changed, instance_dict_array, new_instance_ids) = startstop_instances(module, ec2, instance_ids)
+        (changed, instance_dict_array, new_instance_ids) = startstop_instances(module, ec2, instance_ids, instance_tags)
 
     elif module.params.get('state') == 'present':
         # Changed is always set to true when provisioning new instances


### PR DESCRIPTION
In the ec2 module, allow user to specify instances to start and stop by tags.

Implements #6905
