### PR TITLE
add async fire-forget/check functionality

### DIFF
--- a/docsite/rst/playbooks_async.rst
+++ b/docsite/rst/playbooks_async.rst
@@ -56,6 +56,28 @@ Alternatively, if you do not need to wait on the task to complete, you may
    Using a higher value for ``--forks`` will result in kicking off asynchronous
    tasks even faster.  This also increases the efficiency of polling.
 
+If you would like to perform a variation of the "fire and forget" where you 
+"fire and forget, check on it later" you can perform a task similar to the 
+following::
+
+      --- 
+      # Requires ansible 1.7+
+      - name: 'YUM - fire and forget task'
+        yum: name=docker-io state=installed
+        async: 1000
+        poll: 0
+        register: yum_sleeper
+
+      - name: 'YUM - check on fire and forget task'
+        async_status: jid={{ yum_sleeper.ansible_job_id }}
+        register: job_result
+        until: job_result.finished
+        retries: 30
+
+.. note::
+   If the value of ``async:`` is not high enough, this will cause the 
+   "check on it later" task to fail because the temporary status file that
+   the ``async_status:`` is looking for will not have been written 
 
 .. seealso::
 

--- a/library/internal/async_status
+++ b/library/internal/async_status
@@ -80,7 +80,7 @@ def main():
     except Exception, e:
         if data == '':
             # file not written yet?  That means it is running
-            module.exit_json(results_file=log_path, ansible_job_id=jid, started=1)
+            module.exit_json(results_file=log_path, ansible_job_id=jid, started=1, finished=0)
         else:
             module.fail_json(ansible_job_id=jid, results_file=log_path,
                 msg="Could not parse job output: %s" % data)


### PR DESCRIPTION
I've added the code suggested by "x93..." (I have no other identifier for this person to offer them credit) in [this thread](https://groups.google.com/forum/#!searchin/ansible-project/async/ansible-project/PGlY46HS6LM/Z60BT3vEnhcJ) on the ansible mailing list. 

From the testing I've done it works just fine and I added some docs on how to use it.

The following is a playbook I used for testing.

```

---
# test async checking
#
- hosts: all
  remote_user: root
  tasks:
    - name: 'YUM -  test normal async'
      yum: name=docker-io state=installed 
      async:  20
      poll: 2

    - name: 'YUM - fire and forget task'
      yum: name=docker-io state=installed 
      async: 1000
      poll: 0
      register: yum_sleeper

    - name: 'YUM - check on fire and forget task'
      async_status: jid={{ yum_sleeper.ansible_job_id }}
      register: job_result
      until: job_result.finished
      retries: 30

    - name: 'SHELL -  test normal async'
      shell: 'for i in {1..10}; do printf "$i \n"; sleep 1; done'
      async:  20
      poll: 2

    - name: 'SHELL - fire and forget task'
      shell: 'for i in {1..10}; do printf "$i \n"; sleep 1; done'
      async: 1000
      poll: 0
      register: shell_sleeper

    - name: 'SHELL - check on fire and forget task'
      async_status: jid={{ shell_sleeper.ansible_job_id }}
      register: job_result
      until: job_result.finished
      retries: 30
```
