### PR TITLE
Apply firewall rule to any profile

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -174,7 +174,7 @@ if ($PSVersionTable.PSVersion.Major -lt 3)
  }
  
 #FIrewall
-netsh advfirewall firewall add rule Profile=public name="Allow WinRM HTTPS" dir=in localport=5986 protocol=TCP action=allow
+netsh advfirewall firewall add rule Profile=any name="Allow WinRM HTTPS" dir=in localport=5986 protocol=TCP action=allow
 
 
 


### PR DESCRIPTION
##### Issue Type: Feature Pull Request
##### Ansible Version: ansible 1.7.2
##### Environment:

Managing Windows 7 Hosts
##### Summary:

The ConfigureRemotingForAnsible helper script is incredibly useful for configuring all the necessary pieces to get WinRM working. However, it only applies the firewall rule in the "public" profile, which isn't obvious from the documentation. If your Windows network profile is set to "domain" or "private", the firewall will not get opened appropriately. This PR causes it to open the firewall for WinRM regardless of network configuration.
##### Steps To Reproduce:
- Configure a Windows 7 box with the Network Type set to "Network". 
- Run "ConfigureRemotingForAnsible" via powershell
- From your ansible host, run the `win_ping` module. 

The connection will timeout because the firewall isn't open.
##### Expected Results:

N/A
##### Actual Results:

N/A
