### PR TITLE
Updates composer module to display error msgs when they are written to stdout instead of stderr

### DIFF
--- a/library/packaging/composer
+++ b/library/packaging/composer
@@ -142,6 +142,8 @@ def main():
 
     if rc != 0:
         output = parse_out(err)
+        if not output:
+            output = parse_out(out)
         module.fail_json(msg=output)
     else:
         output = parse_out(out)


### PR DESCRIPTION
**Bug**
Composer module returns a blank error messages when it fails with an exits status = 2.

**Details**
For certain errors (exit status 2 at least) the composer php packaging utility logs error messages to STDOUT instead of STDERR. The Ansible composer module expects all error messages to be on STDERR so and when exit status = 2 a blank message is sent back because STDERR is empty. In reality the error message has been shown on STDOUT but not captured and returned.

**Example**

_Error from Ansible_

```
> ansible-playbook -i INVENTORY playbook.yml
...
TASK: [Install project PHP dependencies] **************************************
failed: [N.N.N.N] => {"failed": true}
```

_Error when running Ansible command manually_

```
> cd ~/.ansible/tmp/ansible-tmp-1405629175.53-27462187925006
> ./composer
{"msg": "", "failed": true}
> echo $?
1
```

_Error when running raw composer module command_

```
> /usr/bin/php /usr/local/bin/composer install --no-interaction --no-ansi --no-progress --no-dev --optimize-autoloader --working-dir=/path/to/working/dir

Loading composer repositories with package information
Installing dependencies from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for mashape/unirest-php 1.2.1 -> satisfiable by mashape/unirest-php[1.2.1].
    - mashape/unirest-php 1.2.1 requires ext-curl * -> the requested PHP extension curl is missing from your system.
  Problem 2
    - mashape/unirest-php 1.2.1 requires ext-curl * -> the requested PHP extension curl is missing from your system.
    - sendgrid/sendgrid 2.0.6 requires mashape/unirest-php 1.2.1 -> satisfiable by mashape/unirest-php[1.2.1].
    - Installation request for sendgrid/sendgrid 2.0.6 -> satisfiable by sendgrid/sendgrid[2.0.6].

> echo $?
2
```

**Solution**
When an error exit status is encountered use STDERR unless it is empty then use STDOUT.

_Error Message After Fix_

```
> ansible-playbook -i INVENTORY playbook.yml

TASK: [Install project PHP dependencies] **************************************
failed: [107.170.174.224] => {"failed": true}
msg: Loading composer repositories with package information Installing dependencies from lock file Your requirements could not be resolved to an installable set of packages. Problem 1 - Installation request for mashape/unirest-php 1.2.1 -> satisfiable by mashape/unirest-php[1.2.1]. - mashape/unirest-php 1.2.1 requires ext-curl * -> the requested PHP extension curl is missing from your system.
```
