### PR TITLE
Fix FreeBSD ports install issue

### DIFF
--- a/library/packaging/portinstall
+++ b/library/packaging/portinstall
@@ -99,15 +99,14 @@ def query_package(module, name):
 def matching_packages(module, name):
 
     ports_glob_path = module.get_bin_path('ports_glob', True)
-    rc, out, err = module.run_command("%s %s | wc" % (ports_glob_path, name))
-    parts = out.split()
-    occurrences = int(parts[0])
+    rc, out, err = module.run_command("%s %s" % (ports_glob_path, name))
+    #counts the numer of packages found
+    occurrences = out.count('\n')
     if occurrences == 0:
         name_without_digits = re.sub('[0-9]', '', name)
         if name != name_without_digits:
-            rc, out, err = module.run_command("%s %s | wc" % (ports_glob_path, name_without_digits))
-            parts = out.split()
-            occurrences = int(parts[0])
+            rc, out, err = module.run_command("%s %s" % (ports_glob_path, name_without_digits))
+            occurrences = out.count('\n')
     return occurrences
 
 


### PR DESCRIPTION
Fixes the port install issue (#7691). Current method uses shell pipe and wc to count the number of packages found. This errors out because piping requires use_unsafe_shell set to true.

Changed to use python's string count to count for newline '\n'.

Tested on FreeBSD 10.0-Release.
