### PR TITLE
Add proper state output to ec2_asg, ec2_metric_alarm, ec2_scaling_policy

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -122,7 +122,7 @@ def create_autoscaling_group(connection, module):
     vpc_zone_identifier = module.params.get('vpc_zone_identifier')
 
     launch_configs = connection.get_all_launch_configurations(names=[launch_config_name])
-    
+
     as_groups = connection.get_all_groups(names=[group_name])
 
     if not vpc_zone_identifier and not availability_zones:
@@ -147,7 +147,8 @@ def create_autoscaling_group(connection, module):
 
         try:
             connection.create_auto_scaling_group(ag)
-            module.exit_json(changed=True)
+            changed=True
+            as_groups = connection.get_all_groups(names=[group_name])
         except BotoServerError, e:
             module.fail_json(msg=str(e))
     else:
@@ -167,9 +168,25 @@ def create_autoscaling_group(connection, module):
         try:
             if changed:
                 as_group.update()
-            module.exit_json(changed=changed)
         except BotoServerError, e:
             module.fail_json(msg=str(e))
+    result = as_groups[0]
+    module.exit_json(changed=changed, name=result.name,
+        autoscaling_group_arn=result.autoscaling_group_arn,
+        availability_zones=result.availability_zones,
+        created_time=str(result.created_time),
+        default_cooldown=result.default_cooldown,
+        health_check_period=result.health_check_period,
+        health_check_type=result.health_check_type,
+        instance_id=result.instance_id,
+        instances=[instance.instance_id for instance in result.instances],
+        launch_config_name=result.launch_config_name,
+        load_balancers=result.load_balancers,
+        min_size=result.min_size, max_size=result.max_size,
+        placement_group=result.placement_group,
+        tags=result.tags,
+        termination_policies=result.termination_policies,
+        vpc_zone_identifier=result.vpc_zone_identifier)
 
 
 def delete_autoscaling_group(connection, module):

--- a/library/cloud/ec2_metric_alarm
+++ b/library/cloud/ec2_metric_alarm
@@ -53,8 +53,8 @@ options:
           - Determines how the threshold value is compared
         required: false
         options: ['<=','<','>','>=']
-    threshold: 
-        description: 
+    threshold:
+        description:
           - Sets the min/max bound for triggering the alarm
         required: false
     period:
@@ -65,7 +65,7 @@ options:
         description:
           - The number of times in which the metric is evaluated before final calculation
         required: false
-    unit: 
+    unit:
         description:
           - The threshold's unit of measurement
         required: false
@@ -79,7 +79,7 @@ options:
           - Describes to what the alarm is applied
         required: false
     alarm_actions:
-        description: 
+        description:
           - A list of the names action(s) taken when the alarm is in the 'alarm' status
         required: false
     insufficient_data_actions:
@@ -129,7 +129,7 @@ except ImportError:
 
 
 def create_metric_alarm(connection, module):
-    
+
     name = module.params.get('name')
     metric = module.params.get('metric')
     namespace = module.params.get('namespace')
@@ -146,12 +146,12 @@ def create_metric_alarm(connection, module):
     ok_actions = module.params.get('ok_actions')
 
     alarms = connection.describe_alarms(alarm_names=[name])
-  
+
     if not alarms:
 
         alm = MetricAlarm(
             name=name,
-            metric=metric,  
+            metric=metric,
             namespace=namespace,
             statistic=statistic,
             comparison=comparison,
@@ -165,9 +165,10 @@ def create_metric_alarm(connection, module):
             insufficient_data_actions=insufficient_data_actions,
             ok_actions=ok_actions
         )
-        try:            
+        try:
             connection.create_alarm(alm)
-            module.exit_json(changed=True)
+            changed = True
+            alarms = connection.describe_alarms(alarm_names=[name])
         except BotoServerError, e:
             module.fail_json(msg=str(e))
 
@@ -186,33 +187,51 @@ def create_metric_alarm(connection, module):
 
         dim1 = module.params.get('dimensions')
         dim2 = alarm.dimensions
-        
+
         for keys in dim1:
             if not isinstance(dim1[keys], list):
                 dim1[keys] = [dim1[keys]]
             if dim1[keys] != dim2[keys]:
                 changed=True
-                setattr(alarm, 'dimensions', dim1)        
+                setattr(alarm, 'dimensions', dim1)
 
-        for attr in ('alarm_actions','insufficient_data_actions','ok_actions'): 
+        for attr in ('alarm_actions','insufficient_data_actions','ok_actions'):
             action = module.params.get(attr) or []
             if getattr(alarm, attr) != action:
                 changed = True
                 setattr(alarm, attr, module.params.get(attr))
-        
+
         try:
             if changed:
                 connection.create_alarm(alarm)
-            module.exit_json(changed=changed)
         except BotoServerError, e:
             module.fail_json(msg=str(e))
-
+    result = alarms[0]
+    module.exit_json(changed=changed, name=result.name,
+        actions_enabled=result.actions_enabled,
+        alarm_actions=result.alarm_actions,
+        alarm_arn=result.alarm_arn,
+        comparison=result.comparison,
+        description=result.description,
+        dimensions=result.dimensions,
+        evaluation_periods=result.evaluation_periods,
+        insufficient_data_actions=result.insufficient_data_actions,
+        last_updated=result.last_updated,
+        metric=result.metric,
+        namespace=result.namespace,
+        ok_actions=result.ok_actions,
+        period=result.period,
+        state_reason=result.state_reason,
+        state_value=result.state_value,
+        statistic=result.statistic,
+        threshold=result.threshold,
+        unit=result.unit)
 
 def delete_metric_alarm(connection, module):
     name = module.params.get('name')
 
     alarms = connection.describe_alarms(alarm_names=[name])
-    
+
     if alarms:
         try:
             connection.delete_alarms([name])

--- a/library/cloud/ec2_scaling_policy
+++ b/library/cloud/ec2_scaling_policy
@@ -23,7 +23,7 @@ options:
       - Name of the associated autoscaling group
     required: true
   adjustment_type:
-    desciption: 
+    desciption:
       - The type of change in capacity of the autoscaling group
     required: false
     choices: ['ChangeInCapacity','ExactCapacity','PercentChangeInCapacity']
@@ -60,7 +60,7 @@ import sys
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-try: 
+try:
     import boto.ec2.autoscale
     from boto.ec2.autoscale import ScalingPolicy
     from boto.exception import BotoServerError
@@ -77,9 +77,9 @@ def create_scaling_policy(connection, module):
     scaling_adjustment = module.params.get('scaling_adjustment')
     min_adjustment_step = module.params.get('min_adjustment_step')
     cooldown = module.params.get('cooldown')
- 
+
     scalingPolicies = connection.get_all_policies(as_group=asg_name,policy_names=[sp_name])
-    
+
     if not scalingPolicies:
         sp = ScalingPolicy(
             name=sp_name,
@@ -98,16 +98,17 @@ def create_scaling_policy(connection, module):
         policy = scalingPolicies[0]
         changed = False
 
-        #min_adjustment_step attribute is only relevant if the adjustment_type
-        #is set to percentage change in capacity, so it is a special case
+        # min_adjustment_step attribute is only relevant if the adjustment_type
+        # is set to percentage change in capacity, so it is a special case
         if getattr(policy, 'adjustment_type') == 'PercentChangeInCapacity':
             if getattr(policy, 'min_adjustment_step') != module.params.get('min_adjustment_step'):
                 changed = True
-        
-        #set the min adjustment step incase the user decided to change their adjustment type to percentage
+
+        # set the min adjustment step incase the user decided to change their
+        # adjustment type to percentage
         setattr(policy, 'min_adjustment_step', module.params.get('min_adjustment_step'))
 
-        #check the remaining attributes
+        # check the remaining attributes
         for attr in ('adjustment_type','scaling_adjustment','cooldown'):
             if getattr(policy, attr) != module.params.get(attr):
                 changed = True
@@ -117,8 +118,7 @@ def create_scaling_policy(connection, module):
             if changed:
                 connection.create_scaling_policy(policy)
                 policy = connection.get_all_policies(policy_names=[sp_name])[0]
-                module.exit_json(changed=changed, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment, cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
-            module.exit_json(changed=changed)
+            module.exit_json(changed=changed, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment, cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
         except BotoServerError, e:
             module.fail_json(msg=str(e))
 
@@ -151,13 +151,13 @@ def main():
             cooldown = dict(type='int'),
             region = dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
             state=dict(default='present', choices=['present', 'absent']),
-        )    
+        )
     )
-    
+
     module = AnsibleModule(argument_spec=argument_spec)
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module)
-    
+
     state = module.params.get('state')
 
     try:
@@ -172,9 +172,3 @@ def main():
 
 
 main()
-
-
-
-
-
-


### PR DESCRIPTION
Fixes the exit_json calls for these modules so that they provide all the internal state.
This is required so that it's possible do access the arn information (amongst other things) which is required for things like hooking metric alarms and scaling policies together.

Example before/after for `ec2_metric_alarm` below. The other modules similarly go from printing almost nothing to printing everything I could get my hands on from boto.

```
ok: [localhost] => {
    "item": "",
    "metric_alarm_high": {
        "changed": false,
        "invocation": {
            "module_args": "",
            "module_name": "ec2_metric_alarm"
        },
        "item": ""
    }
}
```

```
ok: [localhost] => {
    "item": "",
    "metric_alarm_high": {
        "actions_enabled": "true",
        "alarm_actions": [
            "arn:aws:autoscaling:us-east-1:XXX:scalingPolicy:XXX:autoScalingGroupName/asg-XXX:policyName/asg-policy.XXX.high"
        ],
        "alarm_arn": "arn:aws:cloudwatch:us-east-1:XXX:alarm:XXX.cpu-high",
        "changed": false,
        "comparison": "GreaterThanOrEqualToThreshold",
        "description": "Reduce number of XXX when they're too busy",
        "dimensions": {
            "AutoScalingGroupName": [
                "asg-XXX"
            ]
        },
        "evaluation_periods": 3,
        "insufficient_data_actions": [],
        "invocation": {
            "module_args": "",
            "module_name": "ec2_metric_alarm"
        },
        "item": "",
        "last_updated": "2014-05-07T20:57:43.236Z",
        "metric": "CPUUtilization",
        "name": "XXX.cpu-high",
        "namespace": "AWS/EC2",
        "ok_actions": [],
        "period": 300,
        "state_reason": "Threshold Crossed: 2 datapoints were not greater than or equal to the threshold (50.0). The most recent datapoints: [0.352, 1.005].",
        "state_value": "OK",
        "statistic": "Average",
        "threshold": 50.0,
        "unit": "Percent"
    }
}
```
