### PR TITLE
Fixes for issues #8065 and #8075 in mysql_db and #8067 in vsphere_guest

### DIFF
--- a/library/cloud/vsphere_guest
+++ b/library/cloud/vsphere_guest
@@ -598,10 +598,11 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
     datacenter = esxi['datacenter']
     esxi_hostname = esxi['hostname']
     # Datacenter managed object reference
-    dcmor = [k for k,
-             v in vsphere_client.get_datacenters().items() if v == datacenter][0]
-
-    if dcmor is None:
+    dclist = [k for k,
+             v in vsphere_client.get_datacenters().items() if v == datacenter];
+    if dclist:
+        dcmor=dclist[0]
+    else:
         vsphere_client.disconnect()
         module.fail_json(msg="Cannot find datacenter named: %s" % datacenter)
 
@@ -702,7 +703,7 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
     vmfiles.set_element_vmPathName(datastore_name)
     config.set_element_files(vmfiles)
     config.set_element_name(guest)
-    if vm_extra_config['notes'] is not None:
+    if 'notes' in vm_extra_config:
         config.set_element_annotation(vm_extra_config['notes'])
     config.set_element_memoryMB(int(vm_hardware['memory_mb']))
     config.set_element_numCPUs(int(vm_hardware['num_cpus']))
@@ -814,9 +815,8 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
         module.fail_json(msg="Error creating vm: %s" %
                          task.get_error_message())
     else:
-        vm = None
-        if vm_extra_config or state in ['powered_on', 'powered_off']:
-            vm = vsphere_client.get_vm_by_name(guest)
+        # We always need to get the vm because we are going to gather facts
+        vm = vsphere_client.get_vm_by_name(guest)
 
         # VM was created. If there is any extra config options specified, set
         # them here , disconnect from vcenter, then exit.

--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -265,7 +265,7 @@ def main():
             login_host=dict(default="localhost"),
             login_port=dict(default="3306"),
             login_unix_socket=dict(default=None),
-            db=dict(required=True, aliases=['name']),
+            name=dict(required=True, aliases=['db']),
             encoding=dict(default=""),
             collation=dict(default=""),
             target=dict(default=None),
@@ -276,7 +276,7 @@ def main():
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")
 
-    db = module.params["db"]
+    db = module.params["name"]
     encoding = module.params["encoding"]
     collation = module.params["collation"]
     state = module.params["state"]
@@ -319,7 +319,10 @@ def main():
     changed = False
     if db_exists(cursor, db):
         if state == "absent":
-            changed = db_delete(cursor, db)
+            try:
+                changed = db_delete(cursor, db)
+            except Exception, e:
+                module.fail_json(msg="error deleting database: " + str(e))
         elif state == "dump":
             rc, stdout, stderr = db_dump(module, login_host, login_user, 
                                         login_password, db, target, 
@@ -340,7 +343,10 @@ def main():
                 module.exit_json(changed=True, db=db, msg=stdout)
     else:
         if state == "present":
-            changed = db_create(cursor, db, encoding, collation)
+            try:
+                changed = db_create(cursor, db, encoding, collation)
+            except Exception, e:
+                module.fail_json(msg="error creating database: " + str(e))
 
     module.exit_json(changed=changed, db=db)
 


### PR DESCRIPTION
This fixes three traceback errors:
- When creating or deleting a mysql database fails (issue #8065)
- When a named vsphere datacenter does not exist (issue #8067)
- When a vsphere guest is created without notes
- When a vsphere guest is created without a requirement to power on/off (and also without notes)

It also responds to issue #8075 by updating the mysql_db code so it matches the documentation.
