### PR TITLE
In env-setup use basename -- $0 in case $0 starts with a dash.

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -14,7 +14,7 @@ fi
 # When run using source as directed, $0 gets set to bash, so we must use $BASH_SOURCE
 if [ -n "$BASH_SOURCE" ] ; then
     HACKING_DIR=$(dirname "$BASH_SOURCE")
-elif [ $(basename "$0") = "env-setup" ]; then
+elif [ $(basename -- "$0") = "env-setup" ]; then
     HACKING_DIR=$(dirname "$0")
 else
     HACKING_DIR="$PWD/hacking"


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 1.9 (detached HEAD 0a73067153) last updated 2015/01/25 23:21:04 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 670098af2d) last updated 2015/01/25 23:21:57 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 21126a4af3) last updated 2015/01/25 23:21:58 (GMT +200)
  v2/ansible/modules/core: (detached HEAD 670098af2d) last updated 2015/01/25 23:21:58 (GMT +200)
  v2/ansible/modules/extras: (detached HEAD 21126a4af3) last updated 2015/01/25 23:21:58 (GMT +200)
  configured module search path = None
```
##### Environment:

`OpenBSD 5.7-beta (GENERIC.MP) #0: Fri Jan 23 08:52:52 CET 2015`
##### Summary:

hacking/env-setup executes the basename command without protecting it against string values of $0 starting with a dash. For example in pdksh, which is the standard shell on OpenBSD has '-ksh' in $0.
##### Steps To Reproduce:
- use current git checkout of ansible source code
- execute `. hacking/env-setup` inside `ansible` directory
##### Expected Results:

```
[robert@x201|0]$ echo $0
-ksh

[robert@x201|0]$ . hacking/env-setup
running egg_info
creating ansible.egg-info
writing requirements to ansible.egg-info/requires.txt
writing ansible.egg-info/PKG-INFO
writing top-level names to ansible.egg-info/top_level.txt
writing dependency_links to ansible.egg-info/dependency_links.txt
writing manifest file 'ansible.egg-info/SOURCES.txt'
reading manifest file 'ansible.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
no previously-included directories found matching 'lib/ansible/modules/core/.git'
no previously-included directories found matching 'lib/ansible/modules/extras/.git'
writing manifest file 'ansible.egg-info/SOURCES.txt'

Setting up Ansible to run out of checkout...

PATH=/build/data/git/ansible/bin:/home/robert/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin:/usr/games:/data/ports/infrastructure/bin:/build/data/ports/infrastructure/bin:.
PYTHONPATH=/build/data/git/ansible/lib:
MANPATH=/build/data/git/ansible/docs/man:

Remember, you may wish to specify your host file with -i

Done!
```
##### Actual Results:

```
[robert@x201|0]$ echo $0
-ksh

[robert@x201|0]$ . hacking/env-setup
basename: unknown option -- k
usage: basename string [suffix]
ksh: hacking/env-setup[21]: [: env-setup: unexpected operator/operand
running egg_info
creating ansible.egg-info
writing requirements to ansible.egg-info/requires.txt
writing ansible.egg-info/PKG-INFO
writing top-level names to ansible.egg-info/top_level.txt
writing dependency_links to ansible.egg-info/dependency_links.txt
writing manifest file 'ansible.egg-info/SOURCES.txt'
reading manifest file 'ansible.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
no previously-included directories found matching 'lib/ansible/modules/core/.git'
no previously-included directories found matching 'lib/ansible/modules/extras/.git'
writing manifest file 'ansible.egg-info/SOURCES.txt'

Setting up Ansible to run out of checkout...

PATH=/build/data/git/ansible/bin:/home/robert/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin:/usr/games:/data/ports/infrastructure/bin:/build/data/ports/infrastructure/bin:.
PYTHONPATH=/build/data/git/ansible/lib:
MANPATH=/build/data/git/ansible/docs/man:

Remember, you may wish to specify your host file with -i

Done!
```
