### PR TITLE
Add additional Jinja2 template overrides

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -81,7 +81,8 @@ class Flags:
 FILTER_PLUGINS = None
 _LISTRE = re.compile(r"(\w+)\[(\d+)\]")
 JINJA2_OVERRIDE = '#jinja2:'
-JINJA2_ALLOWED_OVERRIDES = ['trim_blocks', 'lstrip_blocks', 'newline_sequence', 'keep_trailing_newline']
+JINJA2_ALLOWED_OVERRIDES = ['trim_blocks', 'lstrip_blocks', 'newline_sequence', 'keep_trailing_newline',
+                            'variable_start_string', 'variable_end_string', 'block_start_string', 'block_end_string']
 
 def lookup(name, *args, **kwargs):
     from ansible import utils


### PR DESCRIPTION
Add the following Jinja2 template overrides:
- `variable_start_string`
- `variable_end_string`
- `block_start_string`
- `block_end_string`

Useful for when templates need to render templates that use similar syntax. More specifically, I'm rendering a `consul-template` template with Ansible which also uses double curly braces for interpolation, but I need Ansible variables rendered in the output as well.
