### PR TITLE
Resolve combined variables in runner so that extra vars override host ones

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -554,11 +554,11 @@ class Runner(object):
 
         # merge the VARS and SETUP caches for this host
         combined_cache = self.setup_cache.copy()
-        combined_cache.get(host, {}).update(self.vars_cache.get(host, {}))
+        combined_cache[host] = utils.combine_vars(combined_cache.get(host, {}), self.vars_cache.get(host, {}))
         hostvars = HostVars(combined_cache, self.inventory, vault_password=self.vault_pass)
 
         # use combined_cache and host_variables to template the module_vars
-        module_vars_inject = utils.combine_vars(combined_cache.get(host, {}), host_variables)
+        module_vars_inject = utils.combine_vars(host_variables, combined_cache.get(host, {}))
         module_vars = template.template(self.basedir, self.module_vars, module_vars_inject)
 
         inject = {}


### PR DESCRIPTION
This pull request fixes the issue where extra variables are being resolved in the wrong order in the runner; it causes the host variables to trump the extras when the task is run. The discussion of the bug is described here, it mentions 1.5.4 but is still present in the 1.6 stream

https://groups.google.com/forum/#!searchin/ansible-project/1.5.4/ansible-project/feCFkDW12Bo/f6kFJDsJ7-kJ

This example repo illustrates the issue 

https://github.com/sgargan/ansible_extras_resolution.git

Let me know if there is anything else I can help with here.
