### PR TITLE
v2 Avoids ssh Runtime error

### DIFF
--- a/v2/ansible/plugins/connections/ssh.py
+++ b/v2/ansible/plugins/connections/ssh.py
@@ -237,6 +237,8 @@ class Connection(ConnectionBase):
                 if line is None or " " not in line:
                     continue
                 tokens = line.split()
+                if not tokens:
+                    continue
                 if tokens[0].find(self.HASHED_KEY_MAGIC) == 0:
                     # this is a hashed known host entry
                     try:


### PR DESCRIPTION
Fixes bug #10225

Prevents an exception from raising in some corner cases where SSH might
be misconfigured. It seems not to fix a specific problem, although it
makes the method a little bit more solid.
