### PR TITLE
Add a module for managing packages for the Atom editor

### DIFF
--- a/library/packaging/apm
+++ b/library/packaging/apm
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2014, Hiroaki Nakamura <hnakamur@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: apm
+short_description: Manage atom packages with apm
+description:
+  - Manage atom packages with Atom Package Manager (apm)
+version_added: 1.6.3
+author: Hiroaki Nakamura
+options:
+  name:
+    description:
+      - The name of a atom library to install
+    required: true
+  version:
+    description:
+      - The version to be installed
+    required: false
+  executable:
+    description:
+      - The executable location for apm.
+      - This is useful if apm is not in the PATH.
+    required: false
+  state:
+    description:
+      - The state of the atom library
+    required: false
+    default: present
+    choices: [ "present", "absent", "latest" ]
+'''
+
+EXAMPLES = '''
+description: Install "project-manager" atom package.
+- apm: name=project-manager state=present
+
+description: Update the package "project-manager" to the latest version.
+- npm: name=project-manager state=latest
+
+description: Remove the package "project-manager".
+- npm: name=project-manager state=absent
+'''
+
+import os
+
+class Apm(object):
+    def __init__(self, module, **kwargs):
+        self.module = module
+        self.name = kwargs['name']
+        self.version = kwargs['version']
+
+        if kwargs['executable']:
+            self.executable = kwargs['executable']
+        else:
+            self.executable = module.get_bin_path('apm', True)
+
+        if kwargs['version']:
+            self.name_version = self.name + '@' + self.version
+        else:
+            self.name_version = self.name
+
+    def _exec(self, args, run_in_check_mode=False, check_rc=True):
+        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+            cmd = [self.executable] + args
+            if self.name:
+                cmd.append(self.name_version)
+            rc, out, err = self.module.run_command(cmd, check_rc=check_rc)
+            return out
+        return ''
+
+    def list(self):
+        cmd = ['list']
+
+        installed = list()
+        missing = list()
+        data = self._exec(cmd, True, False)
+        pattern = re.compile('^(?:\xe2\x94\x9c|\xe2\x94\x94)\xe2\x94\x80\xe2\x94\x80\s+(\S+)@')
+        for dep in data.splitlines():
+            m = pattern.match(dep)
+            if m:
+                installed.append(m.group(1))
+        if self.name not in installed:
+            missing.append(self.name)
+
+        return installed, missing
+
+    def install(self):
+        return self._exec(['install'])
+
+    def update(self):
+        return self._exec(['update'])
+
+    def uninstall(self):
+        return self._exec(['uninstall'])
+
+    def list_outdated(self):
+        outdated = list()
+        data = self._exec(['outdated'], True, False)
+        pattern = re.compile('^(?:\xe2\x94\x9c|\xe2\x94\x94)\xe2\x94\x80\xe2\x94\x80\s+(\S+)')
+        for dep in data.splitlines():
+            m = pattern.match(dep)
+            if m and m.group(1) != '(empty)':
+                outdated.append(m.group(1))
+
+        return outdated
+
+
+def main():
+    arg_spec = dict(
+        name=dict(default=None),
+        version=dict(default=None),
+        executable=dict(default=None),
+        state=dict(default='present', choices=['present', 'absent', 'latest'])
+    )
+    module = AnsibleModule(
+        argument_spec=arg_spec,
+        supports_check_mode=True
+    )
+
+    name = module.params['name']
+    version = module.params['version']
+    executable = module.params['executable']
+    state = module.params['state']
+
+    if not name:
+        module.fail_json(msg='name must be specified')
+
+    apm = Apm(module, name=name, version=version, executable=executable)
+
+    changed = False
+    if state == 'present':
+        installed, missing = apm.list()
+        if len(missing):
+            changed = True
+            apm.install()
+    elif state == 'latest':
+        installed, missing = apm.list()
+        outdated = apm.list_outdated()
+        if len(missing) or len(outdated):
+            changed = True
+            apm.install()
+    else: #absent
+        installed, missing = apm.list()
+        if name in installed:
+            changed = True
+            apm.uninstall()
+
+    module.exit_json(changed=changed)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()


### PR DESCRIPTION
You can try this module with my [atom-packages](https://galaxy.ansible.com/list#/roles/1005) role for Ansible.

To install the Atom editor, please run the following commands:

``` shell-session
brew tap caskroom/cask
brew install brew-cask
brew cask install atom
```

Or you can use my [homebrew-cask-packages](https://galaxy.ansible.com/list#/roles/1004) role for Ansible.
