### PR TITLE
Differentiate machinfo output key/val separator

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1311,8 +1311,11 @@ class HPUX(Hardware):
         rc, out, err = module.run_command("model")
         self.facts['model'] = out.strip()
         if self.facts['architecture'] == 'ia64':
+            separator = ':'
+            if self.facts['distribution_version'] == "B.11.23":
+                separator = '='
             rc, out, err = module.run_command("/usr/contrib/bin/machinfo |grep -i 'Firmware revision' | grep -v BMC", use_unsafe_shell=True)
-            self.facts['firmware_version'] = out.split(':')[1].strip()
+            self.facts['firmware_version'] = out.split(separator)[1].strip()
 
 
 class Darwin(Hardware):


### PR DESCRIPTION
get_hw_facts for HP-UX: machinfo in HP-UX B.11.23 uses '=' as separator between key and value, while B.11.31 uses ':'.
