### PR TITLE
Detect kvm guests through sys_vendor.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2157,6 +2157,11 @@ class LinuxVirtual(Virtual):
             self.facts['virtualization_role'] = 'guest'
             return
 
+        if sys_vendor == 'QEMU':
+            self.facts['virtualization_type'] = 'kvm'
+            self.facts['virtualization_role'] = 'guest'
+            return
+
         if os.path.exists('/proc/self/status'):
             for line in open('/proc/self/status').readlines():
                 if re.match('^VxID: \d+', line):


### PR DESCRIPTION
The two detection methods currently implemented do not cover all cases.

For example qemu guests invoked like this:
qemu -machine pc-i440fx-1.4,accel=kvm -cpu SandyBridge

return this information:
product_name: Standard PC (i440FX + PIIX, 1996)
cpuinfo: model name      : Intel Xeon E312xx (Sandy Bridge)
