### PR TITLE
Merge and intersect lists without using sets.

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1003,21 +1003,19 @@ def is_list_of_strings(items):
             return False
     return True
 
-def _listify(a):
-    if not isinstance(a, (list, tuple)):
-        return [a,]
-    else:
-        return a
-
 def list_union(a, b):
-    set_a = set(_listify(a))
-    set_b = set(_listify(b))
-    return list(set_a.union(set_b))
+    result = list(a)
+    for i in b:
+        if i not in result:
+            result.append(i)
+    return result
 
 def list_intersection(a, b):
-    set_a = set(_listify(a))
-    set_b = set(_listify(b))
-    return list(set_a.intersection(set_b))
+    result = []
+    for i in a:
+        if i in b:
+            result.append(i)
+    return result
 
 def safe_eval(expr, locals={}, include_exceptions=False):
     '''

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1004,17 +1004,20 @@ def is_list_of_strings(items):
     return True
 
 def list_union(a, b):
-    result = list(a)
-    for i in b:
-        if i not in result:
-            result.append(i)
+    result = []
+    for x in a:
+        if x not in result:
+            result.append(x)
+    for x in b:
+        if x not in result:
+            result.append(x)
     return result
 
 def list_intersection(a, b):
     result = []
-    for i in a:
-        if i in b:
-            result.append(i)
+    for x in a:
+        if x in b and x not in result:
+            result.append(x)
     return result
 
 def safe_eval(expr, locals={}, include_exceptions=False):


### PR DESCRIPTION
Using sets for these operations is dangerous because sets cannot contain
certain object types (such as lists) and their iteration order is
undefined.

Fixes #7596
