### PR TITLE
added `include_doc` option for gem

### DIFF
--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -73,6 +73,12 @@ options:
     required: false
     default: "no"
     version_added: "1.6"
+
+  include_doc:
+    description:
+      - Install with or without docs.
+    required: false
+    default: "no"
 author: Johan Wiren
 '''
 
@@ -182,8 +188,9 @@ def install(module):
         cmd.append('--no-user-install')
     if module.params['pre_release']:
         cmd.append('--pre')
-    cmd.append('--no-rdoc')
-    cmd.append('--no-ri')
+    if not module.params['include_doc']:
+        cmd.append('--no-rdoc')
+        cmd.append('--no-ri')
     cmd.append(module.params['gem_source'])
     module.run_command(cmd, check_rc=True)
 
@@ -199,6 +206,7 @@ def main():
             state                = dict(required=False, default='present', choices=['present','absent','latest'], type='str'),
             user_install         = dict(required=False, default=True, type='bool'),
             pre_release           = dict(required=False, default=False, type='bool'),
+            include_doc           = dict(required=False, default=False, type='bool'),
             version              = dict(required=False, type='str'),
         ),
         supports_check_mode = True,


### PR DESCRIPTION
From the documentation it was not clear that --no-rdoc and --no-ri were being called.
