### PR TITLE
Fixes for fetch module when connecting to Windows hosts

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1193,7 +1193,7 @@ class Runner(object):
             return path
 
         if len(split_path) > 1:
-            return os.path.join(initial_fragment, *split_path[1:])
+            return conn.shell.join_path(initial_fragment, *split_path[1:])
         else:
             return initial_fragment
 

--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -193,7 +193,7 @@ class Connection(object):
     def fetch_file(self, in_path, out_path):
         out_path = out_path.replace('\\', '/')
         vvv("FETCH %s TO %s" % (in_path, out_path), host=self.host)
-        buffer_size = 2**20 # 1MB chunks
+        buffer_size = 2**19 # 0.5MB chunks
         if not os.path.exists(os.path.dirname(out_path)):
             os.makedirs(os.path.dirname(out_path))
         out_file = None

--- a/lib/ansible/runner/shell_plugins/powershell.py
+++ b/lib/ansible/runner/shell_plugins/powershell.py
@@ -84,12 +84,24 @@ class ShellModule(object):
         # FIXME: Support system temp path!
         return _encode_script('''(New-Item -Type Directory -Path $env:temp -Name "%s").FullName | Write-Host -Separator '';''' % basefile)
 
-    def md5(self, path):
+    def expand_user(self, user_home_path):
+        # PowerShell only supports "~" (not "~username").  Resolve-Path ~ does
+        # not seem to work remotely, though by default we are always starting
+        # in the user's home directory.
+        if user_home_path == '~':
+            script = 'Write-Host (Get-Location).Path'
+        elif user_home_path.startswith('~\\'):
+            script = 'Write-Host ((Get-Location).Path + "%s")' % _escape(user_home_path[1:])
+        else:
+            script = 'Write-Host "%s"' % _escape(user_home_path)
+        return _encode_script(script)
+
+    def checksum(self, path, python_interp):
         path = _escape(path)
         script = '''
             If (Test-Path -PathType Leaf "%(path)s")
             {
-                $sp = new-object -TypeName System.Security.Cryptography.MD5CryptoServiceProvider;
+                $sp = new-object -TypeName System.Security.Cryptography.SHA1CryptoServiceProvider;
                 $fp = [System.IO.File]::Open("%(path)s", [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read);
                 [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
                 $fp.Dispose();

--- a/test/integration/roles/test_win_fetch/tasks/main.yml
+++ b/test/integration/roles/test_win_fetch/tasks/main.yml
@@ -18,11 +18,11 @@
 
 - name: clean out the test directory
   local_action: file name={{ output_dir|mandatory }} state=absent
-  tags: me
+  run_once: true
 
 - name: create the test directory
   local_action: file name={{ output_dir }} state=directory
-  tags: me
+  run_once: true
 
 - name: fetch a small file
   fetch: src="C:/Windows/win.ini" dest={{ output_dir }}
@@ -145,7 +145,7 @@
       - "not fetch_missing_nofail|changed"
 
 - name: attempt to fetch a non-existent file - fail on missing
-  fetch: src="C:/this_file_should_not_exist.txt" dest={{ output_dir }} fail_on_missing=yes
+  fetch: src="~/this_file_should_not_exist.txt" dest={{ output_dir }} fail_on_missing=yes
   register: fetch_missing
   ignore_errors: true
 
@@ -164,5 +164,6 @@
 - name: check fetch directory result
   assert:
     that:
-      - "fetch_dir|failed"
+      # Doesn't fail anymore, only returns a message.
+      - "not fetch_dir|changed"
       - "fetch_dir.msg"


### PR DESCRIPTION
@abadger made changes in https://github.com/ansible/ansible/commit/f1267c0b053e5975dc08c151530c802015902242 and https://github.com/ansible/ansible/commit/bc4272d2a26e47418c7d588208482d05a34a34cd to shell plugins that weren't applied for PowerShell.

This PR adds PowerShell implementations of the `expand_user` and `checksum` methods.

I also reduced the buffer size for fetching files to 0.5MB; I was getting an IOError with some EC2 Windows hosts when using a 1MB buffer.
