### PR TITLE
azure - added storage account module

### DIFF
--- a/lib/ansible/module_utils/azure.py
+++ b/lib/ansible/module_utils/azure.py
@@ -1,0 +1,61 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright (c), Michael DeHaan <michael.dehaan@gmail.com>, 2012-2013
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+AZURE_LOCATIONS = ['East Asia',
+                   'Southeast Asia',
+                   'Brazil South',
+                   'North Europe',
+                   'West Europe',
+                   'Japan West',
+                   'East US',
+                   'South Central US',
+                   'West US']
+
+
+def get_azure_creds(module):
+    # Check modul args for credentials, then check environment vars
+    subscription_id = module.params.get('subscription_id')
+    management_cert_path = module.params.get('management_cert_path')
+
+    if not subscription_id:
+        subscription_id = os.environ['AZURE_SUBSCRIPTION_ID']
+        management_cert_path = os.environ['AZURE_CERT_PATH']
+
+    return subscription_id, management_cert_path
+
+def wait_for_completion(azure, promise, wait_timeout, msg):
+    if not promise: return
+    wait_timeout = time.time() + wait_timeout
+    while wait_timeout > time.time():
+        operation_result = azure.get_operation_status(promise.request_id)
+        time.sleep(5)
+        if operation_result.status == "Succeeded":
+            return
+
+    raise WindowsAzureError('Timed out waiting for async operation ' + msg + ' "' + str(promise.request_id) + '" to complete.')
+

--- a/library/cloud/azure
+++ b/library/cloud/azure
@@ -19,7 +19,7 @@ DOCUMENTATION = '''
 module: azure
 short_description: create or terminate a virtual machine in azure
 description:
-     - Creates or terminates azure instances. When created optionally waits for it to be 'running'. This module has a dependency on python-azure >= 0.7.1
+     - Creates or terminates azure instances. When created optionally waits for it to be 'running'. This module has a dependency on python-azure >= 0.8.1
 version_added: "1.7"
 options:
   name:
@@ -107,7 +107,7 @@ options:
     aliases: []
 
 requirements: [ "azure" ]
-author: John Whitbeck
+author: John Whitbeck, Martin Joehren
 '''
 
 EXAMPLES = '''
@@ -135,20 +135,10 @@ EXAMPLES = '''
 
 import base64
 import datetime
-import os
 import sys
 import time
 from urlparse import urlparse
 
-AZURE_LOCATIONS = ['East Asia',
-                   'Southeast Asia',
-                   'Brazil South',
-                   'North Europe',
-                   'West Europe',
-                   'Japan West',
-                   'East US',
-                   'South Central US',
-                   'West US']
 
 AZURE_ROLE_SIZES = ['ExtraSmall',
                     'Small',
@@ -178,21 +168,7 @@ except ImportError:
     "failed=True msg='azure required for this module'"
     sys.exit(1)
 
-from distutils.version import LooseVersion
-from types import MethodType
 import json
-
-
-def _wait_for_completion(azure, promise, wait_timeout, msg):
-    if not promise: return
-    wait_timeout = time.time() + wait_timeout
-    while wait_timeout > time.time():
-        operation_result = azure.get_operation_status(promise.request_id)
-        time.sleep(5)
-        if operation_result.status == "Succeeded":
-            return
-
-    raise WindowsAzureError('Timed out waiting for async operation ' + msg + ' "' + str(promise.request_id) + '" to complete.')
 
 
 def get_ssh_certificate_tokens(module, ssh_cert_path):
@@ -221,7 +197,7 @@ def create_virtual_machine(module, azure):
     azure: authenticated azure ServiceManagementService object
 
     Returns:
-        True if a new virtual machine was created, false otherwise
+        True if a new virtual machine was created, false otherwise, deployment_url, raw json object of deployment
     """
     name = module.params.get('name')
     hostname = module.params.get('hostname') or name + ".cloudapp.net"
@@ -239,13 +215,21 @@ def create_virtual_machine(module, azure):
     # Check if a deployment with the same name already exists
     cloud_service_name_available = azure.check_hosted_service_name_availability(name)
     if not cloud_service_name_available.result:
-        changed = False
+        cloud_services = azure.list_hosted_services()
+        if name in [cloud_service_name.service_name for cloud_service_name in cloud_services.hosted_services]:
+            try:
+                deployment = azure.get_deployment_by_name(service_name=name, deployment_name=name)
+                return (False, urlparse(deployment.url).hostname, deployment)
+            except WindowsAzureError as e:
+                module.fail_json(msg="failed to lookup the deployment information for %s in the cloud service %s, error was: %s" % (name, name, str(e)))
+        else:
+            module.fail_json(msg="cloud service name %s is already in use by a different account." % str(name))
     else:
         changed = True
         # Create cloud service if necessary
         try:
             result = azure.create_hosted_service(service_name=name, label=name, location=location)
-            _wait_for_completion(azure, result, wait_timeout, "create_hosted_service")
+            wait_for_completion(azure, result, wait_timeout, "create_hosted_service")
         except WindowsAzureError as e:
             module.fail_json(msg="failed to create the new service name, it already exists: %s" % str(e))
 
@@ -258,7 +242,7 @@ def create_virtual_machine(module, azure):
             fingerprint, pkcs12_base64 = get_ssh_certificate_tokens(module, ssh_cert_path)
             # Add certificate to cloud service
             result = azure.add_service_certificate(name, pkcs12_base64, 'pfx', '')
-            _wait_for_completion(azure, result, wait_timeout, "add_service_certificate")
+            wait_for_completion(azure, result, wait_timeout, "add_service_certificate")
 
             # Create ssh config
             ssh_config = SSH()
@@ -296,16 +280,15 @@ def create_virtual_machine(module, azure):
                                                              network_config=network_config,
                                                              os_virtual_hard_disk=os_hd,
                                                              role_size=role_size)
-            _wait_for_completion(azure, result, wait_timeout, "create_virtual_machine_deployment")
+            wait_for_completion(azure, result, wait_timeout, "create_virtual_machine_deployment")
         except WindowsAzureError as e:
             module.fail_json(msg="failed to create the new virtual machine, error was: %s" % str(e))
 
-
-    try:
-        deployment = azure.get_deployment_by_name(service_name=name, deployment_name=name)
-        return (changed, urlparse(deployment.url).hostname, deployment)
-    except WindowsAzureError as e:
-        module.fail_json(msg="failed to lookup the deployment information for %s, error was: %s" % (name, str(e)))
+        try:
+            deployment = azure.get_deployment_by_name(service_name=name, deployment_name=name)
+            return (changed, urlparse(deployment.url).hostname, deployment)
+        except WindowsAzureError as e:
+            module.fail_json(msg="failed to lookup the deployment information for %s, error was: %s" % (name, str(e)))
 
 
 def terminate_virtual_machine(module, azure):
@@ -315,17 +298,13 @@ def terminate_virtual_machine(module, azure):
     module : AnsibleModule object
     azure: authenticated azure ServiceManagementService object
 
-    Not yet supported: handle deletion of attached data disks.
-
     Returns:
-        True if a new virtual machine was deleted, false otherwise
+        True if a new virtual machine was deleted, false otherwise, deployment_url, raw json object of deployment
     """
 
-    # Whether to wait for termination to complete before returning
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
     name = module.params.get('name')
-    delete_empty_services = module.params.get('delete_empty_services')
 
     changed = False
 
@@ -350,31 +329,23 @@ def terminate_virtual_machine(module, azure):
                     disk_names.append(role_props.os_virtual_hard_disk.disk_name)
 
             result = azure.delete_deployment(name, deployment.name)
-            _wait_for_completion(azure, result, wait_timeout, "delete_deployment")
+            wait_for_completion(azure, result, wait_timeout, "delete_deployment")
 
             for disk_name in disk_names:
                 azure.delete_disk(disk_name, True)
 
             # Now that the vm is deleted, remove the cloud service
             result = azure.delete_hosted_service(service_name=name)
-            _wait_for_completion(azure, result, wait_timeout, "delete_hosted_service")
+            wait_for_completion(azure, result, wait_timeout, "delete_hosted_service")
         except WindowsAzureError as e:
             module.fail_json(msg="failed to delete the service %s, error was: %s" % (name, str(e)))
 
     return changed, urlparse(deployment.url).hostname, deployment
 
 
-def get_azure_creds(module):
-    # Check modul args for credentials, then check environment vars
-    subscription_id = module.params.get('subscription_id')
-    management_cert_path = module.params.get('management_cert_path')
-
-    if not subscription_id:
-        subscription_id = os.environ['AZURE_SUBSCRIPTION_ID']
-        management_cert_path = os.environ['AZURE_CERT_PATH']
-
-    return subscription_id, management_cert_path
-
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.azure import *
 
 def main():
     module = AnsibleModule(
@@ -400,19 +371,12 @@ def main():
     # create azure ServiceManagementService object
     subscription_id, management_cert_path = get_azure_creds(module)
 
-    wait_timeout_redirects = int(module.params.get('wait_timeout_redirects'))
-    if LooseVersion(windows_azure.__version__) <= "0.8.0":
-        # wrapper for handling redirects which the sdk <= 0.8.0 is not following
-        azure = Wrapper(ServiceManagementService(subscription_id, management_cert_path), wait_timeout_redirects)
-    else:
-        azure = ServiceManagementService(subscription_id, management_cert_path), wait_timeout_redirects
+    azure = ServiceManagementService(subscription_id, management_cert_path)
 
-    cloud_service_raw = None
     if module.params.get('state') == 'absent':
         (changed, public_dns_name, deployment) = terminate_virtual_machine(module, azure)
 
     elif module.params.get('state') == 'present':
-        # Changed is always set to true when provisioning new instances
         if not module.params.get('name'):
             module.fail_json(msg='name parameter is required for new instance')
         if not module.params.get('image'):
@@ -427,39 +391,5 @@ def main():
 
     module.exit_json(changed=changed, public_dns_name=public_dns_name, deployment=json.loads(json.dumps(deployment, default=lambda o: o.__dict__)))
 
-
-class Wrapper(object):
-    def __init__(self, obj, wait_timeout):
-        self.other = obj
-        self.wait_timeout = wait_timeout
-
-    def __getattr__(self, name):
-        if hasattr(self.other, name):
-            func = getattr(self.other, name)
-            return lambda *args, **kwargs: self._wrap(func, args, kwargs)
-        raise AttributeError(name)
-
-    def _wrap(self, func, args, kwargs):
-        if type(func) == MethodType:
-            result = self._handle_temporary_redirects(lambda: func(*args, **kwargs))
-        else:
-            result = self._handle_temporary_redirects(lambda: func(self.other, *args, **kwargs))
-        return result
-
-    def _handle_temporary_redirects(self, f):
-        wait_timeout = time.time() + self.wait_timeout
-        while wait_timeout > time.time():
-            try:
-                return f()
-            except WindowsAzureError as e:
-                if not str(e).lower().find("temporary redirect") == -1:
-                    time.sleep(5)
-                    pass
-                else:
-                    raise e
-
-
-# import module snippets
-from ansible.module_utils.basic import *
 
 main()

--- a/library/cloud/azure_storage
+++ b/library/cloud/azure_storage
@@ -1,0 +1,210 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: azure_storage
+short_description: create or deletes a storage account in Azure
+description:
+     - Creates or deletes Azure storage account when all existing containers inside the storage account are empty. This module has a dependency on python-azure >= 0.8.1
+version_added: "1.7"
+options:
+  name:
+    description:
+      - name of the storage.
+    required: true
+    default: null
+  location:
+    description:
+      - the Azure location to use (e.g. 'East US')
+    default: null
+  affinity_group:
+    description:
+      - the Azure affinity group to use
+    default: null
+  subscription_id:
+    description:
+      - Azure subscription id. Overrides the AZURE_SUBSCRIPTION_ID environement variable.
+    required: false
+    default: null
+  management_cert_path:
+    description:
+      - path to an Azure management certificate associated with the subscription id. Overrides the AZURE_CERT_PATH environement variable.
+    required: false
+    default: null
+  wait_timeout:
+    description:
+      - how long before wait gives up, in seconds
+    default: 600
+    aliases: []
+  wait_timeout_redirects:
+    description:
+      - how long before wait gives up for redirects, in seconds
+    default: 300
+    aliases: []
+  state:
+    description:
+      - create or delete storage account
+    required: false
+    default: 'present'
+    aliases: []
+
+requirements: [ "azure" ]
+author: Martin Joehren
+'''
+
+EXAMPLES = '''
+# Note: None of these examples set subscription_id or management_cert_path
+# It is assumed that their matching environment variables are set.
+
+# Create storage account
+- local_action:
+    module: azure_storage
+    name: my-storage
+    location: 'East US'
+
+# Delete storage account
+- local_action:
+    module: azure_storage
+    name: my-storage
+    state: absent
+'''
+
+import base64
+import datetime
+import os
+import sys
+import time
+from urlparse import urlparse
+
+
+try:
+    import azure as windows_azure
+
+    from azure import WindowsAzureError, WindowsAzureMissingResourceError
+    from azure.servicemanagement import (ServiceManagementService, OSVirtualHardDisk, SSH, PublicKeys,
+                                         PublicKey, LinuxConfigurationSet, ConfigurationSetInputEndpoints,
+                                         ConfigurationSetInputEndpoint)
+except ImportError:
+    print
+    "failed=True msg='azure required for this module'"
+    sys.exit(1)
+
+import json
+
+
+
+def create_storage_account(module, azure):
+    """
+    Create new storage account
+
+    module : AnsibleModule object
+    azure: authenticated azure ServiceManagementService object
+
+    Returns:
+        True if a new storage account was created, false otherwise, raw json storage account object
+    """
+    name = module.params.get('name')
+    affinity_group = module.params.get('affinity_group')
+    location = module.params.get('location')
+    wait_timeout = int(module.params.get('wait_timeout'))
+
+    # Check if a storage account with the same name already exists
+    storage_name_available = azure.check_storage_account_name_availability(name)
+    if not storage_name_available.result:
+        storage_accounts = azure.list_storage_accounts()
+        if name in [storage_service.service_name for storage_service in storage_accounts.storage_services]:
+            try:
+                storage = azure.get_storage_account_properties(name)
+                return False, storage
+            except WindowsAzureError as e:
+                module.fail_json(msg="failed to lookup the storage information for %s, error was: %s" % (name, str(e)))
+        else:
+            module.fail_json(msg="storage account name %s is already in use by a different Azure account." % str(name))
+    else:
+        try:
+            result = azure.create_storage_account(service_name=name,
+                                                  description="Storage for " + str(name),
+                                                  label=name,
+                                                  affinity_group=affinity_group,
+                                                  location=location,
+                                                  geo_replication_enabled=True,
+                                                  extended_properties=None)
+
+            wait_for_completion(azure, result, wait_timeout, "create_storage_account")
+            storage = azure.get_storage_account_properties(name)
+            return (True, storage)
+        except WindowsAzureError as e:
+            module.fail_json(msg="failed to create the storage account %s, error was: %s" % (name, str(e)))
+
+def delete_storage_account(module, azure):
+    """
+    Deletes a storage account when no element is located in any existing container, e.g. vhd blob
+
+    module : AnsibleModule object
+    azure: authenticated azure ServiceManagementService object
+
+    Returns:
+        True if the storage was deleted, false otherwise
+    """
+
+    name = module.params.get('name')
+    changed = False
+    try:
+        azure.delete_storage_account(service_name=name)
+        changed = True
+    except WindowsAzureMissingResourceError as e:
+        pass  # no such storage account
+    except WindowsAzureError as e:
+        module.fail_json(msg="failed to delete the storage account %s, error was: %s" % (name, str(e)))
+    return changed
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.azure import *
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True),
+            affinity_group=dict(choices=AZURE_LOCATIONS),
+            location=dict(choices=AZURE_LOCATIONS),
+            subscription_id=dict(no_log=True),
+            management_cert_path=dict(),
+            state=dict(default='present'),
+            wait_timeout=dict(default=600),
+            wait_timeout_redirects=dict(default=300)
+        ),
+        mutually_exclusive = [
+            ['location', 'affinity_group']]
+    )
+    # create azure ServiceManagementService object
+    subscription_id, management_cert_path = get_azure_creds(module)
+
+    azure = ServiceManagementService(subscription_id, management_cert_path)
+
+    if module.params.get('state') == 'absent':
+        changed = delete_storage_account(module, azure)
+        module.exit_json(changed=changed)
+    elif module.params.get('state') == 'present':
+        if not (module.params.get('location') or not module.params.get('affinity_group')):
+            module.fail_json(msg='location or affinity_group parameter is required for new storage')
+        (changed, storage) = create_storage_account(module, azure)
+        module.exit_json(changed=changed, storage=json.loads(json.dumps(storage, default=lambda o: o.__dict__)))
+
+
+main()

--- a/plugins/inventory/windows_azure.py
+++ b/plugins/inventory/windows_azure.py
@@ -80,9 +80,7 @@ class AzureInventory(object):
         elif not self.is_cache_valid():
             self.do_api_calls_update_cache()
 
-        if self.args.list_images:
-            data_to_print = self.json_format_dict(self.get_images(), True)
-        elif self.args.list:
+        if self.args.list:
             # Display list of nodes for inventory
             if len(self.inventory) == 0:
                 data_to_print = self.get_inventory_from_cache()
@@ -90,13 +88,6 @@ class AzureInventory(object):
                 data_to_print = self.json_format_dict(self.inventory, True)
 
         print data_to_print
-
-    def get_images(self):
-        images = []
-        for image in self.sms.list_os_images():
-            if str(image.label).lower().find(self.args.list_images.lower()) >= 0:
-                images.append(vars(image))
-        return json.loads(json.dumps(images, default=lambda o: o.__dict__))
 
     def is_cache_valid(self):
         """Determines if the cache file has expired, or if it is still valid."""
@@ -139,8 +130,6 @@ class AzureInventory(object):
         parser = argparse.ArgumentParser(description='Produce an Ansible Inventory file based on Azure')
         parser.add_argument('--list', action='store_true', default=True,
                            help='List nodes (default: True)')
-        parser.add_argument('--list-images', action='store',
-                           help='Get all available images.')
         parser.add_argument('--refresh-cache', action='store_true', default=False,
                            help='Force refresh of cache by making API requests to Azure (default: False - use cache files)')
         self.args = parser.parse_args()


### PR DESCRIPTION
Added an windows azure storage module
A storage account is needed for the normal azure module to create a vm. The name of the storage account must therefore be provided in the azure module. This module can be combined with the azure module to create at first a storage account and then create a vm.
This pull requests should also fulfill the mentioned improvements from pr #7921, which is now closed. 
