### PR TITLE
zypper_repository: Remove trailing "/"

### DIFF
--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -105,7 +105,7 @@ def repo_exists(module, **kwargs):
 
         for k, v in realrepo.items():
             if k in repocmp:
-                if v != repocmp[k]:
+                if v.rstrip("/") != repocmp[k].rstrip("/"):
                     return False
         return True
 


### PR DESCRIPTION
##### Issue Type:

 “Bugfix Pull Request”
##### Ansible Version:

ansible 1.8 last updated 2014/09/09 09:26:05 (GMT +200)
##### Environment:

SLES 11.3
##### Summary:

ftp://download.nvidia.com/opensuse/12.2 and ftp://download.nvidia.com/opensuse/12.2/ are logical identical, but the module does not recognize it.
##### Steps To Reproduce:

Use following to line in your playbook. First add the repo without the trailing "/" and the next line should remove the repo, but with the trailing "/".
- zypper_repository: name=nvidia-repo repo='ftp://download.nvidia.com/opensuse/12.2' state=present
- zypper_repository: name=nvidia-repo repo='ftp://download.nvidia.com/opensuse/12.2/' state=absent
##### Expected Results:

The second "statement" should remove the repository.
##### Actual Results:

It did not remove it, because the second repo is not "identical".
