### PR TITLE
mysql_user module: adding support for various REQUIRE options.

### DIFF
--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -472,6 +472,10 @@ def main():
     require_subject = module.params["require_subject"]
     require_issuer = module.params["require_issuer"]
     require_cipher = module.params["require_cipher"]
+    requirements = requirements_unpack(module, require_ssl, require_x509,
+                                               require_subject, require_issuer,
+                                               require_cipher)
+
 
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -372,7 +372,7 @@ def requirements_unpack(module, require_ssl, require_x509,
         # only those in (Cipher, Issuer, Subject)
         not options[0] and not options[1] and options[2],
         # no requirements
-        not any([bool(x) for x in options]),
+        not any(options),
     )
 
     if conditions[0]:

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -408,6 +408,11 @@ def main():
             state=dict(default="present", choices=["absent", "present"]),
             priv=dict(default=None),
             append_privs=dict(type="bool", default="no"),
+            require_ssl=dict(type="bool", default="no"),
+            require_x509=dict(type="bool", default="no"),
+            require_subject=dict(default=None),
+            require_issuer=dict(default=None),
+            require_cipher=dict(default=None),
             check_implicit_admin=dict(default=False),
         )
     )
@@ -418,6 +423,11 @@ def main():
     priv = module.params["priv"]
     check_implicit_admin = module.params['check_implicit_admin']
     append_privs = module.boolean(module.params["append_privs"])
+    require_ssl = module.boolean(module.params["require_ssl"])
+    require_x509 = module.boolean(module.params["require_x509"])
+    require_subject = module.params["require_subject"]
+    require_issuer = module.params["require_issuer"]
+    require_cipher = module.params["require_cipher"]
 
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -295,6 +295,37 @@ def privileges_grant(cursor, user,host,db_table,priv):
         query = query + " WITH GRANT OPTION"
     cursor.execute(query)
 
+def requirements_get(cursor, user, host):
+    """ This function is similar to privileges_get(), except it is meant for
+    requirements (REQUIRE ...). Note that this is a somewhat naive
+    implementation based on the assumption that 'REQUIRE' isn't present
+    anywhere else in the GRANT query (e.g. username, password, etc).
+    """
+    cursor.execute("SHOW GRANTS FOR %s@%s", (user,host))
+    grants = cursor.fetchall()
+
+    try:
+        grant_strings = [grant[0] for grant in grants]
+        grant_with_reqs = \
+            list(filter(lambda x: "REQUIRE" in x, grant_strings))[0]
+    except IndexError:
+        return None
+
+    requirements = {}
+    req_string = grant_with_reqs[grant_with_reqs.index("REQUIRE"):]
+
+    if 'SSL' in req_string:
+        requirements["ssl"] = True
+    elif 'X509' in req_string:
+        requirements["x509"] = True
+    else:
+        for param in ('subject', 'issuer', 'cipher'):
+            regex = r".*{} ('[^\']+')".format(param.upper())
+            match = re.match(regex, req_string, re.S)
+            if match:
+                requirements[param] = strip_quotes(match.group(1))
+    return requirements
+
 def requirements_unpack(module, require_ssl, require_x509,
                         require_subject, require_issuer,
                         require_cipher):

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -160,14 +160,14 @@ def user_exists(cursor, user, host):
     count = cursor.fetchone()
     return count[0] > 0
 
-def user_add(cursor, user, host, password, new_priv):
+def user_add(cursor, user, host, password, new_priv, requirements):
     cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
     if new_priv is not None:
         for db_table, priv in new_priv.iteritems():
-            privileges_grant(cursor, user,host,db_table,priv)
+            privileges_grant(cursor, user,host,db_table,priv, requirements)
     return True
 
-def user_mod(cursor, user, host, password, new_priv, append_privs):
+def user_mod(cursor, user, host, password, new_priv, append_privs, requirements):
     changed = False
     grant_option = False
 
@@ -200,7 +200,7 @@ def user_mod(cursor, user, host, password, new_priv, append_privs):
         # we can perform a straight grant operation.
         for db_table, priv in new_priv.iteritems():
             if db_table not in curr_priv:
-                privileges_grant(cursor, user,host,db_table,priv)
+                privileges_grant(cursor, user,host,db_table,priv, requirements)
                 changed = True
 
         # If the db.table specification exists in both the user's current privileges
@@ -211,8 +211,18 @@ def user_mod(cursor, user, host, password, new_priv, append_privs):
             if (len(priv_diff) > 0):
                 if not append_privs:
                     privileges_revoke(cursor, user,host,db_table,grant_option)
-                privileges_grant(cursor, user,host,db_table,new_priv[db_table])
+                privileges_grant(cursor, user,host,db_table,new_priv[db_table], requirements)
                 changed = True
+
+
+    # After privileges have been handled, handle requirements.
+    curr_reqs = requirements_get(cursor, user, host)
+    if curr_reqs != requirements:
+        curr_priv = privileges_get(cursor, user,host)
+        # Not the cleanest solution, but seems to work.
+        for db_table, priv in curr_priv.iteritems():
+            privileges_grant(cursor, user, host, db_table, priv, requirements)
+        changed = True
 
     return changed
 
@@ -287,10 +297,23 @@ def privileges_revoke(cursor, user,host,db_table,grant_option):
     query = "REVOKE ALL PRIVILEGES ON %s FROM '%s'@'%s'" % (db_table,user,host)
     cursor.execute(query)
 
-def privileges_grant(cursor, user,host,db_table,priv):
-
+def privileges_grant(cursor, user,host,db_table,priv, requirements):
     priv_string = ",".join(filter(lambda x: x != 'GRANT', priv))
     query = "GRANT %s ON %s TO '%s'@'%s'" % (priv_string,db_table,user,host)
+    query += " REQUIRE"
+    if requirements is None:
+        query += " NONE"
+    elif requirements.get('ssl', False):
+        query += " SSL"
+    elif requirements.get('x509', False):
+        query += " X509"
+    else:
+        tmp_reqs = []
+        for param in ('subject', 'issuer', 'cipher'):
+            if param in requirements:
+                tmp_reqs.append(" {} '{}'".format(
+                    param.upper(), requirements[param]))
+        query += " AND".join(tmp_reqs)
     if 'GRANT' in priv:
         query = query + " WITH GRANT OPTION"
     cursor.execute(query)
@@ -548,11 +571,11 @@ def main():
 
     if state == "present":
         if user_exists(cursor, user, host):
-            changed = user_mod(cursor, user, host, password, priv, append_privs)
+            changed = user_mod(cursor, user, host, password, priv, append_privs, requirements)
         else:
             if password is None:
                 module.fail_json(msg="password parameter required when adding a user")
-            changed = user_add(cursor, user, host, password, priv)
+            changed = user_add(cursor, user, host, password, priv, requirements)
     elif state == "absent":
         if user_exists(cursor, user, host):
             changed = user_delete(cursor, user, host)

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -332,7 +332,7 @@ def requirements_get(cursor, user, host):
         grant_with_reqs = \
             list(filter(lambda x: "REQUIRE" in x, grant_strings))[0]
     except IndexError:
-        return None
+        return {}
 
     requirements = {}
     req_string = grant_with_reqs[grant_with_reqs.index("REQUIRE"):]

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -93,6 +93,38 @@ options:
     required: false
     default: false
     version_added: "1.3"
+  require_ssl:
+    description:
+        - Require SSL connections. Mutually exclusive with all other C(require_*) options.
+    required: false
+    choices: ["yes", "no"]
+    default: "no"
+    version_added: "1.8"
+  require_x509:
+    description:
+        - Require a valid X509 certificate. Mutually exclusive with all other C(require_*) options.
+    required: false
+    choices: ["yes", "no"]
+    default: "no"
+    version_added: "1.8"
+  require_subject:
+    description:
+        - Require a valid X509 certificate with the specified subject. Mutually exclusive with C(require_ssl) and C(require_x509) options.
+    required: false
+    default: null
+    version_added: "1.8"
+  require_issuer:
+    description:
+        - Require a valid X509 certificate issed by the specified CA (issuer). Mutually exclusive with C(require_ssl) and C(require_x509) options.
+    required: false
+    default: null
+    version_added: "1.8"
+  require_cipher:
+    description:
+        - Require usage of the specified cipher. Mutually exclusive with C(require_ssl) and C(require_x509) options.
+    required: false
+    default: null
+    version_added: "1.8"
 notes:
    - Requires the MySQLdb Python package on the remote host. For Ubuntu, this
      is as easy as apt-get install python-mysqldb.

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -526,10 +526,6 @@ def main():
     require_subject = module.params["require_subject"]
     require_issuer = module.params["require_issuer"]
     require_cipher = module.params["require_cipher"]
-    requirements = requirements_unpack(module, require_ssl, require_x509,
-                                               require_subject, require_issuer,
-                                               require_cipher)
-
 
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")
@@ -569,6 +565,9 @@ def main():
     except Exception, e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials")
 
+    requirements = requirements_unpack(module, require_ssl, require_x509,
+                                               require_subject, require_issuer,
+                                               require_cipher)
     if state == "present":
         if user_exists(cursor, user, host):
             changed = user_mod(cursor, user, host, password, priv, append_privs, requirements)

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -295,6 +295,50 @@ def privileges_grant(cursor, user,host,db_table,priv):
         query = query + " WITH GRANT OPTION"
     cursor.execute(query)
 
+def requirements_unpack(module, require_ssl, require_x509,
+                        require_subject, require_issuer,
+                        require_cipher):
+    """ Similar to privileges_unpack(). This function validates for mutual
+    exclusion of parameters and, if they are valid, returns a dictionary of
+    the same format used in requirements_get() or None, indicating that
+    'REQUIRE NONE' should be run.
+    """
+    # Valid options for REQUIRE
+    options = (
+        require_ssl,
+        require_x509,
+        (require_cipher or require_issuer or require_subject),
+    )
+    # Conditions for proceeding
+    conditions = (
+        # SSL only
+        options[0] and not options[1] and not options[2],
+        # X509 only
+        not options[0] and options[1] and not options[2],
+        # only those in (Cipher, Issuer, Subject)
+        not options[0] and not options[1] and options[2],
+        # no requirements
+        not any([bool(x) for x in options]),
+    )
+
+    if conditions[0]:
+        requirements = {'ssl': True }
+    elif conditions[1]:
+        requirements = {'x509' : True }
+    elif conditions[2]:
+        requirements = {}
+        if require_subject:
+            requirements['subject'] = require_subject
+        if require_issuer:
+            requirements['issuer'] = require_issuer
+        if require_cipher:
+            requirements['cipher'] = require_cipher
+    elif conditions[3]:
+        requirements = None
+    else:
+        module.fail_json(msg="Provided requriements are incompatible. Choose one of SSL, X509, or any of (Subject, Issuer, Cipher).")
+
+    return requirements
 
 def strip_quotes(s):
     """ Remove surrounding single or double quotes

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -390,7 +390,8 @@ def requirements_unpack(module, require_ssl, require_x509,
     elif conditions[3]:
         requirements = None
     else:
-        module.fail_json(msg="Provided requriements are incompatible. Choose one of SSL, X509, or any of (Subject, Issuer, Cipher).")
+        module.fail_json(msg=("Provided requriements are incompatible. "
+            "Choose one of SSL, X509, or any of (Subject, Issuer, Cipher)."))
 
     return requirements
 

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -354,8 +354,7 @@ def requirements_unpack(module, require_ssl, require_x509,
                         require_cipher):
     """ Similar to privileges_unpack(). This function validates for mutual
     exclusion of parameters and, if they are valid, returns a dictionary of
-    the same format used in requirements_get() or None, indicating that
-    'REQUIRE NONE' should be run.
+    the same format used in requirements_get().
     """
     # Valid options for REQUIRE
     options = (

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -375,12 +375,13 @@ def requirements_unpack(module, require_ssl, require_x509,
         not any(options),
     )
 
+    requirements = {}
+
     if conditions[0]:
-        requirements = {'ssl': True }
+        requirements['ssl'] = True
     elif conditions[1]:
-        requirements = {'x509' : True }
+        requirements['x509'] = True
     elif conditions[2]:
-        requirements = {}
         if require_subject:
             requirements['subject'] = require_subject
         if require_issuer:
@@ -388,7 +389,7 @@ def requirements_unpack(module, require_ssl, require_x509,
         if require_cipher:
             requirements['cipher'] = require_cipher
     elif conditions[3]:
-        requirements = None
+        pass
     else:
         module.fail_json(msg=("Provided requriements are incompatible. "
             "Choose one of SSL, X509, or any of (Subject, Issuer, Cipher)."))

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -338,9 +338,9 @@ def requirements_get(cursor, user, host):
     req_string = grant_with_reqs[grant_with_reqs.index("REQUIRE"):]
 
     if 'SSL' in req_string:
-        requirements["ssl"] = True
+        requirements['ssl'] = True
     elif 'X509' in req_string:
-        requirements["x509"] = True
+        requirements['x509'] = True
     else:
         for param in ('subject', 'issuer', 'cipher'):
             regex = r".*{} ('[^\']+')".format(param.upper())

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -301,7 +301,7 @@ def privileges_grant(cursor, user,host,db_table,priv, requirements):
     priv_string = ",".join(filter(lambda x: x != 'GRANT', priv))
     query = "GRANT %s ON %s TO '%s'@'%s'" % (priv_string,db_table,user,host)
     query += " REQUIRE"
-    if requirements is None:
+    if not requirements:
         query += " NONE"
     elif requirements.get('ssl', False):
         query += " SSL"

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -170,6 +170,7 @@ def user_add(cursor, user, host, password, new_priv, requirements):
 def user_mod(cursor, user, host, password, new_priv, append_privs, requirements):
     changed = False
     grant_option = False
+    privileges_granted = False
 
     # Handle passwords.
     if password is not None:
@@ -201,6 +202,7 @@ def user_mod(cursor, user, host, password, new_priv, append_privs, requirements)
         for db_table, priv in new_priv.iteritems():
             if db_table not in curr_priv:
                 privileges_grant(cursor, user,host,db_table,priv, requirements)
+                privileges_granted = True
                 changed = True
 
         # If the db.table specification exists in both the user's current privileges
@@ -212,17 +214,19 @@ def user_mod(cursor, user, host, password, new_priv, append_privs, requirements)
                 if not append_privs:
                     privileges_revoke(cursor, user,host,db_table,grant_option)
                 privileges_grant(cursor, user,host,db_table,new_priv[db_table], requirements)
+                privileges_granted = True
                 changed = True
 
-
-    # After privileges have been handled, handle requirements.
-    curr_reqs = requirements_get(cursor, user, host)
-    if curr_reqs != requirements:
-        curr_priv = privileges_get(cursor, user,host)
-        # Not the cleanest solution, but seems to work.
-        for db_table, priv in curr_priv.iteritems():
-            privileges_grant(cursor, user, host, db_table, priv, requirements)
-        changed = True
+    # If privileges_grant() hasn't run in the above cases, and the
+    # current requirements are different from the provided requirements,
+    # run privileges_grant() with current privileges and new requirements.
+    if not privileges_granted:
+        curr_reqs = requirements_get(cursor, user, host)
+        if curr_reqs != requirements:
+            curr_priv = privileges_get(cursor, user,host)
+            for db_table, priv in curr_priv.iteritems():
+                privileges_grant(cursor, user, host, db_table, priv, requirements)
+            changed = True
 
     return changed
 
@@ -260,6 +264,7 @@ def privileges_get(cursor, user,host):
             privileges.append('GRANT')
         db = res.group(2)
         output[db] = privileges
+
     return output
 
 def privileges_unpack(priv):


### PR DESCRIPTION
This is meant to be a replacement for the incomplete and now closed PR #7744 .

This PR introduces 5 new parameters:
- require_ssl
- require_x509
- require_subject
- require_issuer
- require_cipher

More information about their purpose can be found [here](http://dev.mysql.com/doc/refman/5.1/en/grant.html).

Personally, I've only ever used 'REQUIRE SSL' in MySQL queries, but some might want more fine-grained control, hence the other 4 parameters.
