### PR TITLE
Route53 forcing zone_in, record_in to lower case

### DIFF
--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -178,9 +178,9 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec)
 
     command_in            = module.params.get('command')
-    zone_in               = module.params.get('zone')
+    zone_in               = module.params.get('zone').lower()
     ttl_in                = module.params.get('ttl')
-    record_in             = module.params.get('record')
+    record_in             = module.params.get('record').lower()
     type_in               = module.params.get('type')
     value_in              = module.params.get('value')
     retry_interval_in     = module.params.get('retry_interval')


### PR DESCRIPTION
It turns out the Route53 module cares if the zone and record specified in the playbook are lower case or not when deleting a record. If you use a variable to name your servers and care about case, using that same proper case name will cause Route53 DNS delete requests to fail.

The change requested adds .lower() to the module.params.get for both zone and record.

If you use lowercase names (or don't use a name variable and share it between a tag and DNS entries) then you will never see this issue.

Tested/Confirmed with create/delete in Ansible 1.6.6
