### PR TITLE
Always return a list even if its empty.

### DIFF
--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -660,7 +660,7 @@ def enforce_count(module, ec2):
 
     changed = None
     checkmode = False
-    instance_dict_array = None
+    instance_dict_array = []
     changed_instance_ids = None
 
     if len(instances) == exact_count:


### PR DESCRIPTION
This is not more a fix then it is a standardization of the returns from the module.
All other cases it will return a list except when it doesnt add anything then it returns None.

This messes up a few things when using: "with_subelements".
