### PR TITLE
Set proper permissions for ansible-vault view

### DIFF
--- a/lib/ansible/utils/vault.py
+++ b/lib/ansible/utils/vault.py
@@ -281,8 +281,10 @@ class VaultEditor(object):
         tmpdata = self.read_data(self.filename)
         this_vault = VaultLib(self.password)
         dec_data = this_vault.decrypt(tmpdata)
+        old_umask = os.umask(0o077)
         _, tmp_path = tempfile.mkstemp()
         self.write_data(dec_data, tmp_path)
+        os.umask(old_umask)
 
         # drop the user into pager on the tmp file
         call(self._pager_shell_command(tmp_path))


### PR DESCRIPTION
Fixes issue #10214
Sets umask before creating the temporary file and sets it back to the original value when file is created.
