### PR TITLE
Support for django_manage collectstatic 'clear' boolean flag

### DIFF
--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -80,6 +80,11 @@ options:
      - Will run out-of-order or missing migrations as they are not rollback migrations, you can only use this parameter with 'migrate' command
     required: false
     version_added: "1.3"
+  clear:
+    description:
+     - Will clear any existing files/links in target directory before copying over origianl files. you can only use this parameter with 'collectstatic' command
+    required: false
+    version_added: "1.8"
   link:
     description:
      - Will create links to the files instead of copying them, you can only use this parameter with 'collectstatic' command
@@ -171,7 +176,7 @@ def main():
         test=('failfast', 'testrunner', 'liveserver', 'apps', ),
         validate=(),
         migrate=('apps', 'skip', 'merge'),
-        collectstatic=('link', ),
+        collectstatic=('clear', 'link', ),
         )
 
     command_required_param_map = dict(
@@ -189,11 +194,11 @@ def main():
         )
 
     # These params are allowed for certain commands only
-    specific_params = ('apps', 'database', 'failfast', 'fixtures', 'liveserver', 'testrunner')
+    specific_params = ('apps', 'clear', 'database', 'failfast', 'fixtures', 'liveserver', 'testrunner')
 
     # These params are automatically added to the command if present
     general_params = ('settings', 'pythonpath', 'database',)
-    specific_boolean_params = ('failfast', 'skip', 'merge', 'link')
+    specific_boolean_params = ('clear', 'failfast', 'skip', 'merge', 'link')
     end_of_command_params = ('apps', 'cache_table', 'fixtures')
 
     module = AnsibleModule(
@@ -206,6 +211,7 @@ def main():
 
             apps        = dict(default=None, required=False),
             cache_table = dict(default=None, required=False),
+            clear       = dict(default=None, required=False, type='bool'),
             database    = dict(default=None, required=False),
             failfast    = dict(default='no', required=False, type='bool', aliases=['fail_fast']),
             fixtures    = dict(default=None, required=False),


### PR DESCRIPTION
Hey,
Small patch - added support for the --clear flag on Django's collectstatic command, which is pretty useful to have. This flag clears out any existing files/links in target directory before copying over static files, essentially supporting an overwrite functionality.
