### PR TITLE
Add quotes around variables and substitution in hacking/env-setup

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -3,31 +3,31 @@
 #    modifies environment for running Ansible from checkout
 
 # When run using source as directed, $0 gets set to bash, so we must use $BASH_SOURCE
-if [ -n "$BASH_SOURCE" ] ; then
-    HACKING_DIR=`dirname $BASH_SOURCE`
-elif [ $(basename $0) = "env-setup" ]; then
-    HACKING_DIR=`dirname $0`
+if [[ -n "$BASH_SOURCE" ]] ; then
+    HACKING_DIR="$(dirname $BASH_SOURCE)"
+elif [[ "$(basename $0)" = "env-setup" ]]; then
+    HACKING_DIR="$(dirname $0)"
 else
     HACKING_DIR="$PWD/hacking"
 fi
 # The below is an alternative to readlink -fn which doesn't exist on OS X
 # Source: http://stackoverflow.com/a/1678636
-FULL_PATH=`python -c "import os; print(os.path.realpath('$HACKING_DIR'))"`
-ANSIBLE_HOME=`dirname "$FULL_PATH"`
+FULL_PATH="$(python -c "import os; print(os.path.realpath('$HACKING_DIR'))")"
+ANSIBLE_HOME="$(dirname "$FULL_PATH")"
 
 PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
 PREFIX_PATH="$ANSIBLE_HOME/bin"
 PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 
-[[ $PYTHONPATH != ${PREFIX_PYTHONPATH}* ]] && export PYTHONPATH=$PREFIX_PYTHONPATH:$PYTHONPATH
-[[ $PATH != ${PREFIX_PATH}* ]] && export PATH=$PREFIX_PATH:$PATH
+[[ $PYTHONPATH != ${PREFIX_PYTHONPATH}* ]] && export PYTHONPATH="$PREFIX_PYTHONPATH:$PYTHONPATH"
+[[ $PATH != ${PREFIX_PATH}* ]] && export PATH="$PREFIX_PATH:$PATH"
 unset ANSIBLE_LIBRARY
-export ANSIBLE_LIBRARY="$ANSIBLE_HOME/library:`python $HACKING_DIR/get_library.py`"
-[[ $MANPATH != ${PREFIX_MANPATH}* ]] && export MANPATH=$PREFIX_MANPATH:$MANPATH
+export ANSIBLE_LIBRARY="$ANSIBLE_HOME/library:$(python $HACKING_DIR/get_library.py)"
+[[ $MANPATH != ${PREFIX_MANPATH}* ]] && export MANPATH="$PREFIX_MANPATH:$MANPATH"
 
 # Print out values unless -q is set
 
-if [ $# -eq 0 -o "$1" != "-q" ] ; then
+if [[ $# -eq 0 || "$1" != "-q" ]] ; then
     echo ""
     echo "Setting up Ansible to run out of checkout..."
     echo ""


### PR DESCRIPTION
In Bash, the variables need to be quoted. Fixed strings are fine. See
http://mywiki.wooledge.org/BashPitfalls#A.5B_.24foo_.3D_.22bar.22_.5D to
see more of this.

Every variable could possibly contain spaces, and the output from any
process can contain spaces as well. Therefore it is important to put
quotes around everything.

I also upgraded the tests from `[` to `[[` which is a bash builtin, has
more features and is faster since it does not require a fork. For this
script, it will not matter, but since this is using bash already, one
can use its features. See http://mywiki.wooledge.org/BashFAQ/031 for
more info on `[`, `[[` and `test`.

The backticks are legacy, one can use `$( ... )` in bash that even
allows nesting, see http://mywiki.wooledge.org/CommandSubstitution for
more on this.
