### PR TITLE
Fix group variable precedence in #6734

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -142,11 +142,11 @@ class Inventory(object):
 
         # get group vars from group_vars/ files and vars plugins
         for group in self.groups:
-            group.vars = utils.combine_vars(group.vars, self.get_group_variables(group.name, vault_password=self._vault_password))
+            group.vars = utils.combine_vars(self.get_group_variables(group.name, vault_password=self._vault_password), group.vars)
 
         # get host vars from host_vars/ files and vars plugins
         for host in self.get_hosts():
-            host.vars = utils.combine_vars(host.vars, self.get_host_variables(host.name, vault_password=self._vault_password))
+            host.vars = utils.combine_vars(self.get_host_variables(host.name, vault_password=self._vault_password), host.vars)
 
 
     def _match(self, str, pattern_str):
@@ -588,10 +588,10 @@ class Inventory(object):
             self._playbook_basedir = dir
             # get group vars from group_vars/ files
             for group in self.groups:
-                group.vars = utils.combine_vars(group.vars, self.get_group_vars(group, new_pb_basedir=True))
+                group.vars = utils.combine_vars(self.get_group_vars(group, new_pb_basedir=True), group.vars)
             # get host vars from host_vars/ files
             for host in self.get_hosts():
-                host.vars = utils.combine_vars(host.vars, self.get_host_vars(host, new_pb_basedir=True))
+                host.vars = utils.combine_vars(self.get_host_vars(host, new_pb_basedir=True), host.vars)
             # invalidate cache
             self._vars_per_host = {}
             self._vars_per_group = {}

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -21,7 +21,7 @@ VAULT_PASSWORD_FILE = vault-password
 
 CONSUL_RUNNING := $(shell python consul_running.py)
 
-all: parsing test_var_precedence unicode test_templating_settings non_destructive destructive includes check_mode test_hash test_handlers test_group_by test_vault test_tags
+all: parsing test_var_precedence unicode test_templating_settings non_destructive destructive includes check_mode test_hash test_handlers test_group_by test_vault test_tags test_inv_overrides_group_vars
 
 parsing:
 	ansible-playbook bad_parsing.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -vvv $(TEST_FLAGS) --tags prepare,common,scenario1; [ $$? -eq 3 ]
@@ -78,6 +78,9 @@ test_vault:
 # long as they have permissions to login to their local machine via ssh.
 test_delegate_to:
 	ansible-playbook test_delegate_to.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+
+test_inv_overrides_group_vars:
+	ansible-playbook test_inv_overrides_group_vars.yml -i inventory -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | fgrep from_inventory
 
 test_winrm:
 	ansible-playbook test_winrm.yml -i inventory.winrm -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)

--- a/test/integration/group_vars/local
+++ b/test/integration/group_vars/local
@@ -1,3 +1,4 @@
 tres: 'three'
 hash_test:
   group_vars_local: "this is in group_vars/local"
+inv_overrides_group_vars: from_group_vars

--- a/test/integration/inventory
+++ b/test/integration/inventory
@@ -27,6 +27,7 @@ local
 [local:vars]
 parent_var=6000
 groups_tree_var=5000
+inv_overrides_group_vars=from_inventory
 
 [arbitrary_parent:vars]
 groups_tree_var=4000

--- a/test/integration/test_inv_overrides_group_vars.yml
+++ b/test/integration/test_inv_overrides_group_vars.yml
@@ -1,0 +1,4 @@
+- hosts: local
+  gather_facts: false
+  tasks:
+    - debug: msg={{ inv_overrides_group_vars }}


### PR DESCRIPTION
Group variables defined in inventory should override
entries in the group_vars directories.

Add regression test.
