### PR TITLE
rax_cbs: Remove explicit msg match for invalid size in integration tests

### DIFF
--- a/test/integration/roles/test_rax_cbs/tasks/main.yml
+++ b/test/integration/roles/test_rax_cbs/tasks/main.yml
@@ -103,7 +103,6 @@
   assert:
     that:
       - rax_cbs|failed
-      - rax_cbs.msg == '"size" must be greater than or equal to 100'
 # ============================================================
 
 


### PR DESCRIPTION
This (small) PR, just removes a now invalid test assertion to validate the msg of a failed task when an invalid size was provided.  It's enough to just validate the failure.
