### PR TITLE
Fix wrong distribution facts on SLES/openSUSE

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -351,21 +351,47 @@ class Facts(object):
                             data = get_file_content(path)
                             if 'suse' in data.lower():
                                 if path == '/etc/os-release':
-                                    release = re.search("PRETTY_NAME=[^(]+ \(?([^)]+?)\)", data)
-                                    distdata = get_file_content(path).split('\n')[0]
-                                    self.facts['distribution'] = distdata.split('=')[1]
-                                    if release:
-                                        self.facts['distribution_release'] = release.groups()[0]
-                                        break
+                                    for line in data.splitlines():
+                                        distribution = re.search("^NAME=(.*)", line)
+                                        if distribution:
+                                            self.facts['distribution'] = distribution.group(1).strip('"')
+                                        distribution_version = re.search('^VERSION_ID="?([0-9]+\.?[0-9]*)"?', line) # example pattern are 13.04 13.0 13
+                                        if distribution_version:
+                                             self.facts['distribution_version'] = distribution_version.group(1)
+                                        if 'open' in data.lower():
+                                            release = re.search("^PRETTY_NAME=[^(]+ \(?([^)]+?)\)", line)
+                                            if release:
+                                                self.facts['distribution_release'] = release.groups()[0]
+                                        elif 'enterprise' in data.lower():
+                                             release = re.search('^VERSION_ID="?[0-9]+\.?([0-9]*)"?', line) # SLES doesn't got funny release names
+                                             if release:
+                                                 release = release.group(1)
+                                             else:
+                                                 release = "0" # no minor number, so it is the first release
+                                             self.facts['distribution_release'] = release
                                 elif path == '/etc/SuSE-release':
-                                    data = data.splitlines()
-                                    distdata = get_file_content(path).split('\n')[0]
-                                    self.facts['distribution'] = distdata.split()[0]
-                                    for line in data:
-                                        release = re.search('CODENAME *= *([^\n]+)', line)
-                                        if release:
-                                            self.facts['distribution_release'] = release.groups()[0].strip()
-                                            break
+                                    if 'open' in data.lower():
+                                        data = data.splitlines()
+                                        distdata = get_file_content(path).split('\n')[0]
+                                        self.facts['distribution'] = distdata.split()[0]
+                                        for line in data:
+                                            release = re.search('CODENAME *= *([^\n]+)', line)
+                                            if release:
+                                                self.facts['distribution_release'] = release.groups()[0].strip()
+                                                break
+                                    elif 'enterprise' in data.lower():
+                                        lines = data.splitlines()
+                                        distribution = lines[0].split()[0]
+                                        if "Server" in data:
+                                            self.facts['distribution'] = "SLES"
+                                        elif "Desktop" in data:
+                                            self.facts['distribution'] = "SLED"
+                                        for line in lines:
+                                            release = re.search('PATCHLEVEL = ([0-9]+)', line) # SLES doesn't got funny release names
+                                            if release:
+                                                self.facts['distribution_release'] = release.group(1)
+                                                self.facts['distribution_version'] = self.facts['distribution_version'] + '.' + release.group(1)
+                                                break
                         elif name == 'Debian':
                             data = get_file_content(path)
                             if 'Debian' in data:

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -369,6 +369,7 @@ class Facts(object):
                                              else:
                                                  release = "0" # no minor number, so it is the first release
                                              self.facts['distribution_release'] = release
+                                    break
                                 elif path == '/etc/SuSE-release':
                                     if 'open' in data.lower():
                                         data = data.splitlines()
@@ -378,7 +379,6 @@ class Facts(object):
                                             release = re.search('CODENAME *= *([^\n]+)', line)
                                             if release:
                                                 self.facts['distribution_release'] = release.groups()[0].strip()
-                                                break
                                     elif 'enterprise' in data.lower():
                                         lines = data.splitlines()
                                         distribution = lines[0].split()[0]
@@ -391,7 +391,6 @@ class Facts(object):
                                             if release:
                                                 self.facts['distribution_release'] = release.group(1)
                                                 self.facts['distribution_version'] = self.facts['distribution_version'] + '.' + release.group(1)
-                                                break
                         elif name == 'Debian':
                             data = get_file_content(path)
                             if 'Debian' in data:

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -227,7 +227,7 @@ class Facts(object):
             SLC = 'RedHat', Ascendos = 'RedHat', CloudLinux = 'RedHat', PSBM = 'RedHat',
             OracleLinux = 'RedHat', OVS = 'RedHat', OEL = 'RedHat', Amazon = 'RedHat',
             XenServer = 'RedHat', Ubuntu = 'Debian', Debian = 'Debian', SLES = 'Suse',
-            SLED = 'Suse', OpenSuSE = 'Suse', SuSE = 'Suse', Gentoo = 'Gentoo', Funtoo = 'Gentoo',
+            SLED = 'Suse', openSUSE = 'Suse', SuSE = 'Suse', Gentoo = 'Gentoo', Funtoo = 'Gentoo',
             Archlinux = 'Archlinux', Mandriva = 'Mandrake', Mandrake = 'Mandrake',
             Solaris = 'Solaris', Nexenta = 'Solaris', OmniOS = 'Solaris', OpenIndiana = 'Solaris',
             SmartOS = 'Solaris', AIX = 'AIX', Alpine = 'Alpine', MacOSX = 'Darwin',


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.9 (devel de1aab3711) last updated 2015/01/27 10:20:42 (GMT +200)
##### Environment:

Host: centos 6
Clients: Suse Enterprice Linux Server 11 SP3, Suse Enterprice Linux Server 12
##### Summary:

The collected facts on SLES are not correct. See https://github.com/ansible/ansible/issues/9634
##### Steps To Reproduce:

ansible -m setup $server | grep -i distribution
##### Expected Results:

```
        "ansible_distribution": "SLES",
        "ansible_distribution_major_version": "12",
        "ansible_distribution_release": "0",
        "ansible_distribution_version": "12",
```

or

```
        "ansible_distribution": "SLES",
        "ansible_distribution_major_version": "11",
        "ansible_distribution_release": "3",
        "ansible_distribution_version": "11.3",
```
##### Actual Results:

```
       "ansible_distribution": "SUSE",
        "ansible_distribution_major_version": "11",
        "ansible_distribution_release": "x86_64",
        "ansible_distribution_version": "11",
```

The facts about distribution, release and version are wrong.
Please review the code and give feedback 
