### PR TITLE
Ensure random jinja filter doesn't get cached in loops.

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -28,6 +28,7 @@ from ansible import errors
 from ansible.utils import md5s
 from distutils.version import LooseVersion, StrictVersion
 from random import SystemRandom
+from jinja2.filters import environmentfilter
 
 def to_nice_yaml(*a, **kw):
     '''Make verbose, human readable yaml'''
@@ -185,7 +186,8 @@ def version_compare(value, version, operator='eq', strict=False):
     except Exception, e:
         raise errors.AnsibleFilterError('Version comparison: %s' % e)
 
-def rand(end, start=None, step=None):
+@environmentfilter
+def rand(environment, end, start=None, step=None):
     r = SystemRandom()
     if isinstance(end, (int, long)):
         if not start:


### PR DESCRIPTION
When using the random filter in a template, I noticed that when used in a loop, jinja2 caches the result of the random filter when the parameters are constant.

For instance the following code for me always produces the same random number.

```
{% for item  in [0,1,2] %}
{{ 24 | random }}
{% endfor %}
```

I ran it through a debugger and found it wasn't reaching the random filter method for the second iteration, so Jinja is caching it. In Jinja's own random filter it uses the environmentfilter decorator to disable this.

This patch imitates that and for me it fixes the issue.

Info on the decorator:
http://jinja.pocoo.org/docs/api/#utilities

Jinja's random filter:
https://github.com/mitsuhiko/jinja2/blob/master/jinja2/filters.py#L362
