### PR TITLE
mount module: execute the mount only after path validation

### DIFF
--- a/library/system/mount
+++ b/library/system/mount
@@ -307,7 +307,6 @@ def main():
         module.exit_json(changed=changed, **args)
 
     if state in ['mounted', 'present']:
-        name, changed = set_mount(**args)
         if state == 'mounted':
             if not os.path.exists(name):
                 try:
@@ -315,6 +314,8 @@ def main():
                 except (OSError, IOError), e:
                     module.fail_json(msg="Error making dir %s: %s" % (name, str(e)))
 
+        name, changed = set_mount(**args)
+        if state == 'mounted':
             res = 0
             if os.path.ismount(name):
                 if changed:


### PR DESCRIPTION
This avoids a stale situation where name/path contains some impossible path,
but gets configured (faultly) in fstab, and the module only fails after that,
when creating that path.

I bumped into this situation by a misconfiguration where the path name was set to an empty string, while mounting an nfs share.

The module failed with `msg: Error making dir : [Errno 2] No such file or directory: ''` but left /etc/fstab with a broken configuration that made the host unbootable.
