### PR TITLE
Updating SELinux example doc in lininefile module

### DIFF
--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -127,7 +127,7 @@ options:
 """
 
 EXAMPLES = r"""
-- lineinfile: dest=/etc/selinux/config regexp=^SELINUX= line=SELINUX=disabled
+- lineinfile: dest=/etc/selinux/config regexp=^SELINUX= line=SELINUX=enforcing
 
 - lineinfile: dest=/etc/sudoers state=absent regexp="^%wheel"
 


### PR DESCRIPTION
Encouraging users to use this Ansible module to _enable_ SELinux seems
like a better idea.  It also warms Dan Walsh's heart.

Signed-off-by: Major Hayden major@mhtx.net
