### PR TITLE
Fixes #302 - Copy fails when source file is identical to the destination...

### DIFF
--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -270,7 +270,10 @@ class ActionModule(object):
                     # self.runner._remove_tmp_path(conn, tmp_path)
                     continue
 
-                tmp_src = tmp_path + source_rel
+                if tmp_path:
+                    tmp_src = tmp_path + source_rel
+                else:
+                    tmp_src = source_full
 
                 # Build temporary module_args.
                 new_module_args = dict(


### PR DESCRIPTION
... and destination is a hard link.
