### PR TITLE
Fixed error handling for the enabling of PS Remoting

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -98,13 +98,7 @@ ElseIf ((Get-Service "WinRM").Status -ne "Running")
 If (!(Get-PSSessionConfiguration -Verbose:$false) -or (!(Get-ChildItem WSMan:\localhost\Listener)))
 {
     Write-Verbose "Enabling PS Remoting."
-    Try
-    {
-        Enable-PSRemoting -Force -ErrorAction SilentlyContinue
-    }
-    Catch
-    {
-    }
+    Enable-PSRemoting -Force -ErrorAction Stop
 }
 Else
 {


### PR DESCRIPTION
Power Shell Remoting will throw an exception if you attempt to enable it while one of your network interfaces is set to "public". Currently this error is hidden and the script continues to execute until it attempts to test PS Remoting to localhost. At that point the code fails with the following error:

"Unable to establish an HTTP or HTTPS remoting session."

This happens because PS Remoting didn't start. In actual fact the error that should have been thrown was the one that occurred when an attempt was made to enable PS Remoting.

I have removed the try/catch and set the ErrorAction to Stop so that the script doesn't continue and the correct error is displayed. It will also now be clear why the script failed and how to rectify the problem.
