### PR TITLE
runner + callbacks: allow callbacks to template the delegates

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -611,6 +611,11 @@ class Runner(object):
         inject['environment'] = self.environment
         inject['playbook_dir'] = self.basedir
 
+        # template this one is available, callbacks use this
+        delegate_to = self.module_vars.get('delegate_to')
+        if delegate_to:
+            self.module_vars['delegate_to'] = template.template(self.basedir, delegate_to, inject)
+
         if self.inventory.basedir() is not None:
             inject['inventory_dir'] = self.inventory.basedir()
 


### PR DESCRIPTION
Testing the latest 1.7 devel, I noticed the new feature where delegates are mentioned via the playbook callbacks. Given I often use templates/variables in `delegate_to:` I noticed that wasn't being templated in the callback, which has no access to host variables.

I converted the creation of the runner inject to a method, so callbacks can retrieve it and do the necessary templating, as discussed with @jimi-c.
