### PR TITLE
Enable plugins for jinja2 tests

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -156,6 +156,7 @@ DEFAULT_CONNECTION_PLUGIN_PATH = get_config(p, DEFAULTS, 'connection_plugins', '
 DEFAULT_LOOKUP_PLUGIN_PATH     = get_config(p, DEFAULTS, 'lookup_plugins',     'ANSIBLE_LOOKUP_PLUGINS', '~/.ansible/plugins/lookup_plugins:/usr/share/ansible_plugins/lookup_plugins')
 DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       'ANSIBLE_VARS_PLUGINS', '~/.ansible/plugins/vars_plugins:/usr/share/ansible_plugins/vars_plugins')
 DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '~/.ansible/plugins/filter_plugins:/usr/share/ansible_plugins/filter_plugins')
+DEFAULT_TEST_PLUGIN_PATH       = get_config(p, DEFAULTS, 'test_plugins',       'ANSIBLE_TEST_PLUGINS', '~/.ansible/plugins/test_plugins:/usr/share/ansible_plugins/test_plugins')
 
 CACHE_PLUGIN                   = get_config(p, DEFAULTS, 'fact_caching', 'ANSIBLE_CACHE_PLUGIN', 'memory')
 CACHE_PLUGIN_CONNECTION        = get_config(p, DEFAULTS, 'fact_caching_connection', 'ANSIBLE_CACHE_PLUGIN_CONNECTION', None)

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -74,55 +74,6 @@ def to_nice_json(a, *args, **kw):
         return to_json(a, *args, **kw)
     return json.dumps(a, indent=4, sort_keys=True, *args, **kw)
 
-def failed(*a, **kw):
-    ''' Test if task result yields failed '''
-    item = a[0]
-    if type(item) != dict:
-        raise errors.AnsibleFilterError("|failed expects a dictionary")
-    rc = item.get('rc',0)
-    failed = item.get('failed',False)
-    if rc != 0 or failed:
-        return True
-    else:
-        return False
-
-def success(*a, **kw):
-    ''' Test if task result yields success '''
-    return not failed(*a, **kw)
-
-def changed(*a, **kw):
-    ''' Test if task result yields changed '''
-    item = a[0]
-    if type(item) != dict:
-        raise errors.AnsibleFilterError("|changed expects a dictionary")
-    if not 'changed' in item:
-        changed = False
-        if ('results' in item    # some modules return a 'results' key
-                and type(item['results']) == list
-                and type(item['results'][0]) == dict):
-            for result in item['results']:
-                changed = changed or result.get('changed', False)
-    else:
-        changed = item.get('changed', False)
-    return changed
-
-def skipped(*a, **kw):
-    ''' Test if task result yields skipped '''
-    item = a[0]
-    if type(item) != dict:
-        raise errors.AnsibleFilterError("|skipped expects a dictionary")
-    skipped = item.get('skipped', False)
-    return skipped
-
-def mandatory(a):
-    ''' Make a variable mandatory '''
-    try:
-        a
-    except NameError:
-        raise errors.AnsibleFilterError('Mandatory variable not defined.')
-    else:
-        return a
-
 def bool(a):
     ''' return a bool for the arg '''
     if a is None or type(a) == bool:
@@ -141,27 +92,6 @@ def quote(a):
 def fileglob(pathname):
     ''' return list of matched files for glob '''
     return glob.glob(pathname)
-
-def regex(value='', pattern='', ignorecase=False, match_type='search'):
-    ''' Expose `re` as a boolean filter using the `search` method by default.
-        This is likely only useful for `search` and `match` which already
-        have their own filters.
-    '''
-    if ignorecase:
-        flags = re.I
-    else:
-        flags = 0
-    _re = re.compile(pattern, flags=flags)
-    _bool = __builtins__.get('bool')
-    return _bool(getattr(_re, match_type, 'search')(value))
-
-def match(value, pattern='', ignorecase=False):
-    ''' Perform a `re.match` returning a boolean '''
-    return regex(value, pattern, ignorecase, 'match')
-
-def search(value, pattern='', ignorecase=False):
-    ''' Perform a `re.search` returning a boolean '''
-    return regex(value, pattern, ignorecase, 'search')
 
 def regex_replace(value='', pattern='', replacement='', ignorecase=False):
     ''' Perform a `re.sub` returning a string '''
@@ -299,19 +229,6 @@ class FilterModule(object):
             'realpath': partial(unicode_wrap, os.path.realpath),
             'relpath': partial(unicode_wrap, os.path.relpath),
 
-            # failure testing
-            'failed'  : failed,
-            'success' : success,
-
-            # changed testing
-            'changed' : changed,
-
-            # skip testing
-            'skipped' : skipped,
-
-            # variable existence
-            'mandatory': mandatory,
-
             # value as boolean
             'bool': bool,
 
@@ -333,9 +250,6 @@ class FilterModule(object):
             'fileglob': fileglob,
 
             # regex
-            'match': match,
-            'search': search,
-            'regex': regex,
             'regex_replace': regex_replace,
 
             # ? : ;

--- a/lib/ansible/runner/filter_plugins/mathstuff.py
+++ b/lib/ansible/runner/filter_plugins/mathstuff.py
@@ -67,13 +67,6 @@ def max(a):
     _max = __builtins__.get('max')
     return _max(a);
 
-def isnotanumber(x):
-    try:
-        return math.isnan(x)
-    except TypeError:
-        return False
-
-
 def logarithm(x, base=math.e):
     try:
         if base == 10:
@@ -107,7 +100,6 @@ class FilterModule(object):
     def filters(self):
         return {
             # general math
-            'isnan': isnotanumber,
             'min' : min,
             'max' : max,
 

--- a/lib/ansible/runner/test_plugins/core.py
+++ b/lib/ansible/runner/test_plugins/core.py
@@ -1,0 +1,113 @@
+# (c) 2012, Jeroen Hoekx <jeroen@hoekx.be>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+from ansible import errors
+
+def failed(*a, **kw):
+    ''' Test if task result yields failed '''
+    item = a[0]
+    if type(item) != dict:
+        raise errors.AnsibleFilterError("|failed expects a dictionary")
+    rc = item.get('rc',0)
+    failed = item.get('failed',False)
+    if rc != 0 or failed:
+        return True
+    else:
+        return False
+
+def success(*a, **kw):
+    ''' Test if task result yields success '''
+    return not failed(*a, **kw)
+
+def changed(*a, **kw):
+    ''' Test if task result yields changed '''
+    item = a[0]
+    if type(item) != dict:
+        raise errors.AnsibleFilterError("|changed expects a dictionary")
+    if not 'changed' in item:
+        changed = False
+        if ('results' in item    # some modules return a 'results' key
+                and type(item['results']) == list
+                and type(item['results'][0]) == dict):
+            for result in item['results']:
+                changed = changed or result.get('changed', False)
+    else:
+        changed = item.get('changed', False)
+    return changed
+
+def skipped(*a, **kw):
+    ''' Test if task result yields skipped '''
+    item = a[0]
+    if type(item) != dict:
+        raise errors.AnsibleFilterError("|skipped expects a dictionary")
+    skipped = item.get('skipped', False)
+    return skipped
+
+def mandatory(a):
+    ''' Make a variable mandatory '''
+    try:
+        a
+    except NameError:
+        raise errors.AnsibleFilterError('Mandatory variable not defined.')
+    else:
+        return a
+
+def regex(value='', pattern='', ignorecase=False, match_type='search'):
+    ''' Expose `re` as a boolean filter using the `search` method by default.
+        This is likely only useful for `search` and `match` which already
+        have their own filters.
+    '''
+    if ignorecase:
+        flags = re.I
+    else:
+        flags = 0
+    _re = re.compile(pattern, flags=flags)
+    _bool = __builtins__.get('bool')
+    return _bool(getattr(_re, match_type, 'search')(value))
+
+def match(value, pattern='', ignorecase=False):
+    ''' Perform a `re.match` returning a boolean '''
+    return regex(value, pattern, ignorecase, 'match')
+
+def search(value, pattern='', ignorecase=False):
+    ''' Perform a `re.search` returning a boolean '''
+    return regex(value, pattern, ignorecase, 'search')
+
+class TestModule(object):
+    ''' Ansible core jinja2 tests '''
+
+    def tests(self):
+        return {
+            # failure testing
+            'failed'  : failed,
+            'success' : success,
+
+            # changed testing
+            'changed' : changed,
+
+            # skip testing
+            'skipped' : skipped,
+
+            # variable existence
+            'mandatory': mandatory,
+
+            # regex
+            'match': match,
+            'search': search,
+            'regex': regex,
+        }

--- a/lib/ansible/runner/test_plugins/math.py
+++ b/lib/ansible/runner/test_plugins/math.py
@@ -1,0 +1,36 @@
+# (c) 2014, Brian Coca <bcoca@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+
+import math
+from ansible import errors
+
+def isnotanumber(x):
+    try:
+        return math.isnan(x)
+    except TypeError:
+        return False
+
+class TestModule(object):
+    ''' Ansible math jinja2 tests '''
+
+    def tests(self):
+        return {
+            # general math
+            'isnan': isnotanumber,
+        }

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1403,7 +1403,11 @@ def safe_eval(expr, locals={}, include_exceptions=False):
     for filter in filter_loader.all():
         filter_list.extend(filter.filters().keys())
 
-    CALL_WHITELIST = C.DEFAULT_CALLABLE_WHITELIST + filter_list
+    test_list = []
+    for test in test_loader.all():
+        test_list.extend(test.tests().keys())
+
+    CALL_WHITELIST = C.DEFAULT_CALLABLE_WHITELIST + filter_list + test_list
 
     class CleansingNodeVisitor(ast.NodeVisitor):
         def generic_visit(self, node, inside_call=False):

--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -296,6 +296,13 @@ filter_loader = PluginLoader(
     'filter_plugins'
 )
 
+test_loader = PluginLoader(
+    'TestModule',
+    'ansible.runner.test_plugins',
+    C.DEFAULT_TEST_PLUGIN_PATH,
+    'test_plugins'
+)
+
 fragment_loader = PluginLoader(
     'ModuleDocFragment',
     'ansible.utils.module_docs_fragments',

--- a/v2/ansible/constants.py
+++ b/v2/ansible/constants.py
@@ -162,6 +162,7 @@ DEFAULT_CONNECTION_PLUGIN_PATH = get_config(p, DEFAULTS, 'connection_plugins', '
 DEFAULT_LOOKUP_PLUGIN_PATH     = get_config(p, DEFAULTS, 'lookup_plugins',     'ANSIBLE_LOOKUP_PLUGINS', '~/.ansible/plugins/lookup_plugins:/usr/share/ansible_plugins/lookup_plugins')
 DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       'ANSIBLE_VARS_PLUGINS', '~/.ansible/plugins/vars_plugins:/usr/share/ansible_plugins/vars_plugins')
 DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '~/.ansible/plugins/filter_plugins:/usr/share/ansible_plugins/filter_plugins')
+DEFAULT_TEST_PLUGIN_PATH       = get_config(p, DEFAULTS, 'test_plugins',       'ANSIBLE_TEST_PLUGINS', '~/.ansible/plugins/test_plugins:/usr/share/ansible_plugins/test_plugins')
 
 CACHE_PLUGIN                   = get_config(p, DEFAULTS, 'fact_caching', 'ANSIBLE_CACHE_PLUGIN', 'memory')
 CACHE_PLUGIN_CONNECTION        = get_config(p, DEFAULTS, 'fact_caching_connection', 'ANSIBLE_CACHE_PLUGIN_CONNECTION', None)

--- a/v2/ansible/plugins/__init__.py
+++ b/v2/ansible/plugins/__init__.py
@@ -311,6 +311,13 @@ filter_loader = PluginLoader(
     'filter_plugins'
 )
 
+test_loader = PluginLoader(
+    'TestModule',
+    'ansible.plugins.test',
+    C.DEFAULT_TEST_PLUGIN_PATH,
+    'test_plugins'
+)
+
 fragment_loader = PluginLoader(
     'ModuleDocFragment',
     'ansible.utils.module_docs_fragments',

--- a/v2/ansible/template/safe_eval.py
+++ b/v2/ansible/template/safe_eval.py
@@ -23,7 +23,7 @@ import sys
 from six.moves import builtins
 
 from ansible import constants as C
-from ansible.plugins import filter_loader
+from ansible.plugins import filter_loader, test_loader
 
 def safe_eval(expr, locals={}, include_exceptions=False):
     '''
@@ -77,7 +77,11 @@ def safe_eval(expr, locals={}, include_exceptions=False):
     for filter in filter_loader.all():
         filter_list.extend(filter.filters().keys())
 
-    CALL_WHITELIST = C.DEFAULT_CALLABLE_WHITELIST + filter_list
+    test_list = []
+    for test in test_loader.all():
+        test_list.extend(test.tests().keys())
+
+    CALL_WHITELIST = C.DEFAULT_CALLABLE_WHITELIST + filter_list + test_list
 
     class CleansingNodeVisitor(ast.NodeVisitor):
         def generic_visit(self, node, inside_call=False):


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Summary:
- Move boolean filters to `test_plugins/core.py` and enable users to write their own test plugins.
- Register all test plugins additionally as filter plugins to retain backwards compatibility.

Supersedes #8235
Discussed but never resolved [here](https://groups.google.com/forum/#!topic/ansible-devel/Oa6XSffcHJg)
