### PR TITLE
Make template's relative path available to ansible_managed

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -268,7 +268,8 @@ def template_from_file(basedir, path, vars, vault_password=None):
     managed_str = managed_default.format(
         host = vars['template_host'],
         uid  = vars['template_uid'],
-        file = vars['template_path']
+        file = vars['template_path'],
+        relfile = vars['template_relpath']
     )
     vars['ansible_managed'] = time.strftime(
         managed_str,

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -262,6 +262,7 @@ def template_from_file(basedir, path, vars, vault_password=None):
     vars['template_uid']    = template_uid
     vars['template_fullpath'] = os.path.abspath(realpath)
     vars['template_run_date'] = datetime.datetime.now()
+    vars['template_relpath'] = os.path.relpath(vars['template_fullpath'], os.path.abspath(basedir))
 
     managed_default = C.DEFAULT_MANAGED_STR
     managed_str = managed_default.format(

--- a/library/files/template
+++ b/library/files/template
@@ -10,13 +10,14 @@ description:
        (U(http://jinja.pocoo.org/docs/)) - documentation on the template
        formatting can be found in the Template Designer Documentation
        (U(http://jinja.pocoo.org/docs/templates/)).
-     - "Six additional variables can be used in templates: C(ansible_managed) 
+     - "Seven additional variables can be used in templates: C(ansible_managed)
        (configurable via the C(defaults) section of C(ansible.cfg)) contains a string
        which can be used to describe the template name, host, modification time of the
        template file and the owner uid, C(template_host) contains the node name of 
        the template's machine, C(template_uid) the owner, C(template_path) the
        absolute path of the template, C(template_fullpath) is the absolute path of the 
-       template, and C(template_run_date) is the date that the template was rendered. Note that including
+       template, C(template_relpath) is the path of the template relative to playbook's path,
+       and C(template_run_date) is the date that the template was rendered. Note that including
        a string that uses a date in the template will result in the template being marked 'changed'
        each time."
 options:


### PR DESCRIPTION
Given that `{file}` in _ansible_managed_ gets substituted to an absolute path, it can change in situations where an username is part of that path no matter if the template is the same file with respect to the playbook using it. For example _/home/foo/ansible-site/path/to/template.j2_ vs. _/home/bar/work/tests/ansible-site/path/to/template.j2_)

This changeset exports the template's relative path as `template_relpath` var and also substitutes `relfile` in _ansible_managed_.
