### PR TITLE
Making hacking/env-setup init git submodules

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -2,6 +2,8 @@
 # usage: source ./hacking/env-setup [-q]
 #    modifies environment for running Ansible from checkout
 
+GIT=git
+
 # When run using source as directed, $0 gets set to bash, so we must use $BASH_SOURCE
 if [ -n "$BASH_SOURCE" ] ; then
     HACKING_DIR=`dirname $BASH_SOURCE`
@@ -23,6 +25,12 @@ PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 [[ $PATH != ${PREFIX_PATH}* ]] && export PATH=$PREFIX_PATH:$PATH
 [[ $MANPATH != ${PREFIX_MANPATH}* ]] && export MANPATH=$PREFIX_MANPATH:$MANPATH
 
+for dir in {lib,v2}/ansible/modules/{core,extras}; do
+    if [ ! -d $dir ]; then
+        $GIT submodule update --init $dir
+    fi
+done
+
 # Print out values unless -q is set
 
 if [ $# -eq 0 -o "$1" != "-q" ] ; then
@@ -33,7 +41,7 @@ if [ $# -eq 0 -o "$1" != "-q" ] ; then
     echo "PYTHONPATH=$PYTHONPATH"
     echo "MANPATH=$MANPATH"
     echo ""
-    
+
     echo "Remember, you may wish to specify your host file with -i"
     echo ""
     echo "Done!"


### PR DESCRIPTION
This is more convenient than manually doing it.

```
$ source hacking/env-setup
Submodule 'lib/ansible/modules/extras' (https://github.com/ansible/ansible-modules-extras.git) registered for path 'lib/ansible/modules/extras'
Cloning into 'lib/ansible/modules/extras'...
remote: Counting objects: 18879, done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 18879 (delta 8), reused 10 (delta 3)
Receiving objects: 100% (18879/18879), 5.23 MiB | 607.00 KiB/s, done.
Resolving deltas: 100% (12569/12569), done.
Checking connectivity... done.
Submodule path 'lib/ansible/modules/extras': checked out 'e64751b0eb44c8ada6a6047eaf2303d98f8f505b'
Submodule 'v2/ansible/modules/core' (https://github.com/ansible/ansible-modules-core.git) registered for path 'v2/ansible/modules/core'
Cloning into 'v2/ansible/modules/core'...
remote: Counting objects: 19202, done.
remote: Total 19202 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (19202/19202), 5.45 MiB | 601.00 KiB/s, done.
Resolving deltas: 100% (12765/12765), done.
Checking connectivity... done.
Submodule path 'v2/ansible/modules/core': checked out 'cb69744bcee4b4217d83b4a30006635ba69e2aa0'
Submodule 'v2/ansible/modules/extras' (https://github.com/ansible/ansible-modules-extras.git) registered for path 'v2/ansible/modules/extras'
Cloning into 'v2/ansible/modules/extras'...
remote: Counting objects: 18879, done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 18879 (delta 8), reused 10 (delta 3)
Receiving objects: 100% (18879/18879), 5.23 MiB | 601.00 KiB/s, done.
Resolving deltas: 100% (12569/12569), done.
Checking connectivity... done.
Submodule path 'v2/ansible/modules/extras': checked out '8a4f07eecd2bb877f51b7b04b5352efa6076cce5'

Setting up Ansible to run out of checkout...

PATH=/Users/marca/dev/git-repos/ansible/bin:/Users/marca/.rvm/gems/ruby-2.1.2/bin:/Users/marca/.rvm/gems/ruby-2.1.2@global/bin:/Users/marca/.rvm/rubies/ruby-2.1.2/bin:/Users/marca/go/bin:/Users/marca/bin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Library/Frameworks/Python.framework/Versions/2.6/bin:/Library/Frameworks/Python.framework/Versions/2.5/bin:/Library/Frameworks/Python.framework/Versions/2.4/bin:/Library/Frameworks/Python.framework/Versions/3.4/bin:/Library/Frameworks/Python.framework/Versions/3.3/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/share/npm/bin:/Users/marca/.rvm/bin
PYTHONPATH=/Users/marca/dev/git-repos/ansible/lib:
MANPATH=/Users/marca/dev/git-repos/ansible/docs/man:

Remember, you may wish to specify your host file with -i

Done!

$ bin/ansible-playbook --version
ansible-playbook 1.8 (devel 116109468c) last updated 2014/11/23 09:27:41 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 19b328c4df) last updated 2014/11/23 09:44:44 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD e64751b0eb) last updated 2014/11/23 09:48:22 (GMT -700)
  v2/ansible/modules/core: (detached HEAD cb69744bce) last updated 2014/11/23 09:48:34 (GMT -700)
  v2/ansible/modules/extras: (detached HEAD 8a4f07eecd) last updated 2014/11/23 09:48:45 (GMT -700)
  configured module search path = None
```
