### PR TITLE
vmware inventory fixes and features

### DIFF
--- a/plugins/inventory/vmware.ini
+++ b/plugins/inventory/vmware.ini
@@ -6,8 +6,8 @@ guests_only = True
 #hw_group =
 
 [cache]
-cache_max_age = 3600
-cache_dir = /var/tmp
+max_age = 3600
+dir = ~/.cache/ansible
 
 [auth]
 host = vcenter.example.com

--- a/plugins/inventory/vmware.py
+++ b/plugins/inventory/vmware.py
@@ -14,6 +14,9 @@ i.e vmware.py/vmware_colo.ini vmware_idf.py/vmware_idf.ini
 so if you don't have clustered vcenter  but multiple esx machines or
 just diff clusters you can have a inventory  per each and automatically
 group hosts based on file name or specify a group in the ini.
+
+You can also use <SCRIPT_NAME>_HOST|USER|PASSWORD environment variables
+to override the ini.
 '''
 
 import os
@@ -31,33 +34,40 @@ except ImportError:
 
 def save_cache(cache_item, data, config):
     ''' saves item to cache '''
-    dpath = config.get('defaults', 'cache_dir')
-    try:
-        cache = open('/'.join([dpath,cache_item]), 'w')
-        cache.write(json.dumps(data))
-        cache.close()
-    except IOError, e:
-        pass # not really sure what to do here
+
+    if config.has_option('cache', 'dir'):
+        dpath = os.path.expanduser(config.get('cache', 'dir'))
+        try:
+            if not os.path.exists(dpath):
+                os.makedirs(dpath)
+            if os.path.isdir(dpath):
+                cache = open('/'.join([dpath,cache_item]), 'w')
+                cache.write(json.dumps(data))
+                cache.close()
+        except IOError, e:
+            pass # not really sure what to do here
 
 
 def get_cache(cache_item, config):
     ''' returns cached item  '''
-    dpath = config.get('defaults', 'cache_dir')
+
     inv = {}
-    try:
-        cache = open('/'.join([dpath,cache_item]), 'r')
-        inv = json.loads(cache.read())
-        cache.close()
-    except IOError, e:
-        pass # not really sure what to do here
+    if config.has_option('cache', 'dir'):
+        dpath = os.path.expanduser(config.get('cache', 'dir'))
+        try:
+            cache = open('/'.join([dpath,cache_item]), 'r')
+            inv = json.loads(cache.read())
+            cache.close()
+        except IOError, e:
+            pass # not really sure what to do here
 
     return inv
 
 def cache_available(cache_item, config):
     ''' checks if we have a 'fresh' cache available for item requested '''
 
-    if config.has_option('defaults', 'cache_dir'):
-        dpath = config.get('defaults', 'cache_dir')
+    if config.has_option('cache', 'dir'):
+        dpath = os.path.expanduser(config.get('cache', 'dir'))
 
         try:
             existing = os.stat( '/'.join([dpath,cache_item]))
@@ -65,8 +75,8 @@ def cache_available(cache_item, config):
             # cache doesn't exist or isn't accessible
             return False
 
-        if config.has_option('defaults', 'cache_max_age'):
-            maxage = config.get('defaults', 'cache_max_age')
+        if config.has_option('cache', 'max_age'):
+            maxage = config.get('cache', 'max_age')
 
             if (existing.st_mtime - int(time.time())) <= maxage:
                 return True
@@ -78,9 +88,9 @@ def get_host_info(host):
 
     hostinfo = {
                 'vmware_name' : host.name,
-                'vmware_tag' : host.tag,
                 'vmware_parent': host.parent.name,
                }
+
     for k in host.capability.__dict__.keys():
         if k.startswith('_'):
            continue
@@ -95,9 +105,11 @@ def get_host_info(host):
 def get_inventory(client, config):
     ''' Reads the inventory from cache or vmware api '''
 
+    inv = {}
+
     if cache_available('inventory', config):
         inv = get_cache('inventory',config)
-    else:
+    elif client:
         inv= { 'all': {'hosts': []}, '_meta': { 'hostvars': {} } }
         default_group = os.path.basename(sys.argv[0]).rstrip('.py')
 
@@ -125,39 +137,25 @@ def get_inventory(client, config):
             if not guests_only:
                 inv['all']['hosts'].append(host.name)
                 inv[hw_group].append(host.name)
-                if host.tag:
-                    taggroup = 'vmware_' + host.tag
-                    if taggroup in inv:
-                        inv[taggroup].append(host.name)
-                    else:
-                        inv[taggroup] = [ host.name ]
-
                 inv['_meta']['hostvars'][host.name] = get_host_info(host)
                 save_cache(vm.name, inv['_meta']['hostvars'][host.name], config)
 
             for vm in host.vm:
                 inv['all']['hosts'].append(vm.name)
                 inv[vm_group].append(vm.name)
-                if vm.tag:
-                    taggroup = 'vmware_' + vm.tag
-                    if taggroup in inv:
-                        inv[taggroup].append(vm.name)
-                    else:
-                        inv[taggroup] = [ vm.name ]
-
-                inv['_meta']['hostvars'][vm.name] = get_host_info(host)
+                inv['_meta']['hostvars'][vm.name] = get_host_info(vm)
                 save_cache(vm.name, inv['_meta']['hostvars'][vm.name], config)
 
-    save_cache('inventory', inv, config)
+        save_cache('inventory', inv, config)
+
     return json.dumps(inv)
 
 def get_single_host(client, config, hostname):
 
     inv = {}
-
     if cache_available(hostname, config):
         inv = get_cache(hostname,config)
-    else:
+    elif client:
         hosts = HostSystem.all(client) #TODO: figure out single host getter
         for host in hosts:
             if hostname == host.name:
@@ -165,13 +163,14 @@ def get_single_host(client, config, hostname):
                 break
             for vm in host.vm:
                 if hostname == vm.name:
-                    inv = get_host_info(host)
+                    inv = get_host_info(vm)
                     break
         save_cache(hostname,inv,config)
 
     return json.dumps(inv)
 
 if __name__ == '__main__':
+
     inventory = {}
     hostname = None
 
@@ -181,25 +180,28 @@ if __name__ == '__main__':
 
     # Read config
     config = ConfigParser.SafeConfigParser()
-    for configfilename in [os.path.abspath(sys.argv[0]).rstrip('.py') + '.ini', 'vmware.ini']:
+    me = os.path.abspath(sys.argv[0]).rstrip('.py')
+    for configfilename in [me + '.ini', 'vmware.ini']:
         if os.path.exists(configfilename):
             config.read(configfilename)
             break
 
+    mename = os.path.basename(me).upper()
+    host =  os.getenv('VMWARE_' + mename + '_HOST',os.getenv('VMWARE_HOST', config.get('auth','host')))
+    user = os.getenv('VMWARE_' + mename + '_USER', os.getenv('VMWARE_USER', config.get('auth','user')))
+    password = os.getenv('VMWARE_' + mename + '_PASSWORD',os.getenv('VMWARE_PASSWORD', config.get('auth','password')))
+
     try:
-        client =  Client( config.get('auth','host'),
-                          config.get('auth','user'),
-                          config.get('auth','password'),
-                        )
+        client =  Client( host,user,password )
     except Exception, e:
         client = None
         #print >> STDERR "Unable to login (only cache avilable): %s", str(e)
 
-    # acitually do the work
+    # Actually do the work
     if hostname is None:
         inventory = get_inventory(client, config)
     else:
         inventory = get_single_host(client, config, hostname)
 
-    # return to ansible
+    # Return to ansible
     print inventory

--- a/plugins/inventory/vmware.py
+++ b/plugins/inventory/vmware.py
@@ -70,15 +70,15 @@ def cache_available(cache_item, config):
         dpath = os.path.expanduser(config.get('cache', 'dir'))
 
         try:
-            existing = os.stat( '/'.join([dpath,cache_item]))
+            existing = os.stat('/'.join([dpath,cache_item]))
         except:
             # cache doesn't exist or isn't accessible
             return False
 
         if config.has_option('cache', 'max_age'):
             maxage = config.get('cache', 'max_age')
-
-            if (existing.st_mtime - int(time.time())) <= maxage:
+            fileage = int( time.time() - existing.st_mtime )
+            if (maxage > fileage):
                 return True
 
     return False
@@ -87,10 +87,8 @@ def get_host_info(host):
     ''' Get variables about a specific host '''
 
     hostinfo = {
-                'vmware_name' : host.name,
-                'vmware_parent': host.parent.name,
-               }
-
+        'vmware_name' : host.name,
+    }
     for k in host.capability.__dict__.keys():
         if k.startswith('_'):
            continue


### PR DESCRIPTION
added environment variables as config overrides for vmware inventory
fixed vmware properties, was getting parent's properties
cache now actually works
removed tags, they were not the ones i was looking for
renamed cache defaults fixed ini file to match
avoid several tracebacks you got if misconfigured

this is a resubmit of #8138 (incorporating feedback), trying to update that branch brought in other unwanted commits
