### PR TITLE
vsphere_guest: Adding the Guest Primary IP Address to the vmware_guest_facts run

### DIFF
--- a/library/cloud/vsphere_guest
+++ b/library/cloud/vsphere_guest
@@ -935,6 +935,7 @@ def gather_facts(vm):
         'hw_product_uuid': vm.properties.config.uuid,
         'hw_processor_count': vm.properties.config.hardware.numCPU,
         'hw_memtotal_mb': vm.properties.config.hardware.memoryMB,
+        'guest_primary_ipaddress': vm.properties.guest.ipAddress,
     }
 
     ifidx = 0

--- a/library/cloud/vsphere_guest
+++ b/library/cloud/vsphere_guest
@@ -927,6 +927,13 @@ def gather_facts(vm):
     Gather facts for VM directly from vsphere.
     """
     vm.get_properties()
+
+    # attempt to get guest ipAddress -- If not exist set var to False
+    try:
+        guest_primary_ipaddress = vm.properties.guest.ipAddress
+    except AttributeError:
+        guest_primary_ipaddress = False
+
     facts = {
         'module_hw': True,
         'hw_name': vm.properties.name,


### PR DESCRIPTION
Adding the vm.properties.guest.ipAddress Parameter (Primary IP Address of the VM; Fetched by the VMware Tools) to the vmware_guest_facts run

Very useful if you have deployed an Template Image with DHCP and want to get the current IP
