### PR TITLE
fixing issue #7853 by using the right name for the vpc_id parameter

### DIFF
--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -218,7 +218,7 @@ def find_vpc(module, vpc_conn, vpc_id=None, cidr=None):
     
     if vpc_id == None and cidr == None:
         module.fail_json(
-            msg='You must specify either a vpc id or a cidr block + list of unique tags, aborting'
+            msg='You must specify either a vpc_id or a cidr block + list of unique tags, aborting'
         )
 
     found_vpcs = []
@@ -262,7 +262,7 @@ def create_vpc(module, vpc_conn):
         about the VPC and subnets that were launched 
     """
     
-    id = module.params.get('id')
+    id = module.params.get('vpc_id')
     cidr_block = module.params.get('cidr_block')
     instance_tenancy = module.params.get('instance_tenancy')
     dns_support = module.params.get('dns_support')


### PR DESCRIPTION
This change uses `vpc_id` name for the parameter instead of the wrong `id`.
