### PR TITLE
adding for loop on list to to handle the return of none when the list is empty

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -622,8 +622,8 @@ class Ec2Inventory(object):
                 for group in value:
                     group_ids.append(group.id)
                     group_names.append(group.name)
-                instance_vars["ec2_security_group_ids"] = ','.join(group_ids)
-                instance_vars["ec2_security_group_names"] = ','.join(group_names)
+                instance_vars["ec2_security_group_ids"] = ','.join([str(i) for i in group_ids])
+                instance_vars["ec2_security_group_names"] = ','.join([str(i) for i in group_names])
             else:
                 pass
                 # TODO Product codes if someone finds them useful


### PR DESCRIPTION
adding for loop on list to to handle the return of none when the list is empty. With the previous method if the list was empty the script died. See http://stackoverflow.com/questions/18852324/typeerror-sequence-item-0-expected-string-nonetype-found.

This was causing the inventory script to fail on our account until we made the change. Works good now
