### PR TITLE
Swap out rspec for vagrant in gem module example

### DIFF
--- a/library/packaging/gem
+++ b/library/packaging/gem
@@ -77,8 +77,8 @@ author: Johan Wiren
 '''
 
 EXAMPLES = '''
-# Installs version 1.0 of vagrant.
-- gem: name=vagrant version=1.0 state=present
+# Installs version 3.1.0 of rspec.
+- gem: name=rspec version=3.1.0 state=present
 
 # Installs latest available version of rake.
 - gem: name=rake state=latest


### PR DESCRIPTION
as installing vagrant from gem is very much deprecated.
