### PR TITLE
Augment sys.path to find modules relative to bin/ansible

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -22,6 +22,11 @@
 import os
 import sys
 
+# Augment sys.path (PYTHONPATH) to find Python modules relative to the
+# executed python script.  This is so that we can find the modules when
+# running from a local checkout.
+sys.path.append(os.path.join(os.path.dirname(sys.argv[0]), '..', 'lib'))
+
 from ansible.runner import Runner
 import ansible.constants as C
 from ansible import utils


### PR DESCRIPTION
This avoids the need to source hacking/env-setup when using bin/ansible
from a local git repository clone of the ansible repository.

A similar but slightly different augmentation already exists in bin/ansible-playbook.
