### PR TITLE
fixed bad exampel for library that was library_path

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -12,7 +12,7 @@
 # some basic default values...
 
 hostfile       = /etc/ansible/hosts
-# library_path = /usr/share/my_modules/
+#library        = /usr/share/my_modules/
 remote_tmp     = $HOME/.ansible/tmp
 pattern        = *
 forks          = 5


### PR DESCRIPTION
which of course, did not work as config looks for 'library' to construct the path.
