### PR TITLE
Make the source of template errors visible

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -590,8 +590,10 @@ class Runner(object):
             msg = str(ae)
             self.callbacks.on_unreachable(host, msg)
             return ReturnData(host=host, comm_ok=False, result=dict(failed=True, msg=msg))
-        except Exception:
+        except Exception, e:
             msg = traceback.format_exc()
+            if hasattr(e, "_ansible_srcinfo"):
+                msg = ("%(varname)s from %(basedir)s\n" % e._ansible_srcinfo) + msg
             self.callbacks.on_unreachable(host, msg)
             return ReturnData(host=host, comm_ok=False, result=dict(failed=True, msg=msg))
 

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -122,19 +122,23 @@ def template(basedir, varname, templatevars, lookup_fatal=True, depth=0, expand_
                 varname = "{{%s}}" % varname
 
         if isinstance(varname, basestring):
-            if '{{' in varname or '{%' in varname:
-                try:
-                    varname = template_from_string(basedir, varname, templatevars, fail_on_undefined)
-                except errors.AnsibleError, e:
-                    raise errors.AnsibleError("Failed to template %s: %s" % (varname, str(e)))
+            try:
+                if '{{' in varname or '{%' in varname:
+                    try:
+                        varname = template_from_string(basedir, varname, templatevars, fail_on_undefined)
+                    except errors.AnsibleError, e:
+                        raise errors.AnsibleError("Failed to template %s: %s" % (varname, str(e)))
 
-                # template_from_string may return non strings for the case where the var is just
-                # a reference to a single variable, so we should re_check before we do further evals
-                if isinstance(varname, basestring):
-                    if (varname.startswith("{") and not varname.startswith("{{")) or varname.startswith("["):
-                        eval_results = utils.safe_eval(varname, locals=templatevars, include_exceptions=True)
-                        if eval_results[1] is None:
-                            varname = eval_results[0]
+                    # template_from_string may return non strings for the case where the var is just
+                    # a reference to a single variable, so we should re_check before we do further evals
+                    if isinstance(varname, basestring):
+                        if (varname.startswith("{") and not varname.startswith("{{")) or varname.startswith("["):
+                            eval_results = utils.safe_eval(varname, locals=templatevars, include_exceptions=True)
+                            if eval_results[1] is None:
+                                varname = eval_results[0]
+            except Exception, e:
+                e._ansible_srcinfo = { "basedir": basedir, "varname": varname }
+                raise
 
             return varname
 


### PR DESCRIPTION
This fixes the mysterious-traceback issue in #9888. Instead of template evaluation failure in vars files causing tracebacks like this:

```
  File "/home/zzz/src/ansible/lib/ansible/utils/template.py", line 364, in template_from_string
    res = jinja2.utils.concat(rf)
  File "<template>", line 9, in root
ZeroDivisionError: integer division or modulo by zero
```

with no hint of the source of the error, it will print out the snippet that caused the problem. Instead, you get this:

```
  File "/home/zzz/src/ansible/lib/ansible/utils/template.py", line 367, in template_from_string
    res = jinja2.utils.concat(rf)
  File "<template>", line 9, in root
ZeroDivisionError: integer division or modulo by zero

{{ 256 // intermediate_value|int }}
```

 I think this is actually fairly reasonable, given that most inline templates are pretty short.

The full path to the file would be better, but I couldn't figure out the plumbing.

I looked at v2, but it seems too green right now.
