### PR TITLE
Raise exception if "file_name" isn't passed to bin/ansible-vault

### DIFF
--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -112,7 +112,6 @@ def _read_password(filename):
     return data
 
 def execute_create(args, options, parser):
-
     if len(args) > 1:
         raise errors.AnsibleError("'create' does not accept more than one filename")        
 
@@ -203,6 +202,11 @@ def main():
     action = get_action(sys.argv)
     parser = build_option_parser(action)
     (options, args) = parser.parse_args()
+
+    if not len(args):
+        raise errors.AnsibleError(
+            "The '%s' command requires a filename as the first argument" % action
+        ) 
 
     # execute the desired action
     try:


### PR DESCRIPTION
Ran into this on my first run through with vault.  I was asked to enter my password and got:

```
ansible-vault create --debug
Vault password:
Confirm Vault password:
Traceback (most recent call last):
  File "<virtual_env_root>/bin/ansible-vault", line 211, in main
    fn(args, options, parser)
  File "<virtual_env_root>/bin/ansible-vault", line 126, in execute_create
    this_editor = VaultEditor(cipher, password, args[0])
IndexError: list index out of range

ERROR: list index out of range
```

This pull request checks that we at least have the one required argument before we continue.  
