### PR TITLE
Added module win_domainjoin.

### DIFF
--- a/library/windows/win_domainjoin
+++ b/library/windows/win_domainjoin
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2014, Trond Hindenes <trond@hindenes.com>, and others
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_domainjoin
+version_added: "1.7"
+short_description: Adds a computer to an Active Directory domain
+description:
+     - Adds a computer to an Active Directory domain
+options:
+  domainname:
+    description:
+      - Names of the domain to add the computer to
+    required: true
+    default: null
+    aliases: []
+  domainusername:
+    description:
+      - username of an account with permissions to add a computer to the specified domain. Use the UPN syntax (username@domain) as NetBios-style usernames (DOMAIN\username) don't get passed correctly to the winrm host.
+    required: true
+    default: null
+    aliases: []
+  domainpassword:
+    description:
+      - password for the domainusername account    
+	required: true
+    default: null
+    aliases: []
+  OUPath:
+    description:
+      - The OU in which to place the computer
+    default: null
+    aliases: []
+  Restart:
+    description:
+	  - Performs the required restart automatically after the computer has been successfully joined to the domain
+	choices:
+      - yes
+      - no
+    default: null
+    aliases: []
+author: Trond Hindenes
+'''
+
+EXAMPLES = '''
+# This adds the computer to the domain mytestdomain.com.
+$ ansible -i hosts -m win_domainjoin -a "domainname=mytestdomain.com domainusername=administrator@mytestdomain.com domainpassword=Hello123" all
+$ ansible -i hosts -m win_domainjoin -a "domainname=mytestdomain.com domainusername=administrator@mytestdomain.com domainpassword=Hello123 OUPath=OU=Servers,DC=mytestdomain,DC=com" all
+
+
+# Playbook example
+---
+- name: Join Domain
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Join Domain
+      win_domainjoin:
+        domainname: "mytestdomain.com"
+		domainusername: "administrator@mytestdomain.com"
+		domainpassword: "Hello123"
+		OUPath: "OU=Servers,DC=mytestdomain,DC=com"
+
+
+'''

--- a/library/windows/win_domainjoin.ps1
+++ b/library/windows/win_domainjoin.ps1
@@ -1,0 +1,123 @@
+#!powershell
+# This file is part of Ansible.
+#
+# Copyright 2014, Trond Hindenes <trond@hindenes.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+
+$params = Parse-Args $args;
+
+$result = New-Object psobject @{
+    changed = $false
+}
+
+If ($params.domainname) {
+    $domainname = $params.domainname
+}
+Else {
+    Fail-Json $result "mising required argument: domainname"
+}
+
+If ($params.domainusername) {
+    $domainusername = $params.domainusername
+}
+Else {
+    Fail-Json $result "mising required argument: domainusername"
+}
+
+If ($params.domainpassword) {
+    $domainpassword = $params.domainpassword
+}
+Else {
+    Fail-Json $result "mising required argument: domainpassword"
+}
+
+If ($params.OUPath) {
+    $OUPath = $params.OUPath
+}
+Else {
+    $oupath = $null
+}
+
+If ($params.restart) {
+    $restart = $params.restart | ConvertTo-Bool
+}
+Else {
+    $restart = $false
+}
+
+#Test if we're already member
+if ((gwmi win32_computersystem).domain -eq $domainname)
+{
+    $JoinDOmain = $false
+}
+Else
+{
+    $JoinDomain = $true
+
+}
+
+
+if ($JoinDomain)
+{
+    #Construct credobject from username/password
+    #Test parameters
+    #new-item -ItemType file -Path "C:\win_domainjoin.txt" -Force
+    #Add-Content -Path "C:\win_domainjoin.txt" -Value $domainname
+    #Add-Content -Path "C:\win_domainjoin.txt" -Value $domainusername
+    #Add-Content -Path "C:\win_domainjoin.txt" -Value $domainpassword
+
+    $passwordsecurestring = $domainpassword | ConvertTo-SecureString -AsPlainText -Force
+    $credential = new-object System.Management.Automation.PSCredential($domainusername,$passwordsecurestring)
+
+    #Perform domain join
+    if (!($OUPath))
+    {
+        try
+        {
+            $ErrorActionPreference = "Stop"
+            Add-Computer -DomainName $domainname -Credential $credential -WarningVariable WarningVar -Restart:$restart
+        }
+        catch
+        {
+            Fail-Json $result $_.Exception.Message
+        }
+    }
+    Else
+    {
+        try
+        {
+            $ErrorActionPreference = "Stop"
+            Add-Computer -DomainName $domainname -Credential $credential -OUPath $OUPath -WarningVariable WarningVar -restart:$restart
+        }
+        catch
+        {
+            Fail-Json $result $_.Exception.Message
+        }
+    }
+
+    Set-Attr $result "domainjoin_result" $success
+    $result.changed = $true
+}
+Else
+{
+    #Already part of domain
+    $result.changed = $false
+}
+
+Exit-Json $result;


### PR DESCRIPTION
win_domainjoin allows Ansible to join a windows computer to a domain. Parameters include the ability to auto-restart after a successfull join (this is turned off by default but should possily be enabled) and which OU path (by DistinguishedName) to put the computer into. 
