### PR TITLE
Add primary group in the first user module doc example

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -181,7 +181,7 @@ options:
 
 EXAMPLES = '''
 # Add the user 'johnd' with a specific uid and a primary group of 'admin'
-- user: name=johnd comment="John Doe" uid=1040
+- user: name=johnd comment="John Doe" uid=1040 group=admin
 
 # Add the user 'james' with a bash shell, appending the group 'admins' and 'developers' to the user's groups
 - user: name=james shell=/bin/bash groups=admins,developers append=yes


### PR DESCRIPTION
##### Issue Type:

“Docs Pull Request”.
##### Ansible Version:

ansible 1.5.3
##### Environment:

Debian Jessie - Virtualenv Python 2.7
##### Summary:

The primary group is missing in this example

```
# Add the user 'johnd' with a specific uid and a primary group of 'admin'
- user: name=johnd comment="John Doe" uid=1040
```
##### Steps To Reproduce:

nothing
##### Expected Results:

```
# Add the user 'johnd' with a specific uid and a primary group of 'admin'
- user: name=johnd comment="John Doe" uid=1040 group=admin
```
##### Actual Results:

```
# Add the user 'johnd' with a specific uid and a primary group of 'admin'
- user: name=johnd comment="John Doe" uid=1040
```
