### PR TITLE
OSError in file module for non existing symlink in check mode.

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -251,6 +251,9 @@ def main():
                 except OSError, e:
                     module.fail_json(path=path, msg='Error while linking: %s' % str(e))
 
+        if module.check_mode and not os.path.exists(path):
+            module.exit_json(dest=path, src=src, changed=changed)
+
         changed = module.set_fs_attributes_if_different(file_args, changed)
         module.exit_json(dest=path, src=src, changed=changed)
 


### PR DESCRIPTION
In check mode if a symlink does not exist there is no need to check the ownership properties (which causes an exception)

The following task raises OSError in check mode when the symlink does not exist on the target host.

```
- name: /etc/supervisord.conf -> /etc/supervisor/supervisord.conf
  file: src=/etc/supervisor/supervisord.conf dest=/etc/supervisord.conf owner=root group=root state=link
  when: supervisord_conf_result|success
  tags:
   - supervisor
```
