### PR TITLE
postgresql_user module documentation:  Clarify that the encrypted param must also be set.

### DIFF
--- a/library/database/postgresql_user
+++ b/library/database/postgresql_user
@@ -44,7 +44,7 @@ options:
   password:
     description:
       - set the user's password, before 1.4 this was required.
-      - "When passing an encrypted password it must be generated with the format C('str[\\"md5\\"] + md5[ password + username ]'), resulting in a total of 35 characters.  An easy way to do this is: C(echo \\"md5`echo -n \\"verysecretpasswordJOE\\" | md5`\\")."
+      - "When passing an encrypted password, the encrypted parameter must also be true, and it must be generated with the format C('str[\\"md5\\"] + md5[ password + username ]'), resulting in a total of 35 characters.  An easy way to do this is: C(echo \\"md5`echo -n \\"verysecretpasswordJOE\\" | md5`\\")."
     required: false
     default: null
   db:


### PR DESCRIPTION
While the encrypted parameter's documentation clearly states that it needs to
be set, if you are focused on the password parameter's documentation, there's
nothing to draw your attention to the fact that encrypted may also need to be
set.
