### PR TITLE
Filter empty "volumes" from the list (EC2 module)

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -840,7 +840,7 @@ def create_instances(module, ec2, override_count=None):
 
             if volumes:
                 bdm = BlockDeviceMapping()
-                for volume in volumes: 
+                for volume in filter(None, volumes):
                     if 'device_name' not in volume:
                         module.fail_json(msg = 'Device name must be set for volume')
                     # Minimum volume size is 1GB. We'll use volume size explicitly set to 0


### PR DESCRIPTION
I want Volumes to be dynamic- yet allow for the default (whatever is baked into the AMI). So Sometimes I send:
`Volumes: None`

This filters None, whereas before this change if fails on "Device name must be set..."
