### PR TITLE
Create fstab if not exists

### DIFF
--- a/library/system/mount
+++ b/library/system/mount
@@ -69,7 +69,14 @@ options:
     required: true
     choices: [ "present", "absent", "mounted", "unmounted" ]
     default: null
-     
+  fstab:
+    description:
+      - file to use instead of C(/etc/fstab). You shouldn't use that option
+        unless you really know what you are doing. This might be useful if
+        you need to configure mountpoints in a chroot environment.
+    required: false
+    default: /etc/fstab
+
 notes: []
 requirements: []
 author: Seth Vidal

--- a/library/system/mount
+++ b/library/system/mount
@@ -267,6 +267,13 @@ def main():
     if module.params['fstab'] is not None:
         args['fstab'] = module.params['fstab']
 
+    # if fstab file does not exist, we first need to create it. This mainly
+    # happens when fstab optin is passed to the module.
+    if not os.path.exists(args['fstab']):
+        if not os.path.exists(os.path.dirname(args['fstab'])):
+            os.makedirs(os.path.dirname(args['fstab']))
+        open(args['fstab'],'a').close()
+
     # absent == remove from fstab and unmounted
     # unmounted == do not change fstab state, but unmount
     # present == add to fstab, do not change mount state


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 1.7 (devel 7c2cb58673) last updated 2014/07/17 19:42:12 (GMT +200)
```
##### Environment:

All
##### Summary:

2 issues in the `mount` module:
- The code allows to pass an option `fstab` which was not documented.
- If you pass a `fstab` option you might end up with a file that does not
  exist on the remote file system.

This PR comments the `fstab` option and ensures both directory and file for `fstab` actually exist on target host.

The patch had been split for atomicity purposes.
##### Steps To Reproduce:

use task:

``` yaml
- name: create fstabs
  mount:
    name=/mnt/data
    fstab=/path/to/chroot/etc/fstab
    src='LABEL=DATA'
    fstype=xfs
    opts='rw,noatime,nobarrier,nobootwait'
    state='present'
```
##### Expected Results:

No error (see actual Result below)
##### Actual Results:

```
TASK: [mdadm | create fstabs] *************************************************
failed: [target.example.com] => (item={u'src': u'LABEL=DATA', u'fstab': u'/path/to/chroot/etc/fstab', u'name': u'/mnt/data', u'opts': u'rw,noatime,nobarrier,nobootwait', u'fstype': u'xfs'}) => {"failed": true, "item": {"fstab": "/path/to/chroot/etc/fstab", "fstype": "xfs", "name": "/mnt/data", "opts": "rw,noatime,nobarrier,nobootwait", "src": "LABEL=DATA"}, "parsed": false}
invalid output was: SUDO-SUCCESS-nhgjtwbfwfivkojaaelidzyqmkjxgxhv
Traceback (most recent call last):
  File "<stdin>", line 1625, in <module>
  File "<stdin>", line 296, in main
  File "<stdin>", line 115, in set_mount
IOError: [Errno 2] No such file or directory: '/path/to/chroot/etc/fstab'
```
