### PR TITLE
Improved ConfigureRemotingForAnsible.ps1

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -173,9 +173,13 @@ if ($PSVersionTable.PSVersion.Major -lt 3)
     Write-verbose "basic auth already enabled"
  }
  
-#FIrewall
-netsh advfirewall firewall add rule Profile=public name="Allow WinRM HTTPS" dir=in localport=5986 protocol=TCP action=allow
+#Firewall
 
+$fwtest = netsh advfirewall firewall show rule name="Allow WinRM HTTPS"
+#Very rudymentary text parsing, but should work. Better than relying on a specific OS language.
+if ($fwtest.count -lt 5)
+{
+    netsh advfirewall firewall add rule Profile=any name="Allow WinRM HTTPS" dir=in localport=5986 protocol=TCP action=allow
+}
 
-
- Write-Verbose "PS Remoting successfully setup for Ansible"
+Write-Verbose "PS Remoting successfully setup for Ansible"


### PR DESCRIPTION
```
-now checks for an existing fw rule before creating a new
-fw rule applies to all connection profiles, not just public ones (important in domain-joined scenarios)
```
