### PR TITLE
ignore remnants from doing a setup.py install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ coverage.xml
 venv
 Vagrantfile
 .vagrant
+ansible.egg-info/


### PR DESCRIPTION
Makes it so all the git toolbars/status are clear and show no changes when doing test installs from the repo during development.
