### PR TITLE
Support setting targets on firewall rules

### DIFF
--- a/library/cloud/gce_net
+++ b/library/cloud/gce_net
@@ -66,6 +66,12 @@ options:
     required: false
     default: null
     aliases: []
+  target_tags:
+    description:
+      - the target instance tags for creating a firewall rule
+    required: false
+    default: null
+    aliases: []
   state:
     description:
       - desired state of the persistent disk
@@ -157,6 +163,7 @@ def main():
             name = dict(),
             src_range = dict(),
             src_tags = dict(type='list'),
+            target_tags = dict(type='list'),
             state = dict(default='present'),
             service_account_email = dict(),
             pem_file = dict(),
@@ -172,6 +179,7 @@ def main():
     name = module.params.get('name')
     src_range = module.params.get('src_range')
     src_tags = module.params.get('src_tags')
+    target_tags = module.params.get('target_tags')
     state = module.params.get('state')
 
     changed = False
@@ -204,7 +212,7 @@ def main():
 
         if fwname:
             # user creating a firewall rule
-            if not allowed and not src_range and not src_tags:
+            if not allowed and not src_range and not src_tags and not target_tags:
                 if changed and network:
                     module.fail_json(
                         msg="Network created, but missing required " + \
@@ -217,7 +225,8 @@ def main():
 
             try:
                 gce.ex_create_firewall(fwname, allowed_list, network=name,
-                        source_ranges=src_range, source_tags=src_tags)
+                        source_ranges=src_range, source_tags=src_tags,
+                        target_tags=target_tags)
                 changed = True
             except ResourceExistsError:
                 pass
@@ -228,6 +237,7 @@ def main():
             json_output['allowed'] = allowed
             json_output['src_range'] = src_range
             json_output['src_tags'] = src_tags
+            json_output['target_tags'] = target_tags
 
     if state in ['absent', 'deleted']:
         if fwname:


### PR DESCRIPTION
Using the gce_net module you can't set rules that allow traffic from the inside to certain instances. This patch allows you to list tags of instances that should be the target of the rules.
