### PR TITLE
Add regular expression escaping filter.

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -319,6 +319,11 @@ To replace text in a string with regex, use the "regex_replace" filter::
     # convert "foobar" to "bar"
     {{ 'foobar' | regex_replace('^f.*o(.*)$', '\\1') }}
 
+To escape special characters within a regex, use the "regex_escape" filter::
+
+    # convert '^f.*o(.*)$' to '\^f\.\*o\(\.\*\)\$'
+    {{ '^f.*o(.*)$' | regex_escape() }}
+
 A few useful filters are typically added with each new Ansible release.  The development documentation shows
 how to extend Ansible filters by writing your own as plugins, though in general, we encourage new ones
 to be added to core so everyone can make use of them.

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -210,6 +210,10 @@ def version_compare(value, version, operator='eq', strict=False):
     except Exception, e:
         raise errors.AnsibleFilterError('Version comparison: %s' % e)
 
+def re_escape(string):
+    '''Escape all regular expressions special characters from STRING.'''
+    return re.escape(string)
+
 @environmentfilter
 def rand(environment, end, start=None, step=None):
     r = SystemRandom()
@@ -282,6 +286,7 @@ class FilterModule(object):
             'search': search,
             'regex': regex,
             'regex_replace': regex_replace,
+            're_escape': re_escape,
 
             # list
             'unique' : unique,

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -210,7 +210,7 @@ def version_compare(value, version, operator='eq', strict=False):
     except Exception, e:
         raise errors.AnsibleFilterError('Version comparison: %s' % e)
 
-def re_escape(string):
+def regex_escape(string):
     '''Escape all regular expressions special characters from STRING.'''
     return re.escape(string)
 
@@ -286,7 +286,7 @@ class FilterModule(object):
             'search': search,
             'regex': regex,
             'regex_replace': regex_replace,
-            're_escape': re_escape,
+            'regex_escape': regex_escape,
 
             # list
             'unique' : unique,


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

```
ansible 1.7 (devel 0bb1c85)
```
##### Environment:

All
##### Summary:

Add a `re_escape` filter to allow escaping special re chars. This is useful
for example for the `lineinfile` module if you have special characters.
##### How to use:

``` yml
- name: Create sudo entry
  lineinfile:
    dest: "/etc/sudoers.d/{{ item.name }}"
    mode: 0440
    create: yes
    regexp: '^{{ item.line|re_escape() }}'
    line: '{{ item.line | default() }}'
    state: '{{ item.state | default("present") }}'
  with_items:
    - { name: john, line: 'Host_Alias HOSTS = dev*' }
    - { name: john, line: 'john HOSTS=(ALL) NOPASSWD:ALL' }


```
