### PR TITLE
Documentation - fix path in Test-module hacking/ example

### DIFF
--- a/hacking/README.md
+++ b/hacking/README.md
@@ -29,7 +29,7 @@ a module outside of the ansible program, locally, on the current machine.
 
 Example:
 
-    $ ./hacking/test-module -m library/commands/shell -a "echo hi"
+    $ ./hacking/test-module -m lib/ansible/modules/core/commands/shell -a "echo hi"
 
 This is a good way to insert a breakpoint into a module, for instance.
 


### PR DESCRIPTION
fix a small path issue in the Test-module example command
