### PR TITLE
Enable sudo mode if user explicitely ask for sudo password

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -143,6 +143,10 @@ class Cli(object):
 
         if options.su_user or options.ask_su_pass:
             options.su = True
+
+        if options.ask_sudo_pass:
+            options.sudo = True
+
         options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
         options.su_user = options.su_user or C.DEFAULT_SU_USER
         if options.tree:


### PR DESCRIPTION
Since using ansible -K without --sudo will not result into anything
useful and since we are doing this already for the --ask-su-pass
option, we should as well be consistent on it. A user came on the
irc today with the exact problem of having -K without the required
options.
