### PR TITLE
Correct regex in is_keyid

### DIFF
--- a/library/packaging/rpm_key
+++ b/library/packaging/rpm_key
@@ -156,7 +156,7 @@ class RpmKey:
 
     def is_keyid(self, keystr):
         """Verifies if a key, as provided by the user is a keyid"""
-        return re.match('(0x)?(0-9a-f){8}', keystr, flags=re.IGNORECASE)
+        return re.match('(0x)?[0-9a-f]{8}', keystr, flags=re.IGNORECASE)
 
     def execute_command(self, cmd):
         if self.syslogging:


### PR DESCRIPTION
The `rpm_key` module claims to take a key ID as an argument, however it fails if one is actually given:

```
msg: Not a valid key DEADBEEF
```

The reason for this is the regular expression in the `RpmKey.is_keyid` method is incorrect; it will only match the literal string "0-9a-f" exactly 8 times, rather than exactly 8 characters in the set 0-9 or a-f.
