### PR TITLE
Fix typos in module documentation boilerplate

### DIFF
--- a/hacking/templates/rst.j2
+++ b/hacking/templates/rst.j2
@@ -130,7 +130,7 @@ Should you have a question rather than a bug report, inquries are welcome on the
 
 Documentation updates for this module can also be edited directly by submitting a pull request to the module source code, just look for the "DOCUMENTATION" block in the source tree.
 
-Note that this module is designated a "extras" module.  Non-core modules are still fully usuable, but may receive slightly lower response rates for issues and pull requests.
+Note that this module is designated a "extras" module.  Non-core modules are still fully usable, but may receive slightly lower response rates for issues and pull requests.
 Popular "extras" modules may be promoted to core modules over time.
 
 {% endif %}


### PR DESCRIPTION
These showed up on many pages, and were somewhat painful to see appearing again and again. :)
