### PR TITLE
Fix "InvalidGroup.NotFound" error when using group name in VPC

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -166,7 +166,7 @@ def connect_to_aws(aws_module, region, **params):
     return conn
 
 
-def ec2_connect(module):
+def ec2_connect(module, vpc=False):
 
     """ Return an ec2 connection"""
 
@@ -175,7 +175,10 @@ def ec2_connect(module):
     # If we have a region specified, connect to its endpoint.
     if region:
         try:
-            ec2 = connect_to_aws(boto.ec2, region, **boto_params)
+            if vpc:
+                ec2 = connect_to_aws(boto.vpc, region, **boto_params)
+            else:
+                ec2 = connect_to_aws(boto.ec2, region, **boto_params)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg=str(e))
     # Otherwise, no region so we fallback to the old connection method

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -476,6 +476,7 @@ from ast import literal_eval
 
 try:
     import boto.ec2
+    import boto.vpc
     from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
     from boto.exception import EC2ResponseError
 except ImportError:
@@ -747,14 +748,18 @@ def create_instances(module, ec2, override_count=None):
     try:
         # Here we try to lookup the group id from the security group name - if group is set.
         if group_name:
-            grp_details = ec2.get_all_security_groups()
-            if type(group_name) == list:
-                group_id = [ str(grp.id) for grp in grp_details if str(grp.name) in group_name ]
-            elif type(group_name) == str:
-                for grp in grp_details:
-                    if str(group_name) in str(grp):
-                        group_id = [str(grp.id)]
+            # Wrap the group_name in a list if it's not one already
+            if type(group_name) == str:
                 group_name = [group_name]
+            # Filter by VPC if subnet is set. Group name is only unique within a VPC.
+            if vpc_subnet_id:
+                grp_details = ec2.get_all_security_groups(filters={
+                    'group_name': group_name,
+                    'vpc_id': [ec2.get_all_subnets([vpc_subnet_id])[0].vpc_id],
+                })
+            else:
+                grp_details = ec2.get_all_security_groups(groupnames=group_name)
+            group_id = [ str(grp.id) for grp in grp_details ]
         # Now we try to lookup the group id testing if group exists.
         elif group_id:
             #wrap the group_id in a list if it's not one already
@@ -1131,7 +1136,10 @@ def main():
                              ],
     )
 
-    ec2 = ec2_connect(module)
+    if module.params.get('vpc_subnet_id'):
+        ec2 = ec2_connect(module, vpc=True)
+    else:
+        ec2 = ec2_connect(module)
 
     tagged_instances = [] 
 

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -185,10 +185,13 @@ def main():
     group = None
     groups = {}
     for curGroup in ec2.get_all_security_groups():
+        if curGroup.vpc_id != vpc_id:
+            continue
+
         groups[curGroup.id] = curGroup
         groups[curGroup.name] = curGroup
 
-        if curGroup.name == name and (vpc_id is None or curGroup.vpc_id == vpc_id):
+        if curGroup.name == name:
             group = curGroup
 
     # Ensure requested group is absent


### PR DESCRIPTION
The error can happen when more than one VPC share the same security group name. This has been forcing me to use security group id instead, which is a major pain.
