### PR TITLE
Set delegate on connection plugin before calling connect()

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -931,9 +931,11 @@ class Runner(object):
             return ReturnData(host=host, comm_ok=False, result=result)
 
         try:
-            conn = self.connector.connect(actual_host, actual_port, actual_user, actual_pass, actual_transport, actual_private_key_file)
             if self.delegate_to or host != actual_host:
-                conn.delegate = host
+                delegate_host = host
+            else:
+                delegate_host = None
+            conn = self.connector.connect(actual_host, actual_port, actual_user, actual_pass, actual_transport, actual_private_key_file, delegate_host)
 
             default_shell = getattr(conn, 'default_shell', '')
             shell_type = inject.get('ansible_shell_type')

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -31,10 +31,11 @@ class Connector(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def connect(self, host, port, user, password, transport, private_key_file):
+    def connect(self, host, port, user, password, transport, private_key_file, delegate_host):
         conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password, private_key_file=private_key_file)
         if conn is None:
             raise AnsibleError("unsupported connection type: %s" % transport)
+        conn.delegate = delegate_host
         if private_key_file:
             # If private key is readable by user other than owner, flag an error
             st = None


### PR DESCRIPTION
The `host` argument currently passed to the connection plugin reflects the value of `ansible_ssh_host` or `delegate_to`, whereas inventory variables are looked up by hostname.  Since `conn.delegate` is currently set after the `connect()` method is called on the plugin, it is not always possible to access host variables before connecting.

With this change, a connection plugin can use the following code to read host variables prior to making a connection:

```
def connect(self):
    hostvars = self.runner.inventory.get_variables(self.delegate or self.host)
    # do stuff with hostvars and connect
    return self
```

I'm planning to use this approach to support additional host variables for authentication with a winrm connection, without having to handle these host variables as a special case within runner.
