### PR TITLE
[#9048] convert Route53 TTL to integer before comparison

### DIFF
--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -241,7 +241,7 @@ def main():
             record['ttl'] = rset.ttl
             record['value'] = ','.join(sorted(rset.resource_records))
             record['values'] = sorted(rset.resource_records)
-            if value_list == sorted(rset.resource_records) and record['ttl'] == ttl_in and command_in == 'create':
+            if value_list == sorted(rset.resource_records) and int(record['ttl']) == ttl_in and command_in == 'create':
                 module.exit_json(changed=False)
 
     if command_in == 'get':


### PR DESCRIPTION
boto/Route53 are returning TTL as a string.
The route53 module is comparing it with an integer and therfore thinks the DNS entry has always changed.
