### PR TITLE
Fixed hostname matching with pattern having '~' at the beginning

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -162,14 +162,14 @@ class Inventory(object):
         results = []
         try:
             if not pattern_str.startswith('~'):
-                pattern = re.compile(fnmatch.translate(pattern_str))
+                pattern = re.compile('^' + fnmatch.translate(pattern_str))
             else:
                 pattern = re.compile(pattern_str[1:])
         except Exception, e:
             raise errors.AnsibleError('invalid host pattern: %s' % pattern_str)
 
         for item in items:
-            if pattern.match(getattr(item, item_attr)):
+            if pattern.search(getattr(item, item_attr)):
                 results.append(item)
         return results
 


### PR DESCRIPTION
**Issue Type:**
Bugfix Pull Request

**Ansible Version:**
- ansible 1.7.1
- ansible 1.7.2

**Environment:**
Fedora release 20 (Heisenbug)

**Summary:**
After using match() instead of search() for pattern matching ansible doesn't match hostnames with pattern that started with '~'.

**Steps to reproduce**:

```
$ cat inventory 
foo
bar
foobar
barfoo
```

**Expected Results:**

```
$ ansible '~bar' -i inventory --list-hosts
    bar
    foobar
    barfoo
```

**Actual Results:**

```
$ ansible '~bar' -i inventory --list-hosts
    bar
    barfoo
```
