### PR TITLE
Feature/egg info

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -18,8 +18,8 @@
 
 #######################################################
 
-#__requires__ = ['ansible']
-#import pkg_resources
+__requires__ = ['ansible']
+import pkg_resources
 
 import sys
 import os

--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -20,8 +20,8 @@
 # example playbook to bootstrap this script in the examples/ dir which
 # installs ansible and sets it up to run on cron.
 
-#__requires__ = ['ansible']
-#import pkg_resources
+__requires__ = ['ansible']
+import pkg_resources
 
 import os
 import sys

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -25,6 +25,30 @@ unset ANSIBLE_LIBRARY
 export ANSIBLE_LIBRARY="$ANSIBLE_HOME/library:`python $HACKING_DIR/get_library.py`"
 [[ $MANPATH != ${PREFIX_MANPATH}* ]] && export MANPATH=$PREFIX_MANPATH:$MANPATH
 
+#
+# Generate egg_info so that pkg_resources works
+#
+
+# Do the work in a function so we don't repeat ourselves later
+gen_egg_info()
+{
+    python setup.py egg_info
+    if [ -e $PREFIX_PYTHONPATH/ansible*.egg-info ] ; then
+        rm -r $PREFIX_PYTHONPATH/ansible*.egg-info
+    fi
+    mv ansible*.egg-info $PREFIX_PYTHONPATH
+}
+
+# In some shells if pushd is a no-op then popd sends you to a previous
+# directory in history
+if [ "$ANSIBLE_HOME" != "$PWD" ] ; then
+    pushd "$ANSIBLE_HOME"
+    gen_egg_info
+    popd
+else
+    gen_egg_info
+fi
+
 # Print out values unless -q is set
 
 if [ $# -eq 0 -o "$1" != "-q" ] ; then
@@ -36,7 +60,7 @@ if [ $# -eq 0 -o "$1" != "-q" ] ; then
     echo "ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY"
     echo "MANPATH=$MANPATH"
     echo ""
-    
+
     echo "Remember, you may wish to specify your host file with -i"
     echo ""
     echo "Done!"

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -36,6 +36,16 @@ end
 
 set -gx ANSIBLE_LIBRARY $ANSIBLE_HOME/library
 
+# Generate egg_info so that pkg_resources works
+pushd $ANSIBLE_HOME
+python setup.py egg_info
+if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
+    rm -r $PREFIX_PYTHONPATH/ansible*.egg-info
+end
+mv ansible*egg-info $PREFIX_PYTHONPATH
+popd
+
+
 if set -q argv 
     switch $argv
     case '-q' '--quiet'


### PR DESCRIPTION
pkg_resources does its work by reading in metadata about a python package saved in egg-info files.  Regular installs of ansible (python setup.py install) will create the egg-info but for hacking on ansible from a checkout we need to generate egg-info so that the pkg_resources calls in ansible-vault and ansible-playbook can get the information.  hacking/env-setup is the way that we tell people to setup their dev environment so script creation of the egg-info there.
