### PR TITLE
docker: fix using images without a namespace

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -507,15 +507,22 @@ class DockerManager:
 
     def get_split_image_tag(self, image):
         # If image contains a host or org name, omit that from our check
-        registry, resource = image.rsplit('/', 1)
+        if '/' in image:
+            registry, resource = image.rsplit('/', 1)
+        else:
+            registry = None
+            resource = image
 
         # now we can determine if image has a tag
         if resource.find(':') > 0:
             resource, tag = resource.split(':', 1)
-            return '/'.join((registry, resource)), tag
         else:
             tag = "latest"
-            return image, tag
+
+        if registry:
+            resource = registry + '/' + resource
+
+        return resource, tag
 
     def get_summary_counters_msg(self):
         msg = ""


### PR DESCRIPTION
I wasn't able to run images without a namespace like `busybox`, I always got:

```
Traceback (most recent call last):
  File "/home/mantiz/.ansible/tmp/ansible-tmp-1410827919.81-129122313988220/docker", line 2086, in <module>
    main()
  File "/home/mantiz/.ansible/tmp/ansible-tmp-1410827919.81-129122313988220/docker", line 775, in main
    running_containers = manager.get_running_containers()
  File "/home/mantiz/.ansible/tmp/ansible-tmp-1410827919.81-129122313988220/docker", line 597, in get_running_containers
    for i in self.get_deployed_containers():
  File "/home/mantiz/.ansible/tmp/ansible-tmp-1410827919.81-129122313988220/docker", line 573, in get_deployed_containers
    image, tag = self.get_split_image_tag(image)
  File "/home/mantiz/.ansible/tmp/ansible-tmp-1410827919.81-129122313988220/docker", line 524, in get_split_image_tag
    registry, resource = image.rsplit('/', 1)
ValueError: need more than 1 value to unpack
```

I think this was introduced by 1c3039f0 where the check for `/` was removed.

I hope I didn't break anything.
