### PR TITLE
mysql_user: idempotent user creation

### DIFF
--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -161,7 +161,8 @@ def user_exists(cursor, user, host):
     return count[0] > 0
 
 def user_add(cursor, user, host, password, new_priv):
-    cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
+    cursor.execute("GRANT USAGE ON *.* TO %s@%s IDENTIFIED BY %s", (user,host,
+        password))
     if new_priv is not None:
         for db_table, priv in new_priv.iteritems():
             privileges_grant(cursor, user,host,db_table,priv)


### PR DESCRIPTION
Idempotent way of creating MySQL users.
Fixed an edge case mentioned in #963

Used in replication setups when you might want to first run your playbook on slaves and then on master.
It's not a good practice to make changes on slaves before master, but it doesn't hurt Ansible to support this scenario. 
