### PR TITLE
Added include_defaults

### DIFF
--- a/lib/ansible/runner/action_plugins/include_defaults.py
+++ b/lib/ansible/runner/action_plugins/include_defaults.py
@@ -1,0 +1,62 @@
+# (c) 2014 Daniele Varrazzo <daniele.varrazzo@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Why is this not working?
+# import ansible.runner.action_plugins.include_vars as iv
+
+# class ActionModule(iv.ActionModule):
+#     _target = 'defaults'
+
+import os
+from ansible.utils import template
+from ansible import utils
+from ansible import errors
+from ansible.runner.return_data import ReturnData
+
+class ActionModule(object):
+
+    TRANSFERS_FILES = False
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
+
+        if not module_args:
+            result = dict(failed=True, msg="No source file given")
+            return ReturnData(conn=conn, comm_ok=True, result=result)
+
+        source = module_args
+        source = template.template(self.runner.basedir, source, inject)
+
+        if '_original_file' in inject:
+            source = utils.path_dwim_relative(inject['_original_file'], 'defaults', source, self.runner.basedir)
+        else:
+            source = utils.path_dwim(self.runner.basedir, source)
+
+        if os.path.exists(source):
+            data = utils.parse_yaml_from_file(source, vault_password=self.runner.vault_pass)
+            if data and type(data) != dict:
+                raise errors.AnsibleError("%s must be stored as a dictionary/hash" % source)
+            elif data is None:
+                data = {}
+            inject['defaults'].update(data)
+            return ReturnData(conn=conn, comm_ok=True, result={})
+        else:
+            result = dict(failed=True, msg="Source file not found.", file=source)
+            return ReturnData(conn=conn, comm_ok=True, result=result)
+

--- a/lib/ansible/runner/action_plugins/include_defaults.py
+++ b/lib/ansible/runner/action_plugins/include_defaults.py
@@ -18,8 +18,6 @@
 # Why is this not working?
 # import ansible.runner.action_plugins.include_vars as iv
 
-# class ActionModule(iv.ActionModule):
-#     _target = 'defaults'
 
 import os
 from ansible.utils import template

--- a/library/utilities/include_defaults
+++ b/library/utilities/include_defaults
@@ -30,4 +30,7 @@ EXAMPLES = """
 - include_defaults: webserver_config.yml
   when: has_webserver
 
+# Include the defaults defined by another role
+- include_defaults: roles/webserver/defaults/main.yml
+
 """

--- a/library/utilities/include_defaults
+++ b/library/utilities/include_defaults
@@ -1,0 +1,33 @@
+# -*- mode: python -*-
+
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+author: Daniele Varrazzo
+module: include_defaults
+short_description: Load variables defaults from files, dynamically within a task.
+description:
+     - Loads variables from a YAML file dynamically during task runtime.  Unlike include_vars these values can be overridden by the inventory.
+options:
+  free-form:
+    description:
+       - The file name from which variables should be loaded, if called from a role it will look for 
+         the file in vars/ subdirectory of the role, otherwise the path would be relative to playbook. An absolute path can also be provided.
+    required: true
+version_added: "1.8"
+'''
+
+EXAMPLES = """
+# Include the default vars from a web server configuration.
+# They may be overridden by the inventory.
+- include_defaults: webserver_config.yml
+  when: has_webserver
+
+"""

--- a/test/integration/inventory
+++ b/test/integration/inventory
@@ -12,6 +12,7 @@ local
 [local:vars]
 parent_var=6000
 groups_tree_var=5000
+default1="inventory1"
 
 [arbitrary_parent:vars]
 groups_tree_var=4000

--- a/test/integration/roles/test_var_blending/files/foo.txt
+++ b/test/integration/roles/test_var_blending/files/foo.txt
@@ -29,6 +29,12 @@ The value of 'badwolf' is set via the include_vars plugin.
 
 badwolf = badwolf
 
+The value of these variables is set via the include_defaults plugin.
+The first gets overridden by the inventory.
+
+default1 = inventory1
+default2 = default2
+
 The value of 'winter' is set via the main.yml in the role.   
 
 winter = coming

--- a/test/integration/roles/test_var_blending/tasks/main.yml
+++ b/test/integration/roles/test_var_blending/tasks/main.yml
@@ -17,6 +17,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - include_vars: more_vars.yml
+- include_defaults: ../../test_var_precedence_role1/defaults/main.yml
 
 - name: deploy a template that will use variables at various levels
   template: src=foo.j2 dest={{output_dir}}/foo.templated 

--- a/test/integration/roles/test_var_blending/templates/foo.j2
+++ b/test/integration/roles/test_var_blending/templates/foo.j2
@@ -29,6 +29,12 @@ The value of 'badwolf' is set via the include_vars plugin.
 
 badwolf = {{ badwolf }}
 
+The value of these variables is set via the include_defaults plugin.
+The first gets overridden by the inventory.
+
+default1 = {{ default1 }}
+default2 = {{ default2 }}
+
 The value of 'winter' is set via the main.yml in the role.   
 
 winter = {{ winter }}

--- a/test/integration/roles/test_var_precedence_role1/defaults/main.yml
+++ b/test/integration/roles/test_var_precedence_role1/defaults/main.yml
@@ -3,3 +3,7 @@
 vars_files_var: "BAD!"
 # should be seen in role1 (no override)
 defaults_file_var_role1: "defaults_file_var_role1"
+
+# used by test_var_blending to test include_defaults
+default1: "default1"
+default2: "default2"


### PR DESCRIPTION
Please find my first iteration at providing a command "include_defaults".

include_defaults works like include_vars but gives the variables a lower priority such that their value can be overridden in other places, such as the inventory or a group_vars file.

The feature is tested in test_var_blending and is verified that the imported variables are known to the play and the value gets correctly overridden.
