### PR TITLE
Apply template to task (handler) name on initialization.

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -25,7 +25,7 @@ import sys
 class Task(object):
 
     __slots__ = [
-        'name', 'meta', 'action', 'when', 'async_seconds', 'async_poll_interval',
+        'name', 'templated_name', 'meta', 'action', 'when', 'async_seconds', 'async_poll_interval',
         'notify', 'module_name', 'module_args', 'module_vars', 'play_vars', 'play_file_vars', 'role_vars', 'role_params', 'default_vars',
         'play', 'notified_by', 'tags', 'register', 'role_name',
         'delegate_to', 'first_available_file', 'ignore_errors',
@@ -321,3 +321,5 @@ class Task(object):
             if self.when:
                 new_conditions.append(self.when)
             self.when = new_conditions
+
+        self.templated_name = template.template_from_string(play.basedir, self.name, self.module_vars)


### PR DESCRIPTION
Apply template to task (handler) name on initialization. Saves lots of time when having tens of handlers. It saves hundreds of calls to template().
