### PR TITLE
portage: Add support for --changed-use

### DIFF
--- a/library/packaging/portage
+++ b/library/packaging/portage
@@ -62,6 +62,16 @@ options:
     default: null
     choices: [ "yes" ]
 
+  changed_use:
+    description:
+      - Include installed packages where USE flags have changed, except when
+      - flags that the user has not enabled are added or removed
+      - (--changed-use)
+    required: false
+    default: null
+    choices: [ "yes" ]
+    version_added: 1.8
+
   oneshot:
     description:
       - Do not add the packages to the world file (--oneshot)
@@ -223,14 +233,21 @@ def emerge_packages(module, packages):
             module.exit_json(changed=False, msg='Packages already present.')
 
     args = []
-    for flag in [
-        'update', 'deep', 'newuse',
-        'oneshot', 'noreplace',
-        'nodeps', 'onlydeps',
-        'quiet', 'verbose',
-    ]:
+    emerge_flags = {
+        'update': '--update',
+        'deep': '--deep',
+        'newuse': '--newuse',
+        'changed_use': '--changed-use',
+        'oneshot': '--oneshot',
+        'noreplace': '--noreplace',
+        'nodeps': '--nodeps',
+        'onlydeps': '--onlydeps',
+        'quiet': '--quiet',
+        'verbose': '--verbose',
+    }
+    for flag, arg in emerge_flags.iteritems():
         if p[flag]:
-            args.append('--%s' % flag)
+            args.append(arg)
 
     cmd, (rc, out, err) = run_emerge(module, packages, *args)
     if rc != 0:
@@ -340,6 +357,7 @@ def main():
             update=dict(default=None, choices=['yes']),
             deep=dict(default=None, choices=['yes']),
             newuse=dict(default=None, choices=['yes']),
+            changed_use=dict(default=None, choices=['yes']),
             oneshot=dict(default=None, choices=['yes']),
             noreplace=dict(default=None, choices=['yes']),
             nodeps=dict(default=None, choices=['yes']),


### PR DESCRIPTION
The `--changed-use` flag is an improvement over `--newuse` because it
does not trigger rebuilds for USE flag changes that would not affect the
installed package. Its use is generally recommended over `--newuse`.

Signed-off-by: Dustin C. Hatch dustin@hatch.name
