### PR TITLE
Add support for multiple organizations in spacewalk.

### DIFF
--- a/contrib/inventory/spacewalk.ini
+++ b/contrib/inventory/spacewalk.ini
@@ -1,0 +1,16 @@
+# Put this ini-file in the same directory as spacewalk.py
+# Command line options have precedence over options defined in here.
+
+[spacewalk]
+# To limit the script on one organization in spacewalk, uncomment org_number
+# and fill in the organization ID:
+# org_number=2
+
+# To prefix the group names with the organization ID set prefix_org_name=true.
+# This is convenient when org_number is not set and you have the same group names
+# in multiple organizations within spacewalk
+# The prefix is "org_number-"
+prefix_org_name=false
+
+# Default cache_age for files created with spacewalk-report is 300sec. 
+cache_age=300

--- a/contrib/inventory/spacewalk.py
+++ b/contrib/inventory/spacewalk.py
@@ -16,14 +16,15 @@ This script is dependent upon the spacealk-reports package being installed
 on the same machine. It is basically a CSV-to-JSON converter from the
 output of "spacewalk-report system-groups-systems|inventory".
 
-Tested with Ansible 1.1
+Tested with Ansible 1.9.2 and spacewalk 2.3
 """
 # 
 # Author:: Jon Miller <jonEbird@gmail.com>
 # Copyright:: Copyright (c) 2013, Jon Miller
 # 
-# Extended for support of multiple organizations by
-# Bernhard Lichtinger <bernhard.lichtinger@lrz.de> 2014
+# Extended for support of multiple organizations and
+# adding the "_meta" dictionary to --list output by
+# Bernhard Lichtinger <bernhard.lichtinger@lrz.de> 2015
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -44,6 +45,7 @@ import os
 import time
 from optparse import OptionParser
 import subprocess
+import ConfigParser
 
 try:
     import json
@@ -54,8 +56,9 @@ base_dir  = os.path.dirname(os.path.realpath(__file__))
 SW_REPORT = '/usr/bin/spacewalk-report'
 CACHE_DIR = os.path.join(base_dir, ".spacewalk_reports")
 CACHE_AGE = 300 # 5min
+INI_FILE = os.path.join(base_dir, "spacewalk.ini")
 
-# Sanity check
+    # Sanity check
 if not os.path.exists(SW_REPORT):
     print >> sys.stderr, 'Error: %s is required for operation.' % (SW_REPORT)
     sys.exit(1)
@@ -83,6 +86,8 @@ def spacewalk_report(name):
 
     lines = open(cache_filename, 'r').readlines()
     keys = lines[0].strip().split(',')
+    # add 'spacewalk_' prefix to the keys
+    keys = [ 'spacewalk_' + key for key in keys ]
     for line in lines[1:]:
         values = line.strip().split(',')
         if len(keys) == len(values):
@@ -107,12 +112,25 @@ parser.add_option('-p', default=False, dest="prefix_org_name", action="store_tru
 (options, args) = parser.parse_args()
 
 
+# read spacewalk.ini if present
+#------------------------------
+if os.path.exists(INI_FILE):
+    config = ConfigParser.SafeConfigParser()
+    config.read(INI_FILE)
+    if config.has_option('spacewalk' , 'cache_age'):
+        CACHE_AGE = config.get('spacewalk' , 'cache_age')
+    if not options.org_number and config.has_option('spacewalk' , 'org_number'):
+        options.org_number = config.get('spacewalk' , 'org_number')
+    if not options.prefix_org_name and config.has_option('spacewalk' , 'prefix_org_name'):
+        options.prefix_org_name = config.getboolean('spacewalk' , 'prefix_org_name')
+
+
 # Generate dictionary for mapping group_id to org_id
 #------------------------------
 org_groups = {}
 try:
 	for group in spacewalk_report('system-groups'):
-	    org_groups[group['group_id']] = group['org_id'] 
+	    org_groups[group['spacewalk_group_id']] = group['spacewalk_org_id']
 
 except (OSError), e:
 	print >> sys.stderr, 'Problem executing the command "%s system-groups": %s' % \
@@ -124,32 +142,48 @@ except (OSError), e:
 #------------------------------
 if options.list:
 
+    # to build the "_meta"-Group with hostvars first create dictionary for later use
+    host_vars = {}
+    try:
+        for item in spacewalk_report('inventory'):
+            host_vars[ item['spacewalk_profile_name'] ] = dict( ( key, ( value.split(';') if ';' in value else value) ) for key, value in item.items() )
+
+    except (OSError), e:
+        print >> sys.stderr, 'Problem executing the command "%s inventory": %s' % \
+            (SW_REPORT, str(e))
+        sys.exit(2)
+
     groups = {}
+    meta = { "hostvars" : {} }
     try:
         for system in spacewalk_report('system-groups-systems'):
-	# first get org_id of system
-	    org_id =  org_groups[ system['group_id'] ]
+            # first get org_id of system
+            org_id =  org_groups[ system['spacewalk_group_id'] ]
 
-	# shall we add the org_id as prefix to the group name:
+            # shall we add the org_id as prefix to the group name:
             if options.prefix_org_name:
-		prefix = org_id + "-"
-		group_name = prefix + system['group_name']
-	    else:
-		group_name = system['group_name']
+                prefix = org_id + "-"
+                group_name = prefix + system['spacewalk_group_name']
+            else:
+                group_name = system['spacewalk_group_name']
 
-	# if we are limited to one organization:
-	    if options.org_number:
-		if org_id == options.org_number:
-		    if group_name not in groups:
-			groups[group_name] = set()
+            # if we are limited to one organization:
+            if options.org_number:
+                if org_id == options.org_number:
+                    if group_name not in groups:
+                        groups[group_name] = set()
 
-	            groups[group_name].add(system['server_name'])
-	# or we list all groups and systems:
-	    else:
-		    if group_name not in groups:
-			groups[group_name] = set()
+                    groups[group_name].add(system['spacewalk_server_name'])
+                    if system['spacewalk_server_name'] in host_vars and not system['spacewalk_server_name'] in meta[ "hostvars" ]:
+                        meta[ "hostvars" ][ system['spacewalk_server_name'] ] = host_vars[ system['spacewalk_server_name'] ]
+            # or we list all groups and systems:
+            else:
+                if group_name not in groups:
+                    groups[group_name] = set()
 
-		    groups[group_name].add(system['server_name'])
+                groups[group_name].add(system['spacewalk_server_name'])
+                if system['spacewalk_server_name'] in host_vars and not system['spacewalk_server_name'] in meta[ "hostvars" ]:
+                        meta[ "hostvars" ][ system['spacewalk_server_name'] ] = host_vars[ system['spacewalk_server_name'] ]
 
     except (OSError), e:
         print >> sys.stderr, 'Problem executing the command "%s system-groups-systems": %s' % \
@@ -160,8 +194,10 @@ if options.list:
         for group, systems in groups.iteritems():
             print '[%s]\n%s\n' % (group, '\n'.join(systems))
     else:
-        print json.dumps(dict([ (k, list(s)) for k, s in groups.iteritems() ]))
-
+        final = dict( [ (k, list(s)) for k, s in groups.iteritems() ] )
+        final["_meta"] = meta
+        print json.dumps( final )
+        #print json.dumps(groups)
     sys.exit(0)
 
 
@@ -172,7 +208,7 @@ elif options.host:
     host_details = {}
     try:
         for system in spacewalk_report('inventory'):
-            if system['hostname'] == options.host:
+            if system['spacewalk_hostname'] == options.host:
                 host_details = system
                 break
 
@@ -186,8 +222,7 @@ elif options.host:
         for k, v in host_details.iteritems():
             print '  %s: %s' % (k, '\n    '.join(v.split(';')))
     else:
-        print json.dumps(host_details)
-
+        print json.dumps( dict( ( key, ( value.split(';') if ';' in value else value) ) for key, value in host_details.items() ) )
     sys.exit(0)
 
 else:


### PR DESCRIPTION
I added some code to limit the inventory only to one organization within a spacewalk installation. The option -o takes the organization number. 
Also added the -p option to prefix the group names with the organization id, in case you use the script without -o and there are groups with the same name in more than one organization. Otherwise the groups would be merged to one big group in the inventory.

I hope you like the changes.
