### PR TITLE
More precisely match module names and multiline output

### DIFF
--- a/library/web_infrastructure/apache2_module
+++ b/library/web_infrastructure/apache2_module
@@ -51,7 +51,7 @@ def _disable_module(module):
     a2dismod_binary = module.get_bin_path("a2dismod")
     result, stdout, stderr = module.run_command("%s %s" % (a2dismod_binary, name))
 
-    if re.match(r'.*' + name + r' already disabled.*', stdout, re.S):
+    if re.match('.*Module \\b' + name + '\\b already disabled', stdout, re.S):
         module.exit_json(changed = False, result = "Success")
     elif result != 0:
         module.fail_json(msg="Failed to disable module %s: %s" % (name, stdout))
@@ -63,7 +63,7 @@ def _enable_module(module):
     a2enmod_binary = module.get_bin_path("a2enmod")
     result, stdout, stderr = module.run_command("%s %s" % (a2enmod_binary, name))
 
-    if re.match(r'.*' + name + r' already enabled.*', stdout, re.S):
+    if re.match('.*Module \\b' + name + '\\b already enabled', stdout, re.S):
         module.exit_json(changed = False, result = "Success")
     elif result != 0:
         module.fail_json(msg="Failed to enable module %s: %s" % (name, stdout))


### PR DESCRIPTION
I believe this fixes issue #8844, but I am not a python programmer.
The previous code would fail on multiline output from a2enmod, as well as incorrectly match on module names. e.g. the output "Module notssl already enabled" would be matched for the name ssl.
