### PR TITLE
docker: add support to add/drop capabilities

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -204,6 +204,20 @@ options:
     default: ''
     aliases: []
     version_added: "1.8"
+  cap_add:
+    description:
+      - Add capabilities for the container. Requires docker-py >= 0.5.0.
+    required: false
+    default: false
+    aliases: []
+    version_added: "1.8"
+  cap_drop:
+    description:
+      - Drop capabilities for the container. Requires docker-py > 0.5.0.
+    required: false
+    default: false
+    aliases: []
+    version_added: "1.8"
 
 author: Cove Schneider, Joshua Conner, Pavel Antonov
 requirements: [ "docker-py >= 0.3.0", "docker >= 0.10.0" ]
@@ -651,6 +665,10 @@ class DockerManager:
             params['dns'] = self.module.params.get('dns')
             params['volumes_from'] = self.module.params.get('volumes_from')
 
+        if docker.utils.compare_version('1.14', self.client.version()['ApiVersion']) >= 0 and hasattr(docker, '__version__') and docker.__version__ >= '0.5.0':
+            params['cap_add'] = self.module.params.get('cap_add')
+            params['cap_drop'] = self.module.params.get('cap_drop')
+
         for i in containers:
             self.client.start(i['Id'], **params)
             self.increment_counter('started')
@@ -734,7 +752,9 @@ def main():
             tty             = dict(default=False, type='bool'),
             lxc_conf        = dict(default=None, type='list'),
             name            = dict(default=None),
-            net             = dict(default=None)
+            net             = dict(default=None),
+            cap_add         = dict(default=None, type='list'),
+            cap_drop        = dict(default=None, type='list')
         )
     )
 


### PR DESCRIPTION
These options are available since `docker` `1.2.0` and `docker-py` `0.5.0`.
