### PR TITLE
Update doc for testing PR with mock dependency

### DIFF
--- a/docsite/rst/developing_test_pr.rst
+++ b/docsite/rst/developing_test_pr.rst
@@ -35,6 +35,7 @@ suites. You will need at least::
    git
    python-nosetests (sometimes named python-nose)
    python-passlib
+   python-mock
 
 If you want to run the full integration test suite you'll also need the following packages installed::
 


### PR DESCRIPTION
Update in the docsite reflecting the mock dependency for running the unit tests. For example, for the test introduced in #10346
