### PR TITLE
Fix bdist_wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from ansible.constants import DEFAULT_MODULE_PATH
 module_paths = DEFAULT_MODULE_PATH.split(os.pathsep)
 # always install in /usr/share/ansible if specified
 # otherwise use the first module path listed
-if '/usr/share/ansible' in module_paths:
+if '/usr/share/ansible' in module_paths or 'bdist_wheel' in sys.argv:
     install_path = '/usr/share/ansible'
 else:
     install_path = module_paths[0]


### PR DESCRIPTION
Without this, I get:

```
$ python setup.py bdist_wheel
...
copying ./library/cloud/azure ->
build/bdist.macosx-10.4-x86_64/wheel/private/tmp/ansible.venv/bin/../share/ansible/cloud
error:
build/bdist.macosx-10.4-x86_64/wheel/private/tmp/ansible.venv/bin/../share/ansible/cloud:
No such file or directory
```
