### PR TITLE
module rax_scaling_group: safe normalization of nics

### DIFF
--- a/library/cloud/rax_scaling_group
+++ b/library/cloud/rax_scaling_group
@@ -215,8 +215,12 @@ def rax_asg(module, cooldown=300, disk_config=None, files={}, flavor=None,
                     nics.extend(cnw.get_server_networks(network))
 
             for nic in nics:
-                nic.update(uuid=nic['net-id'])
-                del nic['net-id']
+                # pyrax is currently returning net-id, but we need uuid
+                # this check makes this forward compatible for a time when
+                # pyrax uses uuid instead
+                if nic.get('net-id'):
+                    nic.update(uuid=nic['net-id'])
+                    del nic['net-id']
 
         # Handle the file contents
         personality = []


### PR DESCRIPTION
pyrax currently returns a `net-id` key in it's 'nic' dictionaries.  We can't use `net-id` in asg requests, it must be uuid.

If pyrax updates to return `uuid` this code will prevent the module from breaking.

I will be submitting a pull request to pyrax to get this change made.
