### PR TITLE
Add support for using windows domain or active directory users for WinRM connections

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -173,8 +173,8 @@ if ($PSVersionTable.PSVersion.Major -lt 3)
     Write-verbose "basic auth already enabled"
  }
  
-#FIrewall
-netsh advfirewall firewall add rule Profile=public name="Allow WinRM HTTPS" dir=in localport=5986 protocol=TCP action=allow
+#Firewall
+netsh advfirewall firewall add rule Profile=all name="Allow WinRM HTTPS" dir=in localport=5986 protocol=TCP action=allow
 
 
 

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -30,8 +30,8 @@ class Connector(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def connect(self, host, port, user, password, transport, private_key_file):
-        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password, private_key_file=private_key_file)
+    def connect(self, host, port, user, password, authorization_type, transport, private_key_file):
+        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, authorization_type=authorization_type, user=user, password=password, private_key_file=private_key_file)
         if conn is None:
             raise AnsibleError("unsupported connection type: %s" % transport)
         if private_key_file:


### PR DESCRIPTION
Hi

I have a need to support allowing active directory (also known as domain) users on windows hosts with Ansible.  I've been following https://github.com/ansible/ansible/pull/8345 but it has gone a bit quiet and so I've had a go at adding support and tackling what I can of the comments on the above PR.

In summary this PR adds a new parameter, ansible_authorization_type, which can either be omitted or set to 'plaintext' or 'kerberos'.  If it is set to 'kerberos', ansible will attempt to use kinit to set up the connection, silently (and raise AnsibleError if it isn't installed or fails to execute).

This PR includes documentation changes to intro_windows.rst - feedback on setup instructions would be greatfully appreciated especially as I have not been able to test from an ubuntu controller, and I'm not 100% certain I have capture the correct packages required for either centos or ubuntu.

Please note there is a very small change to the configureAnsibleForRemoting.ps1 so if this has been run previously it will either need running again or the firewall rule called "Allow Winr HTTPS" needs to be changed to Profile=all ( the previous version of the rule excluded domain connections).

(new rule is as follows):

netsh advfirewall firewall add rule Profile=all name="Allow WinRM HTTPS" dir=in localport=5986 protocol=TCP action=allow

Currently the connection credentials are not cached, but need to establish if it is functional before attempting to speed things up.

One other concern I have is the setup instructions for windows now look more complicated.  If that's a concern then I could create a separate page for those needing to use domain accounts - its hard to get a feel for how important this feature is to others.
