### PR TITLE
pkgutil: exception when 'site' parameter is missing

### DIFF
--- a/library/packaging/pkgutil
+++ b/library/packaging/pkgutil
@@ -74,12 +74,10 @@ def package_installed(module, name):
 
 def package_latest(module, name, site):
     # Only supports one package
-    name = pipes.quote(name)
-    site = pipes.quote(site)
     cmd = [ 'pkgutil', '--single', '-c' ]
     if site is not None:
-        cmd += [ '-t', site ]
-    cmd.append(name)
+        cmd += [ '-t', pipes.quote(site) ]
+    cmd.append(pipes.quote(name))
     cmd += [ '| tail -1 | grep -v SAME' ]
     rc, out, err = module.run_command(' '.join(cmd), use_unsafe_shell=True)
     if rc == 1:

--- a/library/packaging/pkgutil
+++ b/library/packaging/pkgutil
@@ -74,12 +74,8 @@ def package_latest(module, name, site):
     if site is not None:
         cmd += [ '-t', pipes.quote(site) ]
     cmd.append(pipes.quote(name))
-    cmd += [ '| tail -1 | grep -v SAME' ]
-    rc, out, err = module.run_command(' '.join(cmd), use_unsafe_shell=True)
-    if rc == 1:
-        return True
-    else:
-        return False
+    (rc, out, err) = run_command(module, cmd)
+    return 'SAME' in out
 
 def run_command(module, cmd):
     progname = cmd[0]

--- a/library/packaging/pkgutil
+++ b/library/packaging/pkgutil
@@ -63,14 +63,10 @@ import os
 import pipes
 
 def package_installed(module, name):
-    cmd = [module.get_bin_path('pkginfo', True)]
-    cmd.append('-q')
+    cmd = [ 'pkginfo', '-q' ]
     cmd.append(name)
-    rc, out, err = module.run_command(' '.join(cmd))
-    if rc == 0:
-        return True
-    else:
-        return False
+    (rc, out, err) = run_command(module, cmd)
+    return rc == 0
 
 def package_latest(module, name, site):
     # Only supports one package


### PR DESCRIPTION
The first of these commits fixes a bug in the pkgutil module. Although the 'site' parameter is intended to be optional, omitting it would cause the following exception if the requested package was already installed:

```
invalid output was: Traceback (most recent call last):
  File "/tmp/ansible-tmp-1402553652.18-229268856436124/pkgutil", line 1398, in <module>
    main()
  File "/tmp/ansible-tmp-1402553652.18-229268856436124/pkgutil", line 153, in main
    if not package_latest(module, name, site):
  File "/tmp/ansible-tmp-1402553652.18-229268856436124/pkgutil", line 78, in package_latest
    site = pipes.quote(site)
  File "/usr/lib/python2.6/pipes.py", line 271, in quote
    for c in file:
TypeError: 'NoneType' object is not iterable
```

The fix was simply not to call `pipes.quote(site)` until after checking whether the argument is Null.

The other two commits in this PR are general cleanup in the pkgutil module, including removal of use_unsafe_shell.
