### PR TITLE
Improve error messages of mysql modules when connection fails

### DIFF
--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -279,7 +279,7 @@ def main():
             db_connection = MySQLdb.connect(host=module.params["login_host"], port=int(module.params["login_port"]), user=login_user, passwd=login_password, db=connect_to_db)
         cursor = db_connection.cursor()
     except Exception, e:
-        module.fail_json(msg="unable to connect, check login_user and login_password are correct, or alternatively check ~/.my.cnf contains credentials")
+        module.fail_json(msg="error %d connecting to database: %s, check login_user and login_password are correct, or alternatively check ~/.my.cnf contains credentials" % (e.args[0],e.args[1]))
 
     changed = False
     if db_exists(cursor, db):

--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -295,7 +295,7 @@ def main():
         else:
             db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
     except Exception, e:
-        module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials")
+        module.fail_json(msg="error %d connecting to database: %s, check login_user and login_password are correct, or alternatively check ~/.my.cnf contains credentials" % (e.args[0],e.args[1]))
     try:
         cursor = db_connection.cursor(cursorclass=MySQLdb.cursors.DictCursor)
     except Exception, e:

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -448,7 +448,7 @@ def main():
         if not cursor:
             cursor = connect(module, login_user, login_password)
     except Exception, e:
-        module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials")
+        module.fail_json(msg="error %d connecting to database: %s, check login_user and login_password are correct, or alternatively check ~/.my.cnf contains credentials" % (e.args[0],e.args[1]))
 
     if state == "present":
         if user_exists(cursor, user, host):

--- a/library/database/mysql_variables
+++ b/library/database/mysql_variables
@@ -228,7 +228,7 @@ def main():
             db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
         cursor = db_connection.cursor()
     except Exception, e:
-        module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials")
+        module.fail_json(msg="error %d connecting to database: %s, check login_user and login_password are correct, or alternatively check ~/.my.cnf contains credentials" % (e.args[0],e.args[1]))
     if mysqlvar is None:
         module.fail_json(msg="Cannot run without variable to operate with")
     mysqlvar_val = getvariable(cursor, mysqlvar)


### PR DESCRIPTION
Mysql connections can fail for a variety of reasons, not just bad credentials. In my case, the database didn't exist. This patch displays the actual mysql error message to aid debugging.
