### PR TITLE
Fix up nova inventory to be modern

### DIFF
--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -2,29 +2,27 @@
 
 [openstack]
 # API version
-version       = 2
+version = 2
 
 # OpenStack nova username
-username      =
+username = someuser
 
-# OpenStack nova api_key
-api_key       =
+# OpenStack password
+password = ckr1t
 
 # OpenStack nova auth_url
-auth_url      =
+auth_url = https://127.0.0.1:35357/v2.0/
+
+# OpenStack nova project_id (also known as tenant_name)
+project_id = someuser-project1
 
 # Authentication system
-auth_system =
+auth_system = keystone
 
-# OpenStack nova project_id
-project_id    = 
+# Server region name to use
+region_name = region-a.geo-1,region-b.geo-1
 
-# Serverarm region name to use
-region_name   =
+# Service type
+service_type = compute
 
-# TODO: Some other options
-# insecure      =
-# endpoint_type =
-# extensions    =
-# service_type  =
-# service_name  =
+insecure = 0

--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -1,8 +1,19 @@
 # Ansible OpenStack external inventory script
-# This file can contain multiple sections if you have multiple clouds
-# By default, if you just have one cloud, then we're going to call it
-# openstack
+# cache related variables
+[cache]
+# API calls to OpenStack are slow. For this reason, we cache the results of an
+# API call. Set this to the path you want cache files to be written to. One
+# file will be written to this directory:
+#   - ansible-nova.cache
+cache_path = ~/.ansible/tmp
 
+# The number of seconds a cache file is considered valid. After this many
+# seconds, a new API call will be made, and the cache file will be updated.
+# To disable the cache, set this value to 0
+cache_max_age = 300
+
+# This file can contain multiple sections if you have multiple clouds. Each
+# section will be read and will represent a cloud.
 [openstack]
 # API version
 version = 2

--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -16,9 +16,6 @@ auth_url = https://127.0.0.1:35357/v2.0/
 # OpenStack nova project_id (also known as tenant_name)
 project_id = someuser-project1
 
-# Authentication system
-auth_system = keystone
-
 # Server region name to use
 region_name = region-a.geo-1,region-b.geo-1
 

--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -1,4 +1,7 @@
 # Ansible OpenStack external inventory script
+# This file can contain multiple sections if you have multiple clouds
+# By default, if you just have one cloud, then we're going to call it
+# openstack
 
 [openstack]
 # API version
@@ -16,7 +19,7 @@ auth_url = https://127.0.0.1:35357/v2.0/
 # OpenStack nova project_id (also known as tenant_name)
 project_id = someuser-project1
 
-# Server region name to use
+# Server region name to use, can be a comma separated list
 region_name = region-a.geo-1,region-b.geo-1
 
 # Service type

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 # (c) 2012, Marco Vito Moscaritolo <marco@agavee.com>
+# (c) 2013, Jesse Keating <jesse.keating@rackspace.com>
+# (c) 2014 Patrick "CaptTofu" Galbraith <patg@patg.net>
 #
 # This file is part of Ansible,
 #
@@ -21,7 +23,11 @@ import sys
 import re
 import os
 import ConfigParser
-from novaclient import client as nova_client
+import argparse
+import collections
+from novaclient.v1_1 import client as nova_client
+from novaclient import exceptions
+from types import NoneType
 
 try:
     import json
@@ -30,21 +36,20 @@ except:
 
 from ansible.module_utils.openstack import *
 
-###################################################
-# executed with no parameters, return the list of
-# all groups and hosts
+NOVA_CONFIG_FILES = [
+    os.getcwd() + "/nova.ini",
+    os.path.expanduser(
+        os.environ.get(
+            'ANSIBLE_CONFIG',
+            "~/nova.ini")
+    ),
+    "/etc/ansible/nova.ini"
+]
 
-NOVA_CONFIG_FILES = [os.getcwd() + "/nova.ini",
-                     os.path.expanduser(os.environ.get('ANSIBLE_CONFIG', "~/nova.ini")),
-                     "/etc/ansible/nova.ini"]
-
-NOVA_DEFAULTS = {
-    'auth_system': None,
-    'region_name': None,
-}
+NON_CALLABLES = (basestring, bool, dict, int, list, NoneType)
 
 
-def nova_load_config_file():
+def nova_load_config_file(NOVA_DEFAULTS):
     p = ConfigParser.SafeConfigParser(NOVA_DEFAULTS)
 
     for path in NOVA_CONFIG_FILES:
@@ -54,79 +59,252 @@ def nova_load_config_file():
 
     return None
 
-config = nova_load_config_file()
-if not config:
-    sys.exit('Unable to find configfile in %s' % ', '.join(NOVA_CONFIG_FILES))
 
-client = nova_client.Client(
-    config.get('openstack', 'version'),
-    config.get('openstack', 'username'),
-    config.get('openstack', 'api_key'),
-    config.get('openstack', 'project_id'),
-    config.get('openstack', 'auth_url'),
-    region_name = config.get('openstack', 'region_name'),
-    auth_system = config.get('openstack', 'auth_system')
-)
+def setup():
+    # use a config file if it exists where expected
+    NOVA_DEFAULTS = {
+        'auth_system': 'keystone',
+        'region_name': 'region1',
+        'service_type': 'compute'
+    }
+    config = nova_load_config_file(NOVA_DEFAULTS)
 
-if len(sys.argv) == 2 and (sys.argv[1] == '--list'):
-    groups = {}
+    project_id = ""
+    project_id = os.getenv('OS_TENANT_NAME')
+    if project_id == '' or project_id is not None:
+        project_id = os.getenv('OS_PROJECT_ID')
 
-    # Cycle on servers
-    for server in client.servers.list():
-        private = openstack_find_nova_addresses(getattr(server, 'addresses'), 'fixed', 'private')
-        public = openstack_find_nova_addresses(getattr(server, 'addresses'), 'floating', 'public')
-	    
-	# Define group (or set to empty string)
-        group = server.metadata['group'] if server.metadata.has_key('group') else 'undefined'
+    nova_client_params = {
+        'username': '',
+        'password': '',
+        'auth_url': 'https://127.0.0.1:35357/v2.0/',
+        'project_id': '',
+        'service_type': 'compute',
+        'auth_system': 'keystone',
+        'insecure': False,
+    }
+    if config is None:
+        nova_client_params['username'] = os.getenv('OS_USERNAME')
+        nova_client_params['password'] = os.getenv('OS_PASSWORD')
+        nova_client_params['auth_url'] = os.getenv('OS_AUTH_URL')
+        nova_client_params['region_name'] = os.getenv('OS_REGION_NAME')
+        nova_client_params['project_id'] = os.getenv('OS_TENANT_NAME')
+        nova_client_params['service_type'] = NOVA_DEFAULTS['service_type']
+        nova_client_params['auth_system'] = NOVA_DEFAULTS['auth_system']
+        nova_client_params['insecure'] = False
+        if (nova_client_params['username'] == "" and
+                nova_client_params['password'] == ""):
+            sys.exit(
+                'Unable to find config file in %s or environement variables'
+                % ','
+                .join(NOVA_CONFIG_FILES))
+    else:
+        nova_client_params['username'] = config.get('openstack', 'username')
+        nova_client_params['password'] = config.get('openstack', 'password')
+        nova_client_params['project_id'] = \
+            config.get('openstack', 'project_id')
+        nova_client_params['auth_url'] = config.get('openstack', 'auth_url')
+        nova_client_params['region_name'] = \
+            config.get('openstack', 'region_name')
+        nova_client_params['service_type'] = \
+            config.get('openstack', 'service_type')
+        nova_client_params['auth_system'] = \
+            config.get('openstack', 'auth_system')
+        nova_client_params['insecure'] = config.get('openstack', 'insecure')
 
-        # Create group if not exist
-        if group not in groups:
-            groups[group] = []
+    nova_client_params['regions'] = \
+        nova_client_params['region_name'].split(',')
 
-        # Append group to list
-	if server.accessIPv4:
-                groups[group].append(server.accessIPv4)
-		continue
-	if public:
-        	groups[group].append(''.join(public))
-		continue
-	if private:
-        	groups[group].append(''.join(private))
-		continue
+    return(nova_client_params)
+
+
+def to_dict(obj):
+    instance = {}
+    for key in dir(obj):
+        value = getattr(obj, key)
+        if (isinstance(value, NON_CALLABLES) and not key.startswith('_')):
+            key = slugify('nova', key)
+            instance[key] = value
+
+    return instance
+
+
+# TODO: this is something both various modules and plugins could use
+def slugify(pre='', value=''):
+    sep = ''
+    if pre is not None and len(pre):
+        sep = '_'
+    return '%s%s%s' % (pre,
+                       sep,
+                       re.sub('[^\w-]', '_', value).lower().lstrip('_'))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Nova Inventory Module')
+    parser.add_argument('--private',
+                        action='store_true',
+                        help='Use private address for ansible host')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--list', action='store_true',
+                       help='List active servers')
+    group.add_argument('--host', help='List details about the specific host')
+    return parser.parse_args()
+
+
+def connect_to_nova(username='',
+                    password='',
+                    project_id='',
+                    auth_url='',
+                    region_name='',
+                    service_type='',
+                    auth_system='',
+                    insecure=False):
+    # Make the connection
+    client = nova_client.Client(
+        username,
+        password,
+        project_id,
+        auth_url,
+        region_name=region_name,
+        service_type=service_type,
+        auth_system=auth_system,
+        insecure=insecure
+    )
+
+    try:
+        client.authenticate()
+    except exceptions.Unauthorized, e:
+        print("Invalid OpenStack Nova credentials.: %s" %
+              e.message)
+        sys.exit(1)
+    except exceptions.AuthorizationFailure, e:
+        print("Unable to authorize user: %s" % e.message)
+        sys.exit(1)
+
+    if client is None:
+        print("Failed to instantiate nova client. This "
+              "could mean that your credentials are wrong.")
+        sys.exit(1)
+
+    return client
+
+
+def host(nova_client_params, hostname, private_flag):
+    hostvars = {}
+    for region in nova_client_params['regions']:
+        # Connect to the region
+        client = connect_to_nova(nova_client_params['username'],
+                                 nova_client_params['password'],
+                                 nova_client_params['project_id'],
+                                 nova_client_params['auth_url'],
+                                 region,
+                                 nova_client_params['service_type'],
+                                 nova_client_params['auth_system'])
+        for server in client.servers.list():
+            # loop through the networks for this instance, append fixed
+            # and floating IPs in a list
+            private = openstack_find_nova_addresses(getattr(server, 'addresses'), 'fixed', 'private')
+            public = openstack_find_nova_addresses(getattr(server, 'addresses'), 'floating', 'public')
+
+            if server.name == hostname:
+                for key, value in to_dict(server).items():
+                    hostvars[key] = value
+
+                # And finally, add an IP address
+                if (private_flag is True):
+                    hostvars[server.name]['ansible_ssh_host'] = private[0]
+                else:
+                    hostvars[server.name]['ansible_ssh_host'] = public[0]
+
+    print(json.dumps(hostvars, sort_keys=True, indent=4))
+
+
+def list_instances(nova_client_params, private_flag):
+    groups = collections.defaultdict(list)
+    hostvars = collections.defaultdict(dict)
+    images = {}
+
+    for region in nova_client_params['regions']:
+        client = connect_to_nova(nova_client_params['username'],
+                                 nova_client_params['password'],
+                                 nova_client_params['project_id'],
+                                 nova_client_params['auth_url'],
+                                 region,
+                                 nova_client_params['service_type'],
+                                 nova_client_params['auth_system'])
+        # Cycle on servers
+        for server in client.servers.list():
+            # loop through the networks for this instance, append fixed
+            # and floating IPs in a list
+            private = openstack_find_nova_addresses(getattr(server, 'addresses'), 'fixed', 'private')
+            public = openstack_find_nova_addresses(getattr(server, 'addresses'), 'floating', 'public')
+
+            # Create a group on region
+            groups[region].append(server.name)
+
+            # Check if group metadata key in servers' metadata
+            group = server.metadata.get('group')
+            if group:
+                groups[group].append(server.name)
+
+            for extra_group in server.metadata.get('groups', '').split(','):
+                if extra_group:
+                    groups[extra_group].append(server.name)
+
+            for key, value in to_dict(server).items():
+                hostvars[server.name][key] = value
+
+            hostvars[server.name]['nova_region'] = region
+
+            for key, value in server.metadata.iteritems():
+                prefix = os.getenv('OS_META_PREFIX', 'meta')
+                groups['%s_%s_%s' % (prefix, key, value)].append(server.name)
+
+            if (private_flag is True):
+                hostvars[server.name]['ansible_ssh_host'] = private[0]
+            else:
+                hostvars[server.name]['ansible_ssh_host'] = public[0]
+
+            groups['instance-%s' % server.id].append(server.name)
+            groups['flavor-%s' % server.flavor['id']].append(server.name)
+
+            try:
+                imagegroup = 'image-%s' % images[server.image['id']]
+                groups[imagegroup].append(server.name)
+                groups['image-%s' % server.image['id']].append(server.name)
+            except KeyError:
+                try:
+                    image = client.images.get(server.image['id'])
+                except client.exceptions.NotFound:
+                    groups['image-%s' % server.image['id']].append(server.name)
+                else:
+                    images[image.id] = image.human_id
+                    groups['image-%s' % image.human_id].append(server.name)
+                    groups['image-%s' % server.image['id']].append(server.name)
+
+            # And finally, add an IP address
+            if (private_flag is True):
+                hostvars[server.name]['ansible_ssh_host'] = private[0]
+            else:
+                hostvars[server.name]['ansible_ssh_host'] = public[0]
+
+        if hostvars:
+            groups['_meta'] = {'hostvars': hostvars}
 
     # Return server list
     print(json.dumps(groups, sort_keys=True, indent=2))
     sys.exit(0)
 
-#####################################################
-# executed with a hostname as a parameter, return the
-# variables for that host
 
-elif len(sys.argv) == 3 and (sys.argv[1] == '--host'):
-    results = {}
-    ips = []
-    for instance in client.servers.list():
-        private = openstack_find_nova_addresses(getattr(instance, 'addresses'), 'fixed', 'private')
-        public = openstack_find_nova_addresses(getattr(instance, 'addresses'), 'floating', 'public')
-        ips.append( instance.accessIPv4)
-	ips.append(''.join(private))
-	ips.append(''.join(public))
-	if sys.argv[2] in ips:
-            for key in vars(instance):
-                # Extract value
-                value = getattr(instance, key)
-
-                # Generate sanitized key
-                key = 'os_' + re.sub("[^A-Za-z0-9\-]", "_", key).lower()
-
-                # Att value to instance result (exclude manager class)
-                #TODO: maybe use value.__class__ or similar inside of key_name
-                if key != 'os_manager':
-                    results[key] = value
-
-    print(json.dumps(results, sort_keys=True, indent=2))
+def main():
+    args = parse_args()
+    nova_client_params = setup()
+    if args.list:
+        list_instances(nova_client_params, args.private)
+    elif args.host:
+        host(nova_client_params, args.host, args.private)
     sys.exit(0)
 
-else:
-    print "usage: --list  ..OR.. --host <hostname>"
-    sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -48,6 +48,8 @@ flavor_cache = None
 
 def nova_load_config_file(NOVA_DEFAULTS):
     p = ConfigParser.SafeConfigParser(NOVA_DEFAULTS)
+    # Add a default section so that our defaults always work
+    p.add_section('openstack')
 
     for path in NOVA_CONFIG_FILES:
         if os.path.exists(path):
@@ -227,6 +229,11 @@ def list_instances(nova_client_params, private_flag):
 
             for key, value in to_dict(server).items():
                 hostvars[server.name][key] = value
+
+            az = server.metadata.get('nova_os-ext-az_availability_zone')
+            if az:
+                hostvars[server.name]['nova_az'] = az
+                groups[az].append(server.name)
 
             hostvars[server.name]['nova_region'] = region
 

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -56,11 +56,12 @@ def nova_load_config_file(NOVA_DEFAULTS):
 
 
 def setup():
+    OS_USERNAME = os.environ.get('OS_USERNAME', 'admin')
     NOVA_DEFAULTS = {
-        'username': os.environ.get('OS_USERNAME', ''),
+        'username': OS_USERNAME,
         'password': os.environ.get('OS_PASSWORD', ''),
+        'project_id': os.environ.get('OS_TENANT_NAME', os.environ.get('OS_PROJECT_ID', OS_USERNAME)),
         'auth_url': os.environ.get('OS_AUTH_URL', 'https://127.0.0.1:35357/v2.0/'),
-        'project_id': os.environ.get('OS_TENANT_NAME', os.environ.get('OS_PROJECT_ID', '')),
         'region_name': os.environ.get('OS_REGION_NAME', ''),
         'service_type': 'compute',
         'insecure': 'false',
@@ -68,7 +69,6 @@ def setup():
 
     # use a config file if it exists where expected
     config = nova_load_config_file(NOVA_DEFAULTS)
-
 
     nova_client_params = dict()
     nova_client_params['username'] = config.get('openstack', 'username')

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -2,7 +2,7 @@
 
 # (c) 2012, Marco Vito Moscaritolo <marco@agavee.com>
 # (c) 2013, Jesse Keating <jesse.keating@rackspace.com>
-# (c) 2014 Patrick "CaptTofu" Galbraith <patg@patg.net>
+# (c) 2014, Hewlett-Packard Development Company, L.P.
 #
 # This file is part of Ansible,
 #

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -157,6 +157,9 @@ class OpenStackInventory(object):
             nova_client_params['region_name'] = config.get(cloud, 'region_name')
             nova_client_params['service_type'] = config.get(cloud, 'service_type')
             nova_client_params['insecure'] = config.getboolean(cloud, 'insecure')
+            # Provide backwards compat for older nova.ini files
+            if nova_client_params['password'] == '':
+                nova_client_params['password'] = config.get(cloud, 'api_key')
 
             if (nova_client_params['username'] == "" and nova_client_params['password'] == ""):
                 sys.exit(


### PR DESCRIPTION
Update the nova inventory module to be more like the ec2 and rax modules. Notably:
- added support for nova.ini to express multiple clouds that the inventory should span
- added caching similar to the ec2 module
- aligned authentication and floating ip handling with the other nova modules
- added "--private" flag so that one can specify "please use the private IP (fixed IP) of the instance as ansible_ssh_host
