### PR TITLE
Fail if monit reload failed; don't mask the error.

### DIFF
--- a/library/monitoring/monit
+++ b/library/monitoring/monit
@@ -66,6 +66,8 @@ def main():
         if module.check_mode:
             module.exit_json(changed=True)
         rc, out, err = module.run_command('%s reload' % MONIT)
+        if rc != 0:
+            module.fail_json(msg='monit reload failed', stdout=out, stderr=err)
         module.exit_json(changed=True, name=name, state=state)
     
     rc, out, err = module.run_command('%s summary | grep "Process \'%s\'"' % (MONIT, pipes.quote(name)), use_unsafe_shell=True)


### PR DESCRIPTION
This is necessary for the scenario when you push a new, broken monit
config out, and then set a state=reloaded handler - the error was
previously swallowed so you could end up with successful play but missing
monitoring (!).

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
