### PR TITLE
Don't use listify_ function, when all we want to do is template variable...

### DIFF
--- a/lib/ansible/runner/lookup_plugins/env.py
+++ b/lib/ansible/runner/lookup_plugins/env.py
@@ -16,6 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 from ansible import utils, errors
+from ansible.utils import template
 import os
 
 class LookupModule(object):
@@ -25,7 +26,10 @@ class LookupModule(object):
 
     def run(self, terms, inject=None, **kwargs):
 
-        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject) 
+        try:
+            terms = template.template(self.basedir, terms, inject)
+        except Exception, e:
+            pass
 
         if isinstance(terms, basestring):
             terms = [ terms ]


### PR DESCRIPTION
...s

This was causing a bug in the env module, due to the fact that we now
pass variables for the module through the templating engine combined
with the fact that we split-up the hostvars and setup variables. As a
result, if a variable in the env lookup had the same name as the variable
in Ansible, it would try and template itself over and over again until
the recursion limit would be hit, at which time an empty string was
returned.

Fixes #7396
