### PR TITLE
Allow ec2 tags to be used to address servers in ec2 dynamic inventory.

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -24,14 +24,17 @@ regions_exclude = us-gov-west-1,cn-north-1
 # This is the normal destination variable to use. If you are running Ansible
 # from outside EC2, then 'public_dns_name' makes the most sense. If you are
 # running Ansible from within EC2, then perhaps you want to use the internal
-# address, and should set this to 'private_dns_name'.
+# address, and should set this to 'private_dns_name'. The key of an EC2 tag
+# may optionally be used; however the boto instance variables hold precedence
+# in the event of a collision.
 destination_variable = public_dns_name
 
 # For server inside a VPC, using DNS names may not make sense. When an instance
 # has 'subnet_id' set, this variable is used. If the subnet is public, setting
 # this to 'ip_address' will return the public IP address. For instances in a
 # private subnet, this should be set to 'private_ip_address', and Ansible must
-# be run from with EC2.
+# be run from with EC2. The key of an EC2 tag may optionally be used; however
+# the boto instance variables hold precedence in the event of a collision.
 vpc_destination_variable = ip_address
 
 # To tag instances on EC2 with the resource records that point to them from

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -385,9 +385,13 @@ class Ec2Inventory(object):
 
         # Select the best destination address
         if instance.subnet_id:
-            dest = getattr(instance, self.vpc_destination_variable)
+            dest = getattr(instance, self.vpc_destination_variable, None)
+            if dest is None:
+                dest = getattr(instance, 'tags').get(self.vpc_destination_variable, None)
         else:
-            dest =  getattr(instance, self.destination_variable)
+            dest = getattr(instance, self.destination_variable, None)
+            if dest is None:
+                dest = getattr(instance, 'tags').get(self.destination_variable, None)
 
         if not dest:
             # Skip instances we cannot address (e.g. private VPC subnet)


### PR DESCRIPTION
My use case for this PR is addressing instances using domain names separate from EC2's public and private dns names. The PR is completely backward-compatible.
