### PR TITLE
Bug fix: Search only for files as candidates

### DIFF
--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -176,7 +176,8 @@ class PluginLoader(object):
         found = None
         for path in [p for p in self._get_paths() if p not in self._searched_paths]:
             if os.path.isdir(path):
-                for potential_file in os.listdir(path):
+                for potential_file in (f for f in os.listdir(path)
+                                       if os.path.isfile(os.path.join(path, f))):
                     for suffix in suffixes:
                         if potential_file.endswith(suffix):
                             full_path = os.path.join(path, potential_file)


### PR DESCRIPTION
Apparently found a recently introduced bug (in 68e86de 2015-02-17 | Optimize the plugin loader). If a folder is found matching the plugin name, it is retrieved. I have experienced the issue using digital_ocean module (it is not usable now).

I have added a test for it, but I have had to add mock as a dependency. I think it is necessary in order to do good testing.
