### PR TITLE
Load callback plugins in the ansible script

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -38,6 +38,7 @@ class Cli(object):
     def __init__(self):
         self.stats = callbacks.AggregateStats()
         self.callbacks = callbacks.CliRunnerCallbacks()
+        callbacks.load_callback_plugins()
 
     # ----------------------------------------------
 


### PR DESCRIPTION
This is an open discussion, since I'm far from an expert on ansible.
However, since I often run some commands on a lot of host, I've written a small callback plugin that summarize output on stdout and stderr.
I need this callback to be called when running ansible (not the playbook), since I only run once a command, and forget it after that.
Maybe the modified line is not enough, too much, or at a wrong location. I just copied it from the ansible-playbook script.
