### PR TITLE
Allow customization of group by tags

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -87,6 +87,12 @@ group_by_route53_names = True
 group_by_rds_engine = True
 group_by_rds_parameter_group = True
 
+# If you only want to group by certain tags, default is grouping by every tag
+# group_by_tag_keys_whitelist = Name,env,role,owner,id
+
+# If you want to change the group by tags prefix, the host group format is "tag_{{TAG_NAME}}_{{TAG_VALUE}}"
+# group_by_tag_keys_prefix = tag_
+
 # If you only want to include hosts that match a certain regular expression
 # pattern_include = stage-*
 

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -83,6 +83,7 @@ group_by_vpc_id = True
 group_by_security_group = True
 group_by_tag_keys = True
 group_by_tag_none = True
+group_by_tag_values = True
 group_by_route53_names = True
 group_by_rds_engine = True
 group_by_rds_parameter_group = True
@@ -92,6 +93,9 @@ group_by_rds_parameter_group = True
 
 # If you want to change the group by tags prefix, the host group format is "tag_{{TAG_NAME}}_{{TAG_VALUE}}"
 # group_by_tag_keys_prefix = tag_
+
+# If you want to whitelist tag name for group_by_tag_values, default is grouping by every tag values
+# group_by_tag_values_whitelist = Name,env,role
 
 # If you only want to include hosts that match a certain regular expression
 # pattern_include = stage-*

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -307,6 +307,16 @@ class Ec2Inventory(object):
                     continue
                 self.ec2_instance_filters[filter_key].append(filter_value)
 
+        # Whitelisting tags to be grouped
+        self.group_by_tag_keys_whitelist = []
+        if config.has_option('ec2', 'group_by_tag_keys_whitelist'):
+            self.group_by_tag_keys_whitelist = config.get('ec2', 'group_by_tag_keys_whitelist').split(',')
+        
+        # Group by tag prefix option
+        self.group_by_tag_keys_prefix = 'tag_'
+        if config.has_option('ec2', 'group_by_tag_keys_prefix'):
+            self.group_by_tag_keys_prefix  = config.get('ec2', 'group_by_tag_keys_prefix')
+
     def parse_cli_args(self):
         ''' Command line argument processing '''
 
@@ -499,11 +509,12 @@ class Ec2Inventory(object):
         # Inventory: Group by tag keys
         if self.group_by_tag_keys:
             for k, v in instance.tags.iteritems():
-                key = self.to_safe("tag_" + k + "=" + v)
-                self.push(self.inventory, key, dest)
-                if self.nested_groups:
-                    self.push_group(self.inventory, 'tags', self.to_safe("tag_" + k))
-                    self.push_group(self.inventory, self.to_safe("tag_" + k), key)
+                if len(self.group_by_tag_keys_whitelist) == 0 or k in self.group_by_tag_keys_whitelist:
+                    key = self.to_safe(self.group_by_tag_keys_prefix + k + "=" + v)
+                    self.push(self.inventory, key, dest)
+                    if self.nested_groups:
+                        self.push_group(self.inventory, 'tags', self.to_safe(self.group_by_tag_keys_prefix + k))
+                        self.push_group(self.inventory, self.to_safe(self.group_by_tag_keys_prefix + k), key)
 
         # Inventory: Group by Route53 domain names if enabled
         if self.route53_enabled and self.group_by_route53_names:


### PR DESCRIPTION
##### SUMMARY
I would like to have a cleaner cache in my EC2 dynamic inventory. This Pull Request:

Enable customization of tag prefix:
- The default is prefixed with `tag_`. Because we have multiple vendors, I would like to customize the prefix to be called `aws_`. I may generate other dynamic inventory group prefixed with `vendorX_`
- This change should keep the backwards compatibility

Enable whitelisting, only certain tags will be used for group by tags:
- There are many other tags may be created manually for other purposes (e.g. human readable record, or managed by other team). I would like to whitelist tags that are only used for managing ec2 resources. 
- You can specify a comma separated list of tag to be used for grouping


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
plugins/inventory/ec2.ini
plugins/inventory/ec2.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


