### PR TITLE
Prevents mysql_replication from failing with "_mysql_exceptions.Warning: Sending pa...

### DIFF
--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -366,3 +366,4 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 main()
+warnings.simplefilter("ignore")


### PR DESCRIPTION
...sswords in plain text without SSL/TLS is extremely insecure." When not using SSL/TLS.

with a task such as:

```
- name: Change the master in slave to start the replication
  mysql_replication: mode=changemaster 
                     master_host={{ mysql_ent_repl_master }}
                     master_log_file={{ repl_stat.File }}
                     master_log_pos={{ repl_stat.Position }}
                     master_user={{ mysql_ent_repl_user }}
                     master_password={{ mysql_ent_repl_password }}
  when: slave|failed and mysql_ent_repl_role == 'slave' and mysql_ent_repl_master is defined
```

and using MySQL 5.6, it is possible that module will error with:

```
TASK: [mysql_ent | Change the master in slave to start the replication] *******
failed: [10.66.0.201] => {"failed": true, "parsed": false}
invalid output was: SUDO-SUCCESS-pzytfrvaxovjdyhgvozwzzncxkhgtbak
Change master
Traceback (most recent call last):
  File "/home/vagrant/.ansible/tmp/ansible-tmp-1410286841.59-104377264010356/mysql_replication", line 1820, in <module>
    main()
  File "/home/vagrant/.ansible/tmp/ansible-tmp-1410286841.59-104377264010356/mysql_replication", line 351, in main
    changemaster(cursor,chm)
  File "/home/vagrant/.ansible/tmp/ansible-tmp-1410286841.59-104377264010356/mysql_replication", line 164, in changemaster
    cursor.execute("CHANGE MASTER TO " + SQLPARAM)
  File "/usr/lib64/python2.6/site-packages/MySQLdb/cursors.py", line 175, in execute
    if not self._defer_warnings: self._warning_check()
  File "/usr/lib64/python2.6/site-packages/MySQLdb/cursors.py", line 89, in _warning_check
    warn(w[-1], self.Warning, 3)
_mysql_exceptions.Warning: Sending passwords in plain text without SSL/TLS is extremely insecure.


FATAL: all hosts have already failed -- aborting
```

The only addition I could think of if the ignore warnings should be an option to the module.
