### PR TITLE
Callbacks set_fact name resolution

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -467,7 +467,13 @@ class PlayBook(object):
         else:
             name = task.name
 
-        self.callbacks.on_task_start(template(play.basedir, name, task.module_vars, lookup_fatal=False, filter_fatal=False), is_handler)
+        def get_module_vars():
+            task_vars = task.module_vars.copy()
+            [task_vars.update(x) for x in self.VARS_CACHE.values()]
+            return task_vars
+
+        self.callbacks.on_task_start(template(play.basedir, name, get_module_vars(), lookup_fatal=False, filter_fatal=False), is_handler)
+
         if hasattr(self.callbacks, 'skip_task') and self.callbacks.skip_task:
             ansible.callbacks.set_task(self.callbacks, None)
             ansible.callbacks.set_task(self.runner_callbacks, None)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -22,6 +22,7 @@ from ansible.utils.template import template
 from ansible import utils
 from ansible import errors
 from ansible.module_utils.splitter import split_args, unquote
+from itertools import groupby
 import ansible.callbacks
 import ansible.cache
 import os
@@ -469,7 +470,15 @@ class PlayBook(object):
 
         def get_module_vars():
             task_vars = task.module_vars.copy()
-            [task_vars.update(x) for x in self.VARS_CACHE.values()]
+            cache_vars = []
+
+            for host, values in self.VARS_CACHE.items():
+                for key, value in values.items():
+                    cache_vars.append((key, host, value))
+
+            for k, g in groupby(cache_vars, lambda x: x[0]):
+                task_vars[k] = dict([(x[1],x[2]) for x in g])
+
             return task_vars
 
         self.callbacks.on_task_start(template(play.basedir, name, get_module_vars(), lookup_fatal=False, filter_fatal=False), is_handler)


### PR DESCRIPTION
Hi, 

I made this small PR to send set_fact variables  to the callbacks.  The problem was:

**Example playbook:**

```
- name: Apply common config
  hosts: all
  tasks:
    - name: Set result result to 11
      set_fact: result="11"

    - name: Get result variable = {{result}}
      command: echo "1"
```

**Current behavior:** 

```
PLAY [Apply common config] ****************************************************

GATHERING FACTS ***************************************************************
ok: [172.20.10.41]
ok: [172.20.10.47]

TASK: [Set result result to 11] ***********************************************
ok: [172.20.10.41]
ok: [172.20.10.47]

TASK: [Get result variable = {{result}}] **************************************
changed: [172.20.10.41]
changed: [172.20.10.47]
```

If you try to get the value of {{result}} in name, it was impossible. I made small function to return at least a dictionary with {host:value} structure. I know that it's not clear, but I didn't found any other solution. In the other hand, sometimes get the var value in the name it's useful. 

**Behavior with the changes:**

```
PLAY [Apply common config] ****************************************************

GATHERING FACTS ***************************************************************
ok: [172.20.10.41]
ok: [172.20.10.47]

TASK: [Set result result to 11] ***********************************************
ok: [172.20.10.47]
ok: [172.20.10.41]

TASK: [Get result variable = {'172.20.10.47': u'11', '172.20.10.41': u'11'}] ***
changed: [172.20.10.41]
changed: [172.20.10.47] 
```

Keep the option as name=value it's quite difficult. If you are running only one host it's ok, in case of two or more host, you can't do. 

Regards. 
