### PR TITLE
Be able to pass in tag names from variables.

### DIFF
--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -69,6 +69,16 @@ tasks:
     tags:
       Name: webserver
       env: prod
+
+# Adding tags with dynamic names as well as dynamic values.
+tasks:
+- name: tag my instance
+  local_action: ec2_ntag resource={{ item.id }} region=us-east-1 state=present
+  with_items: ec2.instances
+  args:
+    tags:
+      - Name: "{{ some_variable }}"
+        Value: "{{ some_other_variable"
 '''
 
 # Note: this module needs to be made idempotent. Possible solution is to use resource tags with the volumes.
@@ -96,7 +106,7 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec)
 
     resource = module.params.get('resource')
-    tags = module.params.get('tags')
+    tags_param = module.params.get('tags')
     state = module.params.get('state')
   
     ec2 = ec2_connect(module)
@@ -110,8 +120,15 @@ def main():
     dictremove = {}
     baddict = {}
     tagdict = {}
+    tags = {}
     for tag in gettags:
         tagdict[tag.name] = tag.value
+
+    if isinstance(tags_param, list):
+        for item in tags_param:
+            tags[item['Name']] = item['Value']
+    else:
+        tags = tags_param
 
     if state == 'present':
         if not tags:


### PR DESCRIPTION
When the module only accepted a dictionary for the tags, the names
could not use Jinja and so had to be statically defined.  This change
is backwards compatible but if you pass in a list of dictionaries, you
get more flexibility for the names you give your instances.
