### PR TITLE
'copy' write new line at end of file if 'content' passed without newline...

### DIFF
--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -315,6 +315,8 @@ class ActionModule(object):
         f = os.fdopen(fd, 'w')
         try:
             f.write(content)
+            if not content.endswith('\n'):
+                f.write('\n')
         except Exception, err:
             os.remove(content_tempfile)
             raise Exception(err)


### PR DESCRIPTION
Fixes #7855. Checked it by using hacking/env-setup and creating a temporary file with ad-hoc ansible.
