### PR TITLE
Add the complex_args to the module execution result

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1078,7 +1078,8 @@ class Runner(object):
 
             result.result['invocation'] = dict(
                 module_args=module_args,
-                module_name=module_name
+                module_name=module_name,
+                complex_args=complex_args
             )
 
             changed_when = self.module_vars.get('changed_when')


### PR DESCRIPTION
Currently, if you write a [callback plugin](http://docs.ansible.com/developing_plugins.html#callbacks), if you use the standard syntax or the pure YAML one (see #10163), you get different objects as the result of the module execution.

Given the following playbook:

``` yaml
# test/integration/mine.yml
- hosts: testhost
  vars_files:
    - vars_file.yml
  gather_facts: True
  tasks:
    - set_fact: output_file={{output_dir}}/foo.txt
    - name: prep with a basic copy
      copy: src=roles/test_copy/files/foo.txt dest={{output_file}}
    - name: prep with a basic copy
      copy:
        src: roles/test_copy/files/foo.txt
        dest: "{{output_file}}"
```

And the following plugin:

``` python
# test/integration/plugins/callbacks/log.py
class CallbackModule(object):
    def on_any(self, *args, **kwargs):
        pass

    def runner_on_failed(self, host, res, ignore_errors=False):
        pass

    def runner_on_ok(self, host, res):
        print res['invocation']

    def runner_on_error(self, host, msg):
        pass

    def runner_on_skipped(self, host, item=None):
        pass

    def runner_on_unreachable(self, host, res):
        pass

    def runner_on_no_hosts(self):
        pass

    def runner_on_async_poll(self, host, res, jid, clock):
        pass

    def runner_on_async_ok(self, host, res, jid):
        pass

    def runner_on_async_failed(self, host, res, jid):
        pass


    def playbook_on_start(self):
        pass

    def playbook_on_notify(self, host, handler):
        pass

    def playbook_on_no_hosts_matched(self):
        pass

    def playbook_on_no_hosts_remaining(self):
        pass

    def playbook_on_task_start(self, name, is_conditional):
        pass

    def playbook_on_vars_prompt(self, varname, private=True, prompt=None,
                                encrypt=None, confirm=False, salt_size=None,
                                salt=None, default=None):
        pass

    def playbook_on_setup(self):
        pass

    def playbook_on_import_for_host(self, host, imported_file):
        pass

    def playbook_on_not_import_for_host(self, host, missing_file):
        pass

    def playbook_on_play_start(self, pattern):
        pass

    def playbook_on_stats(self, stats):
        pass
```

If you run `ANSIBLE_CALLBACK_PLUGINS=plugins/callbacks make mine` from the `test/integration` directory, you will obtain:

```
TASK: [prep with a basic copy] ************************************************
ok: [testhost] => {...}
{'module_name': u'copy', 'module_args': u'src=roles/test_copy/files/foo.txt dest=~/ansible_testing/foo.txt'}

TASK: [prep with a basic copy] ************************************************
ok: [testhost] => {...}
{'module_name': u'copy', 'module_args': ''}
```

With this PR, you will obtain:

```
TASK: [prep with a basic copy] ************************************************
ok: [testhost] => {...}
{'module_name': u'copy', 'complex_args': {}, 'module_args': u'src=roles/test_copy/files/foo.txt dest=~/ansible_testing/foo.txt'}

TASK: [prep with a basic copy] ************************************************
ok: [testhost] => {...}
{'module_name': u'copy', 'complex_args': {'dest': u'~/ansible_testing/foo.txt', 'src': 'roles/test_copy/files/foo.txt'}, 'module_args': ''}
```

You are now able to use `complex_args` to display the same informations as `module_args`.
