### PR TITLE
Show delegate_to hint in callback output

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -448,6 +448,10 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
         self._async_notified = {}
 
     def on_unreachable(self, host, results):
+        delegate_to = self.runner.module_vars.get('delegate_to')
+        if delegate_to:
+            host = '%s -> %s' % (host, delegate_to)
+
         item = None
         if type(results) == dict:
             item = results.get('item', None)
@@ -459,7 +463,9 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
         super(PlaybookRunnerCallbacks, self).on_unreachable(host, results)
 
     def on_failed(self, host, results, ignore_errors=False):
-
+        delegate_to = self.runner.module_vars.get('delegate_to')
+        if delegate_to:
+            host = '%s -> %s' % (host, delegate_to)
 
         results2 = results.copy()
         results2.pop('invocation', None)
@@ -492,6 +498,9 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
         super(PlaybookRunnerCallbacks, self).on_failed(host, results, ignore_errors=ignore_errors)
 
     def on_ok(self, host, host_result):
+        delegate_to = self.runner.module_vars.get('delegate_to')
+        if delegate_to:
+            host = '%s -> %s' % (host, delegate_to)
 
         item = host_result.get('item', None)
 
@@ -528,6 +537,10 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
         super(PlaybookRunnerCallbacks, self).on_ok(host, host_result)
 
     def on_skipped(self, host, item=None):
+        delegate_to = self.runner.module_vars.get('delegate_to')
+        if delegate_to:
+            host = '%s -> %s' % (host, delegate_to)
+
         if constants.DISPLAY_SKIPPED_HOSTS:
             msg = ''
             if item:


### PR DESCRIPTION
This pull request adds additional output to `on_unreachable`, `on_failed`, `on_ok`, `on_error` and `on_skipped` to output a hint indicating the host specified in `delegate_to` (which also covers `local_action`).

Sample output:

```
$ ansible-playbook -i srv1.example.org, delegate.yml

PLAY [all] ********************************************************************

TASK: [delegate_to localhost] *************************************************
ok: [srv1.example.org -> localhost] => {
    "msg": "foo"
}

TASK: [local_action] **********************************************************
ok: [srv1.example.org -> 127.0.0.1] => {
    "msg": "foo"
}

PLAY RECAP ********************************************************************
srv1.example.org            : ok=2    changed=0    unreachable=0    failed=0
```
