### PR TITLE
File Module: Allow path to be relative with state=directory

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -210,7 +210,7 @@ def main():
                 module.exit_json(changed=True)
             changed = True
             curpath = ''
-            for dirname in path.split('/'):
+            for dirname in os.path.realpath(path).split('/'):
                 curpath = '/'.join([curpath, dirname])
                 if not os.path.exists(curpath):
                     os.mkdir(curpath)


### PR DESCRIPTION
Currently, when you specify a relative path in `path` with `state=directory`, ansible tries to create the directory in `/`:

```

---
- hosts: all
  tasks:
    - file:
        path: foo
        state: directory
```

```
TASK: [file ] *****************************************************************
failed: [localhost] => {"failed": true, "parsed": false}
invalid output was: Traceback (most recent call last):
  File "/Users/matt/.ansible/tmp/ansible-tmp-1408123613.88-251928671518108/file", line 1677, in <module>
    main()
  File "/Users/matt/.ansible/tmp/ansible-tmp-1408123613.88-251928671518108/file", line 216, in main
    os.mkdir(curpath)
OSError: [Errno 13] Permission denied: '/foo'
```

This pull request will run `os.path.realpath` on the path before trying to split the path using the `/` separator.

However, I am wondering if it wouldn't actually be better to do this in a more global way such as:

(Although I am not sure what other consequences that may have)

``` diff
diff --git a/library/files/file b/library/files/file
index 6e663e5..67f2c5b 100644
--- a/library/files/file
+++ b/library/files/file
@@ -120,7 +120,7 @@ def main():
     src = params['src']

     # modify source as we later reload and pass, specially relevant when used by other modules.
-    params['path'] = path = os.path.expanduser(params['path'])
+    params['path'] = path = os.path.realpath(os.path.expanduser(params['path']))

     # short-circuit for diff_peek
     if diff_peek is not None:
```
