### PR TITLE
Implement a playbook gather_facts_force flag

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -36,7 +36,7 @@ class Inventory(object):
     Host inventory for ansible.
     """
 
-    __slots__ = [ 'host_list', 'groups', '_restriction', '_also_restriction', '_subset', 
+    __slots__ = [ 'host_list', 'groups', '_restriction', '_also_restriction', '_subset',
                   'parser', '_vars_per_host', '_vars_per_group', '_hosts_cache', '_groups_list',
                   '_pattern_cache', '_vault_password', '_vars_plugins', '_playbook_basedir']
 
@@ -53,7 +53,7 @@ class Inventory(object):
         self._vars_per_host  = {}
         self._vars_per_group = {}
         self._hosts_cache    = {}
-        self._groups_list    = {} 
+        self._groups_list    = {}
         self._pattern_cache  = {}
 
         # to be set by calling set_playbook_basedir by playbook code
@@ -173,8 +173,8 @@ class Inventory(object):
                 results.append(item)
         return results
 
-    def get_hosts(self, pattern="all"):
-        """ 
+    def get_hosts(self, pattern="all", apply_subset=True):
+        """
         find all host names matching a pattern string, taking into account any inventory restrictions or
         applied subsets.
         """
@@ -186,7 +186,7 @@ class Inventory(object):
         hosts = self._get_hosts(patterns)
 
         # exclude hosts not in a subset, if defined
-        if self._subset:
+        if apply_subset and self._subset:
             subset = self._get_hosts(self._subset)
             hosts = [ h for h in hosts if h in subset ]
 
@@ -243,7 +243,7 @@ class Inventory(object):
         return hosts
 
     def __get_hosts(self, pattern):
-        """ 
+        """
         finds hosts that positively match a particular pattern.  Does not
         take into account negative matches.
         """
@@ -288,7 +288,7 @@ class Inventory(object):
         """
         given a pattern like foo, that matches hosts, return all of hosts
         given a pattern like foo[0:5], where foo matches hosts, return the first 6 hosts
-        """ 
+        """
 
         # If there are no hosts to select from, just return the
         # empty set. This prevents trying to do selections on an empty set.
@@ -482,15 +482,15 @@ class Inventory(object):
     def add_group(self, group):
         if group.name not in self.groups_list():
             self.groups.append(group)
-            self._groups_list = None  # invalidate internal cache 
+            self._groups_list = None  # invalidate internal cache
         else:
             raise errors.AnsibleError("group already in inventory: %s" % group.name)
 
-    def list_hosts(self, pattern="all"):
+    def list_hosts(self, pattern="all", apply_subset=True):
 
         """ return a list of hostnames for a pattern """
 
-        result = [ h.name for h in self.get_hosts(pattern) ]
+        result = [ h.name for h in self.get_hosts(pattern, apply_subset) ]
         if len(result) == 0 and pattern in ["localhost", "127.0.0.1"]:
             result = [pattern]
         return result
@@ -503,7 +503,7 @@ class Inventory(object):
         return self._restriction
 
     def restrict_to(self, restriction):
-        """ 
+        """
         Restrict list operations to the hosts given in restriction.  This is used
         to exclude failed hosts in main playbook code, don't use this for other
         reasons.
@@ -520,14 +520,14 @@ class Inventory(object):
         if not isinstance(restriction, list):
             restriction = [ restriction ]
         self._also_restriction = restriction
-    
+
     def subset(self, subset_pattern):
-        """ 
+        """
         Limits inventory results to a subset of inventory that matches a given
         pattern, such as to select a given geographic of numeric slice amongst
-        a previous 'hosts' selection that only select roles, or vice versa.  
+        a previous 'hosts' selection that only select roles, or vice versa.
         Corresponds to --limit parameter to ansible-playbook
-        """        
+        """
         if subset_pattern is None:
             self._subset = None
         else:
@@ -547,7 +547,7 @@ class Inventory(object):
     def lift_restriction(self):
         """ Do not restrict list operations """
         self._restriction = None
-    
+
     def lift_also_restriction(self):
         """ Clears the also restriction """
         self._also_restriction = None
@@ -565,7 +565,7 @@ class Inventory(object):
         dname = os.path.dirname(self.host_list)
         if dname is None or dname == '' or dname == '.':
             cwd = os.getcwd()
-            return os.path.abspath(cwd) 
+            return os.path.abspath(cwd)
         return os.path.abspath(dname)
 
     def src(self):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -36,7 +36,7 @@ class Play(object):
        'hosts', 'name', 'vars', 'default_vars', 'vars_prompt', 'vars_files',
        'handlers', 'remote_user', 'remote_port', 'included_roles', 'accelerate',
        'accelerate_port', 'accelerate_ipv6', 'sudo', 'sudo_user', 'transport', 'playbook',
-       'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
+       'tags', 'gather_facts', 'gather_facts_force', 'serial', '_ds', '_handlers', '_tasks',
        'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts', 'su', 'su_user',
        'vault_password', 'no_log',
     ]
@@ -46,7 +46,7 @@ class Play(object):
     VALID_KEYS = [
        'hosts', 'name', 'vars', 'vars_prompt', 'vars_files',
        'tasks', 'handlers', 'remote_user', 'user', 'port', 'include', 'accelerate', 'accelerate_port', 'accelerate_ipv6',
-       'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'serial',
+       'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'gather_facts_force', 'serial',
        'any_errors_fatal', 'roles', 'role_names', 'pre_tasks', 'post_tasks', 'max_fail_percentage',
        'su', 'su_user', 'vault_password', 'no_log',
     ]
@@ -127,25 +127,26 @@ class Play(object):
             raise errors.AnsibleError('hosts declaration is required')
         elif isinstance(hosts, list):
             hosts = ';'.join(hosts)
-        self.serial           = str(ds.get('serial', 0))
-        self.hosts            = hosts
-        self.name             = ds.get('name', self.hosts)
-        self._tasks           = ds.get('tasks', [])
-        self._handlers        = ds.get('handlers', [])
-        self.remote_user      = ds.get('remote_user', ds.get('user', self.playbook.remote_user))
-        self.remote_port      = ds.get('port', self.playbook.remote_port)
-        self.sudo             = ds.get('sudo', self.playbook.sudo)
-        self.sudo_user        = ds.get('sudo_user', self.playbook.sudo_user)
-        self.transport        = ds.get('connection', self.playbook.transport)
-        self.remote_port      = self.remote_port
-        self.any_errors_fatal = utils.boolean(ds.get('any_errors_fatal', 'false'))
-        self.accelerate       = utils.boolean(ds.get('accelerate', 'false'))
-        self.accelerate_port  = ds.get('accelerate_port', None)
-        self.accelerate_ipv6  = ds.get('accelerate_ipv6', False)
-        self.max_fail_pct     = int(ds.get('max_fail_percentage', 100))
-        self.su               = ds.get('su', self.playbook.su)
-        self.su_user          = ds.get('su_user', self.playbook.su_user)
-        self.no_log           = utils.boolean(ds.get('no_log', 'false'))
+        self.serial             = str(ds.get('serial', 0))
+        self.hosts              = hosts
+        self.name               = ds.get('name', self.hosts)
+        self._tasks             = ds.get('tasks', [])
+        self._handlers          = ds.get('handlers', [])
+        self.remote_user        = ds.get('remote_user', ds.get('user', self.playbook.remote_user))
+        self.remote_port        = ds.get('port', self.playbook.remote_port)
+        self.sudo               = ds.get('sudo', self.playbook.sudo)
+        self.sudo_user          = ds.get('sudo_user', self.playbook.sudo_user)
+        self.transport          = ds.get('connection', self.playbook.transport)
+        self.remote_port        = self.remote_port
+        self.any_errors_fatal   = utils.boolean(ds.get('any_errors_fatal', 'false'))
+        self.accelerate         = utils.boolean(ds.get('accelerate', 'false'))
+        self.accelerate_port    = ds.get('accelerate_port', None)
+        self.accelerate_ipv6    = ds.get('accelerate_ipv6', False)
+        self.max_fail_pct       = int(ds.get('max_fail_percentage', 100))
+        self.su                 = ds.get('su', self.playbook.su)
+        self.su_user            = ds.get('su_user', self.playbook.su_user)
+        self.no_log             = utils.boolean(ds.get('no_log', 'false'))
+        self.gather_facts_force = utils.boolean(ds.get('gather_facts_force', 'false'))
 
         # gather_facts is not a simple boolean, as None means  that a 'smart'
         # fact gathering mode will be used, so we need to be careful here as
@@ -770,7 +771,7 @@ class Play(object):
             """ Render the raw filename into 3 forms """
 
             # filename2 is the templated version of the filename, which will
-            # be fully rendered if any variables contained within it are 
+            # be fully rendered if any variables contained within it are
             # non-inventory related
             filename2 = template(self.basedir, filename, self.vars)
 

--- a/test/units/TestInventory.py
+++ b/test/units/TestInventory.py
@@ -85,6 +85,12 @@ class TestInventory(unittest.TestCase):
         hosts_all = inventory.get_hosts('all')
         self.assertEqual(sorted(hosts), sorted(hosts_all))
 
+    def test_list_hosts_dont_apply_subset(self):
+        inventory = self.simple_inventory()
+        inventory.subset('odin;thor,loki')
+        hosts = inventory.list_hosts(apply_subset=False)
+        self.assertEqual(sorted(hosts), sorted(self.all_simple_hosts))
+
     def test_no_src(self):
         inventory = Inventory('127.0.0.1,')
         self.assertEqual(inventory.src(), None)


### PR DESCRIPTION
Right now when executing a play that makes use of the subsets (via
--limit) or tags, facts are only gathered from the set of hosts that
will comprise the play. This is problematic when those playbooks or
their associated roles attempt to utilize facts gathered from hosts
that are not in the set.

Fact caching has recently been implemented. This would be an alternative
to gather_facts_force, but this requires key-value store solutions (ie.
redis) that might not fit into some environments. Similarly, there may
be some scenarios where the potentially stale facts are problematic.

This change allows subsets to be conditionally applied. The default case
is to apply subsets, but this may be overriden with the apply_subset
argumement to both inventory.list_hosts and inventory.get_hosts.

This is discussed here: https://groups.google.com/forum/#!topic/ansible-project/f90Y4T4SJfQ
