### PR TITLE
python2.4 compatibility issue with urlparse

### DIFF
--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -72,12 +72,14 @@ def get_fqdn(repo_url):
         if 'ssh' not in parts[0] and 'git' not in parts[0]:
             # don't try and scan a hostname that's not ssh
             return None
+        # parts[1] will be empty on python2.4 on ssh:// or git:// urls, so
+        # ensure we actually have a parts[1] before continuing.
         if parts[1] != '':
             result = parts[1]
             if ":" in result:
                 result = result.split(":")[0]
-        if "@" in result:
-            result = result.split("@", 1)[1]
+            if "@" in result:
+                result = result.split("@", 1)[1]
 
     return result
 


### PR DESCRIPTION
On python2.4 clients, urlparse does not actually parse urls correctly when they contain something that's not "http" (e.g. "git://" or "ssh://").  This causes parts[1] in lib/ansible/module_utils/known_hosts.py's get_fqdn() function to end up as an empty string.  Commit 578e881, which fixes urls that contain @ characters, was not indented below the check for an empty parts[1] so it ends up causing a failure/stacktrace on python2.4 clients that looks exactly like the issue described in #9045 (that issue was closed during the recent modules repo reorg).
