### PR TITLE
Make checks work with older Docker version

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -543,7 +543,7 @@ class DockerManager:
                   'tty':          self.module.params.get('tty'),
                   }
 
-        if docker.utils.compare_version('1.10', self.client.version()['ApiVersion']) < 0:
+        if docker.utils.compare_version('0.10', self.client.version()['Version']) < 0:
             params['dns'] = self.module.params.get('dns')
             params['volumes_from'] = self.module.params.get('volumes_from')
 
@@ -574,7 +574,7 @@ class DockerManager:
             'privileged':   self.module.params.get('privileged'),
             'links': self.links,
         }
-        if docker.utils.compare_version('1.10', self.client.version()['ApiVersion']) >= 0 and hasattr(docker, '__version__') and docker.__version__ > '0.3.0':
+        if docker.utils.compare_version('0.10', self.client.version()['Version']) >= 0 and hasattr(docker, '__version__') and docker.__version__ > '0.3.1':
             params['dns'] = self.module.params.get('dns')
             params['volumes_from'] = self.module.params.get('volumes_from')
 


### PR DESCRIPTION
ApiVersion isn't available on older Docker versions. Beside that, 0.3.1 doesn't support 0.10 api commands, so I've changed that check as well.
