### PR TITLE
Eliminate circular import dependency

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import utils
 import sys
 import getpass
 import os
@@ -24,7 +23,7 @@ import random
 import fnmatch
 import tempfile
 import fcntl
-import constants
+from ansible import constants, utils
 from ansible.color import stringc
 
 import logging
@@ -703,3 +702,4 @@ class PlaybookCallbacks(object):
         call_callback_module('playbook_on_stats', stats)
 
 
+utils.set_display_callback(display)

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -28,7 +28,6 @@ from ansible import __version__
 from ansible.utils import template
 from ansible.utils.display_functions import *
 from ansible.utils.plugins import *
-from ansible.callbacks import display
 import ansible.constants as C
 import ast
 import time

--- a/lib/ansible/utils/display_functions.py
+++ b/lib/ansible/utils/display_functions.py
@@ -19,13 +19,18 @@ import textwrap
 
 from ansible import constants as C
 from ansible import errors
-from ansible.callbacks import display
 
-__all__ = ['deprecated', 'warning', 'system_warning']
+__all__ = ['deprecated', 'warning', 'system_warning', 'set_display_callback']
 
 # list of all deprecation messages to prevent duplicate display
 deprecations = {}
 warns = {}
+display = None
+
+def set_display_callback(_display):
+    global display
+
+    display = _display
 
 def deprecated(msg, version, removed=False):
     ''' used to print out a deprecation message.'''


### PR DESCRIPTION
`ansible.callbacks` and `ansible.utils.display_functions` had circular dependencies.

I removed the latter dependency, because it was depending on something at a higher level which is a smell. I did this by adding a `set_display_callback` function, so that display callback can be set at runtime rather than import-time. This is also more flexible.

I also changed the imports of ansible stuff in `ansible.callbacks` from using implicit relative imports to explicit absolute imports. Explicit is better than implicit. With `import constants` or `import utils`, it's a little bit harder to tell that the module being imported is within ansible.

```
$ cat > tox.ini
# Tox (http://tox.testrun.org/) is a tool for running tests
# in multiple virtualenvs. This configuration file will run the
# test suite on all supported python versions. To use it, "pip install tox"
# and then run "tox" from this directory.

[tox]
envlist = py26, py27

[testenv]
deps =
    passlib
    PyCrypto
    nose
    PyYAML
commands =
    nosetests -d -w test/units {posargs}

$ tox
GLOB sdist-make: /Users/marca/dev/git-repos/ansible/setup.py
py26 inst-nodeps: /Users/marca/dev/git-repos/ansible/.tox/dist/ansible-1.7.zip
py26 runtests: commands[0] | nosetests -d -w test/units
.......................................................................................
...........................................................................
----------------------------------------------------------------------
Ran 162 tests in 4.803s

OK
py27 inst-nodeps: /Users/marca/dev/git-repos/ansible/.tox/dist/ansible-1.7.zip
py27 runtests: commands[0] | nosetests -d -w test/units
........................................................................................
..........................................................................
----------------------------------------------------------------------
Ran 162 tests in 4.813s

OK
____________________________________ summary _____________________________________
  py26: commands succeeded
  py27: commands succeeded
  congratulations :)
```

and here's a passing Travis CI build: https://travis-ci.org/msabramo/ansible/builds/28718413
