### PR TITLE
Mention defaults subdirectory in a more visible way

### DIFF
--- a/docsite/rst/playbooks_best_practices.rst
+++ b/docsite/rst/playbooks_best_practices.rst
@@ -51,6 +51,8 @@ The top level of the directory would contain files and directories like so::
                 foo.sh        #  <-- script files for use with the script resource
             vars/             #
                 main.yml      #  <-- variables associated with this role
+            defaults/         #
+                main.yml      #  <-- default lower priority variables for this role
             meta/             #
                 main.yml      #  <-- role dependencies
 

--- a/docsite/rst/playbooks_roles.rst
+++ b/docsite/rst/playbooks_roles.rst
@@ -172,6 +172,7 @@ Example project structure::
          tasks/
          handlers/
          vars/
+         defaults/
          meta/
        webservers/
          files/
@@ -179,6 +180,7 @@ Example project structure::
          tasks/
          handlers/
          vars/
+         defaults/
          meta/
 
 In a playbook, it would look like this::


### PR DESCRIPTION
All examples do not show it, so only someone reading the doc from
end to end would know about it.
