### PR TITLE
 'copy' write new line at end of file if 'content' passed without newlin...

### DIFF
--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -316,6 +316,8 @@ class ActionModule(object):
         f = os.fdopen(fd, 'w')
         try:
             f.write(content)
+            if not content.endswith('\n'):
+                f.write('\n')
         except Exception, err:
             os.remove(content_tempfile)
             raise Exception(err)


### PR DESCRIPTION
...e.

POSIX states that a file should end by a newline.
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206

For previous discussion/github issue, refer to https://github.com/ansible/ansible/pull/8528 / https://github.com/adamchainz/ansible/commit/842a1b976d650b2c3117a6e0ed1329e5d0d62873 and https://github.com/ansible/ansible/issues/7855
