### PR TITLE
Fix to resolve VPC NAT routing issue https://github.com/ansible/ansible/issues/7368

### DIFF
--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -422,7 +422,10 @@ def create_vpc(module, vpc_conn):
                             '(igw) route, but you have no Internet Gateway'
                         )
                     r_gateway = igw.id
-                vpc_conn.create_route(new_rt.id, route['dest'], r_gateway)
+                if r_gateway[:3] == 'igw':
+                    vpc_conn.create_route(new_rt.id, route['dest'], gateway_id=r_gateway)
+                else:
+                    vpc_conn.create_route(new_rt.id, route['dest'], instance_id=r_gateway)
 
             # Associate with subnets
             for sn in rt['subnets']:


### PR DESCRIPTION
See https://github.com/ansible/ansible/issues/7368 for a detailed description

According to [boto.vpc.VPCCOnnection.create_route](http://bit.ly/1sku9W6) there is a need to use named parameters in the method call to differentiate between a gateway ID and an instance ID when trying to create a route.

there is a need to use named parameters in the method call
to differentiate between a gateway ID and an instance ID when
trying to create a route

Otherwise upon trying to register a route with an existing instance ID
instead of the gateway ID one gets an error like follows:

```
failed: [127.0.0.1] => {"failed": true, "item": ""}
msg: Unable to create and associate route table {u'routes': [{u'dest': u'0.0.0.0/0', u'gw': u'i-09d47501'}], u'subnets': [u'10.1.10.0/24', u'10.1.12.0/24', u'10.1.20.0/24']}, error: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidGatewayID.NotFound</Code><Message>The gateway ID 'i-09d47501' does not exist</Message></Error></Errors><RequestID>fa95104e-37ab-44ee-b8fd-2c5033179585</RequestID></Response>
```
