### PR TITLE
Updated version info to include submodule information

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -883,8 +883,11 @@ def _gitinfo():
     for line in f:
         tokens = line.strip().split(' ')
         if tokens[0] == 'path':
-            repo_path = tokens[2]
-            result += "\n  {0}: {1}".format(repo_path, _gitrepoinfo(os.path.join(basedir, repo_path, '.git')))
+            submodule_path = tokens[2]
+            submodule_info =_gitrepoinfo(os.path.join(basedir, submodule_path, '.git'))
+            if not submodule_info:
+                submodule_info = ' not found - use git submodule update --init ' + submodule_path
+            result += "\n  {0}: {1}".format(submodule_path, submodule_info)
     f.close()
     return result
 


### PR DESCRIPTION
`ansible --version` etc. now include information about submodules

```
ansible 1.8 (submodule_ansible_version ffee9a8fe0) last updated 2014/09/28 11:03:14 (GMT +1000)
  lib/ansible/modules/core: (ec2_snapshot_remove 3a77c31ecb) last updated 2014/09/27 18:23:31 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD 110250d344) last updated 2014/09/27 14:33:42 (GMT +1000)
```

Also improved handling of detached HEAD when printing out version
information.
