### PR TITLE
template.py: Handle purposely raised exceptions in lookup()

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -91,6 +91,9 @@ def lookup(name, *args, **kwargs):
         # safely catch run failures per #5059
         try:
             ran = instance.run(*args, inject=vars, **kwargs)
+        except errors.AnsibleError:
+            # Plugin raised this on purpose
+            raise
         except Exception, e:
             ran = None
         if ran:


### PR DESCRIPTION
If a lookup plugin is run by the lookup() template method it should pass
along any AnsibleError (or child exception classes) rather than just eat
them.  These exceptions are purposely raised by the plugin.

This was broken by: https://github.com/ansible/ansible/issues/5059
