### PR TITLE
Fix rax_find_loadbalancer issues

### DIFF
--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -173,9 +173,9 @@ def rax_find_server(module, rax_module, server):
 def rax_find_loadbalancer(module, rax_module, loadbalancer):
     clb = rax_module.cloud_loadbalancers
     try:
-        UUID(loadbalancer)
         found = clb.get(loadbalancer)
     except:
+        found = []
         for lb in clb.list():
             if loadbalancer == lb.name:
                 found.append(lb)


### PR DESCRIPTION
This PR addresses 2 issues in `ansible.module_utils.rax.rax_find_loadbalancer`
- Loadbalancer IDs are not UUIDs
- Ensure `found` list exists before using it

This is to address https://github.com/ansible/ansible-modules-core/issues/282
