### PR TITLE
Fix missing msg argument

### DIFF
--- a/library/cloud/rax_dns
+++ b/library/cloud/rax_dns
@@ -126,7 +126,7 @@ def rax_dns(module, comment, email, name, state, ttl):
                 changed = True
                 domain.get()
             except Exception, e:
-                module.fail_json('%s' % e.message)
+                module.fail_json(msg='%s' % e.message)
 
     elif state == 'absent':
         try:


### PR DESCRIPTION
The following patch adds a missing 'msg=' syntax. An exception is raised
in ansible if this block is reached during the execution of the module

```
TypeError: fail_json() takes exactly 1 argument (2 given)
```

With the 'msg=' added, you get a more informative error. For example

```
msg: No settings provided to update_domain().
```
