### PR TITLE
Add missing dependency to deb package.

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Standards-Version: 3.9.3
 Maintainer: Michael DeHaan <michael.dehaan@gmail.com>
-Build-Depends: cdbs, debhelper (>= 5.0.0), asciidoc, python, python-support, python-setuptools
+Build-Depends: cdbs, debhelper (>= 5.0.0), asciidoc, python, python-support, python-setuptools, ssh-client
 Homepage: http://ansible.github.com/
 
 Package: ansible


### PR DESCRIPTION
I ran into this while testing a playbook in a Docker container using ubuntu/utoptic as the base.
