### PR TITLE
layman: remove my email address

### DIFF
--- a/library/packaging/layman
+++ b/library/packaging/layman
@@ -25,7 +25,7 @@ from urllib2 import Request, urlopen, URLError
 DOCUMENTATION = '''
 ---
 module: layman
-author: Jakub Jirutka <jakub@jirutka.cz>
+author: Jakub Jirutka
 version_added: "1.6"
 short_description: Manage Gentoo overlays
 description:


### PR DESCRIPTION
This is trivial patch just to remove my email address from the documentation.
