### PR TITLE
Limit what is returned by the cobbler inventory plugin based on the filter_status attribute

### DIFF
--- a/plugins/inventory/cobbler.ini
+++ b/plugins/inventory/cobbler.ini
@@ -12,9 +12,13 @@ host = http://PATH_TO_COBBLER_SERVER/cobbler_api
 #   - ansible-cobbler.index
 cache_path = /tmp
 
+# We need to support the ability to filter results from cobbler so inventory
+# can be isolated per environment. For example, if we want staging (acceptance)
+# and production we should only return nodes that have their status attribute
+# set respectively. The filter_status is set to production by default.
+#
+# filter_status = production
+
 # The number of seconds a cache file is considered valid. After this many
 # seconds, a new API call will be made, and the cache file will be updated.
 cache_max_age = 900
-
-
-

--- a/plugins/inventory/cobbler.py
+++ b/plugins/inventory/cobbler.py
@@ -185,14 +185,13 @@ class CobblerInventory(object):
             status = host['status']
             profile = host['profile']
             classes = host['mgmt_classes']
-            # print "status: %s" % status
-            # print "profile: %s" % profile
-            # print "classes: %s" % classes
 
             # allow the ability to limit whats retruned from cobbler by
             # its status attribure. see --status under
             # http://www.cobblerd.org/manuals/2.6.0/3/1/3_-_Systems.html
-            if status in self.filter_status:
+            # check if the filter_status is false (None or empty string)
+
+            if status in self.filter_status or not self.filter_status:
                 self.inventory[status].append(dns_name)
                 self.inventory[profile].append(dns_name)
 

--- a/plugins/inventory/cobbler.py
+++ b/plugins/inventory/cobbler.py
@@ -30,6 +30,10 @@ See http://ansible.github.com/api.html for more info
 Tested with Cobbler 2.0.11.
 
 Changelog:
+    - 2014-09-24 etrikp: Add the ability to limit what cobbler returns based on the
+        cobbler status attribute. See --status under
+        http://www.cobblerd.org/manuals/2.6.0/3/1/3_-_Systems.html see cobbler.ini
+        for examples.
     - 2013-09-01 pgehres: Refactored implementation to make use of caching and to
         limit the number of connections to external cobbler server for performance.
         Added use of cobbler.ini file to configure settings. Tested with Cobbler 2.4.0

--- a/plugins/inventory/cobbler.py
+++ b/plugins/inventory/cobbler.py
@@ -60,6 +60,7 @@ import ConfigParser
 import os
 import re
 from time import time
+from collections import defaultdict
 import xmlrpclib
 
 try:
@@ -78,13 +79,16 @@ class CobblerInventory(object):
         """ Main execution path """
         self.conn = None
 
-        self.inventory = dict()  # A list of groups and the hosts in that group
+        self.inventory = defaultdict(list)  # A list of groups and the hosts in that group
         self.cache = dict()  # Details about hosts in the inventory
 
         # Read settings and parse CLI arguments
         self.read_settings()
         self.parse_cli_args()
 
+        # This cache engine is broken, always refresh,
+        # TODO: replace with PersistentDict used in the vagrant ansible dynamic inventory plugin.
+        self.update_cache()
         # Cache
         if self.args.refresh_cache:
             self.update_cache()


### PR DESCRIPTION
This pull requests adds the ability to limit what the cobbler plugin returns, based on the --status attribute of a system in cobbler. The attribute is configurable via cobbler.ini and supports either a single string, or a list of strings as a value. The attribute defaults to production when its not present in the ini file.
