### PR TITLE
Make file module work on python 2.4, fix #9080

### DIFF
--- a/library/files/file
+++ b/library/files/file
@@ -339,7 +339,7 @@ def main():
                 module.fail_json(msg='Cannot touch other than files and directories')
             try:
                 module.set_fs_attributes_if_different(file_args, True)
-            except SystemExit as e:
+            except SystemExit, e:
                 if e.code:
                     # We take this to mean that fail_json() was called from
                     # somewhere in basic.py


### PR DESCRIPTION
Python 2.4 do not support "except ... as ..." construct, so
revert back to the older syntax.
