### PR TITLE
fixed facts gathering for strict remote umasks

### DIFF
--- a/v1/ansible/runner/__init__.py
+++ b/v1/ansible/runner/__init__.py
@@ -1282,7 +1282,7 @@ class Runner(object):
 
         tmp_mode = None
         if self.remote_user != 'root' or (self.become and self.become_user != 'root'):
-            tmp_mode = 'a+rx'
+            tmp_mode = 0755
 
         cmd = conn.shell.mkdtemp(basefile, use_system_tmp, tmp_mode)
         result = self._low_level_exec_command(conn, cmd, None, sudoable=False)

--- a/v1/ansible/runner/shell_plugins/sh.py
+++ b/v1/ansible/runner/shell_plugins/sh.py
@@ -61,9 +61,14 @@ class ShellModule(object):
         if system and basetmp.startswith('$HOME'):
             basetmp = self.join_path('/tmp', basefile)
         cmd = 'mkdir -p %s' % basetmp
-        if mode:
-            cmd += ' && chmod %s %s' % (mode, basetmp)
         cmd += ' && echo %s' % basetmp
+
+        # change the umask in a subshell to achieve the desired mode
+        # also for directories created with `mkdir -p`
+        if mode:
+            tmp_umask = 0777 & ~mode
+            cmd = '(umask %o && %s)' % (tmp_umask, cmd)
+
         return cmd
 
     def expand_user(self, user_home_path):


### PR DESCRIPTION
**Changes:**
Instead of calling `chmod` to change the mode for the directory _after_ its creation, the umask is temporarily altered _before_ calling `mkdir` to ensure the parent directories that are possibly created have the desired mode too.

**Detailed explanation:**

If the remote umask is very strict (e.g. 077) the facts gathering fails for non-root users with the following message:

```
/usr/bin/python: can't open file '/tmp/ansible/root/ansible-tmp-…/setup': [Errno 13] Permission denied
```

The reason is the following:
In `lib/ansible/runner/shell_plugins/sh.py` a temporary directory is created with `mkdir -p`.
Subsequently, the desired mode is set with `chmod`.
Possibly created parent directories do not get `chmod`ed and the non-root user won't be able to execute the setup module.
