### PR TITLE
Fixed documentation for etype parameter on acl module.

### DIFF
--- a/library/files/acl
+++ b/library/files/acl
@@ -63,7 +63,7 @@ options:
     default: null
     choices: [ 'user', 'group', 'mask', 'other' ]
     description:
-      - if the target is a directory, setting this to yes will make it the default acl for entities created inside the directory. It causes an error if name is a file.
+      - the entity type of the ACL to apply, see setfacl documentation for more info.
 
 
   permissions:


### PR DESCRIPTION
The etype parameter just had a copy of the default parameter documentation.
Changed it to reflect what it really is for.
