### PR TITLE
Do not use the variable name as a key for the result of the module

### DIFF
--- a/lib/ansible/runner/action_plugins/debug.py
+++ b/lib/ansible/runner/action_plugins/debug.py
@@ -52,7 +52,7 @@ class ActionModule(object):
                 result = dict(msg=args['msg'])
         elif 'var' in args and not utils.LOOKUP_REGEX.search(args['var']):
             results = template.template(self.basedir, args['var'], inject, convert_bare=True)
-            result[args['var']] = results
+            result['var'] = { args['var']: results }
 
         # force flag to make debug output module always verbose
         result['verbose_always'] = True


### PR DESCRIPTION
Using the variable name can interfere with various systems
used to communicate between modules and ansible ( as
reported in #7732 , where ansible_facts is a reserved key for
updating the fact cache, for example ).
