### PR TITLE
packaging: add short hash and branch name in package version for unoffici...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,11 @@ VERSION := $(shell cat VERSION)
 # Get the branch information from git
 ifneq ($(shell which git),)
 GIT_DATE := $(shell git log -n 1 --format="%ai")
+GIT_HASH := $(shell git log -n 1 --format="%h")
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD | sed 's/[-_.]//g')
+GITINFO = .$(GIT_HASH).$(GIT_BRANCH)
+else
+GITINFO = ''
 endif
 
 ifeq ($(shell echo $(OS) | egrep -c 'Darwin|FreeBSD|OpenBSD'),1)
@@ -60,7 +65,7 @@ ifeq ($(OFFICIAL),yes)
         DEBUILD_OPTS += -k$(DEBSIGN_KEYID)
     endif
 else
-    DEB_RELEASE = 0.git$(DATE)
+    DEB_RELEASE = 0.git$(DATE)$(GITINFO)
     # Do not sign unofficial builds
     DEBUILD_OPTS += -uc -us
     DPUT_OPTS += -u
@@ -76,7 +81,7 @@ RPMSPEC = $(RPMSPECDIR)/ansible.spec
 RPMDIST = $(shell rpm --eval '%{?dist}')
 RPMRELEASE = 1
 ifneq ($(OFFICIAL),yes)
-    RPMRELEASE = 0.git$(DATE)
+    RPMRELEASE = 0.git$(DATE)$(GITINFO)
 endif
 RPMNVR = "$(NAME)-$(VERSION)-$(RPMRELEASE)$(RPMDIST)"
 


### PR DESCRIPTION
...al builds

/cc @jlaska with whom I discussed this.

Next step would be to show the same git info one gets when running ansible --version from git (hacking script), when running it from a package - at least for unofficial builds.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/8469)

<!-- Reviewable:end -->
