### PR TITLE
ec2_asg: remove ‘tags’ key from asg_properties before exit_json

### DIFF
--- a/library/cloud/ec2_asg
+++ b/library/cloud/ec2_asg
@@ -603,6 +603,7 @@ def main():
        module.exit_json( changed = changed )
     if create_changed or replace_changed:
         changed = True
+    asg_properties.pop('tags', None)
     module.exit_json( changed = changed, **asg_properties )
 
 main()


### PR DESCRIPTION
I am _NOT_ proposing this as the solution to #9176, merely as a reference of the stopgap I'm using
