### PR TITLE
Include unicode and var_precedence tests in 'all' target

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -16,7 +16,7 @@ endif
 
 VAULT_PASSWORD_FILE = vault-password
 
-all: non_destructive destructive includes check_mode test_hash test_handlers test_group_by test_vault parsing
+all: non_destructive destructive includes unicode test_var_precedence check_mode test_hash test_handlers test_group_by test_vault parsing
 
 parsing:
 	ansible-playbook bad_parsing.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -vvv $(TEST_FLAGS) --tags common,scenario1; [ $$? -eq 3 ]


### PR DESCRIPTION
Previously, the `unicode` and `test_var_precedence` targets were not run by the `all` `Makefile` target.  I'm not sure if this is intentional, but I've updated the `Makefile` to include these targets.
