### PR TITLE
Use isinstance() to type check dicts and lists.

### DIFF
--- a/examples/scripts/yaml_to_ini.py
+++ b/examples/scripts/yaml_to_ini.py
@@ -64,7 +64,7 @@ class InventoryParserYaml(object):
 
         # first add all groups
         for item in yaml:
-            if type(item) == dict and 'group' in item:
+            if isinstance(item, dict) and 'group' in item:
                 group = Group(item['group'])
 
                 for subresult in item.get('hosts',[]):
@@ -73,14 +73,14 @@ class InventoryParserYaml(object):
                         host = self._make_host(subresult)
                         group.add_host(host)
                         grouped_hosts.append(host)
-                    elif type(subresult) == dict:
+                    elif isinstance(subresult, dict):
                         host = self._make_host(subresult['host'])
                         vars = subresult.get('vars',{})
-                        if type(vars) == list:
+                        if isinstance(vars, list):
                             for subitem in vars:
                                 for (k,v) in subitem.items():
                                     host.set_variable(k,v)
-                        elif type(vars) == dict:
+                        elif isinstance(vars, dict):
                             for (k,v) in subresult.get('vars',{}).items():
                                 host.set_variable(k,v)
                         else:
@@ -89,12 +89,12 @@ class InventoryParserYaml(object):
                         grouped_hosts.append(host)
 
                 vars = item.get('vars',{})
-                if type(vars) == dict:
+                if isinstance(vars, dict):
                     for (k,v) in item.get('vars',{}).items():
                         group.set_variable(k,v)
-                elif type(vars) == list:
+                elif isinstance(vars, list):
                     for subitem in vars:
-                        if type(subitem) != dict:
+                        if not isinstance(subitem, dict):
                             raise errors.AnsibleError("expected a dictionary")
                         for (k,v) in subitem.items():
                             group.set_variable(k,v)
@@ -109,7 +109,7 @@ class InventoryParserYaml(object):
                 if host not in grouped_hosts:
                     ungrouped.add_host(host)
 
-            elif type(item) == dict and 'host' in item:
+            elif isinstance(item, dict) and 'host' in item:
                 host = self._make_host(item['host'])
 
                 vars = item.get('vars', {})

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -390,7 +390,7 @@ class CliRunnerCallbacks(DefaultRunnerCallbacks):
         super(CliRunnerCallbacks, self).on_ok(host, res)
 
     def on_unreachable(self, host, res):
-        if type(res) == dict:
+        if isinstance(res, dict):
             res = res.get('msg','')
         display("%s | FAILED => %s" % (host, res), stderr=True, color='red', runner=self.runner)
         if self.options.tree:
@@ -456,7 +456,7 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
 
     def on_unreachable(self, host, results):
         item = None
-        if type(results) == dict:
+        if isinstance(results, dict):
             item = results.get('item', None)
         if item:
             msg = "fatal: [%s] => (item=%s) => %s" % (host, item, results)

--- a/lib/ansible/inventory/vars_plugins/group_vars.py
+++ b/lib/ansible/inventory/vars_plugins/group_vars.py
@@ -91,7 +91,7 @@ def _load_vars_from_path(path, results, vault_password=None):
     # regular file
     elif stat.S_ISREG(pathstat.st_mode):
         data = utils.parse_yaml_from_file(path, vault_password=vault_password)
-        if type(data) != dict:
+        if not isinstance(data, dict):
             raise errors.AnsibleError(
                 "%s must be stored as a dictionary/hash" % path)
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -611,7 +611,7 @@ class AnsibleModule(object):
                 self.fail_json(msg="internal error: required and default are mutally exclusive for %s" % k)
             if aliases is None:
                 continue
-            if type(aliases) != list:
+            if not isinstance(aliases, list):
                 self.fail_json(msg='internal error: aliases must be a list')
             for alias in aliases:
                 self._legal_inputs.append(alias)
@@ -691,7 +691,7 @@ class AnsibleModule(object):
             choices = v.get('choices',None)
             if choices is None:
                 continue
-            if type(choices) == list:
+            if isinstance(choices, list):
                 if k in self.params:
                     if self.params[k] not in choices:
                         choices_str=",".join([str(c) for c in choices])

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -227,13 +227,13 @@ class PlayBook(object):
         accumulated_plays = []
         play_basedirs = []
 
-        if type(playbook_data) != list:
+        if not isinstance(playbook_data, list):
             raise errors.AnsibleError("parse error: playbooks must be formatted as a YAML list, got %s" % type(playbook_data))
 
         basedir = os.path.dirname(path) or '.'
         utils.plugins.push_basedir(basedir)
         for play in playbook_data:
-            if type(play) != dict:
+            if not isinstance(play, dict):
                 raise errors.AnsibleError("parse error: each play in a playbook must be a YAML dictionary (hash), recieved: %s" % play)
 
             if 'include' in play:
@@ -467,7 +467,7 @@ class PlayBook(object):
                 # task ran with_ lookup plugin, so facts are encapsulated in
                 # multiple list items in the results key
                 for res in result['results']:
-                    if type(res) == dict:
+                    if isinstance(res, dict):
                         facts = res.get('ansible_facts', {})
                         self.SETUP_CACHE[host].update(facts)
             else:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -71,7 +71,7 @@ class Play(object):
             self.tags = []
         elif type(self.tags) in [ str, unicode ]:
             self.tags = self.tags.split(",")
-        elif type(self.tags) != list:
+        elif not isinstance(self.tags, list):
             self.tags = []
 
         # We first load the vars files from the datastructure
@@ -94,7 +94,7 @@ class Play(object):
         self._update_vars_files_for_host(None)
 
         # apply any extra_vars specified on the command line now
-        if type(self.playbook.extra_vars) == dict:
+        if isinstance(self.playbook.extra_vars, dict):
             self.vars = utils.combine_vars(self.vars, self.playbook.extra_vars)
 
         # template everything to be efficient, but do not pre-mature template
@@ -172,7 +172,7 @@ class Play(object):
         orig_path = template(self.basedir,role,self.vars)
 
         role_vars = {}
-        if type(orig_path) == dict:
+        if isinstance(orig_path, dict):
             # what, not a path?
             role_name = orig_path.get('role', None)
             if role_name is None:
@@ -330,7 +330,7 @@ class Play(object):
             if os.path.exists(filename):
                 new_default_vars = utils.parse_yaml_from_file(filename, vault_password=self.vault_password)
                 if new_default_vars:
-                    if type(new_default_vars) != dict:
+                    if not isinstance(new_default_vars, dict):
                         raise errors.AnsibleError("%s must be stored as dictionary/hash: %s" % (filename, type(new_default_vars)))
 
                     default_vars = utils.combine_vars(default_vars, new_default_vars)
@@ -347,7 +347,7 @@ class Play(object):
 
         if roles is None:
             roles = []
-        if type(roles) != list:
+        if not isinstance(roles, list):
             raise errors.AnsibleError("value of 'roles:' must be a list")
 
         new_tasks = []
@@ -356,7 +356,7 @@ class Play(object):
         defaults_files = []
 
         pre_tasks = ds.get('pre_tasks', None)
-        if type(pre_tasks) != list:
+        if not isinstance(pre_tasks, list):
             pre_tasks = []
         for x in pre_tasks:
             new_tasks.append(x)
@@ -429,13 +429,13 @@ class Play(object):
         handlers   = ds.get('handlers', None)
         vars_files = ds.get('vars_files', None)
 
-        if type(tasks) != list:
+        if not isinstance(tasks, list):
             tasks = []
-        if type(handlers) != list:
+        if not isinstance(handlers, list):
             handlers = []
-        if type(vars_files) != list:
+        if not isinstance(vars_files, list):
             vars_files = []
-        if type(post_tasks) != list:
+        if not isinstance(post_tasks, list):
             post_tasks = []
 
         new_tasks.extend(tasks)
@@ -587,7 +587,7 @@ class Play(object):
                             y['role_name'] = new_role
                 loaded = self._load_tasks(data, mv, default_vars, included_sudo_vars, list(included_additional_conditions), original_file=include_filename, role_name=new_role)
                 results += loaded
-            elif type(x) == dict:
+            elif isinstance(x, dict):
                 task = Task(
                     self, x,
                     module_vars=task_vars,
@@ -645,7 +645,7 @@ class Play(object):
         vars = {}
 
         # translate a list of vars into a dict
-        if type(self.vars) == list:
+        if isinstance(self.vars, list):
             for item in self.vars:
                 if getattr(item, 'items', None) is None:
                     raise errors.AnsibleError("expecting a key-value pair in 'vars' section")
@@ -654,7 +654,7 @@ class Play(object):
         else:
             vars.update(self.vars)
 
-        if type(self.vars_prompt) == list:
+        if isinstance(self.vars_prompt, list):
             for var in self.vars_prompt:
                 if not 'name' in var:
                     raise errors.AnsibleError("'vars_prompt' item is missing 'name:'")
@@ -674,7 +674,7 @@ class Play(object):
                                      vname, private, prompt, encrypt, confirm, salt_size, salt, default
                                   )
 
-        elif type(self.vars_prompt) == dict:
+        elif isinstance(self.vars_prompt, dict):
             for (vname, prompt) in self.vars_prompt.iteritems():
                 prompt_msg = "%s: " % prompt
                 if vname not in self.playbook.extra_vars:
@@ -685,7 +685,7 @@ class Play(object):
         else:
             raise errors.AnsibleError("'vars_prompt' section is malformed, see docs")
 
-        if type(self.playbook.extra_vars) == dict:
+        if isinstance(self.playbook.extra_vars, dict):
             vars = utils.combine_vars(vars, self.playbook.extra_vars)
 
         return vars
@@ -792,7 +792,7 @@ class Play(object):
 
             data = utils.parse_yaml_from_file(filename4, vault_password=self.vault_password)
             if data:
-                if type(data) != dict:
+                if not isinstance(data, dict):
                     raise errors.AnsibleError("%s must be stored as a dictionary/hash" % filename4)
                 if host is not None:
                     if self._has_vars_in(filename2) and not self._has_vars_in(filename3):
@@ -812,7 +812,7 @@ class Play(object):
                         self.vars = utils.combine_vars(self.vars, data)
 
         # Enforce that vars_files is always a list
-        if type(self.vars_files) != list:
+        if not isinstance(self.vars_files, list):
             self.vars_files = [ self.vars_files ]
 
         # Build an inject if this is a host run started by self.update_vars_files
@@ -825,7 +825,7 @@ class Play(object):
             inject = None            
 
         for filename in self.vars_files:
-            if type(filename) == list:
+            if isinstance(filename, list):
                 # loop over all filenames, loading the first one, and failing if none found
                 found = False
                 sequence = []

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -278,7 +278,7 @@ class Task(object):
                 self.tags.append(apply_tags)
             elif type(apply_tags) in [ int, float ]:
                 self.tags.append(str(apply_tags))
-            elif type(apply_tags) == list:
+            elif isinstance(apply_tags, list):
                 self.tags.extend(apply_tags)
         self.tags.extend(import_tags)
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -258,7 +258,7 @@ class Runner(object):
     def _transfer_str(self, conn, tmp, name, data):
         ''' transfer string to remote file '''
 
-        if type(data) == dict:
+        if isinstance(data, dict):
             data = utils.jsonify(data)
 
         afd, afile = tempfile.mkstemp()
@@ -299,7 +299,7 @@ class Runner(object):
         if self.environment:
             enviro = template.template(self.basedir, self.environment, inject, convert_bare=True)
             enviro = utils.safe_eval(enviro)
-            if type(enviro) != dict:
+            if not isinstance(enviro, dict):
                 raise errors.AnsibleError("environment must be a dictionary, received %s" % enviro)
             default_environment.update(enviro)
 
@@ -619,7 +619,7 @@ class Runner(object):
             items_terms = self.module_vars.get('items_lookup_terms', '')
             items_terms = template.template(basedir, items_terms, inject)
             items = utils.plugins.lookup_loader.get(items_plugin, runner=self, basedir=basedir).run(items_terms, inject=inject)
-            if type(items) != list:
+            if not isinstance(items, list):
                 raise errors.AnsibleError("lookup plugins have to return a list: %r" % items)
 
             if len(items) and utils.is_list_of_strings(items) and self.module_name in [ 'apt', 'yum', 'pkgng' ]:
@@ -640,7 +640,7 @@ class Runner(object):
             if isinstance(complex_args, basestring):
                 complex_args = template.template(self.basedir, complex_args, inject, convert_bare=True)
                 complex_args = utils.safe_eval(complex_args)
-                if type(complex_args) != dict:
+                if not isinstance(complex_args, dict):
                     raise errors.AnsibleError("args must be a dictionary, received %s" % complex_args)
             return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
         elif len(items) > 0:
@@ -664,7 +664,7 @@ class Runner(object):
                 if isinstance(self.complex_args, basestring):
                     complex_args = template.template(self.basedir, self.complex_args, this_inject, convert_bare=True)
                     complex_args = utils.safe_eval(complex_args)
-                    if type(complex_args) != dict:
+                    if not isinstance(complex_args, dict):
                         raise errors.AnsibleError("args must be a dictionary, received %s" % complex_args)
                 result = self._executor_internal_inner(
                      host,
@@ -710,7 +710,7 @@ class Runner(object):
         # allow module args to work as a dictionary
         # though it is usually a string
         new_args = ""
-        if type(module_args) == dict:
+        if isinstance(module_args, dict):
             for (k,v) in module_args.iteritems():
                 new_args = new_args + "%s='%s' " % (k,v)
             module_args = new_args
@@ -727,7 +727,7 @@ class Runner(object):
         else:
             handler = utils.plugins.action_loader.get('async', self)
 
-        if type(self.conditional) != list:
+        if not isinstance(self.conditional, list):
             self.conditional = [ self.conditional ]
 
         for cond in self.conditional:

--- a/lib/ansible/runner/action_plugins/group_by.py
+++ b/lib/ansible/runner/action_plugins/group_by.py
@@ -61,7 +61,7 @@ class ActionModule(object):
             data.update(inject)
             data.update(inject['hostvars'][host])
             conds = self.runner.conditional
-            if type(conds) != list:
+            if not isinstance(conds, list):
                 conds = [ conds ]
             next_host = False
             for cond in conds:

--- a/lib/ansible/runner/action_plugins/include_vars.py
+++ b/lib/ansible/runner/action_plugins/include_vars.py
@@ -44,7 +44,7 @@ class ActionModule(object):
 
         if os.path.exists(source):
             data = utils.parse_yaml_from_file(source, vault_password=self.runner.vault_pass)
-            if type(data) != dict:
+            if not isinstance(data, dict):
                 raise errors.AnsibleError("%s must be stored as a dictionary/hash" % source)
             result = dict(ansible_facts=data)
             return ReturnData(conn=conn, comm_ok=True, result=result)

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -45,7 +45,7 @@ def to_nice_json(a, *args, **kw):
 def failed(*a, **kw):
     ''' Test if task result yields failed '''
     item = a[0]
-    if type(item) != dict:
+    if not isinstance(item, dict):
         raise errors.AnsibleFilterError("|failed expects a dictionary")
     rc = item.get('rc',0)
     failed = item.get('failed',False)
@@ -61,13 +61,13 @@ def success(*a, **kw):
 def changed(*a, **kw):
     ''' Test if task result yields changed '''
     item = a[0]
-    if type(item) != dict:
+    if not isinstance(item, dict):
         raise errors.AnsibleFilterError("|changed expects a dictionary")
     if not 'changed' in item:
         changed = False
         if ('results' in item    # some modules return a 'results' key
-                and type(item['results']) == list
-                and type(item['results'][0]) == dict):
+                and isinstance(item['results'], list)
+                and isinstance(item['results'][0], dict)):
             for result in item['results']:
                 changed = changed or result.get('changed', False)
     else:
@@ -77,7 +77,7 @@ def changed(*a, **kw):
 def skipped(*a, **kw):
     ''' Test if task result yields skipped '''
     item = a[0]
-    if type(item) != dict:
+    if not isinstance(item, dict):
         raise errors.AnsibleFilterError("|skipped expects a dictionary")
     skipped = item.get('skipped', False)
     return skipped

--- a/lib/ansible/runner/return_data.py
+++ b/lib/ansible/runner/return_data.py
@@ -48,7 +48,7 @@ class ReturnData(object):
 
         if self.host is None:
             raise Exception("host not set")
-        if type(self.result) != dict:
+        if not isinstance(self.result, dict):
             raise Exception("dictionary result expected")
 
     def communicated_ok(self):

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -356,9 +356,9 @@ def smush_braces(data):
 def smush_ds(data):
     # things like key={{ foo }} are not handled by shlex.split well, so preprocess any YAML we load
     # so we do not have to call smush elsewhere
-    if type(data) == list:
+    if isinstance(data, list):
         return [ smush_ds(x) for x in data ]
-    elif type(data) == dict:
+    elif isinstance(data, dict):
         for (k,v) in data.items():
             data[k] = smush_ds(v)
         return data

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -178,7 +178,8 @@ class _jinja2_vars(object):
                 raise KeyError("undefined variable: %s" % varname)
         var = self.vars[varname]
         # HostVars is special, return it as-is
-        if isinstance(var, dict) and type(var) != dict:
+        from ansible.runner import HostVars
+        if isinstance(var, HostVars):
             return var
         else:
             return template(self.basedir, var, self.vars, fail_on_undefined=self.fail_on_undefined)

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -499,7 +499,7 @@ def find_running_instances_by_count_tag(module, ec2, count_tag):
 def _set_none_to_blank(dictionary):
     result = dictionary
     for k in result.iterkeys():
-        if type(result[k]) == dict:
+        if isinstance(result[k], dict):
             result[k] = _set_non_to_blank(result[k])
         elif not result[k]:
             result[k] = ""
@@ -748,7 +748,7 @@ def create_instances(module, ec2, override_count=None):
         # Here we try to lookup the group id from the security group name - if group is set.
         if group_name:
             grp_details = ec2.get_all_security_groups()
-            if type(group_name) == list:
+            if isinstance(group_name, list):
                 group_id = [ str(grp.id) for grp in grp_details if str(grp.name) in group_name ]
             elif type(group_name) == str:
                 for grp in grp_details:

--- a/library/cloud/virt
+++ b/library/cloud/virt
@@ -404,7 +404,7 @@ def core(module):
 
     if state and command=='list_vms':
         res = v.list_vms(state=state)
-        if type(res) != dict:
+        if not isinstance(res, dict):
             res = { command: res }
         return VIRT_SUCCESS, res
 
@@ -451,13 +451,13 @@ def core(module):
                     res = {'changed': True, 'created': guest}
                 return VIRT_SUCCESS, res
             res = getattr(v, command)(guest)
-            if type(res) != dict:
+            if not isinstance(res, dict):
                 res = { command: res }
             return VIRT_SUCCESS, res
 
         elif hasattr(v, command):
             res = getattr(v, command)()
-            if type(res) != dict:
+            if not isinstance(res, dict):
                 res = { command: res }
             return VIRT_SUCCESS, res
 

--- a/plugins/callbacks/log_plays.py
+++ b/plugins/callbacks/log_plays.py
@@ -32,7 +32,7 @@ if not os.path.exists("/var/log/ansible/hosts"):
     os.makedirs("/var/log/ansible/hosts")
 
 def log(host, category, data):
-    if type(data) == dict:
+    if isinstance(data, dict):
         if 'verbose_override' in data:
             # avoid logging extraneous data from facts
             data = 'omitted'


### PR DESCRIPTION
Here is a pull-request in response to the post on ansible-devel.

https://groups.google.com/forum/#!topic/ansible-devel/d1eUS46H-ZM

I went a bit beyond the original thinking for consistency, I've converted all type checking for dicts AND lists to use is_instance.

All changes are straightforward, except for one in  lib/ansible/utils/template.py, which should be checking whether the class is HostVars. 

https://github.com/smoothify/ansible/commit/b677ec33ff5e5867b1f03c5b44a916ca53b18f58
Here, I had to add a scoped import to avoid a circular dependency error. Rather than importing, and using isinstance, an alternative method would be to do the following:

`type(var).__name__ == 'HostVars'`
