### PR TITLE
Making --one-line truly one line per host by converting newlines in output to the string \n

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -308,6 +308,8 @@ def command_generic_msg(hostname, result, oneline, caption):
             buf += msg
         return buf + "\n"
     else:
+        stderr = stderr.replace('\n', '\\n')
+        stdout = stdout.replace('\n', '\\n')
         if stderr:
             return "%s | %s | rc=%s | (stdout) %s (stderr) %s" % (hostname, caption, rc, stdout, stderr)
         else:


### PR DESCRIPTION
See issue:
https://github.com/ansible/ansible/issues/9343
