### PR TITLE
docker: fix targetting images by name

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -516,7 +516,7 @@ class DockerManager:
             # '{} {}'.format(entrypoint, command)
             command_matches = (not command or running_command.endswith(command))
 
-            if name_matches or (image_matches and tag_matches and command_matches):
+            if name_matches or (name is None and image_matches and tag_matches and command_matches):
                 details = self.client.inspect_container(i['Id'])
                 details = _docker_id_quirk(details)
                 deployed.append(details)


### PR DESCRIPTION
Say you have the following images:

```
$ docker ps -a
CONTAINER ID   IMAGE                            COMMAND     CREATED       STATUS       PORTS   NAMES
4821bfe5d3f1   localhost:5000/my_image:latest   /bin/bash   2 hours ago   Up 2 hours           my_container_1
0f6cf245c7fa   localhost:5000/my_image:latest   /bin/bash   2 hours ago   Up 2 hours           my_container_2
4ed6cdb0a903   localhost:5000/my_image:latest   /bin/bash   2 hours ago   Up 2 hours           my_container_3

```

and a playbook:

```

---
- hosts: all
- tasks:
  - docker:
      image: localhost:5000/my_image:latest
      name: my_container_4
      state: absent
```

Before this patch, running this playbook would cause `my_container_{1,2,3}` to be removed, which is not expected.  With this patch, only `my_container_4` is removed, if present.
