### PR TITLE
Rework the shell quoting of remote checksumming

### DIFF
--- a/lib/ansible/runner/shell_plugins/csh.py
+++ b/lib/ansible/runner/shell_plugins/csh.py
@@ -19,5 +19,8 @@ from ansible.runner.shell_plugins.sh import ShellModule as ShModule
 
 class ShellModule(ShModule):
 
+    # How to end lines in a python script one-liner
+    _SHELL_EMBEDDED_PY_EOL = '\\\n'
+
     def env_prefix(self, **kwargs):
         return 'env %s' % super(ShellModule, self).env_prefix(**kwargs)

--- a/test/integration/check_mode.yml
+++ b/test/integration/check_mode.yml
@@ -1,3 +1,4 @@
 - hosts: testhost
   roles:
   - { role: test_always_run, tags: test_always_run }
+  - { role: test_check_mode, tags: test_check_mode }

--- a/test/integration/roles/test_check_mode/files/foo.txt
+++ b/test/integration/roles/test_check_mode/files/foo.txt
@@ -1,0 +1,1 @@
+templated_var_loaded

--- a/test/integration/roles/test_check_mode/meta/main.yml
+++ b/test/integration/roles/test_check_mode/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies: 
+  - prepare_tests
+

--- a/test/integration/roles/test_check_mode/tasks/main.yml
+++ b/test/integration/roles/test_check_mode/tasks/main.yml
@@ -1,4 +1,4 @@
-# test code for the copy module and action plugin
+# test code for the template module
 # (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
 
 # This file is part of Ansible
@@ -16,16 +16,24 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: fill in a basic template in check mode
+  template: src=foo.j2 dest={{output_dir}}/foo.templated mode=0644
+  register: template_result
 
-- name: clean out the test directory
-  file: name={{output_dir|mandatory}} state=absent
+- name: verify that the file was marked as changed in check mode
+  assert: 
+    that: 
+      - "template_result.changed == true"
+
+- name: Actually create the file
+  template: src=foo.j2 dest={{output_dir}}/foo.templated2 mode=0644
   always_run: True
-  tags:
-    - prepare
 
-- name: create the test directory
-  file: name={{output_dir}} state=directory
-  always_run: True
-  tags:
-    - prepare
+- name: fill in a basic template in check mode
+  template: src=foo.j2 dest={{output_dir}}/foo.templated2 mode=0644
+  register: template_result2
 
+- name: verify that the file was marked as not changed in check mode
+  assert: 
+    that: 
+      - "template_result2.changed == false"

--- a/test/integration/roles/test_check_mode/templates/foo.j2
+++ b/test/integration/roles/test_check_mode/templates/foo.j2
@@ -1,0 +1,1 @@
+{{ templated_var }}

--- a/test/integration/roles/test_check_mode/vars/main.yml
+++ b/test/integration/roles/test_check_mode/vars/main.yml
@@ -1,0 +1,1 @@
+templated_var: templated_var_loaded

--- a/test/integration/roles/test_template/tasks/main.yml
+++ b/test/integration/roles/test_template/tasks/main.yml
@@ -138,3 +138,39 @@
     that:
       - "template_result.changed == False"
 
+# Test strange filenames
+
+- name: Create a temp dir for filename tests
+  file:
+    state: directory
+    dest: '{{ output_dir }}/filename-tests'
+
+- name: create a file with an unusual filename
+  template:
+    src: foo.j2
+    dest: "{{ output_dir }}/filename-tests/foo t'e~m\\plated"
+  register: template_result
+
+- assert:
+    that:
+      - "template_result.changed == True"
+
+- name: check that the unusual filename was created
+  command: "ls {{ output_dir }}/filename-tests/"
+  register: unusual_results
+
+- assert:
+    that:
+      - "\"foo t'e~m\\plated\" in unusual_results.stdout_lines"
+      - "{{unusual_results.stdout_lines| length}} == 1"
+
+- name: check that the unusual filename can be checked for changes
+  template:
+    src: foo.j2
+    dest: "{{ output_dir }}/filename-tests/foo t'e~m\\plated"
+  register: template_result
+
+- assert:
+    that:
+      - "template_result.changed == False"
+


### PR DESCRIPTION
Instead of getting rid of pipes.quote, use pipes.quote and get rid of
the manually entered toplevel quotes.  This should properly escape
backslashes, quotes, and other characters.

Also fix the new checksumming python "one-liner" for csh.
ansible_shell_type needs to be set to csh.

Fixes #10363
Fixes #10353
