### PR TITLE
dont mutate inventory vars (related to hash behavior merge + set_fact with a structured fact)

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -92,7 +92,7 @@ class HostVars(dict):
 
     def __getitem__(self, host):
         if host not in self.lookup:
-            result = self.inventory.get_variables(host, vault_password=self.vault_password)
+            result = self.inventory.get_variables(host, vault_password=self.vault_password).copy()
             result.update(self.vars_cache.get(host, {}))
             self.lookup[host] = result
         return self.lookup[host]


### PR DESCRIPTION
This manifested itself in a fairly specific scenario.  Here is an example setup that will repro the problem (replace `localhost` with any server in `all`):

`export ANSIBLE_HASH_BEHAVIOUR=merge`

**group_vars/all/all.yml**

```
object:
  sub_object:
    key: value
```

**playbook.yml**

``` yml
-- hosts: all
   tasks:
   # this prints the right thing
   - debug: var=object
   - set_fact:
       object:
         sub_object:
           key_2: value_2
   # this prints the "new" (merged) right thing
   - debug: var=object
   # this prints the same right thing (merged)
   - debug: var="hostvars['localhost']"
   # this prints just the values set above in set_fact
   - debug: var=object
```

The final debug prints

```
object:
  sub_object:
    key_2: value_2
```

instead of the expected

```
object:
  sub_object:
    key: value
    key_2: value_2
```

The side effect of accessing the hostvars mutates the inventory vars which results in some unexpected behavior. This PR fixes the one case in which the results are explicitly mutated, but another solution might be to `copy` before returning in `get_variables`.
