### PR TITLE
Make ssh debug easier to read and paste

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -286,7 +286,7 @@ class Connection(object):
             sudocmd, prompt, success_key = utils.make_sudo_cmd(sudo_user, executable, cmd)
             ssh_cmd.append(sudocmd)
 
-        vvv("EXEC %s" % ssh_cmd, host=self.host)
+        vvv("EXEC %s" % ' '.join(ssh_cmd), host=self.host)
 
         not_in_host_file = self.not_in_host_file(self.host)
 


### PR DESCRIPTION
Currently, ansible -vvvv show the following:

```
hostname EXEC ['ssh', '-C', '-vvv', '-o', 'ControlMaster=auto',
```

This is not good if someone want to cut and paste it to see if something
is wrong with the command line, so join the dictionnary strings with spaces
to have 1 string in the output.
