### PR TITLE
Adding a new 'load_callback_plugins' config option, defaults to False

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -38,6 +38,8 @@ class Cli(object):
     def __init__(self):
         self.stats = callbacks.AggregateStats()
         self.callbacks = callbacks.CliRunnerCallbacks()
+        if C.DEFAULT_LOAD_CALLBACK_PLUGINS:
+            callbacks.load_callback_plugins()
 
     # ----------------------------------------------
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -175,6 +175,7 @@ SYSTEM_WARNINGS                = get_config(p, DEFAULTS, 'system_warnings', 'ANS
 DEPRECATION_WARNINGS           = get_config(p, DEFAULTS, 'deprecation_warnings', 'ANSIBLE_DEPRECATION_WARNINGS', True, boolean=True)
 DEFAULT_CALLABLE_WHITELIST     = get_config(p, DEFAULTS, 'callable_whitelist', 'ANSIBLE_CALLABLE_WHITELIST', [], islist=True)
 COMMAND_WARNINGS               = get_config(p, DEFAULTS, 'command_warnings', 'ANSIBLE_COMMAND_WARNINGS', False, boolean=True)
+DEFAULT_LOAD_CALLBACK_PLUGINS  = get_config(p, DEFAULTS, 'load_callback_plugins', 'ANSIBLE_LOAD_CALLBACK_PLUGINS', False, boolean=True)
 
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)


### PR DESCRIPTION
As discussed on the ansible-devel ML, here is the code to allow "ansible" command to load callback plugins.
