### PR TITLE
[lvg] Switch to mapper device name if pvs returns the wrong one.

### DIFF
--- a/library/system/lvg
+++ b/library/system/lvg
@@ -67,7 +67,7 @@ EXAMPLES = '''
 # Create a volume group on top of /dev/sda1 with physical extent size = 32MB.
 - lvg:  vg=vg.services pvs=/dev/sda1 pesize=32
 
-# Create or resize a volume group on top of /dev/sdb1 and /dev/sdc5. 
+# Create or resize a volume group on top of /dev/sdb1 and /dev/sdc5.
 # If, for example, we already have VG vg.services on top of /dev/sdb1,
 # this VG will be extended by /dev/sdc5.  Or if vg.services was created on
 # top of /dev/sda5, we first extend it with /dev/sdb1 and /dev/sdc5,
@@ -89,10 +89,22 @@ def parse_vgs(data):
         })
     return vgs
 
-def parse_pvs(data):
+def find_mapper_device_name(module, dm_device):
+        dmsetup_cmd = module.get_bin_path('dmsetup', True)
+        mapper_prefix = '/dev/mapper/'
+        rc, dm_name, err = module.run_command("%s info -C --noheadings -o name %s" % (dmsetup_cmd, dm_device))
+        if rc != 0:
+            module.fail_json(msg="Failed executing dmsetup command.", rc=rc, err=err)
+        mapper_device = mapper_prefix + dm_name.rstrip()
+        return mapper_device
+
+def parse_pvs(module, data):
     pvs = []
+    dm_prefix = '/dev/dm-'
     for line in data.splitlines():
         parts = line.strip().split(';')
+        if parts[0].startswith(dm_prefix):
+            parts[0] = find_mapper_device_name(module, parts[0])
         pvs.append({
             'name': parts[0],
             'vg_name': parts[1],
@@ -125,7 +137,7 @@ def main():
         module.fail_json(msg="No physical volumes given.")
 
 
-    
+
     if state=='present':
         ### check given devices
         for test_dev in dev_list:
@@ -139,7 +151,7 @@ def main():
             module.fail_json(msg="Failed executing pvs command.",rc=rc, err=err)
 
         ### check pv for devices
-        pvs = parse_pvs(current_pvs)
+        pvs = parse_pvs(module, current_pvs)
         used_pvs = [ pv for pv in pvs if pv['name'] in dev_list and pv['vg_name'] and pv['vg_name'] != vg ]
         if used_pvs:
             module.fail_json(msg="Device %s is already in %s volume group."%(used_pvs[0]['name'],used_pvs[0]['vg_name']))


### PR DESCRIPTION
The lvg module fails after the initial run if the pvs parameter includes device-mapper logical volumes on some older distributions such as Debian Squeeze and Ubuntu 12.04. This issue is encountered when using LVM on LUKS for example.

The issue is caused because on these distro versions "pvs" returns the non-persistent device names like /dev/dm-0 for device-mapper logical volumes. This makes lvg to think the device has not yet been added to the volume group/initialized while in reality it has.

The proposed patch would use dmsetup to find out what the device name is when encountering /dev/dm- prefixed device names in the list from "pvs". This will allow using /dev/mapper/name  but not /dev/vg/name in the pvs parameter.
