### PR TITLE
Adding route53_included_zones parameter to limit zones queried to build inventory

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -45,6 +45,11 @@ route53 = False
 # 'route53_excluded_zones' as a comma-separated list.
 # route53_excluded_zones = samplezone1.com, samplezone2.com
 
+# If you have lots of zones the inventory script can take a long time to run
+# If you only want/need a few of the zones to build your inventory you can 
+# limit the included zones here
+# route53_included_zones = samplezone3.com, samplezone4.com
+
 # By default, only EC2 instances in the 'running' state are returned. Set
 # 'all_instances' to True to return all instances regardless of state.
 all_instances = False

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -218,9 +218,13 @@ class Ec2Inventory(object):
         # Route53
         self.route53_enabled = config.getboolean('ec2', 'route53')
         self.route53_excluded_zones = []
+        self.route53_included_zones = []
         if config.has_option('ec2', 'route53_excluded_zones'):
             self.route53_excluded_zones.extend(
-                config.get('ec2', 'route53_excluded_zones', '').split(','))
+                config.get('ec2', 'route53_excluded_zones', '').replace(' ','').split(','))
+        if config.has_option('ec2', 'route53_included_zones'):
+            self.route53_included_zones.extend(
+                config.get('ec2', 'route53_included_zones', '').replace(' ','').split(','))
 
         # Include RDS instances?
         self.rds_enabled = True
@@ -505,7 +509,12 @@ class Ec2Inventory(object):
         r53_conn = route53.Route53Connection()
         all_zones = r53_conn.get_zones()
 
-        route53_zones = [ zone for zone in all_zones if zone.name[:-1]
+        if self.route53_included_zones:
+            route53_zones = [ zone for zone in all_zones if zone.name[:-1]
+                          in self.route53_included_zones and zone.name[:-1] not
+                          in self.route53_excluded_zones ]
+        else:
+            route53_zones = [ zone for zone in all_zones if zone.name[:-1]
                           not in self.route53_excluded_zones ]
 
         self.route53_records = {}


### PR DESCRIPTION
inventory script.

Rationale: Having many zones can severly slow down the inventory script and it's
conceivable if not likely that one may only want/need a few zones in their inventory.
This is a simple enough addition that it was a no-brainer and is completely opt-in.

Also, now stripping spaces from route53_included_zones and route53_excluded_zones
because spaces around commas would break the list and the example had spaces.
Figured it made more sense to make the parameter more flexible than just fix the
example.
