### PR TITLE
Remove validation of RDS DB instance type names because Amazon frequently adds new ones

### DIFF
--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -60,7 +60,6 @@ options:
     required: false
     default: null
     aliases: []
-    choices: [ 'db.t1.micro', 'db.m1.small', 'db.m1.medium', 'db.m1.large', 'db.m1.xlarge', 'db.m2.xlarge', 'db.m2.2xlarge', 'db.m2.4xlarge', 'db.m3.medium', 'db.m3.large', 'db.m3.xlarge', 'db.m3.2xlarge', 'db.cr1.8xlarge' ]
   username:
     description:
       - Master database username. Used only when command=create.
@@ -290,7 +289,7 @@ def main():
             source_instance   = dict(required=False),
             db_engine         = dict(choices=['MySQL', 'oracle-se1', 'oracle-se', 'oracle-ee', 'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex', 'sqlserver-web', 'postgres'], required=False),
             size              = dict(required=False), 
-            instance_type     = dict(aliases=['type'], choices=['db.t1.micro', 'db.m1.small', 'db.m1.medium', 'db.m1.large', 'db.m1.xlarge', 'db.m2.xlarge', 'db.m2.2xlarge', 'db.m2.4xlarge', 'db.m3.medium', 'db.m3.large', 'db.m3.xlarge', 'db.m3.2xlarge', 'db.cr1.8xlarge'], required=False),
+            instance_type     = dict(aliases=['type'], required=False),
             username          = dict(required=False),
             password          = dict(no_log=True, required=False),
             db_name           = dict(required=False),


### PR DESCRIPTION
This PR removes the `choices` list of Amazon RDS DB instance types. Amazon frequently adds new ones, and if you try to use a newly added instance type that your Ansible distribution doesn't yet include, your deployment fails. E.g.:

```
TASK: [postgresql_rds | create PostgreSQL RDS database instance] ************** 
failed: [db-live] => {"failed": true}
msg: value of instance_type must be one of: db.t1.micro,db.m1.small,db.m1.medium,db.m1.large,db.m1.xlarge,db.m2.xlarge,db.m2.2xlarge,db.m2.4xlarge,db.m3.medium,db.m3.large,db.m3.xlarge,db.m3.2xlarge,db.cr1.8xlarge, got: db.r3.2xlarge
```

The only fix is to wait for an Ansible update that includes the new instance type, or fork/modify Ansible code.

I was the last committer to add to this list with this commit on March 3: https://github.com/ansible/ansible/commit/635fdcb5334a71b3ab798cbe358b8337f02f9314. Since then, new instance types have been added. Instead of continually updating the list in the RDS module, I propose we remove the hard-coded list altogether. This PR does that.
