### PR TITLE
"allow_no_value=True" for ini_file module

### DIFF
--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -94,7 +94,7 @@ import ConfigParser
 def do_ini(module, filename, section=None, option=None, value=None, state='present', backup=False):
 
     changed = False
-    cp = ConfigParser.ConfigParser()
+    cp = ConfigParser.ConfigParser(allow_no_value=True)
     cp.optionxform = identity
 
     try:


### PR DESCRIPTION
I use init_file to edit my.cnf that has values that are only keys. 

Could you please update this? 

Thanks,
Nico
