### PR TITLE
Updates django_manage so it populates VIRTUAL_ENV

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -144,6 +144,7 @@ def _ensure_virtualenv(module):
             _fail(module, vcmd, out_venv, err_venv)
 
     os.environ["PATH"] = "%s:%s" % (vbin, os.environ["PATH"])
+    os.environ["VIRTUAL_ENV"] = venv_param
 
 def createcachetable_filter_output(line):
     return "Already exists" not in line


### PR DESCRIPTION
Virtualenv's activate script sets the VIRTUAL_ENV environment variable to the path of the virtualenv. Checking this variable is a reasonably common way to verify that execution is happening in a virtualenv. It would be convenient if this module's virtualenv handling set this environment variable.
