### PR TITLE
add LANG=C to apt module so the string matches on the output always matc...

### DIFF
--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -148,7 +148,8 @@ import fnmatch
 # APT related constants
 APT_ENV_VARS = dict(
   DEBIAN_FRONTEND = 'noninteractive',
-  DEBIAN_PRIORITY = 'critical'
+  DEBIAN_PRIORITY = 'critical',
+  LANG = 'C'
 )
 
 DPKG_OPTIONS = 'force-confdef,force-confold'


### PR DESCRIPTION
Ansible's apt module is checking the output of the command in order to determine the result. As a result, we need to set the language so that the output can be matched correctly. This change hard codes the value of the LANG environment variable, which is similar to what the "subversion" module does.
