### PR TITLE
Add cache_subnet_group_name in order to use security group ids inside vp...

### DIFF
--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -64,6 +64,12 @@ options:
     required: false
     default: ['default']
     version_added: "1.6"
+  cache_subnet_group_name:
+    description:
+      - The name of the cache subnet group to be used for the cache cluster, required when using security_group_ids
+      required: false
+    default: None
+    version_added: "1.7"
   cache_security_groups:
     description:
       - A list of cache security group names to associate with this cache cluster
@@ -158,7 +164,7 @@ class ElastiCacheManager(object):
     EXIST_STATUSES = ['available', 'creating', 'rebooting', 'modifying']
 
     def __init__(self, module, name, engine, cache_engine_version, node_type,
-                 num_nodes, cache_port, cache_security_groups, security_group_ids, zone, wait,
+                 num_nodes, cache_port, cache_security_groups, security_group_ids, cache_subnet_group_name, zone, wait,
                  hard_modify, aws_access_key, aws_secret_key, region):
         self.module = module
         self.name = name
@@ -169,6 +175,8 @@ class ElastiCacheManager(object):
         self.cache_port = cache_port
         self.cache_security_groups = cache_security_groups
         self.security_group_ids = security_group_ids
+        self.cache_subnet_group_name = cache_subnet_group_name
+
         self.zone = zone
         self.wait = wait
         self.hard_modify = hard_modify
@@ -225,6 +233,7 @@ class ElastiCacheManager(object):
                                                       engine_version=self.cache_engine_version,
                                                       cache_security_group_names=self.cache_security_groups,
                                                       security_group_ids=self.security_group_ids,
+                                                      cache_subnet_group_name=self.cache_subnet_group_name,
                                                       preferred_availability_zone=self.zone,
                                                       port=self.cache_port)
         except boto.exception.BotoServerError, e:
@@ -489,6 +498,7 @@ def main():
                                    'type': 'list'},
             security_group_ids={'required': False, 'default': [],
                                    'type': 'list'},
+            cache_subnet_group_name={'required': False, 'default': None},
             zone={'required': False, 'default': None},
             wait={'required': False, 'type' : 'bool', 'default': True},
             hard_modify={'required': False, 'type': 'bool', 'default': False}
@@ -510,6 +520,7 @@ def main():
     cache_port = module.params['cache_port']
     cache_security_groups = module.params['cache_security_groups']
     security_group_ids = module.params['security_group_ids']
+    cache_subnet_group_name = module.params['cache_subnet_group_name']
     zone = module.params['zone']
     wait = module.params['wait']
     hard_modify = module.params['hard_modify']
@@ -524,7 +535,8 @@ def main():
                                              cache_engine_version, node_type,
                                              num_nodes, cache_port,
                                              cache_security_groups,
-                                             security_group_ids, zone, wait,
+                                             security_group_ids, cache_subnet_group_name,
+                                             zone, wait,
                                              hard_modify, aws_access_key,
                                              aws_secret_key, region)
 


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.6.6
##### Environment:

N/A
##### Summary:

On amazon elastic cache module (library/cloud/elasticache) in order to use a security group id of vpc it is required to add a support to cache_subnet_group_name argument (boto throws error 'Cache subnet group name must be specified along with security group IDs.')
##### Steps To Reproduce:

create a simple playbook that tries to create an elasticache like the next one:

<pre>
- name: Create an elastic cache cluster
  hosts: localhost
  gather_facts: false
  connection: local
  vars:
    num_nodes: 1
  tasks:
    - name: launch elasticache cluster
      local_action:
        module: elasticache
        name: "redis-test"
        state: present
        engine: redis
        cache_engine_version: 2.8.6
        node_type: cache.m3.large
        num_nodes: "{{num_nodes}}"
        cache_port: 6379
        security_group_ids:
          - {{vpc_security_group_id e.g. sg-12345678}}
        cache_subnet_group_name: vpc-name
        cache_security_groups: [] # must be empty otherwise boto throws error
        region: "us-east-1"
        zone: "us-east-1b"
</pre>
##### Expected Results:

a new redis elasticache should be created with success
##### Actual Results:

boto throws error - Cache subnet group name must be specified along with security group IDs.
See the following output:

PLAY [Create an elastic cache cluster] ****************************************

TASK: [launch elasticache cluster] ********************************************
failed: [localhost] => {"failed": true}
msg: Cache subnet group name must be specified along with security group IDs.

FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/Users/ork/launchelasticache.retry

localhost                  : ok=0    changed=0    unreachable=0    failed=1
