### PR TITLE
zypper: consider -%{RELEASE} as part of the version

### DIFF
--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -86,7 +86,7 @@ EXAMPLES = '''
 
 # Function used for getting the name of a currently installed package.
 def get_current_name(m, name):
-    cmd = '/bin/rpm -q --qf \'%{NAME}-%{VERSION}\''
+    cmd = '/bin/rpm -q --qf \'%{NAME}-%{VERSION}-%{RELEASE}\''
     (rc, stdout, stderr) = m.run_command("%s %s" % (cmd, name))
 
     if rc != 0:


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

1.6.6
##### Environment:

SLES 11.3
##### Summary:

packaging/zypper does not recognize "changed = True" when package has the same version, but a different (higher) release number (relevant for state=latest)
##### Steps To Reproduce:

get a package, where the version number on upgrade stays the same, but release number is higher. then run:

``` bash
ansible -m zypper -a 'name=your-package state=latest'
```
##### Expected Results:

package gets upgraded to latest and "Changed" is triggerd
##### Actual Results:

package gets upgraded to latest but no "Changed" is triggerd
