### PR TITLE
Fix hostname when get_distribution_version() returns a string.

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -188,8 +188,11 @@ def get_distribution_version():
         except:
             # FIXME: MethodMissing, I assume?
             distribution_version = platform.dist()[1]
+        if type(distribution_version) == str:
+            distribution_version = 0
     else:
-        distribution_version = None
+        distribution_version = 0
+
     return distribution_version
 
 def load_platform_subclass(cls, *args, **kwargs):


### PR DESCRIPTION
The distro version is a string ('jessie/sid') on Debian unstable and testing.
Because load_platform_subclass() evaluates every subclass as it loops,
comparing numbers when get_distribution_version() does not return a number will
break.

This patch fixes that by returning a number (`0`) when we have an invalid
version, instead of returning `None` or a string.
