### PR TITLE
Add support for tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ venv
 Vagrantfile
 .vagrant
 ansible.egg-info/
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27
+
+[testenv]
+deps =
+    Jinja2
+    mock
+    nose
+    passlib
+    PyCrypto
+    PyYAML
+    unittest2
+commands =
+    nosetests -d -w test/units {posargs}


### PR DESCRIPTION
Tox allows you to run the `nosetests` test suite in multiple Python versions (py26 and py27) and helps to ensure that both work.

Speaking of which, a few tests are broken on py26, because they're using unittest assertions that don't exist in py26 (see https://gist.github.com/msabramo/5e82d78ad9687ddf2cbc)
