### PR TITLE
Used module_args passed to function instead of from runner

### DIFF
--- a/lib/ansible/runner/action_plugins/group_by.py
+++ b/lib/ansible/runner/action_plugins/group_by.py
@@ -41,7 +41,7 @@ class ActionModule(object):
         args = {}
         if complex_args:
             args.update(complex_args)
-        args.update(parse_kv(self.runner.module_args))
+        args.update(parse_kv(module_args))
         if not 'key' in args:
             raise ae("'key' is a required argument.")
 


### PR DESCRIPTION
The module_args passed to the run(...) function is the proper one to use as with other plugins.
