### PR TITLE
Make --version report the active config file

### DIFF
--- a/lib/ansible/config.py
+++ b/lib/ansible/config.py
@@ -1,0 +1,74 @@
+import ConfigParser
+import os
+import sys
+
+
+config_file = None
+
+
+# copied from utils, avoid circular reference fun :)
+def mk_boolean(value):
+    if value is None:
+        return False
+
+    return str(value).lower() in ["true", "t", "y", "1", "yes"]
+
+
+def get_config(p, section, key, env_var, default,
+               boolean=False, integer=False, floating=False, islist=False):
+    ''' return a configuration variable with casting '''
+    value = _get_config(p, section, key, env_var, default)
+    if boolean:
+        return mk_boolean(value)
+    if value and integer:
+        return int(value)
+    if value and floating:
+        return float(value)
+    if value and islist:
+        return [x.strip() for x in value.split(',')]
+    return value
+
+
+def _get_config(p, section, key, env_var, default):
+    ''' helper function for get_config '''
+    if env_var is not None:
+        value = os.environ.get(env_var, None)
+        if value is not None:
+            return value
+    if p is not None:
+        try:
+            return p.get(section, key, raw=True)
+        except:
+            return default
+    return default
+
+
+def load_config_file():
+    ''' Load Config File order(first found is used): ENV, CWD, HOME,
+    /etc/ansible '''
+
+    global config_file
+
+    p = ConfigParser.ConfigParser()
+
+    path0 = os.getenv("ANSIBLE_CONFIG", None)
+    if path0 is not None:
+        path0 = os.path.expanduser(path0)
+    path1 = os.getcwd() + "/ansible.cfg"
+    path2 = os.path.expanduser("~/.ansible.cfg")
+    path3 = "/etc/ansible/ansible.cfg"
+
+    for path in [path0, path1, path2, path3]:
+        if path is not None and os.path.exists(path):
+            try:
+                p.read(path)
+            except ConfigParser.Error as e:
+                print "Error reading config file: \n%s" % e
+                sys.exit(1)
+            config_file = path
+            return p
+    return None
+
+
+def get_config_file():
+    return config_file

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -17,67 +17,10 @@
 
 import os
 import pwd
-import sys
-import ConfigParser
 from string import ascii_letters, digits
 
-# copied from utils, avoid circular reference fun :)
-def mk_boolean(value):
-    if value is None:
-        return False
-    val = str(value)
-    if val.lower() in [ "true", "t", "y", "1", "yes" ]:
-        return True
-    else:
-        return False
+from .config import get_config, load_config_file
 
-def get_config(p, section, key, env_var, default, boolean=False, integer=False, floating=False, islist=False):
-    ''' return a configuration variable with casting '''
-    value = _get_config(p, section, key, env_var, default)
-    if boolean:
-        return mk_boolean(value)
-    if value and integer:
-        return int(value)
-    if value and floating:
-        return float(value)
-    if value and islist:
-        return [x.strip() for x in value.split(',')]
-    return value
-
-def _get_config(p, section, key, env_var, default):
-    ''' helper function for get_config '''
-    if env_var is not None:
-        value = os.environ.get(env_var, None)
-        if value is not None:
-            return value
-    if p is not None:
-        try:
-            return p.get(section, key, raw=True)
-        except:
-            return default
-    return default
-
-def load_config_file():
-    ''' Load Config File order(first found is used): ENV, CWD, HOME, /etc/ansible '''
-
-    p = ConfigParser.ConfigParser()
-
-    path0 = os.getenv("ANSIBLE_CONFIG", None)
-    if path0 is not None:
-        path0 = os.path.expanduser(path0)
-    path1 = os.getcwd() + "/ansible.cfg"
-    path2 = os.path.expanduser("~/.ansible.cfg")
-    path3 = "/etc/ansible/ansible.cfg"
-
-    for path in [path0, path1, path2, path3]:
-        if path is not None and os.path.exists(path):
-            try:
-                p.read(path)
-            except ConfigParser.Error as e:
-                print "Error reading config file: \n%s" % e
-                sys.exit(1)
-            return p
-    return None
 
 def shell_expand_path(path):
     ''' shell_expand_path is needed as os.path.expanduser does not work

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -30,6 +30,7 @@ from ansible.utils.display_functions import *
 from ansible.utils.plugins import *
 from ansible.utils.su_prompts import *
 from ansible.callbacks import display
+from ansible.config import get_config_file, load_config_file
 from ansible.module_utils.splitter import split_args, unquote
 import ansible.constants as C
 import ast
@@ -957,6 +958,8 @@ def version(prog):
     if gitinfo:
         result = result + " {0}".format(gitinfo)
     result = result + "\n  configured module search path = %s" % C.DEFAULT_MODULE_PATH
+    load_config_file()
+    result += "\n  config file = %s" % get_config_file()
     return result
 
 def version_info(gitinfo=False):


### PR DESCRIPTION
This is useful for troubleshooting.

E.g.:

```
$ ansible-playbook --version
ansible-playbook 1.8 (make_hacking_env-setup_init_submodules 4530974b3b) last updated 2014/11/23 09:51:01 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 19b328c4df) last updated 2014/11/23 09:44:44 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD e64751b0eb) last updated 2014/11/23 09:48:22 (GMT -700)
  v2/ansible/modules/core: (detached HEAD cb69744bce) last updated 2014/11/23 09:48:34 (GMT -700)
  v2/ansible/modules/extras: (detached HEAD 8a4f07eecd) last updated 2014/11/23 09:48:45 (GMT -700)
  configured module search path = None
  config file = /etc/ansible/ansible.cfg
```

(Note the last line above).

Note also that [`lib/ansible/config.py`](https://github.com/msabramo/ansible/blob/make_version_report_active_config_file/lib/ansible/config.py) is pretty much just extracted from `lib/ansible/constants.py`, but while I was at it, I made sure that the new file is flake8-compliant:

```
$ pep8 lib/ansible/config.py && echo $?
0

$ flake8 lib/ansible/config.py && echo $?
0
```

Cc: @sontek, @sudarkoff
