### PR TITLE
Document checksum error codes

### DIFF
--- a/docsite/rst/playbooks_error_handling.rst
+++ b/docsite/rst/playbooks_error_handling.rst
@@ -84,6 +84,20 @@ does not cause handlers to fire::
         changed_when: False
 
 
+Error Codes
+```````````
+
+The Checksum function used by the template module and probably others returns
+the following error codes:
+
+    1: File not found
+    2: File not readable
+    3: Path is a directory not a file
+
+Example Message:
+    msg: failed to checksum remote file. Checksum error code: 3
+
+
 .. seealso::
 
    :doc:`playbooks`


### PR DESCRIPTION
##### Issue Type: Docs Pull Request
##### Ansible Version: 1.9
##### Environment: N/A
##### Summary: Document checksum function error codes
##### Steps To Reproduce: Get a checksum error, have to dig through the code to find out what the number means.
##### Expected Results: Error codes documented.
##### Actual Results: See steps to reproduce
