### PR TITLE
get_url: Add force_basic_auth option

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -50,6 +50,7 @@ try:
 except:
     HAS_SSL=False
 
+import base64
 import os
 import re
 import socket
@@ -287,6 +288,7 @@ def url_argument_spec():
         validate_certs = dict(default='yes', type='bool'),
         url_username = dict(required=False),
         url_password = dict(required=False),
+        force_basic_auth = dict(default='no', type='bool')
     )
 
 
@@ -386,6 +388,12 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     # add the custom agent header, to help prevent issues 
     # with sites that block the default urllib agent string 
     request.add_header('User-agent', module.params.get('http_agent'))
+
+    force_basic_auth = module.params.get('force_basic_auth', False)
+
+    if force_basic_auth:
+        basic_auth_pair = base64.b64encode('{0}:{1}'.format(username, password))
+        request.add_header('Authorization', 'Basic {0}'.format(basic_auth_pair))
 
     # if we're ok with getting a 304, set the timestamp in the 
     # header, otherwise make sure we don't get a cached copy

--- a/library/network/get_url
+++ b/library/network/get_url
@@ -102,6 +102,14 @@ options:
         parameter is not specified, the C(url_password) parameter will not be used.
     required: false
     version_added: '1.6'
+  force_basic_auth:
+    description:
+      - Send Basic authentication header on the first request. Per RFC 2617,
+        urllib2 only sends authentication information when a server responds to
+        the initial request with a 401 status. Since some services do not
+        properly send a 401, logins will fail without this option enabled.
+    required: false
+    default: 'no'
   others:
     description:
       - all arguments accepted by the M(file) module also work here


### PR DESCRIPTION
Adds the `force_basic_auth` option to send HTTP Basic authentication information on the first request.

This option already exists in the `uri` module under the same name, and is used to prevent issues when authenticating to services which do not respond with a 401 to the first request.
