### PR TITLE
Add note to section 'Loops' that the 'when:' statement is processed per-item

### DIFF
--- a/docsite/rst/playbooks_conditionals.rst
+++ b/docsite/rst/playbooks_conditionals.rst
@@ -11,6 +11,8 @@ whether the hosts match other criteria.   There are many options to control exec
 
 Let's dig into what they are.
 
+.. _the_when_statement:
+
 The When Statement
 ``````````````````
 

--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -43,6 +43,8 @@ If you have a list of hashes, you can reference subkeys using things like::
         - { name: 'testuser1', groups: 'wheel' }
         - { name: 'testuser2', groups: 'root' }
 
+Also be aware that when combining `when` with `with_items` (or any other loop statement), the `when` statement is processed separately for each item. See :ref:`the_when_statement` for an example.
+
 .. _nested_loops:
 
 Nested Loops


### PR DESCRIPTION
Minor doc enhancement as per discussion in #10400.
