### PR TITLE
Fix the docs for glance_image.endpoint_type

### DIFF
--- a/library/cloud/glance_image
+++ b/library/cloud/glance_image
@@ -106,10 +106,11 @@ options:
      default: None
    endpoint_type:
      description:
-        - endpoint URL type
+        - The name of the glance service's endpoint URL type
      choices: [publicURL, internalURL]
      required: false
      default: publicURL
+     version_added: "1.7"
 requirements: ["glanceclient", "keystoneclient"]
 
 '''


### PR DESCRIPTION
The endpoint_type option was added in version 1.7,
so the docs need to state this.  Also the the description
is too brief.
