### PR TITLE
update version requirement in doc for fire&forget async mode

### DIFF
--- a/docsite/rst/playbooks_async.rst
+++ b/docsite/rst/playbooks_async.rst
@@ -61,7 +61,7 @@ If you would like to perform a variation of the "fire and forget" where you
 following::
 
       --- 
-      # Requires ansible 1.7+
+      # Requires ansible 1.8+
       - name: 'YUM - fire and forget task'
         yum: name=docker-io state=installed
         async: 1000


### PR DESCRIPTION
At the point I opened this pull request[0] the next upcoming version was 1.7, this should be changed to 1.8 now that it's been merged in for the 1.8 release.

@jimi-c please review.

Thanks,
-AdamM

[0] - https://github.com/ansible/ansible/pull/7468
