### PR TITLE
Run keys through Jinja

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -126,6 +126,7 @@ def template(basedir, varname, vars, lookup_fatal=True, depth=0, expand_lists=Tr
         elif isinstance(varname, dict):
             d = {}
             for (k, v) in varname.iteritems():
+                k = template(basedir, k, vars, lookup_fatal, depth, expand_lists, fail_on_undefined=fail_on_undefined)
                 d[k] = template(basedir, v, vars, lookup_fatal, depth, expand_lists, fail_on_undefined=fail_on_undefined)
             return d
         else:


### PR DESCRIPTION
I ran into the same problem as in #7963 — I wanted to dynamically set the names for EC2 tags, in my case to record role info. (Since an instance might have multiple roles and EC2 tag names are unique, the role has to go in the name.) But trying to use a variable in the key didn't work:

```
- name: Set role state tag
  local_action: ec2_tag resource={{ ec2_id }} region=us-east-1
  args:
    tags:
      role-{{ service }}: "{{ 'started' if result.rc == 1 else 'stopped' }}"
```

Since only values are passed through Jinja, the literal "role-{{ service }}" would be set as the EC2 tag name.

Before discovering #7963, I fixed this by passing keys through Jinja as well. I'm not sure if there are any other core modules where it'd be helpful to dynamically set keys, but this seems like it could be a more natural approach in these situations than requiring the use of two separate variables. (If dynamic variables do pose a problem — performance? overriding other keys? — then the approach in #7963 would be fine.)
