### PR TITLE
Updates to win_user module

### DIFF
--- a/library/windows/win_user
+++ b/library/windows/win_user
@@ -31,32 +31,83 @@ description:
 options:
   name:
     description:
-      - Username of the user to manage
+      - Name of the user to create, remove or modify.
     required: true
+  fullname:
+    description:
+      - Full name of the user
+    required: false
     default: null
-    aliases: []
+    version_added: "1.8"
+  description:
+    description:
+      - Description of the user
+    required: false
+    default: null
+    version_added: "1.8"
   password:
     description:
-      - Password for the user (plain text)
-    required: true
+      - Optionally set the user's password to this (plain text) value.
+    required: false
     default: null
-    aliases: []
+  update_password:
+    description:
+      - C(always) will update passwords if they differ.  C(on_create) will only set the password for newly created users.
+    required: false
+    choices: [ 'always', 'on_create' ]
+    default: always
+    version_added: "1.8"
+  password_expired:
+    description:
+      - C(yes) will require the user to change password at next login.  C(no) will clear the expired password flag.
+    required: false
+    choices: [ 'yes', 'no' ]
+    default: null
+    version_added: "1.8"
+  password_never_expires:
+    description:
+      - C(yes) will set the password to never expire.  C(no) will allow the password to expire.
+    required: false
+    choices: [ 'yes', 'no' ]
+    default: null
+    version_added: "1.8"
+  user_cannot_change_password:
+    description:
+      - C(yes) will prevent the user from changing their password.  C(no) will allow the user to change their password.
+    required: false
+    choices: [ 'yes', 'no' ]
+    default: null
+    version_added: "1.8"
+  account_disabled:
+    description:
+      - C(yes) will disable the user account.  C(no) will clear the disabled flag.
+    required: false
+    choices: [ 'yes', 'no' ]
+    default: null
+    version_added: "1.8"
+  account_locked:
+    description:
+      - C(no) will unlock the user account if locked.
+    required: false
+    choices: [ 'no' ]
+    default: null
+    version_added: "1.8"
   state:
     description:
-      - Whether to create or delete a user
+      - Whether the account should exist.  When C(absent), removes the user account.
     required: false
     choices:
       - present
       - absent
     default: present
     aliases: []
-author: Paul Durivage
+author: Paul Durivage / Chris Church
 '''
 
 EXAMPLES = '''
 # Ad-hoc example
 $ ansible -i hosts -m win_user -a "name=bob password=Password12345" all
-$ ansible -i hosts -m win_user -a "name=bob password=Password12345 state=absent" all
+$ ansible -i hosts -m win_user -a "name=bob state=absent" all
 
 # Playbook example
 ---

--- a/library/windows/win_user
+++ b/library/windows/win_user
@@ -52,35 +52,40 @@ options:
     default: null
   update_password:
     description:
-      - C(always) will update passwords if they differ.  C(on_create) will only set the password for newly created users.
+      - C(always) will update passwords if they differ.  C(on_create) will
+      only set the password for newly created users.
     required: false
     choices: [ 'always', 'on_create' ]
     default: always
     version_added: "1.8"
   password_expired:
     description:
-      - C(yes) will require the user to change password at next login.  C(no) will clear the expired password flag.
+      - C(yes) will require the user to change their password at next login.
+        C(no) will clear the expired password flag.
     required: false
     choices: [ 'yes', 'no' ]
     default: null
     version_added: "1.8"
   password_never_expires:
     description:
-      - C(yes) will set the password to never expire.  C(no) will allow the password to expire.
+      - C(yes) will set the password to never expire.  C(no) will allow the
+        password to expire.
     required: false
     choices: [ 'yes', 'no' ]
     default: null
     version_added: "1.8"
   user_cannot_change_password:
     description:
-      - C(yes) will prevent the user from changing their password.  C(no) will allow the user to change their password.
+      - C(yes) will prevent the user from changing their password.  C(no) will
+        allow the user to change their password.
     required: false
     choices: [ 'yes', 'no' ]
     default: null
     version_added: "1.8"
   account_disabled:
     description:
-      - C(yes) will disable the user account.  C(no) will clear the disabled flag.
+      - C(yes) will disable the user account.  C(no) will clear the disabled
+        flag.
     required: false
     choices: [ 'yes', 'no' ]
     default: null
@@ -92,13 +97,34 @@ options:
     choices: [ 'no' ]
     default: null
     version_added: "1.8"
+  groups:
+    description:
+      - Adds or removes the user from this comma-separated lis of groups,
+        depending on the value of I(groups_action). When I(groups_action) is
+        C(replace) and I(groups) is set to the empty string ('groups='), the
+        user is removed from all groups.
+    required: false
+    version_added: "1.8"
+  groups_action:
+    description:
+      - If C(replace), the user is added as a member of each group in
+        I(groups) and removed from any other groups.  If C(add), the user is
+        added to each group in I(groups) where not already a member.  If
+        C(remove), the user is removed from each group in I(groups).
+    required: false
+    choices: [ "replace", "add", "remove" ]
+    default: "replace"
+    version_added: "1.8"
   state:
     description:
-      - Whether the account should exist.  When C(absent), removes the user account.
+      - When C(present), creates or updates the user account.  When C(absent),
+        removes the user account if it exists.  When C(query) (new in 1.8),
+        retrieves the user account details without making any changes.
     required: false
     choices:
       - present
       - absent
+      - query
     default: present
     aliases: []
 author: Paul Durivage / Chris Church
@@ -106,7 +132,7 @@ author: Paul Durivage / Chris Church
 
 EXAMPLES = '''
 # Ad-hoc example
-$ ansible -i hosts -m win_user -a "name=bob password=Password12345" all
+$ ansible -i hosts -m win_user -a "name=bob password=Password12345 groups=Users" all
 $ ansible -i hosts -m win_user -a "name=bob state=absent" all
 
 # Playbook example
@@ -119,4 +145,5 @@ $ ansible -i hosts -m win_user -a "name=bob state=absent" all
       win_user:
         name: ansible
         password: "@ns1bl3"
+        groups: ["Users"]
 '''

--- a/library/windows/win_user.ps1
+++ b/library/windows/win_user.ps1
@@ -30,21 +30,6 @@ function Get-User($user) {
     return
 }
 
-function Create-User([string]$user) {
-   $adsiuser = $adsi.Create("User", $user)
-   $adsiuser
-   return
-}
-
-function Update-Password($user, [string]$passwd) {
-    $user.SetPassword($passwd)
-    $user.SetInfo()
-}
-
-function Delete-User($user) {
-    $adsi.delete("user", $user.Name.Value)
-}
-
 function Get-UserFlag($user, $flag) {
     If ($user.UserFlags[0] -band $flag) {
         $true
@@ -56,12 +41,10 @@ function Get-UserFlag($user, $flag) {
 
 function Set-UserFlag($user, $flag) { 
     $user.UserFlags = ($user.UserFlags[0] -BOR $flag)
-    $user.SetInfo()
 }
 
 function Clear-UserFlag($user, $flag) {
     $user.UserFlags = ($user.UserFlags[0] -BXOR $flag)
-    $user.SetInfo()
 }
 
 ########
@@ -83,8 +66,8 @@ $password = Get-Attr $params "password"
 
 If ($params.state) {
     $state = $params.state.ToString().ToLower()
-    If (($state -ne 'present') -and ($state -ne 'absent')) {
-        Fail-Json $result "state is '$state'; must be 'present' or 'absent'"
+    If (($state -ne 'present') -and ($state -ne 'absent') -and ($state -ne 'query')) {
+        Fail-Json $result "state is '$state'; must be 'present', 'absent' or 'query'"
     }
 }
 ElseIf (!$params.state) {
@@ -101,45 +84,67 @@ ElseIf (!$params.update_password) {
     $update_password = "always"
 }
 
-$password_expired = Get-Attr $params "password_expired" $null;
+$password_expired = Get-Attr $params "password_expired" $null
 If ($password_expired -ne $null) {
-    $password_expired = $password_expired | ConvertTo-Bool;
+    $password_expired = $password_expired | ConvertTo-Bool
 }
 
-$password_never_expires = Get-Attr $params "password_never_expires" $null;
+$password_never_expires = Get-Attr $params "password_never_expires" $null
 If ($password_never_expires -ne $null) {
-    $password_never_expires = $password_never_expires | ConvertTo-Bool;
+    $password_never_expires = $password_never_expires | ConvertTo-Bool
 }
 
-$user_cannot_change_password = Get-Attr $params "user_cannot_change_password" $null;
+$user_cannot_change_password = Get-Attr $params "user_cannot_change_password" $null
 If ($user_cannot_change_password -ne $null) {
-    $user_cannot_change_password = $user_cannot_change_password | ConvertTo-Bool;
+    $user_cannot_change_password = $user_cannot_change_password | ConvertTo-Bool
 }
 
-$account_disabled = Get-Attr $params "account_disabled" $null;
+$account_disabled = Get-Attr $params "account_disabled" $null
 If ($account_disabled -ne $null) {
-    $account_disabled = $account_disabled | ConvertTo-Bool;
+    $account_disabled = $account_disabled | ConvertTo-Bool
 }
 
-$account_locked = Get-Attr $params "account_locked" $null;
+$account_locked = Get-Attr $params "account_locked" $null
 If ($account_locked -ne $null) {
-    $account_locked = $account_locked | ConvertTo-Bool;
+    $account_locked = $account_locked | ConvertTo-Bool
     if ($account_locked) {
         Fail-Json $result "account_locked must be set to 'no' if provided"
     }
 }
 
-$user_obj = Get-User $username
+$groups = Get-Attr $params "groups" $null
+If ($groups -ne $null) {
+    If ($groups.GetType().Name -eq "String") {
+        [string[]]$groups = $groups.Split(",")
+    }
+    ElseIf ($groups.GetType().Name -ne "Object[]") {
+        Fail-Json $result "groups must be a string or array"
+    }
+    $groups = $groups | ForEach { ([string]$_).Trim() } | Where { $_ }
+    If ($groups -eq $null) {
+        $groups = @()
+    }
+}
 
-Set-Attr $result "state" $state
+If ($params.groups_action) {
+    $groups_action = $params.groups_action.ToString().ToLower()
+    If (($groups_action -ne 'replace') -and ($groups_action -ne 'add') -and ($groups_action -ne 'remove')) {
+        Fail-Json $result "groups_action is '$groups_action'; must be 'replace', 'add' or 'remove'"
+    }
+}
+ElseIf (!$params.groups_action) {
+    $groups_action = "replace"
+}
+
+$user_obj = Get-User $username
 
 If ($state -eq 'present') {
     # Add or update user
     try {
         If (!$user_obj.GetType) {
-            $user_obj = Create-User $username
+            $user_obj = $adsi.Create("User", $username)
             If ($password -ne $null) {
-                Update-Password $user_obj $password
+                $user_obj.SetPassword($password)
             }
             $result.changed = $true
         }
@@ -148,23 +153,20 @@ If ($state -eq 'present') {
             $pc = New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalContext 'Machine', $env:COMPUTERNAME
             # FIXME: ValidateCredentials fails if PasswordExpired == 1
             If (!$pc.ValidateCredentials($username, $password)) {
-                Update-Password $user_obj $password
+                $user_obj.SetPassword($password)
                 $result.changed = $true
             }
         }
         If (($fullname -ne $null) -and ($fullname -ne $user_obj.FullName[0])) {
             $user_obj.FullName = $fullname
-            $user_obj.SetInfo()
             $result.changed = $true
         }
         If (($description -ne $null) -and ($description -ne $user_obj.Description[0])) {
             $user_obj.Description = $description
-            $user_obj.SetInfo()
             $result.changed = $true
         }
         If (($password_expired -ne $null) -and ($password_expired -ne ($user_obj.PasswordExpired | ConvertTo-Bool))) {
-            $user_obj.PasswordExpired = If ($password_expired) { 1 } Else { 0 };
-            $user_obj.SetInfo()
+            $user_obj.PasswordExpired = If ($password_expired) { 1 } Else { 0 }
             $result.changed = $true
         }
         If (($password_never_expires -ne $null) -and ($password_never_expires -ne (Get-UserFlag $user_obj $ADS_UF_DONT_EXPIRE_PASSWD))) {
@@ -187,14 +189,68 @@ If ($state -eq 'present') {
         }
         If (($account_disabled -ne $null) -and ($account_disabled -ne $user_obj.AccountDisabled)) {
             $user_obj.AccountDisabled = $account_disabled
-            $user_obj.SetInfo()
             $result.changed = $true
         }
         If (($account_locked -ne $null) -and ($account_locked -ne $user_obj.IsAccountLocked)) {
             $user_obj.IsAccountLocked = $account_locked
-            $user_obj.SetInfo()
             $result.changed = $true
         }
+        If ($groups.GetType) {
+            [string[]]$current_groups = $user_obj.Groups() | ForEach { $_.GetType().InvokeMember("Name", "GetProperty", $null, $_, $null) }
+            If (($groups_action -eq "remove") -or ($groups_action -eq "replace")) {
+                ForEach ($grp in $current_groups) {
+                    If ((($groups_action -eq "remove") -and ($groups -contains $grp)) -or (($groups_action -eq "replace") -and ($groups -notcontains $grp))) {
+                        $group_obj = $adsi.Children | where { $_.SchemaClassName -eq 'Group' -and $_.Name -eq $grp }
+                        If ($group_obj.GetType) {
+                            $group_obj.Remove($user_obj.Path)
+                            $result.changed = $true
+                        }
+                        Else {
+                            Fail-Json $result "group '$grp' not found"
+                        }
+                    }
+                }
+            }
+            If (($groups_action -eq "add") -or ($groups_action -eq "replace")) {
+                ForEach ($grp in $groups) {
+                    If ($current_groups -notcontains $grp) {
+                        $group_obj = $adsi.Children | where { $_.SchemaClassName -eq 'Group' -and $_.Name -eq $grp }
+                        If ($group_obj.GetType) {
+                            $group_obj.Add($user_obj.Path)
+                            $result.changed = $true
+                        }
+                        Else {
+                            Fail-Json $result "group '$grp' not found"
+                        }
+                    }
+                }
+            }
+        }
+        If ($result.changed) {
+            $user_obj.SetInfo()
+        }
+    }
+    catch {
+        Fail-Json $result $_.Exception.Message
+    }
+}
+ElseIf ($state -eq 'absent') {
+    # Remove user
+    try {
+        If ($user_obj.GetType) {
+            $username = $user_obj.Name.Value
+            $adsi.delete("User", $user_obj.Name.Value)
+            $result.changed = $true
+            $user_obj = $null
+        }
+    }
+    catch {
+        Fail-Json $result $_.Exception.Message
+    }
+}
+
+try {
+    If ($user_obj.GetType) {
         $user_obj.RefreshCache()
         Set-Attr $result "name" $user_obj.Name[0]
         Set-Attr $result "fullname" $user_obj.FullName[0]
@@ -206,27 +262,25 @@ If ($state -eq 'present') {
         Set-Attr $result "account_disabled" $user_obj.AccountDisabled
         Set-Attr $result "account_locked" $user_obj.IsAccountLocked
         Set-Attr $result "sid" (New-Object System.Security.Principal.SecurityIdentifier($user_obj.ObjectSid.Value, 0)).Value
+        $user_groups = @()
+        ForEach ($grp in $user_obj.Groups()) {
+            $group_result = New-Object psobject @{
+                name = $grp.GetType().InvokeMember("Name", "GetProperty", $null, $grp, $null)
+                path = $grp.GetType().InvokeMember("ADsPath", "GetProperty", $null, $grp, $null)
+            }
+            $user_groups += $group_result;
+        }
+        Set-Attr $result "groups" $user_groups
+        Set-Attr $result "state" "present"
     }
-    catch {
-        Fail-Json $result $_.Exception.Message
+    Else {
+        Set-Attr $result "name" $username
+        Set-Attr $result "msg" "User '$username' was not found"
+        Set-Attr $result "state" "absent"
     }
 }
-Else {
-    # Remove user
-    try {
-        If ($user_obj.GetType) {
-            Set-Attr $result "name" $user_obj.Name[0]
-            Delete-User $user_obj
-            $result.changed = $true
-        }
-        Else {
-            Set-Attr $result "name" $username
-            Set-Attr $result "msg" "User '$username' was not found"
-        }
-    }
-    catch {
-        Fail-Json $result $_.Exception.Message
-    }
+catch {
+    Fail-Json $result $_.Exception.Message
 }
 
-Exit-Json $result;
+Exit-Json $result

--- a/test/integration/roles/test_win_fetch/tasks/main.yml
+++ b/test/integration/roles/test_win_fetch/tasks/main.yml
@@ -18,11 +18,9 @@
 
 - name: clean out the test directory
   local_action: file name={{ output_dir|mandatory }} state=absent
-  tags: me
 
 - name: create the test directory
   local_action: file name={{ output_dir }} state=directory
-  tags: me
 
 - name: fetch a small file
   fetch: src="C:/Windows/win.ini" dest={{ output_dir }}

--- a/test/integration/roles/test_win_user/defaults/main.yml
+++ b/test/integration/roles/test_win_user/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+test_win_user_name: test_win_user
+test_win_user_password: "T35Tus3rP@ssW0rd"
+test_win_user_password2: "pa55wOrd4te5tU53R!"

--- a/test/integration/roles/test_win_user/files/lockout_user.ps1
+++ b/test/integration/roles/test_win_user/files/lockout_user.ps1
@@ -1,0 +1,17 @@
+trap
+{
+    Write-Error -ErrorRecord $_
+    exit 1;
+}
+
+$username = $args[0]
+[void][system.reflection.assembly]::LoadWithPartialName('System.DirectoryServices.AccountManagement')
+$pc = New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalContext 'Machine', $env:COMPUTERNAME
+For ($i = 1; $i -le 10; $i++) {
+    try {
+        $pc.ValidateCredentials($username, 'b@DP@ssw0rd')
+    }
+    catch {
+        break
+    }
+}

--- a/test/integration/roles/test_win_user/tasks/main.yml
+++ b/test/integration/roles/test_win_user/tasks/main.yml
@@ -21,7 +21,7 @@
   register: win_user_remove_result
 
 - name: check user removal result
-  assert: 
+  assert:
     that:
       - "win_user_remove_result.name"
       - "win_user_remove_result.state == 'absent'"
@@ -31,71 +31,91 @@
   register: win_user_remove_result_again
 
 - name: check user removal result again
-  assert: 
+  assert:
     that:
       - "not win_user_remove_result_again|changed"
       - "win_user_remove_result_again.name"
       - "win_user_remove_result_again.msg"
       - "win_user_remove_result.state == 'absent'"
 
+- name: test missing user with query state
+  win_user: name="{{ test_win_user_name }}" state="query"
+  register: win_user_missing_query_result
+
+- name: check missing query result
+  assert:
+    that:
+      - "not win_user_missing_query_result|changed"
+      - "win_user_missing_query_result.name"
+      - "win_user_missing_query_result.msg"
+      - "win_user_missing_query_result.state == 'absent'"
+
 - name: test create user
   win_user: name="{{ test_win_user_name }}" password="{{ test_win_user_password }}"
   register: win_user_create_result
 
 - name: check user creation result
-  assert: 
+  assert:
     that:
       - "win_user_create_result|changed"
       - "win_user_create_result.name == '{{ test_win_user_name }}'"
       - "win_user_create_result.fullname == '{{ test_win_user_name }}'"
       - "win_user_create_result.path"
+      - "win_user_create_result.state == 'present'"
 
 - name: update user full name and description
   win_user: name="{{ test_win_user_name }}" fullname="Test Ansible User" description="Test user account created by Ansible"
   register: win_user_update_result
 
 - name: check full name and description update result
-  assert: 
+  assert:
     that:
       - "win_user_update_result|changed"
-      - "win_user_update_result.name == '{{ test_win_user_name }}'"
       - "win_user_update_result.fullname == 'Test Ansible User'"
       - "win_user_update_result.description == 'Test user account created by Ansible'"
-      - "win_user_update_result.path"
 
 - name: update user full name and description again with same values
   win_user: name="{{ test_win_user_name }}" fullname="Test Ansible User" description="Test user account created by Ansible"
   register: win_user_update_result_again
 
 - name: check full name and description result again
-  assert: 
+  assert:
     that:
       - "not win_user_update_result_again|changed"
-      - "win_user_update_result_again.name == '{{ test_win_user_name }}'"
       - "win_user_update_result_again.fullname == 'Test Ansible User'"
-      - "win_user_update_result.description == 'Test user account created by Ansible'"
-      - "win_user_update_result_again.path"
+      - "win_user_update_result_again.description == 'Test user account created by Ansible'"
 
 - name: test again with no options or changes
   win_user: name="{{ test_win_user_name }}"
   register: win_user_nochange_result
 
 - name: check no changes result
-  assert: 
+  assert:
     that:
       - "not win_user_nochange_result|changed"
-      - "win_user_nochange_result.name == '{{ test_win_user_name }}'"
-      - "win_user_nochange_result.fullname == 'Test Ansible User'"
-      - "win_user_nochange_result.description == 'Test user account created by Ansible'"
-      - "win_user_nochange_result.path"
-      - "win_user_nochange_result.sid"
+
+- name: test again with query state
+  win_user: name="{{ test_win_user_name }}" state="query"
+  register: win_user_query_result
+
+- name: check query result
+  assert:
+    that:
+      - "not win_user_query_result|changed"
+      - "win_user_query_result.state == 'present'"
+      - "win_user_query_result.name == '{{ test_win_user_name }}'"
+      - "win_user_query_result.fullname == 'Test Ansible User'"
+      - "win_user_query_result.description == 'Test user account created by Ansible'"
+      - "win_user_query_result.path"
+      - "win_user_query_result.sid"
+      - "win_user_query_result.groups == []"
 
 - name: change user password
   win_user: name="{{ test_win_user_name }}" password="{{ test_win_user_password2 }}"
   register: win_user_password_result
 
 - name: check password change result
-  assert: 
+  assert:
     that:
       - "win_user_password_result|changed"
 
@@ -104,7 +124,7 @@
   register: win_user_password_result_again
 
 - name: check password change result again
-  assert: 
+  assert:
     that:
       - "not win_user_password_result_again|changed"
 
@@ -113,7 +133,7 @@
   register: win_user_nopasschange_result
 
 - name: check password change with on_create flag result
-  assert: 
+  assert:
     that:
       - "not win_user_nopasschange_result|changed"
 
@@ -122,7 +142,7 @@
   register: win_user_password_expired_result
 
 - name: check password expired result
-  assert: 
+  assert:
     that:
       - "win_user_password_expired_result|changed"
       - "win_user_password_expired_result.password_expired"
@@ -132,7 +152,7 @@
   register: win_user_clear_password_expired_result
 
 - name: check clear password expired result
-  assert: 
+  assert:
     that:
       - "win_user_clear_password_expired_result|changed"
       - "not win_user_clear_password_expired_result.password_expired"
@@ -142,7 +162,7 @@
   register: win_user_password_never_expires_result
 
 - name: check password never expires result
-  assert: 
+  assert:
     that:
       - "win_user_password_never_expires_result|changed"
       - "win_user_password_never_expires_result.password_never_expires"
@@ -152,7 +172,7 @@
   register: win_user_clear_password_never_expires_result
 
 - name: check clear password never expires result
-  assert: 
+  assert:
     that:
       - "win_user_clear_password_never_expires_result|changed"
       - "not win_user_clear_password_never_expires_result.password_never_expires"
@@ -162,7 +182,7 @@
   register: win_user_cannot_change_password_result
 
 - name: check user cannot change password result
-  assert: 
+  assert:
     that:
       - "win_user_cannot_change_password_result|changed"
       - "win_user_cannot_change_password_result.user_cannot_change_password"
@@ -172,7 +192,7 @@
   register: win_user_can_change_password_result
 
 - name: check clear user cannot change password result
-  assert: 
+  assert:
     that:
       - "win_user_can_change_password_result|changed"
       - "not win_user_can_change_password_result.user_cannot_change_password"
@@ -182,7 +202,7 @@
   register: win_user_account_disabled_result
 
 - name: check account disabled result
-  assert: 
+  assert:
     that:
       - "win_user_account_disabled_result|changed"
       - "win_user_account_disabled_result.account_disabled"
@@ -192,7 +212,7 @@
   register: win_user_clear_account_disabled_result
 
 - name: check clear account disabled result
-  assert: 
+  assert:
     that:
       - "win_user_clear_account_disabled_result|changed"
       - "not win_user_clear_account_disabled_result.account_disabled"
@@ -212,7 +232,7 @@
   script: lockout_user.ps1 "{{ test_win_user_name }}"
 
 - name: get user to check if account locked flag is set
-  win_user: name="{{ test_win_user_name }}"
+  win_user: name="{{ test_win_user_name }}" state="query"
   register: win_user_account_locked_result
 
 - name: clear account locked flag if set
@@ -221,18 +241,160 @@
   when: "win_user_account_locked_result.account_locked"
 
 - name: check clear account lockout result if account was locked
-  assert: 
+  assert:
     that:
       - "win_user_clear_account_locked_result|changed"
       - "not win_user_clear_account_locked_result.account_locked"
   when: "win_user_account_locked_result.account_locked"
+
+- name: assign test user to a group
+  win_user: name="{{ test_win_user_name }}" groups="Users"
+  register: win_user_replace_groups_result
+
+- name: check assign user to group result
+  assert:
+    that:
+      - "win_user_replace_groups_result|changed"
+      - "win_user_replace_groups_result.groups|length == 1"
+      - "win_user_replace_groups_result.groups[0]['name'] == 'Users'"
+
+- name: assign test user to the same group
+  win_user:
+    name: "{{ test_win_user_name }}"
+    groups: ["Users"]
+  register: win_user_replace_groups_again_result
+
+- name: check assign user to group again result
+  assert:
+    that:
+      - "not win_user_replace_groups_again_result|changed"
+
+- name: add user to another group
+  win_user: name="{{ test_win_user_name }}" groups="Power Users" groups_action="add"
+  register: win_user_add_groups_result
+
+- name: check add user to another group result
+  assert:
+    that:
+      - "win_user_add_groups_result|changed"
+      - "win_user_add_groups_result.groups|length == 2"
+      - "win_user_add_groups_result.groups[0]['name'] in ('Users', 'Power Users')"
+      - "win_user_add_groups_result.groups[1]['name'] in ('Users', 'Power Users')"
+
+- name: add user to another group again
+  win_user:
+    name: "{{ test_win_user_name }}"
+    groups: "Power Users"
+    groups_action: add
+  register: win_user_add_groups_again_result
+
+- name: check add user to another group again result
+  assert:
+    that:
+      - "not win_user_add_groups_again_result|changed"
+
+- name: remove user from a group
+  win_user: name="{{ test_win_user_name }}" groups="Users" groups_action="remove"
+  register: win_user_remove_groups_result
+
+- name: check remove user from group result
+  assert:
+    that:
+      - "win_user_remove_groups_result|changed"
+      - "win_user_remove_groups_result.groups|length == 1"
+      - "win_user_remove_groups_result.groups[0]['name'] == 'Power Users'"
+
+- name: remove user from a group again
+  win_user:
+    name: "{{ test_win_user_name }}"
+    groups:
+      - "Users"
+    groups_action: remove
+  register: win_user_remove_groups_again_result
+
+- name: check remove user from group again result
+  assert:
+    that:
+      - "not win_user_remove_groups_again_result|changed"
+
+- name: reassign test user to multiple groups
+  win_user: name="{{ test_win_user_name }}" groups="Users, Guests" groups_action="replace"
+  register: win_user_reassign_groups_result
+
+- name: check reassign user groups result
+  assert:
+    that:
+      - "win_user_reassign_groups_result|changed"
+      - "win_user_reassign_groups_result.groups|length == 2"
+      - "win_user_reassign_groups_result.groups[0]['name'] in ('Users', 'Guests')"
+      - "win_user_reassign_groups_result.groups[1]['name'] in ('Users', 'Guests')"
+
+- name: reassign test user to multiple groups again
+  win_user:
+    name: "{{ test_win_user_name }}"
+    groups:
+      - "Users"
+      - "Guests"
+    groups_action: replace
+  register: win_user_reassign_groups_again_result
+
+- name: check reassign user groups again result
+  assert:
+    that:
+      - "not win_user_reassign_groups_again_result|changed"
+
+- name: remove user from all groups
+  win_user: name="{{ test_win_user_name }}" groups=""
+  register: win_user_remove_all_groups_result
+
+- name: check remove user from all groups result
+  assert:
+    that:
+      - "win_user_remove_all_groups_result|changed"
+      - "win_user_remove_all_groups_result.groups|length == 0"
+
+- name: remove user from all groups again
+  win_user:
+    name: "{{ test_win_user_name }}"
+    groups: []
+  register: win_user_remove_all_groups_again_result
+
+- name: check remove user from all groups again result
+  assert:
+    that:
+      - "not win_user_remove_all_groups_again_result|changed"
+
+- name: assign user to invalid group
+  win_user: name="{{ test_win_user_name }}" groups="Userz"
+  register: win_user_invalid_group_result
+  ignore_errors: true
+
+- name: check invalid group result
+  assert:
+    that:
+      - "win_user_invalid_group_result|failed"
+      - "win_user_invalid_group_result.msg"
 
 - name: remove test user when finished
   win_user: name="{{ test_win_user_name }}" state="absent"
   register: win_user_final_remove_result
 
 - name: check final user removal result
-  assert: 
+  assert:
     that:
       - "win_user_final_remove_result|changed"
       - "win_user_final_remove_result.name"
+      - "win_user_final_remove_result.msg"
+      - "win_user_final_remove_result.state == 'absent'"
+
+- name: test removed user with query state
+  win_user: name="{{ test_win_user_name }}" state="query"
+  register: win_user_removed_query_result
+
+- name: check removed query result
+  assert:
+    that:
+      - "not win_user_removed_query_result|changed"
+      - "win_user_removed_query_result.name"
+      - "win_user_removed_query_result.msg"
+      - "win_user_removed_query_result.state == 'absent'"

--- a/test/integration/roles/test_win_user/tasks/main.yml
+++ b/test/integration/roles/test_win_user/tasks/main.yml
@@ -1,0 +1,238 @@
+# test code for the win_user module
+# (c) 2014, Chris Church <chris@ninemoreminutes.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: remove existing test user if present
+  win_user: name="{{ test_win_user_name }}" state="absent"
+  register: win_user_remove_result
+
+- name: check user removal result
+  assert: 
+    that:
+      - "win_user_remove_result.name"
+      - "win_user_remove_result.state == 'absent'"
+
+- name: try to remove test user again
+  win_user: name="{{ test_win_user_name }}" state="absent"
+  register: win_user_remove_result_again
+
+- name: check user removal result again
+  assert: 
+    that:
+      - "not win_user_remove_result_again|changed"
+      - "win_user_remove_result_again.name"
+      - "win_user_remove_result_again.msg"
+      - "win_user_remove_result.state == 'absent'"
+
+- name: test create user
+  win_user: name="{{ test_win_user_name }}" password="{{ test_win_user_password }}"
+  register: win_user_create_result
+
+- name: check user creation result
+  assert: 
+    that:
+      - "win_user_create_result|changed"
+      - "win_user_create_result.name == '{{ test_win_user_name }}'"
+      - "win_user_create_result.fullname == '{{ test_win_user_name }}'"
+      - "win_user_create_result.path"
+
+- name: update user full name and description
+  win_user: name="{{ test_win_user_name }}" fullname="Test Ansible User" description="Test user account created by Ansible"
+  register: win_user_update_result
+
+- name: check full name and description update result
+  assert: 
+    that:
+      - "win_user_update_result|changed"
+      - "win_user_update_result.name == '{{ test_win_user_name }}'"
+      - "win_user_update_result.fullname == 'Test Ansible User'"
+      - "win_user_update_result.description == 'Test user account created by Ansible'"
+      - "win_user_update_result.path"
+
+- name: update user full name and description again with same values
+  win_user: name="{{ test_win_user_name }}" fullname="Test Ansible User" description="Test user account created by Ansible"
+  register: win_user_update_result_again
+
+- name: check full name and description result again
+  assert: 
+    that:
+      - "not win_user_update_result_again|changed"
+      - "win_user_update_result_again.name == '{{ test_win_user_name }}'"
+      - "win_user_update_result_again.fullname == 'Test Ansible User'"
+      - "win_user_update_result.description == 'Test user account created by Ansible'"
+      - "win_user_update_result_again.path"
+
+- name: test again with no options or changes
+  win_user: name="{{ test_win_user_name }}"
+  register: win_user_nochange_result
+
+- name: check no changes result
+  assert: 
+    that:
+      - "not win_user_nochange_result|changed"
+      - "win_user_nochange_result.name == '{{ test_win_user_name }}'"
+      - "win_user_nochange_result.fullname == 'Test Ansible User'"
+      - "win_user_nochange_result.description == 'Test user account created by Ansible'"
+      - "win_user_nochange_result.path"
+      - "win_user_nochange_result.sid"
+
+- name: change user password
+  win_user: name="{{ test_win_user_name }}" password="{{ test_win_user_password2 }}"
+  register: win_user_password_result
+
+- name: check password change result
+  assert: 
+    that:
+      - "win_user_password_result|changed"
+
+- name: change user password again to same value
+  win_user: name="{{ test_win_user_name }}" password="{{ test_win_user_password2 }}"
+  register: win_user_password_result_again
+
+- name: check password change result again
+  assert: 
+    that:
+      - "not win_user_password_result_again|changed"
+
+- name: check update_password=on_create for existing user
+  win_user: name="{{ test_win_user_name }}" password="ThisP@ssW0rdShouldNotBeUsed" update_password=on_create
+  register: win_user_nopasschange_result
+
+- name: check password change with on_create flag result
+  assert: 
+    that:
+      - "not win_user_nopasschange_result|changed"
+
+- name: set password expired flag
+  win_user: name="{{ test_win_user_name }}" password_expired=yes
+  register: win_user_password_expired_result
+
+- name: check password expired result
+  assert: 
+    that:
+      - "win_user_password_expired_result|changed"
+      - "win_user_password_expired_result.password_expired"
+
+- name: clear password expired flag
+  win_user: name="{{ test_win_user_name }}" password_expired=no
+  register: win_user_clear_password_expired_result
+
+- name: check clear password expired result
+  assert: 
+    that:
+      - "win_user_clear_password_expired_result|changed"
+      - "not win_user_clear_password_expired_result.password_expired"
+
+- name: set password never expires flag
+  win_user: name="{{ test_win_user_name }}" password_never_expires=yes
+  register: win_user_password_never_expires_result
+
+- name: check password never expires result
+  assert: 
+    that:
+      - "win_user_password_never_expires_result|changed"
+      - "win_user_password_never_expires_result.password_never_expires"
+
+- name: clear password never expires flag
+  win_user: name="{{ test_win_user_name }}" password_never_expires=no
+  register: win_user_clear_password_never_expires_result
+
+- name: check clear password never expires result
+  assert: 
+    that:
+      - "win_user_clear_password_never_expires_result|changed"
+      - "not win_user_clear_password_never_expires_result.password_never_expires"
+
+- name: set user cannot change password flag
+  win_user: name="{{ test_win_user_name }}" user_cannot_change_password=yes
+  register: win_user_cannot_change_password_result
+
+- name: check user cannot change password result
+  assert: 
+    that:
+      - "win_user_cannot_change_password_result|changed"
+      - "win_user_cannot_change_password_result.user_cannot_change_password"
+
+- name: clear user cannot change password flag
+  win_user: name="{{ test_win_user_name }}" user_cannot_change_password=no
+  register: win_user_can_change_password_result
+
+- name: check clear user cannot change password result
+  assert: 
+    that:
+      - "win_user_can_change_password_result|changed"
+      - "not win_user_can_change_password_result.user_cannot_change_password"
+
+- name: set account disabled flag
+  win_user: name="{{ test_win_user_name }}" account_disabled=true
+  register: win_user_account_disabled_result
+
+- name: check account disabled result
+  assert: 
+    that:
+      - "win_user_account_disabled_result|changed"
+      - "win_user_account_disabled_result.account_disabled"
+
+- name: clear account disabled flag
+  win_user: name="{{ test_win_user_name }}" account_disabled=false
+  register: win_user_clear_account_disabled_result
+
+- name: check clear account disabled result
+  assert: 
+    that:
+      - "win_user_clear_account_disabled_result|changed"
+      - "not win_user_clear_account_disabled_result.account_disabled"
+
+- name: attempt to set account locked flag
+  win_user: name="{{ test_win_user_name }}" account_locked=yes
+  register: win_user_set_account_locked_result
+  ignore_errors: true
+
+- name: verify that attempting to set account locked flag fails
+  assert:
+    that:
+      - "win_user_set_account_locked_result|failed"
+      - "not win_user_set_account_locked_result|changed"
+
+- name: attempt to lockout test account
+  script: lockout_user.ps1 "{{ test_win_user_name }}"
+
+- name: get user to check if account locked flag is set
+  win_user: name="{{ test_win_user_name }}"
+  register: win_user_account_locked_result
+
+- name: clear account locked flag if set
+  win_user: name="{{ test_win_user_name }}" account_locked=no
+  register: win_user_clear_account_locked_result
+  when: "win_user_account_locked_result.account_locked"
+
+- name: check clear account lockout result if account was locked
+  assert: 
+    that:
+      - "win_user_clear_account_locked_result|changed"
+      - "not win_user_clear_account_locked_result.account_locked"
+  when: "win_user_account_locked_result.account_locked"
+
+- name: remove test user when finished
+  win_user: name="{{ test_win_user_name }}" state="absent"
+  register: win_user_final_remove_result
+
+- name: check final user removal result
+  assert: 
+    that:
+      - "win_user_final_remove_result|changed"
+      - "win_user_final_remove_result.name"

--- a/test/integration/test_winrm.yml
+++ b/test/integration/test_winrm.yml
@@ -29,3 +29,4 @@
     - { role: test_win_get_url, tags: test_win_get_url }
     - { role: test_win_msi, tags: test_win_msi }
     - { role: test_win_service, tags: test_win_service }
+    - { role: test_win_user, tags: test_win_user }


### PR DESCRIPTION
These changes allow for retrieving and updating all of the local user properties available in the _General_ and _Member Of_ tabs in Windows.  It fixes https://github.com/ansible/ansible/issues/8711 by allowing a group to be specified when creating a user.

![image](https://cloud.githubusercontent.com/assets/429563/4206711/932e16d4-384e-11e4-8bdb-959ff05c8e3b.png)

![image](https://cloud.githubusercontent.com/assets/429563/4206720/a6d49ed8-384e-11e4-96c6-cd780e4700b7.png)

The only backwards-incompatible changes are the following result fields that have been renamed:
- `user_name` is now `name`
- `user_fullname` is now `fullname`
- `user_path` is now `path`
