### PR TITLE
Fix vars_prompt no/false default values

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -672,7 +672,7 @@ class PlaybookCallbacks(object):
             result = prompt(msg, private)
 
         # if result is false and default is not None
-        if not result and default:
+        if not result and default is not None:
             result = default
 
 


### PR DESCRIPTION
**Issue Type:** Bug report

**Ansible Version:** 1.8.2

**Environment:** N/A

**Summary:** `no` and `false` default values in `vars_prompt` become `""`

**Steps to Reproduce:** 

```

---
- name: Default values of prompts
  hosts: localhost
  gather_facts: no
  vars_prompt:
    - name: no_val_from_prompt
      prompt: Test default boolean value - press enter
      default: no
      private: no
  tasks:
    - debug: var=no_val_from_prompt
```

**Expected Results:**

```
ok: [localhost] => {
    "no_val_from_prompt": "False"
}
```

**Actual Results:**

```
ok: [localhost] => {
    "no_val_from_prompt": ""
}
```
