### PR TITLE
Fixing a bug where the password file option fails with file not found if...

### DIFF
--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -105,6 +105,9 @@ def get_opt(options, k, defval=""):
 #-------------------------------------------------------------------------------------
 
 def _read_password(filename):
+    if filename.startswith("~"):
+        filename = os.path.expanduser(filename)
+
     f = open(filename, "rb")
     data = f.read()
     f.close

--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -105,8 +105,7 @@ def get_opt(options, k, defval=""):
 #-------------------------------------------------------------------------------------
 
 def _read_password(filename):
-    if filename.startswith("~"):
-        filename = os.path.expanduser(filename)
+    filename = os.path.expanduser(filename)
 
     f = open(filename, "rb")
     data = f.read()


### PR DESCRIPTION
... given a tilde character, because the tilde is not expanded before being given to the open() function.

Adding a tilde (`~`) in front of the filename is a shell/bash helper, but Python passes it straight through to the `open()` method without first expanding it to the user's home directory.  This causes the `open()` method to fail because the file/directory doesn't exist.  The solution is to first check for the existence of the tilde prefix and, if it exists, expand it before proceeding with opening the file.

before fix:

``` bash
$ ansible-vault encrypt --vault-password-file=~/.ansible/common_vault_password roles/app-user/files/bitbucket_deploy_key
ERROR: [Errno 2] No such file or directory: '~/.ansible/common_vault_password'
```

after fix:

``` bash
$ ansible-vault encrypt --vault-password-file=~/.ansible/common_vault_password roles/app-user/files/bitbucket_deploy_key
Encryption successful
```
