### PR TITLE
allow set_fact action plugin to work with loops

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -674,6 +674,17 @@ class Runner(object):
             rd_result = dict(failed=all_failed, changed=all_changed, results=results, msg=msg)
             if not all_failed:
                 del rd_result['failed']
+            # allow set_facts action plugin to work with loops
+            if self.module_name == 'set_fact':
+                facts_list = {}
+                for res in rd_result['results']:
+                    for varname in res['ansible_facts'].keys():
+                        if varname in facts_list:
+                            facts_list[varname].append(res['ansible_facts'][varname])
+                        else:
+                            facts_list[varname]=[res['ansible_facts'][varname]]
+                rd_result['ansible_facts'] = facts_list
+                del rd_result['results']
             return ReturnData(host=host, comm_ok=all_comm_ok, result=rd_result)
         else:
             self.callbacks.on_skipped(host, None)


### PR DESCRIPTION
This patch combines the different set facts in the result set into
a fact holding a list of the original facts.

This allows to create more complex lists, from simple data, to
save a result list to be used in different tasks, without having to
repeat patterns of {{ item.... }} or to combine or nest different
lookup plugins to create a list.

This is by far also a better solution than #4627
## Example:

Given this test playbook:

```

---
- hosts: localhost
  gather_facts: false
  vars:
    users:
      - name: paul
        uid: 1
        hosts:
          - host: apple
          - host: berry
      - name: pete
        uid: 2
        hosts:
          - host: banana
          - host: pear
          - host: kiwi
  tasks:
    - set_fact:
      args:
        userslist:
          name: '{{ item.0.name }}'
          uid:  '{{ item.0.uid }}'
          host: '{{ item.1.host }}'
      with_subelements: 
        - users
        - hosts
```

The original result for the set fact would be

```
    "userslist": {
        "host": "kiwi", 
        "name": "pete", 
        "uid": "2"
    }
```

With this patch, one gets:

```
    "userslist": [
        {
            "host": "apple", 
            "name": "paul", 
            "uid": "1"
        }, 
        {
            "host": "berry", 
            "name": "paul", 
            "uid": "1"
        }, 
        {
            "host": "banana", 
            "name": "pete", 
            "uid": "2"
        }, 
        {
            "host": "pear", 
            "name": "pete", 
            "uid": "2"
        }, 
        {
            "host": "kiwi", 
            "name": "pete", 
            "uid": "2"
        }
    ]

```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/8019)

<!-- Reviewable:end -->
