### PR TITLE
win_powershell attribute validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ New Modules:
 
 Some other notable changes:
 
+* ec2_lc: added support for multiple new parameters like kernel_id, ramdisk_id and ebs_optimized.
+* ec2_elb_lb: added support for the connection_draining_timeout and cross_az_load_balancing options.
 * support for symbolic representations (ie. u+rw) for file permission modes (file/copy/template modules etc.).
 * docker: Added support for specifying the net type of the container.
 * docker: support for specifying read-only volumes.

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -55,40 +55,6 @@ Function Set-Attr($obj, $name, $value)
     $obj | Add-Member -Force -MemberType NoteProperty -Name $name -Value $value
 }
 
-# Helper function to get an "attribute" from a psobject instance in powershell.
-# This is a convenience to make getting Members from an object easier and
-# slightly more pythonic
-# Example: $attr = Get-Attr $response "code" -default "1"
-Function Get-Attr($obj, $name, $default = $null)
-{
-    # Check if the provided Member $name exists in $obj and return it or the
-    # default
-    If ($obj.$name.GetType)
-    {
-        $obj.$name
-    }
-    Else
-    {
-        $default
-    }
-    return
-}
-
-# Helper function to convert a powershell object to JSON to echo it, exiting
-# the script
-# Example: Exit-Json $result
-Function Exit-Json($obj)
-{
-    # If the provided $obj is undefined, define one to be nice
-    If (-not $obj.GetType)
-    {
-        $obj = New-Object psobject
-    }
-
-    echo $obj | ConvertTo-Json
-    Exit
-}
-
 # Helper function to add the "msg" property and "failed" property, convert the
 # powershell object to JSON and echo it, exiting the script
 # Example: Fail-Json $result "This is the failure message"
@@ -112,6 +78,46 @@ Function Fail-Json($obj, $message = $null)
     echo $obj | ConvertTo-Json
     Exit 1
 }
+
+
+# Helper function to get an "attribute" from a psobject instance in powershell.
+# This is a convenience to make getting Members from an object easier and
+# slightly more pythonic
+# Example: $attr = Get-Attr $response "code" -default "1"
+Function Get-Attr($obj, $name, $default = $null, $failifempty=$false)
+{
+    # Check if the provided Member $name exists in $obj and return it or the
+    # default
+    If ($obj.$name.GetType)
+    {
+        $obj.$name
+    }
+    Elseif($failifempty -eq $false)
+    {
+        $default
+    }
+    else
+    {
+        Fail-Json -obj $obj -message "Need to specify a value for the parameter $name"
+    }
+    return
+}
+
+# Helper function to convert a powershell object to JSON to echo it, exiting
+# the script
+# Example: Exit-Json $result
+Function Exit-Json($obj)
+{
+    # If the provided $obj is undefined, define one to be nice
+    If (-not $obj.GetType)
+    {
+        $obj = New-Object psobject
+    }
+
+    echo $obj | ConvertTo-Json
+    Exit
+}
+
 
 # Helper filter/pipeline function to convert a value to boolean following current
 # Ansible practices

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -84,6 +84,7 @@ Function Fail-Json($obj, $message = $null)
 # This is a convenience to make getting Members from an object easier and
 # slightly more pythonic
 # Example: $attr = Get-Attr $response "code" -default "1"
+#Note that if you use the failifempty option, you do need to specify resultobject as well.
 Function Get-Attr($obj, $name, $default = $null,$resultobj, $failifempty=$false, $emptyattributefailmessage)
 {
     # Check if the provided Member $name exists in $obj and return it or the

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -99,7 +99,7 @@ Function Get-Attr($obj, $name, $default = $null,$resultobj, $failifempty=$false,
     }
     else
     {
-        if (!$emptyattributefailmessage) {$emptyattributefailmessage = "Need to specify a value for the parameter $name"}
+        if (!$emptyattributefailmessage) {$emptyattributefailmessage = "Missing required argument: $name"}
         Fail-Json -obj $resultobj -message $emptyattributefailmessage
     }
     return

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -84,7 +84,7 @@ Function Fail-Json($obj, $message = $null)
 # This is a convenience to make getting Members from an object easier and
 # slightly more pythonic
 # Example: $attr = Get-Attr $response "code" -default "1"
-Function Get-Attr($obj, $name, $default = $null, $failifempty=$false)
+Function Get-Attr($obj, $name, $default = $null,$resultobj, $failifempty=$false, $emptyattributefailmessage)
 {
     # Check if the provided Member $name exists in $obj and return it or the
     # default
@@ -98,7 +98,8 @@ Function Get-Attr($obj, $name, $default = $null, $failifempty=$false)
     }
     else
     {
-        Fail-Json -obj $obj -message "Need to specify a value for the parameter $name"
+        if (!$emptyattributefailmessage) {$emptyattributefailmessage = "Need to specify a value for the parameter $name"}
+        Fail-Json -obj $resultobj -message $emptyattributefailmessage
     }
     return
 }

--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -742,6 +742,7 @@ def main():
         state = module.params.get('state')
         count = int(module.params.get('count'))
         name = module.params.get('name')
+        image = module.params.get('image')
 
         if count < 0:
             module.fail_json(msg="Count must be greater than zero")
@@ -760,12 +761,31 @@ def main():
         if state in [ "running", "present" ]:
 
             # make sure a container with `name` exists, if not create and start it
-            if name and "/" + name not in map(lambda x: x.get('Name'), deployed_containers):
-                containers = manager.create_containers(1)
-                if state == "present": #otherwise it get (re)started later anyways..
-                  manager.start_containers(containers)
-                  running_containers = manager.get_running_containers()
-                deployed_containers = manager.get_deployed_containers()
+            if name:
+                # first determine if a container with this name exists
+                existing_container = None
+                for deployed_container in deployed_containers:
+                    if deployed_container.get('Name') == '/%s' % name:
+                        existing_container = deployed_container
+                        break
+
+                # the named container is running, but with a
+                # different image or tag, so we stop it first
+                if existing_container and existing_container.get('Config', dict()).get('Image') != image:
+                    manager.stop_containers([existing_container])
+                    manager.remove_containers([existing_container])
+                    running_containers = manager.get_running_containers()
+                    deployed_containers = manager.get_deployed_containers()
+                    existing_container = None
+
+                # if the container isn't running (or if we stopped the
+                # old version above), create and (maybe) start it up now
+                if not existing_container:
+                    containers = manager.create_containers(1)
+                    if state == "present": # otherwise it get (re)started later anyways..
+                        manager.start_containers(containers)
+                        running_containers = manager.get_running_containers()
+                    deployed_containers = manager.get_deployed_containers()
 
             if state == "running":
                 # make sure a container with `name` is running


### PR DESCRIPTION
Small change to ease the development of PowerShell-based module.
This changes the get-attr function slightly, and lets the module specify whether a param is needed and auto-fails if it is not present. A module can now verify params like so::
$params = Parse-Args $args;
$result = New-Object psobject;
Set-Attr $result "changed" $false;
$path = Get-Attr -obj $params -name path -failifempty $true -resultobj $result

or 

$params = Parse-Args $args;
$result = New-Object psobject;
Set-Attr $result "changed" $false;
$path = Get-Attr -obj $params -name path -failifempty $true -emptyattributefailmessage "Oh man. You forgot the main part!" -resultobj $result
