### PR TITLE
make a mirror clone rather than a regular clone

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -345,6 +345,9 @@ def scm_archive_role(scm, role_url, role_version, role_name):
         return False
     tempdir = tempfile.mkdtemp()
     clone_cmd = [scm, 'clone', role_url, role_name]
+    if scm == 'git':
+        clone_cmd += ['--mirror']
+
     with open('/dev/null', 'w') as devnull:
         try:
             print "- executing: %s" % " ".join(clone_cmd)


### PR DESCRIPTION
This permit to give a git branch as a version for ansible-galaxy,
which in turn open interesting way of managing the roles in a seamless
fashion.
