### PR TITLE
BUGFIX for Issue 7811: Adding file existence check when performing mysql import on...

### DIFF
--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -148,9 +148,9 @@ def db_import(module, host, user, password, db_name, target, port, socket=None):
         cmd += " --host=%s --port=%s" % (pipes.quote(host), pipes.quote(port))
     cmd += " -D %s" % pipes.quote(db_name)
     if os.path.splitext(target)[-1] == '.gz':
-        cmd = 'gunzip < ' + pipes.quote(target) + ' | ' + cmd
+        cmd = 'test -e ' + pipes.quote(target) + ' && gunzip < ' + pipes.quote(target) + ' | ' + cmd
     elif os.path.splitext(target)[-1] == '.bz2':
-        cmd = 'bunzip2 < ' + pipes.quote(target) + ' | ' + cmd
+        cmd = 'test -e ' + pipes.quote(target) + ' && bunzip2 < ' + pipes.quote(target) + ' | ' + cmd
     else:
         cmd += " < %s" % pipes.quote(target)
     rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)

--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -140,6 +140,9 @@ def db_dump(module, host, user, password, db_name, target, port, socket=None):
     return rc, stdout, stderr
 
 def db_import(module, host, user, password, db_name, target, port, socket=None):
+    if not os.path.exists(target):
+        return module.fail_json(msg="target %s does not exist on the host" % target)
+
     cmd = module.get_bin_path('mysql', True)
     cmd += " --user=%s --password=%s" % (pipes.quote(user), pipes.quote(password))
     if socket is not None:
@@ -148,9 +151,9 @@ def db_import(module, host, user, password, db_name, target, port, socket=None):
         cmd += " --host=%s --port=%s" % (pipes.quote(host), pipes.quote(port))
     cmd += " -D %s" % pipes.quote(db_name)
     if os.path.splitext(target)[-1] == '.gz':
-        cmd = 'test -e ' + pipes.quote(target) + ' && gunzip < ' + pipes.quote(target) + ' | ' + cmd
+        cmd = 'gunzip < ' + pipes.quote(target) + ' | ' + cmd
     elif os.path.splitext(target)[-1] == '.bz2':
-        cmd = 'test -e ' + pipes.quote(target) + ' && bunzip2 < ' + pipes.quote(target) + ' | ' + cmd
+        cmd = 'bunzip2 < ' + pipes.quote(target) + ' | ' + cmd
     else:
         cmd += " < %s" % pipes.quote(target)
     rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)


### PR DESCRIPTION
Adding file existence check when performing mysql import on a .gz or .bz2 file, otherwise Ansible will not notice that the underlying *nix command silently died.

The following is sample run showing the issue as well as the fix working on a remote system (Ubuntu 12.04 LTS via Vagrant).

Given the following play:

```

---
- name: add mysql
  apt: pkg=mysql-server state=present update_cache=true
  sudo: yes
- name: add mysqldb python module
  apt: pkg=python-mysqldb state=present
  sudo: yes
- name: ensure database exists
  mysql_db: name=testdb state=present
  sudo: yes
- name: import data from existent file
  mysql_db: name=testdb state=import target=/tmp/exists.sql.gz
  sudo: yes
- name: import data from non-existent file
  mysql_db: name=testdb state=import target=/tmp/missing.sql.gz
  sudo: yes
```

**Note: This assumes you have already performed `$ touch /tmp/exists.sql && gzip /tmp/exists` on the remote system.**

Ansible will run it without error even though the file does not exist:

```
==> default: Running provisioner: ansible...

PLAY [run bugfix provisioning] ************************************************

GATHERING FACTS ***************************************************************
ok: [default]

TASK: [bugfix | add mysql] ****************************************************
ok: [default]

TASK: [bugfix | add mysqldb python module] ************************************
changed: [default]

TASK: [bugfix | ensure database exists] ***************************************
changed: [default]

TASK: [bugfix | import data from non-existent file] ***************************
changed: [default]

PLAY RECAP ********************************************************************
default                    : ok=5    changed=3    unreachable=0    failed=0
```

But after applying the fix to the code and adding an existence check using the `test` unix command, Ansible starts failing on non-existent files but still succeeding on files that exist in the system:

```
==> default: Running provisioner: ansible...

PLAY [run bugfix provisioning] ************************************************

GATHERING FACTS ***************************************************************
ok: [default]

TASK: [bugfix | add mysql] ****************************************************
ok: [default]

TASK: [bugfix | add mysqldb python module] ************************************
ok: [default]

TASK: [bugfix | ensure database exists] ***************************************
ok: [default]

TASK: [bugfix | import data from existent file] *******************************
changed: [default]

TASK: [bugfix | import data from non-existent file] ***************************
failed: [default] => {"failed": true, "item": ""}

FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/Users/scott/playbook.retry

default                    : ok=5    changed=1    unreachable=0    failed=1

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

Although Ansible is now responding correctly to non-existent files, the only downside of this approach is that the `test` command does not respond with an error message, so Ansible cannot tell the end-user why the task failed.

**Note: I am using `test -e` as a test for pure file existence.  I am not making any other assumptions about the type of file.**
