### PR TITLE
Add integration test for ansible-modules-core #460

### DIFF
--- a/test/integration/roles/test_file/tasks/main.yml
+++ b/test/integration/roles/test_file/tasks/main.yml
@@ -106,6 +106,15 @@
     that:
       - "file6_result.changed == true"
 
+- name: touch a hard link
+  file: src={{output_file}} dest={{output_dir}}/hard.txt state=touch
+  register: file6_touch_result  
+
+- name: verify that the hard link was touched
+  assert:
+    that:
+      - "file6_touch_result.changed == true"
+
 - name: create a directory
   file: path={{output_dir}}/foobar state=directory
   register: file7_result


### PR DESCRIPTION
Please see https://github.com/ansible/ansible-modules-core/pull/460

This integration test uses the `file` module to set `state=touch` on a hard link. Currently in Ansible, that causes an error. [ansible-modules-core/pull/460](https://github.com/ansible/ansible-modules-core/pull/460) fixes that.

n.b. If there is generally a better way to coordinate PRs for changes that span across submodules of the project, please let me know.
