### PR TITLE
Fix issue #8578. Setting envvar in ""'s ensures the PYTHONPATH is set to

### DIFF
--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -16,7 +16,7 @@ else
         case "$PREFIX_PYTHONPATH*"
         case "*"
             echo "Appending PYTHONPATH"
-            set -gx PYTHONPATH $PREFIX_PYTHONPATH:$PYTHONPATH
+            set -gx PYTHONPATH "$PREFIX_PYTHONPATH:$PYTHONPATH"
     end
 end
 


### PR DESCRIPTION
Setting envvar in ""'s ensures the PYTHONPATH is set to include the lib/ directory.

Before - PYTHONPATH is empty.. ansible fails to run

```
$ source hacking/env-setup.fish
Appending PYTHONPATH

Setting up Ansible to run out of checkout...

PATH=/Volumes/opt/src/ansible/bin /usr/local/share/python3 /usr/local/bin
/usr/bin /bin /usr/sbin /sbin /usr/local/bin /opt/X11/bin /usr/bin /sbin
/usr/local/bin /Users/ms/bin/
PYTHONPATH=
ANSIBLE_LIBRARY=/Volumes/opt/src/ansible/library
...

Traceback (most recent call last):
  File "/Volumes/opt/src/ansible/bin/ansible", line 25, in <module>
      from ansible.runner import Runner
      ImportError: No module named ansible.runner
```

After change - it's set.. ansible runs.

```
source hacking/env-setup.fish
Appending PYTHONPATH

Setting up Ansible to run out of checkout...

PATH=/Volumes/opt/src/ansible/bin /usr/local/share/python3 /usr/local/bin
/usr/bin /bin /usr/sbin /sbin /usr/local/bin /opt/X11/bin /usr/bin /sbin
/usr/local/bin /Users/ms/bin/
PYTHONPATH=/Volumes/opt/src/ansible/lib:
ANSIBLE_LIBRARY=/Volumes/opt/src/ansible/library
....

$ ansible
Usage: ansible <host-pattern> [options]
```
