### PR TITLE
Allow wait_for to wait on non-traditional files

### DIFF
--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -176,7 +176,8 @@ def main():
         end = start + datetime.timedelta(seconds=timeout)
         while datetime.datetime.now() < end:
             if path:
-                if os.path.exists(path):
+                try:
+                    os.stat(path)
                     if search_regex:
                         try:
                             f = open(path)
@@ -192,8 +193,13 @@ def main():
                             pass
                     else:
                         break
-                else:
-                    time.sleep(1)
+                except OSError, e:
+                    # File not present
+                    if os.errno == 2:
+                        time.sleep(1)
+                    else:
+                        elapsed = datetime.datetime.now() - start
+                        module.fail_json(msg="Failed to stat %s, %s" % (path, e.strerror), elapsed=elapsed.seconds)
             elif port:
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 s.settimeout(connect_timeout)

--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -176,21 +176,24 @@ def main():
         end = start + datetime.timedelta(seconds=timeout)
         while datetime.datetime.now() < end:
             if path:
-                try:
-                    f = open(path)
-                    try:
-                        if search_regex:
-                            if re.search(search_regex, f.read(), re.MULTILINE):
-                                break
-                            else:
-                                time.sleep(1)
-                        else:
-                            break
-                    finally:
-                        f.close()
-                except IOError:
+                if os.path.exists(path):
+                    if search_regex:
+                        try:
+                            f = open(path)
+                            try:
+                                if re.search(search_regex, f.read(), re.MULTILINE):
+                                    break
+                                else:
+                                    time.sleep(1)
+                            finally:
+                                f.close()
+                        except IOError:
+                            time.sleep(1)
+                            pass
+                    else:
+                        break
+                else:
                     time.sleep(1)
-                    pass
             elif port:
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 s.settimeout(connect_timeout)


### PR DESCRIPTION
Use os.path.exists to check for file existence, instead of "can we open
this file for reading".

Fixes #6710
