### PR TITLE
handling case of space in path (given would start with single quote)

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -321,6 +321,9 @@ def path_dwim(basedir, given):
     make relative paths work like folks expect.
     '''
 
+    if given.startswith("'"):
+        given = given[1:-1]
+
     if given.startswith("/"):
         return os.path.abspath(given)
     elif given.startswith("~"):


### PR DESCRIPTION
If you have a space in your `given` path, then python will output the path within single quotes, which results in a false state of the `if given.startswith("/"):` test. These small lines fix the issue.
