### PR TITLE
rax.py inventory: improvements

### DIFF
--- a/plugins/inventory/rax.ini
+++ b/plugins/inventory/rax.ini
@@ -1,0 +1,55 @@
+# Ansible Rackspace external inventory script settings
+#
+
+[rax]
+
+# Environment Variable: RAX_CREDS_FILE
+#
+# An optional configuration that points to a pyrax-compatible credentials
+# file.
+#
+# If not supplied, rax.py will look for a credentials file
+# at ~/.rackspace_cloud_credentials.  It uses the Rackspace Python SDK,
+# and therefore requires a file formatted per the SDK's specifications.
+#
+# https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md
+# creds_file = ~/.rackspace_cloud_credentials
+
+# Environment Variable: RAX_REGION
+#
+# An optional environment variable to narrow inventory search
+# scope. If used, needs a value like ORD, DFW, SYD (a Rackspace
+# datacenter) and optionally accepts a comma-separated list.
+# regions = IAD,ORD,DFW
+
+# Environment Variable: RAX_ENV
+#
+# A configuration that will use an environment as configured in
+# ~/.pyrax.cfg, see
+# https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md
+# env = prod
+
+# Environment Variable: RAX_META_PREFIX
+# Default: meta
+#
+# A configuration that changes the prefix used for meta key/value groups.
+# For compatibility with ec2.py set to "tag"
+# meta_prefix = meta
+
+# Environment Variable: RAX_ACCESS_NETWORK
+# Default: public
+#
+# A configuration that will tell the inventory script to use a specific
+# server network to determine the ansible_ssh_host value. If no address
+# is found, ansible_ssh_host will not be set.
+# access_network = public
+
+# Environment Variable: RAX_ACCESS_IP_VERSION
+# Default: 4
+#
+# A configuration related to "access_network" that will attempt to
+# determine the ansible_ssh_host value for either IPv4 or IPv6. If no
+# address is found, ansible_ssh_host will not be set.
+# Acceptable values are: 4 or 6. Values other than 4 or 6
+# will be ignored, and 4 will be used.
+# access_ip_version = 4

--- a/plugins/inventory/rax.ini
+++ b/plugins/inventory/rax.ini
@@ -41,7 +41,8 @@
 #
 # A configuration that will tell the inventory script to use a specific
 # server network to determine the ansible_ssh_host value. If no address
-# is found, ansible_ssh_host will not be set.
+# is found, ansible_ssh_host will not be set. Accepts a comma-separated
+# list of network names, the first found wins.
 # access_network = public
 
 # Environment Variable: RAX_ACCESS_IP_VERSION
@@ -51,5 +52,6 @@
 # determine the ansible_ssh_host value for either IPv4 or IPv6. If no
 # address is found, ansible_ssh_host will not be set.
 # Acceptable values are: 4 or 6. Values other than 4 or 6
-# will be ignored, and 4 will be used.
+# will be ignored, and 4 will be used. Accepts a comma separated list,
+# the first found wins.
 # access_ip_version = 4


### PR DESCRIPTION
This PR adds the following improvements to the `rax.py` inventory script:
1. Adds support for RackConnect v3 by allowing the user to configure which network to use for `ansible_ssh_host` as well as whether to use IPv4 or IPv6
2. Adds support for reading configurations from a config file as well as environment vars (example config file is provided)
3. Supports servers booted from volume

The ability to specify the access network and access IP version, also supports fallbacks. Specifying `RAX_ACCESS_NETWORK=public,private` and `RAX_ACCESS_IP_VERSION=6,4` will look for public IPv6, public IPv4, private IPv6, and finally private IPv4. If no matching networks are found, `ansible_ssh_host` will not be set, ultimately falling back to the `inventory_hostname`.

Additionally, the in code "documentation" has been cleaned up. 

This PR supersedes #9307 

Extra testing appreciated: @angstwad @claco
