### PR TITLE
ec2_asg: Implements the proper method for terminating an auto scale group.

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -283,15 +283,17 @@ def delete_autoscaling_group(connection, module):
     groups = connection.get_all_groups(names=[group_name])
     if groups:
         group = groups[0]
-        group.shutdown_instances()
-
+        group.max_size = 0
+        group.min_size = 0
+        group.desired_capacity = 0
+        group.update()
         instances = True
         while instances:
-            groups = connection.get_all_groups()
-            for group in groups:
-                if group.name == group_name:
-                    if not group.instances:
-                        instances = False
+            tmp_groups = connection.get_all_groups(names=[group_name])
+            if tmp_groups:
+                tmp_group = tmp_groups[0]
+                if not tmp_group.instances:
+                   instances = False
             time.sleep(10)
 
         group.delete()


### PR DESCRIPTION
The current ec2_asg delete method deletes instances in the group, but then the group attempts to respawn them, resulting in errors such as:

```
  <Error>
    <Type>Sender</Type>
    <Code>ResourceInUse</Code>
    <Message>You cannot delete an AutoScalingGroup while there are instances or pending Spot instance request(s) still in the group.</Message>
  </Error>
  <RequestId>81ac1556-1e76-11e4-bc9b-4deda0593d7f</RequestId>
</ErrorResponse>
```

This pull request [follows Amazon's documentation](http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_DeleteAutoScalingGroup.html) for deleting AutoScale Groups:

`To remove all instances before calling DeleteAutoScalingGroup, you can call UpdateAutoScalingGroup to set the minimum and maximum size of the AutoScalingGroup to zero.`
