### PR TITLE
 	Fix group modification idempotency

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -472,7 +472,7 @@ class User(object):
         groups = []
         info = self.get_pwd_info()
         for group in grp.getgrall():
-            if self.name in group.gr_mem and not info[3] == group.gr_gid:
+            if self.name in group.gr_mem:
                 groups.append(group[0])
         return groups
 


### PR DESCRIPTION
##### Issue Type: Bugfix Pull Request
##### Ansible Version: 1.6.3, devel
##### Environment: Ubuntu 12.04, probably more generally applicable
##### Summary:

If you modify the groups for a user and include the user's namesake group, you will always get a 'changed' notification, whether or not that is true.

This is just #7028 but with the commit message cleaned up.
##### Steps To Reproduce:

```

---
- user: name=bob
- user: name=bob groups=bob # bob is not explicitly a member of bob initially
- user: name=bob groups=bob
  register: group_modify

- assert:
  that:
  - not group_modify|changed
```
##### Expected Results:

The assert succeeds, and the task file finishes successfully.
##### Actual Results:

The assert fails
