### PR TITLE
Add LVM facts to setup module

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -580,6 +580,7 @@ class LinuxHardware(Hardware):
         self.get_memory_facts()
         self.get_dmi_facts()
         self.get_device_facts()
+        self.get_lvm_facts()
         try:
             self.get_mount_facts()
         except TimeoutError:
@@ -835,6 +836,36 @@ class LinuxHardware(Hardware):
                         d['holders'].append(folder)
 
             self.facts['devices'][diskname] = d
+
+    def get_lvm_facts(self):
+        """ Get LVM Facts if running as root and lvm utils are available """
+
+        if os.getuid() == 0 and module.get_bin_path('vgs'):
+            lvm_util_options = '--noheadings --nosuffix --units g'
+
+            #vgs fields: VG #PV #LV #SN Attr VSize VFree
+            vgs={}
+            rc, vg_lines, err = module.run_command(
+                'vgs %s' % lvm_util_options)
+            for vg_line in vg_lines.splitlines():
+                items = vg_line.split()
+                vgs[items[0]] = {'size_g':items[-2],
+                                 'free_g':items[-1],
+                                 'num_lvs': items[2],
+                                 'num_pvs': items[1]}
+
+            #lvs fields:
+            #LV VG Attr LSize Pool Origin Data% Move Log Copy% Convert
+            lvs = {}
+            rc, lv_lines, err = module.run_command(
+                'lvs %s' % lvm_util_options)
+            for lv_line in lv_lines.splitlines():
+                items = lv_line.split()
+                lvs[items[0]] = {'size_g': items[3],
+                                 'vg': items[1]}
+
+            self.facts['lvm'] = {'lvs': lvs,
+                                 'vgs': vgs}
 
 
 class SunOSHardware(Hardware):


### PR DESCRIPTION
##### Issue Type: Feature Pull Request
##### Ansible Version: Devel
##### Environment: Linux
##### Summary: Gather LVM facts in setup module

This commit adds LinuxHardware.get_device_facts() and calls that from
.populate().

LVM facts are only gathered if the setup module is running as root and
the lvm utilities are available (tested by searching for 'vgs').

If the conditions are met, facts are set for each volume group and
logical volume.

Example:

Test LVM Data:

```
$ sudo vgs
  VG   #PV #LV #SN Attr   VSize VFree
  test   1   2   0 wz--n- 5.00g 2.00g
$ sudo lvs
  LV      VG   Attr      LSize Pool Origin Data%  Move Log Copy%  Convert
  testlv  test -wi-a---- 1.00g
  testlv2 test -wi-a---- 2.00g
```

Facts Returned:

```
$ ansible localhost -i /tmp/inv -m setup -a 'filter=ansible_lvm'
localhost | success >> {
    "ansible_facts": {
        "ansible_lvm": {
            "lvs": {
                "testlv": {
                    "size_g": "1.00",
                    "vg": "test"
                },
                "testlv2": {
                    "size_g": "2.00",
                    "vg": "test"
                }
            },
            "vgs": {
                "test": {
                    "free_g": "2.00",
                    "num_lvs": "2",
                    "num_pvs": "1",
                    "size_g": "5.00"
                }
            }
        }
    },
    "changed": false
}
```

Test as non-root:

```
$ ansible localhost -i /tmp/inv-user -m setup -a 'filter=ansible_lvm'
localhost | success >> {
    "ansible_facts": {},
    "changed": false
}
```

Test without lvm utilities available

```
$ sudo mv /sbin/vgs{,.bk}
$ ansible localhost -i /tmp/inv -m setup -a 'filter=ansible_lvm'
localhost | success >> {
    "ansible_facts": {},
    "changed": false
}
```
