### PR TITLE
removed privileged option on container creation

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -588,7 +588,6 @@ class DockerManager:
             'binds': self.binds,
             'port_bindings': self.port_bindings,
             'publish_all_ports': self.module.params.get('publish_all_ports'),
-            'privileged':   self.module.params.get('privileged'),
             'links': self.links,
         }
         if docker.utils.compare_version('1.10', self.client.version()['ApiVersion']) >= 0 and hasattr(docker, '__version__') and docker.__version__ > '0.3.0':


### PR DESCRIPTION
the privilege option is not present in Docker-py code so this ansible module is not working anymore.

FYI, in docker-py, as of version 0.3.2 : 

```
    def create_container(self, image, command=None, hostname=None, user=None,
                         detach=False, stdin_open=False, tty=False,
                         mem_limit=0, ports=None, environment=None, dns=None,
                         volumes=None, volumes_from=None,
                         network_disabled=False, name=None, entrypoint=None,
                         cpu_shares=None, working_dir=None, domainname=None,
                         memswap_limit=0):
```
