### PR TITLE
Fixing ticket 9845: man pages contain duplicate AUTHOR section

### DIFF
--- a/docs/man/man1/ansible-doc.1
+++ b/docs/man/man1/ansible-doc.1
@@ -64,9 +64,3 @@ Ansible is released under the terms of the GPLv3 License\&.
 \fBansible\-playbook\fR(1), \fBansible\fR(1), \fBansible\-pull\fR(1)
 .sp
 Extensive documentation is available in the documentation site: http://docs\&.ansible\&.com\&. IRC and mailing list info can be found in file CONTRIBUTING\&.md, available in: https://github\&.com/ansible/ansible
-.SH "AUTHOR"
-.PP
-\fB:doctype:manpage\fR
-.RS 4
-Author.
-.RE

--- a/docs/man/man1/ansible-playbook.1
+++ b/docs/man/man1/ansible-playbook.1
@@ -176,9 +176,3 @@ Ansible is released under the terms of the GPLv3 License\&.
 \fBansible\fR(1), \fBansible\-pull\fR(1), \fBansible\-doc\fR(1)
 .sp
 Extensive documentation is available in the documentation site: http://docs\&.ansible\&.com\&. IRC and mailing list info can be found in file CONTRIBUTING\&.md, available in: https://github\&.com/ansible/ansible
-.SH "AUTHOR"
-.PP
-\fB:doctype:manpage\fR
-.RS 4
-Author.
-.RE

--- a/docs/man/man1/ansible-pull.1
+++ b/docs/man/man1/ansible-pull.1
@@ -104,9 +104,3 @@ Ansible is released under the terms of the GPLv3 License\&.
 \fBansible\fR(1), \fBansible\-playbook\fR(1), \fBansible\-doc\fR(1)
 .sp
 Extensive documentation is available in the documentation site: http://docs\&.ansible\&.com\&. IRC and mailing list info can be found in file CONTRIBUTING\&.md, available in: https://github\&.com/ansible/ansible
-.SH "AUTHOR"
-.PP
-\fB:doctype:manpage\fR
-.RS 4
-Author.
-.RE

--- a/docs/man/man1/ansible.1
+++ b/docs/man/man1/ansible.1
@@ -206,9 +206,3 @@ Ansible is released under the terms of the GPLv3 License\&.
 \fBansible\-playbook\fR(1), \fBansible\-pull\fR(1), \fBansible\-doc\fR(1)
 .sp
 Extensive documentation is available in the documentation site: http://docs\&.ansible\&.com\&. IRC and mailing list info can be found in file CONTRIBUTING\&.md, available in: https://github\&.com/ansible/ansible
-.SH "AUTHOR"
-.PP
-\fB:doctype:manpage\fR
-.RS 4
-Author.
-.RE


### PR DESCRIPTION
Removed duplicate AUTHOR section in man pages.
