### PR TITLE
make error message easier to understand and to act upon

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -213,7 +213,7 @@ class Play(object):
                 break
 
         if role_path is None:
-            raise errors.AnsibleError("cannot find role in %s" % " or ".join(possible_paths))
+            raise errors.AnsibleError("cannot find role '%s' in %s" % ( role, " or ".join(possible_paths)))
 
         return (role_path, role_vars)
 


### PR DESCRIPTION
Issue Type:
  Feature Pull Request
Ansible Version:
  ansible 1.7.2
Environment:
  N/A
Summary:
  make error message more helpful and clear
Steps To Reproduce: 
  just use a role inside a playbook that isn't defined yet or has a different or a wrong name
Expected Results:
  I'd like to tell me what role ansible was looking for and didn't find. An error message like this what I'd like to see:

```
ERROR: cannot find role 'postgres' in /home/user/src/clients/company/ansible/hosts/machine/roles/postgres or /home/user/src/clients/company/ansible/hosts/machine/postgres or /home/user/src/clients/company/ansible/roles/postgres
```

Actual Results:
The actual error message I am getting from ansible is:

```
ERROR: cannot find role in /home/user/src/clients/company/ansible/hosts/machine/roles/postgres or /home/user/src/clients/company/ansible/hosts/machine/postgres or /home/user/src/clients/company/ansible/roles/postgres
```

If you are used to seeing this kind of error message, you'll quickly know what's wrong. However as an uninitiated you'll wonder. Therefore I propose to explicitly name the role ansible is looking for.

Thanks
