### PR TITLE
Avoid multiple blank lines with --syntax-check

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -247,7 +247,8 @@ def main(args):
                             if getattr(task, 'name', None) is not None:
                                 # meta tasks have no names
                                 print '    %s' % task.name
-                print ''
+                if options.listhosts or options.listtasks:
+                    print ''
             continue
 
         if options.syntax:


### PR DESCRIPTION
  Only print a blank line between plays when also doing --list-hosts and/or
  --list-tasks, otherwise this output just a long list of blank lines, one for
  each play.
