### PR TITLE
Add integration test for the shell module

### DIFF
--- a/test/integration/roles/test_command_shell/tasks/main.yml
+++ b/test/integration/roles/test_command_shell/tasks/main.yml
@@ -198,3 +198,19 @@
     that:
       - "shell_result6.changed"
       - "shell_result6.stdout == '32f3cc201b69ed8afa3902b80f554ca8\nthis is a second line'"
+
+- name: execute a shell command using a literal multiline block with arguments in it
+  shell: |
+    executable=/bin/bash
+    creates={{output_dir_test | expanduser}}/afile.txt
+    echo "test"
+  register: shell_result7
+
+- name: assert the multiline shell command with arguments in it run as expected
+  assert:
+    that:
+      - "shell_result7.changed"
+      - "shell_result7.stdout == 'test'"
+
+- name: remove the previously created file
+  file: path={{output_dir_test}}/afile.txt state=absent


### PR DESCRIPTION
##### Issue Type:

“Bugfix Pull Request”
##### Ansible Version:

```
ansible 1.8 (devel bdf3ec1e21) last updated 2014/10/15 11:15:03 (GMT +900)
  lib/ansible/modules/core: (detached HEAD cb69744bce) last updated 2014/10/14 16:45:41 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD 8a4f07eecd) last updated 2014/10/14 16:45:53 (GMT +900)
  v2/ansible/modules/core: (detached HEAD cb69744bce) last updated 2014/10/14 16:46:09 (GMT +900)
  v2/ansible/modules/extras: (detached HEAD 8a4f07eecd) last updated 2014/10/14 16:46:21 (GMT +900)
```
##### Summary:

It adds test for the issue described here: #9272 

Recently, we updated from Ansible 1.4.5 to 1.7.2, and it's no longer working.
As we didn't find any reference to this in the Changelog, we think it's broken and it should be fixed.
After more research, we found it was fixed in a version not yet released.

By adding this test, I hope we will never have this problem again.
