### PR TITLE
fail module: Add an "all" argument to trigger a fatal error

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -469,6 +469,10 @@ class PlayBook(object):
 
         # add facts to the global setup cache
         for host, result in contacted.iteritems():
+            # check if fail module triggered a fatal error
+            if task.module_name == 'fail' and 'fatal' in result and 'msg' in result:               
+                hosts_remaining = False
+                return hosts_remaining
             if 'results' in result:
                 # task ran with_ lookup plugin, so facts are encapsulated in
                 # multiple list items in the results key

--- a/lib/ansible/runner/action_plugins/fail.py
+++ b/lib/ansible/runner/action_plugins/fail.py
@@ -18,6 +18,7 @@
 import ansible
 
 from ansible import utils
+from ansible import errors
 from ansible.runner.return_data import ReturnData
 
 class ActionModule(object):
@@ -39,6 +40,7 @@ class ActionModule(object):
         args.update(utils.parse_kv(module_args))
         if not 'msg' in args:
             args['msg'] = 'Failed as requested from task'
-
         result = dict(failed=True, msg=args['msg'])
+        if 'all' in args:
+            result = dict(failed=True, msg=args['msg'], fatal=True)        
         return ReturnData(conn=conn, result=result)

--- a/lib/ansible/runner/action_plugins/fail.py
+++ b/lib/ansible/runner/action_plugins/fail.py
@@ -42,5 +42,5 @@ class ActionModule(object):
             args['msg'] = 'Failed as requested from task'
         result = dict(failed=True, msg=args['msg'])
         if 'all' in args:
-            result = dict(failed=True, msg=args['msg'], fatal=True)        
+            result['fatal'] = True
         return ReturnData(conn=conn, result=result)

--- a/library/utilities/fail
+++ b/library/utilities/fail
@@ -25,7 +25,7 @@ short_description: Fail with custom message
 description:
      - This module fails the progress with a custom message. It can be
        useful for bailing out when a certain condition is met using C(when).
-version_added: "1.8"
+version_added: "0.8"
 options:
   msg:
     description:
@@ -38,6 +38,7 @@ options:
       - If used a fatal error will be triggered for all the hosts in the playbook.
     required: false
     default: "no"
+    version_added: "1.8"
 
 author: Dag Wieers
 '''

--- a/library/utilities/fail
+++ b/library/utilities/fail
@@ -25,7 +25,7 @@ short_description: Fail with custom message
 description:
      - This module fails the progress with a custom message. It can be
        useful for bailing out when a certain condition is met using C(when).
-version_added: "0.8"
+version_added: "1.8"
 options:
   msg:
     description:

--- a/library/utilities/fail
+++ b/library/utilities/fail
@@ -32,7 +32,12 @@ options:
       - The customized message used for failing execution. If omitted,
         fail will simple bail out with a generic message.
     required: false
-    default: "'Failed as requested from task'"
+    default: "'Failed as requested from task'"  
+  all:
+    description:
+      - If used a fatal error will be triggered for all the hosts in the playbook.
+    required: false
+    default: "no"
 
 author: Dag Wieers
 '''
@@ -40,5 +45,8 @@ author: Dag Wieers
 EXAMPLES = '''
 # Example playbook using fail and when together
 - fail: msg="The system may not be provisioned according to the CMDB status."
+  when: cmdb_status != "to-be-staged"
+# Example playbook using fail all and when together
+- fail: msg="The system may not be provisioned according to the CMDB status, playbook run aborted" all=yes
   when: cmdb_status != "to-be-staged"
 '''

--- a/test/integration/test_fail.yml
+++ b/test/integration/test_fail.yml
@@ -1,0 +1,47 @@
+# test code for the fail module
+# (c) 2014, Amr Abed <amrenator@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+---
+- hosts: local
+  vars:
+    fail_run: "YES"
+    
+  tasks:
+    - name: test fail with all
+      fail: msg="Failed" all=yes
+      when: fail_run == "YES" and inventory_hostname == "testhost"
+      tags: ["fail_with_all"]    
+      
+    - name: test fail with all
+      debug: msg="Dummy run"
+      tags: ["fail_with_all"]  
+      
+    - name: test fail without all
+      debug: msg="Dummy run"
+      tags: ["fail_without_all"]  
+      
+    - name: test fail without all
+      fail: msg="Failed"
+      when: fail_run == "YES" and inventory_hostname == "testhost"
+      tags: ["fail_without_all"]
+
+    - name:
+      debug: msg="Still running"
+      tags: ["fail_with_all", "fail_without_all"]
+
+


### PR DESCRIPTION
Adds an optional "all" parameter to the "fail" module, which modifies it's behavior to trigger a fatal error for the whole playbook.

this was implemented without raising an ansible error, we only set the remaining_hosts to False and stop the rest of the task execution, and it's triggered by passing a "Fatal" keyword in the module return data.

This PR originated here : https://groups.google.com/forum/#!topic/ansible-project/gDzrZVQ3AMw

An integration test is included under test/integration/test_fail.yml 

```

---
- hosts: local
  vars:
    fail_run: "YES"

  tasks:
    - name: test fail with all
      fail: msg="Failed" all=yes
      when: fail_run == "YES"
      tags: ["fail_with_all"]    

    - name: test fail with all
      debug: msg="Dummy run"
      tags: ["fail_with_all"]  

    - name: test fail without all
      debug: msg="Dummy run"
      tags: ["fail_without_all"]  

    - name: test fail without all
      fail: msg="Failed"
      when: fail_run == "YES" 
      tags: ["fail_without_all"]

    - name:
      debug: msg="Still running"
      tags: ["fail_with_all", "fail_without_all"]
```
