### PR TITLE
ec2 module: Delay instance tagging to later in the instance creation process

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -913,12 +913,6 @@ def create_instances(module, ec2, override_count=None):
         except boto.exception.BotoServerError, e:
             module.fail_json(msg = "Instance creation failed => %s: %s" % (e.error_code, e.error_message))
 
-        if instance_tags:
-            try:
-                ec2.create_tags(instids, instance_tags)
-            except boto.exception.EC2ResponseError, e:
-                module.fail_json(msg = "Instance tagging failed => %s: %s" % (e.error_code, e.error_message))
-
         # wait here until the instances are up
         num_running = 0
         wait_timeout = time.time() + wait_timeout
@@ -949,6 +943,13 @@ def create_instances(module, ec2, override_count=None):
         if not source_dest_check:
             for inst in res.instances:
                 inst.modify_attribute('sourceDestCheck', False)
+
+        # Leave this as late as possible to try and avoid InvalidInstanceID.NotFound
+        if instance_tags:
+            try:
+                ec2.create_tags(instids, instance_tags)
+            except boto.exception.EC2ResponseError, e:
+                module.fail_json(msg = "Instance tagging failed => %s: %s" % (e.error_code, e.error_message))
 
     instance_dict_array = []
     created_instance_ids = []


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.7 (devel aac194e639) last updated 2014/06/19 11:13:25 (GMT +1000)
##### Environment:

N/A
##### Summary:

When creating instances with tags using the ec2 module, the tagging bit can result in
InvalidInstanceID.NotFound errors.

By delaying the tagging until the last part of instance creation, we should be typically more fortunate (handling all such race conditions might need more work such as retry with backoffs)
##### Steps To Reproduce:

This appears to be sporadic but has been reported elsewhere
http://blog.picloud.com/2013/02/17/dealing-with-the-inconsistent-ec2-api/

Until today we'd never hit it (or at least not enough to concern us) but today all instance creation has been failing. 

Essentially create an ec2 instance with the ec2 module using the tags argument. However, a successful instance creation just suggests that the timing glitch was avoided.
##### Expected Results:

Instance gets created and tagged appropriately
##### Actual Results:

failed: [instance123] => {"failed": true}
msg: Instance tagging failed => InvalidInstanceID.NotFound: The instance ID 'i-abcd1234' does not exist
