### PR TITLE
If included file is a symlink, set basedir in utils.path_dwim_relative() to the real path

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -347,6 +347,10 @@ def path_dwim_relative(original, dirname, source, playbook_base, check=True):
     if os.path.islink(basedir):
         basedir = unfrackpath(basedir)
         template2 = os.path.join(basedir, dirname, source)
+    elif os.path.islink(original):
+        linked_file = unfrackpath(original)
+        basedir = os.path.dirname(linked_file)
+        template2 = os.path.join(basedir, "..", dirname, source)
     else:
         template2 = os.path.join(basedir, '..', dirname, source)
     source2 = path_dwim(basedir, template2)

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -347,15 +347,21 @@ def path_dwim_relative(original, dirname, source, playbook_base, check=True):
     if os.path.islink(basedir):
         basedir = unfrackpath(basedir)
         template2 = os.path.join(basedir, dirname, source)
-    elif os.path.islink(original):
-        linked_file = unfrackpath(original)
-        basedir = os.path.dirname(linked_file)
-        template2 = os.path.join(basedir, "..", dirname, source)
     else:
         template2 = os.path.join(basedir, '..', dirname, source)
     source2 = path_dwim(basedir, template2)
     if os.path.exists(source2):
         return source2
+
+    #if the original file is a symlink try to search in real path
+    if os.path.islink(original):
+        linked_file = unfrackpath(original)
+        basedir = os.path.dirname(linked_file)
+        template2 = os.path.join(basedir, "..", dirname, source)
+        source2 = path_dwim(basedir, template2)
+        if os.path.exists(source2):
+            return source2
+
     obvious_local_path = path_dwim(playbook_base, source)
     if os.path.exists(obvious_local_path):
         return obvious_local_path


### PR DESCRIPTION
If a role has following code in the main.yml:

```
- include: test.yml
```

and test.yml is a symlink and has following content:

```
- template: src=test.j2 dest=tmp
```

The file will not be found because the file will be searched in the folder of the main.yml.

With this change the file will be searched in the real folder of the file - like this is done with directories in https://github.com/ansible/ansible/pull/4098
