### PR TITLE
Hack to fix #7738: Allow tag in image parameter of docker module

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -477,6 +477,13 @@ class DockerManager:
         else:
             return image, tag
 
+    def get_split_full_image_tag(self, image):
+        tag = "latest"
+        if image.find(':') > 0:
+            return image.split(':')
+        else:
+            return image, tag
+
     def get_summary_counters_msg(self):
         msg = ""
         for k, v in self.counters.iteritems():
@@ -576,7 +583,8 @@ class DockerManager:
         try:
             containers = do_create(count, params)
         except:
-            self.client.pull(params['image'])
+            image, tag = self.get_split_full_image_tag(params['image'])
+            self.client.pull(image, tag = tag)
             self.increment_counter('pull')
             containers = do_create(count, params)
 


### PR DESCRIPTION
Specifying the tag in the image-Parameter is not allowed in current HEAD (aaa7435):

<pre>
- name: Create volume container
  docker: name=something-volumes
            image="busybox:latest"
            volumes="/var/lib/some-dir"
            command="true"
            state=present
</pre>


You have to omit the tag:

<pre>
- name: Create volume container
  docker: name=something-volumes
            image="busybox"
            volumes="/var/lib/some-dir"
            command="true"
            state=present
</pre>


This results in the following problems:
- If the image is not present on the target host, all versions of the container are pulled. This can take a long time and wastes a lot of disk space. This behavior is consistent with "docker run" but there is a bug for that: https://github.com/dotcloud/docker/issues/5047
- You cannot use any image version other than latest. So rollbacks may be difficult or mixed version deployments.

About the Patch:

It changes the logic for pulling the image if the run fails in the docker module. Maybe it is necessary to adjust the code at other places as well.

It also defaults to the "latest" tag for pulling the image instead of pulling all versions.
