### PR TITLE
adding fix where sometimes state=absent tries to delete wrong asg

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -291,10 +291,11 @@ def delete_autoscaling_group(connection, module):
             for group in groups:
                 if group.name == group_name:
                     if not group.instances:
+                        target_group = group
                         instances = False
             time.sleep(10)
 
-        group.delete()
+        target_group.delete()
         module.exit_json(changed=True)
     else:
         module.exit_json(changed=False)


### PR DESCRIPTION
This was a pretty bad bug where sometimes, after all of the instances of the asg where deleted ec2_asg would try to delete the wrong asg. The good thing is that since the wrong group has running instances it would just fail. This was hard to repro as it didn't happen all the time. This is a small fix which solves the problem.
