### PR TITLE
Update intro_inventory.rst

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -8,7 +8,7 @@ Inventory
 Ansible works against multiple systems in your infrastructure at the
 same time.  It does this by selecting portions of systems listed in
 Ansible's inventory file, which defaults to being saved in 
-the location /etc/ansible/hosts.
+the location /usr/local/etc/ansible/hosts.
 
 Not only is this inventory configurable, but you can also use
 multiple inventory files at the same time (explained below) and also
@@ -19,7 +19,7 @@ pull inventory from dynamic or cloud sources, as described in :doc:`intro_dynami
 Hosts and Groups
 ++++++++++++++++
 
-The format for /etc/ansible/hosts is an INI format and looks like this::
+The format for /usr/local/etc/ansible/hosts is an INI format and looks like this::
 
     mail.example.com
 
@@ -152,14 +152,14 @@ These variable files are in YAML format.  See :doc:`YAMLSyntax` if you are new t
 
 Assuming the inventory file path is::
 
-    /etc/ansible/hosts
+    /usr/local/etc/ansible/hosts
 
 If the host is named 'foosball', and in groups 'raleigh' and 'webservers', variables
 in YAML files at the following locations will be made available to the host::
 
-    /etc/ansible/group_vars/raleigh
-    /etc/ansible/group_vars/webservers
-    /etc/ansible/host_vars/foosball
+    /usr/local/etc/ansible/group_vars/raleigh
+    /usr/local/etc/ansible/group_vars/webservers
+    /usr/local/etc/ansible/host_vars/foosball
 
 For instance, suppose you have hosts grouped by datacenter, and each datacenter
 uses some different servers.  The data in the groupfile '/etc/ansible/group_vars/raleigh' for

--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -7,8 +7,11 @@ Inventory
 
 Ansible works against multiple systems in your infrastructure at the
 same time.  It does this by selecting portions of systems listed in
-Ansible's inventory file, which defaults to being saved in 
-the location /usr/local/etc/ansible/hosts.
+Ansible's inventory file, which defaults to being saved 
+as the file ``/etc/ansible/hosts``.
+
+**NOTE:** If you install Ansible on Mac OS X using HomeBrew, you will need to create the ``hosts`` inventory file 
+in ``/usr/local/etc/`` for it to be automatically detected.
 
 Not only is this inventory configurable, but you can also use
 multiple inventory files at the same time (explained below) and also
@@ -19,7 +22,8 @@ pull inventory from dynamic or cloud sources, as described in :doc:`intro_dynami
 Hosts and Groups
 ++++++++++++++++
 
-The format for /usr/local/etc/ansible/hosts is an INI format and looks like this::
+The format for the ``/etc/ansible/hosts`` (or ``/usr/local/etc/ansible/hosts`` on a Mac OS X HomeBrew installation) 
+inventory file is an INI format and looks like this::
 
     mail.example.com
 
@@ -152,14 +156,14 @@ These variable files are in YAML format.  See :doc:`YAMLSyntax` if you are new t
 
 Assuming the inventory file path is::
 
-    /usr/local/etc/ansible/hosts
+    /etc/ansible/hosts
 
 If the host is named 'foosball', and in groups 'raleigh' and 'webservers', variables
 in YAML files at the following locations will be made available to the host::
 
-    /usr/local/etc/ansible/group_vars/raleigh
-    /usr/local/etc/ansible/group_vars/webservers
-    /usr/local/etc/ansible/host_vars/foosball
+    /etc/ansible/group_vars/raleigh
+    /etc/ansible/group_vars/webservers
+    /etc/ansible/host_vars/foosball
 
 For instance, suppose you have hosts grouped by datacenter, and each datacenter
 uses some different servers.  The data in the groupfile '/etc/ansible/group_vars/raleigh' for


### PR DESCRIPTION
New to ansible, but installing via HomeBrew on Mac OS X (Mountain Lion), I discovered from a note on http://lampros.chaidas.com/index.php/2014/06/22/beginning-with-ansible-on-freebsd-10/ that the inventory file (`hosts`) needs to be in `/usr/local/etc/ansible` not `/etc/ansible`. Submitted change for Intro doc as well. With a hosts file in `/etc/ansible`, ansible did not detect it, and continued to prompt me to specify one with the "-i" parameter. Am I wrong, or is this an OS X anomaly?
