### PR TITLE
Adds localhost to ec2 inventory

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -133,7 +133,17 @@ except ImportError:
 
 class Ec2Inventory(object):
     def _empty_inventory(self):
-        return {"_meta" : {"hostvars" : {}}}
+        return {
+            "_meta": {
+                "hostvars": {}
+            },
+            "local": [
+                "localhost"
+            ],
+            "localhost": [
+                "localhost"
+            ]
+        }
 
     def __init__(self):
         ''' Main execution path '''


### PR DESCRIPTION
`localhost` is important to have in your inventory when running a deployment on AWS: it's the host on which your provisioning plays typically run. So if `ec2.py` doesn't provide a description of `localhost` then one has to create a trivial inventory file just to have localhost. This patch adds `localhost` to the EC2 inventory script's output.
