### PR TITLE
Update lineinfile validate help

### DIFF
--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -112,8 +112,10 @@ options:
   validate:
      required: false
      description:
-       - validation to run before copying into place. The command is passed
-         securely so shell features like expansion and pipes won't work.
+       - validation to run before copying into place. 
+         Use %s in the command to indicate the current file to validate.
+         The command is passed securely so shell features like
+         expansion and pipes won't work.
      required: false
      default: None
      version_added: "1.4"


### PR DESCRIPTION
It wasn't clear that validate requires %s in your command string. I spent a couple minutes debugging before I noticed the %s in the example validate command.
