### PR TITLE
Jinja rand filter now supports repeatable randomness

### DIFF
--- a/test/units/TestFilters.py
+++ b/test/units/TestFilters.py
@@ -4,7 +4,7 @@ Test bundled filters
 
 import os.path
 import unittest, tempfile, shutil
-from ansible import playbook, inventory, callbacks
+from ansible import playbook, inventory, callbacks, errors
 import ansible.runner.filter_plugins.core
 
 INVENTORY = inventory.Inventory(['localhost'])
@@ -144,6 +144,7 @@ class TestFilters(unittest.TestCase):
         #    playbook  = book,
         #    inventory = INVENTORY,
         #    transport = 'local',
+        
         #    callbacks = callbacks.PlaybookCallbacks(),
         #    runner_callbacks = callbacks.DefaultRunnerCallbacks(),
         #    stats  = callbacks.AggregateStats(),
@@ -183,3 +184,23 @@ class TestFilters(unittest.TestCase):
     def test_max(self):
         a = ansible.runner.filter_plugins.core.max([3, 2, 5, 4])
         assert a == 5
+        
+    def test_rand(self):
+        seed = "this is an arbitrary string"
+        
+        a = ansible.runner.filter_plugins.core.rand(None, 60, seed=seed)
+        b = ansible.runner.filter_plugins.core.rand(None, 60, seed=seed)
+        assert a == b
+        
+        c = ansible.runner.filter_plugins.core.rand(None, [0, 1, 2, 3], seed=seed)
+        d = ansible.runner.filter_plugins.core.rand(None, [0, 1, 2, 3], seed=seed)
+        assert c == d
+                
+        try:
+            ansible.runner.filter_plugins.core.rand(None, 60, seed=["mutable containers are not hashable"])
+        except errors.AnsibleFilterError as e:
+            # this should be an exception
+            assert True
+            return
+            
+        assert False


### PR DESCRIPTION
By passing in a seed, which allows for repeatable randomness
- in conjunction with a variable that's unique per-host, this allows for repeatable 'random' values per host that, most importantly, don't change for each run of the playbook
- ex:  ansible all -m debug -a "msg={{ 60|random(seed=inventory_hostname) }}"
- personally, I would like to use this to repeatably splay a set of cron jobs across a cluster of hosts
