### PR TITLE
Make AnsibleError a plain ol' exception

### DIFF
--- a/lib/ansible/errors.py
+++ b/lib/ansible/errors.py
@@ -17,12 +17,7 @@
 
 class AnsibleError(Exception):
     ''' The base Ansible exception from which all others should subclass '''
-
-    def __init__(self, msg):
-        self.msg = msg
-
-    def __str__(self):
-        return self.msg
+    pass
 
 class AnsibleFileNotFound(AnsibleError):
     pass

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -296,7 +296,7 @@ class TestUtils(unittest.TestCase):
             try:
                 ansible.utils.process_yaml_error(exc, data, __file__)
             except ansible.errors.AnsibleYAMLValidationFailed, e:
-                self.assertTrue('Syntax Error while loading' in e.msg)
+                self.assertTrue('Syntax Error while loading' in str(e))
             else:
                 raise AssertionError('Incorrect exception, expected AnsibleYAMLValidationFailed')
 
@@ -307,7 +307,7 @@ class TestUtils(unittest.TestCase):
             try:
                 ansible.utils.process_yaml_error(exc, data, __file__)
             except ansible.errors.AnsibleYAMLValidationFailed, e:
-                self.assertTrue('Syntax Error while loading' in e.msg)
+                self.assertTrue('Syntax Error while loading' in str(e))
             else:
                 raise AssertionError('Incorrect exception, expected AnsibleYAMLValidationFailed')
 
@@ -318,7 +318,7 @@ class TestUtils(unittest.TestCase):
             try:
                 ansible.utils.process_yaml_error(exc, data, __file__)
             except ansible.errors.AnsibleYAMLValidationFailed, e:
-                self.assertTrue('Check over' in e.msg)
+                self.assertTrue('Check over' in str(e))
             else:
                 raise AssertionError('Incorrect exception, expected AnsibleYAMLValidationFailed')
 
@@ -329,7 +329,7 @@ class TestUtils(unittest.TestCase):
             try:
                 ansible.utils.process_yaml_error(exc, data, None)
             except ansible.errors.AnsibleYAMLValidationFailed, e:
-                self.assertTrue('Could not parse YAML.' in e.msg)
+                self.assertTrue('Could not parse YAML.' in str(e))
             else:
                 raise AssertionError('Incorrect exception, expected AnsibleYAMLValidationFailed')
 
@@ -355,7 +355,7 @@ class TestUtils(unittest.TestCase):
         try:
             ansible.utils.parse_yaml_from_file(broken)
         except ansible.errors.AnsibleYAMLValidationFailed, e:
-            self.assertTrue('Syntax Error while loading' in e.msg)
+            self.assertTrue('Syntax Error while loading' in str(e))
         else:
             raise AssertionError('Incorrect exception, expected AnsibleYAMLValidationFailed')
 
@@ -597,8 +597,8 @@ class TestUtils(unittest.TestCase):
         try:
             ansible.utils.deprecated('Ack!', '0.0', True)
         except ansible.errors.AnsibleError, e:
-            self.assertTrue('0.0' not in e.msg)
-            self.assertTrue('[DEPRECATED]' in e.msg)
+            self.assertTrue('0.0' not in str(e))
+            self.assertTrue('[DEPRECATED]' in str(e))
         else:
             raise AssertionError("Incorrect exception, expected AnsibleError")
 


### PR DESCRIPTION
Python's `Exception` constructor already takes a `message` as a parameter, which you can then get at by doing `str(e)` (`e.message` was deprecated).

The reason I bothered to make this change was because I was debugging with pdb and I noticed that `AnsibleError`s don't give useful information in pdb (probably because they don't have a `__repr__` method that prints the `msg` attribute).

```
(Pdb) c
> /Users/marca/dev/git-repos/ansible/lib/ansible/runner/__init__.py(599)_executor()
-> msg = str(ae)
(Pdb) ae
AnsibleError()
```

```
$ make tests
...
test_trivial (TestDocker.DockerSplitImageTagTestCase) ... ok
test_with_org_name (TestDocker.DockerSplitImageTagTestCase) ... ok
test_with_tag (TestDocker.DockerSplitImageTagTestCase) ... ok
test_with_tag_and_org_name (TestDocker.DockerSplitImageTagTestCase) ... ok

----------------------------------------------------------------------
Ran 190 tests in 23.091s

OK
```
