### PR TITLE
Setting the default of wait to false

### DIFF
--- a/library/cloud/ec2_snapshot
+++ b/library/cloud/ec2_snapshot
@@ -122,7 +122,7 @@ def main():
             ec2_url = dict(),
             ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
             ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
-            wait = dict(type='bool', default='true'),
+            wait = dict(type='bool', default='false'),
             wait_timeout = dict(default=0),
             snapshot_tags = dict(type='dict', default=dict()),
         )


### PR DESCRIPTION
The known (and usual) behavior of this is a callback right after the AWS API returns and not wait until the snapshot is complete. So the default of the (undocumented) wait param should be false (which is the recommended way of doing snapshots on EBS).
