### PR TITLE
Ansible is verbose when MySQLdb library import fails

### DIFF
--- a/library/database/mysql_db
+++ b/library/database/mysql_db
@@ -104,10 +104,10 @@ import os
 import pipes
 try:
     import MySQLdb
-except ImportError:
-    mysqldb_found = False
+except ImportError, e:
+    mysqldb_import_error = e
 else:
-    mysqldb_found = True
+    mysqldb_import_error = None
 
 # ===========================================
 # MySQL module specific support methods.
@@ -273,8 +273,8 @@ def main():
         )
     )
 
-    if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+    if mysqldb_import_error is not None:
+        module.fail_json(msg="the python mysqldb module failed to import: %s" % mysqldb_import_error)
 
     db = module.params["name"]
     encoding = module.params["encoding"]

--- a/library/database/mysql_replication
+++ b/library/database/mysql_replication
@@ -123,10 +123,10 @@ import warnings
 
 try:
     import MySQLdb
-except ImportError:
-    mysqldb_found = False
+except ImportError, e:
+    mysqldb_import_error = e
 else:
-    mysqldb_found = True
+    mysqldb_import_error = None
 
 
 def get_master_status(cursor):
@@ -268,8 +268,8 @@ def main():
     master_ssl_key = module.params["master_ssl_key"]
     master_ssl_cipher = module.params["master_ssl_cipher"]
 
-    if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+    if mysqldb_import_error is not None:
+        module.fail_json(msg="the python mysqldb module failed to import: %s" % mysqldb_import_error)
     else:
         warnings.filterwarnings('error', category=MySQLdb.Warning)
 

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -146,10 +146,10 @@ import getpass
 import tempfile
 try:
     import MySQLdb
-except ImportError:
-    mysqldb_found = False
+except ImportError, e:
+    mysqldb_import_error = e
 else:
-    mysqldb_found = True
+    mysqldb_import_error = None
 
 # ===========================================
 # MySQL module specific support methods.
@@ -419,8 +419,8 @@ def main():
     check_implicit_admin = module.params['check_implicit_admin']
     append_privs = module.boolean(module.params["append_privs"])
 
-    if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+    if mysqldb_import_error is not None:
+        module.fail_json(msg="the python mysqldb module failed to import: %s" % mysqldb_import_error)
 
     if priv is not None:
         try:

--- a/library/database/mysql_variables
+++ b/library/database/mysql_variables
@@ -70,10 +70,10 @@ import warnings
 
 try:
     import MySQLdb
-except ImportError:
-    mysqldb_found = False
+except ImportError, e:
+    mysqldb_import_error = e
 else:
-    mysqldb_found = True
+    mysqldb_import_error = None
 
 
 def typedvalue(value):
@@ -201,8 +201,8 @@ def main():
     host = module.params["login_host"]
     mysqlvar = module.params["variable"]
     value = module.params["value"]
-    if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+    if mysqldb_import_error is not None:
+        module.fail_json(msg="the python mysqldb module failed to import: %s" % mysqldb_import_error)
     else:
         warnings.filterwarnings('error', category=MySQLdb.Warning)
 


### PR DESCRIPTION
Ansible displays error message from mysqldb library imports, thus correctly indicating what kind of issue mysqldb library has - i.e. missing, invalid version, link error, etc.

This code 'polishing' change is necessary to correctly debug strange host issues which otherwise take ages to figure out.
