### PR TITLE
Expand description for ec2_facts module

### DIFF
--- a/library/cloud/ec2_facts
+++ b/library/cloud/ec2_facts
@@ -31,9 +31,11 @@ options:
         choices: ['yes', 'no']
         version_added: 1.5.1
 description:
-     - This module fetches data from the metadata servers in ec2 (aws).
+     - This module fetches data from the metadata servers in ec2 (aws) as per
+       http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html.
+       The module must be called from within the EC2 instance itself.
        Eucalyptus cloud provides a similar service and this module should
-       work this cloud provider as well.
+       work with this cloud provider as well.
 notes:
     - Parameters to filter on ec2_facts may be added later.
 author: "Silviu Dicu <silviudicu@gmail.com>"


### PR DESCRIPTION
Make it clearer that this module must be executed on the instance in EC2 itself.
