### PR TITLE
Implement a per-task check_mode setting

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -358,6 +358,11 @@ class PlayBook(object):
         hosts = self._trim_unavailable_hosts(task.play._play_hosts)
         self.inventory.restrict_to(hosts)
 
+        if task.check_mode:
+            check_mode = True
+        else:
+            check_mode = self.check
+
         runner = ansible.runner.Runner(
             pattern=task.play.hosts,
             inventory=self.inventory,
@@ -382,7 +387,7 @@ class PlayBook(object):
             transport=task.transport,
             sudo_pass=task.sudo_pass,
             is_playbook=True,
-            check=self.check,
+            check=check_mode,
             diff=self.diff,
             environment=task.environment,
             complex_args=task.args,

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -31,7 +31,7 @@ class Task(object):
         'local_action', 'transport', 'sudo', 'remote_user', 'sudo_user', 'sudo_pass',
         'items_lookup_plugin', 'items_lookup_terms', 'environment', 'args',
         'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until',
-        'su', 'su_user', 'su_pass', 'no_log',
+        'su', 'su_user', 'su_pass', 'no_log', 'check_mode',
     ]
 
     # to prevent typos and such
@@ -41,7 +41,7 @@ class Task(object):
          'delegate_to', 'local_action', 'transport', 'remote_user', 'sudo', 'sudo_user',
          'sudo_pass', 'when', 'connection', 'environment', 'args',
          'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until',
-         'su', 'su_user', 'su_pass', 'no_log',
+         'su', 'su_user', 'su_pass', 'no_log', 'check_mode',
     ]
 
     def __init__(self, play, ds, module_vars=None, default_vars=None, additional_conditions=None, role_name=None):
@@ -122,6 +122,7 @@ class Task(object):
         self.environment  = ds.get('environment', {})
         self.role_name    = role_name
         self.no_log       = utils.boolean(ds.get('no_log', "false"))
+        self.check_mode   = utils.boolean(ds.get('check_mode', "false"))
 
         #Code to allow do until feature in a Task 
         if 'until' in ds:


### PR DESCRIPTION
This allows an individual task to be run in check mode, so that other
tasks can be made conditional on its result.

Author: Carlos Chapi carlos@2ndQuadrant.com
