### PR TITLE
Cloud Modules STS Support Redux

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -54,7 +54,7 @@ def aws_common_argument_spec():
         aws_secret_key=dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True),
         aws_access_key=dict(aliases=['ec2_access_key', 'access_key']),
         validate_certs=dict(default=True, type='bool'),
-        security_token=dict(no_log=True),
+        security_token=dict(aliases=['access_token'], no_log=True),
         profile=dict(),
     )
 
@@ -87,38 +87,38 @@ def get_aws_connection_info(module):
     validate_certs = module.params.get('validate_certs')
 
     if not ec2_url:
-        if 'EC2_URL' in os.environ:
-            ec2_url = os.environ['EC2_URL']
-        elif 'AWS_URL' in os.environ:
+        if 'AWS_URL' in os.environ:
             ec2_url = os.environ['AWS_URL']
+        elif 'EC2_URL' in os.environ:
+            ec2_url = os.environ['EC2_URL']
 
     if not access_key:
-        if 'EC2_ACCESS_KEY' in os.environ:
-            access_key = os.environ['EC2_ACCESS_KEY']
-        elif 'AWS_ACCESS_KEY_ID' in os.environ:
+        if 'AWS_ACCESS_KEY_ID' in os.environ:
             access_key = os.environ['AWS_ACCESS_KEY_ID']
         elif 'AWS_ACCESS_KEY' in os.environ:
             access_key = os.environ['AWS_ACCESS_KEY']
+        elif 'EC2_ACCESS_KEY' in os.environ:
+            access_key = os.environ['EC2_ACCESS_KEY']
         else:
             # in case access_key came in as empty string
             access_key = None
 
     if not secret_key:
-        if 'EC2_SECRET_KEY' in os.environ:
-            secret_key = os.environ['EC2_SECRET_KEY']
-        elif 'AWS_SECRET_ACCESS_KEY' in os.environ:
+        if 'AWS_SECRET_ACCESS_KEY' in os.environ:
             secret_key = os.environ['AWS_SECRET_ACCESS_KEY']
         elif 'AWS_SECRET_KEY' in os.environ:
             secret_key = os.environ['AWS_SECRET_KEY']
+        elif 'EC2_SECRET_KEY' in os.environ:
+            secret_key = os.environ['EC2_SECRET_KEY']
         else:
             # in case secret_key came in as empty string
             secret_key = None
 
     if not region:
-        if 'EC2_REGION' in os.environ:
-            region = os.environ['EC2_REGION']
-        elif 'AWS_REGION' in os.environ:
+        if 'AWS_REGION' in os.environ:
             region = os.environ['AWS_REGION']
+        elif 'EC2_REGION' in os.environ:
+            region = os.environ['EC2_REGION']
         else:
             # boto.config.get returns None if config not found
             region = boto.config.get('Boto', 'aws_region')
@@ -128,6 +128,8 @@ def get_aws_connection_info(module):
     if not security_token:
         if 'AWS_SECURITY_TOKEN' in os.environ:
             security_token = os.environ['AWS_SECURITY_TOKEN']
+        elif 'EC2_SECURITY_TOKEN' in os.environ:
+            security_token = os.environ['EC2_SECURITY_TOKEN']
         else:
             # in case security_token came in as empty string
             security_token = None

--- a/lib/ansible/utils/module_docs_fragments/aws.py
+++ b/lib/ansible/utils/module_docs_fragments/aws.py
@@ -23,22 +23,29 @@ class ModuleDocFragment(object):
 options:
   ec2_url:
     description:
-      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints).  Must be specified if region is not used. If not set then the value of the EC2_URL environment variable, if any, is used
+      - Url to use to connect to EC2 or your Eucalyptus cloud (by default the module will use EC2 endpoints).  Ignored for modules where region is required.  Must be specified for all other modules if region is not used. If not set then the value of the EC2_URL environment variable, if any, is used.
     required: false
     default: null
     aliases: []
   aws_secret_key:
     description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used. 
+      - AWS secret key. If not set then the value of the AWS_SECRET_ACCESS_KEY, AWS_SECRET_KEY, or EC2_SECRET_KEY environment variable is used. 
     required: false
     default: null
     aliases: [ 'ec2_secret_key', 'secret_key' ]
   aws_access_key:
     description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
+      - AWS access key. If not set then the value of the AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY or EC2_ACCESS_KEY environment variable is used.
     required: false
     default: null
     aliases: [ 'ec2_access_key', 'access_key' ]
+  security_token:
+    description:
+      - AWS STS security token. If not set then the value of the AWS_SECURITY_TOKEN or EC2_SECURITY_TOKEN environment variable is used.
+    required: false
+    default: null
+    aliases: [ 'access_token' ]
+    version_added: "1.6"
   validate_certs:
     description:
       - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
@@ -54,23 +61,18 @@ options:
     default: null
     aliases: []
     version_added: "1.6"
-  security_token:
-    description:
-      - security token to authenticate against AWS
-    required: false
-    default: null
-    aliases: []
-    version_added: "1.6"
 requirements:
   - boto
 notes:
-  - The following environment variables can be used C(AWS_ACCESS_KEY) or 
-    C(EC2_ACCESS_KEY) or C(AWS_ACCESS_KEY_ID),
-    C(AWS_SECRET_KEY) or C(EC2_SECRET_KEY) or C(AWS_SECRET_ACCESS_KEY), 
-    C(AWS_REGION) or C(EC2_REGION), C(AWS_SECURITY_TOKEN)
+  - If parameters are not set within the module, the following
+    environment variables can be used in decreasing order of precedence
+    C(AWS_URL) or C(EC2_URL),
+    C(AWS_ACCESS_KEY_ID) or C(AWS_ACCESS_KEY) or C(EC2_ACCESS_KEY),
+    C(AWS_SECRET_ACCESS_KEY) or C(AWS_SECRET_KEY) or C(EC2_SECRET_KEY),
+    C(AWS_SECURITY_TOKEN) or C(EC2_SECURITY_TOKEN),
+    C(AWS_REGION) or C(EC2_REGION)
   - Ansible uses the boto configuration file (typically ~/.boto) if no
     credentials are provided. See http://boto.readthedocs.org/en/latest/boto_config_tut.html 
   - C(AWS_REGION) or C(EC2_REGION) can be typically be used to specify the 
-    AWS region, when required, but
-    this can also be configured in the boto config file
+    AWS region, when required, but this can also be configured in the boto config file
 """


### PR DESCRIPTION
Supersedes https://github.com/ansible/ansible/pull/9889

Add support for AWS Security Token Service (temporary credentials) to all AWS cloud modules.

Rationalize sources and ordering of security credentials for consistency across modules.

Update documentation to use shared doc fragment and consistent usage information across modules.
