### PR TITLE
Win powershell argumentvalidation

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -55,40 +55,6 @@ Function Set-Attr($obj, $name, $value)
     $obj | Add-Member -Force -MemberType NoteProperty -Name $name -Value $value
 }
 
-# Helper function to get an "attribute" from a psobject instance in powershell.
-# This is a convenience to make getting Members from an object easier and
-# slightly more pythonic
-# Example: $attr = Get-Attr $response "code" -default "1"
-Function Get-Attr($obj, $name, $default = $null)
-{
-    # Check if the provided Member $name exists in $obj and return it or the
-    # default
-    If ($obj.$name.GetType)
-    {
-        $obj.$name
-    }
-    Else
-    {
-        $default
-    }
-    return
-}
-
-# Helper function to convert a powershell object to JSON to echo it, exiting
-# the script
-# Example: Exit-Json $result
-Function Exit-Json($obj)
-{
-    # If the provided $obj is undefined, define one to be nice
-    If (-not $obj.GetType)
-    {
-        $obj = New-Object psobject
-    }
-
-    echo $obj | ConvertTo-Json
-    Exit
-}
-
 # Helper function to add the "msg" property and "failed" property, convert the
 # powershell object to JSON and echo it, exiting the script
 # Example: Fail-Json $result "This is the failure message"
@@ -112,6 +78,46 @@ Function Fail-Json($obj, $message = $null)
     echo $obj | ConvertTo-Json
     Exit 1
 }
+
+
+# Helper function to get an "attribute" from a psobject instance in powershell.
+# This is a convenience to make getting Members from an object easier and
+# slightly more pythonic
+# Example: $attr = Get-Attr $response "code" -default "1"
+Function Get-Attr($obj, $name, $default = $null, $failifempty=$false)
+{
+    # Check if the provided Member $name exists in $obj and return it or the
+    # default
+    If ($obj.$name.GetType)
+    {
+        $obj.$name
+    }
+    Elseif($failifempty -eq $false)
+    {
+        $default
+    }
+    else
+    {
+        Fail-Json -obj $obj -message "Need to specify a value for the parameter $name"
+    }
+    return
+}
+
+# Helper function to convert a powershell object to JSON to echo it, exiting
+# the script
+# Example: Exit-Json $result
+Function Exit-Json($obj)
+{
+    # If the provided $obj is undefined, define one to be nice
+    If (-not $obj.GetType)
+    {
+        $obj = New-Object psobject
+    }
+
+    echo $obj | ConvertTo-Json
+    Exit
+}
+
 
 # Helper filter/pipeline function to convert a value to boolean following current
 # Ansible practices

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -84,6 +84,7 @@ Function Fail-Json($obj, $message = $null)
 # This is a convenience to make getting Members from an object easier and
 # slightly more pythonic
 # Example: $attr = Get-Attr $response "code" -default "1"
+#Note that if you use the failifempty option, you do need to specify resultobject as well.
 Function Get-Attr($obj, $name, $default = $null,$resultobj, $failifempty=$false, $emptyattributefailmessage)
 {
     # Check if the provided Member $name exists in $obj and return it or the

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -99,7 +99,7 @@ Function Get-Attr($obj, $name, $default = $null,$resultobj, $failifempty=$false,
     }
     else
     {
-        if (!$emptyattributefailmessage) {$emptyattributefailmessage = "Need to specify a value for the parameter $name"}
+        if (!$emptyattributefailmessage) {$emptyattributefailmessage = "Missing required argument: $name"}
         Fail-Json -obj $resultobj -message $emptyattributefailmessage
     }
     return

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -84,7 +84,7 @@ Function Fail-Json($obj, $message = $null)
 # This is a convenience to make getting Members from an object easier and
 # slightly more pythonic
 # Example: $attr = Get-Attr $response "code" -default "1"
-Function Get-Attr($obj, $name, $default = $null, $failifempty=$false)
+Function Get-Attr($obj, $name, $default = $null,$resultobj, $failifempty=$false, $emptyattributefailmessage)
 {
     # Check if the provided Member $name exists in $obj and return it or the
     # default
@@ -98,7 +98,8 @@ Function Get-Attr($obj, $name, $default = $null, $failifempty=$false)
     }
     else
     {
-        Fail-Json -obj $obj -message "Need to specify a value for the parameter $name"
+        if (!$emptyattributefailmessage) {$emptyattributefailmessage = "Need to specify a value for the parameter $name"}
+        Fail-Json -obj $resultobj -message $emptyattributefailmessage
     }
     return
 }


### PR DESCRIPTION
mall change to ease the development of PowerShell-based module.
 This changes the get-attr function slightly, and lets the module specify whether a param is needed and auto-fails if it is not present. A module can now verify params like so::
 $params = Parse-Args $args;
 $result = New-Object psobject;
 Set-Attr $result "changed" $false;
 $path = Get-Attr -obj $params -name path -failifempty $true -resultobj $result

or 

$params = Parse-Args $args;
 $result = New-Object psobject;
 Set-Attr $result "changed" $false;
 $path = Get-Attr -obj $params -name path -failifempty $true -emptyattributefailmessage "Oh man. You forgot the main part!" -resultobj $result
