### PR TITLE
Ec2_lc instance_monitoring option

### DIFF
--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -44,6 +44,7 @@ options:
       - The AMI unique identifier to be used for the group
     required: false
   instance_monitoring:
+    version_added: "1.7"
     description:
       - Whether instances in group are launched with detailed monitoring
     required: false
@@ -82,6 +83,14 @@ EXAMPLES = '''
     key_name: default
     security_groups: 'group,group2'
     instance_type: t1.micro
+
+- ec2_lc:
+    name: detailed_monitoring
+    image_id: ami-XXX
+    key_name: default
+    security_groups: 'group,group2'
+    instance_type: t1.micro
+    instance_monitoring: True
 
 '''
 

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -43,6 +43,10 @@ options:
     description:
       - The AMI unique identifier to be used for the group
     required: false
+  instance_monitoring:
+    description:
+      - Whether instances in group are launched with detailed monitoring
+    required: false
   key_name:
     description:
       - The SSH key name to be used for access to managed instances
@@ -126,6 +130,7 @@ def create_launch_config(connection, module):
     user_data = module.params.get('user_data')
     volumes = module.params['volumes']
     instance_type = module.params.get('instance_type')
+    instance_monitoring = module.params.get('instance_monitoring')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -144,7 +149,8 @@ def create_launch_config(connection, module):
         security_groups=security_groups,
         user_data=user_data,
         block_device_mappings=[bdm],
-        instance_type=instance_type)
+        instance_type=instance_type,
+        instance_monitoring=instance_monitoring)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False


### PR DESCRIPTION
We are migrating to Ansible for all our AWS tool management. One of the things we need for creating Launch Configurations is the ability to enable detailed monitoring.

I have checked similar functions and pull requests and hope that this is acceptable.

I would also be happy if a core maintainer were to add the feature in a better way.

Thanks
