### PR TITLE
Add ansible_ssh_host

### DIFF
--- a/plugins/inventory/zabbix.py
+++ b/plugins/inventory/zabbix.py
@@ -72,7 +72,7 @@ class ZabbixInventory(object):
         }
 
     def get_host(self, api, name):
-        data = {}
+        data = {'ansible_ssh_host': name}
         return data
 
     def get_list(self, api):


### PR DESCRIPTION
When execute `zabbix.py --host 'hostname'` returens an empty dict eg. `{}`. Add `ansible_ssh_host` to the dict will returns the host IP that ansible dynamic inventory can do something in the host.
