### PR TITLE
reworded copy option docs

### DIFF
--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -39,7 +39,8 @@ options:
     default: null
   copy:
     description:
-      - Should the file be copied from the local to the remote machine?
+      - If set to yes/true (default), the file is copied from the 'master' to the target machine,
+      if set to no/false, the plugin will look for src archive at the target machine.
     required: false
     choices: [ "yes", "no" ]
     default: "yes"


### PR DESCRIPTION
recent thread shows that the docs were not clear enough to let people know this toggles between using a 'local' archive and a existing remote one
