### PR TITLE
pass pvs as a list to vgcreate

### DIFF
--- a/library/system/lvg
+++ b/library/system/lvg
@@ -188,7 +188,7 @@ def main():
                     else:
                         module.fail_json(msg="Creating physical volume '%s' failed" % current_dev, rc=rc, err=err)
                 vgcreate_cmd = module.get_bin_path('vgcreate')
-                rc,_,err = module.run_command([vgcreate_cmd] + vgoptions + ['-s', str(pesize), vg, dev_string])
+                rc,_,err = module.run_command([vgcreate_cmd] + vgoptions + ['-s', str(pesize), vg] + dev_list])
                 if rc == 0:
                     changed = True
                 else:


### PR DESCRIPTION
This addresses issue #8316 which prevents a volume group from being created when provided with multiple pvs.

E.g.:
lvg: state=present vg=my_volume_group pvs=/dev/sda,/dev/sdb pesize=4 # fails under ansible 1.7
