### PR TITLE
Explicit absolute import of ansible.utils.vault

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -45,8 +45,7 @@ import getpass
 import sys
 import json
 
-#import vault
-from vault import VaultLib
+from ansible.utils.vault import VaultLib
 
 VERBOSITY=0
 


### PR DESCRIPTION
in `ansible.utils`

This is more explicit, more readable, and recommended by PEP8 (http://legacy.python.org/dev/peps/pep-0008/#imports).

It's also Python 3 compatible, whereas implicit relative imports are not.
