### PR TITLE
ec2_ami_search: support for SSD and IOPS provisioned EBS images

### DIFF
--- a/library/cloud/ec2_ami_search
+++ b/library/cloud/ec2_ami_search
@@ -45,7 +45,7 @@ options:
     description: Back-end store for instance
     required: false
     default: "ebs"
-    choices: ["ebs", "instance-store"]
+    choices: ["ebs", "ebs-io1", "ebs-ssd", "instance-store"]
   arch:
     description: CPU architecture
     required: false
@@ -135,7 +135,7 @@ def lookup_ubuntu_ami(table, release, stream, store, arch, region, virt):
                (release, stream, tag, serial, region, ami, aki, ari, virt)
         release: ubuntu release name
         stream: 'server' or 'desktop'
-        store: 'ebs' or 'instance-store'
+        store: 'ebs', 'ebs-io1', 'ebs-ssd' or 'instance-store'
         arch: 'i386' or 'amd64'
         region: EC2 region
         virt: 'paravirtual' or 'hvm'
@@ -172,7 +172,7 @@ def main():
         stream=dict(required=False, default='server',
             choices=['desktop', 'server']),
         store=dict(required=False, default='ebs',
-            choices=['ebs', 'instance-store']),
+            choices=['ebs', 'ebs-io1', 'ebs-ssd', 'instance-store']),
         arch=dict(required=False, default='amd64',
             choices=['i386', 'amd64']),
         region=dict(required=False, default='us-east-1', choices=AWS_REGIONS),


### PR DESCRIPTION
In ec2_ami_search module, add support for the new SSD-backed EBS (ebs-ssd)
volume as well as images with provisioned IOPS (ebs-io1) that Ubuntu images now support.

For details, see this [mailing list announcement](https://lists.ubuntu.com/archives/ubuntu-cloud-announce/2014-June/000055.html).
