### PR TITLE
ansible-galaxy should work when roles directory does not exist

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -704,14 +704,6 @@ def execute_install(args, options, parser):
         print "- please specify a user/role name, or a roles file, but not both"
         sys.exit(1)
 
-    # error checking to ensure the specified roles path exists and is a directory
-    if not os.path.exists(roles_path):
-        print "- the specified role path %s does not exist" % roles_path
-        sys.exit(1)
-    elif not os.path.isdir(roles_path):
-        print "- the specified role path %s is not a directory" % roles_path
-        sys.exit(1)
-
     roles_done = []
     if role_file:
         f = open(role_file, 'r')

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -387,15 +387,12 @@ def role_spec_parse(role_spec):
   
     role_spec = role_spec.strip()
     role_version = ''
+    default_role_versions = dict(git='master', hg='tip')
     if role_spec == "" or role_spec.startswith("#"):
         return (None, None, None, None)
 
     tokens = [s.strip() for s in role_spec.split(',')]
     
-    if not tokens[0].endswith('.tar.gz'): 
-        # pick a reasonable default branch
-        role_version = 'master'
-
     # assume https://github.com URLs are git+https:// URLs and not
     # tarballs unless they end in '.zip'
     if 'github.com/' in tokens[0] and not tokens[0].startswith("git+") and not tokens[0].endswith('.tar.gz'):
@@ -412,6 +409,8 @@ def role_spec_parse(role_spec):
         role_name = tokens[2]
     else:
         role_name = repo_url_to_role_name(tokens[0])
+    if scm and not role_version:
+        role_version = default_role_versions.get(scm, '')
     return dict(scm=scm, src=role_url, version=role_version, name=role_name)
 
 


### PR DESCRIPTION
Roles should be installed when roles directory does not exist (fixes #8950)

This change also fixes installing mercurial roles from ansible-galaxy.

Both of these two changes are codependent because the galaxy tests (make test_galaxy) require both fixes to succeed. 

cc @jimi-c as this reverts a commit of his. 
