### PR TITLE
patch action plugin does not require dest

### DIFF
--- a/lib/ansible/runner/action_plugins/patch.py
+++ b/lib/ansible/runner/action_plugins/patch.py
@@ -34,8 +34,8 @@ class ActionModule(object):
         dest = options.get('dest', None)
         remote_src = utils.boolean(options.get('remote_src', 'yes'))
 
-        if src is None or dest is None:
-            result = dict(failed=True, msg="src and dest are required")
+        if src is None:
+            result = dict(failed=True, msg="src is required")
             return ReturnData(conn=conn, comm_ok=False, result=result)
 
         if remote_src:


### PR DESCRIPTION
dest is not required as patchfile can have that info and the module did not require it
should fix https://github.com/ansible/ansible-modules-extras/issues/258
