### PR TITLE
Added a vm_extra_config option for the folder the VM should be created in

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -31,7 +31,6 @@ import sys
 import pipes
 import jinja2
 import subprocess
-import shlex
 import getpass
 
 import ansible.constants as C

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -39,6 +39,7 @@ from ansible.callbacks import vvv
 from ansible import errors
 from ansible import utils
 from ansible import constants as C
+from ansible.module_utils.basic import atomic_move
             
 AUTHENTICITY_MSG="""
 paramiko: The authenticity of host '%s' can't be established. 
@@ -149,12 +150,16 @@ class Connection(object):
 
         if C.HOST_KEY_CHECKING:
             ssh.load_system_host_keys()
+
         ssh.set_missing_host_key_policy(MyAddPolicy(self.runner))
 
         allow_agent = True
+
         if self.password is not None:
             allow_agent = False
+
         try:
+
             if self.private_key_file:
                 key_filename = os.path.expanduser(self.private_key_file)
             elif self.runner.private_key_file:
@@ -164,7 +169,9 @@ class Connection(object):
             ssh.connect(self.host, username=self.user, allow_agent=allow_agent, look_for_keys=True,
                 key_filename=key_filename, password=self.password,
                 timeout=self.runner.timeout, port=self.port)
+
         except Exception, e:
+
             msg = str(e)
             if "PID check failed" in msg:
                 raise errors.AnsibleError("paramiko version issue, please upgrade paramiko on the machine running ansible")
@@ -184,23 +191,30 @@ class Connection(object):
             raise errors.AnsibleError("Internal Error: this module does not support optimized module pipelining")
 
         bufsize = 4096
+
         try:
+
             chan = self.ssh.get_transport().open_session()
             self.ssh.get_transport().set_keepalive(5)
+
         except Exception, e:
+
             msg = "Failed to open session"
             if len(str(e)) > 0:
                 msg += ": %s" % str(e)
             raise errors.AnsibleConnectionFailed(msg)
 
         if not (self.runner.sudo and sudoable) and not (self.runner.su and su):
+
             if executable:
                 quoted_command = executable + ' -c ' + pipes.quote(cmd)
             else:
                 quoted_command = cmd
             vvv("EXEC %s" % quoted_command, host=self.host)
             chan.exec_command(quoted_command)
+
         else:
+
             # sudo usually requires a PTY (cf. requiretty option), therefore
             # we give it one by default (pty=True in ansble.cfg), and we try
             # to initialise from the calling environment
@@ -213,17 +227,24 @@ class Connection(object):
             elif self.runner.su or su:
                 shcmd, prompt, success_key = utils.make_su_cmd(su_user, executable, cmd)
                 prompt_re = re.compile(prompt)
+
             vvv("EXEC %s" % shcmd, host=self.host)
             sudo_output = ''
+
             try:
+
                 chan.exec_command(shcmd)
+
                 if self.runner.sudo_pass or self.runner.su_pass:
+
                     while True:
+
                         if success_key in sudo_output or \
                             (self.runner.sudo_pass and sudo_output.endswith(prompt)) or \
                             (self.runner.su_pass and prompt_re.match(sudo_output)):
                             break
                         chunk = chan.recv(bufsize)
+
                         if not chunk:
                             if 'unknown user' in sudo_output:
                                 raise errors.AnsibleError(
@@ -232,33 +253,43 @@ class Connection(object):
                                 raise errors.AnsibleError('ssh connection ' +
                                     'closed waiting for password prompt')
                         sudo_output += chunk
+
                     if success_key not in sudo_output:
+
                         if sudoable:
                             chan.sendall(self.runner.sudo_pass + '\n')
                         elif su:
                             chan.sendall(self.runner.su_pass + '\n')
+
             except socket.timeout:
+
                 raise errors.AnsibleError('ssh timed out waiting for sudo.\n' + sudo_output)
 
         stdout = ''.join(chan.makefile('rb', bufsize))
         stderr = ''.join(chan.makefile_stderr('rb', bufsize))
+
         return (chan.recv_exit_status(), '', stdout, stderr)
 
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''
+
         vvv("PUT %s TO %s" % (in_path, out_path), host=self.host)
+
         if not os.path.exists(in_path):
             raise errors.AnsibleFileNotFound("file or module does not exist: %s" % in_path)
+
         try:
             self.sftp = self.ssh.open_sftp()
         except Exception, e:
             raise errors.AnsibleError("failed to open a SFTP connection (%s)" % e)
+
         try:
             self.sftp.put(in_path, out_path)
         except IOError:
             raise errors.AnsibleError("failed to transfer file to %s" % out_path)
 
     def _connect_sftp(self):
+
         cache_key = "%s__%s__" % (self.host, self.user)
         if cache_key in SFTP_CONNECTION_CACHE:
             return SFTP_CONNECTION_CACHE[cache_key]
@@ -268,17 +299,21 @@ class Connection(object):
 
     def fetch_file(self, in_path, out_path):
         ''' save a remote file to the specified path '''
+
         vvv("FETCH %s TO %s" % (in_path, out_path), host=self.host)
+
         try:
             self.sftp = self._connect_sftp()
         except Exception, e:
             raise errors.AnsibleError("failed to open a SFTP connection (%s)", e)
+
         try:
             self.sftp.get(in_path, out_path)
         except IOError:
             raise errors.AnsibleError("failed to transfer file from %s" % in_path)
 
     def _any_keys_added(self):
+
         added_any = False        
         for hostname, keys in self.ssh._host_keys.iteritems():
             for keytype, key in keys.iteritems():
@@ -301,24 +336,32 @@ class Connection(object):
             os.makedirs(path)
 
         f = open(filename, 'w')
+
         for hostname, keys in self.ssh._host_keys.iteritems():
+
             for keytype, key in keys.iteritems():
+
                 # was f.write
                 added_this_time = getattr(key, '_added_by_ansible_this_time', False)
                 if not added_this_time:
                     f.write("%s %s %s\n" % (hostname, keytype, key.get_base64()))
+
         for hostname, keys in self.ssh._host_keys.iteritems():
+
             for keytype, key in keys.iteritems():
                 added_this_time = getattr(key, '_added_by_ansible_this_time', False)
                 if added_this_time:
                     f.write("%s %s %s\n" % (hostname, keytype, key.get_base64()))
+
         f.close()
 
     def close(self):
         ''' terminate the connection '''
+
         cache_key = self._cache_key()
         SSH_CONNECTION_CACHE.pop(cache_key, None)
         SFTP_CONNECTION_CACHE.pop(cache_key, None)
+
         if self.sftp is not None:
             self.sftp.close()
 
@@ -332,12 +375,16 @@ class Connection(object):
 
             KEY_LOCK = open(lockfile, 'w')
             fcntl.lockf(KEY_LOCK, fcntl.LOCK_EX)
+
             try:
                 # just in case any were added recently
+
                 self.ssh.load_system_host_keys()
                 self.ssh._host_keys.update(self.ssh._system_host_keys)
                 self._save_ssh_host_keys(self.keyfile)
+
             except:
+
                 # unable to save keys, including scenario when key was invalid
                 # and caught earlier
                 traceback.print_exc()

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -381,7 +381,13 @@ class Connection(object):
 
                 self.ssh.load_system_host_keys()
                 self.ssh._host_keys.update(self.ssh._system_host_keys)
-                self._save_ssh_host_keys(self.keyfile)
+
+                # save the new keys to a temporary file and move it into place
+                # rather than rewriting the file
+                tmp_keyfile = tempfile.NamedTemporaryFile()
+                self._save_ssh_host_keys(tmp_keyfile)
+                atomic_move(tmp_keyfile.name, self.keyfile)
+                tmp_keyfile.close()
 
             except:
 

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -381,13 +381,7 @@ class Connection(object):
 
                 self.ssh.load_system_host_keys()
                 self.ssh._host_keys.update(self.ssh._system_host_keys)
-
-                # save the new keys to a temporary file and move it into place
-                # rather than rewriting the file
-                tmp_keyfile = tempfile.NamedTemporaryFile()
-                self._save_ssh_host_keys(tmp_keyfile)
-                atomic_move(tmp_keyfile.name, self.keyfile)
-                tmp_keyfile.close()
+                self._save_ssh_host_keys(self.keyfile)
 
             except:
 

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -29,6 +29,7 @@ import pipes
 import socket
 import random
 import logging
+import tempfile
 import traceback
 import fcntl
 import re
@@ -39,7 +40,6 @@ from ansible.callbacks import vvv
 from ansible import errors
 from ansible import utils
 from ansible import constants as C
-from ansible.module_utils.basic import atomic_move
             
 AUTHENTICITY_MSG="""
 paramiko: The authenticity of host '%s' can't be established. 
@@ -381,7 +381,25 @@ class Connection(object):
 
                 self.ssh.load_system_host_keys()
                 self.ssh._host_keys.update(self.ssh._system_host_keys)
-                self._save_ssh_host_keys(self.keyfile)
+
+                # gather information about the current key file, so
+                # we can ensure the new file has the correct mode/owner
+
+                key_dir  = os.path.dirname(self.keyfile)
+                key_stat = os.stat(self.keyfile)
+
+                # Save the new keys to a temporary file and move it into place
+                # rather than rewriting the file. We set delete=False because
+                # the file will be moved into place rather than cleaned up.
+
+                tmp_keyfile = tempfile.NamedTemporaryFile(dir=key_dir, delete=False)
+                os.chmod(tmp_keyfile.name, key_stat.st_mode & 07777)
+                os.chown(tmp_keyfile.name, key_stat.st_uid, key_stat.st_gid)
+
+                self._save_ssh_host_keys(tmp_keyfile.name)
+                tmp_keyfile.close()
+
+                os.rename(tmp_keyfile.name, self.keyfile)
 
             except:
 

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1041,11 +1041,11 @@ def filter_leading_non_json_lines(buf):
     filter only leading lines since multiline JSON is valid.
     '''
 
-    kv_regex = re.compile(r'.*\w+=\w+.*')
+    kv_regex = re.compile(r'\w=\w')
     filtered_lines = StringIO.StringIO()
     stop_filtering = False
     for line in buf.splitlines():
-        if stop_filtering or kv_regex.match(line) or line.startswith('{') or line.startswith('['):
+        if stop_filtering or line.startswith('{') or line.startswith('[') or kv_regex.search(line):
             stop_filtering = True
             filtered_lines.write(line + '\n')
     return filtered_lines.getvalue()

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -694,8 +694,6 @@ def parse_kv(args):
     ''' convert a string of key/value items to a dict '''
     options = {}
     if args is not None:
-        # attempting to split a unicode here does bad things
-        args = args.encode('utf-8')
         try:
             vargs = split_args(args)
         except ValueError, ve:
@@ -703,7 +701,6 @@ def parse_kv(args):
                 raise errors.AnsibleError("error parsing argument string, try quoting the entire line.")
             else:
                 raise
-        vargs = [x.decode('utf-8') for x in vargs]
         for x in vargs:
             if "=" in x:
                 k, v = x.split("=",1)

--- a/library/cloud/vsphere_guest
+++ b/library/cloud/vsphere_guest
@@ -130,6 +130,7 @@ EXAMPLES = '''
       vcpu.hotadd: yes
       mem.hotadd:  yes
       notes: This is a test VM
+      folder: AutoDeploys
     vm_disk:
       disk1:
         size_gb: 10
@@ -621,7 +622,7 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
     if vm_extra_config['folder']:
         if vm_extra_config['folder'] not in vsphere_client._get_managed_objects(MORTypes.Folder).values():
             vsphere_client.disconnect()
-            module.fail_json(msg="Cannot find folder named: %s" % vm_extra_config['folder'])
+            module.fail_json(msg="Could not find folder named: %s" % vm_extra_config['folder'])
 
         for mor, name in vsphere_client._get_managed_objects(MORTypes.Folder).iteritems():
             if name == vm_extra_config['folder']:

--- a/library/cloud/vsphere_guest
+++ b/library/cloud/vsphere_guest
@@ -618,7 +618,16 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
     hfmor = dcprops.hostFolder._obj
 
     # virtualmachineFolder managed object reference
-    vmfmor = dcprops.vmFolder._obj
+    if vm_extra_config['folder']:
+        if vm_extra_config['folder'] not in vsphere_client._get_managed_objects(MORTypes.Folder).values():
+            vsphere_client.disconnect()
+            module.fail_json(msg="Cannot find folder named: %s" % vm_extra_config['folder'])
+
+        for mor, name in vsphere_client._get_managed_objects(MORTypes.Folder).iteritems():
+            if name == vm_extra_config['folder']:
+                vmfmor = mor
+    else:
+        vmfmor = dcprops.vmFolder._obj
 
     # networkFolder managed object reference
     nfmor = dcprops.networkFolder._obj

--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -94,7 +94,7 @@ import ConfigParser
 def do_ini(module, filename, section=None, option=None, value=None, state='present', backup=False):
 
     changed = False
-    cp = ConfigParser.ConfigParser(allow_no_value=True)
+    cp = ConfigParser.ConfigParser()
     cp.optionxform = identity
 
     try:

--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -43,7 +43,7 @@ options:
     required: false
   include_dependencies:
     description:
-      - Wheter to include dependencies or not.
+      - Whether to include dependencies or not.
     required: false
     choices: [ "yes", "no" ]
     default: "yes"

--- a/library/system/hostname
+++ b/library/system/hostname
@@ -344,7 +344,7 @@ class ScientificHostname(Hostname):
 class ScientificLinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Scientific linux'
-    strategy_class = FedoraStrategy
+    strategy_class = RedHatStrategy
 
 class AmazonLinuxHostname(Hostname):
     platform = 'Linux'

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,7 +8,7 @@ Homepage: http://ansible.github.com/
 
 Package: ansible
 Architecture: all
-Depends: python, python-support (>= 0.90), python-jinja2, python-yaml, python-paramiko, python-httplib2, sshpass, ${misc:Depends}
+Depends: python, python-support (>= 0.90), python-jinja2, python-yaml, python-paramiko, python-httplib2, python-crypto (>= 2.6), sshpass, ${misc:Depends}
 Description: A radically simple IT automation platform
  A radically simple IT automation platform that makes your applications and
  systems easier to deploy. Avoid writing scripts or custom code to deploy and

--- a/test/integration/roles/test_command_shell/tasks/main.yml
+++ b/test/integration/roles/test_command_shell/tasks/main.yml
@@ -168,3 +168,23 @@
   assert:
     that:
       - "shell_result4.changed == False"
+
+- name: execute a shell command using a literal multiline block
+  shell: |
+    echo this is a
+    "multiline echo"
+    "with a new line
+    in quotes"
+    | md5sum
+    | tr -s ' '
+    | cut -f1 -d ' '
+  register: shell_result5
+
+- debug: var=shell_result5
+
+- name: assert the multiline shell command ran as expected
+  assert:
+    that:
+      - "shell_result5.changed"
+      - "shell_result5.stdout == '32f3cc201b69ed8afa3902b80f554ca8'"
+

--- a/test/integration/roles/test_copy/tasks/main.yml
+++ b/test/integration/roles/test_copy/tasks/main.yml
@@ -159,3 +159,24 @@
   assert:
     that:
       - "not copy_result5|changed"
+
+# issue 8394
+- name: create a file with content and a literal multiline block
+  copy: |
+    content='this is the first line
+    this is the second line
+
+    this line is after an empty line
+    this line is the last line
+    '
+    dest={{output_dir}}/multiline.txt
+  register: copy_result6
+
+- debug: var=copy_result6
+
+- name: assert the multiline file was created correctly
+  assert:
+    that:
+      - "copy_result6.changed"
+      - "copy_result6.dest == '{{output_dir|expanduser}}/multiline.txt'"
+      - "copy_result6.md5sum == '1627d51e7e607c92cf1a502bf0c6cce3'"

--- a/test/integration/unicode.yml
+++ b/test/integration/unicode.yml
@@ -40,3 +40,4 @@
   gather_facts: true
   tasks:
     - debug: msg='Unicode is a good thing ™'
+    - debug: msg=АБВГД

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -705,8 +705,9 @@ class TestUtils(unittest.TestCase):
         # jinja2 loop blocks with lots of complexity
         _test_combo(
             # in memory of neighbors cat
-            'a {% if x %} y {%else %} {{meow}} {% endif %} cookiechip\ndone',
-            ['a', '{% if x %}', 'y', '{%else %}', '{{meow}}', '{% endif %}', 'cookiechip\ndone']
+            # we only preserve newlines inside of quotes
+            'a {% if x %} y {%else %} {{meow}} {% endif %} "cookie\nchip"\ndone',
+            ['a', '{% if x %}', 'y', '{%else %}', '{{meow}}', '{% endif %}', '"cookie\nchip"', 'done']
         )
 
         # test space preservation within quotes

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -165,6 +165,8 @@ class TestUtils(unittest.TestCase):
     def test_parse_kv_basic(self):
         self.assertEqual(ansible.utils.parse_kv('a=simple b="with space" c="this=that"'),
                 {'a': 'simple', 'b': 'with space', 'c': 'this=that'})
+        self.assertEqual(ansible.utils.parse_kv('msg=АБВГД'),
+                {'msg': 'АБВГД'})
 
 
     def test_jsonify(self):


### PR DESCRIPTION
Added a section in vm_extra_config (folder) which allows you to specify which vm folder the new guest should be created in.

First there is a check that the folder exists on the system, failing if it doesn't.

If it does exist, the vmfmor variable is set to the first key (I am not sure how this behaves if there are multiple folders with the same name) found in the dictionary returned by _get_managed_objects.

If it is not set, it just goes to the current default (the root folder on the datacenter/host).

```
    args:
        vm_extra_config:
          vcpu.hotadd: yes
          mem.hotadd:  yes
          notes: This is a test VM
          folder: AutoDeploy
```
