### PR TITLE
fix the 'KeyError' when skipping asynchronous tasks with poll: 0

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -437,7 +437,7 @@ class PlayBook(object):
                 results = self._async_poll(poller, task.async_seconds, task.async_poll_interval)
             else:
                 for (host, res) in results.get('contacted', {}).iteritems():
-                    if not ('skipped' in res and res['skipped']):
+                    if not res.get('skipped'):
                         self.runner_callbacks.on_async_ok(host, res, poller.runner.vars_cache[host]['ansible_job_id'])
 
         contacted = results.get('contacted',{})

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -437,7 +437,8 @@ class PlayBook(object):
                 results = self._async_poll(poller, task.async_seconds, task.async_poll_interval)
             else:
                 for (host, res) in results.get('contacted', {}).iteritems():
-                    self.runner_callbacks.on_async_ok(host, res, poller.runner.vars_cache[host]['ansible_job_id'])
+                    if not ('skipped' in res and res['skipped']):
+                        self.runner_callbacks.on_async_ok(host, res, poller.runner.vars_cache[host]['ansible_job_id'])
 
         contacted = results.get('contacted',{})
         dark      = results.get('dark', {})

--- a/test/integration/roles/test_async/tasks/main.yml
+++ b/test/integration/roles/test_async/tasks/main.yml
@@ -56,3 +56,34 @@
         - "'ansible_job_id' in async_result"
         - "'started' in async_result"
         - "'finished' not in async_result"
+
+- name: test conditional "fire and forget" task (not skipped)
+  command: sleep 5
+  poll: 0
+  async: 10
+  when: True
+  register: async_result
+
+- debug: var=async_result
+
+- name: validate async without polling returns
+  assert:
+    that:
+        - "'ansible_job_id' in async_result"
+        - "'started' in async_result"
+        - "'finished' not in async_result"
+
+- name: test conditional "fire and forget" task (when skipped)
+  command: sleep 5
+  poll: 0
+  async: 10
+  when: False
+  register: async_result
+
+- debug: var=async_result
+
+- name: validate async without polling returns
+  assert:
+    that:
+        - "'skipped' in async_result"
+        - "async_result['skipped'] == True"


### PR DESCRIPTION
This is related to #7432.
I ran into this issue just now, so I wrote this patch. Hopefully it'll fix the issue. 

The following playbook will reproduce the exception.

``` yaml

---
- hosts: localhost
  tasks:
  - name: test conditional "fire and forget" task (when skipped)
    command: sleep 5
    poll: 0
    async: 10
    when: False
```
