### PR TITLE
wait_for module: check e.errno instead of os.errno. Fixes #8548

### DIFF
--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -198,7 +198,7 @@ def main():
                         break
                 except OSError, e:
                     # File not present
-                    if os.errno == 2:
+                    if e.errno == 2:
                         time.sleep(1)
                     else:
                         elapsed = datetime.datetime.now() - start


### PR DESCRIPTION
Updates to the `wait_for` module from 6efc8008daa8bb70ccbf51df0ff14f81843fc59e are errantly performing `os.errno == 2` instead of `e.errno == 2`.

This is causing `wait_for` to immediately fail on missing files.
