### PR TITLE
Ensure npm packages actually are installed in a reachable way.

### DIFF
--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -163,6 +163,8 @@ class Npm(object):
                     missing.append(dep)
                 else:
                     installed.append(dep)
+            if self.name and self.name not in installed:
+                missing.append(self.name)
         #Named dependency not installed
         else:
             missing.append(self.name)


### PR DESCRIPTION
Fixes #4659 and #6399.
Alternative to #6613

I have a task as follows:

```
- name: install npm dependencies
  npm: name={{item}} state=latest
  sudo: yes
  with_items:
    - stitch
    - underscore
```

Then I can:

```
> require('stitch')
{ compilers: 
   { js: [Function],
     coffee: [Function],
     eco: [Function] },
  Package: [Function: Package],
  createPackage: [Function] }
```

but 

```
> require('underscore')
Error: Cannot find module 'underscore'
```

This is because underscore was installed as a dependency of stitch, and the current behaviour of the `npm` command is to consider a package installed even if it's hidden away as a dependency of some other module (and hence unusable).

Most workarounds involve installing packages in a very specific order (but that's incredibly brittle, and won't work with circular dependencies), or using npm install manually using `command` (which is slow).

This patch ensures that `state=present` or `state=latest` actually mean that the module can be `require`'d without an error.
#6613 does a similar thing, but requires a flag to do so and I'd argue that `toplevel=no` is never what the end user wants (it pretty much is equivalent to [RANDOMLY-LOSE](http://tools.ietf.org/html/rfc748)).

This pull won't break pre-existing code, unless they relied on non-deterministic errors in order to work.
