### PR TITLE
Issue with printing unicode non-english characters #8425 patch

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -205,9 +205,9 @@ def jsonify(result, format=False):
         if type(value) is str:
             result2[key] = value.decode('utf-8', 'ignore')
     if format:
-        return json.dumps(result2, sort_keys=True, indent=4)
+        return json.dumps(result2, sort_keys=True, indent=4, ensure_ascii=False)
     else:
-        return json.dumps(result2, sort_keys=True)
+        return json.dumps(result2, sort_keys=True, ensure_ascii=False)
 
 def write_tree_file(tree, hostname, buf):
     ''' write something into treedir/hostname '''


### PR DESCRIPTION
Hello! This patch can solve #8425 issue.

Before:

```
$ ansible 127.0.0.1 -m debug -a "msg=абв"
127.0.0.1 | success >> {
    "msg": "\u0430\u0431\u0432"
}
```

After:

```
$ ansible 127.0.0.1 -m debug -a "msg=абв"
127.0.0.1 | success >> {
    "msg": "абв"
}
```
