### PR TITLE
synchronize: use a single -F instead of -FF

### DIFF
--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -252,7 +252,7 @@ def main():
     group = module.params['group']
     rsync_opts = module.params['rsync_opts']
 
-    cmd = '%s --delay-updates -FF' % rsync
+    cmd = '%s --delay-updates -F' % rsync
     if compress:
         cmd = cmd + ' --compress'
     if rsync_timeout:


### PR DESCRIPTION
This is needed when one uses an .rsync-filter file to exclude some paths from both being transferred and being deleted (because they are handled with other tasks). Deletions are done on the side of the receiver, so the .rsync-filter file must be transferred to the receiver, so that the receiver knows what files to delete and what not to delete.
