### PR TITLE
Fix for https://github.com/ansible/ansible/issues/7330

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -526,7 +526,8 @@ class DockerManager:
     def get_running_containers(self):
         running = []
         for i in self.get_deployed_containers():
-            if i['State']['Running'] == True and i['State'].get('Ghost', False) == False:
+            if i['State']['Running'] == True and \
+               (i['State'].has_key('Ghost') and i['State']['Ghost'] == False):
                 running.append(i)
 
         return running


### PR DESCRIPTION
i['State']['Ghost'] no longer seems to be defined with newer versions of docker-py. Added logic to handle this.
