### PR TITLE
Fixes 8362, returns stderr if No space left on device

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1090,6 +1090,8 @@ class Runner(object):
                     output = 'SSH encountered an unknown error. The output was:\n%s' % (result['stdout']+result['stderr'])
                 else:
                     output = 'SSH encountered an unknown error during the connection. We recommend you re-run the command using -vvvv, which will enable SSH debugging output to help diagnose the issue'
+            elif 'No space left on device' in result['stderr']:
+                output = result['stderr']
             else:
                 output = 'Authentication or permission failure.  In some cases, you may have been able to authenticate and did not have permissions on the remote directory. Consider changing the remote temp path in ansible.cfg to a path rooted in "/tmp". Failed command was: %s, exited with result %d' % (cmd, result['rc'])
             if 'stdout' in result and result['stdout'] != '':


### PR DESCRIPTION
Fixes #8362 by returning stderr if No space left on device. Since no space is left on device, sometimes ansible throws a traceback anyways, but it always throws 

| FAILED => mkdir: cannot create directory `/root/.ansible/tmp/ansible-tmp-1407266242.8-77064814194129': No space left on device

before a traceback if it does throw one.
