### PR TITLE
Fix extra newline at end of hostname for Fedora

### DIFF
--- a/library/system/hostname
+++ b/library/system/hostname
@@ -259,7 +259,7 @@ class FedoraStrategy(GenericStrategy):
         if rc != 0:
             self.module.fail_json(msg="Command failed rc=%d, out=%s, err=%s" %
                 (rc, out, err))
-        return out
+        return out.strip()
 
     def set_permanent_hostname(self, name):
         cmd = ['hostnamectl', '--pretty', 'set-hostname', name]


### PR DESCRIPTION
This fixes a bug introduced by 138b45e3.
The hostname has an additional newline at the end which leads to the
state always being 'changed: true' even if the hostname is unchanged.
