### PR TITLE
Issue 8872: use getpass.getpass() to read password.

### DIFF
--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -217,7 +217,7 @@ password hashing library is installed.
 
 Once the library is ready, SHA512 password values can then be generated as follows::
 
-    python -c "from passlib.hash import sha512_crypt; print sha512_crypt.encrypt('<password>')"
+    python -c "from passlib.hash import sha512_crypt; import getpass; print sha512_crypt.encrypt(getpass.getpass())"
 
 .. _commercial_support:
 


### PR DESCRIPTION
This avoids passing the plaintext raw password into the script as a
command-line argument, which shells such as bash and zsh will
typically log into a file like ~/bash_history.

As a small bonus, this works a LOT more smoothly if the user's
password has characters in it that either the shell or Python syntax
might like to interpret as metacharacters, like '\' or '"'.

getpass.getpass() is part of Python's standard library in all versions
between 2.4 and 3.3 at least.
