### PR TITLE
ansible-vault: The correct option is password_file. Fixes #8752

### DIFF
--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -129,7 +129,7 @@ def execute_decrypt(args, options, parser):
     if not options.password_file:
         password, new_password = utils.ask_vault_passwords(ask_vault_pass=True)
     else:
-        password = utils.read_vault_file(options.vault_password_file)
+        password = utils.read_vault_file(options.password_file)
 
     cipher = 'AES256'
     if hasattr(options, 'cipher'):


### PR DESCRIPTION
As reported in #8752 `options.vault_password_file` is not the correct option.  The correct option is instead `option.password_file`.
