### PR TITLE
Expose more facts about user on host system

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -29,6 +29,7 @@ import socket
 import struct
 import datetime
 import getpass
+import pwd
 import ConfigParser
 import StringIO
 
@@ -476,6 +477,12 @@ class Facts(object):
     # User
     def get_user_facts(self):
         self.facts['user_id'] = getpass.getuser()
+        pwent = pwd.getpwnam(getpass.getuser())
+        self.facts['user_uid'] = pwent.pw_uid
+        self.facts['user_gid'] = pwent.pw_gid
+        self.facts['user_gecos'] = pwent.pw_gecos
+        self.facts['user_dir'] = pwent.pw_dir
+        self.facts['user_shell'] = pwent.pw_shell
 
     def get_env_facts(self):
         self.facts['env'] = {}


### PR DESCRIPTION
Adds:
- `user_uid`
- `user_gid`
- `user_gecos`
- `user_dir`
- `user_shell`

This is implemented with pure Python, using all built-in modules.

This is useful for writing playbooks that create a user on the remote system that resembles the invoking user on the host system. I've long wanted to have plays that set up my development VM with the same user that I use on my host system.

Example playbook:

``` yaml

---
# Empty play just so that facts are gathered for localhost
- hosts: localhost

- hosts: vagrant
  sudo: yes
  tasks:
    - name: Create user for local user
      user: name="{{ hostvars['localhost']['ansible_user_id'] }}"
            comment="{{ hostvars['localhost']['ansible_user_gecos'] }}"
            uid="{{ hostvars['localhost']['ansible_user_uid'] }}"
            shell=/bin/bash

    - name: Add key to ~/.ssh/authorized_keys
      authorized_key: user={{ hostvars['localhost']['ansible_user_id'] }}
                      key="{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
                      manage_dir=yes
```

Cc: @sontek, @aconrad, @sudarkoff
