### PR TITLE
Extra vars precedence issue with includes  

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -605,10 +605,10 @@ class Runner(object):
         # use combined_cache and host_variables to template the module_vars
         # we update the inject variables with the data we're about to template
         # since some of the variables we'll be replacing may be contained there too
-        module_vars_inject = utils.combine_vars(host_variables, combined_cache.get(host, {}))
+        module_vars_inject = utils.combine_vars(self.extra_vars, combined_cache.get(host, {}))
+        module_vars_inject = utils.combine_vars(host_variables, module_vars_inject)
         module_vars_inject = utils.combine_vars(self.module_vars, module_vars_inject)
         module_vars = template.template(self.basedir, self.module_vars, module_vars_inject)
-
         inject = {}
 
         inject = utils.combine_vars(inject, self.default_vars)

--- a/test/integration/group_vars/all
+++ b/test/integration/group_vars/all
@@ -6,6 +6,7 @@ uno: 1
 dos: 2
 tres: 3
 etest: 'from group_vars'
+extra_var: 'should be overridden'
 inventory_beats_default: 'narf'
 # variables used for hash merging behavior testing
 test_hash:

--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -5,5 +5,5 @@ pip_test_package: epdb
 
 # variables used in precedence tests, here passed to -e
 etest: 'from -e'
-
+extra_var: extra_var
 

--- a/test/integration/test_includes.yml
+++ b/test/integration/test_includes.yml
@@ -1,1 +1,2 @@
-- include: test_includes2.yml parameter1=asdf parameter2=jkl
+# test parameter passing and variable overriding with extras
+- include: test_includes2.yml parameter1=asdf parameter2=jkl parameter3='{{extra_var}}'

--- a/test/integration/test_includes2.yml
+++ b/test/integration/test_includes2.yml
@@ -2,15 +2,16 @@
 - name: verify playbook includes can take parameters
   hosts: testhost
   tasks:
-    - assert: 
+    - assert:
         that:
           - "parameter1 == 'asdf'"
           - "parameter2 == 'jkl'"
+          - "parameter3 == 'extra_var'"
 
 - name: verify task include logic
   hosts: testhost
   gather_facts: True
-  roles: 
+  roles:
     - { role: test_includes, tags: test_includes }
   tasks:
     - include: roles/test_includes/tasks/not_a_role_task.yml
@@ -19,4 +20,3 @@
           - "ca == 33000"
           - "cb == 33001"
           - "cc == 33002"
-          


### PR DESCRIPTION
Issue Type:

Bugfix Pull Request

Ansible Version:

1.7.1+

Environment:

Mac OSX 10.9, bug is not os specific.

Summary:

Fixes variable precedence issue with include files where extra vars were not overriding default values as expected.

If when calling an include file, one of the parameters of the include was overridden with a value passed in as an 'extra', this value was not being passed in correctly to the include call.

Steps To Reproduce:

The test_includes.yml integration test has been updated to illustrate the issue

Expected Results:

when running a playbook containing the following

include: myinclude.yml some_var='{{extra_var}}'

where some_var is set to 'default' in the group vars but -e some_var='overridden' in the ansible call. We would expect the include to see some_var as 'overridden'

Actual Results:

With the scenario above the some_var is not overridden as expected but remains 'default'
