### PR TITLE
Docfix: running background tasks without polling

### DIFF
--- a/docsite/rst/intro_adhoc.rst
+++ b/docsite/rst/intro_adhoc.rst
@@ -230,7 +230,7 @@ checked on later. The same job ID is given to the same task on all
 hosts, so you won't lose track.  If you kick hosts and don't want
 to poll, it looks like this::
 
-    $ ansible all -B 3600 -a "/usr/bin/long_running_operation --do-stuff"
+    $ ansible all -B 3600 -P 0 -a "/usr/bin/long_running_operation --do-stuff"
 
 If you do decide you want to check on the job status later, you can::
 


### PR DESCRIPTION
Fix the example in the doc to explicitly set the poll interval to zero so the job doesn't poll.

To run a background task without polling, you need to set the poll interval to zero. However, Ansible's default poll setting is 15 seconds, so not specifying the poll interval will cause a background job to poll.
