### PR TITLE
[get_url] check against lowered stripped sha256sum

### DIFF
--- a/library/network/get_url
+++ b/library/network/get_url
@@ -283,7 +283,7 @@ def main():
         else:
             destination_checksum = module.sha256(dest)
 
-        if stripped_sha256sum != destination_checksum:
+        if stripped_sha256sum.lower() != destination_checksum:
             os.remove(dest)
             module.fail_json(msg="The SHA-256 checksum for %s did not match %s; it was %s." % (dest, sha256sum, destination_checksum))
 


### PR DESCRIPTION
The content of the sha256sum attribute should be lowered before comparing it with the calculated sha256sum.

In the following example the used sha256sum uses ABC.. and not abc.. and the check failed. This should not happen.

```
TASK: [get_url url=http://ftp.fau.de/apache/hadoop/common/hadoop-2.4.0/hadoop-2.4.0.tar.gz dest=/home/vagrant/hadoop-2.4.0.tar.gz mode=0644 sha256sum=024326AC68A1A68B5566B10F95609EAAFD9F70CFEB37FCA0E97CBB1674E57C3A] ***
failed: [instance000] => {"failed": true}
msg: The SHA-256 checksum for /home/vagrant/hadoop-2.4.0.tar.gz did not match 024326AC68A1A68B5566B10F95609EAAFD9F70CFEB37FCA0E97CBB1674E57C3A; it was 024326ac68a1a68b5566b10f95609eaafd9f70cfeb37fca0e97cbb1674e57c3a.

FATAL: all hosts have already failed -- aborting
```
