### PR TITLE
Ec2 security group name to ID conversion failure

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -841,7 +841,7 @@ def create_instances(module, ec2, override_count=None):
 
             if volumes:
                 bdm = BlockDeviceMapping()
-                for volume in volumes: 
+                for volume in filter(None, volumes):
                     if 'device_name' not in volume:
                         module.fail_json(msg = 'Device name must be set for volume')
                     # Minimum volume size is 1GB. We'll use volume size explicitly set to 0

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -752,13 +752,14 @@ def create_instances(module, ec2, override_count=None):
         # Here we try to lookup the group id from the security group name - if group is set.
         if group_name:
             grp_details = ec2.get_all_security_groups()
+            if type(group_name) == str:
+                group_name = [group_name]
             if type(group_name) == list:
                 group_id = [ str(grp.id) for grp in grp_details if str(grp.name) in group_name ]
-            elif type(group_name) == str:
-                for grp in grp_details:
-                    if str(group_name) in str(grp):
-                        group_id = [str(grp.id)]
-                group_name = [group_name]
+           
+            if len(group_name) != len(group_id):
+                module.fail_json(msg="Group name lookup failed: {0} !=> {1}".format(json.dumps(group_name), json.dumps(group_id)))
+
         # Now we try to lookup the group id testing if group exists.
         elif group_id:
             #wrap the group_id in a list if it's not one already


### PR DESCRIPTION
- I believe the module should fail if any security group conversions fail. 
- Everything except the last 2 lines is logically equivalent. 
- Not sure on the acceptable way to format the lists (vs. json)
