### PR TITLE
Added gp2 volume type support to ec2_vol

### DIFF
--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -24,9 +24,9 @@ version_added: "1.1"
 options:
   instance:
     description:
-      - instance ID if you wish to attach the volume. 
+      - instance ID if you wish to attach the volume.
     required: false
-    default: null 
+    default: null
     aliases: []
   name:
     description:
@@ -42,6 +42,12 @@ options:
     default: null
     aliases: []
     version_added: "1.6"
+  volume_type:
+    description:
+      - volume type (io1, gp2, standard)
+    default: standard
+    aliases: ['device_type']
+    version_added: "1.7"
   volume_size:
     description:
       - size of volume (in GB) to create.
@@ -69,7 +75,7 @@ options:
     aliases: ['aws_region', 'ec2_region']
   zone:
     description:
-      - zone in which to create the volume, if unset uses the zone the instance is in (if set) 
+      - zone in which to create the volume, if unset uses the zone the instance is in (if set)
     required: false
     default: null
     aliases: ['aws_zone', 'ec2_zone']
@@ -88,7 +94,7 @@ options:
     aliases: []
     version_added: "1.5"
   state:
-    description: 
+    description:
       - whether to ensure the volume is present or absent
     required: false
     default: present
@@ -100,17 +106,17 @@ extends_documentation_fragment: aws
 
 EXAMPLES = '''
 # Simple attachment action
-- local_action: 
-    module: ec2_vol 
-    instance: XXXXXX 
-    volume_size: 5 
+- local_action:
+    module: ec2_vol
+    instance: XXXXXX
+    volume_size: 5
     device_name: sdd
 
-# Example using custom iops params   
-- local_action: 
-    module: ec2_vol 
-    instance: XXXXXX 
-    volume_size: 5 
+# Example using custom iops params
+- local_action:
+    module: ec2_vol
+    instance: XXXXXX
+    volume_size: 5
     iops: 200
     device_name: sdd
 
@@ -120,17 +126,17 @@ EXAMPLES = '''
     instance: XXXXXX
     snapshot: "{{ snapshot }}"
 
-# Playbook example combined with instance launch 
-- local_action: 
-    module: ec2 
+# Playbook example combined with instance launch
+- local_action:
+    module: ec2
     keypair: "{{ keypair }}"
     image: "{{ image }}"
-    wait: yes 
+    wait: yes
     count: 3
     register: ec2
-- local_action: 
-    module: ec2_vol 
-    instance: "{{ item.id }} " 
+- local_action:
+    module: ec2_vol
+    instance: "{{ item.id }} "
     volume_size: 5
     with_items: ec2.instances
     register: ec2_vol
@@ -139,19 +145,19 @@ EXAMPLES = '''
 #   * Nothing will happen if the volume is already attached.
 #   * Volume must exist in the same zone.
 
-- local_action: 
-    module: ec2 
+- local_action:
+    module: ec2
     keypair: "{{ keypair }}"
     image: "{{ image }}"
     zone: YYYYYY
     id: my_instance
-    wait: yes 
+    wait: yes
     count: 1
     register: ec2
 
-- local_action: 
-    module: ec2_vol 
-    instance: "{{ item.id }}" 
+- local_action:
+    module: ec2_vol
+    instance: "{{ item.id }}"
     name: my_existing_volume_Name_tag
     device_name: /dev/xvdf
     with_items: ec2.instances
@@ -165,7 +171,7 @@ EXAMPLES = '''
 '''
 
 # Note: this module needs to be made idempotent. Possible solution is to use resource tags with the volumes.
-# if state=present and it doesn't exist, create, tag and attach. 
+# if state=present and it doesn't exist, create, tag and attach.
 # Check for state by looking for volume attachment with tag (and against block device mapping?).
 # Would personally like to revisit this in May when Eucalyptus also has tagging support (3.3).
 
@@ -207,7 +213,7 @@ def delete_volume(module, ec2):
     if not vol:
         module.exit_json(changed=False)
     else:
-       if vol.attachment_state() is not None: 
+       if vol.attachment_state() is not None:
            adata = vol.attach_data
            module.fail_json(msg="Volume %s is attached to an instance %s." % (vol.id, adata.instance_id))
        ec2.delete_volume(vol.id)
@@ -219,13 +225,19 @@ def create_volume(module, ec2, zone):
     id = module.params.get('id')
     instance = module.params.get('instance')
     iops = module.params.get('iops')
+    volume_type = module.params.get('volume_type', 'standard')
     volume_size = module.params.get('volume_size')
     snapshot = module.params.get('snapshot')
-    # If custom iops is defined we use volume_type "io1" rather than the default of "standard"
+
+    if volume_type not in ['standard', 'gp2', 'io1']:
+        module.fail_json(msg = "Unknown volume_type %s: [volume_type] must be standard, gp2, io1" % volume_type)
+
+    if iops and volume_type != 'io1':
+        module.fail_json(msg = "Parameters are not compatible: [iops] is only available for volume_type io1")
+
+    # If custom iops is defined set volume_type to "io1" rather than the default of "standard"
     if iops:
         volume_type = 'io1'
-    else:
-        volume_type = 'standard'
 
     # If no instance supplied, try volume creation based on module parameters.
     if name or id:
@@ -301,6 +313,7 @@ def main():
             id = dict(),
             name = dict(),
             volume_size = dict(),
+            volume_type = dict(aliases=['device_type']),
             iops = dict(),
             device_name = dict(),
             zone = dict(aliases=['availability_zone', 'aws_zone', 'ec2_zone']),
@@ -328,7 +341,7 @@ def main():
     if not (id or name or volume_size):
         module.fail_json(msg="Cannot specify volume_size and either one of name or id")
 
-    # Here we need to get the zone info for the instance. This covers situation where 
+    # Here we need to get the zone info for the instance. This covers situation where
     # instance is specified but zone isn't.
     # Useful for playbooks chaining instance launch with volume create + attach and where the
     # zone doesn't matter to the user.


### PR DESCRIPTION
AWS announced a new EBS volume type (gp2) yesterday (http://aws.amazon.com/blogs/aws/new-ssd-backed-elastic-block-storage/). This patch adds support for the gp2 volume type in addition to io1 and standard.
