### PR TITLE
Fix UnicodeDecodeError when replace interpreter in non-ascii file

### DIFF
--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -168,6 +168,10 @@ class ModuleReplacer(object):
                     facility = inject['ansible_syslog_facility']
                 module_data = module_data.replace('syslog.LOG_USER', "syslog.%s" % facility)
 
+            try:
+                module_data = module_data.decode('utf-8')
+            except UnicodeDecodeError:
+                pass
             lines = module_data.split("\n")
             shebang = None
             if lines[0].startswith("#!"):


### PR DESCRIPTION
I got this error, when using locale_gen module and set interpreter to "/usr/bin/python2" . I'm not quite sure whether assuming unicode is the best solution, but as far as I see at least modules from ansible itself all use utf-8.
