### PR TITLE
fixing some typos in the docs of the yum module

### DIFF
--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -62,7 +62,7 @@ options:
     description:
       - I(Repoid) of repositories to enable for the install/update operation.
         These repos will not persist beyond the transaction.
-        Multiple repos separated with a ','.
+        When specifying multiple repos, separate them with a ",".
     required: false
     version_added: "0.9"
     default: null
@@ -72,7 +72,7 @@ options:
     description:
       - I(Repoid) of repositories to disable for the install/update operation.
         These repos will not persist beyond the transaction.
-        Multiple repos separated with a ','.
+        When specifying multiple repos, separate them with a ",".
     required: false
     version_added: "0.9"
     default: null

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -60,9 +60,9 @@ options:
     default: "present"
   enablerepo:
     description:
-      - Repoid of repositories to enable for the install/update operation.
-        These repos will not persist beyond the transaction
-        multiple repos separated with a ','
+      - I(Repoid) of repositories to enable for the install/update operation.
+        These repos will not persist beyond the transaction.
+        Multiple repos separated with a ','.
     required: false
     version_added: "0.9"
     default: null
@@ -70,9 +70,9 @@ options:
     
   disablerepo:
     description:
-      - I(repoid) of repositories to disable for the install/update operation
-        These repos will not persist beyond the transaction
-        Multiple repos separated with a ','
+      - I(Repoid) of repositories to disable for the install/update operation.
+        These repos will not persist beyond the transaction.
+        Multiple repos separated with a ','.
     required: false
     version_added: "0.9"
     default: null


### PR DESCRIPTION
Just some simple typo fixes to the yum module documentation.
