### PR TITLE
Fix lineinfile module to properly handle files with no newline at EOF

### DIFF
--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Daniel Hokka Zakrisson <daniel@hozac.com>
+# (c) 2014, Ahti Kitsik <ak@ahtik.com>
 #
 # This file is part of Ansible
 #
@@ -25,7 +26,7 @@ import tempfile
 DOCUMENTATION = """
 ---
 module: lineinfile
-author: Daniel Hokka Zakrisson
+author: Daniel Hokka Zakrisson, Ahti Kitsik
 short_description: Ensure a particular line is in a file, or replace an
                    existing line using a back-referenced regular expression.
 description:
@@ -110,7 +111,7 @@ options:
   validate:
      required: false
      description:
-       - validation to run before copying into place. The command is passed 
+       - validation to run before copying into place. The command is passed
          securely so shell features like expansion and pipes won't work.
      required: false
      default: None
@@ -251,6 +252,11 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
     # if insertafter=/insertbefore didn't match anything
     # (so default behaviour is to add at the end)
     elif insertafter == 'EOF':
+
+        # If the file is not empty then ensure there's a newline before the added line
+        if len(lines)>0 and not (lines[-1].endswith('\n') or lines[-1].endswith('\r')):
+            lines.append(os.linesep)
+
         lines.append(line + os.linesep)
         msg = 'line added'
         changed = True

--- a/test/integration/roles/test_lineinfile/files/testnoeof.txt
+++ b/test/integration/roles/test_lineinfile/files/testnoeof.txt
@@ -1,0 +1,2 @@
+This is line 1
+This is line 2

--- a/test/integration/roles/test_lineinfile/tasks/main.yml
+++ b/test/integration/roles/test_lineinfile/tasks/main.yml
@@ -209,3 +209,50 @@
     that:
     - "result.stat.md5 == 'fef1d487711facfd7aa2c87d788c19d9'"
 
+# Test EOF in cases where file has no newline at EOF
+- name: testnoeof deploy the file for lineinfile
+  copy: src=testnoeof.txt dest={{output_dir}}/testnoeof.txt
+  register: result
+
+- name: testnoeof insert a line at the end of the file
+  lineinfile: dest={{output_dir}}/testnoeof.txt state=present line="New line at the end" insertafter="EOF"
+  register: result
+
+- name: testempty assert that the line was inserted at the end of the file
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line added'"
+
+- name: testnoeof stat the no newline EOF test after the insert at the end
+  stat: path={{output_dir}}/testnoeof.txt
+  register: result
+
+- name: testnoeof assert test md5 matches after the insert at the end
+  assert:
+    that:
+    - "result.stat.md5 == 'f75c9d51f45afd7295000e63ce655220'"
+
+# Test EOF with empty file to make sure no unneccessary newline is added
+- name: testempty deploy the testempty file for lineinfile
+  copy: src=testempty.txt dest={{output_dir}}/testempty.txt
+  register: result
+
+- name: testempty insert a line at the end of the file
+  lineinfile: dest={{output_dir}}/testempty.txt state=present line="New line at the end" insertafter="EOF"
+  register: result
+
+- name: testempty assert that the line was inserted at the end of the file
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line added'"
+
+- name: testempty stat the test after the insert at the end
+  stat: path={{output_dir}}/testempty.txt
+  register: result
+
+- name: testempty assert test md5 matches after the insert at the end
+  assert:
+    that:
+    - "result.stat.md5 == '357dcbee8dfb4436f63bab00a235c45a'"


### PR DESCRIPTION
Currently when using lineinfile with insertafter=EOF for a file that has no newline at EOF then the added line is not prefixed with a newline. Instead it's joined with the last line.

As a concrete example, Ubuntu distro default /etc/ssh/sshd_config has no newline so lineinfile module cannot be used to add a new line to the end of the file.

Also found a related bug: #6881

This fix prefixes insertafter=EOF line inserts with a newline when needed (file is not empty and EOF has no newline).
