### PR TITLE
Indicate roles when listing tasks, resolves #6216

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -254,7 +254,11 @@ def main(args):
                             set(task.tags).intersection(pb.skip_tags)):
                             if getattr(task, 'name', None) is not None:
                                 # meta tasks have no names
-                                print '    %s' % task.name
+                                if task.role_name:
+                                    name = '[%s]  %s' % (task.role_name, task.name)
+                                else:
+                                    name = task.name
+                                print '    %s' % name
                 if options.listhosts or options.listtasks:
                     print ''
             continue


### PR DESCRIPTION
Hello,

here's a tiny patch to indicate roles when listing tasks same way we do while running them.

Regards from Moscow and Happy New Year,
Alex
