### PR TITLE
add dictmap function

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -216,6 +216,11 @@ To get the maximum value from a list of numbers::
 
     {{ [3, 4, 2] | max }}
 
+To map the items in a list using a dictionary:
+
+    {{ [3, 1] | dictmap ({ 1: "one", 2: "two", 3: "three" }) }}
+
+
 .. _set_theory_filters:
 
 Set Theory Filters

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -221,6 +221,7 @@ def max(a):
     return _max(a);
 
 def dictmap(l, d):
+    ''' Map the elements of a list using a dictionary '''
     return [d[k] for k in l]
 
 def version_compare(value, version, operator='eq', strict=False):

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -220,6 +220,9 @@ def max(a):
     _max = __builtins__.get('max')
     return _max(a);
 
+def dictmap(l, d):
+    return [d[k] for k in l]
+
 def version_compare(value, version, operator='eq', strict=False):
     ''' Perform a version comparison on a value '''
     op_map = {
@@ -382,6 +385,7 @@ class FilterModule(object):
             'union': union,
             'min' : min,
             'max' : max,
+            'dictmap' : dictmap,
 
             # version comparison
             'version_compare': version_compare,

--- a/test/integration/roles/test_filters/files/foo.txt
+++ b/test/integration/roles/test_filters/files/foo.txt
@@ -52,6 +52,10 @@ files to exist and are passthrus to the python os.path functions
 /etc/motd with basename = motd
 /etc/motd with dirname  = /etc
 
+The dictmap filter maps the items in a list using a dictionary
+
+['three', 'one']
+
 TODO: realpath follows symlinks.  There isn't a test for this just now.
 
 TODO: add tests for set theory operations like union

--- a/test/integration/roles/test_filters/templates/foo.j2
+++ b/test/integration/roles/test_filters/templates/foo.j2
@@ -46,6 +46,10 @@ files to exist and are passthrus to the python os.path functions
 /etc/motd with basename = {{ '/etc/motd' | basename }}
 /etc/motd with dirname  = {{ '/etc/motd' | dirname }}
 
+The dictmap filter maps the items in a list using a dictionary
+
+{{ [3, 1] | dictmap ({ 3: "three", 2: "two", 1: "one" }) }}
+
 TODO: realpath follows symlinks.  There isn't a test for this just now.
 
 TODO: add tests for set theory operations like union


### PR DESCRIPTION
Provides useful function to map a list with keys to values via a dictionary.

Sample usage:

```
[3, 1] | dictmap ({ 1: 'one', 2: 'two', 3: 'three' })
```

Result:

```
['three', 'one']
```
