### PR TITLE
Add with_allocate: allocate a list items over a list of "slots"

### DIFF
--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -218,6 +218,27 @@ One of the provided strings will be selected at random.
 
 At a more basic level, they can be used to add chaos and excitement to otherwise predictable automation environments.
 
+.. _allocating_loop:
+
+Allocating Loop
+```````````````
+
+The 'allocate' feature can be used to allocate some list of things over another list of "slots" in round-robin fashion.  You could use it to distribute a list of resources into some subset.  This returns each item and its assigned slot in the following format::
+
+    - debug: msg="{{ item.current }} is in {{ item.slot }}"
+      with_allocate:
+         slots:
+         - "zone1"
+         - "zone2"
+         items:
+         - "my_server1"
+         - "my_server2"
+         - "my_server3"
+         - "my_server4"
+         - "my_server5"
+
+This can be useful for distributing hosts into a set of zones or networks, for example.
+
 .. _do_until_loops:
 
 Do-Until Loops

--- a/lib/ansible/runner/lookup_plugins/allocate.py
+++ b/lib/ansible/runner/lookup_plugins/allocate.py
@@ -1,0 +1,64 @@
+# (c) 2013, Herby Gillot <herby.gillot@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import ansible.utils as utils
+import ansible.errors as errors
+from itertools import cycle, izip
+
+
+class LookupModule(object):
+    """
+    Allocate a list of items over another list of "slots".
+
+    "Slots" are really just another list of items.
+
+    This will round-robin distribute items into slots, and returns a list
+    of each item and its assigned slot as a dict:
+
+    ['a', 'b'], [1, 2, 3, 4] -> [
+        {'current': 1, 'slot' 'a'},
+        {'current': 2, 'slot' 'b'},
+        {'current': 3, 'slot' 'a'},
+        {'current': 4, 'slot' 'b'},
+    ]
+
+    Can be accessed in Ansible as item.current, item.slot
+    """
+
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
+        self.plugin_name = 'allocate'
+
+    def run(self, terms, inject=None, **kwargs):
+
+        slots = utils.listify_lookup_plugin_terms(
+            terms.get('slots'), self.basedir, inject)
+
+        items = utils.listify_lookup_plugin_terms(
+            terms.get('items'), self.basedir, inject)
+
+        if not items:
+            return []
+
+        if not slots:
+            raise errors.AnsibleError(
+                'Missing "slots" parameter: '
+                'with_{} requires "slots" to be a list (over which the list '
+                'of "items" are allocated)'.format(self.plugin_name))
+
+        idict = lambda item: {'current': item[1], 'slot': item[0]}
+        return [idict(x) for x in izip(*[cycle(slots), items])]


### PR DESCRIPTION
Given some list of hosts for example, it would be useful to have a simple way to distribute them into a given set of networks or zones.  with_allocate provides Ansible a loop feature for doing this.  It takes the list of things to distribute into as the `slots` parameter, and allocates the given items into each slot in round-robin fashion.

Returns results in the format:

```
" {{ item.current }} {{ item.slot }}"
```

Example:

```
    - debug: msg="{{ item.current }} is in {{ item.slot }}"
      with_allocate:
         slots:
         - "zone1"
         - "zone2"
         items:
         - "my_server1"
         - "my_server2"
         - "my_server3"
         - "my_server4"
         - "my_server5"
```
