### PR TITLE
Add a new format for URL in module documentation and improve doc

### DIFF
--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -55,7 +55,7 @@ EXAMPLE_YAML=os.path.abspath(os.path.join(
 _ITALIC = re.compile(r"I\(([^)]+)\)")
 _BOLD   = re.compile(r"B\(([^)]+)\)")
 _MODULE = re.compile(r"M\(([^)]+)\)")
-_URL    = re.compile(r"U\(([^)]+)\)")
+_URL    = re.compile(r"U\(([^)]+)\|([^)]+)\)")
 _CONST  = re.compile(r"C\(([^)]+)\)")
 
 #####################################################################################
@@ -66,7 +66,7 @@ def rst_ify(text):
     t = _ITALIC.sub(r'*' + r"\1" + r"*", text)
     t = _BOLD.sub(r'**' + r"\1" + r"**", t)
     t = _MODULE.sub(r'``' + r"\1" + r"``", t)
-    t = _URL.sub(r"\1", t)
+    t = _URL.sub(r'`' + r"\2 " +  r"<\1>" + r"`_", t)
     t = _CONST.sub(r'``' + r"\1" + r"``", t)
 
     return t
@@ -80,7 +80,7 @@ def html_ify(text):
     t = _ITALIC.sub("<em>" + r"\1" + "</em>", t)
     t = _BOLD.sub("<b>" + r"\1" + "</b>", t)
     t = _MODULE.sub("<span class='module'>" + r"\1" + "</span>", t)
-    t = _URL.sub("<a href='" + r"\1" + "'>" + r"\1" + "</a>", t)
+    t = _URL.sub("<a href='" + r"\1" + "'>" + r"\2" + "</a>", t)
     t = _CONST.sub("<code>" + r"\1" + "</code>", t)
 
     return t

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -30,7 +30,7 @@ options:
     aliases: ['keypair']
   id:
     description:
-      - identifier for this instance or set of instances, so that the module will be idempotent with respect to EC2 instances. This identifier is valid for at least 24 hours after the termination of the instance, and should not be reused for another call later on. For details, see the description of client token at U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html).
+      - identifier for this instance or set of instances, so that the module will be idempotent with respect to EC2 instances. This identifier is valid for at least 24 hours after the termination of the instance, and should not be reused for another call later on. For details, see the U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html|description of client token).
     required: false
     default: null
     aliases: []
@@ -203,7 +203,7 @@ options:
   ebs_optimized:
     version_added: "1.6"
     description:
-      - whether instance is using optimized EBS volumes, see U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html)
+      - whether instance is using optimized EBS volumes, see U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html|the documentation)
     required: false
     default: false
   exact_count:

--- a/library/cloud/gc_storage
+++ b/library/cloud/gc_storage
@@ -20,7 +20,7 @@ module: gc_storage
 version_added: "1.4"
 short_description: This module manages objects/buckets in Google Cloud Storage. 
 description:
-    - This module allows users to manage their objects/buckets in Google Cloud Storage.  It allows upload and download operations and can set some canned permissions. It also allows retrieval of URLs for objects for use in playbooks, and retrieval of string contents of objects.  This module requires setting the default project in GCS prior to playbook usage.  See U(https://developers.google.com/storage/docs/reference/v1/apiversion1) for information about setting the default project.
+    - This module allows users to manage their objects/buckets in Google Cloud Storage.  It allows upload and download operations and can set some canned permissions. It also allows retrieval of URLs for objects for use in playbooks, and retrieval of string contents of objects.  This module requires setting the default project in GCS prior to playbook usage.  See U(https://developers.google.com/storage/docs/reference/v1/apiversion1|the documentation) for information about setting the default project.
 
 options:
   bucket:

--- a/library/cloud/gce
+++ b/library/cloud/gce
@@ -23,7 +23,7 @@ version_added: "1.4"
 short_description: create or terminate GCE instances
 description:
      - Creates or terminates Google Compute Engine (GCE) instances.  See
-       U(https://cloud.google.com/products/compute-engine) for an overview.
+       U(https://cloud.google.com/products/compute-engine|here) for an overview.
        Full install/configuration instructions for the gce* modules can
        be found in the comments of ansible/test/gce_tests.py.
 options:

--- a/library/cloud/gce_lb
+++ b/library/cloud/gce_lb
@@ -26,9 +26,8 @@ description:
       and C(httphealthcheck) resources.  The primary LB resource is the
       C(load_balancer) resource and the health check parameters are all
       prefixed with I(httphealthcheck).
-      The full documentation for Google Compute Engine load balancing is at
-      U(https://developers.google.com/compute/docs/load-balancing/).  However,
-      the ansible module simplifies the configuration by following the
+      The full documentation is on U(https://developers.google.com/compute/docs/load-balancing/|Google Compute Engine load balancing).
+      However, the ansible module simplifies the configuration by following the
       libcloud model.
       Full install/configuration instructions for the gce* modules can
       be found in the comments of ansible/test/gce_tests.py.

--- a/library/cloud/gce_net
+++ b/library/cloud/gce_net
@@ -22,12 +22,12 @@ module: gce_net
 version_added: "1.5"
 short_description: create/destroy GCE networks and firewall rules
 description:
-    - This module can create and destroy Google Compue Engine networks and
-      firewall rules U(https://developers.google.com/compute/docs/networking).
+    - This module can create and destroy Google Compute Engine
+      U(https://developers.google.com/compute/docs/networking|networks and firewall rules).
       The I(name) parameter is reserved for referencing a network while the
       I(fwname) parameter is used to reference firewall rules.
-      IPv4 Address ranges must be specified using the CIDR
-      U(http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) format.
+      IPv4 Address ranges must be specified using the
+      U(http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing|CIDR format).
       Full install/configuration instructions for the gce* modules can
       be found in the comments of ansible/test/gce_tests.py.
 options:

--- a/library/cloud/gce_pd
+++ b/library/cloud/gce_pd
@@ -22,8 +22,8 @@ module: gce_pd
 version_added: "1.4"
 short_description: utilize GCE persistent disk resources
 description:
-    - This module can create and destroy unformatted GCE persistent disks
-      U(https://developers.google.com/compute/docs/disks#persistentdisks).
+    - This module can create and destroy unformatted
+      U(https://developers.google.com/compute/docs/disks#persistentdisks|GCE persistent disks).
       It also supports attaching and detaching disks from running instances.
       Full install/configuration instructions for the gce* modules can
       be found in the comments of ansible/test/gce_tests.py.

--- a/library/files/assemble
+++ b/library/files/assemble
@@ -75,8 +75,7 @@ options:
     description:
       - Assemble files only if C(regex) matches the filename. If not set,
         all files are assembled. All "\\" (backslash) must be escaped as
-        "\\\\" to comply yaml syntax. Uses Python regular expressions; see
-        U(http://docs.python.org/2/library/re.html).
+        "\\\\" to comply yaml syntax. Uses U(http://docs.python.org/2/library/re.html|Python regular expressions).
     required: false
     default: null
 author: Stephen Fromm

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -48,8 +48,7 @@ options:
       - The regular expression to look for in every line of the file. For
         C(state=present), the pattern to replace if found; only the last line
         found will be replaced. For C(state=absent), the pattern of the line
-        to remove.  Uses Python regular expressions; see
-        U(http://docs.python.org/2/library/re.html).
+        to remove.  Uses U(http://docs.python.org/2/library/re.html|Python regular expressions).
   state:
     required: false
     choices: [ present, absent ]

--- a/library/files/replace
+++ b/library/files/replace
@@ -43,8 +43,7 @@ options:
     required: true
     description:
       - The regular expression to look for in the contents of the file.
-        Uses Python regular expressions; see
-        U(http://docs.python.org/2/library/re.html).
+        Uses U(http://docs.python.org/2/library/re.html|Python regular expressions).
         Uses multiline mode, which means C(^) and C($) match the beginning
         and end respectively of I(each line) of the file.
   replace:

--- a/library/files/template
+++ b/library/files/template
@@ -6,10 +6,9 @@ module: template
 version_added: historical
 short_description: Templates a file out to a remote server.
 description:
-     - Templates are processed by the Jinja2 templating language
-       (U(http://jinja.pocoo.org/docs/)) - documentation on the template
-       formatting can be found in the Template Designer Documentation
-       (U(http://jinja.pocoo.org/docs/templates/)).
+     - Templates are processed by the U(http://jinja.pocoo.org/docs/|Jinja2 templating language) -
+       documentation on the template formatting can be found in the
+       U(http://jinja.pocoo.org/docs/templates/|Template Designer Documentation).
      - "Six additional variables can be used in templates: C(ansible_managed) 
        (configurable via the C(defaults) section of C(ansible.cfg)) contains a string
        which can be used to describe the template name, host, modification time of the

--- a/library/internal/async_status
+++ b/library/internal/async_status
@@ -41,7 +41,7 @@ options:
     choices: [ "status", "cleanup" ]
     default: "status"
 notes:
-    - See also U(http://docs.ansible.com/playbooks_async.html)
+    - See also U(http://docs.ansible.com/playbooks_async.html|http://docs.ansible.com/playbooks_async.html)
 requirements: []
 author: Michael DeHaan
 '''

--- a/library/net_infrastructure/dnsimple
+++ b/library/net_infrastructure/dnsimple
@@ -20,7 +20,7 @@ module: dnsimple
 version_added: "1.6"
 short_description: Interface with dnsimple.com (a DNS hosting service).
 description:
-   - "Manages domains and records via the DNSimple API, see the docs: U(http://developer.dnsimple.com/)"
+   - "Manages domains and records via the DNSimple API, see the U(http://developer.dnsimple.com/|docs)"
 options:
   account_email:
     description:

--- a/library/net_infrastructure/dnsmadeeasy
+++ b/library/net_infrastructure/dnsmadeeasy
@@ -20,7 +20,7 @@ module: dnsmadeeasy
 version_added: "1.3"
 short_description: Interface with dnsmadeeasy.com (a DNS hosting service).
 description:
-   - "Manages DNS records via the v2 REST API of the DNS Made Easy service.  It handles records only; there is no manipulation of domains or monitor/account support yet. See: U(http://www.dnsmadeeasy.com/services/rest-api/)"
+   - "Manages DNS records via the v2 REST API of the DNS Made Easy service.  It handles records only; there is no manipulation of domains or monitor/account support yet. See the U(http://www.dnsmadeeasy.com/services/rest-api/|REST API)"
 options:
   account_key:
     description:

--- a/library/notification/mqtt
+++ b/library/notification/mqtt
@@ -79,8 +79,8 @@ options:
 # informational: requirements for nodes
 requirements: [ mosquitto ]
 notes:
- - This module requires a connection to an MQTT broker such as Mosquitto
-   U(http://mosquitto.org) and the I(Paho) C(mqtt) Python client (U(https://pypi.python.org/pypi/paho-mqtt)).
+ - This module requires a connection to an MQTT broker such as
+   U(http://mosquitto.org|Mosquitto) and the U(https://pypi.python.org/pypi/paho-mqtt|Paho mqtt python client).
 author: Jan-Piet Mens
 '''
 

--- a/library/notification/slack
+++ b/library/notification/slack
@@ -22,7 +22,7 @@ DOCUMENTATION = """
 module: slack
 short_description: Send Slack notifications
 description:
-    - The M(slack) module sends notifications to U(http://slack.com) via the Incoming WebHook integration
+    - The M(slack) module sends notifications to U(http://slack.com|slack.com) via the Incoming WebHook integration
 version_added: 1.6
 author: Ramon de la Fuente <ramon@delafuente.nl>
 options:

--- a/library/packaging/cpanm
+++ b/library/packaging/cpanm
@@ -57,7 +57,7 @@ examples:
    - code: "cpanm: name=Dancer"
      description: Install I(Dancer) perl package.
    - code: "cpanm: name=Dancer locallib=/srv/webapps/my_app/extlib"
-     description: "Install I(Dancer) (U(http://perldancer.org/)) into the specified I(locallib)"
+     description: "Install U(http://perldancer.org/|Dancer) into the specified I(locallib)"
    - code: "cpanm: from_path=/srv/webapps/my_app/src/"
      description: Install perl dependencies from local directory.
    - code: "cpanm: name=Dancer notest=True locallib=/srv/webapps/my_app/extlib"
@@ -65,7 +65,7 @@ examples:
    - code: "cpanm: name=Dancer mirror=http://cpan.cpantesters.org/"
      description: Install I(Dancer) perl package from a specific mirror
 notes:
-   - Please note that U(http://search.cpan.org/dist/App-cpanminus/bin/cpanm, cpanm) must be installed on the remote host.
+   - Please note that U(http://search.cpan.org/dist/App-cpanminus/bin/cpanm|cpanm) must be installed on the remote host.
 author: Franck Cuny
 '''
 

--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -98,7 +98,7 @@ options:
     required: false
     default: null
 notes:
-   - Please note that virtualenv (U(http://www.virtualenv.org/)) must be installed on the remote host if the virtualenv parameter is specified.
+   - Please note that U(http://www.virtualenv.org/|virtualenv) must be installed on the remote host if the virtualenv parameter is specified.
 requirements: [ "virtualenv", "pip" ]
 author: Matt Wright
 '''

--- a/library/system/facter
+++ b/library/system/facter
@@ -25,8 +25,8 @@ DOCUMENTATION = '''
 module: facter
 short_description: Runs the discovery program I(facter) on the remote system
 description:
-     - Runs the I(facter) discovery program
-       (U(https://github.com/puppetlabs/facter)) on the remote system, returning
+     - Runs the U(https://github.com/puppetlabs/facter|facter) discovery program
+       on the remote system, returning
        JSON data that can be useful for inventory purposes.
 version_added: "0.2"
 options: {}

--- a/library/system/ohai
+++ b/library/system/ohai
@@ -24,8 +24,8 @@ DOCUMENTATION = '''
 module: ohai
 short_description: Returns inventory data from I(Ohai)
 description:
-     - Similar to the M(facter) module, this runs the I(Ohai) discovery program
-       (U(http://wiki.opscode.com/display/chef/Ohai)) on the remote host and 
+     - Similar to the M(facter) module, this runs the U(http://wiki.opscode.com/display/chef/Ohai|Ohai)
+       discovery program on the remote host and
        returns JSON inventory data.
        I(Ohai) data is a bit more verbose and nested than I(facter).
 version_added: "0.6"

--- a/library/system/user
+++ b/library/system/user
@@ -79,7 +79,7 @@ options:
         description:
             - Optionally set the user's password to this crypted value.  See
               the user example in the github examples directory for what this looks
-              like in a playbook. The `FAQ <http://docs.ansible.com/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module>`_
+              like in a playbook. The U(http://docs.ansible.com/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module|FAQ)
               contains details on various ways to generate these password values.
     state:
         required: false

--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -86,7 +86,7 @@ options:
     required: false
     version_added: "1.3"
 notes:
-   - I(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the virtualenv parameter is specified.
+   - U(http://www.virtualenv.org|virtualenv) must be installed on the remote host if the virtualenv parameter is specified.
    - This module will create a virtualenv if the virtualenv parameter is specified and a virtualenv does not already exist at the given location.
    - This module assumes English error messages for the 'createcachetable' command to detect table existence, unfortunately.
    - To be able to use the migrate command, you must have south installed and added as an app in your settings


### PR DESCRIPTION
Theses 2 commits add a new way to format URL in modules inline documentation that permit to give a test along the URL, resulting in a more readable documentation.

For example, before, we had:
    `U(http://example.com)`
resulting in:
    `<a href="http://example.com/">http://example.com</a>`

 after the patch, it would be: 
    `U(http://example.com|Example)`
resulting in:
    `<a href="http://example.com/">Example</a>`
