### PR TITLE
added django_manage: syncdb --all; migrate --fake

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -75,6 +75,20 @@ options:
      - Will skip over out-of-order missing migrations, you can only use this parameter with I(migrate)
     required: false
     version_added: "1.3"
+  fake:
+    description:
+     - Will fake all migrations in database, you can only use this parameter with I(migrate).
+    required: false
+    version_added: "1.7.2"
+    default: "no"
+    choices: [ "yes", "no" ]
+  all:
+    description:
+     - Will sync all applications in database, you can only use this parameter with I(syncdb).
+    required: false
+    version_added: "1.7.2"
+    default: "no"
+    choices: [ "yes", "no" ]
   merge:
     description:
      - Will run out-of-order or missing migrations as they are not rollback migrations, you can only use this parameter with 'migrate' command
@@ -167,10 +181,10 @@ def main():
         createcachetable=('cache_table', 'database', ),
         flush=('database', ),
         loaddata=('database', 'fixtures', ),
-        syncdb=('database', ),
+        syncdb=('database', 'all'),
         test=('failfast', 'testrunner', 'liveserver', 'apps', ),
         validate=(),
-        migrate=('apps', 'skip', 'merge'),
+        migrate=('apps', 'skip', 'merge', 'fake'),
         collectstatic=('link', ),
         )
 
@@ -193,7 +207,8 @@ def main():
 
     # These params are automatically added to the command if present
     general_params = ('settings', 'pythonpath', 'database',)
-    specific_boolean_params = ('failfast', 'skip', 'merge', 'link')
+    specific_boolean_params = ('failfast', 'skip', 'merge', 'link', 'all',
+                               'fake')
     end_of_command_params = ('apps', 'cache_table', 'fixtures')
 
     module = AnsibleModule(
@@ -214,6 +229,8 @@ def main():
             skip        = dict(default=None, required=False, type='bool'),
             merge       = dict(default=None, required=False, type='bool'),
             link        = dict(default=None, required=False, type='bool'),
+            all         = dict(default=None, required=False, type='bool'),
+            fake        = dict(default=None, required=False, type='bool'),
         ),
     )
 


### PR DESCRIPTION
it is quite common to initialize deployments with syncdb --all and migrate --fake
