### PR TITLE
nova_keypair should fail if 'name' of key exists in keystore, but ssh hash value != public_key offered

### DIFF
--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -115,7 +115,10 @@ def main():
     if module.params['state'] == 'present':
         for key in nova.keypairs.list():
             if key.name == module.params['name']:
-                module.exit_json(changed = False, result = "Key present")
+                if module.params['public_key'] and (module.params['public_key'] != key.public_key ):
+                    module.fail_json(msg = "name {} present but key hash not the same as offered.  Delete key first.".format(key['name']))
+                else:
+                    module.exit_json(changed = False, result = "Key present")            
         try:
             key = nova.keypairs.create(module.params['name'], module.params['public_key'])
         except Exception, e:


### PR DESCRIPTION
if key name already exists on tenant, check when public_key is offered that it matches the existing key

Example: Here is the signature
- nova_keypair: state=present 
               login_username="admin"
               login_password="password"
               login_tenant_name="{{tenant.name}}"
               auth_url="{{os_auth_url}}"
               name="{{tenant_name}}_key"
               public_key="{{ lookup('file', '~.ssh/' + tenant_name + '_key.pub') }}"

Suppose you created a cluster with a certain public key A and deleted the cluster but not the tenant.  You generate a new key B with the same name locally.  If you try to add the new key with the same name but different ssh hash nova_keypair will currently not issue any warning or error.  But you won't be able to login to the new vms.
