### PR TITLE
Do not fail if count=0 in with_sequence statement.

### DIFF
--- a/lib/ansible/runner/lookup_plugins/sequence.py
+++ b/lib/ansible/runner/lookup_plugins/sequence.py
@@ -152,8 +152,7 @@ class LookupModule(object):
         elif self.count is not None:
             # convert count to end
             self.end = self.start + self.count * self.stride - 1
-            del self.count
-        if self.end < self.start:
+        if self.count != 0 and self.end < self.start:
             raise AnsibleError("can't count backwards")
         if self.format.count('%') != 1:
             raise AnsibleError("bad formatting string: %s" % self.format)


### PR DESCRIPTION
This is an attempt to fix issue #10401. It does indeed fix the error described there, but I'm not sure if it introduces any other problems that I'm not aware of. I would have added a unit test, but I couldn't find any for `with_sequence`.

Also, I saw that the files `lib/ansible/runner/lookup_plugins/sequence.py` and `v2/ansible/plugins/lookup/sequence.py` are almost identical. What is the difference between the two? Should I add the fix to the latter as well (once it is approved)?
