### PR TITLE
Allow disabling of autorefresh for zypper repositories

### DIFF
--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -51,9 +51,16 @@ options:
             - A description of the repository
     disable_gpg_check:
         description:
-          - Whether to disable GPG signature checking of
-            all packages. Has an effect only if state is
-            I(present).
+            - Whether to disable GPG signature checking of
+              all packages. Has an effect only if state is
+              I(present).
+        required: false
+        default: "no"
+        choices: [ "yes", "no" ]
+        aliases: []
+    refresh:
+       description:
+           - Enable autorefresh of the repository.
         required: false
         default: "no"
         choices: [ "yes", "no" ]
@@ -117,14 +124,17 @@ def repo_exists(module, **kwargs):
     return False
 
 
-def add_repo(module, repo, alias, description, disable_gpg_check):
-    cmd = ['/usr/bin/zypper', 'ar', '--check', '--refresh']
+def add_repo(module, repo, alias, description, disable_gpg_check, refresh):
+    cmd = ['/usr/bin/zypper', 'ar', '--check']
 
     if description:
         cmd.extend(['--name', description])
 
     if disable_gpg_check:
         cmd.append('--no-gpgcheck')
+
+    if refresh:
+        cmd.append('--refresh')
 
     cmd.append(repo)
 
@@ -169,6 +179,7 @@ def main():
             state=dict(choices=['present', 'absent'], default='present'),
             description=dict(required=False),
             disable_gpg_check = dict(required=False, default='no', type='bool'),
+            refresh = dict(required=False, default='yes', type='bool'),
         ),
         supports_check_mode=False,
     )
@@ -178,6 +189,7 @@ def main():
     name = module.params['name']
     description = module.params['description']
     disable_gpg_check = module.params['disable_gpg_check']
+    refresh = module.params['refresh']
 
     def exit_unchanged():
         module.exit_json(changed=False, repo=repo, state=state, name=name)
@@ -204,7 +216,7 @@ def main():
         if exists:
             exit_unchanged()
 
-        changed = add_repo(module, repo, name, description, disable_gpg_check)
+        changed = add_repo(module, repo, name, description, disable_gpg_check, refresh)
     elif state == 'absent':
         if not exists:
             exit_unchanged()

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 # (c) 2013, Matthias Vogelgesang <matthias.vogelgesang@gmail.com>
+# (c) 2014, Justin Lecher <jlec@gentoo.org>
 #
 # This file is part of Ansible
 #


### PR DESCRIPTION
In case of release repositories or other special cases you might not
need the autorefreshing of the repos. This patch adds a configure
option instead of hard enabling this.

Signed-off-by: Justin Lecher jlec@gentoo.org
