### PR TITLE
Allow npm executable to contain spaces

### DIFF
--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -113,9 +113,9 @@ class Npm(object):
         self.production = kwargs['production']
 
         if kwargs['executable']:
-            self.executable = kwargs['executable']
+            self.executable = kwargs['executable'].split(' ')
         else:
-            self.executable = module.get_bin_path('npm', True)
+            self.executable = [module.get_bin_path('npm', True)]
 
         if kwargs['version']:
             self.name_version = self.name + '@' + self.version
@@ -124,7 +124,7 @@ class Npm(object):
 
     def _exec(self, args, run_in_check_mode=False, check_rc=True):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self.executable] + args
+            cmd = self.executable + args
 
             if self.glbl:
                 cmd.append('--global')


### PR DESCRIPTION
NVM has a special script which loads the correct node version before executing a command.
The syntax for this is `/usr/local/nvm/nvm-exec npm list --json` for example.
But previously when specifying `executable='/usr/local/nvm/nvm-exec nvm'` this would not work because the string was treated as one executable. This PR fixes that.
