### PR TITLE
Name appears to be a required parameter for cron module

### DIFF
--- a/library/system/cron
+++ b/library/system/cron
@@ -45,6 +45,7 @@ options:
     description:
       - Description of a crontab entry.
     default: null
+    required: true
   user:
     description:
       - The specific user whose crontab should be modified.
@@ -395,7 +396,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-            name=dict(required=False),
+            name=dict(required=True),
             user=dict(required=False),
             job=dict(required=False),
             cron_file=dict(required=False),


### PR DESCRIPTION
As far as I can tell, `name` is a required parameter.  The guard test at (now) line 458 says you need name if `state == present` and at 464 if `state != present`, although that's not quite as clear.  Each of the code paths at 485 - 495 pass the name param through to `add_job`, `update_job` and `remove_job`, and the actual _update_job method earlier seems to require it too.  However I don't really know python so I may be wrong, but I can't see the circumstances when `name` is not required.
