### PR TITLE
Tasks use do-until by default

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -144,6 +144,12 @@ DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       '
 DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '/usr/share/ansible_plugins/filter_plugins')
 DEFAULT_LOG_PATH               = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
 
+# When enabled do-until loops will automatically retry, this can be overridden on a task
+DEFAULT_DO_UNTIL_RETRIES_ENABLED = get_config(p, DEFAULTS, 'do_until_retries_enabled', 'ANSIBLE_DO_UNTIL_RETRIES_ENABLED', False, boolean=True)
+DEFAULT_DO_UNTIL_RETRIES         = get_config(p, DEFAULTS, 'do_until_retries', 'ANSIBLE_DO_UNTIL_RETRIES', 3, integer=True)
+DEFAULT_DO_UNTIL_DELAY           = get_config(p, DEFAULTS, 'do_until_delay', 'ANSIBLE_DO_UNTIL_DELAY', 5, integer=True)
+DEFAULT_DO_UNTIL_CONDITION       = get_config(p, DEFAULTS, 'do_until_condition', 'ANSIBLE_DO_UNTIL_CONDITION', '{register}|success')
+
 CACHE_PLUGIN                   = get_config(p, DEFAULTS, 'fact_caching', 'ANSIBLE_CACHE_PLUGIN', 'memory')
 CACHE_PLUGIN_CONNECTION        = get_config(p, DEFAULTS, 'fact_caching_connection', 'ANSIBLE_CACHE_PLUGIN_CONNECTION', None)
 CACHE_PLUGIN_PREFIX            = get_config(p, DEFAULTS, 'fact_caching_prefix', 'ANSIBLE_CACHE_PLUGIN_PREFIX', 'ansible_facts')


### PR DESCRIPTION
By default if a task fails ansible does not retry the task. Ansible
tasks can be dependent on many moving parts and so transient errors are
common. Do-until loops can be used to retry tasks and must be specified
for each task individually.

Retrying a task is such a commonly used feature it would be useful to be
to have this enabled by default.

This patch adds the ability to enable do-until loops on all tasks by
default. This feature is enabled with the constant
DEFAULT_DO_UNTIL_RETRIES_ENABLED.

Three additional constants are added:

```
DEFAULT_DO_UNTIL_RETRIES
DEFAULT_DO_UNTIL_DELAY
DEFAULT_DO_UNTIL_CONDITION
```

DEFAULT_DO_UNTIL_CONDITION is set to '{register}|success' by default
where '{register}' is used as a placeholder for the tasks registered
variable.

A do-until loop can be disabled on a task with 'until: null'.
