### PR TITLE
apt build-dep feature, rebased.

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -84,7 +84,7 @@ options:
     choices: [ "yes", "safe", "full", "dist"]
   build_dep:
     description:
-      - Instead, install the build dependancies for the named pkg (equivalent to 'apt-get build-dep foo')
+      - Instead, install the build dependencies for the named pkg (equivalent to 'apt-get build-dep foo')
     required: false
     default: "no"
     choices: [ "yes", "no" ]

--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -82,6 +82,12 @@ options:
     required: false
     default: "yes"
     choices: [ "yes", "safe", "full", "dist"]
+  build_dep:
+    description:
+      - Instead, install the build dependancies for the named pkg (equivalent to 'apt-get build-dep foo')
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
   dpkg_options:
     description:
       - Add dpkg options to apt command. Defaults to '-o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"'
@@ -133,6 +139,10 @@ EXAMPLES = '''
 
 # Install a .deb package
 - apt: deb=/tmp/mypackage.deb
+
+# Install the build deps for package "foo"
+- apt: pkg=foo build_dep=yes
+
 '''
 
 
@@ -425,6 +435,36 @@ def upgrade(m, mode="yes", force=False, default_release=None,
         m.exit_json(changed=False, msg=out, stdout=out, stderr=err)
     m.exit_json(changed=True, msg=out, stdout=out, stderr=err)
 
+def build_dep(m, pkgspec, cache, force=False,
+        dpkg_options=expand_dpkg_options(DPKG_OPTIONS)):
+    if m.check_mode:
+        check_arg = '--simulate'
+    else:
+        check_arg = ''
+    
+    if force:
+        force_yes = '--force-yes'
+    else:
+        force_yes = ''
+    
+    packages = ""
+    pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
+    for package in pkgspec:
+        name, version = package_split(package)
+        packages += "'%s' " % package
+    
+    if len(packages) == 0:
+        m.exit_json(changed=False)
+    else:
+        apt_cmd_path = m.get_bin_path(APT_GET_CMD, required=True)
+        cmd = '%s %s -y %s %s %s build-dep %s' % (APT_ENVVARS, apt_cmd_path, dpkg_options, force_yes, check_arg, packages)
+        rc, out, err = m.run_command(cmd)
+        if rc:
+            m.fail_json(msg="'%s' failed: %s" % (cmd, err), stdout=out)
+        if APT_GET_ZERO in out:
+            m.exit_json(changed=False, msg=out, stdout=out, stderr=err)
+        m.exit_json(changed=True, msg=out, stdout=out, stderr=err)
+
 def main():
     module = AnsibleModule(
         argument_spec = dict(
@@ -438,10 +478,11 @@ def main():
             install_recommends = dict(default='yes', aliases=['install-recommends'], type='bool'),
             force = dict(default='no', type='bool'),
             upgrade = dict(choices=['yes', 'safe', 'full', 'dist']),
+            build_dep = dict(default='no', type='bool'),
             dpkg_options = dict(default=DPKG_OPTIONS)
         ),
         mutually_exclusive = [['package', 'upgrade', 'deb']],
-        required_one_of = [['package', 'upgrade', 'update_cache', 'deb']],
+        required_one_of = [['package', 'upgrade', 'update_cache', 'build_dep', 'deb']],
         supports_check_mode = True
     )
 
@@ -529,6 +570,9 @@ def main():
                 module.fail_json(msg="invalid package spec: %s" % package)
             if latest and '=' in package:
                 module.fail_json(msg='version number inconsistent with state=latest: %s' % package)
+
+        if p['build_dep']:
+            build_dep(module, packages, cache, force=force_yes, dpkg_options=dpkg_options)
 
         if p['state'] == 'latest':
             result = install(module, packages, cache, upgrade=True,

--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -456,8 +456,10 @@ def build_dep(m, pkgspec, cache, force=False,
     if len(packages) == 0:
         m.exit_json(changed=False)
     else:
+        for (k,v) in APT_ENV_VARS.iteritems():
+            os.environ[k] = v
         apt_cmd_path = m.get_bin_path(APT_GET_CMD, required=True)
-        cmd = '%s %s -y %s %s %s build-dep %s' % (APT_ENVVARS, apt_cmd_path, dpkg_options, force_yes, check_arg, packages)
+        cmd = '%s -y %s %s %s build-dep %s' % (apt_cmd_path, dpkg_options, force_yes, check_arg, packages)
         rc, out, err = m.run_command(cmd)
         if rc:
             m.fail_json(msg="'%s' failed: %s" % (cmd, err), stdout=out)

--- a/test/integration/roles/test_apt/tasks/apt-builddep.yml
+++ b/test/integration/roles/test_apt/tasks/apt-builddep.yml
@@ -1,0 +1,61 @@
+# test installing build-deps using netcat and quilt as test victims.
+#
+# Deps can be discovered like so (taken from ubuntu 12.04)
+# ====
+# root@localhost:~ # apt-rdepends --build-depends --follow=DEPENDS netcat
+# Reading package lists... Done
+# Building dependency tree
+# Reading state information... Done
+# netcat
+#   Build-Depends: debhelper (>= 8.0.0)
+#   Build-Depends: quilt
+# root@localhost:~ #
+# ====
+# Since many things depend on debhelper, let's just uninstall quilt, then
+# install build-dep for netcat to get it back.  build-dep doesn't have an
+# uninstall, so we don't need to test for reverse actions (eg, uninstall
+# build-dep and ensure things are clean)
+
+# uninstall quilt
+- name: check quilt with dpkg
+  shell: dpkg -s quilt
+  register: dpkg_result
+  ignore_errors: true
+
+- name: uninstall quilt with apt
+  apt: pkg=quilt state=absent purge=yes
+  register: apt_result
+  when: dpkg_result|success
+
+# install build-dep for netcat
+- name: install netcat build-dep with apt
+  apt: pkg=netcat build_dep=yes
+  register: apt_result
+
+- name: verify build_dep of netcat
+  assert:
+    that:
+        - "'changed' in apt_result"
+
+# ensure debhelper and qilt are installed
+- name: check build_deps with dpkg
+  shell: dpkg --get-selections | egrep '(debhelper|quilt)'
+  failed_when: False
+  register: dpkg_result
+
+- name: verify build_deps are really there
+  assert:
+    that:
+        - "dpkg_result.rc == 0"
+
+# ensure running build-dep again doesn't yield changes
+- name: install netcat build-dep with apt again
+  apt: pkg=netcat build_dep=yes
+  register: apt_result
+
+- name: verify build_dep of netcat did not change
+  assert:
+    that:
+        - "not apt_result.changed"
+
+

--- a/test/integration/roles/test_apt/tasks/main.yml
+++ b/test/integration/roles/test_apt/tasks/main.yml
@@ -1,4 +1,4 @@
-# test code for the yum module
+# test code for the apt module
 # (c) 2014, James Tanner <tanner.jc@gmail.com>
 
 # This file is part of Ansible
@@ -19,3 +19,5 @@
 - include: 'apt.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
 
+- include: 'apt-builddep.yml'
+  when: ansible_distribution in ('Ubuntu', 'Debian')


### PR DESCRIPTION
Add support for installing apt build dependencies.  This PR replaces PR #5296 and originates from issue #5270
