### PR TITLE
Allow --vault-password-file to work with a script as well as a flat file

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -124,17 +124,8 @@ class Cli(object):
         (sshpass, sudopass, su_pass, vault_pass) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass, ask_su_pass=options.ask_su_pass, ask_vault_pass=options.ask_vault_pass)
 
         # read vault_pass from a file
-        if options.vault_password_file:
-            this_path = os.path.expanduser(options.vault_password_file)
-            try:
-                f = open(this_path, "rb")
-                tmp_vault_pass=f.read().strip()
-                f.close()
-            except (OSError, IOError), e:
-                raise errors.AnsibleError("Could not read %s: %s" % (this_path, e))
-
-            if not options.ask_vault_pass:
-                vault_pass = tmp_vault_pass
+        if not options.ask_vault_pass and options.vault_password_file:
+            vault_pass = utils.read_vault_file(options.vault_password_file)
 
         inventory_manager = inventory.Inventory(options.inventory)
         if options.subset:

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -125,17 +125,9 @@ def main(args):
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
         options.su_user = options.su_user or C.DEFAULT_SU_USER
 
-    if options.vault_password_file:
-        this_path = os.path.expanduser(options.vault_password_file)
-        try:
-            f = open(this_path, "rb")
-            tmp_vault_pass=f.read().strip()
-            f.close()
-        except (OSError, IOError), e:
-            raise errors.AnsibleError("Could not read %s: %s" % (this_path, e))
-
-        if not options.ask_vault_pass:
-            vault_pass = tmp_vault_pass
+    # read vault_pass from a file
+    if not options.ask_vault_pass and options.vault_password_file:
+        vault_pass = utils.read_vault_file(options.vault_password_file)
 
     extra_vars = {}
     for extra_vars_opt in options.extra_vars:

--- a/docsite/rst/playbooks_vault.rst
+++ b/docsite/rst/playbooks_vault.rst
@@ -83,11 +83,15 @@ To run a playbook that contains vault-encrypted data files, you must pass one of
 
 This prompt will then be used to decrypt (in memory only) any vault encrypted files that are accessed.  Currently this requires that all passwords be encrypted with the same password.
 
-Alternatively, passwords can be specified with a file.  If this is done, be careful to ensure permissions on the file are such that no one else can access your key, and do not add your key to source control::
+Alternatively, passwords can be specified with a file or a script.  If this is done, be careful to ensure permissions on the file are such that no one else can access your key, and do not add your key to source control::
 
     ansible-playbook site.yml --vault-password-file ~/.vault_pass.txt
 
+    ansible-playbook site.yml --vault-password-file ~/.vault_pass.py
+
 The password should be a string stored as a single line in the file.
+
+If you are using a script instead of a flat file, ensure that it is marked as executable, and that the password is printed to STDOUT.  If your script needs to prompt for data, prompts can be sent to STDERR.
 
 This is likely something you may wish to do if using Ansible from a continuous integration system like Jenkins.
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -118,6 +118,7 @@ DEFAULT_SUDO_USER         = get_config(p, DEFAULTS, 'sudo_user',        'ANSIBLE
 DEFAULT_ASK_SUDO_PASS     = get_config(p, DEFAULTS, 'ask_sudo_pass',    'ANSIBLE_ASK_SUDO_PASS',    False, boolean=True)
 DEFAULT_REMOTE_PORT       = get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      None, integer=True)
 DEFAULT_ASK_VAULT_PASS    = get_config(p, DEFAULTS, 'ask_vault_pass',    'ANSIBLE_ASK_VAULT_PASS',    False, boolean=True)
+DEFAULT_VAULT_PASSWORD_FILE = shell_expand_path(get_config(p, DEFAULTS, 'vault_password_file', 'ANSIBLE_VAULT_PASSWORD_FILE', None))
 DEFAULT_TRANSPORT         = get_config(p, DEFAULTS, 'transport',        'ANSIBLE_TRANSPORT',        'smart')
 DEFAULT_SCP_IF_SSH        = get_config(p, 'ssh_connection', 'scp_if_ssh',       'ANSIBLE_SCP_IF_SSH',       False, boolean=True)
 DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')


### PR DESCRIPTION
This pull request updates `--vault-password-file` to work much like `-i/--inventory` in that it will check if the file is executable and if so it will execute it.

The password provided by the script should be sent to STDOUT (`\r` and `\n` are stripped from the output).

STDERR is not captured to make it easier for users who may need to prompt for input via the script.

Additionally, this pull request adds an `ANSIBLE_VAULT_PASSWORD_FILE` environment variable, and a config file option of `vault_password_file`.

This would allow for things such as #7097 to be implemented in a way more standard with how ansible works with other scripts.
