### PR TITLE
add elasticache instances to the ec2 inventory

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -50,6 +50,10 @@ all_instances = False
 # 'all_rds_instances' to True return all RDS instances regardless of state.
 all_rds_instances = False
 
+# By default elasticache instances are not added to the inventory.
+# Set 'elasticache' to True to include them.
+elasticache = False
+
 # API calls to EC2 are slow. For this reason, we cache the results of an API
 # call. Set this to the path you want cache files to be written to. Two files
 # will be written to this directory:

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -223,6 +223,8 @@ class Ec2Inventory(object):
             self.route53_excluded_zones.extend(
                 config.get('ec2', 'route53_excluded_zones', '').split(','))
 
+        self.elasticache_enabled = config.getboolean('ec2', 'elasticache')
+
         # Return all EC2/RDS instances
         if config.has_option('ec2', 'all_instances'):
             self.all_instances = config.getboolean('ec2', 'all_instances')
@@ -266,7 +268,8 @@ class Ec2Inventory(object):
         for region in self.regions:
             self.get_instances_by_region(region)
             self.get_rds_instances_by_region(region)
-            self.get_elasticache_instances_by_region(region)
+            if self.elasticache_enabled:
+                self.get_elasticache_instances_by_region(region)
 
         self.write_to_cache(self.inventory, self.cache_path_cache)
         self.write_to_cache(self.index, self.cache_path_index)


### PR DESCRIPTION
This was discussed and "promised" in this issue https://github.com/ansible/ansible/pull/5265#issuecomment-37313014 , but since there hasn't been anything yet, here's a working version.

This is just the first version that works, I'm open to suggestions how to improve it.

The elasticache instances are adder to groups by engine (so elasticache_redis and elaticache_memcached), by region (I copied the RDS approach) there's an elaticache group too.

For ID I prefixed the CacheClusterId with "elasticache:" so to avoid potential conflicts with other instances.

Please coment.
