### PR TITLE
fix for docker backwards compatibility

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -545,7 +545,10 @@ class DockerManager:
                   'tty':          self.module.params.get('tty'),
                   }
 
-        if docker.utils.compare_version('1.10', self.client.version()['ApiVersion']) < 0:
+        version = self.client.version()
+        api_version = version['ApiVersion'] if 'ApiVersion' in version else version['Version']
+
+        if docker.utils.compare_version('1.10', api_version) < 0:
             params['dns'] = self.module.params.get('dns')
             params['volumes_from'] = self.module.params.get('volumes_from')
 
@@ -576,7 +579,11 @@ class DockerManager:
             'privileged':   self.module.params.get('privileged'),
             'links': self.links,
         }
-        if docker.utils.compare_version('1.10', self.client.version()['ApiVersion']) >= 0 and hasattr(docker, '__version__') and docker.__version__ > '0.3.0':
+
+        version = self.client.version()
+        api_version = version['ApiVersion'] if 'ApiVersion' in version else version['Version']
+
+        if docker.utils.compare_version('1.10', api_version) >= 0 and hasattr(docker, '__version__') and docker.__version__ > '0.3.0':
             params['dns'] = self.module.params.get('dns')
             params['volumes_from'] = self.module.params.get('volumes_from')
 


### PR DESCRIPTION
This fixes an issue when using the ansible docker module with an older version of docker.  Specifically 0.9.1 which is the default in ubuntu 14.04.
