### PR TITLE
Fix composer module checkmode and change detection

### DIFF
--- a/library/packaging/composer
+++ b/library/packaging/composer
@@ -101,7 +101,7 @@ def parse_out(string):
     return re.sub("\s+", " ", string).strip()
 
 def has_changed(string):
-    return (re.match("Nothing to install or update", string) != None)
+    return 'Nothing to install or update' not in string
 
 def composer_install(module, command, options):
     php_path      = module.get_bin_path("php", True, ["/usr/local/bin"])
@@ -142,6 +142,8 @@ def main():
 
     # Prepare options
     for i in module.params:
+        if (i == 'CHECKMODE'):
+            continue
         opt = "--%s" % i.replace("_","-")
         p = module.params[i]
         if isinstance(p, (bool)) and p:

--- a/library/packaging/composer
+++ b/library/packaging/composer
@@ -125,31 +125,34 @@ def main():
         supports_check_mode=True
     )
 
-    module.params["working_dir"] = os.path.abspath(module.params["working_dir"])
+    options = []
 
-    options = set([])
     # Default options
-    options.add("--no-ansi")
-    options.add("--no-progress")
-    options.add("--no-interaction")
+    options.append('--no-ansi')
+    options.append('--no-progress')
+    options.append('--no-interaction')
 
-    if module.check_mode:
-        options.add("--dry-run")
+    options.extend(['--working-dir', os.path.abspath(module.params['working_dir'])])
 
-    # Get composer command with fallback to default  
+    # Get composer command with fallback to default
     command = module.params['command']
-    del module.params['command'];
 
     # Prepare options
-    for i in module.params:
-        if (i == 'CHECKMODE'):
-            continue
-        opt = "--%s" % i.replace("_","-")
-        p = module.params[i]
-        if isinstance(p, (bool)) and p:
-            options.add(opt)
-        elif isinstance(p, (str)):
-            options.add("%s=%s" % (opt, p))
+    if module.params['prefer_source']:
+        options.append('--prefer-source')
+    if module.params['prefer_dist']:
+        options.append('--prefer-dist')
+    if module.params['no_dev']:
+        options.append('--no-dev')
+    if module.params['no_scripts']:
+        options.append('--no-scripts')
+    if module.params['no_plugins']:
+        options.append('--no-plugins')
+    if module.params['optimize_autoloader']:
+        options.append('--optimize-autoloader')
+
+    if module.check_mode:
+        options.append('--dry-run')
 
     rc, out, err = composer_install(module, command, options)
 


### PR DESCRIPTION
Hi,

While writing and testing playbooks using the composer module, I ran into two issues:
- check mode didn't work, even if it seems supported
- the changed status detection test was not valid

I propose this simple pull request to address those issues.

Regarding my fix proposal for check mode, I think it is suboptimal, because to me the root cause of the bug resides in the **for** loop which treats each module parameter. It might be a cleaner and safer way to build the options for composer by accessing explicitly each module parameters, as the _gem_ module does. Nevertheless, I thought this quicker proposal might be better suited for reviewing purpose.
