### PR TITLE
Issue #7358 Create non-unique parameter for group module

### DIFF
--- a/library/network/get_url
+++ b/library/network/get_url
@@ -76,6 +76,14 @@ options:
     version_added: "1.3"
     required: false
     default: null
+  md5sum:
+    description:
+      - Performs the same service as sha256sum but using a MD5 checksum. This option
+        cannot be set at the same time as sha256sum. MD5 checksum verification is 
+        available for usage on systems with Python 2.4, whereas SHA-256 checksum
+        verification is not.
+    required: false
+    default: null
   use_proxy:
     description:
       - if C(no), it will not use a proxy, even if one is defined in
@@ -126,6 +134,28 @@ try:
     HAS_HASHLIB=True
 except ImportError:
     HAS_HASHLIB=False
+
+
+# ==============================================================
+# Checksum verification
+def verify_checksum(module, method_name, expected_checksum, destination_checksum, dest):
+    """
+    Verify a MD5 or SHA256 checksum. 
+
+    Function takes as arguments the module object and the name of the verification 
+    method used to check the file. The expected checksum, the checksum of the actual
+    file and the path to the destination file also need to be provided.
+    """
+    # Remove any non-alphanumeric characters, including the infamous
+    # Unicode zero-width space
+    stripped_checksum = re.sub(r'\W+', '', expected_checksum)
+    if stripped_checksum.lower() != destination_checksum:
+        os.remove(dest)
+        module.fail_json(
+            msg="The %s checksum for %s did not match %s; it was %s" % 
+            (method_name, dest, expected_checksum, destination_checksum)
+        )
+
 
 # ==============================================================
 # url handling
@@ -189,9 +219,10 @@ def main():
 
     argument_spec = url_argument_spec()
     argument_spec.update(
-        url = dict(required=True),
-        dest = dict(required=True),
-        sha256sum = dict(default=''),
+        url=dict(required=True),
+        dest=dict(required=True),
+        sha256sum=dict(default=''),
+        md5sum=dict(default=None),
     )
 
     module = AnsibleModule(
@@ -204,6 +235,7 @@ def main():
     dest = os.path.expanduser(module.params['dest'])
     force = module.params['force']
     sha256sum = module.params['sha256sum']
+    expected_md5sum = module.params['md5sum']
     use_proxy = module.params['use_proxy']
 
     dest_is_dir = os.path.isdir(dest)
@@ -272,20 +304,19 @@ def main():
 
     # Check the digest of the destination file and ensure that it matches the
     # sha256sum parameter if it is present
-    if sha256sum != '':
-        # Remove any non-alphanumeric characters, including the infamous
-        # Unicode zero-width space
-        stripped_sha256sum = re.sub(r'\W+', '', sha256sum)
+    if sha256sum and expected_md5sum:
+        module.fail_json(msg="You cannot verify both sha256 and md5 checksums at the same time! You must choose one or the other.")
 
+    if sha256sum:
         if not HAS_HASHLIB:
             os.remove(dest)
             module.fail_json(msg="The sha256sum parameter requires hashlib, which is available in Python 2.5 and higher")
-        else:
-            destination_checksum = module.sha256(dest)
+        destination_checksum = module.sha256(dest)
+        verify_checksum(module, "SHA-256", sha256sum, destination_checksum, dest)
 
-        if stripped_sha256sum.lower() != destination_checksum:
-            os.remove(dest)
-            module.fail_json(msg="The SHA-256 checksum for %s did not match %s; it was %s." % (dest, sha256sum, destination_checksum))
+    if expected_md5sum:
+        verify_checksum(module, "MD5", expected_md5sum, md5sum_src, dest)
+
 
     os.remove(tmpsrc)
 
@@ -296,8 +327,16 @@ def main():
     changed = module.set_fs_attributes_if_different(file_args, changed)
 
     # Mission complete
-    module.exit_json(url=url, dest=dest, src=tmpsrc, md5sum=md5sum_src,
-        sha256sum=sha256sum, changed=changed, msg=info.get('msg', ''))
+    module.exit_json(
+        url=url, 
+        dest=dest, 
+        src=tmpsrc, 
+        md5sum=md5sum_src,
+        expected_md5sum=expected_md5sum,
+        sha256sum=sha256sum,
+        changed=changed, 
+        msg=info.get('msg', '')
+    )
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/library/system/group
+++ b/library/system/group
@@ -48,7 +48,13 @@ options:
         choices: [ "yes", "no" ]
         description:
             - If I(yes), indicates that the group created is a system group.
-
+    
+    non_unique:
+        required: false
+        default: "no"
+        choices: [ "yes", "no" ]
+        description:
+            - Allow to create/modify groups to have a non-unique GID. Will be ignored for AIX platforms
 '''
 
 EXAMPLES = '''
@@ -58,7 +64,7 @@ EXAMPLES = '''
 
 import grp
 import syslog
-import platform
+
 
 class Group(object):
     """
@@ -86,6 +92,7 @@ class Group(object):
         self.name       = module.params['name']
         self.gid        = module.params['gid']
         self.system     = module.params['system']
+        self.non_unique = module.params['non_unique']
         self.syslogging = False
 
     def execute_command(self, cmd):
@@ -105,6 +112,8 @@ class Group(object):
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
                 cmd.append(kwargs[key])
+                if self.non_unique:
+                    cmd.append('-o')
             elif key == 'system' and kwargs[key] == True:
                 cmd.append('-r')
         cmd.append(self.name)
@@ -118,6 +127,8 @@ class Group(object):
                 if kwargs[key] is not None and info[2] != int(kwargs[key]):
                     cmd.append('-g')
                     cmd.append(kwargs[key])
+                    if self.non_unique:
+                        cmd.append('-o')
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -162,6 +173,8 @@ class SunOS(Group):
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
                 cmd.append(kwargs[key])
+                if self.non_unique:
+                    cmd.append('-o')
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -234,6 +247,8 @@ class FreeBsdGroup(Group):
         cmd = [self.module.get_bin_path('pw', True), 'groupadd', self.name]
         if self.gid is not None:
             cmd.append('-g %d' % int(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):
@@ -274,16 +289,19 @@ class OpenBsdGroup(Group):
         if self.gid is not None:
             cmd.append('-g')
             cmd.append('%d' % int(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         cmd.append(self.name)
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):
         cmd = [self.module.get_bin_path('groupmod', True)]
         info = self.group_info()
-        cmd_len = len(cmd)
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
             cmd.append('%d' % int(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -316,16 +334,19 @@ class NetBsdGroup(Group):
         if self.gid is not None:
             cmd.append('-g')
             cmd.append('%d' % int(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         cmd.append(self.name)
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):
         cmd = [self.module.get_bin_path('groupmod', True)]
         info = self.group_info()
-        cmd_len = len(cmd)
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
             cmd.append('%d' % int(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
@@ -337,11 +358,12 @@ class NetBsdGroup(Group):
 
 def main():
     module = AnsibleModule(
-        argument_spec = dict(
+        argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent'], type='str'),
             name=dict(required=True, type='str'),
             gid=dict(default=None, type='str'),
             system=dict(default=False, type='bool'),
+            non_unique=dict(default=False, type='bool'),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
I created a non_unique parameter for all platforms except AIX which requires a chsec call to change group ID security. Furthermore the chsec call has three separate options which is not conducive to being represented with a boolean.
