### PR TITLE
Include el7 mariadb support in mysql integration test

### DIFF
--- a/test/integration/roles/setup_mysql_db/tasks/main.yml
+++ b/test/integration/roles/setup_mysql_db/tasks/main.yml
@@ -17,15 +17,20 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # ============================================================
-- include_vars: '{{ ansible_os_family }}.yml' 
+- include_vars: '{{ item }}'
+  with_first_found:
+      - files:
+        - '{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml'
+        - '{{ ansible_os_family }}.yml'
+      paths: '../vars'
 
 - name: install mysqldb_test rpm dependencies
-  yum: name={{ item }} state=latest 
+  yum: name={{ item }} state=latest
   with_items: mysql_packages
   when: ansible_pkg_mgr  ==  'yum'
 
-- name: install mysqldb_test debian dependencies 
-  apt: name={{ item }} state=latest 
+- name: install mysqldb_test debian dependencies
+  apt: name={{ item }} state=latest
   with_items:  mysql_packages
   when: ansible_pkg_mgr  ==  'apt'
 

--- a/test/integration/roles/setup_mysql_db/vars/RedHat-7.yml
+++ b/test/integration/roles/setup_mysql_db/vars/RedHat-7.yml
@@ -1,0 +1,6 @@
+mysql_service: 'mariadb'
+
+mysql_packages:
+    - mariadb-server
+    - MySQL-python
+    - bzip2


### PR DESCRIPTION
Fixes a problem where mysql-server is no longer available on EL7.
