### PR TITLE
Fix uri failing when HTTP status is 304

### DIFF
--- a/library/network/uri
+++ b/library/network/uri
@@ -406,6 +406,7 @@ def main():
     # Write the file out if requested
     if dest is not None:
         if resp['status'] == 304:
+            status_code = [304]
             changed = False
         else:
             write_file(module, url, dest, content)


### PR DESCRIPTION
We need to explicitly set status_code to 304 otherwise we will run into "Status code was not [200]" if the remote server responds with a 304 status during deployments.
