### PR TITLE
Warn that ssh_args is incompatible with pipelining, note such in documentation

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -653,6 +653,7 @@ Enabling pipelining reduces the number of SSH operations required to
 execute a module on the remote server, by executing many ansible modules without actual file transfer. 
 This can result in a very significant performance improvement when enabled, however when using "sudo:" operations you must
 first disable 'requiretty' in /etc/sudoers on all managed hosts.
+You must also not have any "ssh_args" value in the ssh_configuration section of your Ansible configuration file.
 
 By default, this option is disabled to preserve compatibility with
 sudoers configurations that have requiretty (the default on many distros), but is highly

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -62,6 +62,8 @@ class Connection(object):
         if extra_args is not None:
             # make sure there is no empty string added as this can produce weird errors
             self.common_args += [x.strip() for x in shlex.split(extra_args) if x.strip()]
+            if C.ANSIBLE_SSH_PIPELINING:
+                vvv("WARNING: pipelining is not available when ssh_args is set", host=self.host)
         else:
             self.common_args += ["-o", "ControlMaster=auto",
                                  "-o", "ControlPersist=60s",


### PR DESCRIPTION
Documents the behavior reported in https://github.com/ansible/ansible/issues/7251 (which appears to be deliberate based on a read of ssh.py).
