### PR TITLE
Do not crash when skipping async tasks

### DIFF
--- a/lib/ansible/runner/poller.py
+++ b/lib/ansible/runner/poller.py
@@ -43,6 +43,7 @@ class AsyncPoller(object):
                 self.active = True
             else:
                 skipped = skipped and res.get('skipped', False)
+                self.runner.vars_cache[host]['ansible_job_id'] = ''
                 self.results['contacted'][host] = res
         for (host, res) in results['dark'].iteritems():
             self.runner.vars_cache[host]['ansible_job_id'] = ''

--- a/test/integration/roles/test_async/tasks/main.yml
+++ b/test/integration/roles/test_async/tasks/main.yml
@@ -56,3 +56,9 @@
         - "'ansible_job_id' in async_result"
         - "'started' in async_result"
         - "'finished' not in async_result"
+
+- name: test skipped task handling
+  command: /bin/true 
+  async: 15
+  poll: 0
+  when: False


### PR DESCRIPTION
##### Issue Type: Bugfix Pull Request
##### Ansible Version: 1.6.3, devel
##### Environment: doesn't matter
##### Summary:

This will fix gh-7432. 

Git bisect indicates that this was originally broken [here](https://github.com/ansible/ansible/commit/e09313120c96c00980aef12c3105647bdc3857ca), where previously the job id was always set to None initially. I am unsure of the semantics of  `self.runner.vars_cache`, so I did the simpler (but perhaps less robustly correct) thing.
##### Steps To Reproduce:

```

---
- hosts: localhost
  tasks:
  - action: shell /bin/true 
    async: 15
    poll: 0
    when: False
```
##### Expected Results:

Nothing happens
##### Actual Results:

Ansible crashes
