### PR TITLE
Give useful errors when rsync or ssh are not installed on the system.

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -224,7 +224,13 @@ class Runner(object):
                 self.transport = "paramiko"
             else:
                 # see if SSH can support ControlPersist if not use paramiko
-                cmd = subprocess.Popen(['ssh','-o','ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                try:
+                    cmd = subprocess.Popen(['ssh','-o','ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                except OSError as ex:
+                    if ex.errno == 2:
+                        sys.stderr.write("Could not find 'ssh' command.\n")
+                        sys.exit(1)
+                    raise ex
                 (out, err) = cmd.communicate()
                 if "Bad configuration option" in err:
                     self.transport = "paramiko"

--- a/lib/ansible/runner/action_plugins/synchronize.py
+++ b/lib/ansible/runner/action_plugins/synchronize.py
@@ -209,7 +209,7 @@ class ActionModule(object):
         if result.result['failed'] and result.result['rc'] == 2:
             sys.stderr.write("File not found. Is rsync installed?\n")
 
-        # reset.the sudo property
+        # reset the sudo property
         self.runner.sudo = self.original_sudo
 
         return result

--- a/lib/ansible/runner/action_plugins/synchronize.py
+++ b/lib/ansible/runner/action_plugins/synchronize.py
@@ -17,6 +17,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import os.path
+import sys
 
 from ansible import utils
 from ansible.runner.return_data import ReturnData
@@ -205,8 +206,10 @@ class ActionModule(object):
 
         # run the module and store the result
         result = self.runner._execute_module(conn, tmp, 'synchronize', module_args, complex_args=options, inject=inject)
+        if result.result['failed'] and result.result['rc'] == 2:
+            sys.stderr.write("File not found. Is rsync installed?\n")
 
-        # reset the sudo property                 
+        # reset.the sudo property
         self.runner.sudo = self.original_sudo
 
         return result


### PR DESCRIPTION
I wasted way too much time today trying to figure out "file not found" errors. Especially with synchronize, since there is no traceback provided.

The problem was discovered running Ansible from within Docker. Docker images tend to be fairly stripped down, and their use is increasing. Ansible also seems to be the preferred configuration tool to be paired with Docker.
