### PR TITLE
Restrict ansible-pull to only do scm checkout once

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -169,7 +169,7 @@ def main(args):
     if path is None:
         sys.stderr.write("module '%s' not found.\n" % options.module_name)
         return 1
-    cmd = 'ansible all -i "%s" %s -m %s -a "%s"' % (
+    cmd = 'ansible localhost -i "%s" %s -m %s -a "%s"' % (
             inv_opts, base_opts, options.module_name, repo_opts
             )
 


### PR DESCRIPTION
This addresses a bug in ansible-pull where running ansible-pull
with an existing inventory causes the ansible job that does
the SCM checkout to run twice - once for localhost and once
for the fully qualified hostname.

This can cause a race condition, and usually results in one
of the ansible checkouts failing because one of the scm checkouts
has its references updated underneath it. Although the SCM checkout
actually succeeds, ansible fails with non-zero exit status, and
so ansible-pull does not continue.

Now that localhost is implicit for ansible runs, the ansible
scm checkout can be done using just localhost as a target.
