### PR TITLE
Add support for config_drive to nova_compute module

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -113,6 +113,12 @@ options:
      required: false
      default: None
      version_added: "1.6"
+   config_drive:
+     description:
+        - Enable a config drive to be attached to the instance
+     required: false
+     default: false
+     version_added: "1.6"
 requirements: ["novaclient"]
 '''
 
@@ -165,6 +171,7 @@ def _create_server(module, nova):
                 'security_groups': module.params['security_groups'].split(','),
                 #userdata is unhyphenated in novaclient, but hyphenated here for consistency with the ec2 module:
                 'userdata': module.params['user_data'],
+                'config_drive': module.params['config_drive'],
     }
     if not module.params['key_name']:
         del bootkwargs['key_name']
@@ -241,7 +248,8 @@ def main():
         wait                            = dict(default='yes', choices=['yes', 'no']),
         wait_for                        = dict(default=180),
         state                           = dict(default='present', choices=['absent', 'present']),
-        user_data                       = dict(default=None)
+        user_data                       = dict(default=None),
+        config_drive                    = dict(default=False)
         ),
     )
 


### PR DESCRIPTION
The nova compute module accepts a config_drive parameter. This parameter
will cause nova to attach a CD-ROM device to an instance that contains
metadata for configuring the instance via cloud-init. Default is False.
