### PR TITLE
By default, don't hide undefined variable errors

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -118,7 +118,7 @@ class Play(object):
         temp_vars = utils.merge_hash(self.vars, self.vars_file_vars)
         temp_vars = utils.merge_hash(temp_vars, self.playbook.extra_vars)
 
-        ds = template(basedir, ds, temp_vars)
+        ds = template(basedir, ds, temp_vars, fail_on_undefined=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR)
         ds['tasks'] = _tasks
         ds['handlers'] = _handlers
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -102,7 +102,7 @@ class HostVars(dict):
         if host not in self.lookup:
             result = self.inventory.get_variables(host, vault_password=self.vault_password).copy()
             result.update(self.vars_cache.get(host, {}))
-            self.lookup[host] = template.template('.', result, self.vars_cache)
+            self.lookup[host] = template.template('.', result, self.vars_cache, fail_on_undefined=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR)
         return self.lookup[host]
 
 


### PR DESCRIPTION
Besides, when the variables below are used inside a playbook:

> dir1: "{{ nonexistent }}"
> var1: "{{ lookup('password', 'file' + dir1 + '/filename length=10') }}"

the patch allows to replace the "ERROR: Unexpected error in during lookup: list
index out of range" error message with "jinja2.exceptions.UndefinedError: 'var'
is undefined'."
