### PR TITLE
Add pciid to LinuxNetwork interface fact

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1602,6 +1602,8 @@ class LinuxNetwork(Network):
                     path = os.path.join(path, 'bonding', 'all_slaves_active')
                     if os.path.exists(path):
                         interfaces[device]['all_slaves_active'] = open(path).read() == '1'
+            if os.path.exists(os.path.join(path,'device')):
+                interfaces[device]['pciid'] = os.path.basename(os.readlink(os.path.join(path,'device')))
 
             # Check whether an interface is in promiscuous mode
             if os.path.exists(os.path.join(path,'flags')):


### PR DESCRIPTION
##### Issue Type: Feature Pull Request
##### Ansible Version: Devel
##### Environment: Linux
##### Summary: Add pciid to the LinuxNetwork fact object

This commit adds pciid to the LinuxNetwork fact object.

pciid is gathered if the symlink /sys/class/net/*/device exists.

Example [>>>> emphasis <<<<]:

```
$ readlink /sys/class/net/eth0/device
../../../0000:01:00.0
```

```
$ ansible localhost --ask-pass -i /tmp/hosts -m setup -a "filter=ansible_eth0"
SSH password:
localhost | success >> {
    "ansible_facts": {
        "ansible_eth0": {
            "active": false,
            "device": "eth0",
            "macaddress": "0c:d2:92:5d:6e:8e",
            "module": "alx",
            "mtu": 1500,
       >>>> "pciid": "0000:01:00.0", <<<<
            "promisc": true,
            "type": "ether"
        }
    },
    "changed": false
}
```
