### PR TITLE
Address ignore_errors issue

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -212,10 +212,12 @@ class AggregateStats(object):
         prev = (getattr(self, what)).get(host, 0)
         getattr(self, what)[host] = prev+1
 
-    def compute(self, runner_results, setup=False, poll=False, ignore_errors=False):
+    def compute(self, runner_results, setup=False, poll=False):
         ''' walk through all results and increment stats '''
 
         for (host, value) in runner_results.get('contacted', {}).iteritems():
+            ignore_errors = 'ignore_errors' in value and bool(value['ignore_errors'])
+
             if not ignore_errors and (('failed' in value and bool(value['failed'])) or
                 ('failed_when_result' in value and [value['failed_when_result']] or ['rc' in value and value['rc'] != 0])[0]):
                 self._increment('failures', host)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -473,10 +473,6 @@ class PlayBook(object):
             ansible.callbacks.set_task(self.runner_callbacks, None)
             return True
 
-        # template ignore_errors
-        cond = template(play.basedir, task.ignore_errors, task.module_vars, expand_lists=False)
-        task.ignore_errors =  utils.check_conditional(cond, play.basedir, task.module_vars, fail_on_undefined=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR)
-
         # load up an appropriate ansible runner to run the task in parallel
         results = self._run_task_internal(task)
 
@@ -487,7 +483,7 @@ class PlayBook(object):
             results = {}
 
         contacted = results.get('contacted', {})
-        self.stats.compute(results, ignore_errors=task.ignore_errors)
+        self.stats.compute(results)
 
         def _register_play_vars(host, result):
             # when 'register' is used, persist the result in the vars cache
@@ -524,10 +520,11 @@ class PlayBook(object):
                 _register_play_vars(host, result)
 
         # also have to register some failed, but ignored, tasks
-        if task.ignore_errors and task.register:
+        if task.register:
             failed = results.get('failed', {})
             for host, result in failed.iteritems():
-                _register_play_vars(host, result)
+                if result.get('ignore_errors', False):
+                    _register_play_vars(host, result)
 
         # flag which notify handlers need to be run
         if len(task.notify) > 0:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -213,7 +213,7 @@ class Task(object):
             self.name = self.action
 
         # load various attributes
-        self.when    = ds.get('when', None)
+        self.when = ds.get('when', None)
         self.changed_when = ds.get('changed_when', None)
         self.failed_when = ds.get('failed_when', None)
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1050,6 +1050,8 @@ class Runner(object):
                     if failed_when is not None and 'skipped' not in data:
                         data['failed_when_result'] = data['failed'] = utils.check_conditional(failed_when, self.basedir, inject, fail_on_undefined=self.error_on_undefined_vars)
 
+            ignore_errors = utils.check_conditional(self.module_vars.get('ignore_errors', False), self.basedir, inject, fail_on_undefined=self.error_on_undefined_vars)
+            data['ignore_errors'] = ignore_errors
 
             if is_chained:
                 # no callbacks
@@ -1061,8 +1063,8 @@ class Runner(object):
                 data = utils.censor_unlogged_data(data)
 
             if not result.is_successful():
-                ignore_errors = self.module_vars.get('ignore_errors', False)
                 self.callbacks.on_failed(host, data, ignore_errors)
+                
             else:
                 if self.diff:
                     self.callbacks.on_file_diff(conn.host, result.diff)

--- a/test/integration/roles/test_ignore_errors/tasks/main.yml
+++ b/test/integration/roles/test_ignore_errors/tasks/main.yml
@@ -21,3 +21,7 @@
   register: failed
   ignore_errors: True
 
+- name: this will not stop the playbook
+  shell: /bin/false
+  register: failed
+  ignore_errors: test_bare


### PR DESCRIPTION
Compute the value of `ignore_errors` at the right moment (the same as `when`) so that all the necessary variables are available. One upshot is that `ignore_errors` becomes per-host/per-iteration as opposed to affecting the task as a whole; this might not be desirable but I believe that it matches the old (1.5.5) behavior at least (see #9464).
