### PR TITLE
Resolve issue where repo_path contains multiple '.git' strings

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -845,7 +845,7 @@ def _git_repo_info(repo_path):
                 if os.path.isabs(gitdir):
                     repo_path = gitdir
                 else:
-                    repo_path = os.path.join(repo_path.split('.git')[0], gitdir)
+                    repo_path = os.path.join(repo_path[:-4], gitdir)
             except (IOError, AttributeError):
                 return ''
         f = open(os.path.join(repo_path, "HEAD"))


### PR DESCRIPTION
If the repo_path contained multiple '.git' strings, the _git_repo_info()
call resulted in a traceback.  This change removes the trailing '.git'
and resolves the traceback.
