### PR TITLE
Removed early check for empty inventory

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -167,6 +167,8 @@ def main(args):
 
     inventory = ansible.inventory.Inventory(options.inventory, vault_password=vault_pass)
     inventory.subset(options.subset)
+    if len(inventory.list_hosts()) == 0:
+        utils.warning("provided hosts list is empty")
 
     # run all playbooks specified on the command line
     for playbook in args:

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -167,8 +167,6 @@ def main(args):
 
     inventory = ansible.inventory.Inventory(options.inventory, vault_password=vault_pass)
     inventory.subset(options.subset)
-    if len(inventory.list_hosts()) == 0:
-        raise errors.AnsibleError("provided hosts list is empty")
 
     # run all playbooks specified on the command line
     for playbook in args:


### PR DESCRIPTION
The `ansible-playbook` script throws an error for empty inventory files before creating a playbook object and running its plays.

This is sometimes unwanted since some playbooks may contain only action to be performed on localhost (which is implicit), see #6442 and #9712 .
