### PR TITLE
Let module params to have default values taken from another module param

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -977,12 +977,19 @@ class AnsibleModule(object):
             default = v.get('default', None)
             if pre == True:
                 # this prevents setting defaults on required items
-                if default is not None and k not in self.params:
+                if default is not None and k not in self.params and default not in self.argument_spec:
                     self.params[k] = default
             else:
                 # make sure things without a default still get set None
-                if k not in self.params:
+                if k not in self.params and default not in self.argument_spec:
                     self.params[k] = default
+
+        # now we fill all defaults whose default values are set to be same as some other module var
+        if pre == False:
+            for (k,v) in self.argument_spec.iteritems():
+                default = v.get('default', None)
+                if default in self.argument_spec and k not in self.params:
+                    self.params[k] = self.params[default]
 
     def _load_params(self):
         ''' read the input and return a dictionary and the arguments string '''


### PR DESCRIPTION
This makes it possible to gradually introduce some new variables to a module
without breaking it for older clients.

Good example is file stat "get_md5" (older) and "get_checksum" (newer)
variables, with this patch it is possible to set "get_checksum" to have
default value of "get_md5".

It allows to introduce new variables more gradually without breaking runtime
characteristics for existing playbooks when running using newer version of ansible
(if somebody disalbed get_md5 then obviously they don't want to do get_checksum too)

To enable new behaviour just set default value for module param to a string equal to some other param for the same module, like:

```
    module = AnsibleModule(
        argument_spec = dict(
            path = dict(required=True),
            follow = dict(default='no', type='bool'),
            get_md5 = dict(default='yes', type='bool'),
            get_checksum = dict(default='get_md5', type='bool')  #<< HERE
        ),
        supports_check_mode = True
    )
```
