### PR TITLE
Allow some ansible libraries to be imported on Windows

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import pwd
 import sys
 import ConfigParser
 from string import ascii_letters, digits
@@ -88,7 +87,12 @@ def shell_expand_path(path):
 
 p = load_config_file()
 
-active_user   = pwd.getpwuid(os.geteuid())[0]
+try:
+    import pwd
+    active_user = pwd.getpwuid(os.geteuid())[0]
+except ImportError:
+    import getpass
+    active_user = getpass.getuser()
 
 # check all of these extensions when looking for yaml files for things like
 # group variables -- really anything we can load

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -638,12 +638,12 @@ class Inventory(object):
 
             if group and host is None:
                 # load vars in dir/group_vars/name_of_group
-                base_path = os.path.join(basedir, "group_vars/%s" % group.name)
+                base_path = os.path.join(basedir, "group_vars", group.name)
                 results = utils.load_vars(base_path, results, vault_password=self._vault_password)
 
             elif host and group is None:
                 # same for hostvars in dir/host_vars/name_of_host
-                base_path = os.path.join(basedir, "host_vars/%s" % host.name)
+                base_path = os.path.join(basedir, "host_vars", host.name)
                 results = utils.load_vars(base_path, results, vault_password=self._vault_password)
 
         # all done, results is a dictionary of variables for this particular host.

--- a/lib/ansible/runner/action_plugins/pause.py
+++ b/lib/ansible/runner/action_plugins/pause.py
@@ -18,7 +18,8 @@
 from ansible.callbacks import vv
 from ansible.errors import AnsibleError as ae
 from ansible.runner.return_data import ReturnData
-from ansible.utils import getch, parse_kv
+from ansible.utils import parse_kv
+from ansible.utils.unix import getch
 import ansible.utils.template as template
 from termios import tcflush, TCIFLUSH
 import datetime

--- a/lib/ansible/utils/unix.py
+++ b/lib/ansible/utils/unix.py
@@ -1,0 +1,32 @@
+# (c) 2012-4, Tim Bielawa <tbielawa@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import termios
+import tty
+
+
+def getch():
+    ''' read in a single character '''
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    try:
+        tty.setraw(sys.stdin.fileno())
+        ch = sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+    return ch


### PR DESCRIPTION
The intention is to allow ansible-inventory-grapher to run on
windows. Windows-specific issues with other parts of the codebase
definitely still exist

Remove unix specific dependencies from ansible.utils to ansible.utils.unix
Removed unwanted pwd import from ansible.constants
Import display_function in ansible.utils only when required
Fixed broken path construction for loading host and group vars
Handling filenames that windows doesn't like (typically globs
for hosts in inventory - e.g. web*)

There's a weird copyright conundrum as a result of this change, in terms
of attribution for the additional python module. git blame suggests that
@tbielawa contributed the functionality and so I've credited him in the
copyright for the file.
