### PR TITLE
Shell autocompletion for test-module executable

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 #
@@ -33,7 +34,7 @@ import base64
 import os
 import subprocess
 import traceback
-import optparse
+import argparse
 import ansible.utils as utils
 import ansible.module_common as module_common
 import ansible.constants as C
@@ -43,31 +44,38 @@ try:
 except ImportError:
     import simplejson as json
 
+HAS_ARGCOMPLETE=False
+try:
+    import argcomplete
+    HAS_ARGCOMPLETE=True
+except ImportError:
+    pass
+
 def parse():
     """parse command line
 
     :return : (options, args)"""
-    parser = optparse.OptionParser()
+    parser = argparse.ArgumentParser(usage="%prog -[options] (-h for help)")
 
-    parser.usage = "%prog -[options] (-h for help)"
-
-    parser.add_option('-m', '--module-path', dest='module_path',
+    parser.add_argument('-m', '--module-path', dest='module_path',
         help="REQUIRED: full path of module source to execute")
-    parser.add_option('-a', '--args', dest='module_args', default="",
+    parser.add_argument('-a', '--args', dest='module_args', default="",
         help="module argument string")
-    parser.add_option('-D', '--debugger', dest='debugger', 
+    parser.add_argument('-D', '--debugger', dest='debugger', 
         help="path to python debugger (e.g. /usr/bin/pdb)")
-    parser.add_option('-I', '--interpreter', dest='interpreter',
+    parser.add_argument('-I', '--interpreter', dest='interpreter',
         help="path to interpreter to use for this module (e.g. ansible_python_interpreter=/usr/bin/python)",
         metavar='INTERPRETER_TYPE=INTERPRETER_PATH')
-    parser.add_option('-c', '--check', dest='check', action='store_true',
+    parser.add_argument('-c', '--check', dest='check', action='store_true',
         help="run the module in check mode")
-    options, args = parser.parse_args()
+    if HAS_ARGCOMPLETE:
+        argcomplete.autocomplete(parser)
+    options = parser.parse_args()
     if not options.module_path:
         parser.print_help()
         sys.exit(1)
     else:
-        return options, args
+        return options
 
 def write_argsfile(argstring, json=False):
     """ Write args to a file for old-style module's use. """
@@ -172,7 +180,7 @@ def rundebug(debugger, modfile, argspath):
 
 def main(): 
 
-    options, args = parse()
+    options = parse()
     (modfile, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter, options.check)
 
     argspath=None


### PR DESCRIPTION
Change log:
1) Autocomplete is a useful tool and python provides one! argcomplete is a
python autocomplete tool that can be instaled as follows

```
        $ pip install argcomplete
```

It provides bash completion capabilities.

Currently, I have added this tool optionally for test-module.
If user has installed one, he can get suggestions for arguments on command line.

2) Removed optparse
optparse has been deprecated since version 2.7. According to me, this is
a needed change.
