### PR TITLE
Add stdout_lines to results when using with_items

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -817,6 +817,10 @@ class Runner(object):
                      port,
                      complex_args=complex_args
                 )
+
+                if 'stdout' in result.result and 'stdout_lines' not in result.result:
+                    result.result['stdout_lines'] = result.result['stdout'].splitlines()
+
                 results.append(result.result)
                 if result.comm_ok == False:
                     all_comm_ok = False


### PR DESCRIPTION
Issue Type:

The `stdout_lines` field of a result object created in #1058 does not appear on registered variables created in a `with_items` loop.

Ansible Version:

``` bash
$ ansible --version
ansible 1.9 (stdout_lines 682b987567) last updated 2015/01/13 13:36:56 (GMT -500)
  lib/ansible/modules/core: (detached HEAD 8c8be0e48c) last updated 2015/01/13 13:25:34 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD ffa8abf979) last updated 2015/01/13 13:25:34 (GMT -500)
  v2/ansible/modules/core: (detached HEAD 27d5e5124f) last updated 2015/01/13 13:25:34 (GMT -500)
  v2/ansible/modules/extras: (detached HEAD 8a4f07eecd) last updated 2014/12/11 14:16:22 (GMT -500)
  configured module search path = None
```

Environment:

Arch Linux
CentOS 6
CentOS 7

Summary:

When combining variable registration of shell commands with item lookup loops the registered variables don't contain the `stdout_lines` convenience field.  If this existed it would allow complex loops with the `with_subelements` lookup.

Steps To Reproduce:

The bug is apparent in the ansible documentation.  http://docs.ansible.com/playbooks_loops.html#using-register-with-a-loop

Expected Results:

The example above should have a `stdout_lines` field in each result object.

Actual Results:

The example above does not have a `stdout_lines` field in each result object.
