### PR TITLE
add --vault-new-password-file support to rekey

### DIFF
--- a/bin/ansible-vault
+++ b/bin/ansible-vault
@@ -81,7 +81,8 @@ def build_option_parser(action):
         parser.set_usage("usage: %prog encrypt [options] file_name")
     elif action == "rekey":
         parser.set_usage("usage: %prog rekey [options] file_name")
-    
+        parser.add_option('--vault-new-password-file', dest='new_password_file', help="vault new password file")
+
     # done, return the parser
     return parser
 
@@ -203,7 +204,10 @@ def execute_rekey(args, options, parser):
     else:
         password = utils.read_vault_file(options.password_file)
 
-    __, new_password = utils.ask_vault_passwords(ask_vault_pass=False, ask_new_vault_pass=True, confirm_new=True)
+    if not options.new_password_file:
+        __, new_password = utils.ask_vault_passwords(ask_vault_pass=False, ask_new_vault_pass=True, confirm_new=True)
+    else:
+        new_password = utils.read_vault_file(options.new_password_file)
 
     cipher = None
     for f in args:

--- a/docs/man/man1/ansible-vault.1
+++ b/docs/man/man1/ansible-vault.1
@@ -2,12 +2,12 @@
 .\"     Title: ansible-vault
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 12/09/2014
+.\"      Date: 01/15/2015
 .\"    Manual: System administration commands
 .\"    Source: Ansible 1.9
 .\"  Language: English
 .\"
-.TH "ANSIBLE\-VAULT" "1" "12/09/2014" "Ansible 1\&.9" "System administration commands"
+.TH "ANSIBLE\-VAULT" "1" "01/15/2015" "Ansible 1\&.9" "System administration commands"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -78,6 +78,13 @@ This command will decrypt the file to a temporary file and allow you to edit the
 *$ ansible\-vault rekey [options] FILE_1 [FILE_2, \&..., FILE_N]
 .sp
 The \fBrekey\fR command is used to change the password on a vault\-encrypted files\&. This command can update multiple files at once, and will prompt for both the old and new passwords before modifying any data\&.
+.sp
+The following option is additionally available when running the \fBrekey\fR command:
+.PP
+\fB\-\-vault\-new\-password\-file=\fR\fIFILE\fR
+.RS 4
+A file containing the new vault password to be used during the encryption/decryption steps\&. Be sure to keep this file secured if it is used\&.
+.RE
 .SH "ENCRYPT"
 .sp
 *$ ansible\-vault encrypt [options] FILE_1 [FILE_2, \&..., FILE_N]

--- a/docs/man/man1/ansible-vault.1.asciidoc.in
+++ b/docs/man/man1/ansible-vault.1.asciidoc.in
@@ -82,6 +82,14 @@ The *rekey* command is used to change the password on a vault-encrypted files.
 This command can update multiple files at once, and will prompt for both the
 old and new passwords before modifying any data.
 
+The following option is additionally  available when running the *rekey*
+command:
+
+*--vault-new-password-file=*'FILE'::
+
+A file containing the new vault password to be used during the
+encryption/decryption steps. Be sure to keep this file secured if it is used.
+
 ENCRYPT
 -------
 

--- a/docsite/rst/playbooks_vault.rst
+++ b/docsite/rst/playbooks_vault.rst
@@ -52,7 +52,9 @@ Should you wish to change your password on a vault-encrypted file or files, you 
     ansible-vault rekey foo.yml bar.yml baz.yml
 
 This command can rekey multiple data files at once and will ask for the original
-password and also the new password.
+password and also the new password. To disable the password prompts you can use
+the `--vault-password-file` and, for this command, the `--vault-new-password-file`
+options, see :ref:`_running_a_playbook_with_vault`.
 
 .. _encrypting_files:
 


### PR DESCRIPTION
Added a `--vault-new-password-file` option to the `ansible-vault rekey` command
in order to rekey a vault file without interactive prompts.
