### PR TITLE
Remove duplicate table of contents in Conditionals

### DIFF
--- a/docsite/rst/playbooks_conditionals.rst
+++ b/docsite/rst/playbooks_conditionals.rst
@@ -11,9 +11,6 @@ whether the hosts match other criteria.   There are many options to control exec
 
 Let's dig into what they are.
 
-.. contents::
-   :depth: 2
-
 The When Statement
 ``````````````````
 


### PR DESCRIPTION
Duplicate tables of contents were defined on line 4 and line 14. This removes the one defined on line 14.
