### PR TITLE
FreeBSD does not like spaces around the '=' sign.

### DIFF
--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -265,6 +265,7 @@ class SysctlModule(object):
     def fix_lines(self):
         checked = []
         self.fixed_lines = []
+        is_freebsd = get_platform().lower() == 'freebsd'
         for line in self.file_lines:
             if not line.strip() or line.strip().startswith("#"):
                 self.fixed_lines.append(line)
@@ -277,20 +278,20 @@ class SysctlModule(object):
                 checked.append(k)
                 if k == self.args['name']:
                     if self.args['state'] == "present":
-                        if get_platform().lower() == 'freebsd':
+                        if is_freebsd:
                             new_line = "%s=%s\n" % (k, self.args['value'])
                         else:
                             new_line = "%s = %s\n" % (k, self.args['value'])
                         self.fixed_lines.append(new_line)                    
                 else:
-                    if get_platform().lower() == 'freebsd':
+                    if is_freebsd:
                         new_line = "%s=%s\n" % (k, v)
                     else:
                         new_line = "%s = %s\n" % (k, v)
                     self.fixed_lines.append(new_line)                    
 
         if self.args['name'] not in checked and self.args['state'] == "present":
-            if get_platform().lower() == 'freebsd':
+            if is_freebsd:
                 new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
             else:
                 new_line = "%s=%s\n" % (self.args['name'], self.args['value'])

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -216,19 +216,18 @@ class SysctlModule(object):
         else:
             return rc
 
-    # Run sysctl -p
+    # Run sysctl -p/-f
     def reload_sysctl(self):
         # do it
         if get_platform().lower() == 'freebsd':
-            # freebsd doesn't support -p, so reload the sysctl service
-            rc,out,err = self.module.run_command('/etc/rc.d/sysctl reload')
+            sysctl_args = [self.sysctl_cmd, '-f', self.sysctl_file]
         else:
-            # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
-            if self.args['ignoreerrors']:
-                sysctl_args.insert(1, '-e')
+
+        if self.args['ignoreerrors']:
+            sysctl_args.insert(1, '-e')
             
-            rc,out,err = self.module.run_command(sysctl_args)
+        rc,out,err = self.module.run_command(sysctl_args)
 
         if rc != 0:            
             self.module.fail_json(msg="Failed to reload sysctl: %s" % str(out) + str(err))
@@ -278,14 +277,23 @@ class SysctlModule(object):
                 checked.append(k)
                 if k == self.args['name']:
                     if self.args['state'] == "present":
-                        new_line = "%s = %s\n" % (k, self.args['value'])
+                        if get_platform().lower() == 'freebsd':
+                            new_line = "%s=%s\n" % (k, self.args['value'])
+                        else:
+                            new_line = "%s = %s\n" % (k, self.args['value'])
                         self.fixed_lines.append(new_line)                    
                 else:
-                    new_line = "%s = %s\n" % (k, v)
+                    if get_platform().lower() == 'freebsd':
+                        new_line = "%s=%s\n" % (k, v)
+                    else:
+                        new_line = "%s = %s\n" % (k, v)
                     self.fixed_lines.append(new_line)                    
 
         if self.args['name'] not in checked and self.args['state'] == "present":
-            new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
+            if get_platform().lower() == 'freebsd':
+                new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
+            else:
+                new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
             self.fixed_lines.append(new_line)                    
 
     # Completely rewrite the sysctl file


### PR DESCRIPTION
FreeBSD 10 supports reloading a single sysctl file.
