### PR TITLE
Fixed handling of paths containing whitespaces in the synchronize module

### DIFF
--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -221,8 +221,8 @@ def main():
         supports_check_mode = True
     )
 
-    source = module.params['src']
-    dest = module.params['dest']
+    source = '"' + module.params['src'] + '"'
+    dest = '"' + module.params['dest'] + '"'
     dest_port = module.params['dest_port']
     delete = module.params['delete']
     private_key = module.params['private_key']


### PR DESCRIPTION
It's a very simple fix to make Ansible work with whitespaces in paths. It works for me, and I hope you will accept it in upstream in this form or feel free to modify the code in any way (to comply with your code style or something).
