### PR TITLE
unarchive module: Make sure there's a trailing slash on destination

### DIFF
--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -219,6 +219,10 @@ def main():
                 rc=0
             )
 
+    # make sure destination is a directory
+    if not dest.endswith('/'):
+        dest = dest + '/'
+
     # is dest OK to receive tar file?
     if not os.path.exists(os.path.dirname(dest)):
         module.fail_json(msg="Destination directory '%s' does not exist" % (os.path.dirname(dest)))


### PR DESCRIPTION
If the trailing slash is missing the two following checks in the code will check the parent directory instead of the one where files are going to be extracted to.

This is likely only a problem for people not running everything as root, but here's an example using the following line from the documentation for the module:
`- unarchive: src=foo.tgz dest=/var/lib/foo`

If the user Ansible runs as only has write permissions to the `/var/lib/foo` directory, but not the parent `/var/lib`, then the command will fail due to `os.path.dirname()` being run on the destination path, making it `/var/lib` and the check for write permissions on that folder will fail. This fixes that by always making sure the destination path ends with a /.
