### PR TITLE
Check for empty os-release file, fixes #7885

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -266,7 +266,7 @@ class Facts(object):
             self.facts['distribution_release'] = dist[2] or 'NA'
             # Try to handle the exceptions now ...
             for (path, name) in Facts.OSDIST_DICT.items():
-                if os.path.exists(path):
+                if os.path.exists(path) and os.path.getsize(path) > 0:
                     if self.facts['distribution'] == 'Fedora':
                         pass
                     elif name == 'RedHat':


### PR DESCRIPTION
This will check if the os-release file is empty and skip any further investigation for distribution release information. In particular funtoo might provide an empty /etc/os-release which causes the error described in #7885.
