### PR TITLE
Adds filter allowing user to ensure that a variable ends with a path separator.

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -336,6 +336,10 @@ To get the real path of a link (new in version 1.8)::
 
    {{ path | readlink }}
 
+To ensure a path ends with a path separator (useful with directories provided as prompt vars)::
+
+    {{ path | ensure_separator }}
+
 To work with Base64 encoded strings::
 
     {{ encoded | b64decode }}

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -243,6 +243,11 @@ def randomize_list(mylist):
         pass
     return mylist
 
+
+def ensure_separator(some_directory):
+    """ Ensure that a directory string ends in a path separator"""
+    return os.path.join(some_directory, "")
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -268,6 +273,7 @@ class FilterModule(object):
             'expanduser': os.path.expanduser,
             'realpath': os.path.realpath,
             'relpath': os.path.relpath,
+            'ensure_separator': ensure_separator,
 
             # failure testing
             'failed'  : failed,


### PR DESCRIPTION
Allows playbooks to control path_separator presence for prompted directories without resorting to regexes and relying on os.path to do it the right way for us.

"/some/user/provided/path" -> "/some/user/provided/path/"
"/some/user/provided/path/" -> "/some/user/provided/path/"
