### PR TITLE
on_failure error handlers

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -211,11 +211,11 @@ class AggregateStats(object):
         prev = (getattr(self, what)).get(host, 0)
         getattr(self, what)[host] = prev+1
 
-    def compute(self, runner_results, setup=False, poll=False, ignore_errors=False):
+    def compute(self, runner_results, setup=False, poll=False, ignore_errors=False, on_failure=False):
         ''' walk through all results and increment stats '''
 
         for (host, value) in runner_results.get('contacted', {}).iteritems():
-            if not ignore_errors and (('failed' in value and bool(value['failed'])) or
+            if ((not ignore_errors) or (ignore_errors and on_failure))  and (('failed' in value and bool(value['failed'])) or
                 ('failed_when_result' in value and [value['failed_when_result']] or ['rc' in value and value['rc'] != 0])[0]):
                 self._increment('failures', host)
             elif 'skipped' in value and bool(value['skipped']):

--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -578,6 +578,9 @@ class PlaybookCallbacks(object):
 
     def on_notify(self, host, handler):
         call_callback_module('playbook_on_notify', host, handler)
+        
+    def on_failure(self, host, error_handler):
+        call_callback_module('playbook_on_failure', host, error_handler)
 
     def on_no_hosts_matched(self):
         display("skipping: no hosts matched", color='cyan')

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -495,8 +495,7 @@ class PlayBook(object):
                         self._flag_handler(play, template(play.basedir, handler_name, task.module_vars), host)
                         
         # flag which error handlers need to be run
-        if len(task.on_failure) > 0:
-            task.ignore_errors = True
+        if len(task.on_failure) > 0 and task.ignore_errors:
             for host, results in results.get('contacted',{}).iteritems():
               if (('failed' in results and bool(results['failed'])) or
                   ('failed_when_result' in results and [results['failed_when_result']] or ['rc' in results and results['rc'] != 0])[0]):

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -528,7 +528,7 @@ class PlayBook(object):
     
     # *****************************************************
 
-    def _flag_error_handler(self, play, handler_name, host):
+    def _flag_error_handler(self, play, error_handler_name, host):
         '''
         if a task has any on_failure elements, flag error handlers for run
         at end of task execution for hosts that have indicated

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -496,6 +496,7 @@ class PlayBook(object):
                         
         # flag which error handlers need to be run
         if len(task.on_failure) > 0:
+            task.ignore_errors = True
             for host, results in results.get('contacted',{}).iteritems():
               if (('failed' in results and bool(results['failed'])) or
                   ('failed_when_result' in results and [results['failed_when_result']] or ['rc' in results and results['rc'] != 0])[0]):

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -540,8 +540,7 @@ class PlayBook(object):
             if error_handler_name == template(play.basedir, x.name, x.module_vars):
                 found = True
                 self.callbacks.on_failure(host, x.name)
-                x.notified_by.append(host)
-                self._run_task(play, x, True)
+                x.notified_by.append(host)                
         if not found:
             raise errors.AnsibleError("error handler (%s) is not defined" % error_handler_name)
 
@@ -709,7 +708,8 @@ class PlayBook(object):
                         # if we got exactly no hosts on the first step (setup!) then the host group
                         # just didn't match anything and that's ok
                         return False
-
+                # run any task error handlers
+                self.run_error_handlers(play)
                 # Get a new list of what hosts are left as available, the ones that
                 # did not go fail/dark during the task
                 host_list = self._trim_unavailable_hosts(play._play_hosts)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -35,7 +35,7 @@ class Play(object):
        'handlers', 'remote_user', 'remote_port', 'included_roles', 'accelerate',
        'accelerate_port', 'accelerate_ipv6', 'sudo', 'sudo_user', 'transport', 'playbook',
        'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
-       'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts', 'su', 'su_user', 'vault_password'
+       'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts', 'su', 'su_user', 'vault_password', 'error_handlers'
     ]
 
     # to catch typos and so forth -- these are userland names
@@ -45,7 +45,7 @@ class Play(object):
        'tasks', 'handlers', 'remote_user', 'user', 'port', 'include', 'accelerate', 'accelerate_port', 'accelerate_ipv6',
        'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'serial',
        'any_errors_fatal', 'roles', 'role_names', 'pre_tasks', 'post_tasks', 'max_fail_percentage',
-       'su', 'su_user', 'vault_password'
+       'su', 'su_user', 'vault_password', 'error_handlers'
     ]
 
     # *************************************************
@@ -101,9 +101,11 @@ class Play(object):
         # tasks/handlers as they may have inventory scope overrides
         _tasks    = ds.pop('tasks', [])
         _handlers = ds.pop('handlers', [])
+        _error_handlers = ds.pop('error_handlers', [])
         ds = template(basedir, ds, self.vars)
         ds['tasks'] = _tasks
         ds['handlers'] = _handlers
+        ds['error_handlers'] = _error_handlers
 
         self._ds = ds
 
@@ -117,6 +119,7 @@ class Play(object):
         self.name             = ds.get('name', self.hosts)
         self._tasks           = ds.get('tasks', [])
         self._handlers        = ds.get('handlers', [])
+        self._error_handlers  = ds.get('error_handlers', [])
         self.remote_user      = ds.get('remote_user', ds.get('user', self.playbook.remote_user))
         self.remote_port      = ds.get('port', self.playbook.remote_port)
         self.sudo             = ds.get('sudo', self.playbook.sudo)
@@ -149,8 +152,9 @@ class Play(object):
         if self.playbook.inventory.basedir() is not None:
             load_vars['inventory_dir'] = self.playbook.inventory.basedir()
 
-        self._tasks      = self._load_tasks(self._ds.get('tasks', []), load_vars)
-        self._handlers   = self._load_tasks(self._ds.get('handlers', []), load_vars)
+        self._tasks            = self._load_tasks(self._ds.get('tasks', []), load_vars)
+        self._handlers         = self._load_tasks(self._ds.get('handlers', []), load_vars)
+        self._error_handlers   = self._load_tasks(self._ds.get('error_handlers', []), load_vars)
 
         # apply any missing tags to role tasks
         self._late_merge_role_tags()
@@ -340,9 +344,10 @@ class Play(object):
         # a role is a name that auto-includes the following if they exist
         #    <rolename>/tasks/main.yml
         #    <rolename>/handlers/main.yml
+        #    <rolename>/errors/main.yml
         #    <rolename>/vars/main.yml
         #    <rolename>/library
-        # and it auto-extends tasks/handlers/vars_files/module paths as appropriate if found
+        # and it auto-extends tasks/handlers/vars_files/module/errors paths as appropriate if found
 
         if roles is None:
             roles = []
@@ -351,6 +356,7 @@ class Play(object):
 
         new_tasks = []
         new_handlers = []
+        new_error_handlers = []
         new_vars_files = []
         defaults_files = []
 
@@ -380,23 +386,25 @@ class Play(object):
                 if k in role_vars:
                     special_vars[k] = role_vars[k]
 
-            task_basepath     = utils.path_dwim(self.basedir, os.path.join(role_path, 'tasks'))
-            handler_basepath  = utils.path_dwim(self.basedir, os.path.join(role_path, 'handlers'))
-            vars_basepath     = utils.path_dwim(self.basedir, os.path.join(role_path, 'vars'))
-            meta_basepath     = utils.path_dwim(self.basedir, os.path.join(role_path, 'meta'))
-            defaults_basepath = utils.path_dwim(self.basedir, os.path.join(role_path, 'defaults'))
+            task_basepath            = utils.path_dwim(self.basedir, os.path.join(role_path, 'tasks'))
+            handler_basepath         = utils.path_dwim(self.basedir, os.path.join(role_path, 'handlers'))
+            error_handlers_basepath  = utils.path_dwim(self.basedir, os.path.join(role_path, 'errors'))
+            vars_basepath            = utils.path_dwim(self.basedir, os.path.join(role_path, 'vars'))
+            meta_basepath            = utils.path_dwim(self.basedir, os.path.join(role_path, 'meta'))
+            defaults_basepath        = utils.path_dwim(self.basedir, os.path.join(role_path, 'defaults'))
 
-            task      = self._resolve_main(task_basepath)
-            handler   = self._resolve_main(handler_basepath)
-            vars_file = self._resolve_main(vars_basepath)
-            meta_file = self._resolve_main(meta_basepath)
-            defaults_file = self._resolve_main(defaults_basepath)
+            task            = self._resolve_main(task_basepath)
+            handler         = self._resolve_main(handler_basepath)
+            error_handler   = self._resolve_main(error_handlers_basepath)
+            vars_file       = self._resolve_main(vars_basepath)
+            meta_file       = self._resolve_main(meta_basepath)
+            defaults_file   = self._resolve_main(defaults_basepath)
 
             library   = utils.path_dwim(self.basedir, os.path.join(role_path, 'library'))
 
             missing = lambda f: not os.path.isfile(f)
-            if missing(task) and missing(handler) and missing(vars_file) and missing(defaults_file) and missing(meta_file) and missing(library):
-                raise errors.AnsibleError("found role at %s, but cannot find %s or %s or %s or %s or %s or %s" % (role_path, task, handler, vars_file, defaults_file, meta_file, library))
+            if missing(task) and missing(handler) and missing(error_handler) and missing(vars_file) and missing(defaults_file) and missing(meta_file) and missing(library):
+                raise errors.AnsibleError("found role at %s, but cannot find %s or %s or %s or %s or %s or %s or %s" % (role_path, task, handler, error_handler, vars_file, defaults_file, meta_file, library))
 
             if isinstance(role, dict):
                 role_name = role['role']
@@ -415,7 +423,13 @@ class Play(object):
                 for k in special_keys:
                     if k in special_vars:
                         nt[k] = special_vars[k]
-                new_handlers.append(nt)
+                new_handlers.append(nt)           
+            if os.path.isfile(error_handler):
+                nt = dict(include=pipes.quote(error_handler), vars=role_vars, role_name=role_name)
+                for k in special_keys:
+                    if k in special_vars:
+                        nt[k] = special_vars[k]
+                new_error_handlers.append(nt)
             if os.path.isfile(vars_file):
                 new_vars_files.append(vars_file)
             if os.path.isfile(defaults_file):
@@ -423,15 +437,18 @@ class Play(object):
             if os.path.isdir(library):
                 utils.plugins.module_finder.add_directory(library)
 
-        tasks      = ds.get('tasks', None)
-        post_tasks = ds.get('post_tasks', None)
-        handlers   = ds.get('handlers', None)
-        vars_files = ds.get('vars_files', None)
+        tasks            = ds.get('tasks', None)
+        post_tasks       = ds.get('post_tasks', None)
+        handlers         = ds.get('handlers', None)
+        error_handlers   = ds.get('error_handlers', None)
+        vars_files       = ds.get('vars_files', None)
 
         if type(tasks) != list:
             tasks = []
         if type(handlers) != list:
-            handlers = []
+            handlers = []       
+        if type(error_handlers) != list:
+            error_handlers = []
         if type(vars_files) != list:
             vars_files = []
         if type(post_tasks) != list:
@@ -445,10 +462,12 @@ class Play(object):
         new_tasks.append(dict(meta='flush_handlers'))
 
         new_handlers.extend(handlers)
+        new_error_handlers.extend(error_handlers)
         new_vars_files.extend(vars_files)
 
         ds['tasks'] = new_tasks
         ds['handlers'] = new_handlers
+        ds['error_handlers'] = new_error_handlers
         ds['vars_files'] = new_vars_files
         ds['role_names'] = role_names
 
@@ -627,6 +646,10 @@ class Play(object):
     def handlers(self):
         ''' return handler objects for this play '''
         return self._handlers
+        
+    def error_handlers(self):
+        ''' return error handler objects for this play '''
+        return self._error_handlers
 
     # *************************************************
 
@@ -715,7 +738,9 @@ class Play(object):
             if not task.meta:
                 all_tags.extend(task.tags)
         for handler in self._handlers:
-            all_tags.extend(handler.tags)
+            all_tags.extend(handler.tags)     
+        for error_handler in self._error_handlers:
+            all_tags.extend(error_handler.tags)
 
         # compare the lists of tags using sets and return the matched and unmatched
         all_tags_set = set(all_tags)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -34,7 +34,7 @@ class Play(object):
        'hosts', 'name', 'vars', 'default_vars', 'vars_prompt', 'vars_files',
        'handlers', 'remote_user', 'remote_port', 'included_roles', 'accelerate',
        'accelerate_port', 'accelerate_ipv6', 'sudo', 'sudo_user', 'transport', 'playbook',
-       'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
+       'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks', '_error_handlers',
        'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts', 'su', 'su_user', 'vault_password', 'error_handlers'
     ]
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -31,7 +31,7 @@ class Task(object):
         'local_action', 'transport', 'sudo', 'remote_user', 'sudo_user', 'sudo_pass',
         'items_lookup_plugin', 'items_lookup_terms', 'environment', 'args',
         'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until',
-        'su', 'su_user', 'su_pass', 'no_log',
+        'su', 'su_user', 'su_pass', 'no_log', 'on_failure',
     ]
 
     # to prevent typos and such
@@ -41,7 +41,7 @@ class Task(object):
          'delegate_to', 'local_action', 'transport', 'remote_user', 'sudo', 'sudo_user',
          'sudo_pass', 'when', 'connection', 'environment', 'args',
          'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until',
-         'su', 'su_user', 'su_pass', 'no_log',
+         'su', 'su_user', 'su_pass', 'no_log', 'on_failure',
     ]
 
     def __init__(self, play, ds, module_vars=None, default_vars=None, additional_conditions=None, role_name=None):
@@ -213,6 +213,7 @@ class Task(object):
         self.async_poll_interval = template.template_from_string(play.basedir, self.async_poll_interval, self.module_vars)
         self.async_poll_interval = int(self.async_poll_interval)
         self.notify = ds.get('notify', [])
+        self.on_failure = ds.get('on_failure', [])
         self.first_available_file = ds.get('first_available_file', None)
 
         self.items_lookup_plugin = ds.get('items_lookup_plugin', None)
@@ -231,6 +232,10 @@ class Task(object):
         # notify can be a string or a list, store as a list
         if isinstance(self.notify, basestring):
             self.notify = [ self.notify ]
+            
+        # on_failure can be a string or a list, store as a list
+        if isinstance(self.on_failure, basestring):
+            self.on_failure = [ self.on_failure ]
 
         # split the action line into a module name + arguments
         tokens = self.action.split(None, 1)

--- a/test/integration/roles/test_error_handlers/errors/include_handler.yml
+++ b/test/integration/roles/test_error_handlers/errors/include_handler.yml
@@ -1,0 +1,10 @@
+- name: include 1st error handler
+  set_fact: 
+    error_handler_called: True
+    
+- name: include 2nd error handler
+  debug: msg="include error handler called"  
+  
+- name: 3rd conditional error handler
+  debug: msg="another include error handler"
+

--- a/test/integration/roles/test_error_handlers/errors/main.yml
+++ b/test/integration/roles/test_error_handlers/errors/main.yml
@@ -9,5 +9,4 @@
   debug: msg="3rd error handler will never be called"
   when: inventory_hostname == none  
   
-- name: error handler include
-  include: include_handler.yml
+- include: include_handler.yml

--- a/test/integration/roles/test_error_handlers/errors/main.yml
+++ b/test/integration/roles/test_error_handlers/errors/main.yml
@@ -9,5 +9,5 @@
   debug: msg="3rd error handler will never be called"
   when: inventory_hostname == none  
   
-- name: include error handler
+- name: error handler include
   include: include_handler.yml

--- a/test/integration/roles/test_error_handlers/errors/main.yml
+++ b/test/integration/roles/test_error_handlers/errors/main.yml
@@ -8,4 +8,5 @@
 - name: 3rd conditional error handler
   debug: msg="3rd error handler will never be called"
   when: inventory_hostname == none  
-
+  
+- include: include_handler.yml

--- a/test/integration/roles/test_error_handlers/errors/main.yml
+++ b/test/integration/roles/test_error_handlers/errors/main.yml
@@ -4,3 +4,8 @@
     
 - name: 2nd error handler
   debug: msg="2nd error handler called"
+  when: inventory_hostname = none    
+  
+- name: 3rd conditional error handler
+  debug: msg="3rd error handler will never be called"
+  when: inventory_hostname = none

--- a/test/integration/roles/test_error_handlers/errors/main.yml
+++ b/test/integration/roles/test_error_handlers/errors/main.yml
@@ -7,4 +7,7 @@
   
 - name: 3rd conditional error handler
   debug: msg="3rd error handler will never be called"
-  when: inventory_hostname == none
+  when: inventory_hostname == none  
+  
+- name: include error handler
+  include: include_handler.yml

--- a/test/integration/roles/test_error_handlers/errors/main.yml
+++ b/test/integration/roles/test_error_handlers/errors/main.yml
@@ -3,9 +3,8 @@
     error_handler_called: True
     
 - name: 2nd error handler
-  debug: msg="2nd error handler called"
-  when: inventory_hostname = none    
+  debug: msg="2nd error handler called"  
   
 - name: 3rd conditional error handler
   debug: msg="3rd error handler will never be called"
-  when: inventory_hostname = none
+  when: inventory_hostname == none

--- a/test/integration/roles/test_error_handlers/errors/main.yml
+++ b/test/integration/roles/test_error_handlers/errors/main.yml
@@ -1,3 +1,6 @@
 - name: 1st error handler
   set_fact: 
     error_handler_called: True
+    
+- name: 2nd error handler
+  debug: msg="2nd error handler called"

--- a/test/integration/roles/test_error_handlers/errors/main.yml
+++ b/test/integration/roles/test_error_handlers/errors/main.yml
@@ -1,0 +1,3 @@
+- name: 1st error handler
+  set_fact: 
+    error_handler_called: True

--- a/test/integration/roles/test_error_handlers/errors/main.yml
+++ b/test/integration/roles/test_error_handlers/errors/main.yml
@@ -8,5 +8,4 @@
 - name: 3rd conditional error handler
   debug: msg="3rd error handler will never be called"
   when: inventory_hostname == none  
-  
-- include: include_handler.yml
+

--- a/test/integration/roles/test_error_handlers/meta/main.yml
+++ b/test/integration/roles/test_error_handlers/meta/main.yml
@@ -1,3 +1,0 @@
-dependencies: 
-  - prepare_tests
-

--- a/test/integration/roles/test_error_handlers/meta/main.yml
+++ b/test/integration/roles/test_error_handlers/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies: 
+  - prepare_tests
+

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -30,7 +30,7 @@
 - debug: var=error_handler_called
  
 - name: notify the error handler for current task using failed_when and multi error handlers
-  shell: ping localhost
+  shell: echo 'test'
   failed_when: result is defined
   ignore_errors: yes
   on_failure: 

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -64,7 +64,7 @@
   failed_when: result is defined
   ignore_errors: yes
   on_failure: 
-    - include error handler
+    - include 2nd error handler
     
 - debug: var=error_handler_called
 

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -46,6 +46,16 @@
     - 2nd error handler
     - 3rd conditional error handler
     
+- debug: var=error_handler_called  
+
+- name: test the error handlers with failed_when and single handlers
+  shell: echo 'test'
+  register: result
+  failed_when: result is defined
+  ignore_errors: yes
+  on_failure: 
+    - 1st error handler
+    
 - debug: var=error_handler_called
 
 - name: validate the error handler ran

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -21,7 +21,7 @@
   set_fact:
     error_handler_called: False
 
-- name: notify the error handler for current task
+- name: test the error handlers with a single handler
   shell: wall 'beep'
   ignore_errors: yes
   on_failure: 
@@ -29,9 +29,8 @@
 
 - debug: var=error_handler_called
  
-- name: notify the error handler for current task using failed_when and multi error handlers
-  shell: echo 'test'
-  failed_when: result.failed is defined and result.failed == false
+- name: test the error handlers with multi error handlers
+  shell: wall 'beep'
   ignore_errors: yes
   on_failure: 
     - 1st error handler

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -58,13 +58,13 @@
     
 - debug: var=error_handler_called
 
-- name: test the error handlers with include handlers and failed_when
+- name: test the error handlers with include handlers with duplicate names
   shell: echo 'test'
   register: result
   failed_when: result is defined
   ignore_errors: yes
   on_failure: 
-    - 3rd conditional error handler
+    - include 2nd error handler
     
 - debug: var=error_handler_called
 

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: notify the error handler for current task using failed_when
   shell: wall 'beep'
-  failed_when: result.stderr != ''
+  failed_when: result.stdout == ''
   on_failure: 
     - 1st error handler
 

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -17,17 +17,12 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 
-- name: reset error_handler_called variable to false for all hosts
-  set_fact:
-    error_handler_called: False
-
 - name: test the error handlers with a single handler
   shell: wall 'beep'
   ignore_errors: yes
   on_failure: 
     - 1st error handler
-
-- debug: var=error_handler_called
+  tags: ['role_single']  
  
 - name: test the error handlers with multi error handlers
   shell: wall 'beep'
@@ -35,8 +30,7 @@
   on_failure: 
     - 1st error handler
     - 2nd error handler
-    
-- debug: var=error_handler_called 
+  tags: ['role_multi']  
 
 - name: test the error handlers with multi conditional error handlers
   shell: wall 'beep'
@@ -45,8 +39,7 @@
     - 1st error handler
     - 2nd error handler
     - 3rd conditional error handler
-    
-- debug: var=error_handler_called  
+  tags: ['role_multi_cond'] 
 
 - name: test the error handlers with failed_when
   shell: echo 'test'
@@ -55,8 +48,7 @@
   ignore_errors: yes
   on_failure: 
     - 1st error handler
-    
-- debug: var=error_handler_called
+  tags: ['role_failed_when']    
 
 - name: test the error handlers with include handlers with duplicate names
   shell: echo 'test'
@@ -64,9 +56,8 @@
   failed_when: result is defined
   ignore_errors: yes
   on_failure: 
-    - include 2nd error handler
-    
-- debug: var=error_handler_called
+    - 3rd conditional error handler
+  tags: ['role_include']     
 
 - name: validate the error handler ran
   assert:

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -22,7 +22,8 @@
     error_handler_called: False
 
 - name: notify the error handler for current task using failed_when
-  shell: wall 'beep'  
+  shell: wall 'beep'
+  ignore_errors: yes
   on_failure: 
     - 1st error handler
 

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -40,14 +40,21 @@
     - 2nd error handler
     - 3rd conditional error handler
   tags: ['role_multi_cond'] 
-
-- name: test the error handlers with failed_when
-  shell: echo 'test'
+  
+- name: make sure one of the hosts doesnt fail
+  set_fact:
+    skip_host: True
+  when: inventory_hostname == 'localhost'
+  tags: ['role_failed_when']
+  
+- name: test the error handlers with failed_when and multiple hosts
+  shell: hostname
   register: result
-  failed_when: result is defined
+  failed_when: result is defined and skip_host == True
   ignore_errors: yes
   on_failure: 
     - 1st error handler
+    - 2nd error handler
   tags: ['role_failed_when']    
 
 - name: test the error handlers with include handlers with duplicate names

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -31,7 +31,7 @@
  
 - name: notify the error handler for current task using failed_when and multi error handlers
   shell: echo 'test'
-  failed_when: result is defined
+  failed_when: result.failed is defined and result.failed == false
   ignore_errors: yes
   on_failure: 
     - 1st error handler

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: notify the error handler for current task using failed_when
   shell: wall 'beep'
-  failed_when: result.stdout == ''
+  failed_when: result | failed
   on_failure: 
     - 1st error handler
 

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -22,8 +22,7 @@
     error_handler_called: False
 
 - name: notify the error handler for current task using failed_when
-  shell: wall 'beep'
-  failed_when: result | failed
+  shell: wall 'beep'  
   on_failure: 
     - 1st error handler
 

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -36,6 +36,16 @@
     - 1st error handler
     - 2nd error handler
     
+- debug: var=error_handler_called 
+
+- name: test the error handlers with multi conditional error handlers
+  shell: wall 'beep'
+  ignore_errors: yes
+  on_failure: 
+    - 1st error handler
+    - 2nd error handler
+    - 3rd conditional error handler
+    
 - debug: var=error_handler_called
 
 - name: validate the error handler ran

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -1,0 +1,35 @@
+# test code on_failure error handlers
+# (c) 2014, Amr Abed <amrenator@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+- name: reset error_handler_called variable to false for all hosts
+  set_fact:
+    error_handler_called: False
+
+- name: notify the error handler for current task using failed_when
+  shell: wall 'beep'
+  failed_when: False
+  on_failure: 
+    - 1st error handler
+
+- debug: var=error_handler_called
+
+- name: validate the error handler ran
+  assert:
+    that:
+    - "error_handler_called == True"

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -21,12 +21,22 @@
   set_fact:
     error_handler_called: False
 
-- name: notify the error handler for current task using failed_when
+- name: notify the error handler for current task
   shell: wall 'beep'
   ignore_errors: yes
   on_failure: 
     - 1st error handler
 
+- debug: var=error_handler_called
+ 
+- name: notify the error handler for current task using failed_when and multi error handlers
+  shell: ping localhost
+  failed_when: result is defined
+  ignore_errors: yes
+  on_failure: 
+    - 1st error handler
+    - 2nd error handler
+    
 - debug: var=error_handler_called
 
 - name: validate the error handler ran

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -58,6 +58,16 @@
     
 - debug: var=error_handler_called
 
+- name: test the error handlers with include handlers and failed_when
+  shell: echo 'test'
+  register: result
+  failed_when: result is defined
+  ignore_errors: yes
+  on_failure: 
+    - include error handler
+    
+- debug: var=error_handler_called
+
 - name: validate the error handler ran
   assert:
     that:

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: notify the error handler for current task using failed_when
   shell: wall 'beep'
-  failed_when: False
+  failed_when: result.stderr != ''
   on_failure: 
     - 1st error handler
 

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -48,7 +48,7 @@
     
 - debug: var=error_handler_called  
 
-- name: test the error handlers with failed_when and single handlers
+- name: test the error handlers with failed_when
   shell: echo 'test'
   register: result
   failed_when: result is defined

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -64,7 +64,7 @@
   failed_when: result is defined
   ignore_errors: yes
   on_failure: 
-    - include 2nd error handler
+    - error handler include
     
 - debug: var=error_handler_called
 

--- a/test/integration/roles/test_error_handlers/tasks/main.yml
+++ b/test/integration/roles/test_error_handlers/tasks/main.yml
@@ -64,7 +64,7 @@
   failed_when: result is defined
   ignore_errors: yes
   on_failure: 
-    - error handler include
+    - 3rd conditional error handler
     
 - debug: var=error_handler_called
 

--- a/test/integration/test_error_handlers.yml
+++ b/test/integration/test_error_handlers.yml
@@ -7,7 +7,7 @@
   - { role: test_error_handlers }
 
 
-- name: test error handlers in playbook
+- name: test single error handlers in playbook
   hosts: all
   gather_facts: False
   connection: local
@@ -20,3 +20,24 @@
   error_handlers:
     - name: playbook error handler
       debug: msg="Play Failed"  
+      
+
+- name: test multiple error handlers in playbook
+  hosts: all
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: test the error handlers with multiple handler
+      shell: wall 'beep'
+      ignore_errors: yes
+      on_failure: 
+        - playbook error handler 1   
+        - playbook error handler 2   
+        - playbook error handler 3   
+  error_handlers:
+    - name: playbook error handler 1
+      debug: msg="Play Failed"      
+    - name: playbook error handler 2
+      debug: msg="Do something here"     
+    - name: playbook error handler 3
+      debug: msg="Do something else.. fire fail?"        

--- a/test/integration/test_error_handlers.yml
+++ b/test/integration/test_error_handlers.yml
@@ -1,6 +1,6 @@
 ---
 - name: test error handlers
-  hosts: testgroup
+  hosts: all
   gather_facts: False
   connection: local
   roles:

--- a/test/integration/test_error_handlers.yml
+++ b/test/integration/test_error_handlers.yml
@@ -5,3 +5,18 @@
   connection: local
   roles:
   - { role: test_error_handlers }
+
+
+- name: test error handlers in playbook
+  hosts: all
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: test the error handlers with a single handler
+      shell: wall 'beep'
+      ignore_errors: yes
+      on_failure: 
+        - playbook error handler    
+  error_handlers:
+    - name: playbook error handler
+      debug: msg="Play Failed"  

--- a/test/integration/test_error_handlers.yml
+++ b/test/integration/test_error_handlers.yml
@@ -1,0 +1,7 @@
+---
+- name: test error handlers
+  hosts: testgroup
+  gather_facts: False
+  connection: local
+  roles:
+  - { role: test_error_handlers }


### PR DESCRIPTION
Added `on_failure` error handlers similar to  notify handlers except these will run after each task/hosts they are attached to.

this could be considered a simple interface for error handling similar to `ignore_errors/register/when` except it allows for a cleaner playbooks, by grouping error handling tasks in separate files, it also supports inclusion in roles auto loading directory structure under the `role/errors` folder, it works with `failed_when` as well.

`role handlers go into an /errors directory inside the role main directory and are loaded from main.* file with the ability to use includes just like normal tasks/handlers`

**Things to note:**
`*ignore_errors*` i thought about making ignore_errors the default behavior when using on_failure with any task, it kinda makes sense since it's required for the feature to run properly, but need to look into it further.. 

`*using includes and handlers names*` unlike notify handlers there is no unique name checking for previously triggered handlers, need to consider if this is the right way to go or should we add the same checks present in notify handlers to ensure "an error handler is only ran once"

**Final thoughts**
i'd love to hear what you guys think about this? i am fairly new to ansible been using it for about a month and i love it, but felt like i need a cleaner way to handle errors, my use case for this is single host deployment.. for instance deploying a new appserver in a cloud cluster and wanting a way to rollback on failure without filling the playbook with error catch/handling tasks.

this is also the first time i have worked with python, so be gentle :) and please let me know if there is a better way to do this.

**Examples :**

 **Single error handler in a playbook**

```
- name: test error handlers in playbook
  hosts: all
  gather_facts: False
  connection: local
  tasks:
    - name: test the error handlers with a single handler
      shell: wall 'beep'
      ignore_errors: yes
      on_failure: 
        - playbook error handler    
  error_handlers:
    - name: playbook error handler
      debug: msg="Play Failed"  
```

 **Multiple error handler in a playbook**

```
- name: test multiple error handlers in playbook
  hosts: all
  gather_facts: False
  connection: local
  tasks:
    - name: test the error handlers with multiple handler
      shell: wall 'beep'
      ignore_errors: yes
      on_failure: 
        - playbook error handler 1   
        - playbook error handler 2   
        - playbook error handler 3   
  error_handlers:
    - name: playbook error handler 1
      debug: msg="Play Failed"      
    - name: playbook error handler 2
      debug: msg="Do something here"     
    - name: playbook error handler 3
      debug: msg="Do something else.. fire fail?" 
```

 **Error handlers in roles, Conditional handlers, when_failed**
  **in a role tasks file...**

```
- name: test the error handlers with multi conditional error handlers and failed_when
  shell: echo 'test'
  register: result
  failed_when: result is defined
  ignore_errors: yes
  on_failure: 
    - 1st error handler
    - 2nd error handler
    - 3rd conditional error handler
```

  **in a role error handlers file(s)...** 
  `role_dir\errors\main.yml`

```
- name: 1st error handler
  set_fact: 
    error_handler_called: True

- name: 2nd error handler
  debug: msg="2nd error handler called"  

- name: 3rd conditional error handler
  debug: msg="3rd error handler will never be called"
  when: inventory_hostname == none  

- include: include_handler.yml
```

  `role_dir\errors\include_handler.yml`

```
- name: include 1st error handler
  set_fact: 
    error_handler_called: True

- name: include 2nd error handler
  debug: msg="include error handler called"  

- name: 3rd conditional error handler
  debug: msg="another include error handler"
```

@mpdehaan @jimi-c 
