### PR TITLE
Cache the results for the RackSpace dynamic inventory.

### DIFF
--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -167,7 +167,6 @@ except ImportError:
     print('pyrax is required for this module')
     sys.exit(1)
 
-from tempfile import gettempdir
 from time import time
 
 
@@ -345,7 +344,10 @@ def _list_into_cache(regions):
 
 def get_cache_file_path(regions):
     regions_str = '.'.join([reg.strip().lower() for reg in regions])
-    return os.path.join(gettempdir(),
+    ansible_tmp_path = os.path.join(os.path.expanduser("~"), '.ansible', 'tmp')
+    if not os.path.exists(ansible_tmp_path):
+        os.makedirs(ansible_tmp_path)
+    return os.path.join(ansible_tmp_path,
                         'ansible-rax-%s-%s.cache' % (
                             pyrax.identity.username, regions_str))
 

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -339,23 +339,25 @@ def _list_into_cache(regions):
     if hostvars:
         groups['_meta'] = {'hostvars': hostvars}
 
-    with open(get_cache_file_path(), 'w') as cache_file:
+    with open(get_cache_file_path(regions), 'w') as cache_file:
         json.dump(groups, cache_file)
 
 
-def get_cache_file_path():
+def get_cache_file_path(regions):
+    regions_str = '.'.join([reg.strip().lower() for reg in regions])
     return os.path.join(gettempdir(),
-                        'ansible-rax-{}.cache'.format(pyrax.identity.username))
+                        'ansible-rax-%s-%s.cache' % (
+                            pyrax.identity.username, regions_str))
 
 
 def _list(regions, refresh_cache=True):
-    if (not os.path.exists(get_cache_file_path()) or
+    if (not os.path.exists(get_cache_file_path(regions)) or
         refresh_cache or
-        (time() - os.stat(get_cache_file_path())[-1]) > 600):
+        (time() - os.stat(get_cache_file_path(regions))[-1]) > 600):
         # Cache file doesn't exist or older than 10m or refresh cache requested
         _list_into_cache(regions)
 
-    with open(get_cache_file_path(), 'r') as cache_file:
+    with open(get_cache_file_path(regions), 'r') as cache_file:
         groups = json.load(cache_file)
         print(json.dumps(groups, sort_keys=True, indent=4))
 

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -167,6 +167,10 @@ except ImportError:
     print('pyrax is required for this module')
     sys.exit(1)
 
+from tempfile import gettempdir
+from time import time
+
+
 NON_CALLABLES = (basestring, bool, dict, int, list, type(None))
 
 
@@ -214,7 +218,7 @@ def host(regions, hostname):
     print(json.dumps(hostvars, sort_keys=True, indent=4))
 
 
-def _list(regions):
+def _list_into_cache(regions):
     groups = collections.defaultdict(list)
     hostvars = collections.defaultdict(dict)
     images = {}
@@ -334,7 +338,25 @@ def _list(regions):
 
     if hostvars:
         groups['_meta'] = {'hostvars': hostvars}
-    print(json.dumps(groups, sort_keys=True, indent=4))
+
+    with open(get_cache_file_path(), 'w') as cache_file:
+        json.dump(groups, cache_file)
+
+
+def get_cache_file_path():
+    return os.path.join(gettempdir(), 'ansible-rax.cache')
+
+
+def _list(regions, refresh_cache=True):
+    if (not os.path.exists(get_cache_file_path()) or
+        refresh_cache or
+        (time() - os.stat(get_cache_file_path())[-1]) > 600):
+        # Cache file doesn't exist or older than 10m or refresh cache requested
+        _list_into_cache(regions)
+
+    with open(get_cache_file_path(), 'r') as cache_file:
+        groups = json.load(cache_file)
+        print(json.dumps(groups, sort_keys=True, indent=4))
 
 
 def parse_args():
@@ -344,6 +366,9 @@ def parse_args():
     group.add_argument('--list', action='store_true',
                        help='List active servers')
     group.add_argument('--host', help='List details about the specific host')
+    parser.add_argument('--refresh-cache', action='store_true', default=False,
+                        help=('Force refresh of cache, making API requests to'
+                              'RackSpace (default: False - use cache files)'))
     return parser.parse_args()
 
 
@@ -410,7 +435,7 @@ def main():
     args = parse_args()
     regions = setup()
     if args.list:
-        _list(regions)
+        _list(regions, refresh_cache=args.refresh_cache)
     elif args.host:
         host(regions, args.host)
     sys.exit(0)

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -344,7 +344,8 @@ def _list_into_cache(regions):
 
 
 def get_cache_file_path():
-    return os.path.join(gettempdir(), 'ansible-rax.cache')
+    return os.path.join(gettempdir(),
+                        'ansible-rax-{}.cache'.format(pyrax.identity.username))
 
 
 def _list(regions, refresh_cache=True):


### PR DESCRIPTION
This patch to the RackSpace dynamic inventory plugin makes it cache results for 10m (similar to the EC2 plugin). Running the complete API call for large sites every time can be very slow. Like the EC2 inventory you can force-refresh the cache by running with --refresh-cache, or by deleting the cache file from the temp dir.

@angstwad @j2sol @sivel
