### PR TITLE
ignore VERSION file in ansible-doc

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -34,7 +34,7 @@ import traceback
 MODULEDIR = C.DEFAULT_MODULE_PATH
 
 BLACKLIST_EXTS = ('.pyc', '.swp', '.bak', '~', '.rpm')
-IGNORE_FILES = [ "COPYING", "CONTRIBUTING", "LICENSE", "README" ]
+IGNORE_FILES = [ "COPYING", "CONTRIBUTING", "LICENSE", "README", "VERSION"]
 
 _ITALIC = re.compile(r"I\(([^)]+)\)")
 _BOLD   = re.compile(r"B\(([^)]+)\)")


### PR DESCRIPTION
**Issue Type:**

Bugfix Pull Request

**Ansible Version:**

```
ansible 1.8.2
  configured module search path = None
```

**Environment:**

`OpenBSD 5.7-beta (GENERIC.MP) #791: Sat Jan 17 21:24:04 MST 2015`

**Summary:**

Using "ansible-doc -l" produces a python traceback when it tries to parse the VERSION files inside the modules directories. The VERSION file is missing in the IGNORE_FILES list.

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/ansible/utils/module_docs.py", line 50, in get_docstring
    M = ast.parse(''.join(open(filename)))
  File "/usr/local/lib/python2.7/ast.py", line 37, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "<unknown>", line 1
    1.8.2
        ^
SyntaxError: invalid syntax
Traceback (most recent call last):
  File "/usr/local/bin/ansible-doc", line 189, in get_module_list_text
    desc = tty_ify(doc.get('short_description', '?')).strip()
AttributeError: 'NoneType' object has no attribute 'get'
ERROR: module VERSION has a documentation error formatting or is missing documentation
```

Steps To Reproduce:
- install ansible 1.8.2 package or clone devel branch with git
- run "ansible-doc -l"

**Expected Results:**

List of modules

**Actual Results:**

The traceback (see above) appears while ansible-doc is parsing the module files. After that,  it lists the modules.
