### PR TITLE
Expand shell vars when looking up EC2_INI_PATH in ec2.py

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -186,7 +186,7 @@ class Ec2Inventory(object):
 
         config = ConfigParser.SafeConfigParser()
         ec2_default_ini_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ec2.ini')
-        ec2_ini_path = os.environ.get('EC2_INI_PATH', ec2_default_ini_path)
+        ec2_ini_path = os.path.expanduser(os.path.expandvars(os.environ.get('EC2_INI_PATH', ec2_default_ini_path)))
         config.read(ec2_ini_path)
 
         # is eucalyptus?


### PR DESCRIPTION
Currently when looking up EC2_INI_PATH in plugins/inventory/ec2.py a full and direct path must be given. Environment variables will tend to use other variables and built-ins to allow for portability and this should be expected for this variable. So, expansion of "~" and environment variables has been added to the lookup of the EC2_INI_PATH variable.
