### PR TITLE
Wrap get_distribution_version() in the hostname module

### DIFF
--- a/library/system/hostname
+++ b/library/system/hostname
@@ -45,6 +45,18 @@ from distutils.version import LooseVersion
 from ansible.module_utils.basic import *
 
 
+# wrap get_distribution_version in case it returns a string
+def _get_distribution_version():
+    distribution_version = get_distribution_version()
+
+    if type(distribution_version) is str:
+        distribution_version = 0
+    elif type(distribution_version) is None:
+        distribution_version = 0
+
+    return distribution_version
+
+
 class UnimplementedStrategy(object):
     def __init__(self, module):
         self.module = module
@@ -299,7 +311,7 @@ class RedHat5Hostname(Hostname):
 class RedHatServerHostname(Hostname):
     platform = 'Linux'
     distribution = 'Red hat enterprise linux server'
-    distribution_version = get_distribution_version()
+    distribution_version = _get_distribution_version()
     if distribution_version and LooseVersion(distribution_version) >= LooseVersion("7"):
         strategy_class = FedoraStrategy
     else:
@@ -308,7 +320,7 @@ class RedHatServerHostname(Hostname):
 class RedHatWorkstationHostname(Hostname):
     platform = 'Linux'
     distribution = 'Red hat enterprise linux workstation'
-    distribution_version = get_distribution_version()
+    distribution_version = _get_distribution_version()
     if distribution_version and LooseVersion(distribution_version) >= LooseVersion("7"):
         strategy_class = FedoraStrategy
     else:


### PR DESCRIPTION
We wrap get_distribution_version() with a new function,
_get_distribution_version(), that returns `0` when the result is a string or
`None`.

This accounts for the case when get_distribution_version() returns a string,
and we try to compare it to a float. We do this in the hostname module instead
of the module snippets because other modules may want the real string
version.module snippets because other modules may want the real string version.
