### PR TITLE
mount: fix for #7121

### DIFF
--- a/library/system/mount
+++ b/library/system/mount
@@ -320,6 +320,15 @@ def main():
             if os.path.ismount(name):
                 if changed:
                     res,msg = mount(module, **args)
+            elif "bind" in args['opts']:
+                changed = True
+                allmounts = subprocess.Popen(['mount', '-l'], stdout=subprocess.PIPE).communicate()[0].split('\n')
+                for mounts in allmounts[:-1]:
+                    arguments = mounts.split()
+                    if arguments[0] == args['src'] and arguments[2] == args['name'] and arguments[4] == args['fstype']:
+                        changed = False
+                if changed:
+                    res,msg = mount(module, **args)
             else:
                 changed = True
                 res,msg = mount(module, **args)

--- a/library/system/mount
+++ b/library/system/mount
@@ -322,7 +322,9 @@ def main():
                     res,msg = mount(module, **args)
             elif "bind" in args['opts']:
                 changed = True
-                allmounts = subprocess.Popen(['mount', '-l'], stdout=subprocess.PIPE).communicate()[0].split('\n')
+		cmd = 'mount -l'
+		rc, out, err = module.run_command(cmd)
+		allmounts = out.split('\n')
                 for mounts in allmounts[:-1]:
                     arguments = mounts.split()
                     if arguments[0] == args['src'] and arguments[2] == args['name'] and arguments[4] == args['fstype']:


### PR DESCRIPTION
python does not detect bind mounts using os.path.ismount(), and the only way I could figure out how to see was to parse the output of the mount command. This is intended to be a fix for #7121. Tested it on Centos 6.5 and it works. 
