### PR TITLE
Adding Tests Integration for mysql db

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -7,3 +7,4 @@
     - { role: test_yum, tags: test_yum }
     - { role: test_apt, tags: test_apt }
     - { role: test_apt_repository, tags: test_apt_repository }
+    - { role: test_mysql_db, tags: test_mysql_db}

--- a/test/integration/roles/setup_mysql_db/defaults/main.yml
+++ b/test/integration/roles/setup_mysql_db/defaults/main.yml
@@ -1,0 +1,6 @@
+mysql_service: mysqld
+
+mysql_packages: 
+    - mysql-server
+    - MySQL-python
+    - bzip2

--- a/test/integration/roles/setup_mysql_db/tasks/main.yml
+++ b/test/integration/roles/setup_mysql_db/tasks/main.yml
@@ -1,0 +1,33 @@
+# setup code for the mysql_db module
+# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+- include_vars: '{{ ansible_os_family }}.yml' 
+
+- name: install mysqldb_test rpm dependencies
+  yum: name={{ item }} state=latest 
+  with_items: mysql_packages
+  when: ansible_pkg_mgr  ==  'yum'
+
+- name: install mysqldb_test debian dependencies 
+  apt: name={{ item }} state=latest 
+  with_items:  mysql_packages
+  when: ansible_pkg_mgr  ==  'apt'
+
+- name: start mysql_db service if not running
+  service: name={{ mysql_service }} state=started

--- a/test/integration/roles/setup_mysql_db/vars/Debian.yml
+++ b/test/integration/roles/setup_mysql_db/vars/Debian.yml
@@ -1,0 +1,6 @@
+mysql_service: 'mysql'
+
+mysql_packages: 
+    - mysql-server
+    - python-mysqldb
+    - bzip2

--- a/test/integration/roles/setup_mysql_db/vars/RedHat.yml
+++ b/test/integration/roles/setup_mysql_db/vars/RedHat.yml
@@ -1,0 +1,6 @@
+mysql_service: 'mysqld'
+
+mysql_packages: 
+    - mysql-server
+    - MySQL-python
+    - bzip2

--- a/test/integration/roles/test_lineinfile/tasks/main.yml
+++ b/test/integration/roles/test_lineinfile/tasks/main.yml
@@ -152,7 +152,7 @@
     - "result.stat.md5 == '661603660051991b79429c2dc68d9a67'"
 
 - name: run a validation script that succeeds
-  lineinfile: dest={{output_dir}}/test.txt state=absent regexp="^This is line 5$" validate="/bin/true %s"
+  lineinfile: dest={{output_dir}}/test.txt state=absent regexp="^This is line 5$" validate="true %s"
   register: result
 
 - name: assert that the file validated after removing a line

--- a/test/integration/roles/test_mysql_db/defaults/main.yml
+++ b/test/integration/roles/test_mysql_db/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# defaults file for test_mysql_db
+db_name: 'data'
+db_user1: 'datauser1'
+db_user2: 'datauser2'
+
+tmp_dir: '/tmp'
+

--- a/test/integration/roles/test_mysql_db/meta/main.yml
+++ b/test/integration/roles/test_mysql_db/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_mysql_db

--- a/test/integration/roles/test_mysql_db/tasks/main.yml
+++ b/test/integration/roles/test_mysql_db/tasks/main.yml
@@ -1,0 +1,192 @@
+# test code for the mysql_db module
+# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+- name: test state=present for a database name (expect changed=true)
+  mysql_db: name={{ db_name }} state=present
+  register: result
+
+- name: assert output message that database exist 
+  assert:
+    that:
+       - "result.changed == true"
+       - "result.db =='{{ db_name }}'"
+
+- name: run command to test state=present for a database name (expect db_name in stdout)
+  command: mysql "-e show databases like '{{ db_name }}';"
+  register: result
+
+- name: assert database exist 
+  assert: { that: "'{{ db_name }}' in result.stdout" }
+
+# ============================================================
+- name: test state=absent for a database name (expect changed=true)
+  mysql_db: name={{ db_name }} state=absent
+  register: result
+
+- name: assert output message that database does not exist 
+  assert:
+    that:
+       - "result.changed == true"
+       - "result.db =='{{ db_name }}'"
+
+- name: run command to test state=absent for a database name (expect db_name not in stdout)
+  command: mysql "-e show databases like '{{ db_name }}';"
+  register: result
+
+- name: assert database does not exist   
+  assert: { that: "'{{ db_name }}' not in result.stdout" }
+
+# ============================================================
+- name: test mysql_db encoding param not valid - issue 8075
+  mysql_db: name=datanotvalid state=present encoding=notvalid 
+  register: result
+  ignore_errors: true 
+
+- name: assert test mysql_db encoding param not valid - issue 8075 (failed=true)
+  assert:
+    that:
+       - "result.failed == true"
+       - "'Traceback' not in result.msg"
+       - "'Unknown character set' in result.msg"
+
+# ============================================================
+- name: test mysql_db using a valid encoding utf8 (expect changed=true)
+  mysql_db: name=en{{ db_name }}  state=present encoding=utf8
+  register: result
+ 
+- name: assert output message created a database   
+  assert: { that: "result.changed == true" }
+
+- name: test database was created  
+  command: mysql "-e SHOW CREATE DATABASE en{{ db_name }};"
+  register: result
+
+- name: assert created database is of encoding utf8
+  assert: { that: "'utf8' in result.stdout" }
+
+- name: remove database
+  mysql_db: name=en{{ db_name }} state=absent
+
+# ============================================================
+- name: test mysql_db using valid encoding binary (expect changed=true)
+  mysql_db: name=en{{ db_name }}  state=present encoding=binary
+  register: result
+
+- name: assert output message that database was created 
+  assert: { that: "result.changed == true" }
+
+- name: run command to test database was created 
+  command: mysql "-e SHOW CREATE DATABASE en{{ db_name }};"
+  register: result
+
+- name: assert created database is of encoding binary
+  assert: { that: "'binary' in result.stdout" }
+
+- name: remove database 
+  mysql_db: name=en{{ db_name }}  state=absent
+
+# ============================================================
+- name: create user1 to access database dbuser1
+  mysql_user: name=user1 password=password1 priv=*.*:ALL state=present
+
+- name: create database dbuser1 using user1
+  mysql_db: name={{ db_user1 }} state=present login_user=user1 login_password=password1
+  register: result
+
+- name: assert output message that database was created 
+  assert: { that: "result.changed == true" }
+
+- name: run command to test database was created using user1
+  command: mysql "-e show databases like '{{ db_user1 }}';"
+  register: result
+
+- name: assert database exist 
+  assert: { that: "'{{ db_user1 }}' in result.stdout" }
+
+# ============================================================
+- name: create user2 to access database with privilege select only
+  mysql_user: name=user2 password=password2 priv=*.*:SELECT state=present 
+
+- name: create database dbuser2 using user2 with no privilege to create (expect failed=true)
+  mysql_db: name={{ db_user2 }} state=present login_user=user2 login_password=password2
+  register: result
+  ignore_errors: true
+
+- name: assert output message that database was not created using dbuser2 
+  assert:
+    that:
+       - "result.failed == true"
+       - "'Access denied' in result.msg"
+
+- name: run command to test that database was not created
+  command: mysql "-e show databases like '{{ db_user2 }}';"
+  register: result
+
+- name: assert database does not exist   
+  assert: { that: "'{{ db_user2 }}' not in result.stdout" }
+
+# ============================================================
+- name: delete database using user2 with no privilege to delete (expect failed=true)
+  mysql_db: name={{ db_user1 }} state=absent login_user=user2 login_password=password2
+  register: result
+  ignore_errors: true
+
+- name: assert output message that database was not deleted using dbuser2 
+  assert:
+    that:
+       - "result.failed == true"
+       - "'Access denied' in result.msg"
+
+- name: run command to test database was not deleted
+  command: mysql "-e show databases like '{{ db_user1 }}';"
+  register: result
+
+- name: assert database still exist 
+  assert: { that: "'{{ db_user1 }}' in result.stdout" }
+
+# ============================================================
+- name: delete database using user1 with all privilege to delete a database (expect changed=true)
+  mysql_db: name={{ db_user1 }} state=absent login_user=user1 login_password=password1
+  register: result
+  ignore_errors: true
+
+- name: assert output message that database was deleted using user1
+  assert: { that: "result.changed == true" }
+
+- name: run command to test database was deleted using user1
+  command: mysql "-e show databases like '{{ db_name }}';"
+  register: result
+
+- name: assert database does not exist   
+  assert: { that: "'{{ db_user1 }}' not in result.stdout" }
+
+# ============================================================
+- include: state_dump_import.yml format_type=sql file=dbdata.sql format_msg_type=ASCII
+
+- include: state_dump_import.yml format_type=gz  file=dbdata.gz format_msg_type=gzip
+
+- include: state_dump_import.yml format_type=bz2 file=dbdata.bz2 format_msg_type=bzip2
+  
+
+
+
+
+
+
+

--- a/test/integration/roles/test_mysql_db/tasks/state_dump_import.yml
+++ b/test/integration/roles/test_mysql_db/tasks/state_dump_import.yml
@@ -1,0 +1,75 @@
+# test code for state dump and import for mysql_db module
+# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+- set_fact: db_file_name="{{tmp_dir}}/{{file}}"
+
+- name: state dump/import - create database  
+  mysql_db: name={{ db_name }} state=present
+
+- name: state dump/import - create table employee
+  command: mysql {{ db_name }} '-e create table employee(id int, name varchar(100));'
+
+- name: state dump/import - insert data into table employee
+  command: mysql {{ db_name }} "-e insert into employee value(47,'Joe Smith');"
+
+- name: state dump/import - file name should not exist
+  file: name={{ db_file_name }} state=absent
+
+- name: test state=dump to backup the database of type {{ format_type }} (expect changed=true)
+  mysql_db: name={{ db_name }} state=dump target={{ db_file_name }}
+  register: result
+
+- name: assert output message backup the database
+  assert:
+    that:
+       - "result.changed == true"
+       - "result.db =='{{ db_name }}'"
+
+- name: assert database was backup succesfully  
+  command: file {{ db_file_name }}
+  register: result
+
+- name: assert file format type
+  assert: { that: "'{{format_msg_type}}' in result.stdout" }
+
+- name: update database table employee
+  command: mysql {{ db_name }} "-e update employee set name='John Doe' where id=47;"
+
+- name: test state=import to restore the database of type {{ format_type }} (expect changed=true)
+  mysql_db: name={{ db_name }} state=import target={{ db_file_name }}
+  register: result
+
+- name: assert output message restore the database 
+  assert: { that: "result.changed == true" }
+
+- name: select data from table employee 
+  command: mysql {{ db_name }} "-e select * from  employee;"
+  register: result
+
+- name: assert data in database is from the restore database 
+  assert:
+    that:
+       - "'47' in result.stdout"
+       - "'Joe Smith' in result.stdout"
+
+- name: remove database name
+  mysql_db: name={{ db_name }} state=absent
+
+- name: remove file name 
+  file: name={{ db_file_name }}  state=absent


### PR DESCRIPTION
Adding the following Test Coverage for RedHat and Debian OS:
- Use mysql_db module to create, delete databases using different encoding.
- Backup/Restore databases using different file format: sql, gz and bz2.
- Create and delete databases using different user privilege.
- Assert database creation, deleting and content using system commands.
