### PR TITLE
cron module: Use correct parameter name in error message.

### DIFF
--- a/library/system/cron
+++ b/library/system/cron
@@ -449,7 +449,7 @@ def main():
 
     if cron_file and do_install:
         if not user:
-            module.fail_json(msg="To use file=... parameter you must specify user=... as well")
+            module.fail_json(msg="To use cron_file=... parameter you must specify user=... as well")
 
     if reboot and special_time:
         module.fail_json(msg="reboot and special_time are mutually exclusive")


### PR DESCRIPTION
The parameter is called `cron_file` but the error message uses `file` which is confusing.
