### PR TITLE
WinRM test for long-running command.

### DIFF
--- a/test/integration/roles/test_win_raw/tasks/main.yml
+++ b/test/integration/roles/test_win_raw/tasks/main.yml
@@ -70,3 +70,16 @@
       - "unknown_result.stderr" # An unknown command displays error on stderr.
       - "unknown_result|failed"
       - "not unknown_result|changed"
+
+- name: run a command that takes longer than 60 seconds
+  raw: PowerShell -Command Start-Sleep -s 75
+  register: sleep_command
+
+- name: assert that the sleep command ran
+  assert:
+    that:
+      - "sleep_command.rc == 0"
+      - "not sleep_command.stdout"
+      - "not sleep_command.stderr"
+      - "not sleep_command|failed"
+      - "not sleep_command|changed"


### PR DESCRIPTION
pywinrm accepted my pull request (https://github.com/diyan/pywinrm/pull/25) to fix the issue when commands take longer than 60 seconds (https://github.com/ansible/ansible/issues/8206).  I've added a test to verify it works (when using the latest pywinrm).

https://github.com/ansible/ansible/issues/8206 should be fixed if users update to the latest pywinrm (`pip install -U http://github.com/diyan/pywinrm/archive/master.zip#egg=pywinrm`). 
