### PR TITLE
Add environment to plays and roles.

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -38,7 +38,7 @@ class Play(object):
        'accelerate_port', 'accelerate_ipv6', 'sudo', 'sudo_user', 'transport', 'playbook',
        'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
        'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts', 'su', 'su_user',
-       'vault_password', 'no_log',
+       'vault_password', 'no_log', 'environment',
     ]
 
     # to catch typos and so forth -- these are userland names
@@ -48,7 +48,7 @@ class Play(object):
        'tasks', 'handlers', 'remote_user', 'user', 'port', 'include', 'accelerate', 'accelerate_port', 'accelerate_ipv6',
        'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'serial',
        'any_errors_fatal', 'roles', 'role_names', 'pre_tasks', 'post_tasks', 'max_fail_percentage',
-       'su', 'su_user', 'vault_password', 'no_log',
+       'su', 'su_user', 'vault_password', 'no_log', 'environment',
     ]
 
     # *************************************************
@@ -69,6 +69,7 @@ class Play(object):
         self.roles            = ds.get('roles', None)
         self.tags             = ds.get('tags', None)
         self.vault_password   = vault_password
+        self.environment      = ds.get('environment', {})
 
         if self.tags is None:
             self.tags = []

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -71,6 +71,9 @@ class Play(object):
         self.vault_password   = vault_password
         self.environment      = ds.get('environment', {})
 
+        if not isinstance(self.environment, dict):
+            raise errors.AnsibleError('environment must be a dictionary')
+
         if self.tags is None:
             self.tags = []
         elif type(self.tags) in [ str, unicode ]:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -120,7 +120,7 @@ class Task(object):
         self.register     = ds.get('register', None)
         self.sudo         = utils.boolean(ds.get('sudo', play.sudo))
         self.su           = utils.boolean(ds.get('su', play.su))
-        self.environment  = ds.get('environment', {})
+        self.environment  = ds.get('environment', play.environment)
         self.role_name    = role_name
         self.no_log       = utils.boolean(ds.get('no_log', "false")) or self.play.no_log
         self.run_once     = utils.boolean(ds.get('run_once', 'false'))

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -120,10 +120,16 @@ class Task(object):
         self.register     = ds.get('register', None)
         self.sudo         = utils.boolean(ds.get('sudo', play.sudo))
         self.su           = utils.boolean(ds.get('su', play.su))
-        self.environment  = ds.get('environment', play.environment)
         self.role_name    = role_name
         self.no_log       = utils.boolean(ds.get('no_log', "false")) or self.play.no_log
         self.run_once     = utils.boolean(ds.get('run_once', 'false'))
+
+        # combine play and task environments (task updates/overrides play)
+        if not isinstance(ds.get('environment', {}), dict):
+            raise errors.AnsibleError('environment specified for task %s has invalid type %s' % (ds.get('name', 'environment: %s' % ds.get('environment')), type(ds.get('environment'))))
+        else:
+            self.environment = play.environment.copy()
+            self.environment.update(ds.get('environment', {}))
 
         #Code to allow do until feature in a Task 
         if 'until' in ds:


### PR DESCRIPTION
(See https://groups.google.com/d/msg/ansible-project/w3aqRqZ1hIw/SCMV3qwaE-wJ). Play-level environment is used for every task in the play unless task's environment is set. Task environment overrides play environment (i.e. they are not merged).

Future thoughts:
- Merge play + task environment rather than override or make it optional?
- Add environment settings to roles.
