### PR TITLE
fix group by tag so that equal sign is preserved

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -371,7 +371,7 @@ class Ec2Inventory(object):
 
         # Inventory: Group by tag keys
         for k, v in instance.tags.iteritems():
-            key = self.to_safe("tag_" + k + "=" + v)
+            key = self.to_safe("tag_" + k) + "=" + self.to_safe(v)
             self.push(self.inventory, key, dest)
 
         # Inventory: Group by Route53 domain names if enabled


### PR DESCRIPTION
Unless I'm mistaken, I don't think the equal sign should be passed along in the to_safe function call because its getting converted to an underscore. I updated my own local copy of ec2.py and wanted to submit a pull request to get this updated.
