### PR TITLE
Clear unwanted parameters from both args and complex args when calling file module

### DIFF
--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -145,6 +145,7 @@ class ActionModule(object):
             # the module to follow links.  When doing that, we have to set
             # original_basename to the template just in case the dest is
             # a directory.
+            module_args = ''
             new_module_args = dict(
                 src=None,
                 original_basename=os.path.basename(source),
@@ -154,6 +155,6 @@ class ActionModule(object):
             # rely on the file module to report its changed status
             if self.runner.noop_on_check(inject):
                 new_module_args['CHECKMODE'] = True
-            module_args = utils.merge_module_args(module_args, new_module_args)
-            return self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject, complex_args=complex_args)
+            options.update(new_module_args)
+            return self.runner._execute_module(conn, tmp, 'file', module_args, inject=inject, complex_args=options)
 

--- a/test/integration/roles/test_template/tasks/main.yml
+++ b/test/integration/roles/test_template/tasks/main.yml
@@ -96,3 +96,42 @@
       - "dir_attrs.stat.uid != 0"
       - "dir_attrs.stat.pw_name == 'nobody'"
       - "dir_attrs.stat.mode == '0755'"
+
+- name: make a symlink to the templated file
+  file:
+    path: '{{ output_dir }}/foo.symlink'
+    src: '{{ output_dir }}/foo.templated'
+    state: link
+
+- name: check that templating the symlink results in the file being templated
+  template:
+    src: foo.j2
+    dest: '{{output_dir}}/foo.symlink'
+    mode: 0600
+    follow: True
+  register: template_result
+
+- assert:
+    that:
+      - "template_result.changed == True"
+
+- name: check that the file has the correct attributes
+  stat: path={{output_dir | expanduser}}/template-dir/foo.j2
+  register: file_attrs
+
+- assert:
+    that:
+      - "file_attrs.stat.mode == '0600'"
+
+- name: check that templating the symlink again makes no changes
+  template:
+    src: foo.j2
+    dest: '{{output_dir}}/foo.symlink'
+    mode: 0600
+    follow: True
+  register: template_result
+
+- assert:
+    that:
+      - "template_result.changed == False"
+


### PR DESCRIPTION
Fix usage of template module with symlinks.

Fixes #10208
