### PR TITLE
Fix file mode calculation

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1362,7 +1362,7 @@ class AnsibleModule(object):
             # based on the current value of umask
             umask = os.umask(0)
             os.umask(umask)
-            os.chmod(dest, 0666 ^ umask)
+            os.chmod(dest, 0666 & ~umask)
             if switched_user:
                 os.chown(dest, os.getuid(), os.getgid())
 


### PR DESCRIPTION
Since 9da0627, file mode calculation is incorrect. For example when `umask` is `0077`, file mode is `0611` instead of `0600`.

See 898a38b / #7196.
