### PR TITLE
Revised additions to windows facts

### DIFF
--- a/library/windows/setup.ps1
+++ b/library/windows/setup.ps1
@@ -66,4 +66,13 @@ $ips = @()
 Foreach ($ip in $netcfg.IPAddress) { If ($ip) { $ips += $ip } }
 Set-Attr $result.ansible_facts "ansible_ip_addresses" $ips
 
+$psversion = $PSVersionTable.PSVersion.Major
+$winrm_cert_expiry = Get-ChildItem -Path Cert:\LocalMachine\My | where Subject -EQ "CN=$env:COMPUTERNAME" | select NotAfter
+
+Set-Attr $result.ansible_facts "ansible_powershell_version" $psversion
+if ($winrm_cert_expiry) 
+{
+    Set-Attr $result.ansible_facts "ansible_winrm_certificate_expires" $winrm_cert_expiry.NotAfter.ToString("yyyy-MM-dd HH:mm:ss")
+}
+
 Exit-Json $result;


### PR DESCRIPTION
This PR adds 2 new facts to windows hosts.
Powershell version (major number only)
If found, the expiry date of the certificate used by WinRM when the ConfigureRemotingForAnsible.ps1 script is run.
Added a null check as suggested by Chris Church to handle http connections (or certs not found).  It is perfectly valid to use non-self signed certs.  The code looks for certs in the local system and filters based on the hostname (which should match due to the need for hostnames to be correct when using https).
