### PR TITLE
Fix wrong date in debian/changelog

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -2,7 +2,7 @@ ansible (1.8) unstable; urgency=low
 
   * 1.8 release (PENDING)
 
- -- Michael DeHaan <michael@ansible.com>  TBD
+ -- Michael DeHaan <michael@ansible.com>  Wed, 06 Aug 2014 15:00:00 -0500
 
 ansible (1.7) unstable; urgency=low
 


### PR DESCRIPTION
At the moment (after 1.7 release) `make deb` cannot create a package and returns an error:

```
parsechangelog/debian: warning:     debian/changelog(l5): badly formatted trailer line
LINE:  -- Michael DeHaan <michael@ansible.com>  TBD
parsechangelog/debian: warning:     debian/changelog(l7): found start of entry where expected more change data or trailer
LINE: ansible (1.7-0.git201408062200~unstable) unstable; urgency=low
parsechangelog/debian: warning:     debian/changelog(l7): found eof where expected more change data or trailer
debuild: unknown dpkg-buildpackage/debuild option: --source-option=-I
 dpkg-buildpackage -rfakeroot -D -us -uc --source-option=-I -b
parsechangelog/debian: warning:     debian/changelog(l5): badly formatted trailer line
LINE:  -- Michael DeHaan <michael@ansible.com>  TBD
parsechangelog/debian: warning:     debian/changelog(l7): found start of entry where expected more change data or trailer
LINE: ansible (1.7-0.git201408062200~unstable) unstable; urgency=low
parsechangelog/debian: warning:     debian/changelog(l7): found eof where expected more change data or trailer
dpkg-buildpackage: error: unable to determine source changed by
dpkg-buildpackage: source package ansible
dpkg-buildpackage: source version 1.8-0.git201408062200~unstable
dpkg-buildpackage: source distribution unstable
debuild: fatal error at line 1364:
dpkg-buildpackage -rfakeroot -D -us -uc --source-option=-I -b failed
make: *** [deb] Error 29
```

It seems that Debian changelog format expects a proper date in a changelog entry.
