### PR TITLE
apt_key clear message when downloading key returns an (http) error code

### DIFF
--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -153,8 +153,12 @@ def download_key(module, url):
     # and reuse here
     if url is None:
         module.fail_json(msg="needed a URL but was not specified")
+
     try:
         rsp, info = fetch_url(module, url)
+        if info['status'] != 200:
+            module.fail_json(msg="Failed to download key at %s: %s" % (url, info['msg']))
+
         return rsp.read()
     except Exception:
         module.fail_json(msg="error getting key id from url: %s" % url, traceback=format_exc())


### PR DESCRIPTION
When downloading the key fails it currently gives a very non descriptive error.

In case of a 403 Forbidden for example Ansible returns:

```
failed: [1234.trbs.net] => {"failed": true, "traceback": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1403701692.1-118748049158066/apt_key\", line 158, in download_key\n    return rsp.read()\nAttributeError: 'NoneType' object has no attribute 'read'\n"}
msg: error getting key id from url: http://apt.trbs.com/forbidden.key

FATAL: all hosts have already failed -- aborting
```

This patch uses the error message from the `fetch_url` function to give a useful message:

```
failed: [1234.trbs.net] => {"failed": true}
msg: Failed to download key at http://apt.trbs.com/forbidden.key: HTTP Error 403: Forbidden

FATAL: all hosts have already failed -- aborting
```
