### PR TITLE
Allow group module to handle check_mode properly when group.state=present and group already exists

### DIFF
--- a/library/system/group
+++ b/library/system/group
@@ -121,7 +121,7 @@ class Group(object):
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
-            return (True, '', '')
+	    return (0, '', '')
         cmd.append(self.name)
         return self.execute_command(cmd)
 


### PR DESCRIPTION
The Group.group_mod function always returns (True, '', '') [1] when check_mode is True which is in turn failing the task when requesting group.state = present and group already exists [2]

I compared both user and group modules which are working in a similar way and the proposed fix handles this case much like the user module does.

[1] https://github.com/ansible/ansible/blob/devel/library/system/group#L123-L124
[2] https://github.com/ansible/ansible/blob/devel/library/system/group#L123-L124
