### PR TITLE
Fix invalid digital_ocean_domain example.

### DIFF
--- a/library/cloud/digital_ocean_domain
+++ b/library/cloud/digital_ocean_domain
@@ -59,7 +59,7 @@ EXAMPLES = '''
 
 # Create a droplet and a corresponding domain record
 
-- digital_cean_droplet: >
+- digital_ocean: >
       state=present
       name=test_droplet
       size_id=1


### PR DESCRIPTION
The digital_(o)cean_droplet is not a valid module; presumably this should be
'digital_ocean'.
