### PR TITLE
Fix issue with ssl.wrap_socket not using TLSv1 version by default

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -212,3 +212,12 @@ accelerate_daemon_timeout = 30
 # is "no".
 #accelerate_multi_key = yes
 
+[ssl]
+# SSL/TLS Protocol
+# Configure the default protocol strength of any SSL/TLS connections
+# made by Ansible.  Valid values are
+#  SSLv2  - 0
+#  SSLv3  - 1
+#  SSLv23 - 2
+#  TLSv1  - 3
+ssl_protocol = 3

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -166,6 +166,7 @@ ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'AN
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
+SSL_PROTOCOL                   = get_config(p, 'ssl', 'ssl_protocol', 'SSL_PROTOCOL', 3, integer=True)
 # obsolete -- will be formally removed in 1.6
 ZEROMQ_PORT                    = get_config(p, 'fireball_connection', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099, integer=True)
 ACCELERATE_PORT                = get_config(p, 'accelerate', 'accelerate_port', 'ACCELERATE_PORT', 5099, integer=True)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -269,20 +269,12 @@ class SSLValidationHandler(urllib2.BaseHandler):
                     s.sendall('\r\n')
                     connect_result = s.recv(4096)
                     self.validate_proxy_response(connect_result)
-<<<<<<< HEAD
                     ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=constants.SSL_PROTOCOL)
-=======
-                    ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=ssl.PROTOCOL_TLSv1)
->>>>>>> 797a883... Fix issue with ssl.wrap_socket not using TLSv1 version by default
                 else:
                     self.module.fail_json(msg='Unsupported proxy scheme: %s. Currently ansible only supports HTTP proxies.' % proxy_parts.get('scheme'))
             else:
                 s.connect((self.hostname, self.port))
-<<<<<<< HEAD
                 ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=constants.SSL_PROTOCOL)
-=======
-                ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=ssl.PROTOCOL_TLSv1)
->>>>>>> 797a883... Fix issue with ssl.wrap_socket not using TLSv1 version by default
             # close the ssl connection
             #ssl_s.unwrap()
             s.close()

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -269,12 +269,20 @@ class SSLValidationHandler(urllib2.BaseHandler):
                     s.sendall('\r\n')
                     connect_result = s.recv(4096)
                     self.validate_proxy_response(connect_result)
+<<<<<<< HEAD
                     ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=constants.SSL_PROTOCOL)
+=======
+                    ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=ssl.PROTOCOL_TLSv1)
+>>>>>>> 797a883... Fix issue with ssl.wrap_socket not using TLSv1 version by default
                 else:
                     self.module.fail_json(msg='Unsupported proxy scheme: %s. Currently ansible only supports HTTP proxies.' % proxy_parts.get('scheme'))
             else:
                 s.connect((self.hostname, self.port))
+<<<<<<< HEAD
                 ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=constants.SSL_PROTOCOL)
+=======
+                ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=ssl.PROTOCOL_TLSv1)
+>>>>>>> 797a883... Fix issue with ssl.wrap_socket not using TLSv1 version by default
             # close the ssl connection
             #ssl_s.unwrap()
             s.close()

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -268,12 +268,12 @@ class SSLValidationHandler(urllib2.BaseHandler):
                     s.sendall('\r\n')
                     connect_result = s.recv(4096)
                     self.validate_proxy_response(connect_result)
-                    ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED)
+                    ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=ssl.PROTOCOL_TLSv1)
                 else:
                     self.module.fail_json(msg='Unsupported proxy scheme: %s. Currently ansible only supports HTTP proxies.' % proxy_parts.get('scheme'))
             else:
                 s.connect((self.hostname, self.port))
-                ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED)
+                ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=ssl.PROTOCOL_TLSv1)
             # close the ssl connection
             #ssl_s.unwrap()
             s.close()

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -55,6 +55,7 @@ import os
 import re
 import socket
 import tempfile
+from ansible import constants
 
 
 # This is a dummy cacert provided for Mac OS since you need at least 1
@@ -91,7 +92,7 @@ class CustomHTTPSConnection(httplib.HTTPSConnection):
         if self._tunnel_host:
             self.sock = sock
             self._tunnel()
-        self.sock = ssl.wrap_socket(sock, keyfile=self.key_file, certfile=self.cert_file, ssl_version=ssl.PROTOCOL_TLSv1)
+        self.sock = ssl.wrap_socket(sock, keyfile=self.key_file, certfile=self.cert_file, ssl_version=constants.SSL_PROTOCOL)
 
 class CustomHTTPSHandler(urllib2.HTTPSHandler):
 
@@ -268,12 +269,12 @@ class SSLValidationHandler(urllib2.BaseHandler):
                     s.sendall('\r\n')
                     connect_result = s.recv(4096)
                     self.validate_proxy_response(connect_result)
-                    ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=ssl.PROTOCOL_TLSv1)
+                    ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=constants.SSL_PROTOCOL)
                 else:
                     self.module.fail_json(msg='Unsupported proxy scheme: %s. Currently ansible only supports HTTP proxies.' % proxy_parts.get('scheme'))
             else:
                 s.connect((self.hostname, self.port))
-                ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=ssl.PROTOCOL_TLSv1)
+                ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=constants.SSL_PROTOCOL)
             # close the ssl connection
             #ssl_s.unwrap()
             s.close()

--- a/test/integration/roles/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/roles/setup_postgresql_db/tasks/main.yml
@@ -52,11 +52,12 @@
   command: /sbin/service postgresql initdb
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int <= 6
 
-- name: Iniitalize postgres (upstart)
-  command: /usr/bin/pg_createcluster {{ pg_ver }} main
-  # Sometimes package install creates the db cluster, sometimes this step is needed
-  ignore_errors: True
-  when: ansible_os_family == 'Debian'
+# The package install should initialize a db cluster provided that the old db
+# cluster was entirely removed.  So this shouldn't be needed
+#- name: Iniitalize postgres (upstart)
+#  command: /usr/bin/pg_createcluster {{ pg_ver }} main
+#  ignore_errors: True
+#  when: ansible_os_family == 'Debian'
 
 - name: Copy pg_hba into place
   copy: src=pg_hba.conf dest="{{ pg_hba_location }}" owner="postgres" group="root" mode="0644"

--- a/v2/ansible/constants.py
+++ b/v2/ansible/constants.py
@@ -172,6 +172,7 @@ ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'AN
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
+SSL_PROTOCOL                   = get_config(p, 'ssl', 'ssl_protocol', 'SSL_PROTOCOL', 3, integer=True)
 # obsolete -- will be formally removed in 1.6
 ZEROMQ_PORT                    = get_config(p, 'fireball_connection', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099, integer=True)
 ACCELERATE_PORT                = get_config(p, 'accelerate', 'accelerate_port', 'ACCELERATE_PORT', 5099, integer=True)


### PR DESCRIPTION
Fix a small issue when doing a URL request to a remote that forces TLSv1 and does not support SSLv2 or v3.  Seems we are doing TLSv1 by default anyway in CustomHTTPSConnection.
