### PR TITLE
nova.py: Remove docs for unused config settings

### DIFF
--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -21,10 +21,3 @@ project_id    =
 
 # Serverarm region name to use
 region_name   =
-
-# TODO: Some other options
-# insecure      =
-# endpoint_type =
-# extensions    =
-# service_type  =
-# service_name  =

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -93,30 +93,6 @@ options:
       - In RackSpace use OS_TENANT_NAME
     required: false
     default: null
-  endpoint_type:
-    description:
-      - The endpoint type for novaclient
-      - In RackSpace use 'publicUrl'
-    required: false
-    default: null
-  service_type:
-    description:
-      - The service type you are managing.
-      - In RackSpace use 'compute'
-    required: false
-    default: null
-  service_name:
-    description:
-      - The service name you are managing.
-      - In RackSpace use 'cloudServersOpenStack'
-    required: false
-    default: null
-  insicure:
-    description:
-      - To no check security
-    required: false
-    default: false
-    choices: [ "true", "false" ]
 author: Marco Vito Moscaritolo
 notes:
   - This script assumes Ansible is being executed where the environment variables needed for novaclient have already been set on nova.ini file


### PR DESCRIPTION
AFAICT, these settings are not used. I wonder if @mavimo meant to implement these later, but never got around to it? I'm not the only one who noticed this and was confused by it (see https://github.com/ansible/ansible/pull/7444#issuecomment-43503710).

The other way to go is to implement these settings, but I'm not familiar with these, don't think that my company needs them, and I'm not sure if they require a newer version of python-novaclient or something. In short, I don't feel qualified to implement support, so I'm just removing the docs for the unimplemented feature. Someone else that needs these settings could perhaps add them in at a later date.

BTW, one of settings, `insecure` was misspelled as `insicure` (sic).

Cc: @mavimo, @carsongee (because if this gets merged, #7444 will probably need to be rebased, because it probably touches a lot of the same lines.
