### PR TITLE
ansible-doc now shows return value docs

### DIFF
--- a/bin/ansible-doc
+++ b/bin/ansible-doc
@@ -141,7 +141,11 @@ def get_man_text(doc):
             text.append("%s\n" % (ex['code']))
 
     if 'plainexamples' in doc and doc['plainexamples'] is not None:
+        text.append("EXAMPLES:")
         text.append(doc['plainexamples'])
+    if 'returndocs' in doc and doc['returndocs'] is not None:
+        text.append("RETURN VALUES:")
+        text.append(doc['returndocs'])
     text.append('')
 
     return "\n".join(text)
@@ -299,7 +303,7 @@ def main():
             continue
 
         try:
-            doc, plainexamples = module_docs.get_docstring(filename)
+            doc, plainexamples, returndocs = module_docs.get_docstring(filename)
         except:
             traceback.print_exc()
             sys.stderr.write("ERROR: module %s has a documentation error formatting or is missing documentation\n" % module)
@@ -317,6 +321,7 @@ def main():
             doc['docuri']           = doc['module'].replace('_', '-')
             doc['now_date']         = datetime.date.today().strftime('%Y-%m-%d')
             doc['plainexamples']    = plainexamples
+            doc['returndocs']       = returndocs
 
             if options.show_snippet:
                 text += get_snippet_text(doc)

--- a/lib/ansible/utils/module_docs.py
+++ b/lib/ansible/utils/module_docs.py
@@ -44,6 +44,7 @@ def get_docstring(filename, verbose=False):
 
     doc = None
     plainexamples = None
+    returndocs = None
 
     try:
         # Thank you, Habbie, for this bit of code :-)
@@ -89,10 +90,13 @@ def get_docstring(filename, verbose=False):
 
                 if 'EXAMPLES' in (t.id for t in child.targets):
                     plainexamples = child.value.s[1:]  # Skip first empty line
+
+                if 'RETURN' in (t.id for t in child.targets):
+                    returndocs = child.value.s[1:]
     except:
         traceback.print_exc() # temp
         if verbose == True:
             traceback.print_exc()
             print "unable to parse %s" % filename
-    return doc, plainexamples
+    return doc, plainexamples, returndocs
 


### PR DESCRIPTION
modified ansible-doc to show documented return values (registered var structure) if a module has this data embeded.

TODO: 
- add to docsite/rst (docs.ansible.com)
- create common docs for common data returned by all modules (msg,changed,failed,skipped, etc)
