### PR TITLE
documents group, owner, mode as they're referenced in the examples

### DIFF
--- a/library/files/copy
+++ b/library/files/copy
@@ -69,6 +69,21 @@ options:
     choices: [ "yes", "no" ]
     default: "yes"
     aliases: [ "thirsty" ]
+  mode:
+    description:
+      - mode the file or directory should be, such as 0644 as would be fed to chmod
+    required: false
+    default: null
+  owner:
+    description:
+      - name of the user that should own the file/directory, as would be fed to chown
+    required: false
+    default: null
+  group:
+    description:
+      - name of the group that should own the file/directory, as would be fed to chown
+    required: false
+    default: null
   validate:
     description:
       - The validation command to run before copying into place.  The path to the file to


### PR DESCRIPTION
This require simply adds descriptions for the group, owner, and mode parameters for the copy_module.html page, as they are referenced in the example usage section.  The description text is from the file_module page for the purposes of uniformity.
