### PR TITLE
Tag Based EC2 Inventory Names

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -34,6 +34,11 @@ destination_variable = public_dns_name
 # be run from with EC2.
 vpc_destination_variable = ip_address
 
+# if you would prefer to use an EC2 Instance Tag for the destination, set this
+# to the tag name to override any previous choices above; however, it is your
+# responsibility to ensure the tag will resolve to an IP address.
+# tag_destination_variable = Name
+
 # To tag instances on EC2 with the resource records that point to them from
 # Route53, uncomment and set 'route53' to True.
 route53 = False


### PR DESCRIPTION
This pull request implements a feature to allow an EC2 tag to override the vpc_destination_variable which already overrides the default destination_variable. When using the inventory script, I found it much more meaningful to see a friendly, recognizable host name in the Ansible output than the options available.
