### PR TITLE
Add 'route53_replace_names' feature to ec2 dynamic inventory script

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -38,6 +38,13 @@ vpc_destination_variable = ip_address
 # Route53, uncomment and set 'route53' to True.
 route53 = False
 
+# To replace inventory hostname of EC2 instances with their CNAME in the
+# inventory, uncomment and set 'route53_replace_names' to True. This will only
+# have an effect if 'route53' above is set to True. Note that if an instance
+# has multiple CNAMEs, the first returned by the Route53 API is taken. Wildcard
+# aliases like '*.example.com' are ignored.
+route53_replace_names = False
+
 # To exclude RDS instances from the inventory, uncomment and set to False.
 #rds = False
 


### PR DESCRIPTION
##### SUMMARY
This commit adds a 'route53_replace_names' boolean to the inventory script. It aims at replacing the main name of EC2 instances by their first CNAME in Route 53 if any.

As of the implementation, I simply had to move the route53 related stuff up in the `add_instance` method and use the already collected route53 record sets. I think it's fair to avoid wildcard entries, tell me if I'm wrong.

The corresponding ML thread is here: https://groups.google.com/forum/#!topic/ansible-devel/NbidWZo1GgE

As mentionned in the ML, this change is an other option for / completes the following PRs: #7395, #7601, #9825


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
plugins/inventory/ec2.ini
plugins/inventory/ec2.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


