### PR TITLE
parse /etc/fstab on OpenBSD to get mount facts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -926,6 +926,7 @@ class OpenBSDHardware(Hardware):
         self.get_memory_facts()
         self.get_processor_facts()
         self.get_device_facts()
+        self.get_mount_facts()
         return self.facts
 
     def get_sysctl(self):
@@ -937,6 +938,17 @@ class OpenBSDHardware(Hardware):
             (key, value) = line.split('=')
             sysctl[key] = value.strip()
         return sysctl
+
+    @timeout(10)
+    def get_mount_facts(self):
+        self.facts['mounts'] = []
+        fstab = get_file_content('/etc/fstab')
+        if fstab:
+            for line in fstab.split('\n'):
+                if line.startswith('#') or line.strip() == '':
+                    continue
+                fields = re.sub(r'\s+',' ',line.rstrip('\n')).split()
+                self.facts['mounts'].append({'mount': fields[1], 'device': fields[0], 'fstype' : fields[2], 'options': fields[3]})
 
     def get_memory_facts(self):
         # Get free memory. vmstat output looks like:

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -948,6 +948,8 @@ class OpenBSDHardware(Hardware):
                 if line.startswith('#') or line.strip() == '':
                     continue
                 fields = re.sub(r'\s+',' ',line.rstrip('\n')).split()
+                if fields[1] == 'none' or fields[3] == 'xx':
+                    continue
                 self.facts['mounts'].append({'mount': fields[1], 'device': fields[0], 'fstype' : fields[2], 'options': fields[3]})
 
     def get_memory_facts(self):


### PR DESCRIPTION
Pretty straightforward, copy/paste the code used by NetBSD and FreeBSD.. works here, but i question the usefulness of parsing `/etc/fstab` vs getting the information live from the system, parsing 'mount' command output ? I see that linux parses `/etc/mtab`, and keep only some entries (more or less `grep ^/ /etc/mtab | grep -v none` output), which should be more live/accurate data, no ?

Should the other operating systems (ie BSDs) also try to gather information from the running system and reflect more the actual 'facts', rather than 'what it should be according to fstab' ? Or facts should also mention/know about say, noauto mounts.. right now, parsing fstab here gives me a lot more entries than mount output. Should we also report NFS mounts ?
