### PR TITLE
Fix sanitization of sudo success_key from stdout

### DIFF
--- a/lib/ansible/runner/action_plugins/raw.py
+++ b/lib/ansible/runner/action_plugins/raw.py
@@ -49,6 +49,6 @@ class ActionModule(object):
         # may leak into the stdout due to the way the sudo/su
         # command is constructed, so we filter that out here
         if result.get('stdout','').strip().startswith('SUDO-SUCCESS-'):
-            result['stdout'] = re.sub(r'^(\r)?\nSUDO-SUCCESS.*(\r)?\n', '', result['stdout'])
+            result['stdout'] = re.sub(r'^((\r)?\n)?SUDO-SUCCESS.*(\r)?\n', '', result['stdout'])
 
         return ReturnData(conn=conn, result=result)


### PR DESCRIPTION
Commit 7e3dd10 caused a regression with sanitizing the sudo success_key from stdout.
There is no newline in front of SUDO-SUCCESS when using sudo.
This change adapts the regex to make the line break optional.

Tested on Ubuntu 14.04.
