### PR TITLE
Updated documentation to consistently use yes/no instead of True/False

### DIFF
--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -254,14 +254,14 @@ In Ansible 1.8 and later, if you have a task that you don't want to show the res
 
     - name: secret task
       shell: /usr/bin/do_something --value={{ secret_value }}
-      no_log: True
+      no_log: yes
 
 This can be used to keep verbose output but hide sensitive information from others who would otherwise like to be able to see the output.
 
 The no_log attribute can also apply to an entire play::
 
     - hosts: all
-      no_log: True
+      no_log: yes
 
 Though this will make the play somewhat difficult to debug.  It's recommended that this
 be applied to single tasks only, once a playbook is completed.   

--- a/docsite/rst/glossary.rst
+++ b/docsite/rst/glossary.rst
@@ -92,7 +92,7 @@ Gather Facts (Boolean)
 ++++++++++++++++++++++
 
 Facts are mentioned above.  Sometimes when running a multi-play playbook, it is desirable to have some plays that don't bother with fact
-computation if they aren't going to need to utilize any of these values.  Setting `gather_facts: False` on a playbook allows this implicit
+computation if they aren't going to need to utilize any of these values.  Setting `gather_facts: no` on a playbook allows this implicit
 fact gathering to be skipped.
 
 Globbing

--- a/docsite/rst/guide_aws.rst
+++ b/docsite/rst/guide_aws.rst
@@ -30,7 +30,7 @@ And in your playbook steps we'll typically be using the following pattern for pr
 
     - hosts: localhost
       connection: local
-      gather_facts: False
+      gather_facts: no
 
 .. _aws_provisioning:
 
@@ -83,7 +83,7 @@ With the host group now created, a second play in your provision playbook might 
     - name: Configuration play
       hosts: ec2hosts
       user: ec2-user
-      gather_facts: true
+      gather_facts: yes
 
       tasks:
       - name: Check NTP service
@@ -208,7 +208,7 @@ Example 4
 
     - hosts: localhost
       connection: local
-      gather_facts: False
+      gather_facts: no
       vars:
         ec2_access_key: "--REMOVED--"
         ec2_secret_key: "--REMOVED--"
@@ -254,9 +254,9 @@ Example 4
     # this playbook.
 
     - hosts: ec2hosts
-      gather_facts: True    
+      gather_facts: yes    
       user: ec2-user
-      sudo: True
+      sudo: yes
       tasks:
 
         # fetch instance data from the metadata servers in ec2
@@ -274,7 +274,7 @@ Example 4
     # its state is "absent"
 
     - hosts: ec2hosts
-      gather_facts: True    
+      gather_facts: yes    
       connection: local
       vars:
         ec2_access_key: "--REMOVED--"

--- a/docsite/rst/guide_gce.rst
+++ b/docsite/rst/guide_gce.rst
@@ -195,7 +195,7 @@ A playbook would looks like this:
    - name: Manage new instances
      hosts: new_instances
      connection: ssh
-     sudo: True
+     sudo: yes
      roles:
        - base_configuration
        - production_server
@@ -229,7 +229,7 @@ a basic example of what is possible::
 
         - name: Install lighttpd
           apt: pkg=lighttpd state=installed
-          sudo: True
+          sudo: yes
 
         - name: Allow HTTP
           local_action: gce_net

--- a/docsite/rst/guide_rax.rst
+++ b/docsite/rst/guide_rax.rst
@@ -38,7 +38,7 @@ In playbook steps, we'll typically be using the following pattern:
 
     - hosts: localhost
       connection: local
-      gather_facts: False
+      gather_facts: no
       tasks:
 
 .. _credentials_file:
@@ -300,7 +300,7 @@ This can be achieved with the ``rax_facts`` module and an inventory file similar
 
     - name: Gather info about servers
       hosts: test_servers
-      gather_facts: False
+      gather_facts: no
       tasks:
         - name: Get facts about servers
           local_action:
@@ -419,7 +419,7 @@ Create an isolated cloud network and build a server
     - name: Build Servers on an Isolated Network
       hosts: localhost
       connection: local
-      gather_facts: False
+      gather_facts: no
       tasks:
         - name: Network create request
           local_action:
@@ -463,7 +463,7 @@ Build a complete webserver environment with servers, custom networks and load ba
     - name: Build environment
       hosts: localhost
       connection: local
-      gather_facts: False
+      gather_facts: no
       tasks:
         - name: Load Balancer create request
           local_action:
@@ -579,7 +579,7 @@ Using a Control Machine
     - name: Create an exact count of servers
       hosts: localhost
       connection: local
-      gather_facts: False
+      gather_facts: no
       tasks:
         - name: Server build requests
           local_action:
@@ -611,7 +611,7 @@ Using a Control Machine
     
     - name: Wait for rackconnect and managed cloud automation to complete
       hosts: new_web
-      gather_facts: false
+      gather_facts: no
       tasks:
         - name: Wait for rackconnnect automation to complete
           local_action:

--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -266,7 +266,7 @@ gathering
 
 New in 1.6, the 'gathering' setting controls the default policy of facts gathering (variables discovered about remote systems).
 
-The value 'implicit' is the default, meaning facts will be gathered per play unless 'gather_facts: False' is set in the play.  The value 'explicit' is the inverse, facts will not be gathered unless directly requested in the play.
+The value 'implicit' is the default, meaning facts will be gathered per play unless 'gather_facts: no' is set in the play.  The value 'explicit' is the inverse, facts will not be gathered unless directly requested in the play.
 
 The value 'smart' means each new host that has no facts discovered will be scanned, but if the same host is addressed in multiple plays it will not be contacted again in the playbook run.  This option can be useful for those wishing to save fact gathering time.
 

--- a/docsite/rst/intro_getting_started.rst
+++ b/docsite/rst/intro_getting_started.rst
@@ -126,7 +126,7 @@ Also note that host key checking in paramiko mode is reasonably slow, therefore 
 
 .. _a_note_about_logging:
 
-Ansible will log some information about module arguments on the remote system in the remote syslog, unless a task or play is marked with a "no_log: True" attribute, explained later.
+Ansible will log some information about module arguments on the remote system in the remote syslog, unless a task or play is marked with a "no_log: yes" attribute, explained later.
 
 To enable basic logging on the control machine see :doc:`intro_configuration` document and set the 'log_path' configuration file setting.  Enterprise users may also be interested in :doc:`tower`.  Tower provides a very robust database logging feature where it is possible to drill down and see history based on hosts, projects, and particular inventories over time -- explorable both graphically and through a REST API.
 

--- a/docsite/rst/playbooks_acceleration.rst
+++ b/docsite/rst/playbooks_acceleration.rst
@@ -41,12 +41,12 @@ Accelerated mode offers several improvements over the (deprecated) original fire
 * There are fewer requirements. ZeroMQ is no longer required, nor are there any special packages beyond python-keyczar 
 * python 2.5 or higher is required.
 
-In order to use accelerated mode, simply add `accelerate: true` to your play::
+In order to use accelerated mode, simply add `accelerate: yes` to your play::
 
     ---
 
     - hosts: all
-      accelerate: true
+      accelerate: yes
 
       tasks:
 
@@ -62,7 +62,7 @@ If you wish to change the port Ansible will use for the accelerated connection, 
     ---
 
     - hosts: all
-      accelerate: true
+      accelerate: yes
       # default port is 5099
       accelerate_port: 10000
 

--- a/docsite/rst/playbooks_best_practices.rst
+++ b/docsite/rst/playbooks_best_practices.rst
@@ -316,7 +316,7 @@ This makes a dynamic group of hosts matching certain criteria, even if that grou
    # now just on the CentOS hosts...
 
    - hosts: CentOS
-     gather_facts: False
+     gather_facts: no
 
      tasks:
         - # tasks that only happen on CentOS go here

--- a/docsite/rst/playbooks_conditionals.rst
+++ b/docsite/rst/playbooks_conditionals.rst
@@ -33,7 +33,7 @@ decide to do something conditionally based on success or failure::
     tasks:
       - command: /bin/false
         register: result
-        ignore_errors: True
+        ignore_errors: yes
       - command: /bin/something
         when: result|failed
       - command: /bin/something_else

--- a/docsite/rst/playbooks_delegation.rst
+++ b/docsite/rst/playbooks_delegation.rst
@@ -148,14 +148,14 @@ by configuring "run_once" on a task::
         # ...
 
         - command: /opt/application/upgrade_db.py
-          run_once: true
+          run_once: yes
 
         # ...
 
 This can be optionally paired with "delegate_to" to specify an individual host to execute on::
 
         - command: /opt/application/upgrade_db.py
-          run_once: true
+          run_once: yes
           delegate_to: web01.example.org
 
 When "run_once" is not used with "delegate_to" it will execute on the first host, as defined by inventory,

--- a/docsite/rst/playbooks_error_handling.rst
+++ b/docsite/rst/playbooks_error_handling.rst
@@ -52,7 +52,7 @@ In previous version of Ansible, this can be still be accomplished as follows::
     - name: this command prints FAILED when it fails
       command: /usr/bin/example-command -x -y -z
       register: command_result
-      ignore_errors: True
+      ignore_errors: yes
 
     - name: fail the play if the previous command did not succeed
       fail: msg="the command failed"
@@ -81,7 +81,7 @@ does not cause handlers to fire::
 
       # this will never report 'changed' status
       - shell: wall 'beep'
-        changed_when: False
+        changed_when: no
 
 
 .. seealso::

--- a/docsite/rst/playbooks_intro.rst
+++ b/docsite/rst/playbooks_intro.rst
@@ -223,7 +223,7 @@ Or this::
    tasks:
      - name: run this command and ignore the result
        shell: /usr/bin/somecommand
-       ignore_errors: True
+       ignore_errors: yes
 
 
 If the action line is getting too long for comfort you can break it on

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -137,7 +137,7 @@ The following tasks are illustrative of how filters can be used with conditional
 
       - shell: /usr/bin/foo
         register: result
-        ignore_errors: True
+        ignore_errors: yes
 
       - debug: msg="it failed"
         when: result|failed
@@ -776,7 +776,7 @@ While it's mentioned elsewhere in that document too, here's a quick syntax examp
 
         - shell: /usr/bin/foo
           register: foo_result
-          ignore_errors: True
+          ignore_errors: yes
 
         - shell: /usr/bin/bar
           when: foo_result.rc == 5

--- a/docsite/rst/test_strategies.rst
+++ b/docsite/rst/test_strategies.rst
@@ -48,7 +48,7 @@ want certain steps to always execute in check mode, such as calls to the script 
 
    tasks:
      - script: verify.sh
-       always_run: True
+       always_run: yes
 
 Modules That Are Useful for Testing
 ```````````````````````````````````


### PR DESCRIPTION
Updated documentation to consistently use `yes`/`no`, instead of `True`/`False` and `true`/`false`.
