### PR TITLE
Refactoring and recursive support for the ACL module

### DIFF
--- a/library/files/acl
+++ b/library/files/acl
@@ -79,6 +79,14 @@ options:
     description:
       - DEPRECATED. The acl to set or remove.  This must always be quoted in the form of '<etype>:<qualifier>:<perms>'.  The qualifier may be empty for some types, but the type and perms are always requried. '-' can be used as placeholder when you do not care about permissions. This is now superceeded by entity, type and permissions fields.
 
+  recursive:
+    version_added: "@@@"
+    required: false
+    default: no
+    choices: [ 'yes', 'no' ]
+    description:
+      - Recursively sets the specified ACL (added in Ansible @@@).
+
 author: Brian Coca
 notes:
     - The "acl" module requires that acls are enabled on the target filesystem and that the setfacl and getfacl binaries are installed.
@@ -141,7 +149,7 @@ def build_entry(etype, entity, permissions=None):
         return ':'.join([etype, entity, permissions])
 
 
-def build_command(module, mode, path, follow, default, entry=''):
+def build_command(module, mode, path, follow, default, recursive, entry=''):
     '''Builds and returns agetfacl/setfacl command.'''
     if mode == 'set':
         cmd = [module.get_bin_path('setfacl', True)]
@@ -153,6 +161,9 @@ def build_command(module, mode, path, follow, default, entry=''):
         cmd = [module.get_bin_path('getfacl', True)]
         cmd.append('--omit-header')
         cmd.append('--absolute-names')
+
+    if recursive:
+        cmd.append('--recursive')
 
     if not follow:
         cmd.append('-h')
@@ -210,6 +221,7 @@ def main():
             ),
             follow=dict(required=False, type='bool', default=True),
             default=dict(required=False, type='bool', default=False),
+            recursive=dict(required=False, type='bool', default=False),
         ),
         supports_check_mode=True,
     )
@@ -222,6 +234,7 @@ def main():
     state = module.params.get('state')
     follow = module.params.get('follow')
     default = module.params.get('default')
+    recursive = module.params.get('recursive')
 
     if not os.path.exists(path):
         module.fail_json(msg="path not found or not accessible!")
@@ -243,7 +256,10 @@ def main():
 
     if state == 'present':
         entry = build_entry(etype, entity, permissions)
-        command = build_command(module, 'set', path, follow, default, entry)
+        command = build_command(
+            module, 'set', path, follow,
+            default, recursive, entry
+        )
         changed = acl_changed(module, command)
 
         if changed and not module.check_mode:
@@ -252,7 +268,10 @@ def main():
 
     elif state == 'absent':
         entry = build_entry(etype, entity)
-        command = build_command(module, 'rm', path, follow, default, entry)
+        command = build_command(
+            module, 'rm', path, follow,
+            default, recursive, entry
+        )
         changed = acl_changed(module, command)
 
         if changed and not module.check_mode:
@@ -264,7 +283,7 @@ def main():
 
     acl = run_acl(
         module,
-        build_command(module, 'get', path, follow, default)
+        build_command(module, 'get', path, follow, default, recursive)
     )
 
     module.exit_json(changed=changed, msg=msg, acl=acl)

--- a/library/files/acl
+++ b/library/files/acl
@@ -132,6 +132,15 @@ def split_entry(entry):
 
     return [d,t,e,p]
 
+
+def build_entry(etype, entity, permissions=None):
+    '''Builds and returns an entry string. Does not include the permissions bit if they are not provided.'''
+    if permissions is None:
+        return ':'.join([etype, entity])
+    else:
+        return ':'.join([etype, entity, permissions])
+
+
 def get_acls(module,path,follow):
 
     cmd = [ module.get_bin_path('getfacl', True) ]
@@ -224,6 +233,7 @@ def main():
     currentacls = get_acls(module,path,follow)
 
     if (state == 'present'):
+        entry = build_entry(etype, entity, permissions)
         matched = False
         for oldentry in currentacls:
             if oldentry.count(":") == 0:
@@ -246,10 +256,11 @@ def main():
             changed=True
 
         if changed and not module.check_mode:
-            set_acl(module,path,':'.join([etype, str(entity), permissions]),follow,default)
-        msg="%s is present" % ':'.join([etype, str(entity), permissions])
+            set_acl(module,path,entry,follow,default)
+        msg="%s is present" % entry
 
     elif state == 'absent':
+        entry = build_entry(etype, entity)
         for oldentry in currentacls:
             if oldentry.count(":") == 0:
                 continue
@@ -264,8 +275,8 @@ def main():
                         changed=True
                         break
         if changed and not module.check_mode:
-            rm_acl(module,path,':'.join([etype, entity, '---']),follow,default)
-        msg="%s is absent" % ':'.join([etype, entity, '---'])
+            rm_acl(module,path,entry,follow,default)
+        msg="%s is absent" % entry
     else:
         msg="current acl"
 

--- a/library/files/acl
+++ b/library/files/acl
@@ -102,16 +102,6 @@ EXAMPLES = '''
   register: acl_info
 '''
 
-def normalize_permissions(p):
-    perms = ['-','-','-']
-    for char in p:
-        if char == 'r':
-            perms[0] = 'r'
-        if char == 'w':
-            perms[1] = 'w'
-        if char == 'x':
-            perms[2] = 'x'
-    return ''.join(perms)
 
 def split_entry(entry):
     ''' splits entry and ensures normalized return'''
@@ -139,8 +129,6 @@ def split_entry(entry):
         t = "other"
     else:
         t = None
-
-    p = normalize_permissions(p)
 
     return [d,t,e,p]
 
@@ -211,7 +199,7 @@ def main():
     entry = module.params.get('entry')
     entity = module.params.get('entity')
     etype = module.params.get('etype')
-    permissions = normalize_permissions(module.params.get('permissions'))
+    permissions = module.params.get('permissions')
     state = module.params.get('state')
     follow = module.params.get('follow')
     default = module.params.get('default')

--- a/library/files/acl
+++ b/library/files/acl
@@ -202,7 +202,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(required=True, aliases=['path'], type='str'),
-            entry=dict(required=False, etype='str'),
+            entry=dict(required=False, type='str'),
             entity=dict(required=False, type='str', default=''),
             etype=dict(
                 required=False,

--- a/library/files/acl
+++ b/library/files/acl
@@ -234,17 +234,27 @@ def main():
     recursive = module.params.get('recursive')
 
     if not os.path.exists(path):
-        module.fail_json(msg="path not found or not accessible!")
+        module.fail_json(msg="Path not found or not accessible.")
 
-    if state in ['present', 'absent']:
-        if not entry and not etype:
-            module.fail_json(msg="%s requires either etype and permissions or just entry be set" % state)
+    if not entry:
+        if state == 'absent' and permissions:
+            module.fail_json(msg="'permissions' MUST NOT be set when 'state=absent'.")
+
+        if state == 'absent' and not entity:
+            module.fail_json(msg="'entity' MUST be set when 'state=absent'.")
+
+        if state in ['present', 'absent'] and not etype:
+            module.fail_json(msg="'etype' MUST be set when 'state=%s'." % state)
 
     if entry:
         if etype or entity or permissions:
-            module.fail_json(msg="entry and another incompatible field (entity, etype or permissions) are also set")
-        if entry.count(":") not in [2, 3]:
-            module.fail_json(msg="Invalid entry: '%s', it requires 3 or 4 sections divided by ':'" % entry)
+            module.fail_json(msg="'entry' MUST NOT be set when 'entity', 'etype' or 'permissions' are set.")
+
+        if state == 'present' and entry.count(":") != 3:
+            module.fail_json(msg="'entry' MUST have 3 sections divided by ':' when 'state=present'.")
+
+        if state == 'absent' and entry.count(":") != 2:
+            module.fail_json(msg="'entry' MUST have 2 sections divided by ':' when 'state=absent'.")
 
         default, etype, entity, permissions = split_entry(entry)
 

--- a/library/files/acl
+++ b/library/files/acl
@@ -171,26 +171,11 @@ def acl_changed(module, cmd):
     '''Returns true if the provided command affects the existing ACLs, false otherwise.'''
     cmd = cmd[:]  # lists are mutables so cmd would be overriden without this
     cmd.insert(1, '--test')
-    lines = _run_acl(module, cmd)
+    lines = run_acl(module, cmd)
     return not all(line.endswith('*,*') for line in lines)
 
 
-def get_acls(module,path,follow,default):
-
-    command = build_command(module, 'get', path, follow, default)
-    return _run_acl(module,command)
-
-def set_acl(module,path,entry,follow,default):
-
-    command = build_command(module, 'set', path, follow, default, entry)
-    return _run_acl(module,command)
-
-def rm_acl(module,path,entry,follow,default):
-
-    command = build_command(module, 'rm', path, follow, default, entry)
-    return _run_acl(module,command,False)
-
-def _run_acl(module,cmd,check_rc=True):
+def run_acl(module, cmd, check_rc=True):
 
     try:
         (rc, out, err) = module.run_command(' '.join(cmd), check_rc=check_rc)
@@ -253,7 +238,7 @@ def main():
         changed = acl_changed(module, command)
 
         if changed and not module.check_mode:
-            set_acl(module,path,entry,follow,default)
+            run_acl(module, command)
         msg="%s is present" % entry
 
     elif state == 'absent':
@@ -262,15 +247,17 @@ def main():
         changed = acl_changed(module, command)
 
         if changed and not module.check_mode:
-            rm_acl(module,path,entry,follow,default)
+            run_acl(module, command, False)
         msg="%s is absent" % entry
     else:
         msg="current acl"
 
-    if changed:
-        currentacls = get_acls(module,path,follow,default)
+    acl = run_acl(
+        module,
+        build_command(module, 'get', path, follow, default)
+    )
 
-    module.exit_json(changed=changed, msg=msg, acl=currentacls)
+    module.exit_json(changed=changed, msg=msg, acl=acl)
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/library/files/acl
+++ b/library/files/acl
@@ -167,6 +167,14 @@ def build_command(module, mode, path, follow, default, entry=''):
     return cmd
 
 
+def acl_changed(module, cmd):
+    '''Returns true if the provided command affects the existing ACLs, false otherwise.'''
+    cmd = cmd[:]  # lists are mutables so cmd would be overriden without this
+    cmd.insert(1, '--test')
+    lines = _run_acl(module, cmd)
+    return not all(line.endswith('*,*') for line in lines)
+
+
 def get_acls(module,path,follow,default):
 
     command = build_command(module, 'get', path, follow, default)
@@ -189,9 +197,13 @@ def _run_acl(module,cmd,check_rc=True):
     except Exception, e:
         module.fail_json(msg=e.strerror)
 
-    # trim last line as it is always empty
-    ret = out.splitlines()
-    return ret[0:len(ret)-1]
+    lines = out.splitlines()
+    if lines and not lines[-1].split():
+        # trim last line only when it is empty
+        return lines[:-1]
+    else:
+        return lines
+
 
 def main():
     module = AnsibleModule(
@@ -234,30 +246,11 @@ def main():
 
     changed=False
     msg = ""
-    currentacls = get_acls(module, path, follow, default)
 
     if (state == 'present'):
         entry = build_entry(etype, entity, permissions)
-        matched = False
-        for oldentry in currentacls:
-            if oldentry.count(":") == 0:
-                continue
-            old_default, old_type, old_entity, old_permissions = split_entry(oldentry)
-            if old_default == default:
-                if old_type == etype:
-                    if etype in ['user', 'group']:
-                        if old_entity == entity:
-                            matched = True
-                            if not old_permissions == permissions:
-                                changed = True
-                            break
-                    else:
-                        matched = True
-                        if not old_permissions == permissions:
-                            changed = True
-                        break
-        if not matched:
-            changed=True
+        command = build_command(module, 'set', path, follow, default, entry)
+        changed = acl_changed(module, command)
 
         if changed and not module.check_mode:
             set_acl(module,path,entry,follow,default)
@@ -265,19 +258,9 @@ def main():
 
     elif state == 'absent':
         entry = build_entry(etype, entity)
-        for oldentry in currentacls:
-            if oldentry.count(":") == 0:
-                continue
-            old_default, old_type, old_entity, old_permissions = split_entry(oldentry)
-            if old_default == default:
-                if old_type == etype:
-                    if etype in ['user', 'group']:
-                        if old_entity == entity:
-                            changed=True
-                            break
-                    else:
-                        changed=True
-                        break
+        command = build_command(module, 'rm', path, follow, default, entry)
+        changed = acl_changed(module, command)
+
         if changed and not module.check_mode:
             rm_acl(module,path,entry,follow,default)
         msg="%s is absent" % entry

--- a/library/files/acl
+++ b/library/files/acl
@@ -143,10 +143,7 @@ def split_entry(entry):
 
 def build_entry(etype, entity, permissions=None):
     '''Builds and returns an entry string. Does not include the permissions bit if they are not provided.'''
-    if permissions is None:
-        return ':'.join([etype, entity])
-    else:
-        return ':'.join([etype, entity, permissions])
+    return etype + ':' + entity + (':' + permissions if permissions else '')
 
 
 def build_command(module, mode, path, follow, default, recursive, entry=''):

--- a/library/files/acl
+++ b/library/files/acl
@@ -111,9 +111,9 @@ def split_entry(entry):
     if len(a) == 3:
         a.append(False)
     try:
-        p,e,t,d = a
+        p, e, t, d = a
     except ValueError, e:
-        print "wtf?? %s => %s" % (entry,a)
+        print "wtf?? %s => %s" % (entry, a)
         raise e
 
     if d:
@@ -130,7 +130,7 @@ def split_entry(entry):
     else:
         t = None
 
-    return [d,t,e,p]
+    return [d, t, e, p]
 
 
 def build_entry(etype, entity, permissions=None):
@@ -192,15 +192,24 @@ def run_acl(module, cmd, check_rc=True):
 
 def main():
     module = AnsibleModule(
-        argument_spec = dict(
-            name = dict(required=True,aliases=['path'], type='str'),
-            entry = dict(required=False, etype='str'),
-            entity = dict(required=False, type='str', default=''),
-            etype = dict(required=False, choices=['other', 'user', 'group', 'mask'], type='str'),
-            permissions = dict(required=False, type='str'),
-            state = dict(required=False, default='query', choices=[ 'query', 'present', 'absent' ], type='str'),
-            follow = dict(required=False, type='bool', default=True),
-            default= dict(required=False, type='bool', default=False),
+        argument_spec=dict(
+            name=dict(required=True, aliases=['path'], type='str'),
+            entry=dict(required=False, etype='str'),
+            entity=dict(required=False, type='str', default=''),
+            etype=dict(
+                required=False,
+                choices=['other', 'user', 'group', 'mask'],
+                type='str'
+            ),
+            permissions=dict(required=False, type='str'),
+            state=dict(
+                required=False,
+                default='query',
+                choices=['query', 'present', 'absent'],
+                type='str'
+            ),
+            follow=dict(required=False, type='bool', default=True),
+            default=dict(required=False, type='bool', default=False),
         ),
         supports_check_mode=True,
     )
@@ -217,29 +226,29 @@ def main():
     if not os.path.exists(path):
         module.fail_json(msg="path not found or not accessible!")
 
-    if state in ['present','absent']:
-        if  not entry and not etype:
+    if state in ['present', 'absent']:
+        if not entry and not etype:
             module.fail_json(msg="%s requires either etype and permissions or just entry be set" % state)
 
     if entry:
         if etype or entity or permissions:
             module.fail_json(msg="entry and another incompatible field (entity, etype or permissions) are also set")
-        if entry.count(":") not in [2,3]:
+        if entry.count(":") not in [2, 3]:
             module.fail_json(msg="Invalid entry: '%s', it requires 3 or 4 sections divided by ':'" % entry)
 
         default, etype, entity, permissions = split_entry(entry)
 
-    changed=False
+    changed = False
     msg = ""
 
-    if (state == 'present'):
+    if state == 'present':
         entry = build_entry(etype, entity, permissions)
         command = build_command(module, 'set', path, follow, default, entry)
         changed = acl_changed(module, command)
 
         if changed and not module.check_mode:
             run_acl(module, command)
-        msg="%s is present" % entry
+        msg = "%s is present" % entry
 
     elif state == 'absent':
         entry = build_entry(etype, entity)
@@ -248,9 +257,10 @@ def main():
 
         if changed and not module.check_mode:
             run_acl(module, command, False)
-        msg="%s is absent" % entry
+        msg = "%s is absent" % entry
+
     else:
-        msg="current acl"
+        msg = "current acl"
 
     acl = run_acl(
         module,

--- a/library/files/acl
+++ b/library/files/acl
@@ -141,42 +141,46 @@ def build_entry(etype, entity, permissions=None):
         return ':'.join([etype, entity, permissions])
 
 
-def get_acls(module,path,follow):
+def build_command(module, mode, path, follow, default, entry=''):
+    '''Builds and returns agetfacl/setfacl command.'''
+    if mode == 'set':
+        cmd = [module.get_bin_path('setfacl', True)]
+        cmd.append('-m "%s"' % entry)
+    elif mode == 'rm':
+        cmd = [module.get_bin_path('setfacl', True)]
+        cmd.append('-x "%s"' % entry)
+    else:  # mode == 'get'
+        cmd = [module.get_bin_path('getfacl', True)]
+        cmd.append('--omit-header')
+        cmd.append('--absolute-names')
 
-    cmd = [ module.get_bin_path('getfacl', True) ]
     if not follow:
         cmd.append('-h')
-    # prevents absolute path warnings and removes headers
-    cmd.append('--omit-header')
-    cmd.append('--absolute-names')
-    cmd.append(path)
 
-    return _run_acl(module,cmd)
+    if default:
+        if(mode == 'rm'):
+            cmd.append('-k')
+        else:  # mode == 'set' or mode == 'get'
+            cmd.append('-d')
+
+    cmd.append(path)
+    return cmd
+
+
+def get_acls(module,path,follow,default):
+
+    command = build_command(module, 'get', path, follow, default)
+    return _run_acl(module,command)
 
 def set_acl(module,path,entry,follow,default):
 
-    cmd = [ module.get_bin_path('setfacl', True) ]
-    if not follow:
-        cmd.append('-h')
-    if default:
-        cmd.append('-d')
-    cmd.append('-m "%s"' % entry)
-    cmd.append(path)
-
-    return _run_acl(module,cmd)
+    command = build_command(module, 'set', path, follow, default, entry)
+    return _run_acl(module,command)
 
 def rm_acl(module,path,entry,follow,default):
 
-    cmd = [ module.get_bin_path('setfacl', True) ]
-    if not follow:
-        cmd.append('-h')
-    if default:
-        cmd.append('-k')
-    entry = entry[0:entry.rfind(':')]
-    cmd.append('-x "%s"' % entry)
-    cmd.append(path)
-
-    return _run_acl(module,cmd,False)
+    command = build_command(module, 'rm', path, follow, default, entry)
+    return _run_acl(module,command,False)
 
 def _run_acl(module,cmd,check_rc=True):
 
@@ -230,7 +234,7 @@ def main():
 
     changed=False
     msg = ""
-    currentacls = get_acls(module,path,follow)
+    currentacls = get_acls(module, path, follow, default)
 
     if (state == 'present'):
         entry = build_entry(etype, entity, permissions)
@@ -281,7 +285,7 @@ def main():
         msg="current acl"
 
     if changed:
-        currentacls = get_acls(module,path,follow)
+        currentacls = get_acls(module,path,follow,default)
 
     module.exit_json(changed=changed, msg=msg, acl=currentacls)
 


### PR DESCRIPTION
This PR enables the support for recursive ACLs. Some refactoring was needed to make this work.

Other things were fixed along the way (and other things got probably broken, but that's what reviews are for, right?).

Note that during my work on this PR, I had a discussion on IRC with @bcoca and I realized that I am currently breaking BSD support. However, from this point, I arranged my refactoring so that a compatibility fix/extension would not be a major pain. So it might be worth to **wait before merging** this until I get feedback and apply fixes.
## Advantages of the refactoring
- Permissions do not need to be normalized anymore using the `--test` checking system
- `--test` does not check using `getfacl`, so the code is less verbose and less likely to introduce a parsing error (since there is actually - almost - no parsing)
- `--test` makes `--recursive` doable at no cost, and checking the `changed` status is neither overly complicated or slow
- `default` can now be used on acl queries as well
- [`X` (`capital-x` / _Special execute_)](https://en.wikipedia.org/wiki/Chmod#Symbolic_modes) is now supported in the permissions with no extra code
## Inconvenients of the refactoring
- `--test` does not seem to be supported by BSD's `setfacl` (I learned that afterwards). However, this can now be solved in the `acl_changed` function only without affecting the rest of the file (hopefully). Suggestions below.
- Performance-wise, there is one super small caveat:
  - Before my changes, the steps of the module were the following:
    - If there no changes on the ACLs of a file to be applied: `a = getfacl` > compare `a` and the acls to be set > output `a` in JSON
    - If there are some: `a = getfacl` > compare `a` and the acls to be set > `setfacl` > `a_new = getfacl` > output `a_new` in JSON
  - After my changes:
    - If there no changes on the ACLs of a file to be applied: `setfacl --test` > `a = getfacl` > output `a` in JSON
    - If there are some: > `setfacl --test` > `setfacl` > `a_new = getfacl` > output `a_new` in JSON
  
  Hence cost (in terms of calls to `setfacl` and `getfacl`) is one extra `setfacl --test` when there are no changes. However, there is no manual comparison which will take time in recursive mode.
## General notes (and motivations) to help for the review
- `normalize_permissions` was causing a bug when using entry: `permissions` was needed to avoid an exception (due to call to `normalize_permissions` in `main`) but `entry` and `permissions` were incompatible
- `normalize_permissions` did not support `X` (`capital-x`) and its support would cause problem with the former checking system (since `X` itself is not stateless)
- `_run_acl` was making the usage of `--test` impossible because for the last line returned when using `--test` is relevant and not empty. It now makes sure that the last line is empty before stripping it.
- 2 new builder helpers `build_entry` and `build_command` now factorize some recurring code
- `acl_changed` is a function meant to test if a command changes ACLs. The checking can be extended there rather than in the `main` function
- I removed the `get_acls`, `set_acl` and `rm_acl` wrappers for the following reasons:
  - They were used only once each (at least in the context of this PR)
  - They only contained one call to `build_command` and one call to `run_acl` in the end
  - The command is already built when it is `--test`ed before so I reuse the command rather than rebuilding it
- `_run_acl` is now `run_acl` because it is not a hidden/private function anymore, it is used in the `main` function multiple times
## Suggestions for Linux / BSD support
- The `follow` argument sets `-h`, which is supported by BSD only and not by Linux. To my understanding, the corresponding argument is `-L`, `--logical`. If so, I can add a condition in `build_command`. Can you confirm?
- Before my PR, both BSD and Linux were supported, `--recursive` was not. My PR breaks support for BSD because of its lack of `--test`, but adds support for `--recursive` on Linux. I suggest that a condition checks if this is running on BSD and if so, that `changed` is **always** true when using `recursive=yes`. When not using `recursive=yes`, we can either do the same or replicate the old code for checking state. What I described earlier (notably the `X` bit) will still be a problem.
- The documentation should mention the differences BSD support if there is a difference (for example no support for `recursive` on BSD).
## TODOs before possible merging
- Although I added a documentation bit, I did not specify the version as I prefer your review before. What should I set?
- When using `recursive=yes`, the returned content looks like this:

``` json
{
    "acl": [
        "user::r-x", 
        "group::rwx",
        "other::r-x", 
        "", 
        "user::rw-", 
        "group::rwx",
        "other::r--"
    ]
}
```

This is unusable as is. How do you want to handle this? Grouping and indexing by filename seems the most obvious to me, but maybe you have a better idea. Plus, if we apply this behavior to every returned entry (that is, not depending on the value of `recursive`), this breaks backward-compatibility. So should we let the output index-less when `recursive=no`?
