### PR TITLE
Corrected VM metadata obtention between Abiquo versions

### DIFF
--- a/plugins/inventory/abiquo.ini
+++ b/plugins/inventory/abiquo.ini
@@ -1,23 +1,48 @@
 # Ansible external inventory script settings for Abiquo
 #
+
+# Define an Abiquo user with access to Abiquo API which will be used to
+# perform required queries to obtain infromation to generate the Ansible
+# inventory output.
+#
 [auth]
 apiuser = admin
 apipass = xabiquo
 
+
+# Specify Abiquo API version in major.minor format and the access URI to
+# API endpoint. Tested versions are: 2.6 , 3.0 and 3.1
+# To confirm that your box haves access to Abiquo API you can perform a
+# curl command, replacing with suitable values, similar to this:
+# curl -X GET https://192.168.2.100/api/login -u admin:xabiquo
+# 
 [api]
-uri = http://192.168.2.211:80/api
+version = 3.0
+uri = https://192.168.2.100/api
 # You probably won't need to modify login preferences, but just in case 
 login_path = /login
 login_type = application/vnd.abiquo.user+json
 
+
+# To avoid performing excessive calls to Abiquo API you can define a 
+# cache for the plugin output. Within the time defined in seconds, latest
+# output will be reused. After that time, the cache will be refreshed.
+#
 [cache]
 cache_max_age = 30
-cache_dir = /var/tmp
+cache_dir = /tmp
+
 
 [defaults]
+# Depending in your Abiquo environment, you may want to use only public IP 
+# addresses (if using public cloud providers) or also private IP addresses. 
+# You can set this with public_ip_only configuration.
 public_ip_only = false
 # default_net_interface only is used if public_ip_only = false
+# If public_ip_only is set to false, you can choose default nic to obtain
+# IP address to define the host.
 default_net_interface = nic0
-# Only deployed VM are added to output
+# Only deployed VM are displayed in the plugin output.
 deployed_only = true
+# Define if VM metadata is obtained from Abiquo API.
 get_metadata = false

--- a/plugins/inventory/abiquo.py
+++ b/plugins/inventory/abiquo.py
@@ -167,7 +167,12 @@ def generate_inv_from_api(enterprise_entity,config):
                     meta_entity = next(link for link in (vmcollection['links']) if (link['rel']=='metadata'))
                     try:
                         metadata = api_get(meta_entity,config)
-                        inventory['_meta']['hostvars'][vm_nic] = metadata['metadata']['metadata']
+                        if (config.getfloat("api","version") >= 3.0):                           
+                            vm_metadata = metadata['metadata']
+                        else:
+                            vm_metadata = metadata['metadata']['metadata']
+                        if not vm_metadata is None:
+                            inventory['_meta']['hostvars'][vm_nic] = vm_metadata
                     except Exception, e:
                         pass
 


### PR DESCRIPTION
- Improved abiquo.ini notes (added version property)
- In recent Abiquo versions VM metadata list unmarshalling has been corrected and needs to be taken into count in the inventory plugin
