### PR TITLE
Fix bug in second demo_setup.yml AWS example

### DIFF
--- a/docsite/rst/guide_aws.rst
+++ b/docsite/rst/guide_aws.rst
@@ -104,6 +104,7 @@ From this, we'll use the add_host module to dynamically create a host group cons
                 Name: Demo
              instance_tags:
                 Name: Demo
+          register: ec2
     
        - name: Add all instance public IPs to host group
          add_host: hostname={{ item.public_ip }} groupname=ec2hosts


### PR DESCRIPTION
In the AWS Guide, the second example of the demo_setup.yml did not include the "register: ec2" attribute.
