### PR TITLE
fixed integration test as with_items 

### DIFF
--- a/test/integration/roles/test_conditionals/tasks/main.yml
+++ b/test/integration/roles/test_conditionals/tasks/main.yml
@@ -277,7 +277,7 @@
   assert:
     that:
     - "'skipped' in result"
-    - result.skipped
+    - result.results.skipped
 
 - name: test a with_items loop skipping a single item
   debug: var=item


### PR DESCRIPTION
it now (again) always returns a list, even if empty
