### PR TITLE
Add integration tests for the rax module

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -94,8 +94,7 @@ gce_cleanup:
 	python cleanup_gce.py -y --match="^$(CLOUD_RESOURCE_PREFIX)"
 
 rackspace_cleanup:
-	@echo "FIXME - cleanup_rax.py not yet implemented"
-	@# python cleanup_rax.py -y --match="^$(CLOUD_RESOURCE_PREFIX)"
+	python cleanup_rax.py -y --match="^$(CLOUD_RESOURCE_PREFIX)"
 
 $(CREDENTIALS_FILE):
 	@echo "No credentials file found.  A file named '$(CREDENTIALS_FILE)' is needed to provide credentials needed to run cloud tests.  See sample 'credentials.template' file."

--- a/test/integration/cleanup_rax.py
+++ b/test/integration/cleanup_rax.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+import os
+import yaml
+import argparse
+
+try:
+    import pyrax
+    HAS_PYRAX = True
+except ImportError:
+    HAS_PYRAX = False
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-y', '--yes', action='store_true', dest='assumeyes',
+                        default=False, help="Don't prompt for confirmation")
+    parser.add_argument('--match', dest='match_re',
+                        default='^ansible-testing',
+                        help='Regular expression used to find resources '
+                             '(default: %(default)s)')
+
+    return parser.parse_args()
+
+
+def authenticate():
+    try:
+        with open(os.path.realpath('./credentials.yml')) as f:
+            credentials = yaml.load(f)
+    except Exception as e:
+        raise SystemExit(e)
+
+    try:
+        pyrax.set_credentials(credentials.get('rackspace_username'),
+                              credentials.get('rackspace_api_key'))
+    except Exception as e:
+        raise SystemExit(e)
+
+
+def prompt_and_delete(item, prompt, assumeyes):
+    if not assumeyes:
+        assumeyes = raw_input(prompt).lower() == 'y'
+    assert (hasattr(item, 'delete') or hasattr(item, 'terminate'),
+            "Class <%s> has no delete or terminate attribute" % item.__class__)
+    if assumeyes:
+        if hasattr(item, 'delete'):
+            item.delete()
+            print ("Deleted %s" % item)
+        if hasattr(item, 'terminate'):
+            item.terminate()
+            print ("Terminated %s" % item)
+
+
+def delete_rax(args):
+    """Function for deleting CloudServers"""
+    for region in pyrax.identity.services.compute.regions:
+        cs = pyrax.connect_to_cloudservers(region=region)
+        servers = cs.servers.list(search_opts=dict(name='^%s' % args.match_re))
+        for server in servers:
+            prompt_and_delete(server,
+                              'Delete matching %s? [y/n]: ' % server,
+                              args.assumeyes)
+
+
+def main():
+    if not HAS_PYRAX:
+        raise SystemExit('The pyrax python module is required for this script')
+
+    args = parse_args()
+    authenticate()
+    delete_rax(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/credentials.template
+++ b/test/integration/credentials.template
@@ -1,4 +1,9 @@
 ---
+# Rackspace Credentials
+rackspace_username:
+rackspace_api_key:
+rackspace_region:
+
 # AWS Credentials
 ec2_access_key:
 ec2_secret_key:

--- a/test/integration/rackspace.yml
+++ b/test/integration/rackspace.yml
@@ -1,4 +1,9 @@
-- hosts: testhost
-  gather_facts: True
-  roles: []
-
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  tags:
+    - rackspace
+  roles:
+    - role: test_rax
+      tags: test_rax

--- a/test/integration/roles/test_rax/defaults/main.yml
+++ b/test/integration/roles/test_rax/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+rackspace_region: IAD
+resource_prefix: ansible-testing

--- a/test/integration/roles/test_rax/tasks/main.yml
+++ b/test/integration/roles/test_rax/tasks/main.yml
@@ -1,0 +1,801 @@
+---
+- name: Check for required variables
+  assert:
+    that:
+      - resource_prefix is defined and resource_prefix
+      - rackspace_username is defined and rackspace_username
+      - rackspace_api_key is defined and rackspace_api_key
+      - rackspace_region is defined and rackspace_region
+
+# ============================================================
+- name: Test rax with no args
+  rax:
+  ignore_errors: true
+  register: rax
+
+- name: Validate results of rax with no args
+  assert:
+    that:
+      - rax|failed
+      - rax.msg == 'No credentials supplied!'
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax with credentials
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+  ignore_errors: true
+  register: rax
+
+- name: Validate results of rax with only creds
+  assert:
+    that:
+      - rax|failed
+      - rax.msg.startswith('None is not a valid region')
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax with creds and region
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+  ignore_errors: true
+  register: rax
+
+- name: Validate rax creds and region
+  assert:
+    that:
+      - rax|failed
+      - rax.msg == 'image is required for the "rax" module'
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax with creds, region and image
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+  ignore_errors: true
+  register: rax
+
+- name: Validate rax with creds, region and image
+  assert:
+    that:
+      - rax|failed
+      - rax.msg == 'flavor is required for the "rax" module'
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax with creds, region, image and flavor
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+  ignore_errors: true
+  register: rax
+
+- name: Validate rax with creds, region, image and flavor
+  assert:
+    that:
+      - rax|failed
+      - rax.msg == 'name is required for the "rax" module'
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax with creds, region, image, flavor and name
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-1"
+  register: rax
+
+- name: Validate rax with creds, region, image, flavor and name
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 1
+      - rax.instances[0].name == "{{ resource_prefix }}-1"
+      - rax.instances[0] == rax.success[0]
+      - rax.instances[0].rax_status == 'BUILD'
+
+- name: "Delete integration 1"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-1"
+    state: absent
+    wait: true
+  register: rax
+
+- name: "Validate delete integration 1"
+  assert:
+    that:
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success[0].name == "{{ resource_prefix }}-1"
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax basic idempotency 1
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-2"
+    wait: true
+  register: rax
+
+- name: Validate rax basic idepmpotency 1
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 1
+      - rax.instances[0].name == "{{ resource_prefix }}-2"
+      - rax.instances[0] == rax.success[0]
+      - rax.instances[0].rax_status == 'ACTIVE'
+
+- name: Test rax basic idempotency 2
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-2"
+    wait: true
+  register: rax
+
+- name: Validate rax basic idempotency 2
+  assert:
+    that:
+      - rax|success
+      - not rax|changed
+      - not rax.action
+      - rax.instances|length == 1
+      - rax.instances[0].name == "{{ resource_prefix }}-2"
+      - not rax.success
+
+- name: "Delete integration 2"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-2"
+    state: absent
+    wait: true
+  register: rax
+
+- name: "Validate delete integration 2"
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success[0].name == "{{ resource_prefix }}-2"
+      - rax.success[0].rax_status == "DELETED"
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax basic idempotency with meta 1
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-3"
+    meta:
+      foo: bar
+    wait: true
+  register: rax
+
+- name: Validate rax basic idepmpotency with meta 1
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 1
+      - rax.instances[0].name == "{{ resource_prefix }}-3"
+      - rax.instances[0] == rax.success[0]
+      - rax.instances[0].rax_status == 'ACTIVE'
+      - rax.instances[0].rax_metadata.foo == 'bar'
+
+- name: Test rax basic idempotency with meta 2
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-3"
+    meta:
+      foo: bar
+    wait: true
+  register: rax
+
+- name: Validate rax basic idempotency with meta 2
+  assert:
+    that:
+      - rax|success
+      - not rax|changed
+      - not rax.action
+      - rax.instances|length == 1
+      - rax.instances[0].name == "{{ resource_prefix }}-3"
+      - not rax.success
+
+- name: "Delete integration 3"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-3"
+    state: absent
+    meta:
+      foo: bar
+    wait: true
+  register: rax
+
+- name: "Validate delete integration 3"
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success[0].name == "{{ resource_prefix }}-3"
+      - rax.success[0].rax_status == "DELETED"
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax basic idempotency multi server 1
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-4"
+    count: 2
+    wait: true
+  register: rax
+
+- name: Validate rax basic idepmpotency multi server 1
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 2
+      - rax.instances == rax.success
+
+- name: Test rax basic idempotency multi server 2
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-4"
+    count: 2
+    wait: true
+  register: rax
+
+- name: Validate rax basic idempotency multi server 2
+  assert:
+    that:
+      - rax|success
+      - not rax|changed
+      - not rax.action
+      - rax.instances|length == 2
+      - not rax.success
+
+- name: Test rax basic idempotency multi server 3
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-4"
+    count: 3
+    wait: true
+  register: rax
+
+- name: Validate rax basic idempotency multi server 3
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 3
+      - rax.success|length == 1
+
+- name: "Delete integration 4"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-4"
+    count: 3
+    state: absent
+    wait: true
+  register: rax
+
+- name: "Validate delete integration 4"
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success|length == 3
+      - not rax.instances
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax multi server group without exact_count 1
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-5-%02d"
+    count: 2
+    group: "{{ resource_prefix }}-5"
+    wait: true
+  register: rax
+
+- name: Validate rax multi server group without exact_count 1
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 2
+      - rax.instances == rax.success
+      - rax.instances|map(attribute='rax_name')|unique|length == 2
+
+- name: "Test delete integration 5"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-5-%02d"
+    count: 2
+    group: "{{ resource_prefix }}-5"
+    wait: true
+    state: absent
+  register: rax
+
+- name: "Validate delete integration 5"
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success|length == 2
+      - not rax.instances
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax multi server group without exact_count non-idempotency 1
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-6-%02d"
+    count: 2
+    group: "{{ resource_prefix }}-6"
+    wait: true
+  register: rax
+
+- name: Validate rax multi server group without exact_count non-idempotency 1
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 2
+      - rax.instances == rax.success
+      - rax.instances|map(attribute='rax_name')|unique|length == 2
+
+- name: Test rax multi server group without exact_count non-idempotency 2
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-6-%02d"
+    count: 2
+    group: "{{ resource_prefix }}-6"
+    wait: true
+  register: rax
+
+- name: Validate rax multi server group without exact_count non-idempotency 2
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 4
+      - rax.instances|map(attribute='rax_name')|unique|length == 4
+
+- name: "Test delete integration 6"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-6-%02d"
+    count: 4
+    group: "{{ resource_prefix }}-6"
+    wait: true
+    state: absent
+  register: rax
+
+- name: "Validate delete integration 6"
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success|length == 4
+      - not rax.instances
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax multi server group with exact_count 1
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-7-%02d"
+    count: 2
+    exact_count: true
+    group: "{{ resource_prefix }}-7"
+    wait: true
+  register: rax
+
+- name: Validate rax multi server group with exact_count 1
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 2
+      - rax.instances == rax.success
+      - rax.instances|map(attribute='rax_name')|unique|length == 2
+
+- name: Test rax multi server group with exact_count 2
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-7-%02d"
+    count: 2
+    exact_count: true
+    group: "{{ resource_prefix }}-7"
+    wait: true
+  register: rax
+
+- name: Validate rax multi server group with exact_count 2
+  assert:
+    that:
+      - rax|success
+      - not rax|changed
+      - not rax.action
+      - rax.instances|length == 2
+      - rax.instances|map(attribute='rax_name')|unique|length == 2
+
+- name: Test rax multi server group with exact_count 3
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-7-%02d"
+    count: 4
+    exact_count: true
+    group: "{{ resource_prefix }}-7"
+    wait: true
+  register: rax
+
+- name: Validate rax multi server group with exact_count 3
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 4
+      - rax.success|length == 2
+      - rax.instances|map(attribute='rax_name')|unique|length == 4
+
+
+- name: "Test delete integration 7"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-7-%02d"
+    count: 0
+    exact_count: true
+    group: "{{ resource_prefix }}-7"
+    wait: true
+  register: rax
+
+- name: "Validate delete integration 7"
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success|length == 4
+      - not rax.instances
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax multi server group without exact_count and disabled auto_increment 1
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-8"
+    count: 2
+    group: "{{ resource_prefix }}-8"
+    auto_increment: false
+    wait: true
+  register: rax
+
+- name: Validate rax multi server group without exact_count and disabled auto_increment 1
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 2
+      - rax.instances == rax.success
+      - rax.instances|map(attribute='rax_name')|unique|length == 1
+
+- name: "Test delete integration 8"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-8"
+    count: 2
+    group: "{{ resource_prefix }}-8"
+    auto_increment: false
+    wait: true
+    state: absent
+  register: rax
+
+- name: "Validate delete integration 8"
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success|length == 2
+      - not rax.instances
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax multi server group with exact_count and no printf 1
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-9"
+    count: 2
+    exact_count: true
+    group: "{{ resource_prefix }}-9"
+    wait: true
+  register: rax
+
+- name: Validate rax multi server group with exact_count and no printf 1
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 2
+      - rax.instances == rax.success
+      - rax.instances|map(attribute='rax_name')|unique|list|sort == ['{{ resource_prefix }}-91', '{{ resource_prefix }}-92']
+
+- name: "Test delete integration 9"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-9"
+    count: 0
+    exact_count: true
+    group: "{{ resource_prefix }}-9"
+    wait: true
+  register: rax
+
+- name: "Validate delete integration 9"
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success|length == 2
+      - not rax.instances
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax multi server group with exact_count and offset 1
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-10-%03d"
+    count: 2
+    count_offset: 10
+    exact_count: true
+    group: "{{ resource_prefix }}-10"
+    wait: true
+  register: rax
+
+- name: Validate rax multi server group with exact_count and offset 1
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 2
+      - rax.instances == rax.success
+      - rax.instances|map(attribute='rax_name')|unique|list|sort == ['{{ resource_prefix }}-10-010', '{{ resource_prefix }}-10-011']
+
+- name: "Test delete integration 10"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-10-%03d"
+    count: 0
+    count_offset: 10
+    exact_count: true
+    group: "{{ resource_prefix }}-10"
+    wait: true
+  register: rax
+
+- name: "Validate delete integration 10"
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success|length == 2
+      - not rax.instances
+# ============================================================
+
+
+
+# ============================================================
+- name: Test rax multi server group with exact_count and offset 1
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-10-%03d"
+    count: 2
+    count_offset: 10
+    exact_count: true
+    group: "{{ resource_prefix }}-10"
+    wait: true
+  register: rax
+
+- name: Validate rax multi server group with exact_count and offset 1
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'create'
+      - rax.instances|length == 2
+      - rax.instances == rax.success
+      - rax.instances|map(attribute='rax_name')|unique|list|sort == ['{{ resource_prefix }}-10-010', '{{ resource_prefix }}-10-011']
+
+- name: "Test delete integration 10"
+  rax:
+    username: "{{ rackspace_username }}"
+    api_key: "{{ rackspace_api_key }}"
+    region: "{{ rackspace_region }}"
+    image: ubuntu-1204-lts-precise-pangolin
+    flavor: performance1-1
+    name: "{{ resource_prefix }}-10-%03d"
+    count: 0
+    count_offset: 10
+    exact_count: true
+    group: "{{ resource_prefix }}-10"
+    wait: true
+  register: rax
+
+- name: "Validate delete integration 10"
+  assert:
+    that:
+      - rax|success
+      - rax|changed
+      - rax.action == 'delete'
+      - rax.success|length == 2
+      - not rax.instances
+# ============================================================


### PR DESCRIPTION
This PR includes:
1. A new integration test role (`test_rax`)
2. a new `cleanup_rax.py`

The new integration tests cover the large majority of functionality in the `rax` module.
