### PR TITLE
Adding nested dictionary lookups

### DIFF
--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -119,7 +119,7 @@ And you want to print every user's name and phone number.  You can loop through 
 Nested Hashes
 `````````````
 
-.. versionadded:: 2.0
+.. versionadded:: 2.2
 
 Working with nested hashes is also possible. Suppose you have holidays, nested by year and then month and then day::
 

--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -124,6 +124,7 @@ Nested Hashes
 Working with nested hashes is also possible. Suppose you have holidays, nested by year and then month and then day::
 
     ---
+    current_month: "January"
     holidays_by_year_month_day:
       2016:
         January:
@@ -137,10 +138,10 @@ Working with nested hashes is also possible. Suppose you have holidays, nested b
 
 You can print every holiday in a given month using ``with_nested_dict`` like this::
 
-    - debug:
-        msg:              "Remember {{value}} on {{key_1}} {{'%02d'|format(key_2)}}, {{key_0}}"
-      when:               key_1 == current_month
-      with_nested_dict:   holidays_by_year_month_day
+    - name: Print holidays for this month
+      debug: msg="Remember {{ item.value }} on {{ item.nested[1] }} {{ '%02d' | format(item.nested[2]) }}, {{ item.nested[0] }}"
+      when: item.nested[1] == current_month
+      with_nested_dict: "{{ holidays_by_year_month_day }}"
 
 This lookup flattens nested hashes, with each flattened key denoted by its nesting level. The above would be the equivalent of::
 

--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -143,28 +143,32 @@ You can print every holiday in a given month using ``with_nested_dict`` like thi
       when: item.nested[1] == current_month
       with_nested_dict: "{{ holidays_by_year_month_day }}"
 
-This lookup flattens nested hashes, with each flattened key denoted by its nesting level. The above would be the equivalent of::
+This lookup flattens nested hashes, each with a list of keys ordered by their nesting level. The above would be the equivalent of::
 
     ---
     -
-      key_0: 2016
-      key_1: January
-      key_2: 1
+      nested:
+        - 2016
+        - January
+        - 1
       value: New Years Day
     -
-      key_0: 2016
-      key_1: January
-      key_2: 19
+      nested:
+        - 2016
+        - January
+        - 19
       value: Martin Luther King Day
     -
-      key_0: 2016
-      key_1: February
-      key_2: 14
+      nested:
+        - 2016
+        - February
+        - 14
       value: Valentines Day
     -
-      key_0: 2016
-      key_1: February
-      key_2: 16
+      nested:
+        - 2016
+        - February
+        - 16
       value: Presidents Day
     #...
 

--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -114,6 +114,59 @@ And you want to print every user's name and phone number.  You can loop through 
           msg: "User {{ item.key }} is {{ item.value.name }} ({{ item.value.telephone }})"
         with_dict: "{{ users }}"
 
+.. _nested_hashes:
+
+Nested Hashes
+`````````````
+
+.. versionadded:: 2.0
+
+Working with nested hashes is also possible. Suppose you have holidays, nested by year and then month and then day::
+
+    ---
+    holidays_by_year_month_day:
+      2016:
+        January:
+          1: New Years Day
+          19: Martin Luther King Day
+        February:
+          14: Valentines Day
+          16: Presidents Day
+        #...
+      #...
+
+You can print every holiday in a given month using ``with_nested_dict`` like this::
+
+    - debug:
+        msg:              "Remember {{value}} on {{key_1}} {{'%02d'|format(key_2)}}, {{key_0}}"
+      when:               key_1 == current_month
+      with_nested_dict:   holidays_by_year_month_day
+
+This lookup flattens nested hashes, with each flattened key denoted by its nesting level. The above would be the equivalent of::
+
+    ---
+    -
+      key_0: 2016
+      key_1: January
+      key_2: 1
+      value: New Years Day
+    -
+      key_0: 2016
+      key_1: January
+      key_2: 19
+      value: Martin Luther King Day
+    -
+      key_0: 2016
+      key_1: February
+      key_2: 14
+      value: Valentines Day
+    -
+      key_0: 2016
+      key_1: February
+      key_2: 16
+      value: Presidents Day
+    #...
+
 .. _looping_over_fileglobs:
 
 Looping over Files

--- a/lib/ansible/plugins/lookup/nested_dict.py
+++ b/lib/ansible/plugins/lookup/nested_dict.py
@@ -68,7 +68,7 @@ class LookupModule(LookupBase):
         stack = {} if stack is None else stack
         level = 0 if level is None else level
 
-        for key, val in terms.iteritems():
+        for key, val in terms.items():
             stack['key_%s' % level] = key
             if type(val) is dict:
                 LookupModule._flatten_nested_hash_to_list(terms=val, result=result, stack=stack.copy(), level=level+1)

--- a/lib/ansible/plugins/lookup/nested_dict.py
+++ b/lib/ansible/plugins/lookup/nested_dict.py
@@ -1,0 +1,45 @@
+# (c) 2016, Evan Kaufman <ekaufman@digitalflophouse.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+class LookupModule(LookupBase):
+
+    @staticmethod
+    def _flatten_nested_hash_to_list(terms, result=None, stack=None, level=None):
+        result = [] if result is None else result
+        stack = {} if stack is None else stack
+        level = 0 if level is None else level
+
+        for key, val in terms.iteritems():
+            stack['key_%s' % level] = key
+            if type(val) is dict:
+                LookupModule._flatten_nested_hash_to_list(terms=val, result=result, stack=stack.copy(), level=level+1)
+            else:
+                stack['value'] = val
+                result.append(stack.copy())
+        return result
+
+    def run(self, terms, variables=None, **kwargs):
+        if not isinstance(terms, dict):
+            raise AnsibleError("with_nested_dict expects a dict")
+
+        return self._flatten_nested_hash_to_list(terms)
+

--- a/lib/ansible/plugins/lookup/nested_dict.py
+++ b/lib/ansible/plugins/lookup/nested_dict.py
@@ -60,12 +60,14 @@ The nested keys and value of each are then exposed to an iterative task:
       with_nested_dict: "{{ holidays_by_year_month_day }}"
 
 """
+
+
 class LookupModule(LookupBase):
 
     @staticmethod
     def _flatten_nested_hash_to_list(terms, result=None, stack=None):
-        result = [] if result is None else result
-        stack = { 'nested':[] } if stack is None else stack
+        result = list() if result is None else result
+        stack = dict(nested=list()) if stack is None else stack
 
         for key, val in terms.items():
             working = LookupModule._stack_copy(stack)
@@ -90,4 +92,3 @@ class LookupModule(LookupBase):
             raise AnsibleError("with_nested_dict expects a dict")
 
         return self._flatten_nested_hash_to_list(terms)
-

--- a/lib/ansible/plugins/lookup/nested_dict.py
+++ b/lib/ansible/plugins/lookup/nested_dict.py
@@ -44,10 +44,10 @@ For example, a collection of holidays nested by year, month, and day:
 Would be flattened into an array of shallow dicts, with each original key denoted by its nesting level:
 
     [
-        { 'key_0': '2016', 'key_1': 'January',  'key_2': '1',  'val': 'New Years Day' },
-        { 'key_0': '2016', 'key_1': 'January',  'key_2': '19', 'val': 'Martin Luther King Day' },
-        { 'key_0': '2016', 'key_1': 'February', 'key_2': '14', 'val': 'Valentines Day' },
-        { 'key_0': '2016', 'key_1': 'February', 'key_2': '16', 'val': 'Presidents Day' },
+        { 'key_0': '2016', 'key_1': 'January',  'key_2': '1',  'value': 'New Years Day' },
+        { 'key_0': '2016', 'key_1': 'January',  'key_2': '19', 'value': 'Martin Luther King Day' },
+        { 'key_0': '2016', 'key_1': 'February', 'key_2': '14', 'value': 'Valentines Day' },
+        { 'key_0': '2016', 'key_1': 'February', 'key_2': '16', 'value': 'Presidents Day' },
         ...
     ]
 
@@ -55,7 +55,7 @@ The nested keys and value of each are then exposed to an iterative task:
 
     - name:               "Remind us what holidays are this month"
       debug:
-        msg:              "Remember {{val}} on {{key_1}} {{'%02d'|format(key_2)}} in the year {{key_0}}"
+        msg:              "Remember {{value}} on {{key_1}} {{'%02d'|format(key_2)}} in the year {{key_0}}"
       when:               key_1 == current_month
       with_nested_dict:   holidays_by_year_month_day
 

--- a/lib/ansible/plugins/lookup/nested_dict.py
+++ b/lib/ansible/plugins/lookup/nested_dict.py
@@ -20,6 +20,46 @@ __metaclass__ = type
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
+"""
+Lookup plugin to flatten nested dictionaries for linear iteration
+=================================================================
+
+For example, a collection of holidays nested by year, month, and day:
+
+    {
+        '2016': {
+            'January': {
+                '1':  'New Years Day',
+                '19': 'Martin Luther King Day',
+            },
+            'February': {
+                '14': 'Valentines Day',
+                '16': 'Presidents Day',
+            },
+            ...
+        },
+        ...
+    }
+
+Would be flattened into an array of shallow dicts, with each original key denoted by its nesting level:
+
+    [
+        { 'key_0': '2016', 'key_1': 'January',  'key_2': '1',  'val': 'New Years Day' },
+        { 'key_0': '2016', 'key_1': 'January',  'key_2': '19', 'val': 'Martin Luther King Day' },
+        { 'key_0': '2016', 'key_1': 'February', 'key_2': '14', 'val': 'Valentines Day' },
+        { 'key_0': '2016', 'key_1': 'February', 'key_2': '16', 'val': 'Presidents Day' },
+        ...
+    ]
+
+The nested keys and value of each are then exposed to an iterative task:
+
+    - name:               "Remind us what holidays are this month"
+      debug:
+        msg:              "Remember {{val}} on {{key_1}} {{'%02d'|format(key_2)}} in the year {{key_0}}"
+      when:               key_1 == current_month
+      with_nested_dict:   holidays_by_year_month_day
+
+"""
 class LookupModule(LookupBase):
 
     @staticmethod


### PR DESCRIPTION
##### SUMMARY

This lookup accepts nested dicts of potentially any depth, and recursively flattens them to a single dict with a `value` and `nested` list of keys, in order of their nesting.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

`nested_dict` lookup plugin

##### ANSIBLE VERSION

Originally written for 1.8 (but no longer works) and since updated for 2.0, also tested successfully with 2.1 and 2.2

##### ADDITIONAL INFORMATION

My use case for this was dicts nested two levels deep for configuring an ini file (where the first level was a section name and the second level was the option name and the scalar value for it):

``` yml
# roles/php/vars/main.yml

---
php_ini:
  PHP:
    short_open_tag: "Off"
    expose_php: "Off"
    error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
    display_errors: "Off"
    display_startup_errors: "Off"
    track_errors: "On"
    log_errors: "On"
    error_log: "/var/log/php_error.log"
  Date:
    "date.timezone": "America/Chicago"
  "mail function":
    sendmail_path: "sendmail -t -i"
  opcache:
    "opcache.enable": 1
    "opcache.enable_cli": 0
    "opcache.fast_shutdown": 0
```

And the example task:

``` yml
# roles/php/tasks/main.yml

---
- name: Configure php.ini
  ini_file: >
    dest=/etc/php5/cli/php.ini
    section="{{ item.nested.0 }}"
    option="{{ item.nested.1 }}"
    value="{{ item.value }}"
  with_nested_dict: php_ini
```
