### PR TITLE
Added us-gov-west-1 to list of choices

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -39,7 +39,8 @@ AWS_REGIONS = ['ap-northeast-1',
                'sa-east-1',
                'us-east-1',
                'us-west-1',
-               'us-west-2']
+               'us-west-2',
+               'us-gov-west-1']
 
 
 def aws_common_argument_spec():

--- a/library/cloud/ec2_ami_search
+++ b/library/cloud/ec2_ami_search
@@ -56,7 +56,7 @@ options:
     required: false
     default: us-east-1
     choices: ["ap-northeast-1", "ap-southeast-1", "ap-southeast-2",
-              "eu-west-1", "sa-east-1", "us-east-1", "us-west-1", "us-west-2"]
+              "eu-west-1", "sa-east-1", "us-east-1", "us-west-1", "us-west-2","us-gov-west-1"]
   virt:
     description: virutalization type
     required: false
@@ -92,7 +92,8 @@ AWS_REGIONS = ['ap-northeast-1',
                'sa-east-1',
                'us-east-1',
                'us-west-1',
-               'us-west-2']
+               'us-west-2',
+               'us-gov-west-1']
 
 
 def get_url(module, url):

--- a/library/cloud/ec2_facts
+++ b/library/cloud/ec2_facts
@@ -67,7 +67,8 @@ class Ec2Metadata(object):
                    'sa-east-1',
                    'us-east-1',
                    'us-west-1',
-                   'us-west-2')
+                   'us-west-2',
+                   'us-gov-west-1')
 
     def __init__(self, module, ec2_metadata_uri=None, ec2_sshdata_uri=None, ec2_userdata_uri=None):
         self.module   = module

--- a/library/system/lvg
+++ b/library/system/lvg
@@ -131,7 +131,6 @@ def main():
     vgoptions = module.params['vg_options'].split()
 
     if module.params['pvs']:
-        dev_string = ' '.join(module.params['pvs'])
         dev_list = module.params['pvs']
     elif state == 'present':
         module.fail_json(msg="No physical volumes given.")
@@ -188,7 +187,7 @@ def main():
                     else:
                         module.fail_json(msg="Creating physical volume '%s' failed" % current_dev, rc=rc, err=err)
                 vgcreate_cmd = module.get_bin_path('vgcreate')
-                rc,_,err = module.run_command([vgcreate_cmd] + vgoptions + ['-s', str(pesize), vg, dev_string])
+                rc,_,err = module.run_command([vgcreate_cmd] + vgoptions + ['-s', str(pesize), vg] + dev_list)
                 if rc == 0:
                     changed = True
                 else:


### PR DESCRIPTION
Minor updates to add us-gov-west-1 to the list of allowed choices. 

The `regions_exclude` still contains us-gov-west-1 in ec2.ini so it's still not included when selecting all regions. 

I was able to test this change and verify that it allows me provision and manage GovCloud EC2 instances after setting the `ec2_url` variable in my playbook. 

Also included is a bugfix in the lvg module when trying to create a VG with multiple devices.
