### PR TITLE
rax module: Support config_drive and user_data

### DIFF
--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -136,7 +136,7 @@ options:
   user_data:
     description:
       - Data to be uploaded to the servers config drive. This option implies
-        I(config_drive)
+        I(config_drive). Can be a file path or a string
     version_added: 1.7
   wait:
     description:
@@ -633,7 +633,8 @@ def cloudservers(module, state=None, name=None, flavor=None, image=None,
                meta=meta, key_name=key_name, files=files, wait=wait,
                wait_timeout=wait_timeout, disk_config=disk_config, group=group,
                nics=nics, extra_create_args=extra_create_args,
-               user_data=user_data, config_drive=config_drive, existing=servers)
+               user_data=user_data, config_drive=config_drive,
+               existing=servers)
 
     elif state == 'absent':
         if instance_ids is None:

--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -31,7 +31,18 @@ options:
         created servers. Only applicable when used with the I(group) attribute
         or meta key.
     default: yes
+    choices:
+      - "yes"
+      - "no"
     version_added: 1.5
+  config_drive:
+    description:
+      - Attach read-only configuration drive to server as label config-2
+    default: no
+    choices:
+      - "yes"
+      - "no"
+    version_added: 1.7
   count:
     description:
       - number of instances to launch
@@ -55,6 +66,9 @@ options:
       - Explicitly ensure an exact count of instances, used with
         state=active/present
     default: no
+    choices:
+      - "yes"
+      - "no"
     version_added: 1.4
   extra_client_args:
     description:
@@ -119,6 +133,11 @@ options:
       - present
       - absent
     default: present
+  user_data:
+    description:
+      - Data to be uploaded to the servers config drive. This option implies
+        I(config_drive)
+    version_added: 1.7
   wait:
     description:
       - wait for the instance to be in state 'running' before returning
@@ -216,17 +235,29 @@ def server_to_dict(obj):
 
 def create(module, names, flavor, image, meta, key_name, files,
            wait, wait_timeout, disk_config, group, nics,
-           extra_create_args, existing=[]):
+           extra_create_args, user_data, config_drive, existing=[]):
 
     cs = pyrax.cloudservers
     changed = False
 
-    # Handle the file contents
+    if user_data:
+        config_drive = True
+
+    if user_data and os.path.isfile(user_data):
+        try:
+            f = open(user_data)
+            user_data = f.read()
+            f.close()
+        except Exception, e:
+            module.fail_json(msg='Failed to load %s' % user_data)
+
+     # Handle the file contents
     for rpath in files.keys():
         lpath = os.path.expanduser(files[rpath])
         try:
             fileobj = open(lpath, 'r')
             files[rpath] = fileobj.read()
+            fileobj.close()
         except Exception, e:
             module.fail_json(msg='Failed to load %s' % lpath)
     try:
@@ -237,6 +268,8 @@ def create(module, names, flavor, image, meta, key_name, files,
                                              key_name=key_name,
                                              files=files, nics=nics,
                                              disk_config=disk_config,
+                                             config_drive=config_drive,
+                                             userdata=user_data,
                                              **extra_create_args))
     except Exception, e:
         module.fail_json(msg='%s' % e.message)
@@ -382,7 +415,7 @@ def delete(module, instance_ids, wait, wait_timeout, kept=[]):
 def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                  wait, wait_timeout, disk_config, count, group,
                  instance_ids, exact_count, networks, count_offset,
-                 auto_increment, extra_create_args):
+                 auto_increment, extra_create_args, user_data, config_drive):
     cs = pyrax.cloudservers
     cnw = pyrax.cloud_networks
     if not cnw:
@@ -596,7 +629,7 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
 
         create(module, names, flavor, image, meta, key_name, files,
                wait, wait_timeout, disk_config, group, nics, extra_create_args,
-               existing=servers)
+               user_data, config_drive, existing=servers)
 
     elif state == 'absent':
         if instance_ids is None:
@@ -637,6 +670,7 @@ def main():
     argument_spec.update(
         dict(
             auto_increment=dict(default=True, type='bool'),
+            config_drive=dict(default=False, type='bool'),
             count=dict(default=1, type='int'),
             count_offset=dict(default=1, type='int'),
             disk_config=dict(choices=['auto', 'manual']),
@@ -654,6 +688,7 @@ def main():
             networks=dict(type='list', default=['public', 'private']),
             service=dict(),
             state=dict(default='present', choices=['present', 'absent']),
+            user_data=dict(no_log=True),
             wait=dict(default=False, type='bool'),
             wait_timeout=dict(default=300),
         )
@@ -675,6 +710,7 @@ def main():
                              'playbook pertaining to the "rax" module')
 
     auto_increment = module.params.get('auto_increment')
+    config_drive = module.params.get('config_drive')
     count = module.params.get('count')
     count_offset = module.params.get('count_offset')
     disk_config = module.params.get('disk_config')
@@ -693,6 +729,7 @@ def main():
     name = module.params.get('name')
     networks = module.params.get('networks')
     state = module.params.get('state')
+    user_data = module.params.get('user_data')
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
 
@@ -714,7 +751,7 @@ def main():
     cloudservers(module, state, name, flavor, image, meta, key_name, files,
                  wait, wait_timeout, disk_config, count, group,
                  instance_ids, exact_count, networks, count_offset,
-                 auto_increment, extra_create_args)
+                 auto_increment, extra_create_args, user_data, config_drive)
 
 
 # import module snippets

--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -233,10 +233,10 @@ def server_to_dict(obj):
     return instance
 
 
-def create(module, names, flavor, image, meta, key_name, files,
-           wait, wait_timeout, disk_config, group, nics,
-           extra_create_args, user_data, config_drive, existing=[]):
-
+def create(module, names=[], flavor=None, image=None, meta={}, key_name=None,
+           files={}, wait=True, wait_timeout=300, disk_config=None,
+           group=None, nics=[], extra_create_args={}, user_data=None,
+           config_drive=False, existing=[]):
     cs = pyrax.cloudservers
     changed = False
 
@@ -336,7 +336,7 @@ def create(module, names, flavor, image, meta, key_name, files,
         module.exit_json(**results)
 
 
-def delete(module, instance_ids, wait, wait_timeout, kept=[]):
+def delete(module, instance_ids=[], wait=True, wait_timeout=300, kept=[]):
     cs = pyrax.cloudservers
 
     changed = False
@@ -412,10 +412,12 @@ def delete(module, instance_ids, wait, wait_timeout, kept=[]):
         module.exit_json(**results)
 
 
-def cloudservers(module, state, name, flavor, image, meta, key_name, files,
-                 wait, wait_timeout, disk_config, count, group,
-                 instance_ids, exact_count, networks, count_offset,
-                 auto_increment, extra_create_args, user_data, config_drive):
+def cloudservers(module, state=None, name=None, flavor=None, image=None,
+                 meta={}, key_name=None, files={}, wait=True, wait_timeout=300,
+                 disk_config=None, count=1, group=None, instance_ids=[],
+                 exact_count=False, networks=[], count_offset=0,
+                 auto_increment=False, extra_create_args={}, user_data=None,
+                 config_drive=False):
     cs = pyrax.cloudservers
     cnw = pyrax.cloud_networks
     if not cnw:
@@ -545,8 +547,8 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                     instance_ids = []
                     for server in servers:
                         instance_ids.append(server.id)
-                    delete(module, instance_ids, wait, wait_timeout,
-                           kept=kept)
+                    delete(module, instance_ids=instance_ids, wait=wait,
+                           wait_timeout=wait_timeout, kept=kept)
                 elif len(servers) < count:
                     if auto_increment:
                         names = []
@@ -627,9 +629,11 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
 
                 names = [name] * (count - len(servers))
 
-        create(module, names, flavor, image, meta, key_name, files,
-               wait, wait_timeout, disk_config, group, nics, extra_create_args,
-               user_data, config_drive, existing=servers)
+        create(module, names=names, flavor=flavor, image=image,
+               meta=meta, key_name=key_name, files=files, wait=wait,
+               wait_timeout=wait_timeout, disk_config=disk_config, group=group,
+               nics=nics, extra_create_args=extra_create_args,
+               user_data=user_data, config_drive=config_drive, existing=servers)
 
     elif state == 'absent':
         if instance_ids is None:
@@ -662,7 +666,8 @@ def cloudservers(module, state, name, flavor, image, meta, key_name, files,
                                            'success': [], 'error': [],
                                            'timeout': []})
 
-        delete(module, instance_ids, wait, wait_timeout)
+        delete(module, instance_ids=instance_ids, wait=wait,
+               wait_timeout=wait_timeout)
 
 
 def main():
@@ -748,10 +753,14 @@ def main():
                              'typically indicates an invalid region or an '
                              'incorrectly capitalized region name.')
 
-    cloudservers(module, state, name, flavor, image, meta, key_name, files,
-                 wait, wait_timeout, disk_config, count, group,
-                 instance_ids, exact_count, networks, count_offset,
-                 auto_increment, extra_create_args, user_data, config_drive)
+    cloudservers(module, state=state, name=name, flavor=flavor,
+                 image=image, meta=meta, key_name=key_name, files=files,
+                 wait=wait, wait_timeout=wait_timeout, disk_config=disk_config,
+                 count=count, group=group, instance_ids=instance_ids,
+                 exact_count=exact_count, networks=networks,
+                 count_offset=count_offset, auto_increment=auto_increment,
+                 extra_create_args=extra_create_args, user_data=user_data,
+                 config_drive=config_drive)
 
 
 # import module snippets


### PR DESCRIPTION
This pull request adds attributes for `config_drive` and `user_data`.  This is primarily useful for utilizing cloudinit.

The `user_data` attribute can be a string or a file path.  If `user_data` is supplied on it's own, it implies `config_drive`.  `config_drive` can be used on it's own.

Here is an example task:

``` yaml
    - name: Build CoreOS Servers
      rax:
        credentials: ~/.raxpub
        name: coreos%02d
        flavor: performance1-1
        image: 70210a69-081e-4a5e-b402-3cdbabfdcddd
        region: ORD
        state: present
        count: 3
        exact_count: yes
        group: coreos
        wait: yes
        user_data: files/coreos-cloud-config.yml
```
