### PR TITLE
Add integration tests for git recursive yes and no

### DIFF
--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -22,6 +22,7 @@
     repo_format1: 'https://github.com/jimi-c/test_role'
     repo_format2: 'git@github.com:jimi-c/test_role.git'
     repo_format3: 'ssh://git@github.com/jimi-c/test_role.git'
+    repo_withsubmodule: 'https://github.com/joel-airspring/testRepo1.git'
     known_host_files:
       - "{{ lookup('env','HOME') }}/.ssh/known_hosts"
       - '/etc/ssh/ssh_known_hosts'
@@ -134,3 +135,53 @@
     that:
       - 'git_result.changed'
   when: not git_result|skipped
+
+#
+# Test of recursive=yes
+#
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
+
+- name: checkout of repo with submodule with recursive=yes
+  git: repo={{ repo_withsubmodule }} dest={{ checkout_dir }} recursive=yes
+  register: git_result
+
+- name: check for file from repo 1
+  stat: path={{ checkout_dir }}/fileFromTestRepo1
+  register: fileFromRepo1
+
+- name: check for file from submodule from repo 2
+  stat: path={{ checkout_dir }}/submoduleTestRepo2/fileFromTestRepo2
+  register: fileFromRepo2
+
+- name: assert presence of files from repo 1 and repo 2
+  assert:
+    that:
+      - "fileFromRepo1.stat.isreg"
+      - "fileFromRepo2.stat.isreg"
+
+#
+# Test of recursive=no
+#
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
+
+- name: checkout of repo with submodule with recursive=no
+  git: repo={{ repo_withsubmodule }} dest={{ checkout_dir }} recursive=no
+  register: git_result
+
+- name: check for file from repo 1
+  stat: path={{ checkout_dir }}/fileFromTestRepo1
+  register: fileFromRepo1
+
+- name: check for file from submodule from repo 2
+  stat: path={{ checkout_dir }}/submoduleTestRepo2/fileFromTestRepo2
+  register: fileFromRepo2
+
+- name: assert presence of file from repo 1 and absence of file from repo 2
+  assert:
+    that:
+      - "fileFromRepo1.stat.isreg"
+      - "not fileFromRepo2.stat.exists"


### PR DESCRIPTION
I hit the bug with git recursive=no, fixed by this commit:  https://github.com/ansible/ansible/commit/ef1a8e4cddedf8127a253078ef34b884e95eb860

I was in an older version and didn't realize it was already fixed.  However, I did write integration tests for the two cases of recursive=yes and recursive=no.   You're welcome to the tests if you want them.  Otherwise, just close this PR.

The tests use repositories for my github username:  https://github.com/joel-airspring   Feel free to clone those repos into a different user's namespace if so desired.

Joel Jirak 
