### PR TITLE
9471: Removed blank line when running with --diff

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -433,8 +433,11 @@ class CliRunnerCallbacks(DefaultRunnerCallbacks):
             utils.write_tree_file(self.options.tree, host, utils.jsonify(result2,format=True))
 
     def on_file_diff(self, host, diff):
-        display(utils.get_diff(diff), runner=self.runner)
-        super(CliRunnerCallbacks, self).on_file_diff(host, diff)
+        if diff == {}:
+            pass
+        else:
+            display(utils.get_diff(diff), runner=self.runner)
+            super(CliRunnerCallbacks, self).on_file_diff(host, diff)
 
 ########################################################################
 
@@ -583,8 +586,11 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
         super(PlaybookRunnerCallbacks, self).on_async_failed(host,res,jid)
 
     def on_file_diff(self, host, diff):
-        display(utils.get_diff(diff), runner=self.runner)
-        super(PlaybookRunnerCallbacks, self).on_file_diff(host, diff)
+        if diff == {}:
+            pass
+        else:
+            display(utils.get_diff(diff), runner=self.runner)
+            super(PlaybookRunnerCallbacks, self).on_file_diff(host, diff)
 
 ########################################################################
 


### PR DESCRIPTION
Fixing issue #9471 

Here are test runs using the template module, and checking the diff between two files. 
1. The first run the diff is shown on the output.
2. Then the file is updated
3. diff is run again, since there is no diff, there will be nothing in the output.

``` bash
$ ansible-playbook  -i hosts 9471.yml --diff --check

PLAY [192.168.1.101] **********************************************************

TASK: [diff-test] *******************************************************
--- before: /home/henry/testfile
+++ after: /Users/henry/garage/playbooks/testfile.j2
@@ -1 +1 @@
-bar
+foo

changed: [192.168.1.101]

PLAY RECAP ********************************************************************
192.168.1.101              : ok=1    changed=1    unreachable=0    failed=0

---

$ ansible-playbook  -i hosts 9471.yml

PLAY [192.168.1.101] **********************************************************

TASK: [diff-test] *******************************************************
changed: [192.168.1.101]

PLAY RECAP ********************************************************************
192.168.1.101              : ok=1    changed=1    unreachable=0    failed=0

---

$ ansible-playbook  -i hosts 9471.yml --diff --check

PLAY [192.168.1.101] **********************************************************

TASK: [diff-test] *******************************************************
ok: [192.168.1.101]

PLAY RECAP ********************************************************************
192.168.1.101              : ok=1    changed=0    unreachable=0    failed=0
```

Playbook used for the test:

``` yaml

---
- hosts: 192.168.1.101
  gather_facts: False

  tasks:
  - name: diff-test
    template: src=testfile.j2 dest=/home/henry/testfile
```
