### PR TITLE
Allow modules to provide useful information to --diff

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -543,7 +543,7 @@ class Runner(object):
         data = utils.parse_json(res['stdout'], from_remote=True, no_exceptions=True)
         if 'parsed' in data and data['parsed'] == False:
             data['msg'] += res['stderr']
-        return ReturnData(conn=conn, result=data)
+        return ReturnData(conn=conn, result=data, diff=data.get("diff", {}))
 
     # *****************************************************
 


### PR DESCRIPTION
`--diff` is a very useful feature, but right now it is only available for templates and copies. However, lots of modules would benefit from being allowed to report their differences. Imagine a check/diff run telling you which packages would be installed by apt/yum etc.

This patch allows modules to return a diff value, which gets passed to the relevant callbacks.
