### PR TITLE
nova.py: Set defaults for OpenStack settings

### DIFF
--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -148,8 +148,14 @@ NOVA_CONFIG_FILES = [os.getcwd() + "/nova.ini",
                      os.path.expanduser(os.environ.get('ANSIBLE_CONFIG', "~/nova.ini")),
                      "/etc/ansible/nova.ini"]
 
+NOVA_DEFAULTS = {
+    'auth_system': None,
+    'region_name': None,
+}
+
+
 def nova_load_config_file():
-    p = ConfigParser.SafeConfigParser()
+    p = ConfigParser.SafeConfigParser(NOVA_DEFAULTS)
 
     for path in NOVA_CONFIG_FILES:
         if os.path.exists(path):


### PR DESCRIPTION
`nova.py`: Set defaults for OpenStack settings
- `auth_system`
- `region_name`

These are config settings that could be left out in many scenarios, but the current code is requiring them. With this in place, I can get by with this minimal .ini file:

``` ini
[openstack]
version=1.1
auth_url=http://{keystone_host}:5000/v2.0
project_id=web
username={username}
api_key={password}
```

Cc: @jimi-c, @sontek, @aconrad
