### PR TITLE
adding include_pattern and exclude_pattern options to ec2.py

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -67,3 +67,9 @@ cache_max_age = 300
 
 # Organize groups into a nested/hierarchy instead of a flat namespace.
 nested_groups = False
+
+# If you only want to include hosts that match a certain regular expression
+# pattern_include = stage-*
+
+# If you want to exclude any hosts that match a certain regular expression
+# pattern_exclude = stage-*


### PR DESCRIPTION
Sometimes it's useful to be able to restrict the hosts returned from ec2.py using a pattern. For instance, if you need to make sure you only run against hosts in a specific project, or you are outside of a vpc and and some servers are inside of it, so there's no reason to even include them since you can't ever reach them.

This adds 2 optional parameters to ec2.ini (include_pattern and exclude_pattern) that are just regular expressions that are matched against whatever key you're using for the destination (destination_variable or vpc_destination_variable)
