### PR TITLE
Submodule ansible-examples at examples/playbooks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 	path = v2/ansible/modules/extras
 	url = https://github.com/ansible/ansible-modules-extras.git
 	branch = devel
+[submodule "examples/playbooks"]
+	path = examples/playbooks
+	url = https://github.com/ansible/ansible-examples

--- a/examples/playbooks/README.md
+++ b/examples/playbooks/README.md
@@ -1,7 +1,0 @@
-Playbook Examples
-=================
-
-Playbook examples have moved.
-
-See [the Ansible-Examples repo](https://github.com/ansible/ansible-examples).
-


### PR DESCRIPTION
Instead of this:

```
[marca@marca-mac2 ansible]$ ls -l examples/playbooks
total 8
-rw-r--r--+ 1 marca  staff  147 Dec  3 12:50 README.md
```

let's have this:

```
[marca@marca-mac2 ansible]$ ls -l examples/playbooks
total 8
-rw-r--r--+  1 marca  staff   122 Dec  3 12:43 README.md
drwxr-xr-x+  8 marca  staff   272 Dec  3 12:43 jboss-standalone/
drwxr-xr-x+  9 marca  staff   306 Dec  3 12:43 lamp_haproxy/
drwxr-xr-x+  8 marca  staff   272 Dec  3 12:43 lamp_simple/
drwxr-xr-x+ 42 marca  staff  1428 Dec  3 12:43 language_features/
drwxr-xr-x+ 10 marca  staff   340 Dec  3 12:43 mongodb/
drwxr-xr-x+  8 marca  staff   272 Dec  3 12:43 tomcat-standalone/
drwxr-xr-x+  8 marca  staff   272 Dec  3 12:43 windows/
drwxr-xr-x+  8 marca  staff   272 Dec  3 12:43 wordpress-nginx/
```
