### PR TITLE
atomic_move() only works as root (edit:  "sometimes atomic_move will chown things when it cannot")

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1145,9 +1145,13 @@ class AnsibleModule(object):
                 if self.selinux_enabled():
                     self.set_context_if_different(
                         tmp_dest.name, context, False)
-                tmp_stat = os.stat(tmp_dest.name)
-                if dest_stat and (tmp_stat.st_uid != dest_stat.st_uid or tmp_stat.st_gid != dest_stat.st_gid) and os.getuid() == 0:
-                    os.chown(tmp_dest.name, dest_stat.st_uid, dest_stat.st_gid)
+		try:
+		    tmp_stat = os.stat(tmp_dest.name)
+		    if dest_stat and (tmp_stat.st_uid != dest_stat.st_uid or tmp_stat.st_gid != dest_stat.st_gid):
+			os.chown(tmp_dest.name, dest_stat.st_uid, dest_stat.st_gid)
+		except OSError, e:
+		    if e.errno != errno.EPERM:
+			raise
                 os.rename(tmp_dest.name, dest)
             except (shutil.Error, OSError, IOError), e:
                 self.cleanup(tmp_dest.name)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1146,7 +1146,7 @@ class AnsibleModule(object):
                     self.set_context_if_different(
                         tmp_dest.name, context, False)
                 tmp_stat = os.stat(tmp_dest.name)
-                if dest_stat and (tmp_stat.st_uid != dest_stat.st_uid or tmp_stat.st_gid != dest_stat.st_gid):
+                if dest_stat and (tmp_stat.st_uid != dest_stat.st_uid or tmp_stat.st_gid != dest_stat.st_gid) and os.getuid() == 0:
                     os.chown(tmp_dest.name, dest_stat.st_uid, dest_stat.st_gid)
                 os.rename(tmp_dest.name, dest)
             except (shutil.Error, OSError, IOError), e:

--- a/test/integration/roles/test_copy/tasks/main.yml
+++ b/test/integration/roles/test_copy/tasks/main.yml
@@ -180,3 +180,28 @@
       - "copy_result6.changed"
       - "copy_result6.dest == '{{output_dir|expanduser}}/multiline.txt'"
       - "copy_result6.md5sum == '1627d51e7e607c92cf1a502bf0c6cce3'"
+
+# test overwriting a file as an unprivileged user (pull request #8624)
+# this can't be relative to {{output_dir}} as ~root usually has mode 700
+
+- name: create world writable directory
+  file: dest=/tmp/worldwritable state=directory mode=0777
+
+- name: create world writable file
+  copy: dest=/tmp/worldwritable/file.txt content="bar" mode=0666
+
+- name: overwrite the file as user nobody
+  copy: dest=/tmp/worldwritable/file.txt content="baz"
+  sudo: yes
+  sudo_user: nobody
+  register: copy_result7
+
+- name: assert the file was overwritten
+  assert:
+    that:
+      - "copy_result7.changed"
+      - "copy_result7.dest == '/tmp/worldwritable/file.txt'"
+      - "copy_result7.md5sum == '73feffa4b7f6bb68e44cf984c85f6e88'"
+
+- name: clean up
+  file: dest=/tmp/worldwritable state=absent


### PR DESCRIPTION
Linux and BSD derivatives do not allow unprivileged users to "give away" files to others for security reasons. (System V derivatives allow that but they're rare nowadays.)

Thus, the additional chown in atomic_move() which was apparently introduced with v1.6 and which was already objected to in issue #7372 breaks usage of Ansible by non-root users. An example use case is a group-writable directory on a remote machine where users of the same group may drop off configuration files, possibly overwriting each other's files with newer versions. This used to work with versions prior to v1.6 and is now broken.

It used to be a key selling point of Ansible that it allows for non-root operation, in fact this is still mentioned in glossary.rst ("Ansible does not require root logins"), suggesting that the behaviour of v1.6 and onwards is in fact a bug.
