### PR TITLE
Fact Caching Revisited

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -83,6 +83,8 @@ def main(args):
         help="start the playbook at the task matching this name")
     parser.add_option('--force-handlers', dest='force_handlers', action='store_true',
         help="run handlers even if a task fails")
+    parser.add_option('--flush-cache', dest='flush_cache', action='store_true',
+        help="flush to fact cache")
 
     options, args = parser.parse_args(args)
 
@@ -201,6 +203,10 @@ def main(args):
             vault_password=vault_pass,
             force_handlers=options.force_handlers
         )
+
+        if options.flush_cache:
+            display(callbacks.banner("FLUSHING FACT CACHE"))
+            pb.SETUP_CACHE.flush()
 
         if options.listhosts or options.listtasks or options.syntax:
             print ''
@@ -324,4 +330,3 @@ if __name__ == "__main__":
     except KeyboardInterrupt, ke:
         display("ERROR: interrupted", color='red', stderr=True)
         sys.exit(1)
-

--- a/lib/ansible/cache/__init__.py
+++ b/lib/ansible/cache/__init__.py
@@ -50,10 +50,12 @@ class FactCache(MutableMapping):
         return len(self._plugin.keys())
 
     def copy(self):
-        """
-        Return a primitive copy of the keys and values from the cache.
-        """
+        """ Return a primitive copy of the keys and values from the cache. """
         return dict([(k, v) for (k, v) in self.iteritems()])
 
     def keys(self):
         return self._plugin.keys()
+
+    def flush(self):
+        """ Flush the fact cache of all keys. """
+        self._plugin.flush()

--- a/lib/ansible/cache/__init__.py
+++ b/lib/ansible/cache/__init__.py
@@ -1,0 +1,59 @@
+# (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import MutableMapping
+
+from ansible import utils
+from ansible import constants as C
+from ansible import errors
+
+
+class FactCache(MutableMapping):
+
+    def __init__(self, *args, **kwargs):
+        self._plugin = utils.plugins.cache_loader.get(C.CACHE_PLUGIN)
+        if self._plugin is None:
+            return
+
+    def __getitem__(self, key):
+        if key not in self:
+            raise KeyError
+        return self._plugin.get(key)
+
+    def __setitem__(self, key, value):
+        self._plugin.set(key, value)
+
+    def __delitem__(self, key):
+        self._plugin.delete(key)
+
+    def __contains__(self, key):
+        return self._plugin.contains(key)
+
+    def __iter__(self):
+        return iter(self._plugin.keys())
+
+    def __len__(self):
+        return len(self._plugin.keys())
+
+    def copy(self):
+        """
+        Return a primitive copy of the keys and values from the cache.
+        """
+        return dict([(k, v) for (k, v) in self.iteritems()])
+
+    def keys(self):
+        return self._plugin.keys()

--- a/lib/ansible/cache/base.py
+++ b/lib/ansible/cache/base.py
@@ -13,3 +13,6 @@ class BaseCacheModule(object):
 
     def delete(self, key):
         raise NotImplementedError("Subclasses of {} must implement the '{}' method".format(self.__class__.__name__, self.__name__))
+
+    def flush(self):
+        raise NotImplementedError("Subclasses of {} must implement the '{}' method".format(self.__class__.__name__, self.__name__))

--- a/lib/ansible/cache/base.py
+++ b/lib/ansible/cache/base.py
@@ -1,0 +1,15 @@
+class BaseCacheModule(object):
+    def get(self, key):
+        raise NotImplementedError("Subclasses of {} must implement the '{}' method".format(self.__class__.__name__, self.__name__))
+
+    def set(self, key, value):
+        raise NotImplementedError("Subclasses of {} must implement the '{}' method".format(self.__class__.__name__, self.__name__))
+
+    def keys(self):
+        raise NotImplementedError("Subclasses of {} must implement the '{}' method".format(self.__class__.__name__, self.__name__))
+
+    def contains(self, key):
+        raise NotImplementedError("Subclasses of {} must implement the '{}' method".format(self.__class__.__name__, self.__name__))
+
+    def delete(self, key):
+        raise NotImplementedError("Subclasses of {} must implement the '{}' method".format(self.__class__.__name__, self.__name__))

--- a/lib/ansible/cache/file.py
+++ b/lib/ansible/cache/file.py
@@ -47,13 +47,13 @@ class CacheModule(MemoryCacheModule):
 
     def set(self, *args, **kwargs):
         super(CacheModule, self).set(*args, **kwargs)
-        self.flush()
+        self.fsync()
 
     def delete(self, *args, **kwargs):
         super(CacheModule, self).delete(*args, **kwargs)
-        self.flush()
+        self.fsync()
 
-    def flush(self):
+    def fsync(self):
         temp = tempfile.TemporaryFile('r+b')
 
         try:
@@ -63,3 +63,7 @@ class CacheModule(MemoryCacheModule):
                 shutil.copyfileobj(temp, f)
         finally:
             temp.close()
+
+    def flush(self):
+        super(CacheModule, self).flush()
+        self.fsync()

--- a/lib/ansible/cache/file.py
+++ b/lib/ansible/cache/file.py
@@ -1,0 +1,65 @@
+# (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
+import collections
+import json
+import os
+import shutil
+import sys
+import tempfile
+from datetime import datetime
+
+from ansible import constants as C
+from ansible.cache.memory import CacheModule as MemoryCacheModule
+
+
+class CacheModule(MemoryCacheModule):
+    def __init__(self):
+        super(CacheModule, self).__init__()
+        self._timeout = int(C.CACHE_PLUGIN_TIMEOUT)
+        self._filename = '/tmp/ansible_facts.json'
+
+        if os.access(self._filename, os.R_OK):
+            mtime = datetime.fromtimestamp(os.path.getmtime(self._filename))
+            if self._timeout == 0 or (datetime.now() - mtime).total_seconds() < self._timeout:
+                with open(self._filename, 'rb') as f:
+                    # we could make assumptions about the MemoryCacheModule here if we wanted
+                    # to be more efficient, but performance isn't the priority with this module
+                    data = json.load(f)
+                    if isinstance(data, collections.Mapping):
+                        for k, v in data.items():
+                            super(CacheModule, self).set(k, v)
+
+    def set(self, *args, **kwargs):
+        super(CacheModule, self).set(*args, **kwargs)
+        self.flush()
+
+    def delete(self, *args, **kwargs):
+        super(CacheModule, self).delete(*args, **kwargs)
+        self.flush()
+
+    def flush(self):
+        temp = tempfile.TemporaryFile('r+b')
+
+        try:
+            json.dump(self._cache, temp, separators=(',', ':'))
+            temp.seek(0)
+            with open(self._filename, 'w+b') as f:
+                shutil.copyfileobj(temp, f)
+        finally:
+            temp.close()

--- a/lib/ansible/cache/memcached.py
+++ b/lib/ansible/cache/memcached.py
@@ -110,3 +110,7 @@ class CacheModule(BaseCacheModule):
     def delete(self, key):
         self._cache.delete(self._make_key(key))
         self._keys.discard(key)
+
+    def flush(self):
+        for key in self.keys():
+            self.delete(key)

--- a/lib/ansible/cache/memcached.py
+++ b/lib/ansible/cache/memcached.py
@@ -1,0 +1,112 @@
+# (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+import collections
+import sys
+import time
+
+from ansible import constants as C
+from ansible.cache.base import BaseCacheModule
+
+try:
+    import memcache
+except ImportError:
+    print 'python-memcached is required for the memcached fact cache'
+    sys.exit(1)
+
+
+class CacheModuleKeys(collections.MutableSet):
+    """
+    A set subclass that keeps track of insertion time and persists
+    the set in memcached.
+    """
+    PREFIX = 'ansible_cache_keys'
+
+    def __init__(self, cache, *args, **kwargs):
+        self._cache = cache
+        self._keyset = dict(*args, **kwargs)
+
+    def __contains__(self, key):
+        return key in self._keyset
+
+    def __iter__(self):
+        return iter(self._keyset)
+
+    def __len__(self):
+        return len(self._keyset)
+
+    def add(self, key):
+        self._keyset[key] = time.time()
+        self._cache.set(self.PREFIX, self._keyset)
+
+    def discard(self, key):
+        del self._keyset[key]
+        self._cache.set(self.PREFIX, self._keyset)
+
+    def remove_by_timerange(self, s_min, s_max):
+        for k in self._keyset.keys():
+            t = self._keyset[k]
+            if s_min < t < s_max:
+                del self._keyset[k]
+        self._cache.set(self.PREFIX, self._keyset)
+
+
+class CacheModule(BaseCacheModule):
+
+    def __init__(self, *args, **kwargs):
+        if C.CACHE_PLUGIN_CONNECTION:
+            connection = C.CACHE_PLUGIN_CONNECTION.split(',')
+        else:
+            connection = ['127.0.0.1:11211']
+
+        self._timeout = C.CACHE_PLUGIN_TIMEOUT
+        self._prefix = C.CACHE_PLUGIN_PREFIX
+        self._cache = memcache.Client(connection, debug=0)
+        self._keys = CacheModuleKeys(self._cache, self._cache.get(CacheModuleKeys.PREFIX) or [])
+
+    def _make_key(self, key):
+        return "{}{}".format(self._prefix, key)
+
+    def _expire_keys(self):
+        if self._timeout > 0:
+            expiry_age = time.time() - self._timeout
+        self._keys.remove_by_timerange(0, expiry_age)
+
+    def get(self, key):
+        value = self._cache.get(self._make_key(key))
+        # guard against the key not being removed from the zset;
+        # this could happen in cases where the timeout value is changed
+        # between invocations
+        if value is None:
+            self.delete(key)
+            raise KeyError
+        return value
+
+    def set(self, key, value):
+        self._cache.set(self._make_key(key), value, time=self._timeout)
+        self._keys.add(key)
+
+    def keys(self):
+        self._expire_keys()
+        return list(iter(self._keys))
+
+    def contains(self, key):
+        self._expire_keys()
+        return key in self._keys
+
+    def delete(self, key):
+        self._cache.delete(self._make_key(key))
+        self._keys.discard(key)

--- a/lib/ansible/cache/memory.py
+++ b/lib/ansible/cache/memory.py
@@ -35,3 +35,6 @@ class CacheModule(object):
 
     def delete(self, key):
         del self._cache[key]
+
+    def flush(self):
+        self._cache = {}

--- a/lib/ansible/cache/memory.py
+++ b/lib/ansible/cache/memory.py
@@ -1,0 +1,37 @@
+# (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class CacheModule(object):
+
+    def __init__(self, *args, **kwargs):
+        self._cache = {}
+
+    def get(self, key):
+        return self._cache.get(key)
+
+    def set(self, key, value):
+        self._cache[key] = value
+
+    def keys(self):
+        return self._cache.keys()
+
+    def contains(self, key):
+        return key in self._cache
+
+    def delete(self, key):
+        del self._cache[key]

--- a/lib/ansible/cache/redis.py
+++ b/lib/ansible/cache/redis.py
@@ -17,7 +17,7 @@
 from __future__ import absolute_import
 
 import collections
-import pickle
+import cPickle
 import sys
 import time
 
@@ -40,13 +40,13 @@ class PickledRedis(StrictRedis):
         pickled_value = super(PickledRedis, self).get(name)
         if pickled_value is None:
             return None
-        return pickle.loads(pickled_value)
+        return cPickle.loads(pickled_value)
 
     def set(self, name, value, *args, **kwargs):
-        return super(PickledRedis, self).set(name, pickle.dumps(value), *args, **kwargs)
+        return super(PickledRedis, self).set(name, cPickle.dumps(value), *args, **kwargs)
 
     def setex(self, name, time, value):
-        return super(PickledRedis, self).setex(name, time, pickle.dumps(value))
+        return super(PickledRedis, self).setex(name, time, cPickle.dumps(value))
 
 
 class CacheModule(BaseCacheModule):

--- a/lib/ansible/cache/redis.py
+++ b/lib/ansible/cache/redis.py
@@ -106,3 +106,7 @@ class CacheModule(BaseCacheModule):
     def delete(self, key):
         self._cache.delete(self._make_key(key))
         self._cache.zrem(self._keys_set, key)
+
+    def flush(self):
+        for key in self.keys():
+            self.delete(key)

--- a/lib/ansible/cache/redis.py
+++ b/lib/ansible/cache/redis.py
@@ -1,0 +1,108 @@
+# (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
+import collections
+import pickle
+import sys
+import time
+
+from ansible import constants as C
+from ansible.cache.base import BaseCacheModule
+
+try:
+    from redis import StrictRedis
+except ImportError:
+    print "The 'redis' Python module is required for the redis fact cache"
+    sys.exit(1)
+
+
+class PickledRedis(StrictRedis):
+    """
+    A subclass of StricRedis that uses the pickle module to store and load
+    representations of the provided values.
+    """
+    def get(self, name):
+        pickled_value = super(PickledRedis, self).get(name)
+        if pickled_value is None:
+            return None
+        return pickle.loads(pickled_value)
+
+    def set(self, name, value, *args, **kwargs):
+        return super(PickledRedis, self).set(name, pickle.dumps(value), *args, **kwargs)
+
+    def setex(self, name, time, value):
+        return super(PickledRedis, self).setex(name, time, pickle.dumps(value))
+
+
+class CacheModule(BaseCacheModule):
+    """
+    A caching module backed by redis.
+
+    Keys are maintained in a zset with their score being the timestamp
+    when they are inserted. This allows for the usage of 'zremrangebyscore'
+    to expire keys. This mechanism is used or a pattern matched 'scan' for
+    performance.
+    """
+    def __init__(self, *args, **kwargs):
+        if C.CACHE_PLUGIN_CONNECTION:
+            connection = C.CACHE_PLUGIN_CONNECTION.split(':')
+        else:
+            connection = []
+
+        self._timeout = C.CACHE_PLUGIN_TIMEOUT
+        self._prefix = C.CACHE_PLUGIN_PREFIX
+        self._cache = PickledRedis(*connection)
+        self._keys_set = 'ansible_cache_keys'
+
+    def _make_key(self, key):
+        return "{}{}".format(self._prefix, key)
+
+    def get(self, key):
+        value = self._cache.get(self._make_key(key))
+        # guard against the key not being removed from the zset;
+        # this could happen in cases where the timeout value is changed
+        # between invocations
+        if value is None:
+            self.delete(key)
+            raise KeyError
+        return value
+
+    def set(self, key, value):
+        if self._timeout > 0: # a timeout of 0 is handled as meaning 'never expire'
+            self._cache.setex(self._make_key(key), self._timeout, value)
+        else:
+            self._cache.set(self._make_key(key), value)
+
+        self._cache.zadd(self._keys_set, time.time(), key)
+
+    def _expire_keys(self):
+        if self._timeout > 0:
+            expiry_age = time.time() - self._timeout
+        self._cache.zremrangebyscore(self._keys_set, 0, expiry_age)
+
+    def keys(self):
+        self._expire_keys()
+        return self._cache.zrange(self._keys_set, 0, -1)
+
+    def contains(self, key):
+        self._expire_keys()
+        return (self._cache.zrank(self._keys_set, key) >= 0)
+
+    def delete(self, key):
+        self._cache.delete(self._make_key(key))
+        self._cache.zrem(self._keys_set, key)

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -137,12 +137,18 @@ DEFAULT_ASK_SU_PASS = get_config(p, DEFAULTS, 'ask_su_pass', 'ANSIBLE_ASK_SU_PAS
 DEFAULT_GATHERING = get_config(p, DEFAULTS, 'gathering', 'ANSIBLE_GATHERING', 'implicit').lower()
 
 DEFAULT_ACTION_PLUGIN_PATH     = get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '/usr/share/ansible_plugins/action_plugins')
+DEFAULT_CACHE_PLUGIN_PATH      = get_config(p, DEFAULTS, 'cache_plugins',      'ANSIBLE_CACHE_PLUGINS', '/usr/share/ansible_plugins/cache_plugins')
 DEFAULT_CALLBACK_PLUGIN_PATH   = get_config(p, DEFAULTS, 'callback_plugins',   'ANSIBLE_CALLBACK_PLUGINS', '/usr/share/ansible_plugins/callback_plugins')
 DEFAULT_CONNECTION_PLUGIN_PATH = get_config(p, DEFAULTS, 'connection_plugins', 'ANSIBLE_CONNECTION_PLUGINS', '/usr/share/ansible_plugins/connection_plugins')
 DEFAULT_LOOKUP_PLUGIN_PATH     = get_config(p, DEFAULTS, 'lookup_plugins',     'ANSIBLE_LOOKUP_PLUGINS', '/usr/share/ansible_plugins/lookup_plugins')
 DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       'ANSIBLE_VARS_PLUGINS', '/usr/share/ansible_plugins/vars_plugins')
 DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '/usr/share/ansible_plugins/filter_plugins')
 DEFAULT_LOG_PATH               = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
+
+CACHE_PLUGIN                   = get_config(p, DEFAULTS, 'cache_plugin', 'ANSIBLE_CACHE_PLUGIN', 'memory')
+CACHE_PLUGIN_CONNECTION        = get_config(p, DEFAULTS, 'cache_plugin_connection', 'ANSIBLE_CACHE_PLUGIN_CONNECTION', None)
+CACHE_PLUGIN_PREFIX            = get_config(p, DEFAULTS, 'cache_plugin_prefix', 'ANSIBLE_CACHE_PLUGIN_PREFIX', 'ansible_facts')
+CACHE_PLUGIN_TIMEOUT           = get_config(p, DEFAULTS, 'cache_plugin_timeout', 'ANSIBLE_CACHE_PLUGIN_TIMEOUT', (60 * 60 * 24), integer=True)
 
 ANSIBLE_FORCE_COLOR            = get_config(p, DEFAULTS, 'force_color', 'ANSIBLE_FORCE_COLOR', None, boolean=True)
 ANSIBLE_NOCOLOR                = get_config(p, DEFAULTS, 'nocolor', 'ANSIBLE_NOCOLOR', None, boolean=True)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -28,6 +28,7 @@ import os
 import sys
 import uuid
 
+
 class Play(object):
 
     __slots__ = [
@@ -84,7 +85,7 @@ class Play(object):
         # now we load the roles into the datastructure
         self.included_roles = []
         ds = self._load_roles(self.roles, ds)
-        
+
         # and finally re-process the vars files as they may have
         # been updated by the included roles
         self.vars_files = ds.get('vars_files', [])
@@ -152,6 +153,7 @@ class Play(object):
         self._tasks      = self._load_tasks(self._ds.get('tasks', []), load_vars)
         self._handlers   = self._load_tasks(self._ds.get('handlers', []), load_vars)
 
+
         # apply any missing tags to role tasks
         self._late_merge_role_tags()
 
@@ -166,7 +168,7 @@ class Play(object):
     def _get_role_path(self, role):
         """
         Returns the path on disk to the directory containing
-        the role directories like tasks, templates, etc. Also 
+        the role directories like tasks, templates, etc. Also
         returns any variables that were included with the role
         """
         orig_path = template(self.basedir,role,self.vars)
@@ -241,7 +243,7 @@ class Play(object):
                                 allow_dupes = utils.boolean(meta_data.get('allow_duplicates',''))
 
                         # if any tags were specified as role/dep variables, merge
-                        # them into the current dep_vars so they're passed on to any 
+                        # them into the current dep_vars so they're passed on to any
                         # further dependencies too, and so we only have one place
                         # (dep_vars) to look for tags going forward
                         def __merge_tags(var_obj):
@@ -317,7 +319,7 @@ class Play(object):
                         dep_stack.append([dep,dep_path,dep_vars,dep_defaults_data])
 
             # only add the current role when we're at the top level,
-            # otherwise we'll end up in a recursive loop 
+            # otherwise we'll end up in a recursive loop
             if level == 0:
                 self.included_roles.append(role)
                 dep_stack.append([role,role_path,role_vars,defaults_data])
@@ -505,7 +507,7 @@ class Play(object):
             if not isinstance(x, dict):
                 raise errors.AnsibleError("expecting dict; got: %s, error in %s" % (x, original_file))
 
-            # evaluate sudo vars for current and child tasks 
+            # evaluate sudo vars for current and child tasks
             included_sudo_vars = {}
             for k in ["sudo", "sudo_user"]:
                 if k in x:
@@ -554,7 +556,7 @@ class Play(object):
                 else:
                     default_vars = utils.combine_vars(self.default_vars, default_vars)
 
-                # append the vars defined with the include (from above) 
+                # append the vars defined with the include (from above)
                 # as well as the old-style 'vars' element. The old-style
                 # vars are given higher precedence here (just in case)
                 task_vars = utils.combine_vars(task_vars, include_vars)
@@ -609,8 +611,8 @@ class Play(object):
 
     def _is_valid_tag(self, tag_list):
         """
-        Check to see if the list of tags passed in is in the list of tags 
-        we only want (playbook.only_tags), or if it is not in the list of 
+        Check to see if the list of tags passed in is in the list of tags
+        we only want (playbook.only_tags), or if it is not in the list of
         tags we don't want (playbook.skip_tags).
         """
         matched_skip_tags = set(tag_list) & set(self.playbook.skip_tags)
@@ -773,7 +775,7 @@ class Play(object):
                 inject.update(self.vars)
                 filename4 = template(self.basedir, filename3, inject)
                 filename4 = utils.path_dwim(self.basedir, filename4)
-            else:    
+            else:
                 filename4 = utils.path_dwim(self.basedir, filename3)
             return filename2, filename3, filename4
 
@@ -822,7 +824,7 @@ class Play(object):
             inject.update(self.playbook.SETUP_CACHE.get(host, {}))
             inject.update(self.playbook.VARS_CACHE.get(host, {}))
         else:
-            inject = None            
+            inject = None
 
         for filename in self.vars_files:
             if type(filename) == list:
@@ -853,4 +855,4 @@ class Play(object):
 
         # finally, update the VARS_CACHE for the host, if it is set
         if host is not None:
-            self.playbook.VARS_CACHE[host].update(self.playbook.extra_vars)
+            self.playbook.VARS_CACHE.setdefault(host, {}).update(self.playbook.extra_vars)

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -218,8 +218,8 @@ def check_conditional(conditional, basedir, inject, fail_on_undefined=False):
     conditional = template.template(basedir, presented, inject)
     val = conditional.strip()
     if val == presented:
-        # the templating failed, meaning most likely a 
-        # variable was undefined. If we happened to be 
+        # the templating failed, meaning most likely a
+        # variable was undefined. If we happened to be
         # looking for an undefined variable, return True,
         # otherwise fail
         if "is undefined" in conditional:
@@ -242,7 +242,7 @@ def is_executable(path):
             or stat.S_IXOTH & os.stat(path)[stat.ST_MODE])
 
 def unfrackpath(path):
-    ''' 
+    '''
     returns a path that is free of symlinks, environment
     variables, relative path traversals and symbols (~)
     example:
@@ -392,10 +392,10 @@ def process_common_errors(msg, probline, column):
 
     if ":{{" in replaced and "}}" in replaced:
         msg = msg + """
-This one looks easy to fix.  YAML thought it was looking for the start of a 
+This one looks easy to fix.  YAML thought it was looking for the start of a
 hash/dictionary and was confused to see a second "{".  Most likely this was
-meant to be an ansible template evaluation instead, so we have to give the 
-parser a small hint that we wanted a string instead. The solution here is to 
+meant to be an ansible template evaluation instead, so we have to give the
+parser a small hint that we wanted a string instead. The solution here is to
 just quote the entire value.
 
 For instance, if the original line was:
@@ -410,9 +410,9 @@ It should be written as:
 
     elif len(probline) and len(probline) > 1 and len(probline) > column and probline[column] == ":" and probline.count(':') > 1:
         msg = msg + """
-This one looks easy to fix.  There seems to be an extra unquoted colon in the line 
-and this is confusing the parser. It was only expecting to find one free 
-colon. The solution is just add some quotes around the colon, or quote the 
+This one looks easy to fix.  There seems to be an extra unquoted colon in the line
+and this is confusing the parser. It was only expecting to find one free
+colon. The solution is just add some quotes around the colon, or quote the
 entire line after the first colon.
 
 For instance, if the original line was:
@@ -424,7 +424,7 @@ It can be written as:
     copy: src=file.txt dest='/path/filename:with_colon.txt'
 
 Or:
-    
+
     copy: 'src=file.txt dest=/path/filename:with_colon.txt'
 
 
@@ -444,8 +444,8 @@ Or:
                 unbalanced = True
             if match:
                 msg = msg + """
-This one looks easy to fix.  It seems that there is a value started 
-with a quote, and the YAML parser is expecting to see the line ended 
+This one looks easy to fix.  It seems that there is a value started
+with a quote, and the YAML parser is expecting to see the line ended
 with the same kind of quote.  For instance:
 
     when: "ok" in result.stdout
@@ -463,9 +463,9 @@ or equivalently:
 
             if unbalanced:
                 msg = msg + """
-We could be wrong, but this one looks like it might be an issue with 
-unbalanced quotes.  If starting a value with a quote, make sure the 
-line ends with the same set of quotes.  For instance this arbitrary 
+We could be wrong, but this one looks like it might be an issue with
+unbalanced quotes.  If starting a value with a quote, make sure the
+line ends with the same set of quotes.  For instance this arbitrary
 example:
 
     foo: "bad" "wolf"
@@ -506,8 +506,8 @@ Note: The error may actually appear before this position: line %s, column %s
             else:
                 msg = msg + """
 We could be wrong, but this one looks like it might be an issue with
-missing quotes.  Always quote template expression brackets when they 
-start a value. For instance:            
+missing quotes.  Always quote template expression brackets when they
+start a value. For instance:
 
     with_items:
       - {{ foo }}
@@ -515,7 +515,7 @@ start a value. For instance:
 Should be written as:
 
     with_items:
-      - "{{ foo }}"      
+      - "{{ foo }}"
 
 """
         else:
@@ -753,9 +753,9 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
         help='use this file to authenticate the connection')
     parser.add_option('-K', '--ask-sudo-pass', default=False, dest='ask_sudo_pass', action='store_true',
         help='ask for sudo password')
-    parser.add_option('--ask-su-pass', default=False, dest='ask_su_pass', action='store_true', 
+    parser.add_option('--ask-su-pass', default=False, dest='ask_su_pass', action='store_true',
         help='ask for su password')
-    parser.add_option('--ask-vault-pass', default=False, dest='ask_vault_pass', action='store_true', 
+    parser.add_option('--ask-vault-pass', default=False, dest='ask_vault_pass', action='store_true',
         help='ask for vault password')
     parser.add_option('--vault-password-file', default=None, dest='vault_password_file',
         help="vault password file")
@@ -1032,8 +1032,8 @@ def safe_eval(expr, locals={}, include_exceptions=False):
     http://stackoverflow.com/questions/12523516/using-ast-and-whitelists-to-make-pythons-eval-safe
     '''
 
-    # this is the whitelist of AST nodes we are going to 
-    # allow in the evaluation. Any node type other than 
+    # this is the whitelist of AST nodes we are going to
+    # allow in the evaluation. Any node type other than
     # those listed here will raise an exception in our custom
     # visitor class defined below.
     SAFE_NODES = set(
@@ -1168,5 +1168,9 @@ def before_comment(msg):
     msg = msg.replace("**NOT_A_COMMENT**","#")
     return msg
 
+def update_hash(hash, key, new_value):
+    ''' used to avoid nested .update calls on the parent '''
 
-
+    value = hash.get(key, {})
+    value.update(new_value)
+    hash[key] = value

--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -108,14 +108,14 @@ class PluginLoader(object):
                 if fullpath not in ret:
                     ret.append(fullpath)
 
-        # look in any configured plugin paths, allow one level deep for subcategories 
+        # look in any configured plugin paths, allow one level deep for subcategories
         configured_paths = self.config.split(os.pathsep)
         for path in configured_paths:
             path = os.path.realpath(os.path.expanduser(path))
             contents = glob.glob("%s/*" % path)
             for c in contents:
                 if os.path.isdir(c) and c not in ret:
-                    ret.append(c)       
+                    ret.append(c)
             if path not in ret:
                 ret.append(path)
 
@@ -177,7 +177,7 @@ class PluginLoader(object):
         return getattr(self._module_cache[path], self.class_name)(*args, **kwargs)
 
     def all(self, *args, **kwargs):
-        ''' instantiates all plugins with the same arguments '''       
+        ''' instantiates all plugins with the same arguments '''
 
         for i in self._get_paths():
             matches = glob.glob(os.path.join(i, "*.py"))
@@ -191,52 +191,59 @@ class PluginLoader(object):
                 yield getattr(self._module_cache[path], self.class_name)(*args, **kwargs)
 
 action_loader = PluginLoader(
-    'ActionModule',   
+    'ActionModule',
     'ansible.runner.action_plugins',
     C.DEFAULT_ACTION_PLUGIN_PATH,
     'action_plugins'
 )
 
+cache_loader = PluginLoader(
+    'CacheModule',
+    'ansible.cache',
+    C.DEFAULT_CACHE_PLUGIN_PATH,
+    'cache_plugins'
+)
+
 callback_loader = PluginLoader(
-    'CallbackModule', 
-    'ansible.callback_plugins', 
-    C.DEFAULT_CALLBACK_PLUGIN_PATH, 
+    'CallbackModule',
+    'ansible.callback_plugins',
+    C.DEFAULT_CALLBACK_PLUGIN_PATH,
     'callback_plugins'
 )
 
 connection_loader = PluginLoader(
-    'Connection', 
-    'ansible.runner.connection_plugins', 
-    C.DEFAULT_CONNECTION_PLUGIN_PATH, 
-    'connection_plugins', 
+    'Connection',
+    'ansible.runner.connection_plugins',
+    C.DEFAULT_CONNECTION_PLUGIN_PATH,
+    'connection_plugins',
     aliases={'paramiko': 'paramiko_ssh'}
 )
 
 module_finder = PluginLoader(
-    '', 
-    '', 
-    C.DEFAULT_MODULE_PATH, 
+    '',
+    '',
+    C.DEFAULT_MODULE_PATH,
     'library'
 )
 
 lookup_loader = PluginLoader(
-    'LookupModule',   
-    'ansible.runner.lookup_plugins', 
-    C.DEFAULT_LOOKUP_PLUGIN_PATH, 
+    'LookupModule',
+    'ansible.runner.lookup_plugins',
+    C.DEFAULT_LOOKUP_PLUGIN_PATH,
     'lookup_plugins'
 )
 
 vars_loader = PluginLoader(
-    'VarsModule', 
-    'ansible.inventory.vars_plugins', 
-    C.DEFAULT_VARS_PLUGIN_PATH, 
+    'VarsModule',
+    'ansible.inventory.vars_plugins',
+    C.DEFAULT_VARS_PLUGIN_PATH,
     'vars_plugins'
 )
 
 filter_loader = PluginLoader(
-    'FilterModule', 
-    'ansible.runner.filter_plugins', 
-    C.DEFAULT_FILTER_PLUGIN_PATH, 
+    'FilterModule',
+    'ansible.runner.filter_plugins',
+    C.DEFAULT_FILTER_PLUGIN_PATH,
     'filter_plugins'
 )
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(name='ansible',
       package_dir={ 'ansible': 'lib/ansible' },
       packages=[
          'ansible',
+         'ansible.cache',
          'ansible.utils',
          'ansible.utils.module_docs_fragments',
          'ansible.inventory',


### PR DESCRIPTION
Discussed initially on the project mailing list here: (https://groups.google.com/d/topic/ansible-project/bMWWRPxRQqg/discussion). Also discussed at length in other pulls and mailing list topics:
- [Fact caching (work in progress) infrastructure now on development branch](https://groups.google.com/d/topic/ansible-devel/aC-BjeBTMho/discussion)
- [Pull Request #5534](https://github.com/ansible/ansible/pull/5534)

Reiterating some bits specific to this pull request for posterity:
1. Only SETUP_CACHE is leveraging caching backends. VARS_CACHE is untouched as I'm not quite sure I understand the use-case behind caching play variables between playbook executions.
2. Caching backends have a base class they should extend to ensure the API is properly implemented. All the heavy lifting is done by each caching backend.
3. Given the existing usage of SETUP_CACHE (eg: dictionary based access), caching backends must be able to return the keys that are being held in cache. There are various ways of doing that can be seen in the diff. Redis is perhaps the most interesting and optimal since it allows usage of sorted sets.
4. All unit tests pass and the sample playbooks noted as issues in the previous threads are not present. I haven't had time recently to do so, but I'll work on running the integration tests as well.

As I mentioned on the mailing list, I think redis (and probably memcached) would handle large-scale use-cases fine, but other potential backends (and probably the _file_ backend I've written as well, it flushes writes to disk far to frequently) may not. If someone could advise on how best to set up a testing harness to run this against a large quantity of hosts, I would be happy to do so.

Finally, the commits will be squashed or reworded before merging to fit commit guidelines. The diff should also be viewed ignoring whitespace ([as so](https://github.com/joshdrake/ansible/compare/feature/fact_caching?expand=1&w=1)), but I can fix that immediately if needed.
