### PR TITLE
Don't template play vars by themselves, it's too early

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -88,13 +88,6 @@ class Play(object):
         if self.playbook.inventory.src() is not None:
             load_vars['inventory_file'] = self.playbook.inventory.src()
 
-        # template the play vars with themselves and the extra vars
-        # from the playbook, to make sure they're correct
-        all_vars = utils.combine_vars(self.vars, self.playbook.extra_vars)
-        all_vars = utils.combine_vars(all_vars, load_vars)
-        self.vars = template(basedir, self.vars, all_vars)
-        self.vars = utils.combine_vars(self.vars, load_vars)
-
         # We first load the vars files from the datastructure
         # so we have the default variables to pass into the roles
         self.vars_files = ds.get('vars_files', [])


### PR DESCRIPTION
##### Summary

Templating the play variables before the rest of the variables are loaded can lead to wrong results in variables.
##### Example inventory:

```
localhost ansible_connection=local
[all:vars]
var=value
```
##### Example playbook:

```

---
- name: Default value for inventory variable
  hosts: localhost
  gather_facts: no
  vars:
    var2: "{{ var  | default('none') }}"
  tasks:
    - debug: var=var
    - debug: var=var2
```
##### Expected results:

```
PLAY [Default value for inventory variable] *********************************** 

TASK: [debug var=var] ********************************************************* 
ok: [localhost] => {
    "var": "value"
}

TASK: [debug var=var2] ******************************************************** 
ok: [localhost] => {
    "var2": "value"
}
```
##### Actual results:

```
PLAY [Default value for inventory variable] *********************************** 

TASK: [debug var=var] ********************************************************* 
ok: [localhost] => {
    "var": "value"
}

TASK: [debug var=var2] ******************************************************** 
ok: [localhost] => {
    "var2": "none"
}
```
