### PR TITLE
ec2_lc cleanup

### DIFF
--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -176,7 +176,7 @@ def create_launch_config(connection, module):
     assign_public_ip = module.params.get('assign_public_ip')
     kernel_id = module.params.get('kernel_id')
     ramdisk_id = module.params.get('ramdisk_id')
-    instance_profile_name = module.params.get('instance_profile_name')
+    instance_profile_name = module.params.get('instance_profile_name') or None
     ebs_optimized = module.params.get('ebs_optimized')
     bdm = BlockDeviceMapping()
 
@@ -200,7 +200,7 @@ def create_launch_config(connection, module):
         kernel_id=kernel_id,
         spot_price=spot_price,
         instance_monitoring=instance_monitoring,
-        associate_public_ip_address = assign_public_ip,
+        associate_public_ip_address=assign_public_ip,
         ramdisk_id=ramdisk_id,
         instance_profile_name=instance_profile_name,
         ebs_optimized=ebs_optimized,
@@ -219,7 +219,10 @@ def create_launch_config(connection, module):
 
     module.exit_json(changed=changed, name=result.name, created_time=str(result.created_time),
                      image_id=result.image_id, arn=result.launch_configuration_arn,
-                     security_groups=result.security_groups, instance_type=instance_type)
+                     security_groups=result.security_groups, instance_type=instance_type,
+                     instance_profile_name=instance_profile_name, ebs_optimized=ebs_optimized,
+                     assign_public_ip=assign_public_ip, kernel_id=kernel_id,
+                     ramdisk_id=ramdisk_id)
 
 
 def delete_launch_config(connection, module):


### PR DESCRIPTION
ec2_lc cleanup
- instance_profile_name pulls in None if blank because it doesn't like blank strings or false
- module.exit_json returns more variables that can be used by downstream tasks
