### PR TITLE
Added cross-platform uptime fact

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -140,7 +140,7 @@ class Facts(object):
                 days = int(raw.split()[2])
                 if 'min' in raw:
                     hours = 0
-                    minutes = int(raw[4])
+                    minutes = int(raw.split()[4])
                 else:
                     hours, minutes = map(int, raw.split()[4].split(':'))
                 self.facts['uptime'] = days*24*60*60 + hours*60*60 + minutes*60


### PR DESCRIPTION
Having an uptime fact allows you check after a reboot whether the system was effectively rebooted.

``` yaml
  - name: Safeguard - Was system properly rebooted ?
    action: fail msg="System was not properly rebooted"
    when: ansible_uptime > 900
```

This patch has been tested on Linux, Solaris and HP-UX.
