### PR TITLE
allow executable (+x) non-script inventory files.

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -163,6 +163,7 @@ DEPRECATION_WARNINGS           = get_config(p, DEFAULTS, 'deprecation_warnings',
 DEFAULT_CALLABLE_WHITELIST     = get_config(p, DEFAULTS, 'callable_whitelist', 'ANSIBLE_CALLABLE_WHITELIST', [], islist=True)
 COMMAND_WARNINGS               = get_config(p, DEFAULTS, 'command_warnings', 'ANSIBLE_COMMAND_WARNINGS', False, boolean=True)
 DEFAULT_LOAD_CALLBACK_PLUGINS  = get_config(p, DEFAULTS, 'bin_ansible_callbacks', 'ANSIBLE_LOAD_CALLBACK_PLUGINS', False, boolean=True)
+ALLOW_EXECUTABLE_INVENTORY     = get_config(p, DEFAULTS, 'allow_executable_inventory', 'ALLOW_EXECUTABLE_INVENTORY', True, boolean=True)
 
 RETRY_FILES_ENABLED            = get_config(p, DEFAULTS, 'retry_files_enabled', 'ANSIBLE_RETRY_FILES_ENABLED', True, boolean=True)
 RETRY_FILES_SAVE_PATH          = get_config(p, DEFAULTS, 'retry_files_save_path', 'ANSIBLE_RETRY_FILES_SAVE_PATH', '~/')

--- a/lib/ansible/errors.py
+++ b/lib/ansible/errors.py
@@ -38,3 +38,6 @@ class AnsibleUndefinedVariable(AnsibleError):
 
 class AnsibleFilterError(AnsibleError):
     pass
+
+class AnsibleInvalidInventory(AnsibleError):
+    pass

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -113,7 +113,7 @@ class Inventory(object):
                 except:
                     pass
 
-                if utils.is_executable(host_list):
+                if utils.is_executable(host_list) and C.ALLOW_EXECUTABLE_INVENTORY:
                     try:
                         self.parser = InventoryScript(filename=host_list)
                         self.groups = self.parser.groups.values()

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -146,7 +146,7 @@ class InventoryParser(object):
                             try:
                                 (k,v) = t.split("=", 1)
                             except ValueError, e:
-                                raise errors.AnsibleError("%s:%s: Invalid ini entry: %s - %s" % (self.filename, lineno + 1, t, str(e)))
+                                raise errors.AnsibleInvalidInventory("%s:%s: Invalid ini entry: %s - %s" % (self.filename, lineno + 1, t, str(e)))
                             host.set_variable(k, self._parse_value(v))
                     self.groups[active_group_name].add_host(host)
 
@@ -173,7 +173,7 @@ class InventoryParser(object):
             elif group:
                 kid_group = self.groups.get(line, None)
                 if kid_group is None:
-                    raise errors.AnsibleError("%s:%d: child group is not defined: (%s)" % (self.filename, lineno + 1, line))
+                    raise errors.AnsibleInvalidInventory("%s:%d: child group is not defined: (%s)" % (self.filename, lineno + 1, line))
                 else:
                     group.add_child_group(kid_group)
 
@@ -190,7 +190,7 @@ class InventoryParser(object):
                 line = line.replace("[","").replace(":vars]","")
                 group = self.groups.get(line, None)
                 if group is None:
-                    raise errors.AnsibleError("%s:%d: can't add vars to undefined group: %s" % (self.filename, lineno + 1, line))
+                    raise errors.AnsibleInvalidInventory("%s:%d: can't add vars to undefined group: %s" % (self.filename, lineno + 1, line))
             elif line.startswith("#") or line.startswith(";"):
                 pass
             elif line.startswith("["):
@@ -199,7 +199,7 @@ class InventoryParser(object):
                 pass
             elif group:
                 if "=" not in line:
-                    raise errors.AnsibleError("%s:%d: variables assigned to group must be in key=value form" % (self.filename, lineno + 1))
+                    raise errors.AnsibleInvalidInventory("%s:%d: variables assigned to group must be in key=value form" % (self.filename, lineno + 1))
                 else:
                     (k, v) = [e.strip() for e in line.split("=", 1)]
                     group.set_variable(k, self._parse_value(v))

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -292,6 +292,10 @@ def is_executable(path):
             or stat.S_IXGRP & os.stat(path)[stat.ST_MODE]
             or stat.S_IXOTH & os.stat(path)[stat.ST_MODE])
 
+def has_shebang(path):
+    ''' does the file at the given path start with a #! (shebang)? '''
+    return open(path).read(2) == '#!'
+
 def unfrackpath(path):
     '''
     returns a path that is free of symlinks, environment

--- a/test/units/TestInventory.py
+++ b/test/units/TestInventory.py
@@ -4,6 +4,7 @@ from nose.tools import raises
 
 from ansible import errors
 from ansible.inventory import Inventory
+import ansible.constants as C
 
 class TestInventory(unittest.TestCase):
 
@@ -354,6 +355,14 @@ class TestInventory(unittest.TestCase):
         print "Expected: %s"%(expected_hosts)
         print "Got     : %s"%(hosts)
         assert sorted(hosts) == sorted(expected_hosts)
+
+    def test_script_not_allowed(self):
+        C.ALLOW_EXECUTABLE_INVENTORY = False
+
+        with self.assertRaises(errors.AnsibleError):
+            self.test_script()
+
+        C.ALLOW_EXECUTABLE_INVENTORY = True
 
     def test_script_all(self):
         inventory = self.script_inventory()


### PR DESCRIPTION
This fixes #10068 without breaking backwards compatibility.

Sometimes having an ansible directory on a network share means it mounts +x automatically, with no easy way to get around it.
