### PR TITLE
apt_repository: Check if key already exists before adding it

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -335,14 +335,19 @@ class UbuntuSourcesList(SourcesList):
         line = 'deb http://ppa.launchpad.net/%s/%s/ubuntu %s main' % (ppa_owner, ppa_name, distro.codename)
         return line, ppa_owner, ppa_name
 
+    def _key_already_exists(self, key_fingerprint):
+        rc, out, err = self.module.run_command('apt-key export %s' % key_fingerprint, check_rc=True)
+        return len(err) == 0
+
     def add_source(self, line, comment='', file=None):
         if line.startswith('ppa:'):
             source, ppa_owner, ppa_name = self._expand_ppa(line)
 
             if self.add_ppa_signing_keys_callback is not None:
                 info = self._get_ppa_info(ppa_owner, ppa_name)
-                command = ['apt-key', 'adv', '--recv-keys', '--keyserver', 'hkp://keyserver.ubuntu.com:80', info['signing_key_fingerprint']]
-                self.add_ppa_signing_keys_callback(command)
+                if not self._key_already_exists(info['signing_key_fingerprint']):
+                    command = ['apt-key', 'adv', '--recv-keys', '--keyserver', 'hkp://keyserver.ubuntu.com:80', info['signing_key_fingerprint']]
+                    self.add_ppa_signing_keys_callback(command)
 
             file = file or self._suggest_filename('%s_%s' % (line, distro.codename))
         else:


### PR DESCRIPTION
According to my testing, adding a PPA repository with the `add_repository` module takes around 11-12 seconds, where around half of that time is spent on getting the key from Ubuntu's key servers, even if the key is already added. This commit optimizes that so it will only try to get the key from Ubuntu's servers if they key doesn't already exist. This takes the normal execution time down to around 6-7 seconds.
