### PR TITLE
template, copy: archive, mtime, atime support added, file: mtime, atime support added.

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -162,6 +162,8 @@ FILE_COMMON_ARGUMENTS=dict(
     directory_mode = dict(), # used by copy
 )
 
+# datetime format used by touch on unix, here utilized by file/copy/template Ansible modules
+TOUCH_DATETIME_FORMAT="%Y%m%d%H%M.%S"
 
 def get_platform():
     ''' what's the platform?  example: Linux is a platform. '''
@@ -304,6 +306,8 @@ class AnsibleModule(object):
         mode   = params.get('mode', None)
         owner  = params.get('owner', None)
         group  = params.get('group', None)
+        atime  = params.get('atime', None)
+        mtime  = params.get('mtime', None)
 
         # selinux related options
         seuser    = params.get('seuser', None)
@@ -322,6 +326,7 @@ class AnsibleModule(object):
 
         return dict(
             path=path, mode=mode, owner=owner, group=group,
+            atime=atime, mtime=mtime,
             seuser=seuser, serole=serole, setype=setype,
             selevel=selevel, secontext=secontext,
         )
@@ -664,6 +669,37 @@ class AnsibleModule(object):
         or_reduce = lambda mode, perm: mode | user_perms_to_modes[user][perm]
         return reduce(or_reduce, perms, 0)
 
+    def set_times_if_different(self, path, atime, mtime, changed):
+        path = os.path.expanduser(path)
+        if mtime is None and atime is None:
+            return changed
+
+        st = os.lstat(path)
+        prev_mtime = time.strftime(TOUCH_DATETIME_FORMAT, time.localtime(st.st_mtime))
+        prev_atime = time.strftime(TOUCH_DATETIME_FORMAT, time.localtime(st.st_atime))
+        if prev_mtime != mtime or prev_atime != atime:
+            if self.check_mode:
+                return True
+            try:
+                # self.fail_json(path=path, msg='touching with atime {}, mtime {}'.format(atime, mtime), details='')
+                os.utime(path, (time.mktime(time.strptime(atime,TOUCH_DATETIME_FORMAT)), time.mktime(time.strptime(mtime,TOUCH_DATETIME_FORMAT))))
+            except OSError, e:
+                if os.path.islink(path) and e.errno == errno.EPERM:  # Can't set time on symbolic links
+                    pass
+                elif e.errno == errno.ENOENT: # Can't set time on broken symbolic links
+                    pass
+                else:
+                    raise e
+            except Exception, e:
+                self.fail_json(path=path, msg='touch failed', details=str(e))
+
+            # we won't be detecting changes on atime as we are interested in write-only changes
+            st = os.lstat(path)
+            new_mtime = time.strftime(TOUCH_DATETIME_FORMAT, time.localtime(st.st_mtime))
+            if new_mtime != prev_mtime:
+                changed = True
+        return changed
+
     def set_fs_attributes_if_different(self, file_args, changed):
         # set modes owners and context as needed
         changed = self.set_context_if_different(
@@ -677,6 +713,9 @@ class AnsibleModule(object):
         )
         changed = self.set_mode_if_different(
             file_args['path'], file_args['mode'], changed
+        )
+        changed = self.set_times_if_different(
+            file_args['path'], file_args['atime'], file_args['mtime'], changed
         )
         return changed
 

--- a/library/files/copy
+++ b/library/files/copy
@@ -148,7 +148,10 @@ def main():
             backup            = dict(default=False, type='bool'),
             force             = dict(default=True, aliases=['thirsty'], type='bool'),
             validate          = dict(required=False, type='str'),
-            directory_mode    = dict(required=False)
+            directory_mode    = dict(required=False),
+            atime             = dict(required=False),
+            mtime             = dict(required=False),
+            archive           = dict(type='bool',required=False), # Dissolved into other parameters before delegation to remote host
         ),
         add_file_common_args=True,
         supports_check_mode=True,

--- a/library/files/file
+++ b/library/files/file
@@ -110,6 +110,9 @@ def main():
             state = dict(choices=['file','directory','link','hard','touch','absent'], default=None),
             path  = dict(aliases=['dest', 'name'], required=True),
             original_basename = dict(required=False), # Internal use only, for recursive ops
+            archive = dict(type='bool',required=False), # Internal use only, delegated here (see template)
+            atime = dict(required=False),
+            mtime = dict(required=False),
             recurse  = dict(default='no', type='bool'),
             force = dict(required=False,default=False,type='bool'),
             diff_peek = dict(default=None),

--- a/library/files/template
+++ b/library/files/template
@@ -47,6 +47,12 @@ options:
     required: false
     default: ""
     version_added: "1.2"
+  archive:
+    description:
+      - When set to true, the created file retains permissions and ownership of the source template file.
+    required: false
+    default: ""
+    version_added: "1.8"
 notes:
   - "Since Ansible version 0.9, templates are loaded with C(trim_blocks=True)."
 requirements: []


### PR DESCRIPTION
template, copy: added support for archive parameter to retain permissions, ownership and timestamps of the source(s) on the destination(s).

template, copy, file: added support for mtime, atime - setting access/mod datetime of the destination(s) in unix touch format HHMMDDhhmi[.ss].

Please note: mtime, atime suport addition is a side-effect of archive and cannot be split in separate pull request.
