### PR TITLE
Initial ansible_ssh_proxy support for ssh transport

### DIFF
--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -30,8 +30,8 @@ class Connector(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def connect(self, host, port, user, password, transport, private_key_file):
-        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password, private_key_file=private_key_file)
+    def connect(self, host, port, user, password, transport, private_key_file, ssh_proxy):
+        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password, private_key_file=private_key_file, ssh_proxy=ssh_proxy)
         if conn is None:
             raise AnsibleError("unsupported connection type: %s" % transport)
         if private_key_file:


### PR DESCRIPTION
This pull request adds functionality to supply a host to use with the SSH ProxyCommand as requested in #8963

Currently this only:
1. Adds support for the `ssh` transport
2. Only accepts an IP or hostname, not the full ProxyCommand (The ProxyCommand utilizes `ssh -W`)
3. Only keys off of `ansible_ssh_proxy` as a "global" var (--extra-vars/vars_files/etc...) or from inventory (group_vars and host_vars included)
