### PR TITLE
New apache2_site module

### DIFF
--- a/library/web_infrastructure/apache2_site
+++ b/library/web_infrastructure/apache2_site
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# (c) 2013-2014, Christian Berendt <berendt@b1-systems.de>
+# Copyright 2014, 42 Lines Inc.
+#
+# 2014/05/20 - Jack Neely <jjneely@42lines.net>
+# - Modified for use with a2ensite/a2dissite
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: apache2_site
+version_added: 1.7
+author: Jack Neely and Christian Berendt
+short_description: enables/disables an Apache2 webserver site
+description:
+   - Enables or disables a specified Apache2 webserver site.
+options:
+   name:
+     description:
+        - name of the site to enable/disable
+     required: true
+   state:
+     description:
+        - indicate the desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+notes:
+    - Apache sites are names of configuration files stored in
+      /etc/apache2/sites-available
+'''
+
+EXAMPLES = '''
+# enables the Apache2 site "example.com"
+- apache2_module: state=present name=example.com
+
+# disables the default Apache2 site
+- apache2_module: state=absent name=default
+'''
+
+import re
+
+def _disable_site(module):
+    name = module.params['name']
+    a2dissite_binary = module.get_bin_path("a2dissite")
+    result, stdout, stderr = module.run_command("%s %s" % (a2dissite_binary, name))
+
+    if re.match(r'.*already disabled.*', stdout):
+        module.exit_json(changed = False, result = "Success")
+    elif result != 0:
+        module.fail_json(msg="Failed to disable site %s: %s" % (name, stdout))
+    else:
+        module.exit_json(changed = True, result = "Disabled")
+
+def _enable_site(module):
+    name = module.params['name']
+    a2ensite_binary = module.get_bin_path("a2ensite")
+    result, stdout, stderr = module.run_command("%s %s" % (a2ensite_binary, name))
+
+    if re.match(r'.*already enabled.*', stdout):
+        module.exit_json(changed = False, result = "Success")
+    elif result != 0:
+        module.fail_json(msg="Failed to enable site %s: %s" % (name, stdout))
+    else:
+        module.exit_json(changed = True, result = "Enabled")
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name  = dict(required=True),
+            state = dict(default='present', choices=['absent', 'present'])
+        ),
+    )
+
+    if module.params['state'] == 'present':
+        _enable_site(module)
+
+    if module.params['state'] == 'absent':
+        _disable_site(module)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()

--- a/library/web_infrastructure/apache2_site
+++ b/library/web_infrastructure/apache2_site
@@ -45,10 +45,10 @@ notes:
 
 EXAMPLES = '''
 # enables the Apache2 site "example.com"
-- apache2_module: state=present name=example.com
+- apache2_site: state=present name=example.com
 
 # disables the default Apache2 site
-- apache2_module: state=absent name=default
+- apache2_site: state=absent name=default
 '''
 
 import re


### PR DESCRIPTION
This module wraps the a2ensite and a2dissite commands to manage Apache2
site configurations.  Very much inspired from the apache2_module module.
