### PR TITLE
Client side validation for winrm connections  

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -155,6 +155,7 @@ class Cli(object):
             inventory=inventory_manager,
             timeout=options.timeout,
             private_key_file=options.private_key_file,
+            client_validation_cert=options.client_validation_cert,
             forks=options.forks,
             pattern=pattern,
             callbacks=self.callbacks,
@@ -212,4 +213,3 @@ if __name__ == '__main__':
         # Generic handler for ansible specific errors
         callbacks.display("ERROR: %s" % str(e), stderr=True, color='red')
         sys.exit(1)
-

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -112,6 +112,7 @@ DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE
 DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      active_user)
 DEFAULT_ASK_PASS          = get_config(p, DEFAULTS, 'ask_pass',  'ANSIBLE_ASK_PASS',    False, boolean=True)
 DEFAULT_PRIVATE_KEY_FILE  = shell_expand_path(get_config(p, DEFAULTS, 'private_key_file', 'ANSIBLE_PRIVATE_KEY_FILE', None))
+DEFAULT_VALIDATION_CERT   = shell_expand_path(get_config(p, DEFAULTS, 'client_validation_cert', 'ANSIBLE_CLIENT_VALIDATION_CERT', None))
 DEFAULT_SUDO_USER         = get_config(p, DEFAULTS, 'sudo_user',        'ANSIBLE_SUDO_USER',        'root')
 DEFAULT_ASK_SUDO_PASS     = get_config(p, DEFAULTS, 'ask_sudo_pass',    'ANSIBLE_ASK_SUDO_PASS',    False, boolean=True)
 DEFAULT_REMOTE_PORT       = get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      None, integer=True)

--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -31,8 +31,10 @@ class Connector(object):
     def __init__(self, runner):
         self.runner = runner
 
-    def connect(self, host, port, user, password, transport, private_key_file):
-        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password, private_key_file=private_key_file)
+    def connect(self, host, port, user, password, transport, private_key_file, client_validation_cert):
+        conn = utils.plugins.connection_loader.get(transport, self.runner, host, port, user=user, password=password,
+                                                    private_key_file=private_key_file,
+                                                    client_validation_cert=client_validation_cert)
         if conn is None:
             raise AnsibleError("unsupported connection type: %s" % transport)
         if private_key_file:

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1059,6 +1059,8 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
         help='ask for SSH password')
     parser.add_option('--private-key', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
         help='use this file to authenticate the connection')
+    parser.add_option('--client-validation-cert', default=C.DEFAULT_VALIDATION_CERT, dest='client_validation_cert',
+        help='use this file to validate winrm connections')
     parser.add_option('-K', '--ask-sudo-pass', default=False, dest='ask_sudo_pass', action='store_true',
         help='ask for sudo password')
     parser.add_option('--ask-su-pass', default=False, dest='ask_su_pass', action='store_true',

--- a/v2/ansible/plugins/connections/winrm.py
+++ b/v2/ansible/plugins/connections/winrm.py
@@ -46,7 +46,6 @@ def vvvvv(msg, host=None):
 
 class Connection(object):
     '''WinRM connections over HTTP/HTTPS.'''
-
     def __init__(self,  runner, host, port, user, password, *args, **kwargs):
         self.runner = runner
         self.host = host


### PR DESCRIPTION
Issue Type:

Bugfix Pull Request

Ansible Version:

ansible 1.9 (detached HEAD 16f9ebd) last updated 2015/01/29 22:28:40 (GMT +100)

Environment:

OSX 10.10.1 Yosemite
Windows Server 2012 (Azure)
Python 2.7.9 (default, Dec 15 2014, 10:01:34) [GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.56)] on darwin

Summary:

Since python 2.7.9 ssl certificates are rejected by default if invalid and as a result python will object to self-signed certificates (see https://www.python.org/dev/peps/pep-0476/).

The current configuration for Windows clients sets up a self signed cert for for the HTTPS connector. If a 2.7.9 runtime is used to connect to this server then HTTPS connection will be rejected.

This patch allows you to provide a certificate to validate the ssl connection either via the ansible config property 'ansible_client_validation_cert' or as cli arg --client-validation-cert.

Steps To Reproduce:

Running the window example with a 2.7.9 python install and verbose logging the connection fails with a certificate error.

ESTABLISH WINRM CONNECTION FOR USER: sgargan on PORT 5986 TO sgargan.cloudapp.net
WINRM CONNECT: transport=plaintext endpoint=https://sgargan.cloudapp.net:5986/wsman
WINRM CONNECTION ERROR: 500 WinRMTransport. [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:581)
WINRM CONNECT: transport=plaintext endpoint=http://sgargan.cloudapp.net:5986/wsman

Expected Results:

Running with the certificate specified in the ansible.cfg or from the commandline, the connection succeeds as follows

WINRM CONNECT Context: verification cert=/Users/sgargan/Downloads/ansible.pem
ESTABLISH WINRM CONNECTION FOR USER: sgargan on PORT 5986 TO sgargan.cloudapp.net
WINRM CONNECT: transport=plaintext endpoint=https://sgargan.cloudapp.net:5986/wsman
REMOTE_MODULE win_ping
...
