### PR TITLE
Ld library path

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -108,7 +108,7 @@ DEFAULT_FORKS             = get_config(p, DEFAULTS, 'forks',            'ANSIBLE
 DEFAULT_MODULE_ARGS       = get_config(p, DEFAULTS, 'module_args',      'ANSIBLE_MODULE_ARGS',      '')
 DEFAULT_MODULE_LANG       = get_config(p, DEFAULTS, 'module_lang',      'ANSIBLE_MODULE_LANG',      'en_US.UTF-8')
 DEFAULT_LD_LIBRARY_PATH   = get_config(p, DEFAULTS, 'ld_library_path',  'ANSIBLE_LD_LIBRARY_PATH',  '')
-DEFAULT_SKIP_SELINUX   	  = get_config(p, DEFAULTS, 'skip_selinux',     'ANSIBLE_SKIP_SELINUX',  '')
+DEFAULT_SKIP_SELINUX      = get_config(p, DEFAULTS, 'skip_selinux',     'ANSIBLE_SKIP_SELINUX',  '')
 DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE_TIMEOUT',          10, integer=True)
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15, integer=True)
 DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      active_user)

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -107,6 +107,8 @@ DEFAULT_PATTERN           = get_config(p, DEFAULTS, 'pattern',          None,   
 DEFAULT_FORKS             = get_config(p, DEFAULTS, 'forks',            'ANSIBLE_FORKS',            5, integer=True)
 DEFAULT_MODULE_ARGS       = get_config(p, DEFAULTS, 'module_args',      'ANSIBLE_MODULE_ARGS',      '')
 DEFAULT_MODULE_LANG       = get_config(p, DEFAULTS, 'module_lang',      'ANSIBLE_MODULE_LANG',      'en_US.UTF-8')
+DEFAULT_LD_LIBRARY_PATH   = get_config(p, DEFAULTS, 'ld_library_path',  'ANSIBLE_LD_LIBRARY_PATH',  '')
+DEFAULT_SKIP_SELINUX   	  = get_config(p, DEFAULTS, 'skip_selinux',     'ANSIBLE_SKIP_SELINUX',  '')
 DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE_TIMEOUT',          10, integer=True)
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15, integer=True)
 DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      active_user)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -371,6 +371,8 @@ class AnsibleModule(object):
             return False
 
     def selinux_enabled(self):
+        if C.DEFAULT_SKIP_SELINUX:
+            return False
         if not HAVE_SELINUX:
             seenabled = self.get_bin_path('selinuxenabled')
             if seenabled is not None:

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -327,6 +327,8 @@ class Runner(object):
                 raise errors.AnsibleError("environment must be a dictionary, received %s" % enviro)
 
         custom_ld_library_path = inject['hostvars'][inject['inventory_hostname']].get('ld_library_path', 'python')
+        if len(custom_ld_library_path) < 1:
+            custom_ld_library_path = C.DEFAULT_LD_LIBRARY_PATH
         myenv = conn.shell.env_prefix(**enviro)
         myenv += ' LD_LIBRARY_PATH=%s ' % custom_ld_library_path
         return myenv

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -326,7 +326,10 @@ class Runner(object):
             if type(enviro) != dict:
                 raise errors.AnsibleError("environment must be a dictionary, received %s" % enviro)
 
-        return conn.shell.env_prefix(**enviro)
+        custom_ld_library_path = inject['hostvars'][inject['inventory_hostname']].get('ld_library_path', 'python')
+        myenv = conn.shell.env_prefix(**enviro)
+        myenv += ' LD_LIBRARY_PATH=%s ' % custom_ld_library_path
+        return myenv
 
     # *****************************************************
 


### PR DESCRIPTION
1.
Following changes would  allow for defining custom LD_LIBRARY_PATH 'per host' in inventory (or in  ansible.config - default for all hosts)

example:
[myhosts]
somehostname ld_library_path=/home/user/mycustomlib:/opt/openssl/lib:/usr/local/lib

2.
Allow for skipping SELINUX - important when you use custom ansible_python_interpreter that does not work with selinux (that is installed on host)
usage:
skip_selinux=True
