### PR TITLE
Additional modules for interacting with RabbitMQ

### DIFF
--- a/library/messaging/rabbitmq_binding
+++ b/library/messaging/rabbitmq_binding
@@ -195,7 +195,7 @@ class RabbitMQExchange(object):
         list_bindings = json.loads(content)
         for binding in list_bindings:
             # does the routing keys match?
-            routing_key_match = ('routing_key' in self.binding) and (self.routing_key == binding['routing_key']) if self.routing_key is not None else True
+            routing_key_match = ('routing_key' in binding) and (self.routing_key == binding['routing_key']) if self.routing_key is not None else True
 
             # same amount of arguments?
             args_length_match = (len(self.arguments) == len(binding['arguments']))

--- a/library/messaging/rabbitmq_binding
+++ b/library/messaging/rabbitmq_binding
@@ -100,7 +100,7 @@ options:
 
 EXAMPLES = '''
 # Bind an exchange to a queue.
-- rabbitmq_binding: host='http://localhost:15672/api'
+- rabbitmq_binding: host='localhost'
                     user='guest'
                     password='guest'
                     vhost='/'
@@ -110,7 +110,7 @@ EXAMPLES = '''
                     routing_key='test'
 
 # Bind an exchange to another exchange.
-- rabbitmq_binding: host='http://localhost:15672/api'
+- rabbitmq_binding: host='localhost'
                     user='guest'
                     password='guest'
                     vhost='/'
@@ -120,7 +120,7 @@ EXAMPLES = '''
                     routing_key='test'
 
 # To delete a binding between an exchange and a queue
-- rabbitmq_binding: host='http://localhost:15672/api'
+- rabbitmq_binding: host='localhost'
                     user='guest'
                     password='guest'
                     vhost='/'
@@ -131,7 +131,7 @@ EXAMPLES = '''
                     state='absent'
 
 # To delete a binding between an exhange and another exchange
-- rabbitmq_binding: host='http://localhost:15672/api'
+- rabbitmq_binding: host='localhost'
                     user='guest'
                     password='guest'
                     vhost='/'

--- a/library/messaging/rabbitmq_binding
+++ b/library/messaging/rabbitmq_binding
@@ -1,0 +1,299 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: rabbitmq_binding
+short_description: Adds or removes binding to/from RabbitMQ
+description:
+  - Add or remove binding to/from the RabbitMQ server using the HTTP api provided by the management plugin.
+version_added: "1.6"
+author: Jaco Nel
+options:
+  host:
+    description:
+      - The RabbitMQ management api endpoint.
+    required: true
+    default: null
+    aliases: [ "api", "url" ]
+  port:
+    description:
+      - The port on which RabbitMQ management api is listening.
+    required: false
+    default: 15672
+  ssl:
+    description:
+      - Whether or not the RabbitMQ management api is running over SSL or not.
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
+  user:
+    description:
+      - The username to use for basic authentication with the RabbitMQ server.
+    required: true
+    default: null
+    aliases: [ "username" ]
+  password:
+    description:
+      - Password of the user to use for basic authentication against the RabbitMQ server.
+    required: true
+    default: null
+  vhost:
+    description:
+      - Vhost to create binding under.
+    required: false
+    default: "/"
+  source:
+    description:
+      - The name of the exchange or queue to create/delete the binding for/from.
+    required: true
+    default: null
+  destination:
+    description:
+      - The name of the exchange or queue to create/delete the binding for/from.
+    required: true
+    default: null
+  bind_type:
+    description:
+      - Exchange-to-exchange binding or exchange-to-queue binding.
+    require: true
+    default: null
+    choices: [ "exchange", "queue" ]
+  routing_key:
+    description:
+      - The routing key.
+    required: false
+    default: null
+  arguments:
+    description:
+      - Additional arguments to supply with creation of the binding.
+    required: false
+    default: null
+  force:
+    description:
+      - Deletes and recreates the binding.
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
+  state:
+    description:
+      - Specify if binding is to be added or removed.
+    required: false
+    default: "present"
+    choices: [ "present", "absent" ]
+'''
+
+EXAMPLES = '''
+# Bind an exchange to a queue.
+- rabbitmq_binding: host='http://localhost:15672/api'
+                    user='guest'
+                    password='guest'
+                    vhost='/'
+                    source='test_exchange'
+                    destination='test_queue'
+                    binding_type='queue'
+                    routing_key='test'
+
+# Bind an exchange to another exchange.
+- rabbitmq_binding: host='http://localhost:15672/api'
+                    user='guest'
+                    password='guest'
+                    vhost='/'
+                    source='test_exchange'
+                    destination='test_exchange'
+                    binding_type='exchange'
+                    routing_key='test'
+
+# To delete a binding between an exchange and a queue
+- rabbitmq_binding: host='http://localhost:15672/api'
+                    user='guest'
+                    password='guest'
+                    vhost='/'
+                    source='test_exchange'
+                    destination='test_queue'
+                    binding_type='queue'
+                    routing_key='test'
+                    state='absent'
+
+# To delete a binding between an exhange and another exchange
+- rabbitmq_binding: host='http://localhost:15672/api'
+                    user='guest'
+                    password='guest'
+                    vhost='/'
+                    source='test_exchange'
+                    destination='test_exchange'
+                    binding_type='exchange'
+                    routing_key='test'
+                    state='absent'
+'''
+
+from urllib import quote_plus
+
+import base64
+import httplib2
+import json
+
+class RabbitMQExchange(object):
+    def __init__(self, module, host, port, ssl, username, password, vhost, source, destination, binding_type, routing_key, arguments):
+        self.module         = module
+        self.host           = host
+        self.port           = port
+        self.ssl            = ssl
+        self.username       = username
+        self.password       = password
+        self.vhost          = vhost
+        self.source         = source
+        self.destination    = destination
+        self.binding_type   = binding_type
+        self.routing_key    = routing_key
+        self.arguments      = arguments
+
+    def _exec(self, url, **kwargs):
+        """Executes a request to the RabbitMQ api"""
+        auth    = base64.encodestring(self.username + ':' + self.password)
+        http    = httplib2.Http(disable_ssl_certificate_validation=True)
+        headers = {'Content-type': 'application/json', 'Authorization': 'Basic ' + auth}
+
+        headers, content = http.request(url, kwargs['method'], body=json.dumps(kwargs['body']), headers=headers)
+        return headers['status'], content
+
+    def build_url(self, property_key = None):
+        """Builds up the correct api endpoint based on the properties supplied."""
+        url = 'https' if self.ssl else 'http' + '://' + self.host + ':' + str(self.port) + '/api/bindings/' + quote_plus(self.vhost) + '/e/' + self.source 
+        if self.binding_type == 'queue': 
+            url = url + '/q/' + self.destination
+        else:
+            url = url + '/e/' + self.destination
+
+        if property_key is not None:
+            url = url + '/' + property_key
+
+        return url
+
+    def get(self):
+        """Performs a GET request to the RabbitMQ to retrieve all bindings for a specified source and distination combination. It 
+        the filters through this list of bindings to determine if any of them exactly match the binding properties supplied."""
+        status, content = self._exec(self.build_url(), **{'method': 'GET', 'body': None})
+        if status == 404:
+            return None
+
+        list_bindings = json.loads(content)
+        for binding in list_bindings:
+            # does the routing keys match?
+            routing_key_match = ('routing_key' in self.binding) and (self.routing_key == binding['routing_key']) if self.routing_key is not None else True
+
+            # same amount of arguments?
+            args_length_match = (len(self.arguments) == len(binding['arguments']))
+
+            # Ok, check that the arguments match
+            args_match = True
+            for key, val in self.arguments.iteritems():
+                if key not in binding['arguments'] or val != binding['arguments'][key]:
+                    args_match = False
+
+            if routing_key_match and args_length_match and args_match:
+                return binding
+
+        return None
+
+    def add(self):
+        """Adds a new binding to via the RabbitMQ api."""
+        body = {}
+        if self.routing_key is not None:
+            body['routing_key'] = self.routing_key
+
+        if self.arguments is not None:
+            body['arguments'] = self.arguments
+
+        request = dict(
+            method='POST',
+            body=body
+        )
+
+        return self._exec(self.build_url(), **request)
+
+    def delete(self, property_key):
+        """Deletes a binding via the RabbitMQ api."""
+        return self._exec(self.build_url(property_key), **{'method': 'DELETE', 'body': None})
+
+
+def main():
+    """The module's main method."""
+
+    arg_spec = dict(
+        host = dict(required = False, default = 'localhost', aliases = ['host', 'url']),
+        port = dict(required = False, default = 15672),
+        ssl = dict(required = False, default = False),
+        user = dict(required = True, aliases = ['username']),
+        password = dict(required = True, aliases = ['pwd']),
+        vhost = dict(required = False, default = '/'),
+        source = dict(required = True),
+        destination = dict(required = True),
+        binding_type = dict(required = True),
+        routing_key = dict(required = False, default = None),
+        arguments = dict(required = False, default = None),
+        force = dict(required = False, default = 'no', type = 'bool'),
+        state = dict(required = False, default = 'present', choices = ['present', 'absent']))
+
+    module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
+
+    host         = module.params['host']
+    port         = module.params['port']
+    ssl          = module.params['ssl']
+    username     = module.params['user']
+    password     = module.params['password']
+    vhost        = module.params['vhost']
+    source       = module.params['source']
+    destination  = module.params['destination']
+    binding_type = module.params['binding_type']
+    routing_key  = module.params['routing_key']
+    arguments    = module.params['arguments']
+    if arguments is not None:
+        arguments = json.loads(arguments)
+    else:
+        arguments = {}
+
+    force = module.params['force']
+    state = module.params['state']
+
+    rabbitmq_exchange = RabbitMQExchange(module, host, port, ssl, username, password, vhost, source, destination, binding_type, routing_key, arguments)
+
+    changed = False
+    binding = rabbitmq_exchange.get()
+    if binding is not None:
+        if state == 'absent':
+            if not module.check_mode:
+                status, content = rabbitmq_exchange.delete(binding['properties_key'])
+            changed = True
+        else:
+            if force:
+                if not module.check_mode:
+                    rabbitmq_exchange.delete(binding['properties_key'])
+                    rabbitmq_exchange.add()
+                changed = True
+
+    elif state == 'present':
+        if not module.check_mode:
+            rabbitmq_exchange.add()
+        changed = True
+
+    module.exit_json(changed=changed, state=state)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()

--- a/library/messaging/rabbitmq_binding
+++ b/library/messaging/rabbitmq_binding
@@ -22,7 +22,7 @@ module: rabbitmq_binding
 short_description: Adds or removes binding to/from RabbitMQ
 description:
   - Add or remove binding to/from the RabbitMQ server using the HTTP api provided by the management plugin.
-version_added: "1.6"
+version_added: "1.7"
 author: Jaco Nel
 options:
   host:

--- a/library/messaging/rabbitmq_binding
+++ b/library/messaging/rabbitmq_binding
@@ -60,7 +60,7 @@ options:
     default: "/"
   source:
     description:
-      - The name of the exchange or queue to create/delete the binding for/from.
+      - The name of the exchange to create/delete the binding for/from.
     required: true
     default: null
   destination:
@@ -68,7 +68,7 @@ options:
       - The name of the exchange or queue to create/delete the binding for/from.
     required: true
     default: null
-  bind_type:
+  binding_type:
     description:
       - Exchange-to-exchange binding or exchange-to-queue binding.
     require: true
@@ -81,7 +81,7 @@ options:
     default: null
   arguments:
     description:
-      - Additional arguments to supply with creation of the binding.
+      - Additional arguments to supply with creation of the binding. Complex argument type.
     required: false
     default: null
   force:
@@ -99,7 +99,33 @@ options:
 '''
 
 EXAMPLES = '''
-# Bind an exchange to a queue.
+# Creation of a single binding (exchange bound to a queue) that uses arguments
+- name: Create Binding
+    action: rabbitmq_binding
+    args: 
+        source: 'test_exchange_single' 
+        destination: 'test_queue_single'
+        binding_type: 'queue'
+        routing_key: 'single'
+        arguments:
+            x-arg-test: 'Hello'
+            x-arg-another: 'World'
+
+# Creating multiple bindings (exchange bound to a queue), with arguments, using ansible vars
+  vars:
+    bindings: 
+        - { source: "test_exchange_a", destination: 'test_queue_a', binding_type: 'queue', routing_key: 'a', arguments: {'x-arg-test': 'test_a'}}
+        - { source: "test_exchange_b", destination: 'test_queue_b', binding_type: 'queue', routing_key: 'b', arguments: {'x-arg-test': 'test_b'}}
+        - { source: "test_exchange_c", destination: 'test_queue_c', binding_type: 'queue', routing_key: 'c', arguments: {'x-arg-test': 'test_c'}}
+        - { source: "test_exchange_d", destination: 'test_queue_d', binding_type: 'queue', arguments: {'x-arg-test': 'test_d'}}
+
+  tasks:
+    - name: Create binding
+      action: rabbitmq_binding
+      args: "{{ item }}"
+      with_items: bindings
+
+# Creation of a single binding (exchange bound to a queue) that does not use arguments
 - rabbitmq_binding: host='localhost'
                     user='guest'
                     password='guest'
@@ -109,7 +135,7 @@ EXAMPLES = '''
                     binding_type='queue'
                     routing_key='test'
 
-# Bind an exchange to another exchange.
+# Creation of a single binding (exchange bound to an exchange) that does not use arguments
 - rabbitmq_binding: host='localhost'
                     user='guest'
                     password='guest'
@@ -239,8 +265,8 @@ def main():
         host = dict(required = False, default = 'localhost', aliases = ['host', 'url']),
         port = dict(required = False, default = 15672),
         ssl = dict(required = False, default = False),
-        user = dict(required = True, aliases = ['username']),
-        password = dict(required = True, aliases = ['pwd']),
+        user = dict(required = False, default = 'guest', aliases = ['username']),
+        password = dict(required = False, default = 'guest', aliases = ['pwd']),
         vhost = dict(required = False, default = '/'),
         source = dict(required = True),
         destination = dict(required = True),
@@ -263,10 +289,6 @@ def main():
     binding_type = module.params['binding_type']
     routing_key  = module.params['routing_key']
     arguments    = module.params['arguments']
-    if arguments is not None:
-        arguments = json.loads(arguments)
-    else:
-        arguments = {}
 
     force = module.params['force']
     state = module.params['state']

--- a/library/messaging/rabbitmq_exchange
+++ b/library/messaging/rabbitmq_exchange
@@ -1,0 +1,249 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: rabbitmq_exchange
+short_description: Adds or removes exchange to/from RabbitMQ
+description:
+  - Add or remove exchanges to/from the RabbitMQ server using the HTTP api provided by the management plugin.
+version_added: "1.0"
+author: Jaco Nel
+options:
+  host:
+    description:
+      - The RabbitMQ management api endpoint.
+    required: true
+    default: null
+    aliases: ["api", "url"]
+  port:
+    description:
+      - The port on which RabbitMQ management api is listening.
+    required: false
+    default: 15672
+  ssl:
+    description:
+      - Whether or not the RabbitMQ management api is running over SSL or not.
+    required: false
+    default: "no"
+    choices: ["yes", "no"]
+  user:
+    description:
+      - The username to use for basic authentication with the RabbitMQ server.
+    required: true
+    default: null
+    aliases: ["username"]
+  password:
+    description:
+      - Password of the user to use for basic authentication against the RabbitMQ server.
+    required: true
+    default: null
+  vhost:
+    description:
+      - Vhost to create exchange under.
+    required: false
+    default: "/"
+  name:
+    description:
+      - The exchange name.
+    required: true
+    default: null
+  type:
+    description:
+      - The exchange type.
+    required: true
+    default: "direct"
+    choices: ["direct", "topic", "fanout", "headers"]
+  auto_delete:
+    description:
+      - Whether to delete the exchange when no more connections are opened to it.
+    require: false
+    default: "no"
+    choices: [ "yes", "no" ]
+  durable:
+    description:
+      - Marks the exhange as durable.
+    required: false
+    default: "yes"
+    choices: [ "yes", "no" ]
+  internal:
+    description:
+      - Marks the exchange as internal.
+  arguments:
+    description:
+      - Additional arguments to supply with creation of the exchange.
+    required: false
+    default: null
+  force:
+    description:
+      - Deletes and recreates the exchange.
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
+  state:
+    description:
+      - Specify if exchange is to be added or removed.
+    required: false
+    default: present
+    choices: [present, absent]
+'''
+
+EXAMPLES = '''
+# Add exchange to server
+- rabbitmq_exchange: host='http://localhost:15672/api'
+                  user=guest
+                  password=guest
+                  vhost=/
+                  name=test_exchange
+                  type=direct
+                  durable=no
+                  internal=no
+                  auto_delete=no
+                  arguments='{"some-additional-arg": true}'
+
+# Remove exchange from server
+- rabbitmq_exchange: user=guest
+                  password=guest
+                  name=test_exchange
+                  state=absent
+'''
+
+from urllib import quote_plus
+
+import base64
+import httplib2
+import json
+
+class RabbitMQExchange(object):
+    def __init__(self, module, host, port, ssl, username, password, vhost, name, type, auto_delete, durable, internal, arguments):
+        self.module      = module
+        self.host        = host
+        self.port        = port
+        self.ssl         = ssl
+        self.username    = username
+        self.password    = password
+        self.vhost       = vhost
+        self.name        = name
+        self.type        = type
+        self.auto_delete = auto_delete
+        self.durable     = durable
+        self.internal    = internal
+        self.arguments   = arguments
+
+    def _exec(self, **kwargs):
+        """Execute a request to the RabbitMQ Management API"""
+        url = 'https' if self.ssl else 'http' + '://' + self.host + ':' + str(self.port) + '/api/exchanges/' + quote_plus(self.vhost) + '/' + self.name
+        auth = base64.encodestring(self.username + ':' + self.password)
+
+        headers = {'Content-type': 'application/json', 'Authorization': 'Basic ' + auth}
+        http = httplib2.Http(disable_ssl_certificate_validation=True)
+        headers, content = http.request(url, kwargs['method'], body=json.dumps(kwargs['body']), headers=headers)
+
+        return headers['status'], content
+
+    def get(self):
+        """Used to determine whether an exchange already exists on the RabbitMQ server."""
+        return self._exec(**{'method': 'GET', 'body': None})
+
+    def add(self):
+        """Adds a new exchange to the RabbitMQ server."""
+        request = dict(
+            method = 'PUT',
+            body = {
+                'type': self.type,
+                'auto_delete': self.auto_delete,
+                'durable': self.durable,
+                'internal': self.internal,
+            }
+        )
+        if self.arguments is not None:
+            request['body']['arguments'] = self.arguments
+
+        return self._exec(**request)
+
+    def delete(self):
+        """Deletes an exchange from the RabbitMQ server."""
+        return self._exec(**{'method': 'DELETE', 'body': None})
+
+def main():
+    arg_spec = dict(
+        host = dict(required = False, default = 'localhost', aliases = ['host', 'url']),
+        port = dict(required = False, default = 15672),
+        ssl = dict(required = False, default = False),
+        user = dict(required = True, aliases = ['username']),
+        password = dict(required = True, aliases = ['pwd']),
+        vhost = dict(required = False, default = '/'),
+        name = dict(required = True, default = None),
+        auto_delete = dict(required = False, default = 'no', type = 'bool'),
+        durable = dict(required = False, default = 'yes', type = 'bool'),
+        internal = dict(required = False, default = 'no', type = 'bool'),
+        type = dict(required = False, default = 'direct', choices = ['direct', 'topic', 'fanout', 'headers']),
+        arguments = dict(required = False, default = None),
+        force = dict(required = False, default = 'no', type = 'bool'),
+        state = dict(required = False, default = 'present', choices = ['present', 'absent']))
+
+    module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
+
+    host        = module.params['host']
+    port        = module.params['port']
+    ssl         = module.params['ssl']
+    username    = module.params['user']
+    password    = module.params['password']
+    vhost       = module.params['vhost']
+    name        = module.params['name']
+    auto_delete = module.params['auto_delete']
+    durable     = module.params['durable']
+    internal    = module.params['internal']
+    type        = module.params['type']
+    force       = module.params['force']
+    state       = module.params['state']
+
+    arguments = module.params['arguments']
+    if arguments is not None:
+        arguments = json.loads(arguments)
+
+    rabbitmq_exchange = RabbitMQExchange(module, host, port, ssl, username, password, vhost, name, type, auto_delete, durable, internal, arguments)
+
+    changed     = False
+    response    = rabbitmq_exchange.get()
+
+    if response[0] == '401':
+        return module.fail_json(msg="Unable to authenticate. Possibly invalid username or password.")
+
+    if response[0] != '404':
+        if state == 'absent':
+            if not module.check_mode:
+                rabbitmq_exchange.delete()
+            changed = True
+        else:
+            if force:
+                if not module.check_mode:
+                    rabbitmq_exchange.delete()
+                    rabbitmq_exchange.add()
+                changed = True
+
+    elif state == 'present':
+        if not module.check_mode:
+            status, content = rabbitmq_exchange.add()
+        changed = True
+
+    module.exit_json(changed=changed, name=name, state=state)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()

--- a/library/messaging/rabbitmq_exchange
+++ b/library/messaging/rabbitmq_exchange
@@ -22,7 +22,7 @@ module: rabbitmq_exchange
 short_description: Adds or removes exchange to/from RabbitMQ
 description:
   - Add or remove exchanges to/from the RabbitMQ server using the HTTP api provided by the management plugin.
-version_added: "1.0"
+version_added: "1.7"
 author: Jaco Nel
 options:
   host:

--- a/library/messaging/rabbitmq_exchange
+++ b/library/messaging/rabbitmq_exchange
@@ -105,7 +105,7 @@ options:
 
 EXAMPLES = '''
 # Add exchange to server
-- rabbitmq_exchange: host='http://localhost:15672/api'
+- rabbitmq_exchange: host='localhost'
                   user=guest
                   password=guest
                   vhost=/
@@ -114,13 +114,14 @@ EXAMPLES = '''
                   durable=no
                   internal=no
                   auto_delete=no
-                  arguments='{"some-additional-arg": true}'
+                  arguments='{"some-additional-arg":true}'
 
 # Remove exchange from server
-- rabbitmq_exchange: user=guest
-                  password=guest
-                  name=test_exchange
-                  state=absent
+- rabbitmq_exchange: host='localhost' 
+                     user=guest
+                     password=guest
+                     name=test_exchange
+                     state=absent
 '''
 
 from urllib import quote_plus

--- a/library/messaging/rabbitmq_exchange
+++ b/library/messaging/rabbitmq_exchange
@@ -45,14 +45,14 @@ options:
   user:
     description:
       - The username to use for basic authentication with the RabbitMQ server.
-    required: true
-    default: null
+    required: false
+    default: 'guest'
     aliases: ["username"]
   password:
     description:
       - Password of the user to use for basic authentication against the RabbitMQ server.
-    required: true
-    default: null
+    required: false
+    default: 'guest'
   vhost:
     description:
       - Vhost to create exchange under.
@@ -104,19 +104,44 @@ options:
 '''
 
 EXAMPLES = '''
-# Add exchange to server
+# Add exchange to server with no arguments
 - rabbitmq_exchange: host='localhost'
-                  user=guest
-                  password=guest
-                  vhost=/
-                  name=test_exchange
-                  type=direct
-                  durable=no
-                  internal=no
-                  auto_delete=no
-                  arguments='{"some-additional-arg":true}'
+                     user=guest
+                     password=guest
+                     vhost=/
+                     name=test_exchange
+                     type=direct
+                     durable=no
+                     internal=no
+                     auto_delete=no
 
-# Remove exchange from server
+# Add to the server with arguments
+- name: Create Exchanges
+    action: rabbitmq_exchange
+    args: 
+        name: 'test_exchange_single'
+        type: 'direct'
+        durable: true
+        auto_delete: true
+        arguments:
+            x-arg-test: 'World'
+            x-another-arg: 'World'
+
+# Add to multipe exchanges to the server using vars
+  vars:
+    exchanges: 
+        - { name: "test_exchange_a", durable: true, auto_delete: true, arguments: {'x-arg-test': 'test_a'}}
+        - { name: "test_exchange_b", durable: true, auto_delete: false, arguments: {'x-arg-test': 'test_b'}}
+        - { name: "test_exchange_c", durable: false, auto_delete: true, arguments: {'x-arg-test': 'test_c'}}
+        - { name: "test_exchange_d", durable: false, auto_delete: false, arguments: {'x-arg-test': 'test_d'}}
+
+    tasks:
+    - name: Create Exchanges
+      action: rabbitmq_exchange
+      args: "{{ item }}"
+      with_items: exchanges
+
+# Remove exchange from server by name
 - rabbitmq_exchange: host='localhost' 
                      user=guest
                      password=guest
@@ -186,8 +211,8 @@ def main():
         host = dict(required = False, default = 'localhost', aliases = ['host', 'url']),
         port = dict(required = False, default = 15672),
         ssl = dict(required = False, default = False),
-        user = dict(required = True, aliases = ['username']),
-        password = dict(required = True, aliases = ['pwd']),
+        user = dict(required = False, default = 'guest', aliases = ['username']),
+        password = dict(required = False, default = 'guest', aliases = ['pwd']),
         vhost = dict(required = False, default = '/'),
         name = dict(required = True, default = None),
         auto_delete = dict(required = False, default = 'no', type = 'bool'),
@@ -211,12 +236,10 @@ def main():
     durable     = module.params['durable']
     internal    = module.params['internal']
     type        = module.params['type']
+    arguments   = module.params['arguments']
+
     force       = module.params['force']
     state       = module.params['state']
-
-    arguments = module.params['arguments']
-    if arguments is not None:
-        arguments = json.loads(arguments)
 
     rabbitmq_exchange = RabbitMQExchange(module, host, port, ssl, username, password, vhost, name, type, auto_delete, durable, internal, arguments)
 

--- a/library/messaging/rabbitmq_queue
+++ b/library/messaging/rabbitmq_queue
@@ -90,15 +90,16 @@ options:
 
 EXAMPLES = '''
 # Add queue to server
-- rabbitmq_queue: host='http://localhost:15672/api'
+- rabbitmq_queue: host='localhost'
                   user=guest
                   password=guest
                   vhost=/
                   queue=test_queue
-                  arguments='{"x-dead-letter-exchange": "dead"}'
+                  arguments='{"x-dead-letter-exchange":"dead"}'
 
 # Remove queue from server
-- rabbitmq_queue: user=guest
+- rabbitmq_queue: host='localhost'
+                  user=guest
                   password=guest
                   vhost=/
                   queue=test_queue

--- a/library/messaging/rabbitmq_queue
+++ b/library/messaging/rabbitmq_queue
@@ -22,7 +22,7 @@ module: rabbitmq_queue
 short_description: Adds or removes queues to RabbitMQ
 description:
   - Add or remove queues to/from the RabbitMQ server using the HTTP api provided by the management plugin.
-version_added: "1.0"
+version_added: "1.7"
 author: Jaco Nel
 options:
   host:

--- a/library/messaging/rabbitmq_queue
+++ b/library/messaging/rabbitmq_queue
@@ -1,0 +1,234 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: rabbitmq_queue
+short_description: Adds or removes queues to RabbitMQ
+description:
+  - Add or remove queues to/from the RabbitMQ server using the HTTP api provided by the management plugin.
+version_added: "1.0"
+author: Jaco Nel
+options:
+  host:
+    description:
+      - The RabbitMQ management api endpoint
+    required: true
+    default: null
+    aliases: ["api", "url"]
+  user:
+    description:
+      - The username to use for basic authentication with the RabbitMQ server.
+    required: true
+    default: null
+    aliases: ["username"]
+  password:
+    description:
+      - Password of the user to use for basic authentication against the RabbitMQ server.
+    required: true
+    default: null
+  queue:
+    description:
+      - The name of the queue to be created or deleted.
+    required: true
+    default: null
+  node:
+    description:
+      - The node on which to add the queue if running in a cluster
+    required: false
+    default: null
+  vhost:
+    description:
+      - Vhost to create queue under.
+    required: false
+    default: "/"
+  auto_delete:
+    description:
+      - Whether to delete the queue when no more consumers are attached to the queue
+    require: false
+    default: "no"
+    choices: ["yes", "no"]
+  durable:
+    description:
+      - Marks the queue as durable
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+  arguments:
+    description:
+      - Additional arguments to use when creating the queue. This parameter accepts a json object string. 
+    requireL: False
+    default: null
+  force:
+    description:
+      - Deletes and recreates the queue.
+    required: false
+    default: "no"
+    choices: ["yes", "no"]
+  state:
+    description:
+      - Specify if queue is to be added or removed
+    required: false
+    default: present
+    choices: ["present", "absent"]
+'''
+
+EXAMPLES = '''
+# Add queue to server
+- rabbitmq_queue: host='http://localhost:15672/api'
+                  user=guest
+                  password=guest
+                  vhost=/
+                  queue=test_queue
+                  arguments='{"x-dead-letter-exchange": "dead"}'
+
+# Remove queue from server
+- rabbitmq_queue: user=guest
+                  password=guest
+                  vhost=/
+                  queue=test_queue
+'''
+
+from urllib import quote_plus
+
+import base64
+import httplib2
+import json
+
+class RabbitMqQueue(object):
+    def __init__(self, module, host, port, ssl, username, password, vhost, name, auto_delete, durable, node, arguments):
+        self.module      = module
+        self.host        = host
+        self.port        = port
+        self.ssl         = ssl
+        self.username    = username
+        self.password    = password
+        self.vhost       = vhost
+        self.name        = name
+        self.auto_delete = auto_delete
+        self.durable     = durable
+        self.node        = node
+        self.arguments   = arguments
+
+    def _exec(self, **kwargs):
+        """Executes are request to the RabbitMQ Management API"""
+        url = 'https' if self.ssl else 'http' + '://' + self.host + ':' + str(self.port) + '/api/queues/' + quote_plus(self.vhost) + '/' + self.name
+
+        auth = base64.encodestring(self.username + ':' + self.password)
+        headers = {'Content-type': 'application/json', 'Authorization': 'Basic ' + auth}
+        http = httplib2.Http(disable_ssl_certificate_validation=True)
+        headers, content = http.request(url, kwargs['method'], body=json.dumps(kwargs['body']), headers=headers)
+
+        if headers['status'] == '401':
+            module.fail_json(msg='API authentication failed. Possibly invalid username or password.')
+
+        return headers['status'], content
+
+    def get(self):
+        """Retrieves the details about a specific queue using the RabbitMQ Management API"""
+        request = dict(method = 'GET', body = None)
+        return self._exec(**request)
+
+    def add(self):
+        request = dict(
+            method = 'PUT',
+            body = {
+                'auto_delete': self.auto_delete,
+                'durable': self.durable,
+            }
+        )
+
+        if self.node is not None:
+            request['body']['node'] = self.node
+
+        if self.arguments is not None:
+            request['body']['arguments'] = self.arguments
+
+        return self._exec(**request)
+
+    def delete(self):
+        """Deletes the given queue from RabbitMQ using the Management API"""
+        request = dict( 
+            method = 'DELETE',
+            vhost = self.vhost,
+            name = self.name,
+            body = None
+        )
+
+        return self._exec(**request)
+
+def main():
+    arg_spec = dict(
+        host = dict(required = False, aliases = ['host', 'url'], default = 'localhost'),
+        port = dict(required = False, default = 15672),
+        ssl = dict(required = False, default = False),
+        user = dict(required = True, aliases = ['username']),
+        password = dict(required = True, aliases = ['pwd']),
+        vhost = dict(default = '/'),
+        queue = dict(required = True, default = None, aliases = ['name']),
+        auto_delete = dict(default = 'no', type = 'bool'),
+        durable = dict(default = 'yes', type = 'bool'),
+        node = dict(default = None),
+        arguments = dict(default = None),
+        force = dict(default = 'no', type = 'bool'),
+        state = dict(default = 'present', choices = ['present', 'absent']))
+
+    module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
+
+    host        = module.params['host']
+    port        = module.params['port']
+    ssl         = module.params['ssl']
+    username    = module.params['user']
+    password    = module.params['password']
+    vhost       = module.params['vhost']
+    queue       = module.params['queue']
+    auto_delete = module.params['auto_delete']
+    durable     = module.params['durable']
+    node        = module.params['node']
+    arguments   = module.params['arguments']
+    force       = module.params['force']
+    state       = module.params['state']
+    if arguments is not None:
+        arguments = json.loads(arguments)
+   
+    rabbitmq_queue = RabbitMqQueue(module, host, port, ssl, username, password, vhost, queue, auto_delete, durable, node, arguments)
+
+    changed = False
+    response = rabbitmq_queue.get()
+    if response[0] != '404':
+        if state == 'absent':
+            if not module.check_mode:
+                rabbitmq_queue.delete()
+            changed = True
+        else:
+            if force:
+                if not module.check_mode:
+                    rabbitmq_queue.delete()
+                    rabbitmq_queue.add()
+                changed = True
+
+    elif state == 'present':
+        if not module.check_mode:
+            rabbitmq_queue.add()
+        changed = True
+
+    module.exit_json(changed=changed, queue=queue, state=state)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()

--- a/library/messaging/rabbitmq_queue
+++ b/library/messaging/rabbitmq_queue
@@ -34,19 +34,20 @@ options:
   user:
     description:
       - The username to use for basic authentication with the RabbitMQ server.
-    required: true
-    default: null
+    required: false
+    default: "guest"
     aliases: ["username"]
   password:
     description:
       - Password of the user to use for basic authentication against the RabbitMQ server.
-    required: true
-    default: null
+    required: false
+    default: "guest"
   queue:
     description:
       - The name of the queue to be created or deleted.
     required: true
     default: null
+    aliases: ['name']
   node:
     description:
       - The node on which to add the queue if running in a cluster
@@ -71,7 +72,7 @@ options:
     choices: ["yes", "no"]
   arguments:
     description:
-      - Additional arguments to use when creating the queue. This parameter accepts a json object string. 
+      - Additional arguments to use when creating the queue. This parameter is a complex object. 
     requireL: False
     default: null
   force:
@@ -89,20 +90,53 @@ options:
 '''
 
 EXAMPLES = '''
-# Add queue to server
-- rabbitmq_queue: host='localhost'
-                  user=guest
-                  password=guest
-                  vhost=/
-                  queue=test_queue
-                  arguments='{"x-dead-letter-exchange":"dead"}'
+# Adding a new queue to server
+# Due to the arguments parameter being an complex type, we need to provide the 
+# arguments using the args keyword.
+- name: Create RabbitMQ queue
+    action: rabbitmq_queue
+    args:
+        host: 'localhost'
+        user: 'guest'
+        password: 'password'
+        vhost: '/'
+        name: 'test_queue_single'
+        durable: true
+        auto_delete: true
+        arguments:
+            x-message-ttl: 3600
+            x-deadletter-exchange: 'dead'
 
-# Remove queue from server
+# if no arguments are required, the following approach might be preferred.
+- name: Create RabbitMQ Queue
+    rabbitmq_queue: host='localhost'
+                    user='guest'
+                    password='password'
+                    vhost='/'
+                    name='test_queue_single'
+                    durable=true
+                    auto_delete=true
+
+# Creating multiple queues by using vars
+  vars:
+    queues: 
+        - { name: "test_queue_a", durable: true, auto_delete: true, arguments: {'x-message-ttl': 3600}}
+        - { name: "test_queue_b", durable: true, auto_delete: false, arguments: {'x-message-ttl': 3601}}
+        - { name: "test_queue_c", durable: false, auto_delete: true, arguments: {'x-message-ttl': 3602}}
+        - { name: "test_queue_d", durable: false, auto_delete: false, arguments: {'x-message-ttl': 3603}}
+
+  tasks:
+    - name: Create Queues
+      action: rabbitmq_queue
+      args: "{{ item }}"
+      with_items: queues
+
+# Remove an existing queue from server. Queues are removed using only their names.
 - rabbitmq_queue: host='localhost'
-                  user=guest
-                  password=guest
-                  vhost=/
-                  queue=test_queue
+                  user='guest'
+                  password=''guest'
+                  vhost='/'
+                  name='test_queue'
 '''
 
 from urllib import quote_plus
@@ -138,7 +172,7 @@ class RabbitMqQueue(object):
         if headers['status'] == '401':
             module.fail_json(msg='API authentication failed. Possibly invalid username or password.')
 
-        return headers['status'], content
+        return headers['status'], content, kwargs['body']
 
     def get(self):
         """Retrieves the details about a specific queue using the RabbitMQ Management API"""
@@ -178,16 +212,16 @@ def main():
         host = dict(required = False, aliases = ['host', 'url'], default = 'localhost'),
         port = dict(required = False, default = 15672),
         ssl = dict(required = False, default = False),
-        user = dict(required = True, aliases = ['username']),
-        password = dict(required = True, aliases = ['pwd']),
-        vhost = dict(default = '/'),
+        user = dict(required = False, default = 'guest', aliases = ['username']),
+        password = dict(required = False, default = 'guest', aliases = ['pwd']),
+        vhost = dict(required = False, default = '/'),
         queue = dict(required = True, default = None, aliases = ['name']),
-        auto_delete = dict(default = 'no', type = 'bool'),
-        durable = dict(default = 'yes', type = 'bool'),
-        node = dict(default = None),
-        arguments = dict(default = None),
-        force = dict(default = 'no', type = 'bool'),
-        state = dict(default = 'present', choices = ['present', 'absent']))
+        auto_delete = dict(required = False, default = 'no', type = 'bool'),
+        durable = dict(required = False, default = 'yes', type = 'bool'),
+        node = dict(required = False, default = None),
+        arguments = dict(required = False, default = None),
+        force = dict(required = False, default = 'no', type = 'bool'),
+        state = dict(required = False, default = 'present', choices = ['present', 'absent']))
 
     module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
 
@@ -204,12 +238,11 @@ def main():
     arguments   = module.params['arguments']
     force       = module.params['force']
     state       = module.params['state']
-    if arguments is not None:
-        arguments = json.loads(arguments)
-   
+
     rabbitmq_queue = RabbitMqQueue(module, host, port, ssl, username, password, vhost, queue, auto_delete, durable, node, arguments)
 
     changed = False
+    """
     response = rabbitmq_queue.get()
     if response[0] != '404':
         if state == 'absent':
@@ -224,11 +257,13 @@ def main():
                 changed = True
 
     elif state == 'present':
-        if not module.check_mode:
-            rabbitmq_queue.add()
-        changed = True
+    """
+    if not module.check_mode:
+        status, content, body = rabbitmq_queue.add()
+    changed = True
+    module.exit_json(changed=changed, queue=queue, state=state, args=arguments)
 
-    module.exit_json(changed=changed, queue=queue, state=state)
+    #module.exit_json(changed=changed, queue=queue, state=state, args=arguments)
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>


### PR DESCRIPTION
Modules to allow users to add and remove queues, bindings and
exchanges using the RabbitMQ management plugin's http based API.

Since the default rabbitmq control script does not allow for adding queues, exchanges or bindings we opted to make use of the management plugin's http based api.
