### PR TITLE
Recommend use of 'key: value' syntax instead of content= and key=

### DIFF
--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -154,10 +154,12 @@ It might happen like so::
     - user: name={{ item.name }} state=present generate_ssh_key=yes
       with_items: users
 
-    - authorized_key: "user={{ item.0.name }} key='{{ lookup('file', item.1) }}'"
+    - authorized_key:
+        user: "{{ item.0.name }}"
+        key: "{{ lookup('file', item.1) }}"
       with_subelements:
-         - users
-         - authorized
+        - users
+        - authorized
 
 Subelements walks a list of hashes (aka dictionaries) and then traverses a list with a given key inside of those
 records.

--- a/library/files/copy
+++ b/library/files/copy
@@ -42,7 +42,10 @@ options:
   content:
     version_added: "1.1"
     description:
-      - When used instead of 'src', sets the contents of a file directly to the specified value.
+      - When used instead of 'src', sets the contents of a file directly
+        to the specified value. The use of "key: value" syntax is
+        recommended if the specified content contains quotes or
+        newlines.
     required: false
     default: null
   dest:

--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -37,7 +37,9 @@ options:
     aliases: []
   key:
     description:
-      - The SSH public key, as a string
+      - The SSH public key, as a string (the use of "key: value" syntax
+        is recommended because authorized_keys entries may contain
+        quotes in key options; see examples below).
     required: true
     default: null
   path:
@@ -77,26 +79,31 @@ author: Brad Olson
 
 EXAMPLES = '''
 # Example using key data from a local file on the management machine
-- authorized_key: user=charlie key="{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
+- authorized_key:
+    user: charlie
+    key: "{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
 
 # Using alternate directory locations:
-- authorized_key: user=charlie
-                  key="{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
-                  path='/etc/ssh/authorized_keys/charlie'
-                  manage_dir=no
+- authorized_key:
+    user: charlie
+    key: "{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
+    path: '/etc/ssh/authorized_keys/charlie'
+    manage_dir: no
 
 # Using with_file
 - name: Set up authorized_keys for the deploy user
-  authorized_key: user=deploy
-                  key="{{ item }}"
+  authorized_key:
+    user: deploy
+    key: "{{ item }}"
   with_file:
     - public_keys/doe-jane
     - public_keys/doe-john
 
 # Using key_options:
-- authorized_key: user=charlie
-                  key="{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
-                  key_options='no-port-forwarding,host="10.0.1.1"'
+- authorized_key:
+    user: charlie
+    key: "{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
+    key_options: 'no-port-forwarding,host="10.0.1.1"'
 '''
 
 # Makes sure the public key line is present or absent in the user's .ssh/authorized_keys.


### PR DESCRIPTION
Using key="{{ value }}" syntax with copy's content parameter and authorized_key's key parameter can cause problems when the value contains quotes or newlines. This is especially noticeable when a lookup('file', …) returns a key with quoted key options (issue #6294). There have also been multiple regressions in this area between 1.6.8, 1.6.9, and devel.

The use of "key: value" syntax makes all these problems go away, so this commit recommends this form in the examples for the respective modules. (I feel a more general warning and guidance about when to use key=val and when to use key: val is also needed, but I'll leave it to the maintainers to determine a place for it.)
