### PR TITLE
Set selinux state to 'permissive' for state=disabled

### DIFF
--- a/library/system/selinux
+++ b/library/system/selinux
@@ -174,14 +174,19 @@ def main():
     if (state != runtime_state):
         if module.check_mode:
             module.exit_json(changed=True)
-        if (state == 'disabled'):
-            msgs.append('state change will take effect next reboot')
-        else:
-            if (runtime_enabled):
+        if (runtime_enabled):
+            if (state == 'disabled'):
+                if (runtime_state != 'permissive'):
+                    # Temporarily set state to permissive
+                    set_state('permissive')
+                    msgs.append('runtime state temporarily changed from \'%s\' to \'permissive\', state change will take effect next reboot' % (runtime_state))
+                else:
+                    msgs.append('state change will take effect next reboot')
+            else:
                 set_state(state)
                 msgs.append('runtime state changed from \'%s\' to \'%s\'' % (runtime_state, state))
-            else:
-                msgs.append('state change will take effect next reboot')
+        else:
+            msgs.append('state change will take effect next reboot')
         changed=True
 
     if (state != config_state):


### PR DESCRIPTION
As discussed in https://groups.google.com/forum/#!topic/ansible-devel/uVGldwJUBUQ

A task `- selinux state=disabled` just configures the configuration file to `disabled`, but leaves the current state of SELinux untouched (which is `enforcing` by default), so this task is basically useless until the reboot. This pull request besides disabling SELinux in the config file sets it to `permissive`, so that we can finish a playbook without a need of a reboot in the middle.
