### PR TITLE
Fix neutron floating IP allocation for networks w/ multiple subnets

### DIFF
--- a/library/cloud/quantum_floating_ip
+++ b/library/cloud/quantum_floating_ip
@@ -144,11 +144,15 @@ def _get_server_state(module, nova):
 def _get_port_info(neutron, module, instance_id, internal_network_name=None):
     subnet_id = None
     if internal_network_name:
-        kwargs = {
-            'name': internal_network_name,
-        }
+        kwargs = {'name': internal_network_name}
         networks = neutron.list_networks(**kwargs)
-        subnet_id = networks['networks'][0]['subnets'][0]
+        network_id = networks['networks'][0]['id']
+        kwargs = {
+            'network_id': network_id,
+            'ip_version': 4
+        }
+        subnets = neutron.list_subnets(**kwargs)
+        subnet_id = subnets['subnets'][0]['id']
     kwargs = {
             'device_id': instance_id,
     }
@@ -179,10 +183,11 @@ def _get_floating_ip(module, neutron, fixed_ip_address):
         return None, None
     return ips['floatingips'][0]['id'], ips['floatingips'][0]['floating_ip_address']
 
-def _create_floating_ip(neutron, module, port_id, net_id):
+def _create_floating_ip(neutron, module, port_id, net_id, fixed_ip):
     kwargs = {
             'port_id': port_id,
-            'floating_network_id': net_id
+            'floating_network_id': net_id,
+            'fixed_ip_address': fixed_ip
     }
     try:
         result = neutron.create_floatingip({'floatingip': kwargs})
@@ -252,7 +257,7 @@ def main():
         net_id = _get_net_id(neutron, module)
         if not net_id:
             module.fail_json(msg = "cannot find the network specified, please check")
-        _create_floating_ip(neutron, module, port_id, net_id)
+        _create_floating_ip(neutron, module, port_id, net_id, fixed_ip)
 
     if module.params['state'] == 'absent':
         if floating_ip:


### PR DESCRIPTION
For networks that have both a v4 and a v6 subnet, the floating IP plugin
currently has two problems:
- When determining the subnet for the provided `internal_network_name`, it
  assumes that the first item in the list of subnets is the one you want.
  Instead, it should pick the first v4 subnet.
- When multiple fixed IP's exist for a given port (as is the case in a network
  a v4 and a v6 subnet), neutron needs a hint as to which fixed IP to associate
  to the floating IP address (the v4 one).
