### PR TITLE
Fix known_hosts.py to work on older versions of python

### DIFF
--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -27,7 +27,12 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import hmac
-from hashlib import sha1
+
+try:
+    from hashlib import sha1
+except ImportError:
+    import sha as sha1
+
 HASHED_KEY_MAGIC = "|1|"
 
 def add_git_host_key(module, url, accept_hostkey=True, create_dir=True):


### PR DESCRIPTION
This pull request https://github.com/ansible/ansible/pull/6639 fixed the validation of fingerprint hashes in `known_hosts.py` but broke the git module on managed nodes where the default version of python is older then 2.5 (e.g. rhel5) and would require to also install `python-hashlib` package instead of only `python-simplejson`.
