### PR TITLE
fix TestModuleUtilsBasic.py to run in python 2.6

### DIFF
--- a/test/units/TestModuleUtilsBasic.py
+++ b/test/units/TestModuleUtilsBasic.py
@@ -294,12 +294,20 @@ class TestModuleUtilsBasicHelpers(unittest.TestCase):
         ssh_output = self.module._heuristic_log_sanitize(ssh_data)
 
         # Basic functionality: Successfully hid the password
-        self.assertNotIn('pas:word', url_output)
-        self.assertNotIn('pas:word', ssh_output)
+        if 'assertNotIn' in dir(self):
+            self.assertNotIn('pas:word', url_output)
+            self.assertNotIn('pas:word', ssh_output)
+        else:
+            self.assertFalse('pas:word' in url_output)
+            self.assertFalse('pas:word' in ssh_output)
 
         # Slightly more advanced, we hid all of the password despite the ":"
-        self.assertNotIn('pas', url_output)
-        self.assertNotIn('pas', ssh_output)
+        if 'assertNotIn' in dir(self):
+            self.assertNotIn('pas', url_output)
+            self.assertNotIn('pas', ssh_output)
+        else:
+            self.assertFalse('pas' in url_output)
+            self.assertFalse('pas' in ssh_output)
 
         # In this implementation we replace the password with 8 "*" which is
         # also the length of our password.  The url fields should be able to
@@ -313,7 +321,10 @@ class TestModuleUtilsBasicHelpers(unittest.TestCase):
         # the data, though:
         self.assertTrue(ssh_output.startswith("{'"))
         self.assertTrue(ssh_output.endswith("'}}}}"))
-        self.assertIn(":********@foo.com/data',", ssh_output)
+        if 'assertIn' in dir(self):
+            self.assertIn(":********@foo.com/data',", ssh_output)
+        else:
+            self.assertTrue(":********@foo.com/data'," in ssh_output)
 
         # The overzealous-ness here may lead to us changing the algorithm in
         # the future.  We could make it consume less of the data (with the


### PR DESCRIPTION
The unittest library in python 2.6 does not have the `assertIn()` or `assertNotIn()` methods. This patch checks for their existence and falls back to an `assertTrue()` or `assertFalse()` equivalent.

Without this patch running the unit tests in 2.6 fails with an error like this:

```
ERROR: test_log_sanitize_correctness (TestModuleUtilsBasic.TestModuleUtilsBasicHelpers)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/ansible/test/units/TestModuleUtilsBasic.py", line 297, in test_log_sanitize_correctness
    self.assertNotIn('pas:word', url_output)
AttributeError: 'TestModuleUtilsBasicHelpers' object has no attribute 'assertNotIn'
```
