### PR TITLE
Docs: fix the name of the package that provides apt-add-repository on Ubuntu

### DIFF
--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -177,10 +177,12 @@ To configure the PPA on your machine and install ansible run these commands:
 
 .. code-block:: bash
 
-    $ sudo apt-get install apt-add-repository
+    $ sudo apt-get install software-properties-common
     $ sudo apt-add-repository ppa:rquillo/ansible
     $ sudo apt-get update
     $ sudo apt-get install ansible
+
+.. note:: On older Ubuntu distributions, "software-properties-common" is called "python-software-properties".
 
 Debian/Ubuntu packages can also be built from the source checkout, run:
 


### PR DESCRIPTION
Quick docs fix. The name of the package that provides "apt-add-respository" is not "apt-add-repository", but instead either "software-properties-common" or "python-software-properties", depending on what version of Ubuntu you're on.
