### PR TITLE
Docker: Add insecure registry support

### DIFF
--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -210,6 +210,12 @@ options:
     required: false
     default: false
     aliases: []
+  restart_policy:
+    description:
+      - Set container restart policy
+    required: false
+    default: ''
+    aliases: []
 
 author: Cove Schneider, Joshua Conner, Pavel Antonov
 requirements: [ "docker-py >= 0.3.0", "docker >= 0.10.0" ]
@@ -665,6 +671,7 @@ class DockerManager:
             'privileged':   self.module.params.get('privileged'),
             'links': self.links,
             'network_mode': self.module.params.get('net'),
+            'restart_policy': { "name": self.module.params.get('restart_policy') },
         }
         if docker.utils.compare_version('1.10', self.client.version()['ApiVersion']) >= 0 and hasattr(docker, '__version__') and docker.__version__ > '0.3.0':
             params['dns'] = self.module.params.get('dns')
@@ -754,7 +761,8 @@ def main():
             lxc_conf        = dict(default=None, type='list'),
             name            = dict(default=None),
             net             = dict(default=None),
-            pull_latest     = dict(default=False, type='bool')
+            pull_latest     = dict(default=False, type='bool'),
+            restart_policy  = dict(default=None)
         )
     )
 

--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -216,6 +216,12 @@ options:
     required: false
     default: ''
     aliases: []
+  insecure_registry:
+    description:
+      - Allow pulling from plain HTTP registries
+    required: false
+    default: false
+    aliases: []
 
 author: Cove Schneider, Joshua Conner, Pavel Antonov
 requirements: [ "docker-py >= 0.3.0", "docker >= 0.10.0" ]
@@ -638,15 +644,15 @@ class DockerManager:
                         self.module.params.get('username'),
                         password=self.module.params.get('password'),
                         email=self.module.params.get('email'),
-                        registry=self.module.params.get('registry')
+                        registry=self.module.params.get('registry'),
                     )
                 except:
                     self.module.fail_json(msg="failed to login to the remote registry, check your username/password.")
             try:
-                self.client.pull(resource, tag=tag)
+                self.client.pull(resource, tag=tag, insecure_registry=self.module.params.get('insecure_registry'))
                 self.increment_counter('pull')
-            except:
-                self.module.fail_json(msg="failed to pull the specified image: %s" % resource)
+            except Exception as e:
+                self.module.fail_json(msg="failed to pull the specified image: %s, error: %s" % (resource, e))
 
         resource = self.module.params.get('image')
         image, tag = self.get_split_image_tag(resource)
@@ -762,7 +768,8 @@ def main():
             name            = dict(default=None),
             net             = dict(default=None),
             pull_latest     = dict(default=False, type='bool'),
-            restart_policy  = dict(default=None)
+            restart_policy  = dict(default=None),
+            insecure_registry = dict(default=False, type='bool')
         )
     )
 

--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -204,6 +204,12 @@ options:
     default: ''
     aliases: []
     version_added: "1.8"
+  pull_latest:
+    description:
+      - Pull the latest image before running a container
+    required: false
+    default: false
+    aliases: []
 
 author: Cove Schneider, Joshua Conner, Pavel Antonov
 requirements: [ "docker-py >= 0.3.0", "docker >= 0.10.0" ]
@@ -619,11 +625,7 @@ class DockerManager:
 
             return results
 
-        try:
-            containers = do_create(count, params)
-        except:
-            resource = self.module.params.get('image')
-            image, tag = self.get_split_image_tag(resource)
+        def do_pull(resource, tag):
             if self.module.params.get('username'):
                 try:
                     self.client.login(
@@ -635,11 +637,22 @@ class DockerManager:
                 except:
                     self.module.fail_json(msg="failed to login to the remote registry, check your username/password.")
             try:
-                self.client.pull(image, tag=tag)
+                self.client.pull(resource, tag=tag)
+                self.increment_counter('pull')
             except:
                 self.module.fail_json(msg="failed to pull the specified image: %s" % resource)
-            self.increment_counter('pull')
+
+        resource = self.module.params.get('image')
+        image, tag = self.get_split_image_tag(resource)
+        if self.module.params.get('pull_latest'):
+            do_pull(resource, tag)
+
+        try:
             containers = do_create(count, params)
+        except:
+            if not self.module.params.get('pull_latest'):
+                do_pull(resource, tag)
+                containers = do_create(count, params)
 
         return containers
 
@@ -740,7 +753,8 @@ def main():
             tty             = dict(default=False, type='bool'),
             lxc_conf        = dict(default=None, type='list'),
             name            = dict(default=None),
-            net             = dict(default=None)
+            net             = dict(default=None),
+            pull_latest     = dict(default=False, type='bool')
         )
     )
 


### PR DESCRIPTION
For security reasons, docker-py will only fetch images from HTTPS, not plain HTTP
based registries.

This change adds a insecure_registry flag to the docker module to allow
it to fetch images also via insecure HTTP.

For (my) convenience, this branch also includes my other PRs:
- #8815 
- #8805 

Let me know if you want branches with only those commits - or just cherry-pick the commits. 
