### PR TITLE
More info in "not a legal parameter" error

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -108,7 +108,15 @@ class Task(object):
                 ds['when'] = "%s %s" % (when_name, ds[x])
                 ds.pop(x)
             elif not x in Task.VALID_KEYS:
-                raise errors.AnsibleError("%s is not a legal parameter in an Ansible task or handler" % x)
+                if 'name' in ds:
+                    task_name = ds['name']
+                else:
+                    task_name = '(No name)'
+                line = "%s: %s" % (x, ds[x])
+                raise errors.AnsibleError(
+                    '"%s" is not a legal parameter in an Ansible task or handler\n'
+                    '    task name: "%s"\n    line: "%s"\n    role_name: "%s"'
+                    % (x, task_name, line, role_name))
 
         self.module_vars  = module_vars
         self.default_vars = default_vars


### PR DESCRIPTION
Without this, I was getting:

```
ERROR: apt is not a legal parameter in an Ansible task or handler
```

which doesn't give me any idea what task ansible is having trouble with
(I reference "apt" many times in many roles)

With this, I get:

```
ERROR: "apt" is not a legal parameter in an Ansible task or handler
    task name: "Update apt-get cache"
    line: "apt: update_cache=yes cache_valid_time=86400"
    role_name: "common"
```

which points me right at the task that ansible is having trouble with.
