### PR TITLE
Fix: Add support for SSL protocol version configuration option

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -212,3 +212,12 @@ accelerate_daemon_timeout = 30
 # is "no".
 #accelerate_multi_key = yes
 
+[ssl]
+# SSL/TLS Protocol
+# Configure the default protocol strength of any SSL/TLS connections
+# made by Ansible.  Valid values are
+#  SSLv2  - 0
+#  SSLv3  - 1
+#  SSLv23 - 2
+#  TLSv1  - 3
+ssl_protocol = 3

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -166,6 +166,7 @@ ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'AN
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
+SSL_PROTOCOL                   = get_config(p, 'ssl', 'ssl_protocol', 'SSL_PROTOCOL', 3, integer=True)
 # obsolete -- will be formally removed in 1.6
 ZEROMQ_PORT                    = get_config(p, 'fireball_connection', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099, integer=True)
 ACCELERATE_PORT                = get_config(p, 'accelerate', 'accelerate_port', 'ACCELERATE_PORT', 5099, integer=True)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -55,7 +55,7 @@ import os
 import re
 import socket
 import tempfile
-
+from ansible import constants as C
 
 # This is a dummy cacert provided for Mac OS since you need at least 1
 # ca cert, regardless of validity, for Python on Mac OS to use the
@@ -91,7 +91,7 @@ class CustomHTTPSConnection(httplib.HTTPSConnection):
         if self._tunnel_host:
             self.sock = sock
             self._tunnel()
-        self.sock = ssl.wrap_socket(sock, keyfile=self.key_file, certfile=self.cert_file, ssl_version=ssl.PROTOCOL_TLSv1)
+        self.sock = ssl.wrap_socket(sock, keyfile=self.key_file, certfile=self.cert_file, ssl_version=C.SSL_PROTOCOL)
 
 class CustomHTTPSHandler(urllib2.HTTPSHandler):
 
@@ -268,12 +268,12 @@ class SSLValidationHandler(urllib2.BaseHandler):
                     s.sendall('\r\n')
                     connect_result = s.recv(4096)
                     self.validate_proxy_response(connect_result)
-                    ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED)
+                    ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=C.SSL_PROTOCOL)
                 else:
                     self.module.fail_json(msg='Unsupported proxy scheme: %s. Currently ansible only supports HTTP proxies.' % proxy_parts.get('scheme'))
             else:
                 s.connect((self.hostname, self.port))
-                ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED)
+                ssl_s = ssl.wrap_socket(s, ca_certs=tmp_ca_cert_path, cert_reqs=ssl.CERT_REQUIRED, ssl_version=C.SSL_PROTOCOL)
             # close the ssl connection
             #ssl_s.unwrap()
             s.close()

--- a/v2/ansible/constants.py
+++ b/v2/ansible/constants.py
@@ -172,6 +172,7 @@ ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'AN
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
+SSL_PROTOCOL                   = get_config(p, 'ssl', 'ssl_protocol', 'SSL_PROTOCOL', 3, integer=True)
 # obsolete -- will be formally removed in 1.6
 ZEROMQ_PORT                    = get_config(p, 'fireball_connection', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099, integer=True)
 ACCELERATE_PORT                = get_config(p, 'accelerate', 'accelerate_port', 'ACCELERATE_PORT', 5099, integer=True)


### PR DESCRIPTION
Hello, I am re-submitting this request for @bcoca.  This fix allows you to set the SSL protocol version in the ansible.cfg file.  It also fixes a couple of places where Ansible was not setting the SSL protocol version properly for URL calls.  So connecting to a host where only TLSv1 was supported would not work.
