### PR TITLE
Fixes #9836: Don't check SSH key permisions under Win(Cigwin)

### DIFF
--- a/lib/ansible/runner/connection.py
+++ b/lib/ansible/runner/connection.py
@@ -19,6 +19,7 @@
 ################################################
 
 import os
+import sys
 import stat
 import errno
 
@@ -44,7 +45,7 @@ class Connector(object):
                 if e.errno != errno.ENOENT: # file is missing, might be agent
                     raise(e)
 
-            if st is not None and st.st_mode & (stat.S_IRGRP | stat.S_IROTH):
+            if sys.platform != 'cygwin' and st is not None and st.st_mode & (stat.S_IRGRP | stat.S_IROTH):
                 raise AnsibleError("private_key_file (%s) is group-readable or world-readable and thus insecure - "
                                    "you will probably get an SSH failure"
                                    % (private_key_file,))


### PR DESCRIPTION
This allows to run Ansible as Vagrant provisioner on a Windows control machine (via [Cygwin](https://www.cygwin.com/) or [babun](http://babun.github.io/))

It fixes #9836 with error output: 

``` sh
$ vagrant provision
==> default: Running provisioner: ansible...

PLAY [all] ********************************************************************

GATHERING FACTS ***************************************************************
fatal: [default] => private_key_file (D:/Work/Vagrant/home/insecure_private_key) is group-readable or world-readable and thus insecure - you will probably get an SSH failure

TASK: [Install nginx] *********************************************************
FATAL: no hosts matched or all hosts have already failed -- aborting


PLAY RECAP ********************************************************************
           to retry, use: --limit @/home/ADMIN/playbook.retry

default                    : ok=0    changed=0    unreachable=1    failed=0

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

Also people suffering: 
- https://plus.googleapis.com/+pixelfairy/posts/JCD3HGp45jb
- http://www.opennet.ru/openforum/vsluhforumID1/96005.html
- https://forums.frontier.co.uk/showthread.php?t=57986&page=31&p=1677897&viewfull=1#post1677897
