### PR TITLE
Update rax root pubkey example

### DIFF
--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -164,8 +164,8 @@ EXAMPLES = '''
         name: rax-test1
         flavor: 5
         image: b11d9567-e412-4255-96b9-bd63ab23bcfe
+        key_name: my_rackspace_key
         files:
-          /root/.ssh/authorized_keys: /home/localuser/.ssh/id_rsa.pub
           /root/test.txt: /home/localuser/test.txt
         wait: yes
         state: present


### PR DESCRIPTION
The example was showing how to use the `files` option to pass in a local file as an authorized public key for root. While this works, it's a bit sloppy, given that there's a specific option, `key_name` which will use one of your public keys on your rackspace account and add it as an authorized key for root. In our case, one of our admins didn't notice the `key_name` option because they scrolled straight to the example and saw the `files` strategy.

I propose that the example still shows `files`, but not using a root public key as an example, and instead also demonstrate the `key_name` option so that it's clear from the example how to get the initial root public key deployed.
