### PR TITLE
allow mysql_* modules to get socket connection information from my.cnf

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -1,0 +1,96 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright (c), Michael DeHaan <michael.dehaan@gmail.com>, 2012-2013
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import ConfigParser
+
+def mycnf_options():
+    config_options = dict()
+    config = ConfigParser.RawConfigParser()
+    mycnf = os.path.expanduser('~/.my.cnf')
+    if not os.path.exists(mycnf):
+        return False
+    try:
+        config.readfp(open(mycnf))
+    except (IOError):
+        return False
+    except:
+        config = _safe_cnf_load(config, mycnf)
+
+    # We support two forms of passwords in .my.cnf, both pass= and password=,
+    # as these are both supported by MySQL.
+    try:
+        config_options['passwd'] = config_get(config, 'client', 'password');
+    except (ConfigParser.NoOptionError):
+        try:
+            config_options['passwd'] = config_get(config, 'client', 'pass');
+        except (ConfigParser.NoOptionError):
+            pass
+
+    # get the user if we can
+    try:
+        config_options['user'] = config_get(config, 'client', 'user')
+    except (ConfigParser.NoOptionError):
+        pass
+
+    # get the socket if we can
+    try:
+        config_options['socket'] = config_get(config, 'client', 'socket')
+    except (ConfigParser.NoOptionError):
+        pass
+
+    return config_options
+
+def _safe_cnf_load(config, path):
+
+    data = {'user':'', 'password':'', 'socket': ''}
+
+    # read in user/pass
+    f = open(path, 'r')
+    for line in f.readlines():
+        line = line.strip()
+        if line.startswith('user='):
+            data['user'] = line.split('=', 1)[1].strip()
+        if line.startswith('password=') or line.startswith('pass='):
+            data['password'] = line.split('=', 1)[1].strip()
+        if line.startswith('socket='):
+            data['socket'] = line.split('=', 1)[1].strip()
+    f.close()
+
+    # write out a new cnf file with only user/pass   
+    fh, newpath = tempfile.mkstemp(prefix=path + '.')
+    f = open(newpath, 'wb')
+    f.write('[client]\n')
+    f.write('user=%s\n' % data['user'])
+    f.write('password=%s\n' % data['password'])
+    f.write('socket=%s\n' % data['socket'])
+    f.close()
+
+    config.readfp(open(newpath))
+    os.remove(newpath)
+    return config
+

--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -229,41 +229,6 @@ def config_get(config, section, option):
     return strip_quotes(config.get(section, option))
 
 
-def load_mycnf():
-    config_options = dict()
-    config = ConfigParser.RawConfigParser()
-    mycnf = os.path.expanduser('~/.my.cnf')
-    if not os.path.exists(mycnf):
-        return False
-    try:
-        config.readfp(open(mycnf))
-    except (IOError):
-        return False
-
-    # We support two forms of passwords in .my.cnf, both pass= and password=,
-    # as these are both supported by MySQL.
-    try:
-        config_options['passwd'] = config_get(config, 'client', 'password');
-    except (ConfigParser.NoOptionError):
-        try:
-            config_options['passwd'] = config_get(config, 'client', 'pass');
-        except (ConfigParser.NoOptionError):
-            pass
-
-    # get the user if we can
-    try:
-        config_options['user'] = config_get(config, 'client', 'user')
-    except (ConfigParser.NoOptionError):
-        pass
-
-    # get the socket if we can
-    try:
-        config_options['socket'] = config_get(config, 'client', 'socket')
-    except (ConfigParser.NoOptionError):
-        pass
-
-    return config_options
-
 # ===========================================
 # Module execution.
 #
@@ -303,7 +268,7 @@ def main():
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
     if login_user is None and login_password is None:
-        mycnf = load_mycnf()
+        mycnf = mycnf_options()
         if mycnf and mycnf['user'] and mycnf['passwd']:
             login_user = mycnf["user"]
             login_password = mycnf["passwd"]
@@ -376,4 +341,5 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.mysql import *
 main()

--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -230,6 +230,7 @@ def config_get(config, section, option):
 
 
 def load_mycnf():
+    config_options = dict()
     config = ConfigParser.RawConfigParser()
     mycnf = os.path.expanduser('~/.my.cnf')
     if not os.path.exists(mycnf):
@@ -238,20 +239,30 @@ def load_mycnf():
         config.readfp(open(mycnf))
     except (IOError):
         return False
+
     # We support two forms of passwords in .my.cnf, both pass= and password=,
     # as these are both supported by MySQL.
     try:
-        passwd = config_get(config, 'client', 'password')
+        config_options['passwd'] = config_get(config, 'client', 'password');
     except (ConfigParser.NoOptionError):
         try:
-            passwd = config_get(config, 'client', 'pass')
+            config_options['passwd'] = config_get(config, 'client', 'pass');
         except (ConfigParser.NoOptionError):
-            return False
+            pass
+
+    # get the user if we can
     try:
-        creds = dict(user=config_get(config, 'client', 'user'),passwd=passwd)
+        config_options['user'] = config_get(config, 'client', 'user')
     except (ConfigParser.NoOptionError):
-        return False
-    return creds
+        pass
+
+    # get the socket if we can
+    try:
+        config_options['socket'] = config_get(config, 'client', 'socket')
+    except (ConfigParser.NoOptionError):
+        pass
+
+    return config_options
 
 # ===========================================
 # Module execution.
@@ -292,13 +303,13 @@ def main():
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
     if login_user is None and login_password is None:
-        mycnf_creds = load_mycnf()
-        if mycnf_creds is False:
+        mycnf = load_mycnf()
+        if mycnf and mycnf['user'] and mycnf['passwd']:
+            login_user = mycnf["user"]
+            login_password = mycnf["passwd"]
+        else:
             login_user = "root"
             login_password = ""
-        else:
-            login_user = mycnf_creds["user"]
-            login_password = mycnf_creds["passwd"]
     elif login_password is None or login_user is None:
         module.fail_json(msg="when supplying login arguments, both login_user and login_password must be provided")
     login_host = module.params["login_host"]
@@ -309,9 +320,14 @@ def main():
         connect_to_db = db
     else:
         connect_to_db = 'mysql'
+
+    socket = module.params["login_unix_socket"]
+    if socket is None and mycnf:
+        socket = socket = mycnf['socket']
+
     try:
-        if module.params["login_unix_socket"]:
-            db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db=connect_to_db)
+        if socket:
+            db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=socket, user=login_user, passwd=login_password, db=connect_to_db)
         elif module.params["login_port"] != "3306" and module.params["login_host"] == "localhost":
             module.fail_json(msg="login_host is required when login_port is defined, login_host cannot be localhost when login_port is defined")
         else:

--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -195,42 +195,6 @@ def config_get(config, section, option):
     return strip_quotes(config.get(section, option))
 
 
-def load_mycnf():
-    config_options = dict()
-    config = ConfigParser.RawConfigParser()
-    mycnf = os.path.expanduser('~/.my.cnf')
-    if not os.path.exists(mycnf):
-        return False
-    try:
-        config.readfp(open(mycnf))
-    except (IOError):
-        return False
-
-    # We support two forms of passwords in .my.cnf, both pass= and password=,
-    # as these are both supported by MySQL.
-    try:
-        config_options['passwd'] = config_get(config, 'client', 'password');
-    except (ConfigParser.NoOptionError):
-        try:
-            config_options['passwd'] = config_get(config, 'client', 'pass');
-        except (ConfigParser.NoOptionError):
-            pass
-
-    # get the user if we can
-    try:
-        config_options['user'] = config_get(config, 'client', 'user')
-    except (ConfigParser.NoOptionError):
-        pass
-
-    # get the socket if we can
-    try:
-        config_options['socket'] = config_get(config, 'client', 'socket')
-    except (ConfigParser.NoOptionError):
-        pass
-
-    return config_options
-
-
 def main():
     module = AnsibleModule(
             argument_spec = dict(
@@ -287,7 +251,7 @@ def main():
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
     if login_user is None and login_password is None:
-        mycnf = load_mycnf()
+        mycnf = mycnf_options()
         if mycnf and mycnf['user'] and mycnf['passwd']:
             login_user = mycnf["user"]
             login_password = mycnf["passwd"]
@@ -377,4 +341,5 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.mysql import *
 main()

--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -196,6 +196,7 @@ def config_get(config, section, option):
 
 
 def load_mycnf():
+    config_options = dict()
     config = ConfigParser.RawConfigParser()
     mycnf = os.path.expanduser('~/.my.cnf')
     if not os.path.exists(mycnf):
@@ -204,23 +205,30 @@ def load_mycnf():
         config.readfp(open(mycnf))
     except (IOError):
         return False
+
     # We support two forms of passwords in .my.cnf, both pass= and password=,
     # as these are both supported by MySQL.
     try:
-        passwd = config_get(config, 'client', 'password')
+        config_options['passwd'] = config_get(config, 'client', 'password');
     except (ConfigParser.NoOptionError):
         try:
-            passwd = config_get(config, 'client', 'pass')
+            config_options['passwd'] = config_get(config, 'client', 'pass');
         except (ConfigParser.NoOptionError):
-            return False
+            pass
 
-    # If .my.cnf doesn't specify a user, default to user login name
+    # get the user if we can
     try:
-        user = config_get(config, 'client', 'user')
+        config_options['user'] = config_get(config, 'client', 'user')
     except (ConfigParser.NoOptionError):
-        user = getpass.getuser()
-    creds = dict(user=user, passwd=passwd)
-    return creds
+        pass
+
+    # get the socket if we can
+    try:
+        config_options['socket'] = config_get(config, 'client', 'socket')
+    except (ConfigParser.NoOptionError):
+        pass
+
+    return config_options
 
 
 def main():
@@ -279,19 +287,23 @@ def main():
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
     if login_user is None and login_password is None:
-        mycnf_creds = load_mycnf()
-        if mycnf_creds is False:
+        mycnf = load_mycnf()
+        if mycnf and mycnf['user'] and mycnf['passwd']:
+            login_user = mycnf["user"]
+            login_password = mycnf["passwd"]
+        else:
             login_user = "root"
             login_password = ""
-        else:
-            login_user = mycnf_creds["user"]
-            login_password = mycnf_creds["passwd"]
     elif login_password is None or login_user is None:
         module.fail_json(msg="when supplying login arguments, both login_user and login_password must be provided")
 
+    socket = module.params["login_unix_socket"]
+    if socket is None and mycnf:
+        socket = socket = mycnf['socket']
+
     try:
-        if module.params["login_unix_socket"]:
-            db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db="mysql")
+        if socket:
+            db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=socket, user=login_user, passwd=login_password, db="mysql")
         else:
             db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
     except Exception, e:

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -327,73 +327,6 @@ def config_get(config, section, option):
     return strip_quotes(config.get(section, option))
 
 
-def _safe_cnf_load(config, path):
-
-    data = {'user':'', 'password':'', 'socket': ''}
-
-    # read in user/pass
-    f = open(path, 'r')
-    for line in f.readlines():
-        line = line.strip()
-        if line.startswith('user='):
-            data['user'] = line.split('=', 1)[1].strip()
-        if line.startswith('password=') or line.startswith('pass='):
-            data['password'] = line.split('=', 1)[1].strip()
-        if line.startswith('socket='):
-            data['socket'] = line.split('=', 1)[1].strip()
-    f.close()
-
-    # write out a new cnf file with only user/pass   
-    fh, newpath = tempfile.mkstemp(prefix=path + '.')
-    f = open(newpath, 'wb')
-    f.write('[client]\n')
-    f.write('user=%s\n' % data['user'])
-    f.write('password=%s\n' % data['password'])
-    f.write('socket=%s\n' % data['socket'])
-    f.close()
-
-    config.readfp(open(newpath))
-    os.remove(newpath)
-    return config
-
-def load_mycnf():
-    config_options = dict()
-    config = ConfigParser.RawConfigParser()
-    mycnf = os.path.expanduser('~/.my.cnf')
-    if not os.path.exists(mycnf):
-        return False
-    try:
-        config.readfp(open(mycnf))
-    except (IOError):
-        return False
-    except:
-        config = _safe_cnf_load(config, mycnf)
-
-    # We support two forms of passwords in .my.cnf, both pass= and password=,
-    # as these are both supported by MySQL.
-    try:
-        config_options['passwd'] = config_get(config, 'client', 'password');
-    except (ConfigParser.NoOptionError):
-        try:
-            config_options['passwd'] = config_get(config, 'client', 'pass');
-        except (ConfigParser.NoOptionError):
-            pass
-
-    # get the user if we can
-    try:
-        config_options['user'] = config_get(config, 'client', 'user')
-    except (ConfigParser.NoOptionError):
-        pass
-
-    # get the socket if we can
-    try:
-        config_options['socket'] = config_get(config, 'client', 'socket')
-    except (ConfigParser.NoOptionError):
-        pass
-
-    return config_options
-
-
 def connect(module, login_user, login_password, socket):
     if socket:
         db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=socket, user=login_user, passwd=login_password, db="mysql")
@@ -445,7 +378,7 @@ def main():
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
     if login_user is None and login_password is None:
-        mycnf = load_mycnf()
+        mycnf = mycnf_options()
         if mycnf and mycnf['user'] and mycnf['passwd']:
             login_user = mycnf["user"]
             login_password = mycnf["passwd"]
@@ -488,4 +421,5 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.mysql import *
 main()

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -329,7 +329,7 @@ def config_get(config, section, option):
 
 def _safe_cnf_load(config, path):
 
-    data = {'user':'', 'password':''}
+    data = {'user':'', 'password':'', 'socket': ''}
 
     # read in user/pass
     f = open(path, 'r')
@@ -339,6 +339,8 @@ def _safe_cnf_load(config, path):
             data['user'] = line.split('=', 1)[1].strip()
         if line.startswith('password=') or line.startswith('pass='):
             data['password'] = line.split('=', 1)[1].strip()
+        if line.startswith('socket='):
+            data['socket'] = line.split('=', 1)[1].strip()
     f.close()
 
     # write out a new cnf file with only user/pass   
@@ -347,6 +349,7 @@ def _safe_cnf_load(config, path):
     f.write('[client]\n')
     f.write('user=%s\n' % data['user'])
     f.write('password=%s\n' % data['password'])
+    f.write('socket=%s\n' % data['socket'])
     f.close()
 
     config.readfp(open(newpath))
@@ -354,6 +357,7 @@ def _safe_cnf_load(config, path):
     return config
 
 def load_mycnf():
+    config_options = dict()
     config = ConfigParser.RawConfigParser()
     mycnf = os.path.expanduser('~/.my.cnf')
     if not os.path.exists(mycnf):
@@ -368,24 +372,31 @@ def load_mycnf():
     # We support two forms of passwords in .my.cnf, both pass= and password=,
     # as these are both supported by MySQL.
     try:
-        passwd = config_get(config, 'client', 'password')
+        config_options['passwd'] = config_get(config, 'client', 'password');
     except (ConfigParser.NoOptionError):
         try:
-            passwd = config_get(config, 'client', 'pass')
+            config_options['passwd'] = config_get(config, 'client', 'pass');
         except (ConfigParser.NoOptionError):
-            return False
+            pass
 
-    # If .my.cnf doesn't specify a user, default to user login name
+    # get the user if we can
     try:
-        user = config_get(config, 'client', 'user')
+        config_options['user'] = config_get(config, 'client', 'user')
     except (ConfigParser.NoOptionError):
-        user = getpass.getuser()
-    creds = dict(user=user,passwd=passwd)
-    return creds
+        pass
 
-def connect(module, login_user, login_password):
-    if module.params["login_unix_socket"]:
-        db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db="mysql")
+    # get the socket if we can
+    try:
+        config_options['socket'] = config_get(config, 'client', 'socket')
+    except (ConfigParser.NoOptionError):
+        pass
+
+    return config_options
+
+
+def connect(module, login_user, login_password, socket):
+    if socket:
+        db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=socket, user=login_user, passwd=login_password, db="mysql")
     else:
         db_connection = MySQLdb.connect(host=module.params["login_host"], port=int(module.params["login_port"]), user=login_user, passwd=login_password, db="mysql")
     return db_connection.cursor()
@@ -434,26 +445,30 @@ def main():
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
     if login_user is None and login_password is None:
-        mycnf_creds = load_mycnf()
-        if mycnf_creds is False:
+        mycnf = load_mycnf()
+        if mycnf and mycnf['user'] and mycnf['passwd']:
+            login_user = mycnf["user"]
+            login_password = mycnf["passwd"]
+        else:
             login_user = "root"
             login_password = ""
-        else:
-            login_user = mycnf_creds["user"]
-            login_password = mycnf_creds["passwd"]
     elif login_password is None or login_user is None:
         module.fail_json(msg="when supplying login arguments, both login_user and login_password must be provided")
+
+    socket = module.params["login_unix_socket"]
+    if socket is None and mycnf:
+        socket = socket = mycnf['socket']
 
     cursor = None
     try:
         if check_implicit_admin:
             try:
-                cursor = connect(module, 'root', '')
+                cursor = connect(module, 'root', '', socket)
             except:
                 pass
 
         if not cursor:
-            cursor = connect(module, login_user, login_password)
+            cursor = connect(module, login_user, login_password, socket)
     except Exception, e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials")
 

--- a/library/database/mysql_variables
+++ b/library/database/mysql_variables
@@ -156,42 +156,6 @@ def config_get(config, section, option):
     return strip_quotes(config.get(section, option))
 
 
-def load_mycnf():
-    config_options = dict()
-    config = ConfigParser.RawConfigParser()
-    mycnf = os.path.expanduser('~/.my.cnf')
-    if not os.path.exists(mycnf):
-        return False
-    try:
-        config.readfp(open(mycnf))
-    except (IOError):
-        return False
-
-    # We support two forms of passwords in .my.cnf, both pass= and password=,
-    # as these are both supported by MySQL.
-    try:
-        config_options['passwd'] = config_get(config, 'client', 'password');
-    except (ConfigParser.NoOptionError):
-        try:
-            config_options['passwd'] = config_get(config, 'client', 'pass');
-        except (ConfigParser.NoOptionError):
-            pass
-
-    # get the user if we can
-    try:
-        config_options['user'] = config_get(config, 'client', 'user')
-    except (ConfigParser.NoOptionError):
-        pass
-
-    # get the socket if we can
-    try:
-        config_options['socket'] = config_get(config, 'client', 'socket')
-    except (ConfigParser.NoOptionError):
-        pass
-
-    return config_options
-
-
 def main():
     module = AnsibleModule(
             argument_spec = dict(
@@ -220,7 +184,7 @@ def main():
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
     if login_user is None and login_password is None:
-        mycnf = load_mycnf()
+        mycnf = mycnf_options()
         if mycnf and mycnf['user'] and mycnf['passwd']:
             login_user = mycnf["user"]
             login_password = mycnf["passwd"]
@@ -264,4 +228,5 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.mysql import *
 main()

--- a/library/database/mysql_variables
+++ b/library/database/mysql_variables
@@ -157,6 +157,7 @@ def config_get(config, section, option):
 
 
 def load_mycnf():
+    config_options = dict()
     config = ConfigParser.RawConfigParser()
     mycnf = os.path.expanduser('~/.my.cnf')
     if not os.path.exists(mycnf):
@@ -165,23 +166,30 @@ def load_mycnf():
         config.readfp(open(mycnf))
     except (IOError):
         return False
+
     # We support two forms of passwords in .my.cnf, both pass= and password=,
     # as these are both supported by MySQL.
     try:
-        passwd = config_get(config, 'client', 'password')
+        config_options['passwd'] = config_get(config, 'client', 'password');
     except (ConfigParser.NoOptionError):
         try:
-            passwd = config_get(config, 'client', 'pass')
+            config_options['passwd'] = config_get(config, 'client', 'pass');
         except (ConfigParser.NoOptionError):
-            return False
+            pass
 
-    # If .my.cnf doesn't specify a user, default to user login name
+    # get the user if we can
     try:
-        user = config_get(config, 'client', 'user')
+        config_options['user'] = config_get(config, 'client', 'user')
     except (ConfigParser.NoOptionError):
-        user = getpass.getuser()
-    creds = dict(user=user, passwd=passwd)
-    return creds
+        pass
+
+    # get the socket if we can
+    try:
+        config_options['socket'] = config_get(config, 'client', 'socket')
+    except (ConfigParser.NoOptionError):
+        pass
+
+    return config_options
 
 
 def main():
@@ -212,23 +220,29 @@ def main():
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
     if login_user is None and login_password is None:
-        mycnf_creds = load_mycnf()
-        if mycnf_creds is False:
+        mycnf = load_mycnf()
+        if mycnf and mycnf['user'] and mycnf['passwd']:
+            login_user = mycnf["user"]
+            login_password = mycnf["passwd"]
+        else:
             login_user = "root"
             login_password = ""
-        else:
-            login_user = mycnf_creds["user"]
-            login_password = mycnf_creds["passwd"]
     elif login_password is None or login_user is None:
         module.fail_json(msg="when supplying login arguments, both login_user and login_password must be provided")
+
+    socket = module.params["login_unix_socket"]
+    if socket is None and mycnf:
+        socket = socket = mycnf['socket']
+
     try:
-        if module.params["login_unix_socket"]:
-            db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=module.params["login_unix_socket"], user=login_user, passwd=login_password, db="mysql")
+        if socket:
+            db_connection = MySQLdb.connect(host=module.params["login_host"], unix_socket=socket, user=login_user, passwd=login_password, db="mysql")
         else:
             db_connection = MySQLdb.connect(host=module.params["login_host"], user=login_user, passwd=login_password, db="mysql")
         cursor = db_connection.cursor()
     except Exception, e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials")
+
     if mysqlvar is None:
         module.fail_json(msg="Cannot run without variable to operate with")
     mysqlvar_val = getvariable(cursor, mysqlvar)


### PR DESCRIPTION
This treats socket just like the other connection information (user and passwd) and gets them from my.cnf if it can, when it's not explicitly passed as an option.

This is based on an earlier conversation on the ansible list: https://groups.google.com/d/msg/ansible-project/npSwZM_2OFU/9D4SulSfpi8J
