### PR TITLE
vsphere_guest module doc fix

### DIFF
--- a/library/cloud/vsphere_guest
+++ b/library/cloud/vsphere_guest
@@ -67,7 +67,7 @@ options:
     description:
      - Indicate desired state of the vm.
     default: present
-    choices: ['present', 'powered_on', 'absent', 'powered_on', 'restarted', 'reconfigured']
+    choices: ['present', 'powered_on', 'absent', 'powered_off', 'restarted', 'reconfigured']
   vm_disk:
     description:
       - A key, value list of disks and their sizes and which datastore to keep it in.


### PR DESCRIPTION
state options mentions `powered_on` twice instead of also `powered_off`
