### PR TITLE
rax_cdb* modules: Dedupe code and switch to shared doc fragments

### DIFF
--- a/library/cloud/rax_cdb
+++ b/library/cloud/rax_cdb
@@ -14,35 +14,18 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+# This is a DOCUMENTATION stub specific to this module, it extends
+# a documentation fragment located in ansible.utils.module_docs_fragments
 DOCUMENTATION = '''
 ---
 module: rax_cdb
-short_description: create / delete or resize a Rackspace Cloud Databases instance
+short_description: create/delete or resize a Rackspace Cloud Databases instance
 description:
   - creates / deletes or resize a Rackspace Cloud Databases instance
-    and optionally waits for it to be 'running'. The name option needs to be unique since
-    it's used to identify the instance.
+    and optionally waits for it to be 'running'. The name option needs to be
+    unique since it's used to identify the instance.
 version_added: "1.8"
 options:
-  api_key:
-    description:
-      - Rackspace API key (overrides I(credentials))
-    aliases:
-      - password
-  credentials:
-    description:
-      - File to find the Rackspace credentials in (ignored if I(api_key) and
-        I(username) are provided)
-    default: null
-    aliases:
-      - creds_file
-  region:
-    description:
-      - Region to create an instance in
-    default: DFW
-  username:
-    description:
-      - Rackspace username (overrides I(credentials))
   name:
     description:
       - Name of the databases server instance
@@ -69,15 +52,8 @@ options:
     description:
       - how long before wait gives up, in seconds
     default: 300
-requirements: [ "pyrax" ]
 author: Simon JAILLET
-notes:
-  - The following environment variables can be used, C(RAX_USERNAME),
-    C(RAX_API_KEY), C(RAX_CREDS_FILE), C(RAX_CREDENTIALS), C(RAX_REGION).
-  - C(RAX_CREDENTIALS) and C(RAX_CREDS_FILE) points to a credentials file
-    appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
-  - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
-  - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+extends_documentation_fragment: rackspace
 '''
 
 EXAMPLES = '''
@@ -97,25 +73,11 @@ EXAMPLES = '''
       register: rax_db_server
 '''
 
-import sys
-from types import NoneType
-
 try:
     import pyrax
+    HAS_PYRAX = True
 except ImportError:
-    print("failed=True msg='pyrax is required for this module'")
-    sys.exit(1)
-
-NON_CALLABLES = (basestring, bool, dict, int, list, NoneType)
-
-
-def to_dict(obj):
-    instance = {}
-    for key in dir(obj):
-        value = getattr(obj, key)
-        if (isinstance(value, NON_CALLABLES) and not key.startswith('_')):
-            instance[key] = value
-    return instance
+    HAS_PYRAX = False
 
 
 def find_instance(name):
@@ -168,45 +130,31 @@ def save_instance(module, name, flavor, volume, wait, wait_timeout):
         if instance.volume.size != volume:
             action = 'resize'
             if instance.volume.size > volume:
-                module.fail_json(
-                    changed=False,
-                    action=action,
-                    msg='The new volume size must be larger than the'
-                        ' current volume size',
-                    cdb=to_dict(instance)
-                )
+                module.fail_json(changed=False, action=action,
+                                 msg='The new volume size must be larger than '
+                                     'the current volume size',
+                                cdb=rax_to_dict(instance))
             instance.resize_volume(volume)
             changed = True
 
         if int(instance.flavor.id) != flavor:
             action = 'resize'
-            pyrax.utils.wait_until(
-                instance,
-                'status',
-                'ACTIVE',
-                attempts=wait_timeout
-            )
+            pyrax.utils.wait_until(instance, 'status', 'ACTIVE',
+                                   attempts=wait_timeout)
             instance.resize(flavor)
             changed = True
 
     if wait:
-        pyrax.utils.wait_until(
-            instance,
-            'status',
-            'ACTIVE',
-            attempts=wait_timeout
-        )
+        pyrax.utils.wait_until(instance, 'status', 'ACTIVE',
+                               attempts=wait_timeout)
 
     if wait and instance.status != 'ACTIVE':
-        module.fail_json(
-          changed=changed,
-          action=action,
-          cdb=to_dict(instance),
-          msg='Timeout waiting for "%s" databases instance to be '
-              'created' % name
-        )
+        module.fail_json(changed=changed, action=action,
+                         cdb=rax_to_dict(instance),
+                         msg='Timeout waiting for "%s" databases instance to '
+                             'be created' % name)
 
-    module.exit_json(changed=changed, action=action, cdb=to_dict(instance))
+    module.exit_json(changed=changed, action=action, cdb=rax_to_dict(instance))
 
 
 def delete_instance(module, name, wait, wait_timeout):
@@ -228,23 +176,17 @@ def delete_instance(module, name, wait, wait_timeout):
         changed = True
 
     if wait:
-        pyrax.utils.wait_until(
-            instance,
-            'status',
-            'SHUTDOWN',
-            attempts=wait_timeout
-        )
+        pyrax.utils.wait_until(instance, 'status', 'SHUTDOWN',
+                               attempts=wait_timeout)
 
     if wait and instance.status != 'SHUTDOWN':
-        module.fail_json(
-          changed=changed,
-          action='delete',
-          cdb=to_dict(instance),
-          msg='Timeout waiting for "%s" databases instance to be '
-              'deleted' % name
-        )
+        module.fail_json(changed=changed, action='delete',
+                         cdb=rax_to_dict(instance),
+                         msg='Timeout waiting for "%s" databases instance to '
+                             'be deleted' % name)
 
-    module.exit_json(changed=changed, action='delete', cdb=to_dict(instance))
+    module.exit_json(changed=changed, action='delete',
+                     cdb=rax_to_dict(instance))
 
 
 def rax_cdb(module, state, name, flavor, volume, wait, wait_timeout):
@@ -274,6 +216,9 @@ def main():
         required_together=rax_required_together(),
     )
 
+    if not HAS_PYRAX:
+        module.fail_json(msg='pyrax is required for this module')
+
     name = module.params.get('name')
     flavor = module.params.get('flavor')
     volume = module.params.get('volume')
@@ -289,5 +234,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
+# invoke the module
 main()

--- a/library/cloud/rax_cdb_database
+++ b/library/cloud/rax_cdb_database
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+# This is a DOCUMENTATION stub specific to this module, it extends
+# a documentation fragment located in ansible.utils.module_docs_fragments
 DOCUMENTATION = '''
 module: rax_cdb_database
 short_description: 'create / delete a database in the Cloud Databases'
@@ -21,25 +23,6 @@ description:
   - create / delete a database in the Cloud Databases.
 version_added: "1.8"
 options:
-  api_key:
-    description:
-      - Rackspace API key (overrides I(credentials))
-    aliases:
-      - password
-  credentials:
-    description:
-      - File to find the Rackspace credentials in (ignored if I(api_key) and
-        I(username) are provided)
-    default: null
-    aliases:
-      - creds_file
-  region:
-    description:
-      - Region to create an instance in
-    default: DFW
-  username:
-    description:
-      - Rackspace username (overrides I(credentials))
   cdb_id:
     description:
       - The databases server UUID
@@ -61,16 +44,8 @@ options:
       - Indicate desired state of the resource
     choices: ['present', 'absent']
     default: present
-requirements: 
-   - "pyrax"
 author: Simon JAILLET
-notes:
-  - The following environment variables can be used, C(RAX_USERNAME),
-    C(RAX_API_KEY), C(RAX_CREDS_FILE), C(RAX_CREDENTIALS), C(RAX_REGION).
-  - C(RAX_CREDENTIALS) and C(RAX_CREDS_FILE) points to a credentials file
-    appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
-  - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
-  - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+extends_documentation_fragment: rackspace
 '''
 
 EXAMPLES = '''
@@ -87,25 +62,11 @@ EXAMPLES = '''
       register: rax_db_database
 '''
 
-import sys
-from types import NoneType
-
 try:
     import pyrax
+    HAS_PYRAX = True
 except ImportError:
-    print("failed=True msg='pyrax is required for this module'")
-    sys.exit(1)
-
-NON_CALLABLES = (basestring, bool, dict, int, list, NoneType)
-
-
-def to_dict(obj):
-    instance = {}
-    for key in dir(obj):
-        value = getattr(obj, key)
-        if (isinstance(value, NON_CALLABLES) and not key.startswith('_')):
-            instance[key] = value
-    return instance
+    HAS_PYRAX = False
 
 
 def find_database(instance, name):
@@ -145,11 +106,8 @@ def save_database(module, cdb_id, name, character_set, collate):
         else:
             changed = True
 
-    module.exit_json(
-      changed=changed,
-      action='create',
-      database=to_dict(database)
-    )
+    module.exit_json(changed=changed, action='create',
+                     database=rax_to_dict(database))
 
 
 def delete_database(module, cdb_id, name):
@@ -207,6 +165,9 @@ def main():
         required_together=rax_required_together(),
     )
 
+    if not HAS_PYRAX:
+        module.fail_json(msg='pyrax is required for this module')
+
     cdb_id = module.params.get('cdb_id')
     name = module.params.get('name')
     character_set = module.params.get('character_set')
@@ -221,5 +182,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
+# invoke the module
 main()

--- a/library/cloud/rax_cdb_user
+++ b/library/cloud/rax_cdb_user
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+# This is a DOCUMENTATION stub specific to this module, it extends
+# a documentation fragment located in ansible.utils.module_docs_fragments
 DOCUMENTATION = '''
 ---
 module: rax_cdb_user
@@ -22,25 +24,6 @@ description:
   - create / delete a database in the Cloud Databases.
 version_added: "1.8"
 options:
-  api_key:
-    description:
-      - Rackspace API key (overrides I(credentials))
-    aliases:
-      - password
-  credentials:
-    description:
-      - File to find the Rackspace credentials in (ignored if I(api_key) and
-        I(username) are provided)
-    default: null
-    aliases:
-      - creds_file
-  region:
-    description:
-      - Region to create an instance in
-    default: DFW
-  username:
-    description:
-      - Rackspace username (overrides I(credentials))
   cdb_id:
     description:
       - The databases server UUID
@@ -68,15 +51,8 @@ options:
       - Indicate desired state of the resource
     choices: ['present', 'absent']
     default: present
-requirements: [ "pyrax" ]
 author: Simon JAILLET
-notes:
-  - The following environment variables can be used, C(RAX_USERNAME),
-    C(RAX_API_KEY), C(RAX_CREDS_FILE), C(RAX_CREDENTIALS), C(RAX_REGION).
-  - C(RAX_CREDENTIALS) and C(RAX_CREDS_FILE) points to a credentials file
-    appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
-  - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
-  - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+extends_documentation_fragment: rackspace
 '''
 
 EXAMPLES = '''
@@ -95,25 +71,11 @@ EXAMPLES = '''
       register: rax_db_user
 '''
 
-import sys
-from types import NoneType
-
 try:
     import pyrax
+    HAS_PYRAX = True
 except ImportError:
-    print("failed=True msg='pyrax is required for this module'")
-    sys.exit(1)
-
-NON_CALLABLES = (basestring, bool, dict, int, list, NoneType)
-
-
-def to_dict(obj):
-    instance = {}
-    for key in dir(obj):
-        value = getattr(obj, key)
-        if (isinstance(value, NON_CALLABLES) and not key.startswith('_')):
-            instance[key] = value
-    return instance
+    HAS_PYRAX = False
 
 
 def find_user(instance, name):
@@ -177,7 +139,7 @@ def save_user(module, cdb_id, name, password, databases, host):
             else:
                 changed = True
 
-    module.exit_json(changed=changed, action=action, user=to_dict(user))
+    module.exit_json(changed=changed, action=action, user=rax_to_dict(user))
 
 
 def delete_user(module, cdb_id, name):
@@ -236,6 +198,9 @@ def main():
         required_together=rax_required_together(),
     )
 
+    if not HAS_PYRAX:
+        module.fail_json(msg='pyrax is required for this module')
+
     cdb_id = module.params.get('cdb_id')
     name = module.params.get('db_username')
     password = module.params.get('db_password')
@@ -251,5 +216,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
+# invoke the module
 main()


### PR DESCRIPTION
This pull request removes code now provided by `ansible.module_utils.rax` and switches the DOCUMENTATION strings over to use the rax shared module docs.
