### PR TITLE
support hash merging for ansible_facts

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -469,10 +469,10 @@ class PlayBook(object):
                 for res in result['results']:
                     if type(res) == dict:
                         facts = res.get('ansible_facts', {})
-                        self.SETUP_CACHE[host].update(facts)
+			self.SETUP_CACHE[host] = utils.combine_vars(self.SETUP_CACHE[host], facts)
             else:
                 facts = result.get('ansible_facts', {})
-                self.SETUP_CACHE[host].update(facts)
+		self.SETUP_CACHE[host] = utils.combine_vars(self.SETUP_CACHE[host], facts)
             if task.register:
                 if 'stdout' in result and 'stdout_lines' not in result:
                     result['stdout_lines'] = result['stdout'].splitlines()


### PR DESCRIPTION
This PR enables hash merging for ansible_facts returned by set_fact or include_vars modules.
