### PR TITLE
Customizing groups_vars and host_vars directory structure

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -156,6 +156,10 @@ DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       '
 DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '/usr/share/ansible_plugins/filter_plugins')
 DEFAULT_LOG_PATH               = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
 
+DEFAULT_VARS_PATH              = get_config(p, DEFAULTS, 'vars_path', 'DEFAULT_VARS_PATH', '.')
+DEFAULT_GROUP_VARS_NAME        = get_config(p, DEFAULTS, 'group_vars_name', 'DEFAULT_GROUP_VARS_NAME', 'group_vars')
+DEFAULT_HOST_VARS_NAME         = get_config(p, DEFAULTS, 'host_vars_name', 'DEFAULT_HOST_VARS_NAME', 'host_vars')
+
 CACHE_PLUGIN                   = get_config(p, DEFAULTS, 'fact_caching', 'ANSIBLE_CACHE_PLUGIN', 'memory')
 CACHE_PLUGIN_CONNECTION        = get_config(p, DEFAULTS, 'fact_caching_connection', 'ANSIBLE_CACHE_PLUGIN_CONNECTION', None)
 CACHE_PLUGIN_PREFIX            = get_config(p, DEFAULTS, 'fact_caching_prefix', 'ANSIBLE_CACHE_PLUGIN_PREFIX', 'ansible_facts')

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -612,12 +612,14 @@ class Inventory(object):
         scan_pass = 0
         _basedir = self.basedir()
 
+        basedirs = [os.path.abspath(C.DEFAULT_VARS_PATH)]
+
         # look in both the inventory base directory and the playbook base directory
         # unless we do an update for a new playbook base dir
         if not new_pb_basedir:
-            basedirs = [_basedir, self._playbook_basedir]
+            basedirs.extend((_basedir, self._playbook_basedir))
         else:
-            basedirs = [self._playbook_basedir]
+            basedirs.append(self._playbook_basedir)
 
         for basedir in basedirs:
 
@@ -638,12 +640,12 @@ class Inventory(object):
 
             if group and host is None:
                 # load vars in dir/group_vars/name_of_group
-                base_path = os.path.join(basedir, "group_vars/%s" % group.name)
+                base_path = utils.path_dwim(basedir, os.path.join(C.DEFAULT_GROUP_VARS_NAME, group.name))
                 results = utils.load_vars(base_path, results, vault_password=self._vault_password)
 
             elif host and group is None:
                 # same for hostvars in dir/host_vars/name_of_host
-                base_path = os.path.join(basedir, "host_vars/%s" % host.name)
+                base_path = utils.path_dwim(basedir, os.path.join(C.DEFAULT_HOST_VARS_NAME, host.name))
                 results = utils.load_vars(base_path, results, vault_password=self._vault_password)
 
         # all done, results is a dictionary of variables for this particular host.


### PR DESCRIPTION
As i wanted to create a working directory that would fit my needs, i coded this small patch that allows 3 new vars in the `ansible.cfg` file, named `vars_path`, `group_vars_name` and `host_vars_name`.

I setup those regarding the current logic in `constants.py` with a default values so nothing would break if not customized. The actual customization i've been doing in my `ansible.cfg` file is : 

```
[defaults]
log_path          = ./logs/ansible.log

hostfile          = ./inventories/hosts
roles_path        = ./roles

vars_path         = ./vars
group_vars_name   = group
host_vars_name    = host
```

so my working directory would look like : 

```
.
├── README.md
├── ansible.cfg
├── inventories
│   └── hosts
├── logs
│   └── ansible.log
├── playbooks
│   └── default.yml
├── requirements.yml
├── roles
└── vars
    ├── group
    └── host
```

Mostly, as i think about playbooks as objects, this enhancement would be also effective for playbooks as simple folders having a similar _but lighter_ directory structure as roles :

```
└── playbooks
    └── myplaybook
        ├── main.yml
        └── vars
            ├── group
            └── host
```
