### PR TITLE
Add notes to rax_dns and rax_dns_record to recommend using serial: 1

### DIFF
--- a/library/cloud/rax_dns
+++ b/library/cloud/rax_dns
@@ -44,6 +44,10 @@ options:
     description:
       - Time to live of domain in seconds
     default: 3600
+notes:
+  - "It is recommended that plays utilizing this module be run with C(serial: 1)
+    to avoid exceeding the API request limit imposed by the Rackspace CloudDNS
+    API"
 author: Matt Martz
 extends_documentation_fragment: rackspace
 '''

--- a/library/cloud/rax_dns_record
+++ b/library/cloud/rax_dns_record
@@ -67,6 +67,10 @@ options:
       - SRV
       - TXT
     default: A
+notes:
+  - "It is recommended that plays utilizing this module be run with C(serial: 1)
+    to avoid exceeding the API request limit imposed by the Rackspace CloudDNS
+    API"
 author: Matt Martz
 extends_documentation_fragment: rackspace
 '''


### PR DESCRIPTION
This pull request addresses #7492 in that the API limit for the Rackspace CloudDNS API can easily be exceeded due to the way that API works.

The recommendation is to use `serial: 1` in plays utilizing the `rax_dns` and `rax_dns_record` to avoid exceeding the API limits.
