### PR TITLE
Make sure the port obtained from parsing a URL is an integer.

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -353,6 +353,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
                 netloc = netloc.split('@', 1)[1]
             if ':' in netloc:
                 hostname, port = netloc.split(':', 1)
+                port = int(port)
             else:
                 hostname = netloc
                 port = 443


### PR DESCRIPTION
This playbook demonstrates the problem:

``` yaml
- hosts: localhost
  connection: local
  gather_facts: False
  tasks:
    ze- get_url: url="https://wulczer.org:443/index.html" dest=/tmp/i
```

It fails for me with:

```
TypeError: an integer is required
```
