### PR TITLE
cloudformation: add "stack_parameters" to result

### DIFF
--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -224,6 +224,7 @@ def main():
     # convert the template parameters ansible passes into a tuple for boto
     template_parameters_tup = [(k, v) for k, v in template_parameters.items()]
     stack_outputs = {}
+    stack_parameters = {}
 
     try:
         cf_region = Region(region)
@@ -285,6 +286,10 @@ def main():
         for output in stack.outputs:
             stack_outputs[output.key] = output.value
         result['stack_outputs'] = stack_outputs
+
+        for parameter in stack.parameters:
+            stack_parameters[parameter.key] = parameter.value
+        result['stack_parameters'] = stack_parameters
 
     # absent state is different because of the way delete_stack works.
     # problem is it it doesn't give an error if stack isn't found

--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -35,6 +35,12 @@ options:
     default: "no"
     choices: [ "yes", "no" ]
     aliases: []
+  filtered_parameters:
+    description:
+      - a list of parameters which will be filtered from result['stack_parameters']
+    required: false
+    default: []
+    aliases: []
   template_parameters:
     description:
       - a list of hashes of all the template variables for the stack
@@ -193,6 +199,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
             stack_name=dict(required=True),
+            filtered_parameters=dict(required=False, type='list', default=[]),
             template_parameters=dict(required=False, type='dict', default={}),
             state=dict(default='present', choices=['present', 'absent']),
             template=dict(default=None, required=True),
@@ -209,6 +216,7 @@ def main():
     stack_name = module.params['stack_name']
     template_body = open(module.params['template'], 'r').read()
     disable_rollback = module.params['disable_rollback']
+    filtered_parameters = module.params['filtered_parameters']
     template_parameters = module.params['template_parameters']
     tags = module.params['tags']
 
@@ -288,7 +296,8 @@ def main():
         result['stack_outputs'] = stack_outputs
 
         for parameter in stack.parameters:
-            stack_parameters[parameter.key] = parameter.value
+            if parameter.key not in filtered_parameters:
+                stack_parameters[parameter.key] = parameter.value
         result['stack_parameters'] = stack_parameters
 
     # absent state is different because of the way delete_stack works.


### PR DESCRIPTION
It's often useful to access the running parameters of the stack.
