### PR TITLE
FreeBSD does not like spaces in /etc/sysctl.conf.

### DIFF
--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -293,7 +293,7 @@ class SysctlModule(object):
                 new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
             else:
                 new_line = "%s = %s\n" % (self.args['name'], self.args['value'])
-            self.fixed_lines.append(new_line)
+            self.fixed_lines.append(new_line)                    
 
     # Completely rewrite the sysctl file
     def write_sysctl(self):

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -100,7 +100,7 @@ import re
 class SysctlModule(object):
 
     def __init__(self, module):
-        self.module = module
+        self.module = module 
         self.args = self.module.params
 
         self.sysctl_cmd = self.module.get_bin_path('sysctl', required=True)
@@ -151,11 +151,11 @@ class SysctlModule(object):
             self.write_file = True
 
         # use the sysctl command or not?
-        if self.args['sysctl_set']:
+        if self.args['sysctl_set']:            
             if self.proc_value is None:
                 self.changed = True
             elif not self._values_is_equal(self.proc_value, self.args['value']):
-                self.changed = True
+                self.changed = True 
                 self.set_proc = True
 
         # Do the work
@@ -196,10 +196,10 @@ class SysctlModule(object):
     #   SYSCTL COMMAND MANAGEMENT
     # ==============================================================
 
-    # Use the sysctl command to find the current value
+    # Use the sysctl command to find the current value 
     def get_token_curr_value(self, token):
         thiscmd = "%s -e -n %s" % (self.sysctl_cmd, token)
-        rc,out,err = self.module.run_command(thiscmd)
+        rc,out,err = self.module.run_command(thiscmd)    
         if rc != 0:
             return None
         else:
@@ -230,7 +230,7 @@ class SysctlModule(object):
 
             rc,out,err = self.module.run_command(sysctl_args)
 
-        if rc != 0:
+        if rc != 0:            
             self.module.fail_json(msg="Failed to reload sysctl: %s" % str(out) + str(err))
 
     # ==============================================================
@@ -240,7 +240,7 @@ class SysctlModule(object):
     # Get the token value from the sysctl file
     def read_sysctl_file(self):
 
-        lines = []
+        lines = []            
         if os.path.isfile(self.sysctl_file):
             try:
                 f = open(self.sysctl_file, "r")
@@ -255,7 +255,7 @@ class SysctlModule(object):
 
             # don't split empty lines or comments
             if not line or line.startswith("#"):
-                continue
+                continue 
 
             k, v = line.split('=',1)
             k = k.strip()
@@ -270,7 +270,7 @@ class SysctlModule(object):
             if not line.strip() or line.strip().startswith("#"):
                 self.fixed_lines.append(line)
                 continue
-            tmpline = line.strip()
+            tmpline = line.strip()            
             k, v = line.split('=',1)
             k = k.strip()
             v = v.strip()
@@ -311,7 +311,7 @@ class SysctlModule(object):
         f.close()
 
         # replace the real one
-        self.module.atomic_move(tmp_path, self.sysctl_file)
+        self.module.atomic_move(tmp_path, self.sysctl_file) 
 
 
 # ==============================================================
@@ -333,7 +333,7 @@ def main():
         supports_check_mode=True
     )
 
-    result = SysctlModule(module)
+    result = SysctlModule(module)    
 
     module.exit_json(changed=result.changed)
     sys.exit(0)

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -151,7 +151,7 @@ class SysctlModule(object):
             self.write_file = True
 
         # use the sysctl command or not?
-        if self.args['sysctl_set']:
+        if self.args['sysctl_set']:            
             if self.proc_value is None:
                 self.changed = True
             elif not self._values_is_equal(self.proc_value, self.args['value']):
@@ -269,6 +269,7 @@ class SysctlModule(object):
                 self.fixed_lines.append(line)
                 continue
             tmpline = line.strip()            
+            k, v = line.split('=',1)
             k = k.strip()
             v = v.strip()
             if k not in checked:

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -220,13 +220,15 @@ class SysctlModule(object):
     def reload_sysctl(self):
         # do it
         if get_platform().lower() == 'freebsd':
-            sysctl_args = [self.sysctl_cmd, '-f', self.sysctl_file]
+            # freebsd doesn't support -p, so reload the sysctl service
+            rc,out,err = self.module.run_command('/sbin/sysctl -f /etc/sysctl.conf')
         else:
+            # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
-        if self.args['ignoreerrors']:
-            sysctl_args.insert(1, '-e')
+            if self.args['ignoreerrors']:
+                sysctl_args.insert(1, '-e')
 
-        rc,out,err = self.module.run_command(sysctl_args)
+            rc,out,err = self.module.run_command(sysctl_args)
 
         if rc != 0:
             self.module.fail_json(msg="Failed to reload sysctl: %s" % str(out) + str(err))

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -100,7 +100,7 @@ import re
 class SysctlModule(object):
 
     def __init__(self, module):
-        self.module = module 
+        self.module = module
         self.args = self.module.params
 
         self.sysctl_cmd = self.module.get_bin_path('sysctl', required=True)
@@ -151,11 +151,11 @@ class SysctlModule(object):
             self.write_file = True
 
         # use the sysctl command or not?
-        if self.args['sysctl_set']:            
+        if self.args['sysctl_set']:
             if self.proc_value is None:
                 self.changed = True
             elif not self._values_is_equal(self.proc_value, self.args['value']):
-                self.changed = True 
+                self.changed = True
                 self.set_proc = True
 
         # Do the work
@@ -196,10 +196,10 @@ class SysctlModule(object):
     #   SYSCTL COMMAND MANAGEMENT
     # ==============================================================
 
-    # Use the sysctl command to find the current value 
+    # Use the sysctl command to find the current value
     def get_token_curr_value(self, token):
         thiscmd = "%s -e -n %s" % (self.sysctl_cmd, token)
-        rc,out,err = self.module.run_command(thiscmd)    
+        rc,out,err = self.module.run_command(thiscmd)
         if rc != 0:
             return None
         else:
@@ -221,16 +221,16 @@ class SysctlModule(object):
         # do it
         if get_platform().lower() == 'freebsd':
             # freebsd doesn't support -p, so reload the sysctl service
-            rc,out,err = self.module.run_command('/etc/rc.d/sysctl reload')
+            rc,out,err = self.module.run_command('/sbin/sysctl -f /etc/sysctl.conf')
         else:
             # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
             if self.args['ignoreerrors']:
                 sysctl_args.insert(1, '-e')
-            
+
             rc,out,err = self.module.run_command(sysctl_args)
 
-        if rc != 0:            
+        if rc != 0:
             self.module.fail_json(msg="Failed to reload sysctl: %s" % str(out) + str(err))
 
     # ==============================================================
@@ -240,7 +240,7 @@ class SysctlModule(object):
     # Get the token value from the sysctl file
     def read_sysctl_file(self):
 
-        lines = []            
+        lines = []
         if os.path.isfile(self.sysctl_file):
             try:
                 f = open(self.sysctl_file, "r")
@@ -255,7 +255,7 @@ class SysctlModule(object):
 
             # don't split empty lines or comments
             if not line or line.startswith("#"):
-                continue 
+                continue
 
             k, v = line.split('=',1)
             k = k.strip()
@@ -270,7 +270,7 @@ class SysctlModule(object):
             if not line.strip() or line.strip().startswith("#"):
                 self.fixed_lines.append(line)
                 continue
-            tmpline = line.strip()            
+            tmpline = line.strip()
             k, v = line.split('=',1)
             k = k.strip()
             v = v.strip()
@@ -278,15 +278,24 @@ class SysctlModule(object):
                 checked.append(k)
                 if k == self.args['name']:
                     if self.args['state'] == "present":
-                        new_line = "%s = %s\n" % (k, self.args['value'])
-                        self.fixed_lines.append(new_line)                    
+                        if get_platform().lower() == 'freebsd':
+                            new_line = "%s=%s\n" % (k, self.args['value'])
+                        else:
+                            new_line = "%s = %s\n" % (k, self.args['value'])
+                        self.fixed_lines.append(new_line)
                 else:
-                    new_line = "%s = %s\n" % (k, v)
-                    self.fixed_lines.append(new_line)                    
+                    if get_platform().lower() == 'freebsd':
+                        new_line = "%s=%s\n" % (k, v)
+                    else:
+                        new_line = "%s = %s\n" % (k, v)
+                    self.fixed_lines.append(new_line)
 
         if self.args['name'] not in checked and self.args['state'] == "present":
-            new_line = "%s = %s\n" % (self.args['name'], self.args['value'])
-            self.fixed_lines.append(new_line)                    
+            if get_platform().lower() == 'freebsd':
+                new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
+            else:
+                new_line = "%s = %s\n" % (self.args['name'], self.args['value'])
+            self.fixed_lines.append(new_line)
 
     # Completely rewrite the sysctl file
     def write_sysctl(self):
@@ -302,7 +311,7 @@ class SysctlModule(object):
         f.close()
 
         # replace the real one
-        self.module.atomic_move(tmp_path, self.sysctl_file) 
+        self.module.atomic_move(tmp_path, self.sysctl_file)
 
 
 # ==============================================================
@@ -324,7 +333,7 @@ def main():
         supports_check_mode=True
     )
 
-    result = SysctlModule(module)    
+    result = SysctlModule(module)
 
     module.exit_json(changed=result.changed)
     sys.exit(0)

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -216,19 +216,16 @@ class SysctlModule(object):
         else:
             return rc
 
-    # Run sysctl -p
     def reload_sysctl(self):
         # do it
         if get_platform().lower() == 'freebsd':
-            # freebsd doesn't support -p, so reload the sysctl service
-            rc,out,err = self.module.run_command('/sbin/sysctl -f /etc/sysctl.conf')
+            sysctl_args = [self.sysctl_cmd, '-f', self.sysctl_file]
         else:
-            # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
-            if self.args['ignoreerrors']:
-                sysctl_args.insert(1, '-e')
+        if self.args['ignoreerrors']:
+            sysctl_args.insert(1, '-e')
 
-            rc,out,err = self.module.run_command(sysctl_args)
+        rc,out,err = self.module.run_command(sysctl_args)
 
         if rc != 0:
             self.module.fail_json(msg="Failed to reload sysctl: %s" % str(out) + str(err))

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -227,7 +227,7 @@ class SysctlModule(object):
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
             if self.args['ignoreerrors']:
                 sysctl_args.insert(1, '-e')
-
+            
             rc,out,err = self.module.run_command(sysctl_args)
 
         if rc != 0:            

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -220,18 +220,13 @@ class SysctlModule(object):
     def reload_sysctl(self):
         # do it
         if get_platform().lower() == 'freebsd':
-            # freebsd doesn't support -p, so reload the sysctl service
-            # if the file /etc/sysctl.conf.local does not exist,
-            # this reload will exit with status 1, and the update
-            # will fail. Solution: make sure this file exists.
-            rc,out,err = self.module.run_command('/etc/rc.d/sysctl reload')
+            sysctl_args = [self.sysctl_cmd, '-f', self.sysctl_file]
         else:
-            # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
-            if self.args['ignoreerrors']:
-                sysctl_args.insert(1, '-e')
+        if self.args['ignoreerrors']:
+            sysctl_args.insert(1, '-e')
 
-            rc,out,err = self.module.run_command(sysctl_args)
+        rc,out,err = self.module.run_command(sysctl_args)
 
         if rc != 0:
             self.module.fail_json(msg="Failed to reload sysctl: %s" % str(out) + str(err))

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -100,7 +100,7 @@ import re
 class SysctlModule(object):
 
     def __init__(self, module):
-        self.module = module 
+        self.module = module
         self.args = self.module.params
 
         self.sysctl_cmd = self.module.get_bin_path('sysctl', required=True)
@@ -151,11 +151,11 @@ class SysctlModule(object):
             self.write_file = True
 
         # use the sysctl command or not?
-        if self.args['sysctl_set']:            
+        if self.args['sysctl_set']:
             if self.proc_value is None:
                 self.changed = True
             elif not self._values_is_equal(self.proc_value, self.args['value']):
-                self.changed = True 
+                self.changed = True
                 self.set_proc = True
 
         # Do the work
@@ -196,10 +196,10 @@ class SysctlModule(object):
     #   SYSCTL COMMAND MANAGEMENT
     # ==============================================================
 
-    # Use the sysctl command to find the current value 
+    # Use the sysctl command to find the current value
     def get_token_curr_value(self, token):
         thiscmd = "%s -e -n %s" % (self.sysctl_cmd, token)
-        rc,out,err = self.module.run_command(thiscmd)    
+        rc,out,err = self.module.run_command(thiscmd)
         if rc != 0:
             return None
         else:
@@ -221,16 +221,19 @@ class SysctlModule(object):
         # do it
         if get_platform().lower() == 'freebsd':
             # freebsd doesn't support -p, so reload the sysctl service
-            rc,out,err = self.module.run_command('/sbin/sysctl -f /etc/sysctl.conf')
+            # if the file /etc/sysctl.conf.local does not exist,
+            # this reload will exit with status 1, and the update
+            # will fail. Solution: make sure this file exists.
+            rc,out,err = self.module.run_command('/etc/rc.d/sysctl reload')
         else:
             # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
             if self.args['ignoreerrors']:
                 sysctl_args.insert(1, '-e')
-            
+
             rc,out,err = self.module.run_command(sysctl_args)
 
-        if rc != 0:            
+        if rc != 0:
             self.module.fail_json(msg="Failed to reload sysctl: %s" % str(out) + str(err))
 
     # ==============================================================
@@ -240,7 +243,7 @@ class SysctlModule(object):
     # Get the token value from the sysctl file
     def read_sysctl_file(self):
 
-        lines = []            
+        lines = []
         if os.path.isfile(self.sysctl_file):
             try:
                 f = open(self.sysctl_file, "r")
@@ -255,7 +258,7 @@ class SysctlModule(object):
 
             # don't split empty lines or comments
             if not line or line.startswith("#"):
-                continue 
+                continue
 
             k, v = line.split('=',1)
             k = k.strip()
@@ -270,7 +273,7 @@ class SysctlModule(object):
             if not line.strip() or line.strip().startswith("#"):
                 self.fixed_lines.append(line)
                 continue
-            tmpline = line.strip()            
+            tmpline = line.strip()
             k, v = line.split('=',1)
             k = k.strip()
             v = v.strip()
@@ -311,7 +314,7 @@ class SysctlModule(object):
         f.close()
 
         # replace the real one
-        self.module.atomic_move(tmp_path, self.sysctl_file) 
+        self.module.atomic_move(tmp_path, self.sysctl_file)
 
 
 # ==============================================================
@@ -333,7 +336,7 @@ def main():
         supports_check_mode=True
     )
 
-    result = SysctlModule(module)    
+    result = SysctlModule(module)
 
     module.exit_json(changed=result.changed)
     sys.exit(0)

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -155,7 +155,7 @@ class SysctlModule(object):
             if self.proc_value is None:
                 self.changed = True
             elif not self._values_is_equal(self.proc_value, self.args['value']):
-                self.changed = True
+                self.changed = True 
                 self.set_proc = True
 
         # Do the work
@@ -280,13 +280,13 @@ class SysctlModule(object):
                             new_line = "%s=%s\n" % (k, self.args['value'])
                         else:
                             new_line = "%s = %s\n" % (k, self.args['value'])
-                        self.fixed_lines.append(new_line)
+                        self.fixed_lines.append(new_line)                    
                 else:
                     if get_platform().lower() == 'freebsd':
                         new_line = "%s=%s\n" % (k, v)
                     else:
                         new_line = "%s = %s\n" % (k, v)
-                    self.fixed_lines.append(new_line)
+                    self.fixed_lines.append(new_line)                    
 
         if self.args['name'] not in checked and self.args['state'] == "present":
             if get_platform().lower() == 'freebsd':

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -100,7 +100,7 @@ import re
 class SysctlModule(object):
 
     def __init__(self, module):
-        self.module = module
+        self.module = module 
         self.args = self.module.params
 
         self.sysctl_cmd = self.module.get_bin_path('sysctl', required=True)
@@ -196,10 +196,10 @@ class SysctlModule(object):
     #   SYSCTL COMMAND MANAGEMENT
     # ==============================================================
 
-    # Use the sysctl command to find the current value
+    # Use the sysctl command to find the current value 
     def get_token_curr_value(self, token):
         thiscmd = "%s -e -n %s" % (self.sysctl_cmd, token)
-        rc,out,err = self.module.run_command(thiscmd)
+        rc,out,err = self.module.run_command(thiscmd)    
         if rc != 0:
             return None
         else:
@@ -216,6 +216,7 @@ class SysctlModule(object):
         else:
             return rc
 
+    # Run sysctl -p/-f
     def reload_sysctl(self):
         # do it
         if get_platform().lower() == 'freebsd':
@@ -227,7 +228,7 @@ class SysctlModule(object):
 
         rc,out,err = self.module.run_command(sysctl_args)
 
-        if rc != 0:
+        if rc != 0:            
             self.module.fail_json(msg="Failed to reload sysctl: %s" % str(out) + str(err))
 
     # ==============================================================
@@ -237,7 +238,7 @@ class SysctlModule(object):
     # Get the token value from the sysctl file
     def read_sysctl_file(self):
 
-        lines = []
+        lines = []            
         if os.path.isfile(self.sysctl_file):
             try:
                 f = open(self.sysctl_file, "r")
@@ -252,7 +253,7 @@ class SysctlModule(object):
 
             # don't split empty lines or comments
             if not line or line.startswith("#"):
-                continue
+                continue 
 
             k, v = line.split('=',1)
             k = k.strip()
@@ -267,8 +268,7 @@ class SysctlModule(object):
             if not line.strip() or line.strip().startswith("#"):
                 self.fixed_lines.append(line)
                 continue
-            tmpline = line.strip()
-            k, v = line.split('=',1)
+            tmpline = line.strip()            
             k = k.strip()
             v = v.strip()
             if k not in checked:
@@ -308,7 +308,7 @@ class SysctlModule(object):
         f.close()
 
         # replace the real one
-        self.module.atomic_move(tmp_path, self.sysctl_file)
+        self.module.atomic_move(tmp_path, self.sysctl_file) 
 
 
 # ==============================================================
@@ -330,7 +330,7 @@ def main():
         supports_check_mode=True
     )
 
-    result = SysctlModule(module)
+    result = SysctlModule(module)    
 
     module.exit_json(changed=result.changed)
     sys.exit(0)


### PR DESCRIPTION
Fix so sysctl works on FreeBSD. FreeBSD does not want to see spaces around the ' = ' character.
