### PR TITLE
Memfacts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -571,6 +571,8 @@ class LinuxHardware(Hardware):
 
     platform = 'Linux'
     MEMORY_FACTS = ['MemTotal', 'SwapTotal', 'MemFree', 'SwapFree']
+    EXTRA_MEMORY_FACTS = ['Buffers', 'Cached', 'SwapCached']
+
 
     def __init__(self):
         Hardware.__init__(self)
@@ -587,6 +589,7 @@ class LinuxHardware(Hardware):
         return self.facts
 
     def get_memory_facts(self):
+        memstats = {}
         if not os.access("/proc/meminfo", os.R_OK):
             return
         for line in open("/proc/meminfo").readlines():
@@ -595,6 +598,26 @@ class LinuxHardware(Hardware):
             if key in LinuxHardware.MEMORY_FACTS:
                 val = data[1].strip().split(' ')[0]
                 self.facts["%s_mb" % key.lower()] = long(val) / 1024
+            if key in LinuxHardware.MEMORY_FACTS or key in LinuxHardware.EXTRA_MEMORY_FACTS:
+                 val = data[1].strip().split(' ')[0]
+                 memstats[key.lower()] = long(val) / 1024
+        self.facts['memory_mb'] = {
+                     'real' : {
+                         'total': memstats['memtotal'],
+                         'used': (memstats['memtotal'] - memstats['memfree']),
+                         'free': memstats['memfree']
+                     },
+                     'nocache' : {
+                         'free': memstats['cached'] + memstats['memfree'] + memstats['buffers'],
+                         'used': memstats['memtotal'] - (memstats['cached'] + memstats['memfree'] + memstats['buffers'])
+                     },
+                     'swap' : {
+                         'total': memstats['swaptotal'],
+                         'free': memstats['swapfree'],
+                         'used': memstats['swaptotal'] - memstats['swapfree'],
+                         'cached': memstats['swapcached']
+                     }
+                 }
 
     def get_cpu_facts(self):
         i = 0


### PR DESCRIPTION
As opened originally in #9766 this is the same thing just in it's own branch (as it should have been from the start) to avoid pr conflicts. Original text below:

This fixes problem originally discussed here: https://github.com/ansible/ansible/issues/8035

As discussed in the issue tracker the output now looks like the following:

```
        "ansible_memory": {
            "nocache": {
                "free": 395,
                "used": 197
            },
            "real": {
                "free": 37,
                "total": 592,
                "used": 555
            },
            "swap": {
                "cached": 0,
                "free": 2047,
                "total": 2047,
                "used": 0
            }
        }
```

And it includes the old top-level facts to preserve backwards compatibility.
