### PR TITLE
Expand variables in configuration files, take two

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -105,7 +105,7 @@ DEFAULTS='defaults'
 DEFAULT_HOST_LIST         = shell_expand_path(get_config(p, DEFAULTS, 'hostfile', 'ANSIBLE_HOSTS', '/etc/ansible/hosts'))
 DEFAULT_MODULE_PATH       = get_config(p, DEFAULTS, 'library',          'ANSIBLE_LIBRARY',          DIST_MODULE_PATH)
 DEFAULT_ROLES_PATH        = shell_expand_path(get_config(p, DEFAULTS, 'roles_path',       'ANSIBLE_ROLES_PATH',       '/etc/ansible/roles'))
-DEFAULT_REMOTE_TMP        = shell_expand_path(get_config(p, DEFAULTS, 'remote_tmp',       'ANSIBLE_REMOTE_TEMP',      '$HOME/.ansible/tmp'))
+DEFAULT_REMOTE_TMP        = get_config(p, DEFAULTS, 'remote_tmp',       'ANSIBLE_REMOTE_TEMP',      '$HOME/.ansible/tmp')
 DEFAULT_MODULE_NAME       = get_config(p, DEFAULTS, 'module_name',      None,                       'command')
 DEFAULT_PATTERN           = get_config(p, DEFAULTS, 'pattern',          None,                       '*')
 DEFAULT_FORKS             = get_config(p, DEFAULTS, 'forks',            'ANSIBLE_FORKS',            5, integer=True)

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -79,7 +79,7 @@ def shell_expand_path(path):
     ''' shell_expand_path is needed as os.path.expanduser does not work
         when path is None, which is the default for ANSIBLE_PRIVATE_KEY_FILE '''
     if path:
-        path = os.path.expanduser(path)
+        path = os.path.expanduser(os.path.expandvars(path))
     return path
 
 p = load_config_file()


### PR DESCRIPTION
Let's try this again.

The `remote_tmp` variable shouldn't be expanded in the first place, right? It can lead to some confusing behavior. For example, I might have put `remote_tmp = ~/.ansible/bla` in my configuration. If I use a user called `veeti` on my own computer and execute an ansible module on a server as `root` it'll try to write to `/home/veeti/` on the server.

Is there something else failing after this? My tests pass. 
