### PR TITLE
Set proper file permissions (umask 077) in write_data

### DIFF
--- a/lib/ansible/utils/vault.py
+++ b/lib/ansible/utils/vault.py
@@ -336,9 +336,16 @@ class VaultEditor(object):
     def write_data(self, data, filename):
         if os.path.isfile(filename): 
             os.remove(filename)
+
+        # make sure the umask is set to a sane value
+        old_umask = os.umask(0o077)
+
         f = open(filename, "wb")
         f.write(data)
         f.close()
+
+        # and restore umask
+        os.umask(old_umask)
 
     def shuffle_files(self, src, dest):
         # overwrite dest with src


### PR DESCRIPTION
So the file permissions remain consistent across all ansible-vault operations that use write_data().

Addresses issue #10253
