### PR TITLE
Improvements to OpenStack inventory script

### DIFF
--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -14,13 +14,20 @@ api_key       =
 auth_url      =
 
 # Authentication system
-auth_system =
+auth_system = keystone
 
 # OpenStack nova project_id
 project_id    = 
 
 # Serverarm region name to use
 region_name   =
+
+# Specify a preference for public or private IPs (public is default)
+prefer_private = False
+
+# What service type (required for newer nova client)
+service_type = compute
+
 
 # TODO: Some other options
 # insecure      =

--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -1,37 +1,45 @@
 # Ansible OpenStack external inventory script
 
 [openstack]
+
+#-------------------------------------------------------------------------
+#  Required settings
+#-------------------------------------------------------------------------
+
 # API version
 version       = 2
 
 # OpenStack nova username
 username      =
 
-# OpenStack nova api_key
+# OpenStack nova api_key or password
 api_key       =
 
 # OpenStack nova auth_url
 auth_url      =
 
-# Authentication system
-auth_system = keystone
+# OpenStack nova project_id or tenant name
+project_id    =
 
-# OpenStack nova project_id
-project_id    = 
+#-------------------------------------------------------------------------
+#  Optional settings
+#-------------------------------------------------------------------------
+
+# Authentication system
+# auth_system = keystone
 
 # Serverarm region name to use
-region_name   =
+# region_name   =
 
 # Specify a preference for public or private IPs (public is default)
-prefer_private = False
+# prefer_private = False
 
 # What service type (required for newer nova client)
-service_type = compute
+# service_type = compute
 
 
 # TODO: Some other options
 # insecure      =
 # endpoint_type =
 # extensions    =
-# service_type  =
 # service_name  =

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -39,6 +39,7 @@ NOVA_CONFIG_FILES = [os.getcwd() + "/nova.ini",
 NOVA_DEFAULTS = {
     'auth_system': None,
     'region_name': None,
+    'service_type': 'compute',
 }
 
 

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -143,14 +143,37 @@ config = nova_load_config_file()
 if not config:
     sys.exit('Unable to find configfile in %s' % ', '.join(NOVA_CONFIG_FILES))
 
+# Load up connections info based on config and then environment
+# variables
+username = (get_fallback(config, 'username') or
+            os.environ.get('OS_USERNAME', None))
+api_key = (get_fallback(config, 'api_key') or
+           os.environ.get('OS_PASSWORD', None))
+auth_url = (get_fallback(config, 'auth_url') or
+            os.environ.get('OS_AUTH_URL', None))
+project_id = (get_fallback(config, 'project_id') or
+              os.environ.get('OS_TENANT_NAME', None))
+region_name = (get_fallback(config, 'region_name') or
+               os.environ.get('OS_REGION_NAME', None))
+auth_system = (get_fallback(config, 'auth_system') or
+               os.environ.get('OS_AUTH_SYSTEM', None))
+
+# Determine what type of IP is preferred to return
+prefer_private = False
+try:
+    prefer_private = config.getboolean('openstack', 'prefer_private')
+except ConfigParser.NoOptionError:
+    pass
+
 client = nova_client.Client(
-    version     = config.get('openstack', 'version'),
-    username    = config.get('openstack', 'username'),
-    api_key     = config.get('openstack', 'api_key'),
-    auth_url    = config.get('openstack', 'auth_url'),
-    region_name = config.get('openstack', 'region_name'),
-    project_id  = config.get('openstack', 'project_id'),
-    auth_system = config.get('openstack', 'auth_system')
+    version=config.get('openstack', 'version'),
+    username=username,
+    api_key=api_key,
+    auth_url=auth_url,
+    region_name=region_name,
+    project_id=project_id,
+    auth_system=auth_system,
+    service_type=config.get('openstack', 'service_type'),
 )
 
 # Default or added list option


### PR DESCRIPTION
This adds the option to use common environment variables instead of the just the INI for common things like password and auth URL.  It creates inventory groups for each key/value in the metadata dictionary similar to the ec2.py scripts (but keeps the special group metadata tag as well for backwards compatibility), and adds the _meta host var dictionary added in 1.3 that speeds things up quite a bit. It also adds a configurable flag as to whether to prefer the public or private IP (fixed or floating) of each instance, and prints the json in a more human friendly format.
