### PR TITLE
make zypper_repository recognice --type, --check and --refresh options

### DIFF
--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -59,6 +59,12 @@ options:
         default: "no"
         choices: [ "yes", "no" ]
         aliases: []
+    from_repo:
+        description:
+          - Select  packages from specified repository. This option currently
+            implies --name, but allows using wildcards for specifying packages.
+        required: false
+        default: ""
 
 notes: []
 # informational: requirements for nodes
@@ -72,6 +78,9 @@ EXAMPLES = '''
 
 # Remove the "nmap" package
 - zypper: name=nmap state=absent
+
+# Make sure, nmap is installed from repository 'internal'
+- zypper: name=nmap state=present from_repo=internal
 '''
 
 # Function used for getting the name of a currently installed package.
@@ -102,7 +111,7 @@ def get_package_state(m, name):
         return False
 
 # Function used to make sure a package is present.
-def package_present(m, name, installed_state, disable_gpg_check):
+def package_present(m, name, installed_state, disable_gpg_check, from_repo):
     if installed_state is False:
         cmd = ['/usr/bin/zypper', '--non-interactive']
         # add global options before zypper command
@@ -110,6 +119,10 @@ def package_present(m, name, installed_state, disable_gpg_check):
             cmd.append('--no-gpg-check')
 
         cmd.extend(['install', '--auto-agree-with-licenses'])
+
+        if from_repo:
+            cmd.extend(['--from'], from_repo)
+
         cmd.append(name)
         rc, stdout, stderr = m.run_command(cmd, check_rc=False)
 
@@ -126,10 +139,14 @@ def package_present(m, name, installed_state, disable_gpg_check):
     return (rc, stdout, stderr, changed)
 
 # Function used to make sure a package is the latest available version.
-def package_latest(m, name, installed_state, disable_gpg_check):
+def package_latest(m, name, installed_state, disable_gpg_check, from_repo):
 
     if installed_state is True:
         cmd = ['/usr/bin/zypper', '--non-interactive', 'update', '--auto-agree-with-licenses', name]
+
+        if from_repo:
+            cmd.extend(['--from'], from_repo)
+
         pre_upgrade_name = ''
         post_upgrade_name = ''
 
@@ -178,6 +195,7 @@ def main():
             name = dict(required=True, aliases=['pkg']),
             state = dict(required=False, default='present', choices=['absent', 'installed', 'latest', 'present', 'removed']),
             disable_gpg_check = dict(required=False, default='no', type='bool'),
+            from_repo = dict(required=False),
         ),
         supports_check_mode = False
     )
@@ -188,6 +206,7 @@ def main():
     name  = params['name']
     state = params['state']
     disable_gpg_check = params['disable_gpg_check']
+    from_repo = params['from_repo']
 
     rc = 0
     stdout = ''
@@ -201,11 +220,11 @@ def main():
 
     # Perform requested action
     if state in ['installed', 'present']:
-        (rc, stdout, stderr, changed) = package_present(module, name, installed_state, disable_gpg_check)
+        (rc, stdout, stderr, changed) = package_present(module, name, installed_state, disable_gpg_check, from_repo)
     elif state in ['absent', 'removed']:
         (rc, stdout, stderr, changed) = package_absent(module, name, installed_state)
     elif state == 'latest':
-        (rc, stdout, stderr, changed) = package_latest(module, name, installed_state, disable_gpg_check)
+        (rc, stdout, stderr, changed) = package_latest(module, name, installed_state, disable_gpg_check, from_repo)
 
     if rc != 0:
         if stderr:

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -58,6 +58,29 @@ options:
         default: "no"
         choices: [ "yes", "no" ]
         aliases: []
+    type:
+        required: false
+        default: yast2
+        choices: [ "yast2", "rpm-md", "plaindir" ]
+        description:
+          - Type of the repository. Could either be 
+            yast2, rpm-md, or plaindir.
+    check:
+        required: false
+        default: "yes"
+        choices: [ "yes", "no" ]
+        aliases: []
+        description:
+          - Probe given URI directly.
+    refresh:
+        required: false
+        default: "yes"
+        choices: [ "yes", "no" ]
+        aliases: []
+        description:
+          - Enable autorefresh of the repository. 
+            The autorefresh is disabled by default 
+            when adding new repositories. 
 notes: []
 requirements: [ zypper ]
 '''
@@ -79,14 +102,25 @@ def repo_exists(module, repo):
     return (rc, stdout, stderr, repo in stdout)
 
 
-def add_repo(module, repo, alias, description, disable_gpg_check):
-    cmd = ['/usr/bin/zypper', 'ar', '--check', '--refresh']
+def add_repo(module, repo, alias, description, disable_gpg_check, type, docheck, dorefresh):
+    cmd = ['/usr/bin/zypper', 'ar' ]
 
     if description:
         cmd.extend(['--name', description])
 
     if disable_gpg_check:
         cmd.append('--no-gpgcheck')
+
+    if type:
+        cmd.extend(['--type', type])
+
+    if docheck:
+        cmd.append('--check')
+    else:
+        cmd.append('--no-check')
+
+    if dorefresh:
+        cmd.append('--refresh')
 
     cmd.append(repo)
 
@@ -119,6 +153,9 @@ def main():
             state=dict(choices=['present', 'absent'], default='present'),
             description=dict(required=False),
             disable_gpg_check = dict(required=False, default='no', type='bool'),
+            type = dict(choices=['yast2', 'rpm-md', 'plaindir'], default='yast2'),
+            check = dict(required=False, default='yes', type='bool'),
+            refresh = dict(required=False, default='yes', type='bool'),
         ),
         supports_check_mode=False,
     )
@@ -128,6 +165,9 @@ def main():
     name = module.params['name']
     description = module.params['description']
     disable_gpg_check = module.params['disable_gpg_check']
+    type = module.params['type']
+    docheck = module.params['check']
+    dorefresh = module.params['refresh']
 
     def exit_unchanged():
         module.exit_json(changed=False, repo=repo, state=state, name=name)
@@ -139,7 +179,7 @@ def main():
         if exists:
             exit_unchanged()
 
-        result = add_repo(module, repo, name, description, disable_gpg_check)
+        result = add_repo(module, repo, name, description, disable_gpg_check, type, docheck, dorefresh)
     elif state == 'absent':
         if not exists:
             exit_unchanged()


### PR DESCRIPTION
The defaults for both modules stay the same as before, but with this change in zypper_repository it is possible to:
- add repos without a direct check  (if they are not available yet, for example)
- give the type of the repository (needed if the direct check is not run)
- disable refresh for repositories that do not change (like most of the yast2 repos for example)

For the zypper module, someone can install a package from a specific repository (useful if a package exists in more than one repository and you want to make sure that a package from "your" repository is installed. 
