### PR TITLE
Now its possible to use wildcard for versions in apt

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -230,7 +230,8 @@ def expand_pkgspec_from_fnmatches(m, pkgspec, cache):
     new_pkgspec = []
     for pkgname_or_fnmatch_pattern in pkgspec:
         # note that any of these chars is not allowed in a (debian) pkgname
-        if [c for c in pkgname_or_fnmatch_pattern if c in "*?[]!"]:
+        pkg_name = pkgname_or_fnmatch_pattern.split('=')[0]
+        if [c for c in pkg_name if c in "*?[]!"]:
             if "=" in pkgname_or_fnmatch_pattern:
                 m.fail_json(msg="pkgname wildcard and version can not be mixed")
             # handle multiarch pkgnames, the idea is that "apt*" should

--- a/test/integration/roles/test_apt/tasks/apt.yml
+++ b/test/integration/roles/test_apt/tasks/apt.yml
@@ -77,4 +77,27 @@
     that:
         - "not apt_result.changed"
 
+# UNINSTALL AGAIN
+- name: uninstall hello with apt
+  apt: pkg=hello state=absent purge=yes
+  register: apt_result
+
+# INSTALL WITH VERSION WILDCARD
+- name: install hello with apt
+  apt: name=hello=2.7* state=present
+  register: apt_result
+
+- name: check hello with wildcard with  dpkg
+  shell: dpkg --get-selections | fgrep hello
+  failed_when: False
+  register: dpkg_result
+
+- debug: var=apt_result
+- debug: var=dpkg_result
+
+- name: verify installation of hello
+  assert:
+    that:
+        - "apt_result.changed"
+        - "dpkg_result.rc == 0"
 


### PR DESCRIPTION
This pull request try to solve the issue #6885 letting to use apt with wildcards in the version of the package
