### PR TITLE
Fix ec2_asg delete (and default availability zones)

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -131,7 +131,7 @@ def create_autoscaling_group(connection, module):
             ec2_connection = connect_to_aws(boto.ec2, region, **aws_connect_params)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg=str(e))
-        module.params['availability_zones'] = [zone.name for zone in ec2_connection.get_all_zones()]
+        availability_zones = module.params['availability_zones'] = [zone.name for zone in ec2_connection.get_all_zones()]
 
     if not as_groups:
         ag = AutoScalingGroup(

--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -181,7 +181,7 @@ def delete_autoscaling_group(connection, module):
 
         instances = True
         while instances:
-            connection.get_all_groups()
+            groups = connection.get_all_groups()
             for group in groups:
                 if group.name == group_name:
                     if not group.instances:

--- a/test/integration/amazon.yml
+++ b/test/integration/amazon.yml
@@ -11,6 +11,7 @@
     #- { role: test_ec2_eip, tags: test_ec2_eip }
     #- { role: test_ec2_ami, tags: test_ec2_ami }
     #- { role: test_ec2, tags: test_ec2 }
+    - { role: test_ec2_asg, tags: test_ec2_asg }
 
 # complex test for ec2_elb, split up over multiple plays
 # since there is a setup component as well as the test which

--- a/test/integration/cleanup_ec2.py
+++ b/test/integration/cleanup_ec2.py
@@ -117,12 +117,21 @@ if __name__ == '__main__':
     elb = boto.connect_elb(aws_access_key_id=opts.ec2_access_key,
             aws_secret_access_key=opts.ec2_secret_key)
 
+    asg = boto.connect_autoscale(aws_access_key_id=opts.ec2_access_key,
+            aws_secret_access_key=opts.ec2_secret_key)
+
     try:
         # Delete matching keys
         delete_aws_resources(aws.get_all_key_pairs, 'name', opts)
 
-        # Delete matching groups
+        # Delete matching security groups
         delete_aws_resources(aws.get_all_security_groups, 'name', opts)
+
+        # Delete matching ASGs
+        delete_aws_resources(asg.get_all_groups, 'name', opts)
+
+        # Delete matching launch configs
+        delete_aws_resources(asg.get_all_launch_configurations, 'name', opts)
 
         # Delete ELBs
         delete_aws_resources(elb.get_all_load_balancers, 'name', opts)

--- a/test/integration/roles/test_ec2_asg/tasks/main.yml
+++ b/test/integration/roles/test_ec2_asg/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+# tasks file for test_ec2_asg
+
+# ============================================================
+# create and kill an ASG
+- name: lookup ami id
+  ec2_ami_search: distro=ubuntu region={{ ec2_region }} release=trusty
+  register: ubuntu_image
+- name: ensure launch config exists
+  ec2_lc:
+    name: "{{ resource_prefix }}-lc"
+    ec2_access_key: "{{ ec2_access_key }}"
+    ec2_secret_key: "{{ ec2_secret_key }}"
+    region: "{{ ec2_region }}"
+    image_id: "{{ ubuntu_image.ami }}"
+    instance_type: t1.micro
+- name: launch asg
+  ec2_asg:
+    name: "{{ resource_prefix }}-asg"
+    ec2_access_key: "{{ ec2_access_key }}"
+    ec2_secret_key: "{{ ec2_secret_key }}"
+    launch_config_name: "{{ resource_prefix }}-lc"
+    min_size: 1
+    max_size: 1
+    region: "{{ ec2_region }}"
+    state: present
+- name: pause for a bit to make sure that the group can't be trivially deleted
+  pause: seconds=30
+- name: kill asg
+  ec2_asg:
+    name: "{{ resource_prefix }}-asg"
+    ec2_access_key: "{{ ec2_access_key }}"
+    ec2_secret_key: "{{ ec2_secret_key }}"
+    region: "{{ ec2_region }}"
+    state: absent
+  async: 300


### PR DESCRIPTION
The main issue here is that the asg delete function was not polling the instance count correctly, so it would hang indefinitely.

Along the way (while trying to simplify the integration test) I also fixed the default availability zone logic (sorry for not making a separate pull request for this, but it was another very simple change).

This pull request includes fixes for both bugs as well as a new integration test for the ec2_asg module. Note that, for practical reasons, I only ever ran this test in isolation as

```
TEST_FLAGS=" --tags test_ec2_asg" make amazon
```

 but I don't think that should be a problem...

Also note that I used the async param to enforce a 5 min timeout on the delete, which consistently failed for me with the old/buggy code and passed with my fix, but because of the general non-determinism of all this stuff, you may want to up that a bit. (I'm not sure what your workflow for running the longer-running integration tests is...)
