### PR TITLE
Display Cyan error message instead of Red when ignoring errors.

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -80,13 +80,13 @@ def log_lockfile():
     uid = os.getuid()
     path = os.path.join(tempdir, ".ansible-lock.%s" % uid)
     lockfile = open(path, 'w')
-    # use fcntl to set FD_CLOEXEC on the file descriptor, 
+    # use fcntl to set FD_CLOEXEC on the file descriptor,
     # so that we don't leak the file descriptor later
     lockfile_fd = lockfile.fileno()
     old_flags = fcntl.fcntl(lockfile_fd, fcntl.F_GETFD)
     fcntl.fcntl(lockfile_fd, fcntl.F_SETFD, old_flags | fcntl.FD_CLOEXEC)
     return lockfile
-    
+
 LOG_LOCK = log_lockfile()
 
 def log_flock(runner):
@@ -483,7 +483,9 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
             msg = "failed: [%s] => (item=%s) => %s" % (host, item, utils.jsonify(results2))
         else:
             msg = "failed: [%s] => %s" % (host, utils.jsonify(results2))
-        display(msg, color='red', runner=self.runner)
+        # Display Cyan error message instead of Red when ignoring errors
+        color = 'cyan' if ignore_errors else 'red'
+        display(msg, color=color, runner=self.runner)
 
         if stderr:
             display("stderr: %s" % stderr, color='red', runner=self.runner)


### PR DESCRIPTION
Some tasks are designed to fail under certain conditions and the play should continue as described here:
http://docs.ansible.com/playbooks_error_handling.html

Ansible provides the 'ignore_errors' field you can set to 'yes'. The problem is that Ansible currently still displays a Red error message in this case, which is visually distracting and causes the impression to a casual observer that something went wrong. This change in the on_failed() callback checks if ignore_errors is True and if so displays the error message in Cyan, which is the color of the 'ignoring...' message.
