### PR TITLE
Fix for memory fact gathering

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -635,19 +635,19 @@ class LinuxHardware(Hardware):
                  memstats[key.lower()] = long(val) / 1024
         self.facts['memory_mb'] = {
                      'real' : {
-                         'total': memstats['memtotal'],
-                         'used': (memstats['memtotal'] - memstats['memfree']),
-                         'free': memstats['memfree']
+                         'total': memstats.get('memtotal', 0),
+                         'used': (memstats.get('memtotal', 0) - memstats.get('memfree', 0)),
+                         'free': memstats.get('memfree', 0)
                      },
                      'nocache' : {
-                         'free': memstats['cached'] + memstats['memfree'] + memstats['buffers'],
-                         'used': memstats['memtotal'] - (memstats['cached'] + memstats['memfree'] + memstats['buffers'])
+                         'free': memstats.get('cached', 0) + memstats.get('memfree', 0) + memstats.get('buffers', 0),
+                         'used': memstats.get('memtotal', 0) - (memstats.get('cached', 0) + memstats.get('memfree', 0) + memstats.get('buffers', 0))
                      },
                      'swap' : {
-                         'total': memstats['swaptotal'],
-                         'free': memstats['swapfree'],
-                         'used': memstats['swaptotal'] - memstats['swapfree'],
-                         'cached': memstats['swapcached']
+                         'total': memstats.get('swaptotal', 0),
+                         'free': memstats.get('swapfree', 0),
+                         'used': memstats.get('swaptotal', 0) - memstats.get('swapfree', 0),
+                         'cached': memstats.get('swapcached', 0)
                      }
                  }
 

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -626,10 +626,7 @@ class LinuxHardware(Hardware):
         if not os.access("/proc/meminfo", os.R_OK):
             return
 
-        # No defaultdict in py2.4
-        memstat_keys = self.MEMORY_FACTS.union(
-                ('real:used', 'nocache:free', 'nocache:used', 'swap:used'))
-        memstats = dict(zip(memstat_keys, (None,) * len(memstat_keys)))
+        memstats = {}
         for line in open("/proc/meminfo").readlines():
             data = line.split(":", 1)
             key = data[0]
@@ -641,30 +638,30 @@ class LinuxHardware(Hardware):
                  val = data[1].strip().split(' ')[0]
                  memstats[key.lower()] = long(val) / 1024
 
-        if None not in (memstats['memtotal'], memstats['memfree']):
+        if None not in (memstats.get('memtotal'), memstats.get('memfree')):
             memstats['real:used'] = memstats['memtotal'] - memstats['memfree']
-        if None not in (memstats['cached'], memstats['memfree'], memstats['buffers']):
+        if None not in (memstats.get('cached'), memstats.get('memfree'), memstats.get('buffers')):
             memstats['nocache:free'] = memstats['cached'] + memstats['memfree'] + memstats['buffers']
-        if None not in (memstats['memtotal'], memstats['nocache:free']):
+        if None not in (memstats.get('memtotal'), memstats.get('nocache:free')):
             memstats['nocache:used'] = memstats['memtotal'] - memstats['nocache:free']
-        if None not in (memstats['swaptotal'], memstats['swapfree']):
+        if None not in (memstats.get('swaptotal'), memstats.get('swapfree')):
             memstats['swap:used'] = memstats['swaptotal'] - memstats['swapfree']
 
         self.facts['memory_mb'] = {
                      'real' : {
-                         'total': memstats['memtotal'],
-                         'used': memstats['real:used'],
-                         'free': memstats['memfree'],
+                         'total': memstats.get('memtotal'),
+                         'used': memstats.get('real:used'),
+                         'free': memstats.get('memfree'),
                      },
                      'nocache' : {
-                         'free': memstats['nocache:free'],
-                         'used': memstats['nocache:used'],
+                         'free': memstats.get('nocache:free'),
+                         'used': memstats.get('nocache:used'),
                      },
                      'swap' : {
-                         'total': memstats['swaptotal'],
-                         'free': memstats['swapfree'],
-                         'used': memstats['swap:used'],
-                         'cached': memstats['swapcached'],
+                         'total': memstats.get('swaptotal'),
+                         'free': memstats.get('swapfree'),
+                         'used': memstats.get('swap:used'),
+                         'cached': memstats.get('swapcached'),
                      },
                  }
 


### PR DESCRIPTION
I have a host which started to fail while gathering facts after the addition
of expanded memory facts in PR #9839:

Traceback (most recent call last):
  File "/home/ansible/.ansible/tmp/ansible-tmp-1422536976.05-133253824703289/setup", line 4278, in <module>
    main()
  File "/home/ansible/.ansible/tmp/ansible-tmp-1422536976.05-133253824703289/setup", line 137, in main
    data = run_setup(module)
  File "/home/ansible/.ansible/tmp/ansible-tmp-1422536976.05-133253824703289/setup", line 81, in run_setup
    facts = ansible_facts(module)
  File "/home/ansible/.ansible/tmp/ansible-tmp-1422536976.05-133253824703289/setup", line 4217, in ansible_facts
    facts.update(Hardware().populate())
  File "/home/ansible/.ansible/tmp/ansible-tmp-1422536976.05-133253824703289/setup", line 2339, in populate
    self.get_memory_facts()
  File "/home/ansible/.ansible/tmp/ansible-tmp-1422536976.05-133253824703289/setup", line 2375, in get_memory_facts
    'cached': memstats['swapcached']
KeyError: 'swapcached'

My problem host doesn't have SwapCached in /proc/meminfo. It may be better to
set defaults for these keys, since the values provided by /proc/meminfo can
change from version to version.
