### PR TITLE
improve yaml parsing performance by ~25% by using PyYAML's CParser loader

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -70,6 +70,11 @@ try:
 except ImportError:
     import json
 
+try:
+    from yaml import CSafeLoader as Loader
+except ImportError:
+    from yaml import SafeLoader as Loader
+
 PASSLIB_AVAILABLE = False
 try:
     import passlib.hash
@@ -594,7 +599,7 @@ def parse_yaml(data, path_hint=None):
                 raise errors.AnsibleError(str(ve))
     else:
         # else this is pretty sure to be a YAML document
-        loaded = yaml.safe_load(data)
+        loaded = yaml.load(data, Loader=Loader)
 
     return loaded
 


### PR DESCRIPTION
This is with PyYAML-3.11, the CParser loader is a good bit faster than the python loader in my tests.

With SafeParser:
`% time ansible-playbook -l dummyNonConnectingHost site.yml --vault-password-file=~/.vault_pass > /dev/null
613.76s user 86.28s system 97% cpu 11:54.65 total`

With CSafeParser:
`% time ansible-playbook -l dummyNonConnectingHost site.yml --vault-password-file=~/.vault_pass > /dev/null
439.21s user 82.81s system 98% cpu 8:52.45 total`
