### PR TITLE
apt_repository: do not fetch Ubuntu PPA signing keys if PPA is already added

### DIFF
--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -351,13 +351,16 @@ class UbuntuSourcesList(SourcesList):
         if line.startswith('ppa:'):
             source, ppa_owner, ppa_name = self._expand_ppa(line)
 
-            if self.add_ppa_signing_keys_callback is not None:
-                info = self._get_ppa_info(ppa_owner, ppa_name)
-                if not self._key_already_exists(info['signing_key_fingerprint']):
-                    command = ['apt-key', 'adv', '--recv-keys', '--keyserver', 'hkp://keyserver.ubuntu.com:80', info['signing_key_fingerprint']]
-                    self.add_ppa_signing_keys_callback(command)
-
             file = file or self._suggest_filename('%s_%s' % (line, distro.codename))
+            filepath = self._expand_path(file)
+
+            # As we're dealing with Ubuntu PPA, we can safely assume that
+            # we need to fetch PPA signing keys only if the sources file
+            # doesn't exist yet (i.e. we're about to create it)
+            if not os.path.exists(filepath) and self.add_ppa_signing_keys_callback is not None:
+                info = self._get_ppa_info(ppa_owner, ppa_name)
+                command = ['apt-key', 'adv', '--recv-keys', '--keyserver', 'hkp://keyserver.ubuntu.com:80', info['signing_key_fingerprint']]
+                self.add_ppa_signing_keys_callback(command)
         else:
             source = self._parse(line, raise_if_invalid_or_disabled=True)[2]
             file = file or self._suggest_filename(source)


### PR DESCRIPTION
This solution greatly speeds up consequent uses of apt_repository for PPAs by skipping two extra network calls (fetching PPA info and fetching the actual signing keys).
The assumption is that we don't need to fetch the keys if the corresponding sources file already exists.

While this approach works for me, it feels kind of hackish.
The right solution would be to capture and propagate "changed" state from `_add_valid_source` and act accordingly, but I'm not brave enough to refactor this :)
