### PR TITLE
digital ocean module:  Fail if given an unknown state

### DIFF
--- a/library/cloud/digital_ocean_domain
+++ b/library/cloud/digital_ocean_domain
@@ -212,6 +212,9 @@ def core(module):
 
         event_json = domain.destroy()
         module.exit_json(changed=True, event=event_json)
+        
+    else:
+        raise ValueError('Unknown state: {}'.format(state))
 
 
 def main():


### PR DESCRIPTION
I just lost hours debugging what the hell is going wrong with this module. In the end I found that I mis-spelled the state: "preset" instead of "present". The code just skipped everything, no return, no error report. 

It should fail if given an invalid state.
