### PR TITLE
Module alternatives: support RedHat-based OSes

### DIFF
--- a/library/system/alternatives
+++ b/library/system/alternatives
@@ -62,7 +62,8 @@ def main():
             name = dict(required=True),
             path  = dict(required=True),
             link = dict(required=False),
-        )
+        ),
+        supports_check_mode=True,
     )
 
     params = module.params
@@ -114,6 +115,8 @@ def main():
                     link = value
 
     if current_path != path:
+        if module.check_mode:
+            module.exit_json(changed=True, current_path=current_path)
         try:
             # install the requested path if necessary
             if path not in all_alternatives:


### PR DESCRIPTION
RedHat-based OSes have a version of update-alternatives which comes from
the chkconfig package and does not support the --query parameter. Work
around that.

Also, update the module to support check mode.
