### PR TITLE
Make `pip install -e` work

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -25,6 +25,14 @@ import sys
 import os
 import stat
 
+# Augment PYTHONPATH to find Python modules relative to this file path
+# This is so that we can find the modules when running from a local checkout
+# installed as editable with `pip install -e ...` or `python setup.py develop`
+local_module_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'lib')
+)
+sys.path.append(local_module_path)
+
 import ansible.playbook
 import ansible.constants as C
 import ansible.utils.template

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -94,6 +94,14 @@ if getattr(sys, "real_prefix", None):
 else:
     DIST_MODULE_PATH = '/usr/share/ansible/'
 
+# Look for modules relative to this file path
+# This is so that we can find the modules when running from a local checkout
+# installed as editable with `pip install -e ...` or `python setup.py develop`
+local_module_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', 'library')
+)
+DIST_MODULE_PATH = os.pathsep.join([DIST_MODULE_PATH, local_module_path])
+
 # check all of these extensions when looking for yaml files for things like
 # group variables -- really anything we can load
 YAML_FILENAME_EXTENSIONS = [ "", ".yml", ".yaml", ".json" ]


### PR DESCRIPTION
This allows `pip install -e` and `python setup.py develop` to work without having to do the stuff in http://docs.ansible.com/intro_installation.html#running-from-source so it's a tad nicer for Python programmers who are accustomed to installing packages as editable/in development mode.

Fixes GH-8355 (https://github.com/ansible/ansible/issues/8355)
