### PR TITLE
Regex square-bracket bug

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -235,6 +235,10 @@ class Inventory(object):
         a tuple of (start, stop) or None
         """
 
+        # Do not parse regexes for enumeration info
+        if pattern.startswith('~'):
+            return (pattern, None)
+
         # The regex used to match on the range, which can be [x] or [x-y].
         pattern_re = re.compile("^(.*)\[([-]?[0-9]+)(?:(?:-)([0-9]+))?\](.*)$")
         m = pattern_re.match(pattern)

--- a/test/units/TestInventory.py
+++ b/test/units/TestInventory.py
@@ -274,6 +274,14 @@ class TestInventory(unittest.TestCase):
         print "EXPECTED=%s" % sorted(expected_hosts)
         assert sorted(hosts) == sorted(expected_hosts)
 
+    def test_regex_grouping(self):
+        inventory = self.simple_inventory()
+        hosts = inventory.list_hosts("~(cer[a-z]|berc)(erus00[13])")
+        expected_hosts = ['cerberus001', 'cerberus003']
+        print "HOSTS=%s" % sorted(hosts)
+        print "EXPECTED=%s" % sorted(expected_hosts)
+        assert sorted(hosts) == sorted(expected_hosts)
+
     def test_complex_enumeration(self):
 
 


### PR DESCRIPTION
Regexes were being parsed like ordinary ansible host patterns, so square-bracket groups were getting interpolated wrongly. This PR fixes the issue and adds a regression test.

Steps to reproduce the bug:

```
# Create fake hostnames
$ echo "127.0.0.1       a1.localhost a2.localhost a3.localhost a4.localhost a5.localhost" | sudo tee -a /etc/hosts
$ for i in {1..5}; do echo "a${i}.localhost" >> /tmp/test_inventory

# Try to match 1, 2, and 5 with a regex
$ ./bin/ansible '~(a[12]|a5).localhost)' -i /tmp/test_inventory --list-hosts
Traceback (most recent call last):
  File "./bin/ansible", line 221, in <module>
    (runner, results) = cli.run(options, args)
  File "./bin/ansible", line 142, in run
    hosts = inventory_manager.list_hosts(pattern)
  File "/Library/Python/2.7/site-packages/ansible/inventory/__init__.py", line 414, in list_hosts
    result = [ h.name for h in self.get_hosts(pattern) ]
  File "/Library/Python/2.7/site-packages/ansible/inventory/__init__.py", line 160, in get_hosts
    hosts = self._get_hosts(patterns)
  File "/Library/Python/2.7/site-packages/ansible/inventory/__init__.py", line 205, in _get_hosts
    that = self.__get_hosts(p)
  File "/Library/Python/2.7/site-packages/ansible/inventory/__init__.py", line 226, in __get_hosts
    hpat = self._hosts_in_unenumerated_pattern(name)
  File "/Library/Python/2.7/site-packages/ansible/inventory/__init__.py", line 310, in _hosts_in_unenumerated_pattern
    if pattern == 'all' or self._match(group.name, pattern) or self._match(host.name, pattern):
  File "/Library/Python/2.7/site-packages/ansible/inventory/__init__.py", line 146, in _match
    return re.search(pattern_str[1:], str)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/re.py", line 142, in search
    return _compile(pattern, flags).search(string)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/re.py", line 242, in _compile
    raise error, v # invalid expression
sre_constants.error: unbalanced parenthesis
```
