### PR TITLE
fix bug 9415 - fetch uses conn.host instead of inventory_hostname

### DIFF
--- a/lib/ansible/runner/action_plugins/fetch.py
+++ b/lib/ansible/runner/action_plugins/fetch.py
@@ -109,7 +109,7 @@ class ActionModule(object):
                 dest = utils.path_dwim(self.runner.basedir, dest)
         else:
             # files are saved in dest dir, with a subdir for each host, then the filename
-            dest = "%s/%s/%s" % (utils.path_dwim(self.runner.basedir, dest), conn.host, source_local)
+            dest = "%s/%s/%s" % (utils.path_dwim(self.runner.basedir, dest), inventory_hostname, source_local)
 
         dest = dest.replace("//","/")
 


### PR DESCRIPTION
Use inventory_hostname instead of conn.host to avoid IP addresses as folder names when fetching from multiple servers. See: #9415 
