### PR TITLE
adding min() and max() filters for use in templates

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -180,6 +180,20 @@ Jinja2 provides a useful 'default' filter, that is often a better approach to fa
 In the above example, if the variable 'some_variable' is not defined, the value used will be 5, rather than an error
 being raised.
 
+.. _list_filters:
+
+List Filters
+--------------------
+.. versionadded:: 1.7
+
+To get the minimum value from list of numbers::
+
+    {{ list1 | min }}
+
+To get the maximum value from a list of numbers::
+
+    {{ [3, 4, 2] | max }}
+
 .. _set_theory_filters:
 
 Set Theory Filters

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -159,6 +159,14 @@ def symmetric_difference(a, b):
 def union(a, b):
     return set(a).union(b)
 
+def min(a):
+    _min = __builtins__.get('min')
+    return _min(a);
+
+def max(a):
+    _max = __builtins__.get('max')
+    return _max(a);
+
 def version_compare(value, version, operator='eq', strict=False):
     ''' Perform a version comparison on a value '''
     op_map = {
@@ -264,6 +272,8 @@ class FilterModule(object):
             'difference': difference,
             'symmetric_difference': symmetric_difference,
             'union': union,
+            'min' : min,
+            'max' : max,
 
             # version comparison
             'version_compare': version_compare,

--- a/test/units/TestFilters.py
+++ b/test/units/TestFilters.py
@@ -175,3 +175,11 @@ class TestFilters(unittest.TestCase):
         self.assertTrue(ansible.runner.filter_plugins.core.version_compare(1.0, 1.1, '<='))
 
         self.assertTrue(ansible.runner.filter_plugins.core.version_compare('12.04', 12, 'ge'))
+
+    def test_min(self):
+        a = ansible.runner.filter_plugins.core.min([3, 2, 5, 4])
+        assert a == 2
+
+    def test_max(self):
+        a = ansible.runner.filter_plugins.core.max([3, 2, 5, 4])
+        assert a == 5


### PR DESCRIPTION
In the process of trying to make some of my configuration file templates more dynamic to handle different configurations for different environments I ran into a couple of cases where a `min()` and `max()` filter would have been extremely useful. Basically I wanted to be able to say "derive this value from other host specific values, but never have it go below X (or above Y). I was able to work around it by having some ugly nested if/else stuff. But having a `min()` and `max()` would have made it much simpler.

It basically works just like the python builtins operating only on lists:

``` yaml
- hosts: localhost
  connection: local
  gather_facts: false
  tasks:
    - debug: msg="min 1 - {{ [2,3,1] | min }}"
    - debug: msg="min 3 - {{ [9, 8, 12, 3, 4] | min }}"
    - debug: msg="max 5 - {{ [2,5,1] | max }}"
    - debug: msg="max 12 - {{ [9, 8, 12, 3, 4] | max }}"
```
