### PR TITLE
made nested lists diff lengths - caused confusion

### DIFF
--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -53,7 +53,7 @@ Loops can be nested as well::
     - name: give users access to multiple databases
       mysql_user: name={{ item[0] }} priv={{ item[1] }}.*:ALL append_privs=yes password=foo
       with_nested:
-        - [ 'alice', 'bob', 'eve' ]
+        - [ 'alice', 'bob' ]
         - [ 'clientdb', 'employeedb', 'providerdb' ]
 
 As with the case of 'with_items' above, you can use previously defined variables. Just specify the variable's name without templating it with '{{ }}'::


### PR DESCRIPTION
As a relatively-new user to Ansible, the Nested Loop example made me think it was looping through both lists together (`alice` would go with `clientdb`, `bob` with `employeedb`) and not actually nested. I realize now I was just being stupid, but I feel making the example lists different lengths would prevent such confusion in the future.
