### PR TITLE
Saner ansible-pull output

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -151,7 +151,7 @@ def main(args):
         return 1
 
     now = datetime.datetime.now()
-    print >>sys.stderr, now.strftime("Starting ansible-pull at %F %T")
+    print now.strftime("Starting ansible-pull at %F %T")
 
     # Attempt to use the inventory passed in as an argument
     # It might not yet have been downloaded so use localhost if note
@@ -194,7 +194,7 @@ def main(args):
 
     if rc != 0:
         if options.force:
-            print "Unable to update repository. Continuing with (forced) run of playbook."
+            print >>sys.stderr, "Unable to update repository. Continuing with (forced) run of playbook."
         else:
             return rc
     elif options.ifchanged and '"changed": true' not in out:


### PR DESCRIPTION
I use ansible-pull in a cronjob. I manually redirect stdout to /dev/null in this cronjob because I only want to be notified of errors. My cron is setup in a way that it sends me an email if the cronjob has any output at all. The annoying thing is that I receive an email everyday saying `Starting ansible-pull at 2015-01-29 00:00:20` that's the case because someone decided that it would be a good idea to write this to stderr (even though it isn't an error message). Thus I decided to change this and send a pull request. While doing so I discovered that ansible doesn't write a message to stderr when it was unable to pull the remote repositiory therefore I changed that as well.
