### PR TITLE
Use -z when invoking pkg_add to allow installation of alternatives

### DIFF
--- a/library/packaging/openbsd_pkg
+++ b/library/packaging/openbsd_pkg
@@ -124,9 +124,9 @@ def get_package_state(name, pkg_spec, module):
 # Function used to make sure a package is present.
 def package_present(name, installed_state, pkg_spec, module):
     if module.check_mode:
-        install_cmd = 'pkg_add -Imn'
+        install_cmd = 'pkg_add -Imnz'
     else:
-        install_cmd = 'pkg_add -Im'
+        install_cmd = 'pkg_add -Imz'
 
     if installed_state is False:
 


### PR DESCRIPTION
Ie, when you want to specify you want python-2.7\* over python (which would fail)
or php-fpm-5.4\* over php-fpm..

Tested here in both cases, with php-fpm-5.4 present or absent - nothing done in the first case, installed in the other. Should fix issue 8990
