### PR TITLE
Fix ansible_distribution facts for Ubuntu 8.4 hardy

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -96,6 +96,7 @@ class Facts(object):
                     ('/etc/os-release', 'SuSE'),
                     ('/etc/gentoo-release', 'Gentoo'),
                     ('/etc/os-release', 'Debian'),
+                    ('/etc/lsb-release', 'Debian'),
                     ('/etc/lsb-release', 'Mandriva') )
     SELINUX_MODE_DICT = { 1: 'enforcing', 0: 'permissive', -1: 'disabled' }
 
@@ -344,8 +345,22 @@ class Facts(object):
                             if 'Debian' in data:
                                 release = re.search("PRETTY_NAME=[^(]+ \(?([^)]+?)\)", data)
                                 if release:
-                                    self.facts['distribution_release'] = release.groups()[0]
-                                break
+                                    self.facts['distribution_version'] = release.groups()[0]
+                                    break
+                            elif self.facts['distribution_release'] == 'NA':
+                                dist_version = re.search('DISTRIB_RELEASE=(.*)', data)
+                                dist_codename = re.search('DISTRIB_CODENAME=(.*)', data)
+                                dist_description = re.search('DISTRIB_DESCRIPTION=(.*)', data)
+                                if dist_version and dist_codename and dist_description:
+                                    version = dist_version.groups()[0].strip('"')
+                                    release = dist_codename.groups()[0].strip('"')
+                                    distribution = dist_description.groups()[0].strip('"').split()[0]
+                                    major_version = version.split('.')[0]
+                                    self.facts['distribution'] = distribution
+                                    self.facts['distribution_version'] = version
+                                    self.facts['distribution_release'] = release
+                                    self.facts['distribution_major_version'] = major_version
+                                    break
                         elif name == 'Mandriva':
                             data = get_file_content(path)
                             if 'Mandriva' in data:


### PR DESCRIPTION
This patch fix `ansible_distribution*` facts running on Ubuntu 8.4 hardy

```
root@hardy64:~# lsb_release  -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 8.04
Release:    8.04
Codename:   hardy

root@hardy64:~# python -V
Python 2.5.2
```
##### ansible all -m setup -a 'filter=ansible_distribution*' (before) :

```
hardy64.dev | success >> {
    "ansible_facts": {
        "ansible_distribution": "Debian",
        "ansible_distribution_major_version": "lenny/sid",
        "ansible_distribution_release": "NA",
        "ansible_distribution_version": "lenny/sid"
    },
    "changed": false
}
```
##### ansible all -m setup -a 'filter=ansible_distribution*' (after) :

```
hardy64.dev | success >> {
    "ansible_facts": {
        "ansible_distribution": "Ubuntu",
        "ansible_distribution_major_version": "8",
        "ansible_distribution_release": "hardy",
        "ansible_distribution_version": "8.04"
    },
    "changed": false
}
```
