### PR TITLE
ec2: ebs_optimized can be optional

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -570,8 +570,11 @@ def get_instance_info(inst):
                      'root_device_type': inst.root_device_type,
                      'root_device_name': inst.root_device_name,
                      'state': inst.state,
-                     'hypervisor': inst.hypervisor,
-                     'ebs_optimized': inst.ebs_optimized}
+                     'hypervisor': inst.hypervisor}
+    try:
+       instance_info['ebs_optimized'] = inst.ebs_optimized
+    except AttributeError:
+       instance_info['ebs_optimized'] = None
     try:
         instance_info['virtualization_type'] = getattr(inst,'virtualization_type')
     except AttributeError:


### PR DESCRIPTION
I have old instance of OpenStack and with ansible 1.6 I got traceback from ec2 module:

```
failed: [localhost] => {"failed": true, "parsed": false}
invalid output was: Traceback (most recent call last):
  File "/home/copr/.ansible/tmp/ansible-tmp-1401461599.43-107043805508227/ec2", line 2539, in <module>
    main()
  File "/home/copr/.ansible/tmp/ansible-tmp-1401461599.43-107043805508227/ec2", line 1170, in main
    (instance_dict_array, new_instance_ids, changed) = create_instances(module, ec2)
  File "/home/copr/.ansible/tmp/ansible-tmp-1401461599.43-107043805508227/ec2", line 956, in create_instances
    d = get_instance_info(inst)
  File "/home/copr/.ansible/tmp/ansible-tmp-1401461599.43-107043805508227/ec2", line 574, in get_instance_info
    'ebs_optimized': inst.ebs_optimized}
AttributeError: 'Instance' object has no attribute 'ebs_optimized'
```

This does not happened with ansible 1.4.

It seems that `ebs_optimized` is not always returned and ansible should accomodate.
