### PR TITLE
Fix hostname update on CentOS 6

### DIFF
--- a/library/system/hostname
+++ b/library/system/hostname
@@ -372,7 +372,7 @@ class CentOSHostname(Hostname):
 class CentOSLinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Centos linux'
-    strategy_class = FedoraStrategy
+    strategy_class = RedHatStrategy
 
 class ScientificHostname(Hostname):
     platform = 'Linux'


### PR DESCRIPTION
The actual code fails with the following error on centos 6:

```
$ ansible xxxxxx -m hostname -a 'name=toto'
195.154.117.15 | FAILED >> {
    "failed": true, 
    "msg": "Command failed rc=127, out=, err=/bin/sh: hostnamectl: command not found\n"
}
```
