### PR TITLE
Load existing group_vars file for new group_by group

### DIFF
--- a/lib/ansible/runner/action_plugins/group_by.py
+++ b/lib/ansible/runner/action_plugins/group_by.py
@@ -93,6 +93,7 @@ class ActionModule(object):
             if not inv_group:
                 inv_group = ansible.inventory.Group(name=group)
                 inventory.add_group(inv_group)
+                inv_group.vars = inventory.get_group_variables(group, update_cached=False, vault_password=inventory._vault_password)
             for host in hosts:
                 if host in self.runner.inventory._vars_per_host:
                     del self.runner.inventory._vars_per_host[host]


### PR DESCRIPTION
if it was not loaded yet, which happens if that group
didn't exist yet in the inventory.

fixes #8159

@dshvedchenko can you test this patch?
