### PR TITLE
Clean up template comment text in ansible-galaxy

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -80,8 +80,7 @@ galaxy_info:
   #- {{ category.name }}
   {%- endfor %}
 dependencies: []
-  # List your role dependencies here, one per line. Only
-  # dependencies available via galaxy should be listed here.
+  # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
   {% for dependency in dependencies %}


### PR DESCRIPTION
Since support for non-galaxy templates is available in 1.8, the existing
comment in the default_meta_template requiring specified dependencies be
available via galaxy was no longer valid. That comment is now removed.
