### PR TITLE
ec2_group: Fix for 500 error when creating new security groups

### DIFF
--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -230,6 +230,10 @@ def main():
                 # to 0.0.0.0/0 is added automatically but it's not
                 # reflected in the object returned by the AWS API
                 # call. We re-read the group for getting an updated object
+                # amazon sometimes takes a couple seconds to update the security group so wait till it exists
+                while len(ec2.get_all_security_groups(filters={ 'group_id': group.id, })) == 0:
+                    time.sleep(0.1)
+
                 group = ec2.get_all_security_groups(group_ids=(group.id,))[0]
             changed = True
     else:


### PR DESCRIPTION
Amazon will sometimes not propagate the creation of the new security group fast enough, causing the ansible module to error out with a 500.

This fixes that problem by checking until the security group has propagated and then running:

group = ec2.get_all_security_groups(group_ids=(group.id,))[0]
