### PR TITLE
Make concatenating certs robust in urls.py

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -154,6 +154,7 @@ class SSLValidationHandler(urllib2.BaseHandler):
                         try:
                             cert_file = open(full_path, 'r')
                             os.write(tmp_fd, cert_file.read())
+                            os.write(tmp_fd, '\n')
                             cert_file.close()
                         except:
                             pass


### PR DESCRIPTION
Add a newline after each certificate file explicitly to avoid problems with files that do not end with a newline themselves.

Fixes issue #7218.
