### PR TITLE
Fixing Zypper handling on older distribution versions (SLE 10)

### DIFF
--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -176,7 +176,7 @@ def package_latest(m, name, installed_state, disable_gpg_check, disable_recommen
 
     else:
         # If package was not installed at all just make it present.
-        return package_present(m, name, installed_state, disable_gpg_check, disable_recommends)
+        return package_present(m, name, installed_state, disable_gpg_check, disable_recommends, old_zypper)
 
 # Function used to make sure a package is not installed.
 def package_absent(m, name, installed_state, old_zypper):

--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -84,6 +84,15 @@ EXAMPLES = '''
 - zypper: name=nmap state=absent
 '''
 
+def zypper_version(module):
+    """Return (rc, message) tuple"""
+    cmd = ['/usr/bin/zypper', '-V']
+    rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+    if rc == 0:
+        return rc, stdout
+    else:
+        return rc, stderr
+
 # Function used for getting the name of a currently installed package.
 def get_current_name(m, name):
     cmd = '/bin/rpm -q --qf \'%{NAME}-%{VERSION}\''
@@ -112,7 +121,7 @@ def get_package_state(m, name):
         return False
 
 # Function used to make sure a package is present.
-def package_present(m, name, installed_state, disable_gpg_check, disable_recommends):
+def package_present(m, name, installed_state, disable_gpg_check, disable_recommends, old_zypper):
     if installed_state is False:
         cmd = ['/usr/bin/zypper', '--non-interactive']
         # add global options before zypper command
@@ -139,7 +148,7 @@ def package_present(m, name, installed_state, disable_gpg_check, disable_recomme
     return (rc, stdout, stderr, changed)
 
 # Function used to make sure a package is the latest available version.
-def package_latest(m, name, installed_state, disable_gpg_check, disable_recommends):
+def package_latest(m, name, installed_state, disable_gpg_check, disable_recommends, old_zypper):
 
     if installed_state is True:
         cmd = ['/usr/bin/zypper', '--non-interactive', 'update', '--auto-agree-with-licenses', name]
@@ -165,7 +174,7 @@ def package_latest(m, name, installed_state, disable_gpg_check, disable_recommen
         return package_present(m, name, installed_state, disable_gpg_check, disable_recommends)
 
 # Function used to make sure a package is not installed.
-def package_absent(m, name, installed_state):
+def package_absent(m, name, installed_state, old_zypper):
     if installed_state is True:
         cmd = ['/usr/bin/zypper', '--non-interactive', 'remove', name]
         rc, stdout, stderr = m.run_command(cmd)
@@ -211,16 +220,23 @@ def main():
     result['name'] = name
     result['state'] = state
 
+    rc, out = zypper_version(module)
+    match = re.match(r'zypper\s+(\d+)\.(\d+)\.(\d+)', out)
+    if not match or  int(match.group(1)) > 0:
+        old_zypper = False
+    else:
+        old_zypper = True
+
     # Get package state
     installed_state = get_package_state(module, name)
 
     # Perform requested action
     if state in ['installed', 'present']:
-        (rc, stdout, stderr, changed) = package_present(module, name, installed_state, disable_gpg_check, disable_recommends)
+        (rc, stdout, stderr, changed) = package_present(module, name, installed_state, disable_gpg_check, disable_recommends, old_zypper)
     elif state in ['absent', 'removed']:
-        (rc, stdout, stderr, changed) = package_absent(module, name, installed_state)
+        (rc, stdout, stderr, changed) = package_absent(module, name, installed_state, old_zypper)
     elif state == 'latest':
-        (rc, stdout, stderr, changed) = package_latest(module, name, installed_state, disable_gpg_check, disable_recommends)
+        (rc, stdout, stderr, changed) = package_latest(module, name, installed_state, disable_gpg_check, disable_recommends, old_zypper)
 
     if rc != 0:
         if stderr:

--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -125,12 +125,14 @@ def package_present(m, name, installed_state, disable_gpg_check, disable_recomme
     if installed_state is False:
         cmd = ['/usr/bin/zypper', '--non-interactive']
         # add global options before zypper command
-        if disable_gpg_check:
+        if disable_gpg_check and not old_zypper:
             cmd.append('--no-gpg-check')
+        else:
+            cmd.append('--no-gpg-checks')
 
         cmd.extend(['install', '--auto-agree-with-licenses'])
         # add install parameter
-        if disable_recommends:
+        if disable_recommends and not old_zypper:
             cmd.append('--no-recommends')
         cmd.append(name)
         rc, stdout, stderr = m.run_command(cmd, check_rc=False)
@@ -151,7 +153,10 @@ def package_present(m, name, installed_state, disable_gpg_check, disable_recomme
 def package_latest(m, name, installed_state, disable_gpg_check, disable_recommends, old_zypper):
 
     if installed_state is True:
-        cmd = ['/usr/bin/zypper', '--non-interactive', 'update', '--auto-agree-with-licenses', name]
+        if old_zypper:
+            cmd = ['/usr/bin/zypper', '--non-interactive', 'install', '--auto-agree-with-licenses', name]
+        else:
+            cmd = ['/usr/bin/zypper', '--non-interactive', 'update', '--auto-agree-with-licenses', name]
         pre_upgrade_name = ''
         post_upgrade_name = ''
 
@@ -237,7 +242,6 @@ def main():
         (rc, stdout, stderr, changed) = package_absent(module, name, installed_state, old_zypper)
     elif state == 'latest':
         (rc, stdout, stderr, changed) = package_latest(module, name, installed_state, disable_gpg_check, disable_recommends, old_zypper)
-
     if rc != 0:
         if stderr:
             module.fail_json(msg=stderr)

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -140,7 +140,6 @@ def repo_exists(module, old_zypper, **kwargs):
     else:
         repos = _parse_repos(module)
 
-    from pprint import pprint
     for repo in repos:
         if repo_subset(repo, kwargs):
             return True

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -72,9 +72,17 @@ EXAMPLES = '''
 # Add python development repository
 - zypper_repository: repo=http://download.opensuse.org/repositories/devel:/languages:/python/SLE_11_SP3/devel:languages:python.repo
 '''
-from xml.dom.minidom import parseString as parseXML
 
 REPO_OPTS = ['alias', 'name', 'priority', 'enabled', 'autorefresh', 'gpgcheck']
+
+def zypper_version(module):
+    """Return (rc, message) tuple"""
+    cmd = ['/usr/bin/zypper', '-V']
+    rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+    if rc == 0:
+        return rc, stdout
+    else:
+        return rc, stderr
 
 
 def _parse_repos(module):
@@ -82,6 +90,7 @@ def _parse_repos(module):
     cmd = ['/usr/bin/zypper', '-x', 'lr']
     repos = []
 
+    from xml.dom.minidom import parseString as parseXML
     rc, stdout, stderr = module.run_command(cmd, check_rc=True)
     dom = parseXML(stdout)
     repo_list = dom.getElementsByTagName('repo')
@@ -95,8 +104,25 @@ def _parse_repos(module):
 
     return repos
 
+def _parse_repos_old(module):
+    """parses the output of zypper sl and returns a parse repo dictionary"""
+    cmd = ['/usr/bin/zypper', 'sl']
+    repos = []
+    rc, stdout, stderr = module.run_command(cmd, check_rc=True)
+    for line in stdout.split('\n'):
+        matched = re.search(r'\d+\s+\|\s+(?P<enabled>\w+)\s+\|\s+(?P<autorefresh>\w+)\s+\|\s+(?P<type>\w+)\s+\|\s+(?P<name>\w+)\s+\|\s+(?P<url>.*)', line)
+        if matched == None:
+            continue
 
-def repo_exists(module, **kwargs):
+        m = matched.groupdict()
+        m['alias']= m['name']
+        m['priority'] = 100
+        m['gpgcheck'] = 1
+        repos.append(m)
+
+    return repos
+
+def repo_exists(module, old_zypper, **kwargs):
 
     def repo_subset(realrepo, repocmp):
         for k in repocmp:
@@ -109,21 +135,33 @@ def repo_exists(module, **kwargs):
                     return False
         return True
 
-    repos = _parse_repos(module)
+    if old_zypper:
+        repos = _parse_repos_old(module)
+    else:
+        repos = _parse_repos(module)
 
+    from pprint import pprint
     for repo in repos:
         if repo_subset(repo, kwargs):
             return True
     return False
 
 
-def add_repo(module, repo, alias, description, disable_gpg_check):
-    cmd = ['/usr/bin/zypper', 'ar', '--check', '--refresh']
+def add_repo(module, repo, alias, description, disable_gpg_check, old_zypper):
+    if old_zypper:
+        cmd = ['/usr/bin/zypper', 'sa']
+    else:
+        cmd = ['/usr/bin/zypper', 'ar', '--check', '--refresh']
+
+    if repo.startswith("file:/") and old_zypper:
+        cmd.extend(['-t', 'Plaindir'])
+    else:
+        cmd.extend(['-t', 'plaindir'])
 
     if description:
         cmd.extend(['--name', description])
 
-    if disable_gpg_check:
+    if disable_gpg_check and not old_zypper:
         cmd.append('--no-gpgcheck')
 
     cmd.append(repo)
@@ -138,14 +176,21 @@ def add_repo(module, repo, alias, description, disable_gpg_check):
     elif 'already exists. Please use another alias' in stderr:
         changed = False
     else:
-        module.fail_json(msg=stderr if stderr else stdout)
+#        module.fail_json(msg=stderr if stderr else stdout)
+        if stderr:
+            module.fail_json(msg=stderr)
+        else:
+            module.fail_json(msg=stdout)
 
     return changed
 
 
-def remove_repo(module, repo, alias):
+def remove_repo(module, repo, alias, old_zypper):
 
-    cmd = ['/usr/bin/zypper', 'rr']
+    if old_zypper:
+        cmd = ['/usr/bin/zypper', 'sd']
+    else:
+        cmd = ['/usr/bin/zypper', 'rr']
     if alias:
         cmd.append(alias)
     else:
@@ -158,7 +203,11 @@ def remove_repo(module, repo, alias):
 
 def fail_if_rc_is_null(module, rc, stdout, stderr):
     if rc != 0:
-        module.fail_json(msg=stderr if stderr else stdout)
+#        module.fail_json(msg=stderr if stderr else stdout)
+        if stderr:
+            module.fail_json(msg=stderr)
+        else:
+            module.fail_json(msg=stdout)
 
 
 def main():
@@ -182,6 +231,14 @@ def main():
     def exit_unchanged():
         module.exit_json(changed=False, repo=repo, state=state, name=name)
 
+    rc, out = zypper_version(module)
+    match = re.match(r'zypper\s+(\d+)\.(\d+)\.(\d+)', out)
+    if not match or  int(match.group(1)) > 0:
+        old_zypper = False
+    else:
+        old_zypper = True
+
+
     # Check run-time module parameters
     if state == 'present' and not repo:
         module.fail_json(msg='Module option state=present requires repo')
@@ -196,20 +253,20 @@ def main():
             module.fail_json(msg='Name required when adding non-repo files:')
 
     if repo and repo.endswith('.repo'):
-        exists = repo_exists(module, url=repo, alias=name)
+        exists = repo_exists(module, old_zypper, url=repo, alias=name)
     else:
-        exists = repo_exists(module, alias=name)
+        exists = repo_exists(module, old_zypper, alias=name)
 
     if state == 'present':
         if exists:
             exit_unchanged()
 
-        changed = add_repo(module, repo, name, description, disable_gpg_check)
+        changed = add_repo(module, repo, name, description, disable_gpg_check, old_zypper)
     elif state == 'absent':
         if not exists:
             exit_unchanged()
 
-        changed = remove_repo(module, repo, name)
+        changed = remove_repo(module, repo, name, old_zypper)
 
     module.exit_json(changed=changed, repo=repo, state=state)
 


### PR DESCRIPTION
On older *suse distributions some parameters are broken and not working correctly this patch should fix that.
