### PR TITLE
Error attach volume from snapshot to instance (issue #7719)

### DIFF
--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -325,7 +325,7 @@ def main():
     if id and name:
         module.fail_json(msg="Both id and name cannot be specified")
 
-    if not (id or name or volume_size):
+    if volume_size and (id or name):
         module.fail_json(msg="Cannot specify volume_size and either one of name or id")
 
     # Here we need to get the zone info for the instance. This covers situation where 


### PR DESCRIPTION
Condition regarding volume_size, id, and name does not match comments and does not make sense in the event of reading a volume from a snapshot (no size, no id, no volume)

See https://github.com/ansible/ansible/issues/7719
