### PR TITLE
Fix win_feature result message (fixes #8723)

### DIFF
--- a/library/windows/win_feature.ps1
+++ b/library/windows/win_feature.ps1
@@ -97,9 +97,13 @@ if ($featureresult.FeatureResult)
 {
     ForEach ($item in $featureresult.FeatureResult) {
         $installed_features += New-Object psobject @{
+            $msg = ""
+            ForEach ($m in $item.Message){
+                $msg += $m.ToString()
+            }
             id = $item.id.ToString()
             display_name = $item.DisplayName
-            message = $item.Message.ToString()
+            message = $msg
             restart_needed = $item.RestartNeeded.ToString()
             skip_reason = $item.SkipReason.ToString()
             success = $item.Success.ToString()


### PR DESCRIPTION
Output win_feature result messages properly.  All the features I've installed have no messages though (when done manually, it has an output that says "# Msgs" set to 0).

Fixes: #8723
