### PR TITLE
Prevent empty diffs being written between task messages

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -576,8 +576,10 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
         super(PlaybookRunnerCallbacks, self).on_async_failed(host,res,jid)
 
     def on_file_diff(self, host, diff):
-        display(utils.get_diff(diff), runner=self.runner)
-        super(PlaybookRunnerCallbacks, self).on_file_diff(host, diff)
+        diff_result = utils.get_diff(diff)
+        if diff_result:
+            display(diff_result, runner=self.runner)
+            super(PlaybookRunnerCallbacks, self).on_file_diff(host, diff)
 
 ########################################################################
 


### PR DESCRIPTION
When running a playbook with the --check and --diff options, empty diffs are still passed to the display method, resulting in an empty line being output between each task message.
This PR simply checks a non-empty diff was returned before passing to display.
