### PR TITLE
Allow requesting a list to lookup plugins instead of , delimited string

### DIFF
--- a/docsite/rst/playbooks_lookups.rst
+++ b/docsite/rst/playbooks_lookups.rst
@@ -2,13 +2,15 @@ Using Lookups
 =============
 
 Lookup plugins allow access of data in Ansible from outside sources.  These plugins are evaluated on the Ansible control
-machine, and can include reading the filesystem but also contacting external datastores and services.  
+machine, and can include reading the filesystem but also contacting external datastores and services.
 These values are then made available using the standard templating system
 in Ansible, and are typically used to load variables or templates with information from those systems.
 
-.. note:: This is considered an advanced feature, and many users will probably not rely on these features.  
+.. note:: This is considered an advanced feature, and many users will probably not rely on these features.
 
 .. note:: Lookups occur on the local computer, not on the remote computer.
+
+.. note:: Since 1.9 you can pass wantlist=True to lookups to use in jinja2 template "for" loops.
 
 .. contents:: Topics
 

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -89,6 +89,8 @@ def lookup(name, *args, **kwargs):
     instance = utils.plugins.lookup_loader.get(name.lower(), basedir=kwargs.get('basedir',None))
     tvars = kwargs.get('vars', None)
 
+    wantlist = kwargs.pop('wantlist', False)
+
     if instance is not None:
         try:
             ran = instance.run(*args, inject=tvars, **kwargs)
@@ -98,7 +100,7 @@ def lookup(name, *args, **kwargs):
             raise errors.AnsibleUndefinedVariable("One or more undefined variables: %s" % str(e))
         except Exception, e:
             raise errors.AnsibleError('Unexpected error in during lookup: %s' % e)
-        if ran:
+        if ran and not wantlist:
             ran = ",".join(ran)
         return ran
     else:


### PR DESCRIPTION
so now you can do something like:

```
{% for k in lookup('items',"['one','two','three']",wantlist=True) %}
{{k}}
{% endfor %}
```

should fix #10291 
