### PR TITLE
ansible-vault should support script for --vault-password-file too

### DIFF
--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -27,6 +27,8 @@ import os
 import sys
 import traceback
 
+import ansible.constants as C
+
 from ansible import utils
 from ansible import errors
 from ansible.utils.vault import VaultEditor
@@ -58,7 +60,7 @@ def build_option_parser(action):
     #parser.add_option('-c', '--cipher', dest='cipher', default="AES256", help="cipher to use")
     parser.add_option('--debug', dest='debug', action="store_true", help="debug")
     parser.add_option('--vault-password-file', dest='password_file',
-                    help="vault password file")
+                      help="vault password file", default=C.DEFAULT_VAULT_PASSWORD_FILE)
 
     # options specific to actions
     if action == "create":
@@ -106,21 +108,14 @@ def get_opt(options, k, defval=""):
 # Command functions
 #-------------------------------------------------------------------------------------
 
-def _read_password(filename):
-    f = open(filename, "rb")
-    data = f.read()
-    f.close()
-    data = data.strip()
-    return data
-
 def execute_create(args, options, parser):
     if len(args) > 1:
         raise errors.AnsibleError("'create' does not accept more than one filename")        
 
-    if not options.password_file:        
+    if not options.password_file:
         password, new_password = utils.ask_vault_passwords(ask_vault_pass=True, confirm_vault=True)
     else:
-        password = _read_password(options.password_file)
+        password = utils.read_vault_file(options.password_file)
 
     cipher = 'AES256'
     if hasattr(options, 'cipher'):
@@ -131,10 +126,10 @@ def execute_create(args, options, parser):
 
 def execute_decrypt(args, options, parser):
 
-    if not options.password_file:        
+    if not options.password_file:
         password, new_password = utils.ask_vault_passwords(ask_vault_pass=True)
     else:
-        password = _read_password(options.password_file)
+        password = utils.read_vault_file(options.vault_password_file)
 
     cipher = 'AES256'
     if hasattr(options, 'cipher'):
@@ -151,10 +146,10 @@ def execute_edit(args, options, parser):
     if len(args) > 1:
         raise errors.AnsibleError("edit does not accept more than one filename")        
 
-    if not options.password_file:        
+    if not options.password_file:
         password, new_password = utils.ask_vault_passwords(ask_vault_pass=True)
     else:
-        password = _read_password(options.password_file)
+        password = utils.read_vault_file(options.password_file)
 
     cipher = None
 
@@ -170,7 +165,7 @@ def execute_view(args, options, parser):
     if not options.password_file:        
         password, new_password = utils.ask_vault_passwords(ask_vault_pass=True)
     else:
-        password = _read_password(options.password_file)
+        password = utils.read_vault_file(options.password_file)
 
     cipher = None
 
@@ -180,10 +175,10 @@ def execute_view(args, options, parser):
 
 def execute_encrypt(args, options, parser):
 
-    if not options.password_file:        
+    if not options.password_file:
         password, new_password = utils.ask_vault_passwords(ask_vault_pass=True, confirm_vault=True)
     else:
-        password = _read_password(options.password_file)
+        password = utils.read_vault_file(options.password_file)
 
     cipher = 'AES256'
     if hasattr(options, 'cipher'):
@@ -197,10 +192,10 @@ def execute_encrypt(args, options, parser):
 
 def execute_rekey(args, options, parser):
 
-    if not options.password_file:        
+    if not options.password_file:
         password, __ = utils.ask_vault_passwords(ask_vault_pass=True)
     else:
-        password = _read_password(options.password_file)
+        password = utils.read_vault_file(options.password_file)
 
     __, new_password = utils.ask_vault_passwords(ask_vault_pass=False, ask_new_vault_pass=True, confirm_new=True)
 
@@ -238,4 +233,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Somehow I completely missed adding support to `ansible-vault` to allow `--vault-password-file` to be a script.

This PR adds this functionality to match the now existing functionality of `ansible` and `ansible-playbook`.
