### PR TITLE
Templating of injected vars

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -587,14 +587,7 @@ class Runner(object):
         host_variables = self.inventory.get_variables(host, vault_password=self.vault_pass)
         combined_cache = self.get_combined_cache()
 
-        # use combined_cache and host_variables to template the module_vars
-        # we update the inject variables with the data we're about to template
-        # since some of the variables we'll be replacing may be contained there too
-        module_vars_inject = utils.combine_vars(host_variables, combined_cache.get(host, {}))
-        module_vars_inject = utils.combine_vars(self.module_vars, module_vars_inject)
-        module_vars = template.template(self.basedir, self.module_vars, module_vars_inject)
-
-        inject = {}
+        inject = utils.combine_vars({}, combined_cache.get(host, {}))
 
         # default vars are the lowest priority
         inject = utils.combine_vars(inject, self.default_vars)
@@ -603,11 +596,16 @@ class Runner(object):
         # then the setup_cache which contains facts gathered
         inject = utils.combine_vars(inject, self.setup_cache.get(host, {}))
         # then come the module variables
-        inject = utils.combine_vars(inject, module_vars)
+        inject = utils.combine_vars(inject, self.module_vars)
         # followed by vars (vars, vars_files, vars/main.yml)
         inject = utils.combine_vars(inject, self.vars_cache.get(host, {}))
         # and finally -e vars are the highest priority
         inject = utils.combine_vars(inject, self.extra_vars)
+
+        # once all variables have been gathered and their precedence worked out
+        # resolve any templates within variables.
+        inject = template.template(self.basedir, inject, self.module_vars)
+
         # and then special vars
         inject.setdefault('ansible_ssh_user', self.remote_user)
         inject['group_names']  = host_variables.get('group_names', [])
@@ -620,6 +618,7 @@ class Runner(object):
         inject['combined_cache'] = combined_cache
 
         return inject
+
 
     def _executor_internal(self, host, new_stdin):
         ''' executes any module one or more times '''

--- a/test/integration/group_vars/all
+++ b/test/integration/group_vars/all
@@ -6,6 +6,7 @@ uno: 1
 dos: 2
 tres: 3
 etest: 'from group_vars'
+extra_var: 'should be overridden'
 inventory_beats_default: 'narf'
 # variables used for hash merging behavior testing
 test_hash:

--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -5,5 +5,4 @@ pip_test_package: epdb
 
 # variables used in precedence tests, here passed to -e
 etest: 'from -e'
-
-
+extra_var: extra_var

--- a/test/integration/test_includes.yml
+++ b/test/integration/test_includes.yml
@@ -1,1 +1,2 @@
-- include: test_includes2.yml parameter1=asdf parameter2=jkl
+# test parameter passing and variable overriding with extras
+- include: test_includes2.yml parameter1=asdf parameter2=jkl parameter3='{{extra_var}}'

--- a/test/integration/test_includes2.yml
+++ b/test/integration/test_includes2.yml
@@ -1,12 +1,15 @@
 
 - name: verify playbook includes can take parameters
   hosts: testhost
+  
   tasks:
+    - debug: msg="{{parameter3}}"
     - assert: 
         that:
           - "parameter1 == 'asdf'"
           - "parameter2 == 'jkl'"
-
+          - "parameter3 == 'extra_var'"
+          
 - name: verify task include logic
   hosts: testhost
   gather_facts: True


### PR DESCRIPTION
Issue Type:

Bugfix Pull Request

Ansible Version:

1.7.1+

Environment:

Mac OSX 10.9, bug is not os specific.

Summary:
Only substitute templates in variables once the order of all injected variables has been decided.

If when calling an include file, one of the parameters of the include was overridden with a value passed in as an 'extra', this value was not being passed in correctly to the include call.

So based on comments by James for the previous pull request for this issue #8984, I took another look at what was going on here and it seems that the templates in variables are being resolved before all of the variables sets are combined into the the injected set. Moving the templating to a point where the full set has been gathered removes this issue, with existing and added tests passing. I will close the other pull request.

Steps To Reproduce:

The test_includes.yml integration test has been updated to illustrate the issue

Expected Results:

when running a playbook containing the following

include: myinclude.yml some_var='{{extra_var}}'

where some_var is set to 'default' in the group vars but -e some_var='overridden' in the ansible call. We would expect the include to see some_var as 'overridden'

Actual Results:

With the scenario above the some_var is not overridden as expected but remains 'default'
