### PR TITLE
fix ansible-doc, ignore .git files.

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -33,7 +33,7 @@ import traceback
 
 MODULEDIR = C.DEFAULT_MODULE_PATH
 
-BLACKLIST_EXTS = ('.pyc', '.swp', '.bak', '~', '.rpm')
+BLACKLIST_EXTS = ('.git', '.pyc', '.swp', '.bak', '~', '.rpm')
 
 _ITALIC = re.compile(r"I\(([^)]+)\)")
 _BOLD   = re.compile(r"B\(([^)]+)\)")


### PR DESCRIPTION
As described in issue #5612, ansible-doc tries to parse .git files which were created using git submodules.

Like in #9221 and the corresponding fix 77f91eb031ba9d7f80c9b7a3a443a831e4c53f93, .git files should also be ignored.
