### PR TITLE
Fix skip dir inventory extensions

### DIFF
--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -36,13 +36,12 @@ class InventoryDirectory(object):
         self.parsers = []
         self.hosts = {}
         self.groups = {}
- 
+
         for i in self.names:
 
             # Skip files that end with certain extensions or characters
-            for ext in ("~", ".orig", ".bak", ".ini", ".retry", ".pyc", ".pyo"):
-                if i.endswith(ext):
-                    continue
+            if any(i.endswith(ext) for ext in ("~", ".orig", ".bak", ".ini", ".retry", ".pyc", ".pyo")):
+                continue
             # Skip hidden files
             if i.startswith('.') and not i.startswith('./'):
                 continue

--- a/test/units/TestInventory.py
+++ b/test/units/TestInventory.py
@@ -439,3 +439,7 @@ class TestInventory(unittest.TestCase):
         actual_host_names = [host.name for host in group_greek]
         print "greek : %s " % actual_host_names
         assert actual_host_names == ['zeus', 'morpheus']
+
+    def test_dir_inventory_skip_extension(self):
+        inventory = self.dir_inventory()
+        assert 'skipme' not in [h.name for h in inventory.get_hosts()]

--- a/test/units/inventory_test_data/inventory_dir/4skip_extensions.ini
+++ b/test/units/inventory_test_data/inventory_dir/4skip_extensions.ini
@@ -1,0 +1,2 @@
+[skip]
+skipme


### PR DESCRIPTION
I discovered this after I upgraded from 1.6 to the current devel branch. My /etc/ansible looks like this:

```
├── ansible.cfg
└── hosts
    ├── ec2
    ├── ec2.ini
    └── local
```

(where ec2 is really ec2.py)

And doing e.g. `ansible --list-hosts all` started returning ini errors. I discovered that it was because the extension filtering broke in a recent refactoring of ansible.inventory.dir.InventoryDirectory.

This pull request includes a new test that demonstrates the issue as well as a fix.
