### PR TITLE
Don't skip printing on unmatched tags

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -227,9 +227,6 @@ def main(args):
                     unknown_tags = ((set(pb.only_tags) | set(pb.skip_tags)) -
                                     (matched_tags | unmatched_tags))
 
-                    if unknown_tags:
-                        continue
-
                 if options.listhosts:
                     print '  play #%d (%s): host count=%d' % (playnum, label, len(hosts))
                     for host in hosts:


### PR DESCRIPTION
The way ansible-playbook is using the API for list-tags, each play is
processed/printed as it is read, is different from how plays are
actually executed, where all the plays are read and only if a tag was
unmatched in /all/ the plays would the execution error out.

Without this change, tasks from a play that has unmatched tags would not
print, even if that tag is later matched in a different play. In the
scenario of --skip-tags, those tasks would actually run, because they
don't match the tag to be skipped.

This change makes listing of tasks more inline with how playbooks are
actually executed.
