### PR TITLE
Fix for --list-tasks with multiple tags and plays

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -210,6 +210,8 @@ def main(args):
             print 'playbook: %s' % playbook
             print ''
             playnum = 0
+            matched_tags_all = set()
+            unmatched_tags_all = set()
             for (play_ds, play_basedir) in zip(pb.playbook, pb.play_basedirs):
                 playnum += 1
                 play = ansible.playbook.Play(pb, play_ds, play_basedir,
@@ -227,11 +229,8 @@ def main(args):
                     matched_tags = matched_tags - set(pb.skip_tags)
 
                     unmatched_tags.discard('all')
-                    unknown_tags = ((set(pb.only_tags) | set(pb.skip_tags)) -
-                                    (matched_tags | unmatched_tags))
-
-                    if unknown_tags:
-                        continue
+                    matched_tags_all = matched_tags_all | matched_tags
+                    unmatched_tags_all = unmatched_tags_all | unmatched_tags
 
                 if options.listhosts:
                     print '  play #%d (%s): host count=%d' % (playnum, label, len(hosts))
@@ -249,6 +248,27 @@ def main(args):
                                 print '    %s' % task.name
                 if options.listhosts or options.listtasks:
                     print ''
+
+            # We dupliate the Ansible playbook class function of catching unknown
+            # tags here for extra user visibility
+            only_tags = options.tags.split(",")
+            skip_tags = options.skip_tags
+            if only_tags is None:
+                only_tags = [ 'all' ]
+            if options.skip_tags is not None:
+                skip_tags = options.skip_tags.split(",")
+            else:
+                skip_tags = []
+            unknown_tags = ((set(only_tags) | set(skip_tags)) -
+                            (matched_tags_all | unmatched_tags_all))
+            unknown_tags.discard('all')
+
+            if len(unknown_tags) > 0:
+                msg = 'tag(s) not found in playbook: %s.  possible values: %s'
+                unknown = ','.join(sorted(unknown_tags))
+                unmatched = ','.join(sorted(unmatched_tags_all))
+                raise errors.AnsibleError(msg % (unknown, unmatched))
+
             continue
 
         if options.syntax:


### PR DESCRIPTION
This is a cosmetic fix for the following scenario:
- Playbook with multiple plays
- Multiple tags passed to either `--skip-tags` or `--tags` 
- `--list-tasks` passed to ansible-playbook

Previously the loop which iterated over plays in "no-op" mode (`--list-tasks`, `--list-hosts`, or `--syntax`) would return an empty set of tasks when the above conditions were met. The logic was constructed to break out of the loop when an "unknown" tag is encountered. Breaking out here is inappropriate considering this scope doesn't cover all playbook tags and only sees those inside the current play.

I've elected to duplicate the logic from the main playbook library to throw an error at the user when an unknown tag is encountered. Since `ansible-playbook` catches this under a normal playbook run, the unknown tag logic could be removed in these no-op modes, but my thinking is that it would be nice to catch in check mode vs a live run.

I've ran this change through the full battery of unit and integration tests without any issues. I've also constructed a few sample playbooks to test the fix and it works as expected (would be happy to provide output if desired).
