### PR TITLE
Allow multiple interpreters to be specified

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -222,7 +222,9 @@ mentioned::
       than one Python or not located at "/usr/bin/python" such as \*BSD, or where /usr/bin/python
       is not a 2.X series Python.  We do not use the "/usr/bin/env" mechanism as that requires the remote user's
       path to be set right and also assumes the "python" executable is named python, where the executable might
-      be named something like "python26".
+      be named something like "python26". This can be a comma-separated list of paths that will be tried
+      in turn until a valid executable is found. For example when managing a mix of Linux and \*BSD machines,
+      you can globally set "ansible_python_interpreter=/usr/local/bin/python,/usr/bin/python".
     ansible\_\*\_interpreter
       Works for anything such as ruby or perl and works just like ansible_python_interpreter.
       This replaces shebang of modules which will run on that host.

--- a/lib/ansible/module_common.py
+++ b/lib/ansible/module_common.py
@@ -140,7 +140,7 @@ class ModuleReplacer(object):
 
     # ******************************************************************************
 
-    def modify_module(self, module_path, complex_args, module_args, inject):
+    def modify_module(self, module_path, complex_args, module_args, check_interp, inject):
 
         with open(module_path) as f:
 
@@ -185,8 +185,24 @@ class ModuleReplacer(object):
                 interpreter_config = 'ansible_%s_interpreter' % os.path.basename(interpreter)
 
                 if interpreter_config in inject:
-                    interpreter = to_bytes(inject[interpreter_config], errors='strict')
-                    lines[0] = shebang = "#!%s %s" % (interpreter, " ".join(args[1:]))
+                    interp_list = to_bytes(inject[interpreter_config], errors='strict').split(',')
+                    interp = None
+                    fallback_interp = interp_list[0]
+
+                    # If more than a single interpreter is specified, check
+                    # each candidate value until a valid one is found.
+
+                    if len(interp_list) > 1 and check_interp is not None:
+                        try:
+                            while interp is None:
+                                candidate = interp_list.pop(0).strip()
+                                interp = check_interp(interpreter_config, candidate)
+                        except:
+                            interp = None
+
+                    if interp is None:
+                        interp = fallback_interp
+                    lines[0] = shebang = "#!%s %s" % (interp, " ".join(args[1:]))
                     module_data = "\n".join(lines)
 
             return (module_data, module_style, shebang)

--- a/lib/ansible/runner/shell_plugins/sh.py
+++ b/lib/ansible/runner/shell_plugins/sh.py
@@ -46,6 +46,9 @@ class ShellModule(object):
         path = pipes.quote(path)
         return 'chmod %s %s' % (mode, path)
 
+    def check_interp(self, interp):
+        return '([ -x "%s" ] && echo "%s") || echo NOTFOUND' % (interp, interp)
+
     def remove(self, path, recurse=False):
         path = pipes.quote(path)
         if recurse:

--- a/test/units/TestModuleUtilsBasic.py
+++ b/test/units/TestModuleUtilsBasic.py
@@ -46,7 +46,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
         os.write(self.tmp_fd, TEST_MODULE_DATA)
 
         # template the module code and eval it
-        module_data, module_style, shebang = ModuleReplacer().modify_module(self.tmp_path, {}, "", {})
+        module_data, module_style, shebang = ModuleReplacer().modify_module(self.tmp_path, {}, "", None, {})
 
         d = {}
         exec(module_data, d, d)
@@ -230,7 +230,7 @@ class TestModuleUtilsBasicHelpers(unittest.TestCase):
         os.write(self.tmp_fd, TEST_MODULE_DATA)
 
         # template the module code and eval it
-        module_data, module_style, shebang = ModuleReplacer().modify_module(self.tmp_path, {}, "", {})
+        module_data, module_style, shebang = ModuleReplacer().modify_module(self.tmp_path, {}, "", None, {})
 
         d = {}
         exec(module_data, d, d)


### PR DESCRIPTION
It may be inconvenient to set a specific ansible_*_interpreter
explicitly for each host in inventory. Instead allow the specification
of a comma-separated list of interpreters. The first time an interpreter
is required for a given host, try them in turn until an executable is
found, and cache the value for future use.
