### PR TITLE
Ignore errors from `shutil.rmtree` when removing temporary directory

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -380,7 +380,7 @@ def scm_archive_role(scm, role_url, role_version, role_name):
         print "  in directory %s" % tempdir
         return False
 
-    shutil.rmtree(tempdir)
+    shutil.rmtree(tempdir, ignore_errors=True)
 
     return temp_file.name
 


### PR DESCRIPTION
This fixes an issue I have when installing roles from a YAML requirements file.

Here's my requirements file:

``` yaml

---
- src: https://github.com/bennojoy/nginx
  version: master
```

I am running:

```
ansible-galaxy install -r requirements.yml -p vendor_roles --force
```

Which works the first time, but on subsequent runs:

```
- executing: git clone https://github.com/bennojoy/nginx nginx
- executing: git archive --prefix=nginx/ --output=/var/folders/8z/hgq5jfqn7ms5x4ykzd6gxb6c0000gn/T/tmpfIjENg.tar master
Traceback (most recent call last):
  File "/usr/local/Cellar/ansible/1.8.2/libexec/bin/ansible-galaxy", line 955, in <module>
    main()
  File "/usr/local/Cellar/ansible/1.8.2/libexec/bin/ansible-galaxy", line 949, in main
    fn(args, options, parser)
  File "/usr/local/Cellar/ansible/1.8.2/libexec/bin/ansible-galaxy", line 794, in execute_install
    tmp_file = scm_archive_role(role_scm, role_src, role.get("version"), role.get("name"))
  File "/usr/local/Cellar/ansible/1.8.2/libexec/bin/ansible-galaxy", line 384, in scm_archive_role
    shutil.rmtree(tempdir)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 247, in rmtree
    rmtree(fullname, ignore_errors, onerror)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 247, in rmtree
    rmtree(fullname, ignore_errors, onerror)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 256, in rmtree
    onerror(os.rmdir, path, sys.exc_info())
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 254, in rmtree
    os.rmdir(path)
OSError: [Errno 66] Directory not empty: '/var/folders/8z/hgq5jfqn7ms5x4ykzd6gxb6c0000gn/T/tmpnFRQf6/nginx/.git'
make: *** [install] Error 1
```

I am running OSX 10.0.1

It should be safe to ignore errors here as this is a temporary directory.

Thanks! :sparkling_heart: 
