### PR TITLE
Ec2 asg vpc zone identifier list

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -129,7 +129,9 @@ A basic example of configuration:
     min_size: 1
     max_size: 10
     desired_capacity: 5
-    vpc_zone_identifier: 'subnet-abcd1234,subnet-1a2b3c4d'
+    vpc_zone_identifier:
+      - subnet-abcd1234
+      - subnet-1a2b3c4d
     tags:
       - environment: production
         propagate_at_launch: no

--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -567,7 +567,7 @@ def main():
             min_size=dict(type='int'),
             max_size=dict(type='int'),
             desired_capacity=dict(type='int'),
-            vpc_zone_identifier=dict(type='str'),
+            vpc_zone_identifier=dict(type='list'),
             replace_batch_size=dict(type='int', default=1),
             replace_all_instances=dict(type='bool', default=False),
             replace_instances=dict(type='list', default=[]),


### PR DESCRIPTION
I've changed the type for vpc_zone_identifier from 'str' to 'list' as this makes more sense and is more consistent. I've also changed the example. 

Before:

``` yaml
 vpc_zone_identifier: 'subnet-abcd1234,subnet-1a2b3c4d'
```

Now:

``` yaml
vpc_zone_identifier:
      - subnet-abcd1234
      - subnet-1a2b3c4d
```

This change may not be backwards compatible; however IMO making ansible syntax more consistent is a win for everyone. 
