### PR TITLE
return properties of the newly created scaling policy

### DIFF
--- a/library/cloud/ec2_scaling_policy
+++ b/library/cloud/ec2_scaling_policy
@@ -91,7 +91,8 @@ def create_scaling_policy(connection, module):
 
         try:
             connection.create_scaling_policy(sp)
-            module.exit_json(changed=True)
+            policy = connection.get_all_policies(policy_names=[sp_name])[0]
+            module.exit_json(changed=True, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment, cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
         except BotoServerError, e:
             module.fail_json(msg=str(e))
     else:
@@ -118,7 +119,8 @@ def create_scaling_policy(connection, module):
                 connection.create_scaling_policy(policy)
                 policy = connection.get_all_policies(policy_names=[sp_name])[0]
                 module.exit_json(changed=changed, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment, cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
-            module.exit_json(changed=changed)
+            policy = connection.get_all_policies(policy_names=[sp_name])[0]
+            module.exit_json(changed=changed, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment, cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
         except BotoServerError, e:
             module.fail_json(msg=str(e))
 


### PR DESCRIPTION
This PR enable's the module  to return the properties of the created scaling policy. This is especially useful
when creating cloud watch alarms which requires the arn of the policy.
