### PR TITLE
Give reasonable error when symlink fails

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -201,7 +201,7 @@ def main():
                 module.fail_json(msg="absolute paths are required")
         elif prev_state == 'directory':
             if not force:
-                module.fail_json(path=path, msg='refusing to convert between %s and %s for %s' % (prev_state, state, src))
+                module.fail_json(path=path, msg='refusing to convert between %s and %s for %s' % (prev_state, state, path))
             elif len(os.listdir(path)) > 0:
                 # refuse to replace a directory that has files in it
                 module.fail_json(path=path, msg='the directory %s is not empty, refusing to convert it' % path)

--- a/library/files/file
+++ b/library/files/file
@@ -206,7 +206,7 @@ def main():
                 # refuse to replace a directory that has files in it
                 module.fail_json(path=path, msg='the directory %s is not empty, refusing to convert it' % path)
         elif prev_state in ['file', 'hard'] and not force:
-            module.fail_json(path=path, msg='refusing to convert between %s and %s for %s' % (prev_state, state, src))
+            module.fail_json(path=path, msg='refusing to convert between %s and %s for %s' % (prev_state, state, path))
 
         if prev_state == 'absent':
             changed = True


### PR DESCRIPTION
When a symlink fails because the path already exists and force=no, we should output path in the error message instead of source.
