### PR TITLE
Allow ansible (ad-hoc) to support --extra-vars

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -120,6 +120,8 @@ class Cli(object):
         if not options.ask_vault_pass and options.vault_password_file:
             vault_pass = utils.read_vault_file(options.vault_password_file)
 
+        extra_vars = utils.parse_extra_vars(options.extra_vars, vault_pass)
+
         inventory_manager = inventory.Inventory(options.inventory, vault_password=vault_pass)
         if options.subset:
             inventory_manager.subset(options.subset)
@@ -168,7 +170,8 @@ class Cli(object):
             su=options.su,
             su_pass=su_pass,
             su_user=options.su_user,
-            vault_pass=vault_pass
+            vault_pass=vault_pass,
+            extra_vars=extra_vars,
         )
 
         if options.seconds:

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -47,7 +47,6 @@ import ansible.utils.template
 from ansible import errors
 from ansible import callbacks
 from ansible import utils
-from ansible.utils import to_unicode
 from ansible.color import ANSIBLE_COLOR, stringc
 from ansible.callbacks import display
 
@@ -84,8 +83,6 @@ def main(args):
     )
     #parser.add_option('--vault-password', dest="vault_password",
     #    help="password for vault encrypted files")
-    parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append",
-        help="set additional variables as key=value or YAML/JSON", default=[])
     parser.add_option('-t', '--tags', dest='tags', default='all',
         help="only run plays and tasks tagged with these values")
     parser.add_option('--skip-tags', dest='skip_tags',
@@ -143,18 +140,7 @@ def main(args):
     if not options.ask_vault_pass and options.vault_password_file:
         vault_pass = utils.read_vault_file(options.vault_password_file)
 
-    extra_vars = {}
-    for extra_vars_opt in options.extra_vars:
-        extra_vars_opt = to_unicode(extra_vars_opt)
-        if extra_vars_opt.startswith(u"@"):
-            # Argument is a YAML file (JSON is a subset of YAML)
-            extra_vars = utils.combine_vars(extra_vars, utils.parse_yaml_from_file(extra_vars_opt[1:], vault_password=vault_pass))
-        elif extra_vars_opt and extra_vars_opt[0] in u'[{':
-            # Arguments as YAML
-            extra_vars = utils.combine_vars(extra_vars, utils.parse_yaml(extra_vars_opt))
-        else:
-            # Arguments as Key-value
-            extra_vars = utils.combine_vars(extra_vars, utils.parse_kv(extra_vars_opt))
+    extra_vars = utils.parse_extra_vars(options.extra_vars, vault_pass)
 
     only_tags = options.tags.split(",")
     skip_tags = options.skip_tags

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -189,6 +189,8 @@ def main(args):
     cmd = 'ansible localhost -i "%s" %s -m %s -a "%s"' % (
             inv_opts, base_opts, options.module_name, repo_opts
             )
+    for ev in options.extra_vars:
+        cmd += ' -e "%s"' % ev
 
     if options.sleep:
         try:

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -978,6 +978,8 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
     parser.add_option('-i', '--inventory-file', dest='inventory',
         help="specify inventory host file (default=%s)" % constants.DEFAULT_HOST_LIST,
         default=constants.DEFAULT_HOST_LIST)
+    parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append",
+        help="set additional variables as key=value or YAML/JSON", default=[])
     parser.add_option('-k', '--ask-pass', default=False, dest='ask_pass', action='store_true',
         help='ask for SSH password')
     parser.add_option('--private-key', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
@@ -1047,6 +1049,21 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
 
 
     return parser
+
+def parse_extra_vars(extra_vars_opts, vault_pass):
+    extra_vars = {}
+    for extra_vars_opt in extra_vars_opts:
+        extra_vars_opt = to_unicode(extra_vars_opt)
+        if extra_vars_opt.startswith(u"@"):
+            # Argument is a YAML file (JSON is a subset of YAML)
+            extra_vars = combine_vars(extra_vars, parse_yaml_from_file(extra_vars_opt[1:], vault_password=vault_pass))
+        elif extra_vars_opt and extra_vars_opt[0] in u'[{':
+            # Arguments as YAML
+            extra_vars = combine_vars(extra_vars, parse_yaml(extra_vars_opt))
+        else:
+            # Arguments as Key-value
+            extra_vars = combine_vars(extra_vars, parse_kv(extra_vars_opt))
+    return extra_vars
 
 def ask_vault_passwords(ask_vault_pass=False, ask_new_vault_pass=False, confirm_vault=False, confirm_new=False):
 


### PR DESCRIPTION
Currently the `ansible` command does not allow the use of `--extra-vars`.  This has been a frequent request in IRC recently.  I see no technical reasons why this wasn't included.

This PR adds `--extra-vars` support to the `ansible` command and moves the `--extra-vars` option to `ansible.utils.base_parser` and moves the now common `extra_vars` parsing into `ansible.utils.parse_extra_args`

A common use case is to override `ansible_python_interpreter`.
