### PR TITLE
Interpret comma seperated values in AWS tags as seperate values

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -53,3 +53,7 @@ cache_path = ~/.ansible/tmp
 # seconds, a new API call will be made, and the cache file will be updated.
 # To disable the cache, set this value to 0
 cache_max_age = 300
+
+# If set to true, if a comma seperated value is found in a tag, the value is
+# exploded into a list of values to provide additional groups to the inventory
+treat_csv_in_tags_as_multiple = False

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -230,7 +230,7 @@ class Ec2Inventory(object):
         self.cache_path_cache = cache_dir + "/ansible-ec2.cache"
         self.cache_path_index = cache_dir + "/ansible-ec2.index"
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
-        
+
 
 
     def parse_cli_args(self):
@@ -275,12 +275,12 @@ class Ec2Inventory(object):
             if conn is None:
                 print("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
                 sys.exit(1)
- 
+
             reservations = conn.get_all_instances()
             for reservation in reservations:
                 for instance in reservation.instances:
                     self.add_instance(instance, region)
-        
+
         except boto.exception.BotoServerError, e:
             if  not self.eucalyptus:
                 print "Looks like AWS is down again:"
@@ -358,7 +358,7 @@ class Ec2Inventory(object):
         # Inventory: Group by key pair
         if instance.key_name:
             self.push(self.inventory, self.to_safe('key_' + instance.key_name), dest)
-        
+
         # Inventory: Group by security group
         try:
             for group in instance.groups:
@@ -371,8 +371,14 @@ class Ec2Inventory(object):
 
         # Inventory: Group by tag keys
         for k, v in instance.tags.iteritems():
-            key = self.to_safe("tag_" + k + "=" + v)
-            self.push(self.inventory, key, dest)
+            if ',' in v:
+                v = v.split(',')
+                for value in v:
+                    key = self.to_safe("tag_" + k + "=" + value)
+                    self.push(self.inventory, key, dest)
+            else:
+                key = self.to_safe("tag_" + k + "=" + v)
+                self.push(self.inventory, key, dest)
 
         # Inventory: Group by Route53 domain names if enabled
         if self.route53_enabled:
@@ -416,10 +422,10 @@ class Ec2Inventory(object):
 
         # Inventory: Group by availability zone
         self.push(self.inventory, instance.availability_zone, dest)
-        
+
         # Inventory: Group by instance type
         self.push(self.inventory, self.to_safe('type_' + instance.instance_class), dest)
-        
+
         # Inventory: Group by security group
         try:
             if instance.security_group:
@@ -514,6 +520,9 @@ class Ec2Inventory(object):
                 instance_vars['ec2_placement'] = value.zone
             elif key == 'ec2_tags':
                 for k, v in value.iteritems():
+                    if ',' in v:
+                        v = v.split(',')
+
                     key = self.to_safe('ec2_tag_' + k)
                     instance_vars[key] = v
             elif key == 'ec2_groups':

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -231,6 +231,10 @@ class Ec2Inventory(object):
         self.cache_path_index = cache_dir + "/ansible-ec2.index"
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
 
+        if config.has_option('ec2', 'treat_csv_in_tags_as_multiple'):
+            self.explode_csv = config.getboolean('ec2', 'treat_csv_in_tags_as_multiple')
+        else:
+            self.explode_csv = False
 
 
     def parse_cli_args(self):
@@ -371,7 +375,7 @@ class Ec2Inventory(object):
 
         # Inventory: Group by tag keys
         for k, v in instance.tags.iteritems():
-            if ',' in v:
+            if self.explode_csv and ',' in v:
                 v = v.split(',')
                 for value in v:
                     key = self.to_safe("tag_" + k + "=" + value)
@@ -520,7 +524,7 @@ class Ec2Inventory(object):
                 instance_vars['ec2_placement'] = value.zone
             elif key == 'ec2_tags':
                 for k, v in value.iteritems():
-                    if ',' in v:
+                    if self.explode_csv and ',' in v:
                         v = v.split(',')
 
                     key = self.to_safe('ec2_tag_' + k)


### PR DESCRIPTION
In my current environment, I rely heavily on AWS tags to describe the purpose of boxes, and roles are applied specifically to them via tag values. In instances where a machine is filling more than one role, I needed the flexibility to target specific instances by tag grouping. This commit aims to prevent a significant amount of tags being required by expanding a CSV value for a tag into a list of values.

The hostvars ec2_tag_foo value becomes a list of tag values from splitting the field by comma, and an additional group tag_foo_value is added to the inventory for each of the CSV values.

An example of one of the machine tags is: 
Name: role, Value: webserver,dns,ssh,logger

Without this commit, the value is interpreted as: ec2_tag_role = 'webserver_dns_ssh_logger' and in the inventory there is a key [tag_role_webserver_dns_ssh_logger]

With this commit, the value is interpreted as: ec2_tag_role = [
'webserver', 'dns', 'ssh', 'logger'
]

and in the inventory there are groups: [tag_role_webserver], [tag_role_dns], [tag_role_ssh], [tag_role_logger]

Therefore buying the flexibility of being able to target instances by specific role, and avoiding having to create a tonne of additional tags/hostgroup handlers
