### PR TITLE
Adding ip address to RECAP

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -283,6 +283,9 @@ def main(args):
 
             for h in hosts:
                 t = pb.stats.summarize(h)
+                h_ip = pb.inventory.get_host(h)
+                if host.vars.get('ansible_ssh_host'):
+                    h = '%s - %s' % (h, h_ip.vars['ansible_ssh_host'])
 
                 display("%s : %s %s %s %s" % (
                     hostcolor(h, t),


### PR DESCRIPTION
Sometimes the host information is added in memory
with add_host module (and the host is a VM with a
random ip), and it would be nice to have
an easy way to get the ip address to connect to
the machine when something goes wrong, in order to
debug, without need to go through logs to check
what's the ip address for the specifc machine
