### PR TITLE
Add logging of exceptions

### DIFF
--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -22,6 +22,9 @@ from ansible import utils
 from ansible import errors
 from ansible.runner.return_data import ReturnData
 import base64
+import logging
+
+logger = logging.getLogger(__name__)
 
 class ActionModule(object):
 
@@ -87,6 +90,7 @@ class ActionModule(object):
         try:
             resultant = template.template_from_file(self.runner.basedir, source, inject)
         except Exception, e:
+            logger.exception("Template rendering failed")
             result = dict(failed=True, msg=str(e))
             return ReturnData(conn=conn, comm_ok=False, result=result)
 


### PR DESCRIPTION
This PR needs more changes but here is the gist.
This particular change helped me find out that this particular unhelpful error message:
`fatal: [brocken] => {'msg': "TypeError: 'bool' object is not iterable", 'failed': True}`
was not created bad `with_items` statement, nor by a for loop but by some join.
I still don't know which join but it took me two hours to figure out, that it is a join and not some of the other candidates.
There are probably more places where this logging might help but what I'd also propose is a change of the logging configuration.
As long as no `ANSIBLE_LOG_PATH` is defined, logs are just lost. So I'd propose to change the setting so that at least Errors (Exceptions are also Errors) get displayed on stderr by default
