### PR TITLE
Fix "TypeError: group id must be integer" if groupid passed in for group key

### DIFF
--- a/library/system/user
+++ b/library/system/user
@@ -440,7 +440,7 @@ class User(object):
     def group_exists(self,group):
         try:
             if group.isdigit():
-                if grp.getgrgid(group):
+                if grp.getgrgid(int(group)):
                     return True
             else:
                 if grp.getgrnam(group):


### PR DESCRIPTION
Hi,
Came across this small issue today.

Triggered by:
- user: name='peterkh' comment='Peter Hall' shell='/bin/bash' uid=600 group=600 home=/home/peterkh createhome=False

Cheers
Peter
