### PR TITLE
Add availability zone option to nova_compute

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -87,6 +87,12 @@ options:
         - The name of the security group to which the VM should be added
      required: false
      default: None
+   availability_zone:
+     version_added: "1.7"
+     description:
+        - The name of the availability zone to which the VM should be added
+     required: false
+     default: None
    nics:
      description:
         - A list of network id's to which the VM's interface should be attached
@@ -163,6 +169,7 @@ def _create_server(module, nova):
                 'meta' : module.params['meta'],
                 'key_name': module.params['key_name'],
                 'security_groups': module.params['security_groups'].split(','),
+                'availability_zone': module.params['availability_zone'],
                 #userdata is unhyphenated in novaclient, but hyphenated here for consistency with the ec2 module:
                 'userdata': module.params['user_data'],
     }
@@ -236,6 +243,7 @@ def main():
         flavor_id                       = dict(default=1),
         key_name                        = dict(default=None),
         security_groups                 = dict(default='default'),
+        availability_zone               = dict(default=None),
         nics                            = dict(default=None),
         meta                            = dict(default=None),
         wait                            = dict(default='yes', choices=['yes', 'no']),


### PR DESCRIPTION
This adds an additional parameter to nova_compute to support selecting availability zones for an instance.
