### PR TITLE
Improved handling of already terminated instances

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -918,6 +918,15 @@ def create_instances(module, ec2, override_count=None):
         except boto.exception.BotoServerError, e:
             module.fail_json(msg = "Instance creation failed => %s: %s" % (e.error_code, e.error_message))
 
+        # The instances returned through run_instances can be in
+        # terminated state due to idempotency.
+        terminated_instances = [ str(instance.id) for instance in res.instances
+                                 if instance.state == 'terminated' ]
+        if terminated_instances:
+            module.fail_json(msg = "Instances with id(s) %s " % terminated_instances +
+                                   "were created previously but have since been terminated - " +
+                                   "use a (possibly different) 'instanceid' parameter")
+
         # wait here until the instances are up
         num_running = 0
         wait_timeout = time.time() + wait_timeout


### PR DESCRIPTION
It is possible to create an instance, terminate the instance and then
attempt to recreate the instance with the same parameters. In this case
`ec2.run_instances` returns a reservation list containing the instance ids
but the logic gets stuck waiting for the instance to exist in the call to
`ec2.get_all_instances`, even if wait is no).
