### PR TITLE
Default debug message is misleading.

### DIFF
--- a/lib/ansible/runner/action_plugins/debug.py
+++ b/lib/ansible/runner/action_plugins/debug.py
@@ -42,7 +42,7 @@ class ActionModule(object):
         args.update(kv)
 
         if not 'msg' in args and not 'var' in args:
-            args['msg'] = 'Hello world!'
+            args['msg'] = 'No var or msg supplied to debug'
 
         result = {}
         if 'msg' in args:


### PR DESCRIPTION
Printing Hello world can be misleading and to a newbie can imply that you got some kind of test code hanging around. I think a more specific message would be a better way of doing this.
