### PR TITLE
Makes ansible fail if login_port is defined and login_host is either not...

### DIFF
--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -50,7 +50,7 @@ options:
     default: localhost
   login_port:
     description:
-      - Port of the MySQL server
+      - Port of the MySQL server. Requires login_host be defined as other then localhost if login_port is used
     required: false
     default: 3306
   login_unix_socket:
@@ -308,6 +308,8 @@ def main():
     try:
         if module.params["login_unix_socket"]:
             db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db=connect_to_db)
+        elif module.params["login_port"] != "3306" and module.params["login_host"] == "localhost":
+            module.fail_json(msg="login_host is required when login_port is defined, login_host cannot be localhost when login_port is defined")
         else:
             db_connection = MySQLdb.connect(host=module.params["login_host"], port=int(module.params["login_port"]), user=login_user, passwd=login_password, db=connect_to_db)
         cursor = db_connection.cursor()


### PR DESCRIPTION
... defined, or defined as localhost. This is because if login_host is localhost then MySQLdb will use the socket instead of TCP. This leads to confusion for ansible users as, when a port is defined it gets ignored if login_host is localhost. This is to fix the bug reported by wrosario #8070. Info on MysqlDb can be read here http://mysql-python.sourceforge.net/MySQLdb.html
