### PR TITLE
Allow InventoryScript JSON with childgroups only

### DIFF
--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -85,7 +85,7 @@ class InventoryScript(object):
             if not isinstance(data, dict):
                 data = {'hosts': data}
             # is not those subkeys, then simplified syntax, host with vars
-            elif not any(k in data for k in ('hosts','vars')):
+            elif not any(k in data for k in ('hosts','vars','children')):
                 data = {'hosts': [group_name], 'vars': data}
 
             if 'hosts' in data:


### PR DESCRIPTION
and without hosts and vars

Without this patch, the simplified syntax is triggered when a group
is defined like this:

```
"platforms": {
    "children": [
        "cloudstack"
    ]
}
```

Which results in a group 'platforms' with 1 host 'platforms'.

```
modified:   lib/ansible/inventory/script.py
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/8936)

<!-- Reviewable:end -->
