### PR TITLE
Adds `list_behaviour` to concat unique list items

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -126,6 +126,7 @@ DEFAULT_SUDO              = get_config(p, DEFAULTS, 'sudo', 'ANSIBLE_SUDO', Fals
 DEFAULT_SUDO_EXE          = get_config(p, DEFAULTS, 'sudo_exe', 'ANSIBLE_SUDO_EXE', 'sudo')
 DEFAULT_SUDO_FLAGS        = get_config(p, DEFAULTS, 'sudo_flags', 'ANSIBLE_SUDO_FLAGS', '-H')
 DEFAULT_HASH_BEHAVIOUR    = get_config(p, DEFAULTS, 'hash_behaviour', 'ANSIBLE_HASH_BEHAVIOUR', 'replace')
+DEFAULT_LIST_BEHAVIOUR    = get_config(p, DEFAULTS, 'list_behaviour', 'ANSIBLE_LIST_BEHAVIOUR', 'replace')
 DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBLE_JINJA2_EXTENSIONS', None)
 DEFAULT_EXECUTABLE        = get_config(p, DEFAULTS, 'executable', 'ANSIBLE_EXECUTABLE', '/bin/sh')
 DEFAULT_SU_EXE            = get_config(p, DEFAULTS, 'su_exe', 'ANSIBLE_SU_EXE', 'su')

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -812,9 +812,13 @@ def merge_hash(a, b):
         for k, v in dicts.iteritems():
             # if there's already such key in a
             # and that key contains dict
-            if k in result and isinstance(result[k], dict):
+            if k in result:
+                if isinstance(result[k], dict):
                 # merge those dicts recursively
-                result[k] = merge_hash(a[k], v)
+                    result[k] = merge_hash(a[k], v)
+                elif isinstance(result[k], list) and C.DEFAULT_LIST_BEHAVIOUR == 'merge':
+                    # merge unique list items
+                    result[k].extend([i for i in v if i not in result[k]])
             else:
                 # otherwise, just copy a value from b to a
                 result[k] = v


### PR DESCRIPTION
Just as `hash_behaviour` determines whether clashing key names pointing to `dict` instances should result in those instances being merged or replaced, `list_behaviour` (valid values: `merge`, `replace`) determines whether keys pointing to `list` instances should result in the unique elements of the lists involved being extended into a new list. Uniqueness is determined by trivial comparison (using `list.__in__`)

Having seen the comments about `hash_behaviour` it seems that the ansible team has a use model in mind which is philosophically opposed to the idea that different roles could provide variables definitions which combine to create a coherent description of the deployment target. However, I find that without merging of `dict` and `list` instances, one ends up repeating themselves needlessly, by _e.g._ writing tasks like "install packages via apt" over and over, varying only the `with_items` argument. I don't understand why it's considered undesirable that a `common` role define a `apt_install_packages` list variable, and a `worker` role (which includes `common`) define the same variable but now containing only those packages which are _additional_ to the ones in `common`, to also be installed:

In `roles/common/vars/main.yml`:

``` yml
apt_install_packages:
  - { name: "foo-package", version: "1.23" }
```

In `roles/worker/vars/main.yml`:

``` yml
apt_install_packages:
  - { name: "bar-package", version: "2.34" }
```

That way the task `install apt packages` only needs to be defined in `common/tasks/main.yml` and when the role is included it will run against the `apt_install_packages` list which is the accumulation of all packages that all roles need to request. This would say something which I think is obvious to deployment administrators: all `common` instances get `foo-package=1.23` and `worker` instances also get `bar-package=2.34`. It seems like a simple way to cut down on code and improve the comprehensibility of playbooks. If apt package installation fails, you only need to check the one task defined in `common`.

I hope this feature gets pulled and supported, it's really makes ansible manageable for me. I'd love to know what it is about the ansible philosophy that I'm missing, which is making it so that I feel this feature is needed but the devs feel this is contrary to the ideal use case.
