### PR TITLE
debconf module: add the missing 'error' vtype and reorder vtypes as they...

### DIFF
--- a/library/system/debconf
+++ b/library/system/debconf
@@ -53,7 +53,7 @@ options:
       - The type of the value supplied
     required: false
     default: null
-    choices: [string, boolean, select, multiselect, note, text, password, title]
+    choices: [string, password, boolean, select, multiselect, note, error, title, text]
     aliases: []
   value:
     description:
@@ -120,7 +120,7 @@ def main():
         argument_spec = dict(
            name = dict(required=True, aliases=['pkg'], type='str'),
            question = dict(required=False, aliases=['setting', 'selection'], type='str'),
-           vtype = dict(required=False, type='str', choices=['string', 'boolean', 'select',  'multiselect', 'note', 'text', 'password', 'title']),
+           vtype = dict(required=False, type='str', choices=['string', 'password', 'boolean', 'select',  'multiselect', 'note', 'error', 'title', 'text']),
            value= dict(required=False, type='str'),
            unseen = dict(required=False, type='bool'),
         ),


### PR DESCRIPTION
... appeared in debconf-devel(7).
