### PR TITLE
$powershellpath is called as ".$powershellpath"

### DIFF
--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -79,4 +79,4 @@ else
 $FileName = $DownLoadUrl.Split('/')[-1]
 download-file $downloadurl "$powershellpath\$filename"
 
-Start-Process -FilePath ".$powershellpath\$filename" -ArgumentList /quiet
+Start-Process -FilePath "$powershellpath\$filename" -ArgumentList /quiet


### PR DESCRIPTION
$powershell path is set to "C:\powershell" at line 27. This is fine, but on line 82 $powershellpath is called as ".$powershellpath\$filename". Because the path at line 27 is absolute, a period preceding the $powershellpath is not required at 82. It actually causes an error:

Start-Process : This command cannot be executed due to the error: Unknown error (0x80041002).
At C:\users\Nathan Sosnovske\Documents\ps2to3.ps1:81 char:14

Start-Process <<<< -FilePath ".$powershellpath\$filename" -ArgumentList /quiet
CategoryInfo : InvalidOperation: (:) [Start-Process], InvalidOperationException
FullyQualifiedErrorId : InvalidOperationException,Microsoft.PowerShell.Commands.StartProcessCommand
Removing the period on line 82 before $powershellpath fixes this error.
