### PR TITLE
Adds feature from Boto missing in ec2_lc module

### DIFF
--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -91,6 +91,12 @@ options:
     required: false
     default: null
     aliases: []
+  instance_profile_name:
+    description:
+      - The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instances.
+    required: false
+    default: null
+    aliases: []
 extends_documentation_fragment: aws
 """
 
@@ -153,6 +159,7 @@ def create_launch_config(connection, module):
     instance_monitoring = module.params.get('instance_monitoring')
     kernel_id = module.params.get('kernel_id')
     ramdisk_id = module.params.get('ramdisk_id')
+    instance_profile_name = module.params.get('instance_profile_name')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -175,7 +182,8 @@ def create_launch_config(connection, module):
         instance_monitoring=instance_monitoring,
         kernel_id=kernel_id,
         spot_price=spot_price,
-        ramdisk_id=ramdisk_id)
+        ramdisk_id=ramdisk_id,
+        instance_profile_name=instance_profile_name)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -219,6 +227,7 @@ def main():
             spot_price=dict(type='float'),
             instance_monitoring=dict(default=False, type='bool'),
             ramdisk_id=dict(type='str'),
+            instance_profile_name=dict(type='str'),
         )
     )
 

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -97,6 +97,12 @@ options:
     required: false
     default: null
     aliases: []
+  ebs_optimized:
+    description:
+      - Specifies whether the instance is optimized for EBS I/O (true) or not (false).
+    required: false
+    default: false
+    aliases: []
 extends_documentation_fragment: aws
 """
 
@@ -160,6 +166,7 @@ def create_launch_config(connection, module):
     kernel_id = module.params.get('kernel_id')
     ramdisk_id = module.params.get('ramdisk_id')
     instance_profile_name = module.params.get('instance_profile_name')
+    ebs_optimized = module.params.get('ebs_optimized')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -183,7 +190,8 @@ def create_launch_config(connection, module):
         kernel_id=kernel_id,
         spot_price=spot_price,
         ramdisk_id=ramdisk_id,
-        instance_profile_name=instance_profile_name)
+        instance_profile_name=instance_profile_name,
+        ebs_optimized=ebs_optimized)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -228,6 +236,7 @@ def main():
             instance_monitoring=dict(default=False, type='bool'),
             ramdisk_id=dict(type='str'),
             instance_profile_name=dict(type='str'),
+            ebs_optimized=dict(default=False, type='bool'),
         )
     )
 

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -68,6 +68,12 @@ options:
     required: false
     default: null
     aliases: []
+  kern_id:
+    description:
+      - Kernel id for the EC2 instance
+    required: false
+    default: null
+    aliases: []    
   spot_price:
     description:
       - The spot price you are bidding. Only applies for an autoscaling group with spot instances.
@@ -139,6 +145,7 @@ def create_launch_config(connection, module):
     instance_type = module.params.get('instance_type')
     spot_price = module.params.get('spot_price')
     instance_monitoring = module.params.get('instance_monitoring')
+    kern_id = module.params.get('kern_id')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -158,8 +165,9 @@ def create_launch_config(connection, module):
         user_data=user_data,
         block_device_mappings=[bdm],
         instance_type=instance_type,
-        spot_price=spot_price,
-        instance_monitoring=instance_monitoring)
+        instance_monitoring=instance_monitoring,
+        kern_id=kern_id,
+        spot_price=spot_price)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -196,6 +204,7 @@ def main():
             key_name=dict(type='str'),
             security_groups=dict(type='list'),
             user_data=dict(type='str'),
+            kern_id=dict(type='str'),
             volumes=dict(type='list'),
             instance_type=dict(type='str'),
             state=dict(default='present', choices=['present', 'absent']),

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -193,13 +193,13 @@ def create_launch_config(connection, module):
         user_data=user_data,
         block_device_mappings=[bdm],
         instance_type=instance_type,
-        instance_monitoring=instance_monitoring,
         kernel_id=kernel_id,
         spot_price=spot_price,
         ramdisk_id=ramdisk_id,
         instance_profile_name=instance_profile_name,
         ebs_optimized=ebs_optimized,
-        associate_public_ip_address=associate_public_ip_address)
+        associate_public_ip_address=associate_public_ip_address,
+        instance_monitoring=instance_monitoring)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -241,11 +241,11 @@ def main():
             instance_type=dict(type='str'),
             state=dict(default='present', choices=['present', 'absent']),
             spot_price=dict(type='float'),
-            instance_monitoring=dict(default=False, type='bool'),
             ramdisk_id=dict(type='str'),
             instance_profile_name=dict(type='str'),
             ebs_optimized=dict(default=False, type='bool'),
             associate_public_ip_address=dict(type='bool'),
+            instance_monitoring=dict(default=False, type='bool'),
         )
     )
 

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -103,6 +103,12 @@ options:
     required: false
     default: false
     aliases: []
+  associate_public_ip_address:
+    description: 
+      - Used for Auto Scaling groups that launch instances into an Amazon Virtual Private Cloud. Specifies whether to assign a public IP address to each instance launched in a Amazon VPC.
+    required: false
+    default: false
+    aliases: []
 extends_documentation_fragment: aws
 """
 
@@ -167,6 +173,7 @@ def create_launch_config(connection, module):
     ramdisk_id = module.params.get('ramdisk_id')
     instance_profile_name = module.params.get('instance_profile_name')
     ebs_optimized = module.params.get('ebs_optimized')
+    associate_public_ip_address = module.params.get('associate_public_ip_address')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -191,7 +198,8 @@ def create_launch_config(connection, module):
         spot_price=spot_price,
         ramdisk_id=ramdisk_id,
         instance_profile_name=instance_profile_name,
-        ebs_optimized=ebs_optimized)
+        ebs_optimized=ebs_optimized,
+        associate_public_ip_address=associate_public_ip_address)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -237,6 +245,7 @@ def main():
             ramdisk_id=dict(type='str'),
             instance_profile_name=dict(type='str'),
             ebs_optimized=dict(default=False, type='bool'),
+            associate_public_ip_address=dict(type='bool'),
         )
     )
 

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -68,7 +68,7 @@ options:
     required: false
     default: null
     aliases: []
-  kern_id:
+  kernel_id:
     description:
       - Kernel id for the EC2 instance
     required: false
@@ -84,6 +84,12 @@ options:
       - whether instances in group are launched with detailed monitoring.
     required: false
     default: false
+    aliases: []
+  ramdisk_id:
+    description:
+      - A RAM disk id for the instances.
+    required: false
+    default: null
     aliases: []
 extends_documentation_fragment: aws
 """
@@ -145,7 +151,8 @@ def create_launch_config(connection, module):
     instance_type = module.params.get('instance_type')
     spot_price = module.params.get('spot_price')
     instance_monitoring = module.params.get('instance_monitoring')
-    kern_id = module.params.get('kern_id')
+    kernel_id = module.params.get('kernel_id')
+    ramdisk_id = module.params.get('ramdisk_id')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -166,8 +173,9 @@ def create_launch_config(connection, module):
         block_device_mappings=[bdm],
         instance_type=instance_type,
         instance_monitoring=instance_monitoring,
-        kern_id=kern_id,
-        spot_price=spot_price)
+        kernel_id=kernel_id,
+        spot_price=spot_price,
+        ramdisk_id=ramdisk_id)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -204,12 +212,13 @@ def main():
             key_name=dict(type='str'),
             security_groups=dict(type='list'),
             user_data=dict(type='str'),
-            kern_id=dict(type='str'),
+            kernel_id=dict(type='str'),
             volumes=dict(type='list'),
             instance_type=dict(type='str'),
             state=dict(default='present', choices=['present', 'absent']),
             spot_price=dict(type='float'),
             instance_monitoring=dict(default=False, type='bool'),
+            ramdisk_id=dict(type='str'),
         )
     )
 


### PR DESCRIPTION
This PR adds the feature present in Boto and missing in Ansible ec2_lc:
- kernel_id for custom kernel
- ramdisk_id for custom ramdisk
- instance_profile_name to launch instances within an IAM role
- ebs_optimized (to launch an EBS optimized instance or not)
- associate_public_ip_address to associate a public IP address within a VPC
- instance_monitoring to enable Cloudwatch on the instance (replaces https://github.com/ansible/ansible/pull/7896)
