### PR TITLE
Modified ec2_vol to use the new SSD based storage

### DIFF
--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -225,7 +225,8 @@ def create_volume(module, ec2, zone):
     if iops:
         volume_type = 'io1'
     else:
-        volume_type = 'standard'
+        volume_type = 'gp2'
+        # "gp2" is the new name for the new SSD based general purpose storage - version one (magnetic) was referenced as "standard"
 
     # If no instance supplied, try volume creation based on module parameters.
     if name or id:


### PR DESCRIPTION
The older magnetic storage was referenced as volume_type = 'standard'
The new SSD based general purpose storage is now referenced as volume_type = 'gp2'
The change proposed will leverage the new storage without needing to retrofit the module to have volume_type added as a required type and expect people to know its moved from 'storage' to 'gp2'.
