### PR TITLE
Fix typo in powershell setup module.

### DIFF
--- a/library/windows/setup.ps1
+++ b/library/windows/setup.ps1
@@ -26,7 +26,7 @@ $result = New-Object psobject @{
 };
 
 $osversion = [Environment]::OSVersion
-$memory = Get-WmiObject win32_Pysicalmemory
+$memory = Get-WmiObject win32_Physicalmemory
 $netcfg = Get-WmiObject win32_NetworkAdapterConfiguration
 
 Set-Attr $result.ansible_facts "ansible_hostname" $env:COMPUTERNAME;

--- a/test/integration/roles/test_win_setup/tasks/main.yml
+++ b/test/integration/roles/test_win_setup/tasks/main.yml
@@ -33,3 +33,4 @@
       - "setup_result.ansible_facts.ansible_hostname"
       - "setup_result.ansible_facts.ansible_ip_addresses"
       - "setup_result.ansible_facts.ansible_system"
+      - "setup_result.ansible_facts.ansible_totalmem"


### PR DESCRIPTION
Fix typo, add test for ansible_totalmem.  Thanks to @Yasushi for noticing it.

https://github.com/ansible/ansible/commit/003448defc2f6b9974c68788c3d91a9707866d36#commitcomment-6753027
