### PR TITLE
DOCFIX add another Unix passwd creation solution using OpenSSL

### DIFF
--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -209,21 +209,22 @@ The mkpasswd utility that is available on most Linux systems is a great option::
 
     mkpasswd --method=SHA-512
 
-If this utility is not installed on your system (e.g. you are using OS X) then you can still easily
-generate these passwords using Python. First, ensure that the `Passlib <https://code.google.com/p/passlib/>`_
-password hashing library is installed.
+``mkpasswd`` is often bundled with the ``whois`` package (On Ubuntu, you can do ``sudo apt-get install whois``).  If this utility is not installed on your system (e.g. you are using OS X) then you can still easily
+generate these passwords using Python standard library.  The only requirement is that this is run on the same operating where the encrypted password will be stored (this is due to the way the ``crypt`` implementation is system-dependent).
 
-    pip install passlib
+SHA512 password values can be generated with Python as follows::
 
-Once the library is ready, SHA512 password values can then be generated as follows::
+    python -c 'import crypt; print crypt.crypt("<password>", "$6$<salt>")'
 
-    python -c "from passlib.hash import sha512_crypt; print sha512_crypt.encrypt('<password>')"
+where ``<password>`` is the password to generate a hash, and ``<salt>`` is a set of random characters provided by you.
 
-If you have ``openssl`` installed on your machine, you can generate a password with the following command::
+If you wish Python to automatically generate a randomized salt for you, use this slightly longer one-liner::
 
-    openssl passwd -1 -salt <salt> <password>
+    python -c 'import crypt,random,string; print crypt.crypt("<password>", "$6$" + "".join([ random.choice(string.digits + string.letters + string.punctuation) for x in range(12)]))'
 
-where ``<salt>`` is a random set of characters of your choice, and ``<password>`` is the password that you want to encrypt.  Please review `the OpenSSL docs <https://www.openssl.org/docs/apps/passwd.html>`_ for more information.
+*Obsolete Password Generation Methods*
+
+Do not use ``openssl passwd`` to generate password hashes.  This is due to the lack of a SHA-512 implementation in the OpenSSL library.  As a result, OpenSSL will create a less-secure MD5 password hash.
 
 .. _commercial_support:
 

--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -205,7 +205,7 @@ Ansible 1.4 will also make remote environment variables available via facts in t
 How do I generate crypted passwords for the user module?
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-The mkpasswd utility that is available on most Linux systems is a great option::
+The mkpasswd utility that is available on most Debian-like Linux systems is a great option::
 
     mkpasswd --method=SHA-512
 

--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -219,6 +219,12 @@ Once the library is ready, SHA512 password values can then be generated as follo
 
     python -c "from passlib.hash import sha512_crypt; print sha512_crypt.encrypt('<password>')"
 
+If you have ``openssl`` installed on your machine, you can generate a password with the following command:
+
+    openssl passwd -1 -salt SALT PASSWORD
+
+where ``SALT`` is a random collection of character you choose, and ``PASSWORD`` is the password that you want to encrypt.
+
 .. _commercial_support:
 
 Can I get training on Ansible or find commercial support?

--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -221,9 +221,9 @@ Once the library is ready, SHA512 password values can then be generated as follo
 
 If you have ``openssl`` installed on your machine, you can generate a password with the following command::
 
-    openssl passwd -1 -salt SALT PASSWORD
+    openssl passwd -1 -salt <salt> <password>
 
-where ``SALT`` is a random collection of character you choose, and ``PASSWORD`` is the password that you want to encrypt.
+where ``<salt>`` is a random set of characters of your choice, and ``<password>`` is the password that you want to encrypt.  Please review `the OpenSSL docs <https://www.openssl.org/docs/apps/passwd.html>`_ for more information.
 
 .. _commercial_support:
 

--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -219,7 +219,7 @@ Once the library is ready, SHA512 password values can then be generated as follo
 
     python -c "from passlib.hash import sha512_crypt; print sha512_crypt.encrypt('<password>')"
 
-If you have ``openssl`` installed on your machine, you can generate a password with the following command:
+If you have ``openssl`` installed on your machine, you can generate a password with the following command::
 
     openssl passwd -1 -salt SALT PASSWORD
 


### PR DESCRIPTION
... most people have it installed by default.

It's a simple fix but some people do not want to yak-shave getting pip installed, and mkpasswd doesn't exist in all operating systems.  OpenSSL is typically there by default.
