### PR TITLE
Support insecure endpoints & unprivileged users in quantum module

### DIFF
--- a/library/cloud/quantum_floating_ip
+++ b/library/cloud/quantum_floating_ip
@@ -81,6 +81,14 @@ options:
      required: false
      default: None
      version_added: "1.5"
+   insecure:
+     description:
+       - Allow Neutron client to continue when server SSL certificate can not be validated
+     required: false
+     default: False
+     version_added: "1.6"
+
+
 requirements: ["novaclient", "quantumclient", "neutronclient", "keystoneclient"]
 '''
 
@@ -96,7 +104,8 @@ def _get_ksclient(module, kwargs):
         kclient = ksclient.Client(username=kwargs.get('login_username'),
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+                                 auth_url=kwargs.get('auth_url'),
+                                 insecure=module.params['insecure'])
     except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
@@ -117,7 +126,8 @@ def _get_neutron_client(module, kwargs):
     endpoint = _get_endpoint(module, _ksclient)
     kwargs = {
             'token': token,
-            'endpoint_url': endpoint
+            'endpoint_url': endpoint,
+            'insecure':     module.params['insecure']
     }
     try:
         neutron = client.Client('2.0', **kwargs)
@@ -225,6 +235,7 @@ def main():
             instance_name                   = dict(required=True),
             state                           = dict(default='present', choices=['absent', 'present']),
             internal_network_name           = dict(default=None),
+            insecure                        = dict(default=False, type='bool')
         ),
     )
 

--- a/library/cloud/quantum_floating_ip_associate
+++ b/library/cloud/quantum_floating_ip_associate
@@ -75,6 +75,13 @@ options:
         - floating ip that should be assigned to the instance
      required: true
      default: None
+   insecure:
+     description:
+       - Allow Neutron client to continue when server SSL certificate can not be validated
+     required: false
+     default: False
+     version_added: "1.6"
+
 requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 '''
 
@@ -94,7 +101,8 @@ def _get_ksclient(module, kwargs):
         kclient = ksclient.Client(username=kwargs.get('login_username'),
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+                                 auth_url=kwargs.get('auth_url'),
+                                 insecure=module.params['insecure'])
     except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
@@ -115,7 +123,8 @@ def _get_neutron_client(module, kwargs):
     endpoint = _get_endpoint(module, _ksclient)
     kwargs = {
             'token': token,
-            'endpoint_url': endpoint
+            'endpoint_url': endpoint,
+            'insecure':     module.params['insecure']
     }
     try:
         neutron = client.Client('2.0', **kwargs)
@@ -187,7 +196,9 @@ def main():
             region_name                     = dict(default=None),
             ip_address                      = dict(required=True),
             instance_name                   = dict(required=True),
-            state                           = dict(default='present', choices=['absent', 'present'])
+            state                           = dict(default='present', choices=['absent', 'present']),
+            insecure                        = dict(default=False, type='bool')
+
         ),
     )
 

--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -103,6 +103,19 @@ options:
         - Whether the state should be marked as up or down
      required: false
      default: true
+   insecure:
+     description:
+       - Allow Neutron client to continue when server SSL certificate can not be validated
+     required: false
+     default: False
+     version_added: "1.6"
+   exclude_vars:
+     description:
+       - A comma delimeted list of variable names not to send to neutron when creating network
+     required: false
+     default: none
+     version_added: "1.6"
+
 requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 
 '''
@@ -127,7 +140,8 @@ def _get_ksclient(module, kwargs):
         kclient = ksclient.Client(username=kwargs.get('login_username'),
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+                                 auth_url=kwargs.get('auth_url'),
+                                 insecure=module.params['insecure'])
     except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
@@ -148,7 +162,8 @@ def _get_neutron_client(module, kwargs):
     endpoint = _get_endpoint(module, _ksclient)
     kwargs = {
             'token': token,
-            'endpoint_url': endpoint
+            'endpoint_url': endpoint,
+            'insecure': module.params['insecure']
     }
     try:
         neutron = client.Client('2.0', **kwargs)
@@ -159,14 +174,14 @@ def _get_neutron_client(module, kwargs):
 def _set_tenant_id(module):
     global _os_tenant_id
     if not module.params['tenant_name']:
-        tenant_name = module.params['login_tenant_name']
+        _os_tenant_id = _os_keystone.tenant_id
     else:
         tenant_name = module.params['tenant_name']
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == tenant_name:
-            _os_tenant_id = tenant.id
-            break
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
     if not _os_tenant_id:
         module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
 
@@ -214,6 +229,10 @@ def _create_network(module, neutron):
         network.pop('provider:physical_network', None)
         network.pop('provider:segmentation_id', None)
 
+    if module.params['exclude_vars'] is not None:
+        for item in module.params['exclude_vars']:
+            network.pop(item,None)
+
     try:
         net = neutron.create_network({'network':network})
     except Exception, e:
@@ -245,9 +264,17 @@ def main():
             router_external                 = dict(default=False, type='bool'),
             shared                          = dict(default=False, type='bool'),
             admin_state_up                  = dict(default=True, type='bool'),
-            state                           = dict(default='present', choices=['absent', 'present'])
+            state                           = dict(default='present', choices=['absent', 'present']),
+            insecure                        = dict(default=False, type='bool'),
+            exclude_vars                    = dict(default=None)
         ),
     )
+
+    if module.params['exclude_vars'] is not None:
+        try:
+            module.params['exclude_vars'] = module.params['exclude_vars'].split(",")
+        except TypeError:
+            module.fail_json(msg = " exclude vars is a comma delimited string of variables to exclude from network create")
 
     if module.params['provider_network_type'] in ['vlan' , 'flat']:
             if not module.params['provider_physical_network']:

--- a/library/cloud/quantum_router
+++ b/library/cloud/quantum_router
@@ -78,6 +78,13 @@ options:
         - desired admin state of the created router .
      required: false
      default: true
+   insecure:
+     description:
+       - Allow Neutron client to continue when server SSL certificate can not be validated
+     required: false
+     default: False
+     version_added: "1.6"
+
 requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 '''
 
@@ -98,7 +105,8 @@ def _get_ksclient(module, kwargs):
         kclient = ksclient.Client(username=kwargs.get('login_username'),
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+                                 auth_url=kwargs.get('auth_url'),
+                                 insecure=module.params['insecure'])
     except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
@@ -119,7 +127,8 @@ def _get_neutron_client(module, kwargs):
     endpoint = _get_endpoint(module, _ksclient)
     kwargs = {
             'token': token,
-            'endpoint_url': endpoint
+            'endpoint_url': endpoint,
+            'insecure': module.params['insecure']
     }
     try:
         neutron = client.Client('2.0', **kwargs)
@@ -130,16 +139,16 @@ def _get_neutron_client(module, kwargs):
 def _set_tenant_id(module):
     global _os_tenant_id
     if not module.params['tenant_name']:
-        login_tenant_name = module.params['login_tenant_name']
+        _os_tenant_id = _os_keystone.tenant_id
     else:
-        login_tenant_name = module.params['tenant_name']
+        tenant_name = module.params['tenant_name']
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == login_tenant_name:
-            _os_tenant_id = tenant.id
-            break
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
     if not _os_tenant_id:
-            module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
+        module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
 
 
 def _get_router_id(module, neutron):
@@ -186,6 +195,7 @@ def main():
         tenant_name                     = dict(default=None),
         state                           = dict(default='present', choices=['absent', 'present']),
         admin_state_up                  = dict(type='bool', default=True),
+        insecure                        = dict(default=False, type='bool')
         ),
     )
 

--- a/library/cloud/quantum_router_gateway
+++ b/library/cloud/quantum_router_gateway
@@ -72,6 +72,13 @@ options:
         - Name of the external network which should be attached to the router.
      required: true
      default: None
+   insecure:
+     description:
+       - Allow Neutron client to continue when server SSL certificate can not be validated
+     required: false
+     default: False
+     version_added: "1.6"
+
 requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 '''
 
@@ -88,7 +95,8 @@ def _get_ksclient(module, kwargs):
         kclient = ksclient.Client(username=kwargs.get('login_username'),
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+                                 auth_url=kwargs.get('auth_url'),
+                                 insecure=module.params['insecure'])
     except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
@@ -103,19 +111,22 @@ def _get_endpoint(module, ksclient):
         module.fail_json(msg = "Error getting network endpoint: %s" % e.message)
     return endpoint
 
+
 def _get_neutron_client(module, kwargs):
     _ksclient = _get_ksclient(module, kwargs)
     token = _ksclient.auth_token
     endpoint = _get_endpoint(module, _ksclient)
     kwargs = {
             'token': token,
-            'endpoint_url': endpoint
+            'endpoint_url': endpoint,
+            'insecure': module.params['insecure']
     }
     try:
         neutron = client.Client('2.0', **kwargs)
     except Exception, e:
         module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
     return neutron
+
 
 def _get_router_id(module, neutron):
     kwargs = {
@@ -128,6 +139,7 @@ def _get_router_id(module, neutron):
     if not routers['routers']:
             return None
     return routers['routers'][0]['id']
+
 
 def _get_net_id(neutron, module):
     kwargs = {
@@ -142,6 +154,7 @@ def _get_net_id(neutron, module):
         return None
     return networks['networks'][0]['id']
 
+
 def _get_port_id(neutron, module, router_id, network_id):
     kwargs = {
         'device_id': router_id,
@@ -151,9 +164,18 @@ def _get_port_id(neutron, module, router_id, network_id):
         ports = neutron.list_ports(**kwargs)
     except Exception, e:
         module.fail_json( msg = "Error in listing ports: %s" % e.message)
+
     if not ports['ports']:
+        # Fall Back to a secondary method for looking this up for non privileged users
+        router_info = neutron.show_router(router_id)
+        try:
+            if router_info['router']['external_gateway_info']['network_id'] == network_id:
+                return True
+        except (IndexError, TypeError) as e:
+            return None
         return None
     return ports['ports'][0]['id']
+
 
 def _add_gateway_router(neutron, module, router_id, network_id):
     kwargs = {
@@ -165,12 +187,14 @@ def _add_gateway_router(neutron, module, router_id, network_id):
         module.fail_json(msg = "Error in adding gateway to router: %s" % e.message)
     return True
 
+
 def  _remove_gateway_router(neutron, module, router_id):
     try:
         neutron.remove_gateway_router(router_id)
     except Exception, e:
         module.fail_json(msg = "Error in removing gateway to router: %s" % e.message)
     return True
+
 
 def main():
 
@@ -184,6 +208,7 @@ def main():
             router_name        = dict(required=True),
             network_name       = dict(required=True),
             state              = dict(default='present', choices=['absent', 'present']),
+            insecure           = dict(default=False, type='bool')
         ),
     )
 

--- a/library/cloud/quantum_router_interface
+++ b/library/cloud/quantum_router_interface
@@ -77,6 +77,13 @@ options:
         - Name of the tenant whose subnet has to be attached.
      required: false
      default: None
+   insecure:
+     description:
+       - Allow Neutron client to continue when server SSL certificate can not be validated
+     required: false
+     default: False
+     version_added: "1.6"
+
 requirements: ["quantumclient", "keystoneclient"]
 '''
 
@@ -99,7 +106,8 @@ def _get_ksclient(module, kwargs):
         kclient = ksclient.Client(username=kwargs.get('login_username'),
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+                                 auth_url=kwargs.get('auth_url'),
+                                 insecure=module.params['insecure'])
     except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
@@ -120,7 +128,8 @@ def _get_neutron_client(module, kwargs):
     endpoint = _get_endpoint(module, _ksclient)
     kwargs = {
             'token': token,
-            'endpoint_url': endpoint
+            'endpoint_url': endpoint,
+            'insecure': module.params['insecure']
     }
     try:
         neutron = client.Client('2.0', **kwargs)
@@ -131,14 +140,14 @@ def _get_neutron_client(module, kwargs):
 def _set_tenant_id(module):
     global _os_tenant_id
     if not module.params['tenant_name']:
-        login_tenant_name = module.params['login_tenant_name']
+        _os_tenant_id = _os_keystone.tenant_id
     else:
-        login_tenant_name = module.params['tenant_name']
+        tenant_name = module.params['tenant_name']
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == login_tenant_name:
-            _os_tenant_id = tenant.id
-            break
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
     if not _os_tenant_id:
         module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
 
@@ -219,6 +228,7 @@ def main():
             subnet_name                     = dict(required=True),
             tenant_name                     = dict(default=None),
             state                           = dict(default='present', choices=['absent', 'present']),
+            insecure                        = dict(default=False, type='bool')
         ),
     )
 

--- a/library/cloud/quantum_subnet
+++ b/library/cloud/quantum_subnet
@@ -109,6 +109,13 @@ options:
         - From the subnet pool the last IP that should be assigned to the virtual machines
      required: false
      default: None
+   insecure:
+     description:
+       - Allow Neutron client to continue when server SSL certificate can not be validated
+     required: false
+     default: False
+     version_added: "1.6"
+
 requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 '''
 
@@ -128,7 +135,8 @@ def _get_ksclient(module, kwargs):
         kclient = ksclient.Client(username=kwargs.get('login_username'),
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+                                 auth_url=kwargs.get('auth_url'),
+                                 insecure=module.params['insecure'])
     except Exception, e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
@@ -149,7 +157,8 @@ def _get_neutron_client(module, kwargs):
     endpoint  = _get_endpoint(module, _ksclient)
     kwargs = {
             'token':        token,
-            'endpoint_url': endpoint
+            'endpoint_url': endpoint,
+            'insecure':     module.params['insecure']
     }
     try:
         neutron = client.Client('2.0', **kwargs)
@@ -160,16 +169,16 @@ def _get_neutron_client(module, kwargs):
 def _set_tenant_id(module):
     global _os_tenant_id
     if not module.params['tenant_name']:
-        tenant_name = module.params['login_tenant_name']
+        _os_tenant_id = _os_keystone.tenant_id
     else:
         tenant_name = module.params['tenant_name']
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == tenant_name:
-            _os_tenant_id = tenant.id
-            break
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
     if not _os_tenant_id:
-            module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
+        module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
 
 def _get_net_id(neutron, module):
     kwargs = {
@@ -179,7 +188,7 @@ def _get_net_id(neutron, module):
     try:
         networks = neutron.list_networks(**kwargs)
     except Exception, e:
-        module.fail_json("Error in listing neutron networks: %s" % e.message)
+        module.fail_json(msg = "Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
             return None
     return networks['networks'][0]['id']
@@ -265,6 +274,7 @@ def main():
             dns_nameservers         = dict(default=None),
             allocation_pool_start   = dict(default=None),
             allocation_pool_end     = dict(default=None),
+            insecure                = dict(default=False, type='bool')
         ),
     )
     neutron = _get_neutron_client(module, module.params)


### PR DESCRIPTION
Added an insecure flag to all of the quantum modules to support talking
to keystone and neutron/quantum without validating SSL certificates.
This is helpful in both development environments, and environments where
testing/setup is still being completed.

Additionally several of the modules used a keystone call to get the
tenant ID when you are doing operations on behalf of other users, these
calls however are usually prohibited by policy if you are an end user
creating your own networks (private/bastion type networks).
