### PR TITLE
Print tasks grouped by role when doing --list-tasks

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -251,6 +251,8 @@ def main(args):
 
                     if play.roles:
                         for rol in play.roles:
+			    if isinstance(rol, dict):
+			        rol = rol.get('role')
                             print '    role: %s' % (rol)
                             for task in taskslist:
                                 if task.role_name is rol:

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -241,25 +241,24 @@ def main(args):
                 if options.listtasks:
                     print '  play #%d (%s):' % (playnum, label)
 
+                    taskslist = []
+                    for task in play.tasks():
+                        if (set(task.tags).intersection(pb.only_tags) and not
+                            set(task.tags).intersection(pb.skip_tags)):
+                            if getattr(task, 'name', None) is not None:
+                                # meta tasks have no names
+                                taskslist.append(task)
+
                     if play.roles:
                         for rol in play.roles:
                             print '    role: %s' % (rol)
-                        
-                            for task in play.tasks():
-                                if (set(task.tags).intersection(pb.only_tags) and not
-                                    set(task.tags).intersection(pb.skip_tags)):
-                                    if getattr(task, 'name', None) is not None:
-                                        # meta tasks have no names
-                                        #print '    %s' % task.name
-                                        if task.role_name is rol:
-                                            print '        %s ' % task.name
+                            for task in taskslist:
+                                if task.role_name is rol:
+                                    print '        %s ' % task.name
                     else:    
-                        for task in play.tasks():
-                            if (set(task.tags).intersection(pb.only_tags) and not
-                                set(task.tags).intersection(pb.skip_tags)):
-                                if getattr(task, 'name', None) is not None:
-                                    # meta tasks have no names
-                                    print '    %s' % task.name
+                        for task in taskslist:
+                            print '    %s' % task.name
+
                 if options.listhosts or options.listtasks:
                     print ''
             continue

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -241,12 +241,25 @@ def main(args):
                 if options.listtasks:
                     print '  play #%d (%s):' % (playnum, label)
 
-                    for task in play.tasks():
-                        if (set(task.tags).intersection(pb.only_tags) and not
-                            set(task.tags).intersection(pb.skip_tags)):
-                            if getattr(task, 'name', None) is not None:
-                                # meta tasks have no names
-                                print '    %s' % task.name
+                    if play.roles:
+                        for rol in play.roles:
+                            print '    role: %s' % (rol)
+                        
+                            for task in play.tasks():
+                                if (set(task.tags).intersection(pb.only_tags) and not
+                                    set(task.tags).intersection(pb.skip_tags)):
+                                    if getattr(task, 'name', None) is not None:
+                                        # meta tasks have no names
+                                        #print '    %s' % task.name
+                                        if task.role_name is rol:
+                                            print '        %s ' % task.name
+                    else:    
+                        for task in play.tasks():
+                            if (set(task.tags).intersection(pb.only_tags) and not
+                                set(task.tags).intersection(pb.skip_tags)):
+                                if getattr(task, 'name', None) is not None:
+                                    # meta tasks have no names
+                                    print '    %s' % task.name
                 if options.listhosts or options.listtasks:
                     print ''
             continue


### PR DESCRIPTION
When one playbook include different roles and option --list-tasks is used the different tasks are printed grouped by the role they belong to.

this is the output when doing "ansible-playbook --list-tasks"  

```
$> ansible-playbook web-balancers.yml --list-tasks

playbook: web-balancers.yml

  play #1 (Configure web balancers):
    role: common
        install resolv.conf file {{ rolename }} 
        install every yum repos keys 
        disable selinux 
        Install ntp 
        Copy ntp conf file 
        Start the ntp service 
        Install postfix 
        Copy postfix conf file 
        Start the postfix service 
        Install vim 
        Copy .vimrc for root 
        Copy .vim dir for root 
        Install check_mk monitoring agent 
        Copy config file for check_mk monitoring agent 
        Install munin-node package 
        Copy munin-node config file 
        disable unwanted services 
    role: apache
        Open required IPTables ports 
        Check if apache SSL cert already exists 
        Create self-signed SSL cert for Apache (valid for 10 years) 
        Enable the new SSL cert in Apache conf (line 1) 
        Enable the new SSL cert in Apache conf (line 2) 
```

This is my first look at ansible's code so maybe I am missing something or there is a better way to achieve this but it seems to be working fine for me
