### PR TITLE
Add sysfs info about drives' fw revision and queue.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -721,7 +721,7 @@ class LinuxHardware(Hardware):
                     continue
             d = {}
             diskname = os.path.basename(sysdir)
-            for key in ['vendor', 'model']:
+            for key in ['vendor', 'model', 'rev', 'queue_depth', 'queue_type']:
                 d[key] = get_file_content(sysdir + "/device/" + key)
 
             for key,test in [ ('removable','/removable'), \

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -757,7 +757,7 @@ class LinuxHardware(Hardware):
             d['sectorsize'] = get_file_content(sysdir + "/queue/physical_block_size")
             if not d['sectorsize']:
                 d['sectorsize'] = 512
-            d['size'] = module.pretty_bytes(float(d['sectors']) * float(d['sectorsize']))
+            d['size'] = module.pretty_bytes(float(d['sectors']) * 512)
 
             d['host'] = ""
 

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -740,7 +740,7 @@ class LinuxHardware(Hardware):
                     part['start'] = get_file_content(part_sysdir + "/start",0)
                     part['sectors'] = get_file_content(part_sysdir + "/size",0)
                     part['sectorsize'] = get_file_content(part_sysdir + "/queue/physical_block_size",512)
-                    part['size'] = module.pretty_bytes((float(part['sectors']) * float(part['sectorsize'])))
+                    part['size'] = module.pretty_bytes((float(part['sectors']) * 512))
                     d['partitions'][partname] = part
 
             d['rotational'] = get_file_content(sysdir + "/queue/rotational")


### PR DESCRIPTION
These sysfs attributes contain useful information, so let's add them to ansible-provided facts about disks.
