### PR TITLE
Enable environment keyword at play level

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -38,7 +38,7 @@ class Play(object):
        'accelerate_port', 'accelerate_ipv6', 'sudo', 'sudo_user', 'transport', 'playbook',
        'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
        'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts', 'su', 'su_user',
-       'vault_password', 'no_log',
+       'vault_password', 'no_log', 'environment',
     ]
 
     # to catch typos and so forth -- these are userland names
@@ -48,7 +48,7 @@ class Play(object):
        'tasks', 'handlers', 'remote_user', 'user', 'port', 'include', 'accelerate', 'accelerate_port', 'accelerate_ipv6',
        'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'serial',
        'any_errors_fatal', 'roles', 'role_names', 'pre_tasks', 'post_tasks', 'max_fail_percentage',
-       'su', 'su_user', 'vault_password', 'no_log',
+       'su', 'su_user', 'vault_password', 'no_log', 'environment',
     ]
 
     # *************************************************
@@ -71,6 +71,7 @@ class Play(object):
         self.roles            = ds.get('roles', None)
         self.tags             = ds.get('tags', None)
         self.vault_password   = vault_password
+        self.environment      = ds.get('environment', {})
 
         if self.tags is None:
             self.tags = []

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -133,7 +133,7 @@ class Task(object):
         self.register     = ds.get('register', None)
         self.sudo         = utils.boolean(ds.get('sudo', play.sudo))
         self.su           = utils.boolean(ds.get('su', play.su))
-        self.environment  = ds.get('environment', {})
+        self.environment  = ds.get('environment', play.environment)
         self.role_name    = role_name
         self.no_log       = utils.boolean(ds.get('no_log', "false")) or self.play.no_log
         self.run_once     = utils.boolean(ds.get('run_once', 'false'))


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

`ansible 1.8 (devel f4d649bea0)`
##### Environment:

N/A
##### Summary:

Enable environment keyword at play level. This feature enables to setup environment variables at play level.

[This post in ML](https://groups.google.com/forum/#!topic/ansible-project/w3aqRqZ1hIw) also suggests that this feature would be useful.
##### How to use:

```
- hosts: testhost
  roles:
     - php
     - nginx
  environment:
    http_proxy: http://proxy.example.com:8080
```
