### PR TITLE
Add `groups` back into inline templates

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -678,6 +678,7 @@ class Runner(object):
         temp_vars = utils.merge_hash(temp_vars, self.play_vars)
         temp_vars = utils.merge_hash(temp_vars, self.play_file_vars)
         temp_vars = utils.merge_hash(temp_vars, self.extra_vars)
+        temp_vars = utils.merge_hash(temp_vars, {'groups': inject['groups']})
 
         hostvars = HostVars(temp_vars, self.inventory, vault_password=self.vault_pass)
 


### PR DESCRIPTION
This fixes #9888 in a low-impact way, at the expense of not addressing the entire problem- other things in `inject` not explicitly imported into `temp_vars` (and by extension, `hostvars`).
