### PR TITLE
Document vault_password_file in intro_configuration

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -237,6 +237,15 @@ different locations::
 
 Most users will not need to use this feature.  See :doc:`developing_plugins` for more details
 
+.. _force_color:
+
+force_color
+===========
+
+This options forces color mode even when running without a TTY::
+
+    force_color = 1
+
 .. _forks:
 
 forks

--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -548,6 +548,20 @@ different locations::
 
 Most users will not need to use this feature.  See :doc:`developing_plugins` for more details
 
+
+.. _vault_password_file:
+
+vault_password_file
+===================
+
+.. versionadded:: 1.7
+
+Configures the path to the Vault password file as an alternative to specifying ``--vault-password-file`` on the command line::
+
+   vault_password_file = /path/to/vault_password_file
+
+As of 1.7 this file can also be a script. If you are using a script instead of a flat file, ensure that it is marked as executable, and that the password is printed to standard output. If your script needs to prompt for data, prompts can be sent to standard error.
+
 .. _paramiko_settings:
 
 Paramiko Specific Settings


### PR DESCRIPTION
This was omitted in the PR that added `vault_password_file` support to ansible.cfg.
