### PR TITLE
aks: added to_list filter & tests

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -203,6 +203,9 @@ def union(a, b):
         c = unique(a + b)
     return c
 
+def to_list(a):
+    return type(a) == type([]) and a or [a]
+
 def min(a):
     _min = __builtins__.get('min')
     return _min(a);
@@ -330,6 +333,7 @@ class FilterModule(object):
             'difference': difference,
             'symmetric_difference': symmetric_difference,
             'union': union,
+            'to_list': to_list,
             'min' : min,
             'max' : max,
 

--- a/test/units/TestFilters.py
+++ b/test/units/TestFilters.py
@@ -131,6 +131,18 @@ class TestFilters(unittest.TestCase):
                                                       'a\\1')
         assert a == 'ansible'
 
+    def test_to_list_on_string(self):
+        a = ansible.runner.filter_plugins.core.to_list('ansible')
+        assert type(a) == type([])
+        assert a[0] == 'ansible'
+
+    def test_to_list_on_list(self):
+        a = ansible.runner.filter_plugins.core.to_list(['ansible', 'more stuff'])
+        assert type(a) == type([])
+        assert len(a) == 2
+        assert a[0] == 'ansible'
+        assert a[1] == 'more stuff'
+
     #def test_filters(self):
 
         # this test is pretty low level using a playbook, hence I am disabling it for now -- MPD.

--- a/v2/ansible/plugins/filter/core.py
+++ b/v2/ansible/plugins/filter/core.py
@@ -184,6 +184,9 @@ def union(a, b):
         c = unique(a + b)
     return c
 
+def to_list(a):
+    return type(a) == type([]) and a or [a]
+
 def min(a):
     _min = __builtins__.get('min')
     return _min(a);
@@ -311,6 +314,7 @@ class FilterModule(object):
             'difference': difference,
             'symmetric_difference': symmetric_difference,
             'union': union,
+            'to_list': to_list,
             'min' : min,
             'max' : max,
 


### PR DESCRIPTION
Added a new filter: to_list.

This causes values to be coerced into a list, so the subsequent recipe can iterate on it -- even if it's just a single item.

A use case was the `debops.ansible_users` role, which makes use of a `forward` attribute which is one or more addresses.  The 95% use-case for `~/.forward` is a single address: the average user of this role will leave the forward attribute empty, or put a single address in it.  If that value is not a list, the `debops.ansible_users` role appears to work but it creates a broken address of a list of single-characters, separated by commas, because it's trying to create a list of addresses, separated by commas.  

I've filed an issue on that role, but in examining how to fix it in my own repo, there didn't seem to be an obvious way to coerce a scalar value into a list, and filters seemed to be the Right Way to address this, so here's a new `to_list` filter, used something like this:

```
forward = {{ item.forward | to_list }}
```

This pull modifies `filter_plugins/core.py` and `TestFilters.py`.  The tests passed.

I also added the same filter to the corresponding `core.py` in the `v2` directory, but the tests there don't seem to be as well developed, so I didn't pursue the test implementation there.
