### PR TITLE
netmask_to_cidr function added

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -219,6 +219,10 @@ def version_compare(value, version, operator='eq', strict=False):
     except Exception, e:
         raise errors.AnsibleFilterError('Version comparison: %s' % e)
 
+def netmask_to_cidr(netmask):
+    return sum([bin(int(x)).count('1') for x in netmask.split('.')])
+
+
 @environmentfilter
 def rand(environment, end, start=None, step=None):
     r = SystemRandom()
@@ -312,4 +316,8 @@ class FilterModule(object):
 
             # random numbers
             'random': rand,
+
+            # network math
+            'netmask_to_cidr': netmask_to_cidr,
+
         }


### PR DESCRIPTION
To help convert between netmasks given in the facts to a CIDR
value, supply a jinja function to help us out.

This was discussed in https://github.com/ansible/ansible/issues/8584 but it doesn't look like anyone tried to get it in the tree.
