### PR TITLE
module docker - expose will fail to port forward network connections if there are spaces in the CSV value

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -450,6 +450,7 @@ class DockerManager:
         if expose_list:
             exposed = []
             for port in expose_list:
+                port = port.strip()
                 if port.endswith('/tcp') or port.endswith('/udp'):
                     port_with_proto = tuple(port.split('/'))
                 else:


### PR DESCRIPTION
##### Issue Type:

“Bug Report”, “Bugfix Pull Request”
##### Ansible Version:

ansible 1.8 (devel a419ffdf41) last updated 2014/08/24 10:09:21 (GMT +100)
##### Environment:

OSX but this doesn't apply.

```
$ docker --version
   Docker version 1.2.0, build fa7b24f
```
##### Summary:

If you include spaces in the expose docker module then port forwarding will fail.
##### Steps To Reproduce:

Note my container has port 22/tcp exposed by default but not 53/udp.

This took me forever... to figure out.  Finally I used docker inspect to see why it worked running on the command line and not from my ansible file.

This fails:

```
docker: image="dns" hostname="ns.example.com" expose="22, 53/udp" ports="0.0.0.0:10122:22,0.0.0.0:53:53/udp" state="running"{/code}
```

This works:

```
docker: image="dns" hostname="ns" expose="22,53/udp" ports="0.0.0.0:10122:22,0.0.0.0:53:53/udp" state="running"{/code}
```
##### Expected Results:

Including spaces in expose should not impact port forwarding.
##### Actual Results:

The port specified after the space is not forwarded.

Looking at the diff of the command line vs. ansible I found this:

```
diff -u not-working.txt working.txt
...
-        "Domainname": "",
+        "Domainname": "example.com",
...
         "ExposedPorts": {
-            " 53/udp": {}, <-------- HERE THERE IS A SPACE
-            "22/tcp": {}
+            "22/tcp": {},
+            "53/udp": {}
         },
 -        "Hostname": "ns.example.com",
+        "Hostname": "ns",
...
-        "LxcConf": null,
-        "NetworkMode": "",
+        "LxcConf": [],
+        "NetworkMode": "bridge",
...
         "Ports": {
-            " 53/udp": null,
             "22/tcp": [
                 {
```

Note the domain name doesn't seem to be parsing properly either, but this didn't impact the port fowarding.

I hope this is enough info.
