### PR TITLE
Give a nice message when trying to use undefined variable within jinja2 template

### DIFF
--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -86,6 +86,12 @@ class ActionModule(object):
         try:
             resultant = template.template_from_file(self.runner.basedir, source, inject, vault_password=self.runner.vault_pass)
         except Exception, e:
+            if 'StrictUndefined' in str(e):
+                raise errors.AnsibleUndefinedVariable(
+                    "Unable to look up a name or access an attribute in template string. Is this variable defined? " + \
+                    "Make sure your variable name does not contain invalid characters like '-'."
+                )
+
             result = dict(failed=True, msg=type(e).__name__ + ": " + str(e))
             return ReturnData(conn=conn, comm_ok=False, result=result)
 

--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -85,13 +85,10 @@ class ActionModule(object):
         # template the source data locally & get ready to transfer
         try:
             resultant = template.template_from_file(self.runner.basedir, source, inject, vault_password=self.runner.vault_pass)
+        except TypeError,e:
+                if 'StrictUndefined' in str(e):
+                        raise errors.AnsibleUndefinedVariable("Unable to look up a name or access an attribute in template string. Is this variable defined? Make sure your variable name does not contain invalid characters like '-'.")
         except Exception, e:
-            if 'StrictUndefined' in str(e):
-                raise errors.AnsibleUndefinedVariable(
-                    "Unable to look up a name or access an attribute in template string. Is this variable defined? " + \
-                    "Make sure your variable name does not contain invalid characters like '-'."
-                )
-
             result = dict(failed=True, msg=type(e).__name__ + ": " + str(e))
             return ReturnData(conn=conn, comm_ok=False, result=result)
 


### PR DESCRIPTION
Instead of write:
{'msg': "TypeError: argument of type 'StrictUndefined' is not iterable", 'failed': True}
Give a nice message similar to the one defined in:
template_from_string function.
