### PR TITLE
added the missing -f option to mkfs if force used

### DIFF
--- a/library/system/filesystem
+++ b/library/system/filesystem
@@ -96,9 +96,9 @@ def main():
         mkfs = module.get_bin_path('mkfs', required=True)
         cmd = None
         if opts is None:
-            cmd = "%s -t %s '%s'" % (mkfs, fstype, dev)
+            cmd = "%s -f -t %s '%s'" % (mkfs, fstype, dev)
         else:
-            cmd = "%s -t %s %s '%s'" % (mkfs, fstype, opts, dev)
+            cmd = "%s -f -t %s %s '%s'" % (mkfs, fstype, opts, dev)
         rc,_,err = module.run_command(cmd)
         if rc == 0:
             changed = True

--- a/library/system/filesystem
+++ b/library/system/filesystem
@@ -96,9 +96,9 @@ def main():
         mkfs = module.get_bin_path('mkfs', required=True)
         cmd = None
         if opts is None:
-            cmd = "%s -f -t %s '%s'" % (mkfs, fstype, dev)
+            cmd = "%s -F -t %s '%s'" % (mkfs, fstype, dev)
         else:
-            cmd = "%s -f -t %s %s '%s'" % (mkfs, fstype, opts, dev)
+            cmd = "%s -F -t %s  %s '%s'" % (mkfs, fstype, opts, dev)
         rc,_,err = module.run_command(cmd)
         if rc == 0:
             changed = True


### PR DESCRIPTION
the -f flag is not specified in the mkfs command line, so the fs will not be created even if the force=yes option is set in the playbook.
I added the -f in any case as the test case to stop the format if the fs already exists is done before in the 

```
elif fs and not force:
        module.fail_json(msg="'%s' is already used as %s, use force=yes to overwrite"%(dev,fs), rc=rc, err=err)
```
