### PR TITLE
Fix behavior when insert* doesn't match anything

### DIFF
--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -253,9 +253,9 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
         msg = 'line added'
         changed = True
     # Add it to the end of the file if requested or
-    # if insertafter=/insertbefore didn't match anything
+    # if insertafter/insertbefore didn't match anything
     # (so default behaviour is to add at the end)
-    elif insertafter == 'EOF':
+    elif insertafter == 'EOF' or index[1] == -1:
 
         # If the file is not empty then ensure there's a newline before the added line
         if len(lines)>0 and not (lines[-1].endswith('\n') or lines[-1].endswith('\r')):
@@ -264,9 +264,6 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
         lines.append(line + os.linesep)
         msg = 'line added'
         changed = True
-    # Do nothing if insert* didn't match
-    elif index[1] == -1:
-        pass
     # insert* matched, but not the regexp
     else:
         lines.insert(index[1], line + os.linesep)


### PR DESCRIPTION
If insertbefore/insertafter didn't match anything, lineinfile was doing nothing instead of adding the line at EOF as expected.
