### PR TITLE
Fixes for homebrew and homebrew casks

### DIFF
--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -112,6 +112,7 @@ class Homebrew(object):
 
     VALID_PACKAGE_CHARS = r'''
         \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
+        /                   # slash is used in fully qualified package names
         -                   # dashes
     '''
 

--- a/library/packaging/homebrew_cask
+++ b/library/packaging/homebrew_cask
@@ -35,10 +35,17 @@ options:
         choices: [ 'installed', 'uninstalled' ]
         required: false
         default: present
+    install_options:
+        description:
+            - options flags to install a package
+        required: false
+        default: null
+        version_added: "1.9"
 '''
 EXAMPLES = '''
 - homebrew_cask: name=alfred state=present
 - homebrew_cask: name=alfred state=absent
+- homebrew_cask: name=alfred install_options="appdir=/Applications"
 '''
 
 import os.path
@@ -81,6 +88,7 @@ class HomebrewCask(object):
 
     VALID_CASK_CHARS = r'''
         \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
+        /                   # slash is used in fully qualified package names
         -                   # dashes
     '''
 
@@ -251,10 +259,13 @@ class HomebrewCask(object):
             return cask
     # /class properties -------------------------------------------- }}}
 
-    def __init__(self, module, path=None, casks=None, state=None):
+    def __init__(self, module, path=None, casks=None, state=None, 
+                 install_options=None):
+        if not install_options:
+            install_options = list()
         self._setup_status_vars()
         self._setup_instance_vars(module=module, path=path, casks=casks,
-                                  state=state)
+                                  state=state, install_options=install_options)
 
         self._prep()
 
@@ -397,7 +408,7 @@ class HomebrewCask(object):
 
         cmd = [opt
                for opt in (self.brew_path, 'cask', 'install', self.current_cask)
-               if opt]
+               if opt] + self.install_options
 
         rc, out, err = self.module.run_command(cmd, path_prefix=self.path[0])
 
@@ -478,6 +489,11 @@ def main():
                     "absent", "removed", "uninstalled",
                 ],
             ),
+            install_options=dict(
+                default=None,
+                aliases=['options'],
+                type='list',
+            )
         ),
         supports_check_mode=True,
     )


### PR DESCRIPTION
Homebrew package names can contain the "/" character (fully qualified names). brew cask also can take install options in the same for as brew. 
