### PR TITLE
defining top-level env 'just' for main(), import extensible modules from new lib

### DIFF
--- a/library/cloud/azure
+++ b/library/cloud/azure
@@ -481,4 +481,6 @@ class Wrapper(object):
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -310,4 +310,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/digital_ocean
+++ b/library/cloud/digital_ocean
@@ -431,4 +431,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/digital_ocean_domain
+++ b/library/cloud/digital_ocean_domain
@@ -239,4 +239,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/digital_ocean_sshkey
+++ b/library/cloud/digital_ocean_sshkey
@@ -175,4 +175,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/docker
+++ b/library/cloud/docker
@@ -851,4 +851,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/docker_image
+++ b/library/cloud/docker_image
@@ -249,4 +249,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2
+++ b/library/cloud/ec2
@@ -1196,4 +1196,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_ami
+++ b/library/cloud/ec2_ami
@@ -269,5 +269,7 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -605,4 +605,6 @@ def main():
         changed = True
     module.exit_json( changed = changed, **asg_properties )
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_elb
+++ b/library/cloud/ec2_elb
@@ -336,4 +336,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_elb_lb
+++ b/library/cloud/ec2_elb_lb
@@ -695,4 +695,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_facts
+++ b/library/cloud/ec2_facts
@@ -179,4 +179,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_group
+++ b/library/cloud/ec2_group
@@ -383,4 +383,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_key
+++ b/library/cloud/ec2_key
@@ -235,4 +235,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_lc
+++ b/library/cloud/ec2_lc
@@ -275,4 +275,6 @@ def main():
     elif state == 'absent':
         delete_launch_config(connection, module)
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_metric_alarm
+++ b/library/cloud/ec2_metric_alarm
@@ -279,4 +279,6 @@ def main():
     elif state == 'absent':
         delete_metric_alarm(connection, module)
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_scaling_policy
+++ b/library/cloud/ec2_scaling_policy
@@ -174,4 +174,6 @@ def main():
         delete_scaling_policy(connection, module)
 
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_snapshot
+++ b/library/cloud/ec2_snapshot
@@ -148,4 +148,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_tag
+++ b/library/cloud/ec2_tag
@@ -149,4 +149,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_vol
+++ b/library/cloud/ec2_vol
@@ -431,4 +431,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -623,4 +623,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -544,4 +544,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/gc_storage
+++ b/library/cloud/gc_storage
@@ -417,4 +417,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/gce
+++ b/library/cloud/gce
@@ -471,4 +471,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.gce import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/gce_lb
+++ b/library/cloud/gce_lb
@@ -332,4 +332,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.gce import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/gce_net
+++ b/library/cloud/gce_net
@@ -268,4 +268,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.gce import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/gce_pd
+++ b/library/cloud/gce_pd
@@ -282,4 +282,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.gce import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/glance_image
+++ b/library/cloud/glance_image
@@ -257,4 +257,6 @@ def main():
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/linode
+++ b/library/cloud/linode
@@ -490,4 +490,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/nova_compute
+++ b/library/cloud/nova_compute
@@ -581,5 +581,7 @@ def main():
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/cloud/nova_keypair
+++ b/library/cloud/nova_keypair
@@ -135,5 +135,7 @@ def main():
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/cloud/ovirt
+++ b/library/cloud/ovirt
@@ -422,4 +422,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/quantum_floating_ip
+++ b/library/cloud/quantum_floating_ip
@@ -262,5 +262,7 @@ def main():
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/cloud/quantum_floating_ip_associate
+++ b/library/cloud/quantum_floating_ip_associate
@@ -214,5 +214,7 @@ def main():
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/cloud/quantum_network
+++ b/library/cloud/quantum_network
@@ -275,5 +275,7 @@ def main():
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/cloud/quantum_router
+++ b/library/cloud/quantum_router
@@ -206,5 +206,7 @@ def main():
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/cloud/quantum_router_gateway
+++ b/library/cloud/quantum_router_gateway
@@ -209,5 +209,7 @@ def main():
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/cloud/quantum_router_interface
+++ b/library/cloud/quantum_router_interface
@@ -245,5 +245,7 @@ def main():
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/cloud/quantum_subnet
+++ b/library/cloud/quantum_subnet
@@ -287,5 +287,7 @@ def main():
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/cloud/rax
+++ b/library/cloud/rax
@@ -708,4 +708,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 # invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_cbs
+++ b/library/cloud/rax_cbs
@@ -217,4 +217,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_cbs_attachments
+++ b/library/cloud/rax_cbs_attachments
@@ -223,4 +223,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_cdb
+++ b/library/cloud/rax_cdb
@@ -235,4 +235,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 # invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_cdb_database
+++ b/library/cloud/rax_cdb_database
@@ -183,4 +183,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 # invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_cdb_user
+++ b/library/cloud/rax_cdb_user
@@ -217,4 +217,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 # invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_clb
+++ b/library/cloud/rax_clb
@@ -300,4 +300,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_clb_nodes
+++ b/library/cloud/rax_clb_nodes
@@ -300,4 +300,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_dns
+++ b/library/cloud/rax_dns
@@ -170,4 +170,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_dns_record
+++ b/library/cloud/rax_dns_record
@@ -332,4 +332,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_facts
+++ b/library/cloud/rax_facts
@@ -141,4 +141,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_files
+++ b/library/cloud/rax_files
@@ -376,4 +376,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_files_objects
+++ b/library/cloud/rax_files_objects
@@ -600,4 +600,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_identity
+++ b/library/cloud/rax_identity
@@ -107,4 +107,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_keypair
+++ b/library/cloud/rax_keypair
@@ -171,4 +171,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_meta
+++ b/library/cloud/rax_meta
@@ -175,4 +175,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_network
+++ b/library/cloud/rax_network
@@ -142,4 +142,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_queue
+++ b/library/cloud/rax_queue
@@ -142,4 +142,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 ### invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_scaling_group
+++ b/library/cloud/rax_scaling_group
@@ -348,4 +348,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 # invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rax_scaling_policy
+++ b/library/cloud/rax_scaling_policy
@@ -280,4 +280,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
 # invoke the module
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rds
+++ b/library/cloud/rds
@@ -647,4 +647,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rds_param_group
+++ b/library/cloud/rds_param_group
@@ -310,4 +310,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/rds_subnet_group
+++ b/library/cloud/rds_subnet_group
@@ -163,4 +163,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -278,4 +278,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -511,4 +511,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/virt
+++ b/library/cloud/virt
@@ -490,4 +490,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/cloud/vsphere_guest
+++ b/library/cloud/vsphere_guest
@@ -1222,4 +1222,6 @@ def main():
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/commands/command
+++ b/library/commands/command
@@ -272,4 +272,6 @@ class CommandModule(AnsibleModule):
 
         return (params, params['args'])
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/database/mongodb_user
+++ b/library/database/mongodb_user
@@ -239,4 +239,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -360,4 +360,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -365,5 +365,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()
 warnings.simplefilter("ignore")

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -473,4 +473,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/database/mysql_variables
+++ b/library/database/mysql_variables
@@ -250,4 +250,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/database/postgresql_db
+++ b/library/database/postgresql_db
@@ -298,4 +298,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/database/postgresql_privs
+++ b/library/database/postgresql_privs
@@ -610,4 +610,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/database/postgresql_user
+++ b/library/database/postgresql_user
@@ -523,4 +523,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/database/redis
+++ b/library/database/redis
@@ -326,4 +326,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/database/riak
+++ b/library/database/riak
@@ -252,4 +252,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/files/acl
+++ b/library/files/acl
@@ -292,4 +292,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/files/assemble
+++ b/library/files/assemble
@@ -196,5 +196,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/files/copy
+++ b/library/files/copy
@@ -251,4 +251,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/files/file
+++ b/library/files/file
@@ -354,5 +354,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/files/ini_file
+++ b/library/files/ini_file
@@ -204,4 +204,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/files/lineinfile
+++ b/library/files/lineinfile
@@ -397,4 +397,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.splitter import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/files/replace
+++ b/library/files/replace
@@ -159,4 +159,6 @@ def main():
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/files/stat
+++ b/library/files/stat
@@ -149,4 +149,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/files/synchronize
+++ b/library/files/synchronize
@@ -341,5 +341,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/files/unarchive
+++ b/library/files/unarchive
@@ -247,4 +247,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/files/xattr
+++ b/library/files/xattr
@@ -203,4 +203,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/internal/async_status
+++ b/library/internal/async_status
@@ -96,4 +96,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/messaging/rabbitmq_parameter
+++ b/library/messaging/rabbitmq_parameter
@@ -149,4 +149,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/messaging/rabbitmq_plugin
+++ b/library/messaging/rabbitmq_plugin
@@ -127,4 +127,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/messaging/rabbitmq_policy
+++ b/library/messaging/rabbitmq_policy
@@ -153,4 +153,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/messaging/rabbitmq_user
+++ b/library/messaging/rabbitmq_user
@@ -246,4 +246,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/messaging/rabbitmq_vhost
+++ b/library/messaging/rabbitmq_vhost
@@ -144,4 +144,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/airbrake_deployment
+++ b/library/monitoring/airbrake_deployment
@@ -126,5 +126,7 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/monitoring/bigpanda
+++ b/library/monitoring/bigpanda
@@ -169,4 +169,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/boundary_meter
+++ b/library/monitoring/boundary_meter
@@ -252,5 +252,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/monitoring/datadog_event
+++ b/library/monitoring/datadog_event
@@ -140,4 +140,6 @@ def post_event(module):
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/librato_annotation
+++ b/library/monitoring/librato_annotation
@@ -166,4 +166,6 @@ def main():
   post_annotation(module)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/logentries
+++ b/library/monitoring/logentries
@@ -127,4 +127,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/monit
+++ b/library/monitoring/monit
@@ -152,4 +152,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/nagios
+++ b/library/monitoring/nagios
@@ -877,4 +877,6 @@ class Nagios(object):
 ######################################################################
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/newrelic_deployment
+++ b/library/monitoring/newrelic_deployment
@@ -141,5 +141,7 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/monitoring/pagerduty
+++ b/library/monitoring/pagerduty
@@ -229,4 +229,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/pingdom
+++ b/library/monitoring/pingdom
@@ -132,4 +132,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/rollbar_deployment
+++ b/library/monitoring/rollbar_deployment
@@ -130,4 +130,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/stackdriver
+++ b/library/monitoring/stackdriver
@@ -193,4 +193,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/monitoring/zabbix_maintenance
+++ b/library/monitoring/zabbix_maintenance
@@ -368,4 +368,6 @@ def main():
     module.exit_json(changed=changed)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/net_infrastructure/a10_server
+++ b/library/net_infrastructure/a10_server
@@ -266,4 +266,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 from ansible.module_utils.a10 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/net_infrastructure/a10_service_group
+++ b/library/net_infrastructure/a10_service_group
@@ -338,4 +338,6 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 from ansible.module_utils.a10 import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/net_infrastructure/a10_virtual_server
+++ b/library/net_infrastructure/a10_virtual_server
@@ -295,5 +295,7 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 from ansible.module_utils.a10 import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/net_infrastructure/bigip_facts
+++ b/library/net_infrastructure/bigip_facts
@@ -1666,5 +1666,7 @@ def main():
 
 # include magic from lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/net_infrastructure/bigip_monitor_http
+++ b/library/net_infrastructure/bigip_monitor_http
@@ -460,5 +460,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/net_infrastructure/bigip_monitor_tcp
+++ b/library/net_infrastructure/bigip_monitor_tcp
@@ -485,5 +485,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/net_infrastructure/bigip_node
+++ b/library/net_infrastructure/bigip_node
@@ -290,5 +290,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/net_infrastructure/bigip_pool
+++ b/library/net_infrastructure/bigip_pool
@@ -532,5 +532,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/net_infrastructure/bigip_pool_member
+++ b/library/net_infrastructure/bigip_pool_member
@@ -374,5 +374,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/net_infrastructure/dnsimple
+++ b/library/net_infrastructure/dnsimple
@@ -299,4 +299,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/net_infrastructure/dnsmadeeasy
+++ b/library/net_infrastructure/dnsmadeeasy
@@ -326,4 +326,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/net_infrastructure/lldp
+++ b/library/net_infrastructure/lldp
@@ -79,5 +79,7 @@ def main():
    
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/net_infrastructure/netscaler
+++ b/library/net_infrastructure/netscaler
@@ -187,4 +187,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/net_infrastructure/openvswitch_bridge
+++ b/library/net_infrastructure/openvswitch_bridge
@@ -132,4 +132,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/net_infrastructure/openvswitch_port
+++ b/library/net_infrastructure/openvswitch_port
@@ -136,4 +136,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/network/get_url
+++ b/library/network/get_url
@@ -310,4 +310,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/network/slurp
+++ b/library/network/slurp
@@ -71,5 +71,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/network/uri
+++ b/library/network/uri
@@ -442,4 +442,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/campfire
+++ b/library/notification/campfire
@@ -140,4 +140,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/flowdock
+++ b/library/notification/flowdock
@@ -188,5 +188,7 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/notification/grove
+++ b/library/notification/grove
@@ -96,4 +96,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/hipchat
+++ b/library/notification/hipchat
@@ -146,4 +146,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/irc
+++ b/library/notification/irc
@@ -212,4 +212,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/jabber
+++ b/library/notification/jabber
@@ -143,4 +143,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/mail
+++ b/library/notification/mail
@@ -249,4 +249,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/mqtt
+++ b/library/notification/mqtt
@@ -163,4 +163,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/nexmo
+++ b/library/notification/nexmo
@@ -137,4 +137,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/osx_say
+++ b/library/notification/osx_say
@@ -71,4 +71,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/slack
+++ b/library/notification/slack
@@ -170,4 +170,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/sns
+++ b/library/notification/sns
@@ -187,4 +187,6 @@ def main():
 
     module.exit_json(msg="OK")
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/twilio
+++ b/library/notification/twilio
@@ -132,4 +132,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/notification/typetalk
+++ b/library/notification/typetalk
@@ -113,4 +113,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/apt
+++ b/library/packaging/apt
@@ -559,4 +559,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/apt_key
+++ b/library/packaging/apt_key
@@ -274,4 +274,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/apt_repository
+++ b/library/packaging/apt_repository
@@ -443,4 +443,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/apt_rpm
+++ b/library/packaging/apt_rpm
@@ -169,4 +169,6 @@ def main():
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
     
-main()        
+
+if __name__ == "__main__":
+    main()        

--- a/library/packaging/composer
+++ b/library/packaging/composer
@@ -161,4 +161,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/cpanm
+++ b/library/packaging/cpanm
@@ -142,4 +142,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/easy_install
+++ b/library/packaging/easy_install
@@ -185,4 +185,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -235,4 +235,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/homebrew
+++ b/library/packaging/homebrew
@@ -832,4 +832,6 @@ def main():
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/homebrew_cask
+++ b/library/packaging/homebrew_cask
@@ -510,4 +510,6 @@ def main():
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/homebrew_tap
+++ b/library/packaging/homebrew_tap
@@ -212,4 +212,6 @@ def main():
 
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/layman
+++ b/library/packaging/layman
@@ -233,4 +233,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/macports
+++ b/library/packaging/macports
@@ -214,4 +214,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/npm
+++ b/library/packaging/npm
@@ -260,4 +260,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/openbsd_pkg
+++ b/library/packaging/openbsd_pkg
@@ -370,4 +370,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/opkg
+++ b/library/packaging/opkg
@@ -147,4 +147,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/pacman
+++ b/library/packaging/pacman
@@ -231,4 +231,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
     
-main()        
+
+if __name__ == "__main__":
+    main()        

--- a/library/packaging/pip
+++ b/library/packaging/pip
@@ -353,4 +353,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/pkgin
+++ b/library/packaging/pkgin
@@ -165,4 +165,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/pkgng
+++ b/library/packaging/pkgng
@@ -298,4 +298,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
     
-main()        
+
+if __name__ == "__main__":
+    main()        

--- a/library/packaging/pkgutil
+++ b/library/packaging/pkgutil
@@ -176,4 +176,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/portage
+++ b/library/packaging/portage
@@ -402,4 +402,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/portinstall
+++ b/library/packaging/portinstall
@@ -204,4 +204,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/redhat_subscription
+++ b/library/packaging/redhat_subscription
@@ -393,4 +393,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/rhn_channel
+++ b/library/packaging/rhn_channel
@@ -166,4 +166,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/rhn_register
+++ b/library/packaging/rhn_register
@@ -333,4 +333,6 @@ def main():
             module.exit_json(changed=True, msg="System successfully unregistered from %s." % rhn.hostname)
 
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/rpm_key
+++ b/library/packaging/rpm_key
@@ -203,4 +203,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/svr4pkg
+++ b/library/packaging/svr4pkg
@@ -231,4 +231,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/swdepot
+++ b/library/packaging/swdepot
@@ -192,5 +192,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/packaging/urpmi
+++ b/library/packaging/urpmi
@@ -197,4 +197,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
     
-main()        
+
+if __name__ == "__main__":
+    main()        

--- a/library/packaging/yum
+++ b/library/packaging/yum
@@ -834,5 +834,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/packaging/zypper
+++ b/library/packaging/zypper
@@ -257,4 +257,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/packaging/zypper_repository
+++ b/library/packaging/zypper_repository
@@ -218,4 +218,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/source_control/bzr
+++ b/library/source_control/bzr
@@ -195,4 +195,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/source_control/git
+++ b/library/source_control/git
@@ -604,4 +604,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.known_hosts import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/source_control/github_hooks
+++ b/library/source_control/github_hooks
@@ -175,4 +175,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/source_control/hg
+++ b/library/source_control/hg
@@ -235,4 +235,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/source_control/subversion
+++ b/library/source_control/subversion
@@ -228,4 +228,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/alternatives
+++ b/library/system/alternatives
@@ -137,4 +137,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/at
+++ b/library/system/at
@@ -197,4 +197,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/authorized_key
+++ b/library/system/authorized_key
@@ -418,4 +418,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/capabilities
+++ b/library/system/capabilities
@@ -184,4 +184,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/cron
+++ b/library/system/cron
@@ -520,5 +520,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/system/debconf
+++ b/library/system/debconf
@@ -167,4 +167,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/facter
+++ b/library/system/facter
@@ -52,5 +52,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/system/filesystem
+++ b/library/system/filesystem
@@ -116,4 +116,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/firewalld
+++ b/library/system/firewalld
@@ -394,5 +394,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/system/getent
+++ b/library/system/getent
@@ -139,5 +139,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/system/group
+++ b/library/system/group
@@ -400,4 +400,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/hostname
+++ b/library/system/hostname
@@ -442,4 +442,6 @@ def main():
 
     module.exit_json(changed=changed, name=name)
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/kernel_blacklist
+++ b/library/system/kernel_blacklist
@@ -138,4 +138,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/locale_gen
+++ b/library/system/locale_gen
@@ -148,4 +148,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/lvg
+++ b/library/system/lvg
@@ -250,4 +250,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/lvol
+++ b/library/system/lvol
@@ -232,4 +232,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/modprobe
+++ b/library/system/modprobe
@@ -112,4 +112,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/mount
+++ b/library/system/mount
@@ -335,4 +335,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/ohai
+++ b/library/system/ohai
@@ -51,6 +51,8 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 
 

--- a/library/system/open_iscsi
+++ b/library/system/open_iscsi
@@ -375,5 +375,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/system/ping
+++ b/library/system/ping
@@ -55,5 +55,7 @@ def main():
 
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/system/seboolean
+++ b/library/system/seboolean
@@ -209,4 +209,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/selinux
+++ b/library/system/selinux
@@ -199,5 +199,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/library/system/service
+++ b/library/system/service
@@ -1325,4 +1325,6 @@ def main():
     module.exit_json(**result)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/setup
+++ b/library/system/setup
@@ -143,4 +143,6 @@ from ansible.module_utils.basic import *
 
 from ansible.module_utils.facts import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/sysctl
+++ b/library/system/sysctl
@@ -331,4 +331,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/ufw
+++ b/library/system/ufw
@@ -266,4 +266,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/user
+++ b/library/system/user
@@ -1581,4 +1581,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/system/zfs
+++ b/library/system/zfs
@@ -414,4 +414,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/utilities/accelerate
+++ b/library/utilities/accelerate
@@ -724,4 +724,6 @@ def main():
         # try to start up the daemon
         daemonize(module, password, port, timeout, minutes, ipv6, pid_file)
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/utilities/fireball
+++ b/library/utilities/fireball
@@ -277,4 +277,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/utilities/wait_for
+++ b/library/utilities/wait_for
@@ -459,4 +459,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/web_infrastructure/apache2_module
+++ b/library/web_infrastructure/apache2_module
@@ -86,4 +86,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/web_infrastructure/django_manage
+++ b/library/web_infrastructure/django_manage
@@ -278,4 +278,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/web_infrastructure/ejabberd_user
+++ b/library/web_infrastructure/ejabberd_user
@@ -211,4 +211,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/web_infrastructure/jboss
+++ b/library/web_infrastructure/jboss
@@ -137,4 +137,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/web_infrastructure/jira
+++ b/library/web_infrastructure/jira
@@ -344,4 +344,6 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
-main()
+
+if __name__ == "__main__":
+    main()

--- a/library/web_infrastructure/supervisorctl
+++ b/library/web_infrastructure/supervisorctl
@@ -218,4 +218,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
the call to main() in python-based core modules gets changed to, just

> if **name** == "**main**":
>     main()

it will import all required modules, and still not call main() if imported into any newly created module by users who just wanna extend some functionality over existing modules
