### PR TITLE
Remove references to old module dir from .spec

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.md packaging/rpm/ansible.spec COPYING
 include examples/hosts
 include examples/ansible.cfg
 include lib/ansible/module_utils/powershell.ps1
+recursive-include lib/ansible/modules *
 recursive-include docs *
 include Makefile
 include VERSION

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -104,8 +104,6 @@ rm -rf %{buildroot}
 %{python_sitelib}/ansible*
 %{_bindir}/ansible*
 %dir %{_datadir}/ansible
-%dir %{_datadir}/ansible/*
-%{_datadir}/ansible/*/*
 %config(noreplace) %{_sysconfdir}/ansible
 %doc README.md PKG-INFO COPYING
 %doc %{_mandir}/man1/ansible*

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from glob import glob
 sys.path.insert(0, os.path.abspath('lib'))
 from ansible import __version__, __author__
 try:
-    from setuptools import setup
+    from setuptools import setup, find_packages
 except ImportError:
     print "Ansible now needs setuptools in order to build. " \
           "Install it using your package manager (usually python-setuptools) or via pip (pip install setuptools)."
@@ -22,23 +22,7 @@ setup(name='ansible',
       license='GPLv3',
       install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
       package_dir={ 'ansible': 'lib/ansible' },
-      packages=[
-         'ansible',
-         'ansible.cache',
-         'ansible.utils',
-         'ansible.utils.module_docs_fragments',
-         'ansible.inventory',
-         'ansible.inventory.vars_plugins',
-         'ansible.playbook',
-         'ansible.runner',
-         'ansible.runner.action_plugins',
-         'ansible.runner.lookup_plugins',
-         'ansible.runner.connection_plugins',
-         'ansible.runner.shell_plugins',
-         'ansible.runner.filter_plugins',
-         'ansible.callback_plugins',
-         'ansible.module_utils'
-      ],
+      packages=find_packages('lib'),
       package_data={
          '': ['module_utils/*.ps1'],
       },


### PR DESCRIPTION
Fixes RPM builds by removing old module path from %files.
