### PR TITLE
Support filtering out retrieved EC2 dynamic inventory instances in ec2.ini

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -73,3 +73,23 @@ nested_groups = False
 
 # If you want to exclude any hosts that match a certain regular expression
 # pattern_exclude = stage-*
+
+# Instance filters can be used to control which instances are retrieved for
+# inventory. For the full list of possible filters, please read the EC2 API
+# docs: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeInstances.html#query-DescribeInstances-filters
+# Filters are key/value pairs separated by '=', to list multiple filters use
+# a list separated by commas. See examples below.
+
+# Retrieve only instances with (key=value) env=stage tag
+# instance_filters = tag:env=stage
+
+# Retrieve only instances with role=webservers OR role=dbservers tag
+# instance_filters = tag:role=webservers,tag:role=dbservers
+
+# Retrieve only t1.micro instances OR instances with tag env=stage
+# instance_filters = instance-type=t1.micro,tag:env=stage
+
+# You can use wildcards in filter values also. Below will list instances which
+# tag Name value matches webservers1*
+# (ex. webservers15, webservers1a, webservers123 etc) 
+# instance_filters = tag:Name=webservers1*


### PR DESCRIPTION
This allows filtering out EC2 instances based on various different filters including tags. As requested in #7480 it supports logical "OR" instead of "AND" on the provided list of filters.

Multiple API calls are made if the list of filters in ec2.ini config contains more than 1 different filter key.
See examples in ec2.ini for more information.
