### PR TITLE
minor tweak to documentation of required modules for running tests

### DIFF
--- a/docsite/rst/developing_test_pr.rst
+++ b/docsite/rst/developing_test_pr.rst
@@ -33,7 +33,8 @@ First, you will need to configure your testing environment with the neccessary t
 suites. You will need at least::
 
    git
-   python-nosetests
+   python-nosetests (sometimes named python-nose)
+   python-passlib
 
 Second, if you haven't already, clone the Ansible source code from GitHub::
 


### PR DESCRIPTION
This minor doc change mentions that python-nosetests is sometimes packaged as python-nose. Also mentions python-passlib which is needed to get the tests to pass.
