### PR TITLE
Make --version report the active config file

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -21,6 +21,9 @@ import sys
 import ConfigParser
 from string import ascii_letters, digits
 
+config_file = None
+
+
 # copied from utils, avoid circular reference fun :)
 def mk_boolean(value):
     if value is None:
@@ -60,6 +63,8 @@ def _get_config(p, section, key, env_var, default):
 def load_config_file():
     ''' Load Config File order(first found is used): ENV, CWD, HOME, /etc/ansible '''
 
+    global config_file
+
     p = ConfigParser.ConfigParser()
 
     path0 = os.getenv("ANSIBLE_CONFIG", None)
@@ -76,8 +81,12 @@ def load_config_file():
             except ConfigParser.Error as e:
                 print "Error reading config file: \n%s" % e
                 sys.exit(1)
+            config_file = path
             return p
     return None
+
+def get_config_file():
+    return config_file
 
 def shell_expand_path(path):
     ''' shell_expand_path is needed as os.path.expanduser does not work

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -901,6 +901,8 @@ def version(prog):
     if gitinfo:
         result = result + " {0}".format(gitinfo)
     result = result + "\n  configured module search path = %s" % C.DEFAULT_MODULE_PATH
+    C.load_config_file()
+    result += "\n  config file = %s" % C.get_config_file()
     return result
 
 def version_info(gitinfo=False):


### PR DESCRIPTION
This is useful for troubleshooting.

```
$ ansible --version
ansible 1.9 (make_version_report_active_config_file_2 0f4b72cdfa) last updated 2015/02/26 17:07:30 (GMT -700)
  lib/ansible/modules/core: (detached HEAD b0c534842b) last updated 2015/02/26 17:07:52 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 650d740a3a) last updated 2015/02/26 17:07:52 (GMT -700)
  v2/ansible/modules/core: (detached HEAD 34784b7a61) last updated 2015/02/26 17:07:52 (GMT -700)
  v2/ansible/modules/extras: (detached HEAD 650d740a3a) last updated 2015/02/26 17:07:52 (GMT -700)
  configured module search path = None
  config file = /etc/ansible/ansible.cfg
```

This replaces #9598, which did this but also had a lot of refactoring that made it more complex. This one is much simpler.

Cc: @bcoca, @sontek, @sudarkoff
