### PR TITLE
Make ec2_group module not just fail

### DIFF
--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -106,7 +106,7 @@ def addRulesToLookup(rules, prefix, dict):
                                         grant.group_id, grant.cidr_ip)] = rule
 
 
-def get_target_from_rule(module, rule, name, group, groups):
+def get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id):
     """
     Returns tuple of (group_id, ip) after validating rule params.
 
@@ -249,7 +249,7 @@ def main():
         # Now, go through all provided rules and ensure they are there.
         if rules:
             for rule in rules:
-                group_id, ip, target_group_created = get_target_from_rule(module, rule, name, group, groups)
+                group_id, ip, target_group_created = get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id)
                 if target_group_created:
                     changed = True
 
@@ -289,7 +289,7 @@ def main():
         # Now, go through all provided rules and ensure they are there.
         if rules_egress:
             for rule in rules_egress:
-                group_id, ip, target_group_created = get_target_from_rule(module, rule, name, group, groups)
+                group_id, ip, target_group_created = get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id)
                 if target_group_created:
                     changed = True
 


### PR DESCRIPTION
A function was extracted without attention to local vs global variables. There was already a bugfix related to this but it didn't include the ec2 variable.

How to trigger this: Try to use the ec2_group module to create a new security group. The comments on #7592 are relevant. At that time, it was noticed that the `module` variable was not in scope in `get_target_from_rule` (https://github.com/ansible/ansible/issues/7592#issuecomment-45111472).

Example task:

```
- name: Create a security group
  local_action:
    module: ec2_group
    name: "i-am-a-security-group-that-does-not-exist-yet"
    description: a normal security group
```

You'll need to have AWS credentials set as environment variables, as described in the docs for this module, in order for this task as written to fail. N.B., the security group must not already exist in your AWS account, because if it does, the module will not attempt to create it and will not fail.
