### PR TITLE
Add option to return all EC2/RDS instances regardless of state.

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -42,6 +42,14 @@ route53 = False
 # 'route53_excluded_zones' as a comma-separated list.
 # route53_excluded_zones = samplezone1.com, samplezone2.com
 
+# By default, only EC2 instances in the 'running' state are returned. Set
+# 'all_instances' to True to return all instances regardless of state.
+all_instances = False
+
+# By default, only RDS instances in the 'available' state are returned.  Set
+# 'all_rds_instances' to True return all RDS instances regardless of state.
+all_rds_instances = False
+
 # API calls to EC2 are slow. For this reason, we cache the results of an API
 # call. Set this to the path you want cache files to be written to. Two files
 # will be written to this directory:

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -222,6 +222,16 @@ class Ec2Inventory(object):
             self.route53_excluded_zones.extend(
                 config.get('ec2', 'route53_excluded_zones', '').split(','))
 
+        # Return all EC2/RDS instances
+        if config.has_option('ec2', 'all_instances'):
+            self.all_instances = config.getboolean('ec2', 'all_instances')
+        else:
+            self.all_instances = False
+        if config.has_option('ec2', 'all_rds_instances'):
+            self.all_rds_instances = config.getboolean('ec2', 'all_rds_instances')
+        else:
+            self.all_rds_instances = False
+
         # Cache related
         cache_dir = os.path.expanduser(config.get('ec2', 'cache_path'))
         if not os.path.exists(cache_dir):
@@ -326,8 +336,8 @@ class Ec2Inventory(object):
         ''' Adds an instance to the inventory and index, as long as it is
         addressable '''
 
-        # Only want running instances
-        if instance.state != 'running':
+        # Only want running instances unless all_instances is True
+        if not self.all_instances and instance.state != 'running':
             return
 
         # Select the best destination address
@@ -390,8 +400,8 @@ class Ec2Inventory(object):
         ''' Adds an RDS instance to the inventory and index, as long as it is
         addressable '''
 
-        # Only want available instances
-        if instance.status != 'available':
+        # Only want available instances unless all_rds_instances is True
+        if not self.all_rds_instances and instance.status != 'available':
             return
 
         # Select the best destination address


### PR DESCRIPTION
By default, the inventory plugin only returns instances that are "running" (EC2) or "available" (RDS).  It may be desirable in certain cases (e.g. Tower inventory sync) to retrieve all instances and then filter or group hosts based on their state.  This pull request preserves the default behavior, but adds configurable options for retrieving all instances.
