### PR TITLE
Fix env splitting in docker module

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -384,7 +384,7 @@ class DockerManager:
 
         self.env = None
         if self.module.params.get('env'):
-            self.env = dict(map(lambda x: x.split("="), self.module.params.get('env')))
+            self.env = dict(map(lambda x: x.split("=", 1), self.module.params.get('env')))
 
         # connect to docker server
         docker_url = urlparse(module.params.get('docker_url'))


### PR DESCRIPTION
ENV variable value could contain '=' (for example mysql://host/db?pool=10)

```
- name: Start container
  docker: image=<image> state=present env="DATABASE_URL={{ database_url }}"
```

```
ansible-playbook -i hosts -vvvv -e "database_url=mysql://localhost/db?pool=128" playbook.yml
```

```
Traceback (most recent call last):
  File "/home/deploy/.ansible/tmp/ansible-tmp-1400074971.47-215002668530421/docker", line 1812, in <module>
    main()
  File "/home/deploy/.ansible/tmp/ansible-tmp-1400074971.47-215002668530421/docker", line 646, in main
    manager = DockerManager(module)
  File "/home/deploy/.ansible/tmp/ansible-tmp-1400074971.47-215002668530421/docker", line 371, in __init__
    self.env = dict(map(lambda x: x.split("="), env))
ValueError: dictionary update sequence element #0 has length 3; 2 is required


FATAL: all hosts have already failed -- aborting
```
