### PR TITLE
Prevent unnecessary file copy for unarchive module

### DIFF
--- a/lib/ansible/runner/action_plugins/unarchive.py
+++ b/lib/ansible/runner/action_plugins/unarchive.py
@@ -49,10 +49,29 @@ class ActionModule(object):
         source  = options.get('src', None)
         dest    = options.get('dest', None)
         copy    = utils.boolean(options.get('copy', 'yes'))
+        creates = options.get('creates', None)
 
         if source is None or dest is None:
             result = dict(failed=True, msg="src (or content) and dest are required")
             return ReturnData(conn=conn, result=result)
+
+        if creates:
+            # do not run the command if the line contains creates=filename
+            # and the filename already exists. This allows idempotence
+            # of command executions.
+            module_args_tmp = "path=%s" % creates
+            module_return = self.runner._execute_module(conn, tmp, 'stat', module_args_tmp, inject=inject,
+                                                        complex_args=complex_args, persist_files=True)
+            stat = module_return.result.get('stat', None)
+            if stat and stat.get('exists', False):
+                return ReturnData(
+                    conn=conn,
+                    comm_ok=True,
+                    result=dict(
+                        skipped=True,
+                        msg=("skipped, since %s exists" % creates)
+                    )
+                )
 
         dest = os.path.expanduser(dest) # CCTODO: Fix path for Windows hosts.
         source = template.template(self.runner.basedir, os.path.expanduser(source), inject)

--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -202,20 +202,6 @@ def main():
     if not os.access(src, os.R_OK):
         module.fail_json(msg="Source '%s' not readable" % src)
 
-    if creates:
-        # do not run the command if the line contains creates=filename
-        # and the filename already exists.  This allows idempotence
-        # of command executions.
-        v = os.path.expanduser(creates)
-        if os.path.exists(v):
-            module.exit_json(
-                stdout="skipped, since %s exists" % v,
-                skipped=True,
-                changed=False,
-                stderr=False,
-                rc=0
-            )
-
     # is dest OK to receive tar file?
     if not os.path.exists(os.path.dirname(dest)):
         module.fail_json(msg="Destination directory '%s' does not exist" % (os.path.dirname(dest)))


### PR DESCRIPTION
Suggested fix for #8115.
Checks unarchive module's 'creates' argument earlier to prevent unnecessary copying of file.
