### PR TITLE
Windows powershell encoding fix for python 2.6.

### DIFF
--- a/lib/ansible/module_utils/splitter.py
+++ b/lib/ansible/module_utils/splitter.py
@@ -71,11 +71,10 @@ def split_args(args):
     # here we encode the args, so we have a uniform charset to
     # work with, and split on white space
     args = args.strip()
-    try:
+    do_decode = False
+    if isinstance(args, unicode):
         args = args.encode('utf-8')
         do_decode = True
-    except UnicodeDecodeError:
-        do_decode = False
     items = args.split('\n')
 
     # iterate over the tokens, and reassemble any that may have been

--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -133,6 +133,7 @@ class Connection(object):
         return self
 
     def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False, executable=None, in_data=None, su=None, su_user=None):
+        cmd = cmd.encode('utf-8')
         cmd_parts = shlex.split(cmd, posix=False)
         if '-EncodedCommand' in cmd_parts:
             encoded_cmd = cmd_parts[cmd_parts.index('-EncodedCommand') + 1]

--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -133,7 +133,6 @@ class Connection(object):
         return self
 
     def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False, executable=None, in_data=None, su=None, su_user=None):
-        cmd = cmd.encode('utf-8')
         cmd_parts = shlex.split(cmd, posix=False)
         if '-EncodedCommand' in cmd_parts:
             encoded_cmd = cmd_parts[cmd_parts.index('-EncodedCommand') + 1]

--- a/v2/ansible/parsing/splitter.py
+++ b/v2/ansible/parsing/splitter.py
@@ -119,11 +119,10 @@ def split_args(args):
     # here we encode the args, so we have a uniform charset to
     # work with, and split on white space
     args = args.strip()
-    try:
+    do_decode = False
+    if isinstance(args, unicode):
         args = args.encode('utf-8')
         do_decode = True
-    except UnicodeDecodeError:
-        do_decode = False
     items = args.strip().split('\n')
 
     # iterate over the tokens, and reassemble any that may have been


### PR DESCRIPTION
This commit fixes ansible/ansible#8588 's root cause.

Kudos to Tom for the interesting encoding debug session :-).

Bug scenario:
- The try/catch mechanism doesn't work if no special characters are present in a command (it assumes unicode whereas utf-8 was given).
- This leads to task.module_name to be of type unicode.
- The module_name is part of the command string.
- The command string is then processed by powershell.py.
- powershell.py uses shlex to parse the command but the shlex doc for python 2.6 states that "The shlex module currently does not support Unicode input."
- This leads to a base64encoded string which contains a lot of zeroes and is quite long (like this in b64: ...AAAAAAAAAEEAAAAAAAAAcAAAAAAAAABwAAAAAAAAAEQAAA...).
- Powershell fails to handle this broken base64 string, saying it cannot find a file 'C' (which is the drive letter, rest of command is cut off).
- Symptoms: Running any of the win_\* modules, the following message is shown (using -vvvv debug level)
  <hostname> WINRM RESULT <Response code 0, out "", err "Processing -File 'C'">
  failed: [logonebm6-int] => {"failed": true, "parsed": false}
  invalid output was: Processing -File 'C' failed because the file does not have a '.ps1' extension. Specify a valid Windows PowerShell script file name, and then try again.
  FATAL: all hosts have already failed -- aborting
