### PR TITLE
Correct typo of "actively"

### DIFF
--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -384,7 +384,7 @@ def process_category(category, categories, options, env, template, outputname):
     category_file.write("""\n\n
 .. note::
     - %s: This marks a module as deprecated, which means a module is kept for backwards compatibility but usage is discouraged.  The module documentation details page may explain more about this rationale.
-    - %s: This marks a module as 'extras', which means it ships with ansible but may be a newer module and possibly (but not neccessarily) less activity maintained than 'core' modules.
+    - %s: This marks a module as 'extras', which means it ships with ansible but may be a newer module and possibly (but not neccessarily) less actively maintained than 'core' modules.
     - Tickets filed on modules are filed to different repos than those on the main open source project. Core module tickets should be filed at `ansible/ansible-modules-core on GitHub <http://github.com/ansible/ansible-modules-core>`_, extras tickets to `ansible/ansible-modules-extras on GitHub <http://github.com/ansible/ansible-modules-extras>`_
 """ % (DEPRECATED, NOTCORE))
     category_file.close()


### PR DESCRIPTION
The word "actively" seems more appropriate than "activity" here.
