### PR TITLE
Add support for STS Tokens (aws_security_token) to all cloud modules

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -150,7 +150,7 @@ def get_ec2_creds(module):
     ''' for compatibility mode with old modules that don't/can't yet
         use ec2_connect method '''
     region, ec2_url, boto_params = get_aws_connection_info(module)
-    return ec2_url, boto_params['aws_access_key_id'], boto_params['aws_secret_access_key'], region
+    return ec2_url, boto_params['aws_access_key_id'], boto_params['aws_secret_access_key'], boto_params['security_token'], region
 
 
 def boto_fix_security_token_in_profile(conn, profile_name):

--- a/library/cloud/cloudformation
+++ b/library/cloud/cloudformation
@@ -82,6 +82,13 @@ options:
     default: null
     aliases: [ 'ec2_access_key', 'access_key' ]
     version_added: "1.5"
+  aws_security_token:
+    description:
+      - AWS STS Security Token. If not set then the value of the AWS_SECURITY_TOKEN environment variable is used.
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.8"
   region:
     description:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
@@ -212,7 +219,7 @@ def main():
     template_parameters = module.params['template_parameters']
     tags = module.params['tags']
 
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    ec2_url, aws_access_key, aws_secret_key, aws_security_token, region = get_ec2_creds(module)
 
     kwargs = dict()
     if tags is not None:
@@ -230,6 +237,7 @@ def main():
         cfn = boto.cloudformation.connection.CloudFormationConnection(
                   aws_access_key_id=aws_access_key, 
                   aws_secret_access_key=aws_secret_key,
+                  security_token=aws_security_token,
                   region=cf_region,
               )
     except boto.exception.NoAuthHandlerFound, e:

--- a/library/cloud/ec2_vpc
+++ b/library/cloud/ec2_vpc
@@ -112,6 +112,13 @@ options:
     required: false
     default: None
     aliases: ['ec2_access_key', 'access_key' ]
+  aws_security_token:
+    description:
+      - AWS STS Security Token. If not set then the value of the AWS_SECURITY_TOKEN environment variable is used.
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.8"
   validate_certs:
     description:
       - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
@@ -593,7 +600,7 @@ def main():
 
     state = module.params.get('state')
 
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    ec2_url, aws_access_key, aws_secret_key, aws_security_token, region = get_ec2_creds(module)
 
     # If we have a region specified, connect to its endpoint.
     if region:
@@ -601,7 +608,8 @@ def main():
             vpc_conn = boto.vpc.connect_to_region(
                 region,
                 aws_access_key_id=aws_access_key,
-                aws_secret_access_key=aws_secret_key
+                aws_secret_access_key=aws_secret_key,
+                security_token=aws_security_token
             )
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))

--- a/library/cloud/elasticache
+++ b/library/cloud/elasticache
@@ -98,6 +98,13 @@ options:
     required: false
     default: None
     aliases: ['ec2_access_key', 'access_key']
+  aws_security_token:
+    description:
+      - AWS STS Security Token. If not set then the value of the AWS_SECURITY_TOKEN environment variable is used.
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.8"
   region:
     description:
       - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
@@ -159,7 +166,7 @@ class ElastiCacheManager(object):
 
     def __init__(self, module, name, engine, cache_engine_version, node_type,
                  num_nodes, cache_port, cache_security_groups, security_group_ids, zone, wait,
-                 hard_modify, aws_access_key, aws_secret_key, region):
+                 hard_modify, aws_access_key, aws_secret_key, aws_security_token, region):
         self.module = module
         self.name = name
         self.engine = engine
@@ -175,6 +182,7 @@ class ElastiCacheManager(object):
 
         self.aws_access_key = aws_access_key
         self.aws_secret_key = aws_secret_key
+        self.aws_security_token = aws_security_token
         self.region = region
 
         self.changed = False
@@ -427,6 +435,7 @@ class ElastiCacheManager(object):
             connect_region = RegionInfo(name=self.region, endpoint=endpoint)
             return ElastiCacheConnection(aws_access_key_id=self.aws_access_key,
                                          aws_secret_access_key=self.aws_secret_key,
+                                         security_token=self.aws_security_token,
                                          region=connect_region)
         except boto.exception.NoAuthHandlerFound, e:
             self.module.fail_json(msg=e.message)
@@ -499,7 +508,7 @@ def main():
         argument_spec=argument_spec,
     )
 
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    ec2_url, aws_access_key, aws_secret_key, aws_security_token, region = get_ec2_creds(module)
 
     name = module.params['name']
     state = module.params['state']
@@ -526,7 +535,7 @@ def main():
                                              cache_security_groups,
                                              security_group_ids, zone, wait,
                                              hard_modify, aws_access_key,
-                                             aws_secret_key, region)
+                                             aws_secret_key, aws_security_token, region)
 
     if state == 'present':
         elasticache_manager.ensure_present()

--- a/library/cloud/rds_param_group
+++ b/library/cloud/rds_param_group
@@ -79,6 +79,13 @@ options:
     required: false
     default: null
     aliases: [ 'ec2_secret_key', 'secret_key' ]
+  aws_security_token:
+    description:
+      - AWS STS Security Token. If not set then the value of the AWS_SECURITY_TOKEN environment variable is used.
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.8"
 requirements: [ "boto" ]
 author: Scott Anderson
 '''
@@ -247,13 +254,13 @@ def main():
                 module.fail_json(msg = str("Parameter %s not allowed for state='absent'" % not_allowed))
 
     # Retrieve any AWS settings from the environment.
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    ec2_url, aws_access_key, aws_secret_key, aws_security_token, region = get_ec2_creds(module)
 
     if not region:
         module.fail_json(msg = str("region not specified and unable to determine region from EC2_REGION."))
 
     try:
-        conn = boto.rds.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
+        conn = boto.rds.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key, security_token=aws_security_token)
     except boto.exception.BotoServerError, e:
         module.fail_json(msg = e.error_message)
 

--- a/library/cloud/rds_subnet_group
+++ b/library/cloud/rds_subnet_group
@@ -65,6 +65,13 @@ options:
     required: false
     default: null
     aliases: [ 'ec2_secret_key', 'secret_key' ]
+  aws_security_token:
+    description:
+      - AWS STS Security Token. If not set then the value of the AWS_SECURITY_TOKEN environment variable is used.
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.8"
 requirements: [ "boto" ]
 author: Scott Anderson
 '''
@@ -122,13 +129,13 @@ def main():
                 module.fail_json(msg = str("Parameter %s not allowed for state='absent'" % not_allowed))
 
     # Retrieve any AWS settings from the environment.
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    ec2_url, aws_access_key, aws_secret_key, aws_security_token, region = get_ec2_creds(module)
 
     if not region:
         module.fail_json(msg = str("region not specified and unable to determine region from EC2_REGION."))
 
     try:
-        conn = boto.rds.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key)
+        conn = boto.rds.connect_to_region(region, aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key, security_token=aws_security_token)
     except boto.exception.BotoServerError, e:
         module.fail_json(msg = e.error_message)
 

--- a/library/cloud/route53
+++ b/library/cloud/route53
@@ -72,6 +72,13 @@ options:
     required: false
     default: null
     aliases: ['ec2_access_key', 'access_key']
+  aws_security_token:
+    description:
+      - AWS STS Security Token. If not set then the value of the AWS_SECURITY_TOKEN environment variable is used.
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.8"
   overwrite:
     description:
       - Whether an existing record should be overwritten on create if values do not match
@@ -143,6 +150,7 @@ import time
 try:
     import boto
     from boto import route53
+    from boto.route53 import Route53Connection
     from boto.route53.record import ResourceRecordSets
 except ImportError:
     print "failed=True msg='boto required for this module'"
@@ -185,7 +193,7 @@ def main():
     value_in              = module.params.get('value')
     retry_interval_in     = module.params.get('retry_interval')
 
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    ec2_url, aws_access_key, aws_secret_key, aws_security_token, region = get_ec2_creds(module)
 
     value_list = ()
 
@@ -207,7 +215,10 @@ def main():
 
     # connect to the route53 endpoint 
     try:
-        conn = boto.route53.connection.Route53Connection(aws_access_key, aws_secret_key)
+        conn = Route53Connection(
+            aws_access_key_id=aws_access_key, 
+            aws_secret_access_key=aws_secret_key,
+            security_token=aws_security_token)
     except boto.exception.BotoServerError, e:
         module.fail_json(msg = e.error_message)
 

--- a/library/cloud/s3
+++ b/library/cloud/s3
@@ -89,6 +89,13 @@ options:
     required: false
     default: null
     version_added: "1.6"
+  aws_security_token:
+    description:
+      - AWS STS Security Token. If not set then the value of the AWS_SECURITY_TOKEN environment variable is used.
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.8"
   region:
     description:
      - "AWS region to create the bucket in. If not set then the value of the EC2_REGION and AWS_REGION environment variables are checked, followed by the aws_region and ec2_region settings in the Boto config file.  If none of those are set the region defaults to the S3 Location: US Standard.  Prior to ansible 1.8 this parameter could be specified but had no effect."
@@ -137,6 +144,7 @@ import hashlib
 try:
     import boto
     from boto.s3.connection import Location
+    from boto.s3.connection import S3Connection
 except ImportError:
     print "failed=True msg='boto required for this module'"
     sys.exit(1)
@@ -308,7 +316,7 @@ def main():
     overwrite = module.params.get('overwrite')
     metadata = module.params.get('metadata')
 
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    ec2_url, aws_access_key, aws_secret_key, aws_security_token, region = get_ec2_creds(module)
 
     if region in ('us-east-1', '', None):
         # S3ism for the US Standard region
@@ -348,7 +356,10 @@ def main():
             module.fail_json(msg = str(e))
     else:
         try:
-            s3 = boto.connect_s3(aws_access_key, aws_secret_key)
+            s3 = S3Connection(
+                aws_access_key_id=aws_access_key,
+                aws_secret_access_key=aws_secret_key,
+                security_token=aws_security_token)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
  


### PR DESCRIPTION
Extends get_ec2_creds() in lib/ansible/module_utils/ec2.py to include security token.

Modifies all cloud modules to respect security token and provide to service-specific boto connections as required.

These changes enable ansible's cloud modules to use temporary credentials provided as a result of assuming an IAM Role, rather than using IAM user credentials.
