### PR TITLE
Can override each role's install path

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -526,7 +526,7 @@ def install_role(role_name, role_version, role_filename, options):
         # we strip off the top-level directory for all of the files contained within
         # the tar file here, since the default is 'github_repo-target', and change it 
         # to the specified role's name
-        role_path = os.path.join(get_opt(options, 'roles_path', '/etc/ansible/roles'), role_name)
+        role_path = os.path.join(get_opt(options, 'roles_path'), role_name)
         role_path = os.path.expanduser(role_path)
         print "- extracting %s to %s" % (role_name, role_path)
         try:
@@ -689,6 +689,7 @@ def execute_install(args, options, parser):
     role_file  = get_opt(options, "role_file", None)
     api_server = get_opt(options, "api_server", "galaxy.ansible.com")
     no_deps    = get_opt(options, "no_deps", False)
+    roles_path = get_opt(options, "roles_path")
 
     if len(args) == 0 and not role_file:
         # the user needs to specify one of either --role-file
@@ -723,6 +724,12 @@ def execute_install(args, options, parser):
         role = roles_left.pop(0)
         role_src = role.get("src")
         role_scm = role.get("scm")
+        role_path = role.get("path")
+
+        if role_path:
+            options.roles_path = role_path
+        else:
+            options.roles_path = roles_path
 
         if os.path.isfile(role_src):
             # installing a local tar.gz

--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -69,6 +69,10 @@ And here's an example showing some specific version downloads from multiple sour
     # from github
     - src: https://github.com/bennojoy/nginx
 
+    # from github installing to a relative path
+    - src: https://github.com/bennojoy/nginx
+      path: vagrant/roles/
+
     # from github, overriding the name and specifying a specific tag
     - src: https://github.com/bennojoy/nginx
       name: nginx_role


### PR DESCRIPTION
Defaults to the system wide `roles-path` when `path` is not specified in the
provided `role-file`.  An example installing nginx to a relative path specified
by the `role-file`.

```
- src: https://github.com/bennojoy/nginx
  path: vagrant/roles/
```
