### PR TITLE
Proposing a Debugging section for intro_windows

### DIFF
--- a/docsite/rst/intro_windows.rst
+++ b/docsite/rst/intro_windows.rst
@@ -254,16 +254,18 @@ Debugging
 Start with the win_ping test. If that fails, pass -vvvv to get verbose output.
 
 
-If you get a 401 error code, log into your Windows client and run the following:
+If you get a 401 error code, log into your Windows client and run the following::
+
 
     winrm set winrm/config/service/auth @{Basic="true"}
+
 
 Then test the ping from your Linux Controller again.
 
 
-Note that currently, you must use a local administrator account on the Windows
+*Note that currently, you must use a local administrator account on the Windows
 client. Support for Kerberos and domain accounts has received a pull request
-but isn't integrated quite yet.
+but isn't integrated quite yet.*
 
 
 

--- a/docsite/rst/intro_windows.rst
+++ b/docsite/rst/intro_windows.rst
@@ -248,6 +248,25 @@ Again, recall that the Windows modules are all listed in the Windows category of
 
 .. _windows_contributions:
 
+
+Debugging
+`````````
+Start with the win_ping test. If that fails, pass -vvvv to get verbose output.
+
+
+If you get a 401 error code, log into your Windows client and run the following:
+
+    winrm set winrm/config/service/auth @{Basic="true"}
+
+Then test the ping from your Linux Controller again.
+
+
+Note that currently, you must use a local administrator account on the Windows
+client. Support for Kerberos and domain accounts has received a pull request
+but isn't integrated quite yet.
+
+
+
 Windows Contributions
 `````````````````````
 


### PR DESCRIPTION
I'm thinking something pretty simple like this to handle a few of the issues I hit.
1. The Error 401 code is discussed [here](https://groups.google.com/forum/#!topic/ansible-project/dyOC1cWX90w). If that's something that everyone is seeing (I did with Server 2012 VM edition) then it might need to be moved up in the document.
2. The `-vvvv` is a bit obscure I think if you're new to Ansible. I'm assuming most will have some experience with Linux and will try just `-v` which is what I tried. I then remembered from a demo that `-vvvv` was what I wanted.
3. The local admin account is something I glossed over when reading the instructions. I figured I could substitute my account for testing, since I'm an admin on that box. So calling that out could help.
