### PR TITLE
InventoryDir: fixing yet another corner case

### DIFF
--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -113,7 +113,7 @@ class InventoryDirectory(object):
             for group in allgroup.child_groups[:]:
                 # groups might once have beeen added to all, and later be added
                 # to another group: we need to remove the link wit all then
-                if len(group.parent_groups) > 1:
+                if len(group.parent_groups) > 1 and allgroup in group.parent_groups:
                     # real children of all have just 1 parent, all
                     # this one has more, so not a direct child of all anymore
                     group.parent_groups.remove(allgroup)


### PR DESCRIPTION
I eventually bumped in yet another corner case that causes this traceback.

```
Traceback (most recent call last):
  File "/home/serge/sbin/ansible-inventory", line 190, in <module>
    cli.run()
  File "/home/serge/sbin/ansible-inventory", line 182, in run
    cli.inv_init()
  File "/home/serge/sbin/ansible-inventory", line 101, in inv_init
    self.inventory = inventory.Inventory(self.options.inventory)
  File "/usr/lib/pymodules/python2.7/ansible/inventory/__init__.py", line 100, in __init__
    self.parser = InventoryDirectory(filename=host_list)
  File "/usr/lib/pymodules/python2.7/ansible/inventory/dir.py", line 54, in __init__
    parser = InventoryDirectory(filename=fullpath)
  File "/usr/lib/pymodules/python2.7/ansible/inventory/dir.py", line 119, in __init__
    group.parent_groups.remove(allgroup)
ValueError: list.remove(x): x not in list
```
