### PR TITLE
Fix pip failure when version is parsed as a float

### DIFF
--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -206,7 +206,7 @@ def main():
         argument_spec=dict(
             state=dict(default='present', choices=state_map.keys()),
             name=dict(default=None, required=False),
-            version=dict(default=None, required=False),
+            version=dict(default=None, required=False, type='str'),
             requirements=dict(default=None, required=False),
             virtualenv=dict(default=None, required=False),
             virtualenv_site_packages=dict(default='no', type='bool'),


### PR DESCRIPTION
##### Issue Type: Bugfix Pull Request
##### Ansible Version: 1.7 (8a6cfa1a)
##### Environment: N/A
##### Summary:

See #8108 for more details. Only applies if you're using YAML to specify module arguments instead of the more customary `k=v` format.
##### Steps To Reproduce:

```
- name: Install supervisor
  pip:
    name: supervisor
    version: 3.0
```
##### Expected Results:

`supervisord` should get installed
##### Actual Results:

```
line 153, in _get_full_name
    resp = name + '==' + version
TypeError: cannot concatenate 'str' and 'float' objects
```
