### PR TITLE
In yum module example, use present/absent instead of installed/removed

### DIFF
--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -107,10 +107,10 @@ EXAMPLES = '''
   yum: name=httpd state=latest
 
 - name: remove the Apache package
-  yum: name=httpd state=removed
+  yum: name=httpd state=absent
 
 - name: install the latest version of Apache from the testing repo
-  yum: name=httpd enablerepo=testing state=installed
+  yum: name=httpd enablerepo=testing state=present
 
 - name: upgrade all packages
   yum: name=* state=latest


### PR DESCRIPTION
In yum module code, `installed`/`removed` is defined as aliases for `present`/`absent`. But both of `installed` and `removed` are not listed as choices for `state` parameter in the documentation.
