### PR TITLE
'aformat' Jinja2 filter

### DIFF
--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -306,6 +306,9 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
 def to_uuid(string):
     return str(uuid.uuid5(UUID_NAMESPACE_ANSIBLE, str(string)))
 
+def aformat(item, str_fmt):
+    return str(str_fmt % item)
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -389,4 +392,7 @@ class FilterModule(object):
             # random stuff
             'random': rand,
             'shuffle': randomize_list,
+
+            # alternative string format
+            'aformat': aformat,
         }


### PR DESCRIPTION
This is a simple 'alternative format' filter, which comes in hand
when mapping a data formatting function over a list.

eg. suppose we have a list like

``` yaml
userlist:
  - firstname: John
    surname: Foo
  - firstname: Paul
    surname: Bar
```

we could format + join their names, in a template or playbook, using
the following construct:

``` jinja
{{ userlist|map('aformat', '%(firstname)s %(surname)s')|join(', ') }}
```
