### PR TITLE
Add Frankfurt AWS region

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -37,6 +37,7 @@ AWS_REGIONS = [
     'ap-southeast-1',
     'ap-southeast-2',
     'eu-west-1',
+    'eu-central-1',
     'sa-east-1',
     'us-east-1',
     'us-west-1',

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -164,6 +164,11 @@ def boto_fix_security_token_in_profile(conn, profile_name):
 
 def connect_to_aws(aws_module, region, **params):
     conn = aws_module.connect_to_region(region, **params)
+    if not conn:
+        if region not in [aws_module_region.name for aws_module_region in aws_module.regions()]:
+            raise StandardError("Region %s does not seem to be available for aws module %s. If the region definitely exists, you may need to upgrade boto" % (region, aws_module.__name__))
+        else:
+            raise StandardError("Unknown problem connecting to region %s for aws module %s." % (region, aws_module.__name__))
     if params.get('profile_name'):
         conn = boto_fix_security_token_in_profile(conn, params['profile_name'])
     return conn
@@ -179,13 +184,13 @@ def ec2_connect(module):
     if region:
         try:
             ec2 = connect_to_aws(boto.ec2, region, **boto_params)
-        except boto.exception.NoAuthHandlerFound, e:
+        except (boto.exception.NoAuthHandlerFound, StandardError), e:
             module.fail_json(msg=str(e))
     # Otherwise, no region so we fallback to the old connection method
     elif ec2_url:
         try:
             ec2 = boto.connect_ec2_endpoint(ec2_url, **boto_params)
-        except boto.exception.NoAuthHandlerFound, e:
+        except (boto.exception.NoAuthHandlerFound, StandardError), e:
             module.fail_json(msg=str(e))
     else:
         module.fail_json(msg="Either region or ec2_url must be specified")


### PR DESCRIPTION
AWS recently announced the Frankfurt region.

http://aws.amazon.com/blogs/aws/aws-region-germany

This fixes all AWS modules that rely on the module_utils/ec2.py (the vast majority). The exceptions are `ec2_facts` and `ec2_ami_search`. A fix against ansible/ansible-modules-core will be required to address those two.
