### PR TITLE
Support nested modules with ANSIBLE_LIBRARY env var

### DIFF
--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -127,7 +127,7 @@ class PluginLoader(object):
             configured_paths = self.config.split(os.pathsep)
             for path in configured_paths:
                 path = os.path.realpath(os.path.expanduser(path))
-                contents = glob.glob("%s/*" % path)
+                contents = glob.glob("%s/*" % path) + glob.glob("%s/*/*" % path)
                 for c in contents:
                     if os.path.isdir(c) and c not in ret:
                         ret.append(c)


### PR DESCRIPTION
This PR adds support to look for modules in nested directories when using `ANSIBLE_LIBRARY`.

Due to ansible now using git submodules, I don't init the submodules for dev purposes.  Instead I have my own forks cloned, and I use:

```
export ANSIBLE_LIBRARY=/Users/matt/python_venvs/ansibledev/ansible-modules-core:/Users/matt/python_venvs/ansibledev/ansible-modules-extras
```

Currently, when using ansible set up this way, ansible fails to find any modules:

```
localhost | FAILED => module rax not found in configured module paths
```
