### PR TITLE
Re-add line that allows for complete playbook templating

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -859,6 +859,7 @@ class Play(object):
                             target_filename = filename4
                     update_vars_cache(host, data, target_filename=target_filename)
                 else:
+                    self.vars = utils.combine_vars(self.vars, data)
                     self.vars_file_vars = utils.combine_vars(self.vars_file_vars, data)
                 # we did process this file
                 return True


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

``` bash
ansible 1.9 (devel 2bf269568b) last updated 2014/12/02 15:46:49 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 3a80b734e6) last updated 2014/12/02 09:45:53 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 317654dba5) last updated 2014/12/01 10:08:51 (GMT -700)
  v2/ansible/modules/core: (detached HEAD cb69744bce) last updated 2014/11/08 19:22:54 (GMT -700)
  v2/ansible/modules/extras: (detached HEAD 8a4f07eecd) last updated 2014/11/08 19:22:55 (GMT -700)
  configured module search path = <>
```
##### Environment:

Running from Mac OS X 10.10.1.
Running against Debian Squeeze.
##### Summary:

We currently have a set of playbooks that I want to run on a set of groups of hosts. So, we've added a variable to the "hosts" part of a playbook. We have the group name built by a variable in a group_vars file which also uses some info from --extra-vars and have the group added dynamically.

A line was deleted in commit 9a0f8f0 that breaks this and this commit adds this back in. The tests for `test_var_precedence` have been run without any issues showing up after this revert.
##### Steps To Reproduce:

We use AWS and tagging but you should be able to reproduce this without using AWS.

group_vars/test

``` bash
my_group: "tag_group_{{ group }}"
```

test.yml

``` yaml

---
# Test
- hosts: "{{ my_group }}"
  vars_files:
    - group_vars/test
  tasks:
    - debug: msg="Test message"
```

Run something like the following:

``` bash
$ ansible-playbook -i ec2.py -e "group=test" test.yml
```
##### Expected Results:

``` bash
PLAY [tag_group_test] ***********************************************

GATHERING FACTS ***************************************************************
ok: [ip-10-0-16-40...]
ok: [ip-10-0-16-236...]

TASK: [debug msg="Test message"] **********************************************
ok: [ip-10-0-16-40...] => {
    "msg": "Test message"
}
ok: [ip-10-0-16-236...] => {
    "msg": "Test message"
}

PLAY RECAP ********************************************************************
ip-10-0-16-236... : ok=2    changed=0    unreachable=0    failed=0
ip-10-0-16-40... : ok=2    changed=0    unreachable=0    failed=0
```
##### Actual Results:

``` bash
PLAY [{{ my_group }}] ****************************************************
skipping: no hosts matched

PLAY RECAP ********************************************************************
```
