### PR TITLE
Allow modules to "invoke" add_host

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -498,13 +498,17 @@ class PlayBook(object):
                 # task ran with_ lookup plugin, so facts are encapsulated in
                 # multiple list items in the results key
                 for res in result['results']:
-                    if type(res) == dict:
+                    if isinstance(res, dict):
                         facts = res.get('ansible_facts', {})
                         utils.update_hash(self.SETUP_CACHE, host, facts)
+                        for add_host in res.get('add_host', []):
+                            self.inventory.add_host(add_host)
             else:
                 # when facts are returned, persist them in the setup cache
                 facts = result.get('ansible_facts', {})
                 utils.update_hash(self.SETUP_CACHE, host, facts)
+                for add_host in result.get('add_host', []):
+                    self.inventory.add_host(add_host)
             if task.register:
                 _register_play_vars(host, result)
 

--- a/lib/ansible/runner/action_plugins/add_host.py
+++ b/lib/ansible/runner/action_plugins/add_host.py
@@ -15,14 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import ansible
-
-from ansible.callbacks import vv
 from ansible.errors import AnsibleError as ae
 from ansible.runner.return_data import ReturnData
 from ansible.utils import parse_kv
-from ansible.inventory.host import Host
-from ansible.inventory.group import Group
 
 class ActionModule(object):
     ''' Create inventory hosts and groups in the memory inventory'''
@@ -46,63 +41,6 @@ class ActionModule(object):
         if not 'hostname' in args and not 'name' in args:
             raise ae("'name' is a required argument.")
 
-        result = {}
+        result = self.runner.inventory.add_host(args)
 
-        # Parse out any hostname:port patterns
-        new_name = args.get('name', args.get('hostname', None))
-        vv("creating host via 'add_host': hostname=%s" % new_name)
-
-        if ":" in new_name:
-            new_name, new_port = new_name.split(":")
-            args['ansible_ssh_port'] = new_port
-        
-        # redefine inventory and get group "all"
-        inventory = self.runner.inventory
-        allgroup = inventory.get_group('all')
-
-        # check if host in cache, add if not
-        if new_name in inventory._hosts_cache:
-            new_host = inventory._hosts_cache[new_name]
-        else:
-            new_host = Host(new_name)
-            # only groups can be added directly to inventory
-            inventory._hosts_cache[new_name] = new_host
-            allgroup.add_host(new_host)
-
-        # Add any variables to the new_host
-        for k in args.keys():
-            if not k in [ 'name', 'hostname', 'groupname', 'groups' ]:
-                new_host.set_variable(k, args[k]) 
-                
-        
-        groupnames = args.get('groupname', args.get('groups', args.get('group', ''))) 
-        # add it to the group if that was specified
-        if groupnames:
-            for group_name in groupnames.split(","):
-                group_name = group_name.strip()
-                if not inventory.get_group(group_name):
-                    new_group = Group(group_name)
-                    inventory.add_group(new_group)
-                    new_group.vars = inventory.get_group_variables(group_name, vault_password=inventory._vault_password)
-                grp = inventory.get_group(group_name)
-                grp.add_host(new_host)
-
-                # add this host to the group cache
-                if inventory._groups_list is not None:
-                    if group_name in inventory._groups_list:
-                        if new_host.name not in inventory._groups_list[group_name]:
-                            inventory._groups_list[group_name].append(new_host.name)
-
-                vv("added host to group via add_host module: %s" % group_name)
-            result['new_groups'] = groupnames.split(",")
-            
-        result['new_host'] = new_name
-
-        # clear pattern caching completely since it's unpredictable what
-        # patterns may have referenced the group
-        inventory.clear_pattern_cache()
-        
         return ReturnData(conn=conn, comm_ok=True, result=result)
-
-
-


### PR DESCRIPTION
Currently when cloud modules create new hosts, it is typical that people will run `add_host` afterwards to make each new host available to ansible during it's run time.

This pull request will enable the module to return a top level key called `add_host` that is a list of dictionaries.  The dictionaries returned will be used in populating hosts and groups just as the `add_host` module would.

Assuming this is accepted, modules such as `rax` and `ec2` could be updated to utilize this functionality.

Example module (called "foo" in test playbook below):

``` python
#!/usr/bin/python

import json

foo = {
    "add_host": [
        {
            "name": "foo",
            "groups": "bar",
            "baz": "qux",
        }
    ]
}

print json.dumps(foo, indent=4, sort_keys=True)
```

Test playbook:

```

---
- hosts: localhost
  connection: local
  gather_facts: false
  tasks:
    - action: foo
    - add_host: name=test groups=testgroup something=else
    - assert:
        that: groups.keys() == ['bar', 'all', 'testgroup']
    - assert:
        that: hostvars['foo'] is mapping
    - assert:
        that: hostvars['test'] is mapping
    - assert:
        that: hostvars['foo']['baz'] == 'qux'
    - assert:
        that: hostvars['test']['something'] == 'else'
```

Output (with -vv):

```

PLAY [localhost] ************************************************************** 

TASK: [foo] ******************************************************************* 
<localhost> REMOTE_MODULE foo
ok: [localhost] => {"add_host": [{"baz": "qux", "groups": "bar", "name": "foo"}]}
creating host via 'add_host': hostname=foo
added host to group via add_host module: bar

TASK: [add_host name=test groups=testgroup something=else] ******************** 
creating host via 'add_host': hostname=test
added host to group via add_host module: testgroup
ok: [localhost] => {"new_groups": ["testgroup"], "new_host": "test"}

TASK: [assert ] *************************************************************** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [assert ] *************************************************************** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [assert ] *************************************************************** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [assert ] *************************************************************** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [assert ] *************************************************************** 
ok: [localhost] => {"msg": "all assertions passed"}

PLAY RECAP ******************************************************************** 
localhost                  : ok=7    changed=0    unreachable=0    failed=0   
```
