### PR TITLE
Add the default Homebrew path for OpenSSL certs on OS X

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -219,6 +219,8 @@ class SSLValidationHandler(urllib2.BaseHandler):
         # Write the dummy ca cert if we are running on Mac OS X
         if platform == 'Darwin':
             os.write(tmp_fd, DUMMY_CA_CERT)
+            # Default Homebrew path for OpenSSL certs 
+            paths_checked.append('/usr/local/etc/openssl')
 
         # for all of the paths, find any  .crt or .pem files
         # and compile them into single temp file for use


### PR DESCRIPTION
Per the discussion at https://github.com/ansible/ansible-modules-extras/issues/82, the fix for that issue belongs here. This is merely a reiterated verified fix submitted by @sivel in that issue.

Perhaps this is the right place to discuss a more bullet-proof approach on OS X. Perhaps something like Homebrew itself does when installing OpenSSL: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/openssl.rb#L103-L111

```
keychains = %w[
      /Library/Keychains/System.keychain
      /System/Library/Keychains/SystemRootCertificates.keychain
    ]

openssldir.mkpath
(openssldir/"cert.pem").atomic_write `security find-certificate -a -p #{keychains.join(" ")}`
```

This just dumps the root certificates from OS X's keychain into /usr/local/etc/openssl. Perhaps ansible could do this during installation too?
