### PR TITLE
Fixing improperly closed file handle in ansible vault

### DIFF
--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -107,7 +107,7 @@ def get_opt(options, k, defval=""):
 def _read_password(filename):
     f = open(filename, "rb")
     data = f.read()
-    f.close
+    f.close()
     data = data.strip()
     return data
 


### PR DESCRIPTION
The parentheses are left off the call, telling Python to return a method but not call the method.  You can see how this works in a REPL by calling `close` with and without the parentheses, noting how the file object changes.

``` python
>>> f = open("/etc/passwd", "rb")
>>> f
<open file '/etc/passwd', mode 'rb' at 0x103ce26f0>
>>> f.close
<built-in method close of file object at 0x103ce26f0>
>>> f
<open file '/etc/passwd', mode 'rb' at 0x103ce26f0>
>>> f.close()
>>> f
<closed file '/Users/scott/.ansible/stow_vault_password', mode 'rb' at 0x103ce26f0>
```
