### PR TITLE
Add support for generating a PDF of the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ docsite/_static/*.png
 docsite/_static/websupport.js
 docsite/searchindex.js
 docsite/htmlout
+docsite/pdfout
 # deb building stuff...
 debian/
 deb-build

--- a/docsite/Makefile
+++ b/docsite/Makefile
@@ -10,6 +10,9 @@ docs: clean modules staticmin
 	-(cp *.jpg htmlout/)
 	-(cp *.png htmlout/)
 
+pdf:
+	./build-site.py pdf
+
 variables:
 	(mkdir -p htmlout/)
 	dot variables.dot -Tpng -o htmlout/variables.png
@@ -22,6 +25,7 @@ htmldocs: staticmin
 
 clean:
 	-rm -rf htmlout
+	-rm -rf pdfout
 	-rm -f .buildinfo
 	-rm -f *.inv
 	-rm -rf *.doctrees

--- a/docsite/build-site.py
+++ b/docsite/build-site.py
@@ -30,22 +30,26 @@ except ImportError:
     sys.exit(1)
 import os
 
+try:
+    import rst2pdf
+    HAS_RST2PDF = True
+except ImportError:
+    HAS_RST2PDF = False
+
 
 class SphinxBuilder(object):
     """
     Creates HTML documentation using Sphinx.
     """
 
-    def __init__(self):
+    def __init__(self, buildername='html'):
         """
         Run the DocCommand.
         """
         print "Creating html documentation ..."
 
         try:
-            buildername = 'html'
-
-            outdir = os.path.abspath(os.path.join(os.getcwd(), "htmlout"))
+            outdir = os.path.abspath(os.path.join(os.getcwd(), "%sout" % buildername))
             # Create the output directory if it doesn't exist
             if not os.access(outdir, os.F_OK):
                 os.mkdir(outdir)
@@ -81,10 +85,20 @@ class SphinxBuilder(object):
 def build_rst_docs():
     docgen = SphinxBuilder()
 
+def build_pdf_docs():
+    if not HAS_RST2PDF:
+        print "##################################"
+        print "Dependency missing: Python rst2pdf"
+        print "##################################"
+        sys.exit(1)
+    docgen = SphinxBuilder('pdf')
+
 if __name__ == '__main__':
     if '-h' in sys.argv or '--help' in sys.argv:
         print "This script builds the html documentation from rst/asciidoc sources.\n"
         print "    Run 'make docs' to build everything."
+        print "    Run 'make htmldocs' to build html docs."
+        print "    Run 'make pdf' to build pdf docs."
         print "    Run 'make viewdocs' to build and then preview in a web browser."
         sys.exit(0)
 
@@ -92,10 +106,13 @@ if __name__ == '__main__':
     # parameter' We don't need to run the 'htmlman' target then.
     if "rst" in sys.argv:
         build_rst_docs()
+    elif "pdf" in sys.argv:
+        build_pdf_docs()
     else:
         # By default, preform the rst->html transformation and then
         # the asciidoc->html trasnformation
         build_rst_docs()
+        build_pdf_docs()
 
     if "view" in sys.argv:
         import webbrowser

--- a/docsite/conf.py
+++ b/docsite/conf.py
@@ -15,6 +15,16 @@
 
 import sys
 import os
+try:
+    from ansible import __version__ as ansible_version
+except ImportError:
+    ansible_version = '0.01'
+
+try:
+    import rst2pdf
+    HAS_RST2PDF = True
+except ImportError:
+    HAS_RST2PDF = False
 
 # pip install sphinx_rtd_theme
 #import sphinx_rtd_theme
@@ -28,7 +38,7 @@ import os
 sys.path.insert(0, os.path.join('ansible', 'lib'))
 sys.path.append(os.path.abspath('_themes'))
 
-VERSION='0.01'
+VERSION=ansible_version
 AUTHOR='Ansible, Inc'
 
 
@@ -39,6 +49,8 @@ AUTHOR='Ansible, Inc'
 # They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc']
+if HAS_RST2PDF:
+    extensions.append('rst2pdf.pdfbuilder')
 
 # Later on, add 'sphinx.ext.viewcode' to the list if you want to have
 # colorized code generated too for references.
@@ -186,8 +198,7 @@ htmlhelp_basename = 'Poseidodoc'
 # (source start file, target name, title, author, document class
 # [howto/manual]).
 latex_documents = [
-  ('index', 'ansible.tex', 'Ansible 1.2 Documentation',
-   AUTHOR, 'manual'),
+  (master_doc, 'ansible.tex', project, AUTHOR, 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -208,3 +219,11 @@ latex_documents = [
 #latex_use_modindex = True
 
 autoclass_content = 'both'
+
+pdf_documents = [
+    (master_doc, 'ansible', project, AUTHOR),
+]
+
+pdf_stylesheets = ['sphinx', 'kerning', 'a4']
+
+pdf_verbosity = 0


### PR DESCRIPTION
In every project I have ever worked in people always seem to want PDF versions of the docs (#4265).

This PR adds support for building a PDF via sphinx.  `make webdocs` from the root will build both html and pdf.  `make docs` from the docsite dir will build both.  To build just the PDF `make pdf` from docsite.

This utilizes `rst2pdf` which provides PDF support for sphinx.

The PDF is built as `docsite/pdfout/ansible.pdf`
