### PR TITLE
Add `--limit` option to ansible-pull.

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -114,8 +114,8 @@ def main(args):
                       help='directory to checkout repository to')
     #parser.add_option('-l', '--live', default=True, action='store_live',
     #                  help='Print the ansible-playbook output while running')
-    parser.add_option('-l', '--limit', dest="limit", action="append",
-                      help="further limit selected hosts to an additional pattern", default=[])
+    parser.add_option('-l', '--limit', dest="limit"
+                      help="further limit selected hosts to an additional pattern")
     parser.add_option('-U', '--url', dest='url', default=None,
                       help='URL of the playbook repository')
     parser.add_option('-C', '--checkout', dest='checkout',
@@ -213,8 +213,8 @@ def main(args):
         cmd += ' -e "%s"' % ev
     if options.ask_sudo_pass:
         cmd += ' -K'
-    for lim in options.limit:
-        cmd += ' -l "%s"' % lim
+    if options.limit:
+        cmd += ' -l "%s"' % options.limit
     os.chdir(options.dest)
 
     # RUN THE PLAYBOOK COMMAND

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -114,6 +114,8 @@ def main(args):
                       help='directory to checkout repository to')
     #parser.add_option('-l', '--live', default=True, action='store_live',
     #                  help='Print the ansible-playbook output while running')
+    parser.add_option('-l', '--limit', dest="limit", action="append",
+                      help="further limit selected hosts to an additional pattern", default=[])
     parser.add_option('-U', '--url', dest='url', default=None,
                       help='URL of the playbook repository')
     parser.add_option('-C', '--checkout', dest='checkout',
@@ -211,6 +213,8 @@ def main(args):
         cmd += ' -e "%s"' % ev
     if options.ask_sudo_pass:
         cmd += ' -K'
+    for lim in options.limit:
+        cmd += ' -l "%s"' % lim
     os.chdir(options.dest)
 
     # RUN THE PLAYBOOK COMMAND


### PR DESCRIPTION
This adds the same `--limit` option to **ansible-pull** that **ansible-playbook** already had. The option is simply passed through to **ansible-pull**, in addition to the hardcoded `--limit` of `localhost:$HOSTNAME:127.0.0.1`. This basically enables folk to extend the hardcoded limit, which was previously not possible.

The reason for this is a bit complicated. In short, it was interfering with the combination of ansible-pull and dynamic inventories that add important variables. In a playbook that is invoked at startup to self-update newly launched EC2 instances in an autoscaling group, we rely on several variables added by a dynamic inventory script (ec2.py). These would not be found if the host was not addressed by its proper name (the public EC2 DNS name in this case). So localhost or 127.0.0.1 would not pick these up. The system hostname (the one ansible retrieves via `socket.getfqdn()`) does not match the inventory name, for a number of reasons (mostly related to EC2 names being gibberish, and hostnames being used in various places to identify and group instances in external services such as remote syslog and monitoring). So the hardcoded limit was just not working, and _there was no way to tell ansible-pull to use the hostname we wanted_. This adds that way, without interfering in any way with how ansible-pull works when it is simply omitted.
