### PR TITLE
Allow to select a subset of tasks with --only

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -77,8 +77,9 @@ def main(args):
     #    help="password for vault encrypted files")
     parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append",
         help="set additional variables as key=value or YAML/JSON", default=[])
-    parser.add_option('', '--filter', dest='filter', default='',
-        help="only run tasks whose name or action includes a filter term")
+    parser.add_option('', '--only', dest='only_tasks', default='',
+        help="only run tasks whose name or action includes one of the "
+             "comma-separated terms")
     parser.add_option('-t', '--tags', dest='tags', default='all',
         help="only run plays and tasks tagged with these values")
     parser.add_option('--skip-tags', dest='skip_tags',
@@ -152,7 +153,7 @@ def main(args):
     skip_tags = options.skip_tags
     if options.skip_tags is not None:
         skip_tags = options.skip_tags.split(",")
-    task_filter = options.filter.split(",")
+    only_tasks = options.only_tasks.split(",")
 
     for playbook in args:
         if not os.path.exists(playbook):
@@ -202,7 +203,7 @@ def main(args):
             su_user=options.su_user,
             vault_password=vault_pass,
             force_handlers=options.force_handlers,
-            task_filter=task_filter,
+            only_tasks=only_tasks,
         )
 
         if options.flush_cache:

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -77,6 +77,8 @@ def main(args):
     #    help="password for vault encrypted files")
     parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append",
         help="set additional variables as key=value or YAML/JSON", default=[])
+    parser.add_option('', '--filter', dest='filter', default='',
+        help="only run tasks whose name or action includes a filter term")
     parser.add_option('-t', '--tags', dest='tags', default='all',
         help="only run plays and tasks tagged with these values")
     parser.add_option('--skip-tags', dest='skip_tags',
@@ -150,6 +152,7 @@ def main(args):
     skip_tags = options.skip_tags
     if options.skip_tags is not None:
         skip_tags = options.skip_tags.split(",")
+    task_filter = options.filter.split(",")
 
     for playbook in args:
         if not os.path.exists(playbook):
@@ -198,7 +201,8 @@ def main(args):
             su_pass=su_pass,
             su_user=options.su_user,
             vault_password=vault_pass,
-            force_handlers=options.force_handlers
+            force_handlers=options.force_handlers,
+            task_filter=task_filter,
         )
 
         if options.flush_cache:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -71,7 +71,7 @@ class PlayBook(object):
         extra_vars       = None,
         only_tags        = None,
         skip_tags        = None,
-        task_filter     =  "",
+        only_tasks     =  "",
         subset           = C.DEFAULT_SUBSET,
         inventory        = None,
         check            = False,
@@ -147,7 +147,7 @@ class PlayBook(object):
         self.private_key_file = private_key_file
         self.only_tags        = only_tags
         self.skip_tags        = skip_tags
-        self.task_filter     = task_filter
+        self.only_tasks     = only_tasks
         self.any_errors_fatal = any_errors_fatal
         self.su               = su
         self.su_user          = su_user
@@ -734,7 +734,7 @@ class PlayBook(object):
 
                 # only run the task if name or action matches the filter
                 should_run_filter = False
-                for term in self.task_filter:
+                for term in self.only_tasks:
                     if term in task.name or term in task.action or term in task.tags:
                         should_run_filter = True
                         break

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -71,6 +71,7 @@ class PlayBook(object):
         extra_vars       = None,
         only_tags        = None,
         skip_tags        = None,
+        task_filter     =  "",
         subset           = C.DEFAULT_SUBSET,
         inventory        = None,
         check            = False,
@@ -146,6 +147,7 @@ class PlayBook(object):
         self.private_key_file = private_key_file
         self.only_tags        = only_tags
         self.skip_tags        = skip_tags
+        self.task_filter     = task_filter
         self.any_errors_fatal = any_errors_fatal
         self.su               = su
         self.su_user          = su_user
@@ -722,14 +724,22 @@ class PlayBook(object):
                     continue
 
                 # only run the task if the requested tags match
-                should_run = False
+                should_run_tags = False
                 for x in self.only_tags:
 
                     for y in task.tags:
                         if x == y:
-                            should_run = True
+                            should_run_tags = True
                             break
 
+                # only run the task if name or action matches the filter
+                should_run_filter = False
+                for term in self.task_filter:
+                    if term in task.name or term in task.action:
+                        should_run_filter = True
+                        break
+
+                should_run = should_run_tags and should_run_filter
                 # Check for tags that we need to skip
                 if should_run:
                     if any(x in task.tags for x in self.skip_tags):

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -735,7 +735,7 @@ class PlayBook(object):
                 # only run the task if name or action matches the filter
                 should_run_filter = False
                 for term in self.task_filter:
-                    if term in task.name or term in task.action:
+                    if term in task.name or term in task.action or term in task.tags:
                         should_run_filter = True
                         break
 


### PR DESCRIPTION
Add --only to alow to easily select a subset of tasks to run. This makes development of playbooks easier/faster, because one can select only the tasks that one modified to run instead of starting a full ansible run each time.
