### PR TITLE
Describing the TTL usage in deletion action

### DIFF
--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -43,7 +43,7 @@ options:
     aliases: []
   ttl:
     description:
-      - The TTL to give the new record
+      - The TTL to give the new record, must be provided with deletion request.
     required: false
     default: 3600 (one hour)
     aliases: []


### PR DESCRIPTION
When deleting a record one must provide the TTL, either manually or by reading the TTL from the current record using get.
