### PR TITLE
FreeBSD 10 compatibility fix

### DIFF
--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -285,7 +285,7 @@ class SysctlModule(object):
                     self.fixed_lines.append(new_line)                    
 
         if self.args['name'] not in checked and self.args['state'] == "present":
-            new_line = "%s = %s\n" % (self.args['name'], self.args['value'])
+            new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
             self.fixed_lines.append(new_line)                    
 
     # Completely rewrite the sysctl file


### PR DESCRIPTION
On FreeBSD the whitespace around the `=` triggers a (cryptic) `no such file or directory` error. removing the whitespace like above fixes this.
