### PR TITLE
Handling space in paths / Reversing order or role_path selection

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -191,16 +191,16 @@ class Play(object):
 
         role_path = None
 
-        possible_paths = [
-            utils.path_dwim(self.basedir, os.path.join('roles', role_name)),
-            utils.path_dwim(self.basedir, role_name)
-        ]
+        possible_paths = []
 
         if C.DEFAULT_ROLES_PATH:
             search_locations = C.DEFAULT_ROLES_PATH.split(os.pathsep)
             for loc in search_locations:
                 loc = os.path.expanduser(loc)
                 possible_paths.append(utils.path_dwim(loc, role_name))
+
+        possible_paths.append(utils.path_dwim(self.basedir, role_name))
+        possible_paths.append(utils.path_dwim(self.basedir, os.path.join('roles', role_name)))
 
         for path_option in possible_paths:
             if os.path.isdir(path_option):

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -321,6 +321,9 @@ def path_dwim(basedir, given):
     make relative paths work like folks expect.
     '''
 
+    if given.startswith("'"):
+        given = given[1:-1]
+
     if given.startswith("/"):
         return os.path.abspath(given)
     elif given.startswith("~"):


### PR DESCRIPTION
I think the commit [1b4eb84](https://github.com/ynk/ansible/commit/1b4eb84b696e47ab0c66ac1ca19e63dc7301b2b5) will be very handy for mac users as i am. Thing is, if you have a space in your `given` path, then python will output the path within single quotes, which results in a false state of the `if given.startswith("/"):` test.

The second [298f52a](https://github.com/ynk/ansible/commit/298f52a4f839b06630783b1fd07d0440e02858c2) looks more pratical to me. It looked like the `DEFAULT_ROLE_PATH` constant was added to the end of the `possible_paths` list, resulting in a default-first/configuration-last order, which i think should be reversed, as configuration should be prior to default.
