### PR TITLE
Allow fairly common ssh repo clone path to work

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -704,14 +704,6 @@ def execute_install(args, options, parser):
         print "- please specify a user/role name, or a roles file, but not both"
         sys.exit(1)
 
-    # error checking to ensure the specified roles path exists and is a directory
-    if not os.path.exists(roles_path):
-        print "- the specified role path %s does not exist" % roles_path
-        sys.exit(1)
-    elif not os.path.isdir(roles_path):
-        print "- the specified role path %s is not a directory" % roles_path
-        sys.exit(1)
-
     roles_done = []
     if role_file:
         f = open(role_file, 'r')

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -387,15 +387,12 @@ def role_spec_parse(role_spec):
   
     role_spec = role_spec.strip()
     role_version = ''
+    default_role_versions = dict(git='master', hg='tip')
     if role_spec == "" or role_spec.startswith("#"):
         return (None, None, None, None)
 
     tokens = [s.strip() for s in role_spec.split(',')]
     
-    if not tokens[0].endswith('.tar.gz'): 
-        # pick a reasonable default branch
-        role_version = 'master'
-
     # assume https://github.com URLs are git+https:// URLs and not
     # tarballs unless they end in '.zip'
     if 'github.com/' in tokens[0] and not tokens[0].startswith("git+") and not tokens[0].endswith('.tar.gz'):
@@ -412,6 +409,8 @@ def role_spec_parse(role_spec):
         role_name = tokens[2]
     else:
         role_name = repo_url_to_role_name(tokens[0])
+    if scm and not role_version:
+        role_version = default_role_versions.get(scm, '')
     return dict(scm=scm, src=role_url, version=role_version, name=role_name)
 
 

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -362,7 +362,7 @@ def repo_url_to_role_name(repo_url):
     # gets the role name out of a repo like 
     # http://git.example.com/repos/repo.git" => "repo"
 
-    if '://' not in repo_url:
+    if '://' not in repo_url and '@' not in repo_url:
         return repo_url
     trailing_path = repo_url.split('/')[-1]
     if trailing_path.endswith('.git'):

--- a/test/integration/galaxy_roles.yml
+++ b/test/integration/galaxy_roles.yml
@@ -6,3 +6,8 @@
 
 - src: https://bitbucket.org/willthames/http-ansible-galaxy/get/master.tar.gz
   name: http-role
+
+- src: git@github.com:geerlingguy/ansible-role-php.git
+  scm: git
+  name: php
+

--- a/test/integration/galaxy_rolesfile
+++ b/test/integration/galaxy_rolesfile
@@ -1,3 +1,4 @@
 git+http://bitbucket.org/willthames/git-ansible-galaxy,v1.4
 hg+http://bitbucket.org/willthames/hg-ansible-galaxy
 https://bitbucket.org/willthames/http-ansible-galaxy/get/master.tar.gz,,http-role
+git+git@github.com:geerlingguy/ansible-role-php.git


### PR DESCRIPTION
Allows github-style ssh repo clone paths (i.e. starting `git@...` rather than `ssh://git@...`)

Addresses #8937. 

Brings in #8951 too (as tests rely on it). Recommend merging #8951 first and then this if desired. 
