### PR TITLE
Run sftp in in batch mode.

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -394,7 +394,7 @@ class Connection(object):
             cmd += [in_path,host + ":" + pipes.quote(out_path)]
             indata = None
         else:
-            cmd += ["sftp"] + self.common_args + [host]
+            cmd += ["sftp"] + self.common_args + ["-b", "-", host]
             indata = "put %s %s\n" % (pipes.quote(in_path), pipes.quote(out_path))
 
         (p, stdin) = self._run(cmd, indata)
@@ -420,7 +420,7 @@ class Connection(object):
             cmd += [host + ":" + in_path, out_path]
             indata = None
         else:
-            cmd += ["sftp"] + self.common_args + [host]
+            cmd += ["sftp"] + self.common_args + ["-b", "-", host]
             indata = "get %s %s\n" % (in_path, out_path)
 
         p = subprocess.Popen(cmd, stdin=subprocess.PIPE,


### PR DESCRIPTION
Normally, the return code of sftp is always 0, independent of failure or success of the interactive commands. As a consequence put or get errors in the ssh connection plugin are not detected right now if sftp is used for file transport (which is the default). By switching to batch mode the return code of sftp is nonzero if the put or get fails.
