### PR TITLE
unarchive: do not assume tar supports -C

### DIFF
--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -120,8 +120,8 @@ class TgzFile(object):
         return dict(unarchived=unarchived, rc=rc, out=out, err=err, cmd=cmd)
 
     def unarchive(self):
-        cmd = '%s -C "%s" -x%sf "%s"' % (self.cmd_path, self.dest, self.zipflag, self.src)
-        rc, out, err = self.module.run_command(cmd)
+        cmd = '%s -x%sf "%s"' % (self.cmd_path, self.zipflag, self.src)
+        rc, out, err = self.module.run_command(cmd, cwd=self.dest)
         return dict(cmd=cmd, rc=rc, out=out, err=err)
 
     def can_handle_archive(self):


### PR DESCRIPTION
Fixes #7777
(But don't rewrite the tar invocation in is_unarchived(), since a
tar that supports "--diff" certainly supports "-C" as well).
