### PR TITLE
Adding inventory parameter to documentation

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -205,6 +205,8 @@ mentioned::
       The default ssh user name to use.
     ansible_ssh_pass
       The ssh password to use (this is insecure, we strongly recommend using --ask-pass or SSH keys)
+    ansible_sudo
+      The boolean to decide if sudo should be used for this host. Defaults to false.
     ansible_sudo_pass
       The sudo password to use (this is insecure, we strongly recommend using --ask-sudo-pass)
     ansible_sudo_exe (new in version 1.8)


### PR DESCRIPTION
Adding the inventory parameter `ansible_sudo` to the list of behavioural
inventory parameters in the intro_inventory documentation.
