### PR TITLE
Suppport for kerberos\domain authentication for winrm

### DIFF
--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -72,7 +72,10 @@ class Connection(object):
         if cache_key in _winrm_cache:
             vvvv('WINRM REUSE EXISTING CONNECTION: %s' % cache_key, host=self.host)
             return _winrm_cache[cache_key]
-        transport_schemes = [('plaintext', 'https'), ('plaintext', 'http')] # FIXME: ssl/kerberos
+        if self.user == 'ansible_kerberos' and self.password == 'ansible_kerberos':
+            transport_schemes = [('kerberos', 'https'), ('kerberos', 'http')]
+        else:
+            transport_schemes = [('plaintext', 'https'), ('plaintext', 'http')] # FIXME: ssl/kerberos
         if port == 5985:
             transport_schemes = reversed(transport_schemes)
         exc = None


### PR DESCRIPTION
This patch allows ansible to authenticate to winrm server via kerberos for Domain users.

Pre-requisite steps on Ansible host:

1) kinit user@domain.com  [The user gets a valid kerberos ticket to authenticate]

2) Set the windows variables in ansible. 
 ansible_ssh_user: ansible_kerberos
 ansible_ssh_pass: ansible_kerberos
 ansible_ssh_port: 5986
 ansible_connection: winrm 
Please make sure the username and password is set to 'ansible_kerberos' which tells ansible to use the kerberos ticket for authentication.

Pre-requisite steps on Windows host:

1) Follow the steps on http://docs.ansible.com/intro_windows.html under the section "Window sys prep"

2) Make sure that Kerberos and Negotiate authentication is enabled on WinRm service. 
'winrm g winrm/config/service/auth'

3) Verify connection  with WinRM service using Kerberos.
'winrm id -r:hostname.somedomain.com -a:Kerberos -u:domainusername@somedomain.com -p:'

4) Make sure there are no firewall blocking access to winrm service from ansible host.
on ansible host: 'telnet <host> 5986/5'

Notes:
kinit is provided with the package 'krb5-workstation' in centos/Rhel

An example /etc/krb5.conf file

```
[logging]
 default = FILE:/var/log/krb5libs.log
 kdc = FILE:/var/log/krb5kdc.log
 admin_server = FILE:/var/log/kadmind.log

[libdefaults]
 default_realm = BENNO.COM
 dns_lookup_kdc = false
 ticket_lifetime = 24h
 renew_lifetime = 7d
 forwardable = true
 udp_preference_limit = 1

[realms]
 BENNO.COM = {
  kdc = WIN-EUO6PCEBU37.benno.com
  admin_server = WIN-EUO6PCEBU37.benno.com
  default_domain = benno.com
 }

[appdefaults]
validate=false

[domain_realm]
 .benno.com = BENNO.COM
 benno.com = BENNO.COM

```

Please also make sure the hostnames given in ansible are available in both FORWARD and REVERSE DNS lookups.
