### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Some other notable changes:
 * ec2_asg: fixes related to proper termination of an autoscaling group
 * win_setup: total memory fact correction
 * ec2_vol: ability to list existing volumes
-* ec2_vol: can set optimized flag
+* ec2: can set optimized flag
 * various parser improvements
 * produce a friendly error message if the SSH key is too permissive
 * ec2_ami_searcH: support for SSD and IOPS provisioned EBS images


### PR DESCRIPTION
This change occured int he ec2 module, not ec2_vol

I was searching for this change, thinking it related to setting "gp2" on EBS.  But this is actually a different change and is a typo in the CHANGELOG.
