### PR TITLE
Add cookie option to win_get_url

### DIFF
--- a/library/windows/win_get_url
+++ b/library/windows/win_get_url
@@ -41,6 +41,12 @@ options:
     required: false
     default: yes
     aliases: []
+  cookie:
+    description:
+      - String to pass as cookie for the request for the file
+    required: false
+    default: null
+    aliases: []
 author: Paul Durivage
 '''
 
@@ -54,4 +60,11 @@ $ ansible -i hosts -c winrm -m win_get_url -a "url=http://www.example.com/earthr
   win_get_url:
     url: 'http://www.example.com/earthrise.jpg'
     dest: 'C:\Users\RandomUser\earthrise.jpg'
+    
+# Playbook example with cookie
+- name: Get Java SDK
+  win_get_url:
+    url: 'http://download.oracle.com/otn-pub/java/jdk/7u67-b01/jdk-7u67-windows-x64.exe'
+    dest: 'C:\jdk-7u67-windows-x64.exe'
+    cookie: 'oraclelicense=accept-securebackup-cookie'
 '''

--- a/library/windows/win_get_url.ps1
+++ b/library/windows/win_get_url.ps1
@@ -42,6 +42,11 @@ Else {
 
 $client = New-Object System.Net.WebClient
 
+If ($params.cookie) {
+    $cookie = $params.cookie
+    $client.Headers.Add([System.Net.HttpRequestHeader]::Cookie, $cookie)
+}
+
 Try {
     $client.DownloadFile($url, $dest)
     $result.changed = $true


### PR DESCRIPTION
Add cookie option for win_get_url.  This is useful to download files that require license agreements such as java.

Example:

```
   - name: Get Java SDK
      win_get_url:
        url: "http://download.oracle.com/otn-pub/java/jdk/7u67-b01/jdk-7u67-windows-x64.exe"
        dest: "C:/jdk-7u67-windows-x64.exe"
        cookie: "oraclelicense=accept-securebackup-cookie"
```
