### PR TITLE
Switched primary and alias names of the name/db parameter. Fixes #8065.

### DIFF
--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -265,7 +265,7 @@ def main():
             login_host=dict(default="localhost"),
             login_port=dict(default="3306"),
             login_unix_socket=dict(default=None),
-            db=dict(required=True, aliases=['name']),
+            name=dict(required=True, aliases=['db']),
             encoding=dict(default=""),
             collation=dict(default=""),
             target=dict(default=None),
@@ -276,7 +276,7 @@ def main():
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")
 
-    db = module.params["db"]
+    db = module.params["name"]
     encoding = module.params["encoding"]
     collation = module.params["collation"]
     state = module.params["state"]


### PR DESCRIPTION
In the documentation, the name of the mysql database to create is called "name," with an alias of "db." However, in the code, "db" is the primary name and "name" is the alias. This causes a confusing error message. This patch updates the code to match the documentation.
