### PR TITLE
Supervisorctl enhancements

### DIFF
--- a/library/web_infrastructure/supervisorctl
+++ b/library/web_infrastructure/supervisorctl
@@ -210,10 +210,10 @@ def main():
             module.fail_json(msg=out, name=name, state=state)
 
     if state == 'started':
-        take_action_on_processes(processes, lambda s: s != 'RUNNING', 'start', 'started')
+        take_action_on_processes(processes, lambda s: s not in {'RUNNING', 'STARTING'}, 'start', 'started')
 
     if state == 'stopped':
-        take_action_on_processes(processes, lambda s: s == 'RUNNING', 'stop', 'stopped')
+        take_action_on_processes(processes, lambda s: s in {'RUNNING', 'STARTING'}, 'stop', 'stopped', 'STARTING')
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/library/web_infrastructure/supervisorctl
+++ b/library/web_infrastructure/supervisorctl
@@ -64,7 +64,7 @@ options:
       - The desired state of program/group.
     required: true
     default: null
-    choices: [ "present", "started", "stopped", "restarted" ]
+    choices: [ "present", "started", "stopped", "restarted", "updated" ]
   supervisorctl_path:
     description:
       - path to supervisorctl executable
@@ -90,6 +90,9 @@ EXAMPLES = '''
 
 # Restart my_app, connecting to supervisord with credentials and server URL.
 - supervisorctl: name=my_app state=restarted username=test password=testpass server_url=http://localhost:9001
+
+# Updates configuration for program in supervisor if there are changes.
+- supervisorctl: name=my_app state=updated
 '''
 
 
@@ -101,7 +104,7 @@ def main():
         username=dict(required=False),
         password=dict(required=False),
         supervisorctl_path=dict(required=False),
-        state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped'])
+        state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped', 'updated'])
     )
 
     module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
@@ -214,6 +217,13 @@ def main():
 
     if state == 'stopped':
         take_action_on_processes(processes, lambda s: s in {'RUNNING', 'STARTING'}, 'stop', 'stopped', 'STARTING')
+
+    if state == 'updated':
+        rc, out, err = run_supervisorctl('update', name)
+        if len(out) == 0:
+            module.exit_json(changed=False, name=name)
+        else:
+            module.exit_json(changed=True, name=name)
 
 # import module snippets
 from ansible.module_utils.basic import *


### PR DESCRIPTION
This changes two things:
- If a program is in the state "STARTING" `state=started` will not try to start it again, and `state=stopped` will stop the program.
- `state=updated` is added which simply run `supervisorctl update <program>` to make sure supervisor is using the latest version of the configuration file for the program. This is useful if you keep a configuration file for a program updated ie. via the `copy` module, then using `state=updated` afterwards will only restart the program if there are changes to the configuration.
