### PR TITLE
rax_cbs module: Don't fail when the volume is not found

### DIFF
--- a/library/cloud/rax_cbs
+++ b/library/cloud/rax_cbs
@@ -141,6 +141,8 @@ def cloud_block_storage(module, state, name, description, meta, size,
     except ValueError:
         try:
             volume = cbs.find(name=name)
+        except pyrax.exc.NotFound:
+            pass
         except Exception, e:
             module.fail_json(msg='%s' % e)
 


### PR DESCRIPTION
If the volume is not found, make sure we don't fail the module.  It is expected that the volume may not exist, which is the reason for creating it.

See https://groups.google.com/forum/#!topic/ansible-project/_Ad_Sh8iqsU
