### PR TITLE
Force pseudo-tty allocation on sync (untested)

### DIFF
--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -303,7 +303,7 @@ def main():
     else:
         private_key = '-i '+ private_key 
 
-    ssh_opts = '-S none -o StrictHostKeyChecking=no'
+    ssh_opts = '-S none -t -o StrictHostKeyChecking=no'
     if dest_port != 22:
         cmd += " --rsh 'ssh %s %s -o Port=%s'" % (private_key, ssh_opts, dest_port)
     else:


### PR DESCRIPTION
Force the allocation of a pseudo-tty so that sudo on the remote connection can run.
The sudoers on redhat 6+ and other distros have requiretty enabled by default, requiring the ssh to allocate a tty.
