### PR TITLE
Handle the case where include_pattern and exclude_pattern exist but are empty strings

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -257,7 +257,7 @@ class Ec2Inventory(object):
             pattern_include = config.get('ec2', 'pattern_include')
             if pattern_include and len(pattern_include) > 0:
                 self.pattern_include = re.compile(pattern_include)
-            else
+            else:
                 self.pattern_include = None
         except ConfigParser.NoOptionError, e:
             self.pattern_include = None
@@ -267,7 +267,7 @@ class Ec2Inventory(object):
             pattern_exclude = config.get('ec2', 'pattern_exclude');
             if pattern_exclude and len(pattern_exclude) > 0:
                 self.pattern_exclude = re.compile(pattern_exclude)
-            else
+            else:
                 self.pattern_exclude = None
         except ConfigParser.NoOptionError, e:
             self.pattern_exclude = None

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -257,6 +257,8 @@ class Ec2Inventory(object):
             pattern_include = config.get('ec2', 'pattern_include')
             if pattern_include and len(pattern_include) > 0:
                 self.pattern_include = re.compile(pattern_include)
+            else
+                self.pattern_include = None
         except ConfigParser.NoOptionError, e:
             self.pattern_include = None
 
@@ -265,8 +267,10 @@ class Ec2Inventory(object):
             pattern_exclude = config.get('ec2', 'pattern_exclude');
             if pattern_exclude and len(pattern_exclude) > 0:
                 self.pattern_exclude = re.compile(pattern_exclude)
+            else
+                self.pattern_exclude = None
         except ConfigParser.NoOptionError, e:
-            self.pattern_exclude = ''
+            self.pattern_exclude = None
 
     def parse_cli_args(self):
         ''' Command line argument processing '''


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.8 (devel ab6e1a43e9) last updated 2014/08/12 15:38:36 (GMT -400)
##### Environment:

Fedora 20 and CentOS 6.5
##### Summary:

Blank values for include_pattern or exclude_pattern in ec2.ini results in a traceback.
##### Steps To Reproduce:

Create an ec2.ini config with include_pattern or exclude_pattern in the file, but containing empty strings then using the ec2.py inventory will result in the following traceback:

Traceback (most recent call last):
  File "/etc/ansible/hosts", line 711, in <module>
    Ec2Inventory()
  File "/etc/ansible/hosts", line 156, in **init**
    self.do_api_calls_update_cache()
  File "/etc/ansible/hosts", line 302, in do_api_calls_update_cache
    self.get_instances_by_region(region)
  File "/etc/ansible/hosts", line 329, in get_instances_by_region
    self.add_instance(instance, region)
  File "/etc/ansible/hosts", line 395, in add_instance
    if self.pattern_include and not self.pattern_include.match(dest):
AttributeError: 'Ec2Inventory' object has no attribute 'pattern_include'
##### Expected Results:

Should treat empty strings the same as not having those options in the file.
##### Actual Results:

Throws the above traceback.
