### PR TITLE
updated git module documentation

### DIFF
--- a/library/source_control/git
+++ b/library/source_control/git
@@ -65,8 +65,7 @@ options:
         default: None
         version_added: "1.5"
         description:
-            - Uses the same wrapper method as ssh_opts to pass 
-              "-i <key_file>" to the ssh arguments used by git
+            - Specify an optional private key file to use for the checkout.
     reference:
         required: false
         default: null


### PR DESCRIPTION
Clarified key_file option for the git module, since it requires the user to specify a private key, not a public key.
