### PR TITLE
Issue-9704 Better handling of missing python

### DIFF
--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -192,6 +192,10 @@ class ActionModule(object):
                     dest_file = conn.shell.join_path(dest, source_rel)
                     remote_checksum = self.runner._remote_checksum(conn, tmp_path, dest_file, inject)
 
+            if remote_checksum == '4':
+                result = dict(msg="python isn't present on the system.  Unable to compute checksum", failed=True)
+                return ReturnData(conn=conn, result=result)
+
             if remote_checksum != '1' and not force:
                 # remote_file does not exist so continue to next iteration.
                 continue

--- a/lib/ansible/runner/action_plugins/fetch.py
+++ b/lib/ansible/runner/action_plugins/fetch.py
@@ -129,7 +129,7 @@ class ActionModule(object):
             elif remote_checksum == '3':
                 result = dict(msg="remote file is a directory, fetch cannot work on directories", file=source, changed=False)
             elif remote_checksum == '4':
-                result = dict(msg="python isn't present on the remote system.  Unable to fetch file", file=source, changed=False)
+                result = dict(msg="python isn't present on the system.  Unable to compute checksum", file=source, changed=False)
             return ReturnData(conn=conn, result=result)
 
         # calculate checksum for the local file

--- a/lib/ansible/runner/action_plugins/unarchive.py
+++ b/lib/ansible/runner/action_plugins/unarchive.py
@@ -83,6 +83,9 @@ class ActionModule(object):
                 source = utils.path_dwim(self.runner.basedir, source)
 
         remote_checksum = self.runner._remote_checksum(conn, tmp, dest, inject)
+        if remote_checksum == '4':
+            result = dict(failed=True, msg="python isn't present on the system.  Unable to compute checksum")
+            return ReturnData(conn=conn, result=result)
         if remote_checksum != '3':
             result = dict(failed=True, msg="dest '%s' must be an existing dir" % dest)
             return ReturnData(conn=conn, result=result)


### PR DESCRIPTION
When they python interpreter is set incorrectly for the machine the file
is being checked for (e.g. for the local or the remote), the error
manifests as a readability or directory missing error which can be very
misleading.
