### PR TITLE
Docker inventory bugfix for potential traceback

### DIFF
--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -299,7 +299,7 @@ def list_groups():
 
             try:
                 port = client.port(container, ssh_port)[0]
-            except (IndexError, AttributeError):
+            except (IndexError, AttributeError, TypeError):
                 port = dict()
 
             try:


### PR DESCRIPTION
Docker client occasionally returns a NoneType, so we have to catch the TypeError.  Fixes possible Traceback opportunity.
