### PR TITLE
unarchive: workaround for tar that does not support "-C"

### DIFF
--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -122,6 +122,10 @@ class TgzFile(object):
     def unarchive(self):
         cmd = '%s -C "%s" -x%sf "%s"' % (self.cmd_path, self.dest, self.zipflag, self.src)
         rc, out, err = self.module.run_command(cmd)
+        if rc != 0 and 'Usage' in err:
+            # Error may be due to tar not understanding "-C"
+            cmd = '%s -x%sf "%s"' % (self.cmd_path, self.zipflag, self.src)
+            rc, out, err = self.module.run_command(cmd, cwd=self.dest)
         return dict(cmd=cmd, rc=rc, out=out, err=err)
 
     def can_handle_archive(self):


### PR DESCRIPTION
Fixes #7777

_Only when tar -C is not supported_: Set CWD instead.

The reason I made this workaround conditional, instead of applying it in all cases as a "lowest common denominator", is that on systems with GNU tar the "-C" option is quite well known and commonly used. In particular, when examing the output of "ansible -v", it is easier to understand and test what ansible is doing when a single self-contained tar command is being executed.

But it could have gone either way, and I'm open to other opinions.
