### PR TITLE
EC2 ELB AWS Rate Limit Issue

### DIFF
--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -152,7 +152,7 @@ class ElbManager:
 
             initial_state = self._get_instance_health(lb)
 
-            if initial_state.state == 'InService':
+            if initial_state is not None and initial_state.state == 'InService':
                 continue
 
             if enable_availability_zone:

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -148,7 +148,12 @@ class ElbManager:
         """Register the instance for all ELBs and wait for the ELB
         to report the instance in-service"""
         for lb in self.lbs:
+            time.sleep(1)
+
             initial_state = self._get_instance_health(lb)
+
+            if initial_state.state == 'InService':
+                continue
 
             if enable_availability_zone:
                 self._enable_availailability_zone(lb)


### PR DESCRIPTION
When dealing with large enough number of ELBs registration will throw a rate limit exceeded failure.
Boto doesn't seem to retry, which leads to the failure of the entire task.

My particular situation involved 7 ec2 instances and 34 ELBs.

To combat this I stopped registration calls for instances already "InService" and added a rate limit sleep of 1 second.
