### PR TITLE
Add role templates path to jinja2 loader paths.

### DIFF
--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -78,6 +78,10 @@ class ActionModule(object):
             else:
                 source = utils.path_dwim(self.runner.basedir, source)
 
+        if '_original_file' in inject:
+            templates_paths = [utils.path_dwim_relative(inject['_original_file'], 'templates', '', self.runner.basedir, check=False)]
+        else:
+            templates_paths = None
 
         if dest.endswith("/"):
             base = os.path.basename(source)
@@ -85,7 +89,7 @@ class ActionModule(object):
 
         # template the source data locally & get ready to transfer
         try:
-            resultant = template.template_from_file(self.runner.basedir, source, inject, vault_password=self.runner.vault_pass)
+            resultant = template.template_from_file(self.runner.basedir, source, inject, vault_password=self.runner.vault_pass, extra_search_paths=templates_paths)
         except Exception, e:
             result = dict(failed=True, msg=str(e))
             return ReturnData(conn=conn, comm_ok=False, result=result)

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -202,14 +202,21 @@ class J2Template(jinja2.environment.Template):
     def new_context(self, vars=None, shared=False, locals=None):
         return jinja2.runtime.Context(self.environment, vars.add_locals(locals), self.name, self.blocks)
 
-def template_from_file(basedir, path, vars, vault_password=None):
+def template_from_file(basedir, path, vars, vault_password=None, extra_search_paths=None):
     ''' run a file through the templating engine '''
 
     fail_on_undefined = C.DEFAULT_UNDEFINED_VAR_BEHAVIOR
 
     from ansible import utils
     realpath = utils.path_dwim(basedir, path)
-    loader=jinja2.FileSystemLoader([basedir,os.path.dirname(realpath)])
+    search_paths = [basedir, os.path.dirname(realpath)]
+
+    if extra_search_paths:
+        for p in extra_search_paths:
+            if p not in search_paths:
+                search_paths.append(p)
+
+    loader=jinja2.FileSystemLoader(search_paths)
 
     def my_lookup(*args, **kwargs):
         kwargs['vars'] = vars


### PR DESCRIPTION
Lately, I've found myself wanting to include 'base' templates in a role, and then extend them with more specfic templates outside the roles. This makes the roles more reusable, and can be accomplished now by using a path like `roles/nginx/templates/vhost.j2`. Where it starts to break down is when you have altered `roles_path`, since now the nginx role might not be in the `roles` directory. So, in order to avoid coupling the path to the layout of your directory, I've made a small change to search the role's templates directory when using `extends`.
