### PR TITLE
Added a note about escaping backreferences when using 'regex_replace' filter

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -355,6 +355,9 @@ To replace text in a string with regex, use the "regex_replace" filter::
     # convert "foobar" to "bar"
     {{ 'foobar' | regex_replace('^f.*o(.*)$', '\\1') }}
 
+.. note:: If "regex_replace" filter is used with variables inside YAML arguments (as opposed to simpler 'key=value' arguments),
+   then you need to escape backreferences (e.g. ``\\1``) with 4 backslashes (``\\\\``) instead of 2 (``\\``).
+
 A few useful filters are typically added with each new Ansible release.  The development documentation shows
 how to extend Ansible filters by writing your own as plugins, though in general, we encourage new ones
 to be added to core so everyone can make use of them.


### PR DESCRIPTION
Users will often be puzzled why 'regex_replace' is not working as intended when used inside
YAML arguments. This note explains what they have to do to get it working.
