### PR TITLE
Unarchive no longer transfers archive if creates= check succeeds

### DIFF
--- a/lib/ansible/runner/action_plugins/unarchive.py
+++ b/lib/ansible/runner/action_plugins/unarchive.py
@@ -49,6 +49,7 @@ class ActionModule(object):
         source  = options.get('src', None)
         dest    = options.get('dest', None)
         copy    = utils.boolean(options.get('copy', 'yes'))
+        creates = options.get('creates', None)
 
         if source is None or dest is None:
             result = dict(failed=True, msg="src (or content) and dest are required")
@@ -66,6 +67,20 @@ class ActionModule(object):
         if remote_md5 != '3':
             result = dict(failed=True, msg="dest '%s' must be an existing dir" % dest)
             return ReturnData(conn=conn, result=result)
+
+        # Perform a pre-check for creates parameter on the client,
+        # prevent transferring files if all ok and skipped is indicated
+        if creates is not None:
+            precheck_module_args = utils.merge_module_args(module_args, "precheck=True")
+            creates_result = self.runner._execute_module(conn, tmp, 'unarchive', precheck_module_args, inject=inject, complex_args=complex_args)
+            if not creates_result.is_successful():
+                return creates_result
+            if creates_result.result['skipped']:
+                return creates_result
+            # tmp path might be removed after module execution, we better create a new one for the archive transfer
+            tmp = self.runner._make_tmp_path(conn)
+
+        module_args = utils.merge_module_args(module_args, "precheck=False")
 
         if copy:
             # transfer the file to a remote tmp location


### PR DESCRIPTION
Unarchive no longer transfers the archive in case the creates= parameter yields a successful match, thus preventing lenghty operations over the network (especially with large archive distributions).

Please note: the unpack module on the client is actually called twice to achieve this - with extra signalling using precheck=True/False parameter. Please suggest other form of signalling if this is not the correct way of doing it.
