### PR TITLE
fix UnicodeEncodeError when prompt is unicode.

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -651,9 +651,10 @@ class PlaybookCallbacks(object):
             msg = 'input for %s: ' % varname
 
         def prompt(prompt, private):
+            msg = prompt.encode(sys.stdout.encoding)
             if private:
-                return getpass.getpass(prompt)
-            return raw_input(prompt)
+                return getpass.getpass(msg)
+            return raw_input(msg)
 
 
         if confirm:

--- a/lib/ansible/runner/action_plugins/pause.py
+++ b/lib/ansible/runner/action_plugins/pause.py
@@ -101,7 +101,7 @@ class ActionModule(object):
                 # Clear out any unflushed buffered input which would
                 # otherwise be consumed by raw_input() prematurely.
                 tcflush(sys.stdin, TCIFLUSH)
-                self.result['user_input'] = raw_input(self.prompt)
+                self.result['user_input'] = raw_input(self.prompt.encode(sys.stdout.encoding))
         except KeyboardInterrupt:
             while True:
                 print '\nAction? (a)bort/(c)ontinue: '


### PR DESCRIPTION
UnicodeEncodeError is occured when prompt text is unicode in vars_prompt and pause module.

```
  File "/home/blah/Works/VEnvs/ansible/lib/python2.7/site-packages/ansible/callbacks.py", line 667, in on_vars_prompt
    result = prompt(msg, private)
  File "/home/blah/Works/VEnvs/ansible/lib/python2.7/site-packages/ansible/callbacks.py", line 655, in prompt
    return getpass.getpass(prompt)
  File "/usr/local/lib/python2.7/getpass.py", line 71, in unix_getpass
    passwd = _raw_input(prompt, stream, input=input)
  File "/usr/local/lib/python2.7/getpass.py", line 128, in _raw_input
    prompt = str(prompt)
```

```

---
- hosts: local
  gather_facts: no
  vars_prompt:
    - name: hello
      prompt: "Ĥȅľľő Ŵőŕľď!"
  tasks:
  - debug: msg=hello
  - pause: prompt=Ĥȅľľő
```

This PR fixes this using encode(sys.stdout.encoding).

related PR: #3042
