### PR TITLE
Fix EC2_TAG module output structure when listing tags

### DIFF
--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -142,7 +142,7 @@ def main():
         module.exit_json(msg="Tags %s removed for resource %s." % (dictremove,resource), changed=True)
 
     if state == 'list':
-        module.exit_json(changed=False, **tagdict)
+        module.exit_json(changed=False, tags=tagdict)
     sys.exit(0)
 
 # import module snippets


### PR DESCRIPTION
Fix EC2_TAG module output structure when listing tags
