### PR TITLE
Remove check for Ghost state

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -524,7 +524,7 @@ class DockerManager:
     def get_running_containers(self):
         running = []
         for i in self.get_deployed_containers():
-            if i['State']['Running'] == True and i['State']['Ghost'] == False:
+            if i['State']['Running'] == True and i['State'].get('Ghost', False):
                 running.append(i)
 
         return running


### PR DESCRIPTION
This doesn't exist anymore and causes ansible to throw a KeyError
