### PR TITLE
Fixes bug to allow ELB cross-zone load balancing to be enabled

### DIFF
--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -591,7 +591,7 @@ class ElbManager(object):
 
     def _set_cross_az_load_balancing(self):
         attributes = self.elb.get_attributes()
-        if self.cross_az_load_balancing == 'yes':
+        if self.cross_az_load_balancing == True:
             attributes.cross_zone_load_balancing.enabled = True
         else:
             attributes.cross_zone_load_balancing.enabled = False


### PR DESCRIPTION
This pull request fixes a bug in the ec2_elb_lb module to allow cross zone load balancing to be enabled.  When creating/updating an elb, cross zone load balancing always ends up disabled even when the playbook has it set to enabled.
