### PR TITLE
Google: allow for different libcloud provider to support upcoming DNS mo...

### DIFF
--- a/lib/ansible/module_utils/gce.py
+++ b/lib/ansible/module_utils/gce.py
@@ -32,7 +32,7 @@ import pprint
 USER_AGENT_PRODUCT="Ansible-gce"
 USER_AGENT_VERSION="v1"
 
-def gce_connect(module):
+def gce_connect(module, provider=None):
     """Return a Google Cloud Engine connection."""
     service_account_email = module.params.get('service_account_email', None)
     pem_file = module.params.get('pem_file', None)
@@ -71,8 +71,14 @@ def gce_connect(module):
                              'secrets file.')
         return None
 
+    # Allow for passing in libcloud Google DNS (e.g, Provider.GOOGLE)
+    if provider is None:
+        provider = Provider.GCE
+
     try:
-        gce = get_driver(Provider.GCE)(service_account_email, pem_file, datacenter=module.params.get('zone'), project=project_id)
+        gce = get_driver(provider)(service_account_email, pem_file,
+                datacenter=module.params.get('zone', None),
+                project=project_id)
         gce.connection.user_agent_append("%s/%s" % (
             USER_AGENT_PRODUCT, USER_AGENT_VERSION))
     except (RuntimeError, ValueError), e:


### PR DESCRIPTION
This small fix provides support for additional libcloud providers. The Google modules in ansible utilize libcloud and currently all existing modules use the GCE libcloud provider. However, the libcloud DNS module uses a separate DNS provider.

Before I can contribute the Google DNS ansible module (pull-request coming to `ansible-modules-extras` soon), this must first be merged.

``` sh
$ make tests
...
----------------------------------------------------------------------
Ran 179 tests in 8.642s

OK
```
