### PR TITLE
Updated tag behavior for AutoScale Groups

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -69,7 +69,7 @@ options:
     default: None
   tags:
     description:
-      - List of tag dictionaries to use. Required keys are 'key', 'value'. Optional key is 'propagate_at_launch', which defaults to true.
+      - A list of tags to add to the Auto Scale Group. Optional key is 'propagate_at_launch', which defaults to true.
     required: false
     default: None
     version_added: "1.7"
@@ -98,6 +98,11 @@ EXAMPLES = '''
     max_size: 10
     desired_capacity: 5
     vpc_zone_identifier: 'subnet-abcd1234,subnet-1a2b3c4d'
+    tags:
+      - environment: production
+        propagate_at_launch: no
+
+deprecated method of expressing tags:
     tags:
       - key: environment
         value: production
@@ -167,10 +172,18 @@ def create_autoscaling_group(connection, module):
 
     asg_tags = []
     for tag in set_tags:
-        asg_tags.append(Tag(key=tag.get('key'),
-             value=tag.get('value'),
-             propagate_at_launch=bool(tag.get('propagate_at_launch', True)),
-             resource_id=group_name))
+        if tag.has_key('key') and tag.has_key('value'):  # this block is to support depricated form
+            asg_tags.append(Tag(key=tag.get('key'),
+                value=tag.get('value'),
+                propagate_at_launch=bool(tag.get('propagate_at_launch', True)),
+                resource_id=group_name))
+        else:
+            for k,v in tag.iteritems():
+                if k !='propagate_at_launch':
+                    asg_tags.append(Tag(key=k,
+                         value=v,
+                         propagate_at_launch=bool(tag.get('propagate_at_launch', True)),
+                         resource_id=group_name))
 
     if not as_groups:
         if not vpc_zone_identifier and not availability_zones:
@@ -209,15 +222,24 @@ def create_autoscaling_group(connection, module):
             existing_tags = as_group.tags
             existing_tag_map = dict((tag.key, tag) for tag in existing_tags)
             for tag in set_tags:
-                if 'key' not in tag:
-                    continue
-                if ( not tag['key'] in existing_tag_map or
-                     existing_tag_map[tag['key']].value != tag['value'] or
-                     ('propagate_at_launch' in tag and
-                     existing_tag_map[tag['key']].propagate_at_launch != tag['propagate_at_launch']) ):
-
-                    changed = True
-                    continue
+                if tag.has_key('key') and tag.has_key('value'):  # this is to support deprecated method
+                    if 'key' not in tag:
+                        continue
+                    if ( not tag['key'] in existing_tag_map or
+                        existing_tag_map[tag['key']].value != tag['value'] or
+                        ('propagate_at_launch' in tag and
+                        existing_tag_map[tag['key']].propagate_at_launch != tag['propagate_at_launch']) ):
+                        changed = True
+                        continue
+                else:
+                    for k,v in tag.iteritems():
+                        if k !='propagate_at_launch':
+                            if ( not k in existing_tag_map or
+                                existing_tag_map[k].value != v or
+                                ('propagate_at_launch' in tag and
+                                existing_tag_map[k].propagate_at_launch != tag['propagate_at_launch']) ):
+                                changed = True
+                                continue
             if changed:
                 connection.create_or_update_tags(asg_tags)
 


### PR DESCRIPTION
This pull request is intended to make the ec2_asg behave similar to the ec2 module with regards to tagging:

Currently the module expects tags in this form:

```
tags:
  - key: environment
    value: production
    propagate_at_launch: no
```

With this patch, it can be streamlined to:

```
tags:
  - environment: production
    propagate_at_launch: no
```

And makes it in line with the ec2 module's behavior:

```
instance_tags:
    db: postgres
```
