### PR TITLE
[Docs] Added another example to demonstrate unarchive module working entirely on a remote machine

### DIFF
--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -71,7 +71,7 @@ EXAMPLES = '''
 - unarchive: src=foo.tgz dest=/var/lib/foo
 
 # Unarchive a file on a remote machine
-- unarchive: src=/tmp/foo.zip dest=/usr/local/bin
+- unarchive: src=/tmp/foo.zip dest=/usr/local/bin copy=false
 '''
 
 import os

--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -69,6 +69,9 @@ notes:
 EXAMPLES = '''
 # Example from Ansible Playbooks
 - unarchive: src=foo.tgz dest=/var/lib/foo
+
+# Unarchive a file on a remote machine
+- unarchive: src=/tmp/foo.zip dest=/usr/local/bin
 '''
 
 import os


### PR DESCRIPTION
Like many people in [this thread](https://github.com/ansible/ansible/issues/6131) I missed the part in the unarchive documentation about it being able to work entirely on a remote machine. I've added an example to the docs to remedy this.
