### PR TITLE
Fixed result|success must return 'false' if result.state is 'skipped', fixes #8753

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -58,7 +58,7 @@ def failed(*a, **kw):
 
 def success(*a, **kw):
     ''' Test if task result yields success '''
-    return not failed(*a, **kw)
+    return not failed(*a, **kw) and not skipped(*a, **kw)
 
 def changed(*a, **kw):
     ''' Test if task result yields changed '''

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -19,7 +19,7 @@ TMPDIR = $(shell mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 
 VAULT_PASSWORD_FILE = vault-password
 
-all: parsing test_var_precedence unicode non_destructive destructive includes check_mode test_hash test_handlers test_group_by test_vault
+all: parsing test_var_precedence unicode non_destructive destructive includes check_mode test_hash test_handlers test_group_by test_vault test_var_results
 
 parsing:
 	ansible-playbook bad_parsing.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -vvv $(TEST_FLAGS) --tags prepare,common,scenario1; [ $$? -eq 3 ]
@@ -58,6 +58,9 @@ test_hash:
 
 test_var_precedence:
 	ansible-playbook test_var_precedence.yml -i $(INVENTORY) $(CREDENTIALS_ARG) -v -e 'extra_var=extra_var' -e 'extra_var_override=extra_var_override'
+
+test_var_results:
+	ansible-playbook test_var_results.yml -i $(INVENTORY)
 
 test_vault:
 	ansible-playbook test_vault.yml -i $(INVENTORY) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) --vault-password-file $(VAULT_PASSWORD_FILE) --list-tasks

--- a/test/integration/roles/test_var_results/tasks/changed.yml
+++ b/test/integration/roles/test_var_results/tasks/changed.yml
@@ -1,0 +1,42 @@
+# (c) 2014, René Moser <mail@renemoser.net>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: run a command to be changed
+  shell: echo "changed"
+  register: changed_result
+
+- name: run a command depending on success of the first task
+  shell: echo "skipping if not successful"
+  when: changed_result|success
+  register: result1
+
+- name: run a command depending on fail of the first task
+  shell: echo "skipping if not failed"
+  when: changed_result|failed
+  register: result2
+
+- name: run a command depending on skip of the first task
+  shell: echo "skipping if not skipped"
+  when: changed_result|skipped
+  register: result3
+
+- name: assert that the depending commands were skipped
+  assert:
+    that:
+    - "result1.changed == true"
+    - "result2.skipped == true"
+    - "result3.skipped == true"

--- a/test/integration/roles/test_var_results/tasks/failed.yml
+++ b/test/integration/roles/test_var_results/tasks/failed.yml
@@ -1,0 +1,43 @@
+# (c) 2014, René Moser <mail@renemoser.net>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: run a command which fails
+  shell: /bin/false
+  register: failed_result
+  ignore_errors: yes
+
+- name: run a command depending on success of the first task
+  shell: echo "skipping if not successful"
+  when: failed_result|success
+  register: result1
+
+- name: run a command depending on fail of the first task
+  shell: echo "skipping if not failed"
+  when: failed_result|failed
+  register: result2
+
+- name: run a command depending on skip of the first task
+  shell: echo "skipping if not skipped"
+  when: failed_result|skipped
+  register: result3
+
+- name: assert that the depending commands were skipped
+  assert:
+    that:
+    - "result1.skipped == true"
+    - "result2.changed == true"
+    - "result3.skipped == true"

--- a/test/integration/roles/test_var_results/tasks/main.yml
+++ b/test/integration/roles/test_var_results/tasks/main.yml
@@ -1,0 +1,20 @@
+# (c) 2014, René Moser <mail@renemoser.net>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- include: skipped.yml
+- include: failed.yml
+- include: changed.yml

--- a/test/integration/roles/test_var_results/tasks/skipped.yml
+++ b/test/integration/roles/test_var_results/tasks/skipped.yml
@@ -1,0 +1,43 @@
+# (c) 2014, René Moser <mail@renemoser.net>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: run a command to be skipped
+  shell: echo "skipped"
+  register: skipped_result
+  when: false
+
+- name: run a command depending on success of the first task
+  shell: echo "skipping if not successful"
+  when: skipped_result|success
+  register: result1
+
+- name: run a command depending on fail of the first task
+  shell: echo "skipping if not failed"
+  when: skipped_result|failed
+  register: result2
+
+- name: run a command depending on skip of the first task
+  shell: echo "skipping if not skipped"
+  when: skipped_result|skipped
+  register: result3
+
+- name: assert that the depending commands were skipped
+  assert:
+    that:
+    - "result1.skipped == true"
+    - "result2.skipped == true"
+    - "result3.changed == true"

--- a/test/integration/test_var_results.yml
+++ b/test/integration/test_var_results.yml
@@ -1,0 +1,3 @@
+- hosts: testhost
+  roles:
+  - { role: test_var_results, tags: test_var_results }


### PR DESCRIPTION
Added bug fix and integration tests. This fixes GH-8753 as discussed on the mailing list.
