### PR TITLE
Ignore compiled Python for documentation.

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -33,7 +33,7 @@ import traceback
 
 MODULEDIR = C.DEFAULT_MODULE_PATH
 
-BLACKLIST_EXTS = ('.swp', '.bak', '~', '.rpm')
+BLACKLIST_EXTS = ('.pyc', '.swp', '.bak', '~', '.rpm')
 
 _ITALIC = re.compile(r"I\(([^)]+)\)")
 _BOLD   = re.compile(r"B\(([^)]+)\)")


### PR DESCRIPTION
When running `ansible-doc --list` a lot of errors are
generated when `ansible-doc` tries to find documentation
strings in `.pyc` files.
