### PR TITLE
Reuse aws fragments

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/aws.py
+++ b/lib/ansible/utils/module_docs_fragments/aws.py
@@ -21,6 +21,15 @@ class ModuleDocFragment(object):
     # AWS only documentation fragment
     DOCUMENTATION = """
 options:
+  region:
+    description:
+      - The AWS region to use.  Must be specified if ec2_url is not used. If not specified then the value of the EC2_REGION environment variable, if any, is used.
+    required: false
+    default: null
+    choices: ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'sa-east-1', 'us-east-1', 'us-west-1', 'us-west-2']
+
+    aliases: [ 'aws_region', 'ec2_region' ]
+    version_added: "1.2"
   ec2_url:
     description:
       - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints).  Must be specified if region is not used. If not set then the value of the EC2_URL environment variable, if any, is used

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -47,13 +47,6 @@ options:
     required: false
     default: null
     aliases: []
-  region:
-    version_added: "1.2"
-    description:
-      - The AWS region to use.  Must be specified if ec2_url is not used. If not specified then the value of the EC2_REGION environment variable, if any, is used.
-    required: false
-    default: null
-    aliases: [ 'aws_region', 'ec2_region' ]
   zone:
     version_added: "1.2"
     description:

--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -52,12 +52,6 @@ options:
     required: false
     default: 'present'
     aliases: []
-  region:
-    description:
-      - The AWS region to use.  Must be specified if ec2_url is not used. If not specified then the value of the EC2_REGION environment variable, if any, is used.
-    required: false
-    default: null
-    aliases: [ 'aws_region', 'ec2_region' ]
   description:
     description:
       - An optional human-readable string describing the contents and purpose of the AMI.

--- a/library/cloud/ec2_ami_search
+++ b/library/cloud/ec2_ami_search
@@ -51,12 +51,6 @@ options:
     required: false
     default: "amd64"
     choices: ["i386", "amd64"]
-  region:
-    description: EC2 region
-    required: false
-    default: us-east-1
-    choices: ["ap-northeast-1", "ap-southeast-1", "ap-southeast-2",
-              "eu-west-1", "sa-east-1", "us-east-1", "us-west-1", "us-west-2"]
   virt:
     description: virutalization type
     required: false

--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -57,11 +57,6 @@ options:
     description:
       - Desired number of instances in group
     required: false
-  region:
-    description:
-      - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
-    required: false
-    aliases: ['aws_region', 'ec2_region']
   vpc_zone_identifier:
     description:
       - List of VPC subnets to use

--- a/library/cloud/ec2_eip
+++ b/library/cloud/ec2_eip
@@ -23,12 +23,6 @@ options:
     required: false
     choices: ['present', 'absent']
     default: present
-  region:
-    description:
-      - the EC2 region to use
-    required: false
-    default: null
-    aliases: [ ec2_region ]
   in_vpc:
     description:
       - allocate an EIP inside a VPC or not

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -54,14 +54,6 @@ options:
     required: false
     default: yes
     choices: [ "yes", "no" ] 
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
   wait_timeout:
     description:
       - Number of seconds to wait for an instance to change state. If 0 then this module may return an error if a transient error occurs. If non-zero then any transient errors are ignored until the timeout is reached. Ignored when wait=no.

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -41,11 +41,6 @@ options:
       - List of ELB names, required for registration. The ec2_elbs fact should be used if there was a previous de-register.
     required: false
     default: None
-  region:
-    description:
-      - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
-    required: false
-    aliases: ['aws_region', 'ec2_region']
   enable_availability_zone:
     description:
       - Whether to enable the availability zone of the instance on the target ELB if the availability zone has not already

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -61,11 +61,6 @@ options:
       - An associative array of health check configuration settigs (see example)
     require: false
     default: None
-  region:
-    description:
-      - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
-    required: false
-    aliases: ['aws_region', 'ec2_region']
 extends_documentation_fragment: aws
 """
 

--- a/library/cloud/ec2_facts
+++ b/library/cloud/ec2_facts
@@ -21,15 +21,6 @@ DOCUMENTATION = '''
 module: ec2_facts
 short_description: Gathers facts about remote hosts within ec2 (aws)
 version_added: "1.0"
-options:
-    validate_certs:
-        description:
-            - If C(no), SSL certificates will not be validated. This should only be used
-              on personally controlled sites using self-signed certificates.
-        required: false
-        default: 'yes'
-        choices: ['yes', 'no']
-        version_added: 1.5.1
 description:
      - This module fetches data from the metadata servers in ec2 (aws).
        Eucalyptus cloud provides a similar service and this module should

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -31,12 +31,6 @@ options:
       - List of firewall outbound rules to enforce in this group (see example).
     required: false
     version_added: "1.6"
-  region:
-    description:
-      - the EC2 region to use
-    required: false
-    default: null
-    aliases: []
   state:
     version_added: "1.4"
     description:

--- a/library/cloud/ec2_key
+++ b/library/cloud/ec2_key
@@ -18,12 +18,6 @@ options:
     description:
       - Public key material.
     required: false
-  region:
-    description:
-      - the EC2 region to use
-    required: false
-    default: null
-    aliases: []
   state:
     description:
       - create or delete keypair

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -51,11 +51,6 @@ options:
     description:
       - A list of security groups into which instances should be found
     required: false
-  region:
-    description:
-      - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
-    required: false
-    aliases: ['aws_region', 'ec2_region']
   volumes:
     description:
       - a list of volume dicts, each containing device name and optionally ephemeral id or snapshot id. Size and type (and number of iops for io device type) must be specified for a new volume or a root volume, and may be passed for a snapshot volume. For any volume, a volume size less than 1 will be interpreted as a request not to create the volume.

--- a/library/cloud/ec2_snapshot
+++ b/library/cloud/ec2_snapshot
@@ -22,12 +22,6 @@ description:
     - creates an EC2 snapshot from an existing EBS volume
 version_added: "1.5"
 options:
-  region:
-    description:
-      - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
-    required: false
-    default: null
-    aliases: ['aws_region', 'ec2_region']
   volume_id:
     description:
       - volume from which to take the snapshot

--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -35,12 +35,6 @@ options:
     default: present
     choices: ['present', 'absent', 'list']
     aliases: []
-  region:
-    description:
-      - region in which the resource exists. 
-    required: false
-    default: null
-    aliases: ['aws_region', 'ec2_region']
 
 author: Lester Wade
 extends_documentation_fragment: aws

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -73,14 +73,6 @@ options:
     required: false
     default: null
     version_added: "1.5"
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
   state:
     description: 
       - whether to ensure the volume is present or absent

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -61,12 +61,6 @@ options:
     required: false
     default: null
     aliases: []
-  region:
-    description:
-      - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
-    required: false
-    default: null
-    aliases: ['aws_region', 'ec2_region']
   zone:
     description:
       - zone in which to create the volume, if unset uses the zone the instance is in (if set) 

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -106,14 +106,6 @@ options:
     required: false
     default: None
     aliases: ['ec2_access_key', 'access_key' ]
-  validate_certs:
-    description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-    aliases: []
-    version_added: "1.5"
 
 requirements: [ "boto" ]
 author: Carson Gee

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -94,12 +94,6 @@ options:
     required: true
     default: present
     aliases: []
-  region:
-    description:
-      - region in which the resource exists. 
-    required: false
-    default: null
-    aliases: ['aws_region', 'ec2_region']
   aws_secret_key:
     description:
       - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 


### PR DESCRIPTION
Move _region_ to shared aws documentation fragments (introduced by #6154) and remove some ocurrences of _validate_certs_.
