### PR TITLE
Ungarble output of ansible command

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -144,13 +144,17 @@ def display(msg, color=None, stderr=False, screen_only=False, log_only=False, ru
         if not stderr:
             try:
                 print msg2
+                sys.stdout.flush()
             except UnicodeEncodeError:
                 print msg2.encode('utf-8')
+                sys.stdout.flush()
         else:
             try:
                 print >>sys.stderr, msg2
+                sys.stderr.flush()
             except UnicodeEncodeError:
                 print >>sys.stderr, msg2.encode('utf-8')
+                sys.stderr.flush()
     if constants.DEFAULT_LOG_PATH != '':
         while msg.startswith("\n"):
             msg = msg.replace("\n","")


### PR DESCRIPTION
  I have been trying to use the ansible command and found if there are enough hosts the output is garbled. Which makes it a lot less usable. Since you can't tell what host output came from. 

  I tried various fixes, including locks. I eventually stumbled across this very simple fix of flushing the output buffers.

Example command:
ansible -i inventory * -m shell -a '/bin/cat /etc/passwd | head -3' -f 100 

Garbled output:
hosta.foo.com | success | rc=0 >>
root:x:0:0:root:/root:/bin/bash
bin:x:1:1:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin

daemon:x:2:2 ccess | rc=0 >> root:x:0:0:root:/root:/bin/bash
bin:x:1:1:bin:/bin:/sbin/nologin

Ungarbled output:
hosta.foo.com | success | rc=0 >>
root:x:0:0:root:/root:/bin/bash
bin:x:1:1:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin

hostb.foo.com | success | rc=0 >>
root:x:0:0:root:/root:/bin/bash
bin:x:1:1:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin
