### PR TITLE
Gentoo/OpenRC+systemd: check for systemd if falling back to service command

### DIFF
--- a/library/system/service
+++ b/library/system/service
@@ -459,8 +459,8 @@ class LinuxService(Service):
 
             # All Gentoo profiles keep openrc even if the profile is a systemd type
             # On-going https://bugs.gentoo.org/show_bug.cgi?id=504116
-            systemd_pid = int(self.execute_command('ps ax | head -n 2 | tail -n 1 | grep systemd')[0])
-            if check_systemd(self.name) and systemd_pid == 1:
+            systemd_pid = self.execute_command('ps ax | head -n 2 | tail -n 1 | grep systemd')[0]
+            if check_systemd(self.name) and systemd_pid == '1':
                 self.svc_cmd = location['systemctl']
         elif location.get('start', None) and os.path.exists("/etc/init/%s.conf" % self.name):
             # upstart -- rather than being managed by one command, start/stop/restart are actual commands

--- a/library/system/service
+++ b/library/system/service
@@ -459,8 +459,10 @@ class LinuxService(Service):
 
             # All Gentoo profiles keep openrc even if the profile is a systemd type
             # On-going https://bugs.gentoo.org/show_bug.cgi?id=504116
-            systemd_pid = self.execute_command('ps ax | head -n 2 | tail -n 1 | grep systemd')[0]
-            if check_systemd(self.name) and systemd_pid == '1':
+            psbin = self.module.get_bin_path('ps', True)
+            lines = [x for x in self.module.run_command([psbin, '-ef'])[1].splitlines()
+                     if x.endswith('/systemd') and re.match(r'^root\s+1\s+', x)]
+            if check_systemd(self.name) and len(lines) == 1:
                 self.svc_cmd = location['systemctl']
         elif location.get('start', None) and os.path.exists("/etc/init/%s.conf" % self.name):
             # upstart -- rather than being managed by one command, start/stop/restart are actual commands

--- a/library/system/service
+++ b/library/system/service
@@ -456,6 +456,12 @@ class LinuxService(Service):
         if location.get('service', None) and os.path.exists("/etc/init.d/%s" % self.name):
             # SysV init script
             self.svc_cmd = location['service']
+
+            # All Gentoo profiles keep openrc even if the profile is a systemd type
+            # On-going https://bugs.gentoo.org/show_bug.cgi?id=504116
+            systemd_pid = int(self.execute_command('ps ax | head -n 2 | tail -n 1 | grep systemd')[0])
+            if check_systemd(self.name) and systemd_pid == 1:
+                self.svc_cmd = location['systemctl']
         elif location.get('start', None) and os.path.exists("/etc/init/%s.conf" % self.name):
             # upstart -- rather than being managed by one command, start/stop/restart are actual commands
             self.svc_cmd = ''


### PR DESCRIPTION
Currently there are some issues with systemd on Gentoo:
https://bugs.gentoo.org/show_bug.cgi?id=504116

For this reason, every profile even if systemd has openrc pulled in by default because otherwise some applications and scripts would break. Until the bug is resolved, all Gentoo machines using systemd will have OpenRC installed as well even if it is not necessarily being fully utilised.

This fix ensures that if `service` is found in `$PATH` (which points to `/sbin/rc`) and systemd is detected as PID 1, then `systemctl` gets used. Without this change, `service` will be used (and always say changed as true and somehow not fail).
