### PR TITLE
Now to copy content must define a filename not a directory

### DIFF
--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -70,6 +70,9 @@ class ActionModule(object):
         elif (source is not None or 'first_available_file' in inject) and content is not None:
             result=dict(failed=True, msg="src and content are mutually exclusive")
             return ReturnData(conn=conn, result=result)
+        elif content is not None and dest is not None and dest.endswith("/"):
+            result=dict(failed=True, msg="dest must be a file if content is defined")
+            return ReturnData(conn=conn, result=result)
 
         # Check if the source ends with a "/"
         source_trailing_slash = False
@@ -295,7 +298,7 @@ class ActionModule(object):
             or (not C.DEFAULT_KEEP_REMOTE_FILES and delete_remote_tmp and not module_executed):
             self.runner._remove_tmp_path(conn, tmp_path)
 
-        # the file module returns the file path as 'path', but 
+        # the file module returns the file path as 'path', but
         # the copy module uses 'dest', so add it if it's not there
         if 'path' in module_result and 'dest' not in module_result:
             module_result['dest'] = module_result['path']
@@ -365,7 +368,7 @@ class ActionModule(object):
         if content is not None:
             os.remove(content_tempfile)
 
-    
+
     def _result_key_merge(self, options, results):
         # add keys to file module results to mimic copy
         if 'path' in results.result and 'dest' not in results.result:

--- a/library/files/copy
+++ b/library/files/copy
@@ -42,7 +42,8 @@ options:
   content:
     version_added: "1.1"
     description:
-      - When used instead of 'src', sets the contents of a file directly to the specified value.
+      - When used instead of 'src', sets the contents of a file directly to the
+        specified value. Destination must be a file (without / at the end)
     required: false
     default: null
   dest:
@@ -205,7 +206,7 @@ def main():
                 # os.path.exists() can return false in some
                 # circumstances where the directory does not have
                 # the execute bit for the current user set, in
-                # which case the stat() call will raise an OSError 
+                # which case the stat() call will raise an OSError
                 os.stat(os.path.dirname(dest))
             except OSError, e:
                 if "permission denied" in str(e).lower():

--- a/test/integration/roles/test_copy/tasks/main.yml
+++ b/test/integration/roles/test_copy/tasks/main.yml
@@ -237,3 +237,16 @@
   assert:
     that:
     - replace_follow_result.md5sum == target_file_result.stdout
+
+# test check if raise an error when try to copy content without define
+# a file
+
+- name: trying to copy content without define a dest file
+  copy: content="lorem ipsum" dest={{output_dir}}/follow_test/
+  ignore_errors: true
+  register: failed_copy
+
+- name: check that copy content ran but failed with errors
+  assert:
+    that:
+      - "failed_copy|failed"


### PR DESCRIPTION
Now if you define a copy content task without define a file in the dest property an error is thrown.
