### PR TITLE
Add optional docker_api_version parameter to Docker Module

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -107,6 +107,13 @@ options:
     required: false
     default: unix://var/run/docker.sock
     aliases: []
+  docker_api_version:
+    description:
+      - Remote API version to use
+    required: false
+    default: docker-py default remote API version
+    aliases: []
+    version_added: "1.7"
   username:
     description:
       - Set remote API username
@@ -388,7 +395,8 @@ class DockerManager:
 
         # connect to docker server
         docker_url = urlparse(module.params.get('docker_url'))
-        self.client = docker.Client(base_url=docker_url.geturl())
+        docker_api_version = module.params.get('docker_api_version')
+        self.client = docker.Client(base_url=docker_url.geturl(), version=docker_api_version)
 
 
     def get_links(self, links):
@@ -662,6 +670,7 @@ def main():
             memory_limit    = dict(default=0),
             memory_swap     = dict(default=0),
             docker_url      = dict(default='unix://var/run/docker.sock'),
+            docker_api_version = dict(default=docker.client.DEFAULT_DOCKER_API_VERSION),
             user            = dict(default=None),
             password        = dict(),
             email           = dict(),


### PR DESCRIPTION
When using the Ansible Docker module, I found myself needing to target a later version of the Docker remote API then is defaulted by Docker-py library.  I added an optional parameter to the Ansible Docker module that allows you to specify the desired docker_api_version.  If not provided, the module will default to Docker-py library default version.
