### PR TITLE
Restoring commit 1ed7ac6a00fc66fd51285808a64f80a65575ec4e (do not override variables if host is skipped)

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -464,6 +464,8 @@ class PlayBook(object):
 
         # add facts to the global setup cache
         for host, result in contacted.iteritems():
+            if result.get('skipped', False):
+                continue
             if 'results' in result:
                 # task ran with_ lookup plugin, so facts are encapsulated in
                 # multiple list items in the results key


### PR DESCRIPTION
Hello guys, 
this commit, of almost two years ago, fixed a problem when a skipped task was erroneously (in my opinion) overriding registered variables when skipping a task. This is the PR:

https://github.com/ansible/ansible/pull/1616

The PR got merged but there is no trace of its code neither  inside playbook/**init**.py nor inside the commit list , tracking the history of the file. This PR reintroduces it.

Without this PR, this simple playbook was failing:

```

---
- hosts: localhost
  vars:
    my_val: 10
  remote_user: alfredo
  tasks:
  - name: Print my_val
    shell: echo {{ my_val }}
    register: my_val2

  - name: Print my_val
    shell: echo {{ my_val2.stdout }}

  - name: Skip
    shell: echo {{ my_val2.stdout }}
    register: my_val2
    when: False

  - name: Re-print
    shell: echo {{ my_val2.stdout }}
```

With: 

```
TASK: [Re-print] **************************************************************
fatal: [localhost] => One or more undefined variables: 'dict object' has no attribute 'stdout'

FATAL: all hosts have already failed -- aborting
```

With this PR, now it works as expected:

```
TASK: [Skip] ******************************************************************
skipping: [localhost]

TASK: [Re-print] **************************************************************
changed: [localhost] => {"changed": true, "cmd": "echo 10 ", "delta": "0:00:00.013029", "end": "2014-07-08 11:53:58.444579", "rc": 0, "start": "2014-07-08 11:53:58.431550", "stderr": "", "stdout": "10"}
```
