### PR TITLE
expanded memory facts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -521,7 +521,8 @@ class LinuxHardware(Hardware):
     """
 
     platform = 'Linux'
-    MEMORY_FACTS = ['MemTotal', 'SwapTotal', 'MemFree', 'SwapFree', 'Buffers', 'Cached', 'SwapCached']
+    MEMORY_FACTS = ['MemTotal', 'SwapTotal', 'MemFree', 'SwapFree']
+    EXTRA_MEMORY_FACTS = ['Buffers', 'Cached', 'SwapCached']
 
     def __init__(self):
         Hardware.__init__(self)
@@ -546,8 +547,11 @@ class LinuxHardware(Hardware):
             key = data[0]
             if key in LinuxHardware.MEMORY_FACTS:
                 val = data[1].strip().split(' ')[0]
+                self.facts["%s_mb" % key.lower()] = long(val) / 1024
+            if key in LinuxHardware.MEMORY_FACTS or LinuxHardware.EXTRA_MEMORY_FACTS:
+                val = data[1].strip().split(' ')[0]
                 memstats[key.lower()] = long(val) / 1024
-        self.facts['memory'] = {
+        self.facts['memory_mb'] = {
                     'real' : {
                         'total': memstats['memtotal'],
                         'used': (memstats['memtotal'] - memstats['memfree']),

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -548,7 +548,7 @@ class LinuxHardware(Hardware):
             if key in LinuxHardware.MEMORY_FACTS:
                 val = data[1].strip().split(' ')[0]
                 self.facts["%s_mb" % key.lower()] = long(val) / 1024
-            if key in LinuxHardware.MEMORY_FACTS or LinuxHardware.EXTRA_MEMORY_FACTS:
+            if key in LinuxHardware.MEMORY_FACTS or key in LinuxHardware.EXTRA_MEMORY_FACTS:
                 val = data[1].strip().split(' ')[0]
                 memstats[key.lower()] = long(val) / 1024
         self.facts['memory_mb'] = {

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -521,7 +521,7 @@ class LinuxHardware(Hardware):
     """
 
     platform = 'Linux'
-    MEMORY_FACTS = ['MemTotal', 'SwapTotal', 'MemFree', 'SwapFree']
+    MEMORY_FACTS = ['MemTotal', 'SwapTotal', 'MemFree', 'SwapFree', 'Buffers', 'Cached', 'SwapCached']
 
     def __init__(self):
         Hardware.__init__(self)
@@ -538,6 +538,7 @@ class LinuxHardware(Hardware):
         return self.facts
 
     def get_memory_facts(self):
+        memstats = {}
         if not os.access("/proc/meminfo", os.R_OK):
             return
         for line in open("/proc/meminfo").readlines():
@@ -545,7 +546,24 @@ class LinuxHardware(Hardware):
             key = data[0]
             if key in LinuxHardware.MEMORY_FACTS:
                 val = data[1].strip().split(' ')[0]
-                self.facts["%s_mb" % key.lower()] = long(val) / 1024
+                memstats[key.lower()] = long(val) / 1024
+        self.facts['memory'] = {
+                    'real' : {
+                        'total': memstats['memtotal'],
+                        'used': (memstats['memtotal'] - memstats['memfree']),
+                        'free': memstats['memfree']
+                    },
+                    'nocache' : {
+                        'free': memstats['cached'] + memstats['memfree'] + memstats['buffers'],
+                        'used': memstats['memtotal'] - (memstats['cached'] + memstats['memfree'] + memstats['buffers'])
+                        },
+                    'swap' : {
+                        'total': memstats['swaptotal'],
+                        'free': memstats['swapfree'],
+                        'used': memstats['swaptotal'] - memstats['swapfree'],
+                        'cached': memstats['swapcached']
+                        }
+                }
 
     def get_cpu_facts(self):
         i = 0


### PR DESCRIPTION
This fixes the following problem https://github.com/ansible/ansible/issues/8035

As discussed in the issue tracker the output now looks like the following:

```
        "ansible_memory": {
            "nocache": {
                "free": 395,
                "used": 197
            },
            "real": {
                "free": 37,
                "total": 592,
                "used": 555
            },
            "swap": {
                "cached": 0,
                "free": 2047,
                "total": 2047,
                "used": 0
            }
        }
```
