### PR TITLE
Add a explicit error when fact_caching_connection is not set

### DIFF
--- a/lib/ansible/cache/jsonfile.py
+++ b/lib/ansible/cache/jsonfile.py
@@ -34,6 +34,8 @@ class CacheModule(BaseCacheModule):
         self._timeout = float(C.CACHE_PLUGIN_TIMEOUT)
         self._cache = {}
         self._cache_dir = C.CACHE_PLUGIN_CONNECTION # expects a dir path
+        if not self._cache_dir:
+            utils.exit("error, fact_caching_connection is not set, cannot use fact cache")
 
         if not os.path.exists(self._cache_dir):
             try:


### PR DESCRIPTION
By default, jsonfile is not documented, and the error message
when fact_caching_connection is not set is a bit puzzling, so
a error message would be beeter ( documentation too ). While redis
is faster for bigger setup, jsonfile is fine for a small setup
and is easier to deploy.

The module will then stop ansible-playbook, as this match better
the philosophy of Ansible being a fail-fast system.
