### PR TITLE
Pull Request for Issue #8700 - Slight Refactoring of the EC2 Inventory Script

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -80,6 +80,11 @@ options:
      - Will run out-of-order or missing migrations as they are not rollback migrations, you can only use this parameter with 'migrate' command
     required: false
     version_added: "1.3"
+  clear:
+    description:
+     - Will clear any existing files/links in target directory before copying over origianl files. you can only use this parameter with 'collectstatic' command
+    required: false
+    version_added: "1.8"
   link:
     description:
      - Will create links to the files instead of copying them, you can only use this parameter with 'collectstatic' command
@@ -171,7 +176,7 @@ def main():
         test=('failfast', 'testrunner', 'liveserver', 'apps', ),
         validate=(),
         migrate=('apps', 'skip', 'merge'),
-        collectstatic=('link', ),
+        collectstatic=('clear', 'link', ),
         )
 
     command_required_param_map = dict(
@@ -189,11 +194,11 @@ def main():
         )
 
     # These params are allowed for certain commands only
-    specific_params = ('apps', 'database', 'failfast', 'fixtures', 'liveserver', 'testrunner')
+    specific_params = ('apps', 'clear', 'database', 'failfast', 'fixtures', 'liveserver', 'testrunner')
 
     # These params are automatically added to the command if present
     general_params = ('settings', 'pythonpath', 'database',)
-    specific_boolean_params = ('failfast', 'skip', 'merge', 'link')
+    specific_boolean_params = ('clear', 'failfast', 'skip', 'merge', 'link')
     end_of_command_params = ('apps', 'cache_table', 'fixtures')
 
     module = AnsibleModule(
@@ -206,6 +211,7 @@ def main():
 
             apps        = dict(default=None, required=False),
             cache_table = dict(default=None, required=False),
+            clear       = dict(default=None, required=False, type='bool'),
             database    = dict(default=None, required=False),
             failfast    = dict(default='no', required=False, type='bool', aliases=['fail_fast']),
             fixtures    = dict(default=None, required=False),

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -154,6 +154,8 @@ class Ec2Inventory(object):
         elif not self.is_cache_valid():
             self.do_api_calls_update_cache()
 
+
+    def data_to_print(self):
         # Data to print
         if self.args.host:
             data_to_print = self.get_host_info()
@@ -165,7 +167,7 @@ class Ec2Inventory(object):
             else:
                 data_to_print = self.json_format_dict(self.inventory, True)
 
-        print data_to_print
+        return data_to_print
 
 
     def is_cache_valid(self):
@@ -700,6 +702,6 @@ class Ec2Inventory(object):
             return json.dumps(data)
 
 
-# Run the script
-Ec2Inventory()
-
+if __name__ == "__main__":
+    # Run the Inventory script and print output
+    print Ec2Inventory().data_to_print()


### PR DESCRIPTION
See Discussion in Issue ticket - https://github.com/ansible/ansible/issues/8700.

To recap - This removes any implicit printing, uses the standard pythonic way of making a module runnable, and as such, allows easy re-use of the functionality here by importing this module in another and deriving from EC2Inventory class.
