### PR TITLE
Update EC2 inventory script with changes from Tower.

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -71,6 +71,22 @@ cache_max_age = 300
 # Organize groups into a nested/hierarchy instead of a flat namespace.
 nested_groups = False
 
+# The EC2 inventory output can become very large. To manage its size,
+# configure which groups should be created.
+group_by_instance_id = True
+group_by_region = True
+group_by_availability_zone = True
+group_by_ami_id = True
+group_by_instance_type = True
+group_by_key_pair = True
+group_by_vpc_id = True
+group_by_security_group = True
+group_by_tag_keys = True
+group_by_tag_none = True
+group_by_route53_names = True
+group_by_rds_engine = True
+group_by_rds_parameter_group = True
+
 # If you only want to include hosts that match a certain regular expression
 # pattern_include = stage-*
 


### PR DESCRIPTION
- Adds to changes from #6676 to support nested VPC group and VPC grouping for RDS.
- Adds to changes from #8822 to ignore invalid instance filters.
- Implements grouping by AMI ID based on #7573.
- Implements configuration options to limit which groups are created automatically, based on #7573.
