### PR TITLE
open_iscsi module: support RC 21 when listing logged-in target

### DIFF
--- a/library/system/open_iscsi
+++ b/library/system/open_iscsi
@@ -162,6 +162,8 @@ def target_loggedon(module, target):
     
     if rc == 0:
         return target in out
+    elif rc == 21:
+        return False
     else:
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 


### PR DESCRIPTION
iscsiadm will return with exit code 21 when there are no active sessions.
From manpage: "21     ISCSI_ERR_NO_OBJS_FOUND - no records/targets/sessions/portals found to execute operation on."

This is normal behaviour when, for example, logging into the first target on the system.
Or when asking a target to be logged out when it is already (and there are no others).

Current code treats all return codes other than 0 as failures.
This patch makes the target_loggedon method return False when it gets a RC 21 from iscsiadm.
This allows the uses cases described above to work, while not affecting others (that I could think of).

Cheers
