### PR TITLE
fixing role path sorting in possible_paths list

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -191,16 +191,16 @@ class Play(object):
 
         role_path = None
 
-        possible_paths = [
-            utils.path_dwim(self.basedir, os.path.join('roles', role_name)),
-            utils.path_dwim(self.basedir, role_name)
-        ]
+        possible_paths = []
 
         if C.DEFAULT_ROLES_PATH:
             search_locations = C.DEFAULT_ROLES_PATH.split(os.pathsep)
             for loc in search_locations:
                 loc = os.path.expanduser(loc)
                 possible_paths.append(utils.path_dwim(loc, role_name))
+
+        possible_paths.append(utils.path_dwim(self.basedir, role_name))
+        possible_paths.append(utils.path_dwim(self.basedir, os.path.join('roles', role_name)))
 
         for path_option in possible_paths:
             if os.path.isdir(path_option):


### PR DESCRIPTION
I changed the order of `possible_paths`list. _Before_, **default** values were first appended then the `DEFAULT_ROLE_PATH` constant. That would cause the next for..in [line 205](https://github.com/ynk/ansible/compare/fix/role_path_order?expand=1#diff-30c8c86d294b2f7b782122bc2eb3e4aeR205) to choose first default, then user-defined role path (and break at first occurence). I think should be reversed, as configuration should be prior to default.
