### PR TITLE
postgresql integration tests

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -9,5 +9,5 @@
     - { role: test_apt_repository, tags: test_apt_repository }
     - { role: test_mysql_db, tags: test_mysql_db}
     - { role: test_mysql_user, tags: test_mysql_user}
-    - { role: test_mysql_user, tags: test_mysql_user}    
     - { role: test_mysql_variables, tags: test_mysql_variables}
+    - { role: test_postgresql_db, tags: test_postgresql_db}

--- a/test/integration/roles/setup_postgresql_db/defaults/main.yml
+++ b/test/integration/roles/setup_postgresql_db/defaults/main.yml
@@ -1,0 +1,8 @@
+pg_hba_location: "/var/lib/pgsql/data/pg_hba.conf"
+
+postgresql_service: postgresql
+
+postgresql_packages: 
+    - postgresql
+    - postgresql-server
+    - python-psycopg2

--- a/test/integration/roles/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/roles/setup_postgresql_db/tasks/main.yml
@@ -1,0 +1,62 @@
+# setup code for the postgresql integration test
+# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+- include_vars: '{{ ansible_os_family }}.yml' 
+
+- name: stop postgresql service if running 
+  service: name={{ postgresql_service }} state=stopped
+  ignore_errors: yes
+
+- name: delete directory pqsql data
+  file: path=/var/lib/pgsql/data state=absent recurse=no
+
+- name: install postgresql rpm dependencies
+  yum: name={{ item }} state=latest 
+  with_items: postgresql_packages
+  when: ansible_pkg_mgr  ==  'yum'
+
+- name: install postgresql debian dependencies 
+  apt: name={{ item }} state=latest 
+  with_items:  postgresql_packages
+  when: ansible_pkg_mgr  ==  'apt'
+
+- name: initiate postgreslql service
+  command: service postgresql initdb
+           creates=/var/lib/pgsql/data/postgresql.conf
+  when: ansible_distribution != "Ubuntu"
+
+# `psql --version` output format should be like `psql (PostgreSQL) 9.1.14`
+- name: display psql version
+  shell: psql --version | awk 'NR==1 {print $3}' | cut -c 1-3
+  register: psql_version
+  when: ansible_distribution == "Ubuntu"
+
+- name: Setup pg_bha_location for ubuntu
+  set_fact: pg_hba_location={{pg_hba_path}}{{psql_version.stdout_lines | first}}{{pg_hba_file}}
+  when: ansible_distribution == "Ubuntu"
+
+- name: update postgresql authentication settings
+  template: src=pg_hba.conf dest={{pg_hba_location}} owner=postgres
+  register: pg_hba_conf
+
+- name: start postgresql service 
+  service: name={{ postgresql_service }} state=restarted
+
+- name: wait postgresql service
+  wait_for: host=localhost port=5432 state=started timeout=30

--- a/test/integration/roles/setup_postgresql_db/templates/pg_hba.conf
+++ b/test/integration/roles/setup_postgresql_db/templates/pg_hba.conf
@@ -1,0 +1,11 @@
+# !!! This file managed by Ansible. Any local changes may be overwritten. !!!
+
+# Database administrative login by UNIX sockets
+# note: you may wish to restrict this further later
+local   all         postgres                          trust
+
+# TYPE  DATABASE    USER        CIDR-ADDRESS          METHOD
+local   all         all                               md5
+host    all         all         127.0.0.1/32          md5
+host    all         all         ::1/128               md5
+

--- a/test/integration/roles/setup_postgresql_db/vars/Debian.yml
+++ b/test/integration/roles/setup_postgresql_db/vars/Debian.yml
@@ -1,0 +1,9 @@
+pg_hba_path: "/etc/postgresql/"
+pg_hba_file: "/main/pg_hba.conf"
+
+postgresql_service: postgresql
+
+postgresql_packages: 
+    - postgresql
+    - libpq-dev    
+    - python-psycopg2

--- a/test/integration/roles/setup_postgresql_db/vars/RedHat.yml
+++ b/test/integration/roles/setup_postgresql_db/vars/RedHat.yml
@@ -1,0 +1,8 @@
+pg_hba_location: "/var/lib/pgsql/data/pg_hba.conf"
+
+postgresql_service: postgresql
+
+postgresql_packages:
+    - postgresql
+    - postgresql-server
+    - python-psycopg2

--- a/test/integration/roles/test_postgresql_db/defaults/main.yml
+++ b/test/integration/roles/test_postgresql_db/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# defaults file for test_postgresql
+db_name: 'datadb'
+
+db_name1: 'datadb1'
+db_name2: 'datadb2'
+
+db_user1: 'datauser1'
+db_user2: 'datauser2'
+
+password: 'password1' 
+
+tmp_dir: '/tmp'
+

--- a/test/integration/roles/test_postgresql_db/meta/main.yml
+++ b/test/integration/roles/test_postgresql_db/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_postgresql_db

--- a/test/integration/roles/test_postgresql_db/tasks/assert_db.yml
+++ b/test/integration/roles/test_postgresql_db/tasks/assert_db.yml
@@ -1,0 +1,46 @@
+# test code to assert postgresql db exist
+# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+# Verify database changed and database does not exist
+#
+- name: assert database changed 
+  assert:
+    that:
+       - "output.changed == {{changed}}"
+       - "output.db =='{{ database_name }}'"
+
+- name: list database 
+  command: psql -c "SELECT * FROM pg_database WHERE datname='{{ database_name }}'"
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- name: assert database exists 
+  assert: { that: "'{{ database_name }}' in result.stdout" }
+
+- name: show database owner
+  command: psql -c "\l"
+  sudo: yes
+  sudo_user: postgres
+  register: result
+  when: db_user is defined
+
+- name: assert database owner
+  assert: { that: "'{{ database_user }}' in result.stdout" }
+  when: db_user is defined

--- a/test/integration/roles/test_postgresql_db/tasks/assert_no_db.yml
+++ b/test/integration/roles/test_postgresql_db/tasks/assert_no_db.yml
@@ -1,0 +1,36 @@
+# test code to assert no postgresql db exist
+# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+# Verify database changed and database does not exists
+#
+- name: assert database changed 
+  assert:
+    that:
+       - "output.changed == {{changed}}"
+       - "output.db =='{{ database_name }}'"
+
+- name: list database 
+  command: psql -c "SELECT * FROM pg_database WHERE datname='{{ database_name }}'"
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- name: assert database does not exists 
+  assert: { that: "'{{ database_name }}' not in result.stdout" }
+

--- a/test/integration/roles/test_postgresql_db/tasks/main.yml
+++ b/test/integration/roles/test_postgresql_db/tasks/main.yml
@@ -1,0 +1,138 @@
+# test code for postgresql module
+# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+# Verify postgresql_db successfully creates a database
+#
+- name: create database (expect changed=true)  
+  postgresql_db: name={{ db_name }} state=present
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- include: assert_db.yml changed=true output={{result}} database_name={{db_name}}
+
+# ============================================================
+# Verify postgresql_db works when creating a database that already exists
+#
+- name: create database that already exists (expect changed=false)
+  postgresql_db: name={{ db_name }} state=present
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- include: assert_db.yml changed=false output={{result}} database_name={{db_name}}
+
+# ============================================================
+# Verify postgresql_db successfully removes a database
+#
+- name: remove database (expect changed=true)
+  postgresql_db: name={{ db_name }} state=absent
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- include: assert_no_db.yml changed=true output={{result}} database_name={{db_name}}
+
+# ============================================================
+# Verify postgresql_db works when removing a database that doesn't exist
+#
+- name: remove database that already exists (expect changed=false)
+  postgresql_db: name={{ db_name }} state=absent
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- include: assert_no_db.yml changed=false output={{result}} database_name={{db_name}}
+
+# ============================================================
+# Verify postgresql_db fails to create a database using invalid encoding
+#
+- name: create database with an invalid encoding (expect failed=true)
+  postgresql_db: name=db_not_valid state=present encoding=notvalid
+  sudo: yes
+  sudo_user: postgres 
+  register: result
+  ignore_errors: true 
+
+- name: assert changed equals true and failure msg
+  assert:
+    that:
+       - "result.failed == true"
+       - "'not a valid encoding name' in result.msg"
+
+# ============================================================
+# Verify postgresql_db successfully creates a database using a valid encoding
+#
+- name: create database with a valid encoding (expect changed=true)
+  postgresql_db: name=latin{{ db_name }} state=present encoding=LATIN1 lc_collate=C lc_ctype=C template=template0
+  sudo: yes
+  sudo_user: postgres 
+  register: result
+
+- name: assert changed equals true  
+  assert: { that: "result.changed == true" }
+
+- name: list database encoding (expect encoding=LATIN1)
+  command: psql latin{{ db_name }} -c 'SHOW SERVER_ENCODING'
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- name: assert database encoding is LATIN1
+  assert: { that: "'LATIN1' in result.stdout" }
+
+- name: remove database
+  sudo: yes
+  sudo_user: postgres
+  postgresql_db: name=latin{{ db_name }} state=absent
+
+# ============================================================
+# Verify postgresql_db successfully delete database with new owner
+#
+- name: create a database (expect changed=true)
+  postgresql_db: name={{ db_name }} state=present
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- name: create user1
+  postgresql_user: db={{ db_name }} name={{ db_user1 }} password={{ password }} state=present
+  sudo: yes
+  sudo_user: postgres
+
+- name: update database owner with user1 (expect changed=true)
+  postgresql_db: name={{ db_name }} state=present owner={{ db_user1 }}
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- include: assert_db.yml changed=true output={{result}} database_name={{db_name}} database_user={{db_user1}}
+
+- name: remove database using user1 credentials
+  postgresql_db: name={{ db_name }} state=absent login_user={{ db_user1 }} login_password={{ password }} 
+
+- name: remove user role
+  postgresql_user: name={{ db_user1 }} state=absent
+  sudo: yes
+  sudo_user: postgres
+
+# ============================================================
+# Verify postgresql_db cannot delete database with wrong database owner
+#
+- include: wrong_db_owner.yml  

--- a/test/integration/roles/test_postgresql_db/tasks/wrong_db_owner.yml
+++ b/test/integration/roles/test_postgresql_db/tasks/wrong_db_owner.yml
@@ -1,0 +1,100 @@
+# test code to assert wrong database owner  
+# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+# Verify postgresql_db cannot delete database with wrong database owner or password
+#
+- name: create a database1 
+  postgresql_db: name={{ db_name1 }} state=present
+  sudo: yes
+  sudo_user: postgres
+
+- name: create a database2
+  postgresql_db: name={{ db_name2 }} state=present
+  sudo: yes
+  sudo_user: postgres
+
+- name: create user1 to access database1
+  postgresql_user: db={{ db_name1 }} name={{ db_user1 }} password={{ password }} state=present
+  sudo: yes
+  sudo_user: postgres
+
+- name: create user2 to access database2 
+  postgresql_user: db={{ db_name2 }} name={{ db_user2 }} password={{ password }} state=present
+  sudo: yes
+  sudo_user: postgres
+
+- name: update database1 owner with user1 (expect changed=true)
+  postgresql_db: name={{ db_name1 }} state=present owner={{ db_user1 }}
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- include: assert_db.yml changed=true output={{result}} database_name={{db_name1}} database_user={{db_user1}}
+
+- name: update database2 owner with user2 (expect changed=true)
+  postgresql_db: name={{ db_name2 }} state=present owner={{ db_user2 }}
+  sudo: yes
+  sudo_user: postgres
+  register: result
+
+- include: assert_db.yml changed=true output={{result}} database_name={{db_name2}} database_user={{db_user2}}
+
+- name: remove database1 using wrong owner user2
+  postgresql_db: name={{ db_name1 }} state=absent login_user={{ db_user2 }} login_password={{ password }} 
+  ignore_errors: true 
+  register: result
+
+- name: assert failure and output message
+  assert:
+    that:
+       - "result.failed == true"
+       - "'must be owner of database' in result.msg"
+
+- name: remove database using user1 and wrong password
+  postgresql_db: name={{ db_name1 }} state=absent login_user={{ db_user1 }} login_password=wrongpassword
+  ignore_errors: true 
+  register: result
+
+- name: assert failure and output message
+  assert:
+    that:
+       - "result.failed == true"
+       - "'password authentication failed' in result.msg"
+
+- name: remove database1 using correct owner user1
+  postgresql_db: name={{ db_name1 }} state=absent login_user={{ db_user1 }} login_password={{ password }}
+  register: result
+
+- include: assert_no_db.yml changed=true output={{result}} database_name={{db_name1}}
+
+- name: remove database2 using correct owner user2
+  postgresql_db: name={{ db_name2 }} state=absent login_user={{ db_user2 }} login_password={{ password }}
+  register: result
+
+- include: assert_no_db.yml changed=true output={{result}} database_name={{db_name2}}
+
+- name: remove user role for user1
+  postgresql_user: name={{ db_user1 }} state=absent
+  sudo: yes
+  sudo_user: postgres
+
+- name: remove user role for user2
+  postgresql_user: name={{ db_user2 }} state=absent
+  sudo: yes
+  sudo_user: postgres


### PR DESCRIPTION
Use postgresql_db module to create, delete databases using different encoding.
Create and delete databases using different users.
Assert database creation, deleting and content using system commands.
