### PR TITLE
rds module: Fix undeclared reference to "params" when setting password in modify mode

### DIFF
--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -370,6 +370,9 @@ def main():
         else:
             return 'vpc_security_groups'
 
+    # Package up the optional parameters
+    params = {}
+
     # Validate parameters for each command
     if command == 'create':
         required_vars = [ 'instance_name', 'db_engine', 'size', 'instance_type', 'username', 'password' ]
@@ -412,9 +415,6 @@ def main():
     for v in invalid_vars:
         if module.params.get(v):
             module.fail_json(msg = str("Parameter %s invalid for %s command" % (v, command)))
-
-    # Package up the optional parameters
-    params = {}
 
     if db_engine:
         params["engine"] = db_engine


### PR DESCRIPTION
While modifying an RDS instance with the 'rds' module, one of the actions was to change the password.

While doing so, this happened:

```
TASK: [Set password replica] ******************************************
failed: [localhost] => {"failed": true, "parsed": false}
invalid output was: Traceback (most recent call last):
  File "/Users/herby/.ansible/tmp/ansible-tmp-1399628204.52-67026896752847/rds", line 1865, in <module>
    main()
  File "/Users/herby/.ansible/tmp/ansible-tmp-1399628204.52-67026896752847/rds", line 393, in main
    params["master_password"] = password
UnboundLocalError: local variable 'params' referenced before assignment
```

The proposed change fixes this issue.
