### PR TITLE
Check for links to see if update-rc.d service is enabled

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -99,6 +99,7 @@ EXAMPLES = '''
 import platform
 import os
 import re
+import glob
 import tempfile
 import shlex
 import select
@@ -662,7 +663,9 @@ class LinuxService(Service):
                     self.changed = True
                     break
                 elif not self.enable and 'already exist' in line:
-                    self.changed = True
+                    # Check if those existing links are for starting the service
+                    already_enabled = bool(glob.glob('/etc/rc*.d/S[0-9][0-9]%s' % self.name))
+                    self.changed = already_enabled ^ self.enable
                     break
 
             # Debian compatibility


### PR DESCRIPTION
This is on Ubuntu Precise (12.04), for a service managed with update-rc.d (a script in /etc/init.d/ and none in /etc/init/).
When running `service: name=supervisor enabled=no`, it was always reporting changed=true. This fix changes the update-rc.d change reporting code, to check what kind of links update-rc.d said "already exist".
