### PR TITLE
Bugfix: bulletproof unexpected_error_msg at gce.py

### DIFF
--- a/lib/ansible/module_utils/gce.py
+++ b/lib/ansible/module_utils/gce.py
@@ -64,7 +64,5 @@ def gce_connect(module):
 
 def unexpected_error_msg(error):
     """Create an error string based on passed in error."""
-    msg='Unexpected response: HTTP return_code['
-    msg+='%s], API error code[%s] and message: %s' % (
-        error.http_code, error.code, str(error.value))
-    return msg
+    import pprint
+    return 'Unexpected response: ' + pprint.pformat(vars(error))

--- a/lib/ansible/module_utils/gce.py
+++ b/lib/ansible/module_utils/gce.py
@@ -27,6 +27,8 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+import pprint
+
 USER_AGENT_PRODUCT="Ansible-gce"
 USER_AGENT_VERSION="v1"
 
@@ -64,5 +66,4 @@ def gce_connect(module):
 
 def unexpected_error_msg(error):
     """Create an error string based on passed in error."""
-    import pprint
     return 'Unexpected response: ' + pprint.pformat(vars(error))


### PR DESCRIPTION
This method was still failing for me with a "missing http_code" message. After applying this change, the error message is:

```
msg: Unexpected response: {'value': 'PyCrypto library required for Service Account Authentication.'}
```

I wanted to contribute a rock-solid `unexpected_error_msg` implementation.
