### PR TITLE
tagging util and tagging of SecurityGroups

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -67,6 +67,37 @@ def ec2_argument_spec():
 def boto_supports_profile_name():
     return hasattr(boto.ec2.EC2Connection, 'profile_name')
 
+def is_taggable(object):
+
+    from boto.ec2.ec2object import TaggedEC2Object
+    if not object or not issubclass(object.__class__, TaggedEC2Object):
+        return False
+
+    return True
+
+def do_tags(module, object, tags):
+    """
+    General function for adding tags to objects that are subclasses
+    of boto.ec2.ec2object.TaggedEC2Object.  Currently updates
+    existing tags, as the API overwrites them, but does not remove
+    orphans.
+    :param module:
+    :param object:
+    :param tags:
+    """
+    dry_run = True if module.check_mode else False
+
+    if (is_taggable(object)):
+
+        tag_dict = {}
+
+        for tag in tags:
+            tag_dict[tag['key']] = tag['value']
+
+        object.add_tags(tag_dict, dry_run)
+    else:
+        module.fail_json(msg="Security group object is not a subclass of TaggedEC2Object")
+
 
 def get_aws_connection_info(module):
 

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 
@@ -31,6 +31,11 @@ options:
       - List of firewall outbound rules to enforce in this group (see example).
     required: false
     version_added: "1.6"
+  tags:
+    description:
+      - List of tags to apply to this security group
+    required: false
+    version_added: "1.8"
   region:
     description:
       - the EC2 region to use
@@ -90,6 +95,9 @@ EXAMPLES = '''
         group_name: example-other
         # description to use if example-other needs to be created
         group_desc: other example EC2 group
+    tags:
+      - key: environment
+        value: production
 '''
 
 try:
@@ -153,7 +161,6 @@ def get_target_from_rule(module, rule, name, group, groups):
 
     return group_id, ip, target_group_created
 
-
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
@@ -162,6 +169,7 @@ def main():
             vpc_id=dict(),
             rules=dict(),
             rules_egress=dict(),
+            tags=dict(type='list', default=[]),
             state = dict(default='present', choices=['present', 'absent']),
         )
     )
@@ -175,6 +183,7 @@ def main():
     vpc_id = module.params['vpc_id']
     rules = module.params['rules']
     rules_egress = module.params['rules_egress']
+    tags = module.params['tags']
     state = module.params.get('state')
 
     changed = False
@@ -236,6 +245,9 @@ def main():
 
                 group = ec2.get_all_security_groups(group_ids=(group.id,))[0]
             changed = True
+
+        # tag the security group, function imported from ansible.module_utils.ec2
+        do_tags(module, group, tags)
     else:
         module.fail_json(msg="Unsupported state requested: %s" % state)
 


### PR DESCRIPTION
General utility method for tagging AWS objects that are subclasses of [TaggedEC2Object](https://sourcegraph.com/github.com/boto/boto@develop/.PipPackage/boto/.def/boto/ec2/ec2object/TaggedEC2Object).  Adds functionality to tag SecurityGroups.
