### PR TITLE
added a vars_plugin

### DIFF
--- a/lib/ansible/inventory/vars_plugins/python_vars.py
+++ b/lib/ansible/inventory/vars_plugins/python_vars.py
@@ -1,0 +1,28 @@
+import sys
+import os.path
+import ansible.utils
+
+
+class VarsModule(object):
+    def __init__(self, inventory):
+        self.inventory = inventory
+
+    def run(self, host, vault_password=None):
+        groups = sorted(self.inventory.groups_for_host(host.name), key=lambda g: g.depth)
+        groups.append(host)
+
+        playbook_basedir = self.inventory.playbook_basedir()
+        playbook_basedir = os.path.abspath(playbook_basedir) if playbook_basedir is not None else None
+        inventory_basedir = self.inventory.basedir()
+        result = {}
+        for basedir in filter(None, {playbook_basedir, inventory_basedir}):
+            module_path = os.path.join(basedir, 'python_vars')
+            sys.path.insert(0, module_path)
+            for group in groups:
+                if not os.path.exists(os.path.join(module_path, '%s.py' % group.name)):
+                    continue
+                vars = __import__(group.name).run(host)
+                result = ansible.utils.combine_vars(result, vars)
+            del sys.path[0]
+
+        return result


### PR DESCRIPTION
I have written and used a vars_plugin which other people might find useful, both as an example as well as a variable plugin for the real world use.

I'm adding a new example plugin which uses python files to add extra variables to the current set of variables. The directory `python_vars` is scanned for python files; only the ones named as the current group are taken into account. Each such file is scanned for the function `run(host)` and its result is merged into the current variable set.

For example, let's assume the current host is in the group `dns`. Then, `python_vars/dns.py` can contain

```
def run(host):
    return {'zones': ['example.com']}
```

and the variable `zones` will be defined as the variable for the current host.
