### PR TITLE
removed port from domain name qualification, fixes #7941

### DIFF
--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -74,6 +74,8 @@ def get_fqdn(repo_url):
             return None
         if parts[1] != '':
             result = parts[1]
+            if ":" in result:
+                result = result.split(":")[0]
         if "@" in result:
             result = result.split("@", 1)[1]
 


### PR DESCRIPTION
urlparse "netloc" includes ":port", not wanted for this function. This change fixes issue #7941 
