### PR TITLE
Fix incorrect argument ordering in error message

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -480,7 +480,7 @@ class LinuxService(Service):
     def get_systemd_status_dict(self):
         (rc, out, err) = self.execute_command("%s show %s" % (self.enable_cmd, self.__systemd_unit,))
         if rc != 0:
-            self.module.fail_json('failure %d running systemctl show for %r: %s' % (self.__systemd_unit, rc, err))
+            self.module.fail_json(msg='failure %d running systemctl show for %r: %s' % (rc, self.__systemd_unit, err))
         return dict(line.split('=', 1) for line in out.splitlines())
 
     def get_systemd_service_status(self):


### PR DESCRIPTION
A printf argument mismatch provokes a TypeError and a stack trace (obscuring the actual error) if this error is encountered:

failed: [kitty.dev] => {"failed": true, "parsed": false}
invalid output was: Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1402338384.28-173404306392121/service", line 2446, in <module>
    main()
  File "/root/.ansible/tmp/ansible-tmp-1402338384.28-173404306392121/service", line 1198, in main
    service.get_service_status()
  File "/root/.ansible/tmp/ansible-tmp-1402338384.28-173404306392121/service", line 506, in get_service_status
    return self.get_systemd_service_status()
  File "/root/.ansible/tmp/ansible-tmp-1402338384.28-173404306392121/service", line 487, in get_systemd_service_status
    d = self.get_systemd_status_dict()
  File "/root/.ansible/tmp/ansible-tmp-1402338384.28-173404306392121/service", line 483, in get_systemd_status_dict
    self.module.fail_json('failure %d running systemctl show for %r: %s' % (self.__systemd_unit, rc, err))
TypeError: %d format: a number is required, not str

The change corrects the argument ordering so that this doesn't occur.
