### PR TITLE
Don't log item data for skipped tasks under no_log

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -873,9 +873,13 @@ class Runner(object):
         for cond in self.conditional:
 
             if not utils.check_conditional(cond, self.basedir, inject, fail_on_undefined=self.error_on_undefined_vars):
-                result = utils.jsonify(dict(changed=False, skipped=True))
-                self.callbacks.on_skipped(host, inject.get('item',None))
-                return ReturnData(host=host, result=result)
+                result = dict(changed=False, skipped=True)
+                if self.no_log:
+                    result = utils.censor_unlogged_data(result)
+                    self.callbacks.on_skipped(host, result)
+                else:
+                    self.callbacks.on_skipped(host, inject.get('item',None))
+                return ReturnData(host=host, result=utils.jsonify(result))
 
         if getattr(handler, 'setup', None) is not None:
             handler.setup(module_name, inject)


### PR DESCRIPTION
Tasks with `no_log` set should not log data.
Remove log of item data for skipped tasks in loops

Fix for #10387
