### PR TITLE
A plugin for task timings

### DIFF
--- a/plugins/callbacks/profile_tasks.py
+++ b/plugins/callbacks/profile_tasks.py
@@ -1,0 +1,57 @@
+# (C) 2014, Jharrod LaFon <jlafon@eyesopen.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import time
+
+
+class CallbackModule(object):
+    """
+    A plugin for timing tasks
+    """
+    def __init__(self):
+        self.stats = {}
+        self.current = None
+
+    def playbook_on_task_start(self, name, is_conditional):
+        """
+        Logs the start of each task
+        """
+        if self.current is not None:
+            # Record the running time of the last executed task 
+            self.stats[self.current] = time.time() - self.stats[self.current]
+
+        # Record the start time of the current task
+        self.current = name
+        self.stats[self.current] = time.time()
+
+    def playbook_on_stats(self, stats):
+        """
+        Prints the timings
+        """
+        # Record the timing of the very last task
+        if self.current is not None:
+            self.stats[self.current] = time.time() - self.stats[self.current]
+
+        # Sort the tasks by their running time
+        results = sorted(self.stats.items(), key=lambda value: value[1], reverse=True)
+
+        # Just keep the top 10
+        results = results[:10]
+
+        # Print the timings
+        for name, elapsed in results:
+            print "{0:-<70}{1:->9}".format('{0} '.format(name), ' {0:.02f}s'.format(elapsed))


### PR DESCRIPTION
I've had this plugin in [another repo](https://github.com/jlafon/ansible-profile) for a while, but I thought you might want to include it in Ansible. 

Installing this plugin will cause task timings to be printed at the end of the playbook, as in this example:

``` bash
ansible <args here>
   <normal output here>
   PLAY RECAP ******************************************************************** 
   really slow task  | Download project packages-----------------------------11.61s
   security | Really slow security policies-----------------------------------7.03s
   common-base | Install core system dependencies-----------------------------3.62s
   common | Install pip-------------------------------------------------------3.60s
   common | Install boto------------------------------------------------------3.57s
   nginx | Install nginx------------------------------------------------------3.41s
   serf | Install system dependencies-----------------------------------------3.38s
   duo_security | Install Duo Unix SSH Integration----------------------------3.37s
   loggly | Install TLS version-----------------------------------------------3.36s
```
