### PR TITLE
unarchive: improve failure detection and reporting

### DIFF
--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -234,7 +234,9 @@ def main():
 
     # do the unpack
     try:
-        results = handler.unarchive()
+        res_args['extract_results'] = handler.unarchive()
+        if res_args['extract_results']['rc'] != 0:
+            module.fail_json(msg="failed to unpack %s to %s" % (src, dest), **res_args)
     except IOError:
         module.fail_json(msg="failed to unpack %s to %s" % (src, dest))
 


### PR DESCRIPTION
While this does not fix #7777, it stops unarchive from failing silently. In case of error, the results dict now includes an "extract_results" entry (similar to the "check_results" that already existed), so the output looks like:

```
TASK: [unarchive src=magic.tar dest=/tmp] ************************************* 
failed: [tmp-dls3] => {"check_results": {"cmd": "/usr/sbin/tar -v -C \"/tmp\" --diff -zf \"/tmp/ansible-tmp-1402809524.59-111069519188270/source\"", "err": "Usage: tar {c|r|t|u|x}[BDeEFhilmnopPTvw@/[0-7]][bf][X...] [j|z|Z] [blocksize] [tarfile] [size] [exclude-file...] {file | -I include-file | -C directory file}...\n", "out": "", "rc": 1, "unarchived": false}, "dest": "/tmp", "extract_results": {"cmd": "/usr/sbin/tar -C \"/tmp\" -xzf \"/tmp/ansible-tmp-1402809524.59-111069519188270/source\"", "err": "tar: C: unknown function modifier\nUsage: tar {c|r|t|u|x}[BDeEFhilmnopPTvw@/[0-7]][bf][X...] [j|z|Z] [blocksize] [tarfile] [size] [exclude-file...] {file | -I include-file | -C directory file}...\n", "out": "", "rc": 1}, "failed": true, "gid": 3, "group": "sys", "handler": "TgzFile", "mode": "01777", "owner": "root", "size": 511, "src": "/tmp/ansible-tmp-1402809524.59-111069519188270/source", "state": "directory", "uid": 0}
msg: failed to unpack /tmp/ansible-tmp-1402809524.59-111069519188270/source to /tmp

FATAL: all hosts have already failed -- aborting

PLAY RECAP ******************************************************************** 
           to retry, use: --limit @/holman_homes/towen/tarbug.retry

tmp-dls3                   : ok=1    changed=0    unreachable=0    failed=1   
```
