### PR TITLE
Add mock and nose to requirements for running unit tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,7 @@ mock interfaces rather than producing side effects.
 
 Playbook engine code is better suited for integration tests.
 
-Requirements: sudo pip install paramiko PyYAML jinja2 httplib2 passlib
+Requirements: sudo pip install paramiko PyYAML jinja2 httplib2 passlib nose mock
 
 integration
 -----------


### PR DESCRIPTION
It seems nose and mock are needed to run tests, but they are missing from the README
