### PR TITLE
Add option to perform EC2 inventory by Amazon Machine Image (AMI) IDs.

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -56,4 +56,11 @@ cache_max_age = 300
 
 # The EC2 inventory output can become very large. To manage its size,
 # configure which groups should be created.
+group_instance_id = True
+group_region = True
+group_availability_zone = True
 group_ami_id = False
+group_instance_type = True
+group_key_pair = True
+group_security_group = True
+group_tag_keys = True

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -53,3 +53,7 @@ cache_path = ~/.ansible/tmp
 # seconds, a new API call will be made, and the cache file will be updated.
 # To disable the cache, set this value to 0
 cache_max_age = 300
+
+# The EC2 inventory output can become very large. To manage its size,
+# configure which groups should be created.
+group_ami_id = False

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -230,7 +230,10 @@ class Ec2Inventory(object):
         self.cache_path_cache = cache_dir + "/ansible-ec2.cache"
         self.cache_path_index = cache_dir + "/ansible-ec2.index"
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
-        
+
+        # Group related
+        self.ami_enabled = config.getboolean('ec2', 'group_ami_id')
+
 
 
     def parse_cli_args(self):
@@ -351,6 +354,10 @@ class Ec2Inventory(object):
 
         # Inventory: Group by availability zone
         self.push(self.inventory, instance.placement, dest)
+
+        # Inventory: Group Amazon Machine Image (AMI) ID
+        if self.ami_enabled:
+            self.push(self.inventory, instance.image_id, dest)
 
         # Inventory: Group by instance type
         self.push(self.inventory, self.to_safe('type_' + instance.instance_type), dest)


### PR DESCRIPTION
If only want the option to configure EC2 inventory by AMI IDs.
