### PR TITLE
Add an option to ec2.ini to filter instances based on various things

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -53,3 +53,21 @@ cache_path = ~/.ansible/tmp
 # seconds, a new API call will be made, and the cache file will be updated.
 # To disable the cache, set this value to 0
 cache_max_age = 300
+
+# Instance filters can be used to control which instances are retrieved for
+# inventory. For the full list of possible filters, please read the EC2 API
+# docs: http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-DescribeInstances.html
+#
+# Filters are key/value pairs separated by colons, and you can list multiple
+# filters by separating them by commas.
+#
+# Examples:
+#
+# Retrieve only instances with a tag of key Name with value Webserver:
+# instance_filters = tag:Name=Ben_Tower
+#
+# Retrieve only m1.small instances:
+# instance_filters = instance-type=m1.small
+#
+# Retrieve m1.small with a certain tag:
+# instance_filters = instance-type=m1.small,tag:Name=demo1

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -64,7 +64,7 @@ cache_max_age = 300
 # Examples:
 #
 # Retrieve only instances with a tag of key Name with value Webserver:
-# instance_filters = tag:Name=Ben_Tower
+# instance_filters = tag:Name=Webserver
 #
 # Retrieve only m1.small instances:
 # instance_filters = instance-type=m1.small

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -231,6 +231,11 @@ class Ec2Inventory(object):
         self.cache_path_index = cache_dir + "/ansible-ec2.index"
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
         
+        # Instance filters (see boto and EC2 API docs)
+        self.instance_filters = {}
+        if config.has_option('ec2', 'instance_filters'):
+            filters = config.get('ec2', 'instance_filters', '').split(',')
+            self.instance_filters = dict(x.split('=') for x in filters)
 
 
     def parse_cli_args(self):
@@ -276,7 +281,7 @@ class Ec2Inventory(object):
                 print("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
                 sys.exit(1)
  
-            reservations = conn.get_all_instances()
+            reservations = conn.get_all_instances(filters = self.instance_filters)
             for reservation in reservations:
                 for instance in reservation.instances:
                     self.add_instance(instance, region)


### PR DESCRIPTION
(This is try two for the PR, replacing #7359 which ended up with merge commits. See the previous PR for a bit of commentary.)

This lets you filter instances right at the EC2 API level using the EC2 inventory plugin. You can use this to retrieve only instances with certain tags, or only certain instance types, etc, etc. See ec2.ini for more info and examples.
