### PR TITLE
[openbsd-pkg] Add note regarding package flavors

### DIFF
--- a/library/packaging/openbsd_pkg
+++ b/library/packaging/openbsd_pkg
@@ -53,6 +53,13 @@ EXAMPLES = '''
 
 # Make sure nmap is not installed
 - openbsd_pkg: name=nmap state=absent
+
+# Specify a pkg flavour with '--'
+- openbsd_pkg: name=vim--nox11 state=present
+
+# Getting ambiguity errors?
+# Specify the default flavour:
+- openbsd_pkg: name=vim-- state=present
 '''
 
 # Control if we write debug information to syslog.


### PR DESCRIPTION
This adds a note to the openbsd-pkg module which explains how to specify
package flavors as well as how to avoid ambiguity errors on a package
with multiple flavors.

Technically, this is an Ansible issue, but it's pretty likely the user will
encounter this problem.

--Matt
