### PR TITLE
Split comma separated tags and include in groups

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -447,11 +447,12 @@ class Ec2Inventory(object):
 
         # Inventory: Group by tag keys
         for k, v in instance.tags.iteritems():
-            key = self.to_safe("tag_" + k + "=" + v)
-            self.push(self.inventory, key, dest)
-            if self.nested_groups:
-                self.push_group(self.inventory, 'tags', self.to_safe("tag_" + k))
-                self.push_group(self.inventory, self.to_safe("tag_" + k), key)
+            for mv in v.split(","):
+                key = self.to_safe("tag_" + k + "=" + mv)
+                self.push(self.inventory, key, dest)
+                if self.nested_groups:
+                    self.push_group(self.inventory, 'tags', self.to_safe("tag_" + k))
+                    self.push_group(self.inventory, self.to_safe("tag_" + k), key)
 
         # Inventory: Group by Route53 domain names if enabled
         if self.route53_enabled:


### PR DESCRIPTION
Split tags that are comma separated and add the host to those different groups.

E.g.: myhost: env = "dev,staging"

Instead of having the actual:
"tag_env_dev_staging": [ ..., "myhost" ]

this would result in:
"tag_env_dev": [ ..., "myhost" ],
"tag_env_staging": [ ..., "myhost" ]

I think it's more flexible and allows more grouping options based in tags.
