### PR TITLE
implemented the missing "command" option, defaults to "install"...

### DIFF
--- a/library/packaging/composer
+++ b/library/packaging/composer
@@ -30,7 +30,7 @@ description:
 options:
     command:
         description:
-            - Composer command like "install", "update" and so option
+            - Composer command like "install", "update" and so on
         required: false
         default: install
     working_dir:

--- a/library/packaging/composer
+++ b/library/packaging/composer
@@ -97,16 +97,17 @@ def parse_out(string):
 def has_changed(string):
     return (re.match("Nothing to install or update", string) != None)
 
-def composer_install(module, options):
+def composer_install(module, command, options):
     php_path      = module.get_bin_path("php", True, ["/usr/local/bin"])
     composer_path = module.get_bin_path("composer", True, ["/usr/local/bin"])
-    cmd           = "%s %s install %s" % (php_path, composer_path, " ".join(options))
+    cmd           = "%s %s %s %s" % (php_path, composer_path, command, " ".join(options))
 
     return module.run_command(cmd)
 
 def main():
     module = AnsibleModule(
         argument_spec = dict(
+            command             = dict(default="install", type="str", required=False),
             working_dir         = dict(aliases=["working-dir"], required=True),
             prefer_source       = dict(default="no", type="bool", aliases=["prefer-source"]),
             prefer_dist         = dict(default="no", type="bool", aliases=["prefer-dist"]),
@@ -129,6 +130,10 @@ def main():
     if module.check_mode:
         options.add("--dry-run")
 
+    # Get composer command with fallback to default  
+    command = module.params['command']
+    del module.params['command'];
+
     # Prepare options
     for i in module.params:
         opt = "--%s" % i.replace("_","-")
@@ -138,7 +143,7 @@ def main():
         elif isinstance(p, (str)):
             options.add("%s=%s" % (opt, p))
 
-    rc, out, err = composer_install(module, options)
+    rc, out, err = composer_install(module, command, options)
 
     if rc != 0:
         output = parse_out(err)

--- a/library/packaging/composer
+++ b/library/packaging/composer
@@ -28,6 +28,11 @@ version_added: "1.6"
 description:
     - Composer is a tool for dependency management in PHP. It allows you to declare the dependent libraries your project needs and it will install them in your project for you
 options:
+    command:
+        description:
+            - Composer command like "install", "update" and so option
+        required: false
+        default: install
     working_dir:
         description:
             - Directory of your project ( see --working-dir )
@@ -85,7 +90,7 @@ notes:
 
 EXAMPLES = '''
 # Downloads and installs all the libs and dependencies outlined in the /path/to/project/composer.lock
-- composer: working_dir=/path/to/project
+- composer: command=install working_dir=/path/to/project
 '''
 
 import os


### PR DESCRIPTION
Hello!

I've written the previously documented, but missing "command" option in the composer module, because I needed the ability to do a composer update command. I'd be happy if you could review and add this feature to your repository. 

Thanks in advance & Kind regards,
  Ralf

PS. Updated with some documentation lines...
