### PR TITLE
Set Jinja2's keep_trailing_newline=True in template_from_string.

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -322,7 +322,7 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
         def my_finalize(thing):
             return thing if thing is not None else ''
 
-        environment = jinja2.Environment(trim_blocks=True, undefined=StrictUndefined, extensions=_get_extensions(), finalize=my_finalize)
+        environment = jinja2.Environment(trim_blocks=True, keep_trailing_newline=True, undefined=StrictUndefined, extensions=_get_extensions(), finalize=my_finalize)
         environment.filters.update(_get_filters())
         environment.template_class = J2Template
 

--- a/test/integration/roles/test_template/tasks/main.yml
+++ b/test/integration/roles/test_template/tasks/main.yml
@@ -63,4 +63,10 @@
   assert: 
     that: 
       - "file_result.changed != True"
-        
+
+# VERIFY STRING TEMPLATE PRESERVES NEWLINE
+
+- name: ensure template strings preserve newline
+  assert:
+    that:
+      - "newline_no_template_string == newline_template_string"

--- a/test/integration/roles/test_template/vars/main.yml
+++ b/test/integration/roles/test_template/vars/main.yml
@@ -1,1 +1,3 @@
 templated_var: templated_var_loaded
+newline_template_string: "Hello {{ 'World' }}\n"
+newline_no_template_string: "Hello World\n"


### PR DESCRIPTION
Without this setting, the newline idempotence of scalar strings changes depending on whether
or not they contain any Jinja2 template blocks.

I've included a patch to the test_template integration test to demonstrate the behavior, but to be explicit, consider the following vars:

```
vars:
  x: "Hello\n"
  y: "{{'Hello'}}\n"
  z: "{{'Hello'}}\n\n"
```

Without keep_trailing_newline, x != y, but instead x == z, as Jinja2 strips one trailing newline on y and z. This only affects string templates, as file templates already have code to ensure newline parity.

I expect that newlines should be handled identically for strings, regardless of whether or not a template is used.

Not limited to vars, this affects other places where templates may be used; for example, copy:contents.
