### PR TITLE
fix for dnssec-tools install, fixes #7452

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1161,13 +1161,16 @@ class AnsibleModule(object):
         if data:
             st_in = subprocess.PIPE
 
+        temp_out = tempfile.TemporaryFile()
+        temp_err = tempfile.TemporaryFile()
+
         kwargs = dict(
             executable=executable,
             shell=shell,
             close_fds=close_fds,
             stdin= st_in,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE 
+            stdout=temp_out,
+            stderr=temp_err 
         )
 
         if path_prefix:
@@ -1191,7 +1194,11 @@ class AnsibleModule(object):
             if data:
                 if not binary_data:
                     data += '\n'
-            out, err = cmd.communicate(input=data)
+            cmd.communicate(input=data)
+            temp_out.seek(0)
+            temp_err.seek(0)
+            out = temp_out.read()
+            err = temp_err.read()
             rc = cmd.returncode
         except (OSError, IOError), e:
             self.fail_json(rc=e.errno, msg=str(e), cmd=clean_args)


### PR DESCRIPTION
fixes #7452

problem with using subprocess.PIPE for for large data described here:
http://thraxil.org/users/anders/posts/2008/03/13/Subprocess-Hanging-PIPE-is-your-enemy/

subprocess can hang if PIPE is used, change uses temporary files instead
