### PR TITLE
Skip setting up delegate if using local transport

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -840,7 +840,7 @@ class Runner(object):
         if self.delegate_to:
             self.delegate_to = template.template(self.basedir, self.delegate_to, inject)
 
-        if self.delegate_to is not None:
+        if self.delegate_to is not None and self.transport != 'local':
             delegate = self._compute_delegate(actual_pass, inject)
             actual_transport = delegate['transport']
             actual_host = delegate['ssh_host']


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

ansible 1.8 (devel 1970361) last updated 2014/09/25 10:53:31 (GMT -700)
##### Environment:

Running from: Mac OS X 10.9, Fedora 20
Running against: Debian 7, CentOS 6/7
##### Summary:

If using the "local" transport then there is no need to setup a delegation host. This "feature" skips the delegation setup when `self.transport` is set to "local." The local transport connection plugin sets itself up and does not require any information that is inside of the delegation variable.

This should should not be noticed by the user as nothing really changes, less work is just done.
