### PR TITLE
file: prevent replace failure when overwriting empty directory with hard or soft link on force=yes

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -233,6 +233,8 @@ def main():
                 # try to replace atomically
                 tmppath = '/'.join([os.path.dirname(path), ".%s.%s.tmp" % (os.getpid(),time.time())])
                 try:
+                    if prev_state == 'directory' and (state == 'hard' or state == 'link'):
+                        os.rmdir(path)
                     if state == 'hard':
                         os.link(src,tmppath)
                     else:


### PR DESCRIPTION
Issue #7254 finalization (reopen) - empty directory replacement with a link was unable to be performed (Error while replacing: [Errno 21] Is a directory).
