### PR TITLE
Support variable values with dashes

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -269,7 +269,7 @@ def check_conditional(conditional, basedir, inject, fail_on_undefined=False):
 
     conditional = conditional.replace("jinja2_compare ","")
     # allow variable names
-    if conditional in inject and '-' not in str(inject[conditional]):
+    if conditional in inject:
         conditional = inject[conditional]
     conditional = template.template(basedir, conditional, inject, fail_on_undefined=fail_on_undefined)
     original = str(conditional).replace("jinja2_compare ","")


### PR DESCRIPTION
Undoes 35d138a since it's not needed anymore. Playbook that tests the original bug and the new dashes bug:

```
- name: Test play
  hosts: localhost
  vars:
    with_dash: "a-value-with-dashes"
    with_dash_and_number: "some-host-name-10"
  tasks:
    - debug: msg="with_dash"
      when: with_dash
    - debug: msg="with_dash_and_number"
      when: with_dash_and_number
```
