### PR TITLE
Make copy fail when source is empty

### DIFF
--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -64,10 +64,10 @@ class ActionModule(object):
                 except UnicodeDecodeError:
                     pass
 
-        if (source is None and content is None and not 'first_available_file' in inject) or dest is None:
+        if (not source and content is None and not 'first_available_file' in inject) or dest is None:
             result=dict(failed=True, msg="src (or content) and dest are required")
             return ReturnData(conn=conn, result=result)
-        elif (source is not None or 'first_available_file' in inject) and content is not None:
+        elif (source or 'first_available_file' in inject) and content is not None:
             result=dict(failed=True, msg="src and content are mutually exclusive")
             return ReturnData(conn=conn, result=result)
 


### PR DESCRIPTION
An odd combination of events can cause copy to have some strange
behaviour.

If `with_files_found` finds zero files, and copy is used under
a role with files or templates beneath (at most one file need
exist under either of those two), then the copy tries to
copy the entire data structure under `dest`.

Copy should fail when source is empty - and that should include
the empty string, not just the `None` sentinel.

Other approaches might include failing when `with_files_found`
finds zero files
