### PR TITLE
facts.py throws exception when run on RHEV hypervisor #10383

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -479,7 +479,7 @@ class Facts(object):
             if rc == 0:
                 self.facts['lsb'] = {}
             for line in out.split('\n'):
-                if len(line) < 1:
+                if len(line) < 1 or ':' not in line:
                     continue
                 value = line.split(':', 1)[1].strip()
                 if 'LSB Version:' in line:


### PR DESCRIPTION
This is the pull request for https://github.com/ansible/ansible/issues/10383

Red Hat Enterprise Virtualization Hypervisor 6.6 (20150128.0.el6ev)

The RHEV Hypervisor is a locked down version of RHEL 6.6 that Red Hat provides to RHEV customers. The Ovirt equivalent is called Ovirt Node.

The setup module throws an exception when run against RHEV HVs:

```
tulhv1p11 | FAILED >> {
    "failed": true,
    "msg": "Traceback (most recent call last):\n  File \"<stdin>\", line 4161, in <module>\n  File \"<stdin>\", line 137, in main\n  File \"<stdin>\", line 81, in run_setup\n  File \"<stdin>\", line 4099, in ansible_facts\n  File \"<stdin>\", line 1838, in __init__\n  File \"<stdin>\", line 2126, in get_lsb_facts\nIndexError: list index out of range\n",
    "parsed": false
}
```

The problem lies in the get_lsb_facts function in the file facts.py.

When run, the function attempts to parse the output of the lsb_release command, or the contents of the file /etc/lsb-release if the command is not detected. In either case, the function expects to find colon-delimited key/value pairs, eg -

DistributorId: RedHatEnterpriseLinux

However, the text of the command/file on the HVs only contains: "RedHatEnterpriseVirtualizationHypervisor"

The exception is thrown when the get_lsb_facts function attempts to split the output on the colon:

```
for line in out.split('\n'):
    if len(line) < 1:
        continue
    value = line.split(':', 1)[1].strip()
```

I've worked around the problem by adding a test for a colon to the sanity check that precedes the split:

```
if len(line) < 1 or ':' not in line:
    continue
value = line.split(':',1)[1].strip()
```
