### PR TITLE
Verify prompt is not null

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -335,7 +335,7 @@ class Connection(object):
                         "sudo", "Sorry, try again.")
                     if sudo_errput.strip().endswith("%s%s" % (prompt, incorrect_password)):
                         raise errors.AnsibleError('Incorrect sudo password')
-                    elif sudo_errput.endswith(prompt):
+                    elif prompt and sudo_errput.endswith(prompt):
                         stdin.write(self.runner.sudo_pass + '\n')
 
                 if p.stdout in rfd:


### PR DESCRIPTION
If prompt is None endswith throws the following error:

Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/ansible/runner/**init**.py", line 590, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/usr/lib/python2.6/site-packages/ansible/runner/__init__.py", line 792, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/usr/lib/python2.6/site-packages/ansible/runner/__init__.py", line 1025, in _executor_internal_inner
    result = handler.run(conn, tmp, module_name, module_args, inject, complex_args)
  File "/usr/lib/python2.6/site-packages/ansible/runner/action_plugins/normal.py", line 57, in run
    return self.runner._execute_module(conn, tmp, module_name, module_args, inject=inject, complex_args=complex_args)
  File "/usr/lib/python2.6/site-packages/ansible/runner/__init__.py", line 553, in _execute_module
    res = self._low_level_exec_command(conn, cmd, tmp, su=True, in_data=in_data)
  File "/usr/lib/python2.6/site-packages/ansible/runner/__init__.py", line 1166, in _low_level_exec_command
    in_data=in_data)
  File "/usr/lib/python2.6/site-packages/ansible/runner/connection_plugins/ssh.py", line 337, in exec_command
    elif sudo_errput.endswith(prompt):
TypeError: expected a character buffer object
