### PR TITLE
Unarchive should work when parent directory is not writable

### DIFF
--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -115,8 +115,6 @@ class TgzFile(object):
         self.zipflag = 'z'
 
     def is_unarchived(self):
-        dirof = os.path.dirname(self.dest)
-        destbase = os.path.basename(self.dest)
         cmd = '%s -v -C "%s" --diff -%sf "%s"' % (self.cmd_path, self.dest, self.zipflag, self.src)
         rc, out, err = self.module.run_command(cmd)
         unarchived = (rc == 0)
@@ -220,10 +218,10 @@ def main():
             )
 
     # is dest OK to receive tar file?
-    if not os.path.exists(os.path.dirname(dest)):
-        module.fail_json(msg="Destination directory '%s' does not exist" % (os.path.dirname(dest)))
-    if not os.access(os.path.dirname(dest), os.W_OK):
-        module.fail_json(msg="Destination '%s' not writable" % (os.path.dirname(dest)))
+    if not os.path.isdir(dest):
+        module.fail_json(msg="Destination '%s' is not a directory" % dest)
+    if not os.access(dest, os.W_OK):
+        module.fail_json(msg="Destination '%s' not writable" % dest)
 
     handler = pick_handler(src, dest, module)
 

--- a/test/integration/roles/test_unarchive/tasks/main.yml
+++ b/test/integration/roles/test_unarchive/tasks/main.yml
@@ -111,3 +111,27 @@
 
 - name: remove our test file for the archive
   file: path={{output_dir}}/foo-unarchive.txt state=absent
+
+- name: check if /tmp/foo-unarchive.text exists
+  stat: path=/tmp/foo-unarchive.txt
+  ignore_errors: True
+  register: unarchive04
+
+- name: fail if the proposed destination file exists for safey
+  fail: msg="/tmp/foo-unarchive.txt already exists, aborting"
+  when: unarchive04.stat.exists
+
+- name: try unarchiving to /tmp
+  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest=/tmp copy=no
+  register: unarchive05
+
+- name: verify that the file was marked as changed
+  assert:
+    that:
+      - "unarchive05.changed == true"
+
+- name: verify that the file was unarchived
+  file: path=/tmp/foo-unarchive.txt state=file
+
+- name: remove our unarchive destination
+  file: path=/tmp/foo-unarchive.txt state=absent


### PR DESCRIPTION
Correct unarchive so that the checks for writeability are
sensible.

Added a test for when parent directory is not writable
