### PR TITLE
allow registered vars in playbook to be {{ dynamic }}

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -474,17 +474,19 @@ class PlayBook(object):
                 facts = result.get('ansible_facts', {})
                 self.SETUP_CACHE[host].update(facts)
             if task.register:
+                register = template(play.basedir, task.register, task.module_vars)
                 if 'stdout' in result and 'stdout_lines' not in result:
                     result['stdout_lines'] = result['stdout'].splitlines()
-                self.SETUP_CACHE[host][task.register] = result
+                self.SETUP_CACHE[host][register] = result
 
         # also have to register some failed, but ignored, tasks
         if task.ignore_errors and task.register:
             failed = results.get('failed', {})
             for host, result in failed.iteritems():
+                register = template(play.basedir, task.register, task.module_vars)
                 if 'stdout' in result and 'stdout_lines' not in result:
                     result['stdout_lines'] = result['stdout'].splitlines()
-                self.SETUP_CACHE[host][task.register] = result
+                self.SETUP_CACHE[host][register] = result
 
         # flag which notify handlers need to be run
         if len(task.notify) > 0:


### PR DESCRIPTION
A colleague of mine ran into the problem that registered variables were not being overwritten properly when running a role multiple times on the same host for multiple users.

``` yaml
- name:             foo test
  command:          /usr/bin/test -e /home/{{ user }}
  register:         foo
  failed_when:      false
  changed_when:     false

- name:             foo echo
  command:          /usr/bin/echo HOME EXISTS
  when:             foo.rc != 0
```

I wasn't able to diagnose whether this is intended or not or what to do about it.  I thought of using dynamic names for registered variables.

``` yaml
- name:             foo test
  command:          /usr/bin/test -e /home/{{ user }}
  register:         foo_{{ user }}
  failed_when:      false
  changed_when:     false

- name:             foo echo
  command:          /usr/bin/echo HOME EXISTS
  when:             hostvars[inventory_hostname]['foo_' + user].rc != 0
```

Unfortunately, that didn't work. It seems that the register attribute is not parsed as a template.  I modified ansible to parse the register attribute as a template and now dynamic register variables work and my colleague's problem is solved.

I'd appreciate it if my change could be included in ansible.  `make test` runs fine. If you need more information or if the pull request is not up to your standards please let me know. Thanks.

\- Felix
