### PR TITLE
Enhance zypper repo module: Changed the repo_exists function to respect .repo endings.

### DIFF
--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -95,7 +95,7 @@ def add_repo(module, repo, alias, description, disable_gpg_check):
 
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     changed = rc == 0
-    return (rc, stdout, stderr, changed)
+    return rc, stdout, stderr, changed
 
 
 def remove_repo(module, repo):
@@ -103,7 +103,7 @@ def remove_repo(module, repo):
 
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     changed = rc == 0
-    return (rc, stdout, stderr, changed)
+    return rc, stdout, stderr, changed
 
 
 def fail_if_rc_is_null(module, rc, stdout, stderr):

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 # (c) 2013, Matthias Vogelgesang <matthias.vogelgesang@gmail.com>
+# edited 2014, Mario Mueller <mario@xenji.com>
 #
 # This file is part of Ansible
 #
@@ -22,7 +23,7 @@
 DOCUMENTATION = '''
 ---
 module: zypper_repository
-author: Matthias Vogelgesang
+author: Matthias Vogelgesang, with contributions from Mario Mueller
 version_added: "1.4"
 short_description: Add and remove Zypper repositories
 description:
@@ -74,9 +75,14 @@ EXAMPLES = '''
 def repo_exists(module, repo):
     """Return (rc, stdout, stderr, found) tuple"""
     cmd = ['/usr/bin/zypper', 'lr', '--uri']
-
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
-    return (rc, stdout, stderr, repo in stdout)
+
+    # --uri cuts the .repo, so make it work even if the
+    # input ends with a .repo extension
+    if repo.endswith('.repo'):
+        repo = repo.replace('.repo', '')
+
+    return rc, stdout, stderr, repo in stdout
 
 
 def add_repo(module, repo, alias, description, disable_gpg_check):

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -135,6 +135,7 @@ def main():
     rc, stdout, stderr, exists = repo_exists(module, repo)
     fail_if_rc_is_null(module, rc, stdout, stderr)
 
+    result = list()
     if state == 'present':
         if exists:
             exit_unchanged()

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -125,12 +125,12 @@ def main():
 
     repo = module.params['repo']
     state = module.params['state']
-    name = module.params['name']
+    local_name = module.params['name']
     description = module.params['description']
     disable_gpg_check = module.params['disable_gpg_check']
 
     def exit_unchanged():
-        module.exit_json(changed=False, repo=repo, state=state, name=name)
+        module.exit_json(changed=False, repo=repo, state=state, name=local_name)
 
     rc, stdout, stderr, exists = repo_exists(module, repo)
     fail_if_rc_is_null(module, rc, stdout, stderr)
@@ -138,12 +138,10 @@ def main():
     if state == 'present':
         if exists:
             exit_unchanged()
-
-        result = add_repo(module, repo, name, description, disable_gpg_check)
+        result = add_repo(module, repo, local_name, description, disable_gpg_check)
     elif state == 'absent':
         if not exists:
             exit_unchanged()
-
         result = remove_repo(module, repo)
 
     rc, stdout, stderr, changed = result

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -118,7 +118,7 @@ def main():
             repo=dict(required=True),
             state=dict(choices=['present', 'absent'], default='present'),
             description=dict(required=False),
-            disable_gpg_check = dict(required=False, default='no', type='bool'),
+            disable_gpg_check=dict(required=False, default='no', type='bool'),
         ),
         supports_check_mode=False,
     )


### PR DESCRIPTION
Changed the `repo_exists` function to respect `.repo` endings.
This is important, as a repo url is valid when ending on .repo instead of a slash.
The check of the existance of the .repo url in the output of
`zypper lr --uri`
would always fail, as `--uri` just shows the url variant with the trailing slash.
