### PR TITLE
added new 'shuffle' filter

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -297,6 +297,19 @@ Get a random number from 1 to 100 but in steps of 10::
     {{ 100 |random(start=1, step=10) }}    => 51
 
 
+Shuffle Filter
+--------------
+
+.. versionadded:: 1.8
+
+This filter will randomize an existing list, giving a differnt order every invocation.
+
+To get a random list from an existing  list::
+
+    {{ ['a','b','c']|shuffle }} => ['c','a','b']
+    {{ ['a','b','c']|shuffle }} => ['b','c','a']
+
+
 .. _other_useful_filters:
 
 Other Useful Filters

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -309,6 +309,7 @@ To get a random list from an existing  list::
     {{ ['a','b','c']|shuffle }} => ['c','a','b']
     {{ ['a','b','c']|shuffle }} => ['b','c','a']
 
+note that when used with a non 'listable' item it is a noop, otherwise it always returns a list
 
 .. _other_useful_filters:
 

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -236,7 +236,10 @@ def rand(environment, end, start=None, step=None):
         raise errors.AnsibleFilterError('random can only be used on sequences and integers')
 
 def randomize_list(mylist):
-    shuffle(mylist)
+    try:
+        shuffle(list(mylist))
+    except:
+        pass
     return mylist
 
 class FilterModule(object):

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -237,7 +237,8 @@ def rand(environment, end, start=None, step=None):
 
 def randomize_list(mylist):
     try:
-        shuffle(list(mylist))
+        mylist = list(mylist)
+        shuffle(mylist)
     except:
         pass
     return mylist

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -28,7 +28,7 @@ import operator as py_operator
 from ansible import errors
 from ansible.utils import md5s
 from distutils.version import LooseVersion, StrictVersion
-from random import SystemRandom
+from random import SystemRandom, shuffle
 from jinja2.filters import environmentfilter
 
 
@@ -235,6 +235,9 @@ def rand(environment, end, start=None, step=None):
     else:
         raise errors.AnsibleFilterError('random can only be used on sequences and integers')
 
+def randomize_list(mylist):
+    shuffle(mylist)
+    return mylist
 
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
@@ -305,6 +308,7 @@ class FilterModule(object):
             # version comparison
             'version_compare': version_compare,
 
-            # random numbers
+            # random stuff
             'random': rand,
+            'shuffle': randomize_list,
         }


### PR DESCRIPTION
gives out a different randomized list every time

```
- hosts: localhost
  vars:
    - mylist: [1,2,3,4,5]
  tasks:  
    - debug: msg={{item}}
      with_items: "{{mylist|shuffle}}"
```

in one example:

```
 _________________________ 
< TASK: debug msg={{item}} >
 -------------------------- 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
ok: [host1] => (item=4) => {
    "item": 4,                                                                                                                                                             
    "msg": "4"
}
ok: [host1] => (item=3) => {
    "item": 3, 
    "msg": "3"
}
ok: [host1] => (item=2) => {
    "item": 2, 
    "msg": "2"
}
ok: [host1] => (item=1) => {
    "item": 1, 
    "msg": "1"
}
ok: [host1] => (item=5) => {
    "item": 5, 
    "msg": "5"
}
```
