### PR TITLE
yum module: add support for check_mode /w yum package groups

### DIFF
--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -174,7 +174,7 @@ def po_to_nevra(po):
     else:
         return '%s-%s-%s.%s' % (po.name, po.version, po.release, po.arch)
 
-def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_repos=[], is_pkg=False):
+def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_repos=[], is_pkg=False, group=True):
 
     if not repoq:
 
@@ -197,7 +197,12 @@ def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_
 
     else:
 
-        cmd = repoq + ["--disablerepo=*", "--pkgnarrow=installed", "--qf", qf, pkgspec]
+        if group:
+            cmd = repoq + ["--disablerepo=*", "--pkgnarrow=installed", "--qf", qf]
+            cmd.extend(pkgspec)
+        else:
+            cmd = repoq + ["--disablerepo=*", "--pkgnarrow=installed", "--qf", qf, pkgspec]
+
         rc,out,err = module.run_command(cmd)
         if not is_pkg:
             cmd = repoq + ["--disablerepo=*", "--pkgnarrow=installed", "--qf", qf, "--whatprovides", pkgspec]
@@ -213,7 +218,7 @@ def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_
             
     return []
 
-def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_repos=[]):
+def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_repos=[], group=False):
 
     if not repoq:
 
@@ -245,7 +250,14 @@ def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_
             r_cmd = ['--enablerepo', repoid]
             myrepoq.extend(r_cmd)
 
-        cmd = myrepoq + ["--qf", qf, pkgspec]
+        if group:
+            myrepoq.remove("--show-duplicates")
+            myrepoq.append("--pkgnarrow=available")
+            cmd = myrepoq + ["--qf", qf]
+            cmd.extend(pkgspec)
+        else:
+            cmd = myrepoq + ["--qf", qf, pkgspec]
+
         rc,out,err = module.run_command(cmd)
         if rc == 0:
             return [ p for p in out.split('\n') if p.strip() ]
@@ -255,7 +267,7 @@ def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_
             
     return []
 
-def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_repos=[]):
+def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_repos=[], group=False):
 
     if not repoq:
 
@@ -294,7 +306,13 @@ def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_rep
             r_cmd = ['--enablerepo', repoid]
             myrepoq.extend(r_cmd)
 
-        cmd = myrepoq + ["--pkgnarrow=updates", "--qf", qf, pkgspec]
+        if group:
+            myrepoq.remove("--show-duplicates")
+            cmd = myrepoq + ["--pkgnarrow=updates", "--qf", qf]
+            cmd.extend(pkgspec)
+        else:
+            cmd = myrepoq + ["--pkgnarrow=updates", "--qf", qf, pkgspec]
+
         rc,out,err = module.run_command(cmd)
         
         if rc == 0:
@@ -455,6 +473,51 @@ def list_stuff(module, conf_file, stuff):
     else:
         return [ pkg_to_dict(p) for p in is_installed(module, repoq, stuff, conf_file, qf=qf) + is_available(module, repoq, stuff, conf_file, qf=qf) if p.strip() ]
 
+def expand_group(module, repoq, group, en_repos, dis_repos):
+
+    group_name = group.replace('@', '')
+
+    r_cmd = ""
+    if dis_repos:
+      r_cmd += "--disablerepo=%s" % ','.join(dis_repos)
+    if en_repos:
+      r_cmd += "--enablerepo=%s" % ",".join(en_repos)
+
+    # List the packages provided by group
+    cmd = repoq + [r_cmd, "-g", "-l", group_name]
+    rc,out,err = module.run_command(cmd)
+
+    return [ p for p in out.split('\n') if p.strip() ]
+
+def group_has_available(module, repoq, group, conf_file, en_repos, dis_repos):
+
+    myqf =  '%{name}'
+
+    pkgs = expand_group(module, repoq, group, en_repos, dis_repos)
+
+    ipkgs = is_installed(module, repoq, pkgs, conf_file, qf=myqf, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True, group=True)
+    print len(ipkgs)
+
+    apkgs = is_available(module, repoq, pkgs, conf_file, qf=myqf, en_repos=en_repos, dis_repos=dis_repos, group=True)
+    print len(apkgs)
+
+    # If available package is not in installed packages, this means theres a new package to install (not an update)
+    for pkg in apkgs:
+        if not pkg in ipkgs:
+            print pkg
+            return True
+
+    return False
+
+def group_has_updates(module, repoq, group, conf_file, en_repos, dis_repos):
+    
+    pkgs = expand_group(module, repoq, group, en_repos, dis_repos)
+
+    if is_update(module, repoq, pkgs, conf_file, en_repos=en_repos, dis_repos=dis_repos, group=True):
+        return True
+
+    return False
+
 def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
 
     res = {}
@@ -489,6 +552,13 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         elif  spec.startswith('@'):
             # complete wild ass guess b/c it's a group
             pkg = spec
+
+            if module.check_mode:
+                if group_has_available(module, repoq, spec, conf_file, en_repos, dis_repos):
+                    module.exit_json(changed=True)
+                else:
+                    module.exit_json(changed=False)
+                    
 
         # range requires or file-requires or pkgname :(
         else:
@@ -641,9 +711,16 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         pkg = None
         basecmd = 'update'
         cmd = ''
+
         # groups, again
         if spec.startswith('@'):
             pkg = spec
+
+            if module.check_mode:
+                if group_has_updates(module, repoq, spec, conf_file, en_repos, dis_repos):
+                    module.exit_json(changed=True)
+                else:
+                    module.exit_json(changed=False)
         
         elif spec == '*': #update all
             # use check-update to see if there is any need

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -174,7 +174,7 @@ def po_to_nevra(po):
     else:
         return '%s-%s-%s.%s' % (po.name, po.version, po.release, po.arch)
 
-def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_repos=[], is_pkg=False, group=True):
+def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_repos=[], is_pkg=False, group=False):
 
     if not repoq:
 


### PR DESCRIPTION
Currently, when using check_mode with a package group (@group), ansible will return changed=True all the time. This is inconvenient when running in check_mode to see if your hosts configs are proper. In my use case, I have a playbook that I run in check_mode every morning and an email report is sent if I have any non-compliant hosts/tasks. (changed != 0)

This pull request adds check_mode support for package groups with state=installed or state=latest

Checking for package removal is tricky and I have not found a clean way to implement this. Ideas are welcome.

There is no way to ask yum or repoquery directly if a package group has installable packages or updateable packages. The way this is implemented is by expanding the package group using 'repoquery' and by passing the list of packages to _is_installed_ which will return wether or not it has any packages that would be installed. Since repoquery will list ALL member packages even though they are excluded in yum.conf, there is a need to use both _is_installed_ and _is_available_ to ensure we only check for those packages we would install through you (minus those excluded)
