### PR TITLE
fixed ignore_errors during copy files for relative paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "lib/ansible/modules/core"]
 	path = lib/ansible/modules/core
-	url = git://github.com/ansible/ansible-modules-core.git
+	url = https://github.com/ansible/ansible-modules-core.git
 [submodule "lib/ansible/modules/extras"]
 	path = lib/ansible/modules/extras
-	url = git://github.com/ansible/ansible-modules-extras.git
+	url = https://github.com/ansible/ansible-modules-extras.git
 [submodule "v2/ansible/modules/core"]
 	path = v2/ansible/modules/core
 	url = https://github.com/ansible/ansible-modules-core.git

--- a/bin/ansible
+++ b/bin/ansible
@@ -90,26 +90,6 @@ class Cli(object):
 
         pattern = args[0]
 
-        """
-        inventory_manager = inventory.Inventory(options.inventory)
-        if options.subset:
-            inventory_manager.subset(options.subset)
-        hosts = inventory_manager.list_hosts(pattern)
-        if len(hosts) == 0:
-            callbacks.display("No hosts matched", stderr=True)
-            sys.exit(0)
-
-        if options.listhosts:
-            for host in hosts:
-                callbacks.display('    %s' % host)
-            sys.exit(0)
-
-        if ((options.module_name == 'command' or options.module_name == 'shell')
-                and not options.module_args):
-            callbacks.display("No argument passed to %s module" % options.module_name, color='red', stderr=True)
-            sys.exit(1)
-        """
-
         sshpass = None
         sudopass = None
         su_pass = None

--- a/hacking/templates/rst.j2
+++ b/hacking/templates/rst.j2
@@ -115,7 +115,7 @@ Should you have a question rather than a bug report, inquries are welcome on the
 
 Documentation updates for this module can also be edited directly by submitting a pull request to the module source code, just look for the "DOCUMENTATION" block in the source tree.
 
-This is a "core" ansible module, which means it will recieve slightly higher priority for all requests than those in the "extras" repos.
+This is a "core" ansible module, which means it will receive slightly higher priority for all requests than those in the "extras" repos.
 
 {% else %}
 
@@ -130,7 +130,7 @@ Should you have a question rather than a bug report, inquries are welcome on the
 
 Documentation updates for this module can also be edited directly by submitting a pull request to the module source code, just look for the "DOCUMENTATION" block in the source tree.
 
-Note that this module is designated a "extras" module.  Non-core modules are still fully usuable, but may recieve slightly lower response rates for issues and pull requests.
+Note that this module is designated a "extras" module.  Non-core modules are still fully usuable, but may receive slightly lower response rates for issues and pull requests.
 Popular "extras" modules may be promoted to core modules over time.
 
 {% endif %}

--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -112,7 +112,11 @@ class ActionModule(object):
         else:
             source = template.template(self.runner.basedir, source, inject)
             if '_original_file' in inject:
-                source = utils.path_dwim_relative(inject['_original_file'], 'files', source, self.runner.basedir)
+                try:
+                    source = utils.path_dwim_relative(inject['_original_file'], 'files', source, self.runner.basedir)
+                except Exception, err:
+                    result = dict(failed=True, msg="count not find src: %s" % err)
+                    return ReturnData(conn=conn, result=result)
             else:
                 source = utils.path_dwim(self.runner.basedir, source)
 

--- a/plugins/inventory/freeipa.py
+++ b/plugins/inventory/freeipa.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+import json
+from ipalib import api
+api.bootstrap(context='cli')
+api.finalize()
+api.Backend.xmlclient.connect()    
+inventory = {}
+hostvars={}
+meta={}
+result =api.Command.hostgroup_find()['result']
+for hostgroup in result:
+    inventory[hostgroup['cn'][0]] = { 'hosts': [host for host in  hostgroup['member_host']]}
+    for host in  hostgroup['member_host']:
+        hostvars[host] = {}
+inventory['_meta'] = {'hostvars': hostvars}
+inv_string = json.dumps( inventory)
+print inv_string
+


### PR DESCRIPTION
ignore_errors would never be evaluated for roles using copy. This however works fine for standard play books. output examples below.

https://gist.github.com/jeviolle/202274c74247c12efe4f
