### PR TITLE
Homebrew module: Added `+` and `.` characters to the package name regex.

### DIFF
--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -112,6 +112,8 @@ class Homebrew(object):
 
     VALID_PACKAGE_CHARS = r'''
         \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
+        .                   # dots
+        \+                  # plusses
         -                   # dashes
     '''
 


### PR DESCRIPTION
Solves installation failures for packages like `bonnie++` or
`virtualhost.sh` as described in #8413.
