### PR TITLE
Make behavior consistent when using 'creates' option with modules

### DIFF
--- a/lib/ansible/runner/action_plugins/script.py
+++ b/lib/ansible/runner/action_plugins/script.py
@@ -66,7 +66,7 @@ class ActionModule(object):
                     conn=conn,
                     comm_ok=True,
                     result=dict(
-                        skipped=True,
+                        changed=False,
                         msg=("skipped, since %s exists" % creates)
                     )
                 )
@@ -83,7 +83,7 @@ class ActionModule(object):
                     conn=conn,
                     comm_ok=True,
                     result=dict(
-                        skipped=True,
+                        changed=False,
                         msg=("skipped, since %s does not exist" % removes)
                     )
                 )

--- a/lib/ansible/runner/action_plugins/unarchive.py
+++ b/lib/ansible/runner/action_plugins/unarchive.py
@@ -69,7 +69,6 @@ class ActionModule(object):
                     conn=conn,
                     comm_ok=True,
                     result=dict(
-                        skipped=True,
                         changed=False,
                         msg=("skipped, since %s exists" % creates)
                     )

--- a/test/integration/roles/test_unarchive/tasks/main.yml
+++ b/test/integration/roles/test_unarchive/tasks/main.yml
@@ -96,7 +96,6 @@
   assert:
     that:
       - "unarchive02c.changed == false"
-      - "unarchive02c.skipped == true"
 
 - name: unarchive a tar.gz file with creates over an existing file using complex_args
   unarchive:
@@ -110,7 +109,6 @@
   assert:
     that:
       - "unarchive02d.changed == false"
-      - "unarchive02d.skipped == true"
 
 - name: remove our tar.gz unarchive destination
   file: path={{output_dir}}/test-unarchive-tar-gz state=absent


### PR DESCRIPTION
There are three distinct behaviors in use with modules that have "creates" or "removes" arguments:

command module, shell module:
- changed=False

unarchive module, uri module:
- changed=False and skipped=True

script module:
- skipped=True

This pull request makes these behaviors consistent with the command and shell modules, reserving 'skipped' status for actions which are truly not evaluated. 
