### PR TITLE
Update keystone_user doc for tenant_description

### DIFF
--- a/library/cloud/keystone_user
+++ b/library/cloud/keystone_user
@@ -52,7 +52,7 @@ options:
         - The tenant name that has be added/removed
      required: false
      default: None
-   description:
+   tenant_description:
      description:
         - A description for the tenant
      required: false


### PR DESCRIPTION
The description var should be tenant_description.

Closes-bug: #8299
