### PR TITLE
TTL must be provided with deletion request

### DIFF
--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -113,6 +113,7 @@ EXAMPLES = '''
       record={{ rec.set.record }}
       type={{ rec.set.type }}
       value={{ rec.set.value }}
+      ttl={{ rec.set.value }}
 
 # Add an AAAA record.  Note that because there are colons in the value
 # that the entire parameter list must be quoted:


### PR DESCRIPTION
I spent hours trying to figure what's wrong with my request, then I added the TTL value from the recorded "get" data and it finally worked, must change in all official documentation, really frustrating.
