### PR TITLE
Add mysql_index module

### DIFF
--- a/library/database/mysql_index
+++ b/library/database/mysql_index
@@ -1,0 +1,331 @@
+#!/usr/bin/python
+
+# Ansible module to manage mysql indexes
+#
+# Certain parts are taken from Mark Theunissen's mysqldb module
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: mysql_index
+short_description: Adds or removes an index from a MySQL table.
+description:
+   - Adds or removes an index from a MySQL table.
+version_added: "1.6"
+options:
+  name:
+    description:
+      - name of the index to add or remove
+    required: true
+    default: null
+  login_user:
+    description:
+      - The username used to authenticate with
+    required: false
+    default: null
+  login_password:
+    description:
+      - The password used to authenticate with
+    required: false
+    default: null
+  login_host:
+    description:
+      - Host running the database
+    required: false
+    default: localhost
+  login_port:
+    description:
+      - Port of the MySQL server
+    required: false
+    default: 3306
+  login_unix_socket:
+    description:
+      - The path to a Unix domain socket for local connections
+    required: false
+    default: null
+  table:
+    description:
+      - Table to add the index to
+    required: true
+  database:
+    description:
+      - The database to connect to 
+    required: true
+  columns:
+    description:
+      - The columns to include in the index
+    required: false
+    default: None
+  state:
+    description:
+      - Whether the user should exist.  When C(absent), removes
+        the index.
+    required: false
+    default: present
+    choices: [ "present", "absent" ]
+  check_implicit_admin:
+    description:
+      - Check if mysql allows login as root/nopassword before trying supplied credentials.
+    required: false
+    default: false
+notes:
+   - Requires the MySQLdb Python package on the remote host. For Ubuntu, this
+     is as easy as apt-get install python-mysqldb.
+   - Both C(login_password) and C(login_username) are required when you are
+     passing credentials. If none are present, the module will attempt to read
+     the credentials from C(~/.my.cnf), and finally fall back to using the MySQL
+     default login of 'root' with no password.
+
+requirements: [ "MySQLdb" ]
+author: Tim Rupp
+'''
+
+EXAMPLES = """
+# Create index "idx" on table "tbl"
+- mysql_index: name="idx" table="tbl" database="my_db" state="present"
+
+# Create index "idx" on table "tbl" composed of columns "deleted" and "host"
+- mysql_index: name="idx" table="tbl" database="my_db" state="present" columns: "deleted,host"
+
+# Drop the index "idx" from the table "tbl"
+- mysql_index: name="idx" table="tbl" database="my_db" state="absent"
+
+# Example .my.cnf file for setting the root password
+# Note: don't use quotes around the password, because the mysql_index module
+# will include them in the password but the mysql client will not
+
+[client]
+user=root
+password=n<_665{vS43y
+"""
+
+import ConfigParser
+import getpass
+import tempfile
+try:
+    import MySQLdb
+except ImportError:
+    mysqldb_found = False
+else:
+    mysqldb_found = True
+
+
+def index_exists(cursor, table, index):
+    query = "SHOW INDEX FROM %s WHERE Key_name=%%s" % (table)
+    cursor.execute(query, (index))
+
+    """Cannot iterate using field names because this is not a select stmt
+
+    The list of fields is therefore indexed by integer. Here are the fields
+
+    0 - Table
+    1 - Non_unique
+    2 - Key_name
+    3 - Seq_in_index
+    4 - Column_name
+    5 - Collation
+    6 - Cardinality
+    7 - Sub_part
+    8 - Packed
+    9 - Null
+    10 - Index_type
+    11 - Comment
+    """
+    results = cursor.fetchall()
+    for result in results:
+        if result[2] == index:
+            return True
+    return False
+
+def index_add(cursor, table, index, columns):
+    query = "CREATE INDEX %s ON %s(%s)" % (index, table, columns)
+    cursor.execute(query)
+    return True
+
+def index_delete(cursor, table, index):
+    query = "DROP INDEX %s ON %s" % (index, table)
+    cursor.execute(query)
+    return True
+
+def strip_quotes(s):
+    """ Remove surrounding single or double quotes
+
+    >>> print strip_quotes('hello')
+    hello
+    >>> print strip_quotes('"hello"')
+    hello
+    >>> print strip_quotes("'hello'")
+    hello
+    >>> print strip_quotes("'hello")
+    'hello
+
+    """
+    single_quote = "'"
+    double_quote = '"'
+
+    if s.startswith(single_quote) and s.endswith(single_quote):
+        s = s.strip(single_quote)
+    elif s.startswith(double_quote) and s.endswith(double_quote):
+        s = s.strip(double_quote)
+    return s
+
+
+def config_get(config, section, option):
+    """ Calls ConfigParser.get and strips quotes
+
+    See: http://dev.mysql.com/doc/refman/5.0/en/option-files.html
+    """
+    return strip_quotes(config.get(section, option))
+
+
+def _safe_cnf_load(config, path):
+
+    data = {'user':'', 'password':''}
+
+    # read in user/pass
+    f = open(path, 'r')
+    for line in f.readlines():
+        line = line.strip()
+        if line.startswith('user='):
+            data['user'] = line.split('=', 1)[1].strip()
+        if line.startswith('password=') or line.startswith('pass='):
+            data['password'] = line.split('=', 1)[1].strip()
+    f.close()
+
+    # write out a new cnf file with only user/pass   
+    fh, newpath = tempfile.mkstemp(prefix=path + '.')
+    f = open(newpath, 'wb')
+    f.write('[client]\n')
+    f.write('user=%s\n' % data['user'])
+    f.write('password=%s\n' % data['password'])
+    f.close()
+
+    config.readfp(open(newpath))
+    os.remove(newpath)
+    return config
+
+def load_mycnf():
+    config = ConfigParser.RawConfigParser()
+    mycnf = os.path.expanduser('~/.my.cnf')
+    if not os.path.exists(mycnf):
+        return False
+    try:
+        config.readfp(open(mycnf))
+    except (IOError):
+        return False
+    except:
+        config = _safe_cnf_load(config, mycnf)
+
+    # We support two forms of passwords in .my.cnf, both pass= and password=,
+    # as these are both supported by MySQL.
+    try:
+        passwd = config_get(config, 'client', 'password')
+    except (ConfigParser.NoOptionError):
+        try:
+            passwd = config_get(config, 'client', 'pass')
+        except (ConfigParser.NoOptionError):
+            return False
+
+    # If .my.cnf doesn't specify a user, default to user login name
+    try:
+        user = config_get(config, 'client', 'user')
+    except (ConfigParser.NoOptionError):
+        user = getpass.getuser()
+    creds = dict(user=user,passwd=passwd)
+    return creds
+
+def connect(module, login_user, login_password, database):
+    if module.params["login_unix_socket"]:
+        db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db=database)
+    else:
+        db_connection = MySQLdb.connect(host=module.params["login_host"], port=int(module.params["login_port"]), user=login_user, passwd=login_password, db=database)
+    return db_connection.cursor()
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name=dict(required=True),
+            login_user=dict(default=None),
+            login_password=dict(default=None),
+            login_host=dict(default="localhost"),
+            login_port=dict(default="3306"),
+            login_unix_socket=dict(default=None),
+            database=dict(required=True),
+            table=dict(required=True),
+            columns=dict(required=False, default=None),
+            state=dict(default="present", choices=["absent", "present"]),
+            check_implicit_admin=dict(default=False),
+        )
+    )
+    name = module.params["name"]
+    db = module.params["database"]
+    table = module.params["table"]
+    columns = module.params["columns"]
+    state = module.params["state"]
+    check_implicit_admin = module.params['check_implicit_admin']
+
+    if not mysqldb_found:
+        module.fail_json(msg="the python mysqldb module is required")
+
+    # Either the caller passes both a username and password with which to connect to
+    # mysql, or they pass neither and allow this module to read the credentials from
+    # ~/.my.cnf.
+    login_password = module.params["login_password"]
+    login_user = module.params["login_user"]
+    if login_user is None and login_password is None:
+        mycnf_creds = load_mycnf()
+        if mycnf_creds is False:
+            login_user = "root"
+            login_password = ""
+        else:
+            login_user = mycnf_creds["user"]
+            login_password = mycnf_creds["passwd"]
+    elif login_password is None or login_user is None:
+        module.fail_json(msg="when supplying login arguments, both login_user and login_password must be provided")
+
+    cursor = None
+    try:
+        if check_implicit_admin:
+            try:
+                cursor = connect(module, 'root', '', db)
+            except:
+                pass
+
+        if not cursor:
+            cursor = connect(module, login_user, login_password, db)
+    except Exception, e:
+        module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials")
+
+    if state == "present":
+        if not columns:
+            module.fail_json(msg='You must specify a list of columns to create an index from')
+
+        if index_exists(cursor, table, name):
+            changed = False
+        else:
+            changed = index_add(cursor, table, name, columns)
+    elif state == "absent":
+        if index_exists(cursor, table, name):
+            changed = index_delete(cursor, table, name)
+        else:
+            changed = False
+    module.exit_json(changed=changed, index=name)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()


### PR DESCRIPTION
This module provides the ability for ansible to add and remove indices
from a table in MySQL without needing to use other, more raw, modules to
accomplish similar goals.
