### PR TITLE
Give option on how git tracks submodules.

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -128,6 +128,16 @@ options:
         description:
             - if C(no), repository will be cloned without the --recursive
               option, skipping sub-modules.
+
+    track_branches:
+        required: false
+        default: "yes"
+        choices: ["yes", "no"]
+        version_added: "1.7"
+        description:
+            - if C(no), repository will be cloned without the --recursive
+              option, allowing submodules to be tracked by commit hash
+              instead of branch name.
 notes:
     - "If the task seems to be hanging, first verify remote host is in C(known_hosts).
       SSH will prompt user to authorize the first contact with a remote host.  To avoid this prompt, 
@@ -399,7 +409,7 @@ def get_head_branch(git_path, module, dest, remote, bare=False):
     f.close()
     return branch
 
-def fetch(git_path, module, repo, dest, version, remote, bare):
+def fetch(git_path, module, repo, dest, version, remote, bare, track_branches):
     ''' updates repo from remote sources '''
     (rc, out0, err0) = module.run_command([git_path, 'remote', 'set-url', remote, repo], cwd=dest)
     if rc != 0:
@@ -417,10 +427,10 @@ def fetch(git_path, module, repo, dest, version, remote, bare):
         (rc, out2, err2) = module.run_command("%s fetch --tags %s" % (git_path, remote), cwd=dest)
     if rc != 0:
         module.fail_json(msg="Failed to download remote objects and refs")
-    (rc, out3, err3) = submodule_update(git_path, module, dest)
+    (rc, out3, err3) = submodule_update(git_path, module, dest, track_branches )
     return (rc, out1 + out2 + out3, err1 + err2 + err3)
 
-def submodule_update(git_path, module, dest):
+def submodule_update(git_path, module, dest, track_branches):
     ''' init and update any submodules '''
 
     # get the valid submodule params
@@ -431,7 +441,7 @@ def submodule_update(git_path, module, dest):
         return (0, '', '')
     cmd = [ git_path, 'submodule', 'sync' ]
     (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
-    if 'remote' in params:
+    if 'remote' in params and track_branches:
         cmd = [ git_path, 'submodule', 'update', '--init', '--recursive' ,'--remote' ]
     else:
         cmd = [ git_path, 'submodule', 'update', '--init', '--recursive' ]
@@ -440,8 +450,8 @@ def submodule_update(git_path, module, dest):
         module.fail_json(msg="Failed to init/update submodules: %s" % out + err)
     return (rc, out, err)
 
-def switch_version(git_path, module, dest, remote, version, recursive):
-    ''' once pulled, switch to a particular SHA, tag, or branch '''
+
+def switch_version(git_path, module, dest, remote, version, recursive, track_branches):
     cmd = ''
     if version != 'HEAD':
         if is_remote_branch(git_path, module, dest, remote, version):
@@ -467,7 +477,7 @@ def switch_version(git_path, module, dest, remote, version, recursive):
         else:
             module.fail_json(msg="Failed to checkout branch %s" % (branch))
     if recursive:
-        (rc, out2, err2) = submodule_update(git_path, module, dest)
+        (rc, out2, err2) = submodule_update(git_path, module, dest, track_branches)
         out1 += out2
         err1 += err1
     return (rc, out1, err1)
@@ -491,6 +501,7 @@ def main():
             executable=dict(default=None),
             bare=dict(default='no', type='bool'),
             recursive=dict(default='yes', type='bool'),
+            track_branches=dict(default='yes', type='bool'),
         ),
         supports_check_mode=True
     )
@@ -526,6 +537,7 @@ def main():
         add_git_host_key(module, repo, accept_hostkey=module.params['accept_hostkey'])
 
     recursive = module.params['recursive']
+    track_branches = module.params['track_branches']
 
     if bare:
         gitconfig = os.path.join(dest, 'config')
@@ -575,12 +587,12 @@ def main():
                 module.exit_json(changed=False, before=before, after=remote_head)
         if module.check_mode:
             module.exit_json(changed=True, before=before, after=remote_head)
-        fetch(git_path, module, repo, dest, version, remote, bare)
+        fetch(git_path, module, repo, dest, version, remote, bare, track_branches)
 
     # switch to version specified regardless of whether
     # we cloned or pulled
     if not bare:
-        switch_version(git_path, module, dest, remote, version, recursive)
+        switch_version(git_path, module, dest, remote, version, recursive, track_branches)
 
     # determine if we changed anything
     after = get_version(module, git_path, dest)

--- a/library/source_control/git
+++ b/library/source_control/git
@@ -129,13 +129,13 @@ options:
             - if C(no), repository will be cloned without the --recursive
               option, skipping sub-modules.
 
-    track_branches:
+    track_submodule_branches:
         required: false
         default: "yes"
         choices: ["yes", "no"]
         version_added: "1.7"
         description:
-            - if C(no), repository will be cloned without the --recursive
+            - if C(no), submodules will be updated without the --remote
               option, allowing submodules to be tracked by commit hash
               instead of branch name.
 notes:
@@ -409,7 +409,7 @@ def get_head_branch(git_path, module, dest, remote, bare=False):
     f.close()
     return branch
 
-def fetch(git_path, module, repo, dest, version, remote, bare, track_branches):
+def fetch(git_path, module, repo, dest, version, remote, bare, track_submodule_branches):
     ''' updates repo from remote sources '''
     (rc, out0, err0) = module.run_command([git_path, 'remote', 'set-url', remote, repo], cwd=dest)
     if rc != 0:
@@ -427,10 +427,10 @@ def fetch(git_path, module, repo, dest, version, remote, bare, track_branches):
         (rc, out2, err2) = module.run_command("%s fetch --tags %s" % (git_path, remote), cwd=dest)
     if rc != 0:
         module.fail_json(msg="Failed to download remote objects and refs")
-    (rc, out3, err3) = submodule_update(git_path, module, dest, track_branches )
+    (rc, out3, err3) = submodule_update(git_path, module, dest, track_submodule_branches )
     return (rc, out1 + out2 + out3, err1 + err2 + err3)
 
-def submodule_update(git_path, module, dest, track_branches):
+def submodule_update(git_path, module, dest, track_submodule_branches):
     ''' init and update any submodules '''
 
     # get the valid submodule params
@@ -441,7 +441,7 @@ def submodule_update(git_path, module, dest, track_branches):
         return (0, '', '')
     cmd = [ git_path, 'submodule', 'sync' ]
     (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
-    if 'remote' in params and track_branches:
+    if 'remote' in params and track_submodule_branches:
         cmd = [ git_path, 'submodule', 'update', '--init', '--recursive' ,'--remote' ]
     else:
         cmd = [ git_path, 'submodule', 'update', '--init', '--recursive' ]
@@ -451,7 +451,7 @@ def submodule_update(git_path, module, dest, track_branches):
     return (rc, out, err)
 
 
-def switch_version(git_path, module, dest, remote, version, recursive, track_branches):
+def switch_version(git_path, module, dest, remote, version, recursive, track_submodule_branches):
     cmd = ''
     if version != 'HEAD':
         if is_remote_branch(git_path, module, dest, remote, version):
@@ -477,7 +477,7 @@ def switch_version(git_path, module, dest, remote, version, recursive, track_bra
         else:
             module.fail_json(msg="Failed to checkout branch %s" % (branch))
     if recursive:
-        (rc, out2, err2) = submodule_update(git_path, module, dest, track_branches)
+        (rc, out2, err2) = submodule_update(git_path, module, dest, track_submodule_branches)
         out1 += out2
         err1 += err1
     return (rc, out1, err1)
@@ -501,7 +501,7 @@ def main():
             executable=dict(default=None),
             bare=dict(default='no', type='bool'),
             recursive=dict(default='yes', type='bool'),
-            track_branches=dict(default='yes', type='bool'),
+            track_submodule_branches=dict(default='yes', type='bool'),
         ),
         supports_check_mode=True
     )
@@ -537,7 +537,7 @@ def main():
         add_git_host_key(module, repo, accept_hostkey=module.params['accept_hostkey'])
 
     recursive = module.params['recursive']
-    track_branches = module.params['track_branches']
+    track_submodule_branches = module.params['track_submodule_branches']
 
     if bare:
         gitconfig = os.path.join(dest, 'config')
@@ -587,12 +587,12 @@ def main():
                 module.exit_json(changed=False, before=before, after=remote_head)
         if module.check_mode:
             module.exit_json(changed=True, before=before, after=remote_head)
-        fetch(git_path, module, repo, dest, version, remote, bare, track_branches)
+        fetch(git_path, module, repo, dest, version, remote, bare, track_submodule_branches)
 
     # switch to version specified regardless of whether
     # we cloned or pulled
     if not bare:
-        switch_version(git_path, module, dest, remote, version, recursive, track_branches)
+        switch_version(git_path, module, dest, remote, version, recursive, track_submodule_branches)
 
     # determine if we changed anything
     after = get_version(module, git_path, dest)


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible/issues/7030

Allows user to decide if git submodule should track branches/tags or track commit hashes defined in the superproject.

Add track_branches parameter to the git module.

Defaults to track branches behavior.
