### PR TITLE
Add missing basedir to Runner in _do_setup_step

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -505,6 +505,7 @@ class PlayBook(object):
 
         # push any variables down to the system
         setup_results = ansible.runner.Runner(
+            basedir=self.basedir,
             pattern=play.hosts,
             module_name='setup',
             module_args={},


### PR DESCRIPTION
You can use a string template that does a pipe lookup in your vars yaml file like so:

``` yaml
repo_version: "{{ lookup('pipe', 'git describe --tags') }}"
```

If you do so, the current working directory for that pipe command is currently not set correctly based on the path of the playbooks. It instead defaults to `os.getcwd()` [here](https://github.com/ansible/ansible/blob/release1.6.1/lib/ansible/runner/__init__.py#L161), because the `basedir` is not passed to the Runner instance in `_do_setup_step` [here](https://github.com/ansible/ansible/blob/release1.6.1/lib/ansible/playbook/__init__.py#L507). 
1. To reproduce, use a variable in your vars.yaml, then call from outside your repository.
2. This bug never crops up if you call ansible from your repository root, but if you ever step outside of it, git will fail.

This PR has `_do_setup_step` pass its basedir to the runner. This makes things consistent with pipes in other places, that correctly set cwd.
