### PR TITLE
Allow role paths to be appended on the command line

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -83,6 +83,9 @@ def main(args):
         help="start the playbook at the task matching this name")
     parser.add_option('--force-handlers', dest='force_handlers', action='store_true',
         help="run handlers even if a task fails")
+    parser.add_option('-r', '--roles_path', dest='roles_paths', action='append',
+        default=map(os.path.expanduser, C.DEFAULT_ROLES_PATH.split(os.pathsep)),
+        help="add further additional directories to search for roles (default %default)")
 
     options, args = parser.parse_args(args)
 
@@ -188,7 +191,8 @@ def main(args):
             su_pass=su_pass,
             su_user=options.su_user,
             vault_password=vault_pass,
-            force_handlers=options.force_handlers
+            force_handlers=options.force_handlers,
+            roles_paths=options.roles_paths,
         )
 
         if options.listhosts or options.listtasks or options.syntax:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -78,6 +78,7 @@ class PlayBook(object):
         su_pass          = False,
         vault_password   = False,
         force_handlers   = False,
+        roles_paths      = None,
     ):
 
         """
@@ -99,6 +100,7 @@ class PlayBook(object):
         check:            don't change anything, just try to detect some potential changes
         any_errors_fatal: terminate the entire execution immediately when one of the hosts has failed
         force_handlers:   continue to notify and run handlers even if a task fails 
+        roles_paths:      additional directories to search for roles
         """
 
         self.SETUP_CACHE = SETUP_CACHE
@@ -149,6 +151,7 @@ class PlayBook(object):
         self.su_pass          = su_pass
         self.vault_password   = vault_password
         self.force_handlers   = force_handlers
+        self.roles_paths      = roles_paths
 
         self.callbacks.playbook = self
         self.runner_callbacks.playbook = self

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -34,7 +34,7 @@ class Play(object):
        'hosts', 'name', 'vars', 'default_vars', 'vars_prompt', 'vars_files',
        'handlers', 'remote_user', 'remote_port', 'included_roles', 'accelerate',
        'accelerate_port', 'accelerate_ipv6', 'sudo', 'sudo_user', 'transport', 'playbook',
-       'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
+       'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks', 'roles_paths',
        'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts', 'su', 'su_user', 'vault_password'
     ]
 
@@ -66,6 +66,7 @@ class Play(object):
         self.roles            = ds.get('roles', None)
         self.tags             = ds.get('tags', None)
         self.vault_password   = vault_password
+        self.roles_paths      = self.playbook.roles_paths
 
         if self.tags is None:
             self.tags = []
@@ -186,10 +187,8 @@ class Play(object):
             utils.path_dwim(self.basedir, os.path.join('roles', orig_path)),
             utils.path_dwim(self.basedir, orig_path)
         ]
-
-        if C.DEFAULT_ROLES_PATH:
-            search_locations = C.DEFAULT_ROLES_PATH.split(os.pathsep)
-            for loc in search_locations:
+        if self.roles_paths:
+            for loc in self.roles_paths:
                 loc = os.path.expanduser(loc)
                 possible_paths.append(utils.path_dwim(loc, orig_path))
 


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

ansible 1.7 (devel d4548fdd01) last updated 2014/07/18 11:25:37 (GMT +1000)
##### Environment:

N/A
##### Summary:

Allow role paths to be appended on the command line

Move the DEFAULT_ROLE_PATH handling into bin/ansible-playbook and just pass roles_paths to playbooks (the plays pick up the path from the playbook)

Usage:

```
ansible-playbook -r /opt/local/ansible/common/roles -r /opt/local/ansible/application/roles playbook.yml
```

Still respects the defaults and settings in ansible configuration file.
##### Steps To Reproduce:

N/A
##### Expected Results:

N/A
##### Actual Results:

N/A
