### PR TITLE
Add 'gather_facts: force' capability

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -266,9 +266,9 @@ gathering
 
 New in 1.6, the 'gathering' setting controls the default policy of facts gathering (variables discovered about remote systems).
 
-The value 'implicit' is the default, meaning facts will be gathered per play unless 'gather_facts: False' is set in the play.  The value 'explicit' is the inverse, facts will not be gathered unless directly requested in the play.
+The value 'implicit' is the default, meaning facts will be gathered per play unless 'gather_facts: False' is set in the play.  The value 'explicit' is the inverse, facts will not be gathered unless directly requested in the play. The value 'smart' means each new host that has no facts discovered will be scanned, but if the same host is addressed in multiple plays it will not be contacted again in the playbook run.  This option can be useful for those wishing to save fact gathering time.
 
-The value 'smart' means each new host that has no facts discovered will be scanned, but if the same host is addressed in multiple plays it will not be contacted again in the playbook run.  This option can be useful for those wishing to save fact gathering time.
+New in 1.8, 'gather_facts' supports True, False, and 'force'. Fact gathering is governed by both the default gathering configuration (mentioned immediately above) as well as any play-specific 'gather_facts' declarations. In the case of 'gather_facts: True' (the default), facts will be gathered according to the default gathering policy. Inversely, 'gather_facts: False' will disable fact gathering for the play.  'gather_facts: force' is useful in cases where --limit or --tags are applied to a play. In this case, facts will be gathered for all hosts (again, in accordance with the default gathering policy), not just the subset of hosts limited by those two command line arguments.
 
 hash_behaviour
 ==============
@@ -650,7 +650,7 @@ pipelining
 ==========
 
 Enabling pipelining reduces the number of SSH operations required to
-execute a module on the remote server, by executing many ansible modules without actual file transfer. 
+execute a module on the remote server, by executing many ansible modules without actual file transfer.
 This can result in a very significant performance improvement when enabled, however when using "sudo:" operations you must
 first disable 'requiretty' in /etc/sudoers on all managed hosts.
 
@@ -665,7 +665,7 @@ recommended if you can enable it, eliminating the need for :doc:`playbooks_accel
 Accelerate Mode Settings
 ------------------------
 
-Under the [accelerate] header, the following settings are tunable for :doc:`playbooks_acceleration`.  Acceleration is 
+Under the [accelerate] header, the following settings are tunable for :doc:`playbooks_acceleration`.  Acceleration is
 a useful performance feature to use if you cannot enable :ref:`pipelining` in your environment, but is probably
 not needed if you can.
 

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -36,7 +36,7 @@ class Inventory(object):
     Host inventory for ansible.
     """
 
-    __slots__ = [ 'host_list', 'groups', '_restriction', '_also_restriction', '_subset', 
+    __slots__ = [ 'host_list', 'groups', '_restriction', '_also_restriction', '_subset',
                   'parser', '_vars_per_host', '_vars_per_group', '_hosts_cache', '_groups_list',
                   '_pattern_cache', '_vault_password', '_vars_plugins', '_playbook_basedir']
 
@@ -53,7 +53,7 @@ class Inventory(object):
         self._vars_per_host  = {}
         self._vars_per_group = {}
         self._hosts_cache    = {}
-        self._groups_list    = {} 
+        self._groups_list    = {}
         self._pattern_cache  = {}
 
         # to be set by calling set_playbook_basedir by playbook code
@@ -173,8 +173,8 @@ class Inventory(object):
                 results.append(item)
         return results
 
-    def get_hosts(self, pattern="all"):
-        """ 
+    def get_hosts(self, pattern="all", apply_subset=True):
+        """
         find all host names matching a pattern string, taking into account any inventory restrictions or
         applied subsets.
         """
@@ -186,7 +186,7 @@ class Inventory(object):
         hosts = self._get_hosts(patterns)
 
         # exclude hosts not in a subset, if defined
-        if self._subset:
+        if apply_subset and self._subset:
             subset = self._get_hosts(self._subset)
             hosts = [ h for h in hosts if h in subset ]
 
@@ -243,7 +243,7 @@ class Inventory(object):
         return hosts
 
     def __get_hosts(self, pattern):
-        """ 
+        """
         finds hosts that positively match a particular pattern.  Does not
         take into account negative matches.
         """
@@ -288,7 +288,7 @@ class Inventory(object):
         """
         given a pattern like foo, that matches hosts, return all of hosts
         given a pattern like foo[0:5], where foo matches hosts, return the first 6 hosts
-        """ 
+        """
 
         # If there are no hosts to select from, just return the
         # empty set. This prevents trying to do selections on an empty set.
@@ -482,15 +482,15 @@ class Inventory(object):
     def add_group(self, group):
         if group.name not in self.groups_list():
             self.groups.append(group)
-            self._groups_list = None  # invalidate internal cache 
+            self._groups_list = None  # invalidate internal cache
         else:
             raise errors.AnsibleError("group already in inventory: %s" % group.name)
 
-    def list_hosts(self, pattern="all"):
+    def list_hosts(self, pattern="all", apply_subset=True):
 
         """ return a list of hostnames for a pattern """
 
-        result = [ h.name for h in self.get_hosts(pattern) ]
+        result = [ h.name for h in self.get_hosts(pattern, apply_subset) ]
         if len(result) == 0 and pattern in ["localhost", "127.0.0.1"]:
             result = [pattern]
         return result
@@ -503,7 +503,7 @@ class Inventory(object):
         return self._restriction
 
     def restrict_to(self, restriction):
-        """ 
+        """
         Restrict list operations to the hosts given in restriction.  This is used
         to exclude failed hosts in main playbook code, don't use this for other
         reasons.
@@ -520,14 +520,14 @@ class Inventory(object):
         if not isinstance(restriction, list):
             restriction = [ restriction ]
         self._also_restriction = restriction
-    
+
     def subset(self, subset_pattern):
-        """ 
+        """
         Limits inventory results to a subset of inventory that matches a given
         pattern, such as to select a given geographic of numeric slice amongst
-        a previous 'hosts' selection that only select roles, or vice versa.  
+        a previous 'hosts' selection that only select roles, or vice versa.
         Corresponds to --limit parameter to ansible-playbook
-        """        
+        """
         if subset_pattern is None:
             self._subset = None
         else:
@@ -547,7 +547,7 @@ class Inventory(object):
     def lift_restriction(self):
         """ Do not restrict list operations """
         self._restriction = None
-    
+
     def lift_also_restriction(self):
         """ Clears the also restriction """
         self._also_restriction = None
@@ -565,7 +565,7 @@ class Inventory(object):
         dname = os.path.dirname(self.host_list)
         if dname is None or dname == '' or dname == '.':
             cwd = os.getcwd()
-            return os.path.abspath(cwd) 
+            return os.path.abspath(cwd)
         return os.path.abspath(dname)
 
     def src(self):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -152,7 +152,9 @@ class Play(object):
         # calling utils.boolean(None) returns False
         self.gather_facts = ds.get('gather_facts', None)
         if self.gather_facts:
-            self.gather_facts = utils.boolean(self.gather_facts)
+            self.gather_facts = self.gather_facts.lower()
+            if not self.gather_facts == 'force':
+                self.gather_facts = utils.boolean(self.gather_facts)
 
         # Fail out if user specifies a sudo param with a su param in a given play
         if (ds.get('sudo') or ds.get('sudo_user')) and (ds.get('su') or ds.get('su_user')):
@@ -770,7 +772,7 @@ class Play(object):
             """ Render the raw filename into 3 forms """
 
             # filename2 is the templated version of the filename, which will
-            # be fully rendered if any variables contained within it are 
+            # be fully rendered if any variables contained within it are
             # non-inventory related
             filename2 = template(self.basedir, filename, self.vars)
 

--- a/test/units/TestInventory.py
+++ b/test/units/TestInventory.py
@@ -85,6 +85,12 @@ class TestInventory(unittest.TestCase):
         hosts_all = inventory.get_hosts('all')
         self.assertEqual(sorted(hosts), sorted(hosts_all))
 
+    def test_list_hosts_dont_apply_subset(self):
+        inventory = self.simple_inventory()
+        inventory.subset('odin;thor,loki')
+        hosts = inventory.list_hosts(apply_subset=False)
+        self.assertEqual(sorted(hosts), sorted(self.all_simple_hosts))
+
     def test_no_src(self):
         inventory = Inventory('127.0.0.1,')
         self.assertEqual(inventory.src(), None)


### PR DESCRIPTION
This change adds the 'force' configuration value to the gather_flags
play attribute. With 'gather_facts: force' set, all hosts will have
facts gathered in accordance with the default fact gathering policy
(ie. smart, implicit, etc.).

This is useful in cases where --limit or --tags constrains the subset
of hosts that will be executed against, thereby limiting the number of
hosts that will be fact-gathered in the traditional sense.
