### PR TITLE
Encrypts the vault file after edition only if the contents changed

### DIFF
--- a/lib/ansible/utils/vault.py
+++ b/lib/ansible/utils/vault.py
@@ -238,6 +238,11 @@ class VaultEditor(object):
         call(self._editor_shell_command(tmp_path))
         new_data = self.read_data(tmp_path)
 
+        # if the file was not modified,
+        # let the encrypted version as it was
+        if new_data == dec_data:
+            return
+
         # create new vault
         new_vault = VaultLib(self.password)
 


### PR DESCRIPTION
Whenever I edit a vault-protected file, it is re-encrypted even if I discard the changes or don't do any change, so git thinks that the file was actually modified. It forces me to git-checkout it to the previous version.

To avoid this issue I wrote this little patch.
