### PR TITLE
Fix for #7368 breaks peering connections. Unreak them.

### DIFF
--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -422,8 +422,10 @@ def create_vpc(module, vpc_conn):
                             '(igw) route, but you have no Internet Gateway'
                         )
                     route_kwargs['gateway_id'] = igw.id
-                else:
+                elif route['gw'].startswith('i-'):
                     route_kwargs['instance_id'] = route['gw']
+                else:
+                    route_kwargs['gateway_id'] = route['gw']
                 vpc_conn.create_route(new_rt.id, route['dest'], **route_kwargs)
 
             # Associate with subnets


### PR DESCRIPTION
#7368  breaks peering by making instance routing the default instead of gateway routing. This patch makes gateway routing the default again.
