### PR TITLE
Moved to absolute path for playbook_path... and playbook.basedir

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -162,7 +162,7 @@ class PlayBook(object):
         if self.module_path is not None:
             utils.plugins.module_finder.add_directory(self.module_path)
 
-        self.basedir     = os.path.dirname(playbook) or '.'
+        self.basedir     = os.path.realpath(os.path.dirname(playbook or '.'))
         utils.plugins.push_basedir(self.basedir)
 
         # let inventory know the playbook basedir so it can load more vars

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -62,7 +62,7 @@ class Play(object):
         self.vars_prompt      = ds.get('vars_prompt', {})
         self.playbook         = playbook
         self.vars             = self._get_vars()
-        self.basedir          = basedir
+        self.basedir          = playbook.basedir
         self.roles            = ds.get('roles', None)
         self.tags             = ds.get('tags', None)
         self.vault_password   = vault_password


### PR DESCRIPTION
The goal is to mirror the absolute path like what is in {{inventory_dir}} with {{playbook_dir}} instead of the relative path usually ".". I just wrapped the two primary places based_dir is used in os.path.realpath().

I tested the code with a few ansible runs however I didn't see any unit tests for playbooks specifically... If you point me to the test sweet I should run for this, I'll run it and update this PR.

Thanks
