### PR TITLE
Makes listify_lookup_plugin_terms respect the global setting for undefined variables.

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -48,6 +48,7 @@ import sys
 import json
 import subprocess
 import contextlib
+import jinja2.exceptions
 
 from vault import VaultLib
 
@@ -1419,11 +1420,13 @@ def listify_lookup_plugin_terms(terms, basedir, inject):
             # if not already a list, get ready to evaluate with Jinja2
             # not sure why the "/" is in above code :)
             try:
-                new_terms = template.template(basedir, "{{ %s }}" % terms, inject)
+                new_terms = template.template(basedir, terms, inject, convert_bare=True, fail_on_undefined=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR)
                 if isinstance(new_terms, basestring) and "{{" in new_terms:
                     pass
                 else:
                     terms = new_terms
+            except jinja2.exceptions.UndefinedError, e:
+                raise errors.AnsibleUndefinedVariable('undefined variable in items: %s' % e)
             except:
                 pass
 

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -541,10 +541,19 @@ class TestUtils(unittest.TestCase):
 
     def test_listify_lookup_plugin_terms(self):
         basedir = os.path.dirname(__file__)
+
+        # Straight lookups
         self.assertEqual(ansible.utils.listify_lookup_plugin_terms('things', basedir, dict()),
                          ['things'])
         self.assertEqual(ansible.utils.listify_lookup_plugin_terms('things', basedir, dict(things=['one', 'two'])),
                          ['one', 'two'])
+
+        # Variable interpolation
+        self.assertEqual(ansible.utils.listify_lookup_plugin_terms('things', basedir, dict(things=['{{ foo }}', '{{ bar }}'], foo="hello", bar="world")),
+                         ['hello', 'world'])
+        with self.assertRaises(ansible.errors.AnsibleError) as ex:
+            ansible.utils.listify_lookup_plugin_terms('things', basedir, dict(things=['{{ foo }}', '{{ bar_typo }}'], foo="hello", bar="world"))
+        self.assertTrue("undefined variable in items: 'bar_typo'" in ex.exception.msg)
 
     def test_deprecated(self):
         sys_stderr = sys.stderr


### PR DESCRIPTION
(Fixes #9008.)

With credit to @jimi-c for the first pass: https://github.com/jimi-c/ansible/commit/b18bd6b98edecda1fcb5a85053593e78b46b9709
