### PR TITLE
Add vault support to file lookup plugin

### DIFF
--- a/lib/ansible/runner/lookup_plugins/file.py
+++ b/lib/ansible/runner/lookup_plugins/file.py
@@ -16,13 +16,15 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 from ansible import utils, errors
+from ansible.utils.vault import VaultLib
 import os
 import codecs
 
 class LookupModule(object):
 
-    def __init__(self, basedir=None, **kwargs):
+    def __init__(self, basedir=None, vault_password=None, **kwargs):
         self.basedir = basedir
+        self.vault_password = vault_password
 
     def run(self, terms, inject=None, **kwargs):
 
@@ -55,5 +57,11 @@ class LookupModule(object):
                     break
             else:
                 raise errors.AnsibleError("could not locate file in lookup: %s" % term)
+
+            if self.vault_password:
+                vault = VaultLib(password=self.vault_password)
+                for i in xrange(len(ret)):
+                    if vault.is_encrypted(ret[i]):
+                        ret[i] = vault.decrypt(ret[i])
 
         return ret

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -86,7 +86,9 @@ JINJA2_ALLOWED_OVERRIDES = ['trim_blocks', 'lstrip_blocks', 'newline_sequence', 
 
 def lookup(name, *args, **kwargs):
     from ansible import utils
-    instance = utils.plugins.lookup_loader.get(name.lower(), basedir=kwargs.get('basedir',None))
+    basedir = kwargs.get('basedir', None)
+    vault_password = kwargs.get('vault_password', None)
+    instance = utils.plugins.lookup_loader.get(name.lower(), basedir=basedir, vault_password=vault_password)
     tvars = kwargs.get('vars', None)
 
     wantlist = kwargs.pop('wantlist', False)
@@ -106,7 +108,7 @@ def lookup(name, *args, **kwargs):
     else:
         raise errors.AnsibleError("lookup plugin (%s) not found" % name)
 
-def template(basedir, varname, templatevars, lookup_fatal=True, depth=0, expand_lists=True, convert_bare=False, fail_on_undefined=False, filter_fatal=True):
+def template(basedir, varname, templatevars, lookup_fatal=True, depth=0, expand_lists=True, convert_bare=False, fail_on_undefined=False, filter_fatal=True, vault_password=None):
     ''' templates a data structure by traversing it and substituting for other data structures '''
     from ansible import utils
 
@@ -118,7 +120,7 @@ def template(basedir, varname, templatevars, lookup_fatal=True, depth=0, expand_
 
         if isinstance(varname, basestring):
             if '{{' in varname or '{%' in varname:
-                varname = template_from_string(basedir, varname, templatevars, fail_on_undefined)
+                varname = template_from_string(basedir, varname, templatevars, fail_on_undefined, vault_password=vault_password)
 
                 if (varname.startswith("{") and not varname.startswith("{{")) or varname.startswith("["):
                     eval_results = utils.safe_eval(varname, locals=templatevars, include_exceptions=True)
@@ -128,11 +130,11 @@ def template(basedir, varname, templatevars, lookup_fatal=True, depth=0, expand_
             return varname
 
         elif isinstance(varname, (list, tuple)):
-            return [template(basedir, v, templatevars, lookup_fatal, depth, expand_lists, convert_bare, fail_on_undefined, filter_fatal) for v in varname]
+            return [template(basedir, v, templatevars, lookup_fatal, depth, expand_lists, convert_bare, fail_on_undefined, filter_fatal, vault_password=vault_password) for v in varname]
         elif isinstance(varname, dict):
             d = {}
             for (k, v) in varname.iteritems():
-                d[k] = template(basedir, v, templatevars, lookup_fatal, depth, expand_lists, convert_bare, fail_on_undefined, filter_fatal)
+                d[k] = template(basedir, v, templatevars, lookup_fatal, depth, expand_lists, convert_bare, fail_on_undefined, filter_fatal, vault_password=vault_password)
             return d
         else:
             return varname
@@ -220,6 +222,7 @@ def template_from_file(basedir, path, vars, vault_password=None):
 
     def my_lookup(*args, **kwargs):
         kwargs['vars'] = vars
+        kwargs['vault_password'] = vault_password
         return lookup(*args, basedir=basedir, **kwargs)
     def my_finalize(thing):
         return thing if thing is not None else ''
@@ -303,7 +306,7 @@ def template_from_file(basedir, path, vars, vault_password=None):
 
     # The low level calls above do not preserve the newline
     # characters at the end of the input data, so we use the
-    # calculate the difference in newlines and append them 
+    # calculate the difference in newlines and append them
     # to the resulting output for parity
     res_newlines  = count_newlines_from_end(res)
     data_newlines = count_newlines_from_end(data)
@@ -318,7 +321,7 @@ def template_from_file(basedir, path, vars, vault_password=None):
 
     return result
 
-def template_from_string(basedir, data, vars, fail_on_undefined=False):
+def template_from_string(basedir, data, vars, fail_on_undefined=False, vault_password=None):
     ''' run a string through the (Jinja2) templating engine '''
 
     try:
@@ -357,6 +360,7 @@ def template_from_string(basedir, data, vars, fail_on_undefined=False):
 
         def my_lookup(*args, **kwargs):
             kwargs['vars'] = vars
+            kwargs['vault_password'] = vault_password
             return lookup(*args, basedir=basedir, **kwargs)
 
         t.globals['lookup'] = my_lookup

--- a/test/integration/test_vault.yml
+++ b/test/integration/test_vault.yml
@@ -1,7 +1,7 @@
 - hosts: testhost
   vars_files:
     - vars/test_var_encrypted.yml
-  
+
   gather_facts: False
 
   tasks:
@@ -9,3 +9,11 @@
         that:
           - 'secret_var == "secret"'
 
+    - name: load the encrypted vars file as a fact
+      set_fact:
+        secret_contents: "{{ lookup('file', 'vars/test_var_encrypted.yml') }}"
+
+    - name: verify file lookup supports vault
+      assert:
+        that:
+          - 'secret_contents.splitlines()[0] == "---"'


### PR DESCRIPTION
The file lookup plugin now automatically decrypts ansible-vault encrypted files.

For example:

``` yaml
- hosts: localhost
 connection: local
 tasks:
   - name: "Show secret stuff"
     debug: msg="{{ lookup('file', 'files/secret_stuff') }}"

    - name: "non secret stuff"
     debug: msg="{{ lookup('file', 'files/not_secret') }}"
```

If 'files/secret_stuff' is encrypted with ansible-vault, running the example playbook with a provided vault password will print the contents of 'files/secret_stuff'.

This is based on #8110 and #8533, but updated for the latest devel branch and with an added integration test.
