### PR TITLE
guide_rax.rst: fix add_host invocations

### DIFF
--- a/docsite/rst/guide_rax.rst
+++ b/docsite/rst/guide_rax.rst
@@ -131,7 +131,7 @@ The rax module returns data about the nodes it creates, like IP addresses, hostn
           hostname: "{{ item.name }}"
           ansible_ssh_host: "{{ item.rax_accessipv4 }}"
           ansible_ssh_pass: "{{ item.rax_adminpass }}"
-          groupname: raxhosts
+          groups: raxhosts
       with_items: rax.success
       when: rax.action == 'create'
 
@@ -519,7 +519,7 @@ Build a complete webserver environment with servers, custom networks and load ba
             ansible_ssh_host: "{{ item.rax_accessipv4 }}"
             ansible_ssh_pass: "{{ item.rax_adminpass }}"
             ansible_ssh_user: root
-            groupname: web
+            groups: web
           with_items: rax.success
           when: rax.action == 'create'
     


### PR DESCRIPTION
change `groupname` to `groups`, as per add_host documentation
