### PR TITLE
adds complex tag management

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -227,22 +227,6 @@ def main(args):
                 label = play.name
                 hosts = pb.inventory.list_hosts(play.hosts)
 
-                # Filter all tasks by given tags
-                if pb.only_tags != 'all':
-                    if options.subset and not hosts:
-                        continue
-                    matched_tags, unmatched_tags = play.compare_tags(pb.only_tags)
-
-                    # Remove skipped tasks
-                    matched_tags = matched_tags - set(pb.skip_tags)
-
-                    unmatched_tags.discard('all')
-                    unknown_tags = ((set(pb.only_tags) | set(pb.skip_tags)) -
-                                    (matched_tags | unmatched_tags))
-
-                    if unknown_tags:
-                        continue
-
                 if options.listhosts:
                     print '  play #%d (%s): host count=%d' % (playnum, label, len(hosts))
                     for host in hosts:
@@ -251,12 +235,10 @@ def main(args):
                 if options.listtasks:
                     print '  play #%d (%s):' % (playnum, label)
 
-                    for task in play.tasks():
-                        if (set(task.tags).intersection(pb.only_tags) and not
-                            set(task.tags).intersection(pb.skip_tags)):
-                            if getattr(task, 'name', None) is not None:
-                                # meta tasks have no names
-                                print '    %s' % task.name
+                    for task in pb.tasks_to_run_in_play(play):
+                        if getattr(task, 'name', None) is not None:
+                            # meta tasks have no names
+                            print '    %s' % task.name
                 if options.listhosts or options.listtasks:
                     print ''
             continue

--- a/docsite/rst/playbooks_tags.rst
+++ b/docsite/rst/playbooks_tags.rst
@@ -1,8 +1,8 @@
 Tags
 ====
 
-If you have a large playbook it may become useful to be able to run a 
-specific part of the configuration without running the whole playbook.  
+If you have a large playbook it may become useful to be able to run a
+specific part of the configuration without running the whole playbook.
 
 Both plays and tasks support a "tags:" attribute for this reason.
 
@@ -24,7 +24,7 @@ Example::
 If you wanted to just run the "configuration" and "packages" part of a very long playbook, you could do this::
 
     ansible-playbook example.yml --tags "configuration,packages"
-    
+
 On the other hand, if you want to run a playbook *without* certain tasks, you could do this::
 
     ansible-playbook example.yml --skip-tags "notification"
@@ -39,6 +39,28 @@ And you may also tag basic include statements::
     - include: foo.yml tags=web,foo
 
 Both of these have the function of tagging every single task inside the include statement.
+
+
+Special Tags
+````````````
+
+There is a special 'always' tag that will always run a task, unless specifically skipped (--skip-tags always)
+
+Example::
+
+    tasks:
+
+        - debug: msg="Always runs"
+          tags:
+            - always
+
+        - debug: msg="runs when you use tag1"
+          tags:
+            - tag1
+
+There are another 3 special keywords for tags, 'tagged', 'untagged' and 'all', which run only tagged, only untagged
+and all tasks respectively. By default ansible runs as if --tags all had been specified.
+
 
 .. seealso::
 

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -753,7 +753,7 @@ class PlayBook(object):
                             if task_set == u:
                                 should_run = True
                         else:
-                            if len(task_set.intersection(self.only_tags)) > 0:
+                            if task_set.intersection(self.only_tags):
                                 should_run = True
 
                     # Check for tags that we need to skip
@@ -768,7 +768,7 @@ class PlayBook(object):
                                 should_run = False
                         else:
                             if should_run:
-                                if len(task_set.intersection(self.skip_tags)) > 0:
+                                if task_set.intersection(self.skip_tags):
                                     should_run = False
 
                 if should_run:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -736,7 +736,6 @@ class PlayBook(object):
                     continue
 
                 # only run the task if the requested tags match or has 'always' tag
-                should_run = False
                 if 'always' in task.tags:
                     should_run = True
                 else:
@@ -745,27 +744,32 @@ class PlayBook(object):
 
                     if 'all' in self.only_tags:
                         should_run = True
-                    elif 'tagged' in self.only_tags:
-                        if task_set != u:
-                            should_run = True
-                    elif 'untagged' in self.only_tags:
-                        if task_set == u:
-                            should_run = True
                     else:
-                        if len(set(task.tags).intersection(self.only_tags)) > 0:
-                            should_run = True
+                        should_run = False
+                        if  'tagged' in self.only_tags:
+                            if task_set != u:
+                                should_run = True
+                        elif 'untagged' in self.only_tags:
+                            if task_set == u:
+                                should_run = True
+                        else:
+                            if len(task_set.intersection(self.only_tags)) > 0:
+                                should_run = True
 
                     # Check for tags that we need to skip
-                    if 'tagged' in self.skip_tags:
-                        if task_set == u:
-                            should_run = False
-                    elif 'untagged' in self.only_tags:
-                        if task_set != u:
-                            should_run = False
+                    if 'all' in self.skip_tags:
+                        should_run = False
                     else:
-                        if should_run:
-                            if len(set(task.tags).intersection(self.skip_tags)) > 0:
+                        if 'tagged' in self.skip_tags:
+                            if task_set != u:
                                 should_run = False
+                        elif 'untagged' in self.skip_tags:
+                            if task_set == u:
+                                should_run = False
+                        else:
+                            if should_run:
+                                if len(task_set.intersection(self.skip_tags)) > 0:
+                                    should_run = False
 
                 if should_run:
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -783,8 +783,27 @@ class Play(object):
         # compare the lists of tags using sets and return the matched and unmatched
         all_tags_set = set(all_tags)
         tags_set = set(tags)
-        matched_tags = all_tags_set & tags_set
-        unmatched_tags = all_tags_set - tags_set
+
+        matched_tags = all_tags_set.intersection(tags_set)
+        unmatched_tags = all_tags_set.difference(tags_set)
+
+        a = set(['always'])
+        u = set(['untagged'])
+        if 'always' in all_tags_set:
+            matched_tags = matched_tags.union(a)
+            unmatched_tags = all_tags_set.difference(a)
+
+        if 'all' in tags_set:
+            matched_tags = matched_tags.union(all_tags_set)
+            unmatched_tags = set()
+
+        if 'tagged' in tags_set:
+            matched_tags = all_tags_set.difference(u)
+            unmatched_tags = u
+
+        if 'untagged' in tags_set and 'untagged' in all_tags_set:
+            matched_tags = matched_tags.union(u)
+            unmatched_tags = unmatched_tags.difference(u)
 
         return matched_tags, unmatched_tags
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -669,20 +669,6 @@ class Play(object):
 
     # *************************************************
 
-    def _is_valid_tag(self, tag_list):
-        """
-        Check to see if the list of tags passed in is in the list of tags
-        we only want (playbook.only_tags), or if it is not in the list of
-        tags we don't want (playbook.skip_tags).
-        """
-        matched_skip_tags = set(tag_list) & set(self.playbook.skip_tags)
-        matched_only_tags = set(tag_list) & set(self.playbook.only_tags)
-        if len(matched_skip_tags) > 0 or (self.playbook.only_tags != ['all'] and len(matched_only_tags) == 0):
-            return False
-        return True
-
-    # *************************************************
-
     def tasks(self):
         ''' return task objects for this play '''
         return self._tasks

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -129,7 +129,7 @@ class Task(object):
 
         # load various attributes
         self.name         = ds.get('name', None)
-        self.tags         = [ 'all' ]
+        self.tags         = [ 'untagged' ]
         self.register     = ds.get('register', None)
         self.sudo         = utils.boolean(ds.get('sudo', play.sudo))
         self.su           = utils.boolean(ds.get('su', play.su))
@@ -315,6 +315,9 @@ class Task(object):
             elif type(apply_tags) == list:
                 self.tags.extend(apply_tags)
         self.tags.extend(import_tags)
+
+        if len(self.tags) > 1:
+            self.tags.remove('untagged')
 
         if additional_conditions:
             new_conditions = additional_conditions[:]

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -21,7 +21,7 @@ VAULT_PASSWORD_FILE = vault-password
 
 CONSUL_RUNNING := $(shell python consul_running.py)
 
-all: parsing test_var_precedence unicode non_destructive destructive includes check_mode test_hash test_handlers test_group_by test_vault
+all: parsing test_var_precedence unicode non_destructive destructive includes check_mode test_hash test_handlers test_group_by test_vault test_tags
 
 parsing:
 	ansible-playbook bad_parsing.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -vvv $(TEST_FLAGS) --tags prepare,common,scenario1; [ $$? -eq 3 ]
@@ -81,6 +81,15 @@ test_delegate_to:
 
 test_winrm:
 	ansible-playbook test_winrm.yml -i inventory.winrm -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+
+test_tags:
+	# Run everything by default
+	[ "$$(ansible-playbook --list-tasks test_tags.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | fgrep Task_with | xargs)" = "Task_with_tag Task_with_always_tag Task_without_tag" ]
+	# Run the exact tags, and always
+	[ "$$(ansible-playbook --list-tasks --tags tag test_tags.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | fgrep Task_with | xargs)" = "Task_with_tag Task_with_always_tag" ]
+	# Skip one tag
+	[ "$$(ansible-playbook --list-tasks --skip-tags tag test_tags.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | fgrep Task_with | xargs)" = "Task_with_always_tag Task_without_tag" ]
+
 
 cloud: amazon rackspace
 

--- a/test/integration/test_tags.yml
+++ b/test/integration/test_tags.yml
@@ -1,0 +1,15 @@
+---
+- name: verify tags work as expected
+  hosts: localhost
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: Task_with_tag
+      debug: msg=
+      tags: tag
+    - name: Task_with_always_tag
+      debug: msg=
+      tags: always
+    - name: Task_without_tag
+      debug: msg=
+


### PR DESCRIPTION
Adds a special tag:
- always: always runs no matter what --tags/--skip-tags says

Adds 4 special keywords for --tags
- all: all tagged + untagged tasks
- tagged: only tagged tasks
- untagged: only untagged tasks
- always: only run tasks tagged 'always'

I think this covers all cases described in various tickets asking for more fine control over tags
