### PR TITLE
adding connection draining and cross zone load balancing options to ec2_elb_lb

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -264,14 +264,15 @@ def delete_autoscaling_group(connection, module):
 
         instances = True
         while instances:
-            groups = connection.get_all_groups(names=[group_name])
+            groups = connection.get_all_groups()
             for group in groups:
                 if group.name == group_name:
                     if not group.instances:
+                        target_group = group
                         instances = False
             time.sleep(10)
 
-        group.delete()
+        target_group.delete()
         module.exit_json(changed=True)
     else:
         module.exit_json(changed=False)

--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -264,7 +264,7 @@ def delete_autoscaling_group(connection, module):
 
         instances = True
         while instances:
-            groups = connection.get_all_groups()
+            groups = connection.get_all_groups(names=[group_name])
             for group in groups:
                 if group.name == group_name:
                     if not group.instances:

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -93,6 +93,12 @@ options:
     choices: ["yes", "no"]
     aliases: []
     version_added: "1.5"
+  attributes:
+    description:
+      - An associative array of attribute settings. Only crosszone_load_balancing and connection_draining are implemented right now. See EXAMPLES.
+    required: false
+    default: None
+    version_added: "1.7"
 
 extends_documentation_fragment: aws
 """
@@ -206,6 +212,26 @@ EXAMPLES = """
       - protocol: http
         load_balancer_port: 80
         instance_port: 80
+
+# Creates a ELB with crosszone_load_balancing and connectionDraining enabled.
+- local_action:
+    module: ec2_elb_lb
+    state: present
+    name: 'New ELB'
+    security_group_ids: 'sg-123456, sg-67890'
+    region: us-west-2
+    subnets: 'subnet-123456, subnet-67890'
+    purge_subnets: yes
+    listeners:
+      - protocol: http
+        load_balancer_port: 80
+        instance_port: 80
+    attributes:
+      - crosszone_load_balancing:
+        enabled: true
+      - connection_draining:
+        enabled: true
+        value: 120
 """
 
 import sys
@@ -227,7 +253,7 @@ class ElbManager(object):
     def __init__(self, module, name, listeners=None, purge_listeners=None,
                  zones=None, purge_zones=None, security_group_ids=None, 
                  health_check=None, subnets=None, purge_subnets=None,
-                 scheme="internet-facing", region=None, **aws_connect_params):
+                 scheme="internet-facing", attributes=None, region=None, **aws_connect_params):
 
         self.module = module
         self.name = name
@@ -240,6 +266,7 @@ class ElbManager(object):
         self.subnets = subnets
         self.purge_subnets = purge_subnets
         self.scheme = scheme
+        self.attributes = attributes
 
         self.aws_connect_params = aws_connect_params
         self.region = region
@@ -260,6 +287,7 @@ class ElbManager(object):
             self._set_elb_listeners()
             self._set_subnets()
         self._set_health_check()
+        self._set_attributes()
 
     def ensure_gone(self):
         """Destroy the ELB"""
@@ -308,6 +336,17 @@ class ElbManager(object):
                                      for l in self.listeners]
             else:
                 info['listeners'] = []
+
+            # attributes need to be queried seperately for some reason
+            elb_attrs = self.elb_conn.get_all_lb_attributes(self.name)
+            info['connection_draining'] = {
+                'enabled': elb_attrs.connection_draining.enabled,
+                'timeout': elb_attrs.connection_draining.timeout
+            }
+            info['crosszone_load_balancing'] = {
+                'enabled': elb_attrs.cross_zone_load_balancing.enabled
+            }
+
         return info
 
     def _get_elb(self):
@@ -543,6 +582,26 @@ class ElbManager(object):
 
         return "%s:%s%s" % (protocol, self.health_check['ping_port'], path)
 
+    def _set_attributes(self):
+
+        if self.attributes != None:
+            for attribute in self.attributes:
+                if 'connection_draining' in attribute:
+                    #raise Exception(attribute['enabled'])
+                    attr = self.elb_conn.get_all_lb_attributes(self.elb.name)
+                    attr.connection_draining.enabled = attribute['enabled']
+                    attr.connection_draining.timeout = attribute['value']
+                    lb_attribute = 'connectionDraining' 
+                    value = attr.connection_draining
+                elif 'crosszone_load_balancing' in attribute:
+                    lb_attribute = 'crossZoneLoadBalancing' 
+                    value = attribute['enabled']
+                # todo: add accessLog
+                elif 'access_log' in attribute:
+                    pass
+
+                self.elb_conn.modify_lb_attribute(self.elb.name, lb_attribute, value)
+
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -557,7 +616,8 @@ def main():
             health_check={'default': None, 'required': False, 'type': 'dict'},
             subnets={'default': None, 'required': False, 'type': 'list'},
             purge_subnets={'default': False, 'required': False, 'type': 'bool'},
-            scheme={'default': 'internet-facing', 'required': False}
+            scheme={'default': 'internet-facing', 'required': False},
+            attributes={'default': None, 'required': False, 'type': 'list'}
         )
     )
 
@@ -580,6 +640,7 @@ def main():
     subnets = module.params['subnets']
     purge_subnets = module.params['purge_subnets']
     scheme = module.params['scheme']
+    attributes = module.params['attributes']
 
     if state == 'present' and not listeners:
         module.fail_json(msg="At least one port is required for ELB creation")
@@ -590,7 +651,7 @@ def main():
     elb_man = ElbManager(module, name, listeners, purge_listeners, zones,
                          purge_zones, security_group_ids, health_check,
                          subnets, purge_subnets,
-                         scheme, region=region, **aws_connect_params)
+                         scheme, attributes, region=region, **aws_connect_params)
 
     if state == 'present':
         elb_man.ensure_ok()

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -79,6 +79,12 @@ options:
     required: false
     default: false
     aliases: []
+  associate_public_ip_address:
+    description:
+      - whether to assign a public IP address to each instance launched in a Amazon VPC
+    required: false
+    default: false
+    aliases: []
 extends_documentation_fragment: aws
 """
 
@@ -139,6 +145,7 @@ def create_launch_config(connection, module):
     instance_type = module.params.get('instance_type')
     spot_price = module.params.get('spot_price')
     instance_monitoring = module.params.get('instance_monitoring')
+    associate_public_ip_address=module.params.get('associate_public_ip_address')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -159,7 +166,8 @@ def create_launch_config(connection, module):
         block_device_mappings=[bdm],
         instance_type=instance_type,
         spot_price=spot_price,
-        instance_monitoring=instance_monitoring)
+        instance_monitoring=instance_monitoring,
+        associate_public_ip_address=associate_public_ip_address)
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
     changed = False
@@ -201,6 +209,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent']),
             spot_price=dict(type='float'),
             instance_monitoring=dict(default=False, type='bool'),
+            associate_public_ip_address=dict(default=True, type='bool')
         )
     )
 

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -21,7 +21,7 @@ short_description: Create or delete AWS Autoscaling Launch Configurations
 description:
   - Can create or delete AwS Autoscaling Configurations
   - Works with the ec2_asg module to manage Autoscaling Groups
-version_added: "1.7"
+version_added: "1.6"
 author: Gareth Rushgrove
 options:
   state:

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -85,6 +85,7 @@ options:
     required: false
     default: false
     aliases: []
+    version_added: "1.7"
 extends_documentation_fragment: aws
 """
 

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -21,7 +21,7 @@ short_description: Create or delete AWS Autoscaling Launch Configurations
 description:
   - Can create or delete AwS Autoscaling Configurations
   - Works with the ec2_asg module to manage Autoscaling Groups
-version_added: "1.6"
+version_added: "1.7"
 author: Gareth Rushgrove
 options:
   state:

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -209,7 +209,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent']),
             spot_price=dict(type='float'),
             instance_monitoring=dict(default=False, type='bool'),
-            associate_public_ip_address=dict(default=True, type='bool')
+            associate_public_ip_address=dict(default=False, type='bool')
         )
     )
 


### PR DESCRIPTION
Please let me know if there are any issues with my pull request. I have added a feature to configure ELB attributes. I have done cross zone load balancing and connection draining. I did not implement accessLog as I have no need for that ATM. More information can be found http://boto.readthedocs.org/en/latest/ref/elb.html#module-boto.ec2.elb under modify_lb_attribute.
