### PR TITLE
Add filter to turn a string into a UUID

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -409,6 +409,10 @@ To work with Base64 encoded strings::
     {{ encoded | b64decode }}
     {{ decoded | b64encode }}
 
+To create a UUID from a string (new in version 1.9)::
+
+    {{ hostname | to_uuid }}
+
 To cast values as certain types, such as when you input a string as "True" from a vars_prompt and the system
 doesn't know it is a boolean value::
 

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -29,6 +29,7 @@ import hashlib
 import string
 import operator as py_operator
 from random import SystemRandom, shuffle
+import uuid
 
 import yaml
 from jinja2.filters import environmentfilter
@@ -36,6 +37,9 @@ from distutils.version import LooseVersion, StrictVersion
 
 from ansible import errors
 from ansible.utils import md5s, checksum_s
+
+
+UUID_NAMESPACE_ANSIBLE = uuid.UUID('361E6D51-FAEC-444A-9079-341386DA8E2E')
 
 
 def to_nice_yaml(*a, **kw):
@@ -297,6 +301,8 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
 
     return None
 
+def to_uuid(string):
+    return str(uuid.uuid5(UUID_NAMESPACE_ANSIBLE, str(string)))
 
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
@@ -306,6 +312,9 @@ class FilterModule(object):
             # base 64
             'b64decode': base64.b64decode,
             'b64encode': base64.b64encode,
+
+            # uuid
+            'to_uuid': to_uuid,
 
             # json
             'to_json': to_json,

--- a/test/units/TestFilters.py
+++ b/test/units/TestFilters.py
@@ -131,6 +131,11 @@ class TestFilters(unittest.TestCase):
                                                       'a\\1')
         assert a == 'ansible'
 
+    def test_to_uuid(self):
+        a = ansible.runner.filter_plugins.core.to_uuid('example.com')
+
+        assert a == 'ae780c3a-a3ab-53c2-bfb4-098da300b3fe'
+
     #def test_filters(self):
 
         # this test is pretty low level using a playbook, hence I am disabling it for now -- MPD.


### PR DESCRIPTION
This filter was made because I needed to create idempotent UUIDs when
installing the agent for Go (http://go.cd), which uses UUIds to
distinguish the agents from each other.

The filter doesn't do anything special when the string is empty, would this be a good idea to add an assert for?

I hope this would be useful for inclusion in core. :)
