### PR TITLE
Register list/hash variables

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -30,6 +30,7 @@ import collections
 from play import Play
 import StringIO
 import pipes
+import re
 
 # the setup cache stores all variables about a host
 # gathered during the setup step, while the vars cache
@@ -493,12 +494,39 @@ class PlayBook(object):
         contacted = results.get('contacted', {})
         self.stats.compute(results, ignore_errors=task.ignore_errors)
 
+        def _register_hash(var, key, result):
+            if var not in self.VARS_CACHE[host] or type(self.VARS_CACHE[host][var]) != dict:
+                self.VARS_CACHE[host][var] = {}
+            result_hash = self.VARS_CACHE[host][var]
+            result_hash[key] = result
+            return result_hash
+
+        def _register_list(var, result):
+            if var not in self.VARS_CACHE[host] or type(self.VARS_CACHE[host][var]) != list:
+                self.VARS_CACHE[host][var] = []
+            result_list = self.VARS_CACHE[host][var]
+            result_list.append(result)
+            return result_list
+
+
         def _register_play_vars(host, result):
             # when 'register' is used, persist the result in the vars cache
             # rather than the setup cache - vars should be transient between
             # playbook executions
             if 'stdout' in result and 'stdout_lines' not in result:
                 result['stdout_lines'] = result['stdout'].splitlines()
+
+            m = re.search('^(?P<name>\w+)\[(?P<key>\w+)\]$', task.register)
+            if m is not None:
+                task.register = m.group('name')
+                key = m.group('key')
+                result = _register_hash(task.register, key, result)
+
+            m = re.search('^(?P<name>\w+)\[\]$', task.register)
+            if m is not None:
+                task.register = m.group('name')
+                result = _register_list(task.register, result)
+
             utils.update_hash(self.VARS_CACHE, host, {task.register: result})
 
         def _save_play_facts(host, facts):

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -498,7 +498,7 @@ class PlayBook(object):
             if var not in self.VARS_CACHE[host] or type(self.VARS_CACHE[host][var]) != dict:
                 self.VARS_CACHE[host][var] = {}
             result_hash = self.VARS_CACHE[host][var]
-            result_hash[key] = result
+            result_hash[unquote(key)] = result
             return result_hash
 
         def _register_list(var, result):
@@ -516,16 +516,14 @@ class PlayBook(object):
             if 'stdout' in result and 'stdout_lines' not in result:
                 result['stdout_lines'] = result['stdout'].splitlines()
 
-            m = re.search('^(?P<name>\w+)\[(?P<key>\w+)\]$', task.register)
+            m = re.search('^(?P<name>\w+)\[(?P<key>.*?)\]$', task.register)
             if m is not None:
-                task.register = m.group('name')
                 key = m.group('key')
-                result = _register_hash(task.register, key, result)
-
-            m = re.search('^(?P<name>\w+)\[\]$', task.register)
-            if m is not None:
                 task.register = m.group('name')
-                result = _register_list(task.register, result)
+                if key:
+                    result = _register_hash(task.register, key, result)
+                else:
+                    result = _register_list(task.register, result)
 
             utils.update_hash(self.VARS_CACHE, host, {task.register: result})
 


### PR DESCRIPTION
##### SUMMARY
Reopening of https://github.com/ansible/ansible/pull/6674

Can register result in Hash or List.
Simply add `[]` to the var name to append result in a list, or `[key]` to save result in a hash

exemple:

``` yaml
- hosts: all
  tasks:
    - name: Append first result
      shell: "echo a"
      register: foo_list[]


    - name: Append second result
      shell: 'echo b'
      register: foo_list[]


    - name: Add result to dict with key 'c'
      shell: 'echo key is c'
      register: bar_dict[c]

    - name: Add result to dict with key 'd'
      shell: 'echo key is d'
      register: bar_dict[d]

    - name: Append third result
      shell: 'echo c'
      register: foo_list[]


    - name: display list element index 2
      debug: msg="{{foo_list[2]}}"
# ok: {"msg": "c"}

    - name: display dict, key 'd'
      debug: msg="{{bar_dict['d'].stdout}}"
# ok: {"msg": "key is d"}

    - name: display all values in list
      debug: msg="item= {{item}}"
      with_items: foo_list
#  ok: {"msg": "a"}
#  ok: {"msg": "b"}
#  ok: {"msg": "c"}

    - name: display all values in dict
      debug: msg="bar_dict[{{item.key}}] = {{item.value.stdout}}"
      with_dict: bar_dict
# ok: { "msg": "bar_dict[c] = key is c"}
# ok: { "msg": "bar_dict[d] = key is d"}
```


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
lib/ansible/playbook/__init__.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


