### PR TITLE
Make ALL_IN_SCHEMA for tables affect views

### DIFF
--- a/library/database/postgresql_privs
+++ b/library/database/postgresql_privs
@@ -300,7 +300,7 @@ class Connection(object):
         query = """SELECT relname
                    FROM pg_catalog.pg_class c
                    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                   WHERE nspname = %s AND relkind = 'r'"""
+                   WHERE nspname = %s AND relkind in ('r', 'v')"""
         self.cursor.execute(query, (schema,))
         return [t[0] for t in self.cursor.fetchall()]
 


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.6.6
##### Environment:

N/A
##### Summary:

ALL_IN_SCHEMA on tables does not include views. It should, as per http://www.postgresql.org/docs/9.3/static/sql-grant.html :

```
There is also an option to grant privileges on all objects of the same type within one or more 
schemas. This functionality is currently supported only for tables, sequences, and functions (but
note that ALL TABLES is considered to include views and foreign tables).
```
##### Steps To Reproduce:

On a database with a role that has had all privileges revoked:

```
- name: Give SELECT privilege to site on all tables and views
  postgresql_privs:
    db=some_database
    privs=SELECT
    objs=ALL_IN_SCHEMA
    role=some_role
```
##### Expected Results:

`some_role` should be able to select on a view in the public schema of `some_database`.
##### Actual Results:

`some_role` cannot select on a view in the public schema of `some_database`.
##### Pull Request Details:

ALL TABLES is considered to include views, so we must check for reltypes
'r' and 'v', not just 'r'.
