### PR TITLE
Add support for floating ips in nova

### DIFF
--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -193,21 +193,116 @@ def _delete_server(module, nova):
     module.fail_json(msg = "Timed out waiting for server to get deleted, please check manually")
 
 
+def _add_floating_ip_from_pool(module, nova, server, floating_ip_obj):
+
+    # empty dict and list 
+    usable_floating_ips = {} 
+    pools = []
+
+    # user specified
+    pools = module.params['floating_ip']['pools']
+
+    # get the list of all floating IPs. Mileage may 
+    # vary according to Nova Compute configuration 
+    # per cloud provider
+    all_floating_ips = floating_ip_obj.list()
+
+    # iterate through all pools of IP address. Empty
+    # string means all and is the default value
+    for pool in pools:
+        # temporary list per pool
+        pool_ips = []
+        # loop through all floating IPs
+        for f_ip in all_floating_ips:
+            # if not reserved and the correct pool, add
+            if f_ip.instance_id is None and (f_ip.pool == pool):
+                pool_ips.append(f_ip.ip)
+                # only need one
+                break
+
+        # if the list is empty, add for this pool
+        if not pool_ips:
+            try:
+                new_ip = nova.floating_ips.create(pool)
+            except Exception, e: 
+                module.fail_json(msg = "Unable to create floating ip")
+            pool_ips.append(new_ip.ip)
+        # Add to the main list
+        usable_floating_ips[pool] = pool_ips
+
+    # finally, add ip(s) to instance for each pool
+    for pool in usable_floating_ips:
+        for ip in usable_floating_ips[pool]:
+            try:
+                server.add_floating_ip(ip)
+                # We only need to assign one ip - but there is an inherent
+                # race condition and some other cloud operation may have
+                # stolen an available floating ip
+                break
+            except Exception, e:
+                module.fail_json(msg = "Error attaching IP %s to instance %s: %s " % (ip, server.id, e.message))
+
+
+def _add_floating_ip_no_pool(module, nova, server, floating_ip_obj):
+
+    usable_floating_ips = list()
+
+    # if there is a list of IP addresses, make that the list 
+    if module.params['floating_ip'].has_key('ips'):
+        usable_floating_ips = module.params['floating_ip']['ips']
+    else:
+        # get the list of all floating IPs. Mileage may 
+        # vary according to Nova Compute configuration 
+        # per cloud provider
+        for f_ip in floating_ip_obj.list():
+            # if not reserved and the correct pool, add
+            if f_ip.instance_id is None:
+                usable_floating_ips.append(f_ip.ip)
+
+        if not usable_floating_ips:
+            try:
+                new_ip = nova.floating_ips.create()
+            except Exception, e: 
+                module.fail_json(msg = "Unable to create floating ip")
+            usable_floating_ips.append(new_ip.ip)
+
+    # finally, add ip(s) to instance
+    for ip in usable_floating_ips:
+        try:
+            server.add_floating_ip(ip)
+        except Exception, e:
+            module.fail_json(msg = "Error attaching IP %s to instance %s: %s " % (ip, server.id, e.message))
+
+
+def _add_floating_ip(module, nova, server):
+    # instantiate FloatingIPManager object
+    floating_ip_obj = floating_ips.FloatingIPManager(nova)
+
+    if module.params['floating_ip'].has_key('pools'):
+        _add_floating_ip_from_pool(module, nova, server, floating_ip_obj)
+    else: 
+        _add_floating_ip_no_pool(module, nova, server, floating_ip_obj)
+
+    # this may look redundant, but if there is now a 
+    # floating IP, then it needs to be obtained from
+    # a recent server object if the above code path exec'd 
+    try:
+        server = nova.servers.get(server.id)
+    except Exception, e:
+        module.fail_json(msg = "Error in getting info from instance: %s " % e.message)
+    return server
+
+
 def _create_server(module, nova):
     # issue an error early on and not launch the instance
-    if module.params['floating_ip'] != None:
+    if module.params['floating_ip'] is not None:
         if module.params['floating_ip'].has_key('ips'):
             # can't specify "ips" and "auto" both 
-            if module.params['floating_ip'].has_key('auto') and \
-            module.params['floating_ip']['auto'] is True:
-                err_msg = "For floating_ips - "
-                err_msg += "you cannot specify both 'auto' and 'ips'!"
-                module.fail_json(msg = err_msg)
+            if module.params['floating_ip'].has_key('auto') and module.params['floating_ip']['auto']:
+                module.fail_json(msg = "For floating_ips - you cannot specify both 'auto' and 'ips'!")
             # can't specify "ips" and "pools" both 
             if module.params['floating_ip'].has_key('pools'):
-                err_msg = "For floating_ips - "
-                err_msg += "you cannot specify both 'ips' and 'pools'!"
-                module.fail_json(msg = err_msg)
+                module.fail_json(msg = "For floating_ips - you cannot specify both 'pools' and 'ips'!")
 
     bootargs = [module.params['name'], module.params['image_id'], module.params['flavor_id']]
     bootkwargs = {
@@ -231,86 +326,11 @@ def _create_server(module, nova):
             try:
                 server = nova.servers.get(server.id)
             except Exception, e:
-                    module.fail_json(msg = \
-                                     "Error in getting info from instance: %s"\
-                                     % e.message
-                                    )
+                    module.fail_json( msg = "Error in getting info from instance: %s" % e.message)
             if server.status == 'ACTIVE':
                 # if floating_ip is specified, then attach 
-                if module.params['floating_ip'] != None:
-                    # instantiate FloatingIPManager object
-                    floating_ip_obj = floating_ips.FloatingIPManager(nova)
-                    # empty dict and list 
-                    usable_floating_ips = {} 
-                    pools = []
-
-                    # if floating_ip pools are defined, then make that
-                    # the list of pools
-                    if module.params['floating_ip'].has_key('pools'):
-                        # user specified
-                        pools = module.params['floating_ip']['pools']
-                    else:
-                        # otherwise all
-                        pools = ['']
-
-                    # if there is a list of IP addresses, make that the list 
-                    if module.params['floating_ip'].has_key('ips'):
-                        usable_floating_ips[''] = \
-                        module.params['floating_ip']['ips']
-
-                    # if 'auto', then assign automatically, no pool needed
-                    if module.params['floating_ip'].has_key('auto') and \
-                       module.params['floating_ip']['auto'] is True:        
-                        # get the list of all floating IPs. Mileage may 
-                        # vary according to Nova Compute configuration 
-                        # per cloud provider
-                        all_floating_ips = floating_ip_obj.list()
-
-                        # iterate through all pools of IP address. Empty
-                        # string means all and is the default value
-                        for pool in pools:
-                            # temporary list per pool
-                            pool_ips = []
-                            # loop through all floating IPs
-                            for f_ip in all_floating_ips:
-                                # if not reserved and the correct pool, add
-                                if f_ip.instance_id == None and \
-                                (f_ip.pool == pool or pool == ''):
-                                    pool_ips.append(f_ip.ip)
-                                    # one per pool
-                                    break
-                            # if the list is empty, add for this pool
-                            if len(pool_ips) == 0: 
-                                try:
-                                    new_ip = nova.floating_ips.create(pool)
-                                except Exception, e: 
-                                    module.fail_json(msg = \
-                                                     "Unable to create \
-                                                     floating ip")
-                                pool_ips.append(new_ip.ip)
-                            # Add to the main list
-                            usable_floating_ips[pool] = pool_ips
-
-                    # finally, add ip(s) to instance for each pool
-                    for pool in usable_floating_ips:
-                        for ip in usable_floating_ips[pool]:
-                            try:
-                                server.add_floating_ip(ip)
-                            except Exception, e:
-                                module.fail_json(msg = \
-                                                 "Error attaching IP %s to \
-                                                 instance %s: %s " % \
-                                                 (ip, server.id, e.message))
-
-                    # this may look redundant, but if there is now a 
-                    # floating IP, then it needs to be obtained from
-                    # a recent server object if the above code path exec'd 
-                    try:
-                        server = nova.servers.get(server.id)
-                    except Exception, e:
-                        module.fail_json(msg = \
-                                         "Error in getting info from \
-                                         instance: %s " % e.message)
+                if module.params['floating_ip'] is not None:
+                    server = _add_floating_ip(module, nova, server)
 
                 private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
                 public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'floating']

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -19,7 +19,9 @@
 
 try:
     from novaclient.v1_1 import client as nova_client
+    from novaclient.v1_1 import floating_ips 
     from novaclient import exceptions
+    from novaclient import utils
     import time
 except ImportError:
     print("failed=True msg='novaclient is required for this module'")
@@ -92,6 +94,11 @@ options:
         - A list of network id's to which the VM's interface should be attached
      required: false
      default: None
+   floating_ip:
+     description:
+        - list of key value pairs that determine how to assign, if specified, floating IPs. Either use an explicite list of valid floating IPs, list of floating IP pools to choose from, or auto-assign 
+     required: false
+     default: None
    meta:
      description:
         - A list of key value pairs that should be provided as a metadata to the new VM
@@ -133,7 +140,37 @@ EXAMPLES = '''
        meta:
          hostname: test1
          group: uge_master
+
+# Creates a new VM in HP Cloud AE1 region and automatically assigns a floating IP
+- name: launch a nova instance
+  hosts: localhost
+  tasks:
+  - name: launch an instance
+    nova_compute:
+      state: present
+      login_username: username 
+      login_password: Equality7-2521 
+      login_tenant_name: username-project1
+      name: vm1
+      auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
+      region_name: region-b.geo-1
+      image_id: 9302692b-b787-4b52-a3a6-daebb79cb498
+      key_name: test
+      wait_for: 200
+      flavor_id: 101
+      security_groups: default
+      floating_ip:
+        auto: True
+
+# If one wants to specify a floating ip to use:
+      <snip>
+      floating_ip:
+        ips: 
+          - 15.126.238.160
+
 '''
+
+
 
 def _delete_server(module, nova):
     name = None
@@ -157,6 +194,21 @@ def _delete_server(module, nova):
 
 
 def _create_server(module, nova):
+    # issue an error early on and not launch the instance
+    if module.params['floating_ip'] != None:
+        if module.params['floating_ip'].has_key('ips'):
+            # can't specify "ips" and "auto" both 
+            if module.params['floating_ip'].has_key('auto') and \
+            module.params['floating_ip']['auto'] is True:
+                err_msg = "For floating_ips - "
+                err_msg += "you cannot specify both 'auto' and 'ips'!"
+                module.fail_json(msg = err_msg)
+            # can't specify "ips" and "pools" both 
+            if module.params['floating_ip'].has_key('pools'):
+                err_msg = "For floating_ips - "
+                err_msg += "you cannot specify both 'ips' and 'pools'!"
+                module.fail_json(msg = err_msg)
+
     bootargs = [module.params['name'], module.params['image_id'], module.params['flavor_id']]
     bootkwargs = {
                 'nics' : module.params['nics'],
@@ -179,11 +231,92 @@ def _create_server(module, nova):
             try:
                 server = nova.servers.get(server.id)
             except Exception, e:
-                    module.fail_json( msg = "Error in getting info from instance: %s " % e.message)
+                    module.fail_json(msg = \
+                                     "Error in getting info from instance: %s"\
+                                     % e.message
+                                    )
             if server.status == 'ACTIVE':
+                # if floating_ip is specified, then attach 
+                if module.params['floating_ip'] != None:
+                    # instantiate FloatingIPManager object
+                    floating_ip_obj = floating_ips.FloatingIPManager(nova)
+                    # empty dict and list 
+                    usable_floating_ips = {} 
+                    pools = []
+
+                    # if floating_ip pools are defined, then make that
+                    # the list of pools
+                    if module.params['floating_ip'].has_key('pools'):
+                        # user specified
+                        pools = module.params['floating_ip']['pools']
+                    else:
+                        # otherwise all
+                        pools = ['']
+
+                    # if there is a list of IP addresses, make that the list 
+                    if module.params['floating_ip'].has_key('ips'):
+                        usable_floating_ips[''] = \
+                        module.params['floating_ip']['ips']
+
+                    # if 'auto', then assign automatically, no pool needed
+                    if module.params['floating_ip'].has_key('auto') and \
+                       module.params['floating_ip']['auto'] is True:        
+                        # get the list of all floating IPs. Mileage may 
+                        # vary according to Nova Compute configuration 
+                        # per cloud provider
+                        all_floating_ips = floating_ip_obj.list()
+
+                        # iterate through all pools of IP address. Empty
+                        # string means all and is the default value
+                        for pool in pools:
+                            # temporary list per pool
+                            pool_ips = []
+                            # loop through all floating IPs
+                            for f_ip in all_floating_ips:
+                                # if not reserved and the correct pool, add
+                                if f_ip.instance_id == None and \
+                                (f_ip.pool == pool or pool == ''):
+                                    pool_ips.append(f_ip.ip)
+                                    # one per pool
+                                    break
+                            # if the list is empty, add for this pool
+                            if len(pool_ips) == 0: 
+                                try:
+                                    new_ip = nova.floating_ips.create(pool)
+                                except Exception, e: 
+                                    module.fail_json(msg = \
+                                                     "Unable to create \
+                                                     floating ip")
+                                pool_ips.append(new_ip.ip)
+                            # Add to the main list
+                            usable_floating_ips[pool] = pool_ips
+
+                    # finally, add ip(s) to instance for each pool
+                    for pool in usable_floating_ips:
+                        for ip in usable_floating_ips[pool]:
+                            try:
+                                server.add_floating_ip(ip)
+                            except Exception, e:
+                                module.fail_json(msg = \
+                                                 "Error attaching IP %s to \
+                                                 instance %s: %s " % \
+                                                 (ip, server.id, e.message))
+
+                    # this may look redundant, but if there is now a 
+                    # floating IP, then it needs to be obtained from
+                    # a recent server object if the above code path exec'd 
+                    try:
+                        server = nova.servers.get(server.id)
+                    except Exception, e:
+                        module.fail_json(msg = \
+                                         "Error in getting info from \
+                                         instance: %s " % e.message)
+
                 private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
                 public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'floating']
+                # now exit with info 
                 module.exit_json(changed = True, id = server.id, private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
+
             if server.status == 'ERROR':
                 module.fail_json(msg = "Error in creating the server, please check logs")
             time.sleep(2)
@@ -193,6 +326,7 @@ def _create_server(module, nova):
             module.fail_json(msg = "Error in creating the server.. Please check manually")
     private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'fixed']
     public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'floating']
+
     module.exit_json(changed = True, id = info['id'], private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
 
 
@@ -241,7 +375,8 @@ def main():
         wait                            = dict(default='yes', choices=['yes', 'no']),
         wait_for                        = dict(default=180),
         state                           = dict(default='present', choices=['absent', 'present']),
-        user_data                       = dict(default=None)
+        user_data                       = dict(default=None),
+        floating_ip                     = dict(default=None)
         ),
     )
 

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -249,7 +249,7 @@ def _add_floating_ip_no_pool(module, nova, server, floating_ip_obj):
 
     # if there is a list of IP addresses, make that the list 
     if module.params['floating_ip'].has_key('ips'):
-        usable_floating_ips = module.params['floating_ip']['ips']
+        usable_floating_ips = [dict(ip=f, created=False) for f in module.params['floating_ip']['ips']]
     else:
         # get the list of all floating IPs. Mileage may 
         # vary according to Nova Compute configuration 
@@ -257,20 +257,23 @@ def _add_floating_ip_no_pool(module, nova, server, floating_ip_obj):
         for f_ip in floating_ip_obj.list():
             # if not reserved and the correct pool, add
             if f_ip.instance_id is None:
-                usable_floating_ips.append(f_ip.ip)
+                usable_floating_ips.append(dict(ip=f_ip.ip, created=False))
 
         if not usable_floating_ips:
             try:
                 new_ip = nova.floating_ips.create()
             except Exception, e: 
                 module.fail_json(msg = "Unable to create floating ip")
-            usable_floating_ips.append(new_ip.ip)
+            usable_floating_ips.append(dict(ip=new_ip.ip, created=True))
 
     # finally, add ip(s) to instance
     for ip in usable_floating_ips:
         try:
-            server.add_floating_ip(ip)
+            server.add_floating_ip(ip['ip'])
         except Exception, e:
+            # Clean up - we auto-created this ip, and it's not attached
+            # to the server, so the cloud will not know what to do with it
+            server.floating_ips.delete(ip['ip'])
             module.fail_json(msg = "Error attaching IP %s to instance %s: %s " % (ip, server.id, e.message))
 
 

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -293,6 +293,19 @@ def _add_floating_ip(module, nova, server):
     return server
 
 
+def _get_ips(addresses, ext_tag, key_name):
+
+    ret = []
+    for (k, v) in addresses.iteritems():
+        if k == key_name:
+            ret.extend([addrs['addr'] for addrs in v])
+        else:
+            for interface_spec in v:
+                if 'OS-EXT-IPS:type' in interface_spec and interface_spec['OS-EXT-IPS:type'] == ext_tag:
+                    ret.append(interface_spec['addr'])
+    return ret
+
+
 def _create_server(module, nova):
     # issue an error early on and not launch the instance
     if module.params['floating_ip'] is not None:
@@ -332,8 +345,9 @@ def _create_server(module, nova):
                 if module.params['floating_ip'] is not None:
                     server = _add_floating_ip(module, nova, server)
 
-                private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
-                public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'floating']
+                private = _get_ips(getattr(server, 'addresses'), 'fixed', 'private')
+                public = _get_ips(getattr(server, 'addresses'), 'floating', 'public')
+
                 # now exit with info 
                 module.exit_json(changed = True, id = server.id, private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
 
@@ -344,8 +358,8 @@ def _create_server(module, nova):
         module.fail_json(msg = "Timeout waiting for the server to come up.. Please check manually")
     if server.status == 'ERROR':
             module.fail_json(msg = "Error in creating the server.. Please check manually")
-    private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'fixed']
-    public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if x['OS-EXT-IPS:type'] == 'floating']
+    private = _get_ips(getattr(server, 'addresses'), 'fixed', 'private')
+    public = _get_ips(getattr(server, 'addresses'), 'floating', 'public')
 
     module.exit_json(changed = True, id = info['id'], private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
 
@@ -366,8 +380,8 @@ def _get_server_state(module, nova):
     if server and module.params['state'] == 'present':
         if server.status != 'ACTIVE':
             module.fail_json( msg="The VM is available but not Active. state:" + server.status)
-        private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
-        public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'floating']
+        private = _get_ips(getattr(server, 'addresses'), 'fixed', 'private')
+        public = _get_ips(getattr(server, 'addresses'), 'floating', 'public')
         module.exit_json(changed = False, id = server.id, public_ip = ''.join(public), private_ip = ''.join(private), info = server._info)
     if server and module.params['state'] == 'absent':
         return True

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -94,9 +94,19 @@ options:
         - A list of network id's to which the VM's interface should be attached
      required: false
      default: None
-   floating_ip:
+   auto_floating_ip:
      description:
-        - list of key value pairs that determine how to assign, if specified, floating IPs. Either use an explicite list of valid floating IPs, list of floating IP pools to choose from, or auto-assign 
+        - Should a floating ip be auto created and assigned
+     required: false
+     default: 'yes'
+   floating_ips:
+     decription:
+        - list of valid floating IPs that pre-exist to assign to this node
+     required: false
+     default: None
+   floating_ip_pools:
+     description:
+        - list of floating IP pools from which to choose a floating IP
      required: false
      default: None
    meta:
@@ -193,14 +203,17 @@ def _delete_server(module, nova):
     module.fail_json(msg = "Timed out waiting for server to get deleted, please check manually")
 
 
-def _add_floating_ip_from_pool(module, nova, server, floating_ip_obj):
+def _add_floating_ip_from_pool(module, nova, server):
+
+    # instantiate FloatingIPManager object
+    floating_ip_obj = floating_ips.FloatingIPManager(nova)
 
     # empty dict and list 
     usable_floating_ips = {} 
     pools = []
 
     # user specified
-    pools = module.params['floating_ip']['pools']
+    pools = module.params['floating_ip_pools']
 
     # get the list of all floating IPs. Mileage may 
     # vary according to Nova Compute configuration 
@@ -243,48 +256,41 @@ def _add_floating_ip_from_pool(module, nova, server, floating_ip_obj):
                 module.fail_json(msg = "Error attaching IP %s to instance %s: %s " % (ip, server.id, e.message))
 
 
-def _add_floating_ip_no_pool(module, nova, server, floating_ip_obj):
-
-    usable_floating_ips = list()
-
-    # if there is a list of IP addresses, make that the list 
-    if module.params['floating_ip'].has_key('ips'):
-        usable_floating_ips = [dict(ip=f, created=False) for f in module.params['floating_ip']['ips']]
-    else:
-        # get the list of all floating IPs. Mileage may 
-        # vary according to Nova Compute configuration 
-        # per cloud provider
-        for f_ip in floating_ip_obj.list():
-            # if not reserved and the correct pool, add
-            if f_ip.instance_id is None:
-                usable_floating_ips.append(dict(ip=f_ip.ip, created=False))
-
-        if not usable_floating_ips:
-            try:
-                new_ip = nova.floating_ips.create()
-            except Exception, e: 
-                module.fail_json(msg = "Unable to create floating ip")
-            usable_floating_ips.append(dict(ip=new_ip.ip, created=True))
-
-    # finally, add ip(s) to instance
-    for ip in usable_floating_ips:
+def _add_floating_ip_list(module, server):
+    # add ip(s) to instance
+    for ip in module.params['floating_ips']:
         try:
-            server.add_floating_ip(ip['ip'])
+            server.add_floating_ip(ip)
         except Exception, e:
-            # Clean up - we auto-created this ip, and it's not attached
-            # to the server, so the cloud will not know what to do with it
-            server.floating_ips.delete(ip['ip'])
             module.fail_json(msg = "Error attaching IP %s to instance %s: %s " % (ip, server.id, e.message))
 
 
-def _add_floating_ip(module, nova, server):
-    # instantiate FloatingIPManager object
-    floating_ip_obj = floating_ips.FloatingIPManager(nova)
+def _add_auto_floating_ip(module, nova, server):
 
-    if module.params['floating_ip'].has_key('pools'):
-        _add_floating_ip_from_pool(module, nova, server, floating_ip_obj)
-    else: 
-        _add_floating_ip_no_pool(module, nova, server, floating_ip_obj)
+    try:
+        new_ip = nova.floating_ips.create()
+    except Exception as e:
+        module.fail_json(msg = "Unable to create floating ip: %s" % (e.message))
+
+    try:
+        server.add_floating_ip(new_ip)
+    except Exception as e:
+        # Clean up - we auto-created this ip, and it's not attached
+        # to the server, so the cloud will not know what to do with it
+        server.floating_ips.delete(new_ip)
+        module.fail_json(msg = "Error attaching IP %s to instance %s: %s " % (ip, server.id, e.message))
+
+
+def _add_floating_ip(module, nova, server):
+
+    if module.params['floating_ip_pools']:
+        _add_floating_ip_from_pool(module, nova, server)
+    elif module.params['floating_ips']:
+        _add_floating_ip_list(module, server)
+    elif module.params['auto_floating_ip']:
+        _add_auto_floating_ip(module, nova, server)
+    else:
+        return server
 
     # this may look redundant, but if there is now a 
     # floating IP, then it needs to be obtained from
@@ -310,16 +316,6 @@ def _get_ips(addresses, ext_tag, key_name):
 
 
 def _create_server(module, nova):
-    # issue an error early on and not launch the instance
-    if module.params['floating_ip'] is not None:
-        if module.params['floating_ip'].has_key('ips'):
-            # can't specify "ips" and "auto" both 
-            if module.params['floating_ip'].has_key('auto') and module.params['floating_ip']['auto']:
-                module.fail_json(msg = "For floating_ips - you cannot specify both 'auto' and 'ips'!")
-            # can't specify "ips" and "pools" both 
-            if module.params['floating_ip'].has_key('pools'):
-                module.fail_json(msg = "For floating_ips - you cannot specify both 'pools' and 'ips'!")
-
     bootargs = [module.params['name'], module.params['image_id'], module.params['flavor_id']]
     bootkwargs = {
                 'nics' : module.params['nics'],
@@ -344,9 +340,7 @@ def _create_server(module, nova):
             except Exception, e:
                     module.fail_json( msg = "Error in getting info from instance: %s" % e.message)
             if server.status == 'ACTIVE':
-                # if floating_ip is specified, then attach 
-                if module.params['floating_ip'] is not None:
-                    server = _add_floating_ip(module, nova, server)
+                server = _add_floating_ip(module, nova, server)
 
                 private = _get_ips(getattr(server, 'addresses'), 'fixed', 'private')
                 public = _get_ips(getattr(server, 'addresses'), 'floating', 'public')
@@ -413,9 +407,15 @@ def main():
         wait_for                        = dict(default=180),
         state                           = dict(default='present', choices=['absent', 'present']),
         user_data                       = dict(default=None),
-        floating_ip                     = dict(default=None)
-        ),
-    )
+        auto_floating_ip                = dict(default=False, type='bool'),
+        floating_ips                    = dict(default=None),
+        floating_ip_pools               = dict(default=None),
+    ),
+    mutually_exclusive=[
+        ['auto_floating_ip','floating_ips'],
+        ['auto_floating_ip','floating_ip_pools'],
+        ['floating_ips','floating_ip_pools'],
+    ])
 
     nova = nova_client.Client(module.params['login_username'],
                               module.params['login_password'],

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -256,9 +256,9 @@ def _add_floating_ip_from_pool(module, nova, server):
                 module.fail_json(msg = "Error attaching IP %s to instance %s: %s " % (ip, server.id, e.message))
 
 
-def _add_floating_ip_list(module, server):
+def _add_floating_ip_list(module, server, ips):
     # add ip(s) to instance
-    for ip in module.params['floating_ips']:
+    for ip in ips:
         try:
             server.add_floating_ip(ip)
         except Exception, e:
@@ -286,7 +286,7 @@ def _add_floating_ip(module, nova, server):
     if module.params['floating_ip_pools']:
         _add_floating_ip_from_pool(module, nova, server)
     elif module.params['floating_ips']:
-        _add_floating_ip_list(module, server)
+        _add_floating_ip_list(module, server, module.params['floating_ips'])
     elif module.params['auto_floating_ip']:
         _add_auto_floating_ip(module, nova, server)
     else:
@@ -302,11 +302,11 @@ def _add_floating_ip(module, nova, server):
     return server
 
 
-def _get_ips(addresses, ext_tag, key_name):
+def _get_ips(addresses, ext_tag, key_name=None):
 
     ret = []
     for (k, v) in addresses.iteritems():
-        if k == key_name:
+        if key_name and k == key_name:
             ret.extend([addrs['addr'] for addrs in v])
         else:
             for interface_spec in v:
@@ -361,6 +361,40 @@ def _create_server(module, nova):
     module.exit_json(changed = True, id = info['id'], private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
 
 
+def _delete_floating_ip_list(module, nova, server, extra_ips):
+    for ip in extra_ips:
+        nova.servers.remove_floating_ip(server=server.id, address=ip)
+
+
+def _check_floating_ips(module, nova, server):
+    changed = False
+    if module.params['floating_ip_pools'] or module.params['floating_ips'] or module.params['auto_floating_ip']:
+        ips = _get_ips(server.addresses, 'floating')
+        if not ips:
+            # If we're configured to have a floating but we don't have one,
+            # let's add one
+            server = _add_floating_ip(module, nova, server)
+            changed = True
+        elif module.params['floating_ips']:
+            # we were configured to have specific ips, let's make sure we have
+            # those
+            missing_ips = []
+            for ip in module.params['floating_ips']:
+                if ip not in ips:
+                    missing_ips.append(ip)
+            if missing_ips:
+                server = _add_floating_ip_list(module, server, missing_ips)
+                changed = True
+            extra_ips = []
+            for ip in ips:
+                if ip not in module.params['floating_ips']:
+                    extra_ips.append(ip)
+            if extra_ips:
+                _delete_floating_ip_list(module, server, extra_ips)
+                changed = True
+    return (changed, server)
+
+
 def _get_server_state(module, nova):
     server = None
     try:
@@ -377,9 +411,10 @@ def _get_server_state(module, nova):
     if server and module.params['state'] == 'present':
         if server.status != 'ACTIVE':
             module.fail_json( msg="The VM is available but not Active. state:" + server.status)
+        (ip_changed, server) = _check_floating_ips(module, nova, server)
         private = _get_ips(getattr(server, 'addresses'), 'fixed', 'private')
         public = _get_ips(getattr(server, 'addresses'), 'floating', 'public')
-        module.exit_json(changed = False, id = server.id, public_ip = ''.join(public), private_ip = ''.join(private), info = server._info)
+        module.exit_json(changed = ip_changed, id = server.id, public_ip = ''.join(public), private_ip = ''.join(private), info = server._info)
     if server and module.params['state'] == 'absent':
         return True
     if module.params['state'] == 'absent':

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -19,7 +19,7 @@
 
 try:
     from novaclient.v1_1 import client as nova_client
-    from novaclient.v1_1 import floating_ips 
+    from novaclient.v1_1 import floating_ips
     from novaclient import exceptions
     from novaclient import utils
     import time
@@ -99,16 +99,19 @@ options:
         - Should a floating ip be auto created and assigned
      required: false
      default: 'yes'
+     version_added: "1.7"
    floating_ips:
      decription:
         - list of valid floating IPs that pre-exist to assign to this node
      required: false
      default: None
+     version_added: "1.7"
    floating_ip_pools:
      description:
         - list of floating IP pools from which to choose a floating IP
      required: false
      default: None
+     version_added: "1.7"
    meta:
      description:
         - A list of key value pairs that should be provided as a metadata to the new VM
@@ -158,8 +161,8 @@ EXAMPLES = '''
   - name: launch an instance
     nova_compute:
       state: present
-      login_username: username 
-      login_password: Equality7-2521 
+      login_username: username
+      login_password: Equality7-2521
       login_tenant_name: username-project1
       name: vm1
       auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
@@ -169,15 +172,28 @@ EXAMPLES = '''
       wait_for: 200
       flavor_id: 101
       security_groups: default
-      floating_ip:
-        auto: True
+      auto_floating_ip: yes
 
-# If one wants to specify a floating ip to use:
-      <snip>
-      floating_ip:
-        ips: 
-          - 15.126.238.160
-
+# Creates a new VM in HP Cloud AE1 region availability zone az2 and assigns a pre-known floating IP
+- name: launch a nova instance
+  hosts: localhost
+  tasks:
+    - name: launch an instance
+      nova_compute:
+        state: present
+        login_username: username
+        login_password: Equality7-2521
+        login_tenant_name: username-project1
+        name: vm1
+        auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
+        region_name: region-b.geo-1
+        availability_zone: az2
+        image_id: 9302692b-b787-4b52-a3a6-daebb79cb498
+        key_name: test
+        wait_for: 200
+        flavor_id: 101
+        floating-ips:
+          - 12.34.56.79
 '''
 
 
@@ -208,15 +224,15 @@ def _add_floating_ip_from_pool(module, nova, server):
     # instantiate FloatingIPManager object
     floating_ip_obj = floating_ips.FloatingIPManager(nova)
 
-    # empty dict and list 
-    usable_floating_ips = {} 
+    # empty dict and list
+    usable_floating_ips = {}
     pools = []
 
     # user specified
     pools = module.params['floating_ip_pools']
 
-    # get the list of all floating IPs. Mileage may 
-    # vary according to Nova Compute configuration 
+    # get the list of all floating IPs. Mileage may
+    # vary according to Nova Compute configuration
     # per cloud provider
     all_floating_ips = floating_ip_obj.list()
 
@@ -237,7 +253,7 @@ def _add_floating_ip_from_pool(module, nova, server):
         if not pool_ips:
             try:
                 new_ip = nova.floating_ips.create(pool)
-            except Exception, e: 
+            except Exception, e:
                 module.fail_json(msg = "Unable to create floating ip")
             pool_ips.append(new_ip.ip)
         # Add to the main list
@@ -292,9 +308,9 @@ def _add_floating_ip(module, nova, server):
     else:
         return server
 
-    # this may look redundant, but if there is now a 
+    # this may look redundant, but if there is now a
     # floating IP, then it needs to be obtained from
-    # a recent server object if the above code path exec'd 
+    # a recent server object if the above code path exec'd
     try:
         server = nova.servers.get(server.id)
     except Exception, e:
@@ -345,7 +361,7 @@ def _create_server(module, nova):
                 private = _get_ips(getattr(server, 'addresses'), 'fixed', 'private')
                 public = _get_ips(getattr(server, 'addresses'), 'floating', 'public')
 
-                # now exit with info 
+                # now exit with info
                 module.exit_json(changed = True, id = server.id, private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
 
             if server.status == 'ERROR':


### PR DESCRIPTION
Handling floating ips correctly across various openstack clouds is non-trivial, but it is an understandable problem space. Generally speaking, a user wants either a specific known floating ip, wants a public ip but does not care what ip - or wants one from a pool. This handles all three of those cases, as well as adding code to clean up during deletion, and to verify state on inspection so that if a server was created but did not get an IP, a subsequent run will fix the situation. The last case is also useful in the case that the config for a server is changed - such as promoting a replacement server to be the real server by moving the floating ip.
