### PR TITLE
Variables lookup in a template should handle properly the undefined case

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -93,6 +93,8 @@ def lookup(name, *args, **kwargs):
             ran = instance.run(*args, inject=tvars, **kwargs)
         except errors.AnsibleError:
             raise
+        except jinja2.exceptions.UndefinedError, e:
+            raise errors.AnsibleUndefinedVariable("One or more undefined variables: %s" % str(e))
         except Exception, e:
             raise errors.AnsibleError('Unexpected error in during lookup: %s' % e)
         if ran:


### PR DESCRIPTION
Hi,

If I create a role that is only doing this action :

``` ansible
  - authorized_key: user=deploy key="{{ lookup('file', item) }}"
    with_fileglob:
    - ../keys/*
```

I end up with the following error: `ERROR: Unexpected error in during lookup: 'item' is undefined`.

With the provided patch, Ansible is successfully executing the role.
I'm not familiar with the code base, let me know if there is a better solution to this issue.

Thanks
