### PR TITLE
Add support for Portage emerge's --getbinpkg and --usepkgonly

### DIFF
--- a/library/packaging/portage
+++ b/library/packaging/portage
@@ -122,8 +122,22 @@ options:
     default: null
     choices: [ "yes", "web" ]
 
+  getbinpkg:
+    description:
+      - Prefer packages specified at PORTAGE_BINHOST in make.conf
+    required: false
+    default: null
+    choices: [ "yes" ]
+
+  usepkgonly:
+    description:
+      - Merge only binaries (no compiling). This sets getbinpkg=yes.
+    required: false
+    deafult: null
+    choices: [ "yes" ]
+
 requirements: [ gentoolkit ]
-author: Yap Sok Ann
+author: Yap Sok Ann, Andrew Udvare
 notes:  []
 '''
 
@@ -136,6 +150,12 @@ EXAMPLES = '''
 
 # Update package foo to the "best" version
 - portage: package=foo update=yes
+
+# Install package foo using PORTAGE_BINHOST setup
+- portage: package=foo getbinpkg=yes
+
+# Re-install world from binary packages only and do not allow any compiling
+- portage: package=@world usepkgonly=yes
 
 # Sync repositories and update world
 - portage: package=@world update=yes deep=yes sync=yes
@@ -150,6 +170,7 @@ EXAMPLES = '''
 
 import os
 import pipes
+import re
 
 
 def query_package(module, package, action):
@@ -228,9 +249,14 @@ def emerge_packages(module, packages):
         'oneshot', 'noreplace',
         'nodeps', 'onlydeps',
         'quiet', 'verbose',
+        'getbinpkg', 'usepkgonly',
     ]:
         if p[flag]:
             args.append('--%s' % flag)
+
+    # So that only usepkgonly needs to be specified
+    if p['usepkgonly'] and not p['getbinpkg']:
+        args.append('--getbinpkg')
 
     cmd, (rc, out, err) = run_emerge(module, packages, *args)
     if rc != 0:
@@ -239,9 +265,19 @@ def emerge_packages(module, packages):
             msg='Packages not installed.',
         )
 
+    # Check for SSH error with PORTAGE_BINHOST, since rc is still 0 despite
+    #   this error
+    if (p['usepkgonly'] or p['getbinpkg']) \
+            and 'Permission denied (publickey).' in err:
+        module.fail_json(
+            cmd=cmd, rc=rc, stdout=out, stderr=err,
+            msg='Please check your PORTAGE_BINHOST configuration in make.conf '
+                'and your SSH authorized_keys file',
+        )
+
     changed = True
     for line in out.splitlines():
-        if line.startswith('>>> Emerging (1 of'):
+        if re.match(r'(?:>+) Emerging (?:binary )?\(1 of', line):
             break
     else:
         changed = False
@@ -348,6 +384,8 @@ def main():
             quiet=dict(default=None, choices=['yes']),
             verbose=dict(default=None, choices=['yes']),
             sync=dict(default=None, choices=['yes', 'web']),
+            getbinpkg=dict(default=None, choices=['yes']),
+            usepkgonly=dict(default=None, choices=['yes']),
         ),
         required_one_of=[['package', 'sync', 'depclean']],
         mutually_exclusive=[['nodeps', 'onlydeps'], ['quiet', 'verbose']],


### PR DESCRIPTION
`PORTAGE_BINHOST` allows for quick re-installation on a single machine (example given), and fast distribution of packages for machines that have the same configuration so that only one machine has to do the compiling.

For more information about `PORTAGE_BINHOST`, see https://wiki.gentoo.org/wiki/Binary_package_guide#Rationale

In short form, the arguments `--getbinpkg` and `--usepkgonly` are used in conjunction with `make.conf` with a properly set-up `PORTAGE_BINHOST` argument like the following to a server via SSH:

``` bash
PORTAGE_BINHOST="ssh://somename@192.168.1.100/mnt/portage-stuff/packages"
```

`/mnt/portage-stuff/packages` contains the compiled packages and special metadata such as USE flags so that a match is not made if the USE flags on the target machine are not the same. In that case, if only `getbinpkg` is used, the package will then be compiled. If `usepkgonly` is used, then Portage will exit with a failure because it will not not have the pre-built package expected.

If someone wishes to use this feature on a remote machine, they should install a `make.conf` with the proper configuration prior to using the new arguments with the portage module.

Defined task:

``` yaml
- name: 'Install Wine'
  portage: quiet=yes state=present update=yes package=wine newuse=yes usepkgonly=yes state=emerged
```

Note that `usepkgonly=yes` is effectively `usepkgonly=yes getbinpkg=yes` or `-gK` to the `emerge` command.

This correctly gives the `changed` value:

```
TASK: [system | Install Wine] ***********
changed: [devbox] => {"changed": true, "cmd": ["/usr/bin/emerge", "--update", "--newuse", "--quiet", "--usepkgonly", "--getbinpkg", "wine"], "item": "", "msg": "Packages installed.", "rc": 0, "stderr": "", "stdout": ">>> Running pre-merge checks for app-emulation/wine-1.7.18\n>>> Emerging binary (1 of 1) app-emulation/wine-1.7.18::gentoo\n>>> Installing (1 of 1) app-emulation/wine-1.7.18\n>>> Recording app-emulation/wine in \"world\" favorites file...\n"}
```

Run again after installation:

```
TASK: [system | Install Wine] ***********
ok: [devbox] => {"changed": false, "cmd": ["/usr/bin/emerge", "--update", "--newuse", "--quiet", "--usepkgonly", "--getbinpkg", "wine"], "item": "", "msg": "Packages installed.", "rc": 0, "stderr": "", "stdout": ""}
```
