### PR TITLE
Do not evaluate glob in shell

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -31,9 +31,7 @@ PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 gen_egg_info()
 {
     python setup.py egg_info
-    if [ -e $PREFIX_PYTHONPATH/ansible*.egg-info ] ; then
-        rm -r $PREFIX_PYTHONPATH/ansible*.egg-info
-    fi
+    rm -rf $PREFIX_PYTHONPATH/ansible*.egg-info
     mv ansible*.egg-info $PREFIX_PYTHONPATH
 }
 


### PR DESCRIPTION
I am getting the following error on just cloned repository:

```
~/ansible git:(devel) % source hacking/env-setup
running egg_info
writing requirements to ansible.egg-info/requires.txt
writing ansible.egg-info/PKG-INFO
writing top-level names to ansible.egg-info/top_level.txt
writing dependency_links to ansible.egg-info/dependency_links.txt
reading manifest file 'ansible.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
no previously-included directories found matching 'lib/ansible/modules/core/.git'
no previously-included directories found matching 'lib/ansible/modules/extras/.git'
writing manifest file 'ansible.egg-info/SOURCES.txt'
gen_egg_info:3: no matches found: /Users/akhkharu/ansible/lib/ansible*.egg-info
```
