### PR TITLE
ec2_lc: Add params instance_monitoring and spot_price

### DIFF
--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -51,6 +51,16 @@ options:
     description:
       - A list of security groups into which instances should be found
     required: false
+  instance_type:
+    description:
+      - The type of the instance to launch
+    required: false
+  instance_monitoring:
+    description:
+      - Whether to enable detailed monitoring on the instances
+    required: false
+    default: 'yes'
+    choices: [ 'yes', 'no' ]
   region:
     description:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
@@ -126,6 +136,7 @@ def create_launch_config(connection, module):
     user_data = module.params.get('user_data')
     volumes = module.params['volumes']
     instance_type = module.params.get('instance_type')
+    instance_monitoring = module.params.get('instance_monitoring')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -144,7 +155,9 @@ def create_launch_config(connection, module):
         security_groups=security_groups,
         user_data=user_data,
         block_device_mappings=[bdm],
-        instance_type=instance_type)
+        instance_type=instance_type,
+        instance_monitoring=instance_monitoring,
+    )
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -159,7 +172,8 @@ def create_launch_config(connection, module):
 
     module.exit_json(changed=changed, name=result.name, created_time=str(result.created_time),
                      image_id=result.image_id, arn=result.launch_configuration_arn,
-                     security_groups=result.security_groups, instance_type=instance_type)
+                     security_groups=result.security_groups, instance_type=instance_type,
+                     instance_monitoring=instance_monitoring)
 
 
 def delete_launch_config(connection, module):
@@ -183,6 +197,7 @@ def main():
             user_data=dict(type='str'),
             volumes=dict(type='list'),
             instance_type=dict(type='str'),
+            instance_monitoring=dict(default='yes', type='bool'),
             state=dict(default='present', choices=['present', 'absent']),
         )
     )

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -61,6 +61,10 @@ options:
     required: false
     default: 'yes'
     choices: [ 'yes', 'no' ]
+  spot_price:
+    description:
+      - Bidding price for spot instances
+    required: false
   region:
     description:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
@@ -137,6 +141,7 @@ def create_launch_config(connection, module):
     volumes = module.params['volumes']
     instance_type = module.params.get('instance_type')
     instance_monitoring = module.params.get('instance_monitoring')
+    spot_price = module.params.get('spot_price')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -157,6 +162,7 @@ def create_launch_config(connection, module):
         block_device_mappings=[bdm],
         instance_type=instance_type,
         instance_monitoring=instance_monitoring,
+        spot_price=spot_price,
     )
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
@@ -173,7 +179,7 @@ def create_launch_config(connection, module):
     module.exit_json(changed=changed, name=result.name, created_time=str(result.created_time),
                      image_id=result.image_id, arn=result.launch_configuration_arn,
                      security_groups=result.security_groups, instance_type=instance_type,
-                     instance_monitoring=instance_monitoring)
+                     instance_monitoring=instance_monitoring, spot_price=spot_price)
 
 
 def delete_launch_config(connection, module):
@@ -198,6 +204,7 @@ def main():
             volumes=dict(type='list'),
             instance_type=dict(type='str'),
             instance_monitoring=dict(default='yes', type='bool'),
+            spot_price=dict(type='float'),
             state=dict(default='present', choices=['present', 'absent']),
         )
     )


### PR DESCRIPTION
In EC2 auto scaling setup, `instance_monitoring` is usually enabled, so that the scale-up / scale-down decision can made based on more accurate statistics. Currently, the parameter is not exposed by ansible, while boto has it disabled by default, thus making the module less useful.

The `spot_price` parameter is to allow spot instance bidding.
