### PR TITLE
Rax username and api key

### DIFF
--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -230,6 +230,26 @@ def setup():
 
     region = pyrax.get_setting('region')
 
+    set_credentials(region)
+
+    regions = []
+    if region:
+        regions.append(region)
+    else:
+        for region in os.getenv('RAX_REGION', 'all').split(','):
+            region = region.strip().upper()
+            if region == 'ALL':
+                regions = pyrax.regions
+                break
+            elif region not in pyrax.regions:
+                sys.stderr.write('Unsupported region %s' % region)
+                sys.exit(1)
+            elif region not in regions:
+                regions.append(region)
+
+    return regions
+
+def set_credentials(region):
     username = os.getenv('RAX_USERNAME', None)
     if username:
         api_key = os.getenv('RAX_API_KEY', None)
@@ -260,23 +280,6 @@ def setup():
         except Exception, e:
             sys.stderr.write("%s: %s\n" % (e, e.message))
             sys.exit(1)
-
-    regions = []
-    if region:
-        regions.append(region)
-    else:
-        for region in os.getenv('RAX_REGION', 'all').split(','):
-            region = region.strip().upper()
-            if region == 'ALL':
-                regions = pyrax.regions
-                break
-            elif region not in pyrax.regions:
-                sys.stderr.write('Unsupported region %s' % region)
-                sys.exit(1)
-            elif region not in regions:
-                regions.append(region)
-
-    return regions
 
 
 def main():

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -253,7 +253,7 @@ def set_credentials(region):
     username = os.getenv('RAX_USERNAME', None)
     if username:
         api_key = os.getenv('RAX_API_KEY', None)
-        pyrax.set_credentials(username, api_key)
+        pyrax.set_credentials(username, api_key, region=region)
     else:
         # Attempt to grab credentials from environment first
         try:


### PR DESCRIPTION
Adds support for the RAX_USERNAME & RAX_API_KEY env vars (same as the rax module). Useful when running on a build agent.
