### PR TITLE
Minor fixes to the locale_gen module.

### DIFF
--- a/library/system/locale_gen
+++ b/library/system/locale_gen
@@ -113,8 +113,6 @@ def main():
     )
 
     name = module.params['name']
-    if not "." in name:
-        module.fail_json(msg="Locale does not match pattern. Did you specify the encoding?")
     state = module.params['state']
 
     if not os.path.exists("/etc/locale.gen"):

--- a/library/system/locale_gen
+++ b/library/system/locale_gen
@@ -107,7 +107,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             name = dict(required=True),
-            state = dict(choices=['present','absent'], required=True),
+            state = dict(choices=['present','absent'], required=False),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
-   locale_gen module: make 'state' parameter optional.
  
  The 'state' parameter is optional in doc but required in actual implementation. As it has 'present' as it's default value, it should be safe to make it optional as most modules do.
-   locale_gen module: remove the dot check in locale names.
  
  In fact, most of the locales don't have dot in their names:
  
  ```
  $ lsb_release -ds
  Debian GNU/Linux testing (jessie)
  $ wc -l /usr/share/i18n/SUPPORTED
  471 /usr/share/i18n/SUPPORTED
  $ grep -v \\. /usr/share/i18n/SUPPORTED | wc -l
  308
  ```
