### PR TITLE
Adds support to ec2_group for purging group rules

### DIFF
--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -44,6 +44,20 @@ options:
     required: false
     default: 'present'
     aliases: []
+  purge_rules:
+    version_added: "1.7"
+    description:
+      - Purge existing rules on security group that are not found in rules
+    required: false
+    default: 'true'
+    aliases: []
+  purge_rules_egress:
+    version_added: "1.7"
+    description:
+      - Purge existing rules_egree on security group that are not found in rules_egress
+    required: false
+    default: 'true'
+    aliases: []
 
 extends_documentation_fragment: aws
 
@@ -163,6 +177,9 @@ def main():
             rules=dict(),
             rules_egress=dict(),
             state = dict(default='present', choices=['present', 'absent']),
+            purge_rules=dict(default=True, required=False, type='bool'),
+            purge_rules_egress=dict(default=True, required=False, type='bool'),
+
         )
     )
     module = AnsibleModule(
@@ -176,6 +193,8 @@ def main():
     rules = module.params['rules']
     rules_egress = module.params['rules_egress']
     state = module.params.get('state')
+    purge_rules = module.params['purge_rules']
+    purge_rules_egress = module.params['purge_rules_egress']
 
     changed = False
 
@@ -269,14 +288,15 @@ def main():
                     changed = True
 
         # Finally, remove anything left in the groupRules -- these will be defunct rules
-        for rule in groupRules.itervalues():
-            for grant in rule.grants:
-                grantGroup = None
-                if grant.group_id:
-                    grantGroup = groups[grant.group_id]
-                if not module.check_mode:
-                    group.revoke(rule.ip_protocol, rule.from_port, rule.to_port, grant.cidr_ip, grantGroup)
-                changed = True
+        if purge_rules:
+            for rule in groupRules.itervalues() :
+                for grant in rule.grants:
+                    grantGroup = None
+                    if grant.group_id:
+                        grantGroup = groups[grant.group_id]
+                    if not module.check_mode:
+                        group.revoke(rule.ip_protocol, rule.from_port, rule.to_port, grant.cidr_ip, grantGroup)
+                    changed = True
 
         # Manage egress rules
         groupRules = {}
@@ -333,20 +353,21 @@ def main():
                 del groupRules[default_egress_rule]
 
         # Finally, remove anything left in the groupRules -- these will be defunct rules
-        for rule in groupRules.itervalues():
-            for grant in rule.grants:
-                grantGroup = None
-                if grant.group_id:
-                    grantGroup = groups[grant.group_id].id
-                if not module.check_mode:
-                    ec2.revoke_security_group_egress(
-                            group_id=group.id,
-                            ip_protocol=rule.ip_protocol,
-                            from_port=rule.from_port,
-                            to_port=rule.to_port,
-                            src_group_id=grantGroup,
-                            cidr_ip=grant.cidr_ip)
-                changed = True
+        if purge_rules_egress:
+            for rule in groupRules.itervalues():
+                for grant in rule.grants:
+                    grantGroup = None
+                    if grant.group_id:
+                        grantGroup = groups[grant.group_id].id
+                    if not module.check_mode:
+                        ec2.revoke_security_group_egress(
+                                group_id=group.id,
+                                ip_protocol=rule.ip_protocol,
+                                from_port=rule.from_port,
+                                to_port=rule.to_port,
+                                src_group_id=grantGroup,
+                                cidr_ip=grant.cidr_ip)
+                    changed = True
 
     if group:
         module.exit_json(changed=changed, group_id=group.id)


### PR DESCRIPTION
Similar to ec2_elb_lb, this adds support to dictate wether or not to purge the group rules. This is very useful for updating security groups later on after creation. Default behavior is not changed. 
