### PR TITLE
EC2 Inventory Boto Profile Support

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -134,3 +134,7 @@ group_by_elasticache_replication_group = True
 # tag Name value matches webservers1*
 # (ex. webservers15, webservers1a, webservers123 etc) 
 # instance_filters = tag:Name=webservers1*
+
+# A boto configuration profile may be used to separate out credentials
+# see http://boto.readthedocs.org/en/latest/boto_config_tut.html
+# boto_profile = some-boto-profile-name

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -165,8 +165,7 @@ class Ec2Inventory(object):
         # as pre 2.24 boto will fall over otherwise
         if self.boto_profile:
             if not hasattr(boto.ec2.EC2Connection, 'profile_name'):
-                sys.stderr.write("boto version must be >= 2.24 to use profile\n")
-                sys.exit(1)
+                self.fail_with_error("boto version must be >= 2.24 to use profile")
 
         # Cache
         if self.args.refresh_cache:
@@ -364,7 +363,6 @@ class Ec2Inventory(object):
                     continue
                 self.ec2_instance_filters[filter_key].append(filter_value)
 
-
     def parse_cli_args(self):
         ''' Command line argument processing '''
 
@@ -403,10 +401,7 @@ class Ec2Inventory(object):
             conn = boto.connect_euca(host=self.eucalyptus_host)
             conn.APIVersion = '2010-08-31'
         else:
-            conn = ec2.connect_to_region(region)
-        # connect_to_region will fail "silently" by returning None if the region name is wrong or not supported
-        if conn is None:
-            self.fail_with_error("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
+            conn = self.connect_to_aws(ec2, region)
         return conn
 
     def boto_fix_security_token_in_profile(self, connect_args):
@@ -415,7 +410,6 @@ class Ec2Inventory(object):
         if boto.config.has_option(profile, 'aws_security_token'):
             connect_args['security_token'] = boto.config.get(profile, 'aws_security_token')
         return connect_args
-
 
     def connect_to_aws(self, module, region):
         connect_args = {}
@@ -426,8 +420,10 @@ class Ec2Inventory(object):
             self.boto_fix_security_token_in_profile(connect_args)
 
         conn = module.connect_to_region(region, **connect_args)
+        # connect_to_region will fail "silently" by returning None if the region name is wrong or not supported
+        if conn is None:
+            self.fail_with_error("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
         return conn
-
 
     def get_instances_by_region(self, region):
         ''' Makes an AWS EC2 API call to the list of instances in a particular
@@ -440,14 +436,8 @@ class Ec2Inventory(object):
                 for filter_key, filter_values in self.ec2_instance_filters.items():
                     reservations.extend(conn.get_all_instances(filters = { filter_key : filter_values }))
             else:
-                conn = ec2.connect_to_region(region, profile_name=self.boto_profile)
+                reservations = conn.get_all_instances()
 
-            # connect_to_region will fail "silently" by returning None if the region name is wrong or not supported
-            if conn is None:
-                print("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
-                sys.exit(1)
-
-            reservations = conn.get_all_instances()
             for reservation in reservations:
                 for instance in reservation.instances:
                     self.add_instance(instance, region)
@@ -459,7 +449,6 @@ class Ec2Inventory(object):
                 backend = 'Eucalyptus' if self.eucalyptus else 'AWS' 
                 error = "Error connecting to %s backend.\n%s" % (backend, e.message)
             self.fail_with_error(error)
-
 
     def get_rds_instances_by_region(self, region):
         ''' Makes an AWS API call to the list of RDS instances in a particular

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -296,6 +296,11 @@ class Ec2Inventory(object):
         self.cache_path_index = cache_dir + "/ansible-ec2.index"
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
 
+        # boto configuration profile
+        self.boto_profile = None
+        if config.has_option('ec2', 'boto_profile'):
+            self.boto_profile = config.get('ec2', 'boto_profile')
+
         # Configure nested groups instead of flat namespace.
         if config.has_option('ec2', 'nested_groups'):
             self.nested_groups = config.getboolean('ec2', 'nested_groups')
@@ -430,7 +435,7 @@ class Ec2Inventory(object):
                 for filter_key, filter_values in self.ec2_instance_filters.items():
                     reservations.extend(conn.get_all_instances(filters = { filter_key : filter_values }))
             else:
-                conn = self.connect_to_aws(ec2, region)
+                conn = ec2.connect_to_region(region, profile_name=self.boto_profile)
 
             # connect_to_region will fail "silently" by returning None if the region name is wrong or not supported
             if conn is None:

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -22,11 +22,11 @@ you need to define:
 
     export EC2_URL=http://hostname_of_your_cc:port/services/Eucalyptus
 
-If you're using boto profiles (requires boto>=2.24.0) you can choose a profile 
-using the --profile command line argument (e.g. ec2.py --profile prod) or using
-the EC2_PROFILE variable:
+If you're using boto profiles (requires boto>=2.24.0) you can choose a profile
+using the --boto-profile command line argument (e.g. ec2.py --boto-profile prod) or using
+the AWS_PROFILE variable:
 
-    EC2_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml
+    AWS_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml
 
 For more details, see: http://docs.pythonboto.org/en/latest/boto_config_tut.html
 
@@ -154,20 +154,19 @@ class Ec2Inventory(object):
         # Index of hostname (address) to instance ID
         self.index = {}
 
-        # Parse CLI arguments and read settings
+        # Boto profile to use (if any)
+        self.boto_profile = None
+
+        # Read settings and parse CLI arguments
         self.parse_cli_args()
         self.read_settings()
 
-        # boto profile to use (if any)
         # Make sure that profile_name is not passed at all if not set
         # as pre 2.24 boto will fall over otherwise
-        if self.args.profile:
+        if self.boto_profile:
             if not hasattr(boto.ec2.EC2Connection, 'profile_name'):
                 sys.stderr.write("boto version must be >= 2.24 to use profile\n")
                 sys.exit(1)
-            self.profile = dict(profile_name=self.args.profile)
-        else:
-            self.profile = dict()
 
         # Cache
         if self.args.refresh_cache:
@@ -285,21 +284,21 @@ class Ec2Inventory(object):
         else:
             self.all_elasticache_nodes = False
 
+        # boto configuration profile (prefer CLI argument)
+        self.boto_profile = self.args.boto_profile
+        if config.has_option('ec2', 'boto_profile') and not self.boto_profile:
+            self.boto_profile = config.get('ec2', 'boto_profile')
+
         # Cache related
         cache_dir = os.path.expanduser(config.get('ec2', 'cache_path'))
-        if self.args.profile:
-            cache_dir = os.path.join(cache_dir, 'profile_' + self.args.profile)
+        if self.boto_profile:
+            cache_dir = os.path.join(cache_dir, 'profile_' + self.boto_profile)
         if not os.path.exists(cache_dir):
             os.makedirs(cache_dir)
 
         self.cache_path_cache = cache_dir + "/ansible-ec2.cache"
         self.cache_path_index = cache_dir + "/ansible-ec2.index"
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
-
-        # boto configuration profile
-        self.boto_profile = None
-        if config.has_option('ec2', 'boto_profile'):
-            self.boto_profile = config.get('ec2', 'boto_profile')
 
         # Configure nested groups instead of flat namespace.
         if config.has_option('ec2', 'nested_groups'):
@@ -365,6 +364,7 @@ class Ec2Inventory(object):
                     continue
                 self.ec2_instance_filters[filter_key].append(filter_value)
 
+
     def parse_cli_args(self):
         ''' Command line argument processing '''
 
@@ -375,7 +375,7 @@ class Ec2Inventory(object):
                            help='Get all the variables about a specific instance')
         parser.add_argument('--refresh-cache', action='store_true', default=False,
                            help='Force refresh of cache by making API requests to EC2 (default: False - use cache files)')
-        parser.add_argument('--profile', action='store', default=os.environ.get('EC2_PROFILE'),
+        parser.add_argument('--boto-profile', action='store',
                            help='Use boto profile for connections to EC2')
         self.args = parser.parse_args()
 
@@ -409,18 +409,23 @@ class Ec2Inventory(object):
             self.fail_with_error("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
         return conn
 
-    def boto_fix_security_token_in_profile(self, conn):
+    def boto_fix_security_token_in_profile(self, connect_args):
         ''' monkey patch for boto issue boto/boto#2100 '''
-        profile = 'profile ' + self.profile.get('profile_name')
+        profile = 'profile ' + self.boto_profile
         if boto.config.has_option(profile, 'aws_security_token'):
-            conn.provider.set_security_token(boto.config.get(profile, 'aws_security_token'))
-        return conn
+            connect_args['secuirty_token'] = boto.config.get(profile, 'aws_security_token')
+        return connect_args
 
 
     def connect_to_aws(self, module, region):
-        conn = module.connect_to_region(region, **self.profile)
-        if 'profile_name' in self.profile:
-            conn = self.boto_fix_security_token_in_profile(conn)
+        connect_args = {}
+
+        # only pass the profile name if it's set (as it is not supported by older boto versions)
+        if self.boto_profile:
+            connect_args['profile_name'] = self.boto_profile
+            self.boto_fix_security_token_in_profile(connect_args)
+
+        conn = module.connect_to_region(region, **connect_args)
         return conn
 
 

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -22,6 +22,12 @@ you need to define:
 
     export EC2_URL=http://hostname_of_your_cc:port/services/Eucalyptus
 
+If you're using boto profiles (requires boto>=2.24.0) you can choose a profile 
+using the --profile command line argument (e.g. ec2.py --profile prod) or using
+the EC2_PROFILE variable:
+
+    EC2_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml
+
 For more details, see: http://docs.pythonboto.org/en/latest/boto_config_tut.html
 
 When run against a specific host, this script returns the following variables:
@@ -148,9 +154,20 @@ class Ec2Inventory(object):
         # Index of hostname (address) to instance ID
         self.index = {}
 
-        # Read settings and parse CLI arguments
-        self.read_settings()
+        # Parse CLI arguments and read settings
         self.parse_cli_args()
+        self.read_settings()
+
+        # boto profile to use (if any)
+        # Make sure that profile_name is not passed at all if not set
+        # as pre 2.24 boto will fall over otherwise
+        if self.args.profile:
+            if not hasattr(boto.ec2.EC2Connection, 'profile_name'):
+                sys.stderr.write("boto version must be >= 2.24 to use profile\n")
+                sys.exit(1)
+            self.profile = dict(profile_name=self.args.profile)
+        else:
+            self.profile = dict()
 
         # Cache
         if self.args.refresh_cache:
@@ -270,6 +287,8 @@ class Ec2Inventory(object):
 
         # Cache related
         cache_dir = os.path.expanduser(config.get('ec2', 'cache_path'))
+        if self.args.profile:
+            cache_dir = os.path.join(cache_dir, 'profile_' + self.args.profile)
         if not os.path.exists(cache_dir):
             os.makedirs(cache_dir)
 
@@ -351,6 +370,8 @@ class Ec2Inventory(object):
                            help='Get all the variables about a specific instance')
         parser.add_argument('--refresh-cache', action='store_true', default=False,
                            help='Force refresh of cache by making API requests to EC2 (default: False - use cache files)')
+        parser.add_argument('--profile', action='store', default=os.environ.get('EC2_PROFILE'),
+                           help='Use boto profile for connections to EC2')
         self.args = parser.parse_args()
 
 
@@ -383,6 +404,21 @@ class Ec2Inventory(object):
             self.fail_with_error("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
         return conn
 
+    def boto_fix_security_token_in_profile(self, conn):
+        ''' monkey patch for boto issue boto/boto#2100 '''
+        profile = 'profile ' + self.profile.get('profile_name')
+        if boto.config.has_option(profile, 'aws_security_token'):
+            conn.provider.set_security_token(boto.config.get(profile, 'aws_security_token'))
+        return conn
+
+
+    def connect_to_aws(self, module, region):
+        conn = module.connect_to_region(region, **self.profile)
+        if 'profile_name' in self.profile:
+            conn = self.boto_fix_security_token_in_profile(conn)
+        return conn
+
+
     def get_instances_by_region(self, region):
         ''' Makes an AWS EC2 API call to the list of instances in a particular
         region '''
@@ -394,8 +430,14 @@ class Ec2Inventory(object):
                 for filter_key, filter_values in self.ec2_instance_filters.items():
                     reservations.extend(conn.get_all_instances(filters = { filter_key : filter_values }))
             else:
-                reservations = conn.get_all_instances()
+                conn = self.connect_to_aws(ec2, region)
 
+            # connect_to_region will fail "silently" by returning None if the region name is wrong or not supported
+            if conn is None:
+                print("region name: %s likely not supported, or AWS is down.  connection to region failed." % region)
+                sys.exit(1)
+
+            reservations = conn.get_all_instances()
             for reservation in reservations:
                 for instance in reservation.instances:
                     self.add_instance(instance, region)
@@ -408,12 +450,13 @@ class Ec2Inventory(object):
                 error = "Error connecting to %s backend.\n%s" % (backend, e.message)
             self.fail_with_error(error)
 
+
     def get_rds_instances_by_region(self, region):
         ''' Makes an AWS API call to the list of RDS instances in a particular
         region '''
 
         try:
-            conn = rds.connect_to_region(region)
+            conn = self.connect_to_aws(rds, region)
             if conn:
                 instances = conn.get_all_dbinstances()
                 for instance in instances:

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -413,7 +413,7 @@ class Ec2Inventory(object):
         ''' monkey patch for boto issue boto/boto#2100 '''
         profile = 'profile ' + self.boto_profile
         if boto.config.has_option(profile, 'aws_security_token'):
-            connect_args['secuirty_token'] = boto.config.get(profile, 'aws_security_token')
+            connect_args['security_token'] = boto.config.get(profile, 'aws_security_token')
         return connect_args
 
 

--- a/docsite/rst/intro_dynamic_inventory.rst
+++ b/docsite/rst/intro_dynamic_inventory.rst
@@ -101,6 +101,20 @@ You can test the script by itself to make sure your config is correct::
 
 After a few moments, you should see your entire EC2 inventory across all regions in JSON.
 
+If you use boto profiles to manage multiple AWS accounts, you can pass ``--profile PROFILE`` name to the ``ec2.py`` script. An example profile might be::
+
+    [profile dev]
+    aws_access_key_id = <dev access key>
+    aws_secret_access_key = <dev secret key>
+
+    [profile prod]
+    aws_access_key_id = <prod access key>
+    aws_secret_access_key = <prod secret key>
+
+You can then run ``ec2.py --profile prod`` to get the inventory for the prod account, or run playbooks with: ``ansible-playbook -i 'ec2.py --profile prod' myplaybook.yml``.
+
+Alternatively, use the ``EC2_PROFILE`` variable - e.g. ``EC2_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml``
+
 Since each region requires its own API call, if you are only using a small set of regions, feel free to edit ``ec2.ini`` and list only the regions you are interested in. There are other config options in ``ec2.ini`` including cache control, and destination variables.
 
 At their heart, inventory files are simply a mapping from some name to a destination address. The default ``ec2.ini`` settings are configured for running Ansible from outside EC2 (from your laptop for example) -- and this is not the most efficient way to manage EC2.

--- a/docsite/rst/intro_dynamic_inventory.rst
+++ b/docsite/rst/intro_dynamic_inventory.rst
@@ -113,7 +113,7 @@ If you use boto profiles to manage multiple AWS accounts, you can pass ``--profi
 
 You can then run ``ec2.py --profile prod`` to get the inventory for the prod account, or run playbooks with: ``ansible-playbook -i 'ec2.py --profile prod' myplaybook.yml``.
 
-Alternatively, use the ``EC2_PROFILE`` variable - e.g. ``EC2_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml``
+Alternatively, use the ``AWS_PROFILE`` variable - e.g. ``AWS_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml``
 
 Since each region requires its own API call, if you are only using a small set of regions, feel free to edit ``ec2.ini`` and list only the regions you are interested in. There are other config options in ``ec2.ini`` including cache control, and destination variables.
 

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -75,10 +75,16 @@ class Inventory(object):
         self._also_restriction = None
         self._subset = None
 
+        args = []
         if isinstance(host_list, basestring):
             if "," in host_list:
                 host_list = host_list.split(",")
                 host_list = [ h for h in host_list if h and h.strip() ]
+            elif " " in host_list:
+                # presumably a script with arguments. Don't further parse lists though!
+                tokens = host_list.split()
+                self.host_list = host_list = tokens[0]
+                args = tokens[1:]
 
         if host_list is None:
             self.parser = None
@@ -122,7 +128,7 @@ class Inventory(object):
 
                 if is_executable(host_list):
                     try:
-                        self.parser = InventoryScript(loader=self._loader, filename=host_list)
+                        self.parser = InventoryScript(loader=self._loader, filename=host_list, args=args)
                         self.groups = self.parser.groups.values()
                     except errors.AnsibleError:
                         if not shebang_present:

--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -35,15 +35,15 @@ from ansible.module_utils.basic import json_dict_bytes_to_unicode
 class InventoryScript:
     ''' Host inventory parser for ansible using external inventory scripts. '''
 
-    def __init__(self, loader, filename=C.DEFAULT_HOST_LIST):
+    def __init__(self, loader, filename=C.DEFAULT_HOST_LIST, args=[]):
 
         self._loader = loader
-
         # Support inventory scripts that are not prefixed with some
         # path information but happen to be in the current working
         # directory when '.' is not in PATH.
         self.filename = os.path.abspath(filename)
-        cmd = [ self.filename, "--list" ]
+        self.args = args
+        cmd = [ self.filename, "--list"] + self.args
         try:
             sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError, e:
@@ -149,8 +149,7 @@ class InventoryScript:
             got = self.host_vars_from_top.get(host.name, {})
             return got
 
-
-        cmd = [self.filename, "--host", host.name]
+        cmd = [self.filename, "--host", host.name] + self.args
         try:
             sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError, e:


### PR DESCRIPTION
This PR effectively combines #5987 and #8582. It also fixes the merge conflicts in the two PRs and standardizes the option names.

I also removed the environment variable support as boto has since added AWS_PROFILE (starting with version 2.29) which accomplishes the same thing and is consistent with AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.

There is a minor inconsistency right now with the cache directory names. If you use the AWS_PROFILE environment variable, your cache directory name will not change. However, if you use the CLI option or the config option, the cache directory will be named after the profile. We could check the AWS_PROFILE for naming, but the behavior is debatable and I've started a discussion on the ansible-devel mailing list.
