### PR TITLE
Allow relative paths for jinja2 template extend statements

### DIFF
--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -25,7 +25,8 @@ import time
 from ansible import constants as C
 from ansible.plugins.action import ActionBase
 from ansible.utils.hashing import checksum_s
-from ansible.utils.unicode import to_bytes, to_unicode
+from ansible.utils.unicode import to_bytes
+from ansible.template import Templar
 
 class ActionModule(ActionBase):
 
@@ -84,9 +85,6 @@ class ActionModule(ActionBase):
 
         # template the source data locally & get ready to transfer
         try:
-            with open(source, 'r') as f:
-                template_data = to_unicode(f.read())
-
             try:
                 template_uid = pwd.getpwuid(os.stat(source).st_uid).pw_name
             except:
@@ -113,7 +111,7 @@ class ActionModule(ActionBase):
 
             old_vars = self._templar._available_variables
             self._templar.set_available_variables(temp_vars)
-            resultant = self._templar.template(template_data, preserve_trailing_newlines=True, convert_data=False)
+            resultant = self._templar.template(Templar.FilePath(source), preserve_trailing_newlines=True, convert_data=False)
             self._templar.set_available_variables(old_vars)
         except Exception as e:
             return dict(failed=True, msg=type(e).__name__ + ": " + str(e))

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -42,10 +42,9 @@ class LookupModule(LookupBase):
             lookupfile = self._loader.path_dwim_relative(basedir, 'templates', term)
             self._display.vvvv("File lookup using %s as file" % lookupfile)
             if lookupfile and os.path.exists(lookupfile):
-                with open(lookupfile, 'r') as f:
-                    template_data = f.read()
-                    res = templar.template(template_data, preserve_trailing_newlines=True)
-                    ret.append(res)
+                path = Templar.FilePath(lookupfile)
+                res = templar.template(path, preserve_trailing_newlines=True)
+                ret.append(res)
             else:
                 raise AnsibleError("the template file %s could not be found for the lookup" % term)
 

--- a/lib/ansible/template/template.py
+++ b/lib/ansible/template/template.py
@@ -28,7 +28,7 @@ class AnsibleJ2Template(jinja2.environment.Template):
     '''
     A helper class, which prevents Jinja2 from running _jinja2_vars through dict().
     Without this, {% include %} and similar will create new contexts unlike the special
-    one created in template_from_file. This ensures they are all alike, except for
+    one created in _do_template. This ensures they are all alike, except for
     potential locals.
     '''
 

--- a/test/integration/non_destructive.yml
+++ b/test/integration/non_destructive.yml
@@ -23,6 +23,7 @@
     - { role: test_copy, tags: test_copy }
     - { role: test_stat, tags: test_stat }
     - { role: test_template, tags: test_template }
+    - { role: test_template_relative_paths, tags: test_template_relative_paths }
     - { role: test_file, tags: test_file }
     - { role: test_fetch, tags: test_fetch }
     - { role: test_synchronize, tags: test_synchronize }

--- a/test/integration/roles/test_template_relative_paths/files/foo.txt
+++ b/test/integration/roles/test_template_relative_paths/files/foo.txt
@@ -1,0 +1,5 @@
+grandparent template starts
+parent template starts
+foobar
+parent template ends
+grandparent template ends

--- a/test/integration/roles/test_template_relative_paths/meta/main.yml
+++ b/test/integration/roles/test_template_relative_paths/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+

--- a/test/integration/roles/test_template_relative_paths/tasks/main.yml
+++ b/test/integration/roles/test_template_relative_paths/tasks/main.yml
@@ -1,0 +1,35 @@
+# test code for the relative loads in the template module
+# (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: fill in a template
+  template: src=foo.j2 dest={{output_dir}}/foo.templated mode=0644
+
+# VERIFY CONTENTS
+
+- name: copy known good into place
+  copy: src=foo.txt dest={{output_dir}}/foo.txt
+
+- name: compare templated file to known good
+  shell: diff {{output_dir}}/foo.templated {{output_dir}}/foo.txt
+  register: diff_result
+
+- name: verify templated file matches known good
+  assert:
+    that:
+        - 'diff_result.stdout == ""'
+        - "diff_result.rc == 0"

--- a/test/integration/roles/test_template_relative_paths/templates/base/grandparent.j2
+++ b/test/integration/roles/test_template_relative_paths/templates/base/grandparent.j2
@@ -1,0 +1,3 @@
+grandparent template starts
+{% block document %}{% endblock %}
+grandparent template ends

--- a/test/integration/roles/test_template_relative_paths/templates/base/parent.j2
+++ b/test/integration/roles/test_template_relative_paths/templates/base/parent.j2
@@ -1,0 +1,7 @@
+{% extends 'grandparent.j2' %}
+
+{% block document %}
+parent template starts
+{% block content %}{% endblock %}
+parent template ends
+{% endblock %}

--- a/test/integration/roles/test_template_relative_paths/templates/foo.j2
+++ b/test/integration/roles/test_template_relative_paths/templates/foo.j2
@@ -1,0 +1,5 @@
+{% extends 'base/parent.j2' %}
+
+{% block content %}
+foobar
+{% endblock %}

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -71,8 +71,7 @@ class TestTemplar(unittest.TestCase):
         self.assertEqual(templar.template("{{bad_dict}}"), "{a='b'")
         self.assertEqual(templar.template("{{var_list}}"), [1])
         self.assertEqual(templar.template(1, convert_bare=True), 1)
-        #FIXME: lookup ignores fake file and returns error
-        #self.assertEqual(templar.template("{{lookup('file', '/path/to/my_file.txt')}}"), "foo")
+        self.assertEqual(templar.template("{{lookup('file', '/path/to/my_file.txt')}}"), "foo")
 
         # force errors
         self.assertRaises(UndefinedError, templar.template, "{{bad_var}}")

--- a/v1/ansible/utils/template.py
+++ b/v1/ansible/utils/template.py
@@ -220,6 +220,14 @@ class J2Template(jinja2.environment.Template):
     def new_context(self, vars=None, shared=False, locals=None):
         return jinja2.runtime.Context(self.environment, vars.add_locals(locals), self.name, self.blocks)
 
+class J2RelEnvironment(jinja2.Environment):
+    '''
+    This allows jinja templates to refer to other templates via relative
+    paths. See http://stackoverflow.com/a/8530761/351149 for details.
+    '''
+    def join_path(self, template, parent):
+        return os.path.join(os.path.dirname(parent), template)
+
 def template_from_file(basedir, path, vars, vault_password=None):
     ''' run a file through the templating engine '''
 
@@ -235,7 +243,7 @@ def template_from_file(basedir, path, vars, vault_password=None):
     def my_finalize(thing):
         return thing if thing is not None else ''
 
-    environment = jinja2.Environment(loader=loader, trim_blocks=True, extensions=_get_extensions())
+    environment = J2RelEnvironment(loader=loader, trim_blocks=True, extensions=_get_extensions())
     environment.filters.update(_get_filters())
     environment.globals['lookup'] = my_lookup
     environment.globals['finalize'] = my_finalize


### PR DESCRIPTION
A template cannot extend from another template that in turn extends from _another_ template using a relative path; ansible will assume all relative paths are relative to the first template, breaking the second reference.

This PR adds a test which exhibits this bug and a small fix (based on http://stackoverflow.com/a/8530761/351149) that corrects it.
