### PR TITLE
Add tags for inventory

### DIFF
--- a/plugins/inventory/apache-libcloud.py
+++ b/plugins/inventory/apache-libcloud.py
@@ -222,12 +222,17 @@ class LibcloudInventory(object):
         self.push(self.inventory, self.to_safe('type_' + node.instance_type), dest)
         '''
         # Inventory: Group by key pair
-        if node.extra['keyname']:
-            self.push(self.inventory, self.to_safe('key_' + node.extra['keyname']), dest)
+        if node.extra['key_name']:
+            self.push(self.inventory, self.to_safe('key_' + node.extra['key_name']), dest)
             
         # Inventory: Group by security group, quick thing to handle single sg
-        if node.extra['securitygroup']:
-            self.push(self.inventory, self.to_safe('sg_' + node.extra['securitygroup'][0]), dest)
+        if node.extra['security_group']:
+            self.push(self.inventory, self.to_safe('sg_' + node.extra['security_group'][0]), dest)
+
+        # Inventory: Group by tag
+        if node.extra['tags']:
+            for tagkey in node.extra['tags'].keys():
+                self.push(self.inventory, self.to_safe('tag_' + tagkey + '_' + node.extra['tags'][tagkey]), dest)
 
     def get_host_info(self):
         '''


### PR DESCRIPTION
Adds tags for the dynamic inventory based on libcloud and updates the key name parameter.
key_name is the new parameter and has been so for several versions. All users should have upgraded.
I need this to work with a customer on switching to ansible for his workflow.

thanks
