### PR TITLE
Ignore missing tags when using --skip-tags

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -330,7 +330,7 @@ class PlayBook(object):
         # if the playbook is invoked with --tags or --skip-tags that don't
         # exist at all in the playbooks then we need to raise an error so that
         # the user can correct the arguments.
-        unknown_tags = ((set(self.only_tags) | set(self.skip_tags)) -
+        unknown_tags = (set(self.only_tags) -
                         (matched_tags_all | unmatched_tags_all))
         unknown_tags.discard('all')
 


### PR DESCRIPTION
The rationale behind this change is that I don't really care if a tag is
missing when I want to skip it.

One potential reason to prefer to throw an error is to prevent a user
from executing a tag that they did not intend to execute as theoretically
that could cause issues. But in practice, one should not rely on
--skip-tags for avoiding disastrous results. There are better ways to
not break your hosts.

Alternatively, I can add an option, say --ignore-missing-tags, that will
instruct --skip-tags not to throw an error.
