### PR TITLE
Use full timestamp so backups during the same minute/DST changes are unique

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1268,8 +1268,16 @@ class AnsibleModule(object):
 
     def backup_local(self, fn):
         '''make a date-marked backup of the specified file, return True or False on success or failure'''
-        # backups named basename-YYYY-MM-DD@HH:MM~
-        ext = time.strftime("%Y-%m-%d@%H:%M~", time.localtime(time.time()))
+        # backups named basename-YYYY-MM-DD@HH:MM:SS.ssssssTZ~
+        now = time.time()
+        us = int((now % 1) * 1e6)
+        localtime = time.localtime(now)
+        if localtime.tm_isdst:
+            tzoffset = -time.altzone / 36
+        else:
+            tzoffset = -time.timezone / 36
+        ext_format = "%%Y-%%m-%%d@%%H:%%M:%%S.%06d%+05d~" % (us, tzoffset)
+        ext = time.strftime(ext_format, localtime)
         backupdest = '%s.%s' % (fn, ext)
 
         try:


### PR DESCRIPTION
When testing playbooks on a single host, it's easily possible to make multiple changes to a file within a single minute, and it's possible for there to be confusion during daylight savings rollover.

This patch includes the time zone without resorting to dateutil.tz.

I tested by applying the patch to my installed copy of 1.7.2, as I lack all the dependencies for a full test.

Example output:
grub.conf.2014-11-20@21:22:46.393099-0800~
grub.conf.2014-11-21@06:36:32.014887+0100~
