### PR TITLE
Add support for two common nova parameters

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -92,6 +92,11 @@ options:
         - A list of network id's to which the VM's interface should be attached
      required: false
      default: None
+   availability_zone:
+     description:
+        - Name of the availability zone
+     required: false
+     default: None
    meta:
      description:
         - A list of key value pairs that should be provided as a metadata to the new VM
@@ -166,7 +171,7 @@ def _create_server(module, nova):
                 'userdata': module.params['user_data'],
     }
 
-    for optional_param in ('region_name', 'key_name'):
+    for optional_param in ('region_name', 'key_name', 'availability_zone'):
         if module.params[optional_param]:
             bootkwargs[optional_param] = module.params[optional_param]
     try:
@@ -242,7 +247,8 @@ def main():
         wait                            = dict(default='yes', choices=['yes', 'no']),
         wait_for                        = dict(default=180),
         state                           = dict(default='present', choices=['absent', 'present']),
-        user_data                       = dict(default=None)
+        user_data                       = dict(default=None),
+        availability_zone               = dict(default=None),
         ),
     )
 

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -112,6 +112,11 @@ options:
         - The amount of time the module should wait for the VM to get into active state
      required: false
      default: 180
+   config_drive:
+     description:
+        - Whether to boot the server with config drive enabled
+     required: false
+     default: 'no'
    user_data:
      description:
         - Opaque blob of data which is made available to the instance
@@ -169,6 +174,7 @@ def _create_server(module, nova):
                 'security_groups': module.params['security_groups'].split(','),
                 #userdata is unhyphenated in novaclient, but hyphenated here for consistency with the ec2 module:
                 'userdata': module.params['user_data'],
+                'config_drive': module.params['config_drive'],
     }
 
     for optional_param in ('region_name', 'key_name', 'availability_zone'):
@@ -249,6 +255,7 @@ def main():
         state                           = dict(default='present', choices=['absent', 'present']),
         user_data                       = dict(default=None),
         availability_zone               = dict(default=None),
+        config_drive                    = dict(default=False, type='bool'),
         ),
     )
 

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -161,13 +161,14 @@ def _create_server(module, nova):
     bootkwargs = {
                 'nics' : module.params['nics'],
                 'meta' : module.params['meta'],
-                'key_name': module.params['key_name'],
                 'security_groups': module.params['security_groups'].split(','),
                 #userdata is unhyphenated in novaclient, but hyphenated here for consistency with the ec2 module:
                 'userdata': module.params['user_data'],
     }
-    if not module.params['key_name']:
-        del bootkwargs['key_name']
+
+    for optional_param in ('region_name', 'key_name'):
+        if module.params[optional_param]:
+            bootkwargs[optional_param] = module.params[optional_param]
     try:
         server = nova.servers.create(*bootargs, **bootkwargs)
         server = nova.servers.get(server.id)


### PR DESCRIPTION
Availability zones and config drive are present on OpenStack public clouds in the wild. Support them.
