### PR TITLE
Replace all occurrences of "Digital Ocean" with "DigitalOcean"

### DIFF
--- a/docsite/rst/guides.rst
+++ b/docsite/rst/guides.rst
@@ -13,5 +13,5 @@ This section is new and evolving.  The idea here is explore particular use cases
    guide_rolling_upgrade
    test_strategies
 
-Pending topics may include: Docker, Jenkins, Google Compute Engine, Linode/Digital Ocean, Continuous Deployment, and more.
+Pending topics may include: Docker, Jenkins, Google Compute Engine, Linode/DigitalOcean, Continuous Deployment, and more.
 

--- a/docsite/rst/intro_dynamic_inventory.rst
+++ b/docsite/rst/intro_dynamic_inventory.rst
@@ -199,7 +199,7 @@ Other inventory scripts
 In addition to Cobbler and EC2, inventory scripts are also available for::
 
    BSD Jails
-   Digital Ocean
+   DigitalOcean
    Google Compute Engine
    Linode
    OpenShift

--- a/library/cloud/digital_ocean_domain
+++ b/library/cloud/digital_ocean_domain
@@ -30,10 +30,10 @@ options:
     choices: ['present', 'active', 'absent', 'deleted']
   client_id:
      description:
-     - Digital Ocean manager id.
+     - DigitalOcean manager id.
   api_key:
     description:
-     - Digital Ocean api key.
+     - DigitalOcean api key.
   id:
     description:
      - Numeric, the droplet id you want to operate on.

--- a/library/cloud/digital_ocean_sshkey
+++ b/library/cloud/digital_ocean_sshkey
@@ -30,10 +30,10 @@ options:
     choices: ['present', 'absent']
   client_id:
      description:
-     - Digital Ocean manager id.
+     - DigitalOcean manager id.
   api_key:
     description:
-     - Digital Ocean api key.
+     - DigitalOcean api key.
   id:
     description:
      - Numeric, the SSH key id you want to operate on.


### PR DESCRIPTION
"DigitalOcean" is the correct spelling. :)

Thanks for the amazing docs -- I'm switching from SaltStack to Ansible and I'm finding them _very_ helpful!
