### PR TITLE
Fix sync_binlog name in mysql_variables example

### DIFF
--- a/library/database/mysql_variables
+++ b/library/database/mysql_variables
@@ -56,8 +56,8 @@ options:
             - unix socket to connect mysql server
 '''
 EXAMPLES = '''
-# Check for sync_binary_log setting
-- mysql_variables: variable=sync_binary_log
+# Check for sync_binlog setting
+- mysql_variables: variable=sync_binlog
 
 # Set read_only variable to 1
 - mysql_variables: variable=read_only value=1


### PR DESCRIPTION
The previous sync_binary_log is not a real MySQL variable.
