### PR TITLE
Allow ansible-galaxy to install roles from URLs

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -696,10 +696,12 @@ def execute_install(args, options, parser):
 
     roles_done = []
     if role_file:
-        # roles listed in a file, one per line
-        # so we'll go through and grab them all
         f = open(role_file, 'r')
-        roles_left = f.readlines()
+        if role_file.endswith('.yaml') or role_file.endswith('.yml'):
+            roles_left = map(ansible.utils.role_yaml_parse, yaml.safe_load(f))
+        else:
+            # roles listed in a file, one per line
+            roles_left = map(ansible.utils.role_spec_parse, f.readlines())
         f.close()
     else:
         # roles were specified directly, so we'll just go out grab them
@@ -708,16 +710,18 @@ def execute_install(args, options, parser):
 
     while len(roles_left) > 0:
         # query the galaxy API for the role data
-        (scm, role_src, role_version, role_name) = ansible.utils.role_spec_parse(roles_left.pop(0))
         role_data = None
+        role = roles_left.pop(0)
+        role_src = role.get("src")
+        role_scm = role.get("scm")
 
         if os.path.isfile(role_src):
             # installing a local tar.gz
             tmp_file = role_src
         else:
-            if scm:
+            if role_scm:
                 # create tar file from scm url
-                tmp_file = scm_archive_role(scm, role_src, role_version, role_name)
+                tmp_file = scm_archive_role(role_scm, role_src, role.get("version"), role.get("name"))
             elif '://' in role_src:
                 # just download a URL - version will probably be in the URL
                 tmp_file = fetch_role(role_src, None, None, options)
@@ -729,7 +733,7 @@ def execute_install(args, options, parser):
                     continue
 
                 role_versions = api_fetch_role_related(api_server, 'versions', role_data['id'])
-                if not role_version: 
+                if "version" not in role:
                     # convert the version names to LooseVersion objects
                     # and sort them to get the latest version. If there
                     # are no versions in the list, we'll grab the head 
@@ -737,40 +741,43 @@ def execute_install(args, options, parser):
                     if len(role_versions) > 0:
                         loose_versions = [LooseVersion(a.get('name',None)) for a in role_versions]
                         loose_versions.sort()
-                        role_version = str(loose_versions[-1])
+                        role["version"] = str(loose_versions[-1])
                     else:
-                        role_version = 'master'
-                    print " no version specified, installing %s" % role_version
+                        role["version"] = 'master'
+                    print " no version specified, installing %s" % role.version
                 else:
-                    if role_versions and role_version not in [a.get('name',None) for a in role_versions]:
-                        print "The specified version (%s) was not found in the list of available versions." % role_version
+                    if role_versions and role["version"] not in [a.get('name',None) for a in role_versions]:
+                        print "The specified version (%s) was not found in the list of available versions." % role.version
                         exit_without_ignore(options)
                         continue
 
                 # download the role. if --no-deps was specified, we stop here, 
                 # otherwise we recursively grab roles and all of their deps.
-                tmp_file = fetch_role(role_src, role_version, role_data, options)
-        if tmp_file and install_role(role_name, role_version, tmp_file, options):
+                tmp_file = fetch_role(role_src, role["version"], role_data, options)
+        if tmp_file and install_role(role.get("name"), role.get("version"), tmp_file, options):
             # we're done with the temp file, clean it up
             os.unlink(tmp_file)
             # install dependencies, if we want them
             if not no_deps:
                 if not role_data:
-                    role_data = get_role_metadata(role_name, options)
+                    role_data = get_role_metadata(role.get("name"), options)
                     role_dependencies = role_data['dependencies']
                 else:
                     role_dependencies = role_data['summary_fields']['dependencies'] # api_fetch_role_related(api_server, 'dependencies', role_data['id'])
-                for dep_name in role_dependencies:
-                    #dep_name = "%s.%s" % (dep['owner'], dep['name'])
-                    if not get_role_metadata(dep_name.split('/')[-1], options):
-                        print ' adding dependency: %s' % dep_name
-                        roles_left.append(dep_name)
+                for dep in role_dependencies:
+                    if isinstance(dep, str):
+                        dep = ansible.utils.role_spec_parse(dep)
                     else:
-                        print ' dependency %s is already installed, skipping.' % dep_name
+                        dep = ansible.utils.role_yaml_parse(dep)
+                    if not get_role_metadata(dep["name"], options):
+                        print ' adding dependency: %s' % dep["name"]
+                        roles_left.append(dep)
+                    else:
+                        print ' dependency %s is already installed, skipping.' % dep["name"]
         else:
             if tmp_file:
                 os.unlink(tmp_file)
-            print "%s was NOT installed successfully." % role_name
+            print "%s was NOT installed successfully." % role.get("name")
             exit_without_ignore(options)
     sys.exit(0)
 

--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -174,6 +174,9 @@ def build_option_parser(action):
             '-p', '--init-path', dest='init_path', default="./",
             help='The path in which the skeleton role will be created. '
                  'The default is the current working directory.')
+        parser.add_option(
+            '--offline', dest='offline', default=False, action='store_true',
+            help="Don't query the galaxy API when creating roles")
     elif action == "install":
         parser.set_usage("usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]")
         parser.add_option(
@@ -573,11 +576,13 @@ def execute_init(args, options, parser):
     init_path  = get_opt(options, 'init_path', './')
     api_server = get_opt(options, "api_server", "galaxy.ansible.com")
     force      = get_opt(options, 'force', False)
+    offline    = get_opt(options, 'offline', False)
 
-    api_config = api_get_config(api_server)
-    if not api_config:
-        print "The API server (%s) is not responding, please try again later." % api_server
-        sys.exit(1)
+    if not offline:
+        api_config = api_get_config(api_server)
+        if not api_config:
+            print "The API server (%s) is not responding, please try again later." % api_server
+            sys.exit(1)
 
     try:
         role_name = args.pop(0).strip()
@@ -623,12 +628,12 @@ def execute_init(args, options, parser):
             # datastructure in place, plus with all of the available 
             # tags/platforms included (but commented out) and the 
             # dependencies section
-            platforms = api_get_list(api_server, "platforms")
-            if not platforms:
-                platforms = []
-            categories = api_get_list(api_server, "categories")
-            if not categories:
-                categories = []
+            platforms = []
+            if not offline:
+                platforms = api_get_list(api_server, "platforms") or []
+            categories = []
+            if not offline:
+                categories = api_get_list(api_server, "categories") or []
             
             # group the list of platforms from the api based
             # on their names, with the release field being 
@@ -692,11 +697,6 @@ def execute_install(args, options, parser):
         print "Please specify a user/role name, or a roles file, but not both"
         sys.exit(1)
 
-    api_config = api_get_config(api_server)
-    if not api_config:
-        print "The API server (%s) is not responding, please try again later." % api_server
-        sys.exit(1)
-
     roles_done = []
     if role_file:
         f = open(role_file, 'r')
@@ -709,7 +709,7 @@ def execute_install(args, options, parser):
     else:
         # roles were specified directly, so we'll just go out grab them
         # (and their dependencies, unless the user doesn't want us to).
-        roles_left = args
+        roles_left = map(ansible.utils.role_spec_parse, args)
 
     while len(roles_left) > 0:
         # query the galaxy API for the role data
@@ -730,6 +730,11 @@ def execute_install(args, options, parser):
                 tmp_file = fetch_role(role_src, None, None, options)
             else:
                 # installing from galaxy
+                api_config = api_get_config(api_server)
+                if not api_config:
+                    print "The API server (%s) is not responding, please try again later." % api_server
+                    sys.exit(1)
+
                 role_data = api_lookup_role_by_name(api_server, role_src)
                 if not role_data:
                     print "Sorry, %s was not found on %s." % (role_src, api_server)

--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -332,13 +332,12 @@ def api_get_list(api_server, what):
 # scm repo utility functions
 #-------------------------------------------------------------------------------------
 
-def scm_archive_role(scm, role_url, role_version):
+def scm_archive_role(scm, role_url, role_version, role_name):
     if scm not in ['hg', 'git']:
         print "SCM %s is not currently supported" % scm
         return False
     tempdir = tempfile.mkdtemp()
-    role_name = ansible.utils.repo_url_to_role_name(role_url)
-    clone_cmd = [scm, 'clone', role_url]
+    clone_cmd = [scm, 'clone', role_url, role_name]
     with open('/dev/null', 'w') as devnull:
         popen = subprocess.Popen(clone_cmd, cwd=tempdir, stdout=devnull, stderr=devnull)
         rc = popen.wait()
@@ -464,7 +463,10 @@ def fetch_role(role_name, target, role_data, options):
     """
 
     # first grab the file and save it to a temp location
-    archive_url = 'https://github.com/%s/%s/archive/%s.tar.gz' % (role_data["github_user"], role_data["github_repo"], target)
+    if '://' in role_name:
+        archive_url = role_name
+    else: 
+        archive_url = 'https://github.com/%s/%s/archive/%s.tar.gz' % (role_data["github_user"], role_data["github_repo"], target)
     print " - downloading role from %s" % archive_url
 
     try:
@@ -706,39 +708,24 @@ def execute_install(args, options, parser):
 
     while len(roles_left) > 0:
         # query the galaxy API for the role data
-        role_name = roles_left.pop(0).strip()
-        role_version = None
+        (scm, role_src, role_version, role_name) = ansible.utils.role_spec_parse(roles_left.pop(0))
+        role_data = None
 
-        if role_name == "" or role_name.startswith("#"):
-            continue
-        elif ',' in role_name:
-            role_name,role_version = role_name.split(',',1)
-            role_name = role_name.strip()
-            role_version = role_version.strip()
-
-        if os.path.isfile(role_name):
+        if os.path.isfile(role_src):
             # installing a local tar.gz
-            tar_file = role_name
-            role_name = os.path.basename(role_name).replace('.tar.gz','')
-            if tarfile.is_tarfile(tar_file):
-                print " - installing %s as %s" % (tar_file, role_name)
-                if not install_role(role_name, role_version, tar_file, options):
-                    exit_without_ignore(options)
-            else:
-                print "%s (%s) was NOT installed successfully." % (role_name,tar_file)
-                exit_without_ignore(options)
+            tmp_file = role_src
         else:
-            if '+' in role_name:
-                (scm, role_url) = role_name.split('+',1)
-                role_name = ansible.utils.repo_url_to_role_name(role_name)
+            if scm:
                 # create tar file from scm url
-                tmp_file = scm_archive_role(scm, role_url, role_version)
-                role_data = None
+                tmp_file = scm_archive_role(scm, role_src, role_version, role_name)
+            elif '://' in role_src:
+                # just download a URL - version will probably be in the URL
+                tmp_file = fetch_role(role_src, None, None, options)
             else:
-                # installing remotely
-                role_data = api_lookup_role_by_name(api_server, role_name)
+                # installing from galaxy
+                role_data = api_lookup_role_by_name(api_server, role_src)
                 if not role_data:
-                    print "Sorry, %s was not found on %s." % (role_name, api_server)
+                    print "Sorry, %s was not found on %s." % (role_src, api_server)
                     continue
 
                 role_versions = api_fetch_role_related(api_server, 'versions', role_data['id'])
@@ -762,29 +749,29 @@ def execute_install(args, options, parser):
 
                 # download the role. if --no-deps was specified, we stop here, 
                 # otherwise we recursively grab roles and all of their deps.
-                tmp_file = fetch_role(role_name, role_version, role_data, options)
-            if tmp_file and install_role(role_name, role_version, tmp_file, options):
-                # we're done with the temp file, clean it up
-                os.unlink(tmp_file)
-                # install dependencies, if we want them
-                if not no_deps:
-                    if not role_data:
-                        role_data = get_role_metadata(role_name, options)
-                        role_dependencies = role_data['dependencies']
+                tmp_file = fetch_role(role_src, role_version, role_data, options)
+        if tmp_file and install_role(role_name, role_version, tmp_file, options):
+            # we're done with the temp file, clean it up
+            os.unlink(tmp_file)
+            # install dependencies, if we want them
+            if not no_deps:
+                if not role_data:
+                    role_data = get_role_metadata(role_name, options)
+                    role_dependencies = role_data['dependencies']
+                else:
+                    role_dependencies = role_data['summary_fields']['dependencies'] # api_fetch_role_related(api_server, 'dependencies', role_data['id'])
+                for dep_name in role_dependencies:
+                    #dep_name = "%s.%s" % (dep['owner'], dep['name'])
+                    if not get_role_metadata(dep_name.split('/')[-1], options):
+                        print ' adding dependency: %s' % dep_name
+                        roles_left.append(dep_name)
                     else:
-                        role_dependencies = role_data['summary_fields']['dependencies'] # api_fetch_role_related(api_server, 'dependencies', role_data['id'])
-                    for dep_name in role_dependencies:
-                        #dep_name = "%s.%s" % (dep['owner'], dep['name'])
-                        if not get_role_metadata(dep_name.split('/')[-1], options):
-                            print ' adding dependency: %s' % dep_name
-                            roles_left.append(dep_name)
-                        else:
-                            print ' dependency %s is already installed, skipping.' % dep_name
-            else:
-                if tmp_file:
-                    os.unlink(tmp_file)
-                print "%s was NOT installed successfully." % role_name
-                exit_without_ignore(options)
+                        print ' dependency %s is already installed, skipping.' % dep_name
+        else:
+            if tmp_file:
+                os.unlink(tmp_file)
+            print "%s was NOT installed successfully." % role_name
+            exit_without_ignore(options)
     sys.exit(0)
 
 def execute_remove(args, options, parser):

--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -343,10 +343,10 @@ def scm_archive_role(scm, role_url, role_version, role_name):
         rc = popen.wait()
     if rc != 0:
         print "Command %s failed" % ' '.join(clone_cmd)
-        print "in directory %s" % temp_dir
+        print "in directory %s" % tempdir
         return False
 
-    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.tar.gz')
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.tar')
     if scm == 'hg':
         archive_cmd = ['hg', 'archive', '--prefix', "%s/" % role_name]
         if role_version:
@@ -491,7 +491,10 @@ def install_role(role_name, role_version, role_filename, options):
         print "Error: the file downloaded was not a tar.gz"
         return False
     else:
-        role_tar_file = tarfile.open(role_filename, "r:gz")
+        if role_filename.endswith('.gz'):
+            role_tar_file = tarfile.open(role_filename, "r:gz")
+        else:
+            role_tar_file = tarfile.open(role_filename, "r")
         # verify the role's meta file
         meta_file = None
         members = role_tar_file.getmembers()

--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -40,6 +40,7 @@ from jinja2 import Environment
 from optparse import OptionParser
 
 import ansible.constants as C
+import ansible.utils
 
 default_meta_template = """---
 galaxy_info:
@@ -174,7 +175,7 @@ def build_option_parser(action):
             help='The path in which the skeleton role will be created. '
                  'The default is the current working directory.')
     elif action == "install":
-        parser.set_usage("usage: %prog install [options] [-r FILE | role_name(s)[,version] | tar_file(s)]")
+        parser.set_usage("usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]")
         parser.add_option(
             '-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
             help='Ignore errors and continue with the next specified role.')
@@ -336,7 +337,7 @@ def scm_archive_role(scm, role_url, role_version):
         print "SCM %s is not currently supported" % scm
         return False
     tempdir = tempfile.mkdtemp()
-    role_name = role_url.split('/')[-1]
+    role_name = ansible.utils.repo_url_to_role_name(role_url)
     clone_cmd = [scm, 'clone', role_url]
     with open('/dev/null', 'w') as devnull:
         popen = subprocess.Popen(clone_cmd, cwd=tempdir, stdout=devnull, stderr=devnull)
@@ -728,8 +729,8 @@ def execute_install(args, options, parser):
                 exit_without_ignore(options)
         else:
             if '+' in role_name:
-                (scm, role_url) = role_name.split('+')
-                role_name = role_name.split('/')[-1]
+                (scm, role_url) = role_name.split('+',1)
+                role_name = ansible.utils.repo_url_to_role_name(role_name)
                 # create tar file from scm url
                 tmp_file = scm_archive_role(scm, role_url, role_version)
                 role_data = None

--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -331,21 +331,10 @@ def api_get_list(api_server, what):
 # scm repo utility functions
 #-------------------------------------------------------------------------------------
 
-def repo_fetch_role(role_name, role_version):
-    check_repo_cmd = { 'git': ['git', 'ls-remote', role_name],
-                       'hg': ['hg', 'identify', role_name]}
-    with open('/dev/null', 'w') as devnull:
-        for (scm, cmd) in check_repo_cmd.items():
-            popen = subprocess.Popen(cmd, stdout=devnull, stderr=devnull)
-            rc = popen.wait()
-            if rc == 0:
-                return scm_archive_role(scm, role_name, role_version)
-
-    print "Repo doesn't seem to be hg or git"
-    sys.exit(2)
-
-
 def scm_archive_role(scm, role_url, role_version):
+    if scm not in ['hg', 'git']:
+        print "SCM %s is not currently supported" % scm
+        return False
     tempdir = tempfile.mkdtemp()
     role_name = role_url.split('/')[-1]
     clone_cmd = [scm, 'clone', role_url]
@@ -355,7 +344,7 @@ def scm_archive_role(scm, role_url, role_version):
     if rc != 0:
         print "Command %s failed" % ' '.join(clone_cmd)
         print "in directory %s" % temp_dir
-        sys.exit(1)
+        return False
 
     temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.tar.gz')
     if scm == 'hg':
@@ -377,7 +366,7 @@ def scm_archive_role(scm, role_url, role_version):
     if rc != 0:
         print "Command %s failed" % ' '.join(archive_cmd)
         print "in directory %s" % tempdir
-        sys.exit(1)
+        return False
 
     shutil.rmtree(tempdir)
 
@@ -738,10 +727,11 @@ def execute_install(args, options, parser):
                 print "%s (%s) was NOT installed successfully." % (role_name,tar_file)
                 exit_without_ignore(options)
         else:
-            if '://' in role_name:
-                # installing from scm url
-                tmp_file = repo_fetch_role(role_name, role_version)
+            if '+' in role_name:
+                (scm, role_url) = role_name.split('+')
                 role_name = role_name.split('/')[-1]
+                # create tar file from scm url
+                tmp_file = scm_archive_role(scm, role_url, role_version)
                 role_data = None
             else:
                 # installing remotely
@@ -784,7 +774,7 @@ def execute_install(args, options, parser):
                         role_dependencies = role_data['summary_fields']['dependencies'] # api_fetch_role_related(api_server, 'dependencies', role_data['id'])
                     for dep_name in role_dependencies:
                         #dep_name = "%s.%s" % (dep['owner'], dep['name'])
-                        if not get_role_metadata(dep_name, options):
+                        if not get_role_metadata(dep_name.split('/')[-1], options):
                             print ' adding dependency: %s' % dep_name
                             roles_left.append(dep_name)
                         else:

--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -26,6 +26,7 @@ import json
 import os
 import os.path
 import shutil
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -325,6 +326,63 @@ def api_get_list(api_server, what):
     except:
         print " - failed to download the %s list" % what
         return None
+
+#-------------------------------------------------------------------------------------
+# scm repo utility functions
+#-------------------------------------------------------------------------------------
+
+def repo_fetch_role(role_name, role_version):
+    check_repo_cmd = { 'git': ['git', 'ls-remote', role_name],
+                       'hg': ['hg', 'identify', role_name]}
+    with open('/dev/null', 'w') as devnull:
+        for (scm, cmd) in check_repo_cmd.items():
+            popen = subprocess.Popen(cmd, stdout=devnull, stderr=devnull)
+            rc = popen.wait()
+            if rc == 0:
+                return scm_archive_role(scm, role_name, role_version)
+
+    print "Repo doesn't seem to be hg or git"
+    sys.exit(2)
+
+
+def scm_archive_role(scm, role_url, role_version):
+    tempdir = tempfile.mkdtemp()
+    role_name = role_url.split('/')[-1]
+    clone_cmd = [scm, 'clone', role_url]
+    with open('/dev/null', 'w') as devnull:
+        popen = subprocess.Popen(clone_cmd, cwd=tempdir, stdout=devnull, stderr=devnull)
+        rc = popen.wait()
+    if rc != 0:
+        print "Command %s failed" % ' '.join(clone_cmd)
+        print "in directory %s" % temp_dir
+        sys.exit(1)
+
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.tar.gz')
+    if scm == 'hg':
+        archive_cmd = ['hg', 'archive', '--prefix', "%s/" % role_name]
+        if role_version:
+            archive_cmd.extend(['-r', role_version])
+        archive_cmd.append(temp_file.name)
+    if scm == 'git':
+        archive_cmd = ['git', 'archive', '--prefix=%s/' % role_name, '--output=%s' % temp_file.name]
+        if role_version:
+            archive_cmd.append(role_version)
+        else:
+            archive_cmd.append('HEAD')
+
+    with open('/dev/null', 'w') as devnull:
+        popen = subprocess.Popen(archive_cmd, cwd=os.path.join(tempdir, role_name),
+                                 stderr=devnull, stdout=devnull)
+        rc = popen.wait()
+    if rc != 0:
+        print "Command %s failed" % ' '.join(archive_cmd)
+        print "in directory %s" % tempdir
+        sys.exit(1)
+
+    shutil.rmtree(tempdir)
+
+    return temp_file.name
+
 
 #-------------------------------------------------------------------------------------
 # Role utility functions
@@ -680,40 +738,50 @@ def execute_install(args, options, parser):
                 print "%s (%s) was NOT installed successfully." % (role_name,tar_file)
                 exit_without_ignore(options)
         else:
-            # installing remotely
-            role_data = api_lookup_role_by_name(api_server, role_name)
-            if not role_data:
-                print "Sorry, %s was not found on %s." % (role_name, api_server)
-                continue
-
-            role_versions = api_fetch_role_related(api_server, 'versions', role_data['id'])
-            if not role_version: 
-                # convert the version names to LooseVersion objects
-                # and sort them to get the latest version. If there
-                # are no versions in the list, we'll grab the head 
-                # of the master branch
-                if len(role_versions) > 0:
-                    loose_versions = [LooseVersion(a.get('name',None)) for a in role_versions]
-                    loose_versions.sort()
-                    role_version = str(loose_versions[-1])
-                else:
-                    role_version = 'master'
-                print " no version specified, installing %s" % role_version
+            if '://' in role_name:
+                # installing from scm url
+                tmp_file = repo_fetch_role(role_name, role_version)
+                role_name = role_name.split('/')[-1]
+                role_data = None
             else:
-                if role_versions and role_version not in [a.get('name',None) for a in role_versions]:
-                    print "The specified version (%s) was not found in the list of available versions." % role_version
-                    exit_without_ignore(options)
+                # installing remotely
+                role_data = api_lookup_role_by_name(api_server, role_name)
+                if not role_data:
+                    print "Sorry, %s was not found on %s." % (role_name, api_server)
                     continue
 
-            # download the role. if --no-deps was specified, we stop here, 
-            # otherwise we recursively grab roles and all of their deps.
-            tmp_file = fetch_role(role_name, role_version, role_data, options)
+                role_versions = api_fetch_role_related(api_server, 'versions', role_data['id'])
+                if not role_version: 
+                    # convert the version names to LooseVersion objects
+                    # and sort them to get the latest version. If there
+                    # are no versions in the list, we'll grab the head 
+                    # of the master branch
+                    if len(role_versions) > 0:
+                        loose_versions = [LooseVersion(a.get('name',None)) for a in role_versions]
+                        loose_versions.sort()
+                        role_version = str(loose_versions[-1])
+                    else:
+                        role_version = 'master'
+                    print " no version specified, installing %s" % role_version
+                else:
+                    if role_versions and role_version not in [a.get('name',None) for a in role_versions]:
+                        print "The specified version (%s) was not found in the list of available versions." % role_version
+                        exit_without_ignore(options)
+                        continue
+
+                # download the role. if --no-deps was specified, we stop here, 
+                # otherwise we recursively grab roles and all of their deps.
+                tmp_file = fetch_role(role_name, role_version, role_data, options)
             if tmp_file and install_role(role_name, role_version, tmp_file, options):
                 # we're done with the temp file, clean it up
                 os.unlink(tmp_file)
                 # install dependencies, if we want them
                 if not no_deps:
-                    role_dependencies = role_data['summary_fields']['dependencies'] # api_fetch_role_related(api_server, 'dependencies', role_data['id'])
+                    if not role_data:
+                        role_data = get_role_metadata(role_name, options)
+                        role_dependencies = role_data['dependencies']
+                    else:
+                        role_dependencies = role_data['summary_fields']['dependencies'] # api_fetch_role_related(api_server, 'dependencies', role_data['id'])
                     for dep_name in role_dependencies:
                         #dep_name = "%s.%s" % (dep['owner'], dep['name'])
                         if not get_role_metadata(dep_name, options):

--- a/docsite/rst/playbooks_roles.rst
+++ b/docsite/rst/playbooks_roles.rst
@@ -299,6 +299,13 @@ Role dependencies can also be specified as a full path, just like top level role
     dependencies:
        - { role: '/path/to/common/roles/foo', x: 1 }
 
+Role dependencies can also be installed from source control repos or tar files, using a comma separated format of path, an optional version (tag, commit, branch etc) and optional friendly role name (an attempt is made to derive a role name from the repo name or archive filename)::
+
+    ---
+    dependencies:
+      - { role: 'git+http://git.example.com/repos/role-foo,v1.1,foo' }
+      - { role: '/path/to/tar/file.tgz,,friendly-name' }
+
 Roles dependencies are always executed before the role that includes them, and are recursive. By default, 
 roles can also only be added as a dependency once - if another role also lists it as a dependency it will
 not be run again. This behavior can be overridden by adding `allow_duplicates: yes` to the `meta/main.yml` file.

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -179,7 +179,7 @@ class Play(object):
         if '+' in orig_path and '://' in orig_path:
             # dependency name pointing to SCM URL
             # assume role name is last part of the URL
-            orig_path = orig_path.split('/')[-1]
+            orig_path = utils.repo_url_to_role_name(orig_path)
 
         role_vars = {}
         if type(orig_path) == dict:
@@ -413,7 +413,7 @@ class Play(object):
             else:
                 role_name = role
             if '+' in role_name and '://' in role_name:
-                role_name = role_name.split('/')[-1]
+                role_name = utils.repo_url_to_role_name(role_name)
 
             role_names.append(role_name)
             if os.path.isfile(task):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -185,7 +185,7 @@ class Play(object):
                 raise errors.AnsibleError("expected a role name in dictionary: %s" % orig_path)
             role_vars = orig_path
         else:
-            (scm, role_src, role_version, role_name) = utils.role_spec_parse(orig_path)
+            role_name = utils.role_spec_parse(orig_path)["name"]
 
         role_path = None
 
@@ -408,8 +408,7 @@ class Play(object):
             if isinstance(role, dict):
                 role_name = role['role']
             else:
-                role_name = role
-            (scm, role_src, role_version, role_name) = utils.role_spec_parse(role_name)
+                role_name = utils.role_spec_parse(role)["name"]
 
             role_names.append(role_name)
             if os.path.isfile(task):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -180,6 +180,9 @@ class Play(object):
             # dependency name pointing to SCM URL
             # assume role name is last part of the URL
             orig_path = utils.repo_url_to_role_name(orig_path)
+        if ',' in orig_path:
+            # version information for role dependency used by galaxy
+            orig_path = orig_path.split(',')[0]
 
         role_vars = {}
         if type(orig_path) == dict:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -176,6 +176,10 @@ class Play(object):
         returns any variables that were included with the role
         """
         orig_path = template(self.basedir,role,self.vars)
+        if '+' in orig_path and '://' in orig_path:
+            # dependency name pointing to SCM URL
+            # assume role name is last part of the URL
+            orig_path = orig_path.split('/')[-1]
 
         role_vars = {}
         if type(orig_path) == dict:
@@ -408,6 +412,8 @@ class Play(object):
                 role_name = role['role']
             else:
                 role_name = role
+            if '+' in role_name and '://' in role_name:
+                role_name = role_name.split('/')[-1]
 
             role_names.append(role_name)
             if os.path.isfile(task):

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -351,9 +351,32 @@ def repo_url_to_role_name(repo_url):
     trailing_path = repo_url.split('/')[-1]
     if trailing_path.endswith('.git'):
         trailing_path = trailing_path[:-4]
+    if trailing_path.endswith('.tar.gz'):
+        trailing_path = trailing_path[:-7]
     if ',' in trailing_path:
         trailing_path = trailing_path.split(',')[0]
     return trailing_path
+
+
+def role_spec_parse(role_spec):
+    role_spec = role_spec.strip()
+    role_version = ''
+    if role_spec == "" or role_spec.startswith("#"):
+        return (None, None, None, None)
+    tokens = map(lambda s: s.strip(), role_spec.split(','))
+    if '+' in tokens[0]:
+        (scm, role_url) = tokens[0].split('+')
+    else:
+        scm = None
+        role_url = tokens[0]
+    if len(tokens) >= 2:
+        role_version = tokens[1]
+    if len(tokens) == 3:
+        role_name = tokens[2]
+    else:
+        role_name = repo_url_to_role_name(tokens[0])
+    return (scm, role_url, role_version, role_name)
+
 
 def json_loads(data):
     ''' parse a JSON string and return a data structure '''

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -375,7 +375,17 @@ def role_spec_parse(role_spec):
         role_name = tokens[2]
     else:
         role_name = repo_url_to_role_name(tokens[0])
-    return (scm, role_url, role_version, role_name)
+    return dict(scm=scm, src=role_url, version=role_version, name=role_name)
+
+
+def role_yaml_parse(role):
+    if '+' in role["src"]:
+        (scm, src) = role["src"].split('+')
+        role["scm"] = scm
+        role["src"] = src
+    if 'name' not in role:
+        role["name"] = repo_url_to_role_name(role["src"])
+    return role
 
 
 def json_loads(data):

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -348,6 +348,8 @@ def path_dwim_relative(original, dirname, source, playbook_base, check=True):
     return source2 # which does not exist
 
 def repo_url_to_role_name(repo_url):
+    if '://' not in repo_url:
+        return repo_url
     trailing_path = repo_url.split('/')[-1]
     if trailing_path.endswith('.git'):
         trailing_path = trailing_path[:-4]

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -351,6 +351,8 @@ def repo_url_to_role_name(repo_url):
     trailing_path = repo_url.split('/')[-1]
     if trailing_path.endswith('.git'):
         trailing_path = trailing_path[:-4]
+    if ',' in trailing_path:
+        trailing_path = trailing_path.split(',')[0]
     return trailing_path
 
 def json_loads(data):

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -347,6 +347,12 @@ def path_dwim_relative(original, dirname, source, playbook_base, check=True):
         raise errors.AnsibleError("input file not found at %s or %s" % (source2, obvious_local_path))
     return source2 # which does not exist
 
+def repo_url_to_role_name(repo_url):
+    trailing_path = repo_url.split('/')[-1]
+    if trailing_path.endswith('.git'):
+        trailing_path = trailing_path[:-4]
+    return trailing_path
+
 def json_loads(data):
     ''' parse a JSON string and return a data structure '''
 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -14,9 +14,12 @@ else
 CREDENTIALS_ARG =
 endif
 
+# http://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x
+TMPDIR = $(shell mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+
 VAULT_PASSWORD_FILE = vault-password
 
-all: non_destructive destructive includes unicode test_var_precedence check_mode test_hash test_handlers test_group_by test_vault parsing
+all: non_destructive destructive includes unicode test_var_precedence check_mode test_hash test_handlers test_group_by test_vault parsing test_galaxy
 
 parsing:
 	ansible-playbook bad_parsing.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -vvv $(TEST_FLAGS) --tags common,scenario1; [ $$? -eq 3 ]
@@ -101,3 +104,12 @@ rackspace: $(CREDENTIALS_FILE)
     RC=$$? ; \
     CLOUD_RESOURCE_PREFIX="$(CLOUD_RESOURCE_PREFIX)" make rackspace_cleanup ; \
     exit $$RC;
+
+test_galaxy:
+	mytmpdir=$(TMPDIR) ; \
+	ansible-galaxy install -r galaxy_rolesfile -p $$mytmpdir/roles ; \
+    cp galaxy_playbook.yml $$mytmpdir ; \
+    ansible-playbook -i $(INVENTORY) $$mytmpdir/galaxy_playbook.yml -v $(TEST_FLAGS) ; \
+    RC=$$? ; \
+    rm -rf $$mytmpdir ; \
+    exit $$RC 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -105,11 +105,22 @@ rackspace: $(CREDENTIALS_FILE)
     CLOUD_RESOURCE_PREFIX="$(CLOUD_RESOURCE_PREFIX)" make rackspace_cleanup ; \
     exit $$RC;
 
-test_galaxy:
+test_galaxy: test_galaxy_spec test_galaxy_yaml
+
+test_galaxy_spec:
 	mytmpdir=$(TMPDIR) ; \
 	ansible-galaxy install -r galaxy_rolesfile -p $$mytmpdir/roles ; \
     cp galaxy_playbook.yml $$mytmpdir ; \
     ansible-playbook -i $(INVENTORY) $$mytmpdir/galaxy_playbook.yml -v $(TEST_FLAGS) ; \
     RC=$$? ; \
     rm -rf $$mytmpdir ; \
-    exit $$RC 
+    exit $$RC
+
+test_galaxy_yaml:
+	mytmpdir=$(TMPDIR) ; \
+	ansible-galaxy install -r galaxy_roles.yml -p $$mytmpdir/roles ; \
+    cp galaxy_playbook.yml $$mytmpdir ; \
+    ansible-playbook -i $(INVENTORY) $$mytmpdir/galaxy_playbook.yml -v $(TEST_FLAGS) ; \
+    RC=$$? ; \
+    rm -rf $$mytmpdir ; \
+    exit $$RC

--- a/test/integration/galaxy_playbook.yml
+++ b/test/integration/galaxy_playbook.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  connection: local
+
+  roles:
+  - "git-ansible-galaxy"

--- a/test/integration/galaxy_playbook.yml
+++ b/test/integration/galaxy_playbook.yml
@@ -4,3 +4,4 @@
   roles:
   - "git-ansible-galaxy"
   - "http-role"
+  - "hg-ansible-galaxy"

--- a/test/integration/galaxy_playbook.yml
+++ b/test/integration/galaxy_playbook.yml
@@ -3,3 +3,4 @@
 
   roles:
   - "git-ansible-galaxy"
+  - "http-role"

--- a/test/integration/galaxy_roles.yml
+++ b/test/integration/galaxy_roles.yml
@@ -1,0 +1,8 @@
+- src: git+http://bitbucket.org/willthames/git-ansible-galaxy
+  version: v1.4
+
+- src: ssh://hg@bitbucket.org/willthames/hg-ansible-galaxy
+  scm: hg
+
+- src: https://bitbucket.org/willthames/http-ansible-galaxy/get/master.tar.gz
+  name: http-role

--- a/test/integration/galaxy_roles.yml
+++ b/test/integration/galaxy_roles.yml
@@ -1,7 +1,7 @@
 - src: git+http://bitbucket.org/willthames/git-ansible-galaxy
   version: v1.4
 
-- src: ssh://hg@bitbucket.org/willthames/hg-ansible-galaxy
+- src: http://bitbucket.org/willthames/hg-ansible-galaxy
   scm: hg
 
 - src: https://bitbucket.org/willthames/http-ansible-galaxy/get/master.tar.gz

--- a/test/integration/galaxy_rolesfile
+++ b/test/integration/galaxy_rolesfile
@@ -1,2 +1,3 @@
-git+http://bitbucket.org/willthames/git-ansible-galaxy,v1.3
+git+http://bitbucket.org/willthames/git-ansible-galaxy,v1.4
 hg+ssh://hg@bitbucket.org/willthames/hg-ansible-galaxy
+https://bitbucket.org/willthames/http-ansible-galaxy/get/master.tar.gz,,http-role

--- a/test/integration/galaxy_rolesfile
+++ b/test/integration/galaxy_rolesfile
@@ -1,2 +1,2 @@
-git+http://bitbucket.org/willthames/git-ansible-galaxy,v1.2
+git+http://bitbucket.org/willthames/git-ansible-galaxy,v1.3
 hg+ssh://hg@bitbucket.org/willthames/hg-ansible-galaxy

--- a/test/integration/galaxy_rolesfile
+++ b/test/integration/galaxy_rolesfile
@@ -1,3 +1,3 @@
 git+http://bitbucket.org/willthames/git-ansible-galaxy,v1.4
-hg+ssh://hg@bitbucket.org/willthames/hg-ansible-galaxy
+hg+http://bitbucket.org/willthames/hg-ansible-galaxy
 https://bitbucket.org/willthames/http-ansible-galaxy/get/master.tar.gz,,http-role

--- a/test/integration/galaxy_rolesfile
+++ b/test/integration/galaxy_rolesfile
@@ -1,0 +1,2 @@
+git+http://bitbucket.org/willthames/git-ansible-galaxy,v1.2
+hg+ssh://hg@bitbucket.org/willthames/hg-ansible-galaxy

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -784,3 +784,12 @@ class TestUtils(unittest.TestCase):
                  ("ssh://git@git.example.com:repos/role-name,v0.1", "role-name")]
         for (url, result) in tests:
             self.assertEqual(ansible.utils.repo_url_to_role_name(url), result)
+
+    def test_role_spec_parse(self):
+        tests = [("git+http://git.example.com/repos/repo.git,v1.0", ('git', 'http://git.example.com/repos/repo.git', 'v1.0', 'repo')),
+                 ("http://repo.example.com/download/tarfile.tar.gz", (None, 'http://repo.example.com/download/tarfile.tar.gz', '', 'tarfile')),
+                 ("http://repo.example.com/download/tarfile.tar.gz,,nicename", (None, 'http://repo.example.com/download/tarfile.tar.gz', '', 'nicename')),
+                 ("git+http://git.example.com/repos/repo.git,v1.0,awesome", ('git', 'http://git.example.com/repos/repo.git', 'v1.0', 'awesome'))]
+        for (spec, result) in tests:
+            self.assertEqual(ansible.utils.role_spec_parse(spec), result)
+

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -780,6 +780,7 @@ class TestUtils(unittest.TestCase):
 
     def test_repo_url_to_role_name(self):
         tests = [("http://git.example.com/repos/repo.git", "repo"),
-                 ("ssh://git@git.example.com:repos/role-name", "role-name")]
+                 ("ssh://git@git.example.com:repos/role-name", "role-name"),
+                 ("ssh://git@git.example.com:repos/role-name,v0.1", "role-name")]
         for (url, result) in tests:
             self.assertEqual(ansible.utils.repo_url_to_role_name(url), result)

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -781,15 +781,16 @@ class TestUtils(unittest.TestCase):
     def test_repo_url_to_role_name(self):
         tests = [("http://git.example.com/repos/repo.git", "repo"),
                  ("ssh://git@git.example.com:repos/role-name", "role-name"),
-                 ("ssh://git@git.example.com:repos/role-name,v0.1", "role-name")]
+                 ("ssh://git@git.example.com:repos/role-name,v0.1", "role-name"),
+                 ("directory/role/is/installed/in", "directory/role/is/installed/in")]
         for (url, result) in tests:
             self.assertEqual(ansible.utils.repo_url_to_role_name(url), result)
 
     def test_role_spec_parse(self):
-        tests = [("git+http://git.example.com/repos/repo.git,v1.0", ('git', 'http://git.example.com/repos/repo.git', 'v1.0', 'repo')),
-                 ("http://repo.example.com/download/tarfile.tar.gz", (None, 'http://repo.example.com/download/tarfile.tar.gz', '', 'tarfile')),
-                 ("http://repo.example.com/download/tarfile.tar.gz,,nicename", (None, 'http://repo.example.com/download/tarfile.tar.gz', '', 'nicename')),
-                 ("git+http://git.example.com/repos/repo.git,v1.0,awesome", ('git', 'http://git.example.com/repos/repo.git', 'v1.0', 'awesome'))]
+        tests = [("git+http://git.example.com/repos/repo.git,v1.0", {'scm': 'git', 'src': 'http://git.example.com/repos/repo.git', 'version': 'v1.0', 'name': 'repo'}),
+                ("http://repo.example.com/download/tarfile.tar.gz", {'scm': None, 'src': 'http://repo.example.com/download/tarfile.tar.gz', 'version': '', 'name': 'tarfile'}),
+                ("http://repo.example.com/download/tarfile.tar.gz,,nicename", {'scm': None, 'src': 'http://repo.example.com/download/tarfile.tar.gz', 'version': '', 'name': 'nicename'}),
+                ("git+http://git.example.com/repos/repo.git,v1.0,awesome", {'scm': 'git', 'src': 'http://git.example.com/repos/repo.git', 'version': 'v1.0', 'name': 'awesome'})]
         for (spec, result) in tests:
             self.assertEqual(ansible.utils.role_spec_parse(spec), result)
 

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -778,3 +778,8 @@ class TestUtils(unittest.TestCase):
         assert 'msg' not in data
         assert data['censored'] == 'results hidden due to no_log parameter'
 
+    def test_repo_url_to_role_name(self):
+        tests = [("http://git.example.com/repos/repo.git", "repo"),
+                 ("ssh://git@git.example.com:repos/role-name", "role-name")]
+        for (url, result) in tests:
+            self.assertEqual(ansible.utils.repo_url_to_role_name(url), result)


### PR DESCRIPTION
ansible-galaxy can now refer to SCM URLs (git and hg at this point)
for role names
Dependencies need to use the full SCM URLs too.
Otherwise all seems to work well

Test rolesfile

```
http://bitbucket.org/willthames/git-ansible-galaxy,v1.1
https://bitbucket.org/willthames/hg-ansible-galaxy
```

(works with ssh too)
