### PR TITLE
portage: Successful exit if sync=yes and no package provided

### DIFF
--- a/library/packaging/portage
+++ b/library/packaging/portage
@@ -362,7 +362,7 @@ def main():
     if p['sync']:
         sync_repositories(module, webrsync=(p['sync'] == 'web'))
         if not p['package']:
-            return
+            module.exit_json(msg='Sync successfuly finished.')
 
     packages = p['package'].split(',') if p['package'] else []
 

--- a/library/packaging/portage
+++ b/library/packaging/portage
@@ -362,7 +362,7 @@ def main():
     if p['sync']:
         sync_repositories(module, webrsync=(p['sync'] == 'web'))
         if not p['package']:
-            module.exit_json(msg='Sync successfuly finished.')
+            module.exit_json(msg='Sync successfully finished.')
 
     packages = p['package'].split(',') if p['package'] else []
 


### PR DESCRIPTION
When you call the module with parameter sync=yes and without the package, it was always failed:

```
$ ansible -i stage 192.168.1.213 -m portage -a 'sync=yes'
192.168.1.213 | FAILED >> {
    "failed": true, 
    "msg": "", 
    "parsed": false
}
```

after changes:

```
$ ansible -i stage 192.168.1.213 -m portage -a 'sync=yes'
192.168.1.213 | success >> {
    "changed": false, 
    "msg": "Sync successfully finished."
}
```

And call with package parameter:

```
$ ansible -i stage 192.168.1.213 -m portage -a 'package=app-misc/screen sync=yes verbose=yes'
192.168.1.213 | success >> {
    "changed": true, 
    "cmd": [
        "/usr/bin/emerge", 
        "--verbose", 
        "app-misc/screen"
    ], 
    "msg": "Packages installed.", 
```
