### PR TITLE
added solaris fact detection for ansible_pkg_mgr

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -109,6 +109,8 @@ class Facts(object):
                  { 'path' : '/usr/sbin/pkg',        'name' : 'pkgng' },
                  { 'path' : '/usr/sbin/swlist',     'name' : 'SD-UX' },
                  { 'path' : '/usr/bin/emerge',      'name' : 'portage' },
+                 { 'path' : '/usr/sbin/pkgadd',     'name' : 'svr4pkg' },
+                 { 'path' : '/usr/bin/pkg',         'name' : 'pkg' },
     ]
 
     def __init__(self):


### PR DESCRIPTION
The fact for ansible_pkg_mgr is not detected for Solaris and it is not possible to use ansible_pkg_mgr in any playbook (overwriting with group_vars is not possible).

Thats why I added the detection of the Solaris package manager. It is svr4pkg for solaris 10 (and older) and pkg for Solaris 11. The pkg module is still pending in pull request #6522
