### PR TITLE
turned on unsafe shell handling so synchronize can work with unix wildcards

### DIFF
--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -314,7 +314,7 @@ def main():
 
     cmd = ' '.join([cmd, source, dest])
     cmdstr = cmd
-    (rc, out, err) = module.run_command(cmd)
+    (rc, out, err) = module.run_command(cmd, use_unsafe_shell=True)
     if rc:
         return module.fail_json(msg=err, rc=rc, cmd=cmdstr)
     else:


### PR DESCRIPTION
This pull request addresses the problem reported in #7728.
