### PR TITLE
Documentation edit for vsphere_guest module

### DIFF
--- a/library/cloud/vsphere_guest
+++ b/library/cloud/vsphere_guest
@@ -60,7 +60,7 @@ options:
     default: None
   esxi:
     description:
-      - Dictionary which includes datacenter and hostname on which the VM should be created.
+      - Dictionary which includes datacenter and hostname on which the VM should be created. For standalone ESXi hosts, ha-datacenter should be used as the datacenter name
     required: false
     default: null
   state:


### PR DESCRIPTION
I initially couldn't get the vpshere_guest module to work with a standard esxi host. After using pysphere to try to create a vm by hand, I realized that every standalone ESXi host has a default datacenter called ha-datacenter. This isn't displayed anywhere in the web-gui, and I couldn't find it in vmware's documentation. My initial attempt was leaving the datacenter as an empty string (I suspect this would be what others would try as well). I think it would be nice if the module documentation mentioned that standalone connections should use ha-datacenter. If I should make the change somewhere else in the docstring, let me know! 
