### PR TITLE
Further refactoring of OpenStack code

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -100,6 +100,17 @@ class OpenStackCloud(object):
         self.image_cache = image_cache
         self.flavor_cache = flavor_cache
 
+    @classmethod
+    def from_module(klass, module):
+        return klass(
+            name='openstack',
+            username=module.params['login_username'],
+            password=module.params['login_password'],
+            project_id=module.params['login_tenant_name'],
+            auth_url=module.params['auth_url'],
+            region_name=module.params['region_name'],
+            service_type='compute')
+
     def get_name(self):
         return self.name
 

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -121,7 +121,7 @@ def openstack_cloud_from_module(module, name='openstack'):
         service_type='compute')
 
 
-class OpenStackAnsibleException(Exception):
+class OpenStackCloudException(Exception):
     pass
 
 
@@ -132,7 +132,7 @@ class OpenStackCloud(object):
                  image_cache=dict(), flavor_cache=None):
 
         if not HAVE_NOVACLIENT:
-            raise OpenStackAnsibleException(
+            raise OpenStackCloudException(
                 "novaclient is required. Install python-novaclient and try again")
         self.name = name
         self.username = username
@@ -176,14 +176,14 @@ class OpenStackCloud(object):
             try:
                 self._nova_client.authenticate()
             except nova_exceptions.Unauthorized, e:
-                raise OpenStackAnsibleException(
+                raise OpenStackCloudException(
                     "Invalid OpenStack Nova credentials.: %s" % e.message)
             except nova_exceptions.AuthorizationFailure, e:
-                raise OpenStackAnsibleException(
+                raise OpenStackCloudException(
                     "Unable to authorize user: %s" % e.message)
 
             if self._nova_client is None:
-                raise OpenStackAnsibleException(
+                raise OpenStackCloudException(
                     "Failed to instantiate nova client. This could mean that your"
                     " credentials are wrong.")
 

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -75,6 +75,18 @@ def openstack_find_nova_addresses(addresses, ext_tag, key_name=None):
     return ret
 
 
+def openstack_cloud_from_module(module, name='openstack'):
+
+    return OpenStackCloud(
+        name=name,
+        username=module.params['login_username'],
+        password=module.params['login_password'],
+        project_id=module.params['login_tenant_name'],
+        auth_url=module.params['auth_url'],
+        region_name=module.params['region_name'],
+        service_type='compute')
+
+
 class OpenStackAnsibleException(Exception):
     pass
 
@@ -101,17 +113,6 @@ class OpenStackCloud(object):
         self.flavor_cache = flavor_cache
 
         self._nova_client = None
-
-    @classmethod
-    def from_module(klass, module):
-        return klass(
-            name='openstack',
-            username=module.params['login_username'],
-            password=module.params['login_password'],
-            project_id=module.params['login_tenant_name'],
-            auth_url=module.params['auth_url'],
-            region_name=module.params['region_name'],
-            service_type='compute')
 
     def get_name(self):
         return self.name

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -57,45 +57,6 @@ try:
 except:
     HAVE_CINDERCLIENT = False
 
-OPENSTACK_OPTIONS = '''
-   login_username:
-     description:
-        - login username to authenticate to keystone
-     required: true
-     default: admin
-   login_password:
-     description:
-        - Password of login user
-     required: true
-     default: 'yes'
-   login_tenant_name:
-     description:
-        - The tenant name of the login user
-     required: true
-     default: 'yes'
-   auth_url:
-     description:
-        - The keystone url for authentication
-     required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
-   region_name:
-     description:
-        - Name of the region
-     required: false
-     default: None
-   availability_zone:
-     description:
-        - Name of the availability zone
-     required: false
-     default: None
-     version_added: "1.8"
-   endpoint_type:
-     description:
-        - endpoint URL type
-     choices: [publicURL, internalURL]
-     required: false
-     default: publicURL
-'''
 
 
 def openstack_argument_spec():

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -138,8 +138,7 @@ def openstack_cloud_from_module(module, name='openstack'):
         project_id=module.params['login_tenant_name'],
         auth_url=module.params['auth_url'],
         region_name=module.params['region_name'],
-        endpoint_type=module.params['endpoint_type'],
-        service_type='compute')
+        endpoint_type=module.params['endpoint_type'])
 
 
 class OpenStackCloudException(Exception):
@@ -149,7 +148,8 @@ class OpenStackCloudException(Exception):
 class OpenStackCloud(object):
 
     def __init__(self, name, username, password, project_id, auth_url,
-                 region_name, service_type, insecure, private=False,
+                 region_name, nova_service_type='compute',
+                 private=False, insecure=False,
                  endpoint_type='publicURL', image_cache=None,
                  flavor_cache=None):
 
@@ -159,15 +159,11 @@ class OpenStackCloud(object):
         self.project_id = project_id
         self.auth_url = auth_url
         self.region_name = region_name
-        self.service_type = service_type
+        self.nova_service_type = nova_service_type
         self.insecure = insecure
-<<<<<<< HEAD
         self.private = private
-        self.image_cache = image_cache
-=======
         self.endpoint_type = endpoint_type
         self._image_cache = image_cache
->>>>>>> fe05bea... Add glance support to OpenStackCloud
         self.flavor_cache = flavor_cache
 
         self._nova_client = None
@@ -198,7 +194,7 @@ class OpenStackCloud(object):
                 self.project_id,
                 self.auth_url,
                 region_name=self.region_name,
-                service_type=self.service_type,
+                service_type=self.nova_service_type,
                 insecure=self.insecure
             )
 

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -35,6 +35,40 @@ try:
 except:
     HAVE_NOVACLIENT = False
 
+OPENSTACK_OPTIONS = '''
+   login_username:
+     description:
+        - login username to authenticate to keystone
+     required: true
+     default: admin
+   login_password:
+     description:
+        - Password of login user
+     required: true
+     default: 'yes'
+   login_tenant_name:
+     description:
+        - The tenant name of the login user
+     required: true
+     default: 'yes'
+   auth_url:
+     description:
+        - The keystone url for authentication
+     required: false
+     default: 'http://127.0.0.1:35357/v2.0/'
+   region_name:
+     description:
+        - Name of the region
+     required: false
+     default: None
+   availability_zone:
+     description:
+        - Name of the availability zone
+     required: false
+     default: None
+     version_added: "1.8"
+'''
+
 
 def openstack_argument_spec():
     # Consume standard OpenStack environment variables.

--- a/lib/ansible/utils/module_docs_fragments/openstack.py
+++ b/lib/ansible/utils/module_docs_fragments/openstack.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2014 Hewlett-Packard Development Company, L.P.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # Standard openstack documentation fragment
+    DOCUMENTATION = '''
+options:
+  login_username:
+   description:
+      - login username to authenticate to keystone
+   required: true
+   default: admin
+  login_password:
+   description:
+      - Password of login user
+   required: true
+   default: 'yes'
+  login_tenant_name:
+   description:
+      - The tenant name of the login user
+   required: true
+   default: 'yes'
+  auth_url:
+   description:
+      - The keystone url for authentication
+   required: false
+   default: 'http://127.0.0.1:35357/v2.0/'
+  region_name:
+   description:
+      - Name of the region
+   required: false
+   default: None
+  availability_zone:
+   description:
+      - Name of the availability zone
+   required: false
+   default: None
+   version_added: "1.8"
+  endpoint_type:
+   description:
+      - endpoint URL type
+   choices: [publicURL, internalURL]
+   required: false
+   default: publicURL
+'''

--- a/library/cloud/cinder_volume
+++ b/library/cloud/cinder_volume
@@ -26,9 +26,10 @@ DOCUMENTATION = '''
 module: cinder_volume
 version_added: "1.8"
 short_description: Create/Delete Cinder Volumes
+extends_documentation_fragment: openstack
 description:
    - Create or Remove cinder block storage volumes
-options:%(openstack_options)s
+options:
    state:
      description:
         - Indicate desired state of the resource
@@ -70,7 +71,7 @@ options:%(openstack_options)s
      required: false
      default: None
 requirements: ["cinderclient"]
-''' % dict(openstack_options=OPENSTACK_OPTIONS)
+'''
 
 EXAMPLES = '''
 # Creates a new cinder volume

--- a/library/cloud/cinder_volume
+++ b/library/cloud/cinder_volume
@@ -1,0 +1,187 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+import time
+
+try:
+    from cinderclient.v1 import client as cinder_client
+    from cinderclient import exceptions as cinder_exc
+except ImportError:
+    print("failed=True msg='cinderclient is required for this module'")
+
+DOCUMENTATION = '''
+---
+module: cinder_volume
+version_added: "1.8"
+short_description: Create/Delete Cinder Volumes
+description:
+   - Create or Remove cinder block storage volumes
+options:%(openstack_options)s
+   state:
+     description:
+        - Indicate desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+   size:
+     description:
+        - Size of volume in GB
+     requried: true
+     default: None
+   display_name:
+     description:
+        - Name of volume
+     required: true
+     default: None
+   display_description:
+     description:
+       - String describing the volume
+     required: false
+     default: None
+   volume_type:
+     description:
+       - Volume type for volume
+     required: false
+     default: None
+   image_id:
+     descritpion:
+       - Image id for boot from volume 
+     required: false
+     default: None
+   image_name:
+     descritpion:
+       - Image name for boot from volume 
+     required: false
+     default: None
+   snapshot_id:
+     description:
+       - Volume snapshot id to create from
+     required: false
+     default: None
+requirements: ["cinderclient"]
+''' % dict(openstack_options=OPENSTACK_OPTIONS)
+
+EXAMPLES = '''
+# Creates a new cinder volume
+- name: create a cinder volume
+  hosts: localhost
+  tasks:  - name: create 40g test volume
+    cinder_volume:
+      state: present
+      login_username: username
+      login_password: Equality7-2521
+      login_tenant_name: username-project1
+      auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
+      region_name: region-b.geo-1
+      availability_zone: az2
+      size: 40
+      display_name: test_volume
+'''
+
+def _present_volume(module, cinder, cloud):
+    for v in cinder.volumes.list():
+        if v.display_name == module.params['display_name']:
+            module.exit_json(changed=False, id=v.id, info=v._info)
+    image_id = module.params['image_id']
+    if module.params['image_name']:
+        image_id = cloud.get_image_id(module.params['image_name'])
+    volume_args = dict(
+        size=module.params['size'],
+        volume_type=module.params['volume_type'],
+        display_name=module.params['display_name'],
+        display_description=module.params['display_description'],
+        imageRef=image_id,
+        snapshot_id=module.params['snapshot_id'],
+        availability_zone=module.params['availability_zone'],
+    )
+    try:
+        vol = cinder.volumes.create(**volume_args)
+    except Exception as e:
+        module.fail_json(msg='Error creating volume:%s' % str(e))
+
+    if module.params['wait']:
+        expires = float(module.params['timeout']) + time.time()
+        while time.time() < expires:
+            volume = cinder.volumes.get(vol.id)
+            if volume.status == 'available':
+                break
+            if volume.status == 'error':
+                module.fail_json(msg='Error creating volume')
+            time.sleep(5)
+    module.exit_json(changed=True, id=vol.id, info=vol._info)
+
+
+def _wait_for_delete(cinder, vol_id, timeout):
+    expires = float(timeout) + time.time()
+    while time.time() < expires:
+        try:
+            cinder.volumes.get(vol_id)
+        except cinder_exc.NotFound:
+            return True
+        time.sleep(5)
+    return False
+
+
+def _absent_volume(module, cinder, cloud):
+
+    volume_id = cloud.get_volume_id(module.params['display_name'])
+    if not volume_id:
+        module.exit_json(changed=False, result="Volume not Found")
+    try:
+        cinder.volumes.delete(v.id)
+    except cinder_exc, e:
+        module.fail_json(msg='Cannot delete volume:%s' % str(e))
+    if module.params['wait']:
+        if not _wait_for_delete(cinder, v.id, module.params['timeout']):
+            module.exit_json(changed=False, result="Volume deletion timed-out")
+    module.exit_json(changed=True, result='Volume Deleted')
+
+
+def main():
+    argument_spec = openstack_argument_spec()
+    argument_spec.update(dict(
+        state                        = dict(required=True, choices=['present', 'absent']),
+        size                         = dict(required=True),
+        volume_type                  = dict(default=None),
+        display_name                 = dict(required=True),
+        display_description          = dict(default=None),
+        image_id                     = dict(default=None),
+        image_name                   = dict(default=None),
+        snapshot_id                  = dict(default=None),
+        wait                         = dict(default=False, choices=[True, False]),
+        timeout                      = dict(default=180)
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive = [
+            ['image_id', 'snapshot_id'],
+            ['image_name', 'snapshot_id'],
+            ['image_id', 'image_name']
+        ],
+    )
+
+    try:
+        cloud = openstack_cloud_from_module(module)
+        cinder = cloud.cinder_client
+        if module.params['state'] == 'present':
+            _present_volume(module, cinder, cloud)
+        if module.params['state'] == 'absent':
+            _absent_volume(module, cinder, cloud)
+    except OpenStackCloudException as e:
+        module.fail_json(msg=e.message)
+
+# this is magic, see lib/ansible/module.params['common.py
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+main()

--- a/library/cloud/cinder_volume
+++ b/library/cloud/cinder_volume
@@ -181,7 +181,7 @@ def main():
     except OpenStackCloudException as e:
         module.fail_json(msg=e.message)
 
-# this is magic, see lib/ansible/module.params['common.py
+# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()

--- a/library/cloud/glance_image
+++ b/library/cloud/glance_image
@@ -177,7 +177,7 @@ def main():
     except OpenStackCloudException as e:
         module.fail_json(msg=e.message)
 
-# this is magic, see lib/ansible/module.params['common.py
+# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()

--- a/library/cloud/glance_image
+++ b/library/cloud/glance_image
@@ -23,32 +23,7 @@ version_added: "1.2"
 short_description: Add/Delete images from glance
 description:
    - Add or Remove images from the glance repository.
-options:
-   login_username:
-     description:
-        - login username to authenticate to keystone
-     required: true
-     default: admin
-   login_password:
-     description:
-        - Password of login user
-     required: true
-     default: 'yes'
-   login_tenant_name:
-     description:
-        - The tenant name of the login user
-     required: true
-     default: 'yes'
-   auth_url:
-     description:
-        - The keystone url for authentication
-     required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
-   region_name:
-     description:
-        - Name of the region
-     required: false
-     default: None
+options:%(openstack_options)s
    state:
      description:
         - Indicate desired state of the resource
@@ -104,15 +79,9 @@ options:
         - The path to the file which has to be uploaded, mutually exclusive with copy_from
      required: false
      default: None
-   endpoint_type:
-     description:
-        - endpoint URL type
-     choices: [publicURL, internalURL]
-     required: false
-     default: publicURL
 requirements: ["glanceclient", "keystoneclient"]
 
-'''
+''' % dict(openstack_options=OPENSTACK_OPTIONS)
 
 EXAMPLES = '''
 # Upload an image from an HTTP URL
@@ -127,54 +96,6 @@ EXAMPLES = '''
 '''
 
 import time
-try:
-    import glanceclient
-    from keystoneclient.v2_0 import client as ksclient
-except ImportError:
-    print("failed=True msg='glanceclient and keystone client are required'")
-
-
-def _get_ksclient(module, kwargs):
-    try:
-        client = ksclient.Client(username=kwargs.get('login_username'),
-                                 password=kwargs.get('login_password'),
-                                 tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
-    except Exception, e:
-        module.fail_json(msg="Error authenticating to the keystone: %s " % e.message)
-    return client 
-
-
-def _get_endpoint(module, client, endpoint_type):
-    try:
-        endpoint = client.service_catalog.url_for(service_type='image', endpoint_type=endpoint_type)
-    except Exception, e:
-        module.fail_json(msg="Error getting endpoint for glance: %s" % e.message)
-    return endpoint
-
-
-def _get_glance_client(module, kwargs):
-    _ksclient = _get_ksclient(module, kwargs)
-    token = _ksclient.auth_token
-    endpoint =_get_endpoint(module, _ksclient, kwargs.get('endpoint_type'))
-    kwargs = {
-            'token': token,
-    }
-    try:
-        client = glanceclient.Client('1', endpoint, **kwargs)
-    except Exception, e:
-        module.fail_json(msg="Error in connecting to glance: %s" % e.message)
-    return client
-
-
-def _glance_image_present(module, params, client):
-    try:
-        for image in client.images.list():
-            if image.name == params['name']:
-                return image.id 
-        return None
-    except Exception, e:
-        module.fail_json(msg="Error in fetching image list: %s" % e.message)
 
 
 def _glance_image_create(module, params, client):
@@ -229,7 +150,6 @@ def main():
         copy_from         = dict(default= None),
         timeout           = dict(default=180),
         file              = dict(default=None),
-        endpoint_type     = dict(default='publicURL', choices=['publicURL', 'internalURL']),
         state             = dict(default='present', choices=['absent', 'present'])
     ))
     module = AnsibleModule(
@@ -239,19 +159,23 @@ def main():
     if module.params['state'] == 'present':
         if not module.params['file'] and not module.params['copy_from']:
             module.fail_json(msg="Either file or copy_from variable should be set to create the image")
-        client = _get_glance_client(module, module.params)
-        id = _glance_image_present(module, module.params, client)
-        if not id:
-            _glance_image_create(module, module.params, client)
-        module.exit_json(changed=False, id=id, result="success")
 
-    if module.params['state'] == 'absent':
-        client = _get_glance_client(module, module.params)
-        id = _glance_image_present(module, module.params, client)
-        if not id:
-            module.exit_json(changed=False, result="Success")
-        else:
-            _glance_delete_image(module, module.params, client)
+    try:
+        cloud = openstack_cloud_from_module(module)
+        id = cloud.get_image_id(module.params['name'])
+
+        if module.params['state'] == 'present':
+            if not id:
+                _glance_image_create(module, module.params, cloud.glance_client)
+            module.exit_json(changed=False, id=id, result="success")
+
+        if module.params['state'] == 'absent':
+            if not id:
+                module.exit_json(changed=False, result="Success")
+            else:
+                _glance_delete_image(module, module.params, cloud.glance_client)
+    except OpenStackCloudException as e:
+        module.fail_json(msg=e.message)
 
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *

--- a/library/cloud/glance_image
+++ b/library/cloud/glance_image
@@ -21,9 +21,10 @@ DOCUMENTATION = '''
 module: glance_image
 version_added: "1.2"
 short_description: Add/Delete images from glance
+extends_documentation_fragment: openstack
 description:
    - Add or Remove images from the glance repository.
-options:%(openstack_options)s
+options:
    state:
      description:
         - Indicate desired state of the resource
@@ -80,8 +81,7 @@ options:%(openstack_options)s
      required: false
      default: None
 requirements: ["glanceclient", "keystoneclient"]
-
-''' % dict(openstack_options=OPENSTACK_OPTIONS)
+'''
 
 EXAMPLES = '''
 # Upload an image from an HTTP URL

--- a/library/cloud/keystone_user
+++ b/library/cloud/keystone_user
@@ -8,9 +8,10 @@ DOCUMENTATION = '''
 module: keystone_user
 version_added: "1.2"
 short_description: Manage OpenStack Identity (keystone) users, tenants and roles
+extends_documentation_fragment: openstack
 description:
    - Manage users,tenants, roles from OpenStack.
-options:%(openstack_options)s
+options:
    token:
      description:
         - The token to be uses in case the password is not specified
@@ -58,7 +59,7 @@ options:%(openstack_options)s
      default: present
 requirements: [ python-keystoneclient ]
 author: Lorin Hochstein
-''' % dict(openstack_options=OPENSTACK_OPTIONS)
+'''
 
 EXAMPLES = '''
 # Create a tenant

--- a/library/cloud/keystone_user
+++ b/library/cloud/keystone_user
@@ -10,23 +10,7 @@ version_added: "1.2"
 short_description: Manage OpenStack Identity (keystone) users, tenants and roles
 description:
    - Manage users,tenants, roles from OpenStack.
-options:
-   login_user:
-     description:
-        - login username to authenticate to keystone
-     required: false
-     default: admin
-   login_password:
-     description:
-        - Password of login user
-     required: false
-     default: 'yes'
-   login_tenant_name:
-     description:
-        - The tenant login_user belongs to
-     required: false
-     default: None
-     version_added: "1.3"
+options:%(openstack_options)s
    token:
      description:
         - The token to be uses in case the password is not specified
@@ -74,7 +58,7 @@ options:
      default: present
 requirements: [ python-keystoneclient ]
 author: Lorin Hochstein
-'''
+''' % dict(openstack_options=OPENSTACK_OPTIONS)
 
 EXAMPLES = '''
 # Create a tenant
@@ -86,23 +70,6 @@ EXAMPLES = '''
 # Apply the admin role to the john user in the demo tenant
 - keystone_user: role=admin user=john tenant=demo
 '''
-
-try:
-    from keystoneclient.v2_0 import client
-except ImportError:
-    keystoneclient_found = False
-else:
-    keystoneclient_found = True
-
-
-def authenticate(endpoint, token, login_user, login_password, login_tenant_name):
-    """Return a keystone client object"""
-
-    if token:
-        return client.Client(endpoint=endpoint, token=token)
-    else:
-        return client.Client(auth_url=endpoint, username=login_user,
-                             password=login_password, tenant_name=login_tenant_name)
 
 
 def tenant_exists(keystone, tenant):
@@ -293,25 +260,17 @@ def main():
             email=dict(required=False),
             role=dict(required=False),
             state=dict(default='present', choices=['present', 'absent']),
-            endpoint=dict(required=False,
-                          default="http://127.0.0.1:35357/v2.0"),
+            endpoint=dict(required=False),
             token=dict(required=False),
-            login_user=dict(required=False),
-            login_password=dict(required=False),
-            login_tenant_name=dict(required=False)
     ))
-    # keystone operations themselves take an endpoint, not a keystone auth_url
-    del(argument_spec['auth_url'])
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         mutually_exclusive=[['token', 'login_user'],
                             ['token', 'login_password'],
-                            ['token', 'login_tenant_name']]
+                            ['token', 'login_tenant_name'],
+                            ['endpoint', 'auth_url']],
     )
-
-    if not keystoneclient_found:
-        module.fail_json(msg="the python-keystoneclient module is required")
 
     user = module.params['user']
     password = module.params['password']
@@ -320,20 +279,19 @@ def main():
     email = module.params['email']
     role = module.params['role']
     state = module.params['state']
-    endpoint = module.params['endpoint']
-    token = module.params['token']
-    login_user = module.params['login_user']
-    login_password = module.params['login_password']
-    login_tenant_name = module.params['login_tenant_name']
-
-    keystone = authenticate(endpoint, token, login_user, login_password, login_tenant_name)
+    if module.params['endpoint']:
+        module.params['auth_url'] = module.params['endpoint']
 
     check_mode = module.check_mode
 
     try:
+        keystone = openstack_cloud_from_module(module).keystone_client
+    except OpenStackCloudException as e:
+        module.fail_json(msg=e.message)
+
+    try:
         d = dispatch(keystone, user, password, tenant, tenant_description,
-                     email, role, state, endpoint, token, login_user,
-                     login_password, check_mode)
+                     email, role, state, check_mode)
     except Exception, e:
         if check_mode:
             # If we have a failure in check mode
@@ -347,8 +305,7 @@ def main():
 
 def dispatch(keystone, user=None, password=None, tenant=None,
              tenant_description=None, email=None, role=None,
-             state="present", endpoint=None, token=None, login_user=None,
-             login_password=None, check_mode=False):
+             state="present", check_mode=False):
     """ Dispatch to the appropriate method.
 
         Returns a dict that will be passed to exit_json

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -556,7 +556,7 @@ def main():
     )
 
     try:
-        nova = openstack_cloud_from_module(module)
+        nova = openstack_cloud_from_module(module).nova_client
 
         if module.params['state'] == 'present':
             if not module.params['image_id'] and not module.params['image_name']:

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -36,32 +36,7 @@ version_added: "1.2"
 short_description: Create/Delete VMs from OpenStack
 description:
    - Create or Remove virtual machines from Openstack.
-options:
-   login_username:
-     description:
-        - login username to authenticate to keystone
-     required: true
-     default: admin
-   login_password:
-     description:
-        - Password of login user
-     required: true
-     default: 'yes'
-   login_tenant_name:
-     description:
-        - The tenant name of the login user
-     required: true
-     default: 'yes'
-   auth_url:
-     description:
-        - The keystone url for authentication
-     required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
-   region_name:
-     description:
-        - Name of the region
-     required: false
-     default: None
+options:%(openstack_options)s
    state:
      description:
         - Indicate desired state of the resource
@@ -135,12 +110,6 @@ options:
      required: false
      default: None
      version_added: "1.8"
-   availability_zone:
-     description:
-        - Name of the availability zone
-     required: false
-     default: None
-     version_added: "1.8"
    meta:
      description:
         - A list of key value pairs that should be provided as a metadata to the new VM
@@ -169,7 +138,7 @@ options:
      default: None
      version_added: "1.6"
 requirements: ["novaclient"]
-'''
+''' % dict(openstack_options=OPENSTACK_OPTIONS)
 
 EXAMPLES = '''
 # Creates a new VM and attaches to a network and passes metadata to the instance

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -536,7 +536,7 @@ def main():
         if module.params['state'] == 'absent':
             _get_server_state(module, nova)
             _delete_server(module, nova)
-    except OpenStackAnsibleException as e:
+    except OpenStackCloudException as e:
         module.fail_json(msg=e.message)
 
 # this is magic, see lib/ansible/module_common.py

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -555,18 +555,11 @@ def main():
         ],
     )
 
-    nova = nova_client.Client(module.params['login_username'],
-                              module.params['login_password'],
-                              module.params['login_tenant_name'],
-                              module.params['auth_url'],
-                              region_name=module.params['region_name'],
-                              service_type='compute')
     try:
-        nova.authenticate()
-    except exceptions.Unauthorized, e:
-        module.fail_json(msg = "Invalid OpenStack Nova credentials.: %s" % e.message)
-    except exceptions.AuthorizationFailure, e:
-        module.fail_json(msg = "Unable to authorize user: %s" % e.message)
+        nova = OpenStackCloud.from_module(module)
+        nova.connect()
+    except OpenStackAnsibleException as e:
+        module.fail_json(msg=e.message)
 
     if module.params['state'] == 'present':
         if not module.params['image_id'] and not module.params['image_name']:

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -34,9 +34,10 @@ DOCUMENTATION = '''
 module: nova_compute
 version_added: "1.2"
 short_description: Create/Delete VMs from OpenStack
+extends_documentation_fragment: openstack
 description:
    - Create or Remove virtual machines from Openstack.
-options:%(openstack_options)s
+options:
    state:
      description:
         - Indicate desired state of the resource
@@ -138,7 +139,7 @@ options:%(openstack_options)s
      default: None
      version_added: "1.6"
 requirements: ["novaclient"]
-''' % dict(openstack_options=OPENSTACK_OPTIONS)
+'''
 
 EXAMPLES = '''
 # Creates a new VM and attaches to a network and passes metadata to the instance

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -556,7 +556,7 @@ def main():
     )
 
     try:
-        nova = OpenStackCloud.from_module(module)
+        nova = openstack_cloud_from_module(module)
 
         if module.params['state'] == 'present':
             if not module.params['image_id'] and not module.params['image_name']:

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -557,19 +557,18 @@ def main():
 
     try:
         nova = OpenStackCloud.from_module(module)
-        nova.connect()
+
+        if module.params['state'] == 'present':
+            if not module.params['image_id'] and not module.params['image_name']:
+                module.fail_json( msg = "Parameter 'image_id' or `image_name` is required if state == 'present'")
+            else:
+                _get_server_state(module, nova)
+                _create_server(module, nova)
+        if module.params['state'] == 'absent':
+            _get_server_state(module, nova)
+            _delete_server(module, nova)
     except OpenStackAnsibleException as e:
         module.fail_json(msg=e.message)
-
-    if module.params['state'] == 'present':
-        if not module.params['image_id'] and not module.params['image_name']:
-            module.fail_json( msg = "Parameter 'image_id' or `image_name` is required if state == 'present'")
-        else:
-            _get_server_state(module, nova)
-            _create_server(module, nova)
-    if module.params['state'] == 'absent':
-        _get_server_state(module, nova)
-        _delete_server(module, nova)
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -357,13 +357,13 @@ def _add_floating_ip(module, nova, server):
     return server
 
 
-def _get_image_id(module, nova):
+def _get_image_id(module, cloud):
     if module.params['image_name']:
-        for image in nova.images.list():
-            if (module.params['image_name'] in image.name and (
+        for (image_id, image_name) in cloud.list_images().items():
+            if (module.params['image_name'] in image_name and (
                     not module.params['image_exclude']
-                    or module.params['image_exclude'] not in image.name)):
-                return image.id
+                    or module.params['image_exclude'] not in image_name)):
+                return image_id
         module.fail_json(msg = "Error finding image id from name(%s)" % module.params['image_name'])
     return module.params['image_id']
 
@@ -378,8 +378,8 @@ def _get_flavor_id(module, nova):
     return module.params['flavor_id']
 
 
-def _create_server(module, nova):
-    image_id = _get_image_id(module, nova)
+def _create_server(module, cloud, nova):
+    image_id = _get_image_id(module, cloud)
     flavor_id = _get_flavor_id(module, nova)
     bootargs = [module.params['name'], image_id, flavor_id]
     bootkwargs = {
@@ -525,14 +525,15 @@ def main():
     )
 
     try:
-        nova = openstack_cloud_from_module(module).nova_client
+        cloud = openstack_cloud_from_module(module)
+        nova = cloud.nova_client
 
         if module.params['state'] == 'present':
             if not module.params['image_id'] and not module.params['image_name']:
                 module.fail_json( msg = "Parameter 'image_id' or `image_name` is required if state == 'present'")
             else:
                 _get_server_state(module, nova)
-                _create_server(module, nova)
+                _create_server(module, cloud, nova)
         if module.params['state'] == 'absent':
             _get_server_state(module, nova)
             _delete_server(module, nova)

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -92,33 +92,32 @@ def main():
 
     try:
         nova = OpenStackCloud.from_module(module)
-        nova.connect()
+
+        if module.params['state'] == 'present':
+            for key in nova.list_keypairs():
+                if key.name == module.params['name']:
+                    if module.params['public_key'] and (module.params['public_key'] != key.public_key ):
+                        module.fail_json(msg = "name {} present but key hash not the same as offered.  Delete key first.".format(key['name']))
+                    else:
+                        module.exit_json(changed = False, result = "Key present")            
+            try:
+                key = nova.create_keypair(module.params['name'], module.params['public_key'])
+            except Exception, e:
+                module.exit_json(msg = "Error in creating the keypair: %s" % e.message)
+            if not module.params['public_key']:
+                module.exit_json(changed = True, key = key.private_key)
+            module.exit_json(changed = True, key = None)
+        if module.params['state'] == 'absent':
+            for key in nova.list_keypairs():
+                if key.name == module.params['name']:
+                    try:
+                        nova.delete_keypair(module.params['name'])
+                    except Exception, e:
+                        module.fail_json(msg = "The keypair deletion has failed: %s" % e.message)
+                    module.exit_json( changed = True, result = "deleted")
+            module.exit_json(changed = False, result = "not present")
     except OpenStackAnsibleException as e:
         module.fail_json(msg=e.message)
-
-    if module.params['state'] == 'present':
-        for key in nova.keypairs.list():
-            if key.name == module.params['name']:
-                if module.params['public_key'] and (module.params['public_key'] != key.public_key ):
-                    module.fail_json(msg = "name {} present but key hash not the same as offered.  Delete key first.".format(key['name']))
-                else:
-                    module.exit_json(changed = False, result = "Key present")            
-        try:
-            key = nova.keypairs.create(module.params['name'], module.params['public_key'])
-        except Exception, e:
-            module.exit_json(msg = "Error in creating the keypair: %s" % e.message)
-        if not module.params['public_key']:
-            module.exit_json(changed = True, key = key.private_key)
-        module.exit_json(changed = True, key = None)
-    if module.params['state'] == 'absent':
-        for key in nova.keypairs.list():
-            if key.name == module.params['name']:
-                try:
-                    nova.keypairs.delete(module.params['name'])
-                except Exception, e:
-                    module.fail_json(msg = "The keypair deletion has failed: %s" % e.message)
-                module.exit_json( changed = True, result = "deleted")
-        module.exit_json(changed = False, result = "not present")
 
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -24,9 +24,10 @@ DOCUMENTATION = '''
 module: nova_keypair
 version_added: "1.2"
 short_description: Add/Delete key pair from nova
+extends_documentation_fragment: openstack
 description:
    - Add or Remove key pair from nova .
-options:%(openstack_options)s
+options:
    state:
      description:
         - Indicate desired state of the resource
@@ -44,7 +45,8 @@ options:%(openstack_options)s
      default: None
 
 requirements: ["novaclient"]
-''' % dict(openstack_options=OPENSTACK_OPTIONS)
+'''
+
 EXAMPLES = '''
 # Creates a key pair with the running users public key
 - nova_keypair: state=present login_username=admin

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -91,7 +91,7 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec)
 
     try:
-        nova = OpenStackCloud.from_module(module)
+        nova = openstack_cloud_from_module(module)
 
         if module.params['state'] == 'present':
             for key in nova.list_keypairs():

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -26,32 +26,7 @@ version_added: "1.2"
 short_description: Add/Delete key pair from nova
 description:
    - Add or Remove key pair from nova .
-options:
-   login_username:
-     description:
-        - login username to authenticate to keystone
-     required: true
-     default: admin
-   login_password:
-     description:
-        - Password of login user
-     required: true
-     default: 'yes'
-   login_tenant_name:
-     description:
-        - The tenant name of the login user
-     required: true
-     default: 'yes'
-   auth_url:
-     description:
-        - The keystone url for authentication
-     required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
-   region_name:
-     description:
-        - Name of the region
-     required: false
-     default: None
+options:%(openstack_options)s
    state:
      description:
         - Indicate desired state of the resource
@@ -69,7 +44,7 @@ options:
      default: None
 
 requirements: ["novaclient"]
-'''
+''' % dict(openstack_options=OPENSTACK_OPTIONS)
 EXAMPLES = '''
 # Creates a key pair with the running users public key
 - nova_keypair: state=present login_username=admin

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -91,7 +91,7 @@ def main():
                         module.fail_json(msg = "The keypair deletion has failed: %s" % e.message)
                     module.exit_json( changed = True, result = "deleted")
             module.exit_json(changed = False, result = "not present")
-    except OpenStackAnsibleException as e:
+    except OpenStackCloudException as e:
         module.fail_json(msg=e.message)
 
 # this is magic, see lib/ansible/module.params['common.py

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -94,7 +94,7 @@ def main():
     except OpenStackCloudException as e:
         module.fail_json(msg=e.message)
 
-# this is magic, see lib/ansible/module.params['common.py
+# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -17,12 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
-try:
-    from novaclient.v1_1 import client as nova_client
-    from novaclient import exceptions as exc
-    import time
-except ImportError:
-    print("failed=True msg='novaclient is required for this module to work'")
+import time
 
 DOCUMENTATION = '''
 ---
@@ -95,18 +90,11 @@ def main():
     ))
     module = AnsibleModule(argument_spec=argument_spec)
 
-    nova = nova_client.Client(module.params['login_username'],
-                              module.params['login_password'],
-                              module.params['login_tenant_name'],
-                              module.params['auth_url'],
-                              region_name=module.params['region_name'],
-                              service_type='compute')
     try:
-        nova.authenticate()
-    except exc.Unauthorized, e:
-        module.fail_json(msg = "Invalid OpenStack Nova credentials.: %s" % e.message)
-    except exc.AuthorizationFailure, e:
-        module.fail_json(msg = "Unable to authorize user: %s" % e.message)
+        nova = OpenStackCloud.from_module(module)
+        nova.connect()
+    except OpenStackAnsibleException as e:
+        module.fail_json(msg=e.message)
 
     if module.params['state'] == 'present':
         for key in nova.keypairs.list():

--- a/library/cloud/nova_volume
+++ b/library/cloud/nova_volume
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+try:
+    from novaclient.v1_1 import client as nova_client
+    from novaclient import exceptions as nova_exc
+except ImportError:
+    print("failed=True msg='novaclient is required for this module'")
+try:
+    from cinderclient.v1 import client as cinder_client
+    from cinderclient import exceptions as cinder_exc
+except ImportError:
+    print("failed=True msg='cinderclient is required for this module'")
+
+import time
+
+DOCUMENTATION = '''
+---
+module: nova_volume
+version_added: "1.8"
+short_description: Attach/Detach Volumes from OpenStack VM's
+description:
+   - Attach or Detach volumes from OpenStack VM's
+options:
+   state:
+     description:
+        - Indicate desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+   server_name:
+     description:
+       - Name of server you want to attach a volume to
+     required: false
+     default: None
+   server_id:
+     description:
+       - ID of server you want to attach a volume to
+     required: false
+     default: None
+   volume_name:
+     description:
+      - Name of volume you want to attach to a server
+     required: false
+     default: None
+   volume_id:
+     descripiton:
+      - ID of volume you want to attach to a server
+     required: false
+     default: None
+   device:
+     description:
+      - Device you want to attach
+     required: false
+     default: None
+requirements: ["novaclient", "cinderclient"]
+''' % dict(openstack_options=OPENSTACK_OPTIONS)
+
+
+EXAMPLES = '''
+# Creates a new VM and attaches to a network and passes metadata to the instance
+- nova_compute:
+       state: present
+       os_username: admin
+       os_password: admin
+       os_tenant_name: admin
+       server_name: Mysql-server
+       volume_name: mysql-data
+       device: /dev/vdb
+'''
+
+def _wait_for_detach(cinder, module):
+    expires = float(module.params['timeout']) + time.time()
+    while time.time() < expires:
+        volume = cinder.volumes.get(module.params['volume_id'])
+        if volume.status == 'available':
+            break
+    return volume
+
+
+def _check_server_attachments(volume, server_id, volume_id):
+    for attach in volume.attachments:
+        if server_id == attach['server_id']:
+            return True
+    return False
+
+def _present_volume(nova, cinder, module):
+    try:
+        volume = cinder.volumes.get(module.params['volume_id'])
+    except Exception as e:
+        module.fail_json(msg='Error getting volume:%s' % str(e))
+
+    try:
+        if _check_server_attachments(volume, module.params['server_id']):
+            # Attached. Now, do we care about device?
+            if module.params['device'] and not _check_device_attachment(volume, modules.params['device']):
+                nova.volumes.delete_server_volume(
+                    module.params['server_id'],
+                    module.params['volume_id'])
+                volume = _wait_for_detach(cinder, module)
+            else:
+                module.exit_json(changed=False, result='Volume already attached')
+    except Exception as e:
+        module.fail_json(msg='Error processing volume:%s' % str(e))
+
+    if volume.status != 'available':
+        module.fail_json(msg='Cannot attach volume, not available')
+    try:
+        nova.volumes.create_server_volume(module.params['server_id'],
+                                          module.params['volume_id'],
+                                          module.params['device'])
+    except Exception as e:
+        module.fail_json(msg='Cannot add volume to server:%s' % str(n))
+
+    if module.params['wait']:
+        expires = float(module.params['timeout']) + time.time()
+        attachment = None
+        while time.time() < expires:
+            volume = cinder.volumes.get(module.params['volume_id'])
+            for attach in volume.attachments:
+                if attach['server_id'] == module.params['server_id']:
+                    attachment = attach
+                    break
+    module.exit_json(changed=True, id=volume.id, info=attachment)
+
+
+def _absent_volume(nova, cinder, module):
+    try:
+        volume = cinder.volumes.get(module.params['volume_id'])
+    except Exception as e:
+        module.fail_json(msg='Error getting volume:%s' % str(e))
+
+    if not _check_server_attachments(volume, module.params['server_id']):
+        module.exit_json(changed=False, msg='Volume is not attached to server')
+
+    try:
+        nova.volumes.delete_server_volume(module.params['server_id'],
+                                          module.params['volume_id'])
+        if module.params['wait']:
+            _wait_for_detach(cinder, module)
+    except Exception as e:
+        module.fail_json(msg='Error removing volume from server:%s' % str(e))
+    module.exit_json(changed=True, result='Detached volume from server')
+
+
+def main():
+    argument_spec = openstack_argument_spec()
+    argument_spec.update(dict(
+        server_id                    = dict(default=None),
+        server_name                  = dict(default=None),
+        volume_name                  = dict(default=None),
+        volume_id                    = dict(default=None),
+        device                       = dict(default=None),
+        state                        = dict(default='present', choices=['absent', 'present']),
+        wait                         = dict(default=False, choices=[True, False]),
+        timeout                      = dict(default=180)
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive = [
+            ['volume_id','volume_name'],
+            ['server_id', 'server_name']
+        ],
+    )
+
+    try:
+        cloud = openstack_cloud_from_module(module)
+        cinder = cloud.cinder_client
+        nova = cloud.nova_client
+
+        if module.params['volume_name'] != None:
+            module.params['volume_id'] = cloud.get_volume_id(
+                module.params['volume_name'])
+
+        if module.params['server_name'] != None:
+            module.params['server_id'] = cloud.get_server_id(
+                module.params['server_name'])
+
+        if module.params['state'] == 'present':
+            _present_volume(nova, cinder, module)
+        if module.params['state'] == 'absent':
+            _absent_volume(nova, cinder, module)
+
+    except OpenStackCloudException as e:
+        module.fail_json(msg=e.message)
+
+# this is magic, see lib/ansible/module_utils/common.py
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+main()

--- a/library/cloud/nova_volume
+++ b/library/cloud/nova_volume
@@ -31,6 +31,7 @@ DOCUMENTATION = '''
 module: nova_volume
 version_added: "1.8"
 short_description: Attach/Detach Volumes from OpenStack VM's
+extends_documentation_fragment: openstack
 description:
    - Attach or Detach volumes from OpenStack VM's
 options:
@@ -65,8 +66,7 @@ options:
      required: false
      default: None
 requirements: ["novaclient", "cinderclient"]
-''' % dict(openstack_options=OPENSTACK_OPTIONS)
-
+'''
 
 EXAMPLES = '''
 # Creates a new VM and attaches to a network and passes metadata to the instance

--- a/library/cloud/quantum_floating_ip
+++ b/library/cloud/quantum_floating_ip
@@ -259,7 +259,7 @@ def main():
             _update_floating_ip(neutron, module, None, floating_id)
         module.exit_json(changed=False)
 
-# this is magic, see lib/ansible/module.params['common.py
+# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()

--- a/library/cloud/quantum_floating_ip_associate
+++ b/library/cloud/quantum_floating_ip_associate
@@ -211,7 +211,7 @@ def main():
             _update_floating_ip(neutron, module, None, floating_ip_id)
         module.exit_json(changed = True, result = "detached")
 
-# this is magic, see lib/ansible/module.params['common.py
+# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()

--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -272,7 +272,7 @@ def main():
             _delete_network(module, network_id, neutron)
             module.exit_json(changed = True, result = "Deleted")
 
-# this is magic, see lib/ansible/module.params['common.py
+# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()

--- a/library/cloud/quantum_router
+++ b/library/cloud/quantum_router
@@ -203,7 +203,7 @@ def main():
             _delete_router(module, neutron, router_id)
             module.exit_json(changed=True, result="deleted")
 
-# this is magic, see lib/ansible/module.params['common.py
+# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()

--- a/library/cloud/quantum_router_gateway
+++ b/library/cloud/quantum_router_gateway
@@ -206,7 +206,7 @@ def main():
         _remove_gateway_router(neutron, module, router_id)
         module.exit_json(changed=True, result="Deleted")
 
-# this is magic, see lib/ansible/module.params['common.py
+# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()

--- a/library/cloud/quantum_router_interface
+++ b/library/cloud/quantum_router_interface
@@ -242,7 +242,7 @@ def main():
         _remove_interface_router(neutron, module, router_id, subnet_id)
         module.exit_json(changed=True, result="Deleted")
 
-# this is magic, see lib/ansible/module.params['common.py
+# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()

--- a/library/cloud/quantum_subnet
+++ b/library/cloud/quantum_subnet
@@ -284,7 +284,7 @@ def main():
             _delete_subnet(module, neutron, subnet_id)
             module.exit_json(changed = True, result = "deleted")
 
-# this is magic, see lib/ansible/module.params['common.py
+# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()

--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -2,29 +2,27 @@
 
 [openstack]
 # API version
-version       = 2
+version = 2
 
 # OpenStack nova username
-username      =
+username = someuser
 
-# OpenStack nova api_key
-api_key       =
+# OpenStack password
+password = ckr1t
 
 # OpenStack nova auth_url
-auth_url      =
+auth_url = https://127.0.0.1:35357/v2.0/
+
+# OpenStack nova project_id (also known as tenant_name)
+project_id = someuser-project1
 
 # Authentication system
-auth_system =
+auth_system = keystone
 
-# OpenStack nova project_id
-project_id    = 
+# Server region name to use
+region_name = region-a.geo-1,region-b.geo-1
 
-# Serverarm region name to use
-region_name   =
+# Service type
+service_type = compute
 
-# TODO: Some other options
-# insecure      =
-# endpoint_type =
-# extensions    =
-# service_type  =
-# service_name  =
+insecure = 0

--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -1,8 +1,19 @@
 # Ansible OpenStack external inventory script
-# This file can contain multiple sections if you have multiple clouds
-# By default, if you just have one cloud, then we're going to call it
-# openstack
+# cache related variables
+[cache]
+# API calls to OpenStack are slow. For this reason, we cache the results of an
+# API call. Set this to the path you want cache files to be written to. One
+# file will be written to this directory:
+#   - ansible-nova.cache
+cache_path = ~/.ansible/tmp
 
+# The number of seconds a cache file is considered valid. After this many
+# seconds, a new API call will be made, and the cache file will be updated.
+# To disable the cache, set this value to 0
+cache_max_age = 300
+
+# This file can contain multiple sections if you have multiple clouds. Each
+# section will be read and will represent a cloud.
 [openstack]
 # API version
 version = 2

--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -16,9 +16,6 @@ auth_url = https://127.0.0.1:35357/v2.0/
 # OpenStack nova project_id (also known as tenant_name)
 project_id = someuser-project1
 
-# Authentication system
-auth_system = keystone
-
 # Server region name to use
 region_name = region-a.geo-1,region-b.geo-1
 

--- a/plugins/inventory/nova.ini
+++ b/plugins/inventory/nova.ini
@@ -1,4 +1,7 @@
 # Ansible OpenStack external inventory script
+# This file can contain multiple sections if you have multiple clouds
+# By default, if you just have one cloud, then we're going to call it
+# openstack
 
 [openstack]
 # API version
@@ -16,7 +19,7 @@ auth_url = https://127.0.0.1:35357/v2.0/
 # OpenStack nova project_id (also known as tenant_name)
 project_id = someuser-project1
 
-# Server region name to use
+# Server region name to use, can be a comma separated list
 region_name = region-a.geo-1,region-b.geo-1
 
 # Service type

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -97,7 +97,7 @@ class NovaInventory(object):
             nova_client_params['project_id'] = config.get(cloud, 'project_id')
             nova_client_params['auth_url'] = config.get(cloud, 'auth_url')
             nova_client_params['region_name'] = config.get(cloud, 'region_name')
-            nova_client_params['service_type'] = config.get(cloud, 'service_type')
+            nova_client_params['nova_service_type'] = config.get(cloud, 'service_type')
             nova_client_params['insecure'] = config.getboolean(cloud, 'insecure')
             nova_client_params['private'] = config.getboolean(cloud, 'private')
             # Provide backwards compat for older nova.ini files

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 # (c) 2012, Marco Vito Moscaritolo <marco@agavee.com>
+# (c) 2013, Jesse Keating <jesse.keating@rackspace.com>
+# (c) 2014 Patrick "CaptTofu" Galbraith <patg@patg.net>
 #
 # This file is part of Ansible,
 #
@@ -21,7 +23,11 @@ import sys
 import re
 import os
 import ConfigParser
-from novaclient import client as nova_client
+import argparse
+import collections
+from novaclient.v1_1 import client as nova_client
+from novaclient import exceptions
+from types import NoneType
 
 try:
     import json
@@ -30,21 +36,20 @@ except:
 
 from ansible.module_utils.openstack import *
 
-###################################################
-# executed with no parameters, return the list of
-# all groups and hosts
+NOVA_CONFIG_FILES = [
+    os.getcwd() + "/nova.ini",
+    os.path.expanduser(
+        os.environ.get(
+            'ANSIBLE_CONFIG',
+            "~/nova.ini")
+    ),
+    "/etc/ansible/nova.ini"
+]
 
-NOVA_CONFIG_FILES = [os.getcwd() + "/nova.ini",
-                     os.path.expanduser(os.environ.get('ANSIBLE_CONFIG', "~/nova.ini")),
-                     "/etc/ansible/nova.ini"]
-
-NOVA_DEFAULTS = {
-    'auth_system': None,
-    'region_name': None,
-}
+NON_CALLABLES = (basestring, bool, dict, int, list, NoneType)
 
 
-def nova_load_config_file():
+def nova_load_config_file(NOVA_DEFAULTS):
     p = ConfigParser.SafeConfigParser(NOVA_DEFAULTS)
 
     for path in NOVA_CONFIG_FILES:
@@ -54,79 +59,252 @@ def nova_load_config_file():
 
     return None
 
-config = nova_load_config_file()
-if not config:
-    sys.exit('Unable to find configfile in %s' % ', '.join(NOVA_CONFIG_FILES))
 
-client = nova_client.Client(
-    config.get('openstack', 'version'),
-    config.get('openstack', 'username'),
-    config.get('openstack', 'api_key'),
-    config.get('openstack', 'project_id'),
-    config.get('openstack', 'auth_url'),
-    region_name = config.get('openstack', 'region_name'),
-    auth_system = config.get('openstack', 'auth_system')
-)
+def setup():
+    # use a config file if it exists where expected
+    NOVA_DEFAULTS = {
+        'auth_system': 'keystone',
+        'region_name': 'region1',
+        'service_type': 'compute'
+    }
+    config = nova_load_config_file(NOVA_DEFAULTS)
 
-if len(sys.argv) == 2 and (sys.argv[1] == '--list'):
-    groups = {}
+    project_id = ""
+    project_id = os.getenv('OS_TENANT_NAME')
+    if project_id == '' or project_id is not None:
+        project_id = os.getenv('OS_PROJECT_ID')
 
-    # Cycle on servers
-    for server in client.servers.list():
-        private = openstack_find_nova_addresses(getattr(server, 'addresses'), 'fixed', 'private')
-        public = openstack_find_nova_addresses(getattr(server, 'addresses'), 'floating', 'public')
-	    
-	# Define group (or set to empty string)
-        group = server.metadata['group'] if server.metadata.has_key('group') else 'undefined'
+    nova_client_params = {
+        'username': '',
+        'password': '',
+        'auth_url': 'https://127.0.0.1:35357/v2.0/',
+        'project_id': '',
+        'service_type': 'compute',
+        'auth_system': 'keystone',
+        'insecure': False,
+    }
+    if config is None:
+        nova_client_params['username'] = os.getenv('OS_USERNAME')
+        nova_client_params['password'] = os.getenv('OS_PASSWORD')
+        nova_client_params['auth_url'] = os.getenv('OS_AUTH_URL')
+        nova_client_params['region_name'] = os.getenv('OS_REGION_NAME')
+        nova_client_params['project_id'] = os.getenv('OS_TENANT_NAME')
+        nova_client_params['service_type'] = NOVA_DEFAULTS['service_type']
+        nova_client_params['auth_system'] = NOVA_DEFAULTS['auth_system']
+        nova_client_params['insecure'] = False
+        if (nova_client_params['username'] == "" and
+                nova_client_params['password'] == ""):
+            sys.exit(
+                'Unable to find config file in %s or environement variables'
+                % ','
+                .join(NOVA_CONFIG_FILES))
+    else:
+        nova_client_params['username'] = config.get('openstack', 'username')
+        nova_client_params['password'] = config.get('openstack', 'password')
+        nova_client_params['project_id'] = \
+            config.get('openstack', 'project_id')
+        nova_client_params['auth_url'] = config.get('openstack', 'auth_url')
+        nova_client_params['region_name'] = \
+            config.get('openstack', 'region_name')
+        nova_client_params['service_type'] = \
+            config.get('openstack', 'service_type')
+        nova_client_params['auth_system'] = \
+            config.get('openstack', 'auth_system')
+        nova_client_params['insecure'] = config.get('openstack', 'insecure')
 
-        # Create group if not exist
-        if group not in groups:
-            groups[group] = []
+    nova_client_params['regions'] = \
+        nova_client_params['region_name'].split(',')
 
-        # Append group to list
-	if server.accessIPv4:
-                groups[group].append(server.accessIPv4)
-		continue
-	if public:
-        	groups[group].append(''.join(public))
-		continue
-	if private:
-        	groups[group].append(''.join(private))
-		continue
+    return(nova_client_params)
+
+
+def to_dict(obj):
+    instance = {}
+    for key in dir(obj):
+        value = getattr(obj, key)
+        if (isinstance(value, NON_CALLABLES) and not key.startswith('_')):
+            key = slugify('nova', key)
+            instance[key] = value
+
+    return instance
+
+
+# TODO: this is something both various modules and plugins could use
+def slugify(pre='', value=''):
+    sep = ''
+    if pre is not None and len(pre):
+        sep = '_'
+    return '%s%s%s' % (pre,
+                       sep,
+                       re.sub('[^\w-]', '_', value).lower().lstrip('_'))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Nova Inventory Module')
+    parser.add_argument('--private',
+                        action='store_true',
+                        help='Use private address for ansible host')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--list', action='store_true',
+                       help='List active servers')
+    group.add_argument('--host', help='List details about the specific host')
+    return parser.parse_args()
+
+
+def connect_to_nova(username='',
+                    password='',
+                    project_id='',
+                    auth_url='',
+                    region_name='',
+                    service_type='',
+                    auth_system='',
+                    insecure=False):
+    # Make the connection
+    client = nova_client.Client(
+        username,
+        password,
+        project_id,
+        auth_url,
+        region_name=region_name,
+        service_type=service_type,
+        auth_system=auth_system,
+        insecure=insecure
+    )
+
+    try:
+        client.authenticate()
+    except exceptions.Unauthorized, e:
+        print("Invalid OpenStack Nova credentials.: %s" %
+              e.message)
+        sys.exit(1)
+    except exceptions.AuthorizationFailure, e:
+        print("Unable to authorize user: %s" % e.message)
+        sys.exit(1)
+
+    if client is None:
+        print("Failed to instantiate nova client. This "
+              "could mean that your credentials are wrong.")
+        sys.exit(1)
+
+    return client
+
+
+def host(nova_client_params, hostname, private_flag):
+    hostvars = {}
+    for region in nova_client_params['regions']:
+        # Connect to the region
+        client = connect_to_nova(nova_client_params['username'],
+                                 nova_client_params['password'],
+                                 nova_client_params['project_id'],
+                                 nova_client_params['auth_url'],
+                                 region,
+                                 nova_client_params['service_type'],
+                                 nova_client_params['auth_system'])
+        for server in client.servers.list():
+            # loop through the networks for this instance, append fixed
+            # and floating IPs in a list
+            private = openstack_find_nova_addresses(getattr(server, 'addresses'), 'fixed', 'private')
+            public = openstack_find_nova_addresses(getattr(server, 'addresses'), 'floating', 'public')
+
+            if server.name == hostname:
+                for key, value in to_dict(server).items():
+                    hostvars[key] = value
+
+                # And finally, add an IP address
+                if (private_flag is True):
+                    hostvars[server.name]['ansible_ssh_host'] = private[0]
+                else:
+                    hostvars[server.name]['ansible_ssh_host'] = public[0]
+
+    print(json.dumps(hostvars, sort_keys=True, indent=4))
+
+
+def list_instances(nova_client_params, private_flag):
+    groups = collections.defaultdict(list)
+    hostvars = collections.defaultdict(dict)
+    images = {}
+
+    for region in nova_client_params['regions']:
+        client = connect_to_nova(nova_client_params['username'],
+                                 nova_client_params['password'],
+                                 nova_client_params['project_id'],
+                                 nova_client_params['auth_url'],
+                                 region,
+                                 nova_client_params['service_type'],
+                                 nova_client_params['auth_system'])
+        # Cycle on servers
+        for server in client.servers.list():
+            # loop through the networks for this instance, append fixed
+            # and floating IPs in a list
+            private = openstack_find_nova_addresses(getattr(server, 'addresses'), 'fixed', 'private')
+            public = openstack_find_nova_addresses(getattr(server, 'addresses'), 'floating', 'public')
+
+            # Create a group on region
+            groups[region].append(server.name)
+
+            # Check if group metadata key in servers' metadata
+            group = server.metadata.get('group')
+            if group:
+                groups[group].append(server.name)
+
+            for extra_group in server.metadata.get('groups', '').split(','):
+                if extra_group:
+                    groups[extra_group].append(server.name)
+
+            for key, value in to_dict(server).items():
+                hostvars[server.name][key] = value
+
+            hostvars[server.name]['nova_region'] = region
+
+            for key, value in server.metadata.iteritems():
+                prefix = os.getenv('OS_META_PREFIX', 'meta')
+                groups['%s_%s_%s' % (prefix, key, value)].append(server.name)
+
+            if (private_flag is True):
+                hostvars[server.name]['ansible_ssh_host'] = private[0]
+            else:
+                hostvars[server.name]['ansible_ssh_host'] = public[0]
+
+            groups['instance-%s' % server.id].append(server.name)
+            groups['flavor-%s' % server.flavor['id']].append(server.name)
+
+            try:
+                imagegroup = 'image-%s' % images[server.image['id']]
+                groups[imagegroup].append(server.name)
+                groups['image-%s' % server.image['id']].append(server.name)
+            except KeyError:
+                try:
+                    image = client.images.get(server.image['id'])
+                except client.exceptions.NotFound:
+                    groups['image-%s' % server.image['id']].append(server.name)
+                else:
+                    images[image.id] = image.human_id
+                    groups['image-%s' % image.human_id].append(server.name)
+                    groups['image-%s' % server.image['id']].append(server.name)
+
+            # And finally, add an IP address
+            if (private_flag is True):
+                hostvars[server.name]['ansible_ssh_host'] = private[0]
+            else:
+                hostvars[server.name]['ansible_ssh_host'] = public[0]
+
+        if hostvars:
+            groups['_meta'] = {'hostvars': hostvars}
 
     # Return server list
     print(json.dumps(groups, sort_keys=True, indent=2))
     sys.exit(0)
 
-#####################################################
-# executed with a hostname as a parameter, return the
-# variables for that host
 
-elif len(sys.argv) == 3 and (sys.argv[1] == '--host'):
-    results = {}
-    ips = []
-    for instance in client.servers.list():
-        private = openstack_find_nova_addresses(getattr(instance, 'addresses'), 'fixed', 'private')
-        public = openstack_find_nova_addresses(getattr(instance, 'addresses'), 'floating', 'public')
-        ips.append( instance.accessIPv4)
-	ips.append(''.join(private))
-	ips.append(''.join(public))
-	if sys.argv[2] in ips:
-            for key in vars(instance):
-                # Extract value
-                value = getattr(instance, key)
-
-                # Generate sanitized key
-                key = 'os_' + re.sub("[^A-Za-z0-9\-]", "_", key).lower()
-
-                # Att value to instance result (exclude manager class)
-                #TODO: maybe use value.__class__ or similar inside of key_name
-                if key != 'os_manager':
-                    results[key] = value
-
-    print(json.dumps(results, sort_keys=True, indent=2))
+def main():
+    args = parse_args()
+    nova_client_params = setup()
+    if args.list:
+        list_instances(nova_client_params, args.private)
+    elif args.host:
+        host(nova_client_params, args.host, args.private)
     sys.exit(0)
 
-else:
-    print "usage: --list  ..OR.. --host <hostname>"
-    sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -48,6 +48,8 @@ flavor_cache = None
 
 def nova_load_config_file(NOVA_DEFAULTS):
     p = ConfigParser.SafeConfigParser(NOVA_DEFAULTS)
+    # Add a default section so that our defaults always work
+    p.add_section('openstack')
 
     for path in NOVA_CONFIG_FILES:
         if os.path.exists(path):
@@ -227,6 +229,11 @@ def list_instances(nova_client_params, private_flag):
 
             for key, value in to_dict(server).items():
                 hostvars[server.name][key] = value
+
+            az = server.metadata.get('nova_os-ext-az_availability_zone')
+            if az:
+                hostvars[server.name]['nova_az'] = az
+                groups[az].append(server.name)
 
             hostvars[server.name]['nova_region'] = region
 

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -56,11 +56,12 @@ def nova_load_config_file(NOVA_DEFAULTS):
 
 
 def setup():
+    OS_USERNAME = os.environ.get('OS_USERNAME', 'admin')
     NOVA_DEFAULTS = {
-        'username': os.environ.get('OS_USERNAME', ''),
+        'username': OS_USERNAME,
         'password': os.environ.get('OS_PASSWORD', ''),
+        'project_id': os.environ.get('OS_TENANT_NAME', os.environ.get('OS_PROJECT_ID', OS_USERNAME)),
         'auth_url': os.environ.get('OS_AUTH_URL', 'https://127.0.0.1:35357/v2.0/'),
-        'project_id': os.environ.get('OS_TENANT_NAME', os.environ.get('OS_PROJECT_ID', '')),
         'region_name': os.environ.get('OS_REGION_NAME', ''),
         'service_type': 'compute',
         'insecure': 'false',
@@ -68,7 +69,6 @@ def setup():
 
     # use a config file if it exists where expected
     config = nova_load_config_file(NOVA_DEFAULTS)
-
 
     nova_client_params = dict()
     nova_client_params['username'] = config.get('openstack', 'username')

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -277,7 +277,7 @@ def main():
             inventory.list_instances()
         elif args.host:
             inventory.get_host(args.host)
-    except OpenStackAnsibleException as e:
+    except OpenStackCloudException as e:
         print(e.message)
         sys.exit(1)
     sys.exit(0)

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -149,11 +149,6 @@ class NovaInventory(object):
         hostvars = collections.defaultdict(dict)
 
         for cloud in self.clouds:
-            try:
-                cloud.connect()
-            except OpenStackAnsibleException as e:
-                print(e.message)
-                sys.exit(1)
             region = cloud.get_region()
             cloud_name = cloud.get_name()
 
@@ -276,11 +271,15 @@ def parse_args():
 
 def main():
     args = parse_args()
-    inventory = NovaInventory(args.private, args.refresh)
-    if args.list:
-        inventory.list_instances()
-    elif args.host:
-        inventory.get_host(args.host)
+    try:
+        inventory = NovaInventory(args.private, args.refresh)
+        if args.list:
+            inventory.list_instances()
+        elif args.host:
+            inventory.get_host(args.host)
+    except OpenStackAnsibleException as e:
+        print(e.message)
+        sys.exit(1)
     sys.exit(0)
 
 

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -2,7 +2,7 @@
 
 # (c) 2012, Marco Vito Moscaritolo <marco@agavee.com>
 # (c) 2013, Jesse Keating <jesse.keating@rackspace.com>
-# (c) 2014 Patrick "CaptTofu" Galbraith <patg@patg.net>
+# (c) 2014, Hewlett-Packard Development Company, L.P.
 #
 # This file is part of Ansible,
 #

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -157,6 +157,9 @@ class OpenStackInventory(object):
             nova_client_params['region_name'] = config.get(cloud, 'region_name')
             nova_client_params['service_type'] = config.get(cloud, 'service_type')
             nova_client_params['insecure'] = config.getboolean(cloud, 'insecure')
+            # Provide backwards compat for older nova.ini files
+            if nova_client_params['password'] == '':
+                nova_client_params['password'] = config.get(cloud, 'api_key')
 
             if (nova_client_params['username'] == "" and nova_client_params['password'] == ""):
                 sys.exit(


### PR DESCRIPTION
This is a follow on to #8388 and should really be ignored probably until that merges since there's no real way here to submit a dependent PR and not show the contents of the first one. BUT ...

I wanted to put this up there because I've been doing a lot of hacking which is getting long in the tooth. The end goal here is to get all of the code which groks OpenStack internal logic, things like "how do I authenticate" or "how do I get a list of images" into the openstack module_utils library so that the things in library/ are more concerned with being expressions of _ansible_ logic, not tons of repeated cantrips that shore up deficiencies in the upstream libraries. Then, the next step from us at OpenStack is to take the code in the module_utils library and get it into upstream libraries, because most of it is not even partially ansible specific, but ansible has been an excellent case study in the deficiencies of our SDK world. Once that's done, then we can start deleting code in module_utils and replacing with cleaner calls to upstream library.

I've got a POC of the end state of that all on my laptop, but the upstream library changes aren't landed yet, so it's not possible to present that here - but I think that showing the movement of the code in general to module_utils should be clear enough, so that the slimming of module_utils and replacement with a better upstream library should similarly be an easy patch to review.

In the process, and because I needed more features in the OpenStack Infra project, I sucked in some of tylernorth's code to support cinder volumes. I took two of his patches, fixed them up to work with module_utils and then squashed them into a single patch.
