### PR TITLE
Docker inventory script tls connection support

### DIFF
--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -272,6 +272,17 @@ def list_groups():
         default_ip = host.get('default_ip', None)
         hostname = server.get('base_url')
 
+        # Setup tls_config
+        if server.get('tls_config'):
+            try:
+                tls_config = server.pop('tls_config')
+                tls = docker.tls.TLSConfig(**tls_config)
+                server['tls'] = tls
+            except TypeError as e:
+                write_stderr("Error parsing host tls_config.")
+                write_stderr(e)
+                sys.exit(1)
+
         try:
             client = docker.Client(**server)
             containers = client.containers(all=True)

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -222,15 +222,15 @@ def setup():
             for host in hosts_list:
                 # Compatibility with old server configuration
                 if not host.get('server'):
-                    host_server = dict()
+                    host['server'] = dict()
                     if host.get('host'):
                         host['server']['base_url'] = host.pop('host')
                     if host.get('version'):
                         host['server']['version'] = host.pop('version')
                     if host.get('timeout'):
                         host['server']['timeout'] = host.pop('timeout')
-                else:
-                    host_server = host.pop('server')
+                
+                host_server = host.pop('server')
 
                 # Host configuration
                 host_config = dict()

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -210,6 +210,7 @@ def setup():
                 defaults['server']['version'] = defaults.pop('version')
             if defaults.get('timeout'):
                 defaults['server']['timeout'] = defaults.pop('timeout')
+            defaults['server']['tls_config'] = 'None'
 
     hosts = list()
 
@@ -229,6 +230,7 @@ def setup():
                         host['server']['version'] = host.pop('version')
                     if host.get('timeout'):
                         host['server']['timeout'] = host.pop('timeout')
+                    host['server']['tls_config'] = 'None'
                 
                 host_server = host.pop('server')
 

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -58,6 +58,8 @@
 #    DOCKER_HOST
 #    DOCKER_VERSION
 #    DOCKER_TIMEOUT
+#    DOCKER_TLS_VERIFY
+#    DOCKER_CERT_PATH
 #    DOCKER_PRIVATE_SSH_PORT
 #    DOCKER_DEFAULT_IP
 #
@@ -83,6 +85,19 @@
 #     description:
 #         - Timeout in seconds for connections to Docker daemon API
 #     default: Uses docker.docker.Client constructor defaults
+#     required: false
+# environment variable: DOCKER_TLS_VERIFY
+#     description:
+#         - Sets client-side TLS certificate verification.
+#     default: Uses docker.utils.kwargs_from_env function defaults
+#     required: false
+# environment variable: DOCKER_CERT_PATH
+#     description: 
+#         - File system path to the directory holding:
+#             - ca.pem (CA certificate)
+#             - cert.pem (client certificate)
+#             - key.pem (client certificate key)
+#     default: Uses docker.utils.kwargs_from_env function defaults
 #     required: false
 # environment variable: DOCKER_PRIVATE_SSH_PORT
 #     description:

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -133,7 +133,6 @@ import sys
 import json
 import argparse
 
-from UserDict import UserDict
 from collections import defaultdict
 
 import yaml
@@ -154,25 +153,6 @@ try:
 except ImportError:
     print('docker-py is required for this module')
     sys.exit(1)
-
-
-class HostDict(UserDict):
-    def __setitem__(self, key, value):
-        if value is not None:
-            self.data[key] = value
-
-    def update(self, dict=None, **kwargs):
-        if dict is None:
-            pass
-        elif isinstance(dict, UserDict):
-            for k, v in dict.data.items():
-                self[k] = v
-        else:
-            for k, v in dict.items():
-                self[k] = v
-        if len(kwargs):
-            for k, v in kwargs.items():
-                self[k] = v
 
 
 def write_stderr(string):

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -203,6 +203,16 @@ def setup():
     env_vars['default_ip'] = os.environ.get('DOCKER_DEFAULT_IP', '127.0.0.1')
     # Config file defaults
     defaults = config.get('defaults', dict())
+    # Compatibility with old server configuration
+    if defaults:
+        if not defaults.get('server'):
+            defaults['server'] = dict()
+            if defaults.get('host'):
+                defaults['server']['base_url'] = defaults.pop('host')
+            if defaults.get('version'):
+                defaults['server']['version'] = defaults.pop('version')
+            if defaults.get('timeout'):
+                defaults['server']['timeout'] = defaults.pop('timeout')
 
     hosts = list()
 
@@ -213,7 +223,18 @@ def setup():
         # Look to the config file's defined hosts
         if hosts_list:
             for host in hosts_list:
-                
+                # Compatibility with old server configuration
+                if not host.get('server'):
+                    host_server = dict()
+                    if host.get('host'):
+                        host['server']['base_url'] = host.pop('host')
+                    if host.get('version'):
+                        host['server']['version'] = host.pop('version')
+                    if host.get('timeout'):
+                        host['server']['timeout'] = host.pop('timeout')
+                else:
+                    host_server = host.pop('server')
+
                 # Host configuration
                 host_config = dict()
                 host_config.update(env_vars)

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -59,6 +59,8 @@
 #    DOCKER_VERSION
 #    DOCKER_TIMEOUT
 #    DOCKER_TLS_VERIFY
+#    DOCKER_SSL_VERSION
+#    DOCKER_ASSERT_HOSTNAME
 #    DOCKER_CERT_PATH
 #    DOCKER_PRIVATE_SSH_PORT
 #    DOCKER_DEFAULT_IP
@@ -90,6 +92,21 @@
 #     description:
 #         - Sets client-side TLS certificate verification.
 #     default: Uses docker.utils.kwargs_from_env function defaults
+#     required: false
+# environment variable: DOCKER_SSL_VERSION
+#     description:
+#         - Sets TLS version used.
+#           See: https://docs.python.org/3.4/library/ssl.html#ssl.PROTOCOL_TLSv1
+#     default: TLSv1 
+#     required: false
+# environment variable: DOCKER_ASSERT_HOSTNAME
+#     description:
+#         - Sets the TLS library server certificate CN assertion behaviour
+#         - If True: asserts that the CN equals the hostname in the url 
+#           (default value)
+#         - If False: no CN assertion takes place
+#         - Some string: asserts that the CN matches the given string
+#     default: True
 #     required: false
 # environment variable: DOCKER_CERT_PATH
 #     description: 
@@ -193,7 +210,15 @@ def setup():
 
     # Environment Variables
     env_vars = dict()
-    env_vars['server'] = docker.utils.kwargs_from_env(assert_hostname=False)
+    env_ssl_version =  os.environ.get('DOCKER_SSL_VERSION', 'TLSv1')
+    env_assert_hostname =  os.environ.get('DOCKER_ASSERT_HOSTNAME', None)
+    if isinstance(env_assert_hostname, str):
+        if env_assert_hostname.lower() == 'false':
+            env_assert_hostname = False
+        elif env_assert_hostname.lower() == 'true':
+            env_assert_hostname = None
+    env_vars['server'] = docker.utils.kwargs_from_env(
+        ssl_version=env_ssl_version, assert_hostname=env_assert_hostname)
     env_vars['ssh_port'] = os.environ.get('DOCKER_PRIVATE_SSH_PORT', '22')
     env_vars['default_ip'] = os.environ.get('DOCKER_DEFAULT_IP', '127.0.0.1')
     # Config file defaults

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -375,5 +375,5 @@ def main():
         sys.exit(1)
     sys.exit(0)
 
-
-main()
+if __name__ == '__main__':
+    main()

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -331,7 +331,8 @@ def list_groups():
 
             hostvars[name].update(container_info)
 
-    groups['docker_hosts'] = [host.get('base_url') for host in hosts]
+    groups['docker_hosts'] = list(set(
+        [host.get('server', {}).get('base_url') for host in hosts]))
     groups['_meta'] = dict()
     groups['_meta']['hostvars'] = hostvars
     print json.dumps(groups, sort_keys=True, indent=4)

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -202,7 +202,9 @@ def setup():
     env_vars['ssh_port'] = os.environ.get('DOCKER_PRIVATE_SSH_PORT', '22')
     env_vars['default_ip'] = os.environ.get('DOCKER_DEFAULT_IP', '127.0.0.1')
     # Config file defaults
-    defaults = config.get('defaults', dict())
+    defaults = dict()
+    if config:
+        defaults = config.get('defaults', dict())
     # Compatibility with old server configuration
     if defaults:
         if not defaults.get('server'):

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -48,7 +48,7 @@
 #    docker_volumes_rw
 #
 # Requirements:
-# The docker-py module: https://github.com/dotcloud/docker-py
+# The docker-py module version >= 0.6.0: https://github.com/dotcloud/docker-py
 #
 # Notes:
 # A config file can be used to configure this inventory module, and there

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -270,15 +270,19 @@ def list_groups():
         hostname = server.get('base_url')
 
         # Setup tls_config
-        if server.get('tls_config'):
-            try:
-                tls_config = server.pop('tls_config')
-                tls = docker.tls.TLSConfig(**tls_config)
-                server['tls'] = tls
-            except TypeError as e:
-                write_stderr("Error parsing host tls_config.")
-                write_stderr(e)
-                sys.exit(1)
+        if server.has_key('tls_config'):
+            tls_config = server.pop('tls_config')
+            if isinstance(tls_config,dict):
+                try:
+                    tls = docker.tls.TLSConfig(**tls_config)
+                    server['tls'] = tls
+                except TypeError as e:
+                    write_stderr("Error parsing host tls_config.")
+                    write_stderr(tls_config)
+                    write_stderr(e)
+                    sys.exit(1)
+            else:
+                server.pop('tls', None)
 
         try:
             client = docker.Client(**server)

--- a/plugins/inventory/docker.yml
+++ b/plugins/inventory/docker.yml
@@ -7,7 +7,7 @@
 # inventory information.
 #
 # This plugin does not support targeting of specific hosts using the --host
-# flag. Instead, it it queries the Docker API for each container, running
+# flag. Instead, it queries the Docker API for each container, running
 # or not, and returns this data all once.
 #
 # The plugin returns the following custom attributes on Docker containers:
@@ -30,7 +30,7 @@
 #    docker_volumes_rw
 #
 # Requirements:
-# The docker-py module: https://github.com/dotcloud/docker-py
+# The docker-py module version >= 0.6.0: https://github.com/dotcloud/docker-py
 #
 # Notes:
 # A config file can be used to configure this inventory module, and there
@@ -40,6 +40,8 @@
 #    DOCKER_HOST
 #    DOCKER_VERSION
 #    DOCKER_TIMEOUT
+#    DOCKER_TLS_VERIFY
+#    DOCKER_CERT_PATH
 #    DOCKER_PRIVATE_SSH_PORT
 #    DOCKER_DEFAULT_IP
 #
@@ -65,6 +67,19 @@
 #     description:
 #         - Timeout in seconds for connections to Docker daemon API
 #     default: Uses docker.docker.Client constructor defaults
+#     required: false
+# environment variable: DOCKER_TLS_VERIFY
+#     description:
+#         - Sets client-side TLS certificate verification.
+#     default: Uses docker.utils.kwargs_from_env function defaults
+#     required: false
+# environment variable: DOCKER_CERT_PATH
+#     description: 
+#         - File system path to the directory holding:
+#             - ca.pem (CA certificate)
+#             - cert.pem (client certificate)
+#             - key.pem (client certificate key)
+#     default: Uses docker.utils.kwargs_from_env function defaults
 #     required: false
 # environment variable: DOCKER_PRIVATE_SSH_PORT
 #     description:

--- a/plugins/inventory/docker.yml
+++ b/plugins/inventory/docker.yml
@@ -41,6 +41,8 @@
 #    DOCKER_VERSION
 #    DOCKER_TIMEOUT
 #    DOCKER_TLS_VERIFY
+#    DOCKER_SSL_VERSION
+#    DOCKER_ASSERT_HOSTNAME
 #    DOCKER_CERT_PATH
 #    DOCKER_PRIVATE_SSH_PORT
 #    DOCKER_DEFAULT_IP
@@ -72,6 +74,21 @@
 #     description:
 #         - Sets client-side TLS certificate verification.
 #     default: Uses docker.utils.kwargs_from_env function defaults
+#     required: false
+# environment variable: DOCKER_SSL_VERSION
+#     description:
+#         - Sets TLS version used.
+#           See: https://docs.python.org/3.4/library/ssl.html#ssl.PROTOCOL_TLSv1
+#     default: TLSv1 
+#     required: false
+# environment variable: DOCKER_ASSERT_HOSTNAME
+#     description:
+#         - Sets the TLS library server certificate CN assertion behaviour
+#         - If True: asserts that the CN equals the hostname in the url 
+#           (default value)
+#         - If False: no CN assertion takes place
+#         - Some string: asserts that the CN matches the given string
+#     default: True
 #     required: false
 # environment variable: DOCKER_CERT_PATH
 #     description: 

--- a/plugins/inventory/docker.yml
+++ b/plugins/inventory/docker.yml
@@ -155,7 +155,9 @@
 #    private_ssh_port: 22
 #    # Simple host configuration without tls
 #  - server:
-#      base_url: https://192.168.59.102:2376
+#      base_url: tcp://192.168.59.102:2375
+#      # Setting 'tls_config: None' explicitly disallows tls
+#      tls_config: None
 #    default_ip: 172.16.3.45
 #    private_ssh_port: 22
 #    # Old-style host configuration example

--- a/plugins/inventory/docker.yml
+++ b/plugins/inventory/docker.yml
@@ -132,18 +132,35 @@
 # over environment variables.
 #
 # Variable precedence is: hosts > defaults > environment
-
----
-defaults:
-  host: unix:///var/run/docker.sock
-  version: 1.9
-  timeout: 60
-  private_ssh_port: 22
-  default_ip: 127.0.0.1
-hosts:
+#
+#---
+#defaults:
+#  server:
+#    base_url: tcp://192.168.59.104:2375
+#hosts:
+#  # Full host configuration example with tls encryption 
+#  - server:
+#      base_url: https://192.168.59.103:2376
+#      tls_config:
+#        client_cert:
+#          - /home/me/.boot2docker/certs/boot2docker-vm-docker-dev/cert.pem
+#          - /home/me/.boot2docker/certs/boot2docker-vm-docker-dev/key.pem
+#        ca_cert: /home/me/.boot2docker/certs/boot2docker-vm-docker-dev/ca.pem
+#        verify: true
+#        assert_hostname: false
+#        ssl_version: TLSv1
+#      version: 1.9
+#      timeout: 60
+#    default_ip: 172.16.3.45
+#    private_ssh_port: 22
+#    # Simple host configuration without tls
+#  - server:
+#      base_url: https://192.168.59.102:2376
+#    default_ip: 172.16.3.45
+#    private_ssh_port: 22
+#    # Old-style host configuration example
 #  - host: tcp://10.45.5.16:4243
 #    version: 1.9
 #    timeout: 60
 #    private_ssh_port: 2022
 #    default_ip: 172.16.3.45
-#  - host: tcp://localhost:4243


### PR DESCRIPTION
This PR adds TLS connection support for the docker inventory script.

I have come across the problem of the docker-inventory script not working any more with boot2docker 1.3+.
The issue is that boot2docker creates a server that wants to use a full TLS mutually authenticated connection (e.g. server cert+client cert).
The current docker inventory script does not support TLS connection settings setup.

Notable changes:
- Now you can use the script to inventorize one docker instance by having the configuration variables stored in shell environment variables.
  
  boot2docker example:
  
  (By default boot2docker will use tls as of version 1.3.0)
  
  ```
  boot2docker init
  eval "$(boot2docker shellinit)"
  export DOCKER_ASSERT_HOSTNAME="boot2docker"
  ./docker.py --list
  ```
- Now the connection settings stored in shell environment variables are imported using docker-py's docker.utils.kwargs_from_env() function. That properly sets up the kwargs (including the docker.tls.TLSConfig) needed by the Connection constructor.
- The configuration data structures -and so the YAML confguration file- were changed, so that the server connection configuration sits in its own dict.
  
  Now the script supports multiple connection methods (plain, simple unauthenticated https://, mutually authenticated tls). This means that the docker Client connection **init** now can be called with may different signatures. Cherrypicking the options can lead to problems: either leaving something out, or calling with an incompatible constellation of options. It's cleaner and more maintainable to keep this settings in a seperate dict, that can be used as kwargs for the Connection constructor.
  
  Now the variable names in the 'server' configuration stanza correspond to the arguments of the constructor of the docker.Client class, the exception being the tls object. The TLSConfig class is instantiated with the kwargs in the tls_config object.
  
  For reference, the signature of the docker.tls.TLSConfig **init**:
  
  ```
  def __init__(self, client_cert=None, ca_cert=None, verify=None,
               ssl_version=None, assert_hostname=None):
  ```
  
  The signature of the docker.Client **init**:
  
  ```
  def __init__(self, base_url=None, version=DEFAULT_DOCKER_API_VERSION,
               timeout=DEFAULT_TIMEOUT_SECONDS, tls=False)
  ```
  
  Configuration example:
  
  ```
  ---
  - defaults:
      server:
        base_url: https://192.168.59.103:2376
        tls_config:
          client_cert:
            - /home/me/.boot2docker/certs/boot2docker-vm-docker-dev/cert.pem
            - /home/me/.boot2docker/certs/boot2docker-vm-docker-dev/key.pem
          ca_cert: /home/me/.boot2docker/certs/boot2docker-vm-docker-dev/ca.pem
          verify: true
          assert_hostname: false
          ssl_version: TLSv1
        version: 1.9
        timeout: 60
  ```
- The old-style settings are imported, for the script needs to be backward-compatible. For imported settings, TLS is disabled (as the old configuration had no support for tls settings.) If you have an old-style configuration file and you want tls connections, you will have to convert your settings. If you don't want tls, you don't need to do anything.
