### PR TITLE
Fix a bug causing yum module to not update to latest in some cases

### DIFF
--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -672,7 +672,7 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                     nothing_to_do = False
                     break
                     
-                if basecmd == 'update' and is_update(module, repoq, this, conf_file, en_repos=en_repos, dis_repos=en_repos):
+                if basecmd == 'update' and is_update(module, repoq, this, conf_file, en_repos=en_repos, dis_repos=dis_repos):
                     nothing_to_do = False
                     break
                     


### PR DESCRIPTION
No updates when using state=latest, enablerepo=<something> and yum-utils package is not installed on target server. Because of a typo, the list of disabled repos was set to the list of enabled repos.
