### PR TITLE
Allow .gitkeep in the jsonfile fact cache dir

### DIFF
--- a/lib/ansible/cache/jsonfile.py
+++ b/lib/ansible/cache/jsonfile.py
@@ -98,7 +98,7 @@ class CacheModule(BaseCacheModule):
     def keys(self):
         keys = []
         for k in os.listdir(self._cache_dir):
-            if not self.has_expired(k):
+            if not (k.startswith('.') or self.has_expired(k)):
                 keys.append(k)
         return keys
 


### PR DESCRIPTION
##### Issue Type:

“Feature Pull Request”
##### Ansible Version:

devel
##### Environment:

Ubuntu 12.04 managed from Arch
##### Summary:

I would like to add a `.gitkeep` file to the `cache_dir` used by the `jsonfile` fact cache so I can run ansible from a fresh checkout of my repo without any additional setup. This PR modifies the `jsonfile` fact cache so that it ignores hidden files in the `cache_dir`.

RFC @bcoca 
