### PR TITLE
fix package state detection for opkg

### DIFF
--- a/library/packaging/opkg
+++ b/library/packaging/opkg
@@ -67,7 +67,7 @@ def query_package(module, opkg_path, name, state="present"):
 
     if state == "present":
 
-        rc, out, err = module.run_command("%s list-installed | grep -q ^%s" % (pipes.quote(opkg_path), pipes.quote(name)), use_unsafe_shell=True)
+        rc, out, err = module.run_command("%s list-installed | grep -q \"^%s \"" % (pipes.quote(opkg_path), pipes.quote(name)), use_unsafe_shell=True)
         if rc == 0:
             return True
 


### PR DESCRIPTION
Looking for installed packages needs to be more specific. It has to match the whole package name not only the beginning.

Example: installing the `ip` package.

In the previous version it would run more less following command (I'm skipping -q to show what I mean):

```
#opkg list-installed | grep ^ip
iperf - 2.0.5-1
iptables - 1.4.10-5
iptables-mod-conntrack-extra - 1.4.10-5
iptables-mod-filter - 1.4.10-5
iptables-mod-ipopt - 1.4.10-5
```

This means that it will find something although no `ip` is installed.
