### PR TITLE
Respect global settings when merging hashes

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -818,7 +818,7 @@ def merge_hash(a, b):
         for k, v in dicts.iteritems():
             # if there's already such key in a
             # and that key contains dict
-            if k in result and isinstance(result[k], dict):
+            if C.DEFAULT_HASH_BEHAVIOUR == "merge" and k in result and isinstance(result[k], dict):
                 # merge those dicts recursively
                 result[k] = merge_hash(a[k], v)
             else:


### PR DESCRIPTION
This patch improving a condition in the `merge_hash` function to respect the global settings for merging hashes. It allows to merge hashes only if the `hash_behaviour` is set to `merge` in `ansible.cfg`.
