### PR TITLE
Handle PowerShell parameters passed via splatting

### DIFF
--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -143,7 +143,7 @@ class Connection(object):
             vvv("EXEC %s" % cmd, host=self.host)
         # For script/raw support.
         if cmd_parts and cmd_parts[0].lower().endswith('.ps1'):
-            script = powershell._build_file_cmd(cmd_parts)
+            script = powershell._build_file_cmd(cmd_parts, quote_args=False)
             cmd_parts = powershell._encode_script(script, as_list=True)
         try:
             result = self._winrm_exec(cmd_parts[0], cmd_parts[1:], from_exec=True)

--- a/lib/ansible/runner/shell_plugins/powershell.py
+++ b/lib/ansible/runner/shell_plugins/powershell.py
@@ -53,9 +53,11 @@ def _encode_script(script, as_list=False):
         return cmd_parts
     return ' '.join(cmd_parts)
 
-def _build_file_cmd(cmd_parts):
+def _build_file_cmd(cmd_parts, quote_args=True):
     '''Build command line to run a file, given list of file name plus args.'''
-    return ' '.join(_common_args + ['-ExecutionPolicy', 'Unrestricted', '-File'] + ['"%s"' % x for x in cmd_parts])
+    if quote_args:
+        cmd_parts = ['"%s"' % x for x in cmd_parts]
+    return ' '.join(['&'] + cmd_parts)
 
 class ShellModule(object):
 
@@ -110,7 +112,7 @@ class ShellModule(object):
         cmd_parts = shlex.split(cmd, posix=False)
         if not cmd_parts[0].lower().endswith('.ps1'):
             cmd_parts[0] = '%s.ps1' % cmd_parts[0]
-        script = _build_file_cmd(cmd_parts)
+        script = _build_file_cmd(cmd_parts, quote_args=False)
         if rm_tmp:
             rm_tmp = _escape(rm_tmp)
             script = '%s; Remove-Item "%s" -Force -Recurse;' % (script, rm_tmp)

--- a/test/integration/roles/test_win_script/defaults/main.yml
+++ b/test/integration/roles/test_win_script/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+# Parameters to pass to test scripts.
+test_win_script_value: VaLuE
+test_win_script_splat: "@{This='THIS'; That='THAT'; Other='OTHER'}"

--- a/test/integration/roles/test_win_script/files/test_script_with_splatting.ps1
+++ b/test/integration/roles/test_win_script/files/test_script_with_splatting.ps1
@@ -1,0 +1,6 @@
+# Test script to make sure the Ansible script module works when arguments are
+# passed via splatting (http://technet.microsoft.com/en-us/magazine/gg675931.aspx)
+
+Write-Host $args.This
+Write-Host $args.That
+Write-Host $args.Other

--- a/test/integration/roles/test_win_script/tasks/main.yml
+++ b/test/integration/roles/test_win_script/tasks/main.yml
@@ -46,6 +46,38 @@
       - "not test_script_with_args_result|failed"
       - "test_script_with_args_result|changed"
 
+- name: run test script that takes parameters passed via splatting
+  script: test_script_with_splatting.ps1 "@{ This = 'this'; That = '{{ test_win_script_value }}'; Other = 'other'}"
+  register: test_script_with_splatting_result
+
+- name: check that script ran and received parameters via splatting
+  assert:
+    that:
+      - "test_script_with_splatting_result.rc == 0"
+      - "test_script_with_splatting_result.stdout"
+      - "test_script_with_splatting_result.stdout_lines[0] == 'this'"
+      - "test_script_with_splatting_result.stdout_lines[1] == test_win_script_value"
+      - "test_script_with_splatting_result.stdout_lines[2] == 'other'"
+      - "not test_script_with_splatting_result.stderr"
+      - "not test_script_with_splatting_result|failed"
+      - "test_script_with_splatting_result|changed"
+
+- name: run test script that takes splatted parameters from a variable
+  script: test_script_with_splatting.ps1 {{ test_win_script_splat|quote }}
+  register: test_script_with_splatting2_result
+
+- name: check that script ran and received parameters via splatting from a variable
+  assert:
+    that:
+      - "test_script_with_splatting2_result.rc == 0"
+      - "test_script_with_splatting2_result.stdout"
+      - "test_script_with_splatting2_result.stdout_lines[0] == 'THIS'"
+      - "test_script_with_splatting2_result.stdout_lines[1] == 'THAT'"
+      - "test_script_with_splatting2_result.stdout_lines[2] == 'OTHER'"
+      - "not test_script_with_splatting2_result.stderr"
+      - "not test_script_with_splatting2_result|failed"
+      - "test_script_with_splatting2_result|changed"
+
 - name: run test script that has errors
   script: test_script_with_errors.ps1
   register: test_script_with_errors_result


### PR DESCRIPTION
Allows PowerShell arguments such as the following to be passed to scripts/cmdlets:

```
script: myscript.ps1 "@{This='THIS'; That='THAT'; Other='OTHER'}"
```

More info on splatting: http://technet.microsoft.com/en-us/magazine/gg675931.aspx

Via discussion on ansible-project mailing list: https://groups.google.com/forum/#!topic/ansible-project/jojvFohOwqM
