### PR TITLE
Fix #8666 for real

### DIFF
--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -575,11 +575,11 @@ def main():
             wait_timeout = dict(default=300),
             dns_support = dict(type='bool', default=True),
             dns_hostnames = dict(type='bool', default=True),
-            subnets = dict(type='list', default=[]),
+            subnets = dict(type='list'),
             vpc_id = dict(),
             internet_gateway = dict(type='bool', default=False),
             resource_tags = dict(type='dict', required=True),
-            route_tables = dict(type='list', default=[]),
+            route_tables = dict(type='list'),
             state = dict(choices=['present', 'absent'], default='present'),
         )
     )


### PR DESCRIPTION
Commit 311ec543af7605bdfcd30d74ea5f77448609b995 ("If not specified, do not modify subnet/route_tables for ec2 VPCs") mostly fixed the problem, except that it left defaults for subnets and route_tables so that not specifying them still deleted them.
