### PR TITLE
Add exclusive option to authorized_keys

### DIFF
--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -70,6 +70,15 @@ options:
     required: false
     default: null
     version_added: "1.4"
+  exclusive:
+    description:
+      - Whether to remove all other non-specified keys from the
+        authorized_keys file. Multiple keys can be specified in a single
+        key= string value by separating them by newlines.
+    required: false
+    choices: [ yes", "no" ]
+    default: "no"
+    version_added: "1.7"
 description:
     - "Adds or removes authorized keys for particular user accounts"
 author: Brad Olson
@@ -97,6 +106,10 @@ EXAMPLES = '''
 - authorized_key: user=charlie
                   key="{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
                   key_options='no-port-forwarding,host="10.0.1.1"'
+
+# Set up authorized_keys exclusively with one key
+- authorized_keys: user=root key=public_keys/doe-jane state=present
+                   exclusive=yes
 '''
 
 # Makes sure the public key line is present or absent in the user's .ssh/authorized_keys.
@@ -332,6 +345,7 @@ def enforce_state(module, params):
     manage_dir  = params.get("manage_dir", True)
     state       = params.get("state", "present")
     key_options = params.get("key_options", None)
+    exclusive   = params.get("exclusive", False)
 
     # extract indivial keys into an array, skipping blank lines and comments
     key = [s for s in key.splitlines() if s and not s.startswith('#')]
@@ -341,6 +355,10 @@ def enforce_state(module, params):
     do_write = False
     params["keyfile"] = keyfile(module, user, do_write, path, manage_dir)
     existing_keys = readkeys(module, params["keyfile"])
+
+    # Add a place holder for keys that should exist in the state=present and
+    # exclusive=true case
+    keys_to_exist = []
 
     # Check our new keys, if any of them exist we'll continue.
     for new_key in key:
@@ -371,6 +389,7 @@ def enforce_state(module, params):
 
         # handle idempotent state=present
         if state=="present":
+            keys_to_exist.append(parsed_new_key[0])
             if len(non_matching_keys) > 0:
                 for non_matching_key in non_matching_keys:
                     if non_matching_key[0] in existing_keys:
@@ -386,6 +405,14 @@ def enforce_state(module, params):
                 continue
             del existing_keys[parsed_new_key[0]]
             do_write = True
+
+    # remove all other keys to honor exclusive
+    if state == "present" and exclusive:
+        # use .items() here so that we can modify the dict in the loop
+        for existing in existing_keys.items():
+            if existing[0] not in keys_to_exist:
+                del existing_keys[existing[0]]
+                do_write = True
 
     if do_write:
         writekeys(module, keyfile(module, user, do_write, path, manage_dir), existing_keys)
@@ -404,6 +431,7 @@ def main():
            state       = dict(default='present', choices=['absent','present']),
            key_options = dict(required=False, type='str'),
            unique      = dict(default=False, type='bool'),
+           exclusive   = dict(default=False, type='bool'),
         )
     )
 


### PR DESCRIPTION
This option allows the module to ensure that ONLY the specified keys
exist in the authorized_keys file. All others will be removed. This is
quite useful when rotating keys and ensuring no other key will be
accepted.
