### PR TITLE
Update mysql_user doc and example

### DIFF
--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -123,6 +123,9 @@ EXAMPLES = """
 # Specify grants composed of more than one word
 - mysql_user: name=replication password=12345 priv=*.*:"REPLICATION CLIENT" state=present
 
+# Revoke all privileges for user 'bob' and password '12345' 
+- mysql_user: name=bob password=12345 priv=*.*:USAGE state=present
+
 # Example privileges string format
 mydb.*:INSERT,UPDATE/anotherdb.*:SELECT/yetanotherdb.*:ALL
 


### PR DESCRIPTION
Update to mysql_user comments and adding an example 

Updated mysql_user doc to add an example of revoking user permissions.  Also remind users where to find acceptable values for the 'priv' parameter".
