### PR TITLE
ec2_snapshot idempotency feature + some other changes

### DIFF
--- a/library/cloud/ec2_snapshot
+++ b/library/cloud/ec2_snapshot
@@ -73,6 +73,23 @@ options:
     default: null
     aliases: []
     version_added: "1.6"
+  snapshot_max_age:
+    description:
+      - If the volume's most recent snapshot has started less than `snapshot_max_age' minutes ago, a new snapshot will not be created.
+    required: false
+    default: 0
+  wait:
+    description:
+      - Whether to wait until the snapshot creation is complete.
+    required: false
+    default: false
+    version_added: "1.6"
+  wait_timeout:
+    description:
+      - How long to wait (if `wait' is true) for the snapshot to complete before timing out. A value of 0 means forever.
+    required: false
+    default: 0
+    version_added: "1.6"
 
 author: Will Thames
 extends_documentation_fragment: aws
@@ -122,8 +139,9 @@ def main():
             ec2_url = dict(),
             ec2_secret_key = dict(aliases=['aws_secret_key', 'secret_key'], no_log=True),
             ec2_access_key = dict(aliases=['aws_access_key', 'access_key']),
-            wait = dict(type='bool', default='true'),
-            wait_timeout = dict(default=0),
+            wait = dict(type='bool', default='false'),
+            wait_timeout = dict(type='int', default=0),
+            snapshot_max_age = dict(type='int', default=0),
             snapshot_tags = dict(type='dict', default=dict()),
         )
     )
@@ -134,7 +152,10 @@ def main():
     device_name = module.params.get('device_name')
     wait = module.params.get('wait')
     wait_timeout = module.params.get('wait_timeout')
+    snapshot_max_age = module.params.get('snapshot_max_age')
     snapshot_tags = module.params.get('snapshot_tags')
+    snapshot = None
+    changed = False
 
     if not volume_id and not instance_id or volume_id and instance_id:
         module.fail_json('One and only one of volume_id or instance_id must be specified')
@@ -152,10 +173,38 @@ def main():
         except boto.exception.BotoServerError, e:
             module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
 
+    if snapshot_max_age > 0:
+        try:
+            snapshot_max_age = snapshot_max_age * 60 # Convert to seconds
+            current_snapshots = ec2.get_all_snapshots(filters={'volume_id': volume_id})
+            # Find the most recent snapshot
+            recent = dict(start_time=0, snapshot=None)
+            for s in current_snapshots:
+                start_time = time.mktime(time.strptime(s.start_time, '%Y-%m-%dT%H:%M:%S.000Z'))
+                if start_time > recent['start_time']:
+                    recent['start_time'] = start_time
+                    recent['snapshot'] = s
+
+            # Adjust snapshot start time to local timezone
+            tz_adjustment = time.daylight and time.altzone or time.timezone
+            recent['start_time'] -= tz_adjustment
+
+            # See if the snapshot is younger that the given max age
+            current_time = time.mktime(time.localtime())
+            snapshot_age = current_time - recent['start_time']
+            if snapshot_age < snapshot_max_age:
+                file('/tmp/ansible', 'w').write("Start time is %d\nAge is %d\n" % (recent['start_time'], snapshot_age))
+                snapshot = recent['snapshot']
+        except boto.exception.BotoServerError, e:
+            module.fail_json(msg="%s: %s" % (e.error_code, e.error_message))
+
     try:
-        snapshot = ec2.create_snapshot(volume_id, description=description)
-        time_waited = 0
+        # Create a new snapshot if we didn't find an existing one to use
+        if snapshot is None:
+            snapshot = ec2.create_snapshot(volume_id, description=description)
+            changed = True
         if wait:
+            time_waited = 0
             snapshot.update()
             while snapshot.status != 'completed':
                 time.sleep(3)
@@ -166,9 +215,9 @@ def main():
         for k, v in snapshot_tags.items():
             snapshot.add_tag(k, v)
     except boto.exception.BotoServerError, e:
-        module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
+        module.fail_json(msg="%s: %s" % (e.error_code, e.error_message))
 
-    module.exit_json(changed=True, snapshot_id=snapshot.id, volume_id=snapshot.volume_id,
+    module.exit_json(changed=changed, snapshot_id=snapshot.id, volume_id=snapshot.volume_id,
             volume_size=snapshot.volume_size, tags=snapshot.tags.copy())
 
 # import module snippets

--- a/library/cloud/ec2_snapshot
+++ b/library/cloud/ec2_snapshot
@@ -193,7 +193,6 @@ def main():
             current_time = time.mktime(time.localtime())
             snapshot_age = current_time - recent['start_time']
             if snapshot_age < snapshot_max_age:
-                file('/tmp/ansible', 'w').write("Start time is %d\nAge is %d\n" % (recent['start_time'], snapshot_age))
                 snapshot = recent['snapshot']
         except boto.exception.BotoServerError, e:
             module.fail_json(msg="%s: %s" % (e.error_code, e.error_message))


### PR DESCRIPTION
Added a snapshot_max_age parameter, that allows you to check for an existing snapshot to the volume and only create a new one if it's older than a given age.

"Side" changes:
- Added snapshot_max_age, wait and wait_timeout to the docs
- Made the default value of wait to be false. This restores the behavior to what it was before #6697.
