### PR TITLE
Fixed tracebacks during VM creation. Fixes #8067.

### DIFF
--- a/library/cloud/vsphere_guest
+++ b/library/cloud/vsphere_guest
@@ -604,10 +604,11 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
     datacenter = esxi['datacenter']
     esxi_hostname = esxi['hostname']
     # Datacenter managed object reference
-    dcmor = [k for k,
-             v in vsphere_client.get_datacenters().items() if v == datacenter][0]
-
-    if dcmor is None:
+    dclist = [k for k,
+             v in vsphere_client.get_datacenters().items() if v == datacenter]
+    if dclist:
+        dcmor=dclist[0]
+    else:
         vsphere_client.disconnect()
         module.fail_json(msg="Cannot find datacenter named: %s" % datacenter)
 
@@ -710,7 +711,7 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
     vmfiles.set_element_vmPathName(datastore_name)
     config.set_element_files(vmfiles)
     config.set_element_name(guest)
-    if vm_extra_config['notes'] is not None:
+    if 'notes' in vm_extra_config:
         config.set_element_annotation(vm_extra_config['notes'])
     config.set_element_memoryMB(int(vm_hardware['memory_mb']))
     config.set_element_numCPUs(int(vm_hardware['num_cpus']))
@@ -822,9 +823,8 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
         module.fail_json(msg="Error creating vm: %s" %
                          task.get_error_message())
     else:
-        vm = None
-        if vm_extra_config or state in ['powered_on', 'powered_off']:
-            vm = vsphere_client.get_vm_by_name(guest)
+        # We always need to get the vm because we are going to gather facts
+        vm = vsphere_client.get_vm_by_name(guest)
 
         # VM was created. If there is any extra config options specified, set
         # them here , disconnect from vcenter, then exit.


### PR DESCRIPTION
This patch fixes three tracebacks that can occur when creating a vSphere virtual machine:
1. If the datacenter name in the playbook does not exist on the vCenter server, the list comprehension gives an empty result and dereferencing to [0] fails. Instead of checking if [0]==None, we check if the list has any members. If it does, then we can use [0] safely.
2. If the playbook does not supply a value for the notes parameter in vm_extra_config, this causes a traceback when we try to compare it to None. Instead, we should check if the "notes" key is present in the dictionary. If it is present and also has the value None, then we wind up setting the annotation to None, which seems like reasonable behavior.
3. If vm_extra_config is not supplied and the power state is not requested to be on or off, then we are not retrieving the vm from pysphere, which causes a traceback when we try to gather facts about it at the end of the module. Since we always want to gather these facts, we always need the vm reference.
