### PR TITLE
Docker links need alias specified

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -380,7 +380,7 @@ class DockerManager:
 
         self.links = None
         if self.module.params.get('links'):
-            self.links = dict(map(lambda x: x.split(':'), self.module.params.get('links')))
+            self.links = self.get_links(self.module.params.get('links'))
 
         self.env = None
         if self.module.params.get('env'):
@@ -389,6 +389,22 @@ class DockerManager:
         # connect to docker server
         docker_url = urlparse(module.params.get('docker_url'))
         self.client = docker.Client(base_url=docker_url.geturl())
+
+
+    def get_links(self, links):
+        """
+        Parse the links passed, if a link is specified without an alias then just create the alias of the same name as the link
+        """
+        processed_links = {}
+
+        for link in links:
+            parsed_link = link.split(':', 1)
+            if(len(parsed_link) == 2):
+                processed_links[parsed_link[0]] = parsed_link[1]
+            else:
+                processed_links[parsed_link[0]] = parsed_link[0]
+
+        return processed_links
 
 
     def get_exposed_ports(self, expose_list):
@@ -450,7 +466,6 @@ class DockerManager:
                 binds[container_port] = bind
 
         return binds
-
 
 
     def get_split_image_tag(self, image):


### PR DESCRIPTION
##### Issue Type:

 “Bugfix Pull Request”
##### Ansible Version:

1.6.3
##### Environment:

RHEL 5/6, Centos 5/6, Mac OS X
##### Summary:

When specifying a link in the Docker module, according to the documentation, I should be able to specify the link with or without the alias, for example:

`link=container1:alias1` or `link=container`, the latter should just create the alias name for me. This has tripped up quite a few people.
##### Steps To Reproduce:
##### Expected Results:

```
PLAY [Deploy containers] *********************************************

GATHERING FACTS ***************************************************************
ok: [10.0.0.1]
ok: [10.0.0.2]

TASK: [start container] **********************************
changed: [10.0.0.1]
changed: [10.0.0.2]

PLAY RECAP ********************************************************************
10.0.0.1              : ok=3    changed=1    unreachable=0    failed=0
```
##### Actual Results:

```
TASK: [dns | start authoritative server] *********************************
failed: [10.0.0.1] => {"failed": true, "parsed": false}
invalid output was: Traceback (most recent call last):
  File "/var/tmp/ansible-tmp-1402405446.07-170195533473948/docker", line 1971, in <module>
    main()
  File "/var/tmp/ansible-tmp-1402405446.07-170195533473948/docker", line 670, in main
    manager = DockerManager(module)
  File "/var/tmp/ansible-tmp-1402405446.07-170195533473948/docker", line 383, in __init__
    self.links = dict(map(lambda x: x.split(':'), self.module.params.get('links')))
ValueError: dictionary update sequence element #0 has length 1; 2 is required

failed: [10.0.0.2] => {"failed": true, "parsed": false}
invalid output was: Traceback (most recent call last):
  File "/var/tmp/ansible-tmp-1402405446.07-25177571174266/docker", line 1971, in <module>
    main()
  File "/var/tmp/ansible-tmp-1402405446.07-25177571174266/docker", line 670, in main
    manager = DockerManager(module)
  File "/var/tmp/ansible-tmp-1402405446.07-25177571174266/docker", line 383, in __init__
    self.links = dict(map(lambda x: x.split(':'), self.module.params.get('links')))
ValueError: dictionary update sequence element #0 has length 1; 2 is required


FATAL: all hosts have already failed -- aborting
```
