### PR TITLE
Addition of LD_LIBRARY_PATH for custom python/openssl environments

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -110,6 +110,7 @@ DEFAULT_PATTERN           = get_config(p, DEFAULTS, 'pattern',          None,   
 DEFAULT_FORKS             = get_config(p, DEFAULTS, 'forks',            'ANSIBLE_FORKS',            5, integer=True)
 DEFAULT_MODULE_ARGS       = get_config(p, DEFAULTS, 'module_args',      'ANSIBLE_MODULE_ARGS',      '')
 DEFAULT_MODULE_LANG       = get_config(p, DEFAULTS, 'module_lang',      'ANSIBLE_MODULE_LANG',      'en_US.UTF-8')
+DEFAULT_LD_LIBRARY_PATH   = get_config(p, DEFAULTS, 'ld_library_path',  'ANSIBLE_LD_LIBRARY_PATH',  '')
 DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE_TIMEOUT',          10, integer=True)
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15, integer=True)
 DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      active_user)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -326,7 +326,11 @@ class Runner(object):
             if type(enviro) != dict:
                 raise errors.AnsibleError("environment must be a dictionary, received %s" % enviro)
 
-        return conn.shell.env_prefix(**enviro)
+        myenv = conn.shell.env_prefix(**enviro)
+        custom_ld_library_path = inject['hostvars'][inject['inventory_hostname']].get('ld_library_path', '')
+        if len(custom_ld_library_path) > 0:
+            myenv += ' LD_LIBRARY_PATH=%s ' % custom_ld_library_path
+        return myenv
 
     # *****************************************************
 


### PR DESCRIPTION
Following changes would allow for defining custom LD_LIBRARY_PATH 'per host' in inventory (or in ansible.config - default for all hosts)

That is important for environments with custom python/openssl settings

example:
[myhosts]
somehostname ld_library_path=/home/user/mycustomlib:/opt/openssl/lib:/usr/local/lib
