### PR TITLE
Adding readlink to filters ?

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -30,6 +30,7 @@ from ansible.utils import md5s
 from distutils.version import LooseVersion, StrictVersion
 from random import SystemRandom
 from jinja2.filters import environmentfilter
+from os import readlink
 
 
 def to_nice_yaml(*a, **kw):
@@ -261,6 +262,9 @@ class FilterModule(object):
             'expanduser': os.path.expanduser,
             'realpath': os.path.realpath,
             'relpath': os.path.relpath,
+            
+            #os
+            'readlink': readlink,
 
             # failure testing
             'failed'  : failed,


### PR DESCRIPTION
Hello,

It is useful at least for installing software to /opt/xxx, where /opt/xxx-version is the real directory and /opt/xxx is a symlink

At ansible host:
ls -l
2.4/
latest -> 2.4

So you can play with latest and readlink in your playbook

Thanks
