### PR TITLE
RDS rewrite to use boto.rds and boto.rds2

### DIFF
--- a/test/integration/amazon.yml
+++ b/test/integration/amazon.yml
@@ -12,6 +12,7 @@
     #- { role: test_ec2_ami, tags: test_ec2_ami }
     #- { role: test_ec2, tags: test_ec2 }
     - { role: test_ec2_asg, tags: test_ec2_asg }
+    - { role: test_rds, tags: test_rds }
 
 # complex test for ec2_elb, split up over multiple plays
 # since there is a setup component as well as the test which

--- a/test/integration/requirements-rds.yml
+++ b/test/integration/requirements-rds.yml
@@ -1,0 +1,5 @@
+Jinja2==2.7.1
+PyYAML==3.10
+boto==2.25.0
+pycrypto==2.6.1
+python-keyczar==0.71c

--- a/test/integration/requirements-rds2.yml
+++ b/test/integration/requirements-rds2.yml
@@ -1,0 +1,5 @@
+Jinja2==2.7.1
+PyYAML==3.10
+boto==2.32.1
+pycrypto==2.6.1
+python-keyczar==0.71c

--- a/test/integration/roles/test_rds/meta/main.yml
+++ b/test/integration/roles/test_rds/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/roles/test_rds/tasks/main.yml
+++ b/test/integration/roles/test_rds/tasks/main.yml
@@ -1,6 +1,60 @@
 - name: setup DB name
   set_fact: instancename="{{random_string.stdout}}db"
+
+- name: get facts on non existent db
+  rds:
+    instance_name: "{{instancename}}"
+    command: facts
+  register: noinstance
+  ignore_errors: True
+  tags: test_rds
+
+- name: check facts failed
+  assert:
+    that:
+    - noinstance|failed == True
+  tags: test_rds
+
+- name: snapshot non existent db
+  rds:
+    instance_name: "{{instancename}}"
+    command: snapshot
+    snapshot: "snap-{{instancename}}"
+    wait: True
+  register: snapnoinstance
+  ignore_errors: True
+  tags: test_rds
+
+- name: check snapshot failed
+  assert:
+    that:
+    - snapnoinstance|failed == True
+  tags: test_rds
   
+- name: test broken RDS DB creation
+  rds:
+    instance_name: "{{instancename}}"
+    command: create
+    instance_type: db.t2.micro
+    db_engine: MySQL
+    engine_version: "5.5.37"
+    username: dummyuser
+    password: Mysql123
+    size: 5
+    wait: True
+    wait_timeout: 1200
+    tags:
+    - Name: my database
+      Application: dummy
+  tags: test_rds
+  ignore_errors: True
+  register: rds_fail
+
+- name: the last task should fail
+  assert:
+    that:
+    - rds_fail|failed == True
+
 - name: test RDS DB creation
   rds:
     instance_name: "{{instancename}}"
@@ -13,7 +67,7 @@
     wait: True
     wait_timeout: 1200
     tags:
-      Name: my database
+    - Name: my database
       Application: dummy
   tags: test_rds
 

--- a/test/integration/roles/test_rds/tasks/main.yml
+++ b/test/integration/roles/test_rds/tasks/main.yml
@@ -1,0 +1,94 @@
+- name: setup DB name
+  set_fact: instancename="{{random_string.stdout}}db"
+  
+- name: test RDS DB creation
+  rds:
+    instance_name: "{{instancename}}"
+    command: create
+    instance_type: db.t2.micro
+    db_engine: MySQL
+    username: dummyuser
+    password: Mysql123
+    size: 5
+    wait: True
+    wait_timeout: 1200
+    tags:
+      Name: my database
+      Application: dummy
+  tags: test_rds
+
+- name: test RDS modify DB
+  rds:
+    command: modify
+    instance_name: "{{instancename}}"
+    password: Mysql1234
+    size: 6
+  tags: test_rds
+
+- name: test RDS DB facts
+  rds:
+    instance_name: "{{instancename}}"
+    command: facts
+  tags: test_rds
+
+- name: test create read replica DB
+  rds:
+    command: replicate
+    instance_name: "{{instancename}}-replica"
+    source_instance: "{{instancename}}"
+    wait: True
+    wait_timeout: 1200
+  tags: test_rds
+
+- name: test snapshot DB
+  rds:
+    instance_name: "{{instancename}}"
+    command: snapshot
+    snapshot: "snap-{{instancename}}"
+    wait: True
+  tags: test_rds
+
+- name: test restore from snapshot
+  rds:
+    command: restore
+    snapshot: "snap-{{instancename}}"
+    instance_name: "{{instancename}}-from-snap"
+    wait: True
+  tags: test_rds
+
+- name: test snapshot facts
+  rds:
+    snapshot: "snap-{{instancename}}"
+    command: facts
+  tags: test_rds
+
+- name: test promote read replica DB
+  rds:
+    command: promote
+    instance_name: "{{instancename}}-replica"
+  tags: test_rds
+
+- name: test delete snapshot
+  rds:
+    command: delete
+    snapshot: "snap-{{instancename}}"
+    wait: True
+  tags: test_rds
+
+- name: test delete DB
+  rds:
+    instance_name: "{{instancename}}"
+    command: delete
+  tags: test_rds
+
+- name: test delete restore
+  rds:
+    instance_name: "{{instancename}}-from-snap"
+    command: delete
+  tags: test_rds
+
+- name: test delete replica
+  rds:
+    instance_name: "{{instancename}}-replica"
+    command: delete
+  tags: test_rds

--- a/test/integration/test_rds.yml
+++ b/test/integration/test_rds.yml
@@ -2,4 +2,4 @@
   connection: local
 
   roles:
-    - /home/will/src/ansible/test/integration/roles/test_rds
+    - test_rds

--- a/test/integration/test_rds.yml
+++ b/test/integration/test_rds.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  connection: local
+
+  roles:
+    - /home/will/src/ansible/test/integration/roles/test_rds


### PR DESCRIPTION
Using rds2 allows tags and the control over whether or not DBs are
publicly accessible.
Move RDS towards a pair of interfaces implementing the details of rds
and rds2
Added tests to ensure that all operations work correctly as well as
requirements files that allow virtualenvs to test either boto.rds or
boto.rds2
