### PR TITLE
'is up to date' is stdout

### DIFF
--- a/library/packaging/cpanm
+++ b/library/packaging/cpanm
@@ -134,7 +134,7 @@ def main():
         if rc_cpanm != 0:
             module.fail_json(msg=err_cpanm, cmd=cmd)
 
-        if err_cpanm and 'is up to date' not in err_cpanm:
+        if out_cpanm and 'is up to date' not in out_cpanm:
             changed = True
 
     module.exit_json(changed=changed, binary=cpanm, name=name)


### PR DESCRIPTION
Left in stderr, as perhaps it's changed among perl/cpanm versions
