### PR TITLE
roles: make role_path (path of current role) available as variable to the task

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -373,10 +373,12 @@ class Play(object):
 
         roles = self._build_role_dependencies(roles, [], self.vars)
 
-        # give each role an uuid
+        # give each role an uuid and
+        # make role_path available as variable to the task
         for idx, val in enumerate(roles):
             this_uuid = str(uuid.uuid4())
             roles[idx][-2]['role_uuid'] = this_uuid
+            roles[idx][-2]['role_path'] = roles[idx][1]
 
         role_names = []
 


### PR DESCRIPTION
Use case: several, e.g. need to do "local_action: command ls files/' to get a list of file to be handled in a later task into a registered variable. Right now there is no certain way to know that path when writing a public role, given command/shell module doesn't look any basedirs.

Also one of the requests in #6955
