### PR TITLE
inventory: extra type validations in combining dicts and parsing script json

### DIFF
--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -84,10 +84,14 @@ class InventoryScript(object):
 
             if not isinstance(data, dict):
                 data = {'hosts': data}
+            # is not those subkeys, then simplified syntax, host with vars
             elif not any(k in data for k in ('hosts','vars')):
                 data = {'hosts': [group_name], 'vars': data}
 
             if 'hosts' in data:
+                if not isinstance(data['hosts'], list):
+                    raise errors.AnsibleError("You defined a group \"%s\" with bad "
+                        "data for the host list:\n %s" % (group_name, data))
 
                 for hostname in data['hosts']:
                     if not hostname in all_hosts:
@@ -96,6 +100,10 @@ class InventoryScript(object):
                     group.add_host(host)
 
             if 'vars' in data:
+                if not isinstance(data['vars'], dict):
+                    raise errors.AnsibleError("You defined a group \"%s\" with bad "
+                        "data for variables:\n %s" % (group_name, data))
+
                 for k, v in data['vars'].iteritems():
                     if group.name == all.name:
                         all.set_variable(k, v)

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -696,10 +696,17 @@ def parse_kv(args):
                 options[k.strip()] = unquote(v.strip())
     return options
 
+def _validate_both_dicts(a, b):
+
+    if not (isinstance(a, dict) and isinstance(b, dict)):
+        raise errors.AnsibleError("Failed to combine two values which are not "
+            "both hashes, got these differing values now:\n\n%s\n and\n%s" % (a, b))
+
 def merge_hash(a, b):
     ''' recursively merges hash b into a
     keys from b take precedence over keys from a '''
 
+    _validate_both_dicts(a, b)
     result = {}
 
     for dicts in a, b:
@@ -1307,6 +1314,8 @@ def listify_lookup_plugin_terms(terms, basedir, inject):
     return terms
 
 def combine_vars(a, b):
+
+    _validate_both_dicts(a, b)
 
     if C.DEFAULT_HASH_BEHAVIOUR == "merge":
         return merge_hash(a, b)


### PR DESCRIPTION
- avoids a stacktrace when trying to combine vars that are not both dictionaries, and returns a proper error
- detects wrong variable types in the InventoryScript json

fixes #8704
