### PR TITLE
Adding support for spot instances in ansible_lc.

### DIFF
--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -68,6 +68,12 @@ options:
     required: false
     default: null
     aliases: []
+  spot_price:
+    description:
+      - The spot price you are bidding. Only applies for an autoscaling group with spot instances.
+    required: false
+    default: null
+    aliases: []
 extends_documentation_fragment: aws
 """
 
@@ -126,6 +132,7 @@ def create_launch_config(connection, module):
     user_data = module.params.get('user_data')
     volumes = module.params['volumes']
     instance_type = module.params.get('instance_type')
+    spot_price = module.params.get('spot_price')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -144,7 +151,8 @@ def create_launch_config(connection, module):
         security_groups=security_groups,
         user_data=user_data,
         block_device_mappings=[bdm],
-        instance_type=instance_type)
+        instance_type=instance_type,
+        spot_price=spot_price)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -184,6 +192,7 @@ def main():
             volumes=dict(type='list'),
             instance_type=dict(type='str'),
             state=dict(default='present', choices=['present', 'absent']),
+            spot_price=dict(type='float'),
         )
     )
 


### PR DESCRIPTION
AWS allows to define launch configuration with spot instances. This is also natively supported by boto (see http://boto.readthedocs.org/en/latest/ref/autoscale.html)
