### PR TITLE
Don't double (or triple) up common error messages

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -501,7 +501,6 @@ Note: The error may actually appear before this position: line %s, column %s
                 if '"{{' not in probline or "'{{" not in probline:
                     unquoted_var = True
 
-            msg = process_common_errors(msg, probline, mark.column)
             if not unquoted_var:
                 msg = process_common_errors(msg, probline, mark.column)
             else:
@@ -519,7 +518,6 @@ Should be written as:
       - "{{ foo }}"      
 
 """
-                msg = process_common_errors(msg, probline, mark.column)
         else:
             # most likely displaying a file with sensitive content,
             # so don't show any of the actual lines of yaml just the


### PR DESCRIPTION
process_common_errors() was called thrice, each time appending to the
existing error message, and leading to confusing repetition in the
message that was finally displayed.

Fixes #7498
