### PR TITLE
ec2_asg: Added a more verbose response to the module.

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -124,6 +124,8 @@ def create_autoscaling_group(connection, module):
     launch_configs = connection.get_all_launch_configurations(names=[launch_config_name])
     
     as_groups = connection.get_all_groups(names=[group_name])
+    attributes = ('launch_config_name', 'max_size', 'min_size', 'desired_capacity',
+                     'vpc_zone_identifier', 'availability_zones')
 
     if not vpc_zone_identifier and not availability_zones:
         region, ec2_url, aws_connect_params = get_aws_connection_info(module)
@@ -147,14 +149,16 @@ def create_autoscaling_group(connection, module):
 
         try:
             connection.create_auto_scaling_group(ag)
-            module.exit_json(changed=True)
+            asg = {}
+            for attr in attributes:
+                asg[attr] = getattr(ag, attr)
+            module.exit_json(changed=True, **asg)
         except BotoServerError, e:
             module.fail_json(msg=str(e))
     else:
         as_group = as_groups[0]
         changed = False
-        for attr in ('launch_config_name', 'max_size', 'min_size', 'desired_capacity',
-                     'vpc_zone_identifier', 'availability_zones'):
+        for attr in attributes:
             if getattr(as_group, attr) != module.params.get(attr):
                 changed = True
                 setattr(as_group, attr, module.params.get(attr))
@@ -167,7 +171,11 @@ def create_autoscaling_group(connection, module):
         try:
             if changed:
                 as_group.update()
-            module.exit_json(changed=changed)
+            asg = {}
+            for attr in attributes:
+                asg[attr] = getattr(as_group, attr)
+            asg['instances'] = [i.instance_id for i in as_group.instances]
+            module.exit_json(changed=changed, **asg)
         except BotoServerError, e:
             module.fail_json(msg=str(e))
 


### PR DESCRIPTION
Now includes its settable attributes and a list of its instances

Response like:

```
TASK: [ec2_asg ] ************************************************************** 
ok: [localhost] => {"availability_zones": ["us-east-1a"], "changed": false, "desired_capacity": 1, "instances": ["i-e9038fb9"], "launch_config_name": "dx_auto-deploy_test_lc", "max_size": 2, "min_size": 1, "vpc_zone_identifier": "subnet-c9c906a8"}
```
