### PR TITLE
fixes the now-incorrect module for ApiError -- noticed since 0.3.2

### DIFF
--- a/library/cloud/docker_image
+++ b/library/cloud/docker_image
@@ -113,6 +113,11 @@ except ImportError, e:
     print "failed=True msg='failed to import python module: %s'" % e
     sys.exit(1)
 
+try:
+    from docker.errors import APIError as DockerAPIError
+except ImportError:
+    from docker.client import APIError as DockerAPIError
+
 class DockerImageManager:
 
     def __init__(self, module):
@@ -187,7 +192,7 @@ class DockerImageManager:
             try:
                 self.client.remove_image(i['Id'])
                 self.changed = True
-            except docker.APIError as e:
+            except DockerAPIError as e:
                 # image can be removed by docker if not used
                 pass
 
@@ -235,7 +240,7 @@ def main():
 
         module.exit_json(failed=failed, changed=manager.has_changed(), msg=msg, image_id=image_id)
 
-    except docker.errors.APIError as e:
+    except DockerAPIError as e:
         module.exit_json(failed=True, changed=manager.has_changed(), msg="Docker API error: " + e.explanation)
 
     except RequestException as e:

--- a/library/cloud/docker_image
+++ b/library/cloud/docker_image
@@ -235,7 +235,7 @@ def main():
 
         module.exit_json(failed=failed, changed=manager.has_changed(), msg=msg, image_id=image_id)
 
-    except docker.client.APIError as e:
+    except docker.errors.APIError as e:
         module.exit_json(failed=True, changed=manager.has_changed(), msg="Docker API error: " + e.explanation)
 
     except RequestException as e:


### PR DESCRIPTION
https://github.com/dotcloud/docker-py/blob/0.3.2/docker/errors.py
- ApiError is now(0.3.2) under the docker.errors

this is the commit that made it break: https://github.com/dotcloud/docker-py/commit/18d4db09ecc79cef49830fa2c28c5e99dd02be42
