### PR TITLE
Standardize logging to stderr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ASCII2MAN = @echo "ERROR: AsciiDoc 'a2x' command is not installed but is require
 endif
 
 PYTHON=python
-SITELIB = $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
+SITELIB = $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib()"))
 
 # VERSION file provides one place to update the software version
 VERSION := $(shell cat VERSION)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ASCII2MAN = @echo "ERROR: AsciiDoc 'a2x' command is not installed but is require
 endif
 
 PYTHON=python
-SITELIB = $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib()"))
+SITELIB = $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 # VERSION file provides one place to update the software version
 VERSION := $(shell cat VERSION)

--- a/bin/ansible
+++ b/bin/ansible
@@ -130,7 +130,7 @@ class Cli(object):
                 f = open(this_path, "rb")
                 tmp_vault_pass=f.read().strip()
                 f.close()
-            except (OSError, IOError), e:
+            except ((OSError, IOError), e):
                 raise errors.AnsibleError("Could not read %s: %s" % (this_path, e))
 
             if not options.ask_vault_pass:
@@ -224,7 +224,7 @@ if __name__ == '__main__':
                 sys.exit(2)
         if results['dark']:
             sys.exit(3)
-    except errors.AnsibleError, e:
+    except(errors.AnsibleError, e):
         # Generic handler for ansible specific errors
         callbacks.display("ERROR: %s" % str(e), stderr=True, color='red')
         sys.exit(1)

--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -46,7 +46,7 @@ LESS_OPTS = 'FRSX' # -F (quit-if-one-screen) -R (allow raw ansi control chars)
 
 def pager_print(text):
     ''' just print text '''
-    print text
+    print(text)
 
 def pager_pipe(text, cmd):
     ''' pipe text through a pager '''

--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -228,7 +228,7 @@ def exit_without_ignore(options, rc=1):
     """
 
     if not get_opt(options, "ignore_errors", False):
-        print 'You can use --ignore-errors to skip failed roles.'
+        print('You can use --ignore-errors to skip failed roles.')
         sys.exit(rc)
 
 #-------------------------------------------------------------------------------------
@@ -262,10 +262,10 @@ def api_lookup_role_by_name(api_server, role_name):
         parts = role_name.split(".")
         user_name = ".".join(parts[0:-1])
         role_name = parts[-1]
-        print " downloading role '%s', owned by %s" % (role_name, user_name)
+        print(" downloading role '%s', owned by %s" % (role_name, user_name))
     except:
         parser.print_help()
-        print "Invalid role name (%s). You must specify username.rolename" % role_name
+        print("Invalid role name (%s). You must specify username.rolename" % role_name)
         sys.exit(1)
 
     url = 'https://%s/api/v1/roles/?owner__username=%s&name=%s' % (api_server,user_name,role_name)
@@ -292,7 +292,7 @@ def api_fetch_role_related(api_server, related, role_id):
         done = (data.get('next', None) == None)
         while not done:
             url = 'https://%s%s' % (api_server, data['next'])
-            print url
+            print(url)
             data = json.load(urllib2.urlopen(url))
             results += data['results']
             done = (data.get('next', None) == None)
@@ -317,13 +317,13 @@ def api_get_list(api_server, what):
             done = (data.get('next', None) == None)
         while not done:
             url = 'https://%s%s' % (api_server, data['next'])
-            print url
+            print(url)
             data = json.load(urllib2.urlopen(url))
             results += data['results']
             done = (data.get('next', None) == None)
         return results
     except:
-        print " - failed to download the %s list" % what
+        print(" - failed to download the %s list" % what)
         return None
 
 #-------------------------------------------------------------------------------------
@@ -417,7 +417,7 @@ def fetch_role(role_name, target, role_data, options):
 
     # first grab the file and save it to a temp location
     archive_url = 'https://github.com/%s/%s/archive/%s.tar.gz' % (role_data["github_user"], role_data["github_repo"], target)
-    print " - downloading role from %s" % archive_url
+    print(" - downloading role from %s" % archive_url)
 
     try:
         url_file = urllib2.urlopen(archive_url)
@@ -431,14 +431,14 @@ def fetch_role(role_name, target, role_data, options):
     except Exception, e:
         # TODO: better urllib2 error handling for error 
         #       messages that are more exact
-        print "Error: failed to download the file."
+        print("Error: failed to download the file.")
         return False
 
 def install_role(role_name, role_version, role_filename, options):
     # the file is a tar, so open it that way and extract it
     # to the specified (or default) roles directory
     if not tarfile.is_tarfile(role_filename):
-        print "Error: the file downloaded was not a tar.gz"
+        print("Error: the file downloaded was not a tar.gz")
         return False
     else:
         role_tar_file = tarfile.open(role_filename, "r:gz")
@@ -450,13 +450,13 @@ def install_role(role_name, role_version, role_filename, options):
                 meta_file = member
                 break
         if not meta_file:
-            print "Error: this role does not appear to have a meta/main.yml file."
+            print("Error: this role does not appear to have a meta/main.yml file.")
             return False
         else:
             try:
                 meta_file_data = yaml.safe_load(role_tar_file.extractfile(meta_file))
             except:
-                print "Error: this role does not appear to have a valid meta/main.yml file."
+                print("Error: this role does not appear to have a valid meta/main.yml file.")
                 return False
 
         # we strip off the top-level directory for all of the files contained within
@@ -464,20 +464,20 @@ def install_role(role_name, role_version, role_filename, options):
         # to the specified role's name
         role_path = os.path.join(get_opt(options, 'roles_path', '/etc/ansible/roles'), role_name)
         role_path = os.path.expanduser(role_path)
-        print " - extracting %s to %s" % (role_name, role_path)
+        print(" - extracting %s to %s" % (role_name, role_path))
         try:
             if os.path.exists(role_path):
                 if not os.path.isdir(role_path):
-                    print "Error: the specified roles path exists and is not a directory."
+                    print("Error: the specified roles path exists and is not a directory.")
                     return False
                 elif not get_opt(options, "force", False):
-                    print "Error: the specified role %s appears to already exist. Use --force to replace it." % role_name
+                    print("Error: the specified role %s appears to already exist. Use --force to replace it." % role_name)
                     return False
                 else:
                     # using --force, remove the old path
                     if not remove_role(role_name, options):
-                        print "Error: %s doesn't appear to contain a role." % role_path
-                        print "Please remove this directory manually if you really want to put the role here."
+                        print("Error: %s doesn't appear to contain a role." % role_path)
+                        print("Please remove this directory manually if you really want to put the role here.")
                         return False
             else:
                 os.makedirs(role_path)
@@ -492,11 +492,11 @@ def install_role(role_name, role_version, role_filename, options):
             # write out the install info file for later use
             write_galaxy_install_info(role_name, role_version, options)
         except OSError, e:
-            print "Error: you do not have permission to modify files in %s" % role_path
+            print("Error: you do not have permission to modify files in %s" % role_path)
             return False
 
         # return the parsed yaml metadata
-        print "%s was installed successfully" % role_name
+        print("%s was installed successfully" % role_name)
         return meta_file_data
 
 #-------------------------------------------------------------------------------------
@@ -515,7 +515,7 @@ def execute_init(args, options, parser):
 
     api_config = api_get_config(api_server)
     if not api_config:
-        print "The API server (%s) is not responding, please try again later." % api_server
+        print("The API server (%s) is not responding, please try again later." % api_server)
         sys.exit(1)
 
     try:
@@ -525,18 +525,18 @@ def execute_init(args, options, parser):
         role_path = os.path.join(init_path, role_name)
         if os.path.exists(role_path):
             if os.path.isfile(role_path):
-                print "The path %s already exists, but is a file - aborting" % role_path
+                print("The path %s already exists, but is a file - aborting" % role_path)
                 sys.exit(1)
             elif not force:
-                print "The directory %s already exists." % role_path
-                print ""
-                print "You can use --force to re-initialize this directory,\n" + \
+                print("The directory %s already exists." % role_path)
+                print()
+                print("You can use --force to re-initialize this directory,\n" + \
                       "however it will reset any main.yml files that may have\n" + \
-                      "been modified there already."
+                      "been modified there already.")
                 sys.exit(1)
     except Exception, e:
         parser.print_help()
-        print "No role name specified for init"
+        print("No role name specified for init")
         sys.exit(1)
 
     ROLE_DIRS = ('defaults','files','handlers','meta','tasks','templates','vars')
@@ -595,7 +595,7 @@ def execute_init(args, options, parser):
             f = open(main_yml_path, 'w')
             f.write('---\n# %s file for %s\n' % (dir,role_name))
             f.close()
-    print "%s was created successfully" % role_name
+    print("%s was created successfully" % role_name)
 
 def execute_info(args, options, parser):
     """
@@ -622,18 +622,18 @@ def execute_install(args, options, parser):
         # the user needs to specify one of either --role-file
         # or specify a single user/role name
         parser.print_help()
-        print "You must specify a user/role name or a roles file"
+        print("You must specify a user/role name or a roles file")
         sys.exit()
     elif len(args) == 1 and role_file:
         # using a role file is mutually exclusive of specifying
         # the role name on the command line
         parser.print_help()
-        print "Please specify a user/role name, or a roles file, but not both"
+        print("Please specify a user/role name, or a roles file, but not both")
         sys.exit(1)
 
     api_config = api_get_config(api_server)
     if not api_config:
-        print "The API server (%s) is not responding, please try again later." % api_server
+        print("The API server (%s) is not responding, please try again later." % api_server)
         sys.exit(1)
 
     roles_done = []
@@ -665,17 +665,17 @@ def execute_install(args, options, parser):
             tar_file = role_name
             role_name = os.path.basename(role_name).replace('.tar.gz','')
             if tarfile.is_tarfile(tar_file):
-                print " - installing %s as %s" % (tar_file, role_name)
+                print( " - installing %s as %s" % (tar_file, role_name))
                 if not install_role(role_name, role_version, tar_file, options):
                     exit_without_ignore(options)
             else:
-                print "%s (%s) was NOT installed successfully." % (role_name,tar_file)
+                print("%s (%s) was NOT installed successfully." % (role_name,tar_file))
                 exit_without_ignore(options)
         else:
             # installing remotely
             role_data = api_lookup_role_by_name(api_server, role_name)
             if not role_data:
-                print "Sorry, %s was not found on %s." % (role_name, api_server)
+                print("Sorry, %s was not found on %s." % (role_name, api_server))
                 continue
 
             role_versions = api_fetch_role_related(api_server, 'versions', role_data['id'])
@@ -690,10 +690,10 @@ def execute_install(args, options, parser):
                     role_version = str(loose_versions[-1])
                 else:
                     role_version = 'master'
-                print " no version specified, installing %s" % role_version
+                print(" no version specified, installing %s" % role_version)
             else:
                 if role_versions and role_version not in [a.get('name',None) for a in role_versions]:
-                    print "The specified version (%s) was not found in the list of available versions." % role_version
+                    print("The specified version (%s) was not found in the list of available versions." % role_version)
                     exit_without_ignore(options)
                     continue
 
@@ -709,14 +709,14 @@ def execute_install(args, options, parser):
                     for dep_name in role_dependencies:
                         #dep_name = "%s.%s" % (dep['owner'], dep['name'])
                         if not get_role_metadata(dep_name, options):
-                            print ' adding dependency: %s' % dep_name
+                            print(' adding dependency: %s' % dep_name)
                             roles_left.append(dep_name)
                         else:
-                            print ' dependency %s is already installed, skipping.' % dep_name
+                            print(' dependency %s is already installed, skipping.' % dep_name)
             else:
                 if tmp_file:
                     os.unlink(tmp_file)
-                print "%s was NOT installed successfully." % role_name
+                print("%s was NOT installed successfully." % role_name)
                 exit_without_ignore(options)
     sys.exit(0)
 
@@ -728,17 +728,17 @@ def execute_remove(args, options, parser):
 
     if len(args) == 0:
         parser.print_help()
-        print 'You must specify at least one role to remove.'
+        print('You must specify at least one role to remove.')
         sys.exit()
 
     for role in args:
         if get_role_metadata(role, options):
             if remove_role(role, options):
-                print 'successfully removed %s' % role
+                print('successfully removed %s' % role)
             else:
-                print "failed to remove role: %s" % role
+                print("failed to remove role: %s" % role)
         else:
-            print '%s is not installed, skipping.' % role
+            print('%s is not installed, skipping.' % role)
     sys.exit(0)
 
 def execute_list(args, options, parser):
@@ -750,7 +750,7 @@ def execute_list(args, options, parser):
     """
 
     if len(args) > 1:
-        print "Please specify only one role to list, or specify no roles to see a full list"
+        print("Please specify only one role to list, or specify no roles to see a full list")
         sys.exit(1)
 
     if len(args) == 1:
@@ -765,19 +765,19 @@ def execute_list(args, options, parser):
             if not version:
                 version = "(unknown version)"
             # show some more info about single roles here
-            print " %s, %s" % (role_name, version)
+            print(" %s, %s" % (role_name, version))
         else:
-            print "The role %s was not found" % role_name
+            print("The role %s was not found" % role_name)
     else:
         # show all valid roles in the roles_path directory
         roles_path = get_opt(options, 'roles_path')
         roles_path = os.path.expanduser(roles_path)
         if not os.path.exists(roles_path):
             parser.print_help()
-            print "The path %s does not exist. Please specify a valid path with --roles-path" % roles_path
+            print("The path %s does not exist. Please specify a valid path with --roles-path" % roles_path)
             sys.exit(1)
         elif not os.path.isdir(roles_path):
-            print "%s exists, but it is not a directory. Please specify a valid path with --roles-path" % roles_path
+            print("%s exists, but it is not a directory. Please specify a valid path with --roles-path" % roles_path)
             parser.print_help()
             sys.exit(1)
         path_files = os.listdir(roles_path)
@@ -789,7 +789,7 @@ def execute_list(args, options, parser):
                     version = install_info.get("version", None)
                 if not version:
                     version = "(unknown version)"
-                print " %s, %s" % (path_file, version)
+                print(" %s, %s" % (path_file, version))
     sys.exit(0)
 
 #-------------------------------------------------------------------------------------
@@ -807,7 +807,7 @@ def main():
         fn = globals()["execute_%s" % action]
         fn(args, options, parser)
     #except KeyError, e:
-    #    print "Error: %s is not a valid action. Valid actions are: %s" % (action, ", ".join(VALID_ACTIONS))
+    #    print("Error: %s is not a valid action. Valid actions are: %s" % (action, ", ".join(VALID_ACTIONS)))
     #    sys.exit(1)
 
 if __name__ == "__main__":

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -203,9 +203,9 @@ def main(args):
         )
 
         if options.listhosts or options.listtasks or options.syntax:
-            print ''
-            print 'playbook: %s' % playbook
-            print ''
+            print()
+            print('playbook: %s' % playbook)
+            print()
             playnum = 0
             for (play_ds, play_basedir) in zip(pb.playbook, pb.play_basedirs):
                 playnum += 1
@@ -231,25 +231,25 @@ def main(args):
                         continue
 
                 if options.listhosts:
-                    print '  play #%d (%s): host count=%d' % (playnum, label, len(hosts))
+                    print('  play #%d (%s): host count=%d' % (playnum, label, len(hosts)))
                     for host in hosts:
-                        print '    %s' % host
+                        print('    %s' % host)
 
                 if options.listtasks:
-                    print '  play #%d (%s):' % (playnum, label)
+                    print('  play #%d (%s):' % (playnum, label))
 
                     for task in play.tasks():
                         if (set(task.tags).intersection(pb.only_tags) and not
                             set(task.tags).intersection(pb.skip_tags)):
                             if getattr(task, 'name', None) is not None:
                                 # meta tasks have no names
-                                print '    %s' % task.name
-                print ''
+                                print('    %s' % task.name)
+                print()
             continue
 
         if options.syntax:
             # if we've not exited by now then we are fine.
-            print 'Playbook Syntax is fine'
+            print('Playbook Syntax is fine')
             return 0
 
         failed_hosts = []
@@ -299,7 +299,7 @@ def main(args):
                 )
 
 
-            print ""
+            print()
             if len(failed_hosts) > 0:
                 return 2
             if len(unreachable_hosts) > 0:

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -189,11 +189,11 @@ def main(args):
 
     if rc != 0:
         if options.force:
-            print "Unable to update repository. Continuing with (forced) run of playbook."
+            print("Unable to update repository. Continuing with (forced) run of playbook.")
         else:
             return rc
     elif options.ifchanged and '"changed": true' not in out:
-        print "Repository has not changed, quitting."
+        print("Repository has not changed, quitting.")
         return 0
 
     playbook = select_playbook(options.dest, args)

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -75,7 +75,7 @@ def select_playbook(path, args):
         playbook = "%s/%s" % (path, args[0])
         rc = try_playbook(playbook)
         if rc != 0:
-            print >>sys.stderr, "%s: %s" % (playbook, PLAYBOOK_ERRORS[rc])
+            sys.stderr.write("%s: %s" % (playbook, PLAYBOOK_ERRORS[rc]))
             return None
         return playbook
     else:
@@ -92,7 +92,7 @@ def select_playbook(path, args):
             else:
                 errors.append("%s: %s" % (pb, PLAYBOOK_ERRORS[rc]))
         if playbook is None:
-            print >>sys.stderr, "\n".join(errors)
+            sys.stderr.write("\n".join(errors))
         return playbook
 
 
@@ -148,7 +148,7 @@ def main(args):
         return 1
 
     now = datetime.datetime.now()
-    print >>sys.stderr, now.strftime("Starting ansible-pull at %F %T")
+    sys.stderr.write(strftime("Starting ansible-pull at %F %T"))
 
     if not options.inventory:
         inv_opts = 'localhost,'
@@ -180,7 +180,7 @@ def main(args):
             parser.error("%s is not a number." % options.sleep)
             return 1
 
-        print >>sys.stderr, "Sleeping for %d seconds..." % secs
+        sys.stderr.write("Sleeping for %d seconds..." % secs)
         time.sleep(secs);
 
 
@@ -199,7 +199,7 @@ def main(args):
     playbook = select_playbook(options.dest, args)
 
     if playbook is None:
-        print >>sys.stderr, "Could not find a playbook to run."
+        sys.stderr.write("Could not find a playbook to run.")
         return 1
 
     cmd = 'ansible-playbook %s %s' % (base_opts, playbook)
@@ -221,7 +221,7 @@ def main(args):
         try:
             shutil.rmtree(options.dest)
         except Exception, e:
-            print >>sys.stderr, "Failed to remove %s: %s" % (options.dest, str(e))
+            sys.stderr.write("Failed to remove %s: %s" % (options.dest, str(e)))
 
     return rc
 
@@ -229,5 +229,5 @@ if __name__ == '__main__':
     try:
         sys.exit(main(sys.argv[1:]))
     except KeyboardInterrupt, e:
-        print >>sys.stderr, "Exit on user request.\n"
+        sys.stderr.write("Exit on user request.\n")
         sys.exit(1)

--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -143,7 +143,7 @@ def execute_decrypt(args, options, parser):
         this_editor = VaultEditor(cipher, password, f)
         this_editor.decrypt_file()
 
-    print "Decryption successful"
+    print("Decryption successful")
 
 def execute_edit(args, options, parser):
 
@@ -176,7 +176,7 @@ def execute_encrypt(args, options, parser):
         this_editor = VaultEditor(cipher, password, f)
         this_editor.encrypt_file()
 
-    print "Encryption successful"
+    print("Encryption successful")
 
 def execute_rekey(args, options, parser):
 
@@ -192,7 +192,7 @@ def execute_rekey(args, options, parser):
         this_editor = VaultEditor(cipher, password, f)
         this_editor.rekey_file(new_password)
 
-    print "Rekey successful"
+    print("Rekey successful")
 
 #-------------------------------------------------------------------------------------
 # MAIN
@@ -210,8 +210,8 @@ def main():
         fn(args, options, parser)
     except Exception, err:
         if options.debug:
-            print traceback.format_exc()
-        print "ERROR:",err
+            print(traceback.format_exc())
+        print("ERROR:",err)
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/docsite/Makefile
+++ b/docsite/Makefile
@@ -1,5 +1,5 @@
 #!/usr/bin/make
-SITELIB = $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
+SITELIB = $(shell python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 FORMATTER=../hacking/module_formatter.py
 
 all: clean docs

--- a/docsite/build-site.py
+++ b/docsite/build-site.py
@@ -72,7 +72,7 @@ class SphinxBuilder(object):
         except ImportError, ie:
             traceback.print_exc()
         except Exception, ex:
-            print >> sys.stderr, "FAIL! exiting ... (%s)" % ex
+            sys.stderr.write("FAIL! exiting ... (%s)" % ex)
 
     def build_docs(self):
         self.app.builder.build_all()
@@ -100,4 +100,4 @@ if __name__ == '__main__':
     if "view" in sys.argv:
         import webbrowser
         if not webbrowser.open('htmlout/index.html'):
-            print >> sys.stderr, "Could not open on your webbrowser."
+            sys.stderr.write("Could not open on your webbrowser.")

--- a/docsite/build-site.py
+++ b/docsite/build-site.py
@@ -24,9 +24,9 @@ import traceback
 try:
     from sphinx.application import Sphinx
 except ImportError:
-    print "#################################"
-    print "Dependency missing: Python Sphinx"
-    print "#################################"
+    print("#################################")
+    print("Dependency missing: Python Sphinx")
+    print("#################################")
     sys.exit(1)
 import os
 
@@ -40,7 +40,7 @@ class SphinxBuilder(object):
         """
         Run the DocCommand.
         """
-        print "Creating html documentation ..."
+        print("Creating html documentation ...")
 
         try:
             buildername = 'html'
@@ -83,9 +83,9 @@ def build_rst_docs():
 
 if __name__ == '__main__':
     if '-h' in sys.argv or '--help' in sys.argv:
-        print "This script builds the html documentation from rst/asciidoc sources.\n"
-        print "    Run 'make docs' to build everything."
-        print "    Run 'make viewdocs' to build and then preview in a web browser."
+        print("This script builds the html documentation from rst/asciidoc sources.\n")
+        print("    Run 'make docs' to build everything.")
+        print("    Run 'make viewdocs' to build and then preview in a web browser.")
         sys.exit(0)
 
     # The 'htmldocs' make target will call this scrip twith the 'rst'

--- a/docsite/rst/developing_api.rst
+++ b/docsite/rst/developing_api.rst
@@ -70,22 +70,22 @@ The following script prints out the uptime information for all hosts::
     ).run()
 
     if results is None:
-       print "No hosts found"
+       print("No hosts found")
        sys.exit(1)
 
-    print "UP ***********"
+    print("UP ***********")
     for (hostname, result) in results['contacted'].items():
         if not 'failed' in result:
-            print "%s >>> %s" % (hostname, result['stdout'])
+            print("%s >>> %s" % (hostname, result['stdout']))
 
-    print "FAILED *******"
+    print("FAILED *******")
     for (hostname, result) in results['contacted'].items():
         if 'failed' in result:
-            print "%s >>> %s" % (hostname, result['msg'])
+            print("%s >>> %s" % (hostname, result['msg']))
 
-    print "DOWN *********"
+    print("DOWN *********")
     for (hostname, result) in results['dark'].items():
-        print "%s >>> %s" % (hostname, result)
+        print("%s >>> %s" % (hostname, result))
 
 Advanced programmers may also wish to read the source to ansible itself, for
 it uses the Runner() API (with all available options) to implement the

--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -48,9 +48,9 @@ Ok, let's get going with an example.  We'll use Python.  For starters, save this
     import json
 
     date = str(datetime.datetime.now())
-    print json.dumps({
+    print(json.dumps({
         "time" : date
-    })
+    }))
 
 .. _module_testing:
 
@@ -151,10 +151,10 @@ a lot shorter than this::
                 # can be added.
 
                 if rc != 0:
-                    print json.dumps({
+                    print(json.dumps({
                         "failed" : True,
                         "msg"    : "failed setting the time"
-                    })
+                    }))
                     sys.exit(1)
 
                 # when things do not fail, we do not
@@ -165,10 +165,10 @@ a lot shorter than this::
                 # notifiers to be used in playbooks.
 
                 date = str(datetime.datetime.now())
-                print json.dumps({
+                print(json.dumps({
                     "time" : date,
                     "changed" : True
-                })
+                }))
                 sys.exit(0)
 
     # if no parameters are sent, the module may or
@@ -176,9 +176,9 @@ a lot shorter than this::
     # return the time
 
     date = str(datetime.datetime.now())
-    print json.dumps({
+    print(json.dumps({
         "time" : date
-    })
+    }))
 
 Let's test that module::
 
@@ -298,7 +298,7 @@ Common Pitfalls
 
 You should also never do this in a module::
 
-    print "some status message"
+    print("some status message")
 
 Because the output is supposed to be valid JSON.  Except that's not quite true,
 but we'll get to that later.

--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -217,7 +217,7 @@ password hashing library is installed.
 
 Once the library is ready, SHA512 password values can then be generated as follows::
 
-    python -c "from passlib.hash import sha512_crypt; print sha512_crypt.encrypt('<password>')"
+    python -c "from passlib.hash import sha512_crypt; print(sha512_crypt.encrypt('<password>'))"
 
 .. _commercial_support:
 

--- a/examples/scripts/uptime.py
+++ b/examples/scripts/uptime.py
@@ -12,20 +12,20 @@ results = ansible.runner.Runner(
 ).run()
 
 if results is None:
-   print "No hosts found"
+   print("No hosts found")
    sys.exit(1)
 
-print "UP ***********"
+print("UP ***********")
 for (hostname, result) in results['contacted'].items():
     if not 'failed' in result:
-        print "%s >>> %s" % (hostname, result['stdout'])
+        print("%s >>> %s" % (hostname, result['stdout']))
 
-print "FAILED *******"
+print("FAILED *******")
 for (hostname, result) in results['contacted'].items():
     if 'failed' in result:
-        print "%s >>> %s" % (hostname, result['msg'])
+        print("%s >>> %s" % (hostname, result['msg']))
 
-print "DOWN *********"
+print("DOWN *********")
 for (hostname, result) in results['dark'].items():
-    print "%s >>> %s" % (hostname, result)
+    print("%s >>> %s" % (hostname, result))
 

--- a/examples/scripts/yaml_to_ini.py
+++ b/examples/scripts/yaml_to_ini.py
@@ -142,7 +142,7 @@ class InventoryParserYaml(object):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print "usage: yaml_to_ini.py /path/to/ansible/hosts"
+        print("usage: yaml_to_ini.py /path/to/ansible/hosts")
         sys.exit(1)
 
     result = ""
@@ -168,10 +168,10 @@ if __name__ == "__main__":
 
         groupfiledir = os.path.join(dirname, "group_vars")
         if not os.path.exists(groupfiledir):
-            print "* creating: %s" % groupfiledir
+            print("* creating: %s" % groupfiledir)
             os.makedirs(groupfiledir)
         groupfile = os.path.join(groupfiledir, group_name)
-        print "* writing group variables for %s into %s" % (group_name, groupfile)
+        print("* writing group variables for %s into %s" % (group_name, groupfile))
         groupfh = open(groupfile, 'w')
         groupfh.write(yaml.dump(record.get_variables()))
         groupfh.close()
@@ -179,10 +179,10 @@ if __name__ == "__main__":
     for (host_name, host_record) in yamlp._hosts.iteritems():
         hostfiledir = os.path.join(dirname, "host_vars")
         if not os.path.exists(hostfiledir):
-            print "* creating: %s" % hostfiledir
+            print("* creating: %s" % hostfiledir)
             os.makedirs(hostfiledir)
         hostfile = os.path.join(hostfiledir, host_record.name)
-        print "* writing host variables for %s into %s" % (host_record.name, hostfile)
+        print("* writing host variables for %s into %s" % (host_record.name, hostfile))
         hostfh = open(hostfile, 'w')
         hostfh.write(yaml.dump(host_record.get_variables()))
         hostfh.close()
@@ -197,10 +197,10 @@ if __name__ == "__main__":
     fdh.write(result)
     fdh.close()
 
-    print "* COMPLETE: review your new inventory file and replace your original when ready"
-    print "*           new inventory file saved as %s" % newfilepath
-    print "*           edit group specific variables in %s/group_vars/" % dirname
-    print "*           edit host specific variables in %s/host_vars/" % dirname
+    print("* COMPLETE: review your new inventory file and replace your original when ready")
+    print("*           new inventory file saved as %s" % newfilepath)
+    print("*           edit group specific variables in %s/group_vars/" % dirname)
+    print("*           edit host specific variables in %s/host_vars/" % dirname)
 
     # now need to write this to disk as (oldname).new
     # and inform the user

--- a/hacking/get_library.py
+++ b/hacking/get_library.py
@@ -22,7 +22,7 @@ import ansible.constants as C
 import sys
 
 def main():
-    print C.DEFAULT_MODULE_PATH
+    print(C.DEFAULT_MODULE_PATH)
     return 0
 
 if __name__ == '__main__':

--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -110,7 +110,7 @@ def write_data(text, options, outputname, module):
         f.write(text.encode('utf-8'))
         f.close()
     else:
-        print text
+        print(text)
 
 #####################################################################################
 
@@ -180,7 +180,7 @@ def jinja2_environment(template_dir, typ):
 
 def process_module(module, options, env, template, outputname, module_map):
 
-    print "rendering: %s" % module
+    print("rendering: %s" % module)
 
     fname = module_map[module]
 
@@ -242,7 +242,7 @@ def process_category(category, categories, options, env, template, outputname):
 
     category_file_path = os.path.join(options.output_dir, "list_of_%s_modules.rst" % category)
     category_file = open(category_file_path, "w")
-    print "*** recording category %s in %s ***" % (category, category_file_path)
+    print("*** recording category %s in %s ***" % (category, category_file_path))
 
     # TODO: start a new category file
 
@@ -286,7 +286,7 @@ def validate_options(options):
         sys.stderr.write("--module-dir does not exist: %s" % options.module_dir)
         sys.exit(1)
     if not options.template_dir:
-        print "--template-dir must be specified"
+        print("--template-dir must be specified")
         sys.exit(1)
 
 #####################################################################################

--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -280,10 +280,10 @@ def validate_options(options):
     ''' validate option parser options '''
 
     if not options.module_dir:
-        print >>sys.stderr, "--module-dir is required"
+        sys.stderr.write("--module-dir is required")
         sys.exit(1)
     if not os.path.exists(options.module_dir):
-        print >>sys.stderr, "--module-dir does not exist: %s" % options.module_dir
+        sys.stderr.write("--module-dir does not exist: %s" % options.module_dir)
         sys.exit(1)
     if not options.template_dir:
         print "--template-dir must be specified"

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -101,7 +101,7 @@ def boilerplate_module(modfile, args, interpreter):
     inject = {}
     if interpreter:
         if '=' not in interpreter:
-            print 'interpeter must by in the form of ansible_python_interpreter=/usr/bin/python'
+            print('interpeter must by in the form of ansible_python_interpreter=/usr/bin/python')
             sys.exit(1)
         interpreter_type, interpreter_path = interpreter.split('=')
         if not interpreter_type.startswith('ansible_'):
@@ -117,8 +117,8 @@ def boilerplate_module(modfile, args, interpreter):
     )
 
     modfile2_path = os.path.expanduser("~/.ansible_module_generated")
-    print "* including generated source, if any, saving to: %s" % modfile2_path
-    print "* this may offset any line numbers in tracebacks/debuggers!"
+    print("* including generated source, if any, saving to: %s" % modfile2_path)
+    print("* this may offset any line numbers in tracebacks/debuggers!")
     modfile2 = open(modfile2_path, 'w')
     modfile2.write(module_data)
     modfile2.close()
@@ -139,21 +139,21 @@ def runtest( modfile, argspath):
     (out, err) = cmd.communicate()
 
     try:
-        print "***********************************"
-        print "RAW OUTPUT"
-        print out
-        print err
+        print("***********************************")
+        print("RAW OUTPUT")
+        print(out)
+        print(err)
         results = utils.parse_json(out)
     except:
-        print "***********************************"
-        print "INVALID OUTPUT FORMAT"
-        print out
+        print("***********************************")
+        print("INVALID OUTPUT FORMAT")
+        print(out)
         traceback.print_exc()
         sys.exit(1)
 
-    print "***********************************"
-    print "PARSED OUTPUT"
-    print utils.jsonify(results,format=True)
+    print("***********************************")
+    print("PARSED OUTPUT")
+    print(utils.jsonify(results,format=True))
 
 def rundebug(debugger, modfile, argspath):
     """Run interactively with console debugger."""

--- a/legacy/gce_tests.py
+++ b/legacy/gce_tests.py
@@ -669,13 +669,13 @@ def main(tests_to_run=[]):
     for test in test_cases:
         if tests_to_run and test['id'] not in tests_to_run:
             continue
-        print "=> starting/setup '%s:%s'"% (test['id'], test['desc'])
-        if DEBUG: print "=debug>", test['setup']
+        print("=> starting/setup '%s:%s'"% (test['id'], test['desc']))
+        if DEBUG: print("=debug>", test['setup'])
         for c in test['setup']:
             (s,o) = run(c)
         test_i = 1
         for t in test['tests']:
-            if DEBUG: print "=>debug>", test_i, t['desc']
+            if DEBUG: print("=>debug>", test_i, t['desc'])
             # run any test-specific setup commands
             if t.has_key('setup'):
                 for setup in t['setup']:
@@ -690,14 +690,14 @@ def main(tests_to_run=[]):
             # an empty 'a' directive allows test to run
             # setup/teardown for a subsequent test.
             if t['a']:
-                if DEBUG: print "=>debug>", t['m'], t['a']
+                if DEBUG: print("=>debug>", t['m'], t['a'])
                 acmd = "ansible all -o -m %s -a \"%s\"" % (t['m'],t['a'])
                 #acmd = "ANSIBLE_KEEP_REMOTE_FILES=1 ansible all -vvv -m %s -a \"%s\"" % (t['m'],t['a'])
                 (s,o) = run(acmd)
 
                 # check expected output
-                if DEBUG: print "=debug>", o.strip(), "!=", t['r']
-                print "=> %s.%02d '%s':" % (test['id'], test_i, t['desc']),
+                if DEBUG: print("=debug>", o.strip(), "!=", t['r'])
+                print("=> %s.%02d '%s':" % (test['id'], test_i, t['desc']))
                 if t.has_key('strip_numbers'):
                     # strip out all numbers so we don't trip over different
                     # IP addresses
@@ -706,13 +706,13 @@ def main(tests_to_run=[]):
                     is_good = (o.strip() == t['r'])
 
                 if is_good:
-                    print "PASS"
+                    print("PASS")
                 else:
-                    print "FAIL"
+                    print("FAIL")
                     if VERBOSE:
-                        print "=>", acmd
-                        print "=> Expected:", t['r']
-                        print "=>      Got:", o.strip()
+                        print("=>", acmd)
+                        print("=> Expected:", t['r'])
+                        print("=>      Got:", o.strip())
 
             # run any 'peek_after' commands
             if t.has_key('peek_after') and PEEKING_ENABLED:
@@ -725,8 +725,8 @@ def main(tests_to_run=[]):
                     (status, output) = run(td)
             test_i += 1
 
-        print "=> completing/teardown '%s:%s'" % (test['id'], test['desc'])
-        if DEBUG: print "=debug>", test['teardown']
+        print("=> completing/teardown '%s:%s'" % (test['id'], test['desc']))
+        if DEBUG:(print("=debug>", test['teardown']))
         for c in test['teardown']:
             (s,o) = run(c)
 
@@ -735,13 +735,13 @@ if __name__ == '__main__':
     tests_to_run = []
     if len(sys.argv) == 2:
         if sys.argv[1] in ["--help", "--list"]:
-            print "usage: %s [id1,id2,...,idN]" % sys.argv[0]
-            print "  * An empty argument list will execute all tests"
-            print "  * Do not need to specify tests in numerical order"
-            print "  * List test categories with --list or --help"
-            print ""
+            print("usage: %s [id1,id2,...,idN]" % sys.argv[0])
+            print("  * An empty argument list will execute all tests")
+            print("  * Do not need to specify tests in numerical order")
+            print("  * List test categories with --list or --help")
+            print()
             for test in test_cases:
-                print "\t%s:%s" % (test['id'], test['desc'])
+                print("\t%s:%s" % (test['id'], test['desc']))
             sys.exit(0)
         else:
             tests_to_run = sys.argv[1].split(',')

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -147,9 +147,9 @@ def display(msg, color=None, stderr=False, screen_only=False, log_only=False, ru
                 print msg2.encode('utf-8')
         else:
             try:
-                print >>sys.stderr, msg2
+                sys.stderr.write(msg2)
             except UnicodeEncodeError:
-                print >>sys.stderr, msg2.encode('utf-8')
+                sys.stderr.write(msg2.encode('utf-8'))
     if constants.DEFAULT_LOG_PATH != '':
         while msg.startswith("\n"):
             msg = msg.replace("\n","")

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import utils
+import ansible.utils
 import sys
 import getpass
 import os
@@ -24,7 +24,7 @@ import random
 import fnmatch
 import tempfile
 import fcntl
-import constants
+from ansible import constants
 from ansible.color import stringc
 
 import logging
@@ -142,9 +142,9 @@ def display(msg, color=None, stderr=False, screen_only=False, log_only=False, ru
     if not log_only:
         if not stderr:
             try:
-                print msg2
+                print(msg2)
             except UnicodeEncodeError:
-                print msg2.encode('utf-8')
+                print(msg2.encode('utf-8'))
         else:
             try:
                 sys.stderr.write(msg2)

--- a/lib/ansible/color.py
+++ b/lib/ansible/color.py
@@ -16,7 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-import constants
+from ansible import constants
 
 ANSIBLE_COLOR=True
 if constants.ANSIBLE_NOCOLOR:

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -18,7 +18,10 @@
 import os
 import pwd
 import sys
-import ConfigParser
+try:
+    import configparser as ConfigParser
+except ImportError:
+    import ConfigParser
 from string import ascii_letters, digits
 
 # copied from utils, avoid circular reference fun :)

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -135,7 +135,7 @@ class InventoryParser(object):
                                 break
                             try:
                                 (k,v) = t.split("=", 1)
-                            except ValueError, e:
+                            except(ValueError, e):
                                 raise errors.AnsibleError("Invalid ini entry: %s - %s" % (t, str(e)))
                             host.set_variable(k, self._parse_value(v))
                     self.groups[active_group_name].add_host(host)

--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -38,7 +38,8 @@ class InventoryScript(object):
         cmd = [ self.filename, "--list" ]
         try:
             sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        except OSError, e:
+        except OSError:
+            e = sys.exc_info()[1]
             raise errors.AnsibleError("problem running %s (%s)" % (' '.join(cmd), e))
         (stdout, stderr) = sp.communicate()
         self.data = stdout
@@ -120,7 +121,8 @@ class InventoryScript(object):
         cmd = [self.filename, "--host", host.name]
         try:
             sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        except OSError, e:
+        except OSError:
+            e = sys.exc_info()[1]
             raise errors.AnsibleError("problem running %s (%s)" % (' '.join(cmd), e))
         (out, err) = sp.communicate()
         return utils.parse_json(out)

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -18,7 +18,7 @@
 # from python and deps
 
 try:
-    from io import StringIO
+    import io.StringIO as StringIO
 except ImportError:
     from cStringIO import StringIO
 import inspect

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -16,7 +16,11 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # from python and deps
-from cStringIO import StringIO
+
+try:
+    from io import StringIO
+except ImportError:
+    from cStringIO import StringIO
 import inspect
 import os
 import shlex

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -936,7 +936,7 @@ class AnsibleModule(object):
         if not 'changed' in kwargs:
             kwargs['changed'] = False
         self.do_cleanup_files()
-        print self.jsonify(kwargs)
+        print(self.jsonify(kwargs))
         sys.exit(0)
 
     def fail_json(self, **kwargs):
@@ -945,7 +945,7 @@ class AnsibleModule(object):
         assert 'msg' in kwargs, "implementation error -- msg to explain the error is required"
         kwargs['failed'] = True
         self.do_cleanup_files()
-        print self.jsonify(kwargs)
+        print(self.jsonify(kwargs))
         sys.exit(1)
 
     def is_executable(self, path):

--- a/lib/ansible/runner/action_plugins/pause.py
+++ b/lib/ansible/runner/action_plugins/pause.py
@@ -95,7 +95,7 @@ class ActionModule(object):
         try:
             self._start()
             if not self.pause_type == 'prompt':
-                print "[%s]\nPausing for %s seconds" % (hosts, self.seconds)
+                print("[%s]\nPausing for %s seconds" % (hosts, self.seconds))
                 time.sleep(self.seconds)
             else:
                 # Clear out any unflushed buffered input which would
@@ -104,7 +104,7 @@ class ActionModule(object):
                 self.result['user_input'] = raw_input(self.prompt.encode(sys.stdout.encoding))
         except KeyboardInterrupt:
             while True:
-                print '\nAction? (a)bort/(c)ontinue: '
+                print('\nAction? (a)bort/(c)ontinue: ')
                 c = getch()
                 if c == 'c':
                     # continue playbook evaluation
@@ -122,7 +122,7 @@ class ActionModule(object):
         self.start = time.time()
         self.result['start'] = str(datetime.datetime.now())
         if not self.pause_type == 'prompt':
-            print "(^C-c = continue early, ^C-a = abort)"
+            print("(^C-c = continue early, ^C-a = abort)")
 
     def _stop(self):
         ''' calculate the duration we actually paused for and then

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -149,9 +149,9 @@ def decrypt(key, msg):
 ###############################################################
 
 def err(msg):
-    ''' print an error message to stderr '''
+    ''' write an error message to stderr '''
 
-    print >> sys.stderr, msg
+    sys.stderr.write(msg)
 
 def exit(msg, rc=1):
     ''' quit with an error to stdout and a failure code '''

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1122,7 +1122,7 @@ def safe_eval(expr, locals={}, include_exceptions=False):
             return (expr, None)
         return expr
     except(Exception):
-        e = = sys.exc_info()[1]
+        e = sys.exc_info()[1]
         if include_exceptions:
             return (expr, e)
         return expr

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -37,9 +37,9 @@ except Exception:
 import ast
 import time
 try:
-    from io import StringIO
+    import io.StringIO as StringIO
 except ImportError:
-    from cStringIO import StringIO
+    import StringIO
 import stat
 import termios
 import tty
@@ -973,7 +973,7 @@ def make_su_cmd(su_user, executable, cmd):
     )
     return ('/bin/sh -c ' + pipes.quote(sudocmd), prompt, success_key)
 
-_TO_UNICODE_TYPES = (unicode(), type(None))
+_TO_UNICODE_TYPES = (unicode, type(None))
 
 def to_unicode(value):
     # TODO this is causing issues with Python3

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -973,11 +973,12 @@ def make_su_cmd(su_user, executable, cmd):
     )
     return ('/bin/sh -c ' + pipes.quote(sudocmd), prompt, success_key)
 
-#_TO_UNICODE_TYPES = (unicode(), type(None))
+_TO_UNICODE_TYPES = (unicode(), type(None))
 
 def to_unicode(value):
-    #if isinstance(value, _TO_UNICODE_TYPES):
-    #    return value
+    # TODO this is causing issues with Python3
+    if isinstance(value, _TO_UNICODE_TYPES):
+        return value
     return value.decode("utf-8")
 
 def get_diff(diff):

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -36,10 +36,10 @@ except Exception:
     bytes = str
 import ast
 import time
-try:
-    import io.StringIO as StringIO
-except ImportError:
-    import StringIO
+#try:
+#    from io import StringIO
+#except ImportError:
+import StringIO
 import stat
 import termios
 import tty
@@ -116,7 +116,7 @@ def key_for_hostname(hostname):
 
     key_path = os.path.expanduser(C.ACCELERATE_KEYS_DIR)
     if not os.path.exists(key_path):
-        os.makedirs(key_path, mode=0o700)
+        os.makedirs(key_path, mode=int('700', 8))
         os.chmod(key_path, int(C.ACCELERATE_KEYS_DIR_PERMS, 8))
     elif not os.path.isdir(key_path):
         raise errors.AnsibleError('ACCELERATE_KEYS_DIR is not a directory.')
@@ -257,12 +257,12 @@ def unfrackpath(path):
     '''
     return os.path.normpath(os.path.realpath(os.path.expandvars(os.path.expanduser(path))))
 
-def prepare_writeable_dir(tree,mode=0o777):
+def prepare_writeable_dir(tree,mode=int('777', 8)):
     ''' make sure a directory exists and is writeable '''
 
     # modify the mode to ensure the owner at least
     # has read/write access to this directory
-    mode |= 0o700
+    mode |= int('700', 8)
 
     # make sure the tree path is always expanded
     # and normalized and free of symlinks

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -387,7 +387,8 @@ def parse_yaml(data, path_hint=None):
         # since the line starts with { or [ we can infer this is a JSON document.
         try:
             loaded = json.loads(data)
-        except(ValueError, ve):
+        except(ValueError):
+            ve = sys.exc_info()[1]
             if path_hint:
                 raise errors.AnsibleError(path_hint + ": " + str(ve))
             else:
@@ -566,7 +567,8 @@ def parse_yaml_from_file(path, vault_password=None):
 
     try:
         return parse_yaml(data, path_hint=path)
-    except(yaml.YAMLError, exc):
+    except(yaml.YAMLError):
+        exc = sys.exc_info()[1]
         process_yaml_error(exc, data, path, show_content)
 
 def parse_kv(args):
@@ -577,7 +579,8 @@ def parse_kv(args):
         args = args.encode('utf-8')
         try:
             vargs = shlex.split(args, posix=True)
-        except(ValueError, ve):
+        except(ValueError):
+            ve = sys.exc_info()[1]
             if 'no closing quotation' in str(ve).lower():
                 raise errors.AnsibleError("error parsing argument string, try quoting the entire line.")
             else:
@@ -632,7 +635,8 @@ def md5(filename):
             digest.update(block)
             block = infile.read(blocksize)
         infile.close()
-    except(IOError, e):
+    except(IOError):
+        e = sys.exc_info()[1]
         raise errors.AnsibleError("error while accessing the file %s, error was: %s" % (filename, e))
     return digest.hexdigest()
 
@@ -1110,13 +1114,14 @@ def safe_eval(expr, locals={}, include_exceptions=False):
             return (result, None)
         else:
             return result
-    except(SyntaxError, e):
+    except(SyntaxError):
         # special handling for syntax errors, we just return
         # the expression string back as-is
         if include_exceptions:
             return (expr, None)
         return expr
-    except(Exception, e):
+    except(Exception):
+        e = = sys.exc_info()[1]
         if include_exceptions:
             return (expr, e)
         return expr

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -30,9 +30,16 @@ from ansible.utils.display_functions import *
 from ansible.utils.plugins import *
 from ansible.callbacks import display
 import ansible.constants as C
+try:
+    bytes
+except Exception:
+    bytes = str
 import ast
 import time
-import StringIO
+try:
+    from io import StringIO
+except ImportError:
+    from cStringIO import StringIO
 import stat
 import termios
 import tty
@@ -46,7 +53,7 @@ import sys
 import json
 
 #import vault
-from vault import VaultLib
+#from vault import VaultLib
 
 VERBOSITY=0
 
@@ -109,7 +116,7 @@ def key_for_hostname(hostname):
 
     key_path = os.path.expanduser(C.ACCELERATE_KEYS_DIR)
     if not os.path.exists(key_path):
-        os.makedirs(key_path, mode=0700)
+        os.makedirs(key_path, mode=0o700)
         os.chmod(key_path, int(C.ACCELERATE_KEYS_DIR_PERMS, 8))
     elif not os.path.isdir(key_path):
         raise errors.AnsibleError('ACCELERATE_KEYS_DIR is not a directory.')
@@ -250,12 +257,12 @@ def unfrackpath(path):
     '''
     return os.path.normpath(os.path.realpath(os.path.expandvars(os.path.expanduser(path))))
 
-def prepare_writeable_dir(tree,mode=0777):
+def prepare_writeable_dir(tree,mode=0o777):
     ''' make sure a directory exists and is writeable '''
 
     # modify the mode to ensure the owner at least
     # has read/write access to this directory
-    mode |= 0700
+    mode |= 0o700
 
     # make sure the tree path is always expanded
     # and normalized and free of symlinks
@@ -264,7 +271,11 @@ def prepare_writeable_dir(tree,mode=0777):
     if not os.path.exists(tree):
         try:
             os.makedirs(tree, mode)
-        except (IOError, OSError), e:
+        except IOError:
+            e = sys.exc_info()[1]
+            raise errors.AnsibleError("Could not make dir %s: %s" % (tree, e))
+        except OSError:
+            e = sys.exc_info()[1]
             raise errors.AnsibleError("Could not make dir %s: %s" % (tree, e))
     if not os.access(tree, os.W_OK):
         raise errors.AnsibleError("Cannot write to path %s" % tree)
@@ -326,7 +337,7 @@ def parse_json(raw_data):
         try:
             tokens = shlex.split(data)
         except:
-            print "failed to parse json: "+ data
+            print("failed to parse json: "+ data)
             raise
 
         for t in tokens:
@@ -376,7 +387,7 @@ def parse_yaml(data, path_hint=None):
         # since the line starts with { or [ we can infer this is a JSON document.
         try:
             loaded = json.loads(data)
-        except ValueError, ve:
+        except(ValueError, ve):
             if path_hint:
                 raise errors.AnsibleError(path_hint + ": " + str(ve))
             else:
@@ -555,7 +566,7 @@ def parse_yaml_from_file(path, vault_password=None):
 
     try:
         return parse_yaml(data, path_hint=path)
-    except yaml.YAMLError, exc:
+    except(yaml.YAMLError, exc):
         process_yaml_error(exc, data, path, show_content)
 
 def parse_kv(args):
@@ -566,7 +577,7 @@ def parse_kv(args):
         args = args.encode('utf-8')
         try:
             vargs = shlex.split(args, posix=True)
-        except ValueError, ve:
+        except(ValueError, ve):
             if 'no closing quotation' in str(ve).lower():
                 raise errors.AnsibleError("error parsing argument string, try quoting the entire line.")
             else:
@@ -621,7 +632,7 @@ def md5(filename):
             digest.update(block)
             block = infile.read(blocksize)
         infile.close()
-    except IOError, e:
+    except(IOError, e):
         raise errors.AnsibleError("error while accessing the file %s, error was: %s" % (filename, e))
     return digest.hexdigest()
 
@@ -662,7 +673,7 @@ def _gitinfo():
             else:
                 offset = time.altzone
             result = "({0} {1}) last updated {2} (GMT {3:+04d})".format(branch, commit,
-                time.strftime("%Y/%m/%d %H:%M:%S", date), offset / -36)
+                time.strftime("%Y/%m/%d %H:%M:%S", date), offset // -36)
     else:
         result = ''
     return result
@@ -958,11 +969,11 @@ def make_su_cmd(su_user, executable, cmd):
     )
     return ('/bin/sh -c ' + pipes.quote(sudocmd), prompt, success_key)
 
-_TO_UNICODE_TYPES = (unicode, type(None))
+#_TO_UNICODE_TYPES = (unicode(), type(None))
 
 def to_unicode(value):
-    if isinstance(value, _TO_UNICODE_TYPES):
-        return value
+    #if isinstance(value, _TO_UNICODE_TYPES):
+    #    return value
     return value.decode("utf-8")
 
 def get_diff(diff):
@@ -1099,13 +1110,13 @@ def safe_eval(expr, locals={}, include_exceptions=False):
             return (result, None)
         else:
             return result
-    except SyntaxError, e:
+    except(SyntaxError, e):
         # special handling for syntax errors, we just return
         # the expression string back as-is
         if include_exceptions:
             return (expr, None)
         return expr
-    except Exception, e:
+    except(Exception, e):
         if include_exceptions:
             return (expr, e)
         return expr

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -53,7 +53,7 @@ import sys
 import json
 
 #import vault
-#from vault import VaultLib
+from vault import VaultLib
 
 VERBOSITY=0
 

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -36,10 +36,10 @@ except Exception:
     bytes = str
 import ast
 import time
-#try:
-#    from io import StringIO
-#except ImportError:
-import StringIO
+try:
+    import StringIO
+except ImportError:
+    import io
 import stat
 import termios
 import tty

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -151,7 +151,7 @@ def decrypt(key, msg):
 def err(msg):
     ''' write an error message to stderr '''
 
-    sys.stderr.write(msg)
+    sys.stderr.write(msg + "\n")
 
 def exit(msg, rc=1):
     ''' quit with an error to stdout and a failure code '''

--- a/lib/ansible/utils/module_docs.py
+++ b/lib/ansible/utils/module_docs.py
@@ -93,6 +93,6 @@ def get_docstring(filename, verbose=False):
         traceback.print_exc() # temp
         if verbose == True:
             traceback.print_exc()
-            print "unable to parse %s" % filename
+            print("unable to parse %s" % filename)
     return doc, plainexamples
 

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -91,10 +91,10 @@ def lookup(name, *args, **kwargs):
         # safely catch run failures per #5059
         try:
             ran = instance.run(*args, inject=vars, **kwargs)
-        except errors.AnsibleError:
+        except(errors.AnsibleError):
             # Plugin raised this on purpose
             raise
-        except Exception, e:
+        except(Exception, e):
             ran = None
         if ran:
             ran = ",".join(ran)
@@ -132,7 +132,7 @@ def template(basedir, varname, vars, lookup_fatal=True, depth=0, expand_lists=Tr
             return d
         else:
             return varname
-    except errors.AnsibleFilterError:
+    except(errors.AnsibleFilterError):
         if filter_fatal:
             raise
         else:
@@ -226,7 +226,7 @@ def template_from_file(basedir, path, vars, vault_password=None):
 
     try:
         data = codecs.open(realpath, encoding="utf8").read()
-    except UnicodeDecodeError:
+    except(UnicodeDecodeError):
         raise errors.AnsibleError("unable to process as utf-8: %s" % realpath)
     except:
         raise errors.AnsibleError("unable to read %s" % realpath)
@@ -244,7 +244,7 @@ def template_from_file(basedir, path, vars, vault_password=None):
     environment.template_class = J2Template
     try:
         t = environment.from_string(data)
-    except TemplateSyntaxError, e:
+    except(TemplateSyntaxError, e):
         # Throw an exception which includes a more user friendly error message
         values = {'name': realpath, 'lineno': e.lineno, 'error': str(e)}
         msg = 'file: %(name)s, line number: %(lineno)s, error: %(error)s' % \
@@ -279,7 +279,7 @@ def template_from_file(basedir, path, vars, vault_password=None):
     # passed through dict(o), but I have not found that yet.
     try:
         res = jinja2.utils.concat(t.root_render_func(t.new_context(_jinja2_vars(basedir, vars, t.globals, fail_on_undefined), shared=True)))
-    except jinja2.exceptions.UndefinedError, e:
+    except(jinja2.exceptions.UndefinedError, e):
         raise errors.AnsibleUndefinedVariable("One or more undefined variables: %s" % str(e))
 
     # The low level calls above do not preserve the newline
@@ -323,12 +323,12 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
         if isinstance(data, unicode):
             try:
                 data = data.decode('utf-8')
-            except UnicodeEncodeError, e:
+            except(UnicodeEncodeError, e):
                 pass
 
         try:
             t = environment.from_string(data)
-        except Exception, e:
+        except(Exception, e):
             if 'recursion' in str(e):
                 raise errors.AnsibleError("recursive loop detected in template string: %s" % data)
             else:
@@ -345,7 +345,7 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
         rf = t.root_render_func(new_context)
         try:
             res = jinja2.utils.concat(rf)
-        except TypeError, te:
+        except(TypeError, te):
             if 'StrictUndefined' in str(te):
                 raise errors.AnsibleUndefinedVariable(
                     "Unable to look up a name or access an attribute in template string. " + \
@@ -354,7 +354,7 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
             else:
                 raise errors.AnsibleError("an unexpected type error occured. Error was %s" % te)
         return res
-    except (jinja2.exceptions.UndefinedError, errors.AnsibleUndefinedVariable):
+    except(jinja2.exceptions.UndefinedError, errors.AnsibleUndefinedVariable):
         if fail_on_undefined:
             raise
         else:

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -94,7 +94,8 @@ def lookup(name, *args, **kwargs):
         except(errors.AnsibleError):
             # Plugin raised this on purpose
             raise
-        except(Exception, e):
+        except(Exception):
+            e = sys.exc_info()[1]
             ran = None
         if ran:
             ran = ",".join(ran)
@@ -244,7 +245,8 @@ def template_from_file(basedir, path, vars, vault_password=None):
     environment.template_class = J2Template
     try:
         t = environment.from_string(data)
-    except(TemplateSyntaxError, e):
+    except(TemplateSyntaxError):
+        e = sys.exc_info()[1]
         # Throw an exception which includes a more user friendly error message
         values = {'name': realpath, 'lineno': e.lineno, 'error': str(e)}
         msg = 'file: %(name)s, line number: %(lineno)s, error: %(error)s' % \
@@ -279,7 +281,8 @@ def template_from_file(basedir, path, vars, vault_password=None):
     # passed through dict(o), but I have not found that yet.
     try:
         res = jinja2.utils.concat(t.root_render_func(t.new_context(_jinja2_vars(basedir, vars, t.globals, fail_on_undefined), shared=True)))
-    except(jinja2.exceptions.UndefinedError, e):
+    except(jinja2.exceptions.UndefinedError):
+        e = sys.exc_info()[1] 
         raise errors.AnsibleUndefinedVariable("One or more undefined variables: %s" % str(e))
 
     # The low level calls above do not preserve the newline
@@ -323,12 +326,13 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
         if isinstance(data, unicode):
             try:
                 data = data.decode('utf-8')
-            except(UnicodeEncodeError, e):
+            except(UnicodeEncodeError):
                 pass
 
         try:
             t = environment.from_string(data)
-        except(Exception, e):
+        except(Exception):
+            e = sys.exc_info()[1]
             if 'recursion' in str(e):
                 raise errors.AnsibleError("recursive loop detected in template string: %s" % data)
             else:
@@ -345,7 +349,8 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
         rf = t.root_render_func(new_context)
         try:
             res = jinja2.utils.concat(rf)
-        except(TypeError, te):
+        except(TypeError):
+            te = sys.exc_info()[1]
             if 'StrictUndefined' in str(te):
                 raise errors.AnsibleUndefinedVariable(
                     "Unable to look up a name or access an attribute in template string. " + \

--- a/lib/ansible/utils/vault.py
+++ b/lib/ansible/utils/vault.py
@@ -191,7 +191,7 @@ class VaultEditor(object):
             raise errors.AnsibleError("%s exists, please use 'edit' instead" % self.filename)
 
         # drop the user into vim on file
-        old_umask = os.umask(0077)
+        old_umask = os.umask(0o077)
         call(self._editor_shell_command(self.filename))
         tmpdata = self.read_data(self.filename)
         this_vault = VaultLib(self.password)
@@ -225,7 +225,7 @@ class VaultEditor(object):
             raise errors.AnsibleError(CRYPTO_UPGRADE)
 
         # make sure the umask is set to a sane value
-        old_mask = os.umask(0077)
+        old_mask = os.umask(0o077)
 
         # decrypt to tmpfile
         tmpdata = self.read_data(self.filename)

--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -118,7 +118,7 @@ try:
     import boto
     import boto.cloudformation.connection
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 

--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -170,11 +170,11 @@ try:
     import dopy
     from dopy.manager import DoError, DoManager
 except ImportError, e:
-    print "failed=True msg='dopy >= 0.2.3 required for this module'"
+    print("failed=True msg='dopy >= 0.2.3 required for this module'")
     sys.exit(1)
 
 if dopy.__version__ < '0.2.3':
-    print "failed=True msg='dopy >= 0.2.3 required for this module'"
+    print("failed=True msg='dopy >= 0.2.3 required for this module'")
     sys.exit(1)
 
 class TimeoutError(DoError):

--- a/library/cloud/digital_ocean_domain
+++ b/library/cloud/digital_ocean_domain
@@ -80,7 +80,7 @@ import time
 try:
     from dopy.manager import DoError, DoManager
 except ImportError as e:
-    print "failed=True msg='dopy required for this module'"
+    print("failed=True msg='dopy required for this module'")
     sys.exit(1)
 
 class TimeoutError(DoError):

--- a/library/cloud/digital_ocean_sshkey
+++ b/library/cloud/digital_ocean_sshkey
@@ -70,7 +70,7 @@ import time
 try:
     from dopy.manager import DoError, DoManager
 except ImportError as e:
-    print "failed=True msg='dopy required for this module'"
+    print("failed=True msg='dopy required for this module'")
     sys.exit(1)
 
 class TimeoutError(DoError):

--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -326,7 +326,7 @@ def _human_to_bytes(number):
             return int(number[:-len(each)]) * (1024 ** i)
         i = i + 1
 
-    print "failed=True msg='Could not convert %s to integer'" % (number)
+    print("failed=True msg='Could not convert %s to integer'" % (number))
     sys.exit(1)
 
 def _ansible_facts(container_list):

--- a/library/cloud/docker_image
+++ b/library/cloud/docker_image
@@ -110,7 +110,7 @@ try:
     from requests.exceptions import *
     from urlparse import urlparse
 except ImportError, e:
-    print "failed=True msg='failed to import python module: %s'" % e
+    print("failed=True msg='failed to import python module: %s'" % e)
     sys.exit(1)
 
 class DockerImageManager:

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -479,7 +479,7 @@ try:
     from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
     from boto.exception import EC2ResponseError
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 def find_running_instances_by_count_tag(module, ec2, count_tag):

--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -142,7 +142,7 @@ try:
     import boto
     import boto.ec2
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 def create_image(module, ec2):

--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -93,7 +93,7 @@ try:
     from boto.ec2.autoscale import AutoScaleConnection, AutoScalingGroup
     from boto.exception import BotoServerError
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -108,7 +108,7 @@ try:
     import boto.ec2.elb
     from boto.regioninfo import RegionInfo
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 class ElbManager:

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -217,7 +217,7 @@ try:
     from boto.ec2.elb.healthcheck import HealthCheck
     from boto.regioninfo import RegionInfo
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -95,7 +95,7 @@ EXAMPLES = '''
 try:
     import boto.ec2
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 

--- a/library/cloud/ec2_key
+++ b/library/cloud/ec2_key
@@ -89,7 +89,7 @@ EXAMPLES = '''
 try:
     import boto.ec2
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 import random

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -93,7 +93,7 @@ try:
     from boto.ec2.autoscale import LaunchConfiguration
     from boto.exception import BotoServerError
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 

--- a/library/cloud/ec2_metric_alarm
+++ b/library/cloud/ec2_metric_alarm
@@ -124,7 +124,7 @@ try:
     from boto.ec2.cloudwatch import CloudWatchConnection, MetricAlarm
     from boto.exception import BotoServerError
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 

--- a/library/cloud/ec2_scaling_policy
+++ b/library/cloud/ec2_scaling_policy
@@ -66,7 +66,7 @@ try:
     from boto.exception import BotoServerError
 
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 

--- a/library/cloud/ec2_snapshot
+++ b/library/cloud/ec2_snapshot
@@ -83,7 +83,7 @@ import time
 try:
     import boto.ec2
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 def main():

--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -82,7 +82,7 @@ import time
 try:
     import boto.ec2
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 def main():

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -175,7 +175,7 @@ import time
 try:
     import boto.ec2
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 def get_volume(module, ec2):

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -188,7 +188,7 @@ try:
     import boto.vpc
     from boto.exception import EC2ResponseError
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 def get_vpc_info(vpc):

--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -148,7 +148,7 @@ try:
     from boto.elasticache.layer1 import ElastiCacheConnection
     from boto.regioninfo import RegionInfo
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 

--- a/library/cloud/gc_storage
+++ b/library/cloud/gc_storage
@@ -115,7 +115,7 @@ import hashlib
 try:
     import boto
 except ImportError:
-    print "failed=True msg='boto 2.9+ required for this module'"
+    print("failed=True msg='boto 2.9+ required for this module'")
     sys.exit(1)
 
 def grant_check(module, gs, obj):

--- a/library/cloud/ovirt
+++ b/library/cloud/ovirt
@@ -209,7 +209,7 @@ try:
     from ovirtsdk.api import API
     from ovirtsdk.xml import params
 except ImportError:
-    print "failed=True msg='ovirtsdk required for this module'"
+    print("failed=True msg='ovirtsdk required for this module'")
     sys.exit(1)
 
 # ------------------------------------------------------------------- #
@@ -220,7 +220,7 @@ def conn(url, user, password):
     try:
         value = api.test()
     except:
-        print "error connecting to the oVirt API"
+        print("error connecting to the oVirt API")
         sys.exit(1)
     return api
 
@@ -249,17 +249,17 @@ def create_vm(conn, vmtype, vmname, zone, vmdisk_size, vmcpus, vmnic, vmnetwork,
     try:
         conn.vms.add(vmparams)
     except:
-        print "Error creating VM with specified parameters"
+        print("Error creating VM with specified parameters")
         sys.exit(1)
     vm = conn.vms.get(name=vmname)
     try:
         vm.disks.add(vmdisk)
     except:
-        print "Error attaching disk"
+        print("Error attaching disk")
     try:
         vm.nics.add(nic_net1)
     except:
-        print "Error adding nic"
+        print("Error adding nic")
 
 
 # create an instance from a template
@@ -268,7 +268,7 @@ def create_vm_template(conn, vmname, image, zone):
     try:
         conn.vms.add(vmparams)
     except:
-        print 'error adding template %s' % image
+        print('error adding template %s' % image)
         sys.exit(1)
 
 
@@ -302,7 +302,7 @@ def vm_remove(conn, vmname):
 # Get the VMs status
 def vm_status(conn, vmname):
     status = conn.vms.get(name=vmname).status.state
-    print "vm status is : %s" % status
+    print("vm status is : %s" % status)
     return status
 
 
@@ -311,10 +311,10 @@ def get_vm(conn, vmname):
     vm = conn.vms.get(name=vmname)
     if vm == None:
         name = "empty"
-        print "vmname: %s" % name
+        print("vmname: %s" % name)
     else:
         name = vm.get_name()
-        print "vmname: %s" % name
+        print("vmname: %s" % name)
     return name
 
 # ------------------------------------------------------------------- #

--- a/library/cloud/quantum_floating_ip_associate
+++ b/library/cloud/quantum_floating_ip_associate
@@ -25,7 +25,7 @@ try:
     from keystoneclient.v2_0 import client as ksclient
     import time
 except ImportError:
-    print "failed=True msg='novaclient, keystone, and quantumclient (or neutronclient) client are required'"
+    print("failed=True msg='novaclient, keystone, and quantumclient (or neutronclient) client are required'")
 
 DOCUMENTATION = '''
 ---

--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -271,7 +271,7 @@ import time
 try:
     import boto.rds
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 def get_current_resource(conn, resource, command):

--- a/library/cloud/rds_param_group
+++ b/library/cloud/rds_param_group
@@ -123,7 +123,7 @@ try:
     import boto.rds
     from boto.exception import BotoServerError
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 # returns a tuple: (whether or not a parameter was changed, the remaining parameters that weren't found in this parameter group)

--- a/library/cloud/rds_subnet_group
+++ b/library/cloud/rds_subnet_group
@@ -93,7 +93,7 @@ try:
     import boto.rds
     from boto.exception import BotoServerError
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 def main():

--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -139,7 +139,7 @@ try:
     from boto import route53
     from boto.route53.record import ResourceRecordSets
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 def commit(changes):

--- a/library/cloud/virt
+++ b/library/cloud/virt
@@ -88,7 +88,7 @@ import sys
 try:
     import libvirt
 except ImportError:
-    print "failed=True msg='libvirt python module unavailable'"
+    print("failed=True msg='libvirt python module unavailable'")
     sys.exit(1)
 
 ALL_COMMANDS = []

--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -316,7 +316,7 @@ def main():
             module.fail_json(msg="Server is not configured as mysql slave")
 
     elif mode in "changemaster":
-        print "Change master"
+        print("Change master")
         chm=[]
         if master_host:
             chm.append("MASTER_HOST='" + master_host + "'")

--- a/library/files/acl
+++ b/library/files/acl
@@ -112,7 +112,7 @@ def split_entry(entry):
     try:
         p,e,t,d = a
     except ValueError, e:
-        print "wtf?? %s => %s" % (entry,a)
+        print("wtf?? %s => %s" % (entry,a))
         raise e
 
     if d:

--- a/library/internal/async_wrapper
+++ b/library/internal/async_wrapper
@@ -42,7 +42,7 @@ def daemonize_self():
             # exit first parent
             sys.exit(0)
     except OSError, e:
-        print >>sys.stderr, "fork #1 failed: %d (%s)" % (e.errno, e.strerror)
+        sys.stderr.write("fork #1 failed: %d (%s)" % (e.errno, e.strerror))
         sys.exit(1)
 
     # decouple from parent environment
@@ -57,7 +57,7 @@ def daemonize_self():
             # print "Daemon PID %d" % pid
             sys.exit(0)
     except OSError, e:
-        print >>sys.stderr, "fork #2 failed: %d (%s)" % (e.errno, e.strerror)
+        sys.stderr.write("fork #2 failed: %d (%s)" % (e.errno, e.strerror))
         sys.exit(1)
 
     dev_null = file('/dev/null','rw')

--- a/library/internal/async_wrapper
+++ b/library/internal/async_wrapper
@@ -54,7 +54,7 @@ def daemonize_self():
     try:
         pid = os.fork()
         if pid > 0:
-            # print "Daemon PID %d" % pid
+            # print("Daemon PID %d" % pid)
             sys.exit(0)
     except OSError, e:
         sys.stderr.write("fork #2 failed: %d (%s)" % (e.errno, e.strerror))
@@ -66,10 +66,10 @@ def daemonize_self():
     os.dup2(dev_null.fileno(), sys.stderr.fileno())
 
 if len(sys.argv) < 3:
-    print json.dumps({
+    print(json.dumps({
         "failed" : True,
         "msg"    : "usage: async_wrapper <jid> <time_limit> <modulescript> <argsfile>.  Humans, do not call directly!"
-    })
+    }))
     sys.exit(1)
 
 jid = "%s.%d" % (sys.argv[1], os.getpid())
@@ -89,10 +89,10 @@ if not os.path.exists(logdir):
     try:
         os.makedirs(logdir)
     except:
-        print json.dumps({
+        print(json.dumps({
             "failed" : 1,
             "msg" : "could not create: %s" % logdir
-        })
+        }))
 
 def _run_command(wrapped_cmd, jid, log_path):
 
@@ -154,7 +154,7 @@ try:
         # the argsfile at the very first start of their execution anyway
         time.sleep(1)
         debug("Return async_wrapper task started.")
-        print json.dumps({ "started" : 1, "ansible_job_id" : jid, "results_file" : log_path })
+        print(json.dumps({ "started" : 1, "ansible_job_id" : jid, "results_file" : log_path }))
         sys.stdout.flush()
         sys.exit(0)
     else:

--- a/library/net_infrastructure/dnsimple
+++ b/library/net_infrastructure/dnsimple
@@ -134,7 +134,7 @@ try:
     from dnsimple import DNSimple
     from dnsimple.dnsimple import DNSimpleException
 except ImportError:
-    print "failed=True msg='dnsimple required for this module'"
+    print("failed=True msg='dnsimple required for this module'")
     sys.exit(1)
 
 def main():

--- a/library/notification/sns
+++ b/library/notification/sns
@@ -107,7 +107,7 @@ try:
     import boto
     import boto.sns
 except ImportError:
-    print "failed=True msg='boto required for this module'"
+    print("failed=True msg='boto required for this module'")
     sys.exit(1)
 
 

--- a/library/source_control/github_hooks
+++ b/library/source_control/github_hooks
@@ -87,8 +87,8 @@ def clean504(module, hookurl, oauthkey, repo, user):
 
     for hook in decoded:
         if hook['last_response']['code'] == 504:
-            # print "Last response was an ERROR for hook:"
-            # print hook['id']
+            # print("Last response was an ERROR for hook:")
+            # print(hook['id'])
             delete(module, hookurl, oauthkey, repo, user, hook['id'])
             
     return 0, current_hooks
@@ -99,8 +99,8 @@ def cleanall(module, hookurl, oauthkey, repo, user):
 
     for hook in decoded:
         if hook['last_response']['code'] != 200:
-            # print "Last response was an ERROR for hook:"
-            # print hook['id']
+            # print("Last response was an ERROR for hook:")
+            # print(hook['id'])
             delete(module, hookurl, oauthkey, repo, user, hook['id'])
             
     return 0, current_hooks

--- a/library/system/firewalld
+++ b/library/system/firewalld
@@ -88,10 +88,10 @@ try:
     if not fw.connected:
         raise Exception('failed to connect to the firewalld daemon')
 except ImportError:
-    print "failed=True msg='firewalld required for this module'"
+    print("failed=True msg='firewalld required for this module'")
     sys.exit(1)
 except Exception, e:
-    print "failed=True msg='%s'" % str(e)
+    print("failed=True msg='%s'" % str(e))
     sys.exit(1)
 
 ################

--- a/library/system/selinux
+++ b/library/system/selinux
@@ -61,7 +61,7 @@ import sys
 try:
     import selinux
 except ImportError:
-    print "failed=True msg='libselinux-python required for this module'"
+    print("failed=True msg='libselinux-python required for this module'")
     sys.exit(1)
 
 # getter subroutines

--- a/plugins/callbacks/context_demo.py
+++ b/plugins/callbacks/context_demo.py
@@ -28,4 +28,4 @@ class CallbackModule(object):
     def on_any(self, *args, **kwargs):
         play = getattr(self, 'play', None)
         task = getattr(self, 'task', None)
-        print "play = %s, task = %s, args = %s, kwargs = %s" % (play,task,args,kwargs)
+        print("play = %s, task = %s, args = %s, kwargs = %s" % (play,task,args,kwargs))

--- a/plugins/callbacks/osx_say.py
+++ b/plugins/callbacks/osx_say.py
@@ -37,8 +37,8 @@ class CallbackModule(object):
         # ansible will not call any callback if disabled is set to True
         if not os.path.exists(SAY_CMD):
             self.disabled = True
-            print "%s does not exist, plugin %s disabled" % \
-                    (SAY_CMD, os.path.basename(__file__))
+            print("%s does not exist, plugin %s disabled" % \
+                    (SAY_CMD, os.path.basename(__file__)))
 
     def on_any(self, *args, **kwargs):
         pass

--- a/plugins/inventory/abiquo.py
+++ b/plugins/inventory/abiquo.py
@@ -44,8 +44,14 @@ imagetemplate: Creates a host group for each image template containing all hosts
 import os
 import sys
 import time
-import ConfigParser
-import urllib2
+try:
+    import configparser as ConfigParser
+except ImportError:
+    import ConfigParser
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 import base64
 
 try:
@@ -76,7 +82,7 @@ def save_cache(data, config):
         cache = open('/'.join([dpath,'inventory']), 'w')
         cache.write(json.dumps(data))
         cache.close()
-    except IOError, e:
+    except IOError:
         pass # not really sure what to do here
 
 
@@ -88,7 +94,7 @@ def get_cache(cache_item, config):
         cache = open('/'.join([dpath,'inventory']), 'r')
         inv = cache.read()
         cache.close()
-    except IOError, e:
+    except IOError:
         pass # not really sure what to do here
 
     return inv
@@ -168,7 +174,7 @@ def generate_inv_from_api(enterprise_entity,config):
                     try:
                         metadata = api_get(meta_entity,config)
                         inventory['_meta']['hostvars'][vm_nic] = metadata['metadata']['metadata']
-                    except Exception, e:
+                    except Exception:
                         pass
 
                 inventory[vm_vapp]['children'].append(vmcollection['name'])
@@ -179,7 +185,7 @@ def generate_inv_from_api(enterprise_entity,config):
                 inventory[vmcollection['name']].append(vm_nic)
 
         return inventory
-    except Exception, e:
+    except Exception:
         # Return empty hosts output
         return { 'all': {'hosts': []}, '_meta': { 'hostvars': {} } }
 
@@ -210,7 +216,7 @@ if __name__ == '__main__':
     try:
         login = api_get(None,config)
         enterprise = next(link for link in (login['links']) if (link['rel']=='enterprise'))
-    except Exception, e:
+    except Exception:
         enterprise = None
 
     if cache_available(config):

--- a/plugins/inventory/apache-libcloud.py
+++ b/plugins/inventory/apache-libcloud.py
@@ -35,7 +35,10 @@ import os
 import argparse
 import re
 from time import time
-import ConfigParser
+try:
+    import configparser as ConfigParser
+except ImportError:
+    import ConfigParser
 
 from libcloud.compute.types import Provider
 from libcloud.compute.providers import get_driver

--- a/plugins/inventory/apache-libcloud.py
+++ b/plugins/inventory/apache-libcloud.py
@@ -79,7 +79,7 @@ class LibcloudInventory(object):
             else:
                 data_to_print = self.json_format_dict(self.inventory, True)
 
-        print data_to_print
+        print(data_to_print)
 
 
     def is_cache_valid(self):
@@ -277,9 +277,9 @@ class LibcloudInventory(object):
             else:
                 pass
                 # TODO Product codes if someone finds them useful
-                #print key
-                #print type(value)
-                #print value
+                #print(key)
+                #print(type(value))
+                #print(value)
 
         return self.json_format_dict(instance_vars, True)
 

--- a/plugins/inventory/cobbler.py
+++ b/plugins/inventory/cobbler.py
@@ -107,7 +107,7 @@ class CobblerInventory(object):
         else:  # default action with no options
             data_to_print = self.json_format_dict(self.inventory, True)
 
-        print data_to_print
+        print(data_to_print)
 
     def _connect(self):
         if not self.conn:

--- a/plugins/inventory/digital_ocean.py
+++ b/plugins/inventory/digital_ocean.py
@@ -140,7 +140,7 @@ except ImportError:
 try:
     from dopy.manager import DoError, DoManager
 except ImportError, e:
-    print "failed=True msg='`dopy` library required for this script'"
+    print("failed=True msg='`dopy` library required for this script'")
     sys.exit(1)
 
 
@@ -170,14 +170,14 @@ class DigitalOceanInventory(object):
 
         # Verify credentials were set
         if not hasattr(self, 'client_id') or not hasattr(self, 'api_key'):
-            print '''Could not find values for DigitalOcean client_id and api_key.
+            print('''Could not find values for DigitalOcean client_id and api_key.
 They must be specified via either ini file, command line argument (--client-id and --api-key),
-or environment variables (DO_CLIENT_ID and DO_API_KEY)'''
+or environment variables (DO_CLIENT_ID and DO_API_KEY)''')
             sys.exit(-1)
 
         # env command, show DigitalOcean credentials
         if self.args.env:
-            print "DO_CLIENT_ID=%s DO_API_KEY=%s" % (self.client_id, self.api_key)
+            print("DO_CLIENT_ID=%s DO_API_KEY=%s" % (self.client_id, self.api_key))
             sys.exit(0)
 
         # Manage cache
@@ -190,7 +190,7 @@ or environment variables (DO_CLIENT_ID and DO_API_KEY)'''
             self.load_from_cache()
             if len(self.data) == 0:
                 if self.args.force_cache:
-                    print '''Cache is empty and --force-cache was specified'''
+                    print('''Cache is empty and --force-cache was specified''')
                     sys.exit(-1)
                 self.load_all_data_from_digital_ocean()
             else:
@@ -214,9 +214,9 @@ or environment variables (DO_CLIENT_ID and DO_API_KEY)'''
                                  json_data = self.inventory
 
         if self.args.pretty:
-            print json.dumps(json_data, sort_keys=True, indent=2)
+            print(json.dumps(json_data, sort_keys=True, indent=2))
         else:
-            print json.dumps(json_data)
+            print(json.dumps(json_data))
         # That's all she wrote...
 
 

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -334,7 +334,7 @@ def list_groups():
     groups['docker_hosts'] = [host.get('base_url') for host in hosts]
     groups['_meta'] = dict()
     groups['_meta']['hostvars'] = hostvars
-    print json.dumps(groups, sort_keys=True, indent=4)
+    print(json.dumps(groups, sort_keys=True, indent=4))
     sys.exit(0)
 
 

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -165,7 +165,7 @@ class Ec2Inventory(object):
             else:
                 data_to_print = self.json_format_dict(self.inventory, True)
 
-        print data_to_print
+        print(data_to_print)
 
 
     def is_cache_valid(self):
@@ -283,8 +283,8 @@ class Ec2Inventory(object):
         
         except boto.exception.BotoServerError, e:
             if  not self.eucalyptus:
-                print "Looks like AWS is down again:"
-            print e
+                print("Looks like AWS is down again:")
+            print(e)
             sys.exit(1)
 
     def get_rds_instances_by_region(self, region):
@@ -299,8 +299,8 @@ class Ec2Inventory(object):
                     self.add_rds_instance(instance, region)
         except boto.exception.BotoServerError, e:
             if not e.reason == "Forbidden":
-                print "Looks like AWS RDS is down: "
-                print e
+                print("Looks like AWS RDS is down: ")
+                print(e)
                 sys.exit(1)
 
     def get_instance(self, region, instance_id):
@@ -365,8 +365,8 @@ class Ec2Inventory(object):
                 key = self.to_safe("security_group_" + group.name)
                 self.push(self.inventory, key, dest)
         except AttributeError:
-            print 'Package boto seems a bit older.'
-            print 'Please upgrade boto >= 2.3.0.'
+            print('Package boto seems a bit older.')
+            print('Please upgrade boto >= 2.3.0.')
             sys.exit(1)
 
         # Inventory: Group by tag keys
@@ -426,8 +426,8 @@ class Ec2Inventory(object):
                 key = self.to_safe("security_group_" + instance.security_group.name)
                 self.push(self.inventory, key, dest)
         except AttributeError:
-            print 'Package boto seems a bit older.'
-            print 'Please upgrade boto >= 2.3.0.'
+            print('Package boto seems a bit older.')
+            print('Please upgrade boto >= 2.3.0.')
             sys.exit(1)
 
         # Inventory: Group by engine
@@ -527,9 +527,9 @@ class Ec2Inventory(object):
             else:
                 pass
                 # TODO Product codes if someone finds them useful
-                #print key
-                #print type(value)
-                #print value
+                #print(key)
+                #print(type(value))
+                #print(value)
 
         return instance_vars
 

--- a/plugins/inventory/gce.py
+++ b/plugins/inventory/gce.py
@@ -102,12 +102,12 @@ class GceInventory(object):
 
         # Just display data for specific host
         if self.args.host:
-            print self.json_format_dict(self.node_to_dict(
-                    self.get_instance(self.args.host)))
+            print(self.json_format_dict(self.node_to_dict(
+                    self.get_instance(self.args.host))))
             sys.exit(0)
 
         # Otherwise, assume user wants all instances grouped
-        print self.json_format_dict(self.group_instances())
+        print(self.json_format_dict(self.group_instances()))
         sys.exit(0)
 
 

--- a/plugins/inventory/jail.py
+++ b/plugins/inventory/jail.py
@@ -30,8 +30,8 @@ result['all']['vars'] = {}
 result['all']['vars']['ansible_connection'] = 'jail'
 
 if len(sys.argv) == 2 and sys.argv[1] == '--list':
-    print json.dumps(result)
+    print(json.dumps(result))
 elif len(sys.argv) == 3 and sys.argv[1] == '--host':
-    print json.dumps({'ansible_connection': 'jail'})
+    print(json.dumps({'ansible_connection': 'jail'}))
 else:
-    print "Need a argument, either --list or --host <host>"
+    print("Need a argument, either --list or --host <host>")

--- a/plugins/inventory/libvirt_lxc.py
+++ b/plugins/inventory/libvirt_lxc.py
@@ -30,8 +30,8 @@ result['all']['vars'] = {}
 result['all']['vars']['ansible_connection'] = 'lxc'
 
 if len(sys.argv) == 2 and sys.argv[1] == '--list':
-    print json.dumps(result)
+    print(json.dumps(result))
 elif len(sys.argv) == 3 and sys.argv[1] == '--host':
-    print json.dumps({'ansible_connection': 'lxc'})
+    print(json.dumps({'ansible_connection': 'lxc'}))
 else:
-    print "Need a argument, either --list or --host <host>"
+    print("Need a argument, either --list or --host <host>")

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -139,7 +139,7 @@ class LinodeInventory(object):
             else:
                 data_to_print = self.json_format_dict(self.inventory, True)
 
-        print data_to_print
+        print(data_to_print)
 
     def is_cache_valid(self):
         """Determines if the cache file has expired, or if it is still valid."""
@@ -185,9 +185,9 @@ class LinodeInventory(object):
             for node in Linode.search(status=Linode.STATUS_RUNNING):
                 self.add_node(node)
         except chube_api.linode_api.ApiError, e:
-            print "Looks like Linode's API is down:"
-            print
-            print e
+            print("Looks like Linode's API is down:")
+            print()
+            print(e)
             sys.exit(1)
 
     def get_node(self, linode_id):
@@ -195,9 +195,9 @@ class LinodeInventory(object):
         try:
             return Linode.find(api_id=linode_id)
         except chube_api.linode_api.ApiError, e:
-            print "Looks like Linode's API is down:"
-            print
-            print e
+            print("Looks like Linode's API is down:")
+            print()
+            print(e)
             sys.exit(1)
 
     def populate_datacenter_cache(self):

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -199,7 +199,7 @@ if len(sys.argv) == 2 and (sys.argv[1] == '--list'):
 		continue
 
     # Return server list
-    print json.dumps(groups)
+    print(json.dumps(groups))
     sys.exit(0)
 
 #####################################################
@@ -228,9 +228,9 @@ elif len(sys.argv) == 3 and (sys.argv[1] == '--host'):
                 if key != 'os_manager':
                     results[key] = value
 
-    print json.dumps(results)
+    print(json.dumps(results))
     sys.exit(0)
 
 else:
-    print "usage: --list  ..OR.. --host <hostname>"
+    print("usage: --list  ..OR.. --host <hostname>")
     sys.exit(1)

--- a/plugins/inventory/openshift.py
+++ b/plugins/inventory/openshift.py
@@ -61,7 +61,7 @@ def get_config(env_var, config_var):
     if not result:
         result = get_from_rhc_config(config_var)
     if not result:
-        print "failed=True msg='missing %s'" % env_var
+        print("failed=True msg='missing %s'" % env_var)
         sys.exit(1)
     return result
 
@@ -109,8 +109,8 @@ for app in response:
     result[app_name]['vars']['ansible_ssh_user'] = user
 
 if len(sys.argv) == 2 and sys.argv[1] == '--list':
-    print json.dumps(result)
+    print(json.dumps(result))
 elif len(sys.argv) == 3 and sys.argv[1] == '--host':
-    print json.dumps({})
+    print(json.dumps({}))
 else:
-    print "Need a argument, either --list or --host <host>"
+    print("Need a argument, either --list or --host <host>")

--- a/plugins/inventory/softlayer.py
+++ b/plugins/inventory/softlayer.py
@@ -53,10 +53,10 @@ class SoftLayerInventory(object):
 
         if self.args.list:
             self.get_all_servers()
-            print self.json_format_dict(self.inventory, True)
+            print(self.json_format_dict(self.inventory, True))
         elif self.args.host:
             self.get_virtual_servers(client)
-            print self.json_format_dict(self.inventory["_meta"]["hostvars"][self.args.host], True)
+            print(self.json_format_dict(self.inventory["_meta"]["hostvars"][self.args.host], True))
 
     def to_safe(self, word):
         '''Converts 'bad' characters in a string to underscores so they can be used as Ansible groups'''

--- a/plugins/inventory/spacewalk.py
+++ b/plugins/inventory/spacewalk.py
@@ -54,7 +54,7 @@ CACHE_AGE = 300 # 5min
 
 # Sanity check
 if not os.path.exists(SW_REPORT):
-    print >> sys.stderr, 'Error: %s is required for operation.' % (SW_REPORT)
+    sys.stderr.write('Error: %s is required for operation.' % (SW_REPORT))
     sys.exit(1)
 
 # Pre-startup work
@@ -113,8 +113,8 @@ if options.list:
             groups[system['group_name']].add(system['server_name'])
 
     except (OSError), e:
-        print >> sys.stderr, 'Problem executing the command "%s system-groups-systems": %s' % \
-            (SW_REPORT, str(e))
+        sys.stderr.write('Problem executing the command "%s system-groups-systems": %s' % \
+            (SW_REPORT, str(e)))
         sys.exit(2)
 
     if options.human:
@@ -138,8 +138,8 @@ elif options.host:
                 break
 
     except (OSError), e:
-        print >> sys.stderr, 'Problem executing the command "%s inventory": %s' % \
-            (SW_REPORT, str(e))
+        sys.stderr.write('Problem executing the command "%s inventory": %s' % \
+            (SW_REPORT, str(e)))
         sys.exit(2)
     
     if options.human:

--- a/plugins/inventory/spacewalk.py
+++ b/plugins/inventory/spacewalk.py
@@ -119,9 +119,9 @@ if options.list:
 
     if options.human:
         for group, systems in groups.iteritems():
-            print '[%s]\n%s\n' % (group, '\n'.join(systems))
+            print('[%s]\n%s\n' % (group, '\n'.join(systems)))
     else:
-        print json.dumps(dict([ (k, list(s)) for k, s in groups.iteritems() ]))
+        print(json.dumps(dict([ (k, list(s)) for k, s in groups.iteritems() ])))
 
     sys.exit(0)
 
@@ -143,11 +143,11 @@ elif options.host:
         sys.exit(2)
     
     if options.human:
-        print 'Host: %s' % options.host
+        print('Host: %s' % options.host)
         for k, v in host_details.iteritems():
-            print '  %s: %s' % (k, '\n    '.join(v.split(';')))
+            print('  %s: %s' % (k, '\n    '.join(v.split(';'))))
     else:
-        print json.dumps(host_details)
+        print(json.dumps(host_details))
 
     sys.exit(0)
 

--- a/plugins/inventory/ssh_config.py
+++ b/plugins/inventory/ssh_config.py
@@ -79,12 +79,12 @@ def print_list():
         if tmp_dict:
             meta['hostvars'][alias] = tmp_dict
 
-    print json.dumps({_key: list(set(meta['hostvars'].keys())), '_meta': meta})
+    print(json.dumps({_key: list(set(meta['hostvars'].keys())), '_meta': meta}))
 
 
 def print_host(host):
     cfg = get_config()
-    print json.dumps(cfg[host])
+    print(json.dumps(cfg[host]))
 
 
 def get_args(args_list):

--- a/plugins/inventory/vagrant.py
+++ b/plugins/inventory/vagrant.py
@@ -106,7 +106,7 @@ if options.list:
     for data in ssh_config:
         hosts['vagrant'].append(data['HostName'])
 
-    print json.dumps(hosts)
+    print(json.dumps(hosts))
     sys.exit(1)
 
 # Get out the host details
@@ -121,7 +121,7 @@ elif options.host:
         result = details[0]
         result['ansible_ssh_port'] = result['Port']
 
-    print json.dumps(result)
+    print(json.dumps(result))
     sys.exit(1)
 
 

--- a/plugins/inventory/vmware.py
+++ b/plugins/inventory/vmware.py
@@ -193,7 +193,7 @@ if __name__ == '__main__':
                         )
     except Exception, e:
         client = None
-        #print >> STDERR "Unable to login (only cache avilable): %s", str(e)
+        #sys.stderr.write("Unable to login (only cache avilable): %s", str(e))
 
     # acitually do the work
     if hostname is None:
@@ -202,4 +202,4 @@ if __name__ == '__main__':
         inventory = get_single_host(client, config, hostname)
 
     # return to ansible
-    print inventory
+    print(inventory)

--- a/plugins/inventory/windows_azure.py
+++ b/plugins/inventory/windows_azure.py
@@ -51,7 +51,7 @@ try:
     from azure import WindowsAzureError
     from azure.servicemanagement import ServiceManagementService
 except ImportError as e:
-    print "failed=True msg='`azure` library required for this script'"
+    print("failed=True msg='`azure` library required for this script'")
     sys.exit(1)
 
 
@@ -89,7 +89,7 @@ class AzureInventory(object):
             else:
                 data_to_print = self.json_format_dict(self.inventory, True)
 
-        print data_to_print
+        print(data_to_print)
 
     def get_images(self):
         images = []
@@ -157,9 +157,9 @@ class AzureInventory(object):
             for cloud_service in self.sms.list_hosted_services():
                 self.add_deployments(cloud_service)
         except WindowsAzureError as e:
-            print "Looks like Azure's API is down:"
-            print
-            print e
+            print("Looks like Azure's API is down:")
+            print()
+            print(e)
             sys.exit(1)
 
     def add_deployments(self, cloud_service):
@@ -169,9 +169,9 @@ class AzureInventory(object):
                 if deployment.deployment_slot == "Production":
                     self.add_deployment(cloud_service, deployment)
         except WindowsAzureError as e:
-            print "Looks like Azure's API is down:"
-            print
-            print e
+            print("Looks like Azure's API is down:")
+            print()
+            print(e)
             sys.exit(1)
 
     def add_deployment(self, cloud_service, deployment):

--- a/plugins/inventory/zabbix.py
+++ b/plugins/inventory/zabbix.py
@@ -116,11 +116,11 @@ class ZabbixInventory(object):
 
             if self.options.host:
                 data = self.get_host(api, self.options.host)
-                print json.dumps(data, indent=2)
+                print(json.dumps(data, indent=2))
 
             elif self.options.list:
                 data = self.get_list(api)
-                print json.dumps(data, indent=2)
+                print(json.dumps(data, indent=2))
 
             else:
                 sys.stderr.write("usage: --list  ..OR.. --host <hostname>")

--- a/plugins/inventory/zabbix.py
+++ b/plugins/inventory/zabbix.py
@@ -33,12 +33,15 @@ Tested with Zabbix Server 2.0.6.
 import os, sys
 import json
 import argparse
-import ConfigParser
+try:
+    import configparser as ConfigParser
+except ImportError:
+    import ConfigParser
 
 try:
     from zabbix_api import ZabbixAPI
 except:
-    sys.stderr.write("Error: Zabbix API library must be installed: pip install zabbix-api.")
+    sys.stderr.write("Error: Zabbix API library must be installed: pip install zabbix-api.\n")
     sys.exit(1)
 
 try:
@@ -110,7 +113,7 @@ class ZabbixInventory(object):
             try:
                 api = ZabbixAPI(server=self.zabbix_server)
                 api.login(user=self.zabbix_username, password=self.zabbix_password)
-            except BaseException, e:
+            except BaseException:
                 sys.stderr.write("Error: Could not login to Zabbix server. Check your zabbix.ini.")
                 sys.exit(1)
 

--- a/plugins/inventory/zabbix.py
+++ b/plugins/inventory/zabbix.py
@@ -38,7 +38,7 @@ import ConfigParser
 try:
     from zabbix_api import ZabbixAPI
 except:
-    print >> sys.stderr, "Error: Zabbix API library must be installed: pip install zabbix-api."
+    sys.stderr.write("Error: Zabbix API library must be installed: pip install zabbix-api.")
     sys.exit(1)
 
 try:
@@ -111,7 +111,7 @@ class ZabbixInventory(object):
                 api = ZabbixAPI(server=self.zabbix_server)
                 api.login(user=self.zabbix_username, password=self.zabbix_password)
             except BaseException, e:
-                print >> sys.stderr, "Error: Could not login to Zabbix server. Check your zabbix.ini."
+                sys.stderr.write("Error: Could not login to Zabbix server. Check your zabbix.ini.")
                 sys.exit(1)
 
             if self.options.host:
@@ -123,11 +123,11 @@ class ZabbixInventory(object):
                 print json.dumps(data, indent=2)
 
             else:
-                print >> sys.stderr, "usage: --list  ..OR.. --host <hostname>"
+                sys.stderr.write("usage: --list  ..OR.. --host <hostname>")
                 sys.exit(1)
 
         else:
-            print >> sys.stderr, "Error: Configuration of server and credentials are required. See zabbix.ini."
+            sys.stderr.write("Error: Configuration of server and credentials are required. See zabbix.ini.")
             sys.exit(1)
 
 ZabbixInventory()

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ from ansible import __version__, __author__
 try:
     from setuptools import setup
 except ImportError:
-    print "Ansible now needs setuptools in order to build. " + \
-          "Install it using your package manager (usually python-setuptools) or via pip (pip install setuptools)."
+    print("Ansible now needs setuptools in order to build. " + \
+          "Install it using your package manager (usually python-setuptools) or via pip (pip install setuptools).")
     sys.exit(1)
 
 # find library modules

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -3,7 +3,7 @@ VARS_FILE ?= integration_config.yml
 
 # Create a semi-random string for use when testing cloud-based resources
 ifndef CLOUD_RESOURCE_PREFIX
-CLOUD_RESOURCE_PREFIX := $(shell python -c "import string,random; print 'ansible-testing-' + ''.join(random.choice(string.ascii_letters + string.digits) for _ in xrange(8));")
+CLOUD_RESOURCE_PREFIX := $(shell python -c "import string,random; print('ansible-testing-' + ''.join(random.choice(string.ascii_letters + string.digits) for _ in xrange(8)));")
 endif
 
 CREDENTIALS_FILE = credentials.yml

--- a/test/integration/cleanup_ec2.py
+++ b/test/integration/cleanup_ec2.py
@@ -25,7 +25,7 @@ def delete_aws_eips(get_func, attr, opts):
     try:
       eip_log = open(opts.eip_log, 'r').read().splitlines()
     except IOError:
-      print opts.eip_log, 'not found.'
+      print(opts.eip_log, 'not found.')
       return
 
     for item in get_func():
@@ -45,10 +45,10 @@ def prompt_and_delete(item, prompt, assumeyes):
     if assumeyes:
         if  hasattr(item, 'delete'):
             item.delete()
-            print ("Deleted %s" % item)
+            print("Deleted %s" % item)
         if  hasattr(item, 'terminate'):
             item.terminate()
-            print ("Terminated %s" % item)
+            print("Terminated %s" % item)
 
 def parse_args():
     # Load details from credentials.yml
@@ -144,4 +144,4 @@ if __name__ == '__main__':
         delete_aws_instances(aws.get_all_instances(filters=filters), opts)
 
     except KeyboardInterrupt, e:
-        print "\nExiting on user command."
+        print("\nExiting on user command.")

--- a/test/integration/roles/setup_ec2/tasks/main.yml
+++ b/test/integration/roles/setup_ec2/tasks/main.yml
@@ -17,7 +17,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: generate random string
-  shell: python -c "import string,random; print ''.join(random.choice(string.ascii_lowercase) for _ in xrange(8));"
+  shell: python -c "import string,random; print(''.join(random.choice(string.ascii_lowercase) for _ in xrange(8)));"
   register: random_string
   tags:
     - prepare

--- a/test/units/TestConstants.py
+++ b/test/units/TestConstants.py
@@ -39,7 +39,7 @@ class TestConstants(unittest.TestCase):
         
         res = get_config(p, 'defaults', 'test_key', env_var, 'default')
 
-        print res
+        print(res)
         assert res == 'test_value'
 
 

--- a/test/units/TestInventory.py
+++ b/test/units/TestInventory.py
@@ -27,8 +27,8 @@ class TestInventory(unittest.TestCase):
         if sort:
             left = sorted(left)
             right = sorted(right)
-        print left
-        print right
+        print(left)
+        print(right)
         assert left == right
 
     def empty_inventory(self):
@@ -233,7 +233,7 @@ class TestInventory(unittest.TestCase):
         inventory = self.complex_inventory()
 
         vars = inventory.get_variables('rtp_a')
-        print vars
+        print(vars)
 
         expected = dict(
             a=1, b=2, c=3, d=10002, e=10003, f='10004 != 10005',
@@ -243,8 +243,8 @@ class TestInventory(unittest.TestCase):
             inventory_hostname='rtp_a', inventory_hostname_short='rtp_a',
             group_names=[ 'eastcoast', 'nc', 'redundantgroup', 'redundantgroup2', 'redundantgroup3', 'rtp', 'us' ]
         )
-        print vars
-        print expected
+        print(vars)
+        print(expected)
         assert vars == expected
 
     def test_complex_group_names(self):
@@ -262,16 +262,16 @@ class TestInventory(unittest.TestCase):
         inventory = self.complex_inventory()
         hosts = inventory.list_hosts("nc:florida:!triangle:!orlando")
         expected_hosts = ['miami', 'rtp_a', 'rtp_b', 'rtp_c']
-        print "HOSTS=%s" % sorted(hosts)
-        print "EXPECTED=%s" % sorted(expected_hosts)
+        print("HOSTS=%s" % sorted(hosts))
+        print("EXPECTED=%s" % sorted(expected_hosts))
         assert sorted(hosts) == sorted(expected_hosts)
 
     def test_regex_exclude(self):
         inventory = self.complex_inventory()
         hosts = inventory.list_hosts("~rtp_[ac]")
         expected_hosts = ['rtp_a', 'rtp_c']
-        print "HOSTS=%s" % sorted(hosts)
-        print "EXPECTED=%s" % sorted(expected_hosts)
+        print("HOSTS=%s" % sorted(hosts))
+        print("EXPECTED=%s" % sorted(expected_hosts))
         assert sorted(hosts) == sorted(expected_hosts)
 
     def test_complex_enumeration(self):
@@ -343,8 +343,8 @@ class TestInventory(unittest.TestCase):
 
         expected_hosts=['jupiter', 'saturn', 'zeus', 'hera', 'poseidon', 'thor', 'odin', 'loki']
 
-        print "Expected: %s"%(expected_hosts)
-        print "Got     : %s"%(hosts)
+        print("Expected: %s"%(expected_hosts))
+        print("Got     : %s"%(hosts))
         assert sorted(hosts) == sorted(expected_hosts)
 
     def test_script_all(self):
@@ -388,7 +388,7 @@ class TestInventory(unittest.TestCase):
         inventory = self.script_inventory()
         vars = inventory.get_variables('thor')
 
-        print "VARS=%s" % vars
+        print("VARS=%s" % vars)
 
         assert vars == {'hammer':True,
                         'group_names': ['norse'],
@@ -407,7 +407,7 @@ class TestInventory(unittest.TestCase):
         inventory = self.script_inventory()
         vars = inventory.get_variables('zeus')
 
-        print "VARS=%s" % vars
+        print("VARS=%s" % vars)
 
         assert vars == {'inventory_hostname': 'zeus',
                         'inventory_hostname_short': 'zeus',
@@ -428,8 +428,8 @@ class TestInventory(unittest.TestCase):
                          'group_names': ['greek', 'major-god', 'ungrouped'],
                          'var_a': '3#4'}
 
-        print "HOST     VARS=%s" % host_vars
-        print "EXPECTED VARS=%s" % expected_vars
+        print("HOST     VARS=%s" % host_vars)
+        print("EXPECTED VARS=%s" % expected_vars)
 
         assert host_vars == expected_vars
 
@@ -437,7 +437,7 @@ class TestInventory(unittest.TestCase):
         inventory = self.dir_inventory()
         group_greek = inventory.get_hosts('greek')
         actual_host_names = [host.name for host in group_greek]
-        print "greek : %s " % actual_host_names
+        print("greek : %s " % actual_host_names)
         assert actual_host_names == ['zeus', 'morpheus']
 
     def test_dir_inventory_skip_extension(self):

--- a/test/units/inventory_test_data/inventory_api.py
+++ b/test/units/inventory_test_data/inventory_api.py
@@ -27,14 +27,14 @@ variables = {
 }
 
 if options.list_hosts == True:
-    print json.dumps(systems)
+    print(json.dumps(systems))
     sys.exit(0)
 
 if options.host is not None:
     if options.extra:
         k,v = options.extra.split("=")
         variables[options.host][k] = v
-    print json.dumps(variables[options.host])
+    print(json.dumps(variables[options.host]))
     sys.exit(0)
 
 parser.print_help()


### PR DESCRIPTION
Standardize logging to stderr to use the sys.stderr.write() which is forward compatible with Python 3. Tested via the make tests and by local execution.

Notes:
- hacking/module_formatter.py has an unrelated local execution issue.
- tactical fix to lib/ansible/utils/**init**.py
