### PR TITLE
Fix in pkgutil: don't call pipes.quote() on None

### DIFF
--- a/library/packaging/pkgutil
+++ b/library/packaging/pkgutil
@@ -74,12 +74,10 @@ def package_installed(module, name):
 
 def package_latest(module, name, site):
     # Only supports one package
-    name = pipes.quote(name)
-    site = pipes.quote(site)
     cmd = [ 'pkgutil', '--single', '-c' ]
     if site is not None:
-        cmd += [ '-t', site ]
-    cmd.append(name)
+        cmd += [ '-t', pipes.quote(site) ]
+    cmd.append(pipes.quote(name))
     cmd += [ '| tail -1 | grep -v SAME' ]
     rc, out, err = module.run_command(' '.join(cmd), use_unsafe_shell=True)
     if rc == 1:


### PR DESCRIPTION
(resubmission based on #7735)

Although the 'site' parameter is intended to be optional, omitting it would cause the following exception if the requested package was already installed:

```
invalid output was: Traceback (most recent call last):
  File "/tmp/ansible-tmp-1402553652.18-229268856436124/pkgutil", line 1398, in <module>
    main()
  File "/tmp/ansible-tmp-1402553652.18-229268856436124/pkgutil", line 153, in main
    if not package_latest(module, name, site):
  File "/tmp/ansible-tmp-1402553652.18-229268856436124/pkgutil", line 78, in package_latest
    site = pipes.quote(site)
  File "/usr/lib/python2.6/pipes.py", line 271, in quote
    for c in file:
TypeError: 'NoneType' object is not iterable
```
