### PR TITLE
Add examples for `shell` and `command` modules.

### DIFF
--- a/library/commands/command
+++ b/library/commands/command
@@ -77,11 +77,19 @@ author: Michael DeHaan
 '''
 
 EXAMPLES = '''
-# Example from Ansible Playbooks
+# Example from Ansible Playbooks.
 - command: /sbin/shutdown -t now
 
-# Run the command if the specified file does not exist
+# Run the command if the specified file does not exist.
 - command: /usr/bin/make_database.sh arg1 arg2 creates=/path/to/database
+
+# You can also use the 'args' form to provide the options. This command
+# will change the working directory to somedir/ and will only run when
+# /path/to/database doesn't exist.
+- command: /usr/bin/make_database.sh arg1 arg2
+  args:
+    chdir: somedir/
+    creates: /path/to/database
 '''
 
 def main():

--- a/library/commands/shell
+++ b/library/commands/shell
@@ -53,6 +53,17 @@ author: Michael DeHaan
 
 EXAMPLES = '''
 # Execute the command in remote shell; stdout goes to the specified
-# file on the remote
+# file on the remote.
 - shell: somescript.sh >> somelog.txt
+
+# Change the working directory to somedir/ before executing the command.
+- shell: somescript.sh >> somelog.txt chdir=somedir/
+
+# You can also use the 'args' form to provide the options. This command
+# will change the working directory to somedir/ and will only run when
+# somedir/somelog.txt doesn't exist.
+- shell: somescript.sh >> somelog.txt
+  args:
+    chdir: somedir/
+    creates: somelog.txt
 '''


### PR DESCRIPTION
I added examples that make use of the `args` form (https://github.com/ansible/ansible-examples/blob/master/language_features/complex_args.yml). This allows people to make their `shell` or `command` actions more clear if they use the options.

I didn't know about this language feature so for me it was quite a search before I found it out. It would be nice to add it to the examples of these modules because you would probably use this language feature faster with these modules than others.
