### PR TITLE
updated to quantum_network for non-admin users.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ coverage.xml
 venv
 Vagrantfile
 .vagrant
+ansible.egg-info

--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -103,6 +103,16 @@ options:
         - Whether the state should be marked as up or down
      required: false
      default: true
+   insecure:
+     description:
+       - Allow Neutron client to continue when a valid SSL certificate is not used by the server
+     required: false
+     default: False
+   exclude_vars:
+     description:
+       - A comma delimeted list of variable names not to send to neutron when creating network
+    required: false
+    default: none
 requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 
 '''

--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -225,8 +225,8 @@ def _create_network(module, neutron):
         network.pop('provider:physical_network', None)
         network.pop('provider:segmentation_id', None)
 
-    for item in network:
-        if item in module.params['exclude_vars']:
+    if module.params['exclude_vars'] is not None:
+        for item in module.params['exclude_vars']:
             network.pop(item,None)
 
     try:

--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -148,7 +148,8 @@ def _get_neutron_client(module, kwargs):
     endpoint = _get_endpoint(module, _ksclient)
     kwargs = {
             'token': token,
-            'endpoint_url': endpoint
+            'endpoint_url': endpoint,
+            'insecure': module.params['insecure']
     }
     try:
         neutron = client.Client('2.0', **kwargs)
@@ -159,14 +160,14 @@ def _get_neutron_client(module, kwargs):
 def _set_tenant_id(module):
     global _os_tenant_id
     if not module.params['tenant_name']:
-        tenant_name = module.params['login_tenant_name']
+        _os_tenant_id = _os_keystone.tenant_id
     else:
         tenant_name = module.params['tenant_name']
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == tenant_name:
-            _os_tenant_id = tenant.id
-            break
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
     if not _os_tenant_id:
         module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
 
@@ -214,6 +215,10 @@ def _create_network(module, neutron):
         network.pop('provider:physical_network', None)
         network.pop('provider:segmentation_id', None)
 
+    for item in network:
+        if item in module.params['exclude_vars']:
+            network.pop(item,None)
+
     try:
         net = neutron.create_network({'network':network})
     except Exception, e:
@@ -245,9 +250,17 @@ def main():
             router_external                 = dict(default=False, type='bool'),
             shared                          = dict(default=False, type='bool'),
             admin_state_up                  = dict(default=True, type='bool'),
-            state                           = dict(default='present', choices=['absent', 'present'])
+            state                           = dict(default='present', choices=['absent', 'present']),
+            insecure                        = dict(default=False, type='bool'),
+            exclude_vars                    = dict(default=None)
         ),
     )
+
+    if module.params['exclude_vars'] is not None:
+        try:
+            module.params['exclude_vars'] = module.params['exclude_vars'].split(",")
+        except TypeError:
+            module.fail_json(msg = " exclude vars is a comma delimited string of variables to exclude from network create")
 
     if module.params['provider_network_type'] in ['vlan' , 'flat']:
             if not module.params['provider_physical_network']:

--- a/library/cloud/quantum_subnet
+++ b/library/cloud/quantum_subnet
@@ -109,6 +109,12 @@ options:
         - From the subnet pool the last IP that should be assigned to the virtual machines
      required: false
      default: None
+   insecure:
+     description:
+       - Allow connections without valid SSL certificates to continue
+      required: false
+      default: False
+
 requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 '''
 
@@ -149,7 +155,8 @@ def _get_neutron_client(module, kwargs):
     endpoint  = _get_endpoint(module, _ksclient)
     kwargs = {
             'token':        token,
-            'endpoint_url': endpoint
+            'endpoint_url': endpoint,
+            'insecure':     module.params['insecure']
     }
     try:
         neutron = client.Client('2.0', **kwargs)
@@ -160,16 +167,17 @@ def _get_neutron_client(module, kwargs):
 def _set_tenant_id(module):
     global _os_tenant_id
     if not module.params['tenant_name']:
-        tenant_name = module.params['login_tenant_name']
+        _os_tenant_id = _os_keystone.tenant_id
     else:
         tenant_name = module.params['tenant_name']
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == tenant_name:
-            _os_tenant_id = tenant.id
-            break
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
     if not _os_tenant_id:
-            module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
+        module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
+
 
 def _get_net_id(neutron, module):
     kwargs = {
@@ -179,7 +187,7 @@ def _get_net_id(neutron, module):
     try:
         networks = neutron.list_networks(**kwargs)
     except Exception, e:
-        module.fail_json("Error in listing neutron networks: %s" % e.message)
+        module.fail_json(msg = "Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
             return None
     return networks['networks'][0]['id']
@@ -265,6 +273,7 @@ def main():
             dns_nameservers         = dict(default=None),
             allocation_pool_start   = dict(default=None),
             allocation_pool_end     = dict(default=None),
+            insecure                = dict(default=False, type='bool')
         ),
     )
     neutron = _get_neutron_client(module, module.params)


### PR DESCRIPTION
Some clouds allow regular tenants to create their own networks. In order for this module to accept that it must not try and list all tenants from keystone, and must allow users to exclude some variables from being included as part of the create network payload. The module should also support insecure connections, since some dev/test environments may not use properly resolving SSL certificates.
