### PR TITLE
Handle exceptions during config file parsing

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -71,7 +71,11 @@ def load_config_file():
 
     for path in [path0, path1, path2, path3]:
         if path is not None and os.path.exists(path):
-            p.read(path)
+            try:
+                p.read(path)
+            except ConfigParser.Error as e:
+                print "Error reading config file: \n%s" % e
+                sys.exit(1)
             return p
     return None
 


### PR DESCRIPTION
Hello, this mini patch handles uncaught exceptions that can arise when the `ansible.cfg` file is malformed in some way, e.g., no section headers, invalid lines etc.
