### PR TITLE
Default for fstab missing, causing KeyError: 'fstab'

### DIFF
--- a/library/system/mount
+++ b/library/system/mount
@@ -244,7 +244,7 @@ def main():
             dump   = dict(default=None),
             src    = dict(required=True),
             fstype = dict(required=True),
-            fstab  = dict(default=None)
+            fstab  = dict(default='/etc/fstab')
         )
     )
 


### PR DESCRIPTION
fstab misses default I think, get this:

failed: [a.b.rootbsd.net] => {"failed": true, "parsed": false}
invalid output was: Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1406163834.52-79827425762471/mount", line 1641, in <module>
    main()
  File "/root/.ansible/tmp/ansible-tmp-1406163834.52-79827425762471/mount", line 272, in main
    if not os.path.exists(args['fstab']):
KeyError: 'fstab'
