### PR TITLE
fix an issue that copying directory will fail when trying to change file attributes

### DIFF
--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -268,6 +268,7 @@ class ActionModule(object):
                 new_module_args = dict(
                     src=tmp_src,
                     dest=dest,
+                    original_basename=source_rel
                 )
                 if self.runner.noop_on_check(inject):
                     new_module_args['CHECKMODE'] = True

--- a/test/integration/roles/test_copy/tasks/main.yml
+++ b/test/integration/roles/test_copy/tasks/main.yml
@@ -151,5 +151,11 @@
 #  ignore_errors: True
 #  register: failed_copy
 
+- name: copy already copied directory again
+  copy: src=subdir dest={{output_subdir | expanduser}} owner={{ansible_ssh_user}}
+  register: copy_result5
 
-
+- name: assert that the directory was not changed
+  assert:
+    that:
+      - "not copy_result5|changed"


### PR DESCRIPTION
As I already discussed with @jimi-c on the https://github.com/ansible/ansible/commit/84759faa0950146a6bae8452580b4a4cede6d871#commitcomment-7109780, copying directory will fail when trying to change file attributes and the target file already exists on remote.

I added brief testing and you can run the test as follows

```
$ cd test/integration
$ TEST_FLAGS="--tags=test_copy" make non_destructive
```

If you need more info, kindly let me know. Thanks!
