### PR TITLE
host-pattern as dynamic inventory script argument

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -45,12 +45,12 @@ class Cli(object):
         ''' create an options parser for bin/ansible '''
 
         parser = utils.base_parser(
-            constants=C, 
-            runas_opts=True, 
-            subset_opts=True, 
+            constants=C,
+            runas_opts=True,
+            subset_opts=True,
             async_opts=True,
-            output_opts=True, 
-            connect_opts=True, 
+            output_opts=True,
+            connect_opts=True,
             check_opts=True,
             diff_opts=False,
             usage='%prog <host-pattern> [options]'
@@ -135,7 +135,8 @@ class Cli(object):
 
             if not options.ask_vault_pass:
                 vault_pass = tmp_vault_pass
-
+        if options.inventory_arguments is True:
+            options.inventory = tuple([options.inventory, pattern])
         inventory_manager = inventory.Inventory(options.inventory)
         if options.subset:
             inventory_manager.subset(options.subset)

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -100,6 +100,9 @@ def main(args):
     if (options.ask_vault_pass and options.vault_password_file):
             parser.error("--ask-vault-pass and --vault-password-file are mutually exclusive")
 
+    if options.inventory_arguments is True:
+        options.inventory = tuple([options.inventory, ' '.join(args)])
+    print options.inventory
     inventory = ansible.inventory.Inventory(options.inventory)
     inventory.subset(options.subset)
     if len(inventory.list_hosts()) == 0:

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -102,7 +102,6 @@ def main(args):
 
     if options.inventory_arguments is True:
         options.inventory = tuple([options.inventory, ' '.join(args)])
-    print options.inventory
     inventory = ansible.inventory.Inventory(options.inventory)
     inventory.subset(options.subset)
     if len(inventory.list_hosts()) == 0:

--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -29,13 +29,17 @@ import sys
 class InventoryScript(object):
     ''' Host inventory parser for ansible using external inventory scripts. '''
 
-    def __init__(self, filename=C.DEFAULT_HOST_LIST):
+    def __init__(self, filename=C.DEFAULT_HOST_LIST, script_args=None):
 
         # Support inventory scripts that are not prefixed with some
         # path information but happen to be in the current working
         # directory when '.' is not in PATH.
         self.filename = os.path.abspath(filename)
-        cmd = [ self.filename, "--list" ]
+        self.script_args = script_args
+        if self.script_args:
+            cmd = [ self.filename, "--list", self.script_args ]
+        else:
+            cmd = [ self.filename, "--list" ]
         try:
             sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError, e:
@@ -60,7 +64,7 @@ class InventoryScript(object):
             raise errors.AnsibleError("failed to parse executable inventory script results: %s" % self.raw)
 
         for (group_name, data) in self.raw.items():
- 
+
             # in Ansible 1.3 and later, a "_meta" subelement may contain
             # a variable "hostvars" which contains a hash for each host
             # if this "hostvars" exists at all then do not call --host for each

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -218,8 +218,8 @@ def check_conditional(conditional, basedir, inject, fail_on_undefined=False):
     conditional = template.template(basedir, presented, inject)
     val = conditional.strip()
     if val == presented:
-        # the templating failed, meaning most likely a 
-        # variable was undefined. If we happened to be 
+        # the templating failed, meaning most likely a
+        # variable was undefined. If we happened to be
         # looking for an undefined variable, return True,
         # otherwise fail
         if "is undefined" in conditional:
@@ -242,7 +242,7 @@ def is_executable(path):
             or stat.S_IXOTH & os.stat(path)[stat.ST_MODE])
 
 def unfrackpath(path):
-    ''' 
+    '''
     returns a path that is free of symlinks, environment
     variables, relative path traversals and symbols (~)
     example:
@@ -392,10 +392,10 @@ def process_common_errors(msg, probline, column):
 
     if ":{{" in replaced and "}}" in replaced:
         msg = msg + """
-This one looks easy to fix.  YAML thought it was looking for the start of a 
+This one looks easy to fix.  YAML thought it was looking for the start of a
 hash/dictionary and was confused to see a second "{".  Most likely this was
-meant to be an ansible template evaluation instead, so we have to give the 
-parser a small hint that we wanted a string instead. The solution here is to 
+meant to be an ansible template evaluation instead, so we have to give the
+parser a small hint that we wanted a string instead. The solution here is to
 just quote the entire value.
 
 For instance, if the original line was:
@@ -410,9 +410,9 @@ It should be written as:
 
     elif len(probline) and len(probline) > 1 and len(probline) > column and probline[column] == ":" and probline.count(':') > 1:
         msg = msg + """
-This one looks easy to fix.  There seems to be an extra unquoted colon in the line 
-and this is confusing the parser. It was only expecting to find one free 
-colon. The solution is just add some quotes around the colon, or quote the 
+This one looks easy to fix.  There seems to be an extra unquoted colon in the line
+and this is confusing the parser. It was only expecting to find one free
+colon. The solution is just add some quotes around the colon, or quote the
 entire line after the first colon.
 
 For instance, if the original line was:
@@ -424,7 +424,7 @@ It can be written as:
     copy: src=file.txt dest='/path/filename:with_colon.txt'
 
 Or:
-    
+
     copy: 'src=file.txt dest=/path/filename:with_colon.txt'
 
 
@@ -444,8 +444,8 @@ Or:
                 unbalanced = True
             if match:
                 msg = msg + """
-This one looks easy to fix.  It seems that there is a value started 
-with a quote, and the YAML parser is expecting to see the line ended 
+This one looks easy to fix.  It seems that there is a value started
+with a quote, and the YAML parser is expecting to see the line ended
 with the same kind of quote.  For instance:
 
     when: "ok" in result.stdout
@@ -463,9 +463,9 @@ or equivalently:
 
             if unbalanced:
                 msg = msg + """
-We could be wrong, but this one looks like it might be an issue with 
-unbalanced quotes.  If starting a value with a quote, make sure the 
-line ends with the same set of quotes.  For instance this arbitrary 
+We could be wrong, but this one looks like it might be an issue with
+unbalanced quotes.  If starting a value with a quote, make sure the
+line ends with the same set of quotes.  For instance this arbitrary
 example:
 
     foo: "bad" "wolf"
@@ -506,8 +506,8 @@ Note: The error may actually appear before this position: line %s, column %s
             else:
                 msg = msg + """
 We could be wrong, but this one looks like it might be an issue with
-missing quotes.  Always quote template expression brackets when they 
-start a value. For instance:            
+missing quotes.  Always quote template expression brackets when they
+start a value. For instance:
 
     with_items:
       - {{ foo }}
@@ -515,7 +515,7 @@ start a value. For instance:
 Should be written as:
 
     with_items:
-      - "{{ foo }}"      
+      - "{{ foo }}"
 
 """
         else:
@@ -747,15 +747,17 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
     parser.add_option('-i', '--inventory-file', dest='inventory',
         help="specify inventory host file (default=%s)" % constants.DEFAULT_HOST_LIST,
         default=constants.DEFAULT_HOST_LIST)
+    parser.add_option('-r', '--inventory-arguments', action="store_true",
+        help='call inventory script with these additional arguments', dest='inventory_arguments')
     parser.add_option('-k', '--ask-pass', default=False, dest='ask_pass', action='store_true',
         help='ask for SSH password')
     parser.add_option('--private-key', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
         help='use this file to authenticate the connection')
     parser.add_option('-K', '--ask-sudo-pass', default=False, dest='ask_sudo_pass', action='store_true',
         help='ask for sudo password')
-    parser.add_option('--ask-su-pass', default=False, dest='ask_su_pass', action='store_true', 
+    parser.add_option('--ask-su-pass', default=False, dest='ask_su_pass', action='store_true',
         help='ask for su password')
-    parser.add_option('--ask-vault-pass', default=False, dest='ask_vault_pass', action='store_true', 
+    parser.add_option('--ask-vault-pass', default=False, dest='ask_vault_pass', action='store_true',
         help='ask for vault password')
     parser.add_option('--vault-password-file', default=None, dest='vault_password_file',
         help="vault password file")
@@ -1032,8 +1034,8 @@ def safe_eval(expr, locals={}, include_exceptions=False):
     http://stackoverflow.com/questions/12523516/using-ast-and-whitelists-to-make-pythons-eval-safe
     '''
 
-    # this is the whitelist of AST nodes we are going to 
-    # allow in the evaluation. Any node type other than 
+    # this is the whitelist of AST nodes we are going to
+    # allow in the evaluation. Any node type other than
     # those listed here will raise an exception in our custom
     # visitor class defined below.
     SAFE_NODES = set(


### PR DESCRIPTION
### Hello!

Very interested in taking Ansible out for a test drive in my current position, however I ran into a problem with the dynamic script implementation that didn't quite work for our current inventory system ([range](https://github.com/ytoolshed/range)).

The way range works (for us) is to provide a cluster name to expand, and you recieve back a list of hosts, for example:

```
$ range --expand "%datacenter.cluster.instance"
host1.localdomain
host2.localdomain
host3.localdomain
```

You can also get information about a single host by various means (akin to the --host implementation expected to be returned by dynamic inventory scripts)

While it is possible to return every cluster and subsequent members of each cluster by querying range, it's a somewhat expensive and potentially slow thing to do (especially when dealing with 10s of thousands of hosts).

The cleanest and most obvious way to deal with this would be to provide a clustername to the dynamic inventory query in order to only get back cluster members from specific clusters, akin to:

```
$ /etc/ansible/range.py --list %datacenter.cluster.instance
{
  '%datacenter.cluster.instance': [
    'host1.localdomain',
    'host2.localdomain',
    'host3.localdomain'
    ],
  '_meta': {
    'hostvars': {
      'host1.localdomain': {},
      'host2.localdomain': {},
      'host3.localdomain': {}
      }
    }
  }
```

In order to accomplish this without having to do anything drastic to ansible.inventory.Inventory() I simply added a boolean '-r' argument to bin/ansible that indicates that the host-pattern should be passed to the dynamic inventory script as an argument. This limits the scope of the query to only the cluster I care about, while keeping the usage syntax the same. 

I recognize that there are probably better ways to do this than what is represented in my pull request, but think of it more as a proof of concept. All tests pass, all default syntax remains the same, merely adding the option to pass the host-pattern to the dynamic inventory script.

Thanks for looking!

P.S. Sorry about the whitespaces in the diff, I have a VIM plugin that automatically cleans them up :(
