### PR TITLE
Fix for lvcreate vs. lvs case-sensitivity

### DIFF
--- a/library/system/lvol
+++ b/library/system/lvol
@@ -132,7 +132,7 @@ def main():
 
         # LVCREATE(8) -L --size option unit
         elif size[-1].isalpha():
-            if size[-1] in 'bBsSkKmMgGtTpPeE':
+            if size[-1].lower() in 'bskmgtpe':
                 size_unit = size[-1].lower()
                 if size[0:-1].isdigit():
                     size = int(size[0:-1])

--- a/library/system/lvol
+++ b/library/system/lvol
@@ -133,7 +133,7 @@ def main():
         # LVCREATE(8) -L --size option unit
         elif size[-1].isalpha():
             if size[-1] in 'bBsSkKmMgGtTpPeE':
-                size_unit = size[-1]
+                size_unit = size[-1].lower()
                 if size[0:-1].isdigit():
                     size = int(size[0:-1])
                 else:


### PR DESCRIPTION
lvcreate is case-_insenstive_ with respect to units
i.e. 'g' = 'G' = GiB = powers of 2

lvs is case-_senstive_ with respect to units
i.e. 'g' = powers of 10; 'G' = powers of 2

This causes the lvol module to want to shrink LV's if the size argument
is specified with an uppercase unit.

The fix is to always set the size unit to lower case.
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.6.7
##### Environment:

Red Hat Enterprise Linux Server release 6.5 (Santiago)
##### Summary:

lvcreate is case-_insenstive_ with respect to units (i.e. 'g' = 'G' = GiB = powers of 2)
lvs is case-_senstive_ with respect to units (i.e. 'g' = powers of 10; 'G' = powers of 2)

This causes the lvol module to want to shrink LV's if the size argument is specified with an uppercase unit.

My proposed fix is in this pull request.
##### Steps To Reproduce:

Using this play:

```
- name: Create the u01 LVM LV
  lvol: vg=data lv=u01 size=40G
```

Results in a 40GiB LV being created:

```
  --- Logical volume ---
  LV Path                /dev/data/u01
  LV Name                u01
  VG Name                data
<SNIP>
  LV Size                40.00 GiB
<SNIP>
```

However, on a 2nd run through, we get an error about shrinking the partition:

```
TASK: [partitioning | Create the u01 LVM LV] **********************************
failed: [testwebpost21] => {"failed": true}
msg: Sorry, no shrinking of u01 without force=yes.

FATAL: all hosts have already failed -- aborting
```

This is due to lvs case-sensitivity:

```
$ sudo lvs --units G
  LV   VG   Attr       LSize  Pool Origin Data%  Move Log Cpy%Sync Convert
  u01  data -wi-ao---- 42.95G
$ sudo lvs --units g
  LV   VG   Attr       LSize  Pool Origin Data%  Move Log Cpy%Sync Convert
  u01  data -wi-ao---- 40.00g
```
##### Expected Results:

I expect to be able to re-run the lvol module multiple times with consistent results.
##### Actual Results:

Actual results as above in reproduction section
