### PR TITLE
Fix missing variable initialization so an unspecified internal_network works

### DIFF
--- a/library/cloud/quantum_floating_ip
+++ b/library/cloud/quantum_floating_ip
@@ -142,6 +142,7 @@ def _get_server_state(module, nova):
     return server_info, server
 
 def _get_port_info(neutron, module, instance_id, internal_network_name=None):
+    subnet_id = None
     if internal_network_name:
         kwargs = {
             'name': internal_network_name,


### PR DESCRIPTION
Without this line the module fails when leaving internal_network unspecified from calling an if on an undeclared variable.
