### PR TITLE
Setting LC_MESSAGES: prevent unparseable messages (fixes issue #9635)

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -772,6 +772,7 @@ class AnsibleModule(object):
             locale.setlocale(locale.LC_ALL, 'C')
             os.environ['LANG']     = 'C'
             os.environ['LC_CTYPE'] = 'C'
+            os.environ['LC_MESSAGES'] = 'C'
         except Exception, e:
             self.fail_json(msg="An unknown error was encountered while attempting to validate the locale: %s" % e)
 

--- a/lib/ansible/runner/shell_plugins/sh.py
+++ b/lib/ansible/runner/shell_plugins/sh.py
@@ -29,6 +29,7 @@ class ShellModule(object):
         env = dict(
             LANG     = C.DEFAULT_MODULE_LANG,
             LC_CTYPE = C.DEFAULT_MODULE_LANG,
+            LC_MESSAGES = C.DEFAULT_MODULE_LANG,
         )
         env.update(kwargs)
         return ' '.join(['%s=%s' % (k, pipes.quote(unicode(v))) for k,v in env.items()])


### PR DESCRIPTION
This locale variable defines how tools should display their messages.
This is for example gonna change the yum message from "Nothing to do" to
"Rien a faire" in my case (french).

As the yum module parses that string in err, if the message is not
enforced in english this is gonna fail.

So this commits just enriches a bit more the code that's already written
for that enforcement.

This commit fixes issue #9635.
