### PR TITLE
EC2 Inventory Enhancement - Adds ability to address dynamic servers by local DNS or /etc/hosts.

### DIFF
--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -40,7 +40,7 @@ options:
     description:
       - the hash of the user's password to be passed directly to mysql. This is mutually exclusive with the plain text password.
 		required: false
-    default: no
+    default: null
     version_added: '1.7'
   host:
     description:

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -36,6 +36,12 @@ options:
       - set the user's password
     required: false
     default: null
+  password_is_hashed:
+    description:
+      - password value is specified as a hash that is used by mysql
+		required: false
+    default: no
+    version_added: '1.7'
   host:
     description:
       - the 'host' part of the MySQL username
@@ -157,14 +163,17 @@ def user_exists(cursor, user, host):
     count = cursor.fetchone()
     return count[0] > 0
 
-def user_add(cursor, user, host, password, new_priv):
-    cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
+def user_add(cursor, user, host, password, new_priv, password_is_hashed):
+    if password_is_hashed:
+        cursor.execute("CREATE USER %s@%s IDENTIFIED BY PASSWORD %s", (user,host,password))
+    else:
+        cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
     if new_priv is not None:
         for db_table, priv in new_priv.iteritems():
             privileges_grant(cursor, user,host,db_table,priv)
     return True
 
-def user_mod(cursor, user, host, password, new_priv, append_privs):
+def user_mod(cursor, user, host, password, new_priv, append_privs, password_is_hashed):
     changed = False
     grant_option = False
 
@@ -172,11 +181,16 @@ def user_mod(cursor, user, host, password, new_priv, append_privs):
     if password is not None:
         cursor.execute("SELECT password FROM user WHERE user = %s AND host = %s", (user,host))
         current_pass_hash = cursor.fetchone()
-        cursor.execute("SELECT PASSWORD(%s)", (password,))
-        new_pass_hash = cursor.fetchone()
-        if current_pass_hash[0] != new_pass_hash[0]:
-            cursor.execute("SET PASSWORD FOR %s@%s = PASSWORD(%s)", (user,host,password))
-            changed = True
+        if password_is_hashed:
+            if current_pass_hash[0] != password:
+                cursor.execute("SET PASSWORD FOR %s@%s = %s", (user,host,password))
+                changed = True
+        else:
+            cursor.execute("SELECT PASSWORD(%s)", (password,))
+            new_pass_hash = cursor.fetchone()
+            if current_pass_hash[0] != new_pass_hash[0]:
+                cursor.execute("SET PASSWORD FOR %s@%s = PASSWORD(%s)", (user,host,password))
+                changed = True
 
     # Handle privileges.
     if new_priv is not None:
@@ -405,6 +419,7 @@ def main():
             priv=dict(default=None),
             append_privs=dict(type="bool", default="no"),
             check_implicit_admin=dict(default=False),
+            password_is_hashed=dict(type="bool", default="no"),
         )
     )
     user = module.params["user"]
@@ -414,6 +429,7 @@ def main():
     priv = module.params["priv"]
     check_implicit_admin = module.params['check_implicit_admin']
     append_privs = module.boolean(module.params["append_privs"])
+    password_is_hashed = module.boolean(module.params['password_is_hashed'])
 
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")
@@ -455,11 +471,11 @@ def main():
 
     if state == "present":
         if user_exists(cursor, user, host):
-            changed = user_mod(cursor, user, host, password, priv, append_privs)
+            changed = user_mod(cursor, user, host, password, priv, append_privs, password_is_hashed)
         else:
             if password is None:
                 module.fail_json(msg="password parameter required when adding a user")
-            changed = user_add(cursor, user, host, password, priv)
+            changed = user_add(cursor, user, host, password, priv, password_is_hashed)
     elif state == "absent":
         if user_exists(cursor, user, host):
             changed = user_delete(cursor, user, host)

--- a/library/database/mysql_user
+++ b/library/database/mysql_user
@@ -33,12 +33,12 @@ options:
     default: null
   password:
     description:
-      - set the user's password
+      - set the user's plain text password
     required: false
     default: null
-  password_is_hashed:
+  password_hash:
     description:
-      - password value is specified as a hash that is used by mysql
+      - the hash of the user's password to be passed directly to mysql. This is mutually exclusive with the plain text password.
 		required: false
     default: no
     version_added: '1.7'
@@ -135,6 +135,15 @@ mydb.*:INSERT,UPDATE/anotherdb.*:SELECT/yetanotherdb.*:ALL
 # Example using login_unix_socket to connect to server
 - mysql_user: name=root password=abc123 login_unix_socket=/var/run/mysqld/mysqld.sock
 
+# Example using a mysql password hash for a user
+- mysql_user: name=bob password_hash=*973D12C21B4F274E09461F56EEAB92AB7B6FC20A priv=*.*:ALL state=present
+
+# To get the password hash, first connect to mysql
+# then use the mysql database
+use mysql;
+# then grab the password from the user in user table
+select User,Password from user;
+
 # Example .my.cnf file for setting the root password
 # Note: don't use quotes around the password, because the mysql_user module
 # will include them in the password but the mysql client will not
@@ -163,9 +172,9 @@ def user_exists(cursor, user, host):
     count = cursor.fetchone()
     return count[0] > 0
 
-def user_add(cursor, user, host, password, new_priv, password_is_hashed):
-    if password_is_hashed:
-        cursor.execute("CREATE USER %s@%s IDENTIFIED BY PASSWORD %s", (user,host,password))
+def user_add(cursor, user, host, password, password_hash, new_priv):
+    if password_hash:
+        cursor.execute("CREATE USER %s@%s IDENTIFIED BY PASSWORD %s", (user,host,password_hash))
     else:
         cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
     if new_priv is not None:
@@ -173,19 +182,19 @@ def user_add(cursor, user, host, password, new_priv, password_is_hashed):
             privileges_grant(cursor, user,host,db_table,priv)
     return True
 
-def user_mod(cursor, user, host, password, new_priv, append_privs, password_is_hashed):
+def user_mod(cursor, user, host, password, password_hash, new_priv, append_privs):
     changed = False
     grant_option = False
 
     # Handle passwords.
-    if password is not None:
+    if password is not None or password_hash is not None:
         cursor.execute("SELECT password FROM user WHERE user = %s AND host = %s", (user,host))
         current_pass_hash = cursor.fetchone()
-        if password_is_hashed:
-            if current_pass_hash[0] != password:
-                cursor.execute("SET PASSWORD FOR %s@%s = %s", (user,host,password))
+        if password_hash is not None:
+            if current_pass_hash[0] != password_hash:
+                cursor.execute("SET PASSWORD FOR %s@%s = %s", (user,host,password_hash))
                 changed = True
-        else:
+        if password is not None:
             cursor.execute("SELECT PASSWORD(%s)", (password,))
             new_pass_hash = cursor.fetchone()
             if current_pass_hash[0] != new_pass_hash[0]:
@@ -414,22 +423,22 @@ def main():
             login_unix_socket=dict(default=None),
             user=dict(required=True, aliases=['name']),
             password=dict(default=None),
+            password_hash=dict(default=None),
             host=dict(default="localhost"),
             state=dict(default="present", choices=["absent", "present"]),
             priv=dict(default=None),
             append_privs=dict(type="bool", default="no"),
             check_implicit_admin=dict(default=False),
-            password_is_hashed=dict(type="bool", default="no"),
         )
     )
     user = module.params["user"]
     password = module.params["password"]
+    password_hash = module.params["password_hash"]
     host = module.params["host"]
     state = module.params["state"]
     priv = module.params["priv"]
     check_implicit_admin = module.params['check_implicit_admin']
     append_privs = module.boolean(module.params["append_privs"])
-    password_is_hashed = module.boolean(module.params['password_is_hashed'])
 
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")
@@ -439,6 +448,9 @@ def main():
             priv = privileges_unpack(priv)
         except:
             module.fail_json(msg="invalid privileges string")
+
+    if password is not None and password_hash is not None:
+        module.fail_json(msg="password and password_hash arguments are mutually exclusive")
 
     # Either the caller passes both a username and password with which to connect to
     # mysql, or they pass neither and allow this module to read the credentials from
@@ -471,11 +483,11 @@ def main():
 
     if state == "present":
         if user_exists(cursor, user, host):
-            changed = user_mod(cursor, user, host, password, priv, append_privs, password_is_hashed)
+            changed = user_mod(cursor, user, host, password, password_hash, priv, append_privs)
         else:
-            if password is None:
-                module.fail_json(msg="password parameter required when adding a user")
-            changed = user_add(cursor, user, host, password, priv, password_is_hashed)
+            if password is None and password_hash is None:
+                module.fail_json(msg="a password or password_hash parameter is required when adding a user")
+            changed = user_add(cursor, user, host, password, password_hash, priv)
     elif state == "absent":
         if user_exists(cursor, user, host):
             changed = user_delete(cursor, user, host)

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -38,6 +38,12 @@ vpc_destination_variable = ip_address
 # Route53, uncomment and set 'route53' to True.
 route53 = False
 
+# To refer to hosts by using local reverse DNS lookup such as
+# /etc/hosts or a private DNS server, set 'use_local_dns' to True
+# the script will then attempt to perform a reverse DNS lookup
+# based on IP and use the result for addressing the server.
+use_local_dns = False
+
 # To exclude RDS instances from the inventory, uncomment and set to False.
 #rds = False
 

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -117,6 +117,7 @@ import sys
 import os
 import argparse
 import re
+import socket
 from time import time
 import boto
 from boto import ec2
@@ -222,6 +223,11 @@ class Ec2Inventory(object):
         if config.has_option('ec2', 'route53_excluded_zones'):
             self.route53_excluded_zones.extend(
                 config.get('ec2', 'route53_excluded_zones', '').split(','))
+
+        # Perform local reverse DNS lookup
+        self.use_local_dns = False
+        if config.has_option('ec2', 'use_local_dns'):
+            self.use_local_dns = config.getboolean('ec2', 'use_local_dns')
 
         # Include RDS instances?
         self.rds_enabled = True
@@ -388,6 +394,11 @@ class Ec2Inventory(object):
             dest = getattr(instance, self.vpc_destination_variable)
         else:
             dest =  getattr(instance, self.destination_variable)
+
+        if self.use_local_dns:
+            res = socket.gethostbyaddr(socket.gethostbyname(getattr(instance, 'public_dns_name')))
+            if res[0]:
+                dest = res[0]
 
         if not dest:
             # Skip instances we cannot address (e.g. private VPC subnet)


### PR DESCRIPTION
If you run a local DNS server and/or have your EC2 hosts stored in /etc/hosts using friendlier names than the default amazon FQDN, it is convenient to be able to address them. This also allows for nice tricks such as defining groups and variables in a static inventory/hosts file and merging them with the dynamic inventory such that all the variables become available.

Example: assuming that a host web0 is defined in /etc/hosts, 
Default behavior:

```
ansible tag_Name_web0 -m ping
ec2-xx-xx-xx-xx.us-west-1.compute.amazonaws.com | success >> {
    "changed": false, 
    "ping": "pong"
}
```

New behavior when enabled via ec2.ini: use_local_dns = True

```
ansible tag_Name_web0 -m ping
web0 | success >> {
    "changed": false, 
    "ping": "pong"
}
```

As a bonus - it allows merging with groups defined in inventory/hosts.
For example:

```
[my_group]
web0

[my_group:vars]
server_type=development
```

In the above example assuming that web0 exists in /etc/hosts, one can address it via tag_Name or via web0, and the server_type variable will properly be pulled. This helps avoid accidents in certain configurations when one invokes a playbook via tag and another via a hostname and causes differences in configured variables.
