### PR TITLE
add 'description' parameter.

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -38,7 +38,7 @@ class Play(object):
        'accelerate_port', 'accelerate_ipv6', 'sudo', 'sudo_user', 'transport', 'playbook',
        'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
        'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts', 'su', 'su_user',
-       'vault_password', 'no_log',
+       'vault_password', 'no_log', 'description',
     ]
 
     # to catch typos and so forth -- these are userland names
@@ -48,7 +48,7 @@ class Play(object):
        'tasks', 'handlers', 'remote_user', 'user', 'port', 'include', 'accelerate', 'accelerate_port', 'accelerate_ipv6',
        'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'serial',
        'any_errors_fatal', 'roles', 'role_names', 'pre_tasks', 'post_tasks', 'max_fail_percentage',
-       'su', 'su_user', 'vault_password', 'no_log',
+       'su', 'su_user', 'vault_password', 'no_log', 'description',
     ]
 
     # *************************************************

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -32,7 +32,7 @@ class Task(object):
         'local_action', 'transport', 'sudo', 'remote_user', 'sudo_user', 'sudo_pass',
         'items_lookup_plugin', 'items_lookup_terms', 'environment', 'args',
         'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until',
-        'su', 'su_user', 'su_pass', 'no_log', 'run_once',
+        'su', 'su_user', 'su_pass', 'no_log', 'run_once', 'description',
     ]
 
     # to prevent typos and such
@@ -42,7 +42,7 @@ class Task(object):
          'delegate_to', 'local_action', 'transport', 'remote_user', 'sudo', 'sudo_user',
          'sudo_pass', 'when', 'connection', 'environment', 'args',
          'any_errors_fatal', 'changed_when', 'failed_when', 'always_run', 'delay', 'retries', 'until',
-         'su', 'su_user', 'su_pass', 'no_log', 'run_once',
+         'su', 'su_user', 'su_pass', 'no_log', 'run_once', 'description',
     ]
 
     def __init__(self, play, ds, module_vars=None, default_vars=None, additional_conditions=None, role_name=None):


### PR DESCRIPTION
PROPOSAL: 'description' parameter

I'd like to add a "description" parameter.
Ansible does nothing about on it. it just describing what is it.

I know YAML can have a comment and a name is good to know what this task
do. But a comment is not structured and a name can not be long because
handlers use it.

If ansible defines "description", a documentation tool such as
Sphinx can read it and produces a good document.

```

---
- hosts: all
  description: This playbook is an example for describe directive
  tasks:
    - name: create empty file
      file: path=/tmp/empty state=touch
      description: >
        This empty file is needed to later tasks,
        such as A, B, and C.
    - name: do some script
      script: /some/local/script.sh
      description:
        - a
        - b
        - c
    - script: /some/local/script.sh
      description:
        can: use map
        some: thing
        other: thing

- include: other.yml
  description:
    - include can have description also
```

I will send this proposal to the ansible-project mailing list.
