### PR TITLE
Use send instead of sendv on the systemd.journal (fixes #9886)

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1104,12 +1104,11 @@ class AnsibleModule(object):
             msg = msg.encode('utf-8')
 
         if (has_journal):
-            journal_args = ["MESSAGE=%s %s" % (module, msg)]
-            journal_args.append("MODULE=%s" % os.path.basename(__file__))
+            journal_args = [("MODULE", os.path.basename(__file__))]
             for arg in log_args:
-                journal_args.append(arg.upper() + "=" + str(log_args[arg]))
+                journal_args.append((arg.upper(), str(log_args[arg])))
             try:
-                journal.sendv(*journal_args)
+                journal.send("%s %s" % (module, msg), **dict(journal_args))
             except IOError, e:
                 # fall back to syslog since logging to journal failed
                 syslog.openlog(str(module), 0, syslog.LOG_USER)


### PR DESCRIPTION
On `systemd-216-13.fc21` with `ansible-1.8.2-1.fc21` the simple example from #9886 is triggering journald assertions. For some reason the ansible module arguments being passed into `journal.sendv` are causing the problem, but passing them into `journal.send` as keyword arguments seems to work around the issue.
