### PR TITLE
Memcached factcache improvements

### DIFF
--- a/lib/ansible/cache/memcached.py
+++ b/lib/ansible/cache/memcached.py
@@ -150,7 +150,7 @@ class CacheModule(BaseCacheModule):
         self._keys = CacheModuleKeys(self._cache, self._cache.get(CacheModuleKeys.PREFIX) or [])
 
     def _make_key(self, key):
-        return "{}{}".format(self._prefix, key)
+        return "{0}{1}".format(self._prefix, key)
 
     def _expire_keys(self):
         if self._timeout > 0:

--- a/lib/ansible/cache/memcached.py
+++ b/lib/ansible/cache/memcached.py
@@ -168,7 +168,7 @@ class CacheModule(BaseCacheModule):
         return value
 
     def set(self, key, value):
-        self._cache.set(self._make_key(key), value, time=self._timeout)
+        self._cache.set(self._make_key(key), value, time=self._timeout, min_compress_len=1)
         self._keys.add(key)
 
     def keys(self):


### PR DESCRIPTION
This pull request addresses 2 things:
1. `.format()` fields should have index references for python2.6 compatibility
2. Add `min_compress_len=1` to `set()` to avoid an issue where the data being inserted exceeds the configured memcached data size limit.  The default value for memcached is 1MB.  If the size of the string or pickled data is larger than the size limit, the python-memcached module will silently discard it. Specifying `min_compress_len=1` will cause the python-memcached module to always compress the data.  I prefer always compressing over sometimes compressing so that the data in memcached is more standardized.
