### PR TITLE
allow missing subelement keywords to be optionally ignored

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -160,6 +160,7 @@ DEPRECATION_WARNINGS           = get_config(p, DEFAULTS, 'deprecation_warnings',
 DEFAULT_CALLABLE_WHITELIST     = get_config(p, DEFAULTS, 'callable_whitelist', 'ANSIBLE_CALLABLE_WHITELIST', [], islist=True)
 COMMAND_WARNINGS               = get_config(p, DEFAULTS, 'command_warnings', 'ANSIBLE_COMMAND_WARNINGS', False, boolean=True)
 DEFAULT_LOAD_CALLBACK_PLUGINS  = get_config(p, DEFAULTS, 'bin_ansible_callbacks', 'ANSIBLE_LOAD_CALLBACK_PLUGINS', False, boolean=True)
+IGNORE_MISSING_SUBELEMENTS     = get_config(p, DEFAULTS, 'ignore_missing_subelements', 'IGNORE_MISSING_SUBELEMENTS', False, boolean=True)
 
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)

--- a/lib/ansible/runner/lookup_plugins/subelements.py
+++ b/lib/ansible/runner/lookup_plugins/subelements.py
@@ -17,6 +17,7 @@
 
 import ansible.utils as utils
 import ansible.errors as errors
+import ansible.constants as constants
 
 
 class LookupModule(object):
@@ -56,6 +57,8 @@ class LookupModule(object):
                 # this particular item is to be skipped
                 continue 
             if not subelement in item0:
+                if constants.IGNORE_MISSING_SUBELEMENTS:
+                    continue      # skip this item because it has no subelement
                 raise errors.AnsibleError("could not find '%s' key in iterated item '%s'" % (subelement, item0))
             if not isinstance(item0[subelement], list):
                 raise errors.AnsibleError("the key %s should point to a list, got '%s'" % (subelement, item0[subelement]))


### PR DESCRIPTION
This request is a simple change to `subelements.py` and `constants.py`, which allows the user to optionally ignore missing keywords on a `with_subelements` loop.  The change is a new configuration item: `ignore_missing_subelements`, and the logic to use the variable in `subelements.py`.

The default for this config variable is false, which causes the code in `subelements.py` to behave as usual and raise an error when subelement keywords are missing.  The default behavior is less flexible, but since some users may have written their playbooks or roles to depend on this, we leave it as the default.

However, the more flexible -- and typical -- usage of this feature will be to have `ignore_missing_subelements` set to true, which allows for flexible data patterns in the application of tasks looping with `with_subelements`.  The items for which there is no corresponding key are simply ignored.

At our site, this feature is important (and in use) for using ansible in managing keys in our user's `authorized_keys` file, in that (a) not all of our users have the same number of ssh keys, and (b) some of our users have no ssh key.
