### PR TITLE
plaintext https transport connecting over http

### DIFF
--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -56,7 +56,7 @@ class Connection(object):
 
     transport_schemes = {
         'http': [('kerberos', 'http'), ('plaintext', 'http'), ('plaintext', 'https')],
-        'https': [('kerberos', 'https'), ('plaintext', 'https'), ('plaintext', 'https')],
+        'https': [('kerberos', 'https'), ('plaintext', 'https')],
         }
 
     def __init__(self,  runner, host, port, user, password, *args, **kwargs):

--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -56,7 +56,7 @@ class Connection(object):
 
     transport_schemes = {
         'http': [('kerberos', 'http'), ('plaintext', 'http'), ('plaintext', 'https')],
-        'https': [('kerberos', 'https'), ('plaintext', 'http'), ('plaintext', 'https')],
+        'https': [('kerberos', 'https'), ('plaintext', 'https'), ('plaintext', 'https')],
         }
 
     def __init__(self,  runner, host, port, user, password, *args, **kwargs):


### PR DESCRIPTION
fixes https transport but where if using https winrm via plaintext auth ansible attempts to connect over http instead
