### PR TITLE
Standardize logging to stderr

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -75,7 +75,7 @@ def select_playbook(path, args):
         playbook = "%s/%s" % (path, args[0])
         rc = try_playbook(playbook)
         if rc != 0:
-            print >>sys.stderr, "%s: %s" % (playbook, PLAYBOOK_ERRORS[rc])
+            sys.stderr.write("%s: %s" % (playbook, PLAYBOOK_ERRORS[rc]))
             return None
         return playbook
     else:
@@ -92,7 +92,7 @@ def select_playbook(path, args):
             else:
                 errors.append("%s: %s" % (pb, PLAYBOOK_ERRORS[rc]))
         if playbook is None:
-            print >>sys.stderr, "\n".join(errors)
+            sys.stderr.write("\n".join(errors))
         return playbook
 
 
@@ -148,7 +148,7 @@ def main(args):
         return 1
 
     now = datetime.datetime.now()
-    print >>sys.stderr, now.strftime("Starting ansible-pull at %F %T")
+    sys.stderr.write(strftime("Starting ansible-pull at %F %T"))
 
     if not options.inventory:
         inv_opts = 'localhost,'
@@ -180,7 +180,7 @@ def main(args):
             parser.error("%s is not a number." % options.sleep)
             return 1
 
-        print >>sys.stderr, "Sleeping for %d seconds..." % secs
+        sys.stderr.write("Sleeping for %d seconds..." % secs)
         time.sleep(secs);
 
 
@@ -199,7 +199,7 @@ def main(args):
     playbook = select_playbook(options.dest, args)
 
     if playbook is None:
-        print >>sys.stderr, "Could not find a playbook to run."
+        sys.stderr.write("Could not find a playbook to run.")
         return 1
 
     cmd = 'ansible-playbook %s %s' % (base_opts, playbook)
@@ -221,7 +221,7 @@ def main(args):
         try:
             shutil.rmtree(options.dest)
         except Exception, e:
-            print >>sys.stderr, "Failed to remove %s: %s" % (options.dest, str(e))
+            sys.stderr.write("Failed to remove %s: %s" % (options.dest, str(e)))
 
     return rc
 
@@ -229,5 +229,5 @@ if __name__ == '__main__':
     try:
         sys.exit(main(sys.argv[1:]))
     except KeyboardInterrupt, e:
-        print >>sys.stderr, "Exit on user request.\n"
+        sys.stderr.write("Exit on user request.\n")
         sys.exit(1)

--- a/docsite/build-site.py
+++ b/docsite/build-site.py
@@ -72,7 +72,7 @@ class SphinxBuilder(object):
         except ImportError, ie:
             traceback.print_exc()
         except Exception, ex:
-            print >> sys.stderr, "FAIL! exiting ... (%s)" % ex
+            sys.stderr.write("FAIL! exiting ... (%s)" % ex)
 
     def build_docs(self):
         self.app.builder.build_all()
@@ -100,4 +100,4 @@ if __name__ == '__main__':
     if "view" in sys.argv:
         import webbrowser
         if not webbrowser.open('htmlout/index.html'):
-            print >> sys.stderr, "Could not open on your webbrowser."
+            sys.stderr.write("Could not open on your webbrowser.")

--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -280,10 +280,10 @@ def validate_options(options):
     ''' validate option parser options '''
 
     if not options.module_dir:
-        print >>sys.stderr, "--module-dir is required"
+        sys.stderr.write("--module-dir is required")
         sys.exit(1)
     if not os.path.exists(options.module_dir):
-        print >>sys.stderr, "--module-dir does not exist: %s" % options.module_dir
+        sys.stderr.write("--module-dir does not exist: %s" % options.module_dir)
         sys.exit(1)
     if not options.template_dir:
         print "--template-dir must be specified"

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -147,9 +147,9 @@ def display(msg, color=None, stderr=False, screen_only=False, log_only=False, ru
                 print msg2.encode('utf-8')
         else:
             try:
-                print >>sys.stderr, msg2
+                sys.stderr.write(msg2)
             except UnicodeEncodeError:
-                print >>sys.stderr, msg2.encode('utf-8')
+                sys.stderr.write(msg2.encode('utf-8'))
     if constants.DEFAULT_LOG_PATH != '':
         while msg.startswith("\n"):
             msg = msg.replace("\n","")

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -149,9 +149,9 @@ def decrypt(key, msg):
 ###############################################################
 
 def err(msg):
-    ''' print an error message to stderr '''
+    ''' write an error message to stderr '''
 
-    print >> sys.stderr, msg
+    sys.stderr.write(msg)
 
 def exit(msg, rc=1):
     ''' quit with an error to stdout and a failure code '''

--- a/library/internal/async_wrapper
+++ b/library/internal/async_wrapper
@@ -42,7 +42,7 @@ def daemonize_self():
             # exit first parent
             sys.exit(0)
     except OSError, e:
-        print >>sys.stderr, "fork #1 failed: %d (%s)" % (e.errno, e.strerror)
+        sys.stderr.write("fork #1 failed: %d (%s)" % (e.errno, e.strerror))
         sys.exit(1)
 
     # decouple from parent environment
@@ -57,7 +57,7 @@ def daemonize_self():
             # print "Daemon PID %d" % pid
             sys.exit(0)
     except OSError, e:
-        print >>sys.stderr, "fork #2 failed: %d (%s)" % (e.errno, e.strerror)
+        sys.stderr.write("fork #2 failed: %d (%s)" % (e.errno, e.strerror))
         sys.exit(1)
 
     dev_null = file('/dev/null','rw')

--- a/plugins/inventory/spacewalk.py
+++ b/plugins/inventory/spacewalk.py
@@ -54,7 +54,7 @@ CACHE_AGE = 300 # 5min
 
 # Sanity check
 if not os.path.exists(SW_REPORT):
-    print >> sys.stderr, 'Error: %s is required for operation.' % (SW_REPORT)
+    sys.stderr.write('Error: %s is required for operation.' % (SW_REPORT))
     sys.exit(1)
 
 # Pre-startup work
@@ -113,8 +113,8 @@ if options.list:
             groups[system['group_name']].add(system['server_name'])
 
     except (OSError), e:
-        print >> sys.stderr, 'Problem executing the command "%s system-groups-systems": %s' % \
-            (SW_REPORT, str(e))
+        sys.stderr.write('Problem executing the command "%s system-groups-systems": %s' % \
+            (SW_REPORT, str(e)))
         sys.exit(2)
 
     if options.human:
@@ -138,8 +138,8 @@ elif options.host:
                 break
 
     except (OSError), e:
-        print >> sys.stderr, 'Problem executing the command "%s inventory": %s' % \
-            (SW_REPORT, str(e))
+        sys.stderr.write('Problem executing the command "%s inventory": %s' % \
+            (SW_REPORT, str(e)))
         sys.exit(2)
     
     if options.human:

--- a/plugins/inventory/zabbix.py
+++ b/plugins/inventory/zabbix.py
@@ -38,7 +38,7 @@ import ConfigParser
 try:
     from zabbix_api import ZabbixAPI
 except:
-    print >> sys.stderr, "Error: Zabbix API library must be installed: pip install zabbix-api."
+    sys.stderr.write("Error: Zabbix API library must be installed: pip install zabbix-api.")
     sys.exit(1)
 
 try:
@@ -111,7 +111,7 @@ class ZabbixInventory(object):
                 api = ZabbixAPI(server=self.zabbix_server)
                 api.login(user=self.zabbix_username, password=self.zabbix_password)
             except BaseException, e:
-                print >> sys.stderr, "Error: Could not login to Zabbix server. Check your zabbix.ini."
+                sys.stderr.write("Error: Could not login to Zabbix server. Check your zabbix.ini.")
                 sys.exit(1)
 
             if self.options.host:
@@ -123,11 +123,11 @@ class ZabbixInventory(object):
                 print json.dumps(data, indent=2)
 
             else:
-                print >> sys.stderr, "usage: --list  ..OR.. --host <hostname>"
+                sys.stderr.write("usage: --list  ..OR.. --host <hostname>")
                 sys.exit(1)
 
         else:
-            print >> sys.stderr, "Error: Configuration of server and credentials are required. See zabbix.ini."
+            sys.stderr.write("Error: Configuration of server and credentials are required. See zabbix.ini.")
             sys.exit(1)
 
 ZabbixInventory()


### PR DESCRIPTION
Standardize logging to stderr to use the sys.stderr.write() which is forward compatible with Python 3. Tested via the make tests and by local execution.

Note: hacking/module_formatter.py has an unrelated local execution issue.

(First Pull Request, hope it looks right)
