### PR TITLE
Fix TypeError exception if sudo password is integer

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -846,7 +846,7 @@ class Runner(object):
         actual_private_key_file = template.template(self.basedir, actual_private_key_file, inject, fail_on_undefined=True)
         self.sudo = utils.boolean(inject.get('ansible_sudo', self.sudo))
         self.sudo_user = inject.get('ansible_sudo_user', self.sudo_user)
-        self.sudo_pass = inject.get('ansible_sudo_pass', self.sudo_pass)
+        self.sudo_pass = str(inject.get('ansible_sudo_pass', self.sudo_pass))
         self.su = inject.get('ansible_su', self.su)
         self.su_pass = inject.get('ansible_su_pass', self.su_pass)
         self.sudo_exe = inject.get('ansible_sudo_exe', self.sudo_exe)


### PR DESCRIPTION
Hi, I have a virtual machine for testing where sudo password is integer

Inventory file:

```
[staging]
192.168.0.100 ansible_ssh_port=2222 ansible_ssh_user=ubuntu ansible_ssh_pass="123456" ansible_sudo_pass="123456"
```

When I run anisble, it fails with the next exception

```
fatal: [192.168.0.100] => Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 561, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 666, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 884, in _executor_internal_inner
    result = handler.run(conn, tmp, module_name, module_args, inject, complex_args)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/action_plugins/normal.py", line 57, in run
    return self.runner._execute_module(conn, tmp, module_name, module_args, inject=inject, complex_args=complex_args)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 526, in _execute_module
    res = self._low_level_exec_command(conn, cmd, tmp, sudoable=sudoable, in_data=in_data)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 1025, in _low_level_exec_command
    in_data=in_data)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/connection_plugins/ssh.py", line 352, in exec_command
    stdin.write(self.runner.sudo_pass + '\n')
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```
