### PR TITLE
return the most up-to-date info about an instance when starting/stopping it

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -1083,10 +1083,12 @@ def startstop_instances(module, ec2, instance_ids, state):
     ## Wait for all the instances to finish starting or stopping
     wait_timeout = time.time() + wait_timeout
     while wait and wait_timeout > time.time():
+        instance_dict_array = []
         matched_instances = []
         for res in ec2.get_all_instances(instance_ids):
             for i in res.instances:
                 if i.state == state:
+                    instance_dict_array.append(get_instance_info(i))
                     matched_instances.append(i)
         if len(matched_instances) < len(instance_ids):
             time.sleep(5)


### PR DESCRIPTION
otherwise the module will return the info about the instance that it got prior to the action taken
So if you had a task to start an instance:

```
  ec2:
     instance_ids: ...
     state: running
  register: ec2_info
```

the registered data would have empty public_dns_name, public_ip, private_dns_name, private_ip
