### PR TITLE
gce.py: Add hosts to group "all" 

### DIFF
--- a/plugins/inventory/gce.py
+++ b/plugins/inventory/gce.py
@@ -259,6 +259,9 @@ class GceInventory(object):
             stat = 'status_%s' % status.lower()
             if groups.has_key(stat): groups[stat].append(name)
             else: groups[stat] = [name]
+            
+            if groups.has_key('all'): groups['all'].append(name)
+            else: groups['all'] = [name]
         return groups
 
     def json_format_dict(self, data, pretty=False):


### PR DESCRIPTION
`gce.py` is not populating the group `all` with the instances retrieved from GCE. As a result, vars specified for the "all" group are not being applied to these hosts. This commit fixes that.
