### PR TITLE
Synchronize .deb package version with VERSION file

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+ansible (1.7) unstable; urgency=low
+
+  * 1.7 release (PENDING)
+
+ -- Michael DeHaan <michael.dehaan@gmail.com>  Wed, 07 May 2014 15:00:03 -0500
+
 ansible (1.6) unstable; urgency=low
 
   * 1.6.0 release


### PR DESCRIPTION
`make deb` at the moment builds `ansible_1.6_all.deb` package which cannot be automatically installed using information from `VERSION` file ("1.7"). This patch fixes that issue.
