### PR TITLE
simple fix for allowing zero length sequences

### DIFF
--- a/lib/ansible/runner/lookup_plugins/sequence.py
+++ b/lib/ansible/runner/lookup_plugins/sequence.py
@@ -151,7 +151,7 @@ class LookupModule(object):
             )
         elif self.count is not None:
             # convert count to end
-            self.end = self.start + self.count * self.stride - 1
+            self.end = self.start + self.count * self.stride
             del self.count
         if self.end < self.start:
             raise AnsibleError("can't count backwards")
@@ -159,7 +159,7 @@ class LookupModule(object):
             raise AnsibleError("bad formatting string: %s" % self.format)
 
     def generate_sequence(self):
-        numbers = xrange(self.start, self.end + 1, self.stride)
+        numbers = xrange(self.start, self.end, self.stride)
 
         for i in numbers:
             try:


### PR DESCRIPTION
Currently, there is no way to have a zero count with_sequence

```
 - name: Test count = 0
   debug: msg='hello'
   with_sequence: count=0
```

This fails with "can't count backwards"
     - name: Test start = end 
       debug: msg='hello'
       with_sequence: start=1 end=1
This runs the action once

see gist for tests: https://gist.github.com/darKoram/baa4c6e2a025b48d67ae

Simplest fix is the easiest to code and makes the start, end semantics consistent with python 'range' command
range(start,end) produces [start,end), that is, from start to, but not including, end.

The downside is that this will break the most code.

Behavior changes
1. with_sequence: start=1 end=1 previously ran the action once, now it skips
2. with_sequence: start=1 end=2 previously ran the action twice, now it runs once
3. with_sequence: count=1 previously ran the action once, now it still runs once
4. with_sequence: count=0 previously errored with "can't count backwards", now it skips

The other options include leaving the semantics of start,end as is, but changing count to accept 0. This will require less clean code but would leave 1 and 2 unchanged breaking less code (but keeping the inconsistency with python semantics).  If we leave start, end as is then the next simplest fix would allow end = start-1 to represent a zero count.  Kinda hooky.
