### PR TITLE
Remove unreachable code

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -54,7 +54,6 @@ def aws_common_argument_spec():
         security_token=dict(no_log=True),
         profile=dict(),
     )
-    return spec
 
 
 def ec2_argument_spec():


### PR DESCRIPTION
Remove an unreachable `return` statement from `aws_common_argument_spec()`.
