### PR TITLE
Handle quoting of values in dict parameters

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1070,7 +1070,32 @@ class AnsibleModule(object):
                         raise TypeError('unable to evaluate string as dictionary')
                     return result
             elif '=' in value:
-                return dict([x.strip().split("=", 1) for x in value.split(",")])
+                fields = []
+                field_buffer = []
+                in_quote = False
+                in_escape = False
+                for c in value.strip():
+                    if in_escape:
+                        field_buffer.append(c)
+                        in_escape = False
+                    elif c == '\\':
+                        in_escape = True
+                    elif not in_quote and c in ('\'', '"'):
+                        in_quote = c
+                    elif in_quote and in_quote == c:
+                        in_quote = False
+                    elif not in_quote and c in (',', ' '):
+                        field = ''.join(field_buffer)
+                        if field:
+                            fields.append(field)
+                        field_buffer = []
+                    else:
+                        field_buffer.append(c)
+
+                field = ''.join(field_buffer)
+                if field:
+                    fields.append(field)
+                return dict(x.split("=", 1) for x in fields)
             else:
                 raise TypeError("dictionary requested, could not parse JSON or key=value")
 


### PR DESCRIPTION
In https://github.com/ansible/ansible-modules-core/issues/543 the user is trying to set a dictionary parameter via a string (non-complex args syntax).  This is failing because the value contains a comma inside of quotes and the naive parsing of the parameter thinks that the comma is a dictionary field separator.

This will fix that.  As a side effect it also allows space to be a separator, not just comma.  For example the new code should do this:

```
in a playbook:
ex_dictionary: a='test' b='test,test_b',c='foo bar',    d='yep, "this" too'
==>
inside the module:
ex_dictionary == {'a': 'test', 'b': 'test,test_b', 'c': 'foo bar', 'd': 'yep, "this" too'}
```
