### PR TITLE
Support SCM URLs containing spaces (for branch specifiers)

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -347,7 +347,7 @@ def scm_archive_role(scm, role_url, role_version, role_name):
         print "- scm %s is not currently supported" % scm
         return False
     tempdir = tempfile.mkdtemp()
-    clone_cmd = [scm, 'clone', role_url, role_name]
+    clone_cmd = [scm, 'clone'] + role_url.split() + [role_name]
     with open('/dev/null', 'w') as devnull:
         try:
             print "- executing: %s" % " ".join(clone_cmd)


### PR DESCRIPTION
It's become common practice to specify branches to clone from git repositories using -b, as in

```
git://my.git.server/repository.git -b branch
```

ansible-galaxy doesn't support this as is, but enabling it is easy: all it takes is to split the role URL. This comes at the expense of supporting URLs containing unescaped spaces, but that's probably not an issue...
