### PR TITLE
Add port knocking

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -796,6 +796,15 @@ class Runner(object):
             return ReturnData(host=host, comm_ok=False, result=result)
 
         try:
+	    actual_port_knock = inject.get('ansible_ssh_port_knock')
+	    if actual_port_knock:
+		s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		s.settimeout(0.0)
+		try:
+		    s.connect((actual_host, actual_port_knock))
+		except:
+		    pass
+
             conn = self.connector.connect(actual_host, actual_port, actual_user, actual_pass, actual_transport, actual_private_key_file)
             if delegate_to or host != actual_host:
                 conn.delegate = host


### PR DESCRIPTION
Hi,

I'm using port knocking which opens ssh port, to avoid some garbage in logs and "protect" from some bots trying to access ssh.

It's done by those simple iptables rules:

```
iptables -A INPUT -p tcp -m state --state NEW -m tcp --dport 22 -m recent --update --seconds 300 --name SSH --rsource -j ACCEPT
iptables -I INPUT -p tcp -m state --state NEW -m tcp --dport 1234 -m recent --remove --name SSH --rsource
iptables -I INPUT -p tcp -m state --state NEW -m tcp --dport 1235 -m recent --set --name SSH --rsource
iptables -I INPUT -p tcp -m state --state NEW -m tcp --dport 1236 -m recent --remove --name SSH --rsource
```

It will be quite good to have a variable which defines a port on which ansible will "knock" before trying to ssh there.
