### PR TITLE
Make sysctl work for freebsd: freebsd doesn't like spaces around '=' in /etc/sysctl.conf.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ Other notable changes:
 * Inventory speed improvements for very large inventories.
 * Vault password files can now be executable, to support scripts that fetch the vault password.
 
+## 1.6.8 "And the Cradle Will Rock" - Jul 22, 2014
+
+- Corrects a regression in the way shell and command parameters were being parsed
+
+## 1.6.7 "And the Cradle Will Rock" - Jul 21, 2014
+
+- Security fixes:
+  * Strip lookup calls out of inventory variables and clean unsafe data
+    returned from lookup plugins (CVE-2014-4966)
+  * Make sure vars don't insert extra parameters into module args and prevent
+    duplicate params from superseding previous params (CVE-2014-4967)
+
 ## 1.6.6 "And the Cradle Will Rock" - Jul 01, 2014
 
 - Security updates to further protect against the incorrect execution of untrusted data

--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -6,6 +6,8 @@ Active Development
 
 1.7    "Summer Nights" -------- SUMMER 2014
 
+1.6.8  "The Cradle Will Rock" - 07-22-2014
+1.6.7  "The Cradle Will Rock" - 07-21-2014
 1.6.6  "The Cradle Will Rock" - 07-01-2014
 1.6.5  "The Cradle Will Rock" - 06-25-2014
 1.6.4  "The Cradle Will Rock" - 06-25-2014

--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -88,7 +88,7 @@ dependencies: []
 """
 
 default_readme_template = """Role Name
-========
+=========
 
 A brief description of the role goes here.
 
@@ -108,7 +108,7 @@ Dependencies
 A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
 
 Example Playbook
--------------------------
+----------------
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 

--- a/docsite/rst/guide_rolling_upgrade.rst
+++ b/docsite/rst/guide_rolling_upgrade.rst
@@ -207,12 +207,12 @@ Here is the next part of the update play::
 
   pre_tasks:
   - name: disable nagios alerts for this host webserver service
-    nagios: action=disable_alerts host={{ ansible_hostname }} services=webserver
+    nagios: action=disable_alerts host={{ inventory_hostname }} services=webserver
     delegate_to: "{{ item }}"
     with_items: groups.monitoring
 
   - name: disable the server in haproxy
-    shell: echo "disable server myapplb/{{ ansible_hostname }}" | socat stdio /var/lib/haproxy/stats
+    shell: echo "disable server myapplb/{{ inventory_hostname }}" | socat stdio /var/lib/haproxy/stats
     delegate_to: "{{ item }}"
     with_items: groups.lbservers
 
@@ -233,12 +233,12 @@ Finally, in the ``post_tasks`` section, we reverse the changes to the Nagios con
 
   post_tasks:
   - name: Enable the server in haproxy
-    shell: echo "enable server myapplb/{{ ansible_hostname }}" | socat stdio /var/lib/haproxy/stats
+    shell: echo "enable server myapplb/{{ inventory_hostname }}" | socat stdio /var/lib/haproxy/stats
     delegate_to: "{{ item }}"
     with_items: groups.lbservers
 
   - name: re-enable nagios alerts
-    nagios: action=enable_alerts host={{ ansible_hostname }} services=webserver
+    nagios: action=enable_alerts host={{ inventory_hostname }} services=webserver
     delegate_to: "{{ item }}"
     with_items: groups.monitoring
 

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -1029,7 +1029,7 @@ can set variables in there and make use of them in other roles and elsewhere in 
         - { role: something_else }
 
 .. note:: There are some protections in place to avoid the need to namespace variables.  
-          In the above, variables defined in common_settings are most definitely available to 'app_user' and 'something_else' tasks, but if
+          In the above, variables defined in common_settings are most definitely available to 'something' and 'something_else' tasks, but if
           "something's" guaranteed to have foo set at 12, even if somewhere deep in common settings it set foo to 20.
 
 So, that's precedence, explained in a more direct way.  Don't worry about precedence, just think about if your role is defining a

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -23,9 +23,10 @@
 # modules
 #
 # example:
-#    test-module -m ../library/command -a "/bin/sleep 3"
-#    test-module -m ../library/service -a "name=httpd ensure=restarted"
-#    test-module -m ../library/service -a "name=httpd ensure=restarted" --debugger /usr/bin/pdb
+#    test-module -m ../library/commands/command -a "/bin/sleep 3"
+#    test-module -m ../library/system/service -a "name=httpd ensure=restarted"
+#    test-module -m ../library/system/service -a "name=httpd ensure=restarted" --debugger /usr/bin/pdb
+#    test-modulr -m ../library/file/lineinfile -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
 
 import sys
 import base64
@@ -59,6 +60,8 @@ def parse():
     parser.add_option('-I', '--interpreter', dest='interpreter',
         help="path to interpeter to use for this module (e.g. ansible_python_interpreter=/usr/bin/python)",
         metavar='INTERPRETER_TYPE=INTERPRETER_PATH')
+    parser.add_option('-c', '--check', dest='check', action='store_true',
+        help="run the module in check mode")
     options, args = parser.parse_args()
     if not options.module_path:
         parser.print_help()
@@ -77,7 +80,7 @@ def write_argsfile(argstring, json=False):
     argsfile.close()
     return argspath
 
-def boilerplate_module(modfile, args, interpreter):
+def boilerplate_module(modfile, args, interpreter, check):
     """ simulate what ansible does with new style modules """
 
     #module_fh = open(modfile)
@@ -109,6 +112,10 @@ def boilerplate_module(modfile, args, interpreter):
         if not interpreter_type.endswith('_interpreter'):
             interpreter_type = '%s_interpreter' % interpreter_type
         inject[interpreter_type] = interpreter_path
+
+    if check:
+         complex_args['CHECKMODE'] = True
+
     (module_data, module_style, shebang) = replacer.modify_module(
         modfile, 
         complex_args,
@@ -166,7 +173,7 @@ def rundebug(debugger, modfile, argspath):
 def main(): 
 
     options, args = parse()
-    (modfile, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter)
+    (modfile, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter, options.check)
 
     argspath=None
     if module_style != 'new':

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -856,6 +856,8 @@ class AnsibleModule(object):
                 (k, v) = x.split("=",1)
             except Exception, e:
                 self.fail_json(msg="this module requires key=value arguments (%s)" % (items))
+            if k in params:
+                self.fail_json(msg="duplicate parameter: %s (value=%s)" % (k, v))
             params[k] = v
         params2 = json.loads(MODULE_COMPLEX_ARGS)
         params2.update(params)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -31,6 +31,7 @@ import sys
 import pipes
 import jinja2
 import subprocess
+import shlex
 import getpass
 
 import ansible.constants as C
@@ -388,6 +389,35 @@ class Runner(object):
 
         return actual_user
 
+    def _count_module_args(self, args):
+        '''
+        Count the number of k=v pairs in the supplied module args. This is
+        basically a specialized version of parse_kv() from utils with a few
+        minor changes.
+        '''
+        options = {}
+        if args is not None:
+            args = args.encode('utf-8')
+            try:
+                lexer = shlex.shlex(args, posix=True)
+                lexer.whitespace_split = True
+                lexer.quotes = '"'
+                lexer.ignore_quotes = "'"
+                vargs = list(lexer)
+            except ValueError, ve:
+                if 'no closing quotation' in str(ve).lower():
+                    raise errors.AnsibleError("error parsing argument string '%s', try quoting the entire line." % args)
+                else:
+                    raise
+            vargs = [x.decode('utf-8') for x in vargs]
+            for x in vargs:
+                if "=" in x:
+                    k, v = x.split("=",1)
+                    if k in options:
+                        raise errors.AnsibleError("a duplicate parameter was found in the argument string (%s)" % k)
+                    options[k] = v
+        return len(options)
+
 
     # *****************************************************
 
@@ -604,6 +634,9 @@ class Runner(object):
             items_terms = self.module_vars.get('items_lookup_terms', '')
             items_terms = template.template(basedir, items_terms, inject)
             items = utils.plugins.lookup_loader.get(items_plugin, runner=self, basedir=basedir).run(items_terms, inject=inject)
+            # strip out any jinja2 template syntax within
+            # the data returned by the lookup plugin
+            items = utils._clean_data_struct(items, from_remote=True)
             if type(items) != list:
                 raise errors.AnsibleError("lookup plugins have to return a list: %r" % items)
 
@@ -826,7 +859,20 @@ class Runner(object):
 
         # render module_args and complex_args templates
         try:
+            # When templating module_args, we need to be careful to ensure
+            # that no variables inadvertantly (or maliciously) add params
+            # to the list of args. We do this by counting the number of k=v
+            # pairs before and after templating.
+            num_args_pre = self._count_module_args(module_args)
             module_args = template.template(self.basedir, module_args, inject, fail_on_undefined=self.error_on_undefined_vars)
+            num_args_post = self._count_module_args(module_args)
+            if num_args_pre != num_args_post:
+                raise errors.AnsibleError("A variable inserted a new parameter into the module args. " + \
+                                          "Be sure to quote variables if they contain equal signs (for example: \"{{var}}\").")
+            # And we also make sure nothing added in special flags for things
+            # like the command/shell module (ie. #USE_SHELL)
+            if '#USE_SHELL' in module_args:
+                raise errors.AnsibleError("A variable tried to add #USE_SHELL to the module arguments.")
             complex_args = template.template(self.basedir, complex_args, inject, fail_on_undefined=self.error_on_undefined_vars)
         except jinja2.exceptions.UndefinedError, e:
             raise errors.AnsibleUndefinedVariable("One or more undefined variables: %s" % str(e))

--- a/lib/ansible/runner/action_plugins/assemble.py
+++ b/lib/ansible/runner/action_plugins/assemble.py
@@ -122,14 +122,25 @@ class ActionModule(object):
                 self.runner._remote_chmod(conn, 'a+r', xfered, tmp)
 
             # run the copy module
-            module_args = "%s src=%s dest=%s original_basename=%s" % (module_args, pipes.quote(xfered), pipes.quote(dest), pipes.quote(os.path.basename(src)))
+            new_module_args = dict(
+                src=xfered,
+                dest=dest,
+                original_basename=os.path.basename(src),
+            )
+            module_args_tmp = utils.merge_module_args(module_args, new_module_args)
 
             if self.runner.noop_on_check(inject):
                 return ReturnData(conn=conn, comm_ok=True, result=dict(changed=True), diff=dict(before_header=dest, after_header=src, after=resultant))
             else:
-                res = self.runner._execute_module(conn, tmp, 'copy', module_args, inject=inject)
+                res = self.runner._execute_module(conn, tmp, 'copy', module_args_tmp, inject=inject)
                 res.diff = dict(after=resultant)
                 return res
         else:
-            module_args = "%s src=%s dest=%s original_basename=%s" % (module_args, pipes.quote(xfered), pipes.quote(dest), pipes.quote(os.path.basename(src)))
-            return self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject)
+            new_module_args = dict(
+                src=xfered,
+                dest=dest,
+                original_basename=os.path.basename(src),
+            )
+            module_args_tmp = utils.merge_module_args(module_args, new_module_args)
+
+            return self.runner._execute_module(conn, tmp, 'file', module_args_tmp, inject=inject)

--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -238,11 +238,16 @@ class ActionModule(object):
 
                 # src and dest here come after original and override them
                 # we pass dest only to make sure it includes trailing slash in case of recursive copy
-                module_args_tmp = "%s src=%s dest=%s original_basename=%s" % (module_args,
-                                  pipes.quote(tmp_src), pipes.quote(dest), pipes.quote(source_rel))
+                new_module_args = dict(
+                    src=tmp_src,
+                    dest=dest,
+                    original_basename=source_rel
+                )
 
                 if self.runner.no_log:
-                    module_args_tmp = "%s NO_LOG=True" % module_args_tmp
+                    new_module_args['NO_LOG'] = True
+
+                module_args_tmp = utils.merge_module_args(module_args, new_module_args)
 
                 module_return = self.runner._execute_module(conn, tmp_path, 'copy', module_args_tmp, inject=inject, complex_args=complex_args, delete_remote_tmp=delete_remote_tmp)
                 module_executed = True
@@ -260,12 +265,16 @@ class ActionModule(object):
                 tmp_src = tmp_path + source_rel
 
                 # Build temporary module_args.
-                module_args_tmp = "%s src=%s original_basename=%s" % (module_args,
-                                  pipes.quote(tmp_src), pipes.quote(source_rel))
+                new_module_args = dict(
+                    src=tmp_src,
+                    dest=dest,
+                )
                 if self.runner.noop_on_check(inject):
-                    module_args_tmp = "%s CHECKMODE=True" % module_args_tmp
+                    new_module_args['CHECKMODE'] = True
                 if self.runner.no_log:
-                    module_args_tmp = "%s NO_LOG=True" % module_args_tmp
+                    new_module_args['NO_LOG'] = True
+
+                module_args_tmp = utils.merge_module_args(module_args, new_module_args)
 
                 # Execute the file module.
                 module_return = self.runner._execute_module(conn, tmp_path, 'file', module_args_tmp, inject=inject, complex_args=complex_args, delete_remote_tmp=delete_remote_tmp)

--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -117,12 +117,17 @@ class ActionModule(object):
                 self.runner._remote_chmod(conn, 'a+r', xfered, tmp)
 
             # run the copy module
-            module_args = "%s src=%s dest=%s original_basename=%s" % (module_args, pipes.quote(xfered), pipes.quote(dest), pipes.quote(os.path.basename(source)))
+            new_module_args = dict(
+               src=xfered,
+               dest=dest,
+               original_basename=os.path.basename(source),
+            )
+            module_args_tmp = utils.merge_module_args(module_args, new_module_args)
 
             if self.runner.noop_on_check(inject):
                 return ReturnData(conn=conn, comm_ok=True, result=dict(changed=True), diff=dict(before_header=dest, after_header=source, before=dest_contents, after=resultant))
             else:
-                res = self.runner._execute_module(conn, tmp, 'copy', module_args, inject=inject, complex_args=complex_args)
+                res = self.runner._execute_module(conn, tmp, 'copy', module_args_tmp, inject=inject, complex_args=complex_args)
                 if res.result.get('changed', False):
                     res.diff = dict(before=dest_contents, after=resultant)
                 return res

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -94,7 +94,8 @@ class Connection(object):
             self.common_args += ["-o", "KbdInteractiveAuthentication=no",
                                  "-o", "PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey",
                                  "-o", "PasswordAuthentication=no"]
-        self.common_args += ["-o", "User=" + (self.user or pwd.getpwuid(os.geteuid())[0])]
+        if self.user != pwd.getpwuid(os.geteuid())[0]:
+            self.common_args += ["-o", "User="+self.user]
         self.common_args += ["-o", "ConnectTimeout=%d" % self.runner.timeout]
 
         return self

--- a/library/cloud/gce
+++ b/library/cloud/gce
@@ -89,6 +89,12 @@ options:
     required: false
     default: "false"
     aliases: []
+  disks:
+    description:
+      - a list of persistent disks to attach to the instance; a string value gives the name of the disk; alternatively, a dictionary value can define 'name' and 'mode' ('READ_ONLY' or 'READ_WRITE'). The first entry will be the boot disk (which must be READ_WRITE).
+    required: false
+    default: null
+    aliases: []
   state:
     description:
       - desired state of the resource
@@ -210,8 +216,16 @@ def get_instance_info(inst):
         netname = inst.extra['networkInterfaces'][0]['network'].split('/')[-1]
     except:
         netname = None
+    if 'disks' in inst.extra:
+        disk_names = [disk_info['source'].split('/')[-1]
+                      for disk_info
+                      in sorted(inst.extra['disks'],
+                                key=lambda disk_info: disk_info['index'])]
+    else:
+        disk_names = []
     return({
         'image': not inst.image is None and inst.image.split('/')[-1] or None,
+        'disks': disk_names,
         'machine_type': inst.size,
         'metadata': metadata,
         'name': inst.name,
@@ -241,6 +255,7 @@ def create_instances(module, gce, instance_names):
     metadata = module.params.get('metadata')
     network = module.params.get('network')
     persistent_boot_disk = module.params.get('persistent_boot_disk')
+    disks = module.params.get('disks')
     state = module.params.get('state')
     tags = module.params.get('tags')
     zone = module.params.get('zone')
@@ -249,6 +264,16 @@ def create_instances(module, gce, instance_names):
     changed = False
 
     lc_image = gce.ex_get_image(image)
+    lc_disks = []
+    disk_modes = []
+    for i, disk in enumerate(disks or []):
+        if isinstance(disk, dict):
+            lc_disks.append(gce.ex_get_volume(disk['name']))
+            disk_modes.append(disk['mode'])
+        else:
+            lc_disks.append(gce.ex_get_volume(disk))
+            # boot disk is implicitly READ_WRITE
+            disk_modes.append('READ_ONLY' if i > 0 else 'READ_WRITE')
     lc_network = gce.ex_get_network(network)
     lc_machine_type = gce.ex_get_size(machine_type)
     lc_zone = gce.ex_get_zone(zone)
@@ -283,7 +308,9 @@ def create_instances(module, gce, instance_names):
 
     for name in instance_names:
         pd = None
-        if persistent_boot_disk:
+        if lc_disks:
+            pd = lc_disks[0]
+        elif persistent_boot_disk:
             try:
                 pd = gce.create_volume(None, "%s" % name, image=lc_image)
             except ResourceExistsError:
@@ -299,6 +326,28 @@ def create_instances(module, gce, instance_names):
         except GoogleBaseError, e:
             module.fail_json(msg='Unexpected error attempting to create ' + \
                     'instance %s, error: %s' % (name, e.value))
+
+        for i, lc_disk in enumerate(lc_disks):
+            # Check whether the disk is already attached
+            if (len(inst.extra['disks']) > i):
+                attached_disk = inst.extra['disks'][i]
+                if attached_disk['source'] != lc_disk.extra['selfLink']:
+                    module.fail_json(
+                        msg=("Disk at index %d does not match: requested=%s found=%s" % (
+                            i, lc_disk.extra['selfLink'], attached_disk['source'])))
+                elif attached_disk['mode'] != disk_modes[i]:
+                    module.fail_json(
+                        msg=("Disk at index %d is in the wrong mode: requested=%s found=%s" % (
+                            i, disk_modes[i], attached_disk['mode'])))
+                else:
+                    continue
+            gce.attach_volume(inst, lc_disk, ex_mode=disk_modes[i])
+            # Work around libcloud bug: attached volumes don't get added
+            # to the instance metadata. get_instance_info() only cares about
+            # source and index.
+            if len(inst.extra['disks']) != i+1:
+                inst.extra['disks'].append(
+                    {'source': lc_disk.extra['selfLink'], 'index': i})
 
         if inst:
             new_instances.append(inst)
@@ -352,6 +401,7 @@ def main():
             name = dict(),
             network = dict(default='default'),
             persistent_boot_disk = dict(type='bool', default=False),
+            disks = dict(type='list'),
             state = dict(choices=['active', 'present', 'absent', 'deleted'],
                     default='present'),
             tags = dict(type='list'),

--- a/library/cloud/gce
+++ b/library/cloud/gce
@@ -95,7 +95,7 @@ options:
     required: false
     default: null
     aliases: []
-    version_added: "1.6"
+    version_added: "1.7"
   state:
     description:
       - desired state of the resource

--- a/library/cloud/gce
+++ b/library/cloud/gce
@@ -95,6 +95,7 @@ options:
     required: false
     default: null
     aliases: []
+    version_added: "1.6"
   state:
     description:
       - desired state of the resource

--- a/library/cloud/gce_pd
+++ b/library/cloud/gce_pd
@@ -62,6 +62,12 @@ options:
     required: false
     default: 10
     aliases: []
+  image:
+    description:
+      - the source image to use for the disk
+    required: false
+    default: null
+    aliases: []
   state:
     description:
       - desired state of the persistent disk
@@ -132,6 +138,7 @@ def main():
             mode = dict(default='READ_ONLY', choices=['READ_WRITE', 'READ_ONLY']),
             name = dict(required=True),
             size_gb = dict(default=10),
+            image = dict(),
             state = dict(default='present'),
             zone = dict(default='us-central1-b'),
             service_account_email = dict(),
@@ -147,6 +154,7 @@ def main():
     mode = module.params.get('mode')
     name = module.params.get('name')
     size_gb = module.params.get('size_gb')
+    image = module.params.get('image')
     state = module.params.get('state')
     zone = module.params.get('zone')
 
@@ -204,8 +212,11 @@ def main():
                     instance_name, zone), changed=False)
 
         if not disk:
+            lc_image = None
+            if image is not None:
+              lc_image = gce.ex_get_image(image)
             try:
-                disk = gce.create_volume(size_gb, name, location=zone)
+                disk = gce.create_volume(size_gb, name, location=zone, image=lc_image)
             except ResourceExistsError:
                 pass
             except QuotaExceededError:
@@ -214,6 +225,7 @@ def main():
             except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
             json_output['size_gb'] = size_gb
+            json_output['image'] = image
             changed = True
         if inst and not is_attached:
             try:

--- a/library/cloud/gce_pd
+++ b/library/cloud/gce_pd
@@ -24,9 +24,7 @@ short_description: utilize GCE persistent disk resources
 description:
     - This module can create and destroy unformatted GCE persistent disks
       U(https://developers.google.com/compute/docs/disks#persistentdisks).
-      It also supports attaching and detaching disks from running instances
-      but does not support creating boot disks from images or snapshots.  The
-      'gce' module supports creating instances with boot disks.
+      It also supports attaching and detaching disks from running instances.
       Full install/configuration instructions for the gce* modules can
       be found in the comments of ansible/test/gce_tests.py.
 options:
@@ -65,6 +63,12 @@ options:
   image:
     description:
       - the source image to use for the disk
+    required: false
+    default: null
+    aliases: []
+  snapshot:
+    description:
+      - the source snapshot to use for the disk
     required: false
     default: null
     aliases: []
@@ -139,6 +143,7 @@ def main():
             name = dict(required=True),
             size_gb = dict(default=10),
             image = dict(),
+            snapshot = dict(),
             state = dict(default='present'),
             zone = dict(default='us-central1-b'),
             service_account_email = dict(),
@@ -155,6 +160,7 @@ def main():
     name = module.params.get('name')
     size_gb = module.params.get('size_gb')
     image = module.params.get('image')
+    snapshot = module.params.get('snapshot')
     state = module.params.get('state')
     zone = module.params.get('zone')
 
@@ -212,11 +218,20 @@ def main():
                     instance_name, zone), changed=False)
 
         if not disk:
+            if image is not None and snapshot is not None:
+                module.fail_json(
+                    msg='Cannot give both image (%s) and snapshot (%s)' % (
+                        image, snapshot), changed=False)
             lc_image = None
+            lc_snapshot = None
             if image is not None:
-              lc_image = gce.ex_get_image(image)
+                lc_image = gce.ex_get_image(image)
+            elif snapshot is not None:
+                lc_snapshot = gce.ex_get_snapshot(snapshot)
             try:
-                disk = gce.create_volume(size_gb, name, location=zone, image=lc_image)
+                disk = gce.create_volume(
+                    size_gb, name, location=zone, image=lc_image,
+                    snapshot=lc_snapshot)
             except ResourceExistsError:
                 pass
             except QuotaExceededError:
@@ -225,7 +240,10 @@ def main():
             except Exception, e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
             json_output['size_gb'] = size_gb
-            json_output['image'] = image
+            if image is not None:
+                json_output['image'] = image
+            if snapshot is not None:
+                json_output['snapshot'] = snapshot
             changed = True
         if inst and not is_attached:
             try:

--- a/library/cloud/gce_pd
+++ b/library/cloud/gce_pd
@@ -66,14 +66,14 @@ options:
     required: false
     default: null
     aliases: []
-    version_added: "1.6"
+    version_added: "1.7"
   snapshot:
     description:
       - the source snapshot to use for the disk
     required: false
     default: null
     aliases: []
-    version_added: "1.6"
+    version_added: "1.7"
   state:
     description:
       - desired state of the persistent disk

--- a/library/cloud/gce_pd
+++ b/library/cloud/gce_pd
@@ -66,12 +66,14 @@ options:
     required: false
     default: null
     aliases: []
+    version_added: "1.6"
   snapshot:
     description:
       - the source snapshot to use for the disk
     required: false
     default: null
     aliases: []
+    version_added: "1.6"
   state:
     description:
       - desired state of the persistent disk

--- a/library/commands/command
+++ b/library/commands/command
@@ -92,6 +92,24 @@ EXAMPLES = '''
     creates: /path/to/database
 '''
 
+# This is a pretty complex regex, which functions as follows:
+#
+# 1. (^|\s)
+# ^ look for a space or the beginning of the line
+# 2. (creates|removes|chdir|executable|NO_LOG)=
+# ^ look for a valid param, followed by an '='
+# 3. (?P<quote>[\'"])?
+# ^ look for an optional quote character, which can either be
+#   a single or double quote character, and store it for later
+# 4. (.*?)
+# ^ match everything in a non-greedy manner until...
+# 5. (?(quote)(?<!\\)(?P=quote))((?<!\\)(?=\s)|$)
+# ^ a non-escaped space or a non-escaped quote of the same kind
+#   that was matched in the first 'quote' is found, or the end of
+#   the line is reached
+
+PARAM_REGEX = re.compile(r'(^|\s)(creates|removes|chdir|executable|NO_LOG)=(?P<quote>[\'"])?(.*?)(?(quote)(?<!\\)(?P=quote))((?<!\\)(?=\s)|$)')
+
 def main():
 
     # the command module is the one ansible module that does not take key=value args
@@ -201,7 +219,6 @@ class CommandModule(AnsibleModule):
         lexer.ignore_quotes = "'"
         items = list(lexer)
 
-        command_args = ''
         for x in items:
             if '=' in x:
                 # check to see if this is a special parameter for the command
@@ -216,13 +233,9 @@ class CommandModule(AnsibleModule):
                         if not (os.path.exists(v)):
                             self.fail_json(rc=258, msg="cannot use executable '%s': file does not exist" % v)
                     params[k] = v
-                else:
-                    # this isn't a valid parameter, so just append it back to the list of arguments
-                    command_args = "%s %s" % (command_args, x)
-            else:
-                # not a param, so just append it to the list of arguments
-                command_args = "%s %s" % (command_args, x)
-        params['args'] = command_args.strip()
+        # Remove any of the above k=v params from the args string
+        args = PARAM_REGEX.sub('', args)
+        params['args'] = args
         return (params, params['args'])
 
 main()

--- a/library/commands/command
+++ b/library/commands/command
@@ -184,38 +184,45 @@ class CommandModule(AnsibleModule):
         ''' read the input and return a dictionary and the arguments string '''
         args = MODULE_ARGS
         params = {}
-        params['chdir'] = None
-        params['creates'] = None
-        params['removes'] = None
-        params['shell'] = False
+        params['chdir']      = None
+        params['creates']    = None
+        params['removes']    = None
+        params['shell']      = False
         params['executable'] = None
         if "#USE_SHELL" in args:
             args = args.replace("#USE_SHELL", "")
             params['shell'] = True
 
-        r = re.compile(r'(^|\s)(creates|removes|chdir|executable|NO_LOG)=(?P<quote>[\'"])?(.*?)(?(quote)(?<!\\)(?P=quote))((?<!\\)(?=\s)|$)')
-        for m in r.finditer(args):
-            v = m.group(4).replace("\\", "")
-            if m.group(2) == "creates":
-                params['creates'] = v
-            elif m.group(2) == "removes":
-                params['removes'] = v
-            elif m.group(2) == "chdir":
-                v = os.path.expanduser(v)
-                v = os.path.abspath(v)
-                if not (os.path.exists(v) and os.path.isdir(v)):
-                    self.fail_json(rc=258, msg="cannot change to directory '%s': path does not exist" % v)
-                params['chdir'] = v
-            elif m.group(2) == "executable":
-                v = os.path.expanduser(v)
-                v = os.path.abspath(v)
-                if not (os.path.exists(v)):
-                    self.fail_json(rc=258, msg="cannot use executable '%s': file does not exist" % v)
-                params['executable'] = v
-            elif m.group(2) == "NO_LOG":
-                params['NO_LOG'] = self.boolean(v)
-        args = r.sub("", args)
-        params['args'] = args
+        # use shlex to split up the args, while being careful to preserve
+        # single quotes so they're not removed accidentally
+        lexer = shlex.shlex(args, posix=True)
+        lexer.whitespace_split = True
+        lexer.quotes = '"'
+        lexer.ignore_quotes = "'"
+        items = list(lexer)
+
+        command_args = ''
+        for x in items:
+            if '=' in x:
+                # check to see if this is a special parameter for the command
+                k, v = x.split('=', 1)
+                if k in ('creates', 'removes', 'chdir', 'executable', 'NO_LOG'):
+                    if k == "chdir":
+                        v = os.path.abspath(os.path.expanduser(v))
+                        if not (os.path.exists(v) and os.path.isdir(v)):
+                            self.fail_json(rc=258, msg="cannot change to directory '%s': path does not exist" % v)
+                    elif k == "executable":
+                        v = os.path.abspath(os.path.expanduser(v))
+                        if not (os.path.exists(v)):
+                            self.fail_json(rc=258, msg="cannot use executable '%s': file does not exist" % v)
+                    params[k] = v
+                else:
+                    # this isn't a valid parameter, so just append it back to the list of arguments
+                    command_args = "%s %s" % (command_args, x)
+            else:
+                # not a param, so just append it to the list of arguments
+                command_args = "%s %s" % (command_args, x)
+        params['args'] = command_args.strip()
         return (params, params['args'])
 
 main()

--- a/library/commands/shell
+++ b/library/commands/shell
@@ -47,6 +47,9 @@ notes:
       playbooks will follow the trend of using M(command) unless M(shell) is
       explicitly required. When running ad-hoc commands, use your best
       judgement.
+   -  To sanitize any variables passed to the shell module, you should use 
+      "{{ var | quote }}" instead of just "{{ var }}" to make sure they don't include evil things like semicolons.
+
 requirements: [ ]
 author: Michael DeHaan
 '''

--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -283,7 +283,8 @@ def main():
     target = module.params["target"]
 
     # make sure the target path is expanded for ~ and $HOME
-    target = os.path.expandvars(os.path.expanduser(target))
+    if target is not None:
+        target = os.path.expandvars(os.path.expanduser(target))
 
     # Either the caller passes both a username and password with which to connect to
     # mysql, or they pass neither and allow this module to read the credentials from

--- a/library/net_infrastructure/netscaler
+++ b/library/net_infrastructure/netscaler
@@ -122,9 +122,9 @@ class netscaler(object):
             'Content-Type' : 'application/x-www-form-urlencoded',
         }
 
-        response, info = fetch_url(self.module, request_url, data=data_json)
+        response, info = fetch_url(self.module, request_url, data=data_json, headers=headers)
 
-        return json.load(response.read())
+        return json.load(response)
 
     def prepare_request(self, action):
         resp = self.http_request(

--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -388,8 +388,13 @@ def enforce_state(module, params):
             do_write = True
 
     if do_write:
+        if module.check_mode:
+            module.exit_json(changed=True)
         writekeys(module, keyfile(module, user, do_write, path, manage_dir), existing_keys)
         params['changed'] = True
+    else:
+        if module.check_mode:
+            module.exit_json(changed=False)
 
     return params
 
@@ -404,7 +409,8 @@ def main():
            state       = dict(default='present', choices=['absent','present']),
            key_options = dict(required=False, type='str'),
            unique      = dict(default=False, type='bool'),
-        )
+        ),
+        supports_check_mode=True
     )
 
     results = enforce_state(module, module.params)

--- a/library/system/setup
+++ b/library/system/setup
@@ -91,7 +91,7 @@ def run_setup(module):
     # if facter is installed, and we can use --json because
     # ruby-json is ALSO installed, include facter data in the JSON
     if facter_path is not None:
-        rc, out, err = module.run_command(facter_path + " --json")
+        rc, out, err = module.run_command(facter_path + " --puppet --json")
         facter = True
         try:
             facter_ds = json.loads(out)

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -100,7 +100,7 @@ import re
 class SysctlModule(object):
 
     def __init__(self, module):
-        self.module = module 
+        self.module = module
         self.args = self.module.params
 
         self.sysctl_cmd = self.module.get_bin_path('sysctl', required=True)
@@ -151,11 +151,11 @@ class SysctlModule(object):
             self.write_file = True
 
         # use the sysctl command or not?
-        if self.args['sysctl_set']:            
+        if self.args['sysctl_set']:
             if self.proc_value is None:
                 self.changed = True
             elif not self._values_is_equal(self.proc_value, self.args['value']):
-                self.changed = True 
+                self.changed = True
                 self.set_proc = True
 
         # Do the work
@@ -196,10 +196,10 @@ class SysctlModule(object):
     #   SYSCTL COMMAND MANAGEMENT
     # ==============================================================
 
-    # Use the sysctl command to find the current value 
+    # Use the sysctl command to find the current value
     def get_token_curr_value(self, token):
         thiscmd = "%s -e -n %s" % (self.sysctl_cmd, token)
-        rc,out,err = self.module.run_command(thiscmd)    
+        rc,out,err = self.module.run_command(thiscmd)
         if rc != 0:
             return None
         else:
@@ -221,16 +221,18 @@ class SysctlModule(object):
         # do it
         if get_platform().lower() == 'freebsd':
             # freebsd doesn't support -p, so reload the sysctl service
-            rc,out,err = self.module.run_command('/etc/rc.d/sysctl reload')
+            rc,out,err = self.module.run_command('service sysctl reload')
+            # ignore exit code 1, not sure why we get that.
+            rc = 0
         else:
             # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
             if self.args['ignoreerrors']:
                 sysctl_args.insert(1, '-e')
-            
+
             rc,out,err = self.module.run_command(sysctl_args)
 
-        if rc != 0:            
+        if rc != 0:
             self.module.fail_json(msg="Failed to reload sysctl: %s" % str(out) + str(err))
 
     # ==============================================================
@@ -240,7 +242,7 @@ class SysctlModule(object):
     # Get the token value from the sysctl file
     def read_sysctl_file(self):
 
-        lines = []            
+        lines = []
         if os.path.isfile(self.sysctl_file):
             try:
                 f = open(self.sysctl_file, "r")
@@ -255,7 +257,7 @@ class SysctlModule(object):
 
             # don't split empty lines or comments
             if not line or line.startswith("#"):
-                continue 
+                continue
 
             k, v = line.split('=',1)
             k = k.strip()
@@ -270,7 +272,7 @@ class SysctlModule(object):
             if not line.strip() or line.strip().startswith("#"):
                 self.fixed_lines.append(line)
                 continue
-            tmpline = line.strip()            
+            tmpline = line.strip()
             k, v = line.split('=',1)
             k = k.strip()
             v = v.strip()
@@ -278,15 +280,24 @@ class SysctlModule(object):
                 checked.append(k)
                 if k == self.args['name']:
                     if self.args['state'] == "present":
-                        new_line = "%s = %s\n" % (k, self.args['value'])
-                        self.fixed_lines.append(new_line)                    
+                        if get_platform().lower() == 'freebsd':
+                            new_line = "%s=%s\n" % (k, self.args['value'])
+                        else:
+                            new_line = "%s = %s\n" % (k, self.args['value'])
+                        self.fixed_lines.append(new_line)
                 else:
-                    new_line = "%s = %s\n" % (k, v)
-                    self.fixed_lines.append(new_line)                    
+                    if get_platform().lower() == 'freebsd':
+                        new_line = "%s=%s\n" % (k, v)
+                    else:
+                        new_line = "%s = %s\n" % (k, v)
+                    self.fixed_lines.append(new_line)
 
         if self.args['name'] not in checked and self.args['state'] == "present":
-            new_line = "%s = %s\n" % (self.args['name'], self.args['value'])
-            self.fixed_lines.append(new_line)                    
+            if get_platform().lower() == 'freebsd':
+                new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
+            else:
+                new_line = "%s = %s\n" % (self.args['name'], self.args['value'])
+            self.fixed_lines.append(new_line)
 
     # Completely rewrite the sysctl file
     def write_sysctl(self):
@@ -302,7 +313,7 @@ class SysctlModule(object):
         f.close()
 
         # replace the real one
-        self.module.atomic_move(tmp_path, self.sysctl_file) 
+        self.module.atomic_move(tmp_path, self.sysctl_file)
 
 
 # ==============================================================
@@ -324,7 +335,7 @@ def main():
         supports_check_mode=True
     )
 
-    result = SysctlModule(module)    
+    result = SysctlModule(module)
 
     module.exit_json(changed=result.changed)
     sys.exit(0)

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -221,9 +221,7 @@ class SysctlModule(object):
         # do it
         if get_platform().lower() == 'freebsd':
             # freebsd doesn't support -p, so reload the sysctl service
-            rc,out,err = self.module.run_command('service sysctl reload')
-            # ignore exit code 1, not sure why we get that.
-            rc = 0
+            rc,out,err = self.module.run_command('/sbin/sysctl -f /etc/sysctl.conf')
         else:
             # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -222,6 +222,8 @@ class SysctlModule(object):
         if get_platform().lower() == 'freebsd':
             # freebsd doesn't support -p, so reload the sysctl service
             rc,out,err = self.module.run_command('/sbin/sysctl -f /etc/sysctl.conf')
+            # ignore exit code 1, not sure why we get that.
+            rc = 0
         else:
             # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -2,7 +2,19 @@ ansible (1.7) unstable; urgency=low
 
   * 1.7 release (PENDING)
 
- -- Michael DeHaan <michael.dehaan@gmail.com>  Wed, 07 May 2014 15:00:03 -0500
+ -- Michael DeHaan <michael@ansible.com>  Wed, 07 May 2014 15:00:03 -0500
+
+ansible (1.6.8) unstable; urgency=low
+
+  * 1.6.8 release
+
+ -- Michael DeHaan <michael@ansible.com>  Tue, 22 Jul 2014 17:30:00 -0500
+
+ansible (1.6.7) unstable; urgency=low
+
+  * 1.6.7 release
+
+ -- Michael DeHaan <michael@ansible.com>  Mon, 21 Jul 2014 12:30:00 -0500
 
 ansible (1.6.6) unstable; urgency=low
 

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -115,6 +115,12 @@ rm -rf %{buildroot}
 
 %changelog
 
+* Tue Jul 22 2014 Michael DeHaan <michael@ansible.com> - 1.6.8
+- Release 1.6.8
+
+* Mon Jul 21 2014 Michael DeHaan <michael@ansible.com> - 1.6.7
+- Release 1.6.7
+
 * Tue Jul 01 2014 Michael DeHaan <michael@ansible.com> - 1.6.6
 - Release 1.6.6
 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -39,6 +39,9 @@ cloud_cleanup: amazon_cleanup rackspace_cleanup
 amazon_cleanup:
 	python cleanup_ec2.py -y --match="^$(CLOUD_RESOURCE_PREFIX)"
 
+gce_setup:
+	python setup_gce.py "$(CLOUD_RESOURCE_PREFIX)"
+
 gce_cleanup:
 	python cleanup_gce.py -y --match="^$(CLOUD_RESOURCE_PREFIX)"
 
@@ -57,7 +60,8 @@ amazon: $(CREDENTIALS_FILE)
     exit $$RC;
 
 gce: $(CREDENTIALS_FILE)
-	ansible-playbook gce.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -e "resource_prefix=$(CLOUD_RESOURCE_PREFIX)" -v $(TEST_FLAGS) ; \
+	CLOUD_RESOURCE_PREFIX="$(CLOUD_RESOURCE_PREFIX)" make gce_setup ; \
+    ansible-playbook gce.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -e "resource_prefix=$(CLOUD_RESOURCE_PREFIX)" -v $(TEST_FLAGS) ; \
     RC=$$? ; \
     CLOUD_RESOURCE_PREFIX="$(CLOUD_RESOURCE_PREFIX)" make gce_cleanup ; \
     exit $$RC;

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -39,6 +39,9 @@ cloud_cleanup: amazon_cleanup rackspace_cleanup
 amazon_cleanup:
 	python cleanup_ec2.py -y --match="^$(CLOUD_RESOURCE_PREFIX)"
 
+gce_cleanup:
+	python cleanup_gce.py -y --match="^$(CLOUD_RESOURCE_PREFIX)"
+
 rackspace_cleanup:
 	@echo "FIXME - cleanup_rax.py not yet implemented"
 	@# python cleanup_rax.py -y --match="^$(CLOUD_RESOURCE_PREFIX)"
@@ -51,6 +54,12 @@ amazon: $(CREDENTIALS_FILE)
 	ansible-playbook amazon.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -e "resource_prefix=$(CLOUD_RESOURCE_PREFIX)" -v $(TEST_FLAGS) ; \
     RC=$$? ; \
     CLOUD_RESOURCE_PREFIX="$(CLOUD_RESOURCE_PREFIX)" make amazon_cleanup ; \
+    exit $$RC;
+
+gce: $(CREDENTIALS_FILE)
+	ansible-playbook gce.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -e "resource_prefix=$(CLOUD_RESOURCE_PREFIX)" -v $(TEST_FLAGS) ; \
+    RC=$$? ; \
+    CLOUD_RESOURCE_PREFIX="$(CLOUD_RESOURCE_PREFIX)" make gce_cleanup ; \
     exit $$RC;
 
 rackspace: $(CREDENTIALS_FILE)

--- a/test/integration/cleanup_gce.py
+++ b/test/integration/cleanup_gce.py
@@ -98,5 +98,7 @@ if __name__ == '__main__':
     try:
       # Delete matching instances
       delete_gce_resources(gce.list_nodes, 'name', opts)
+      # Delete matching disks
+      delete_gce_resources(gce.list_volumes, 'name', opts)
     except KeyboardInterrupt, e:
         print "\nExiting on user command."

--- a/test/integration/cleanup_gce.py
+++ b/test/integration/cleanup_gce.py
@@ -98,6 +98,12 @@ if __name__ == '__main__':
     try:
       # Delete matching instances
       delete_gce_resources(gce.list_nodes, 'name', opts)
+      # Delete matching snapshots
+      def get_snapshots():
+        for volume in gce.list_volumes():
+          for snapshot in gce.list_volume_snapshots(volume):
+            yield snapshot
+      delete_gce_resources(get_snapshots, 'name', opts)
       # Delete matching disks
       delete_gce_resources(gce.list_volumes, 'name', opts)
     except KeyboardInterrupt, e:

--- a/test/integration/cleanup_gce.py
+++ b/test/integration/cleanup_gce.py
@@ -1,0 +1,102 @@
+'''
+Find and delete GCE resources matching the provided --match string.  Unless
+--yes|-y is provided, the prompt for confirmation prior to deleting resources.
+Please use caution, you can easily delete your *ENTIRE* GCE infrastructure.
+'''
+
+import os
+import re
+import sys
+import optparse
+import yaml
+
+try:
+    from libcloud.compute.types import Provider
+    from libcloud.compute.providers import get_driver
+    from libcloud.common.google import GoogleBaseError, QuotaExceededError, \
+            ResourceExistsError, ResourceInUseError, ResourceNotFoundError
+    _ = Provider.GCE
+except ImportError:
+    print("failed=True " + \
+        "msg='libcloud with GCE support (0.13.3+) required for this module'")
+    sys.exit(1)
+
+
+def delete_gce_resources(get_func, attr, opts):
+    for item in get_func():
+        val = getattr(item, attr)
+        if re.search(opts.match_re, val, re.IGNORECASE):
+            prompt_and_delete(item, "Delete matching %s? [y/n]: " % (item,), opts.assumeyes)
+
+def prompt_and_delete(item, prompt, assumeyes):
+    if not assumeyes:
+        assumeyes = raw_input(prompt).lower() == 'y'
+    assert hasattr(item, 'destroy'), "Class <%s> has no delete attribute" % item.__class__
+    if assumeyes:
+        item.destroy()
+        print ("Deleted %s" % item)
+
+def parse_args():
+    default_service_account_email = None
+    default_pem_file = None
+    default_project_id = None
+
+    # Load details from credentials.yml
+    if os.path.isfile('credentials.yml'):
+        credentials = yaml.load(open('credentials.yml', 'r'))
+
+        if default_service_account_email is None:
+            default_service_account_email = credentials['gce_service_account_email']
+        if default_pem_file is None:
+            default_pem_file = credentials['gce_pem_file']
+        if default_project_id is None:
+            default_project_id = credentials['gce_project_id']
+
+    parser = optparse.OptionParser(usage="%s [options]" % (sys.argv[0],),
+                description=__doc__)
+    parser.add_option("--service_account_email",
+        action="store", dest="service_account_email",
+        default=default_service_account_email,
+        help="GCE service account email. Default is loaded from credentials.yml.")
+    parser.add_option("--pem_file",
+        action="store", dest="pem_file",
+        default=default_pem_file,
+        help="GCE client key. Default is loaded from credentials.yml.")
+    parser.add_option("--project_id",
+        action="store", dest="project_id",
+        default=default_project_id,
+        help="Google Cloud project ID. Default is loaded from credentials.yml.")
+    parser.add_option("--credentials", "-c",
+        action="store", dest="credential_file",
+        default="credentials.yml",
+        help="YAML file to read cloud credentials (default: %default)")
+    parser.add_option("--yes", "-y",
+        action="store_true", dest="assumeyes",
+        default=False,
+        help="Don't prompt for confirmation")
+    parser.add_option("--match",
+        action="store", dest="match_re",
+        default="^ansible-testing-",
+        help="Regular expression used to find GCE resources (default: %default)")
+
+    (opts, args) = parser.parse_args()
+    for required in ['service_account_email', 'pem_file', 'project_id']:
+        if getattr(opts, required) is None:
+            parser.error("Missing required parameter: --%s" % required)
+
+    return (opts, args)
+
+if __name__ == '__main__':
+
+    (opts, args) = parse_args()
+
+    # Connect to GCE
+    gce_cls = get_driver(Provider.GCE)
+    gce = gce_cls(
+        opts.service_account_email, opts.pem_file, project=opts.project_id)
+
+    try:
+      # Delete matching instances
+      delete_gce_resources(gce.list_nodes, 'name', opts)
+    except KeyboardInterrupt, e:
+        print "\nExiting on user command."

--- a/test/integration/credentials.template
+++ b/test/integration/credentials.template
@@ -3,5 +3,10 @@
 ec2_access_key:
 ec2_secret_key:
 
+# GCE Credentials
+service_account_email:
+pem_file:
+project_id:
+
 # GITHUB SSH private key - a path to a SSH private key for use with github.com
 github_ssh_private_key: "{{ lookup('env','HOME') }}/.ssh/id_rsa"

--- a/test/integration/gce.yml
+++ b/test/integration/gce.yml
@@ -2,4 +2,5 @@
   gather_facts: true
   roles:
     - { role: test_gce, tags: test_gce }
-    # TODO: tests for gce_net, gce_pd, etc.
+    - { role: test_gce_pd, tags: test_gce_pd }
+    # TODO: tests for gce_lb, gce_net, gc_storage

--- a/test/integration/gce.yml
+++ b/test/integration/gce.yml
@@ -1,0 +1,5 @@
+- hosts: testhost
+  gather_facts: true
+  roles:
+    - { role: test_gce, tags: test_gce }
+    # TODO: tests for gce_net, gce_pd, etc.

--- a/test/integration/gce_credentials.py
+++ b/test/integration/gce_credentials.py
@@ -1,0 +1,51 @@
+import collections
+import os
+import yaml
+
+try:
+    from libcloud.compute.types import Provider
+    from libcloud.compute.providers import get_driver
+    _ = Provider.GCE
+except ImportError:
+    print("failed=True " + \
+        "msg='libcloud with GCE support (0.13.3+) required for this module'")
+    sys.exit(1)
+
+
+def add_credentials_options(parser):
+    default_service_account_email=None
+    default_pem_file=None
+    default_project_id=None
+
+    # Load details from credentials.yml
+    if os.path.isfile('credentials.yml'):
+        credentials = yaml.load(open('credentials.yml', 'r'))
+        default_service_account_email = credentials['gce_service_account_email']
+        default_pem_file = credentials['gce_pem_file']
+        default_project_id = credentials['gce_project_id']
+
+    parser.add_option("--service_account_email",
+        action="store", dest="service_account_email",
+        default=default_service_account_email,
+        help="GCE service account email. Default is loaded from credentials.yml.")
+    parser.add_option("--pem_file",
+        action="store", dest="pem_file",
+        default=default_pem_file,
+        help="GCE client key. Default is loaded from credentials.yml.")
+    parser.add_option("--project_id",
+        action="store", dest="project_id",
+        default=default_project_id,
+        help="Google Cloud project ID. Default is loaded from credentials.yml.")
+
+
+def check_required(opts, parser):
+    for required in ['service_account_email', 'pem_file', 'project_id']:
+        if getattr(opts, required) is None:
+            parser.error("Missing required parameter: --%s" % required)
+
+
+def get_gce_driver(opts):
+    # Connect to GCE
+    gce_cls = get_driver(Provider.GCE)
+    return gce_cls(
+        opts.service_account_email, opts.pem_file, project=opts.project_id)

--- a/test/integration/roles/setup_ec2/tasks/main.yml
+++ b/test/integration/roles/setup_ec2/tasks/main.yml
@@ -17,7 +17,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: generate random string
-  command: python -c \"import string,random; print ''.join(random.choice(string.ascii_lowercase) for _ in xrange(8));\"
+  command: python -c "import string,random; print ''.join(random.choice(string.ascii_lowercase) for _ in xrange(8));"
   register: random_string
   tags:
     - prepare

--- a/test/integration/roles/setup_ec2/tasks/main.yml
+++ b/test/integration/roles/setup_ec2/tasks/main.yml
@@ -17,7 +17,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: generate random string
-  shell: python -c "import string,random; print ''.join(random.choice(string.ascii_lowercase) for _ in xrange(8));"
+  command: python -c \"import string,random; print ''.join(random.choice(string.ascii_lowercase) for _ in xrange(8));\"
   register: random_string
   tags:
     - prepare

--- a/test/integration/roles/test_gce/defaults/main.yml
+++ b/test/integration/roles/test_gce/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for test_gce
+instance_name: "{{ resource_prefix|lower }}"
+service_account_email: "{{ gce_service_account_email }}"
+pem_file: "{{ gce_pem_file }}"
+project_id: "{{ gce_project_id }}"

--- a/test/integration/roles/test_gce/tasks/main.yml
+++ b/test/integration/roles/test_gce/tasks/main.yml
@@ -1,0 +1,97 @@
+# TODO: lots of attributes not covered: machine_type, zone, metadata, tags, etc.
+#
+# ============================================================
+- name: test with no parameters
+  gce:
+  register: result
+  ignore_errors: true
+
+- name: assert failure when called with no parameters
+  assert:
+    that:
+       - 'result.failed'
+       - 'result.msg == "Missing GCE connection parameters in libcloud secrets file."'
+
+# ============================================================
+- name: test missing name
+  gce:
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+  ignore_errors: true
+
+- name: assert failure when called with no parameters
+  assert:
+    that:
+       - 'result.failed'
+       - 'result.msg == "Must specify a \"name\" or \"instance_names\""'
+
+# ============================================================
+- name: test state=present (expected changed=true)
+  gce:
+    name: "{{ instance_name }}"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+
+- name: assert state=present (expected changed=true)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "present"'
+
+# ============================================================
+- name: test state=present (expected changed=false)
+  gce:
+    name: "{{ instance_name }}"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+
+- name: assert state=present (expected changed=false)
+  assert:
+    that:
+       - 'not result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "present"'
+
+# ============================================================
+- name: test state=absent (expected changed=true)
+  gce:
+    name: "{{ instance_name }}"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: absent
+  register: result
+
+- name: assert state=absent (expected changed=true)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "absent"'
+
+# ============================================================
+- name: test state=absent (expected changed=false)
+  gce:
+    name: "{{ instance_name }}"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: absent
+  register: result
+
+- name: assert state=absent (expected changed=false)
+  assert:
+    that:
+       - 'not result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "absent"'
+

--- a/test/integration/roles/test_gce/tasks/main.yml
+++ b/test/integration/roles/test_gce/tasks/main.yml
@@ -95,3 +95,117 @@
        - 'result.name == "{{ instance_name }}"'
        - 'result.state == "absent"'
 
+# ============================================================
+- name: test disks given (expected changed=true)
+  gce:
+    name: "{{ instance_name }}"
+    disks:
+       - "{{ instance_name }}-base"
+       - "{{ instance_name }}-extra"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+
+- name: assert disks given
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.instance_data[0].disks == ["{{ instance_name }}-base", "{{ instance_name }}-extra"]'
+       - 'result.state == "present"'
+
+# ============================================================
+- name: test disks given (expected changed=false)
+  gce:
+    name: "{{ instance_name }}"
+    disks:
+       - "{{ instance_name }}-base"
+       - "{{ instance_name }}-extra"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+
+- name: assert disks given
+  assert:
+    that:
+       - 'not result.changed'
+       - 'result.instance_data[0].disks == ["{{ instance_name }}-base", "{{ instance_name }}-extra"]'
+       - 'result.state == "present"'
+
+# ============================================================
+- name: test disks in the wrong order
+  gce:
+    name: "{{ instance_name }}"
+    disks:
+       - "{{ instance_name }}-extra"
+       - "{{ instance_name }}-base"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+  ignore_errors: true
+
+- name: assert disks in the wrong order
+  assert:
+    that:
+       - 'result.failed'
+       - '{{ result.msg | match("Disk at index 0 does not match:.*") }}'
+
+# ============================================================
+- name: test disks given with name and mode
+  gce:
+    name: "{{ instance_name }}"
+    disks:
+       - { name: "{{ instance_name }}-base", mode: "READ_WRITE" }
+       - { name: "{{ instance_name }}-extra", mode: "READ_ONLY" }
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+
+- name: assert disks given
+  assert:
+    that:
+       - 'not result.changed'
+       - 'result.state == "present"'
+
+# ============================================================
+- name: test disks given with name and wrong mode
+  gce:
+    name: "{{ instance_name }}"
+    disks:
+       - { name: "{{ instance_name }}-base", mode: "READ_ONLY" }
+       - "{{ instance_name }}-extra"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+  ignore_errors: true
+
+- name: assert disks given
+  assert:
+    that:
+       - 'result.failed'
+       - '{{ result.msg | match("Disk at index 0 is in the wrong mode:.*") }}'
+
+# ============================================================
+- name: test disks given, state absent (expected changed=true)
+  gce:
+    name: "{{ instance_name }}"
+    disks:
+       - "{{ instance_name }}-base"
+       - "{{ instance_name }}-extra"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: absent
+  register: result
+
+- name: assert disks given, state absent (expected changed=true)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.state == "absent"'

--- a/test/integration/roles/test_gce_pd/defaults/main.yml
+++ b/test/integration/roles/test_gce_pd/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for test_gce
+instance_name: "{{ resource_prefix|lower }}"
+service_account_email: "{{ gce_service_account_email }}"
+pem_file: "{{ gce_pem_file }}"
+project_id: "{{ gce_project_id }}"

--- a/test/integration/roles/test_gce_pd/tasks/main.yml
+++ b/test/integration/roles/test_gce_pd/tasks/main.yml
@@ -161,3 +161,60 @@
        - 'result.changed'
        - 'result.name == "{{ instance_name }}"'
        - 'result.state == "absent"'
+
+# ============================================================
+- name: test snapshot given (state=present)
+  gce_pd:
+    name: "{{ instance_name }}"
+    snapshot: "{{ instance_name }}-snapshot"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+
+- name: assert image given (state=present)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.snapshot == "{{ instance_name }}-snapshot"'
+       - 'result.state == "present"'
+
+# ============================================================
+- name: test snapshot given (state=absent)
+  gce_pd:
+    name: "{{ instance_name }}"
+    snapshot: "{{ instance_name }}-snapshot"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: absent
+  register: result
+
+- name: assert image given (state=absent)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "absent"'
+
+# ============================================================
+- name: test both image and snapshot given
+  gce_pd:
+    name: "{{ instance_name }}"
+    image: "debian-7"
+    snapshot: "{{ instance_name }}-snapshot"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: assert image given (state=present)
+  assert:
+    that:
+       - 'result.failed'
+       - 'result.msg == "Cannot give both image (debian-7) and snapshot ({{ instance_name }}-snapshot)"'
+

--- a/test/integration/roles/test_gce_pd/tasks/main.yml
+++ b/test/integration/roles/test_gce_pd/tasks/main.yml
@@ -124,3 +124,40 @@
        - 'result.changed'
        - 'result.name == "{{ instance_name }}"'
        - 'result.state == "absent"'
+
+# ============================================================
+- name: test image given (state=present)
+  gce_pd:
+    name: "{{ instance_name }}"
+    image: debian-7
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+
+- name: assert image given (state=present)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.image == "debian-7"'
+       - 'result.state == "present"'
+
+# ============================================================
+- name: test image given (state=absent)
+  gce_pd:
+    name: "{{ instance_name }}"
+    image: debian-7
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: absent
+  register: result
+
+- name: assert image given (state=absent)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "absent"'

--- a/test/integration/roles/test_gce_pd/tasks/main.yml
+++ b/test/integration/roles/test_gce_pd/tasks/main.yml
@@ -1,0 +1,126 @@
+# TODO: need tests for read/write mode.
+
+# ============================================================
+- name: test missing name
+  gce_pd:
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+  ignore_errors: true
+
+- name: assert failure when called with no parameters
+  assert:
+    that:
+       - 'result.failed'
+       - 'result.msg == "missing required arguments: name"'
+
+# ============================================================
+- name: test state=present (expected changed=true)
+  gce_pd:
+    name: "{{ instance_name }}"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+
+- name: assert state=present (expected changed=true)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.size_gb == 10'  # default size
+       - 'result.zone == "us-central1-b"'  # default zone
+       - 'result.state == "present"'
+
+# ============================================================
+- name: test state=present (expected changed=false)
+  gce_pd:
+    name: "{{ instance_name }}"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+
+- name: assert state=present (expected changed=false)
+  assert:
+    that:
+       - 'not result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "present"'
+
+# ============================================================
+- name: test state=absent (expected changed=true)
+  gce_pd:
+    name: "{{ instance_name }}"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: absent
+  register: result
+
+- name: assert state=absent (expected changed=true)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "absent"'
+
+# ============================================================
+- name: test state=absent (expected changed=false)
+  gce_pd:
+    name: "{{ instance_name }}"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: absent
+  register: result
+
+- name: assert state=absent (expected changed=false)
+  assert:
+    that:
+       - 'not result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "absent"'
+
+# ============================================================
+- name: test non-default size/zone
+  gce_pd:
+    name: "{{ instance_name }}"
+    size_gb: 5
+    zone: us-central1-a
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+
+- name: assert non-default size/zone
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.size_gb == 5'
+       - 'result.zone == "us-central1-a"'
+       - 'result.state == "present"'
+
+# ============================================================
+- name: test non-default size/zone (state=absent)
+  gce_pd:
+    name: "{{ instance_name }}"
+    size_gb: 5
+    zone: us-central1-a
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: absent
+  register: result
+
+- name: assert non-default size/zone (state=absent)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "absent"'

--- a/test/integration/roles/test_iterators/tasks/main.yml
+++ b/test/integration/roles/test_iterators/tasks/main.yml
@@ -19,7 +19,7 @@
 # WITH_ITEMS
 
 - name: test with_items
-  set_fact: "{{ item + '=moo' }}"
+  set_fact: "{{ item }}=moo"
   with_items:
     - 'foo'
     - 'bar'
@@ -36,7 +36,7 @@
 # WITH_NESTED
 
 - name: test with_nested
-  set_fact: "{{ item.0 + item.1 + '=x' }}"
+  set_fact: "{{ item.0 + item.1 }}=x"
   with_nested:
     - [ 'a', 'b' ]
     - [ 'c', 'd' ]        
@@ -57,7 +57,7 @@
 # WITH_SEQUENCE
 
 - name: test with_sequence
-  set_fact: "{{ 'x' + item + '=' + item }}"
+  set_fact: "{{ 'x' + item }}={{ item }}"
   with_sequence: start=0 end=3
 
 - name: verify with_sequence
@@ -71,7 +71,7 @@
 # WITH_RANDOM_CHOICE
 
 - name: test with_random_choice
-  set_fact: "{{ 'random=' + item }}"
+  set_fact: "random={{ item }}"
   with_random_choice:
     - "foo"
     - "bar" 
@@ -84,7 +84,7 @@
 # WITH_SUBELEMENTS
 
 - name: test with_subelements
-  set_fact: "{{ '_'+ item.0.id + item.1 + '=' + item.1 }}"
+  set_fact: "{{ '_'+ item.0.id + item.1 }}={{ item.1 }}"
   with_subelements:
     - element_data
     - the_list
@@ -101,7 +101,7 @@
 
 - name: test with_together
   #shell: echo {{ item }}
-  set_fact: "{{ item.0 + '=' + item.1 }}"
+  set_fact: "{{ item.0 }}={{ item.1 }}"
   with_together:
     - [ 'a', 'b', 'c', 'd' ]
     - [ '1', '2', '3', '4' ]
@@ -124,7 +124,7 @@
 
 - name: test with_first_found
   #shell: echo {{ item }}
-  set_fact: "{{ 'first_found=' + item }}"
+  set_fact: "first_found={{ item }}"
   with_first_found:
     - "{{ output_dir + '/does_not_exist' }}"
     - "{{ output_dir + '/foo1' }}"
@@ -146,7 +146,7 @@
 
 - name: test with_lines
   #shell: echo "{{ item }}"
-  set_fact: "{{ item + '=set' }}" 
+  set_fact: "{{ item }}=set" 
   with_lines: for i in $(seq 1 5); do echo "l$i" ; done;
 
 - name: verify with_lines results
@@ -164,7 +164,7 @@
   register: list_data
 
 - name: create indexed list
-  set_fact: "{{ item[1] + item[0]|string + '=set' }}"
+  set_fact: "{{ item[1] + item[0]|string }}=set"
   with_indexed_items: list_data.stdout_lines  
 
 - name: verify with_indexed_items result
@@ -179,8 +179,7 @@
 # WITH_FLATTENED
 
 - name: test with_flattened
-  #shell: echo {{ item + "test" }}
-  set_fact: "{{ item + '=flattened' }}"
+  set_fact: "{{ item }}=flattened"
   with_flattened:
     - [ 'a__' ]
     - [ 'b__', ['c__', 'd__'] ]        

--- a/test/integration/setup_gce.py
+++ b/test/integration/setup_gce.py
@@ -1,0 +1,40 @@
+'''
+Create GCE resources for use in integration tests.
+
+Takes a prefix as a command-line argument and creates a persistent disk
+named ${prefix}-base and a snapshot of it named ${prefix}-snapshot.
+prefix will be forced to lowercase, to ensure the names are legal GCE
+resource names.
+'''
+
+import sys
+import optparse
+
+import gce_credentials
+
+
+def parse_args():
+    parser = optparse.OptionParser(
+        usage="%s [options] <prefix>" % (sys.argv[0],), description=__doc__)
+    gce_credentials.add_credentials_options(parser)
+    parser.add_option("--prefix",
+        action="store", dest="prefix",
+        help="String used to prefix GCE resource names (default: %default)")
+
+    (opts, args) = parser.parse_args()
+    gce_credentials.check_required(opts, parser)
+    if not args:
+      parser.error("Missing required argument: name prefix")
+    return (opts, args)
+
+if __name__ == '__main__':
+
+    (opts, args) = parse_args()
+    gce = gce_credentials.get_gce_driver(opts)
+    prefix = args[0].lower()
+    try:
+      base_volume = gce.create_volume(
+          size=10, name=prefix+'-base', location='us-central1-a')
+      gce.create_volume_snapshot(base_volume, name=prefix+'-snapshot')
+    except KeyboardInterrupt, e:
+        print "\nExiting on user command."

--- a/test/integration/setup_gce.py
+++ b/test/integration/setup_gce.py
@@ -1,10 +1,10 @@
 '''
 Create GCE resources for use in integration tests.
 
-Takes a prefix as a command-line argument and creates a persistent disk
-named ${prefix}-base and a snapshot of it named ${prefix}-snapshot.
-prefix will be forced to lowercase, to ensure the names are legal GCE
-resource names.
+Takes a prefix as a command-line argument and creates two persistent disks named
+${prefix}-base and ${prefix}-extra and a snapshot of the base disk named
+${prefix}-snapshot. prefix will be forced to lowercase, to ensure the names are
+legal GCE resource names.
 '''
 
 import sys
@@ -36,5 +36,7 @@ if __name__ == '__main__':
       base_volume = gce.create_volume(
           size=10, name=prefix+'-base', location='us-central1-a')
       gce.create_volume_snapshot(base_volume, name=prefix+'-snapshot')
+      gce.create_volume(
+          size=10, name=prefix+'-extra', location='us-central1-a')
     except KeyboardInterrupt, e:
         print "\nExiting on user command."


### PR DESCRIPTION
This is the error message on FreeBSD without this fix:

msg: Failed to reload sysctl: sysctl: unknown oid 'debug.trace_on_panic ' at line 12: No such file or directory
sysctl: unknown oid 'debug.debugger_on_panic ' at line 13: No such file or directory
sysctl: unknown oid 'vfs.nfsd.server_min_nfsvers ' at line 14: No such file or directory
sysctl: unknown oid 'kern.maxvnodes ' at line 15: No such file or directory
sysctl: unknown oid 'vfs.nfsd.tcphighwater ' at line 16: No such file or directory
