### PR TITLE
add implict --sudo (edit: for /bin/ansible)

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -145,9 +145,10 @@ class Cli(object):
             callbacks.display("No argument passed to %s module" % options.module_name, color='red', stderr=True)
             sys.exit(1)
 
-
         if options.su_user or options.ask_su_pass:
             options.su = True
+        elif options.sudo_user or options.ask_sudo_pass:
+            options.sudo = True
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
         options.su_user = options.su_user or C.DEFAULT_SU_USER
         if options.tree:


### PR DESCRIPTION
add implict --sudo when --ask-sudo-pass or --sudo-user=SUDO_USER is specified
This code was removed between version 1.5.6 and 1.6.0
