### PR TITLE
[get_url module]parse content-disposition filename parameter even if it's not quoted

### DIFF
--- a/library/network/get_url
+++ b/library/network/get_url
@@ -169,7 +169,7 @@ def extract_filename_from_headers(headers):
 
     Looks for the content-disposition header and applies a regex.
     Returns the filename if successful, else None."""
-    cont_disp_regex = 'attachment; ?filename="(.+)"'
+    cont_disp_regex = 'attachment; ?filename="?([^"]+)'
     res = None
 
     if 'content-disposition' in headers:


### PR DESCRIPTION
`get_url` module currently parses `content-disposition` response header field if `filename` parameter is double quoted.
But some servers do not quote `filename` parameter. One notable example is github's download server.

```
$ curl --head https://codeload.github.com/antirez/redis/tar.gz/3.0.0-beta8
HTTP/1.1 200 OK
Content-Length: 1327483
Access-Control-Allow-Origin: https://render.githubusercontent.com
Content-Security-Policy: default-src 'none'
X-XSS-Protection: 1; mode=block
X-Frame-Options: deny
X-Content-Type-Options: nosniff
Strict-Transport-Security: max-age=31536000
Vary: Authorization,Accept-Encoding
ETag: "f3b0cbd15c2e5afb1d309ed4de548d334ef85900"
Content-Type: application/x-gzip
Content-Disposition: attachment; filename=redis-3.0.0-beta8.tar.gz
Date: Sat, 23 Aug 2014 02:59:29 GMT
```

This PR tries to parse this parameter even if it's not double quoted.

For RFC specification wise, `Content-Disposition` has a lot more varieties(See RFC 6266).
But the spec is too complex and this simple PR should solve more than 99.99% cases.

OK pattern : Content-Disposition: attachment; filename="foo.tar.gz"
OK pattern : Content-Disposition: attachment; filename=foo.tar.gz <- previously NG
OK pattern : Content-Disposition: attachment;filename="foo.tar.gz"
OK pattern : Content-Disposition: attachment;filename=foo.tar.gz <- previously NG
