### PR TITLE
Add documentation for required parameter name to quantum_subnet

### DIFF
--- a/library/cloud/quantum_subnet
+++ b/library/cloud/quantum_subnet
@@ -68,6 +68,11 @@ options:
         - Name of the network to which the subnet should be attached
      required: true
      default: None
+   name:
+     description:
+       - The name of the subnet that should be created
+     required: true
+     default: None
    cidr:
      description:
         - The CIDR representation of the subnet that should be assigned to the subnet


### PR DESCRIPTION
The module quantum_subnet was missing documentation about the required parameter name.

I added the corresponding documentation to the Docstring.
