### PR TITLE
Do not remove local role file if given on the commandline

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -787,7 +787,8 @@ def execute_install(args, options, parser):
         if tmp_file:
             installed = install_role(role.get("name"), role.get("version"), tmp_file, options)
             # we're done with the temp file, clean it up
-            os.unlink(tmp_file)
+            if tmp_file != role_src:
+                os.unlink(tmp_file)
             # install dependencies, if we want them
             if not no_deps and installed:
                 if not role_data:


### PR DESCRIPTION
using this (for testing purpose):

```
$ ansible-galaxy install COPYING
- error: the file downloaded was not a tar.gz
- COPYING was NOT installed successfully.
- you can use --ignore-errors to skip failed roles.
```

this result in COPYING being erased, which is surprising for the user.
This also prevent erasing requirements.yml if someone use the wrong flag.
