### PR TITLE
Callback plugin cleanup

### DIFF
--- a/lib/ansible/callback_plugins/noop.py
+++ b/lib/ansible/callback_plugins/noop.py
@@ -41,9 +41,6 @@ class CallbackModule(object):
     def runner_on_ok(self, host, res):
         pass
 
-    def runner_on_error(self, host, msg):
-        pass
-
     def runner_on_skipped(self, host, item=None):
         pass
 

--- a/lib/ansible/callback_plugins/noop.py
+++ b/lib/ansible/callback_plugins/noop.py
@@ -89,7 +89,7 @@ class CallbackModule(object):
     def playbook_on_not_import_for_host(self, host, missing_file):
         pass
 
-    def playbook_on_play_start(self, pattern):
+    def playbook_on_play_start(self, name):
         pass
 
     def playbook_on_stats(self, stats):

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -343,9 +343,6 @@ class DefaultRunnerCallbacks(object):
     def on_ok(self, host, res):
         call_callback_module('runner_on_ok', host, res)
 
-    def on_error(self, host, msg):
-        call_callback_module('runner_on_error', host, msg)
-
     def on_skipped(self, host, item=None):
         call_callback_module('runner_on_skipped', host, item=item)
 
@@ -403,10 +400,6 @@ class CliRunnerCallbacks(DefaultRunnerCallbacks):
     def on_skipped(self, host, item=None):
         display("%s | skipped" % (host), runner=self.runner)
         super(CliRunnerCallbacks, self).on_skipped(host, item)
-
-    def on_error(self, host, err):
-        display("err: [%s] => %s\n" % (host, err), stderr=True, runner=self.runner)
-        super(CliRunnerCallbacks, self).on_error(host, err)
 
     def on_no_hosts(self):
         display("no hosts matched\n", stderr=True, runner=self.runner)
@@ -533,18 +526,6 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
             else:
                 display(msg, color='yellow', runner=self.runner)
         super(PlaybookRunnerCallbacks, self).on_ok(host, host_result)
-
-    def on_error(self, host, err):
-
-        item = err.get('item', None)
-        msg = ''
-        if item:
-            msg = "err: [%s] => (item=%s) => %s" % (host, item, err)
-        else:
-            msg = "err: [%s] => %s" % (host, err)
-
-        display(msg, color='red', stderr=True, runner=self.runner)
-        super(PlaybookRunnerCallbacks, self).on_error(host, err)
 
     def on_skipped(self, host, item=None):
         if constants.DISPLAY_SKIPPED_HOSTS:

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -695,9 +695,9 @@ class PlaybookCallbacks(object):
         display(msg, color='cyan')
         call_callback_module('playbook_on_not_import_for_host', host, missing_file)
 
-    def on_play_start(self, pattern):
-        display(banner("PLAY [%s]" % pattern))
-        call_callback_module('playbook_on_play_start', pattern)
+    def on_play_start(self, name):
+        display(banner("PLAY [%s]" % name))
+        call_callback_module('playbook_on_play_start', name)
 
     def on_stats(self, stats):
         call_callback_module('playbook_on_stats', stats)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -322,8 +322,9 @@ class PlayBook(object):
             ansible.callbacks.set_play(self.runner_callbacks, play)
             if not self._run_play(play):
                 break
-            ansible.callbacks.set_play(self.callbacks, None)
-            ansible.callbacks.set_play(self.runner_callbacks, None)
+
+        ansible.callbacks.set_play(self.callbacks, None)
+        ansible.callbacks.set_play(self.runner_callbacks, None)
 
         # summarize the results
         results = {}

--- a/plugins/callbacks/hipchat.py
+++ b/plugins/callbacks/hipchat.py
@@ -91,9 +91,6 @@ class CallbackModule(object):
     def runner_on_ok(self, host, res):
         pass
 
-    def runner_on_error(self, host, msg):
-        pass
-
     def runner_on_skipped(self, host, item=None):
         pass
 

--- a/plugins/callbacks/hipchat.py
+++ b/plugins/callbacks/hipchat.py
@@ -138,7 +138,7 @@ class CallbackModule(object):
     def playbook_on_not_import_for_host(self, host, missing_file):
         pass
 
-    def playbook_on_play_start(self, pattern):
+    def playbook_on_play_start(self, name):
         """Display Playbook and play start messages"""
 
         # This block sends information about a playbook when it starts
@@ -167,7 +167,7 @@ class CallbackModule(object):
 
         # This is where we actually say we are starting a play
         self.send_msg("%s: Starting play: %s" %
-                      (self.playbook_name, pattern))
+                      (self.playbook_name, name))
 
     def playbook_on_stats(self, stats):
         """Display info about playbook statistics"""

--- a/plugins/callbacks/log_plays.py
+++ b/plugins/callbacks/log_plays.py
@@ -108,7 +108,7 @@ class CallbackModule(object):
     def playbook_on_not_import_for_host(self, host, missing_file):
         log(host, 'NOTIMPORTED', missing_file)
 
-    def playbook_on_play_start(self, pattern):
+    def playbook_on_play_start(self, name):
         pass
 
     def playbook_on_stats(self, stats):

--- a/plugins/callbacks/log_plays.py
+++ b/plugins/callbacks/log_plays.py
@@ -63,9 +63,6 @@ class CallbackModule(object):
     def runner_on_ok(self, host, res):
         log(host, 'OK', res)
 
-    def runner_on_error(self, host, msg):
-        log(host, 'ERROR', msg)
-
     def runner_on_skipped(self, host, item=None):
         log(host, 'SKIPPED', '...')
 

--- a/plugins/callbacks/mail.py
+++ b/plugins/callbacks/mail.py
@@ -66,12 +66,6 @@ class CallbackModule(object):
         body += 'A complete dump of the error:\n\n' + str(res)
         mail(sender=sender, subject=subject, body=body)
                   
-    def runner_on_error(self, host, msg):
-        sender = '"Ansible: %s" <root>' % host
-        subject = 'Error: %s' % msg.strip('\r\n').split('\n')[0]
-        body = 'An error occured for host ' + host + ' with the following message:\n\n' + msg
-        mail(sender=sender, subject=subject, body=body)
-
     def runner_on_unreachable(self, host, res):
         sender = '"Ansible: %s" <root>' % host
         if isinstance(res, basestring):

--- a/plugins/callbacks/osx_say.py
+++ b/plugins/callbacks/osx_say.py
@@ -49,9 +49,6 @@ class CallbackModule(object):
     def runner_on_ok(self, host, res):
         say("pew", LASER_VOICE)
 
-    def runner_on_error(self, host, msg):
-        pass
-
     def runner_on_skipped(self, host, item=None):
         say("pew", LASER_VOICE)
 

--- a/plugins/callbacks/osx_say.py
+++ b/plugins/callbacks/osx_say.py
@@ -97,8 +97,8 @@ class CallbackModule(object):
     def playbook_on_not_import_for_host(self, host, missing_file):
         pass
 
-    def playbook_on_play_start(self, pattern):
-        say("Starting play: %s" % pattern, HAPPY_VOICE)
+    def playbook_on_play_start(self, name):
+        say("Starting play: %s" % name, HAPPY_VOICE)
 
     def playbook_on_stats(self, stats):
         say("Play complete", HAPPY_VOICE)


### PR DESCRIPTION
on_error / runner_on_error is never used by runner, and I can't find any indication of it being used a least as far back as v1.0, so I've removed it from built-in callbacks and example callback plugins (955dadf7431f184f249e7b1903c05f661c232908).

The playbook_on_play_start callback receives the name of the play as its argument (https://github.com/ansible/ansible/blob/devel/lib/ansible/playbook/__init__.py#L615) instead of the host pattern.  The two will be the same only if the play didn't explicitly specify a name.  I've changed the argument from 'pattern' to 'name' (30fae95efeec959be880800470459e0e58311a4b and afbc7f8a0f344c0f82d07709a0da9f353c47f54a).

When a play fails, we break out of the loop and don't clear the 'play' attribute stored on each callback plugin instance.  I've changed it so that the play is cleared whenever we finish running all plays in the playbook (4e98e3785acee725b6f70f9f30d179b62662dd10).
