### PR TITLE
Add module for windows package management via chocolatey

### DIFF
--- a/library/windows/win_choco
+++ b/library/windows/win_choco
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2014, Paul Durivage <paul.durivage@rackspace.com>, Trond Hindenes <trond@hindenes.com> and others
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_choco
+version_added: "1.7"
+short_description: Installs and uninstalls packages via chocolatey package manager
+description:
+     - Installs or uninstalls packages via chocolatey package manager
+     - See http://chocolatey.org
+     - Note - oneget will replace this, see https://github.com/OneGet/oneget
+options:
+  name:
+    description:
+      - Name of package to install
+    required: true
+    default: null
+    aliases: []
+  state:
+    description:
+      - State of the package on the system
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+    aliases: []
+  source:
+    description:
+      - Which source to install from.
+      - * webpi requires that you install webpicmd first.  `choco install webpicmd`
+    required: false
+    choices:
+      - https://chocolatey.org/api/v2/
+      - webpi
+      - windowsfeatures
+author: Peter Mounce
+'''
+
+EXAMPLES = '''
+# This installs notepad2-mod (http://xhmikosr.github.io/notepad2-mod/).
+# The names of packages available for install can be run by running the following Powershell Command:
+# PS C:\Users\Administrator> choco list
+# See also https://github.com/chocolatey/chocolatey/wiki/CommandsReference
+$ ansible -i hosts -m win_choco -a "name=notepad2-mod" all
+
+
+# Playbook example
+---
+- name: Install notepad2-mod
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Install notepad2-mod
+      win_choco:
+        name: "notepad2-mod"
+        state: present
+'''

--- a/library/windows/win_choco.ps1
+++ b/library/windows/win_choco.ps1
@@ -1,0 +1,1 @@
+win_choco.ps1


### PR DESCRIPTION
Work in progress - this PR is a stub to start discussion and gauge interest.
http://chocolatey.org for information. It allows package management from a few different sources, including the chocolatey itself, the Web Platform Installer, and DISM.

Note - chocolatey will be replaced by [OneGet](https://github.com/OneGet/oneget) once powershell v5 comes out, but who wants to wait for that? ;-)
Note2 - this is my first ansible module of any sort, after spending a bit of time playing with it to provision a windows 2012 server in AWS to use as the basis for AMI baking. I've got no idea how to go about writing test automation for this, so guidance and steers there would be appreciated.
