### PR TITLE
Make --ask-sudo-pass/-K imply --sudo for `ansible`

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -63,6 +63,8 @@ class Cli(object):
             default=C.DEFAULT_MODULE_NAME)
 
         options, args = parser.parse_args()
+        if options.ask_sudo_pass:
+            options.sudo = True
         self.callbacks.options = options
 
         if len(args) == 0 or len(args) > 1:

--- a/bin/ansible
+++ b/bin/ansible
@@ -63,8 +63,6 @@ class Cli(object):
             default=C.DEFAULT_MODULE_NAME)
 
         options, args = parser.parse_args()
-        if options.ask_sudo_pass:
-            options.sudo = True
         self.callbacks.options = options
 
         if len(args) == 0 or len(args) > 1:
@@ -159,6 +157,8 @@ class Cli(object):
 
         if options.su_user or options.ask_su_pass:
             options.su = True
+        elif options.sudo_user or options.ask_sudo_pass:
+            options.sudo = True
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
         options.su_user = options.su_user or C.DEFAULT_SU_USER
         if options.tree:


### PR DESCRIPTION
As per subject: make the `--ask-sudo-pass` / `-K` imply `--sudo` for `ansible`. I think this is only natural for `ansible`; and having it not be so would be kind of meaningless when you ask for a password, but never act on it as in the case when you give `--ask-sudo-pass`, but miss out on `--sudo`.
