### PR TITLE
Remove colon which breaks installation of 1.6.2.

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -175,7 +175,7 @@ options:
   instance_ids:
     version_added: "1.3"
     description:
-      - list of instance ids, currently used for states: absent, running, stopped
+      - list of instance ids, currently used for the states 'absent', 'running', and 'stopped'
     required: false
     default: null
     aliases: []


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.6.2 (master 49564cbad8) last updated 2014/05/23 23:47:02 (GMT +000)
##### Environment:

N/A
##### Summary:

The addition of a colon in the description of the ec2 library causes the installation to crash with a python error.
##### Steps To Reproduce:

Compile and install ansible 1.6.2
##### Expected Results:

The installation completes successfully.
##### Actual Results:

```
rendering: ec2
Traceback (most recent call last):
  File "../hacking/module_formatter.py", line 323, in <module>
    main()
  File "../hacking/module_formatter.py", line 318, in main
    process_category(category, categories, options, env, template, outputname)
  File "../hacking/module_formatter.py", line 268, in process_category
    result = process_module(module, options, env, template, outputname, module_map)
  File "../hacking/module_formatter.py", line 234, in process_module
    text = template.render(doc)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 969, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 742, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "../hacking/templates/rst.j2", line 64, in top-level template code
    <td>{% for desc in v.description -%}@{ desc | html_ify }@{% endfor -%}{% if v['version_added'] %} (added in Ansible @{v['version_added']}@){% endif %}</td>
  File "../hacking/module_formatter.py", line 79, in html_ify
    t = cgi.escape(text)
  File "/usr/lib/python2.7/cgi.py", line 1043, in escape
    s = s.replace("&", "&amp;") # Must be done first!
AttributeError: 'dict' object has no attribute 'replace'
Makefile:39: recipe for target 'modules' failed
```
