### PR TITLE
Fix portability issue when checking local facts file permission.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -16,6 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import stat
 import array
 import errno
 import fcntl
@@ -173,7 +174,7 @@ class Facts(object):
         for fn in sorted(glob.glob(fact_path + '/*.fact')):
             # where it will sit under local facts
             fact_base = os.path.basename(fn).replace('.fact','')
-            if os.access(fn, os.X_OK):
+            if stat.S_IXUSR & os.stat(fn)[stat.ST_MODE]:
                 # run it
                 # try to read it as json first
                 # if that fails read it with ConfigParser


### PR DESCRIPTION
Under Solaris, os.access(fn, os.X_OK) return True for user root even if the file is not executable by user root. In that way, ansible always try to execute non-executable local facts files instead of reading it.

I suggest use os.stat() to check the executable bit for portability reason.

Please refer the following link for more info.

http://bugs.python.org/issue14706
