### PR TITLE
Add doc of @filename in intro_patterns.rst

### DIFF
--- a/docsite/rst/intro_patterns.rst
+++ b/docsite/rst/intro_patterns.rst
@@ -84,6 +84,10 @@ While we're jumping a bit ahead, additionally, you can add an exclusion criteria
 
     ansible-playbook site.yml --limit datacenter2
 
+And if you want to read the list of hosts from a file, prefix the file name with '@'.  Since Ansible 1.2::
+
+    ansible-playbook site.yml --limit @retry_hosts.txt
+
 Easy enough.  See :doc:`intro_adhoc` and then :doc:`playbooks` for how to apply this knowledge.
 
 .. seealso::


### PR DESCRIPTION
I noticed that the @filename notation for the --limit argument was not
conveniently described.

This patch adds a simple example to the intro_patterns.rst file.
