### PR TITLE
Inventory Plugin to get hostgroups from FreeIPA

### DIFF
--- a/plugins/inventory/freeipa.py
+++ b/plugins/inventory/freeipa.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+import json
+from ipalib import api
+api.bootstrap(context='cli')
+api.finalize()
+api.Backend.xmlclient.connect()    
+inventory = {}
+hostvars={}
+meta={}
+result =api.Command.hostgroup_find()['result']
+for hostgroup in result:
+    inventory[hostgroup['cn'][0]] = { 'hosts': [host for host in  hostgroup['member_host']]}
+    for host in  hostgroup['member_host']:
+        hostvars[host] = {}
+inventory['_meta'] = {'hostvars': hostvars}
+inv_string = json.dumps( inventory)
+print inv_string
+


### PR DESCRIPTION
Only handles the default:  ignore the command line params and assumes --list was called, but uses _meta to handle host data. 
