### PR TITLE
Fix loading vars relative to playbook basedir.

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -582,6 +582,9 @@ class Inventory(object):
             # get host vars from host_vars/ files
             for host in self.get_hosts():
                 host.vars = utils.combine_vars(host.vars, self.get_host_vars(host, new_pb_basedir=True))
+            # invalidate cache
+            self._vars_per_host = {}
+            self._vars_per_group = {}
 
     def get_host_vars(self, host, new_pb_basedir=False):
         """ Read host_vars/ files """

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -585,11 +585,11 @@ class Inventory(object):
 
     def get_host_vars(self, host, new_pb_basedir=False):
         """ Read host_vars/ files """
-        return self._get_hostgroup_vars(host=host, group=None, new_pb_basedir=False)
+        return self._get_hostgroup_vars(host=host, group=None, new_pb_basedir=new_pb_basedir)
 
     def get_group_vars(self, group, new_pb_basedir=False):
         """ Read group_vars/ files """
-        return self._get_hostgroup_vars(host=None, group=group, new_pb_basedir=False)
+        return self._get_hostgroup_vars(host=None, group=group, new_pb_basedir=new_pb_basedir)
 
     def _get_hostgroup_vars(self, host=None, group=None, new_pb_basedir=False):
         """


### PR DESCRIPTION
A bug introduced by the inventory refactoring.

This PR fixes a logic bug to optimize loading extra vars for an extra playbook basedir.
It also invalidates the var caches to allow those new vars to be retrieved from Inventory.
