### PR TITLE
Added support for general purpose SSD EBS volume_type

### DIFF
--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -48,6 +48,13 @@ options:
     required: false
     default: null
     aliases: []
+  volume_type:
+    description:
+      - Type of EBS volume volume: gp2 (general purpose SSD), io1 (Provisioned IOPS SSD), standard (EBS magnetic). For more info: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-CreateVolume.html 
+    required: false
+    default: standard
+    aliases: []
+    version_added: "1.7"
   iops:
     description:
       - the provisioned IOPs you want to associate with this volume (integer).
@@ -113,6 +120,14 @@ EXAMPLES = '''
     volume_size: 5 
     iops: 200
     device_name: sdd
+
+# Example using general purpose SSD
+- local_action:
+    module: ec2_vol
+    instance: XXXXXX
+    volume_size: 5
+    volume_type: gp2
+    device_name: xvdf
 
 # Example using snapshot id
 - local_action:
@@ -221,11 +236,13 @@ def create_volume(module, ec2, zone):
     iops = module.params.get('iops')
     volume_size = module.params.get('volume_size')
     snapshot = module.params.get('snapshot')
-    # If custom iops is defined we use volume_type "io1" rather than the default of "standard"
-    if iops:
+    volume_type = module.params.get('volume_type')
+    # If custom iops is defined we use volume_type "io1" rather than the default of "standard", as long as volume type != gp2
+    # This is backwards compatible with the previous implementation of "if iops: volume_type = io1" and prevents users from assuming they are provisioning iops for a general purpose ssd
+    if iops and volume_type == "standard":
         volume_type = 'io1'
-    else:
-        volume_type = 'standard'
+    elif iops and volume_type == "gp2":
+        module.fail_json(msg = "Parameters are not compatible: [iops and volume_type of gp2] General Purpose SSD's cannot use provisioned iops.")
 
     # If no instance supplied, try volume creation based on module parameters.
     if name or id:
@@ -305,7 +322,8 @@ def main():
             device_name = dict(),
             zone = dict(aliases=['availability_zone', 'aws_zone', 'ec2_zone']),
             snapshot = dict(),
-            state = dict(choices=['absent', 'present'], default='present')
+            state = dict(choices=['absent', 'present'], default='present'),
+            volume_type = dict(choices=['standard', 'io1', 'gp2'], default='standard')
         )
     )
     module = AnsibleModule(argument_spec=argument_spec)
@@ -319,6 +337,7 @@ def main():
     zone = module.params.get('zone')
     snapshot = module.params.get('snapshot')
     state = module.params.get('state')
+    volume_type = module.params.get('volume_type')
 
     ec2 = ec2_connect(module)
 


### PR DESCRIPTION
This adds support for AWS general purpose SSD volumes: http://aws.amazon.com/ebs/details/ 
- volume_type module parameter added which defaults to standard if one is not specified
- if standard and iops are both specified, volume_type is changed to io1 for backwards compatibility (as opposed to requiring the user to now specify volume_type in plays) .
- if gp2 volume_type is specified with an iops value, the play will error. Defaulting this to io1 as well seemed assuming to much since it's reasonable that one could mix up he ssd types, and there are performance/cost ramifications between the two types. 

Not a huge fan of assuming if iops are specified the volume_type should be silently changed to io1 from standard, but it seemed best for maintaining backwards compatibility. 

Thanks!
iain
