### PR TITLE
Enable puppet facts

### DIFF
--- a/library/system/setup
+++ b/library/system/setup
@@ -91,7 +91,7 @@ def run_setup(module):
     # if facter is installed, and we can use --json because
     # ruby-json is ALSO installed, include facter data in the JSON
     if facter_path is not None:
-        rc, out, err = module.run_command(facter_path + " --json")
+        rc, out, err = module.run_command(facter_path + " --puppet --json")
         facter = True
         try:
             facter_ds = json.loads(out)


### PR DESCRIPTION
Currently facter facts omit facts that a distributed via Puppet. This
commit adds the `--puppet` option.

In cases where puppet is not installed, the command sends a warning to
STDERR _but_ completes successfully. So should not cause any issues.

The benefit is, filtering can be done based on facts set by Puppet.
