### PR TITLE
Adding oVirt recognition for oVirt guests. oVirt uses KVM.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2406,6 +2406,11 @@ class LinuxVirtual(Virtual):
             self.facts['virtualization_role'] = 'guest'
             return
 
+	if sys_vendor == 'oVirt':
+            self.facts['virtualization_type'] = 'kvm'
+            self.facts['virtualization_role'] = 'guest'
+            return
+
         if os.path.exists('/proc/self/status'):
             for line in get_file_lines('/proc/self/status'):
                 if re.match('^VxID: \d+', line):


### PR DESCRIPTION
This is a quick check definition to make oVirt VMs register themselves as 'kvm' virtualization_type and 'guest' virtualization_role.
