### PR TITLE
get_url module: Add timeout parameter

### DIFF
--- a/library/network/get_url
+++ b/library/network/get_url
@@ -90,6 +90,12 @@ options:
     required: false
     default: 'yes'
     choices: ['yes', 'no']
+  timeout:
+    description:
+      - Timeout for URL request
+    required: false
+    default: 10
+    version_added: '1.8'
   url_username:
     description:
       - The username for use in HTTP basic authentication. This parameter can be used
@@ -136,14 +142,14 @@ def url_filename(url):
         return 'index.html'
     return fn
 
-def url_get(module, url, dest, use_proxy, last_mod_time, force):
+def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10):
     """
     Download data from the url and store in a temporary file.
 
     Return (tempfile, info about the request)
     """
 
-    rsp, info = fetch_url(module, url, use_proxy=use_proxy, force=force, last_mod_time=last_mod_time)
+    rsp, info = fetch_url(module, url, use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout)
 
     if info['status'] == 304:
         module.exit_json(url=url, dest=dest, changed=False, msg=info.get('msg', ''))
@@ -192,6 +198,7 @@ def main():
         url = dict(required=True),
         dest = dict(required=True),
         sha256sum = dict(default=''),
+        timeout = dict(required=False, type='int', default=10),
     )
 
     module = AnsibleModule(
@@ -205,6 +212,7 @@ def main():
     force = module.params['force']
     sha256sum = module.params['sha256sum']
     use_proxy = module.params['use_proxy']
+    timeout = module.params['timeout']
 
     dest_is_dir = os.path.isdir(dest)
     last_mod_time = None
@@ -219,7 +227,7 @@ def main():
         last_mod_time = datetime.datetime.utcfromtimestamp(mtime)
 
     # download to tmpsrc
-    tmpsrc, info = url_get(module, url, dest, use_proxy, last_mod_time, force)
+    tmpsrc, info = url_get(module, url, dest, use_proxy, last_mod_time, force, timeout)
 
     # Now the request has completed, we can finally generate the final
     # destination file name from the info dict.


### PR DESCRIPTION
Having a timeout is useful. The `module_utils.urls` already provides this so it's just a matter of using it in `get_url`
