### PR TITLE
ec2_ami_search: Added support for ssd and io1 AMI images

### DIFF
--- a/library/cloud/ec2_ami_search
+++ b/library/cloud/ec2_ami_search
@@ -45,7 +45,7 @@ options:
     description: Back-end store for instance
     required: false
     default: "ebs"
-    choices: ["ebs", "instance-store"]
+    choices: ["ebs", "ebs-ssd", "ebs-io1", "instance-store"]
   arch:
     description: CPU architecture
     required: false
@@ -135,7 +135,7 @@ def lookup_ubuntu_ami(table, release, stream, store, arch, region, virt):
                (release, stream, tag, serial, region, ami, aki, ari, virt)
         release: ubuntu release name
         stream: 'server' or 'desktop'
-        store: 'ebs' or 'instance-store'
+        store: 'ebs', 'ebs-ssd', 'ebs-io1' or 'instance-store'
         arch: 'i386' or 'amd64'
         region: EC2 region
         virt: 'paravirtual' or 'hvm'
@@ -172,7 +172,7 @@ def main():
         stream=dict(required=False, default='server',
             choices=['desktop', 'server']),
         store=dict(required=False, default='ebs',
-            choices=['ebs', 'instance-store']),
+            choices=['ebs', 'ebs-ssd', 'ebs-io1', 'instance-store']),
         arch=dict(required=False, default='amd64',
             choices=['i386', 'amd64']),
         region=dict(required=False, default='us-east-1', choices=AWS_REGIONS),


### PR DESCRIPTION
Until now only ebs and instance-store as story types were supported. There are another two store types for AMI images (ssd, io1). Added those options.
