### PR TITLE
Is it not possible to set a comment in the same line

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -759,7 +759,8 @@ To configure fact caching, enable it in ansible.cfg as follows::
 
     [defaults]
     fact_caching = redis
-    fact_caching_timeout = 86400 # seconds
+    fact_caching_timeout = 86400
+    # seconds
 
 At the time of writing, Redis is the only supported fact caching engine.  
 To get redis up and running, perform the equivalent OS commands::


### PR DESCRIPTION
Error if variable defined with the comment:

```
$ ansible hostname -a id
Traceback (most recent call last):
  File "/usr/local/bin/ansible", line 25, in <module>
    from ansible.runner import Runner
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 36, in <module>
    import ansible.constants as C
  File "/usr/local/lib/python2.7/dist-packages/ansible/constants.py", line 150, in <module>
    CACHE_PLUGIN_TIMEOUT           = get_config(p, DEFAULTS, 'fact_caching_timeout', 'ANSIBLE_CACHE_PLUGIN_TIMEOUT', 24 * 60 * 60, integer=True)
  File "/usr/local/lib/python2.7/dist-packages/ansible/constants.py", line 40, in get_config
    return int(value)
ValueError: invalid literal for int() with base 10: '86400 # seconds'
```
