### PR TITLE
fine tuned lookup/templating errors

### DIFF
--- a/lib/ansible/runner/lookup_plugins/flattened.py
+++ b/lib/ansible/runner/lookup_plugins/flattened.py
@@ -50,7 +50,7 @@ class LookupModule(object):
 
             if isinstance(term, basestring):
                 # convert a variable to a list
-                term2 = utils.listify_lookup_plugin_terms(term, self.basedir, inject, fail_on_undefined=False)
+                term2 = utils.listify_lookup_plugin_terms(term, self.basedir, inject)
                 # but avoid converting a plain string to a list of one string
                 if term2 != [ term ]:
                     term = term2
@@ -59,7 +59,7 @@ class LookupModule(object):
                 # if it's a list, check recursively for items that are a list
                 term = self.flatten(term, inject)
                 ret.extend(term)
-            else:   
+            else:
                 ret.append(term)
 
         return ret

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1451,7 +1451,7 @@ def safe_eval(expr, locals={}, include_exceptions=False):
         return expr
 
 
-def listify_lookup_plugin_terms(terms, basedir, inject, fail_on_undefined=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR):
+def listify_lookup_plugin_terms(terms, basedir, inject):
 
     from ansible.utils import template
 
@@ -1469,11 +1469,13 @@ def listify_lookup_plugin_terms(terms, basedir, inject, fail_on_undefined=C.DEFA
             # if not already a list, get ready to evaluate with Jinja2
             # not sure why the "/" is in above code :)
             try:
-                new_terms = template.template(basedir, "{{%s}}" % terms, inject, convert_bare=True, fail_on_undefined=fail_on_undefined)
+                new_terms = template.template(basedir, terms, inject, convert_bare=True, fail_on_undefined=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR)
                 if isinstance(new_terms, basestring) and "{{" in new_terms:
                     pass
                 else:
                     terms = new_terms
+            except errors.AnsibleUndefinedVariable:
+                raise
             except jinja2.exceptions.UndefinedError, e:
                 raise errors.AnsibleUndefinedVariable('undefined variable in items: %s' % e)
             except:

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -86,12 +86,14 @@ JINJA2_ALLOWED_OVERRIDES = ['trim_blocks', 'lstrip_blocks', 'newline_sequence', 
 def lookup(name, *args, **kwargs):
     from ansible import utils
     instance = utils.plugins.lookup_loader.get(name.lower(), basedir=kwargs.get('basedir',None))
-    vars = kwargs.get('vars', None)
+    tvars = kwargs.get('vars', None)
 
     if instance is not None:
         # safely catch run failures per #5059
         try:
-            ran = instance.run(*args, inject=vars, **kwargs)
+            ran = instance.run(*args, inject=tvars, **kwargs)
+        except errors.AnsibleUndefinedVariable:
+            raise
         except Exception, e:
             ran = None
         if ran:


### PR DESCRIPTION
this fixes the case where relative lookups for file/template stopped working, also improves error handling and reverts a few recent changes that are now not needed.
