### PR TITLE
use recurse=yes for directory removal

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -133,8 +133,11 @@ def main():
     changed = False
 
     recurse = params['recurse']
-    if recurse and state != 'directory':
-        module.fail_json(path=path, msg="recurse option requires state to be 'directory'")
+    if recurse:
+        if state not in ["directory", "absent"]:
+            module.fail_json(path=path, msg="recurse option requires state to be 'directory' or 'absent'")
+        if state == 'absent' and prev_state != 'directory':
+            module.fail_json(path=path, msg="recurse option with state 'absent' operates on directories only")
 
     if state == 'absent':
         if state != prev_state:


### PR DESCRIPTION
The [documentation](http://docs.ansible.com/file_module.html) says that recursive directory removal should work, but the existing logic only works for directory creation because an exception is thrown unless state=directory. This PR fixes that while ensuring that recursive removals fail when the previous state is anything other than "directory".

NOTE: sorry, no tests yet. I'm at work and don;t have time to grok playbook testing.
