### PR TITLE
Pass region_name to nova_keypair

### DIFF
--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -104,6 +104,7 @@ def main():
                               module.params['login_password'],
                               module.params['login_tenant_name'],
                               module.params['auth_url'],
+                              region_name=module.params['region_name'],
                               service_type='compute')
     try:
         nova.authenticate()


### PR DESCRIPTION
Again, on things with regions, when we're configuring it, we should
actually pass it in to the compute constructor.
