### PR TITLE
Handle ValueError during json.loads of json data from build

### DIFF
--- a/library/cloud/docker_image
+++ b/library/cloud/docker_image
@@ -140,7 +140,10 @@ class DockerImageManager:
             if not chunk:
                 continue
 
-            chunk_json = json.loads(chunk)
+            try:
+                chunk_json = json.loads(chunk)
+            except ValueError:
+                continue
 
             if 'error' in chunk_json:
                 self.error_msg = chunk_json['error']
@@ -152,6 +155,12 @@ class DockerImageManager:
                 match = re.search(success_search, output)
                 if match:
                     image_id = match.group(1)
+
+        # Just in case we skipped evaluating the JSON returned from build
+        # during every iteration, add an error if the image_id was never
+        # populated
+        if not image_id:
+            self.error_msg = 'Unknown error encountered'
 
         return image_id
 


### PR DESCRIPTION
See #7367

When building an image from a Dockerfile, the first time the base image is downloaded from the index, that portion of the build step returns invalid JSON data that causes `json.loads` to raise a ValueError.

This pull request catches that exception and continues on, ignoring the parsing failure.

If for some reason we skip every iteration of looping through the stream and no `image_id` was set, indicate that an unknown error was encountered.
