### PR TITLE
Allow multiple vault password files

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -78,7 +78,7 @@ class Cli(object):
                          "and su arguments ('-su', '--su-user', and '--ask-su-pass') are "
                          "mutually exclusive")
 
-        if (options.ask_vault_pass and options.vault_password_file):
+        if (options.ask_vault_pass and options.vault_password_files):
             parser.error("--ask-vault-pass and --vault-password-file are mutually exclusive")
 
         return (options, args)
@@ -93,7 +93,7 @@ class Cli(object):
         sshpass = None
         sudopass = None
         su_pass = None
-        vault_pass = None
+        vault_passwords = []
 
         options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
         # Never ask for an SSH password when we run with local connection
@@ -104,12 +104,15 @@ class Cli(object):
         options.ask_vault_pass = options.ask_vault_pass or C.DEFAULT_ASK_VAULT_PASS
 
         (sshpass, sudopass, su_pass, vault_pass) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass, ask_su_pass=options.ask_su_pass, ask_vault_pass=options.ask_vault_pass)
+        if vault_pass is not None:
+            vault_passwords.append(vault_pass)
 
         # read vault_pass from a file
-        if not options.ask_vault_pass and options.vault_password_file:
-            vault_pass = utils.read_vault_file(options.vault_password_file)
+        if not options.ask_vault_pass and options.vault_password_files:
+            vault_passwords.extend(
+                utils.read_vault_file(f) for f in options.vault_password_files)
 
-        inventory_manager = inventory.Inventory(options.inventory, vault_password=vault_pass)
+        inventory_manager = inventory.Inventory(options.inventory, vault_passwords=vault_passwords)
         if options.subset:
             inventory_manager.subset(options.subset)
         hosts = inventory_manager.list_hosts(pattern)

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -107,13 +107,13 @@ def main(args):
                          "and su arguments ('-su', '--su-user', and '--ask-su-pass') are "
                          "mutually exclusive")
 
-    if (options.ask_vault_pass and options.vault_password_file):
+    if (options.ask_vault_pass and options.vault_password_files):
             parser.error("--ask-vault-pass and --vault-password-file are mutually exclusive")
 
     sshpass = None
     sudopass = None
     su_pass = None
-    vault_pass = None
+    vault_passwords = []
 
     options.ask_vault_pass = options.ask_vault_pass or C.DEFAULT_ASK_VAULT_PASS
 
@@ -127,18 +127,21 @@ def main(args):
         options.ask_sudo_pass = options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
         options.ask_su_pass = options.ask_su_pass or C.DEFAULT_ASK_SU_PASS
         (sshpass, sudopass, su_pass, vault_pass) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass, ask_su_pass=options.ask_su_pass, ask_vault_pass=options.ask_vault_pass)
+        if vault_pass:
+            vault_passwords.append(vault_pass)
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
         options.su_user = options.su_user or C.DEFAULT_SU_USER
 
     # read vault_pass from a file
-    if not options.ask_vault_pass and options.vault_password_file:
-        vault_pass = utils.read_vault_file(options.vault_password_file)
+    if not options.ask_vault_pass and options.vault_password_files:
+        vault_passwords.extend(
+            utils.read_vault_file(f) for f in options.vault_password_files)
 
     extra_vars = {}
     for extra_vars_opt in options.extra_vars:
         if extra_vars_opt.startswith("@"):
             # Argument is a YAML file (JSON is a subset of YAML)
-            extra_vars = utils.combine_vars(extra_vars, utils.parse_yaml_from_file(extra_vars_opt[1:], vault_password=vault_pass))
+            extra_vars = utils.combine_vars(extra_vars, utils.parse_yaml_from_file(extra_vars_opt[1:], vault_passwords=vault_passwords))
         elif extra_vars_opt and extra_vars_opt[0] in '[{':
             # Arguments as YAML
             extra_vars = utils.combine_vars(extra_vars, utils.parse_yaml(extra_vars_opt))
@@ -157,7 +160,7 @@ def main(args):
         if not (os.path.isfile(playbook) or stat.S_ISFIFO(os.stat(playbook).st_mode)):
             raise errors.AnsibleError("the playbook: %s does not appear to be a file" % playbook)
 
-    inventory = ansible.inventory.Inventory(options.inventory, vault_password=vault_pass)
+    inventory = ansible.inventory.Inventory(options.inventory, vault_passwords=vault_passwords)
     inventory.subset(options.subset)
     if len(inventory.list_hosts()) == 0:
         raise errors.AnsibleError("provided hosts list is empty")
@@ -197,7 +200,7 @@ def main(args):
             su=options.su,
             su_pass=su_pass,
             su_user=options.su_user,
-            vault_password=vault_pass,
+            vault_passwords=vault_passwords,
             force_handlers=options.force_handlers
         )
 
@@ -213,7 +216,7 @@ def main(args):
             for (play_ds, play_basedir) in zip(pb.playbook, pb.play_basedirs):
                 playnum += 1
                 play = ansible.playbook.Play(pb, play_ds, play_basedir,
-                                              vault_password=pb.vault_password)
+                                             vault_passwords=pb.vault_passwords)
                 label = play.name
                 hosts = pb.inventory.list_hosts(play.hosts)
 

--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -131,8 +131,9 @@ def main(args):
                       default=DEFAULT_REPO_TYPE,
                       help='Module name used to check out repository.  '
                       'Default is %s.' % DEFAULT_REPO_TYPE)
-    parser.add_option('--vault-password-file', dest='vault_password_file',
-                    help="vault password file")
+    parser.add_option('--vault-password-file', dest='vault_password_files',
+                      default=[], action='append',
+                      help="vault password file")
     parser.add_option('-K', '--ask-sudo-pass', default=False, dest='ask_sudo_pass', action='store_true',
                       help='ask for sudo password')
     parser.add_option('-t', '--tags', dest='tags', default=False,
@@ -208,8 +209,8 @@ def main(args):
         return 1
 
     cmd = 'ansible-playbook %s %s' % (base_opts, playbook)
-    if options.vault_password_file:
-        cmd += " --vault-password-file=%s" % options.vault_password_file
+    for password_file in options.vault_password_files:
+        cmd += " --vault-password-file=%s" % password_file
     if options.inventory:
         cmd += ' -i "%s"' % options.inventory
     for ev in options.extra_vars:

--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -57,8 +57,12 @@ def build_option_parser(action):
     # options for all actions
     #parser.add_option('-c', '--cipher', dest='cipher', default="AES256", help="cipher to use")
     parser.add_option('--debug', dest='debug', action="store_true", help="debug")
+    if C.DEFAULT_VAULT_PASSWORD_FILES:
+        default_password_file = C.DEFAULT_VAULT_PASSWORD_FILES[0]
+    else:
+        default_password_file = None
     parser.add_option('--vault-password-file', dest='password_file',
-                      help="vault password file", default=C.DEFAULT_VAULT_PASSWORD_FILE)
+                      help="vault password file", default=default_password_file)
 
     # options specific to actions
     if action == "create":

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -116,7 +116,7 @@ DEFAULT_SUDO_USER         = get_config(p, DEFAULTS, 'sudo_user',        'ANSIBLE
 DEFAULT_ASK_SUDO_PASS     = get_config(p, DEFAULTS, 'ask_sudo_pass',    'ANSIBLE_ASK_SUDO_PASS',    False, boolean=True)
 DEFAULT_REMOTE_PORT       = get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      None, integer=True)
 DEFAULT_ASK_VAULT_PASS    = get_config(p, DEFAULTS, 'ask_vault_pass',    'ANSIBLE_ASK_VAULT_PASS',    False, boolean=True)
-DEFAULT_VAULT_PASSWORD_FILE = shell_expand_path(get_config(p, DEFAULTS, 'vault_password_file', 'ANSIBLE_VAULT_PASSWORD_FILE', None))
+DEFAULT_VAULT_PASSWORD_FILES = map(shell_expand_path, get_config(p, DEFAULTS, 'vault_password_file', 'ANSIBLE_VAULT_PASSWORD_FILE', [], islist=True))
 DEFAULT_TRANSPORT         = get_config(p, DEFAULTS, 'transport',        'ANSIBLE_TRANSPORT',        'smart')
 DEFAULT_SCP_IF_SSH        = get_config(p, 'ssh_connection', 'scp_if_ssh',       'ANSIBLE_SCP_IF_SSH',       False, boolean=True)
 DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -79,7 +79,7 @@ class PlayBook(object):
         su               = False,
         su_user          = False,
         su_pass          = False,
-        vault_password   = False,
+        vault_passwords  = False,
         force_handlers   = False,
     ):
 
@@ -150,7 +150,7 @@ class PlayBook(object):
         self.su               = su
         self.su_user          = su_user
         self.su_pass          = su_pass
-        self.vault_password   = vault_password
+        self.vault_passwords  = vault_passwords
         self.force_handlers   = force_handlers
 
         self.callbacks.playbook = self
@@ -257,7 +257,7 @@ class PlayBook(object):
         run top level error checking on playbooks and allow them to include other playbooks.
         '''
 
-        playbook_data = utils.parse_yaml_from_file(path, vault_password=self.vault_password)
+        playbook_data = utils.parse_yaml_from_file(path, vault_passwords=self.vault_passwords)
         accumulated_plays = []
         play_basedirs = []
 
@@ -310,7 +310,7 @@ class PlayBook(object):
         # loop through all patterns and run them
         self.callbacks.on_start()
         for (play_ds, play_basedir) in zip(self.playbook, self.play_basedirs):
-            play = Play(self, play_ds, play_basedir, vault_password=self.vault_password)
+            play = Play(self, play_ds, play_basedir, vault_passwords=self.vault_passwords)
             assert play is not None
 
             matched_tags, unmatched_tags = play.compare_tags(self.only_tags)
@@ -427,7 +427,7 @@ class PlayBook(object):
             su=task.su,
             su_user=task.su_user,
             su_pass=task.su_pass,
-            vault_pass = self.vault_password,
+            vault_pass=self.vault_passwords,
             run_hosts=hosts,
             no_log=task.no_log,
             run_once=task.run_once,
@@ -605,7 +605,7 @@ class PlayBook(object):
             su=play.su,
             su_user=play.su_user,
             su_pass=self.su_pass,
-            vault_pass=self.vault_password,
+            vault_pass=self.vault_passwords,
             transport=play.transport,
             is_playbook=True,
             module_vars=play.vars,
@@ -675,7 +675,7 @@ class PlayBook(object):
 
         # now with that data, handle contentional variable file imports!
         all_hosts = self._trim_unavailable_hosts(play._play_hosts)
-        play.update_vars_files(all_hosts, vault_password=self.vault_password)
+        play.update_vars_files(all_hosts, vault_passwords=self.vault_passwords)
         hosts_count = len(all_hosts)
 
         if play.serial.endswith("%"):

--- a/test/units/TestPlayVarsFiles.py
+++ b/test/units/TestPlayVarsFiles.py
@@ -26,7 +26,7 @@ class FakeInventory(object):
         return "."        
     def src(self):
         return "fakeinventory"
-    def get_variables(self, host, vault_password=None):
+    def get_variables(self, host, vault_passwords=None):
         if host in self.hosts:
             return self.hosts[host]        
         else:

--- a/test/units/TestVault.py
+++ b/test/units/TestVault.py
@@ -107,6 +107,20 @@ class TestVaultLib(TestCase):
         assert enc_data != "foobar", "encryption failed"
         assert dec_data == "foobar", "decryption failed"           
 
+    def test_decrypt_multiple_passwords(self):
+        if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:
+            raise SkipTest
+        v = VaultLib('ansible')
+        v.cipher_name = 'AES256'
+        enc_data = v.encrypt("foobar")
+        assert enc_data != "foobar", "encryption failed"
+        print enc_data
+
+        v = VaultLib(['dummy_pass', 'ansible'])
+        v.cipher_name = 'AES256'
+        dec_data = v.decrypt(enc_data)
+        assert dec_data == "foobar", "decryption failed"
+
     def test_encrypt_encrypted(self):
         if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:
             raise SkipTest

--- a/v2/ansible/constants.py
+++ b/v2/ansible/constants.py
@@ -122,7 +122,7 @@ DEFAULT_SUDO_USER         = get_config(p, DEFAULTS, 'sudo_user',        'ANSIBLE
 DEFAULT_ASK_SUDO_PASS     = get_config(p, DEFAULTS, 'ask_sudo_pass',    'ANSIBLE_ASK_SUDO_PASS',    False, boolean=True)
 DEFAULT_REMOTE_PORT       = get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      None, integer=True)
 DEFAULT_ASK_VAULT_PASS    = get_config(p, DEFAULTS, 'ask_vault_pass',    'ANSIBLE_ASK_VAULT_PASS',    False, boolean=True)
-DEFAULT_VAULT_PASSWORD_FILE = shell_expand_path(get_config(p, DEFAULTS, 'vault_password_file', 'ANSIBLE_VAULT_PASSWORD_FILE', None))
+DEFAULT_VAULT_PASSWORD_FILES = map(shell_expand_path, get_config(p, DEFAULTS, 'vault_password_file', 'ANSIBLE_VAULT_PASSWORD_FILE', [], islist=True))
 DEFAULT_TRANSPORT         = get_config(p, DEFAULTS, 'transport',        'ANSIBLE_TRANSPORT',        'smart')
 DEFAULT_SCP_IF_SSH        = get_config(p, 'ssh_connection', 'scp_if_ssh',       'ANSIBLE_SCP_IF_SSH',       False, boolean=True)
 DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')

--- a/v2/ansible/parsing/vault/__init__.py
+++ b/v2/ansible/parsing/vault/__init__.py
@@ -71,8 +71,11 @@ CIPHER_WHITELIST=['AES', 'AES256']
 
 class VaultLib(object):
 
-    def __init__(self, password):
-        self.password = password
+    def __init__(self, passwords):
+        if isinstance(passwords, basestring):
+            self.passwords = [passwords]
+        else:
+            self.passwords = passwords
         self.cipher_name = None
         self.version = '1.1'
 
@@ -104,14 +107,14 @@ class VaultLib(object):
         """
 
         # encrypt sha + data
-        enc_data = this_cipher.encrypt(data, self.password)
+        enc_data = this_cipher.encrypt(data, self.passwords[0])
 
         # add header 
         tmp_data = self._add_header(enc_data)
         return tmp_data
 
     def decrypt(self, data):
-        if self.password is None:
+        if not self.passwords:
             raise errors.AnsibleError("A vault password must be specified to decrypt data")
 
         if not self.is_encrypted(data):
@@ -128,11 +131,14 @@ class VaultLib(object):
             raise errors.AnsibleError("%s cipher could not be found" % self.cipher_name)
 
         # try to unencrypt data
-        data = this_cipher.decrypt(data, self.password)
-        if data is None:
+        for password in self.passwords:
+            dec_data = this_cipher.decrypt(data, password)
+            if dec_data is not None:
+                break
+        else:
             raise errors.AnsibleError("Decryption failed")
 
-        return data            
+        return dec_data
 
     def _add_header(self, data):     
         # combine header and encrypted data in 80 char columns

--- a/v2/ansible/parsing/yaml/__init__.py
+++ b/v2/ansible/parsing/yaml/__init__.py
@@ -55,9 +55,9 @@ class DataLoader():
 
     _FILE_CACHE = dict()
 
-    def __init__(self, vault_password=None):
+    def __init__(self, vault_passwords=[]):
         self._basedir = '.'
-        self._vault = VaultLib(password=vault_password)
+        self._vault = VaultLib(passwords=vault_passwords)
 
     def load(self, data, file_name='<string>', show_content=True):
         '''

--- a/v2/test/parsing/vault/test_vault.py
+++ b/v2/test/parsing/vault/test_vault.py
@@ -116,6 +116,20 @@ class TestVaultLib(unittest.TestCase):
         assert enc_data != "foobar", "encryption failed"
         assert dec_data == "foobar", "decryption failed"           
 
+    def test_decrypt_multiple_passwords(self):
+        if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:
+            raise SkipTest
+        v = VaultLib('ansible')
+        v.cipher_name = 'AES256'
+        enc_data = v.encrypt("foobar")
+        assert enc_data != "foobar", "encryption failed"
+        print(enc_data)
+
+        v = VaultLib(['dummy_pass', 'ansible'])
+        v.cipher_name = 'AES256'
+        dec_data = v.decrypt(enc_data)
+        assert dec_data == "foobar", "decryption failed"
+
     def test_encrypt_encrypted(self):
         if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:
             raise SkipTest


### PR DESCRIPTION
This PR adds support for passing multiple --vault-password-file. When decrypting, all the files will be used in turn until one matches.
I tried not to break vars_plugins (which are passed the current vault password) in case there's 0 or 1 password, but they will break for >1 (they'll get a list in `vault_password`).

I tried to change v2/\* too. `make newtests` passes, but I don't really know how to make sure the v2 changes work.
