### PR TITLE
Introduce 'play_hosts_all' next to 'play_hosts'

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -426,6 +426,7 @@ class PlayBook(object):
         )
 
         runner.module_vars.update({'play_hosts': hosts})
+        runner.module_vars.update({'play_hosts_all': task.play._play_hosts_all})
         runner.module_vars.update({'ansible_version': self._ansible_version})
 
         if task.async_seconds == 0:
@@ -653,7 +654,7 @@ class PlayBook(object):
 
         self.callbacks.on_play_start(play.name)
         # Get the hosts for this play
-        play._play_hosts = self.inventory.list_hosts(play.hosts)
+        play._play_hosts_all = play._play_hosts = self.inventory.list_hosts(play.hosts)
         # if no hosts matches this play, drop out
         if not play._play_hosts:
             self.callbacks.on_no_hosts_matched()

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -37,8 +37,8 @@ class Play(object):
        'handlers', 'remote_user', 'remote_port', 'included_roles', 'accelerate',
        'accelerate_port', 'accelerate_ipv6', 'sudo', 'sudo_user', 'transport', 'playbook',
        'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
-       'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts', 'su', 'su_user',
-       'vault_password', 'no_log',
+       'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts_all',
+       '_play_hosts', 'su', 'su_user', 'vault_password', 'no_log',
     ]
 
     # to catch typos and so forth -- these are userland names


### PR DESCRIPTION
`play_hosts` are all (active) hosts in the current serialized play.
`play_hosts_all` (_now_) are all (active) hosts in the full play = all serial batches.

use case: in context of deploying clusters of 2 nodes with `serial: 1`, performing a pre-deploy healtcheck, only if the peer node is part of the (full) play: `when: peer_hostname in play_hosts_all`

`play_hosts` didn't suit, as it only contains the serialized batch in a play.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/9047)

<!-- Reviewable:end -->
