### PR TITLE
added retry-file command line option

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -93,7 +93,7 @@ def main(args):
         help="run handlers even if a task fails")
     parser.add_option('--flush-cache', dest='flush_cache', action='store_true',
         help="clear the fact cache")
-
+    parser.add_option('-r', '--retry-file', dest='retry_file', help="retry filename for failed hosts")
     options, args = parser.parse_args(args)
 
     if len(args) == 0:
@@ -198,7 +198,8 @@ def main(args):
             su_pass=su_pass,
             su_user=options.su_user,
             vault_password=vault_pass,
-            force_handlers=options.force_handlers
+            force_handlers=options.force_handlers,
+            retry_file=options.retry_file
         )
 
         if options.flush_cache:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -81,6 +81,7 @@ class PlayBook(object):
         su_pass          = False,
         vault_password   = False,
         force_handlers   = False,
+        retry_file       = None,
     ):
 
         """
@@ -102,6 +103,7 @@ class PlayBook(object):
         check:            don't change anything, just try to detect some potential changes
         any_errors_fatal: terminate the entire execution immediately when one of the hosts has failed
         force_handlers:   continue to notify and run handlers even if a task fails
+        retry_file:       filename of the retry file for failed hosts
         """
 
         self.SETUP_CACHE = SETUP_CACHE
@@ -152,6 +154,7 @@ class PlayBook(object):
         self.su_pass          = su_pass
         self.vault_password   = vault_password
         self.force_handlers   = force_handlers
+        self.retry_file       = retry_file
 
         self.callbacks.playbook = self
         self.runner_callbacks.playbook = self
@@ -643,10 +646,13 @@ class PlayBook(object):
         buf = StringIO.StringIO()
         for x in replay_hosts:
             buf.write("%s\n" % x)
-        basedir = self.inventory.basedir()
-        filename = "%s.retry" % os.path.basename(self.filename)
-        filename = filename.replace(".yml","")
-        filename = os.path.join(os.path.expandvars('$HOME/'), filename)
+        if self.retry_file is None:
+            basedir = self.inventory.basedir()
+            filename = "%s.retry" % os.path.basename(self.filename)
+            filename = filename.replace(".yml","")
+            filename = os.path.join(os.path.expandvars('$HOME/'), filename)
+        else:
+            filename = self.retry_file
 
         try:
             fd = open(filename, 'w')


### PR DESCRIPTION
In some cases I need to run  the same playbook with differnet options. In ths case the retry file is overrited.

I added option to specify custom retry file, if not specified, the default is used.

Not I'm able to run these playbook paralel

```
ansible-playbook playbook1.yml -e "var1=val1" -r playbook1_val1.retry -l@playbook1_val1.retry
ansible-playbook playbook1.yml -e "var1=val2" -r playbook1_val2.retry -l@playbook1_val2.retry
```
