### PR TITLE
win_json_facts_setup_improvements; All changes referenced in PRs #8767 , #8768 , #8769

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -1,4 +1,3 @@
-
 # This particular file snippet, and this file snippet only, is BSD licensed.
 # Modules you write using this snippet, which is embedded dynamically by Ansible
 # still belong to the author of the module, and may assign their own license
@@ -55,25 +54,6 @@ Function Set-Attr($obj, $name, $value)
     $obj | Add-Member -Force -MemberType NoteProperty -Name $name -Value $value
 }
 
-# Helper function to get an "attribute" from a psobject instance in powershell.
-# This is a convenience to make getting Members from an object easier and
-# slightly more pythonic
-# Example: $attr = Get-Attr $response "code" -default "1"
-Function Get-Attr($obj, $name, $default = $null)
-{
-    # Check if the provided Member $name exists in $obj and return it or the
-    # default
-    If ($obj.$name.GetType)
-    {
-        $obj.$name
-    }
-    Else
-    {
-        $default
-    }
-    return
-}
-
 # Helper function to convert a powershell object to JSON to echo it, exiting
 # the script
 # Example: Exit-Json $result
@@ -85,7 +65,7 @@ Function Exit-Json($obj)
         $obj = New-Object psobject
     }
 
-    echo $obj | ConvertTo-Json
+    echo $obj | ConvertTo-Json -Depth 99
     Exit
 }
 
@@ -109,8 +89,33 @@ Function Fail-Json($obj, $message = $null)
 
     Set-Attr $obj "msg" $message
     Set-Attr $obj "failed" $true
-    echo $obj | ConvertTo-Json
+    echo $obj | ConvertTo-Json -Depth 99
     Exit 1
+}
+
+# Helper function to get an "attribute" from a psobject instance in powershell.
+# This is a convenience to make getting Members from an object easier and
+# slightly more pythonic
+# Example: $attr = Get-Attr $response "code" -default "1"
+#Note that if you use the failifempty option, you do need to specify resultobject as well.
+Function Get-Attr($obj, $name, $default = $null,$resultobj, $failifempty=$false, $emptyattributefailmessage)
+{
+    # Check if the provided Member $name exists in $obj and return it or the
+    # default
+    If ($obj.$name.GetType)
+    {
+        $obj.$name
+    }
+    Elseif($failifempty -eq $false)
+    {
+        $default
+    }
+    else
+    {
+        if (!$emptyattributefailmessage) {$emptyattributefailmessage = "Missing required argument: $name"}
+        Fail-Json -obj $resultobj -message $emptyattributefailmessage
+    }
+    return
 }
 
 # Helper filter/pipeline function to convert a value to boolean following current
@@ -136,3 +141,4 @@ Function ConvertTo-Bool
     }
     return
 }
+

--- a/library/windows/setup.ps1
+++ b/library/windows/setup.ps1
@@ -32,6 +32,27 @@ $capacity = 0
 $memory | foreach {$capacity += $_.Capacity}
 $netcfg = Get-WmiObject win32_NetworkAdapterConfiguration
 
+$ActiveNetcfg = @(); $ActiveNetcfg+= $netcfg | where {$_.ipaddress -ne $null}
+$formattednetcfg = @()
+foreach ($adapter in $ActiveNetcfg)
+{
+    $thisadapter = New-Object psobject @{
+    interface_name = $adapter.description
+    dns_domain = $adapter.dnsdomain
+    default_gateway = $null
+    interface_index = $adapter.InterfaceIndex
+    }
+    
+    if ($adapter.defaultIPGateway)
+    {
+        $thisadapter.default_gateway = $adapter.DefaultIPGateway[0].ToString()
+    }
+    
+    $formattednetcfg += $thisadapter;$thisadapter = $null
+}
+
+Set-Attr $result.ansible_facts "ansible_interfaces" $formattednetcfg
+
 Set-Attr $result.ansible_facts "ansible_hostname" $env:COMPUTERNAME;
 Set-Attr $result.ansible_facts "ansible_fqdn" "$([System.Net.Dns]::GetHostByName((hostname)).HostName)"
 Set-Attr $result.ansible_facts "ansible_system" $osversion.Platform.ToString()


### PR DESCRIPTION
get-attr improvements:
This changes the get-attr function slightly, and lets the module specify whether a param is needed and auto-fails if it is not present. A module can now verify params like so::
 $params = Parse-Args $args;
 $result = New-Object psobject;
 Set-Attr $result "changed" $false;
 $path = Get-Attr -obj $params -name path -failifempty $true -resultobj $result

or

$params = Parse-Args $args;
 $result = New-Object psobject;
 Set-Attr $result "changed" $false;
 $path = Get-Attr -obj $params -name path -failifempty $true -emptyattributefailmessage "Oh man. You forgot the main part!" -resultobj $result

json improvements:
slight tweak in how the powershell module converts to json in order to support nested objects (allows for more complex facts, among others)

facts improvements:
This script gathers some extended facts on windows hosts in a json array attribute called "ansible_interfaces". This info is needed for some network-related modules I'm working on. Required the update to powershell.ps1 to return deeply nested json objects.
