### PR TITLE
mysql_db module: Escape "_" in database name for "SHOW DATABASES" statement

### DIFF
--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -114,7 +114,7 @@ else:
 #
 
 def db_exists(cursor, db):
-    res = cursor.execute("SHOW DATABASES LIKE %s", (db,))
+    res = cursor.execute("SHOW DATABASES LIKE %s", (db.replace("_","\_"),))
     return bool(res)
 
 def db_delete(cursor, db):


### PR DESCRIPTION
##### Issue Type:

“Bugfix Pull Request”
##### Ansible Version:

ansible 1.7 (devel fafc35911a) last updated 2014/07/11 10:18:42 (GMT +900)
##### Environment:

Centos 6, MySQL5.5.28
##### Summary:

mysql_db module check database existence with "SHOW DATABASES LIKE %s" statement.
If database name contains  `_` (underscore), it works as wildcard.
So if it match existing database name, I cant create database which name contains `_` (underscore).
This PR escape `_` (underscore).
##### Steps To Reproduce:

Create database contains `_` (underscore) as database name.

```
tasks:
  - mysql_db: >
      name=company state=present
  - mysql_db: >
      name=com_any state=present
```
##### Expected Results:

Database named "company" and "com_any" will be created.
##### Actual Results:

Only database named "company" is created.
