### PR TITLE
library/source_control/hg - revision option should always be used if specified

### DIFF
--- a/library/source_control/hg
+++ b/library/source_control/hg
@@ -170,13 +170,10 @@ class Hg(object):
             ['pull', '-R', self.dest, self.repo])
 
     def update(self):
-        return self._command(['update', '-R', self.dest])
+        return self._command(['update', '-R', self.dest, '-r', self.revision])
 
     def clone(self):
         return self._command(['clone', self.repo, self.dest, '-r', self.revision])
-
-    def switch_version(self):
-        return self._command(['update', '-r', self.revision, '-R', self.dest])
 
 # ===========================================
 
@@ -223,11 +220,10 @@ def main():
         if rc != 0:
             module.fail_json(msg=err)
 
-        (rc, out, err) = hg.update()
-        if rc != 0:
-            module.fail_json(msg=err)
+    (rc, out, err) = hg.update()
+    if rc != 0:
+        module.fail_json(msg=err)
 
-    hg.switch_version()
     after = hg.get_revision()
     if before != after or cleaned:
         changed = True


### PR DESCRIPTION
##### Issue Type:

Bug Report
##### Ansible Version:

ansible 1.6.6
##### Summary:

When the repo is on a branch with more than one head, and the current head is not the tip, mercurial will fail to perform "hg update" without a specified revision and issue the following error:

```
abandon : not a linear update
(merge or update --check to force update)
```

The usual workaround if to specify the revision with the -r option.

Ansible's hg module calls hg update without the -r option even if specified, therefore it keeps throwing the error.
##### Steps to reproduce:

I don't know how to reliably reproduce the bug since branch tips can be different between repository clones, but the following steps should create the blocking situation.

Mercurial non linear update situation:

```
hg init test && cd test
hg bookmark alpha
echo foo > file1 && hg add file1 && hg ci -m "first"

# One would clone/update the repo here with ansible, still a linear history so far
# the ansible task would read like this :
# hg: dest=<myrepo> revision=alpha


hg up -r 00000000000
hg bookmark beta
echo bar > file2 && hg add file2 && hg ci -m "second"

# This creates a new head, a subsequent update with ansible and 
# revision=beta specified  should fail

# Simulate locally :

hg up alpha   # Go back to the first head to have the same repo status as the remote
hg up         # Should fail, this is issued at library/source_control/hg#L226
hg up -r beta # Works, this is how hg update should be called by ansible
```
##### Expected results :

```
hg: dest=<repo> revision=<rev>
```

should do 

```
hg update -R <repo> -r <rev>
```

instead of

```
hg update -R <repo> #Hg.update, fails if nonlinear
hg update -R <repo> -r <rev> #Hg.switch_version
```
##### Patch :
- Enforce -r on update invocation (the subsequent call to switch_version does that anyway)
- Remove switch_version (now a redundant call)

```
diff --git a/library/source_control/hg b/library/source_control/hg
index 1b95bcd..eee107b 100644
--- a/library/source_control/hg
+++ b/library/source_control/hg
@@ -170,14 +170,11 @@ class Hg(object):
             ['pull', '-R', self.dest, self.repo])

     def update(self):
-        return self._command(['update', '-R', self.dest])
+        return self._command(['update', '-R', self.dest, '-r', self.revision])

     def clone(self):
         return self._command(['clone', self.repo, self.dest, '-r', self.revision])

-    def switch_version(self):
-        return self._command(['update', '-r', self.revision, '-R', self.dest])
-
 # ===========================================

 def main():
@@ -223,11 +220,10 @@ def main():
         if rc != 0:
             module.fail_json(msg=err)

-        (rc, out, err) = hg.update()
-        if rc != 0:
-            module.fail_json(msg=err)
+    (rc, out, err) = hg.update()
+    if rc != 0:
+        module.fail_json(msg=err)

-    hg.switch_version()
     after = hg.get_revision()
     if before != after or cleaned:
         changed = True
```
