### PR TITLE
Add an option to allow an inventory that does not define any host

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -159,7 +159,7 @@ def main(args):
 
     inventory = ansible.inventory.Inventory(options.inventory, vault_password=vault_pass)
     inventory.subset(options.subset)
-    if len(inventory.list_hosts()) == 0:
+    if len(inventory.list_hosts()) == 0 and not options.allow_empty_inventory:
         raise errors.AnsibleError("provided hosts list is empty")
 
     # run all playbooks specified on the command line

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -134,6 +134,7 @@ DEFAULT_SU_FLAGS          = get_config(p, DEFAULTS, 'su_flags', 'ANSIBLE_SU_FLAG
 DEFAULT_SU_USER           = get_config(p, DEFAULTS, 'su_user', 'ANSIBLE_SU_USER', 'root')
 DEFAULT_ASK_SU_PASS       = get_config(p, DEFAULTS, 'ask_su_pass', 'ANSIBLE_ASK_SU_PASS', False, boolean=True)
 DEFAULT_GATHERING         = get_config(p, DEFAULTS, 'gathering', 'ANSIBLE_GATHERING', 'implicit').lower()
+DEFAULT_ALLOW_EMPTY_INVENTORY = get_config(p, DEFAULTS, 'allow_empty_inventory', 'ANSIBLE_ALLOW_EMPTY_INVENTORY', False, boolean=True)
 
 DEFAULT_ACTION_PLUGIN_PATH     = get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '/usr/share/ansible_plugins/action_plugins')
 DEFAULT_CACHE_PLUGIN_PATH      = get_config(p, DEFAULTS, 'cache_plugins',      'ANSIBLE_CACHE_PLUGINS', '/usr/share/ansible_plugins/cache_plugins')

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1055,6 +1055,8 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
     parser.add_option('-i', '--inventory-file', dest='inventory',
         help="specify inventory host file (default=%s)" % constants.DEFAULT_HOST_LIST,
         default=constants.DEFAULT_HOST_LIST)
+    parser.add_option('--allow-empty-inventory', default=C.DEFAULT_ALLOW_EMPTY_INVENTORY, dest='allow_empty_inventory',
+        action='store_true', help='Allow an inventory file to not define any host')
     parser.add_option('-k', '--ask-pass', default=False, dest='ask_pass', action='store_true',
         help='ask for SSH password')
     parser.add_option('--private-key', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',


### PR DESCRIPTION
The use case for this is when hosts are first dynamically detected/provisionned on a local play and added to the inventory with add_host.

Currently, we can use the "comma hack", but:
1) it's a hack and may disappear
2) it does not allow the use of a group_vars directory at the same level as the inventory file (the comma makes is_file return false, so no basedir is set, and then no basedir is searched)
