### PR TITLE
apache2_module handles multiple lines of output, fixes #7736 and #7857

### DIFF
--- a/library/web_infrastructure/apache2_module
+++ b/library/web_infrastructure/apache2_module
@@ -51,7 +51,7 @@ def _disable_module(module):
     a2dismod_binary = module.get_bin_path("a2dismod")
     result, stdout, stderr = module.run_command("%s %s" % (a2dismod_binary, name))
 
-    if re.match(r'.*already disabled.*', stdout):
+    if re.match(r'.*' + name + r' already disabled.*', stdout, re.S):
         module.exit_json(changed = False, result = "Success")
     elif result != 0: 
         module.fail_json(msg="Failed to disable module %s: %s" % (name, stdout))
@@ -63,7 +63,7 @@ def _enable_module(module):
     a2enmod_binary = module.get_bin_path("a2enmod")
     result, stdout, stderr = module.run_command("%s %s" % (a2enmod_binary, name))
 
-    if re.match(r'.*already enabled.*', stdout):
+    if re.match(r'.*' + name + r' already enabled.*', stdout, re.S):
         module.exit_json(changed = False, result = "Success")
     elif result != 0: 
         module.fail_json(msg="Failed to enable module %s: %s" % (name, stdout))


### PR DESCRIPTION
apache2_modules was not handling multiple lines of output, which caused it to report 'changed'  for any action that had 'already enabled' or 'already disabled' on the second line or further. Fixes #7736 and #7857 (same issue).
