### PR TITLE
warn if remote SSL cert is not checked in linode

### DIFF
--- a/library/cloud/linode
+++ b/library/cloud/linode
@@ -88,7 +88,7 @@ options:
     description:
      - how long before wait gives up, in seconds
     default: 300
-requirements: [ "linode-python" ]
+requirements: [ "linode-python", "pycurl" ]
 author: Vincent Viallet
 notes:
   - LINODE_API_KEY env variable can be used instead
@@ -156,13 +156,18 @@ import time
 import os
 
 try:
-    # linode module raise warning due to ssl - silently ignore them ...
-    import warnings
-    warnings.simplefilter("ignore")
+    import pycurl
+except ImportError:
+    print("failed=True msg='pycurl required for this module'")
+    sys.exit(1)
+
+
+try:
     from linode import api as linode_api
 except ImportError:
     print("failed=True msg='linode-python required for this module'")
     sys.exit(1)
+
 
 def randompass():
     '''


### PR DESCRIPTION
`linode-python` optionally requires `pycurl` to do [SSL certificate verification](https://github.com/tjfontaine/linode-python/blob/master/linode/api.py#L81). Without `pycurl`, `linode-python` will use `urllib` and skips checking the SSL cert. It's probably not a good idea (?) to suppress this warning.
