### PR TITLE
Windows specific filter that supports splattering

### DIFF
--- a/lib/ansible/runner/filter_plugins/windows.py
+++ b/lib/ansible/runner/filter_plugins/windows.py
@@ -1,0 +1,27 @@
+import yaml
+from ansible import errors
+
+
+def toPowershellHash(x):
+    try:
+        powershell ="@{"
+        if isinstance(x, dict):
+            for key, value in x.items():
+               powershell += "'{0}'='{1}';".format(key,value)
+            powershell +="}"
+            return powershell
+        else:
+            raise errors.AnsibleFilterError("failed expects a dictionary")
+            #return False
+    except TypeError:
+        return False
+
+class FilterModule(object):
+    ''' Ansible powershell jinja2 filters '''
+
+    def filters(self):
+        return {
+            # convert yaml array to powershell hash
+            'toPowershellHash': toPowershellHash,
+
+        }

--- a/test/integration/roles/test_win_script/defaults/main.yml
+++ b/test/integration/roles/test_win_script/defaults/main.yml
@@ -3,3 +3,8 @@
 # Parameters to pass to test scripts.
 test_win_script_value: VaLuE
 test_win_script_splat: "@{This='THIS'; That='THAT'; Other='OTHER'}"
+test_win_script_yaml_dict_value:
+  This: this
+  That: that
+  Other: other
+

--- a/test/integration/roles/test_win_script/tasks/main.yml
+++ b/test/integration/roles/test_win_script/tasks/main.yml
@@ -62,6 +62,22 @@
       - "not test_script_with_splatting_result|failed"
       - "test_script_with_splatting_result|changed"
 
+- name: run test script that takes parameters passed via splatting filter
+  script: 'test_script_with_splatting.ps1 "{{ test_win_script_yaml_dict_value|toPowershellHash }}"'
+  register: test_script_with_splatting_filter_result
+
+- name: check that script ran and received parameters via splatting filter
+  assert:
+    that:
+      - "test_script_with_splatting_filter_result.rc == 0"
+      - "test_script_with_splatting_filter_result.stdout"
+      - "test_script_with_splatting_filter_result.stdout_lines[0] == 'this'"
+      - "test_script_with_splatting_filter_result.stdout_lines[1] == 'that'"
+      - "test_script_with_splatting_filter_result.stdout_lines[2] == 'other'"
+      - "not test_script_with_splatting_filter_result.stderr"
+      - "not test_script_with_splatting_filter_result|failed"
+      - "test_script_with_splatting_filter_result|changed"
+
 - name: run test script that takes splatted parameters from a variable
   script: test_script_with_splatting.ps1 {{ test_win_script_splat|quote }}
   register: test_script_with_splatting2_result

--- a/test/integration/roles/test_win_splat_filter/defaults/main.yml
+++ b/test/integration/roles/test_win_splat_filter/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# Parameters to pass to test scripts.
+test_powershell_hash_filter_value:
+  This: THIS
+  That: THAT
+  Other: OTHER
+
+test_powershell_hash_filter_expected: "@{This=THIS;Other=OTHER;That=THAT;}"
+
+test_powershell_hash_filter_value_invalid:
+  - This
+  - That
+  - Other

--- a/test/integration/roles/test_win_splat_filter/tasks/main.yml
+++ b/test/integration/roles/test_win_splat_filter/tasks/main.yml
@@ -1,0 +1,47 @@
+# Test toPowershellHash filter
+# (c) 2015, Michael Perzel <michaelperzel@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: Convert yaml dict to powershell hash
+  command: "echo '{{ test_powershell_hash_filter_value | toPowershellHash }}'"
+  register: powershell_hash
+  delegate_to: 127.0.0.1
+
+- name: Check that actual equals expected
+  assert:
+    that:
+      - "powershell_hash.rc == 0"
+      - "powershell_hash.stdout"
+      - "not powershell_hash.stderr"
+      - "not powershell_hash|failed"
+      - "powershell_hash|changed"
+      - "powershell_hash.stdout == test_powershell_hash_filter_expected"
+
+- name: Try to convert yaml dict to powershell hash for invalid data
+  shell: "echo '{{ test_powershell_hash_filter_value_invalid | toPowershellHash }}'"
+  delegate_to: 127.0.0.1
+  ignore_errors: yes
+  register: powershell_hash_invalid
+
+- name: check that filter ran but failed with errors
+  assert:
+    that:
+      - "powershell_hash_invalid.rc != 0"
+      - "not powershell_hash_invalid.stdout"
+      - "powershell_hash_invalid.stderr"
+      - "powershell_hash_invalid|failed"
+      - "powershell_hash_invalid|changed"

--- a/test/integration/test_winrm.yml
+++ b/test/integration/test_winrm.yml
@@ -33,3 +33,4 @@
     - { role: test_win_file, tags: test_win_file }
     - { role: test_win_copy, tags: test_win_copy }
     - { role: test_win_template, tags: test_win_template }
+    - { role: test_win_splat_filter, tags: test_win_splat_filter }


### PR DESCRIPTION
Convert yaml dict to powershell hash. Based upon conversation from https://groups.google.com/forum/#!starred/ansible-project/jojvFohOwqM

Tested with TEST_FLAGS="-t test_win_splat_filter -i /etc/ansible/hosts" make test_winrm
