### PR TITLE
Adds support for Cloudwatch detailled monitoring in ec2_lc module.

### DIFF
--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -73,6 +73,11 @@ options:
       - The spot price you are bidding. Only applies for an autoscaling group with spot instances.
     required: false
     default: null
+  instance_monitoring:
+    description:
+      - whether instances in group are launched with detailed monitoring.
+    required: false
+    default: false
     aliases: []
 extends_documentation_fragment: aws
 """
@@ -133,6 +138,7 @@ def create_launch_config(connection, module):
     volumes = module.params['volumes']
     instance_type = module.params.get('instance_type')
     spot_price = module.params.get('spot_price')
+    instance_monitoring = module.params.get('instance_monitoring')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -152,7 +158,8 @@ def create_launch_config(connection, module):
         user_data=user_data,
         block_device_mappings=[bdm],
         instance_type=instance_type,
-        spot_price=spot_price)
+        spot_price=spot_price,
+        instance_monitoring=instance_monitoring)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -193,6 +200,7 @@ def main():
             instance_type=dict(type='str'),
             state=dict(default='present', choices=['present', 'absent']),
             spot_price=dict(type='float'),
+            instance_monitoring=dict(default=False, type='bool'),
         )
     )
 


### PR DESCRIPTION
Enabling detailled monitoring in the launch config is mandatory to be able to activate cloudwatch in the to be created autoscaling group.
