### PR TITLE
Update intro_getting_started.rst

### DIFF
--- a/docsite/rst/intro_getting_started.rst
+++ b/docsite/rst/intro_getting_started.rst
@@ -47,8 +47,9 @@ Your first commands
 
 Now that you've installed Ansible, it's time to get started with some basics.
 
-Edit (or create) /usr/local/etc/ansible/hosts and put one or more remote systems in it, for
-which you have your SSH key in ``authorized_keys``::
+Edit (or create) your ``hosts`` inventory file. This file should normally be in ``/etc/ansible`` (or 
+``usr/local/etc/ansible`` if installed on Mac OS X using HomeBrew). Put one or more remote systems in it, for
+which you have your SSH key in their respective ``authorized_keys`` files::
 
     192.168.1.50
     aserver.example.org

--- a/docsite/rst/intro_getting_started.rst
+++ b/docsite/rst/intro_getting_started.rst
@@ -48,7 +48,7 @@ Your first commands
 Now that you've installed Ansible, it's time to get started with some basics.
 
 Edit (or create) your ``hosts`` inventory file. This file should normally be in ``/etc/ansible`` (or 
-``usr/local/etc/ansible`` if installed on Mac OS X using HomeBrew). Put one or more remote systems in it, for
+``/usr/local/etc/ansible`` if installed on Mac OS X using HomeBrew). Put one or more remote systems in it, for
 which you have your SSH key in their respective ``authorized_keys`` files::
 
     192.168.1.50

--- a/docsite/rst/intro_getting_started.rst
+++ b/docsite/rst/intro_getting_started.rst
@@ -47,7 +47,7 @@ Your first commands
 
 Now that you've installed Ansible, it's time to get started with some basics.
 
-Edit (or create) /etc/ansible/hosts and put one or more remote systems in it, for
+Edit (or create) /usr/local/etc/ansible/hosts and put one or more remote systems in it, for
 which you have your SSH key in ``authorized_keys``::
 
     192.168.1.50


### PR DESCRIPTION
New to ansible, but installing via HomeBrew on Mac OS X (Mountain Lion), I discovered from a note on http://lampros.chaidas.com/index.php/2014/06/22/beginning-with-ansible-on-freebsd-10/ that the inventory file (`hosts`) needs to be in `/usr/local/etc/ansible` not `/etc/ansible`. Will submit change for Inventory doc as well. With a hosts file in `/etc/ansible`, ansible did not detect it, and continued to prompt me to specify one with the "-i" parameter. Am I wrong, or is this an OS X anomaly?
