### PR TITLE
Fix detecting distribution release on OpenSuSE

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -328,10 +328,11 @@ class Facts(object):
                                     break
                             elif path == '/etc/SuSE-release':
                                 data = data.splitlines()
-                                release = re.search('CODENAME *= *([^\n]+)\n', data)
-                                if release:
-                                    self.facts['distribution_release'] = release.groups()[0].strip()
-                                    break
+                                for line in data:
+                                    release = re.search('CODENAME *= *([^\n]+)', line)
+                                    if release:
+                                        self.facts['distribution_release'] = release.groups()[0].strip()
+                                        break
                     elif name == 'Debian':
                         data = get_file_content(path)
                         if 'Debian' in data:


### PR DESCRIPTION
Ansible raised exception during parsering /etc/SuSE-release file.
Regular expresion should use string instead of list.
Fix tested on OpenSuse 13.1
