### PR TITLE
cache json fixes

### DIFF
--- a/lib/ansible/cache/jsonfile.py
+++ b/lib/ansible/cache/jsonfile.py
@@ -17,13 +17,11 @@
 
 import os
 import time
-import json
 import errno
 
 from ansible import constants as C
 from ansible import utils
 from ansible.cache.base import BaseCacheModule
-
 
 class CacheModule(BaseCacheModule):
     """
@@ -70,12 +68,11 @@ class CacheModule(BaseCacheModule):
 
         cachefile = "%s/%s" % (self._cache_dir, key)
         try:
-            #TODO: check if valid keys can have invalid FS chars, base32?
             f = open(cachefile, 'w')
         except (OSError,IOError), e:
             utils.warning("error while trying to read %s : %s" % (cachefile, str(e)))
         else:
-            json.dump(value, f, ensure_ascii=False)
+            f.write(utils.jsonify(value))
         finally:
             f.close()
 

--- a/lib/ansible/cache/redis.py
+++ b/lib/ansible/cache/redis.py
@@ -20,9 +20,9 @@ import collections
 # FIXME: can we store these as something else before we ship it?
 import sys
 import time
-import json
 
 from ansible import constants as C
+from ansible.utils import jsonify
 from ansible.cache.base import BaseCacheModule
 
 try:
@@ -65,7 +65,7 @@ class CacheModule(BaseCacheModule):
         return json.loads(value)
 
     def set(self, key, value):
-        value2 = json.dumps(value)
+        value2 = jsonify(value)
         if self._timeout > 0: # a timeout of 0 is handled as meaning 'never expire'
             self._cache.setex(self._make_key(key), int(self._timeout), value2)
         else:


### PR DESCRIPTION
now uses utils.jsonify which does proper utf8 encoding
removed unneeded and possibly error producing json import

this should fix #9700
