### PR TITLE
When ansible_ssh_user is a number ssh fail to connect due to string concat

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -41,7 +41,7 @@ class Connection(object):
         self.host = host
         self.ipv6 = ':' in self.host
         self.port = port
-        self.user = user
+        self.user = str(user)
         self.password = password
         self.private_key_file = private_key_file
         self.HASHED_KEY_MAGIC = "|1|"


### PR DESCRIPTION
Convert to string to fix runtime error due to string concat in self.common_args += ["-o", "User="+self.user] when ansible_ssh_user is a number
