### PR TITLE
added option for associate_public_ip_address to ec2_lc module

### DIFF
--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -79,6 +79,12 @@ options:
     required: false
     default: false
     aliases: []
+  associate_public_ip_address:
+    description:
+      - whether to assign a public IP address to each instance launched in a Amazon VPC
+    required: false
+    default: false
+    aliases: []
 extends_documentation_fragment: aws
 """
 

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -140,6 +140,10 @@ def create_launch_config(connection, module):
     spot_price = module.params.get('spot_price')
     instance_monitoring = module.params.get('instance_monitoring')
     bdm = BlockDeviceMapping()
+    if module.params['associate_public_ip_address'] == 'yes':
+      associate_public_ip_address = True
+    else:
+      associate_public_ip_address = False
 
     if volumes:
         for volume in volumes:
@@ -159,7 +163,8 @@ def create_launch_config(connection, module):
         block_device_mappings=[bdm],
         instance_type=instance_type,
         spot_price=spot_price,
-        instance_monitoring=instance_monitoring)
+        instance_monitoring=instance_monitoring,
+        associate_public_ip_address=associate_public_ip_address)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -201,6 +206,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent']),
             spot_price=dict(type='float'),
             instance_monitoring=dict(default=False, type='bool'),
+            associate_public_ip_address=dict(default=True, type='bool')
         )
     )
 


### PR DESCRIPTION
I need this option for using launch configs in VPC.  More information can be found here:

http://boto.readthedocs.org/en/latest/ref/autoscale.html#module-boto.ec2.autoscale.launchconfig
