### PR TITLE
defining Top-level env for main(), modules easily extensible via import

### DIFF
--- a/library/cloud/azure
+++ b/library/cloud/azure
@@ -478,7 +478,10 @@ class Wrapper(object):
                     raise e
 
 
-# import module snippets
-from ansible.module_utils.basic import *
+if __name__ == "__main__":
 
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -228,7 +228,7 @@ def main():
     try:
         cf_region = Region(region)
         cfn = boto.cloudformation.connection.CloudFormationConnection(
-                  aws_access_key_id=aws_access_key, 
+                  aws_access_key_id=aws_access_key,
                   aws_secret_access_key=aws_secret_key,
                   region=cf_region,
               )
@@ -306,8 +306,11 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -428,7 +428,10 @@ def main():
     except (DoError, Exception), e:
         module.fail_json(msg=str(e))
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/cloud/digital_ocean_domain
+++ b/library/cloud/digital_ocean_domain
@@ -145,7 +145,7 @@ class Domain(JsonfyMixIn):
             return False
 
         domains = Domain.list_all()
-        
+
         if id is not None:
             for domain in domains:
                 if domain.id == id:
@@ -181,7 +181,7 @@ def core(module):
 
         if not domain:
             domain = Domain.find(name=getkeyordie("name"))
-            
+
         if not domain:
             domain = Domain.add(getkeyordie("name"),
                                 getkeyordie("ip"))
@@ -203,10 +203,10 @@ def core(module):
         domain = None
         if "id" in module.params:
             domain = Domain.find(id=module.params["id"])
-                
+
         if not domain and "name" in module.params:
             domain = Domain.find(name=module.params["name"])
-                
+
         if not domain:
             module.exit_json(changed=False, msg="Domain not found.")
 
@@ -236,7 +236,10 @@ def main():
     except (DoError, Exception) as e:
         module.fail_json(msg=str(e))
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/cloud/digital_ocean_sshkey
+++ b/library/cloud/digital_ocean_sshkey
@@ -172,7 +172,10 @@ def main():
     except (DoError, Exception) as e:
         module.fail_json(msg=str(e))
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -388,7 +388,7 @@ class DockerManager:
                 if len(parts) == 2:
                     self.volumes[parts[1]] = {}
                     self.binds[parts[0]] = parts[1]
-                # with bind mode 
+                # with bind mode
                 elif len(parts) == 3:
                     if parts[2] not in ['ro', 'rw']:
                         self.module.fail_json(msg='bind mode needs to either be "ro" or "rw"')
@@ -842,7 +842,10 @@ def main():
         changed = manager.has_changed()
         module.exit_json(failed=True, changed=changed, msg=repr(e))
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/cloud/docker_image
+++ b/library/cloud/docker_image
@@ -245,8 +245,11 @@ def main():
 
     except RequestException as e:
         module.exit_json(failed=True, changed=manager.has_changed(), msg=repr(e))
-        
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -209,14 +209,14 @@ options:
   exact_count:
     version_added: "1.5"
     description:
-      - An integer value which indicates how many instances that match the 'count_tag' parameter should be running. Instances are either created or terminated based on this value. 
+      - An integer value which indicates how many instances that match the 'count_tag' parameter should be running. Instances are either created or terminated based on this value.
     required: false
     default: null
     aliases: []
   count_tag:
     version_added: "1.5"
     description:
-      - Used with 'exact_count' to determine how many nodes based on a specific tag criteria should be running.  This can be expressed in multiple ways and is shown in the EXAMPLES section.  For instance, one can request 25 servers that are tagged with "class=webserver".  
+      - Used with 'exact_count' to determine how many nodes based on a specific tag criteria should be running.  This can be expressed in multiple ways and is shown in the EXAMPLES section.  For instance, one can request 25 servers that are tagged with "class=webserver".
     required: false
     default: null
     aliases: []
@@ -249,7 +249,7 @@ EXAMPLES = '''
     wait: yes
     wait_timeout: 500
     count: 5
-    instance_tags: 
+    instance_tags:
        db: postgres
     monitoring: yes
 
@@ -281,7 +281,7 @@ local_action:
     wait: yes
     wait_timeout: 500
     count: 5
-    instance_tags: 
+    instance_tags:
         db: postgres
     monitoring: yes
 
@@ -438,11 +438,11 @@ local_action:
     image: emi-40603AD1
     wait: yes
     group: webserver
-    instance_tags: 
+    instance_tags:
         Name: database
         dbtype: postgres
     exact_count: 5
-    count_tag: 
+    count_tag:
         Name: database
         dbtype: postgres
 
@@ -492,8 +492,8 @@ def find_running_instances_by_count_tag(module, ec2, count_tag):
     for res in reservations:
         if hasattr(res, 'instances'):
             for inst in res.instances:
-                instances.append(inst) 
-                
+                instances.append(inst)
+
     return reservations, instances
 
 
@@ -504,7 +504,7 @@ def _set_none_to_blank(dictionary):
             result[k] = _set_non_to_blank(result[k])
         elif not result[k]:
             result[k] = ""
-    return result                        
+    return result
 
 
 def get_reservations(module, ec2, tags=None, state=None):
@@ -619,7 +619,7 @@ def create_block_device(module, ec2, volume):
     # http://aws.amazon.com/about-aws/whats-new/2013/10/09/ebs-provisioned-iops-maximum-iops-gb-ratio-increased-to-30-1/
     MAX_IOPS_TO_SIZE_RATIO = 30
     if 'snapshot' not in volume and 'ephemeral' not in volume:
-        if 'volume_size' not in volume: 
+        if 'volume_size' not in volume:
             module.fail_json(msg = 'Size must be specified when creating a new volume or modifying the root volume')
     if 'snapshot' in volume:
         if 'device_type' in volume and volume.get('device_type') == 'io1' and 'iops' not in volume:
@@ -630,7 +630,7 @@ def create_block_device(module, ec2, volume):
             if int(volume['iops']) > MAX_IOPS_TO_SIZE_RATIO * size:
                 module.fail_json(msg = 'IOPS must be at most %d times greater than size' % MAX_IOPS_TO_SIZE_RATIO)
     if 'ephemeral' in volume:
-        if 'snapshot' in volume: 
+        if 'snapshot' in volume:
             module.fail_json(msg = 'Cannot set both ephemeral and snapshot')
     return BlockDeviceType(snapshot_id=volume.get('snapshot'),
                            ephemeral_name=volume.get('ephemeral'),
@@ -689,18 +689,18 @@ def enforce_count(module, ec2):
             for inst in instance_dict_array:
                 inst['state'] = "terminated"
                 terminated_list.append(inst)
-            instance_dict_array = terminated_list            
-   
-    # ensure all instances are dictionaries 
+            instance_dict_array = terminated_list
+
+    # ensure all instances are dictionaries
     all_instances = []
     for inst in instances:
         if type(inst) is not dict:
             inst = get_instance_info(inst)
-        all_instances.append(inst)            
+        all_instances.append(inst)
 
     return (all_instances, instance_dict_array, changed_instance_ids, changed)
-    
-        
+
+
 def create_instances(module, ec2, override_count=None):
     """
     Creates new instances
@@ -831,7 +831,7 @@ def create_instances(module, ec2, override_count=None):
                             groups=group_id,
                             associate_public_ip_address=assign_public_ip)
                     interfaces = boto.ec2.networkinterface.NetworkInterfaceCollection(interface)
-                    params['network_interfaces'] = interfaces                   
+                    params['network_interfaces'] = interfaces
             else:
                 params['subnet_id'] = vpc_subnet_id
                 if vpc_subnet_id:
@@ -841,11 +841,11 @@ def create_instances(module, ec2, override_count=None):
 
             if volumes:
                 bdm = BlockDeviceMapping()
-                for volume in volumes: 
+                for volume in volumes:
                     if 'device_name' not in volume:
                         module.fail_json(msg = 'Device name must be set for volume')
                     # Minimum volume size is 1GB. We'll use volume size explicitly set to 0
-                    # to be a signal not to create this volume 
+                    # to be a signal not to create this volume
                     if 'volume_size' not in volume or int(volume['volume_size']) > 0:
                         bdm[volume['device_name']] = create_block_device(module, ec2, volume)
 
@@ -931,7 +931,7 @@ def create_instances(module, ec2, override_count=None):
         num_running = 0
         wait_timeout = time.time() + wait_timeout
         while wait_timeout > time.time() and num_running < len(instids):
-            try: 
+            try:
                 res_list = ec2.get_all_instances(instids)
             except boto.exception.BotoServerError, e:
                 if e.error_code == 'InvalidInstanceID.NotFound':
@@ -944,7 +944,7 @@ def create_instances(module, ec2, override_count=None):
             for res in res_list:
                 num_running += len([ i for i in res.instances if i.state=='running' ])
             if len(res_list) <= 0:
-                # got a bad response of some sort, possibly due to 
+                # got a bad response of some sort, possibly due to
                 # stale/cached data. Wait a second and then try again
                 time.sleep(1)
                 continue
@@ -1065,12 +1065,12 @@ def startstop_instances(module, ec2, instance_ids, state):
     "changed" will be set to False.
 
     """
-    
+
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
     changed = False
     instance_dict_array = []
-    
+
     if not isinstance(instance_ids, list) or len(instance_ids) < 1:
         module.fail_json(msg='instance_ids should be a list of instances, aborting')
 
@@ -1158,7 +1158,7 @@ def main():
 
     ec2 = ec2_connect(module)
 
-    tagged_instances = [] 
+    tagged_instances = []
 
     state = module.params.get('state')
 
@@ -1188,8 +1188,11 @@ def main():
 
     module.exit_json(changed=changed, instance_ids=new_instance_ids, instances=instance_dict_array, tagged_instances=tagged_instances)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -89,7 +89,7 @@ extends_documentation_fragment: aws
 '''
 
 # Thank you to iAcquire for sponsoring development of this module.
-# 
+#
 # See http://alestic.com/2011/06/ec2-ami-security for more information about ensuring the security of your AMI.
 
 EXAMPLES = '''
@@ -265,9 +265,12 @@ def main():
         create_image(module, ec2)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
+if __name__ == "__main__":
 
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()
 

--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -68,7 +68,7 @@ options:
       - Number of instances you'd like to replace at a time.  Used with replace_all_instances.
     required: false
     version_added: "1.8"
-    default: 1  
+    default: 1
   replace_instances:
     description:
       - List of instance_ids belonging to the named ASG that you would like to terminate and be replaced with instances matching the current launch configuration.
@@ -134,9 +134,9 @@ A basic example of configuration:
       - environment: production
         propagate_at_launch: no
 
-Below is an example of how to assign a new launch config to an ASG and terminate old instances.  
+Below is an example of how to assign a new launch config to an ASG and terminate old instances.
 
-All instances in "myasg" that do not have the launch configuration named "my_new_lc" will be terminated in 
+All instances in "myasg" that do not have the launch configuration named "my_new_lc" will be terminated in
 a rolling fashion with instances using the current launch configuration, "my_new_lc".
 
 This could also be considered a rolling deploy of a pre-baked AMI.
@@ -261,7 +261,7 @@ def create_autoscaling_group(connection, module):
     set_tags = module.params.get('tags')
     health_check_period = module.params.get('health_check_period')
     health_check_type = module.params.get('health_check_type')
-    
+
     as_groups = connection.get_all_groups(names=[group_name])
 
     if not vpc_zone_identifier and not availability_zones:
@@ -431,8 +431,8 @@ def replace(connection, module):
     min_size =  module.params.get('min_size')
     desired_capacity =  module.params.get('desired_capacity')
     replace_instances = module.params.get('replace_instances')
-    
-    
+
+
     # wait for instance list to be populated on a newly provisioned ASG
     instance_wait = time.time() + 30
     while instance_wait > time.time():
@@ -456,7 +456,7 @@ def replace(connection, module):
     if replaceable == 0:
         changed = False
         return(changed, props)
-        
+
     # set temporary settings and wait for them to be reached
     as_group.max_size = max_size + batch_size
     as_group.min_size = min_size + batch_size
@@ -478,8 +478,8 @@ def replace(connection, module):
         replace_batch(connection, module, i)
     # return settings to normal
     as_group = connection.get_all_groups(names=[group_name])[0]
-    as_group.max_size = max_size 
-    as_group.min_size = min_size 
+    as_group.max_size = max_size
+    as_group.min_size = min_size
     as_group.desired_capacity = desired_capacity
     as_group.update()
     as_group = connection.get_all_groups(names=[group_name])[0]
@@ -488,8 +488,8 @@ def replace(connection, module):
     return(changed, asg_properties)
 
 def replace_batch(connection, module, replace_instances):
-    
-    
+
+
     group_name = module.params.get('group_name')
     wait_timeout = int(module.params.get('wait_timeout'))
     lc_check = module.params.get('lc_check')
@@ -512,7 +512,7 @@ def replace_batch(connection, module, replace_instances):
     # set all instances given to unhealthy
     for instance_id in old_instances:
         connection.set_instance_health(instance_id,'Unhealthy')
-    
+
     # we wait to make sure the machines we marked as Unhealthy are
     # no longer in the list
 
@@ -605,4 +605,7 @@ def main():
         changed = True
     module.exit_json( changed = changed, **asg_properties )
 
-main()
+
+if __name__ == "__main__":
+
+    main()

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -55,10 +55,10 @@ options:
     choices: [ "yes", "no" ]
   wait:
     description:
-      - Wait for instance registration or deregistration to complete successfully before returning.  
+      - Wait for instance registration or deregistration to complete successfully before returning.
     required: false
     default: yes
-    choices: [ "yes", "no" ] 
+    choices: [ "yes", "no" ]
   validate_certs:
     description:
       - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
@@ -128,9 +128,9 @@ class ElbManager:
         to report it out-of-service"""
 
         for lb in self.lbs:
-            initial_state = self._get_instance_health(lb) 
+            initial_state = self._get_instance_health(lb)
             if initial_state is None:
-                # The instance isn't registered with this ELB so just 
+                # The instance isn't registered with this ELB so just
                 # return unchanged
                 return
 
@@ -256,7 +256,7 @@ class ElbManager:
                   are attached to self.instance_id"""
 
         try:
-            elb = connect_to_aws(boto.ec2.elb, self.region, 
+            elb = connect_to_aws(boto.ec2.elb, self.region,
                                  **self.aws_connect_params)
         except boto.exception.NoAuthHandlerFound, e:
             self.module.fail_json(msg=str(e))
@@ -276,7 +276,7 @@ class ElbManager:
     def _get_instance(self):
         """Returns a boto.ec2.InstanceObject for self.instance_id"""
         try:
-            ec2 = connect_to_aws(boto.ec2, self.region, 
+            ec2 = connect_to_aws(boto.ec2, self.region,
                                  **self.aws_connect_params)
         except boto.exception.NoAuthHandlerFound, e:
             self.module.fail_json(msg=str(e))
@@ -301,7 +301,7 @@ def main():
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module)
 
-    if not region: 
+    if not region:
         module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
 
     ec2_elbs = module.params['ec2_elbs']
@@ -313,7 +313,7 @@ def main():
         module.fail_json(msg="ELBs are required for registration")
 
     instance_id = module.params['instance_id']
-    elb_man = ElbManager(module, instance_id, ec2_elbs, 
+    elb_man = ElbManager(module, instance_id, ec2_elbs,
                          region=region, **aws_connect_params)
 
     if ec2_elbs is not None:
@@ -332,8 +332,11 @@ def main():
 
     module.exit_json(**ec2_facts_result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -68,7 +68,7 @@ options:
     aliases: ['aws_region', 'ec2_region']
   subnets:
     description:
-      - A list of VPC subnets to use when creating ELB. Zones should be empty if using this. 
+      - A list of VPC subnets to use when creating ELB. Zones should be empty if using this.
     required: false
     default: None
     aliases: []
@@ -77,7 +77,7 @@ options:
     description:
       - Purge existing subnet on ELB that are not found in subnets
     required: false
-    default: false  
+    default: false
     version_added: "1.7"
   scheme:
     description:
@@ -141,7 +141,7 @@ EXAMPLES = """
     name: "test-vpc"
     scheme: internal
     state: present
-    subnets: 
+    subnets:
       - subnet-abcd1234
       - subnet-1a2b3c4d
     listeners:
@@ -207,7 +207,7 @@ EXAMPLES = """
         instance_port: 80
     purge_zones: yes
 
-# Creates a ELB and assigns a list of subnets to it. 
+# Creates a ELB and assigns a list of subnets to it.
 - local_action:
     module: ec2_elb_lb
     state: present
@@ -257,7 +257,7 @@ class ElbManager(object):
     """Handles ELB creation and destruction"""
 
     def __init__(self, module, name, listeners=None, purge_listeners=None,
-                 zones=None, purge_zones=None, security_group_ids=None, 
+                 zones=None, purge_zones=None, security_group_ids=None,
                  health_check=None, subnets=None, purge_subnets=None,
                  scheme="internet-facing", connection_draining_timeout=None,
                  cross_az_load_balancing=None,  region=None, **aws_connect_params):
@@ -532,7 +532,7 @@ class ElbManager(object):
                 self._attach_subnets(subnets_to_attach)
             if subnets_to_detach:
                 self._detach_subnets(subnets_to_detach)
-                
+
     def _set_zones(self):
         """Determine which zones need to be enabled or disabled on the ELB"""
         if self.zones:
@@ -691,8 +691,11 @@ def main():
 
     module.exit_json(**ec2_facts_result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/ec2_facts
+++ b/library/cloud/ec2_facts
@@ -48,7 +48,7 @@ EXAMPLES = '''
   action: debug msg="This instance is a t1.micro"
   when: ansible_ec2_instance_type == "t1.micro"
 '''
-   
+
 import socket
 import re
 
@@ -100,7 +100,7 @@ class Ec2Metadata(object):
         for pattern in filter_patterns:
             for key in new_fields.keys():
                 match = re.search(pattern, key)
-                if match: 
+                if match:
                     new_fields.pop(key)
         return new_fields
 
@@ -173,8 +173,11 @@ def main():
 
     module.exit_json(**ec2_facts_result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -339,7 +339,7 @@ def main():
                                 cidr_ip=ip)
                     changed = True
         elif vpc_id and not module.check_mode:
-            # when using a vpc, but no egress rules are specified, 
+            # when using a vpc, but no egress rules are specified,
             # we add in a default allow all out rule, which was the
             # default behavior before egress rules were added
             default_egress_rule = 'out--1-None-None-None-0.0.0.0/0'
@@ -379,8 +379,11 @@ def main():
     else:
         module.exit_json(changed=changed, group_id=None)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/ec2_key
+++ b/library/cloud/ec2_key
@@ -153,7 +153,7 @@ def main():
         if key:
             # existing key found
             if key_material:
-                # EC2's fingerprints are non-trivial to generate, so push this key 
+                # EC2's fingerprints are non-trivial to generate, so push this key
                 # to a temporary name and make ec2 calculate the fingerprint for us.
                 #
                 # http://blog.jbrowne.com/?p=23
@@ -176,7 +176,7 @@ def main():
                 if key.fingerprint != tmpfingerprint:
                     if not module.check_mode:
                         key.delete()
-                        key = ec2.import_key_pair(name, key_material)    
+                        key = ec2.import_key_pair(name, key_material)
 
                         if wait:
                             start = time.time()
@@ -201,7 +201,7 @@ def main():
                     key = ec2.import_key_pair(name, key_material)
                 else:
                     '''
-                    No material provided, let AWS handle the key creation and 
+                    No material provided, let AWS handle the key creation and
                     retrieve the private key
                     '''
                     key = ec2.create_key_pair(name)
@@ -231,8 +231,11 @@ def main():
     else:
         module.exit_json(changed=changed, key=None)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -73,7 +73,7 @@ options:
       - Kernel id for the EC2 instance
     required: false
     default: null
-    aliases: []    
+    aliases: []
   spot_price:
     description:
       - The spot price you are bidding. Only applies for an autoscaling group with spot instances.
@@ -271,4 +271,7 @@ def main():
     elif state == 'absent':
         delete_launch_config(connection, module)
 
-main()
+
+if __name__ == "__main__":
+
+    main()

--- a/library/cloud/ec2_metric_alarm
+++ b/library/cloud/ec2_metric_alarm
@@ -279,4 +279,7 @@ def main():
     elif state == 'absent':
         delete_metric_alarm(connection, module)
 
-main()
+
+if __name__ == "__main__":
+
+    main()

--- a/library/cloud/ec2_scaling_policy
+++ b/library/cloud/ec2_scaling_policy
@@ -174,4 +174,7 @@ def main():
         delete_scaling_policy(connection, module)
 
 
-main()
+if __name__ == "__main__":
+
+
+    main()

--- a/library/cloud/ec2_snapshot
+++ b/library/cloud/ec2_snapshot
@@ -55,27 +55,27 @@ extends_documentation_fragment: aws
 
 EXAMPLES = '''
 # Simple snapshot of volume using volume_id
-- local_action: 
-    module: ec2_snapshot 
-    volume_id: vol-abcdef12   
+- local_action:
+    module: ec2_snapshot
+    volume_id: vol-abcdef12
     description: snapshot of /data from DB123 taken 2013/11/28 12:18:32
 
 # Snapshot of volume mounted on device_name attached to instance_id
-- local_action: 
-    module: ec2_snapshot 
+- local_action:
+    module: ec2_snapshot
     instance_id: i-12345678
     device_name: /dev/sdb1
     description: snapshot of /data from DB123 taken 2013/11/28 12:18:32
 
 # Snapshot of volume with tagging
-- local_action: 
-    module: ec2_snapshot 
+- local_action:
+    module: ec2_snapshot
     instance_id: i-12345678
     device_name: /dev/sdb1
     snapshot_tags:
         frequency: hourly
         source: /data
-'''    
+'''
 
 import sys
 import time
@@ -144,8 +144,11 @@ def main():
     module.exit_json(changed=True, snapshot_id=snapshot.id, volume_id=snapshot.volume_id,
             volume_size=snapshot.volume_size, tags=snapshot.tags.copy())
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -16,7 +16,7 @@
 
 DOCUMENTATION = '''
 ---
-module: ec2_tag 
+module: ec2_tag
 short_description: create and remove tag(s) to ec2 resources.
 description:
     - Creates, removes and lists tags from any EC2 resource.  The resource is referenced by its resource id (e.g. an instance being i-XXXXXXX). It is designed to be used with complex args (tags), see the examples.  This module has a dependency on python-boto.
@@ -24,9 +24,9 @@ version_added: "1.3"
 options:
   resource:
     description:
-      - The EC2 resource id. 
+      - The EC2 resource id.
     required: true
-    default: null 
+    default: null
     aliases: []
   state:
     description:
@@ -37,7 +37,7 @@ options:
     aliases: []
   region:
     description:
-      - region in which the resource exists. 
+      - region in which the resource exists.
     required: false
     default: null
     aliases: ['aws_region', 'ec2_region']
@@ -72,7 +72,7 @@ tasks:
 '''
 
 # Note: this module needs to be made idempotent. Possible solution is to use resource tags with the volumes.
-# if state=present and it doesn't exist, create, tag and attach. 
+# if state=present and it doesn't exist, create, tag and attach.
 # Check for state by looking for volume attachment with tag (and against block device mapping?).
 # Would personally like to revisit this in May when Eucalyptus also has tagging support (3.3).
 
@@ -98,14 +98,14 @@ def main():
     resource = module.params.get('resource')
     tags = module.params.get('tags')
     state = module.params.get('state')
-  
+
     ec2 = ec2_connect(module)
-    
+
     # We need a comparison here so that we can accurately report back changed status.
     # Need to expand the gettags return format and compare with "tags" and then tag or detag as appropriate.
     filters = {'resource-id' : resource}
     gettags = ec2.get_all_tags(filters=filters)
-   
+
     dictadd = {}
     dictremove = {}
     baddict = {}
@@ -119,13 +119,13 @@ def main():
         if set(tags.items()).issubset(set(tagdict.items())):
             module.exit_json(msg="Tags already exists in %s." %resource, changed=False)
         else:
-            for (key, value) in set(tags.items()): 
+            for (key, value) in set(tags.items()):
                 if (key, value) not in set(tagdict.items()):
                     dictadd[key] = value
         tagger = ec2.create_tags(resource, dictadd)
         gettags = ec2.get_all_tags(filters=filters)
         module.exit_json(msg="Tags %s created for resource %s." % (dictadd,resource), changed=True)
- 
+
     if state == 'absent':
         if not tags:
             module.fail_json(msg="tags argument is required when state is absent")
@@ -145,8 +145,11 @@ def main():
         module.exit_json(changed=False, tags=tagdict)
     sys.exit(0)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -24,9 +24,9 @@ version_added: "1.1"
 options:
   instance:
     description:
-      - instance ID if you wish to attach the volume. 
+      - instance ID if you wish to attach the volume.
     required: false
-    default: null 
+    default: null
     aliases: []
   name:
     description:
@@ -74,7 +74,7 @@ options:
     aliases: ['aws_region', 'ec2_region']
   zone:
     description:
-      - zone in which to create the volume, if unset uses the zone the instance is in (if set) 
+      - zone in which to create the volume, if unset uses the zone the instance is in (if set)
     required: false
     default: null
     aliases: ['aws_zone', 'ec2_zone']
@@ -93,7 +93,7 @@ options:
     aliases: []
     version_added: "1.5"
   state:
-    description: 
+    description:
       - whether to ensure the volume is present or absent, or to list existing volumes
     required: false
     default: present
@@ -105,17 +105,17 @@ extends_documentation_fragment: aws
 
 EXAMPLES = '''
 # Simple attachment action
-- local_action: 
-    module: ec2_vol 
-    instance: XXXXXX 
-    volume_size: 5 
+- local_action:
+    module: ec2_vol
+    instance: XXXXXX
+    volume_size: 5
     device_name: sdd
 
-# Example using custom iops params   
-- local_action: 
-    module: ec2_vol 
-    instance: XXXXXX 
-    volume_size: 5 
+# Example using custom iops params
+- local_action:
+    module: ec2_vol
+    instance: XXXXXX
+    volume_size: 5
     iops: 200
     device_name: sdd
 
@@ -125,17 +125,17 @@ EXAMPLES = '''
     instance: XXXXXX
     snapshot: "{{ snapshot }}"
 
-# Playbook example combined with instance launch 
-- local_action: 
-    module: ec2 
+# Playbook example combined with instance launch
+- local_action:
+    module: ec2
     keypair: "{{ keypair }}"
     image: "{{ image }}"
-    wait: yes 
+    wait: yes
     count: 3
     register: ec2
-- local_action: 
-    module: ec2_vol 
-    instance: "{{ item.id }} " 
+- local_action:
+    module: ec2_vol
+    instance: "{{ item.id }} "
     volume_size: 5
     with_items: ec2.instances
     register: ec2_vol
@@ -144,19 +144,19 @@ EXAMPLES = '''
 #   * Nothing will happen if the volume is already attached.
 #   * Volume must exist in the same zone.
 
-- local_action: 
-    module: ec2 
+- local_action:
+    module: ec2
     keypair: "{{ keypair }}"
     image: "{{ image }}"
     zone: YYYYYY
     id: my_instance
-    wait: yes 
+    wait: yes
     count: 1
     register: ec2
 
-- local_action: 
-    module: ec2_vol 
-    instance: "{{ item.id }}" 
+- local_action:
+    module: ec2_vol
+    instance: "{{ item.id }}"
     name: my_existing_volume_Name_tag
     device_name: /dev/xvdf
     with_items: ec2.instances
@@ -176,7 +176,7 @@ EXAMPLES = '''
 '''
 
 # Note: this module needs to be made idempotent. Possible solution is to use resource tags with the volumes.
-# if state=present and it doesn't exist, create, tag and attach. 
+# if state=present and it doesn't exist, create, tag and attach.
 # Check for state by looking for volume attachment with tag (and against block device mapping?).
 # Would personally like to revisit this in May when Eucalyptus also has tagging support (3.3).
 
@@ -231,7 +231,7 @@ def delete_volume(module, ec2):
     if not vol:
         module.exit_json(changed=False)
     else:
-       if vol.attachment_state() is not None: 
+       if vol.attachment_state() is not None:
            adata = vol.attach_data
            module.fail_json(msg="Volume %s is attached to an instance %s." % (vol.id, adata.instance_id))
        ec2.delete_volume(vol.id)
@@ -392,7 +392,7 @@ def main():
     if encrypted and not boto_supports_volume_encryption():
         module.fail_json(msg="You must use boto >= v2.29.0 to use encrypted volumes")
 
-    # Here we need to get the zone info for the instance. This covers situation where 
+    # Here we need to get the zone info for the instance. This covers situation where
     # instance is specified but zone isn't.
     # Useful for playbooks chaining instance launch with volume create + attach and where the
     # zone doesn't matter to the user.
@@ -427,8 +427,11 @@ def main():
             attach_volume(module, ec2, volume, inst)
         module.exit_json(volume_id=volume.id, device=device_name)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -616,8 +616,11 @@ def main():
 
     module.exit_json(changed=changed, vpc_id=new_vpc_id, vpc=vpc_dict, subnets=subnets_changed)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -88,7 +88,7 @@ options:
     choices: [ "yes", "no" ]
   aws_secret_key:
     description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
     required: false
     default: None
     aliases: ['ec2_secret_key', 'secret_key']
@@ -540,8 +540,11 @@ def main():
 
     module.exit_json(**facts_result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/gc_storage
+++ b/library/cloud/gc_storage
@@ -18,16 +18,16 @@ DOCUMENTATION = '''
 ---
 module: gc_storage
 version_added: "1.4"
-short_description: This module manages objects/buckets in Google Cloud Storage. 
+short_description: This module manages objects/buckets in Google Cloud Storage.
 description:
     - This module allows users to manage their objects/buckets in Google Cloud Storage.  It allows upload and download operations and can set some canned permissions. It also allows retrieval of URLs for objects for use in playbooks, and retrieval of string contents of objects.  This module requires setting the default project in GCS prior to playbook usage.  See U(https://developers.google.com/storage/docs/reference/v1/apiversion1) for information about setting the default project.
 
 options:
   bucket:
     description:
-      - Bucket name. 
+      - Bucket name.
     required: true
-    default: null 
+    default: null
     aliases: []
   object:
     description:
@@ -56,7 +56,7 @@ options:
     description:
       - This option let's the user set the canned permissions on the object/bucket that are created. The permissions that can be set are 'private', 'public-read', 'authenticated-read'.
     required: false
-    default: private 
+    default: private
   expiration:
     description:
       - Time limit (in seconds) for the URL generated and returned by GCA when performing a mode=put or mode=get_url operation. This url is only avaialbe when public-read is the acl for the object.
@@ -65,14 +65,14 @@ options:
     aliases: []
   mode:
     description:
-      - Switches the module behaviour between upload, download, get_url (return download url) , get_str (download object as string), create (bucket) and delete (bucket). 
+      - Switches the module behaviour between upload, download, get_url (return download url) , get_str (download object as string), create (bucket) and delete (bucket).
     required: true
     default: null
     aliases: []
     choices: [ 'get', 'put', 'get_url', 'get_str', 'delete', 'create' ]
   gcs_secret_key:
     description:
-      - GCS secret key. If not set then the value of the GCS_SECRET_KEY environment variable is used. 
+      - GCS secret key. If not set then the value of the GCS_SECRET_KEY environment variable is used.
     required: true
     default: null
   gcs_access_key:
@@ -125,17 +125,17 @@ def grant_check(module, gs, obj):
             grant = [ x for x in acp.entries.entry_list if x.scope.type == 'AllUsers']
             if not grant:
                 obj.set_acl('public-read')
-                module.exit_json(changed=True, result="The objects permission as been set to public-read") 
+                module.exit_json(changed=True, result="The objects permission as been set to public-read")
         if module.params.get('permission') == 'authenticated-read':
             grant = [ x for x in acp.entries.entry_list if x.scope.type == 'AllAuthenticatedUsers']
             if not grant:
                 obj.set_acl('authenticated-read')
-                module.exit_json(changed=True, result="The objects permission as been set to authenticated-read") 
+                module.exit_json(changed=True, result="The objects permission as been set to authenticated-read")
     except gs.provider.storage_response_error, e:
         module.fail_json(msg= str(e))
     return True
 
-        
+
 
 def key_check(module, gs, bucket, obj):
     try:
@@ -198,7 +198,7 @@ def delete_key(module, gs, bucket, obj):
         module.exit_json(msg="Object deleted from bucket ", changed=True)
     except gs.provider.storage_response_error, e:
         module.fail_json(msg= str(e))
- 
+
 def create_dirkey(module, gs, bucket, obj):
     try:
         bucket = gs.lookup(bucket)
@@ -219,14 +219,14 @@ def upload_file_check(src):
 
 def path_check(path):
     if os.path.exists(path):
-        return True 
+        return True
     else:
         return False
 
 def upload_gsfile(module, gs, bucket, obj, src, expiry):
     try:
         bucket = gs.lookup(bucket)
-        key = bucket.new_key(obj)  
+        key = bucket.new_key(obj)
         key.set_contents_from_filename(src)
         key.set_acl(module.params.get('permission'))
         url = key.generate_url(expiry)
@@ -286,15 +286,15 @@ def handle_put(module, gs, bucket, obj, overwrite, src, expiration):
             module.exit_json(msg="WARNING: Checksums do not match. Use overwrite parameter to force upload.", failed=True)
         else:
             upload_gsfile(module, gs, bucket, obj, src, expiration)
-                                                                                                            
-    if not bucket_rc:      
+
+    if not bucket_rc:
         create_bucket(module, gs, bucket)
         upload_gsfile(module, gs, bucket, obj, src, expiration)
 
     # If bucket exists but key doesn't, just upload.
     if bucket_rc and not key_rc:
             upload_gsfile(module, gs, bucket, obj, src, expiration)
-    
+
 def handle_delete(module, gs, bucket, obj):
     if bucket and not obj:
         if bucket_check(module, gs, bucket):
@@ -311,9 +311,9 @@ def handle_delete(module, gs, bucket, obj):
             module.exit_json(msg="Bucket does not exist.", changed=False)
     else:
         module.fail_json(msg="Bucket or Bucket & object  parameter is required.", failed=True)
- 
+
 def handle_create(module, gs, bucket, obj):
-    if bucket and not obj: 
+    if bucket and not obj:
         if bucket_check(module, gs, bucket):
             module.exit_json(msg="Bucket already exists.", changed=False)
         else:
@@ -326,7 +326,7 @@ def handle_create(module, gs, bucket, obj):
                 dirobj = obj + "/"
             if key_check(module, gs, bucket, dirobj):
                 module.exit_json(msg="Bucket %s and key %s already exists."% (bucket, obj), changed=False)
-            else:      
+            else:
                 create_dirkey(module, gs, bucket, dirobj)
         else:
             create_bucket(module, gs, bucket)
@@ -373,7 +373,7 @@ def main():
         gs = boto.connect_gs(gs_access_key, gs_secret_key)
     except boto.exception.NoAuthHandlerFound, e:
         module.fail_json(msg = str(e))
- 
+
     if mode == 'get':
         if not bucket_check(module, gs, bucket) or not key_check(module, gs, bucket, obj):
             module.fail_json(msg="Target bucket/key cannot be found", failed=True)
@@ -381,19 +381,19 @@ def main():
             download_gsfile(module, gs, bucket, obj, dest)
         else:
             handle_get(module, gs, bucket, obj, overwrite, dest)
-        
+
     if mode == 'put':
         if not path_check(src):
             module.fail_json(msg="Local object for PUT does not exist", failed=True)
         handle_put(module, gs, bucket, obj, overwrite, src, expiry)
 
-    # Support for deleting an object if we have both params.  
+    # Support for deleting an object if we have both params.
     if mode == 'delete':
         handle_delete(module, gs, bucket, obj)
-    
+
     if mode == 'create':
         handle_create(module, gs, bucket, obj)
-    
+
     if mode == 'get_url':
         if bucket and obj:
             if bucket_check(module, gs, bucket) and key_check(module, gs, bucket, obj):
@@ -414,7 +414,10 @@ def main():
             module.fail_json(msg="Bucket and Object parameters must be set", failed=True)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
+if __name__ == "__main__":
 
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/cloud/gce
+++ b/library/cloud/gce
@@ -467,8 +467,11 @@ def main():
     print json.dumps(json_output)
     sys.exit(0)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.gce import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.gce import *
+
+    main()

--- a/library/cloud/gce_lb
+++ b/library/cloud/gce_lb
@@ -82,7 +82,7 @@ options:
     description:
       - the protocol used for the load-balancer packet forwarding, tcp or udp
     required: false
-    default: "tcp" 
+    default: "tcp"
     choices: ['tcp', 'udp']
   region:
     description:
@@ -137,7 +137,7 @@ author: Eric Johnson <erjohnso@google.com>
 
 EXAMPLES = '''
 # Simple example of creating a new LB, adding members, and a health check
-- local_action: 
+- local_action:
     module: gce_lb
     name: testlb
     region: us-central1
@@ -328,8 +328,11 @@ def main():
     print json.dumps(json_output)
     sys.exit(0)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.gce import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.gce import *
+
+    main()

--- a/library/cloud/gce_net
+++ b/library/cloud/gce_net
@@ -35,7 +35,7 @@ options:
     description:
       - the protocol:ports to allow ('tcp:80' or 'tcp:80,443' or 'tcp:80-800')
     required: false
-    default: null 
+    default: null
     aliases: []
   ipv4_range:
     description:
@@ -101,13 +101,13 @@ author: Eric Johnson <erjohnso@google.com>
 
 EXAMPLES = '''
 # Simple example of creating a new network
-- local_action: 
+- local_action:
     module: gce_net
     name: privatenet
     ipv4_range: '10.240.16.0/24'
-   
+
 # Simple example of creating a new firewall rule
-- local_action: 
+- local_action:
     module: gce_net
     name: privatenet
     allowed: tcp:80,8080
@@ -264,8 +264,11 @@ def main():
     print json.dumps(json_output)
     sys.exit(0)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.gce import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.gce import *
+
+    main()

--- a/library/cloud/gce_pd
+++ b/library/cloud/gce_pd
@@ -37,22 +37,22 @@ options:
     aliases: []
   instance_name:
     description:
-      - instance name if you wish to attach or detach the disk 
+      - instance name if you wish to attach or detach the disk
     required: false
-    default: null 
+    default: null
     aliases: []
   mode:
     description:
       - GCE mount mode of disk, READ_ONLY (default) or READ_WRITE
     required: false
-    default: "READ_ONLY" 
+    default: "READ_ONLY"
     choices: ["READ_WRITE", "READ_ONLY"]
     aliases: []
   name:
     description:
       - name of the disk
     required: true
-    default: null 
+    default: null
     aliases: []
   size_gb:
     description:
@@ -209,9 +209,9 @@ def main():
             module.fail_json(msg="Must supply a size_gb", changed=False)
         try:
             size_gb = int(round(float(size_gb)))
-            if size_gb < 1: 
+            if size_gb < 1:
                 raise Exception
-        except:        
+        except:
             module.fail_json(msg="Must supply a size_gb larger than 1 GB",
                     changed=False)
 
@@ -278,8 +278,11 @@ def main():
     print json.dumps(json_output)
     sys.exit(0)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.gce import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.gce import *
+
+    main()

--- a/library/cloud/glance_image
+++ b/library/cloud/glance_image
@@ -143,7 +143,7 @@ def _get_ksclient(module, kwargs):
                                  auth_url=kwargs.get('auth_url'))
     except Exception, e:
         module.fail_json(msg="Error authenticating to the keystone: %s " % e.message)
-    return client 
+    return client
 
 
 def _get_endpoint(module, client, endpoint_type):
@@ -172,7 +172,7 @@ def _glance_image_present(module, params, client):
     try:
         for image in client.images.list():
             if image.name == params['name']:
-                return image.id 
+                return image.id
         return None
     except Exception, e:
         module.fail_json(msg="Error in fetching image list: %s" % e.message)
@@ -254,7 +254,10 @@ def main():
         else:
             _glance_delete_image(module, module.params, client)
 
-# this is magic, see lib/ansible/module.params['common.py
-from ansible.module_utils.basic import *
-from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module.params['common.py
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.openstack import *
+    main()

--- a/library/cloud/linode
+++ b/library/cloud/linode
@@ -173,14 +173,14 @@ def randompass():
     '''
     Generate a long random password that comply to Linode requirements
     '''
-    # Linode API currently requires the following: 
-    # It must contain at least two of these four character classes: 
+    # Linode API currently requires the following:
+    # It must contain at least two of these four character classes:
     # lower case letters - upper case letters - numbers - punctuation
     # we play it safe :)
     import random
     import string
     # as of python 2.4, this reseeds the PRNG from urandom
-    random.seed() 
+    random.seed()
     lower = ''.join(random.choice(string.ascii_lowercase) for x in range(6))
     upper = ''.join(random.choice(string.ascii_uppercase) for x in range(6))
     number = ''.join(random.choice(string.digits) for x in range(6))
@@ -212,11 +212,11 @@ def getInstanceDetails(api, server):
                                         'ip_id': ip['IPADDRESSID']})
     return instance
 
-def linodeServers(module, api, state, name, plan, distribution, datacenter, linode_id, 
+def linodeServers(module, api, state, name, plan, distribution, datacenter, linode_id,
                   payment_term, password, ssh_pub_key, swap, wait, wait_timeout):
     instances = []
     changed = False
-    new_server = False   
+    new_server = False
     servers = []
     disks = []
     configs = []
@@ -227,7 +227,7 @@ def linodeServers(module, api, state, name, plan, distribution, datacenter, lino
         # For the moment we only consider linode_id as criteria for match
         # Later we can use more (size, name, etc.) and update existing
         servers = api.linode_list(LinodeId=linode_id)
-        # Attempt to fetch details about disks and configs only if servers are 
+        # Attempt to fetch details about disks and configs only if servers are
         # found with linode_id
         if servers:
             disks = api.linode_disk_list(LinodeId=linode_id)
@@ -241,7 +241,7 @@ def linodeServers(module, api, state, name, plan, distribution, datacenter, lino
         #  - need linode_id (entity)
         #  - need disk_id for linode_id - create disk from distrib
         #  - need config_id for linode_id - create config (need kernel)
-        
+
         # Any create step triggers a job that need to be waited for.
         if not servers:
             for arg in ('name', 'plan', 'distribution', 'datacenter'):
@@ -250,7 +250,7 @@ def linodeServers(module, api, state, name, plan, distribution, datacenter, lino
             # Create linode entity
             new_server = True
             try:
-                res = api.linode_create(DatacenterID=datacenter, PlanID=plan, 
+                res = api.linode_create(DatacenterID=datacenter, PlanID=plan,
                                         PaymentTerm=payment_term)
                 linode_id = res['LinodeID']
                 # Update linode Label to match name
@@ -276,17 +276,17 @@ def linodeServers(module, api, state, name, plan, distribution, datacenter, lino
                 size = servers[0]['TOTALHD'] - swap
                 if ssh_pub_key:
                     res = api.linode_disk_createfromdistribution(
-                              LinodeId=linode_id, DistributionID=distribution, 
+                              LinodeId=linode_id, DistributionID=distribution,
                               rootPass=password, rootSSHKey=ssh_pub_key,
                               Label='%s data disk (lid: %s)' % (name, linode_id), Size=size)
                 else:
                     res = api.linode_disk_createfromdistribution(
-                              LinodeId=linode_id, DistributionID=distribution, rootPass=password, 
+                              LinodeId=linode_id, DistributionID=distribution, rootPass=password,
                               Label='%s data disk (lid: %s)' % (name, linode_id), Size=size)
                 jobs.append(res['JobID'])
                 # Create SWAP disk
-                res = api.linode_disk_create(LinodeId=linode_id, Type='swap', 
-                                             Label='%s swap disk (lid: %s)' % (name, linode_id), 
+                res = api.linode_disk_create(LinodeId=linode_id, Type='swap',
+                                             Label='%s swap disk (lid: %s)' % (name, linode_id),
                                              Size=swap)
                 jobs.append(res['JobID'])
             except Exception, e:
@@ -358,12 +358,12 @@ def linodeServers(module, api, state, name, plan, distribution, datacenter, lino
                 time.sleep(5)
             if wait and wait_timeout <= time.time():
                 # waiting took too long
-                module.fail_json(msg = 'Timeout waiting on %s (lid: %s)' % 
+                module.fail_json(msg = 'Timeout waiting on %s (lid: %s)' %
                                  (server['LABEL'], server['LINODEID']))
             # Get a fresh copy of the server details
             server = api.linode_list(LinodeId=server['LINODEID'])[0]
             if server['STATUS'] == -2:
-                module.fail_json(msg = '%s (lid: %s) failed to boot' % 
+                module.fail_json(msg = '%s (lid: %s) failed to boot' %
                                  (server['LABEL'], server['LINODEID']))
             # From now on we know the task is a success
             # Build instance report
@@ -374,7 +374,7 @@ def linodeServers(module, api, state, name, plan, distribution, datacenter, lino
             else:
                 instance['status'] = 'Starting'
 
-            # Return the root password if this is a new box and no SSH key 
+            # Return the root password if this is a new box and no SSH key
             # has been provided
             if new_server and not ssh_pub_key:
                 instance['password'] = password
@@ -418,7 +418,7 @@ def linodeServers(module, api, state, name, plan, distribution, datacenter, lino
             instance['status'] = 'Restarting'
             changed = True
             instances.append(instance)
-            
+
     elif state in ('absent', 'deleted'):
         for server in servers:
             instance = getInstanceDetails(api, server)
@@ -484,10 +484,13 @@ def main():
     except Exception, e:
         module.fail_json(msg = '%s' % e.value[0]['ERRORMESSAGE'])
 
-    linodeServers(module, api, state, name, plan, distribution, datacenter, linode_id, 
+    linodeServers(module, api, state, name, plan, distribution, datacenter, linode_id,
                  payment_term, password, ssh_pub_key, swap, wait, wait_timeout)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -22,7 +22,7 @@ import os
 
 try:
     from novaclient.v1_1 import client as nova_client
-    from novaclient.v1_1 import floating_ips 
+    from novaclient.v1_1 import floating_ips
     from novaclient import exceptions
     from novaclient import utils
     import time
@@ -294,15 +294,15 @@ def _add_floating_ip_from_pool(module, nova, server):
     # instantiate FloatingIPManager object
     floating_ip_obj = floating_ips.FloatingIPManager(nova)
 
-    # empty dict and list 
-    usable_floating_ips = {} 
+    # empty dict and list
+    usable_floating_ips = {}
     pools = []
 
     # user specified
     pools = module.params['floating_ip_pools']
 
-    # get the list of all floating IPs. Mileage may 
-    # vary according to Nova Compute configuration 
+    # get the list of all floating IPs. Mileage may
+    # vary according to Nova Compute configuration
     # per cloud provider
     all_floating_ips = floating_ip_obj.list()
 
@@ -323,7 +323,7 @@ def _add_floating_ip_from_pool(module, nova, server):
         if not pool_ips:
             try:
                 new_ip = nova.floating_ips.create(pool)
-            except Exception, e: 
+            except Exception, e:
                 module.fail_json(msg = "Unable to create floating ip")
             pool_ips.append(new_ip.ip)
         # Add to the main list
@@ -378,9 +378,9 @@ def _add_floating_ip(module, nova, server):
     else:
         return server
 
-    # this may look redundant, but if there is now a 
+    # this may look redundant, but if there is now a
     # floating IP, then it needs to be obtained from
-    # a recent server object if the above code path exec'd 
+    # a recent server object if the above code path exec'd
     try:
         server = nova.servers.get(server.id)
     except Exception, e:
@@ -443,7 +443,7 @@ def _create_server(module, nova):
                 private = openstack_find_nova_addresses(getattr(server, 'addresses'), 'fixed', 'private')
                 public = openstack_find_nova_addresses(getattr(server, 'addresses'), 'floating', 'public')
 
-                # now exit with info 
+                # now exit with info
                 module.exit_json(changed = True, id = server.id, private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
 
             if server.status == 'ERROR':
@@ -578,8 +578,11 @@ def main():
         _get_server_state(module, nova)
         _delete_server(module, nova)
 
-# this is magic, see lib/ansible/module_common.py
-from ansible.module_utils.basic import *
-from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module_common.py
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.openstack import *
+    main()
 

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -114,7 +114,7 @@ def main():
                 if module.params['public_key'] and (module.params['public_key'] != key.public_key ):
                     module.fail_json(msg = "name {} present but key hash not the same as offered.  Delete key first.".format(key['name']))
                 else:
-                    module.exit_json(changed = False, result = "Key present")            
+                    module.exit_json(changed = False, result = "Key present")
         try:
             key = nova.keypairs.create(module.params['name'], module.params['public_key'])
         except Exception, e:
@@ -132,8 +132,11 @@ def main():
                 module.exit_json( changed = True, result = "deleted")
         module.exit_json(changed = False, result = "not present")
 
-# this is magic, see lib/ansible/module.params['common.py
-from ansible.module_utils.basic import *
-from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module.params['common.py
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.openstack import *
+    main()
 

--- a/library/cloud/ovirt
+++ b/library/cloud/ovirt
@@ -158,33 +158,33 @@ EXAMPLES = '''
 # Basic example provisioning from image.
 
 action: ovirt >
-    user=admin@internal 
-    url=https://ovirt.example.com 
-    instance_name=ansiblevm04 
-    password=secret 
-    image=centos_64 
-    zone=cluster01 
+    user=admin@internal
+    url=https://ovirt.example.com
+    instance_name=ansiblevm04
+    password=secret
+    image=centos_64
+    zone=cluster01
     resource_type=template"
 
 # Full example to create new instance from scratch
-action: ovirt > 
-    instance_name=testansible 
-    resource_type=new 
-    instance_type=server 
-    user=admin@internal 
-    password=secret 
-    url=https://ovirt.example.com 
-    instance_disksize=10 
-    zone=cluster01 
-    region=datacenter1 
-    instance_cpus=1 
-    instance_nic=nic1 
-    instance_network=rhevm 
-    instance_mem=1000 
-    disk_alloc=thin 
-    sdomain=FIBER01 
-    instance_cores=1 
-    instance_os=rhel_6x64 
+action: ovirt >
+    instance_name=testansible
+    resource_type=new
+    instance_type=server
+    user=admin@internal
+    password=secret
+    url=https://ovirt.example.com
+    instance_disksize=10
+    zone=cluster01
+    region=datacenter1
+    instance_cpus=1
+    instance_nic=nic1
+    instance_network=rhevm
+    instance_mem=1000
+    disk_alloc=thin
+    sdomain=FIBER01
+    instance_cores=1
+    instance_os=rhel_6x64
     disk_int=virtio"
 
 # stopping an instance
@@ -197,10 +197,10 @@ action: ovirt >
 
 # starting an instance
 action: ovirt >
-    instance_name=testansible 
-    state=started 
-    user=admin@internal 
-    password=secret 
+    instance_name=testansible
+    state=started
+    user=admin@internal
+    password=secret
     url=https://ovirt.example.com
 
 
@@ -245,7 +245,7 @@ def create_vm(conn, vmtype, vmname, zone, vmdisk_size, vmcpus, vmnic, vmnetwork,
         # define network parameters
         network_net = params.Network(name=vmnetwork)
         nic_net1 = params.NIC(name=vmnic, network=network_net, interface='virtio')
-        
+
     try:
         conn.vms.add(vmparams)
     except:
@@ -364,7 +364,7 @@ def main():
     vmcpus        = module.params['instance_cpus']      # number of cpu
     vmnic         = module.params['instance_nic']       # network interface
     vmnetwork     = module.params['instance_network']   # logical network
-    vmmem         = module.params['instance_mem']       # mem size 
+    vmmem         = module.params['instance_mem']       # mem size
     vmdisk_alloc  = module.params['disk_alloc']         # thin, preallocated
     vmdisk_int    = module.params['disk_int']           # disk interface virtio or ide
     vmos          = module.params['instance_os']        # Operating System
@@ -402,7 +402,7 @@ def main():
         else:
             vm_stop(c, vmname)
             module.exit_json(changed=True, msg="VM %s is shutting down" % vmname)
-    
+
     if state == 'restart':
         if vm_status(c, vmname) == 'up':
             vm_restart(c, vmname)
@@ -418,8 +418,11 @@ def main():
             module.exit_json(changed=True, msg="VM %s removed" % vmname)
 
 
+if __name__ == "__main__":
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/cloud/quantum_floating_ip
+++ b/library/cloud/quantum_floating_ip
@@ -259,8 +259,11 @@ def main():
             _update_floating_ip(neutron, module, None, floating_id)
         module.exit_json(changed=False)
 
-# this is magic, see lib/ansible/module.params['common.py
-from ansible.module_utils.basic import *
-from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module.params['common.py
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.openstack import *
+    main()
 

--- a/library/cloud/quantum_floating_ip_associate
+++ b/library/cloud/quantum_floating_ip_associate
@@ -211,8 +211,11 @@ def main():
             _update_floating_ip(neutron, module, None, floating_ip_id)
         module.exit_json(changed = True, result = "detached")
 
-# this is magic, see lib/ansible/module.params['common.py
-from ansible.module_utils.basic import *
-from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module.params['common.py
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.openstack import *
+    main()
 

--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -272,8 +272,11 @@ def main():
             _delete_network(module, network_id, neutron)
             module.exit_json(changed = True, result = "Deleted")
 
-# this is magic, see lib/ansible/module.params['common.py
-from ansible.module_utils.basic import *
-from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module.params['common.py
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.openstack import *
+    main()
 

--- a/library/cloud/quantum_router
+++ b/library/cloud/quantum_router
@@ -203,8 +203,11 @@ def main():
             _delete_router(module, neutron, router_id)
             module.exit_json(changed=True, result="deleted")
 
-# this is magic, see lib/ansible/module.params['common.py
-from ansible.module_utils.basic import *
-from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module.params['common.py
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.openstack import *
+    main()
 

--- a/library/cloud/quantum_router_gateway
+++ b/library/cloud/quantum_router_gateway
@@ -206,8 +206,11 @@ def main():
         _remove_gateway_router(neutron, module, router_id)
         module.exit_json(changed=True, result="Deleted")
 
-# this is magic, see lib/ansible/module.params['common.py
-from ansible.module_utils.basic import *
-from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module.params['common.py
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.openstack import *
+    main()
 

--- a/library/cloud/quantum_router_interface
+++ b/library/cloud/quantum_router_interface
@@ -242,8 +242,11 @@ def main():
         _remove_interface_router(neutron, module, router_id, subnet_id)
         module.exit_json(changed=True, result="Deleted")
 
-# this is magic, see lib/ansible/module.params['common.py
-from ansible.module_utils.basic import *
-from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module.params['common.py
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.openstack import *
+    main()
 

--- a/library/cloud/quantum_subnet
+++ b/library/cloud/quantum_subnet
@@ -284,8 +284,11 @@ def main():
             _delete_subnet(module, neutron, subnet_id)
             module.exit_json(changed = True, result = "deleted")
 
-# this is magic, see lib/ansible/module.params['common.py
-from ansible.module_utils.basic import *
-from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module.params['common.py
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.openstack import *
+    main()
 

--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -703,9 +703,12 @@ def main():
                  config_drive=config_drive)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-# invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    # invoke the module
+    main()

--- a/library/cloud/rax_cbs
+++ b/library/cloud/rax_cbs
@@ -212,9 +212,12 @@ def main():
     cloud_block_storage(module, state, name, description, meta, size,
                         snapshot_id, volume_type, wait, wait_timeout)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_cbs_attachments
+++ b/library/cloud/rax_cbs_attachments
@@ -218,9 +218,12 @@ def main():
     cloud_block_storage_attachments(module, state, volume, server, device,
                                     wait, wait_timeout)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_cdb
+++ b/library/cloud/rax_cdb
@@ -230,9 +230,12 @@ def main():
     rax_cdb(module, state, name, flavor, volume, wait, wait_timeout)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-# invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    # invoke the module
+    main()

--- a/library/cloud/rax_cdb_database
+++ b/library/cloud/rax_cdb_database
@@ -178,9 +178,12 @@ def main():
     rax_cdb_database(module, state, cdb_id, name, character_set, collate)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-# invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    # invoke the module
+    main()

--- a/library/cloud/rax_cdb_user
+++ b/library/cloud/rax_cdb_user
@@ -212,9 +212,12 @@ def main():
     rax_cdb_user(module, state, cdb_id, name, password, databases, host)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-# invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    # invoke the module
+    main()

--- a/library/cloud/rax_clb
+++ b/library/cloud/rax_clb
@@ -295,9 +295,12 @@ def main():
                         vip_type, timeout, wait, wait_timeout, vip_id)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-### invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_clb_nodes
+++ b/library/cloud/rax_clb_nodes
@@ -295,9 +295,12 @@ def main():
     module.exit_json(changed=True, state=state, **kwargs)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-### invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_dns
+++ b/library/cloud/rax_dns
@@ -165,9 +165,12 @@ def main():
     rax_dns(module, comment, email, name, state, ttl)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-### invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_dns_record
+++ b/library/cloud/rax_dns_record
@@ -327,9 +327,12 @@ def main():
                        state=state, ttl=ttl)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-### invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_facts
+++ b/library/cloud/rax_facts
@@ -136,9 +136,12 @@ def main():
     rax_facts(module, address, name, server_id)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-### invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_files
+++ b/library/cloud/rax_files
@@ -373,7 +373,10 @@ def main():
                private, web_index, web_error)
 
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-main()
+
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    main()

--- a/library/cloud/rax_files_objects
+++ b/library/cloud/rax_files_objects
@@ -597,7 +597,10 @@ def main():
     cloudfiles(module, container, src, dest, method, typ, meta, clear_meta, structure, expires)
 
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-main()
+
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    main()

--- a/library/cloud/rax_identity
+++ b/library/cloud/rax_identity
@@ -102,9 +102,12 @@ def main():
 
     cloud_identity(module, state, pyrax.identity)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_keypair
+++ b/library/cloud/rax_keypair
@@ -166,9 +166,12 @@ def main():
     rax_keypair(module, name, public_key, state)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-### invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_meta
+++ b/library/cloud/rax_meta
@@ -170,9 +170,12 @@ def main():
     rax_meta(module, address, name, server_id, meta)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-### invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_network
+++ b/library/cloud/rax_network
@@ -137,9 +137,12 @@ def main():
     cloud_network(module, state, label, cidr)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-### invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_queue
+++ b/library/cloud/rax_queue
@@ -137,9 +137,12 @@ def main():
     cloud_queue(module, state, name)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-### invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    ### invoke the module
+    main()

--- a/library/cloud/rax_scaling_group
+++ b/library/cloud/rax_scaling_group
@@ -343,9 +343,12 @@ def main():
             state=state)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-# invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    # invoke the module
+    main()

--- a/library/cloud/rax_scaling_policy
+++ b/library/cloud/rax_scaling_policy
@@ -275,9 +275,12 @@ def main():
             state=state)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.rax import *
+if __name__ == "__main__":
 
-# invoke the module
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.rax import *
+
+    # invoke the module
+    main()

--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -24,7 +24,7 @@ description:
 options:
   command:
     description:
-      - Specifies the action to take.  
+      - Specifies the action to take.
     required: true
     default: null
     aliases: []
@@ -43,7 +43,7 @@ options:
     aliases: []
   db_engine:
     description:
-      - The type of database.  Used only when command=create. 
+      - The type of database.  Used only when command=create.
     required: false
     default: null
     aliases: []
@@ -56,7 +56,7 @@ options:
     aliases: []
   instance_type:
     description:
-      - The instance type of the database.  Must be specified when command=create. Optional when command=replicate, command=modify or command=restore. If not specified then the replica inherits the same instance type as the source instance. 
+      - The instance type of the database.  Must be specified when command=create. Optional when command=replicate, command=modify or command=restore. If not specified then the replica inherits the same instance type as the source instance.
     required: false
     default: null
     aliases: []
@@ -98,7 +98,7 @@ options:
     aliases: []
   license_model:
     description:
-      - The license model for this DB instance. Used only when command=create or command=restore. 
+      - The license model for this DB instance. Used only when command=create or command=restore.
     required: false
     default: null
     aliases: []
@@ -106,7 +106,7 @@ options:
   multi_zone:
     description:
       - Specifies if this is a Multi-availability-zone deployment. Can not be used in conjunction with zone parameter. Used only when command=create or command=modify.
-    choices: [ "yes", "no" ] 
+    choices: [ "yes", "no" ]
     required: false
     default: null
     aliases: []
@@ -136,7 +136,7 @@ options:
     aliases: []
   upgrade:
     description:
-      - Indicates that minor version upgrades should be applied automatically. Used only when command=create or command=replicate. 
+      - Indicates that minor version upgrades should be applied automatically. Used only when command=create or command=replicate.
     required: false
     default: no
     choices: [ "yes", "no" ]
@@ -185,7 +185,7 @@ options:
     aliases: []
   aws_secret_key:
     description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
     required: false
     default: null
     aliases: [ 'ec2_secret_key', 'secret_key' ]
@@ -261,7 +261,7 @@ EXAMPLES = '''
       instance_name=new_database
       new_instance_name=renamed_database
       wait=yes
-    
+
 '''
 
 import sys
@@ -288,7 +288,7 @@ def main():
             instance_name     = dict(required=True),
             source_instance   = dict(required=False),
             db_engine         = dict(choices=['MySQL', 'oracle-se1', 'oracle-se', 'oracle-ee', 'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex', 'sqlserver-web', 'postgres'], required=False),
-            size              = dict(required=False), 
+            size              = dict(required=False),
             instance_type     = dict(aliases=['type'], required=False),
             username          = dict(required=False),
             password          = dict(no_log=True, required=False),
@@ -297,7 +297,7 @@ def main():
             parameter_group   = dict(required=False),
             license_model     = dict(choices=['license-included', 'bring-your-own-license', 'general-public-license'], required=False),
             multi_zone        = dict(type='bool', default=False),
-            iops              = dict(required=False), 
+            iops              = dict(required=False),
             security_groups   = dict(required=False),
             vpc_security_groups = dict(type='list', required=False),
             port              = dict(required=False),
@@ -305,7 +305,7 @@ def main():
             option_group      = dict(required=False),
             maint_window      = dict(required=False),
             backup_window     = dict(required=False),
-            backup_retention  = dict(required=False), 
+            backup_retention  = dict(required=False),
             zone              = dict(aliases=['aws_zone', 'ec2_zone'], required=False),
             subnet            = dict(required=False),
             wait              = dict(type='bool', default=False),
@@ -398,7 +398,7 @@ def main():
     elif command == 'promote':
         required_vars = [ 'instance_name' ]
         invalid_vars = [ 'db_engine', 'size', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'vpc_security_groups', 'security_groups', 'option_group', 'maint_window', 'subnet', 'source_instance', 'snapshot', 'apply_immediately', 'new_instance_name' ]
-    
+
     elif command == 'snapshot':
         required_vars = [ 'instance_name', 'snapshot']
         invalid_vars = [ 'db_engine', 'size', 'username', 'password', 'db_name', 'engine_version', 'parameter_group', 'license_model', 'multi_zone', 'iops', 'vpc_security_groups', 'security_groups', 'option_group', 'maint_window', 'subnet', 'source_instance', 'apply_immediately', 'new_instance_name' ]
@@ -406,11 +406,11 @@ def main():
     elif command == 'restore':
         required_vars = [ 'instance_name', 'snapshot', 'instance_type' ]
         invalid_vars = [ 'db_engine', 'db_name', 'username', 'password', 'engine_version',  'option_group', 'source_instance', 'apply_immediately', 'new_instance_name', 'vpc_security_groups', 'security_groups' ]
- 
+
     for v in required_vars:
         if not module.params.get(v):
             module.fail_json(msg = str("Parameter %s required for %s command" % (v, command)))
-            
+
     for v in invalid_vars:
         if module.params.get(v):
             module.fail_json(msg = str("Parameter %s invalid for %s command" % (v, command)))
@@ -429,7 +429,7 @@ def main():
 
     if zone:
         params["availability_zone"] = zone
-  
+
     if maint_window:
         params["preferred_maintenance_window"] = maint_window
 
@@ -480,7 +480,7 @@ def main():
             changed = False
         except boto.exception.BotoServerError, e:
             try:
-                if command == 'create': 
+                if command == 'create':
                     result = conn.create_dbinstance(instance_name, size, instance_type, username, password, **params)
                 if command == 'restore':
                     result = conn.restore_dbinstance_from_dbsnapshot(snapshot, instance_name, instance_type, **params)
@@ -498,7 +498,7 @@ def main():
                 result = conn.create_dbsnapshot(snapshot, instance_name)
             except boto.exception.BotoServerError, e:
                 module.fail_json(msg = e.error_message)
-        
+
     if command == 'delete':
         try:
             result = conn.get_all_dbinstances(instance_name)[0]
@@ -517,7 +517,7 @@ def main():
             module.fail_json(msg = e.error_message)
 
     if command == 'replicate':
-        try: 
+        try:
             if instance_type:
                 params["instance_class"] = instance_type
             result = conn.create_dbinstance_read_replica(instance_name, source_instance, **params)
@@ -571,7 +571,7 @@ def main():
 
     # Wait for the resource to be available if requested
     if wait:
-        try: 
+        try:
             wait_timeout = time.time() + wait_timeout
             time.sleep(5)
 
@@ -582,17 +582,17 @@ def main():
                 resource = get_current_resource(conn, result.id, command)
         except boto.exception.BotoServerError, e:
             # If we're waiting for an instance to be deleted then
-            # get_all_dbinstances will eventually throw a 
+            # get_all_dbinstances will eventually throw a
             # DBInstanceNotFound error.
             if command == 'delete' and e.error_code == 'DBInstanceNotFound':
-                module.exit_json(changed=True)                
+                module.exit_json(changed=True)
             else:
                 module.fail_json(msg = e.error_message)
 
     # If we got here then pack up all the instance details to send
     # back to ansible
     if command == 'snapshot':
-        d = { 
+        d = {
             'id'                 : resource.id,
             'create_time'        : resource.snapshot_create_time,
             'status'             : resource.status,
@@ -643,8 +643,11 @@ def main():
 
     module.exit_json(changed=changed, instance=d)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/rds_param_group
+++ b/library/cloud/rds_param_group
@@ -75,7 +75,7 @@ options:
     aliases: [ 'ec2_access_key', 'access_key' ]
   aws_secret_key:
     description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
     required: false
     default: null
     aliases: [ 'ec2_secret_key', 'secret_key' ]
@@ -209,7 +209,7 @@ def modify_group(group, params, immediate=False):
                     raise NotModifiableError('Parameter %s is not modifiable.' % key)
 
                 changed[key] = {'old': param.value, 'new': new_value}
-                
+
                 set_parameter(param, new_value, immediate)
 
                 del new_params[key]
@@ -269,7 +269,7 @@ def main():
             if e.error_code != 'DBParameterGroupNotFound':
                 module.fail_json(msg = e.error_message)
             exists = False
-        
+
         if state == 'absent':
             if exists:
                 conn.delete_parameter_group(group_name)
@@ -293,7 +293,7 @@ def main():
                     marker = next_group.Marker
                 else:
                     break
-                
+
 
     except BotoServerError, e:
         module.fail_json(msg = e.error_message)
@@ -306,8 +306,11 @@ def main():
 
     module.exit_json(changed=changed)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/rds_subnet_group
+++ b/library/cloud/rds_subnet_group
@@ -61,7 +61,7 @@ options:
     aliases: [ 'ec2_access_key', 'access_key' ]
   aws_secret_key:
     description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
     required: false
     default: null
     aliases: [ 'ec2_secret_key', 'secret_key' ]
@@ -142,7 +142,7 @@ def main():
         except BotoServerError, e:
             if e.error_code != 'DBSubnetGroupNotFoundFault':
                 module.fail_json(msg = e.error_message)
-        
+
         if state == 'absent':
             if exists:
                 conn.delete_db_subnet_group(group_name)
@@ -159,8 +159,11 @@ def main():
 
     module.exit_json(changed=changed)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -24,7 +24,7 @@ description:
 options:
   command:
     description:
-      - Specifies the action to take.  
+      - Specifies the action to take.
     required: true
     default: null
     aliases: []
@@ -62,13 +62,13 @@ options:
     aliases: []
   aws_secret_key:
     description:
-      - AWS secret key. 
+      - AWS secret key.
     required: false
     default: null
     aliases: ['ec2_secret_key', 'secret_key']
   aws_access_key:
     description:
-      - AWS access key. 
+      - AWS access key.
     required: false
     default: null
     aliases: ['ec2_access_key', 'access_key']
@@ -170,7 +170,7 @@ def main():
             record          = dict(required=True),
             ttl             = dict(required=False, default=3600),
             type            = dict(choices=['A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS'], required=True),
-            value           = dict(required=False), 
+            value           = dict(required=False),
             overwrite       = dict(required=False, type='bool'),
             retry_interval  = dict(required=False, default=500)
         )
@@ -205,7 +205,7 @@ def main():
         if not value_in:
             module.fail_json(msg = "parameter 'value' required for create/delete")
 
-    # connect to the route53 endpoint 
+    # connect to the route53 endpoint
     try:
         conn = boto.route53.connection.Route53Connection(aws_access_key, aws_secret_key)
     except boto.exception.BotoServerError, e:
@@ -224,7 +224,7 @@ def main():
         module.fail_json(msg = errmsg)
 
     record = {}
-    
+
     found_record = False
     sets = conn.get_all_rrsets(zones[zone_in])
     for rset in sets:
@@ -274,8 +274,11 @@ def main():
 
     module.exit_json(changed=True)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -24,9 +24,9 @@ version_added: "1.1"
 options:
   bucket:
     description:
-      - Bucket name. 
+      - Bucket name.
     required: true
-    default: null 
+    default: null
     aliases: []
   object:
     description:
@@ -56,13 +56,13 @@ options:
     version_added: "1.2"
   mode:
     description:
-      - Switches the module behaviour between put (upload), get (download), geturl (return download url (Ansible 1.3+), getstr (download object as string (1.3+)), create (bucket) and delete (bucket). 
+      - Switches the module behaviour between put (upload), get (download), geturl (return download url (Ansible 1.3+), getstr (download object as string (1.3+)), create (bucket) and delete (bucket).
     required: true
     default: null
     aliases: []
   expiration:
     description:
-      - Time limit (in seconds) for the URL generated and returned by S3/Walrus when performing a mode=put or mode=geturl operation. 
+      - Time limit (in seconds) for the URL generated and returned by S3/Walrus when performing a mode=put or mode=geturl operation.
     required: false
     default: 600
     aliases: []
@@ -73,7 +73,7 @@ options:
     aliases: [ S3_URL ]
   aws_secret_key:
     description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
     required: false
     default: null
     aliases: ['ec2_secret_key', 'secret_key']
@@ -106,7 +106,7 @@ EXAMPLES = '''
 # Simple GET operation
 - s3: bucket=mybucket object=/my/desired/key.txt dest=/usr/local/myfile.txt mode=get
 # GET/download and overwrite local file (trust remote)
-- s3: bucket=mybucket object=/my/desired/key.txt dest=/usr/local/myfile.txt mode=get 
+- s3: bucket=mybucket object=/my/desired/key.txt dest=/usr/local/myfile.txt mode=get
 # GET/download and do not overwrite local file (trust remote)
 - s3: bucket=mybucket object=/my/desired/key.txt dest=/usr/local/myfile.txt mode=get force=false
 # PUT/upload and overwrite remote file (trust local)
@@ -198,7 +198,7 @@ def delete_key(module, s3, bucket, obj):
         module.exit_json(msg="Object deleted from bucket %s"%bucket, changed=True)
     except s3.provider.storage_response_error, e:
         module.fail_json(msg= str(e))
- 
+
 def create_dirkey(module, s3, bucket, obj):
     try:
         bucket = s3.lookup(bucket)
@@ -219,7 +219,7 @@ def upload_file_check(src):
 
 def path_check(path):
     if os.path.exists(path):
-        return True 
+        return True
     else:
         return False
 
@@ -351,17 +351,17 @@ def main():
             s3 = boto.connect_s3(aws_access_key, aws_secret_key)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
- 
+
     # If our mode is a GET operation (download), go through the procedure as appropriate ...
     if mode == 'get':
-    
+
         # First, we check to see if the bucket exists, we get "bucket" returned.
         bucketrtn = bucket_check(module, s3, bucket)
         if bucketrtn is False:
             module.fail_json(msg="Target bucket cannot be found", failed=True)
 
         # Next, we check to see if the key in the bucket exists. If it exists, it also returns key_matches md5sum check.
-        keyrtn = key_check(module, s3, bucket, obj)    
+        keyrtn = key_check(module, s3, bucket, obj)
         if keyrtn is False:
             module.fail_json(msg="Target key cannot be found", failed=True)
 
@@ -370,7 +370,7 @@ def main():
         if pathrtn is False:
             download_s3file(module, s3, bucket, obj, dest)
 
-        # Compare the remote MD5 sum of the object with the local dest md5sum, if it already exists. 
+        # Compare the remote MD5 sum of the object with the local dest md5sum, if it already exists.
         if pathrtn is True:
             md5_remote = keysum(module, s3, bucket, obj)
             md5_local = hashlib.md5(open(dest, 'rb').read()).hexdigest()
@@ -386,8 +386,8 @@ def main():
                     download_s3file(module, s3, bucket, obj, dest)
                 else:
                     module.fail_json(msg="WARNING: Checksums do not match. Use overwrite parameter to force download.", failed=True)
-        
-        # Firstly, if key_matches is TRUE and overwrite is not enabled, we EXIT with a helpful message. 
+
+        # Firstly, if key_matches is TRUE and overwrite is not enabled, we EXIT with a helpful message.
         if sum_matches is True and overwrite is False:
             module.exit_json(msg="Local and remote object are identical, ignoring. Use overwrite parameter to force.", changed=False)
 
@@ -395,9 +395,9 @@ def main():
         if sum_matches is True and pathrtn is True and overwrite is True:
             download_s3file(module, s3, bucket, obj, dest)
 
-        # If sum does not match but the destination exists, we 
-               
-    # if our mode is a PUT operation (upload), go through the procedure as appropriate ...        
+        # If sum does not match but the destination exists, we
+
+    # if our mode is a PUT operation (upload), go through the procedure as appropriate ...
     if mode == 'put':
 
         # Use this snippet to debug through conditionals:
@@ -408,7 +408,7 @@ def main():
         pathrtn = path_check(src)
         if pathrtn is False:
             module.fail_json(msg="Local object for PUT does not exist", failed=True)
-        
+
         # Lets check to see if bucket exists to get ground truth.
         bucketrtn = bucket_check(module, s3, bucket)
         if bucketrtn is True:
@@ -440,7 +440,7 @@ def main():
         if bucketrtn is True and pathrtn is True and keyrtn is False:
             upload_s3file(module, s3, bucket, obj, src, expiry, metadata)
 
-    # Support for deleting an object if we have both params.  
+    # Support for deleting an object if we have both params.
     if mode == 'delete':
         if bucket:
             bucketrtn = bucket_check(module, s3, bucket)
@@ -452,11 +452,11 @@ def main():
                 module.fail_json(msg="Bucket does not exist.", changed=False)
         else:
             module.fail_json(msg="Bucket parameter is required.", failed=True)
- 
+
     # Need to research how to create directories without "populating" a key, so this should just do bucket creation for now.
     # WE SHOULD ENABLE SOME WAY OF CREATING AN EMPTY KEY TO CREATE "DIRECTORY" STRUCTURE, AWS CONSOLE DOES THIS.
     if mode == 'create':
-        if bucket and not obj: 
+        if bucket and not obj:
             bucketrtn = bucket_check(module, s3, bucket)
             if bucketrtn is True:
                 module.exit_json(msg="Bucket already exists.", changed=False)
@@ -470,9 +470,9 @@ def main():
                 dirobj = obj + "/"
             if bucketrtn is True:
                 keyrtn = key_check(module, s3, bucket, dirobj)
-                if keyrtn is True: 
+                if keyrtn is True:
                     module.exit_json(msg="Bucket %s and key %s already exists."% (bucket, obj), changed=False)
-                else:      
+                else:
                     create_dirkey(module, s3, bucket, dirobj)
             if bucketrtn is False:
                 created = create_bucket(module, s3, bucket, location)
@@ -507,8 +507,11 @@ def main():
 
     module.exit_json(failed=False)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.ec2 import *
+
+    main()

--- a/library/cloud/virt
+++ b/library/cloud/virt
@@ -488,6 +488,9 @@ def main():
         module.exit_json(**result)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/cloud/vsphere_guest
+++ b/library/cloud/vsphere_guest
@@ -1220,6 +1220,9 @@ def main():
         vcenter=vcenter_hostname)
 
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+if __name__ == "__main__":
+
+
+    # this is magic, see lib/ansible/module_common.py
+    #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+    main()

--- a/library/commands/command
+++ b/library/commands/command
@@ -272,4 +272,7 @@ class CommandModule(AnsibleModule):
 
         return (params, params['args'])
 
-main()
+
+if __name__ == "__main__":
+
+    main()

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -237,6 +237,9 @@ def main():
 
     module.exit_json(changed=True, user=user)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -332,8 +332,8 @@ def main():
             except Exception, e:
                 module.fail_json(msg="error deleting database: " + str(e))
         elif state == "dump":
-            rc, stdout, stderr = db_dump(module, login_host, login_user, 
-                                        login_password, db, target, 
+            rc, stdout, stderr = db_dump(module, login_host, login_user,
+                                        login_password, db, target,
                                         port=module.params['login_port'],
                                         socket=module.params['login_unix_socket'])
             if rc != 0:
@@ -341,8 +341,8 @@ def main():
             else:
                 module.exit_json(changed=True, db=db, msg=stdout)
         elif state == "import":
-            rc, stdout, stderr = db_import(module, login_host, login_user, 
-                                        login_password, db, target, 
+            rc, stdout, stderr = db_import(module, login_host, login_user,
+                                        login_password, db, target,
                                         port=module.params['login_port'],
                                         socket=module.params['login_unix_socket'])
             if rc != 0:
@@ -358,6 +358,9 @@ def main():
 
     module.exit_json(changed=changed, db=db)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -363,7 +363,10 @@ def main():
         else:
             module.exit_json(msg="Slave already stopped", changed=False)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
-warnings.simplefilter("ignore")
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()
+    warnings.simplefilter("ignore")

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -123,7 +123,7 @@ EXAMPLES = """
 # Specify grants composed of more than one word
 - mysql_user: name=replication password=12345 priv=*.*:"REPLICATION CLIENT" state=present
 
-# Revoke all privileges for user 'bob' and password '12345' 
+# Revoke all privileges for user 'bob' and password '12345'
 - mysql_user: name=bob password=12345 priv=*.*:USAGE state=present
 
 # Example privileges string format
@@ -341,7 +341,7 @@ def _safe_cnf_load(config, path):
             data['password'] = line.split('=', 1)[1].strip()
     f.close()
 
-    # write out a new cnf file with only user/pass   
+    # write out a new cnf file with only user/pass
     fh, newpath = tempfile.mkstemp(prefix=path + '.')
     f = open(newpath, 'wb')
     f.write('[client]\n')
@@ -471,6 +471,9 @@ def main():
             changed = False
     module.exit_json(changed=changed, user=user)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/database/mysql_variables
+++ b/library/database/mysql_variables
@@ -248,6 +248,9 @@ def main():
         else:
             module.fail_json(msg=result, changed=False)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/database/postgresql_db
+++ b/library/database/postgresql_db
@@ -176,7 +176,7 @@ def db_create(cursor, db, owner, template, encoding, lc_collate, lc_ctype):
         return True
     else:
         db_info = get_db_info(cursor, db)
-        if (encoding and 
+        if (encoding and
             get_encoding_id(cursor, encoding) != db_info['encoding_id']):
             raise NotSupportedError(
                 'Changing database encoding is not supported. '
@@ -202,7 +202,7 @@ def db_matches(cursor, db, owner, template, encoding, lc_collate, lc_ctype):
        return False
     else:
         db_info = get_db_info(cursor, db)
-        if (encoding and 
+        if (encoding and
             get_encoding_id(cursor, encoding) != db_info['encoding_id']):
             return False
         elif lc_collate and lc_collate != db_info['lc_collate']:
@@ -249,7 +249,7 @@ def main():
     state = module.params["state"]
     changed = False
 
-    # To use defaults values, keyword arguments must be absent, so 
+    # To use defaults values, keyword arguments must be absent, so
     # check which values are empty and don't include in the **kw
     # dictionary
     params_map = {
@@ -258,7 +258,7 @@ def main():
         "login_password":"password",
         "port":"port"
     }
-    kw = dict( (params_map[k], v) for (k, v) in module.params.iteritems() 
+    kw = dict( (params_map[k], v) for (k, v) in module.params.iteritems()
               if k in params_map and v != '' )
     try:
         db_connection = psycopg2.connect(database="template1", **kw)
@@ -296,6 +296,9 @@ def main():
 
     module.exit_json(changed=changed, db=db)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/database/postgresql_privs
+++ b/library/database/postgresql_privs
@@ -29,7 +29,7 @@ description:
 options:
   database:
     description:
-      - Name of database to connect to. 
+      - Name of database to connect to.
       - 'Alias: I(db)'
     required: yes
   state:
@@ -53,7 +53,7 @@ options:
               schema, language, tablespace, group]
   objs:
     description:
-      - Comma separated list of database objects to set privileges on. 
+      - Comma separated list of database objects to set privileges on.
       - If I(type) is C(table) or C(sequence), the special value
         C(ALL_IN_SCHEMA) can be provided instead to specify all database
         objects of type I(type) in the schema specified via I(schema). (This
@@ -135,7 +135,7 @@ author: Bernhard Weitzhofer
 
 EXAMPLES = """
 # On database "library":
-# GRANT SELECT, INSERT, UPDATE ON TABLE public.books, public.authors 
+# GRANT SELECT, INSERT, UPDATE ON TABLE public.books, public.authors
 # TO librarian, reader WITH GRANT OPTION
 - postgresql_privs: >
     database=library
@@ -155,8 +155,8 @@ EXAMPLES = """
     roles=librarian,reader
     grant_option=yes
 
-# REVOKE GRANT OPTION FOR INSERT ON TABLE books FROM reader 
-# Note that role "reader" will be *granted* INSERT privilege itself if this 
+# REVOKE GRANT OPTION FOR INSERT ON TABLE books FROM reader
+# Note that role "reader" will be *granted* INSERT privilege itself if this
 # isn't already the case (since state=present).
 - postgresql_privs: >
     db=library
@@ -214,7 +214,7 @@ EXAMPLES = """
     role=librarian
 
 # GRANT ALL PRIVILEGES ON DATABASE library TO librarian
-# If objs is omitted for type "database", it defaults to the database 
+# If objs is omitted for type "database", it defaults to the database
 # to which the connection is established
 - postgresql_privs: >
     db=library
@@ -386,9 +386,9 @@ class Connection(object):
 
     def get_group_memberships(self, groups):
         query = """SELECT roleid, grantor, member, admin_option
-                   FROM pg_catalog.pg_auth_members am 
+                   FROM pg_catalog.pg_auth_members am
                    JOIN pg_catalog.pg_roles r ON r.oid = am.roleid
-                   WHERE r.rolname = ANY(%s) 
+                   WHERE r.rolname = ANY(%s)
                    ORDER BY roleid, grantor, member"""
         self.cursor.execute(query, (groups,))
         return self.cursor.fetchall()
@@ -402,14 +402,14 @@ class Connection(object):
 
         :param obj_type: Type of database object to grant/revoke
                          privileges for.
-        :param privs: Either a list of privileges to grant/revoke 
+        :param privs: Either a list of privileges to grant/revoke
                       or None if type is "group".
         :param objs: List of database objects to grant/revoke
                      privileges for.
         :param roles: Either a list of role names or "PUBLIC"
                       for the implicitly defined "PUBLIC" group
         :param state: "present" to grant privileges, "absent" to revoke.
-        :param grant_option: Only for state "present": If True, set 
+        :param grant_option: Only for state "present": If True, set
                              grant/admin option. If False, revoke it.
                              If None, don't change grant option.
         :param schema_qualifier: Some object types ("TABLE", "SEQUENCE",
@@ -459,7 +459,7 @@ class Connection(object):
         if obj_type == 'group':
             set_what = ','.join(obj_ids)
         else:
-            set_what = '%s ON %s %s' % (','.join(privs), obj_type, 
+            set_what = '%s ON %s %s' % (','.join(privs), obj_type,
                                         ','.join(obj_ids))
 
         # for_whom: SQL-fragment specifying for whom to set the above
@@ -476,7 +476,7 @@ class Connection(object):
                 else:
                     query = 'GRANT %s TO %s WITH GRANT OPTION'
             else:
-                query = 'GRANT %s TO %s' 
+                query = 'GRANT %s TO %s'
             self.cursor.execute(query % (set_what, for_whom))
 
             # Only revoke GRANT/ADMIN OPTION if grant_option actually is False.
@@ -487,7 +487,7 @@ class Connection(object):
                     query = 'REVOKE GRANT OPTION FOR %s FROM %s'
                 self.cursor.execute(query % (set_what, for_whom))
         else:
-            query = 'REVOKE %s FROM %s' 
+            query = 'REVOKE %s FROM %s'
             self.cursor.execute(query % (set_what, for_whom))
         status_after = get_status(objs)
         return status_before != status_after
@@ -511,7 +511,7 @@ def main():
             objs=dict(required=False, aliases=['obj']),
             schema=dict(required=False),
             roles=dict(required=True, aliases=['role']),
-            grant_option=dict(required=False, type='bool', 
+            grant_option=dict(required=False, type='bool',
                               aliases=['admin_option']),
             host=dict(default='', aliases=['login_host']),
             port=dict(type='int', default=5432),
@@ -608,6 +608,9 @@ def main():
     module.exit_json(changed=changed)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/database/postgresql_user
+++ b/library/database/postgresql_user
@@ -521,6 +521,9 @@ def main():
     kw['changed'] = changed
     module.exit_json(**kw)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/database/redis
+++ b/library/database/redis
@@ -306,7 +306,7 @@ def main():
         except Exception, e:
             module.fail_json(msg="unable to connect to database: %s" % e)
 
-        
+
         try:
             old_value = r.config_get(name)[name]
         except Exception, e:
@@ -324,6 +324,9 @@ def main():
     else:
         module.fail_json(msg='A valid command must be provided')
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/database/riak
+++ b/library/database/riak
@@ -164,7 +164,7 @@ def main():
     ring_size = stats['ring_creation_size']
     rc, out, err = module.run_command([riak_bin, 'version'] )
     version = out.strip()
-    
+
     result = dict(node_name=node_name,
               nodes=nodes,
               ring_size=ring_size,
@@ -248,8 +248,11 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/files/acl
+++ b/library/files/acl
@@ -289,7 +289,10 @@ def main():
 
     module.exit_json(changed=changed, msg=msg, acl=currentacls)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/files/assemble
+++ b/library/files/assemble
@@ -193,8 +193,11 @@ def main():
     # Mission complete
     module.exit_json(src=src, dest=dest, md5sum=pathmd5, changed=changed, msg="OK")
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/files/copy
+++ b/library/files/copy
@@ -202,7 +202,7 @@ def main():
                 # os.path.exists() can return false in some
                 # circumstances where the directory does not have
                 # the execute bit for the current user set, in
-                # which case the stat() call will raise an OSError 
+                # which case the stat() call will raise an OSError
                 os.stat(os.path.dirname(dest))
             except OSError, e:
                 if "permission denied" in str(e).lower():
@@ -246,6 +246,9 @@ def main():
 
     module.exit_json(**res_args)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/files/file
+++ b/library/files/file
@@ -34,7 +34,7 @@ module: file
 version_added: "historical"
 short_description: Sets attributes of files
 extends_documentation_fragment: files
-description: 
+description:
      - Sets attributes of files, symlinks, and directories, or removes
        files/symlinks/directories. Many other modules support the same options as
        the M(file) module - including M(copy), M(template), and M(assemble).
@@ -48,7 +48,7 @@ options:
       - 'path to the file being managed.  Aliases: I(dest), I(name)'
     required: true
     default: []
-    aliases: ['dest', 'name'] 
+    aliases: ['dest', 'name']
   state:
     description:
       - If C(directory), all immediate subdirectories will be created if they
@@ -82,7 +82,7 @@ options:
     default: "no"
     choices: [ "yes", "no" ]
     description:
-      - 'force the creation of the symlinks in two cases: the source file does 
+      - 'force the creation of the symlinks in two cases: the source file does
         not exist (but will appear later); the destination exists and is a file (so, we need to unlink the
         "path" file and create symlink to the "src" file in place of it).'
 '''
@@ -346,7 +346,10 @@ def main():
 
     module.fail_json(path=path, msg='unexpected position reached')
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()
 

--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -27,7 +27,7 @@ description:
      - Manage (add, remove, change) individual settings in an INI-style file without having
        to manage the file as a whole with, say, M(template) or M(assemble). Adds missing
        sections if they don't exist.
-     - Comments are discarded when the source file is read, and therefore will not 
+     - Comments are discarded when the source file is read, and therefore will not
        show up in the destination file.
 version_added: "0.9"
 options:
@@ -95,7 +95,7 @@ import sys
 def do_ini(module, filename, section=None, option=None, value=None, state='present', backup=False):
 
     changed = False
-    if (sys.version_info[0] == 2 and sys.version_info[1] >= 7) or sys.version_info[0] >= 3: 
+    if (sys.version_info[0] == 2 and sys.version_info[1] >= 7) or sys.version_info[0] >= 3:
     	cp = ConfigParser.ConfigParser(allow_no_value=True)
     else:
     	cp = ConfigParser.ConfigParser()
@@ -202,6 +202,9 @@ def main():
     # Mission complete
     module.exit_json(dest=dest, changed=changed, msg="OK")
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -113,7 +113,7 @@ options:
   validate:
      required: false
      description:
-       - validation to run before copying into place. 
+       - validation to run before copying into place.
          Use %s in the command to indicate the current file to validate.
          The command is passed securely so shell features like
          expansion and pipes won't work.
@@ -372,7 +372,7 @@ def main():
         # always add one layer of quotes
         line = "'%s'" % line
 
-        # Replace escape sequences like '\n' while being sure 
+        # Replace escape sequences like '\n' while being sure
         # not to replace octal escape sequences (\ooo) since they
         # match the backref syntax.
         if backrefs:
@@ -393,8 +393,11 @@ def main():
 
         absent(module, dest, params['regexp'], params.get('line', None), backup)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.splitter import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.splitter import *
+
+    main()

--- a/library/files/replace
+++ b/library/files/replace
@@ -156,7 +156,10 @@ def main():
     msg, changed = check_file_attrs(module, changed, msg)
     module.exit_json(changed=changed, msg=msg)
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 
-main()
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module_common.py
+    #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+
+    main()

--- a/library/files/stat
+++ b/library/files/stat
@@ -146,7 +146,10 @@ def main():
 
     module.exit_json(changed=False, stat=d)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -130,7 +130,7 @@ options:
     required: false
   rsync_timeout:
     description:
-      - Specify a --timeout for the rsync command in seconds. 
+      - Specify a --timeout for the rsync command in seconds.
     default: 0
     required: false
   set_remote_user:
@@ -148,12 +148,12 @@ notes:
    - Inspect the verbose output to validate the destination user/host/path
      are what was expected.
    - The remote user for the dest path will always be the remote_user, not
-     the sudo_user. 
+     the sudo_user.
    - Expect that dest=~/x will be ~<remote_user>/x even if using sudo.
-   - To exclude files and directories from being synchronized, you may add 
+   - To exclude files and directories from being synchronized, you may add
      C(.rsync-filter) files to the source directory.
-     
-     
+
+
 author: Timothy Appnel
 '''
 
@@ -197,7 +197,7 @@ synchronize: src=some/relative/path dest=/some/absolute/path rsync_path="sudo rs
 + /var/conf # include /var/conf even though it was previously excluded
 
 # Synchronize passing in extra rsync options
-synchronize: src=/tmp/helloworld dest=/var/www/helloword rsync_opts=--no-motd,--exclude=.git 
+synchronize: src=/tmp/helloworld dest=/var/www/helloword rsync_opts=--no-motd,--exclude=.git
 '''
 
 
@@ -301,7 +301,7 @@ def main():
     if private_key is None:
         private_key = ''
     else:
-        private_key = '-i '+ private_key 
+        private_key = '-i '+ private_key
 
     ssh_opts = '-S none -o StrictHostKeyChecking=no'
     if dest_port != 22:
@@ -320,9 +320,9 @@ def main():
 
     # expand the paths
     if '@' not in source:
-        source = os.path.expanduser(source) 
+        source = os.path.expanduser(source)
     if '@' not in dest:
-        dest = os.path.expanduser(dest) 
+        dest = os.path.expanduser(dest)
 
     cmd = ' '.join([cmd, source, dest])
     cmdstr = cmd
@@ -333,13 +333,16 @@ def main():
         changed = changed_marker in out
         out_clean=out.replace(changed_marker,'')
         out_lines=out_clean.split('\n')
-        while '' in out_lines: 
+        while '' in out_lines:
             out_lines.remove('')
         return module.exit_json(changed=changed, msg=out_clean,
                                 rc=rc, cmd=cmdstr, stdout_lines=out_lines)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -79,7 +79,7 @@ import os
 
 # class to handle .zip files
 class ZipFile(object):
-    
+
     def __init__(self, src, dest, module):
         self.src = src
         self.dest = dest
@@ -106,7 +106,7 @@ class ZipFile(object):
 
 # class to handle gzipped tar files
 class TgzFile(object):
-    
+
     def __init__(self, src, dest, module):
         self.src = src
         self.dest = dest
@@ -245,6 +245,9 @@ def main():
 
     module.exit_json(**res_args)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/files/xattr
+++ b/library/files/xattr
@@ -200,7 +200,10 @@ def main():
 
     module.exit_json(changed=changed, msg=msg, xattr=res)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/internal/async_status
+++ b/library/internal/async_status
@@ -94,6 +94,9 @@ def main():
 
     module.exit_json(**data)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/messaging/rabbitmq_parameter
+++ b/library/messaging/rabbitmq_parameter
@@ -147,6 +147,9 @@ def main():
 
     module.exit_json(changed=changed, component=component, name=name, vhost=vhost, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/messaging/rabbitmq_plugin
+++ b/library/messaging/rabbitmq_plugin
@@ -125,6 +125,9 @@ def main():
     changed = len(enabled) > 0 or len(disabled) > 0
     module.exit_json(changed=changed, enabled=enabled, disabled=disabled)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/messaging/rabbitmq_policy
+++ b/library/messaging/rabbitmq_policy
@@ -151,6 +151,9 @@ def main():
 
     module.exit_json(changed=changed, name=name, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/messaging/rabbitmq_user
+++ b/library/messaging/rabbitmq_user
@@ -244,6 +244,9 @@ def main():
 
     module.exit_json(changed=changed, user=username, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/messaging/rabbitmq_vhost
+++ b/library/messaging/rabbitmq_vhost
@@ -142,6 +142,9 @@ def main():
 
     module.exit_json(changed=changed, name=name, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/monitoring/airbrake_deployment
+++ b/library/monitoring/airbrake_deployment
@@ -122,9 +122,12 @@ def main():
     else:
         module.fail_json(msg="HTTP result code: %d connecting to %s" % (info['status'], url))
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()
 

--- a/library/monitoring/bigpanda
+++ b/library/monitoring/bigpanda
@@ -6,7 +6,7 @@ module: bigpanda
 author: BigPanda
 short_description: Notify BigPanda about deployments
 version_added: "1.8"
-description: 
+description:
    - Notify BigPanda when deployments start and end (successfully or not). Returns a deployment object containing all the parameters for future module calls.
 options:
   component:
@@ -165,8 +165,11 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e))
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/monitoring/boundary_meter
+++ b/library/monitoring/boundary_meter
@@ -89,7 +89,7 @@ def auth_encode(apikey):
     auth = base64.standard_b64encode(apikey)
     auth.replace("\n", "")
     return auth
-    
+
 def build_url(name, apiid, action, meter_id=None, cert_type=None):
     if action == "create":
         return 'https://%s/%s/meters' % (api_host, apiid)
@@ -103,7 +103,7 @@ def build_url(name, apiid, action, meter_id=None, cert_type=None):
         return  "https://%s/%s/meters/%s" % (api_host, apiid, meter_id)
 
 def http_request(module, name, apiid, apikey, action, data=None, meter_id=None, cert_type=None):
-    
+
     if meter_id is None:
         url = build_url(name, apiid, action)
     else:
@@ -191,7 +191,7 @@ def delete_meter(module, name, apiid, apikey):
             try:
                 cert_file = '%s/%s.pem' % (config_directory,cert_type)
                 os.remove(cert_file)
-            except OSError, e:  
+            except OSError, e:
                 module.fail_json("Failed to remove " + cert_type + ".pem file")
 
     return 0, "Meter " + name + " deleted"
@@ -214,7 +214,7 @@ def download_request(module, name, apiid, apikey, cert_type):
                 cert_file.write(body)
                 cert_file.close
                 os.chmod(cert_file_path, 0o600)
-            except: 
+            except:
                 module.fail_json("Could not write to certificate file")
 
         return True
@@ -249,8 +249,11 @@ def main():
 
     module.exit_json(status=result,changed=True)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+    main()
 

--- a/library/monitoring/datadog_event
+++ b/library/monitoring/datadog_event
@@ -136,8 +136,11 @@ def post_event(module):
     else:
         module.fail_json(**info)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/monitoring/librato_annotation
+++ b/library/monitoring/librato_annotation
@@ -165,5 +165,8 @@ def main():
 
   post_annotation(module)
 
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    from ansible.module_utils.basic import *
+    main()

--- a/library/monitoring/logentries
+++ b/library/monitoring/logentries
@@ -20,7 +20,7 @@ DOCUMENTATION = '''
 ---
 module: logentries
 author: Ivan Vanderbyl
-short_description: Module for tracking logs via logentries.com 
+short_description: Module for tracking logs via logentries.com
 description:
     - Sends logs to LogEntries in realtime
 version_added: "1.6"
@@ -124,7 +124,10 @@ def main():
     elif p["state"] in ["absent", "unfollowed"]:
         unfollow_log(module, le_path, logs)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/monitoring/monit
+++ b/library/monitoring/monit
@@ -67,7 +67,7 @@ def main():
         if rc != 0:
             module.fail_json(msg='monit reload failed', stdout=out, stderr=err)
         module.exit_json(changed=True, name=name, state=state)
-    
+
     def status():
         """Return the status of the process in monit, or the empty string if not present."""
         rc, out, err = module.run_command('%s summary' % MONIT, check_rc=True)
@@ -149,7 +149,10 @@ def main():
 
     module.exit_json(changed=False, name=name, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/monitoring/nagios
+++ b/library/monitoring/nagios
@@ -189,7 +189,7 @@ def main():
     services = module.params['services']
     cmdfile = module.params['cmdfile']
     command = module.params['command']
-    
+
     ##################################################################
     # Required args per action:
     # downtime = (minutes, service, host)
@@ -356,7 +356,7 @@ class Nagios(object):
         notif_str = "[%s] %s" % (entry_time, cmd)
         if host is not None:
             notif_str += ";%s" % host
-            
+
             if svc is not None:
                 notif_str += ";%s" % svc
 
@@ -784,42 +784,42 @@ class Nagios(object):
             return return_str_list
         else:
             return "Fail: could not write to the command file"
-    
+
     def silence_nagios(self):
         """
         This command is used to disable notifications for all hosts and services
         in nagios.
-        
+
         This is a 'SHUT UP, NAGIOS' command
         """
         cmd = 'DISABLE_NOTIFICATIONS'
         self._write_command(self._fmt_notif_str(cmd))
-    
+
     def unsilence_nagios(self):
         """
         This command is used to enable notifications for all hosts and services
         in nagios.
-        
+
         This is a 'OK, NAGIOS, GO'' command
         """
         cmd = 'ENABLE_NOTIFICATIONS'
         self._write_command(self._fmt_notif_str(cmd))
-        
+
     def nagios_cmd(self, cmd):
         """
         This sends an arbitrary command to nagios
-        
+
         It prepends the submitted time and appends a \n
-        
+
         You just have to provide the properly formatted command
         """
-        
+
         pre = '[%s]' % int(time.time())
-        
+
         post = '\n'
         cmdstr = '%s %s %s' % (pre, cmd, post)
         self._write_command(cmdstr)
-        
+
     def act(self):
         """
         Figure out what you want to do from ansible, and then do the
@@ -859,13 +859,13 @@ class Nagios(object):
                                                services=self.services)
         elif self.action == 'silence_nagios':
             self.silence_nagios()
-            
+
         elif self.action == 'unsilence_nagios':
             self.unsilence_nagios()
-            
+
         elif self.action == 'command':
             self.nagios_cmd(self.command)
-            
+
         # wtf?
         else:
             self.module.fail_json(msg="unknown action specified: '%s'" % \
@@ -874,7 +874,10 @@ class Nagios(object):
         self.module.exit_json(nagios_commands=self.command_results,
                               changed=True)
 
-######################################################################
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    ######################################################################
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/monitoring/newrelic_deployment
+++ b/library/monitoring/newrelic_deployment
@@ -116,7 +116,7 @@ def main():
         params["application_id"] = module.params["application_id"]
     else:
         module.fail_json(msg="you must set one of 'app_name' or 'application_id'")
-    
+
     for item in [ "changelog", "description", "revision", "user", "appname", "environment" ]:
         if module.params[item]:
             params[item] = module.params[item]
@@ -137,9 +137,12 @@ def main():
     else:
         module.fail_json(msg="unable to update newrelic: %s" % info['msg'])
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()
 

--- a/library/monitoring/pagerduty
+++ b/library/monitoring/pagerduty
@@ -225,8 +225,11 @@ def main():
 
     module.exit_json(msg="success", result=out)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/monitoring/pingdom
+++ b/library/monitoring/pingdom
@@ -130,6 +130,9 @@ def main():
 
     module.exit_json(checkid=checkid, name=name, status=result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/monitoring/rollbar_deployment
+++ b/library/monitoring/rollbar_deployment
@@ -127,7 +127,10 @@ def main():
         else:
             module.fail_json(msg='HTTP result code: %d connecting to %s' % (info['status'], url))
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/monitoring/stackdriver
+++ b/library/monitoring/stackdriver
@@ -42,16 +42,16 @@ options:
     required: false
     default: null
   msg:
-    description: 
+    description:
       - The contents of the annotation message, in plain text.  Limited to 256 characters. Required for annotation.
     required: false
     default: null
-  annotated_by: 
+  annotated_by:
     description:
       - The person or robot who the annotation should be attributed to.
     required: false
     default: "Ansible"
-  level: 
+  level:
     description:
       - one of INFO/WARN/ERROR, defaults to INFO if not supplied.  May affect display.
     choices: ['INFO', 'WARN', 'ERROR']
@@ -189,8 +189,11 @@ def main():
     changed = True
     module.exit_json(changed=changed, deployed_by=deployed_by)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/monitoring/zabbix_maintenance
+++ b/library/monitoring/zabbix_maintenance
@@ -367,5 +367,8 @@ def main():
 
     module.exit_json(changed=changed)
 
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    from ansible.module_utils.basic import *
+    main()

--- a/library/net_infrastructure/a10_server
+++ b/library/net_infrastructure/a10_server
@@ -95,7 +95,7 @@ options:
 
 EXAMPLES = '''
 # Create a new server
-- a10_server: 
+- a10_server:
     host: a10.mydomain.com
     username: myadmin
     password: mypassword
@@ -183,8 +183,8 @@ def main():
 
     json_post = {
         'server': {
-            'name': slb_server, 
-            'host': slb_server_ip, 
+            'name': slb_server,
+            'host': slb_server_ip,
             'status': axapi_enabled_disabled(slb_server_status),
             'port_list': slb_server_ports,
         }
@@ -261,9 +261,12 @@ def main():
     axapi_call(module, session_url + '&method=session.close')
     module.exit_json(changed=changed, content=result)
 
-# standard ansible module imports
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-from ansible.module_utils.a10 import *
 
-main()
+if __name__ == "__main__":
+
+    # standard ansible module imports
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+    from ansible.module_utils.a10 import *
+
+    main()

--- a/library/net_infrastructure/a10_service_group
+++ b/library/net_infrastructure/a10_service_group
@@ -105,7 +105,7 @@ options:
 
 EXAMPLES = '''
 # Create a new service-group
-- a10_service_group: 
+- a10_service_group:
     host: a10.mydomain.com
     username: myadmin
     password: mypassword
@@ -333,9 +333,12 @@ def main():
     axapi_call(module, session_url + '&method=session.close')
     module.exit_json(changed=changed, content=result)
 
-# standard ansible module imports
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-from ansible.module_utils.a10 import *
 
-main()
+if __name__ == "__main__":
+
+    # standard ansible module imports
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+    from ansible.module_utils.a10 import *
+
+    main()

--- a/library/net_infrastructure/a10_virtual_server
+++ b/library/net_infrastructure/a10_virtual_server
@@ -105,7 +105,7 @@ options:
 
 EXAMPLES = '''
 # Create a new virtual server
-- a10_virtual_server: 
+- a10_virtual_server:
     host: a10.mydomain.com
     username: myadmin
     password: mypassword
@@ -290,10 +290,13 @@ def main():
     axapi_call(module, session_url + '&method=session.close')
     module.exit_json(changed=changed, content=result)
 
-# standard ansible module imports
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-from ansible.module_utils.a10 import *
 
-main()
+if __name__ == "__main__":
+
+    # standard ansible module imports
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+    from ansible.module_utils.a10 import *
+
+    main()
 

--- a/library/net_infrastructure/bigip_facts
+++ b/library/net_infrastructure/bigip_facts
@@ -1664,7 +1664,10 @@ def main():
 
     module.exit_json(**result)
 
-# include magic from lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+
+if __name__ == "__main__":
+
+    # include magic from lib/ansible/module_common.py
+    #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+    main()
 

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -458,7 +458,10 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()
 

--- a/library/net_infrastructure/bigip_monitor_tcp
+++ b/library/net_infrastructure/bigip_monitor_tcp
@@ -94,19 +94,19 @@ options:
         required: true
         default: none
     ip:
-        description: 
+        description:
             - IP address part of the ipport definition. The default API setting
               is "0.0.0.0".
         required: false
         default: none
     port:
-        description: 
+        description:
             - port address part op the ipport definition. The default API
               setting is 0.
         required: false
         default: none
     interval:
-        description: 
+        description:
             - The interval specifying how frequently the monitor instance
               of this template will run. By default, this interval is used for up and
               down states. The default API setting is 5.
@@ -218,7 +218,7 @@ def check_monitor_exists(module, api, monitor, parent):
 
 def create_monitor(api, monitor, template_attributes):
 
-    try: 
+    try:
         api.LocalLB.Monitor.create_template(templates=[{'template_name': monitor, 'template_type': TEMPLATE_TYPE}], template_attributes=[template_attributes])
     except bigsuds.OperationFailed, e:
         if "already exists" in str(e):
@@ -319,7 +319,7 @@ def set_ipport(api, monitor, ipport):
 # ===========================================
 # main loop
 #
-# writing a module for other monitor types should 
+# writing a module for other monitor types should
 # only need an updated main() (and monitor specific functions)
 
 def main():
@@ -386,17 +386,17 @@ def main():
         if port is None:
             port = cur_ipport['ipport']['port']
     else: # use API defaults if not defined to create it
-        if interval is None:        
+        if interval is None:
             interval = 5
-        if timeout is None:         
+        if timeout is None:
             timeout = 16
-        if ip is None:              
+        if ip is None:
             ip = '0.0.0.0'
-        if port is None:            
+        if port is None:
             port = 0
-        if send is None:            
+        if send is None:
             send = ''
-        if receive is None:         
+        if receive is None:
             receive = ''
 
     # define and set address type
@@ -445,7 +445,7 @@ def main():
         if state == 'absent':
             if monitor_exists:
                 if not module.check_mode:
-                    # possible race condition if same task 
+                    # possible race condition if same task
                     # on other node deleted it first
                     result['changed'] |= delete_monitor(api, monitor)
                 else:
@@ -454,11 +454,11 @@ def main():
         else: # state present
             ## check for monitor itself
             if not monitor_exists: # create it
-                if not module.check_mode: 
+                if not module.check_mode:
                     # again, check changed status here b/c race conditions
                     # if other task already created it
                     result['changed'] |= create_monitor(api, monitor, template_attributes)
-                else: 
+                else:
                     result['changed'] |= True
 
             ## check for monitor parameters
@@ -473,7 +473,7 @@ def main():
 
             # we just have to update the ipport if monitor already exists and it's different
             if monitor_exists and cur_ipport != ipport:
-                set_ipport(api, monitor, ipport)    
+                set_ipport(api, monitor, ipport)
                 result['changed'] |= True
             #else: monitor doesn't exist (check mode) or ipport is already ok
 
@@ -483,7 +483,10 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()
 

--- a/library/net_infrastructure/bigip_node
+++ b/library/net_infrastructure/bigip_node
@@ -288,7 +288,10 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()
 

--- a/library/net_infrastructure/bigip_pool
+++ b/library/net_infrastructure/bigip_pool
@@ -530,7 +530,10 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()
 

--- a/library/net_infrastructure/bigip_pool_member
+++ b/library/net_infrastructure/bigip_pool_member
@@ -372,7 +372,10 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()
 

--- a/library/net_infrastructure/dnsimple
+++ b/library/net_infrastructure/dnsimple
@@ -32,7 +32,7 @@ options:
     description:
       - Account API token. See I(account_email) for info.
     required: false
-    default: null      
+    default: null
 
   domain:
     description:
@@ -67,7 +67,7 @@ options:
     default: 3600 (one hour)
 
   value:
-    description: 
+    description:
       - Record value
       - "Must be specified when trying to ensure a record exists"
     required: false
@@ -148,7 +148,7 @@ def main():
             type              = dict(required=False, choices=['A', 'ALIAS', 'CNAME', 'MX', 'SPF', 'URL', 'TXT', 'NS', 'SRV', 'NAPTR', 'PTR', 'AAAA', 'SSHFP', 'HINFO', 'POOL']),
             ttl               = dict(required=False, default=3600, type='int'),
             value             = dict(required=False),
-            priority          = dict(required=False, type='int'), 
+            priority          = dict(required=False, type='int'),
             state             = dict(required=False, choices=['present', 'absent']),
             solo              = dict(required=False, type='bool'),
         ),
@@ -296,7 +296,10 @@ def main():
 
     module.fail_json(msg="Unknown what you wanted me to do")
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/net_infrastructure/dnsmadeeasy
+++ b/library/net_infrastructure/dnsmadeeasy
@@ -27,25 +27,25 @@ options:
       - Accout API Key.
     required: true
     default: null
-    
+
   account_secret:
     description:
       - Accout Secret Key.
     required: true
     default: null
-    
+
   domain:
     description:
       - Domain to work with. Can be the domain name (e.g. "mydomain.com") or the numeric ID of the domain in DNS Made Easy (e.g. "839989") for faster resolution.
     required: true
     default: null
-    
+
   record_name:
     description:
       - Record name to get/create/delete/update. If record_name is not specified; all records for the domain will be returned in "result" regardless of the state argument.
     required: false
     default: null
-    
+
   record_type:
     description:
       - Record type.
@@ -54,25 +54,25 @@ options:
     default: null
 
   record_value:
-    description: 
+    description:
       - "Record value. HTTPRED: <redirection URL>, MX: <priority> <target name>, NS: <name server>, PTR: <target name>, SRV: <priority> <weight> <port> <target name>, TXT: <text value>"
       - "If record_value is not specified; no changes will be made and the record will be returned in 'result' (in other words, this module can be used to fetch a record's current id, type, and ttl)"
     required: false
     default: null
-    
+
   record_ttl:
     description:
       - record's "Time to live".  Number of seconds the record remains cached in DNS servers.
     required: false
     default: 1800
-    
+
   state:
     description:
       - whether the record should exist or not
     required: true
     choices: [ 'present', 'absent' ]
     default: null
-    
+
   validate_certs:
     description:
       - If C(no), SSL certificates will not be validated. This should only be used
@@ -83,9 +83,9 @@ options:
     version_added: 1.5.1
 
 notes:
-  - The DNS Made Easy service requires that machines interacting with the API have the proper time and timezone set. Be sure you are within a few seconds of actual time by using NTP. 
+  - The DNS Made Easy service requires that machines interacting with the API have the proper time and timezone set. Be sure you are within a few seconds of actual time by using NTP.
   - This module returns record(s) in the "result" element when 'state' is set to 'present'. This value can be be registered and used in your playbooks.
-  
+
 requirements: [ urllib, urllib2, hashlib, hmac ]
 author: Brice Burgess
 '''
@@ -94,7 +94,7 @@ EXAMPLES = '''
 # fetch my.com domain records
 - dnsmadeeasy: account_key=key account_secret=secret domain=my.com state=present
   register: response
-  
+
 # create / ensure the presence of a record
 - dnsmadeeasy: account_key=key account_secret=secret domain=my.com state=present record_name="test" record_type="A" record_value="127.0.0.1"
 
@@ -104,7 +104,7 @@ EXAMPLES = '''
 # fetch a specific record
 - dnsmadeeasy: account_key=key account_secret=secret domain=my.com state=present record_name="test"
   register: response
-  
+
 # delete a record / ensure it is absent
 - dnsmadeeasy: account_key=key account_secret=secret domain=my.com state=absent record_name="test"
 '''
@@ -322,8 +322,11 @@ def main():
         module.fail_json(
             msg="'%s' is an unknown value for the state argument" % state)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/net_infrastructure/lldp
+++ b/library/net_infrastructure/lldp
@@ -26,14 +26,14 @@ description:
 options: {}
 author: Andy Hill
 notes:
-  - Requires lldpd running and lldp enabled on switches 
+  - Requires lldpd running and lldp enabled on switches
 '''
 
 EXAMPLES = '''
 # Retrieve switch/port information
  - name: Gather information from lldp
    lldp:
- 
+
  - name: Print each switch/port
    debug: msg="{{ lldp[item]['chassis']['name'] }} / {{ lldp[item]['port']['ifalias'] }}
    with_items: lldp.keys()
@@ -65,7 +65,7 @@ def gather_lldp():
                 current_dict = current_dict[path_component]
             current_dict[final] = value
         return output_dict
-            
+
 
 def main():
     module = AnsibleModule({})
@@ -75,9 +75,12 @@ def main():
         data = {'lldp': lldp_output['lldp']}
         module.exit_json(ansible_facts=data)
     except TypeError:
-        module.fail_json(msg="lldpctl command failed. is lldpd running?")    
-   
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+        module.fail_json(msg="lldpctl command failed. is lldpd running?")
+
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()
 

--- a/library/net_infrastructure/netscaler
+++ b/library/net_infrastructure/netscaler
@@ -184,7 +184,10 @@ def main():
         module.exit_json(**result)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+    main()

--- a/library/net_infrastructure/openvswitch_bridge
+++ b/library/net_infrastructure/openvswitch_bridge
@@ -130,6 +130,9 @@ def main():
         br.run()
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/net_infrastructure/openvswitch_port
+++ b/library/net_infrastructure/openvswitch_port
@@ -134,6 +134,9 @@ def main():
         port.run()
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/network/get_url
+++ b/library/network/get_url
@@ -307,7 +307,10 @@ def main():
     module.exit_json(url=url, dest=dest, src=tmpsrc, md5sum=md5sum_src,
         sha256sum=sha256sum, changed=changed, msg=info.get('msg', ''))
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+    main()

--- a/library/network/slurp
+++ b/library/network/slurp
@@ -43,7 +43,7 @@ author: Michael DeHaan
 EXAMPLES = '''
 ansible host -m slurp -a 'src=/tmp/xx'
    host | success >> {
-      "content": "aGVsbG8gQW5zaWJsZSB3b3JsZAo=", 
+      "content": "aGVsbG8gQW5zaWJsZSB3b3JsZAo=",
       "encoding": "base64"
    }
 '''
@@ -68,8 +68,11 @@ def main():
 
     module.exit_json(content=data, encoding='base64')
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/network/uri
+++ b/library/network/uri
@@ -88,9 +88,9 @@ options:
   follow_redirects:
     description:
       - Whether or not the URI module should follow redirects. C(all) will follow all redirects.
-        C(safe) will follow only "safe" redirects, where "safe" means that the client is only 
+        C(safe) will follow only "safe" redirects, where "safe" means that the client is only
         doing a GET or HEAD on the URI to which it is being redirected. C(none) will not follow
-        any redirects. Note that C(yes) and C(no) choices are accepted for backwards compatibility, 
+        any redirects. Note that C(yes) and C(no) choices are accepted for backwards compatibility,
         where C(yes) is the equivalent of C(all) and C(no) is the equivalent of C(safe). C(yes) and C(no)
         are deprecated and will be removed in some future version of Ansible.
     required: false
@@ -111,7 +111,7 @@ options:
     default: 200
   timeout:
     description:
-      - The socket level timeout in seconds 
+      - The socket level timeout in seconds
     required: false
     default: 30
   HEADER_:
@@ -145,25 +145,25 @@ EXAMPLES = '''
 
 # Create a JIRA issue
 
-- uri: url=https://your.jira.example.com/rest/api/2/issue/ 
-       method=POST user=your_username password=your_pass 
-       body="{{ lookup('file','issue.json') }}" force_basic_auth=yes 
-       status_code=201 HEADER_Content-Type="application/json"  
+- uri: url=https://your.jira.example.com/rest/api/2/issue/
+       method=POST user=your_username password=your_pass
+       body="{{ lookup('file','issue.json') }}" force_basic_auth=yes
+       status_code=201 HEADER_Content-Type="application/json"
 
 # Login to a form based webpage, then use the returned cookie to
 # access the app in later tasks
 
-- uri: url=https://your.form.based.auth.examle.com/index.php 
-       method=POST body="name=your_username&password=your_password&enter=Sign%20in" 
+- uri: url=https://your.form.based.auth.examle.com/index.php
+       method=POST body="name=your_username&password=your_password&enter=Sign%20in"
        status_code=302 HEADER_Content-Type="application/x-www-form-urlencoded"
   register: login
 
 - uri: url=https://your.form.based.auth.example.com/dashboard.php
        method=GET return_content=yes HEADER_Cookie="{{login.set_cookie}}"
-            
+
 # Queue build of a project in Jenkins:
 
-- uri: url=http://{{jenkins.host}}/job/{{jenkins.job}}/build?token={{jenkins.token}} 
+- uri: url=http://{{jenkins.host}}/job/{{jenkins.job}}/build?token={{jenkins.token}}
        method=GET user={{jenkins.user}} password={{jenkins.password}} force_basic_auth=yes status_code=201
 
 '''
@@ -193,10 +193,10 @@ def write_file(module, url, dest, content):
         os.remove(tmpsrc)
         module.fail_json(msg="failed to create temporary content file: %s" % str(err))
     f.close()
- 
+
     md5sum_src   = None
     md5sum_dest  = None
- 
+
     # raise an error if there is no tmpsrc file
     if not os.path.exists(tmpsrc):
         os.remove(tmpsrc)
@@ -205,7 +205,7 @@ def write_file(module, url, dest, content):
         os.remove(tmpsrc)
         module.fail_json( msg="Source %s not readable" % (tmpsrc))
     md5sum_src = module.md5(tmpsrc)
- 
+
     # check if there is no dest file
     if os.path.exists(dest):
         # raise an error if copy has no permission on dest
@@ -220,14 +220,14 @@ def write_file(module, url, dest, content):
         if not os.access(os.path.dirname(dest), os.W_OK):
             os.remove(tmpsrc)
             module.fail_json( msg="Destination dir %s not writable" % (os.path.dirname(dest)))
-     
+
     if md5sum_src != md5sum_dest:
         try:
             shutil.copyfile(tmpsrc, dest)
         except Exception, err:
             os.remove(tmpsrc)
             module.fail_json(msg="failed to copy %s to %s: %s" % (tmpsrc, dest, str(err)))
- 
+
     os.remove(tmpsrc)
 
 
@@ -242,7 +242,7 @@ def uri(module, url, dest, user, password, body, method, headers, redirects, soc
     # To debug
     #httplib2.debug = 4
 
-    # Handle Redirects         
+    # Handle Redirects
     if redirects == "all" or redirects == "yes":
         follow_redirects = True
         follow_all_redirects = True
@@ -298,8 +298,8 @@ def uri(module, url, dest, user, password, body, method, headers, redirects, soc
     h.follow_redirects=follow_redirects
 
     # Make the request, or try to :)
-    try: 
-        resp, content = h.request(url, method=method, body=body, headers=headers)     
+    try:
+        resp, content = h.request(url, method=method, body=body, headers=headers)
         r['redirected'] = redirected
         r.update(resp_redir)
         r.update(resp)
@@ -374,7 +374,7 @@ def main():
             skey = key.replace("HEADER_", "")
             dict_headers[skey] = value
 
-  
+
     if creates is not None:
         # do not run the command if the line contains creates=filename
         # and the filename already exists.  This allows idempotence
@@ -394,9 +394,9 @@ def main():
 
     # httplib2 only sends authentication after the server asks for it with a 401.
     # Some 'basic auth' servies fail to send a 401 and require the authentication
-    # up front. This creates the Basic authentication header and sends it immediately. 
+    # up front. This creates the Basic authentication header and sends it immediately.
     if force_basic_auth:
-        dict_headers["Authorization"] = "Basic {0}".format(base64.b64encode("{0}:{1}".format(user, password))) 
+        dict_headers["Authorization"] = "Basic {0}".format(base64.b64encode("{0}:{1}".format(user, password)))
 
 
     # Make the request
@@ -422,7 +422,7 @@ def main():
     # Transmogrify the headers, replacing '-' with '_', since variables dont work with dashes.
     uresp = {}
     for key, value in resp.iteritems():
-        ukey = key.replace("-", "_")  
+        ukey = key.replace("-", "_")
         uresp[ukey] = value
 
     if 'content_type' in uresp:
@@ -440,6 +440,9 @@ def main():
         module.exit_json(changed=changed, **uresp)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/notification/campfire
+++ b/library/notification/campfire
@@ -138,6 +138,9 @@ def main():
 
     module.exit_json(changed=True, room=room, msg=msg, notify=notify)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/notification/flowdock
+++ b/library/notification/flowdock
@@ -135,7 +135,7 @@ def main():
         url = "https://api.flowdock.com/v1/messages/team_inbox/%s" % (token)
     else:
         url = "https://api.flowdock.com/v1/messages/chat/%s" % (token)
-    
+
     params = {}
 
     # required params
@@ -184,9 +184,12 @@ def main():
 
     module.exit_json(changed=True, msg=module.params["msg"])
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()
 

--- a/library/notification/grove
+++ b/library/notification/grove
@@ -25,11 +25,11 @@ options:
     required: true
   url:
     description:
-      - Service URL for the web client 
+      - Service URL for the web client
     required: false
   icon_url:
     description:
-      -  Icon for the service 
+      -  Icon for the service
     required: false
   validate_certs:
     description:
@@ -94,6 +94,9 @@ def main():
     # Mission complete
     module.exit_json(msg="OK")
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/notification/hipchat
+++ b/library/notification/hipchat
@@ -142,8 +142,11 @@ def main():
     changed = True
     module.exit_json(changed=changed, room=room, msg_from=msg_from, msg=msg)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/notification/irc
+++ b/library/notification/irc
@@ -49,7 +49,7 @@ options:
     default: null
   color:
     description:
-      - Text color for the message. ("none" is a valid option in 1.6 or later, in 1.6 and prior, the default color is black, not "none"). 
+      - Text color for the message. ("none" is a valid option in 1.6 or later, in 1.6 and prior, the default color is black, not "none").
     required: false
     default: "none"
     choices: [ "none", "yellow", "red", "green", "blue", "black" ]
@@ -210,6 +210,9 @@ def main():
     module.exit_json(changed=False, channel=channel, nick=nick,
                      msg=msg)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/notification/jabber
+++ b/library/notification/jabber
@@ -141,6 +141,9 @@ def main():
 
     module.exit_json(changed=False, to=to, user=user, msg=msg.getBody())
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/notification/mail
+++ b/library/notification/mail
@@ -247,6 +247,9 @@ def main():
 
     module.exit_json(changed=False)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/notification/mqtt
+++ b/library/notification/mqtt
@@ -161,6 +161,9 @@ def main():
 
     module.exit_json(changed=False, topic=topic)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/notification/nexmo
+++ b/library/notification/nexmo
@@ -133,8 +133,11 @@ def main():
     send_msg(module)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
+if __name__ == "__main__":
 
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/notification/osx_say
+++ b/library/notification/osx_say
@@ -26,7 +26,7 @@ short_description: Makes an OSX computer to speak.
 description:
    - makes an OS computer speak!  Amuse your friends, annoy your coworkers!
 notes:
-   - If you like this module, you may also be interested in the osx_say callback in the plugins/ directory of the source checkout. 
+   - If you like this module, you may also be interested in the osx_say callback in the plugins/ directory of the source checkout.
 options:
   msg:
     description:
@@ -67,8 +67,11 @@ def main():
 
     say(module, msg, voice)
 
-    module.exit_json(msg=msg, changed=False) 
+    module.exit_json(msg=msg, changed=False)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/notification/slack
+++ b/library/notification/slack
@@ -167,7 +167,10 @@ def main():
 
     module.exit_json(msg="OK")
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+    main()

--- a/library/notification/sns
+++ b/library/notification/sns
@@ -61,7 +61,7 @@ options:
     required: false
   aws_secret_key:
     description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
     required: false
     default: None
     aliases: ['ec2_secret_key', 'secret_key']
@@ -187,4 +187,7 @@ def main():
 
     module.exit_json(msg="OK")
 
-main()
+
+if __name__ == "__main__":
+
+    main()

--- a/library/notification/twilio
+++ b/library/notification/twilio
@@ -24,9 +24,9 @@ version_added: "1.6"
 module: twilio
 short_description: Sends a text message to a mobile phone through Twilio.
 description:
-   - Sends a text message to a phone number through an the Twilio SMS service. 
+   - Sends a text message to a phone number through an the Twilio SMS service.
 notes:
-   - Like the other notification modules, this one requires an external 
+   - Like the other notification modules, this one requires an external
      dependency to work. In this case, you'll need a Twilio account with
      a purchased or verified phone number to send the text message.
 options:
@@ -49,7 +49,7 @@ options:
     description:
       what phone number to send the text message from, format +15551112222
     required: true
-  
+
 requirements: [ urllib, urllib2 ]
 author: Matt Makai
 '''
@@ -57,7 +57,7 @@ author: Matt Makai
 EXAMPLES = '''
 # send a text message from the local server about the build status to (555) 303 5681
 # note: you have to have purchased the 'from_number' on your Twilio account
-- local_action: text msg="All servers with webserver role are now configured." 
+- local_action: text msg="All servers with webserver role are now configured."
   account_sid={{ twilio_account_sid }}
   auth_token={{ twilio_auth_token }}
   from_number=+15552014545 to_number=+15553035681
@@ -68,7 +68,7 @@ EXAMPLES = '''
   account_sid={{ twilio_account_sid }}
   auth_token={{ twilio_auth_token }}
   from_number=+15553258899 to_number=+15551113232
-  
+
 '''
 
 # =======================================
@@ -115,7 +115,7 @@ def main():
         ),
         supports_check_mode=True
     )
-  
+
     account_sid = module.params['account_sid']
     auth_token = module.params['auth_token']
     msg = module.params['msg']
@@ -123,13 +123,16 @@ def main():
     to_number = module.params['to_number']
 
     try:
-        response = post_text(module, account_sid, auth_token, msg, 
+        response = post_text(module, account_sid, auth_token, msg,
             from_number, to_number)
     except Exception, e:
         module.fail_json(msg="unable to send text message to %s" % to_number)
 
-    module.exit_json(msg=msg, changed=False) 
+    module.exit_json(msg=msg, changed=False)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/notification/typetalk
+++ b/library/notification/typetalk
@@ -111,6 +111,9 @@ def main():
     module.exit_json(changed=True, topic=topic, msg=msg)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -555,7 +555,10 @@ def main():
     except apt.cache.LockFailedException:
         module.fail_json(msg="Failed to lock apt for exclusive operation")
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -271,7 +271,10 @@ def main():
 
     module.exit_json(changed=changed, **return_values)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+    main()

--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -439,8 +439,11 @@ def main():
 
     module.exit_json(changed=changed, repo=repo, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/packaging/apt_rpm
+++ b/library/packaging/apt_rpm
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Evgenii Terechkov
-# Written by Evgenii Terechkov <evg@altlinux.org> 
-# Based on urpmi module written by Philippe Makowski <philippem@mageia.org> 
+# Written by Evgenii Terechkov <evg@altlinux.org>
+# Based on urpmi module written by Philippe Makowski <philippem@mageia.org>
 #
 # This module is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -53,10 +53,10 @@ EXAMPLES = '''
 - apt_rpm: pkg=foo state=present
 # remove package foo
 - apt_rpm: pkg=foo state=absent
-# description: remove packages foo and bar 
+# description: remove packages foo and bar
 - apt_rpm: pkg=foo,bar state=absent
-# description: update the package database and install bar (bar will be the updated if a newer version exists) 
-- apt_rpm: name=bar state=present update_cache=yes     
+# description: update the package database and install bar (bar will be the updated if a newer version exists)
+- apt_rpm: name=bar state=present update_cache=yes
 '''
 
 
@@ -94,7 +94,7 @@ def update_package_db(module):
         module.fail_json(msg="could not update package db")
 
 def remove_packages(module, packages):
-    
+
     remove_c = 0
     # Using a for loop incase of error, we can report the package that failed
     for package in packages:
@@ -106,7 +106,7 @@ def remove_packages(module, packages):
 
         if rc != 0:
             module.fail_json(msg="failed to remove %s" % (package))
-    
+
         remove_c += 1
 
     if remove_c > 0:
@@ -148,7 +148,7 @@ def main():
                 state        = dict(default='installed', choices=['installed', 'removed', 'absent', 'present']),
                 update_cache = dict(default=False, aliases=['update-cache'], type='bool'),
                 package      = dict(aliases=['pkg', 'name'], required=True)))
-                
+
 
     if not os.path.exists(APT_PATH) or not os.path.exists(RPM_PATH):
         module.fail_json(msg="cannot find /usr/bin/apt-get and/or /usr/bin/rpm")
@@ -166,7 +166,10 @@ def main():
     elif p['state'] in [ 'removed', 'absent' ]:
         remove_packages(module, packages)
 
-# this is magic, see lib/ansible/module_common.py
-from ansible.module_utils.basic import *
-    
-main()        
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module_common.py
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/composer
+++ b/library/packaging/composer
@@ -136,7 +136,7 @@ def main():
     if module.check_mode:
         options.add("--dry-run")
 
-    # Get composer command with fallback to default  
+    # Get composer command with fallback to default
     command = module.params['command']
     del module.params['command'];
 
@@ -158,7 +158,10 @@ def main():
         output = parse_out(out)
         module.exit_json(changed=has_changed(output), msg=output)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/cpanm
+++ b/library/packaging/cpanm
@@ -77,7 +77,7 @@ def _is_package_installed(module, name, locallib, cpanm):
     res, stdout, stderr = module.run_command(cmd, check_rc=False)
     if res == 0:
        return True
-    else: 
+    else:
        return False
 
 def _build_cmd_line(name, from_path, notest, locallib, mirror, cpanm):
@@ -139,7 +139,10 @@ def main():
 
     module.exit_json(changed=changed, binary=cpanm, name=name)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/easy_install
+++ b/library/packaging/easy_install
@@ -182,7 +182,10 @@ def main():
     module.exit_json(changed=changed, binary=easy_install,
                      name=name, virtualenv=env)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -233,6 +233,9 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -830,6 +830,9 @@ def main():
     else:
         module.exit_json(changed=changed, msg=message)
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module_common.py
+    #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+    main()

--- a/library/packaging/homebrew_cask
+++ b/library/packaging/homebrew_cask
@@ -508,6 +508,9 @@ def main():
     else:
         module.exit_json(changed=changed, msg=message)
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module_common.py
+    #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+    main()

--- a/library/packaging/homebrew_tap
+++ b/library/packaging/homebrew_tap
@@ -210,6 +210,9 @@ def main():
         else:
             module.exit_json(changed=changed, msg=msg)
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+
+if __name__ == "__main__":
+
+    # this is magic, see lib/ansible/module_common.py
+    #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+    main()

--- a/library/packaging/layman
+++ b/library/packaging/layman
@@ -105,7 +105,7 @@ def download_url(url, dest):
         response = urlopen(request)
     except URLError, e:
         raise ModuleError("Failed to get %s: %s" % (url, str(e)))
-    
+
     try:
         with open(dest, 'w') as f:
             shutil.copyfileobj(response, f)
@@ -231,6 +231,9 @@ def main():
         module.exit_json(changed=changed, name=name)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/packaging/macports
+++ b/library/packaging/macports
@@ -211,7 +211,10 @@ def main():
     elif p["state"] == "inactive":
         deactivate_packages(module, port_path, pkgs)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -258,6 +258,9 @@ def main():
 
     module.exit_json(changed=changed)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/packaging/openbsd_pkg
+++ b/library/packaging/openbsd_pkg
@@ -368,6 +368,9 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/packaging/opkg
+++ b/library/packaging/opkg
@@ -144,7 +144,10 @@ def main():
     elif p["state"] in ["absent", "removed"]:
         remove_packages(module, opkg_path, pkgs)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/pacman
+++ b/library/packaging/pacman
@@ -228,7 +228,10 @@ def main():
         elif p['state'] == 'absent':
             remove_packages(module, pkgs)
 
-# import module snippets
-from ansible.module_utils.basic import *
-    
-main()        
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -144,7 +144,7 @@ def _get_cmd_options(module, cmd):
     words = stdout.strip().split()
     cmd_options = [ x for x in words if x.startswith('--') ]
     return cmd_options
-    
+
 
 def _get_full_name(name, version=None):
     if version is None:
@@ -278,11 +278,11 @@ def main():
     pip = _get_pip(module, env, module.params['executable'])
 
     cmd = '%s %s' % (pip, state_map[state])
-    
+
     # If there's a virtualenv we want things we install to be able to use other
-    # installations that exist as binaries within this virtualenv. Example: we 
-    # install cython and then gevent -- gevent needs to use the cython binary, 
-    # not just a python package that will be found by calling the right python. 
+    # installations that exist as binaries within this virtualenv. Example: we
+    # install cython and then gevent -- gevent needs to use the cython binary,
+    # not just a python package that will be found by calling the right python.
     # So if there's a virtualenv, we add that bin/ to the beginning of the PATH
     # in run_command by setting path_prefix here.
     path_prefix = None
@@ -308,7 +308,7 @@ def main():
         cmd += ' %s' % _get_full_name(name, version)
     elif requirements:
         cmd += ' -r %s' % requirements
-    
+
     this_dir = tempfile.gettempdir()
     if chdir:
         this_dir = os.path.join(this_dir, chdir)
@@ -319,7 +319,7 @@ def main():
         elif name.startswith('svn+') or name.startswith('git+') or \
                 name.startswith('hg+') or name.startswith('bzr+'):
             module.exit_json(changed=True)
-        
+
         freeze_cmd = '%s freeze' % pip
         rc, out_pip, err_pip = module.run_command(freeze_cmd, cwd=this_dir)
 
@@ -350,7 +350,10 @@ def main():
     module.exit_json(changed=changed, cmd=cmd, name=name, version=version,
                      state=state, requirements=requirements, virtualenv=env, stdout=out, stderr=err)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/pkgin
+++ b/library/packaging/pkgin
@@ -162,7 +162,10 @@ def main():
     elif p["state"] == "absent":
         remove_packages(module, pkgin_path, pkgs)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/pkgng
+++ b/library/packaging/pkgng
@@ -4,7 +4,7 @@
 # (c) 2013, bleader
 # Written by bleader <bleader@ratonland.org>
 # Based on pkgin module written by Shaun Zinck <shaun.zinck at gmail.com>
-# that was based on pacman module written by Afterburn <http://github.com/afterburn> 
+# that was based on pacman module written by Afterburn <http://github.com/afterburn>
 #  that was based on apt module written by Matthew Williams <matthew@flowroute.com>
 #
 # This module is free software: you can redistribute it and/or modify
@@ -50,7 +50,7 @@ options:
         description:
             - a comma-separated list of keyvalue-pairs of the form
               <+/-/:><key>[=<value>]. A '+' denotes adding an annotation, a
-              '-' denotes removing an annotation, and ':' denotes modifying an 
+              '-' denotes removing an annotation, and ':' denotes modifying an
               annotation.
               If setting or modifying annotations, a value must be provided.
         required: false
@@ -75,7 +75,7 @@ EXAMPLES = '''
 # Annotate package foo and bar
 - pkgng: name=foo,bar annotation=+test1=baz,-test2,:test3=foobar
 
-# Remove packages foo and bar 
+# Remove packages foo and bar
 - pkgng: name=foo,bar state=absent
 '''
 
@@ -113,7 +113,7 @@ def pkgng_older_than(module, pkgng_path, compare_version):
 
 
 def remove_packages(module, pkgng_path, packages):
-    
+
     remove_c = 0
     # Using a for loop incase of error, we can report the package that failed
     for package in packages:
@@ -126,7 +126,7 @@ def remove_packages(module, pkgng_path, packages):
 
         if not module.check_mode and query_package(module, pkgng_path, package):
             module.fail_json(msg="failed to remove %s: %s" % (package, out))
-    
+
         remove_c += 1
 
     if remove_c > 0:
@@ -171,7 +171,7 @@ def install_packages(module, pkgng_path, packages, cached, pkgsite):
             module.fail_json(msg="failed to install %s: %s" % (package, out), stderr=err)
 
         install_c += 1
-    
+
     if install_c > 0:
         return (True, "added %s package(s)" % (install_c))
 
@@ -294,8 +294,11 @@ def main():
     module.exit_json(changed=changed, msg=", ".join(msgs))
 
 
+if __name__ == "__main__":
 
-# import module snippets
-from ansible.module_utils.basic import *
-    
-main()        
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/pkgutil
+++ b/library/packaging/pkgutil
@@ -23,7 +23,7 @@
 
 DOCUMENTATION = '''
 ---
-module: pkgutil 
+module: pkgutil
 short_description: Manage CSW-Packages on Solaris
 description:
     - Manages CSW packages (SVR4 format) on Solaris 10 and 11.
@@ -95,7 +95,7 @@ def package_install(module, state, name, site):
     if site is not None:
         cmd += [ '-t', site ]
     if state == 'latest':
-        cmd += [ '-f' ] 
+        cmd += [ '-f' ]
     cmd.append(name)
     (rc, out, err) = run_command(module, cmd)
     return (rc, out, err)
@@ -150,7 +150,7 @@ def main():
         else:
             if not package_latest(module, name, site):
                 if module.check_mode:
-                    module.exit_json(changed=True) 
+                    module.exit_json(changed=True)
                 (rc, out, err) = package_upgrade(module, name, site)
                 if len(out) > 75:
                     out = out[:75] + '...'
@@ -174,6 +174,9 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/packaging/portage
+++ b/library/packaging/portage
@@ -399,7 +399,10 @@ def main():
     elif p['state'] in portage_absent_states:
         unmerge_packages(module, packages)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/portinstall
+++ b/library/packaging/portinstall
@@ -201,7 +201,10 @@ def main():
     elif p["state"] == "absent":
         remove_packages(module, pkgs)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/redhat_subscription
+++ b/library/packaging/redhat_subscription
@@ -174,7 +174,7 @@ class Rhsm(RegistrationBase):
         for k,v in kwargs.items():
             if re.search(r'^(system|rhsm)_', k):
                 args.append('--%s=%s' % (k.replace('_','.'), v))
-        
+
         self.module.run_command(args, check_rc=True)
 
     @property
@@ -391,6 +391,9 @@ def main():
                 module.exit_json(changed=True, msg="System successfully unregistered from %s." % server_hostname)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/packaging/rhn_channel
+++ b/library/packaging/rhn_channel
@@ -26,7 +26,7 @@ description:
 version_added: "1.1"
 author: Vincent Van der Kussen
 notes:
-    - this module fetches the system id from RHN. 
+    - this module fetches the system id from RHN.
 requirements:
     - none
 options:
@@ -46,7 +46,7 @@ options:
         required: false
         default: present
     url:
-        description: 
+        description:
             - The full url to the RHN/Satellite api
         required: true
     user:
@@ -135,18 +135,18 @@ def main():
     saturl = module.params['url']
     user = module.params['user']
     password = module.params['password']
-    
+
     #initialize connection
     client = xmlrpclib.Server(saturl, verbose=0)
     session = client.auth.login(user, password)
-     
+
     # get systemid
     sys_id = get_systemid(client, session, systname)
 
     # get channels for system
     chans = base_channels(client, session, sys_id)
-    
-    
+
+
     if state == 'present':
         if channelname in chans:
             module.exit_json(changed=False, msg="Channel %s already exists" % channelname)
@@ -164,6 +164,9 @@ def main():
     client.auth.logout(session)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/packaging/rhn_register
+++ b/library/packaging/rhn_register
@@ -333,4 +333,7 @@ def main():
             module.exit_json(changed=True, msg="System successfully unregistered from %s." % rhn.hostname)
 
 
-main()
+if __name__ == "__main__":
+
+
+    main()

--- a/library/packaging/rpm_key
+++ b/library/packaging/rpm_key
@@ -199,8 +199,11 @@ def main():
     RpmKey(module)
 
 
+if __name__ == "__main__":
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-main()
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+    main()

--- a/library/packaging/svr4pkg
+++ b/library/packaging/svr4pkg
@@ -137,7 +137,7 @@ def run_command(module, cmd):
 
 def package_install(module, name, src, proxy, response_file, zone, category):
     adminfile = create_admin_file()
-    cmd = [ 'pkgadd', '-n'] 
+    cmd = [ 'pkgadd', '-n']
     if zone == 'current':
         cmd += [ '-G' ]
     cmd += [ '-a', adminfile, '-d', src ]
@@ -229,6 +229,9 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/packaging/swdepot
+++ b/library/packaging/swdepot
@@ -189,8 +189,11 @@ def main():
 
     module.exit_json(changed=changed, name=name, state=state, msg=msg)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/packaging/urpmi
+++ b/library/packaging/urpmi
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Philippe Makowski
-# Written by Philippe Makowski <philippem@mageia.org> 
+# Written by Philippe Makowski <philippem@mageia.org>
 # Based on apt module written by Matthew Williams <matthew@flowroute.com>
 #
 # This module is free software: you can redistribute it and/or modify
@@ -65,10 +65,10 @@ EXAMPLES = '''
 - urpmi: pkg=foo state=present
 # remove package foo
 - urpmi: pkg=foo state=absent
-# description: remove packages foo and bar 
+# description: remove packages foo and bar
 - urpmi: pkg=foo,bar state=absent
-# description: update the package database (urpmi.update -a -q) and install bar (bar will be the updated if a newer version exists) 
-- urpmi: name=bar, state=present, update_cache=yes     
+# description: update the package database (urpmi.update -a -q) and install bar (bar will be the updated if a newer version exists)
+- urpmi: name=bar, state=present, update_cache=yes
 '''
 
 
@@ -103,10 +103,10 @@ def update_package_db(module):
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     if rc != 0:
         module.fail_json(msg="could not update package db")
-         
+
 
 def remove_packages(module, packages):
-    
+
     remove_c = 0
     # Using a for loop incase of error, we can report the package that failed
     for package in packages:
@@ -119,7 +119,7 @@ def remove_packages(module, packages):
 
         if rc != 0:
             module.fail_json(msg="failed to remove %s" % (package))
-    
+
         remove_c += 1
 
     if remove_c > 0:
@@ -173,7 +173,7 @@ def main():
                 force        = dict(default=True, type='bool'),
                 no_suggests  = dict(default=True, aliases=['no-suggests'], type='bool'),
                 package      = dict(aliases=['pkg', 'name'], required=True)))
-                
+
 
     if not os.path.exists(URPMI_PATH):
         module.fail_json(msg="cannot find urpmi, looking for %s" % (URPMI_PATH))
@@ -194,7 +194,10 @@ def main():
     elif p['state'] in [ 'removed', 'absent' ]:
         remove_packages(module, packages)
 
-# import module snippets
-from ansible.module_utils.basic import *
-    
-main()        
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -67,7 +67,7 @@ options:
     version_added: "0.9"
     default: null
     aliases: []
-    
+
   disablerepo:
     description:
       - I(Repoid) of repositories to disable for the install/update operation.
@@ -152,16 +152,16 @@ def yum_base(conf_file=None, cachedir=False):
         else:
             cachedir = yum.misc.getCacheDir()
             my.repos.setCacheDir(cachedir)
-            my.conf.cache = 0 
+            my.conf.cache = 0
 
     return my
 
 def install_yum_utils(module):
 
-    if not module.check_mode:    
+    if not module.check_mode:
         yum_path = module.get_bin_path('yum')
         if yum_path:
-            rc, so, se = module.run_command('%s -y install yum-utils' % yum_path) 
+            rc, so, se = module.run_command('%s -y install yum-utils' % yum_path)
             if rc == 0:
                 this_path = module.get_bin_path('repoquery')
                 global repoquery
@@ -185,7 +185,7 @@ def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_
                 my.repos.enableRepo(rid)
             for rid in dis_repos:
                 my.repos.disableRepo(rid)
-                
+
             e,m,u = my.rpmdb.matchPackageNames([pkgspec])
             pkgs = e + m
             if not pkgs:
@@ -204,13 +204,13 @@ def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_
             rc2,out2,err2 = module.run_command(cmd)
         else:
             rc2,out2,err2 = (0, '', '')
-            
+
         if rc == 0 and rc2 == 0:
             out += out2
             return [ p for p in out.split('\n') if p.strip() ]
         else:
             module.fail_json(msg='Error from repoquery: %s: %s' % (cmd, err + err2))
-            
+
     return []
 
 def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_repos=[]):
@@ -231,12 +231,12 @@ def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_
                 pkgs.extend(my.returnPackagesByDep(pkgspec))
         except Exception, e:
             module.fail_json(msg="Failure talking to yum: %s" % e)
-            
+
         return [ po_to_nevra(p) for p in pkgs ]
 
     else:
         myrepoq = list(repoq)
-                 
+
         for repoid in dis_repos:
             r_cmd = ['--disablerepo', repoid]
             myrepoq.extend(r_cmd)
@@ -252,7 +252,7 @@ def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_
         else:
             module.fail_json(msg='Error from repoquery: %s: %s' % (cmd, err))
 
-            
+
     return []
 
 def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_repos=[]):
@@ -274,14 +274,14 @@ def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_rep
             if not pkgs:
                 e,m,u = my.pkgSack.matchPackageNames([pkgspec])
                 pkgs = e + m
-            updates = my.doPackageLists(pkgnarrow='updates').updates 
+            updates = my.doPackageLists(pkgnarrow='updates').updates
         except Exception, e:
             module.fail_json(msg="Failure talking to yum: %s" % e)
 
         for pkg in pkgs:
             if pkg in updates:
                 retpkgs.append(pkg)
-            
+
         return set([ po_to_nevra(p) for p in retpkgs ])
 
     else:
@@ -296,12 +296,12 @@ def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=[], dis_rep
 
         cmd = myrepoq + ["--pkgnarrow=updates", "--qf", qf, pkgspec]
         rc,out,err = module.run_command(cmd)
-        
+
         if rc == 0:
             return set([ p for p in out.split('\n') if p.strip() ])
         else:
             module.fail_json(msg='Error from repoquery: %s: %s' % (cmd, err))
-            
+
     return []
 
 def what_provides(module, repoq, req_spec, conf_file,  qf=def_qf, en_repos=[], dis_repos=[]):
@@ -355,9 +355,9 @@ def what_provides(module, repoq, req_spec, conf_file,  qf=def_qf, en_repos=[], d
     return []
 
 def transaction_exists(pkglist):
-    """ 
-    checks the package list to see if any packages are 
-    involved in an incomplete transaction 
+    """
+    checks the package list to see if any packages are
+    involved in an incomplete transaction
     """
 
     conflicts = []
@@ -395,15 +395,15 @@ def transaction_exists(pkglist):
 
 def local_nvra(module, path):
     """return nvra of a local rpm passed in"""
-    
-    cmd = ['/bin/rpm', '-qp' ,'--qf', 
+
+    cmd = ['/bin/rpm', '-qp' ,'--qf',
             '%{name}-%{version}-%{release}.%{arch}\n', path ]
     rc, out, err = module.run_command(cmd)
     if rc != 0:
         return None
     nvra = out.split('\n')[0]
     return nvra
-    
+
 def pkg_to_dict(pkgstr):
 
     if pkgstr.strip():
@@ -500,7 +500,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                 if pkgs:
                     res['results'].append('%s providing %s is already installed' % (pkgs[0], spec))
                     continue
-            
+
             # look up what pkgs provide this
             pkglist = what_provides(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos)
             if not pkglist:
@@ -533,7 +533,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                 if is_installed(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos):
                     found = True
                     res['results'].append('package providing %s is already installed' % (spec))
-                    
+
             if found:
                 continue
 
@@ -609,13 +609,13 @@ def remove(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         res['results'].append(out)
         res['msg'] += err
 
-        # compile the results into one batch. If anything is changed 
+        # compile the results into one batch. If anything is changed
         # then mark changed
         # at the end - if we've end up failed then fail out of the rest
         # of the process
 
         # at this point we should check to see if the pkg is no longer present
-        
+
         if not is_group: # we can't sensibly check for a group being uninstalled reliably
             # look to see if the pkg shows up from is_installed. If it doesn't
             if not is_installed(module, repoq, pkg, conf_file, en_repos=en_repos, dis_repos=dis_repos):
@@ -625,7 +625,7 @@ def remove(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
 
         if rc != 0:
             module.fail_json(**res)
-            
+
     module.exit_json(**res)
 
 def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
@@ -644,7 +644,7 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         # groups, again
         if spec.startswith('@'):
             pkg = spec
-        
+
         elif spec == '*': #update all
             # use check-update to see if there is any need
             rc,out,err = module.run_command(yum_basecmd + ['check-update'])
@@ -653,7 +653,7 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
             else:
                 res['results'].append('All packages up to date')
                 continue
-        
+
         # dep/pkgname  - find it
         else:
             if is_installed(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos):
@@ -665,17 +665,17 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
             if not pkglist:
                 res['msg'] += "No Package matching '%s' found available, installed or updated" % spec
                 module.fail_json(**res)
-            
+
             nothing_to_do = True
             for this in pkglist:
                 if basecmd == 'install' and is_available(module, repoq, this, conf_file, en_repos=en_repos, dis_repos=dis_repos):
                     nothing_to_do = False
                     break
-                    
+
                 if basecmd == 'update' and is_update(module, repoq, this, conf_file, en_repos=en_repos, dis_repos=dis_repos):
                     nothing_to_do = False
                     break
-                    
+
             if nothing_to_do:
                 res['results'].append("All packages providing %s are up to date" % spec)
                 continue
@@ -719,7 +719,7 @@ def ensure(module, state, pkgspec, conf_file, enablerepo, disablerepo,
     # need debug level 2 to get 'Nothing to do' for groupinstall.
     yum_basecmd = [yumbin, '-d', '2', '-y']
 
-        
+
     if not repoquery:
         repoq = None
     else:
@@ -736,7 +736,7 @@ def ensure(module, state, pkgspec, conf_file, enablerepo, disablerepo,
         dis_repos = disablerepo.split(',')
     if enablerepo:
         en_repos = enablerepo.split(',')
-           
+
     for repoid in dis_repos:
         r_cmd = ['--disablerepo=%s' % repoid]
         yum_basecmd.extend(r_cmd)
@@ -832,7 +832,10 @@ def main():
                      disablerepo, disable_gpg_check)
         module.fail_json(msg="we should never get here unless this all failed", **res)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()
 

--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -62,7 +62,7 @@ options:
     disable_recommends:
         version_added: "1.8"
         description:
-          - Corresponds to the C(--no-recommends) option for I(zypper). Default behavior (C(yes)) modifies zypper's default behavior; C(no) does install recommended packages. 
+          - Corresponds to the C(--no-recommends) option for I(zypper). Default behavior (C(yes)) modifies zypper's default behavior; C(no) does install recommended packages.
         required: false
         default: "yes"
         choices: [ "yes", "no" ]
@@ -255,6 +255,9 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -215,7 +215,10 @@ def main():
 
     module.exit_json(changed=changed, repo=repo, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/source_control/bzr
+++ b/library/source_control/bzr
@@ -193,6 +193,9 @@ def main():
 
     module.exit_json(changed=changed, before=before, after=after)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/source_control/git
+++ b/library/source_control/git
@@ -49,8 +49,8 @@ options:
         choices: [ "yes", "no" ]
         version_added: "1.5"
         description:
-            - if C(yes), adds the hostkey for the repo url if not already 
-              added. If ssh_args contains "-o StrictHostKeyChecking=no", 
+            - if C(yes), adds the hostkey for the repo url if not already
+              added. If ssh_args contains "-o StrictHostKeyChecking=no",
               this parameter is ignored.
     ssh_opts:
         required: false
@@ -65,7 +65,7 @@ options:
         default: None
         version_added: "1.5"
         description:
-            - Uses the same wrapper method as ssh_opts to pass 
+            - Uses the same wrapper method as ssh_opts to pass
               "-i <key_file>" to the ssh arguments used by git
     reference:
         required: false
@@ -128,8 +128,8 @@ options:
               option, skipping sub-modules.
 notes:
     - "If the task seems to be hanging, first verify remote host is in C(known_hosts).
-      SSH will prompt user to authorize the first contact with a remote host.  To avoid this prompt, 
-      one solution is to add the remote host public key in C(/etc/ssh/ssh_known_hosts) before calling 
+      SSH will prompt user to authorize the first contact with a remote host.  To avoid this prompt,
+      one solution is to add the remote host public key in C(/etc/ssh/ssh_known_hosts) before calling
       the git module, with the following command: ssh-keyscan -H remote_host.com >> /etc/ssh/ssh_known_hosts."
 '''
 
@@ -151,13 +151,13 @@ import tempfile
 
 def get_submodule_update_params(module, git_path, cwd):
 
-    #or: git submodule [--quiet] update [--init] [-N|--no-fetch] 
-    #[-f|--force] [--rebase] [--reference <repository>] [--merge] 
+    #or: git submodule [--quiet] update [--init] [-N|--no-fetch]
+    #[-f|--force] [--rebase] [--reference <repository>] [--merge]
     #[--recursive] [--] [<path>...]
 
     params = []
 
-    # run a bad submodule command to get valid params    
+    # run a bad submodule command to get valid params
     cmd = "%s submodule update --help" % (git_path)
     rc, stdout, stderr = module.run_command(cmd, cwd=cwd)
     lines = stderr.split('\n')
@@ -170,7 +170,7 @@ def get_submodule_update_params(module, git_path, cwd):
         update_line = update_line.replace(']','')
         update_line = update_line.replace('|',' ')
         parts = shlex.split(update_line)
-        for part in parts:    
+        for part in parts:
             if part.startswith('--'):
                 part = part.replace('--', '')
                 params.append(part)
@@ -218,7 +218,7 @@ def set_git_ssh(ssh_wrapper, key_file, ssh_opts):
         del os.environ["GIT_KEY"]
 
     if key_file:
-        os.environ["GIT_KEY"] = key_file    
+        os.environ["GIT_KEY"] = key_file
 
     if os.environ.get("GIT_SSH_OPTS"):
         del os.environ["GIT_SSH_OPTS"]
@@ -261,7 +261,7 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
     if bare:
         if remote != 'origin':
             module.run_command([git_path, 'remote', 'add', remote, repo], check_rc=True, cwd=dest)
-  
+
 def has_local_mods(module, git_path, dest, bare):
     if bare:
         return False
@@ -503,7 +503,7 @@ def main():
     bare      = module.params['bare']
     reference = module.params['reference']
     git_path  = module.params['executable'] or module.get_bin_path('git', True)
-    
+
     key_file   = module.params['key_file']
     ssh_opts   = module.params['ssh_opts']
 
@@ -516,11 +516,11 @@ def main():
         set_git_ssh(ssh_wrapper, key_file, ssh_opts)
         module.add_cleanup_file(path=ssh_wrapper)
 
-    # add the git repo's hostkey 
+    # add the git repo's hostkey
     if module.params['ssh_opts'] is not None:
         if not "-o StrictHostKeyChecking=no" in module.params['ssh_opts']:
             add_git_host_key(module, repo, accept_hostkey=module.params['accept_hostkey'])
-    else:            
+    else:
         add_git_host_key(module, repo, accept_hostkey=module.params['accept_hostkey'])
 
     recursive = module.params['recursive']
@@ -589,12 +589,15 @@ def main():
 
     # cleanup the wrapper script
     if ssh_wrapper:
-        os.remove(ssh_wrapper) 
+        os.remove(ssh_wrapper)
 
     module.exit_json(changed=changed, before=before, after=after)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.known_hosts import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.known_hosts import *
+
+    main()

--- a/library/source_control/github_hooks
+++ b/library/source_control/github_hooks
@@ -90,7 +90,7 @@ def clean504(module, hookurl, oauthkey, repo, user):
             # print "Last response was an ERROR for hook:"
             # print hook['id']
             delete(module, hookurl, oauthkey, repo, user, hook['id'])
-            
+
     return 0, current_hooks
 
 def cleanall(module, hookurl, oauthkey, repo, user):
@@ -102,7 +102,7 @@ def cleanall(module, hookurl, oauthkey, repo, user):
             # print "Last response was an ERROR for hook:"
             # print hook['id']
             delete(module, hookurl, oauthkey, repo, user, hook['id'])
-            
+
     return 0, current_hooks
 
 def create(module, hookurl, oauthkey, repo, user):
@@ -171,8 +171,11 @@ def main():
     module.exit_json(msg="success", result=out)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
+if __name__ == "__main__":
 
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+
+    main()

--- a/library/source_control/hg
+++ b/library/source_control/hg
@@ -72,8 +72,8 @@ options:
               the normal mechanism for resolving binary paths will be used.
 notes:
     - "If the task seems to be hanging, first verify remote host is in C(known_hosts).
-      SSH will prompt user to authorize the first contact with a remote host.  To avoid this prompt, 
-      one solution is to add the remote host public key in C(/etc/ssh/ssh_known_hosts) before calling 
+      SSH will prompt user to authorize the first contact with a remote host.  To avoid this prompt,
+      one solution is to add the remote host public key in C(/etc/ssh/ssh_known_hosts) before calling
       the hg module, with the following command: ssh-keyscan remote_host.com >> /etc/ssh/ssh_known_hosts."
 requirements: [ ]
 '''
@@ -233,6 +233,9 @@ def main():
         changed = True
     module.exit_json(before=before, after=after, changed=changed, cleaned=cleaned)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/source_control/subversion
+++ b/library/source_control/subversion
@@ -120,7 +120,7 @@ class Subversion(object):
     def checkout(self):
         '''Creates new svn working directory if it does not already exist.'''
         self._exec(["checkout", "-r", self.revision, self.repo, self.dest])
-		
+
     def export(self, force=False):
         '''Export svn repo to directory'''
         self._exec(["export", "-r", self.revision, self.repo, self.dest])
@@ -226,6 +226,9 @@ def main():
     changed = before != after or local_mods
     module.exit_json(changed=changed, before=before, after=after)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/alternatives
+++ b/library/system/alternatives
@@ -135,6 +135,9 @@ def main():
         module.exit_json(changed=False)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/at
+++ b/library/system/at
@@ -195,6 +195,9 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -122,7 +122,7 @@ import shlex
 class keydict(dict):
 
     """ a dictionary that maintains the order of keys as they are added """
-    
+
     # http://stackoverflow.com/questions/2328235/pythonextend-the-dict-class
 
     def __init__(self, *args, **kw):
@@ -130,7 +130,7 @@ class keydict(dict):
         self.itemlist = super(keydict,self).keys()
     def __setitem__(self, key, value):
         self.itemlist.append(key)
-        super(keydict,self).__setitem__(key, value)        
+        super(keydict,self).__setitem__(key, value)
     def __iter__(self):
         return iter(self.itemlist)
     def keys(self):
@@ -138,7 +138,7 @@ class keydict(dict):
     def values(self):
         return [self[key] for key in self]
     def itervalues(self):
-        return (self[key] for key in self)    
+        return (self[key] for key in self)
 
 def keyfile(module, user, write=False, path=None, manage_dir=True):
     """
@@ -198,8 +198,8 @@ def keyfile(module, user, write=False, path=None, manage_dir=True):
     return keysfile
 
 def parseoptions(module, options):
-    ''' 
-    reads a string containing ssh-key options 
+    '''
+    reads a string containing ssh-key options
     and returns a dictionary of those options
     '''
     options_dict = keydict() #ordered dict
@@ -230,7 +230,7 @@ def parsekey(module, raw_key):
         'ssh-ed25519',
         'ecdsa-sha2-nistp256',
         'ecdsa-sha2-nistp384',
-        'ecdsa-sha2-nistp521', 
+        'ecdsa-sha2-nistp521',
         'ssh-dss',
         'ssh-rsa',
     ]
@@ -416,6 +416,9 @@ def main():
     results = enforce_state(module, module.params)
     module.exit_json(**results)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/capabilities
+++ b/library/system/capabilities
@@ -76,7 +76,7 @@ class CapabilitiesModule(object):
     distribution = None
 
     def __init__(self, module):
-        self.module         = module 
+        self.module         = module
         self.path           = module.params['path'].strip()
         self.capability     = module.params['capability'].strip().lower()
         self.state          = module.params['state']
@@ -114,7 +114,7 @@ class CapabilitiesModule(object):
     def getcap(self, path):
         rval = []
         cmd = "%s -v %s" % (self.getcap_cmd, path)
-        rc, stdout, stderr = self.module.run_command(cmd)    
+        rc, stdout, stderr = self.module.run_command(cmd)
         # If file xattrs are set but no caps are set the output will be:
         #   '/foo ='
         # If file xattrs are unset the output will be:
@@ -141,7 +141,7 @@ class CapabilitiesModule(object):
     def setcap(self, path, caps):
         caps = ' '.join([ ''.join(cap) for cap in caps ])
         cmd = "%s '%s' %s" % (self.setcap_cmd, caps, path)
-        rc, stdout, stderr = self.module.run_command(cmd)    
+        rc, stdout, stderr = self.module.run_command(cmd)
         if rc != 0:
             self.module.fail_json(msg="Unable to set capabilities of %s" % path, stdout=stdout, stderr=stderr)
         else:
@@ -182,6 +182,9 @@ def main():
 
     sys.exit(0)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/cron
+++ b/library/system/cron
@@ -517,8 +517,11 @@ def main():
     # --- should never get here
     module.exit_json(msg="Unable to execute cron task.")
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -164,7 +164,10 @@ def main():
 
     module.exit_json(changed=changed, msg=msg, current=prev)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/system/facter
+++ b/library/system/facter
@@ -49,8 +49,11 @@ def main():
     rc, out, err = module.run_command(cmd, check_rc=True)
     module.exit_json(**json.loads(out))
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/system/filesystem
+++ b/library/system/filesystem
@@ -114,6 +114,9 @@ def main():
 
     module.exit_json(changed=changed)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/firewalld
+++ b/library/system/firewalld
@@ -128,7 +128,7 @@ def set_port_disabled_permanent(zone, port, protocol):
     fw_settings = fw_zone.getSettings()
     fw_settings.removePort(port, protocol)
     fw_zone.update(fw_settings)
-    
+
 
 ####################
 # service handling
@@ -164,7 +164,7 @@ def set_service_disabled_permanent(zone, service):
     fw_settings = fw_zone.getSettings()
     fw_settings.removeService(service)
     fw_zone.update(fw_settings)
-    
+
 
 ####################
 # rich rule handling
@@ -390,9 +390,12 @@ def main():
     module.exit_json(changed=changed, msg=', '.join(msgs))
 
 
-#################################################
-# import module snippets
-from ansible.module_utils.basic import *
+if __name__ == "__main__":
 
-main()
+
+    #################################################
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/system/getent
+++ b/library/system/getent
@@ -51,7 +51,7 @@ options:
         description:
             - If a supplied key is missing this will make the task fail if True
 
-notes: 
+notes:
    - "Not all databases support enumeration, check system documentation for details"
 requirements: [ ]
 author: Brian Coca
@@ -136,8 +136,11 @@ def main():
 
     module.fail_json(msg=msg)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/system/group
+++ b/library/system/group
@@ -150,7 +150,7 @@ class SunOS(Group):
 
     This overrides the following methods from the generic class:-
         - group_add()
-    """ 
+    """
 
     platform = 'SunOS'
     distribution = None
@@ -398,6 +398,9 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/hostname
+++ b/library/system/hostname
@@ -434,4 +434,7 @@ def main():
 
     module.exit_json(changed=changed, name=name)
 
-main()
+
+if __name__ == "__main__":
+
+    main()

--- a/library/system/kernel_blacklist
+++ b/library/system/kernel_blacklist
@@ -136,6 +136,9 @@ def main():
 
     module.exit_json(**args)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/locale_gen
+++ b/library/system/locale_gen
@@ -55,7 +55,7 @@ def replace_line(existing_line, new_line):
 
 def apply_change(targetState, name, encoding):
     """Create or remove locale.
-    
+
     Keyword arguments:
     targetState -- Desired state, either present or absent.
     name -- Name including encoding such as de_CH.UTF-8.
@@ -67,14 +67,14 @@ def apply_change(targetState, name, encoding):
     else:
         # Delete locale.
         replace_line(name+" "+encoding, "# "+name+" "+encoding)
-    
+
     localeGenExitValue = call("locale-gen")
     if localeGenExitValue!=0:
         raise EnvironmentError(localeGenExitValue, "locale.gen failed to execute, it returned "+str(localeGenExitValue))
 
 def apply_change_ubuntu(targetState, name, encoding):
     """Create or remove locale.
-    
+
     Keyword arguments:
     targetState -- Desired state, either present or absent.
     name -- Name including encoding such as de_CH.UTF-8.
@@ -95,7 +95,7 @@ def apply_change_ubuntu(targetState, name, encoding):
         # Purge locales and regenerate.
         # Please provide a patch if you know how to avoid regenerating the locales to keep!
         localeGenExitValue = call(["locale-gen", "--purge"])
-    
+
     if localeGenExitValue!=0:
         raise EnvironmentError(localeGenExitValue, "locale.gen failed to execute, it returned "+str(localeGenExitValue))
 
@@ -126,10 +126,10 @@ def main():
     else:
         # We found the common way to manage locales.
         ubuntuMode = False
-    
+
     prev_state = "present" if is_present(name) else "absent"
     changed = (prev_state!=state)
-    
+
     if module.check_mode:
         module.exit_json(changed=changed)
     else:
@@ -142,10 +142,13 @@ def main():
                     apply_change_ubuntu(state, name, encoding)
             except EnvironmentError as e:
                 module.fail_json(msg=e.strerror, exitValue=e.errno)
-      
+
         module.exit_json(name=name, changed=changed, msg="OK")
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/system/lvg
+++ b/library/system/lvg
@@ -248,6 +248,9 @@ def main():
 
     module.exit_json(changed=changed)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/lvol
+++ b/library/system/lvol
@@ -229,7 +229,10 @@ def main():
 
     module.exit_json(changed=changed, msg=msg)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/system/modprobe
+++ b/library/system/modprobe
@@ -110,6 +110,9 @@ def main():
 
     module.exit_json(**args)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/mount
+++ b/library/system/mount
@@ -62,7 +62,7 @@ options:
   state:
     description:
       - If C(mounted) or C(unmounted), the device will be actively mounted or unmounted
-        as needed and appropriately configured in I(fstab). 
+        as needed and appropriately configured in I(fstab).
         C(absent) and C(present) only deal with
         I(fstab) but will not affect current mounting. If specifying C(mounted) and the mount
         point is not present, the mount point will be created. Similarly, specifying C(absent)        will remove the mount point directory.
@@ -333,6 +333,9 @@ def main():
     module.fail_json(msg='Unexpected position reached')
     sys.exit(0)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/ohai
+++ b/library/system/ohai
@@ -25,7 +25,7 @@ module: ohai
 short_description: Returns inventory data from I(Ohai)
 description:
      - Similar to the M(facter) module, this runs the I(Ohai) discovery program
-       (U(http://wiki.opscode.com/display/chef/Ohai)) on the remote host and 
+       (U(http://wiki.opscode.com/display/chef/Ohai)) on the remote host and
        returns JSON inventory data.
        I(Ohai) data is a bit more verbose and nested than I(facter).
 version_added: "0.6"
@@ -48,9 +48,12 @@ def main():
     rc, out, err = module.run_command(cmd, check_rc=True)
     module.exit_json(**json.loads(out))
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 
 

--- a/library/system/open_iscsi
+++ b/library/system/open_iscsi
@@ -159,7 +159,7 @@ def target_loggedon(module, target):
 
     cmd = '%s --mode session' % iscsiadm_cmd
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc == 0:
         return target in out
     elif rc == 21:
@@ -186,7 +186,7 @@ def target_login(module, target):
 
     cmd = '%s --mode node --targetname %s --login' % (iscsiadm_cmd, target)
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc > 0:
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 
@@ -195,7 +195,7 @@ def target_logout(module, target):
 
     cmd = '%s --mode node --targetname %s --logout' % (iscsiadm_cmd, target)
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc > 0:
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 
@@ -224,7 +224,7 @@ def target_isauto(module, target):
 
     cmd = '%s --mode node --targetname %s' % (iscsiadm_cmd, target)
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc == 0:
         lines = out.splitlines()
         for line in lines:
@@ -239,7 +239,7 @@ def target_setauto(module, target):
 
     cmd = '%s --mode node --targetname %s --op=update --name node.startup --value automatic' % (iscsiadm_cmd, target)
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc > 0:
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 
@@ -248,7 +248,7 @@ def target_setmanual(module, target):
 
     cmd = '%s --mode node --targetname %s --op=update --name node.startup --value manual' % (iscsiadm_cmd, target)
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc > 0:
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 
@@ -259,7 +259,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
 
-            # target 
+            # target
             portal = dict(required=False, aliases=['ip']),
             port = dict(required=False, default=3260),
             target = dict(required=False, aliases=['name', 'targetname']),
@@ -272,14 +272,14 @@ def main():
             auto_node_startup = dict(type='bool', aliases=['automatic']),
             discover = dict(type='bool', default=False),
             show_nodes = dict(type='bool', default=False)
-        ),  
+        ),
 
         required_together=[['discover_user', 'discover_pass'],
                            ['node_user', 'node_pass']],
         supports_check_mode=True
     )
 
-    global iscsiadm_cmd 
+    global iscsiadm_cmd
     iscsiadm_cmd = module.get_bin_path('iscsiadm', required=True)
 
     # parameters
@@ -295,7 +295,7 @@ def main():
 
     cached = iscsi_get_cached_nodes(module, portal)
 
-    # return json dict 
+    # return json dict
     result = {}
     result['changed'] = False
 
@@ -371,9 +371,12 @@ def main():
     module.exit_json(**result)
 
 
+if __name__ == "__main__":
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/system/ping
+++ b/library/system/ping
@@ -53,7 +53,10 @@ def main():
         result['ping'] = module.params['data']
     module.exit_json(**result)
 
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/system/seboolean
+++ b/library/system/seboolean
@@ -207,6 +207,9 @@ def main():
         module.fail_json(msg="Failed to commit pending boolean %s value" % name)
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/selinux
+++ b/library/system/selinux
@@ -195,9 +195,12 @@ def main():
         configfile=configfile,
         policy=policy, state=state)
 
-#################################################
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    #################################################
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()
 

--- a/library/system/service
+++ b/library/system/service
@@ -1262,5 +1262,8 @@ def main():
 
     module.exit_json(**result)
 
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/setup
+++ b/library/system/setup
@@ -137,10 +137,13 @@ def main():
     data = run_setup(module)
     module.exit_json(**data)
 
-# import module snippets
 
-from ansible.module_utils.basic import *
+if __name__ == "__main__":
 
-from ansible.module_utils.facts import *
+    # import module snippets
 
-main()
+    from ansible.module_utils.basic import *
+
+    from ansible.module_utils.facts import *
+
+    main()

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -100,7 +100,7 @@ import re
 class SysctlModule(object):
 
     def __init__(self, module):
-        self.module = module 
+        self.module = module
         self.args = self.module.params
 
         self.sysctl_cmd = self.module.get_bin_path('sysctl', required=True)
@@ -151,11 +151,11 @@ class SysctlModule(object):
             self.write_file = True
 
         # use the sysctl command or not?
-        if self.args['sysctl_set']:            
+        if self.args['sysctl_set']:
             if self.proc_value is None:
                 self.changed = True
             elif not self._values_is_equal(self.proc_value, self.args['value']):
-                self.changed = True 
+                self.changed = True
                 self.set_proc = True
 
         # Do the work
@@ -196,10 +196,10 @@ class SysctlModule(object):
     #   SYSCTL COMMAND MANAGEMENT
     # ==============================================================
 
-    # Use the sysctl command to find the current value 
+    # Use the sysctl command to find the current value
     def get_token_curr_value(self, token):
         thiscmd = "%s -e -n %s" % (self.sysctl_cmd, token)
-        rc,out,err = self.module.run_command(thiscmd)    
+        rc,out,err = self.module.run_command(thiscmd)
         if rc != 0:
             return None
         else:
@@ -227,10 +227,10 @@ class SysctlModule(object):
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
             if self.args['ignoreerrors']:
                 sysctl_args.insert(1, '-e')
-            
+
             rc,out,err = self.module.run_command(sysctl_args)
 
-        if rc != 0:            
+        if rc != 0:
             self.module.fail_json(msg="Failed to reload sysctl: %s" % str(out) + str(err))
 
     # ==============================================================
@@ -240,7 +240,7 @@ class SysctlModule(object):
     # Get the token value from the sysctl file
     def read_sysctl_file(self):
 
-        lines = []            
+        lines = []
         if os.path.isfile(self.sysctl_file):
             try:
                 f = open(self.sysctl_file, "r")
@@ -255,7 +255,7 @@ class SysctlModule(object):
 
             # don't split empty lines or comments
             if not line or line.startswith("#"):
-                continue 
+                continue
 
             k, v = line.split('=',1)
             k = k.strip()
@@ -270,7 +270,7 @@ class SysctlModule(object):
             if not line.strip() or line.strip().startswith("#"):
                 self.fixed_lines.append(line)
                 continue
-            tmpline = line.strip()            
+            tmpline = line.strip()
             k, v = line.split('=',1)
             k = k.strip()
             v = v.strip()
@@ -279,14 +279,14 @@ class SysctlModule(object):
                 if k == self.args['name']:
                     if self.args['state'] == "present":
                         new_line = "%s = %s\n" % (k, self.args['value'])
-                        self.fixed_lines.append(new_line)                    
+                        self.fixed_lines.append(new_line)
                 else:
                     new_line = "%s = %s\n" % (k, v)
-                    self.fixed_lines.append(new_line)                    
+                    self.fixed_lines.append(new_line)
 
         if self.args['name'] not in checked and self.args['state'] == "present":
             new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
-            self.fixed_lines.append(new_line)                    
+            self.fixed_lines.append(new_line)
 
     # Completely rewrite the sysctl file
     def write_sysctl(self):
@@ -302,7 +302,7 @@ class SysctlModule(object):
         f.close()
 
         # replace the real one
-        self.module.atomic_move(tmp_path, self.sysctl_file) 
+        self.module.atomic_move(tmp_path, self.sysctl_file)
 
 
 # ==============================================================
@@ -324,11 +324,14 @@ def main():
         supports_check_mode=True
     )
 
-    result = SysctlModule(module)    
+    result = SysctlModule(module)
 
     module.exit_json(changed=result.changed)
     sys.exit(0)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/ufw
+++ b/library/system/ufw
@@ -263,7 +263,10 @@ def main():
 
     return module.exit_json(changed=changed, commands=cmds, msg=post_state.rstrip())
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/system/user
+++ b/library/system/user
@@ -95,7 +95,7 @@ options:
         description:
             - Unless set to C(no), a home directory will be made for the user
               when the account is created or if the home directory does not
-              exist. 
+              exist.
     move_home:
         required: false
         default: "no"
@@ -148,7 +148,7 @@ options:
         default: rsa
         version_added: "0.9"
         description:
-            - Optionally specify the type of SSH key to generate. 
+            - Optionally specify the type of SSH key to generate.
               Available SSH key types will depend on implementation
               present on target host.
     ssh_key_file:
@@ -296,8 +296,8 @@ class User(object):
             cmd.append(self.group)
         elif self.group_exists(self.name):
             # use the -N option (no user group) if a group already
-            # exists with the same name as the user to prevent 
-            # errors from useradd trying to create a group when 
+            # exists with the same name as the user to prevent
+            # errors from useradd trying to create a group when
             # USERGROUPS_ENAB is set in /etc/login.defs.
             cmd.append('-N')
 
@@ -526,7 +526,7 @@ class User(object):
         if not os.path.exists(info[5]):
             return (1, '', 'User %s home directory does not exist' % self.name)
         ssh_key_file = self.get_ssh_key_path()
-        ssh_dir = os.path.dirname(ssh_key_file) 
+        ssh_dir = os.path.dirname(ssh_key_file)
         if not os.path.exists(ssh_dir):
             try:
                 os.mkdir(ssh_dir, 0700)
@@ -615,7 +615,7 @@ class User(object):
                     os.chown(os.path.join(root, f), uid, gid)
         except OSError, e:
             self.module.exit_json(failed=True, msg="%s" % e)
-           
+
 
 # ===========================================
 
@@ -704,7 +704,7 @@ class FreeBsdUser(User):
                 self.module.get_bin_path('chpass', True),
                 '-p',
                 self.password,
-                self.name 
+                self.name
             ]
             return self.execute_command(cmd)
 
@@ -715,7 +715,7 @@ class FreeBsdUser(User):
             self.module.get_bin_path('pw', True),
             'usermod',
             '-n',
-            self.name 
+            self.name
         ]
         cmd_len = len(cmd)
         info = self.user_info()
@@ -790,7 +790,7 @@ class FreeBsdUser(User):
                 self.module.get_bin_path('chpass', True),
                 '-p',
                 self.password,
-                self.name 
+                self.name
             ]
             return self.execute_command(cmd)
 
@@ -1121,7 +1121,7 @@ class SunOS(User):
     """
     This is a SunOS User manipulation class - The main difference between
     this class and the generic user class is that Solaris-type distros
-    don't support the concept of a "system" account and we need to 
+    don't support the concept of a "system" account and we need to
     edit the /etc/shadow file manually to set a password. (Ugh)
 
     This overrides the following methods from the generic class:-
@@ -1187,7 +1187,7 @@ class SunOS(User):
             if rc is not None and rc != 0:
                 self.module.fail_json(name=self.name, msg=err, rc=rc)
 
-            # we have to set the password by editing the /etc/shadow file 
+            # we have to set the password by editing the /etc/shadow file
             if self.password is not None:
                 try:
                     lines = []
@@ -1274,7 +1274,7 @@ class SunOS(User):
             else:
                 (rc, out, err) = (None, '', '')
 
-            # we have to set the password by editing the /etc/shadow file 
+            # we have to set the password by editing the /etc/shadow file
             if self.update_password == 'always' and self.password is not None and info[1] != self.password:
                 try:
                     lines = []
@@ -1284,7 +1284,7 @@ class SunOS(User):
                             lines.append(line)
                             continue
                         fields[1] = self.password
-                        fields[2] = str(int(time.time() / 86400))	
+                        fields[2] = str(int(time.time() / 86400))
                         line = ':'.join(fields)
                         lines.append('%s\n' % line)
                     open(self.SHADOWFILE, 'w+').writelines(lines)
@@ -1579,6 +1579,9 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/system/zfs
+++ b/library/system/zfs
@@ -213,7 +213,7 @@ EXAMPLES = '''
 # Create a new file system called myfs in pool rpool
 - zfs: name=rpool/myfs state=present
 
-# Create a new volume called myvol in pool rpool. 
+# Create a new volume called myvol in pool rpool.
 - zfs: name=rpool/myvol state=present volsize=10M
 
 # Create a snapshot of rpool/myfs file system.
@@ -307,7 +307,7 @@ class Zfs(object):
                 if prop in self.immutable_properties:
                     self.module.fail_json(msg='Cannot change property %s after creation.' % prop)
                 else:
-                    self.set_property(prop, value) 
+                    self.set_property(prop, value)
 
     def get_current_properties(self):
         def get_properties_by_name(propname):
@@ -412,6 +412,9 @@ def main():
     result['changed'] = zfs.changed
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/utilities/accelerate
+++ b/library/utilities/accelerate
@@ -55,7 +55,7 @@ options:
     default: false
   multi_key:
     description:
-      - When enabled, the daemon will open a local socket file which can be used by future daemon executions to 
+      - When enabled, the daemon will open a local socket file which can be used by future daemon executions to
         upload a new key to the already running daemon, so that multiple users can connect using different keys.
         This access still requires an ssh connection as the uid for which the daemon is currently running.
     required: false
@@ -105,13 +105,13 @@ from ansible.module_utils.basic import *
 
 syslog.openlog('ansible-%s' % os.path.basename(__file__))
 
-# the chunk size to read and send, assuming mtu 1500 and 
+# the chunk size to read and send, assuming mtu 1500 and
 # leaving room for base64 (+33%) encoding and header (100 bytes)
-# 4 * (975/3) + 100 = 1400 
+# 4 * (975/3) + 100 = 1400
 # which leaves room for the TCP/IP header
 CHUNK_SIZE=10240
 
-# FIXME: this all should be moved to module_common, as it's 
+# FIXME: this all should be moved to module_common, as it's
 #        pretty much a copy from the callbacks/util code
 DEBUG_LEVEL=0
 def log(msg, cap=0):
@@ -143,7 +143,7 @@ SOCKET_FILE = os.path.join(get_module_path(), '.ansible-accelerate', ".local.soc
 
 def get_pid_location(module):
     """
-    Try to find a pid directory in the common locations, falling 
+    Try to find a pid directory in the common locations, falling
     back to the user's home directory if no others exist
     """
     for dir in ['/var/run', '/var/lib/run', '/run', os.path.expanduser("~/")]:
@@ -621,7 +621,7 @@ def daemonize(module, password, port, timeout, minutes, use_ipv6, pid_file):
                 vv("Failed to create the TCP server (tries left = %d) (error: %s) " % (tries,e))
             tries -= 1
             time.sleep(0.2)
-        
+
         if tries == 0:
             vv("Maximum number of attempts to create the TCP server reached, bailing out")
             raise Exception("max # of attempts to serve reached")
@@ -724,4 +724,7 @@ def main():
         # try to start up the daemon
         daemonize(module, password, port, timeout, minutes, ipv6, pid_file)
 
-main()
+
+if __name__ == "__main__":
+
+    main()

--- a/library/utilities/fireball
+++ b/library/utilities/fireball
@@ -49,7 +49,7 @@ author: Michael DeHaan
 '''
 
 EXAMPLES = '''
-# This example playbook has two plays: the first launches 'fireball' mode on all hosts via SSH, and 
+# This example playbook has two plays: the first launches 'fireball' mode on all hosts via SSH, and
 # the second actually starts using it for subsequent management over the fireball connection
 
 - hosts: devservers
@@ -275,6 +275,9 @@ def main():
     daemonize(module, password, port, minutes)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -38,14 +38,14 @@ DOCUMENTATION = '''
 module: wait_for
 short_description: Waits for a condition before continuing.
 description:
-     - Waiting for a port to become available is useful for when services 
-       are not immediately available after their init scripts return - 
-       which is true of certain Java application servers. It is also 
+     - Waiting for a port to become available is useful for when services
+       are not immediately available after their init scripts return -
+       which is true of certain Java application servers. It is also
        useful when starting guests with the M(virt) module and
-       needing to pause until they are ready. 
+       needing to pause until they are ready.
      - This module can also be used to wait for a regex match a string to be present in a file.
-     - In 1.6 and later, this module can 
-       also be used to wait for a file to be available or absent on the 
+     - In 1.6 and later, this module can
+       also be used to wait for a file to be available or absent on the
        filesystem.
      - In 1.8 and later, this module can also be used to wait for active
        connections to be closed before continuing, useful if a node
@@ -118,7 +118,7 @@ EXAMPLES = '''
 - wait_for: path=/tmp/foo search_regex=completed
 
 # wait until the lock file is removed
-- wait_for: path=/var/lock/file.lock state=absent 
+- wait_for: path=/var/lock/file.lock state=absent
 
 # wait until the process is finished and pid was destroyed
 - wait_for: path=/proc/3466/status state=absent
@@ -326,7 +326,7 @@ def main():
         exclude_hosts = params['exclude_hosts'].split(',')
     else:
         exclude_hosts = []
-    
+
     if port and path:
         module.fail_json(msg="port and path parameter can not both be passed to wait_for")
     if path and state == 'stopped':
@@ -335,7 +335,7 @@ def main():
         module.fail_json(msg="state=drained should only be used for checking a port in the wait_for module")
     if exclude_hosts and state != 'drained':
         module.fail_json(msg="exclude_hosts should only be with state=drained")
-        
+
     start = datetime.datetime.now()
 
     if delay:
@@ -457,6 +457,9 @@ def main():
     elapsed = datetime.datetime.now() - start
     module.exit_json(state=state, port=port, search_regex=search_regex, path=path, elapsed=elapsed.seconds)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/web_infrastructure/apache2_module
+++ b/library/web_infrastructure/apache2_module
@@ -84,6 +84,9 @@ def main():
     if module.params['state'] == 'absent':
         _disable_module(module)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -275,7 +275,10 @@ def main():
     module.exit_json(changed=changed, out=out, cmd=cmd, app_path=app_path, virtualenv=virtualenv,
                      settings=module.params['settings'], pythonpath=module.params['pythonpath'])
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()

--- a/library/web_infrastructure/ejabberd_user
+++ b/library/web_infrastructure/ejabberd_user
@@ -209,6 +209,9 @@ def main():
     module.exit_json(**result)
 
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+if __name__ == "__main__":
+
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/web_infrastructure/jboss
+++ b/library/web_infrastructure/jboss
@@ -135,6 +135,9 @@ def main():
 
     module.exit_json(changed=changed)
 
-# import module snippets
-from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+    main()

--- a/library/web_infrastructure/jira
+++ b/library/web_infrastructure/jira
@@ -112,7 +112,7 @@ EXAMPLES = """
 
 - name: Comment on issue
   jira: uri={{server}} username={{user}} password={{pass}}
-        issue={{issue.meta.key}} operation=comment 
+        issue={{issue.meta.key}} operation=comment
         comment="A comment added by Ansible"
 
 # Assign an existing issue using edit
@@ -125,20 +125,20 @@ EXAMPLES = """
 - name: Create an assigned issue
   jira: uri={{server}} username={{user}} password={{pass}}
         project=ANS operation=create
-        summary="Assigned issue" description="Created and assigned using Ansible" 
+        summary="Assigned issue" description="Created and assigned using Ansible"
         issuetype=Task assignee=ssmith
 
 # Edit an issue using free-form fields
 - name: Set the labels on an issue using free-form fields
   jira: uri={{server}} username={{user}} password={{pass}}
-        issue={{issue.meta.key}} operation=edit 
+        issue={{issue.meta.key}} operation=edit
   args: { fields: {labels: ["autocreated", "ansible"]}}
 
 - name: Set the labels on an issue, YAML version
   jira: uri={{server}} username={{user}} password={{pass}}
-        issue={{issue.meta.key}} operation=edit 
-  args: 
-    fields: 
+        issue={{issue.meta.key}} operation=edit
+  args:
+    fields:
       labels:
         - "autocreated"
         - "ansible"
@@ -175,7 +175,7 @@ def request(url, user, passwd, data=None, method=None):
     # inject the basic-auth header up-front to ensure that JIRA treats
     # the requests as authorized for this user.
     auth = base64.encodestring('%s:%s' % (user, passwd)).replace('\n', '')
-    response, info = fetch_url(module, url, data=data, method=method, 
+    response, info = fetch_url(module, url, data=data, method=method,
                                headers={'Content-Type':'application/json',
                                         'Authorization':"Basic %s" % auth})
 
@@ -214,7 +214,7 @@ def create(restbase, user, passwd, params):
 
     url = restbase + '/issue/'
 
-    ret = post(url, user, passwd, data) 
+    ret = post(url, user, passwd, data)
 
     return ret
 
@@ -236,16 +236,16 @@ def edit(restbase, user, passwd, params):
         'fields': params['fields']
         }
 
-    url = restbase + '/issue/' + params['issue']    
+    url = restbase + '/issue/' + params['issue']
 
-    ret = put(url, user, passwd, data) 
+    ret = put(url, user, passwd, data)
 
     return ret
 
 
 def fetch(restbase, user, passwd, params):
     url = restbase + '/issue/' + params['issue']
-    ret = get(url, user, passwd) 
+    ret = get(url, user, passwd)
     return ret
 
 
@@ -327,7 +327,7 @@ def main():
 
     # Dispatch
     try:
-        
+
         # Lookup the corresponding method for this operation. This is
         # safe as the AnsibleModule should remove any unknown operations.
         thismod = sys.modules[__name__]
@@ -342,6 +342,9 @@ def main():
     module.exit_json(changed=True, meta=ret)
 
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-main()
+if __name__ == "__main__":
+
+
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.urls import *
+    main()

--- a/library/web_infrastructure/supervisorctl
+++ b/library/web_infrastructure/supervisorctl
@@ -30,7 +30,7 @@ version_added: "0.7"
 options:
   name:
     description:
-      - The name of the supervisord program or group to manage.  
+      - The name of the supervisord program or group to manage.
       - The name will be taken as group name when it ends with a colon I(:)
       - Group support is only available in Ansible version 1.6 or later.
     required: true
@@ -215,7 +215,10 @@ def main():
     if state == 'stopped':
         take_action_on_processes(processes, lambda s: s == 'RUNNING', 'stop', 'stopped')
 
-# import module snippets
-from ansible.module_utils.basic import *
 
-main()
+if __name__ == "__main__":
+
+    # import module snippets
+    from ansible.module_utils.basic import *
+
+    main()


### PR DESCRIPTION
The way core modules are written, they are not extensible (import and build upon).
Suppose if I want to import ansible file module for reusing existing pieces of "library/files/lineinfile" level functions, currently... the module is like

```
# import module snippets
from ansible.module_utils.basic import *
from ansible.module_utils.splitter import *

main()
```

which will call main() even if it is imported.

This Pull Request modifies, all such module definitions (all python, except one in Powershell for Windows), to be like

```
if __name__ == "__main__":

    # import module snippets
    from ansible.module_utils.basic import *
    from ansible.module_utils.splitter import *

    main()
```

which will make sure, "main()" only runs when it get called as a script and not when it gets imported to be extended.
