### PR TITLE
New Jinja2 filters: hash_merge & hash_replace

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -260,6 +260,33 @@ Get a random number from 1 to 100 but in steps of 10::
     {{ 100 |random(1, 10) }}    => 31
     {{ 100 |random(start=1, step=10) }}    => 51
 
+.. _hash_filters:
+
+Hash Merge Filters
+------------------
+
+.. versionadded:: 1.7
+
+These two filters allow fine-grained control over `hash_behaviour <intro_configuration.html#hash-behaviour>`_ at template level.
+``hash_merge`` is deep version that mimics ``hash_behaviour=merge`` and
+``hash_replace`` is shallow version that mimics ``hash_behaviour=replace``.
+Both filters do not modify existing dictionary and produce new one::
+
+    {{ dict_one | hash_merge(dict_two, dict_three) }}
+    {{ dict_one | hash_replace(dict_two, dict_so_on) }}
+
+These filters can be especially useful while constructing `complex-args <https://github.com/ansible/ansible-examples/blob/master/language_features/complex_args.yml>`_ to pass them to module. Attempt to ``hash_merge`` two hashes with different schema may lead to template rendering failure::
+
+    vars:
+      fatality: { foo: { bar: 42 } }
+      brutality: { foo: }
+    tasks:
+      - name: Replace wins!
+        debug:
+          msg: '{{ fatality | hash_replace(brutality) }}'
+      - name: NoneType fatality!
+        debug:
+          msg: '{{ fatality | hash_merge(brutality) }}'
 
 .. _other_useful_filters:
 

--- a/lib/ansible/runner/filter_plugins/hash_merge.py
+++ b/lib/ansible/runner/filter_plugins/hash_merge.py
@@ -1,0 +1,46 @@
+# (c) 2014, Leonid Evdokimov <leon@darkk.net.ru>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import itertools
+
+from ansible import utils
+from ansible import errors
+
+# These are two possible behaviours expressed by `ansible.utils.combine_vars`.
+
+def hash_merge(*terms):
+    for t in terms:
+        if not isinstance(t, dict):
+            raise errors.AnsibleFilterError("|hash_merge expects dictionaries, got " + repr(t))
+
+    return reduce(utils.merge_hash, terms)
+
+def hash_replace(*terms):
+    for t in terms:
+        if not isinstance(t, dict):
+            raise errors.AnsibleFilterError("|hash_replace expects dictionaries, got " + repr(t))
+
+    return dict(itertools.chain(*map(dict.iteritems, terms)))
+
+class FilterModule(object):
+    ''' Ansible jinja2 filter to avoid global hash_behaviour=merge when it's needed '''
+
+    def filters(self):
+        return {
+            'hash_merge': hash_merge,
+            'hash_replace': hash_replace,
+        }

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -382,6 +382,8 @@ class TestUtils(unittest.TestCase):
                dict(foo='baz', baz='qux'))
         self.assertEqual(ansible.utils.merge_hash(dict(foo=dict(bar='baz')), dict(foo=dict(bar='qux'))),
                dict(foo=dict(bar='qux')))
+        self.assertEqual(ansible.utils.merge_hash(dict(foo=dict(bar='baz'), bar=1), dict(foo=dict(bar='qux'), baz=2)),
+               dict(foo=dict(bar='qux'), bar=1, baz=2))
 
     def test_md5s(self):
         self.assertEqual(ansible.utils.md5s('ansible'), '640c8a5376aa12fa15cf02130ce239a6')


### PR DESCRIPTION
Link to intro_configuration.html#hash-behaviour is coded without :doc: prefix as I've not managed to create proper link with anchor for sphinx.

This code was inspired by PR #7629
