### PR TITLE
Add networking mode parameter (net) to docker

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -183,6 +183,13 @@ options:
     default: false
     aliases: []
     version_added: "1.6"
+  net:
+    description:
+      - Set Network mode for the container (bridge, none, container:<name|id>, host)
+    required: false
+    default: false
+    aliases: []
+    version_added: "1.11"
 author: Cove Schneider, Joshua Conner, Pavel Antonov
 requirements: [ "docker-py >= 0.3.0", "docker >= 0.10.0" ]
 '''
@@ -575,6 +582,7 @@ class DockerManager:
             'publish_all_ports': self.module.params.get('publish_all_ports'),
             'privileged':   self.module.params.get('privileged'),
             'links': self.links,
+            'network_mode': self.module.params.get('net'),
         }
         if docker.utils.compare_version('1.10', self.client.version()['ApiVersion']) >= 0 and hasattr(docker, '__version__') and docker.__version__ > '0.3.0':
             params['dns'] = self.module.params.get('dns')
@@ -660,7 +668,8 @@ def main():
             stdin_open      = dict(default=False, type='bool'),
             tty             = dict(default=False, type='bool'),
             lxc_conf        = dict(default=None, type='list'),
-            name            = dict(default=None)
+            name            = dict(default=None),
+            net             = dict(default=None)
         )
     )
 


### PR DESCRIPTION
Since 0.11 Docker supports different networking modes (see docker run --net). This commit add support for that to the ansible docker module.

This depends on dotcloud/docker-py@2d58351
