### PR TITLE
Add a connection backend to manage remote LXC containers

### DIFF
--- a/lib/ansible/runner/connection_plugins/lxc_remote.py
+++ b/lib/ansible/runner/connection_plugins/lxc_remote.py
@@ -1,0 +1,171 @@
+# (c) 2014, Gu1 <gu1@aeroxteam.fr>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+import functools
+import pipes
+import os.path
+
+from ansible.runner.connection_plugins import ssh
+from ansible import errors
+from ansible import utils
+from ansible.callbacks import vvv
+
+
+def lxc_check(func):
+    @functools.wraps(func)
+    def inner(self, *args, **kwargs):
+        if self.lxc_name is None:
+            raise errors.AnsibleError("to use the lxc_remote connection mode, you must specify a container name")
+        return func(self, *args, **kwargs)
+    return inner
+
+
+class Connection(ssh.Connection):
+    """
+    Connection module for LXC containers located on a remote machine.
+
+    This module inherits the ssh connection module.
+    To use it, you could put something like this in your inventory:
+    container_name ansible_ssh_user=user ansible_ssh_host=1.2.3.4 ansible_ssh_port=22 ansible_connection=lxc_remote
+
+    Where "user" is the user you want to connect to on the lxc host using ssh,
+    ansible_ssh_host and ansible_ssh_port are the host and port of the lxc host.
+    If you specify a su or sudo_user, it will be used on the lxc host before running lxc-attach.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(Connection, self).__init__(*args, **kwargs)
+        self.delegate = None
+        self.lxc_rootfs = None
+        self.host_tmp_path = None
+
+    @property
+    def lxc_name(self):
+        # set by the Runner class after connect() has been called
+        return self.delegate
+
+    def _lxc_cmd(self, cmd):
+        return 'lxc-attach --name %s -- /bin/su %s -c %s' \
+                % (pipes.quote(self.lxc_name),
+                   pipes.quote(self.runner.remote_user),
+                   pipes.quote(cmd))
+
+    def _su_sudo_cmd(self, cmd):
+        if self.runner.su and self.runner.su_user:
+            return utils.make_su_cmd(self.runner.su_user, '/bin/sh', cmd)
+        elif self.runner.sudo:
+            return utils.make_sudo_cmd(self.runner.sudo_exe, self.runner.sudo_user, '/bin/sh', cmd)
+        else:
+            return cmd, None, None
+
+    def connect(self):
+        return super(Connection, self).connect()
+
+    @lxc_check
+    def exec_command(self, cmd, tmp_path, *args, **kwargs):
+        kwargs['sudoable'] = True
+        kwargs['su'] = True
+        #if kwargs.get('sudoable', False) or kwargs.get('su', False):
+        cmd = self._lxc_cmd(cmd)
+        return super(Connection, self).exec_command(cmd, tmp_path, *args, **kwargs)
+
+    @lxc_check
+    def put_file(self, in_path, out_path):
+        vvv("PUT %s TO %s" % (in_path, out_path), host=self.host)
+        if not os.path.exists(in_path):
+            raise errors.AnsibleFileNotFound("file or module does not exist: %s" % in_path)
+
+        host = self.host
+        if self.ipv6:
+            host = '[%s]' % host
+
+        remote_cmd, prompt, success_key = self._su_sudo_cmd(
+            self._lxc_cmd('cat > %s; echo -n done' % pipes.quote(out_path))
+        )
+
+        cmd  = self._password_cmd()
+        cmd += ['ssh'] + self.common_args + [host, remote_cmd]
+
+        (p, stdin) = self._run(cmd, True)
+        self._send_password()
+        if (self.runner.sudo and self.runner.sudo_pass) or \
+                (self.runner.su and self.runner.su_pass):
+            (no_prompt_out, no_prompt_err) = self.send_su_sudo_password(p, stdin, success_key,
+                                                                        True, prompt)
+
+        com = self.CommunicateCallbacks(self.runner, open(in_path, 'r'),
+                                        su=True, sudoable=True, prompt=prompt)
+        returncode = self._communicate(p, stdin, callbacks=(com.stdin_cb, com.stdout_cb, com.stderr_cb))
+
+        if com.stdout[-4:] != 'done':
+            raise errors.AnsibleError("failed to transfer file to %s" % out_path)
+
+        if returncode != 0:
+            raise errors.AnsibleError("failed to transfer file to %s:\n%s\n%s" % (out_path, stdout, stderr))
+
+
+    class FetchCommCB(ssh.Connection.CommunicateCallbacks):
+        def __init__(self, *args, **kwargs):
+            self.outfile = kwargs.pop('outfile')
+            super(Connection.FetchCommCB, self).__init__(*args, **kwargs)
+
+        def stdout_cb(self, data):
+            # try to keep the last 4096 for check
+            self.stdout += data
+            self._check_for_su_sudo_fail(self.stdout)
+            if len(self.stdout) > 4096:
+                self.stdout = self.stdout[2048:]
+
+            self.outfile.write(data)
+
+    @lxc_check
+    def fetch_file(self, in_path, out_path):
+        vvv("FETCH %s TO %s" % (in_path, out_path), host=self.host)
+        cmd = self._password_cmd()
+
+        host = self.host
+        if self.ipv6:
+            host = '[%s]' % host
+
+        remote_cmd, prompt, success_key = self._su_sudo_cmd(
+            self._lxc_cmd('cat %s' % pipes.quote(in_path))
+        )
+
+        cmd  = self._password_cmd()
+        cmd += ['ssh'] + self.common_args + [host, remote_cmd]
+
+        (p, stdin) = self._run(cmd, True)
+        self._send_password()
+        if (self.runner.sudo and self.runner.sudo_pass) or \
+                (self.runner.su and self.runner.su_pass):
+            (no_prompt_out, no_prompt_err) = self.send_su_sudo_password(p, stdin, success_key,
+                                                                        True, prompt)
+
+        try:
+            outfile = open(out_path, 'w')
+        except IOError as e:
+            raise errors.AnsibleError('could not open destination file %s: %s' % (out_path, e))
+
+        com = self.FetchCommCB(self.runner, None, su=True, sudoable=True, prompt=prompt, outfile=outfile)
+        returncode = self._communicate(p, stdin, callbacks=(com.stdin_cb, com.stdout_cb, com.stderr_cb))
+        outfile.close()
+
+        if p.returncode != 0:
+            raise errors.AnsibleError("failed to transfer file from %s:\n%s\n%s" % (in_path, com.stdout, com.stderr))
+
+    def close(self):
+        return super(Connection, self).close()

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -29,6 +29,7 @@ import pwd
 import gettext
 import pty
 from hashlib import sha1
+from cStringIO import StringIO
 import ansible.constants as C
 from ansible.callbacks import vvv
 from ansible import errors
@@ -140,59 +141,77 @@ class Connection(object):
             os.write(self.wfd, "%s\n" % self.password)
             os.close(self.wfd)
 
-    def _communicate(self, p, stdin, indata, su=False, sudoable=False, prompt=None):
-        fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
-        fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) & ~os.O_NONBLOCK)
-        # We can't use p.communicate here because the ControlMaster may have stdout open as well
-        stdout = ''
-        stderr = ''
-        rpipes = [p.stdout, p.stderr]
-        wpipes = []
-        if isinstance(indata, basestring) and indata:
-            try:
-                stdin.write(indata)
-                stdin.close()
-            except:
-                raise errors.AnsibleError('SSH Error: data could not be sent to the remote host. Make sure this host can be reached over ssh')
-        elif isinstance(indata, object) and hasattr(indata, 'read'):
-            wpipes = [stdin]
-        # Read stdout/stderr from process
-        while True:
-            rfd, wfd, efd = select.select(rpipes, wpipes, rpipes+wpipes, 1)
+    class CommunicateCallbacks(object):
+        def __init__(self, runner, indata, su=False, sudoable=False, prompt=None):
+            self.stdout = ''
+            self.stderr = ''
+            self.runner = runner
+            self.su = su
+            self.sudoable = sudoable
+            self.prompt = prompt
+            if isinstance(indata, basestring) and indata:
+                self.indata = StringIO(indata)
+            elif not indata: # None, False..
+                self.indata = StringIO('')
+            else:
+                self.indata = indata # file-like object
 
-            # fail early if the sudo/su password is wrong
-            if self.runner.sudo and sudoable:
+        def _check_for_su_sudo_fail(self, data):
+            if self.runner.sudo and self.sudoable:
                 if self.runner.sudo_pass:
                     incorrect_password = gettext.dgettext(
                         "sudo", "Sorry, try again.")
-                    if stdout.endswith("%s\r\n%s" % (incorrect_password,
-                                                     prompt)):
+                    if data.endswith("%s\r\n%s" % (incorrect_password,
+                                                   self.prompt)):
                         raise errors.AnsibleError('Incorrect sudo password')
 
-                if stdout.endswith(prompt):
+                if data.endswith(self.prompt):
                     raise errors.AnsibleError('Missing sudo password')
 
             if self.runner.su and su and self.runner.su_pass:
                 incorrect_password = gettext.dgettext(
                     "su", "Sorry")
-                if stdout.endswith("%s\r\n%s" % (incorrect_password, prompt)):
+                if data.endswith("%s\r\n%s" % (incorrect_password, self.prompt)):
                     raise errors.AnsibleError('Incorrect su password')
+
+        def stdout_cb(self, data):
+            self.stdout += data
+            # fail early if the sudo/su password is wrong
+            self._check_for_su_sudo_fail(self.stdout)
+
+        def stderr_cb(self, data):
+            self.stderr += data
+
+        def stdin_cb(self, size):
+            return self.indata.read(size)
+
+    def _communicate(self, p, stdin, callbacks=(None, None, None)):
+        fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
+        fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) & ~os.O_NONBLOCK)
+        # We can't use p.communicate here because the ControlMaster may have stdout open as well
+        rpipes = [p.stdout, p.stderr]
+        wpipes = []
+        if callable(callbacks[0]):
+            wpipes = [stdin]
+        # Read stdout/stderr from process
+        while True:
+            rfd, wfd, efd = select.select(rpipes, wpipes, rpipes+wpipes, 1)
 
             if p.stdout in rfd:
                 dat = os.read(p.stdout.fileno(), 9000)
-                stdout += dat
+                callbacks[1](dat)
                 if dat == '':
                     rpipes.remove(p.stdout)
             if p.stderr in rfd:
                 dat = os.read(p.stderr.fileno(), 9000)
-                stderr += dat
+                callbacks[2](dat)
                 if dat == '':
                     rpipes.remove(p.stderr)
             if stdin in wfd:
-                dat = indata.read(select.PIPE_BUF)
+                dat = callbacks[0](select.PIPE_BUF)
                 if dat != '':
                     wrote = os.write(stdin.fileno(), dat)
-                    assert len(dat) == wrote # XXX
+                    #assert len(dat) == wrote
                 else:
                     wpipes.remove(stdin)
                     stdin.close()
@@ -212,7 +231,7 @@ class Connection(object):
         # close stdin after process is terminated and stdout/stderr are read
         # completely (see also issue #848)
         stdin.close()
-        return (p.returncode, stdout, stderr)
+        return p.returncode
 
     def not_in_host_file(self, host):
         if 'USER' in os.environ:
@@ -375,15 +394,16 @@ class Connection(object):
                 (self.runner.su and su and self.runner.su_pass):
             (no_prompt_out, no_prompt_err) = self.send_su_sudo_password(p, stdin, success_key, sudoable, prompt)
 
-        (returncode, stdout, stderr) = self._communicate(p, stdin, in_data, su=su, sudoable=sudoable, prompt=prompt)
+        com = self.CommunicateCallbacks(self.runner, in_data, su=su, sudoable=sudoable, prompt=prompt)
+        returncode = self._communicate(p, stdin, callbacks=(com.stdin_cb, com.stdout_cb, com.stderr_cb))
 
         if C.HOST_KEY_CHECKING and not_in_host_file:
             # lock around the initial SSH connectivity so the user prompt about whether to add 
             # the host to known hosts is not intermingled with multiprocess output.
             fcntl.lockf(self.runner.output_lockfile, fcntl.LOCK_UN)
             fcntl.lockf(self.runner.process_lockfile, fcntl.LOCK_UN)
-        controlpersisterror = 'Bad configuration option: ControlPersist' in stderr or \
-                              'unknown configuration option: ControlPersist' in stderr
+        controlpersisterror = 'Bad configuration option: ControlPersist' in com.stderr or \
+                              'unknown configuration option: ControlPersist' in com.stderr
 
         if C.HOST_KEY_CHECKING:
             if ssh_cmd[0] == "sshpass" and p.returncode == 6:
@@ -394,7 +414,7 @@ class Connection(object):
         if p.returncode == 255 and (in_data or self.runner.module_name == 'raw'):
             raise errors.AnsibleError('SSH Error: data could not be sent to the remote host. Make sure this host can be reached over ssh')
 
-        return (p.returncode, '', no_prompt_out + stdout, no_prompt_err + stderr)
+        return (p.returncode, '', no_prompt_out + com.stdout, no_prompt_err + com.stderr)
 
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''
@@ -419,10 +439,11 @@ class Connection(object):
 
         self._send_password()
 
-        (returncode, stdout, stderr) = self._communicate(p, stdin, indata)
+        com = self.CommunicateCallbacks(self.runner, indata)
+        returncode = self._communicate(p, stdin, callbacks=(com.stdin_cb, com.stdout_cb, com.stderr_cb))
 
         if returncode != 0:
-            raise errors.AnsibleError("failed to transfer file to %s:\n%s\n%s" % (out_path, stdout, stderr))
+            raise errors.AnsibleError("failed to transfer file to %s:\n%s\n%s" % (out_path, com.stdout, com.stderr))
 
     def fetch_file(self, in_path, out_path):
         ''' fetch a file from remote to local '''


### PR DESCRIPTION
This pull request introduces a new connection backend to manage remote LXC containers by ssh'ing into the host machine and using lxc-attach to get a shell on the container.

The rationale for it is to allow to manage LXC containers without having to run a publicly accessible ssh daemon on every single one of them, with all the hassle it causes (having to assign a public ipv4 on each container or having to do port forwarding for each containers's ssh daemon on the host, or having ipv6 assigned to each container but requiring ipv6 to access them...).

While the code in this pull request should work, it definitely still needs more testing and some polishing (the CommunicateCallbacks class still feels a bit clunky).

Please review.
