### PR TITLE
(edited) remove manpage output from source control

### DIFF
--- a/docs/man/man1/ansible-pull.1
+++ b/docs/man/man1/ansible-pull.1
@@ -2,12 +2,21 @@
 .\"     Title: ansible
 .\"    Author: :doctype:manpage
 .\" Generator: DocBook XSL Stylesheets v1.76.1 <http://docbook.sf.net/>
-.\"      Date: 01/02/2014
+.\"      Date: 05/06/2014
 .\"    Manual: System administration commands
-.\"    Source: Ansible 1.5
+.\"    Source: Ansible 1.6
 .\"  Language: English
 .\"
-.TH "ANSIBLE" "1" "01/03/2014" "Ansible 1\&.5" "System administration commands"
+.TH "ANSIBLE" "1" "05/06/2014" "Ansible 1\&.6" "System administration commands"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
 .\" -----------------------------------------------------------------
 .\" * set default formatting
 .\" -----------------------------------------------------------------
@@ -94,7 +103,7 @@ Ansible is released under the terms of the GPLv3 License\&.
 .sp
 \fBansible\fR(1), \fBansible\-playbook\fR(1), \fBansible\-doc\fR(1)
 .sp
-Extensive documentation as well as IRC and mailing list info is available on the ansible home page: https://ansible\&.github\&.com/
+Extensive documentation is available in the documentation site: http://docs\&.ansible\&.com\&. IRC and mailing list info can be found in file CONTRIBUTING\&.md, available in: https://github\&.com/ansible/ansible
 .SH "AUTHOR"
 .PP
 \fB:doctype:manpage\fR


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.6 (master 812851cb8b) last updated 2014/05/06 01:23:59 (GMT +000)
##### Environment:

N/A
##### Summary:

There is a minor manpage bug in ansible-pull.1 due to a missing macro definition.
##### Steps To Reproduce:

Running:

``` bash
LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80  \
  man --warnings -E UTF-8 -l -Tutf8 -Z ansible-pull.1 >/dev/null
```

will produce the following error:

```
<standard input>:28: warning: macro `Aq' not defined
```
##### Expected Results:

N/A
##### Actual Results:

N/A
