### PR TITLE
set CPU architecture correctly for OpenBSD (powerpc not macppc, etc.)

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -168,6 +168,8 @@ class Facts(object):
             rc, out, err = module.run_command("/usr/sbin/bootinfo -p")
             data = out.split('\n')
             self.facts['architecture'] = data[0]
+        elif self.facts['system'] == 'OpenBSD':
+            self.facts['architecture'] = platform.uname()[5]
 
 
     def get_local_facts(self):


### PR DESCRIPTION
On some OpenBSD arch, cpu arch != machine arch. For example, cpu arch "powerpc" has two possibilities for machine arch, "macppc" and "socppc". Similar for some other architectures e.g. arm, mips64, mips64el, sh. OpenBSD packages are built by cpu arch, not machine arch, so this information is required in order to construct a URL to fetch packages from.

Before this diff:

```
$ ansible -m setup mala -a filter=*chi*             
mala | success >> {
    "ansible_facts": {
        "ansible_architecture": "macppc", 
        "ansible_machine": "macppc"
    }, 
    "changed": false
}
```

After:

```
$ ansible -m setup mala -a filter=*chi*             
mala | success >> {
    "ansible_facts": {
        "ansible_architecture": "powerpc", 
        "ansible_machine": "macppc"
    }, 
    "changed": false
}
```
