### PR TITLE
Adding same_vpc_only option to EC2 dynamic inventory configuration

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -14,6 +14,12 @@
 regions = all
 regions_exclude = us-gov-west-1,cn-north-1
 
+# If you are running this inventory script inside of a VPC and want to restrict
+# the list of hosts returned to just those inside of the same VPC, set this to
+# true. If you aren't running inside of a VPC setting to "True" will have no
+# effect
+same_vpc_only = False
+
 # When generating inventory, Ansible needs to know how to address a server.
 # Each EC2 instance has a lot of variables associated with it. Here is the list:
 #   http://docs.pythonboto.org/en/latest/ref/ec2.html#module-boto.ec2.instance

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -123,6 +123,7 @@ from boto import ec2
 from boto import rds
 from boto import route53
 import ConfigParser
+import requests
 
 try:
     import json
@@ -230,7 +231,13 @@ class Ec2Inventory(object):
         self.cache_path_cache = cache_dir + "/ansible-ec2.cache"
         self.cache_path_index = cache_dir + "/ansible-ec2.index"
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
-        
+
+        # just get things in our own VPC?
+        try:
+            self.same_vpc_only = config.getboolean('ec2', 'same_vpc_only');
+        except ConfigParser.NoOptionError, e:
+            self.same_vpc_only = False
+        self.same_vpc_id = None
 
 
     def parse_cli_args(self):
@@ -252,9 +259,21 @@ class Ec2Inventory(object):
         if self.route53_enabled:
             self.get_route53_records()
 
+        # if we are restricting to just the VPC we are running in then let's find out what that is
+        if self.same_vpc_only:
+            # get a list of macs and from there get any potential VPC
+            r = requests.get('http://instance-data.ec2.internal/2014-02-25/meta-data/network/interfaces/macs/')
+            macs = r.text.split('\n')
+            for mac in macs:
+                vpc_r = requests.get('http://instance-data.ec2.internal/2014-02-25/meta-data/network/interfaces/macs/' + mac + 'vpc-id')
+                mac_vpc_id = vpc_r.text
+                if mac_vpc_id:
+                    self.same_vpc_id = mac_vpc_id
+
         for region in self.regions:
             self.get_instances_by_region(region)
-            self.get_rds_instances_by_region(region)
+            if not self.same_vpc_id:
+                self.get_rds_instances_by_region(region)
 
         self.write_to_cache(self.inventory, self.cache_path_cache)
         self.write_to_cache(self.index, self.cache_path_index)
@@ -338,6 +357,10 @@ class Ec2Inventory(object):
 
         if not dest:
             # Skip instances we cannot address (e.g. private VPC subnet)
+            return
+
+        # Skip instance that aren't in our VPC if we care about that
+        if self.same_vpc_id and (not instance.vpc_id or instance.vpc_id != self.same_vpc_id):
             return
 
         # Add to index


### PR DESCRIPTION
This will filter the list of hosts that are returned to be just those
in the same VPC where the inventory script is being run
