### PR TITLE
Disk size for advanced drives over 2 TB is incorrect

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -791,7 +791,7 @@ class LinuxHardware(Hardware):
 
                     part['start'] = get_file_content(part_sysdir + "/start",0)
                     part['sectors'] = get_file_content(part_sysdir + "/size",0)
-                    part['sectorsize'] = get_file_content(part_sysdir + "/queue/physical_block_size")
+                    part['sectorsize'] = get_file_content(part_sysdir + "/queue/logical_block_size")
                     if not part['sectorsize']:
                         part['sectorsize'] = get_file_content(part_sysdir + "/queue/hw_sector_size",512)
                     part['size'] = module.pretty_bytes((float(part['sectors']) * float(part['sectorsize'])))
@@ -808,7 +808,7 @@ class LinuxHardware(Hardware):
             d['sectors'] = get_file_content(sysdir + "/size")
             if not d['sectors']:
                 d['sectors'] = 0
-            d['sectorsize'] = get_file_content(sysdir + "/queue/physical_block_size")
+            d['sectorsize'] = get_file_content(sysdir + "/queue/logical_block_size")
             if not d['sectorsize']:
                 d['sectorsize'] = get_file_content(sysdir + "/queue/hw_sector_size",512)
             d['size'] = module.pretty_bytes(float(d['sectors']) * float(d['sectorsize']))


### PR DESCRIPTION
/sys/block/sdX/queue/physical_block_size does not correlate with /sys/block/sdX/size for advanced drives larger than 2TB, /sys/block/sdX/queue/logical_block_size correlates with both see #9549 

This undoes work done by #5761

We may want to rather keep displaying the physical_block_size for sector size but then the math of "sectors" \* "sectorsize" will no longer hold true. Perhaps we want to report "logicalsectorsize" and "physicalsectorsize". Using logical_sector_size seems like the best option for now?
