### PR TITLE
mysql_user module: add option to require SSL to GRANT queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,34 @@ New Modules:
 - Fixed a bug in apt_repository triggered when python-apt not being installed/available.
 - Fixed a bug in the apache2_module module, where modules were not being disabled correctly.
 
+## 1.6.3 "And the Cradle Will Rock" - Jun 09, 2014
+
+- Corrects a regression where handlers were run across all hosts, not just those that triggered the handler.
+- Fixed a bug in which modules did not support properly moving a file atomically when su was in use.
+- Fixed two bugs related to symlinks with directories when using the file module.
+- Fixed a bug related to MySQL master replication syntax.
+- Corrects a regression in the order of variable merging done by the internal runner code.
+- Various other minor bug fixes.
+
+## 1.6.2 "And the Cradle Will Rock" - May 23, 2014
+
+- If an improper locale is specified, core modules will now automatically revert to using the 'C' locale.
+- Modules using the fetch_url utility will now obey proxy environment variables.
+- The SSL validation step in fetch_url will likewise obey proxy settings, however only proxies using the http protocol are supported.
+- Fixed multiple bugs in docker module related to version changes upstream.
+- Fixed a bug in the ec2_group module where egress rules were lost when a VPC was specified.
+- Fixed two bugs in the synchronize module:
+  * a trailing slash might be lost when calculating relative paths, resulting in an incorrect destination.
+  * the sync might use the inventory directory incorrectly instead of the playbook or role directory.
+- Files will now only be chown'd on an atomic move if the src/dest uid/gid do not match.
+
+## 1.6.1 "And the Cradle Will Rock" - May 7, 2014
+
+- Fixed a bug in group_by, where systems were being grouped incorrectly.
+- Fixed a bug where file descriptors may leak to a child process when using accelerate.
+- Fixed a bug in apt_repository triggered when python-apt not being installed/available.
+- Fixed a bug in the apache2_module module, where modules were not being disabled correctly.
+
 ## 1.6 "And the Cradle Will Rock" - May 5, 2014
 
 Major features/changes:

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -167,7 +167,7 @@ def user_add(cursor, user, host, password, new_priv, require_ssl):
     cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
     if new_priv is not None:
         for db_table, priv in new_priv.iteritems():
-            privileges_grant(cursor, user,host,db_table,priv, require_ssl)
+            privileges_grant(cursor, user,host,db_table,priv,require_ssl)
     return True
 
 def user_mod(cursor, user, host, password, new_priv, append_privs, require_ssl):

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -80,6 +80,12 @@ options:
     choices: [ "yes", "no" ]
     default: "no"
     version_added: "1.4"
+  require_ssl:
+    description:
+        - "Corresponds to MySQL's REQUIRE SSL option for GRANT"
+    required: false
+    choices: [ "yes", "no" ]
+    default: "no"
   state:
     description:
       - Whether the user should exist.  When C(absent), removes
@@ -157,14 +163,14 @@ def user_exists(cursor, user, host):
     count = cursor.fetchone()
     return count[0] > 0
 
-def user_add(cursor, user, host, password, new_priv):
+def user_add(cursor, user, host, password, new_priv, require_ssl):
     cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
     if new_priv is not None:
         for db_table, priv in new_priv.iteritems():
-            privileges_grant(cursor, user,host,db_table,priv)
+            privileges_grant(cursor, user,host,db_table,priv, require_ssl)
     return True
 
-def user_mod(cursor, user, host, password, new_priv, append_privs):
+def user_mod(cursor, user, host, password, new_priv, append_privs, require_ssl):
     changed = False
     grant_option = False
 
@@ -197,7 +203,7 @@ def user_mod(cursor, user, host, password, new_priv, append_privs):
         # we can perform a straight grant operation.
         for db_table, priv in new_priv.iteritems():
             if db_table not in curr_priv:
-                privileges_grant(cursor, user,host,db_table,priv)
+                privileges_grant(cursor, user,host,db_table,priv,require_ssl)
                 changed = True
 
         # If the db.table specification exists in both the user's current privileges
@@ -207,7 +213,7 @@ def user_mod(cursor, user, host, password, new_priv, append_privs):
             priv_diff = set(new_priv[db_table]) ^ set(curr_priv[db_table])
             if (len(priv_diff) > 0):
                 privileges_revoke(cursor, user,host,db_table,grant_option)
-                privileges_grant(cursor, user,host,db_table,new_priv[db_table])
+                privileges_grant(cursor, user,host,db_table,new_priv[db_table],require_ssl)
                 changed = True
 
     return changed
@@ -283,10 +289,12 @@ def privileges_revoke(cursor, user,host,db_table,grant_option):
     query = "REVOKE ALL PRIVILEGES ON %s FROM '%s'@'%s'" % (db_table,user,host)
     cursor.execute(query)
 
-def privileges_grant(cursor, user,host,db_table,priv):
+def privileges_grant(cursor, user,host,db_table,priv,require_ssl):
 
     priv_string = ",".join(filter(lambda x: x != 'GRANT', priv))
     query = "GRANT %s ON %s TO '%s'@'%s'" % (priv_string,db_table,user,host)
+    if require_ssl:
+        query = query + " REQUIRE SSL"
     if 'GRANT' in priv:
         query = query + " WITH GRANT OPTION"
     cursor.execute(query)
@@ -337,7 +345,7 @@ def _safe_cnf_load(config, path):
             data['password'] = line.split('=', 1)[1].strip()
     f.close()
 
-    # write out a new cnf file with only user/pass   
+    # write out a new cnf file with only user/pass
     fh, newpath = tempfile.mkstemp(prefix=path + '.')
     f = open(newpath, 'wb')
     f.write('[client]\n')
@@ -404,6 +412,7 @@ def main():
             state=dict(default="present", choices=["absent", "present"]),
             priv=dict(default=None),
             append_privs=dict(type="bool", default="no"),
+            require_ssl=dict(type="bool", default="no"),
             check_implicit_admin=dict(default=False),
         )
     )
@@ -414,6 +423,7 @@ def main():
     priv = module.params["priv"]
     check_implicit_admin = module.params['check_implicit_admin']
     append_privs = module.boolean(module.params["append_privs"])
+    require_ssl = module.boolean(module.params["require_ssl"])
 
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")
@@ -455,11 +465,11 @@ def main():
 
     if state == "present":
         if user_exists(cursor, user, host):
-            changed = user_mod(cursor, user, host, password, priv, append_privs)
+            changed = user_mod(cursor, user, host, password, priv, append_privs, require_ssl)
         else:
             if password is None:
                 module.fail_json(msg="password parameter required when adding a user")
-            changed = user_add(cursor, user, host, password, priv)
+            changed = user_add(cursor, user, host, password, priv, require_ssl)
     elif state == "absent":
         if user_exists(cursor, user, host):
             changed = user_delete(cursor, user, host)

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -86,6 +86,7 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "no"
+    version_added: "1.7"
   state:
     description:
       - Whether the user should exist.  When C(absent), removes


### PR DESCRIPTION
Adding an option to append 'REQUIRE SSL' to GRANT queries, which is necessary for establishing SSL connections to a MySQL database.
