### PR TITLE
Make sure to load ec2 submodule before referencing it

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -70,6 +70,7 @@ def ec2_argument_spec():
 
 
 def boto_supports_profile_name():
+    import boto.ec2
     return hasattr(boto.ec2.EC2Connection, 'profile_name')
 
 


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request, Bug Report
##### Ansible Version:

1.8.2
##### Summary:

The **profile** argument does not work for the **s3** module because the `boto.ec2` submodule is never imported when evaluating `ansible.module_utils.ec2.boto_supports_profile_name`
##### Steps To Reproduce:

Run a playbook using the s3 module with the boto `profile` argument 

```
- name: EC2 Start Instances
  hosts: localhost
  gather_facts: no
  sudo: no
  tasks:
    - name: Create s3 buckets
      s3: profile=my_boto_profile ...
```
##### Actual Results:

```
Traceback (most recent call last):
....
line 2150, in boto_supports_profile_name
    return hasattr(boto.ec2.EC2Connection, 'profile_name')
AttributeError: 'module' object has no attribute 'ec2'
```
