### PR TITLE
Error checking and reporting on interface ufw rule

### DIFF
--- a/library/system/ufw
+++ b/library/system/ufw
@@ -205,6 +205,9 @@ def main():
     if len(commands) < 1:
         module.fail_json(msg="Not any of the command arguments %s given" % commands)
 
+    if('interface' in params and 'direction' not in params):
+      module.fail_json(msg="Direction must be specified when creating a rule on an interface")
+
     # Ensure ufw is available
     ufw_bin = module.get_bin_path('ufw', True)
 


### PR DESCRIPTION
If someone fails to specify the direction on a rule for an interface, they are met with this message:

```
failed: [my_super_cool_server] => {"failed": true}
msg: ERROR: Invalid token 'on'
```

This just provides a check and a more informative message.
