### PR TITLE
Fixing issue with symlinked vaults

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1494,7 +1494,7 @@ def _load_vars_from_path(path, results, vault_password=None):
                 % (path, err2.strerror, ))
         # follow symbolic link chains by recursing, so we repeat the same
         # permissions checks above and provide useful errors.
-        return _load_vars_from_path(target, results)
+        return _load_vars_from_path(target, results, vault_password)
 
     # directory
     if stat.S_ISDIR(pathstat.st_mode):


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.7.1
##### Environment:

Running from OSX, managing Ubuntu 14.04 LTS, but this should affect all platforms.
##### Summary:

The provided vault-password isn't used to decrypt symlinked vaults.
##### Steps To Reproduce:

I've set up an example repo at https://github.com/nfelger/ansible-vault-symlink-bug to show the problem. The tree looks like this:

```
.
├── group_vars
│   ├── another_host
│   │   └── vars.yml
│   └── localhost
│       └── vars.yml -> ../another_host/vars.yml
├── localhost
└── site.yml
```

Notice the symlinked group_var, which points to an **unencrypted** vars file. Running this example works fine:

```
$ ansible-playbook -i localhost site.yml
PLAY [all] ********************************************************************

GATHERING FACTS ***************************************************************
ok: [127.0.0.1]

TASK: [debug var=foo] *********************************************************
ok: [127.0.0.1] => {
    "foo": "bar"
}

PLAY RECAP ********************************************************************
127.0.0.1                  : ok=2    changed=0    unreachable=0    failed=0
```

However, if I now **encrypt** the symlinked vars file with `ansible-vault encrypt group_vars/another_host/vars.yml`, and then try to run the playbook again, I get this error (even though I entered the password):

```
$ ansible-playbook --ask-vault-pass -i localhost site.yml
Vault password:
ERROR: A vault password must be specified to decrypt data
```
##### Solution

The reason I believe this is due to, is that the vault_password isn't being passed along when dealing with symlinks. Adding the password to the relevant method call fixes the problem in this instance.
