### PR TITLE
Include tip for getting the 'walking a group' to work

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -812,11 +812,17 @@ For example::
       # something that applies to all app servers.
    {% endfor %}
 
-A frequently used idiom is walking a group to find all IP addresses in that group::
+A frequently used idiom is walking a group to find all IP addresses in that group.::
 
    {% for host in groups['app_servers'] %}
       {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}
    {% endfor %}
+   
+Note that for this example, facts must be gathered for all hosts for the ansible_eth0 variable to be populated.
+To do this, set up an empty tasks list at the beginning of your playbook like this::
+
+   - hosts: all
+     tasks: []
 
 An example of this could include pointing a frontend proxy server to all of the app servers, setting up the correct firewall rules between servers, etc.
 


### PR DESCRIPTION
The example for 'walking a group to find all IP addresses' does not work if facts for all hosts are not gathered.
This example to add an empty tasks list for all hosts forces ansible to populate its facts array.
