### PR TITLE
add hostname to generated user SSH key comment

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -159,7 +159,7 @@ options:
             - Optionally specify the SSH key filename.
     ssh_key_comment:
         required: false
-        default: ansible-generated
+        default: ansible-generated on $HOSTNAME
         version_added: "0.9"
         description:
             - Optionally define the comment for the SSH key.
@@ -198,6 +198,7 @@ import pwd
 import grp
 import syslog
 import platform
+import socket
 
 try:
     import spwd
@@ -1453,7 +1454,7 @@ def main():
             'bits': '2048',
             'type': 'rsa',
             'passphrase': None,
-            'comment': 'ansible-generated'
+            'comment': 'ansible-generated on %s' % socket.gethostname()
     }
     module = AnsibleModule(
         argument_spec = dict(


### PR DESCRIPTION
have several user and ssh keys. So adding the hostname is a improvement.
