### PR TITLE
Prevents trailing zeros to be truncated from strings in hosts ini inventory variables

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -54,7 +54,11 @@ class InventoryParser(object):
     def _parse_value(v):
         if "#" not in v:
             try:
-                return ast.literal_eval(v)
+                re = ast.literal_eval(v)
+                if type(re) == float:
+                    # Do not trim floats. Eg: "1.20" to 1.2
+                    return v
+                return re
             # Using explicit exceptions.
             # Likely a string that literal_eval does not like. We wil then just set it.
             except ValueError:

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -54,11 +54,11 @@ class InventoryParser(object):
     def _parse_value(v):
         if "#" not in v:
             try:
-                re = ast.literal_eval(v)
-                if type(re) == float:
+                ret = ast.literal_eval(v)
+                if type(ret) == float:
                     # Do not trim floats. Eg: "1.20" to 1.2
                     return v
-                return re
+                return ret
             # Using explicit exceptions.
             # Likely a string that literal_eval does not like. We wil then just set it.
             except ValueError:


### PR DESCRIPTION
Fixes bug #10281

During the string conversion process, trailing zeros were lost as
a result of the conversion of the value to a float number. That
means that, for instance, given the "1.20", the value read was
1.2, which caused issues under some circumstances.
