### PR TITLE
add entrypoint parameter to docker module

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -47,6 +47,12 @@ options:
     required: false
     default: null
     aliases: []
+  entrypoint:
+    description:
+       - Set container entrypoint
+    required: false
+    default: null
+    aliases: []
   name:
     description:
        - Set name for container (used to find single container or to provide links)
@@ -586,6 +592,7 @@ class DockerManager:
     def create_containers(self, count=1):
         params = {'image':        self.module.params.get('image'),
                   'command':      self.module.params.get('command'),
+                  'entrypoint':   self.module.params.get('entrypoint'),
                   'ports':        self.exposed_ports,
                   'volumes':      self.volumes,
                   'mem_limit':    _human_to_bytes(self.module.params.get('memory_limit')),
@@ -706,6 +713,7 @@ def main():
             count           = dict(default=1),
             image           = dict(required=True),
             command         = dict(required=False, default=None),
+            entrypoint      = dict(required=False, default=None),
             expose          = dict(required=False, default=None, type='list'),
             ports           = dict(required=False, default=None, type='list'),
             publish_all_ports = dict(default=False, type='bool'),


### PR DESCRIPTION
Without this parameter, due to the different semantics Docker uses for 'CMD' and 'ENTRYPOINT', it was impossible to override a container's startup command if it had been specified with ENTRYPOINT. This PR simply adds an entrypoint parameter (w/ documentation), which uses already existing docker-py functionality.
