### PR TITLE
Docker network mode selection

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -169,6 +169,13 @@ options:
     default: null
     aliases: []
     version_added: "1.5"
+  network_mode:
+    description:
+      - Set network mode for the container, e.g. network_mode=host
+    required: false
+    default: "bridge"
+    aliases: []
+    version_added: "1.6"
   stdin_open:
     description:
       - Keep stdin open
@@ -594,6 +601,8 @@ class DockerManager:
         if docker.utils.compare_version('1.10', self.client.version()['ApiVersion']) >= 0 and hasattr(docker, '__version__') and docker.__version__ > '0.3.0':
             params['dns'] = self.module.params.get('dns')
             params['volumes_from'] = self.module.params.get('volumes_from')
+            if docker.__version__ >= '0.3.2':
+                params['network_mode'] = self.module.params.get('network_mode')
 
         for i in containers:
             self.client.start(i['Id'], **params)
@@ -668,6 +677,7 @@ def main():
             hostname        = dict(default=None),
             env             = dict(type='list'),
             dns             = dict(),
+            network_mode    = dict(default='bridge'),
             detach          = dict(default=True, type='bool'),
             state           = dict(default='running', choices=['absent', 'present', 'running', 'stopped', 'killed', 'restarted']),
             debug           = dict(default=False, type='bool'),


### PR DESCRIPTION
Enables selection of the 'NetworkMode' option present in Docker

Granted this is nearly identical to of https://github.com/ansible/ansible/pull/7408 except after some testing the 0.3.2 checking seems important and I believe setting a default is required.

I believe adding might be important as without it, it doesn't seem docker-py sets it as the default, though I could be wrong. It was just another observation from testing.

This would close https://github.com/ansible/ansible/issues/7324

Cheers,

Pauly
