### PR TITLE
if python >=2.7  use the option allow_no_value=True for ini_file.

### DIFF
--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -87,6 +87,7 @@ EXAMPLES = '''
 '''
 
 import ConfigParser
+import sys
 
 # ==============================================================
 # do_ini
@@ -94,7 +95,10 @@ import ConfigParser
 def do_ini(module, filename, section=None, option=None, value=None, state='present', backup=False):
 
     changed = False
-    cp = ConfigParser.ConfigParser()
+    if (sys.version_info[0] == 2 and sys.version_info[1] >= 7) or sys.version_info[0] >= 3: 
+    	cp = ConfigParser.ConfigParser(allow_no_value=True)
+    else:
+    	cp = ConfigParser.ConfigParser()
     cp.optionxform = identity
 
     try:


### PR DESCRIPTION
After some failed attempts:

https://github.com/ansible/ansible/pull/8400
https://github.com/ansible/ansible/issues/8430
https://github.com/ansible/ansible/pull/8434
https://github.com/ansible/ansible/pull/8436

.... I think this one has no conflict. 

Thanks,
Nico
