### PR TITLE
Do not use 'remote_user' in the variable passing with include statements example.

### DIFF
--- a/docsite/rst/playbooks_roles.rst
+++ b/docsite/rst/playbooks_roles.rst
@@ -85,7 +85,7 @@ which also supports structured variables::
 
       - include: wordpress.yml
         vars:
-            remote_user: timmy
+            user: timmy
             some_list_variable:
               - alpha
               - beta


### PR DESCRIPTION
Previous documentation might erroneously lead readers into assuming that
passing a variable named 'remote_user' with an include statement will set the
'remote_user' parameter to the given value on all the included tasks.
This is not the case, so it is better to use another variable name in the
example.
Also, using 'user' for the variable name is consistent with the examples
showing passing variables with a different syntax.
