### PR TITLE
ansible.utils._git_repo_info() now supports branch names with slashes

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -393,16 +393,20 @@ class CLI(object):
                 except (IOError, AttributeError):
                     return ''
             f = open(os.path.join(repo_path, "HEAD"))
-            branch = f.readline().split('/')[-1].rstrip("\n")
+            line = f.readline().rstrip("\n")
+            if line.startswith("ref:"):
+                branch_path = os.path.join(repo_path, line[5:])
+            else:
+                branch_path = None
             f.close()
-            branch_path = os.path.join(repo_path, "refs", "heads", branch)
-            if os.path.exists(branch_path):
+            if branch_path and os.path.exists(branch_path):
+                branch = '/'.join(line.split('/')[2:])
                 f = open(branch_path)
                 commit = f.readline()[:10]
                 f.close()
             else:
                 # detached HEAD
-                commit = branch[:10]
+                commit = line[:10]
                 branch = 'detached HEAD'
                 branch_path = os.path.join(repo_path, "HEAD")
 


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel 4651155942) last updated 2016/01/22 12:28:13 (GMT +900)
  lib/ansible/modules/core: (detached HEAD 09e2457eb0) last updated 2016/01/22 12:30:10 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD e8427cb32a) last updated 2016/01/22 12:30:10 (GMT +900)
  config file =
  configured module search path = Default w/o overrides
```
##### Environment:

OSX 10.9/10.10
##### Summary:

If your branch name contains a `/`, the branch name is not shown properly.
##### Steps To Reproduce:

`git checkout -b test/git-repo-info-branch`
##### Expected Results:

```
$ ansible --version
ansible 2.1.0 (fixes/git-repo-info-branch 3b71710827) last updated 2016/01/22 12:32:15 (GMT +900)
...
```
##### Actual Results:

```
$ ansible --version
ansible 2.1.0 (detached HEAD git-repo-i) last updated 2016/01/22 12:29:41 (GMT +900)
...
```
