### PR TITLE
Find IPs on OpenStack clouds without floating-ips

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -156,6 +156,16 @@ def _delete_server(module, nova):
     module.fail_json(msg = "Timed out waiting for server to get deleted, please check manually")
 
 
+def _get_ips(addresses, ext_tag, key_name):
+    ret = []
+    for (k, v) in addresses.iteritems():
+        if 'OS-EXT-IPS:type' in v and v['OS-EXT-IPS:type'] == ext_tag:
+            ret.append(v['addr'])
+        elif k == key_name:
+            ret.extend([x['addr'] for addrs in v])
+    return ret
+
+
 def _create_server(module, nova):
     bootargs = [module.params['name'], module.params['image_id'], module.params['flavor_id']]
     bootkwargs = {
@@ -181,8 +191,8 @@ def _create_server(module, nova):
             except Exception, e:
                     module.fail_json( msg = "Error in getting info from instance: %s " % e.message)
             if server.status == 'ACTIVE':
-                private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
-                public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'floating']
+                private = _get_ips(gettattr(server, 'addresses'), 'fixed', 'private')
+                public = _get_ips(gettattr(server, 'addresses'), 'floating', 'public')
                 module.exit_json(changed = True, id = server.id, private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
             if server.status == 'ERROR':
                 module.fail_json(msg = "Error in creating the server, please check logs")
@@ -191,8 +201,8 @@ def _create_server(module, nova):
         module.fail_json(msg = "Timeout waiting for the server to come up.. Please check manually")
     if server.status == 'ERROR':
             module.fail_json(msg = "Error in creating the server.. Please check manually")
-    private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'fixed']
-    public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'floating']
+    private = _get_ips(gettattr(server, 'addresses'), 'fixed', 'private')
+    public = _get_ips(gettattr(server, 'addresses'), 'floating', 'public')
     module.exit_json(changed = True, id = info['id'], private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
 
 


### PR DESCRIPTION
The floating-ip extension, while pretty ubiquitous, is not a
foregone conclusion. Specifically, Rackspace, while also
served by the rax module, is a valid OpenStack cloud and can
be interacted with directly via nova interfaces.

Add support for determining public and private IPs for
OpenStack clouds that don't use floating ips by reading
the public and private keys from the addresses dict.
