### PR TITLE
Implement default_omit

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -855,10 +855,6 @@ class Runner(object):
         if type(module_args) == dict:
             new_args = []
             for (k, v) in module_args.iteritems():
-                # see if the value is OMIT_PLACE_HOLDER, if it is, skip it
-                arg_value = template.template(self.basedir, v, inject, fail_on_undefined=self.error_on_undefined_vars)
-                if arg_value.strip() == OMIT_PLACE_HOLDER:
-                    continue
                 new_args.append("%s='%s'" % (k, v))
             module_args = ' '.join(new_args)
 
@@ -882,6 +878,13 @@ class Runner(object):
         except jinja2.exceptions.UndefinedError, e:
             raise errors.AnsibleUndefinedVariable("One or more undefined variables: %s" % str(e))
 
+        # filter omitted arguments out
+        new_complex_args = {}
+        for key, value in complex_args.iteritems():
+            if value == OMIT_PLACE_HOLDER:
+                continue
+            new_complex_args[key] = value
+        complex_args = new_complex_args
 
         result = handler.run(conn, tmp, module_name, module_args, inject, complex_args)
         # Code for do until feature

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import base64
 import json
 import os.path
@@ -25,9 +24,8 @@ import pipes
 import glob
 import re
 import operator as py_operator
-import hashlib
 from ansible import errors
-from ansible.utils import md5s, OMIT_PLACE_HOLDER
+from ansible.utils import md5s
 from distutils.version import LooseVersion, StrictVersion
 from random import SystemRandom
 from jinja2.filters import environmentfilter

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -31,6 +31,7 @@ from ansible.utils import md5s, OMIT_PLACE_HOLDER
 from distutils.version import LooseVersion, StrictVersion
 from random import SystemRandom
 from jinja2.filters import environmentfilter
+from jinja2.runtime import Undefined
 
 
 def to_nice_yaml(*a, **kw):
@@ -205,13 +206,11 @@ def rand(environment, end, start=None, step=None):
     else:
         raise errors.AnsibleFilterError('random can only be used on sequences and integers')
 
+
 def default_omit(a):
-    try:
-        a
-    except NameError:
+    if isinstance(a, Undefined):
         return OMIT_PLACE_HOLDER
-    else:
-        return a
+    return a
 
 
 class FilterModule(object):

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -31,7 +31,6 @@ from ansible.utils import md5s, OMIT_PLACE_HOLDER
 from distutils.version import LooseVersion, StrictVersion
 from random import SystemRandom
 from jinja2.filters import environmentfilter
-from jinja2.runtime import Undefined
 
 
 def to_nice_yaml(*a, **kw):
@@ -207,12 +206,6 @@ def rand(environment, end, start=None, step=None):
         raise errors.AnsibleFilterError('random can only be used on sequences and integers')
 
 
-def default_omit(a):
-    if isinstance(a, Undefined):
-        return OMIT_PLACE_HOLDER
-    return a
-
-
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -282,6 +275,4 @@ class FilterModule(object):
 
             # random numbers
             'random': rand,
-
-            'default_omit': default_omit,
         }

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import base64
 import json
 import os.path
@@ -24,11 +25,13 @@ import pipes
 import glob
 import re
 import operator as py_operator
+import hashlib
 from ansible import errors
-from ansible.utils import md5s
+from ansible.utils import md5s, OMIT_PLACE_HOLDER
 from distutils.version import LooseVersion, StrictVersion
 from random import SystemRandom
 from jinja2.filters import environmentfilter
+
 
 def to_nice_yaml(*a, **kw):
     '''Make verbose, human readable yaml'''
@@ -202,6 +205,15 @@ def rand(environment, end, start=None, step=None):
     else:
         raise errors.AnsibleFilterError('random can only be used on sequences and integers')
 
+def default_omit(a):
+    try:
+        a
+    except NameError:
+        return OMIT_PLACE_HOLDER
+    else:
+        return a
+
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -271,5 +283,6 @@ class FilterModule(object):
 
             # random numbers
             'random': rand,
-        }
 
+            'default_omit': default_omit,
+        }

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -716,6 +716,12 @@ def parse_kv(args):
                 options[k] = unquote(v.strip())
     return options
 
+
+def serialize_args(args):
+    ''' convert a dict to a string of key/value items '''
+    return ' '.join("%s='%s'" % item for item in args.iteritems())
+
+
 def merge_hash(a, b):
     ''' recursively merges hash b into a
     keys from b take precedence over keys from a '''

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -57,6 +57,7 @@ MAX_FILE_SIZE_FOR_DIFF=1*1024*1024
 # to check for lookup calls within data
 LOOKUP_REGEX=re.compile(r'lookup\s*\(')
 
+
 try:
     import json
 except ImportError:
@@ -105,6 +106,11 @@ try:
         KEYCZAR_AVAILABLE=True
 except ImportError:
     pass
+
+
+OMIT_PLACE_HOLDER = (
+    '__omit_place_holder__%s' % _md5(os.urandom(64)).hexdigest()
+)
 
 ###############################################################
 # Abstractions around keyczar

--- a/test/integration/roles/test_good_parsing/tasks/main.yml
+++ b/test/integration/roles/test_good_parsing/tasks/main.yml
@@ -183,6 +183,7 @@
     default_omitted="{{ not_exists|default(omit) }}"
     should_not_omit_1="prefix{{ omit }}"
     should_not_omit_2="{{ omit }}suffix"
+    should_not_omit_3="__omit_place_holder__afb6b9bc3d20bfeaa00a1b23a5930f89"
 
 - assert:
     that:
@@ -191,3 +192,4 @@
       - default_omitted is undefined
       - should_not_omit_1 == "prefix{{ omit }}"
       - should_not_omit_2 == "{{ omit }}suffix"
+      - should_not_omit_3 == "__omit_place_holder__afb6b9bc3d20bfeaa00a1b23a5930f89"

--- a/test/integration/roles/test_good_parsing/tasks/main.yml
+++ b/test/integration/roles/test_good_parsing/tasks/main.yml
@@ -164,3 +164,30 @@
       - result.invocation.module_name == "debug"
       - result.msg == "this should be debugged"
 
+- name: test omit in complex args
+  set_fact:
+    foo: bar
+    spam: "{{ omit }}"
+    should_not_omit: "prefix{{ omit }}"
+
+- assert:
+    that:
+      - foo == 'bar'
+      - spam is undefined
+      - should_not_omit == "prefix{{ omit }}"
+
+- name: test omit in module args
+  set_fact: >
+    yo=whatsup
+    eggs="{{ omit }}"
+    default_omitted="{{ not_exists|default(omit) }}"
+    should_not_omit_1="prefix{{ omit }}"
+    should_not_omit_2="{{ omit }}suffix"
+
+- assert:
+    that:
+      - yo == 'whatsup'
+      - eggs is undefined
+      - default_omitted is undefined
+      - should_not_omit_1 == "prefix{{ omit }}"
+      - should_not_omit_2 == "{{ omit }}suffix"


### PR DESCRIPTION
The idea and design rationale mentioned in https://groups.google.com/forum/#!topic/ansible-project/W9bG0tAI3aU

An example, if you want to omit `git` argument when `item.gid` is not defined, you can pass arguments in dict form, then use `default_omit` filter

``` yaml
- name: generic-users | Make sure all groups are present
  group:
    name: "{{ item.name }}"
    system: "{{ item.system|default('no') }}"
    # Notice: we don't need gid now, it's tricky to omit argument now
    gid: "{{ item.gid|default_omit }}"
    state: present
  with_items: genericusers_groups
```

The way it works is pretty simple, if the value is not defined, it will return a place holder like

```
__omit_place_holder__e3e37a415b04109b9b0a7df6dce4a7f4
```

It has a random nonce as a part of it, so attackers cannot omit that value for you if they don't know the value. If the module runner sees the place holder in `complex_args` value, it will ignore that item (key and value). This is just a simple demonstration of my solution. For string based arguments, it's also possible to remove the key value pair if it sees the same place holder pattern. But just need to be careful with some corner cases.
