### PR TITLE
Docker: add support for restart policy

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -210,6 +210,12 @@ options:
     required: false
     default: false
     aliases: []
+  restart_policy:
+    description:
+      - Set container restart policy
+    required: false
+    default: ''
+    aliases: []
 
 author: Cove Schneider, Joshua Conner, Pavel Antonov
 requirements: [ "docker-py >= 0.3.0", "docker >= 0.10.0" ]
@@ -665,6 +671,7 @@ class DockerManager:
             'privileged':   self.module.params.get('privileged'),
             'links': self.links,
             'network_mode': self.module.params.get('net'),
+            'restart_policy': { "name": self.module.params.get('restart_policy') },
         }
         if docker.utils.compare_version('1.10', self.client.version()['ApiVersion']) >= 0 and hasattr(docker, '__version__') and docker.__version__ > '0.3.0':
             params['dns'] = self.module.params.get('dns')
@@ -754,7 +761,8 @@ def main():
             lxc_conf        = dict(default=None, type='list'),
             name            = dict(default=None),
             net             = dict(default=None),
-            pull_latest     = dict(default=False, type='bool')
+            pull_latest     = dict(default=False, type='bool'),
+            restart_policy  = dict(default=None)
         )
     )
 

--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -204,6 +204,12 @@ options:
     default: ''
     aliases: []
     version_added: "1.8"
+  pull_latest:
+    description:
+      - Pull the latest image before running a container
+    required: false
+    default: false
+    aliases: []
 
 author: Cove Schneider, Joshua Conner, Pavel Antonov
 requirements: [ "docker-py >= 0.3.0", "docker >= 0.10.0" ]
@@ -619,11 +625,7 @@ class DockerManager:
 
             return results
 
-        try:
-            containers = do_create(count, params)
-        except:
-            resource = self.module.params.get('image')
-            image, tag = self.get_split_image_tag(resource)
+        def do_pull(resource, tag):
             if self.module.params.get('username'):
                 try:
                     self.client.login(
@@ -635,11 +637,22 @@ class DockerManager:
                 except:
                     self.module.fail_json(msg="failed to login to the remote registry, check your username/password.")
             try:
-                self.client.pull(image, tag=tag)
+                self.client.pull(resource, tag=tag)
+                self.increment_counter('pull')
             except:
                 self.module.fail_json(msg="failed to pull the specified image: %s" % resource)
-            self.increment_counter('pull')
+
+        resource = self.module.params.get('image')
+        image, tag = self.get_split_image_tag(resource)
+        if self.module.params.get('pull_latest'):
+            do_pull(resource, tag)
+
+        try:
             containers = do_create(count, params)
+        except:
+            if not self.module.params.get('pull_latest'):
+                do_pull(resource, tag)
+                containers = do_create(count, params)
 
         return containers
 
@@ -740,7 +753,8 @@ def main():
             tty             = dict(default=False, type='bool'),
             lxc_conf        = dict(default=None, type='list'),
             name            = dict(default=None),
-            net             = dict(default=None)
+            net             = dict(default=None),
+            pull_latest     = dict(default=False, type='bool')
         )
     )
 


### PR DESCRIPTION
This adds support for the restart_policy introduced in docker 1.2.0: https://blog.docker.com/2014/08/announcing-docker-1-2-0/

This requires the latest master of docker-py, so it might make sense to wait with merging this until a new stable version is released.

PS: This includes #8805
