### PR TITLE
Simpler fix for module suffixes than c02e8d8c8.

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1224,7 +1224,7 @@ class Runner(object):
 
         # Search module path(s) for named module.
         module_suffixes = getattr(conn, 'default_suffixes', None)
-        module_path = utils.plugins.module_finder.find_plugin(module_name, module_suffixes, transport=self.transport)
+        module_path = utils.plugins.module_finder.find_plugin(module_name, module_suffixes)
         if module_path is None:
             module_path2 = utils.plugins.module_finder.find_plugin('ping', module_suffixes)
             if module_path2 is not None:

--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -155,17 +155,14 @@ class PluginLoader(object):
                 self._extra_dirs.append(directory)
                 self._paths = None
 
-    def find_plugin(self, name, suffixes=None, transport=''):
+    def find_plugin(self, name, suffixes=None):
         ''' Find a plugin named name '''
 
         if not suffixes:
             if self.class_name:
                 suffixes = ['.py']
             else:
-                if transport == 'winrm':
-                    suffixes = ['.ps1', '']
-                else:
-                    suffixes = ['.py', '']
+                suffixes = ['.py', '']
 
         for suffix in suffixes:
             full_name = '%s%s' % (name, suffix)


### PR DESCRIPTION
The winrm connection plugin already provides its own list of suffixes via https://github.com/ansible/ansible/blob/devel/lib/ansible/runner/connection_plugins/winrm.py#L58, so there's no need to pass the transport into the plugin loader.
