### PR TITLE
preliminary privlege escalation unification  + pbrun

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -58,12 +58,12 @@ class Cli(object):
         ''' create an options parser for bin/ansible '''
 
         parser = utils.base_parser(
-            constants=C, 
-            runas_opts=True, 
-            subset_opts=True, 
+            constants=C,
+            runas_opts=True,
+            subset_opts=True,
             async_opts=True,
-            output_opts=True, 
-            connect_opts=True, 
+            output_opts=True,
+            connect_opts=True,
             check_opts=True,
             diff_opts=False,
             usage='%prog <host-pattern> [options]'
@@ -82,12 +82,8 @@ class Cli(object):
             parser.print_help()
             sys.exit(1)
 
-        # su and sudo command line arguments need to be mutually exclusive
-        if (options.su or options.su_user or options.ask_su_pass) and \
-                (options.sudo or options.sudo_user or options.ask_sudo_pass):
-            parser.error("Sudo arguments ('--sudo', '--sudo-user', and '--ask-sudo-pass') "
-                         "and su arguments ('-su', '--su-user', and '--ask-su-pass') are "
-                         "mutually exclusive")
+        # privlege escalation command line arguments need to be mutually exclusive
+        utils.check_mutually_exclusive_privilege(options, parser)
 
         if (options.ask_vault_pass and options.vault_password_file):
             parser.error("--ask-vault-pass and --vault-password-file are mutually exclusive")
@@ -101,20 +97,20 @@ class Cli(object):
 
         pattern = args[0]
 
-        sshpass = None
-        sudopass = None
-        su_pass = None
-        vault_pass = None
+        sshpass = becomepass = vault_pass = become_method = None
 
-        options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
         # Never ask for an SSH password when we run with local connection
         if options.connection == "local":
             options.ask_pass = False
-        options.ask_sudo_pass = options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
-        options.ask_su_pass = options.ask_su_pass or C.DEFAULT_ASK_SU_PASS
+        else:
+            options.ask_pass = options.ask_pass or C.DEFAULT_ASK_PASS
+
         options.ask_vault_pass = options.ask_vault_pass or C.DEFAULT_ASK_VAULT_PASS
 
-        (sshpass, sudopass, su_pass, vault_pass) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass, ask_su_pass=options.ask_su_pass, ask_vault_pass=options.ask_vault_pass)
+        # become
+        utils.normalize_become_options(options)
+        prompt_method = utils.choose_pass_prompt(options)
+        (sshpass, becomepass, vault_pass) = utils.ask_passwords(ask_pass=options.ask_pass, become_ask_pass=options.become_ask_pass, ask_vault_pass=options.ask_vault_pass, become_method=prompt_method)
 
         # read vault_pass from a file
         if not options.ask_vault_pass and options.vault_password_file:
@@ -126,6 +122,7 @@ class Cli(object):
         if options.subset:
             inventory_manager.subset(options.subset)
         hosts = inventory_manager.list_hosts(pattern)
+
         if len(hosts) == 0:
             callbacks.display("No hosts matched", stderr=True)
             sys.exit(0)
@@ -135,16 +132,10 @@ class Cli(object):
                 callbacks.display('    %s' % host)
             sys.exit(0)
 
-        if ((options.module_name == 'command' or options.module_name == 'shell')
-                and not options.module_args):
+        if options.module_name in ['command','shell'] and not options.module_args:
             callbacks.display("No argument passed to %s module" % options.module_name, color='red', stderr=True)
             sys.exit(1)
 
-
-        if options.su_user or options.ask_su_pass:
-            options.su = True
-        options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
-        options.su_user = options.su_user or C.DEFAULT_SU_USER
         if options.tree:
             utils.prepare_writeable_dir(options.tree)
 
@@ -160,17 +151,15 @@ class Cli(object):
             forks=options.forks,
             pattern=pattern,
             callbacks=self.callbacks,
-            sudo=options.sudo,
-            sudo_pass=sudopass,
-            sudo_user=options.sudo_user,
             transport=options.connection,
             subset=options.subset,
             check=options.check,
             diff=options.check,
-            su=options.su,
-            su_pass=su_pass,
-            su_user=options.su_user,
             vault_pass=vault_pass,
+            become=options.become,
+            become_method=options.become_method,
+            become_pass=becomepass,
+            become_user=options.become_user,
             extra_vars=extra_vars,
         )
 

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -108,19 +108,14 @@ def main(args):
         parser.print_help(file=sys.stderr)
         return 1
 
-    # su and sudo command line arguments need to be mutually exclusive
-    if (options.su or options.su_user or options.ask_su_pass) and \
-                (options.sudo or options.sudo_user or options.ask_sudo_pass):
-            parser.error("Sudo arguments ('--sudo', '--sudo-user', and '--ask-sudo-pass') "
-                         "and su arguments ('-su', '--su-user', and '--ask-su-pass') are "
-                         "mutually exclusive")
+    # privlege escalation command line arguments need to be mutually exclusive
+    utils.check_mutually_exclusive_privilege(options, parser)
 
     if (options.ask_vault_pass and options.vault_password_file):
             parser.error("--ask-vault-pass and --vault-password-file are mutually exclusive")
 
     sshpass = None
-    sudopass = None
-    su_pass = None
+    becomepass = None
     vault_pass = None
 
     options.ask_vault_pass = options.ask_vault_pass or C.DEFAULT_ASK_VAULT_PASS
@@ -132,11 +127,14 @@ def main(args):
         # Never ask for an SSH password when we run with local connection
         if options.connection == "local":
             options.ask_pass = False
-        options.ask_sudo_pass = options.ask_sudo_pass or C.DEFAULT_ASK_SUDO_PASS
-        options.ask_su_pass = options.ask_su_pass or C.DEFAULT_ASK_SU_PASS
-        (sshpass, sudopass, su_pass, vault_pass) = utils.ask_passwords(ask_pass=options.ask_pass, ask_sudo_pass=options.ask_sudo_pass, ask_su_pass=options.ask_su_pass, ask_vault_pass=options.ask_vault_pass)
-        options.sudo_user = options.sudo_user or C.DEFAULT_SUDO_USER
-        options.su_user = options.su_user or C.DEFAULT_SU_USER
+
+        # set pe options
+        utils.normalize_become_options(options)
+        prompt_method = utils.choose_pass_prompt(options)
+        (sshpass, becomepass, vault_pass) = utils.ask_passwords(ask_pass=options.ask_pass,
+                                                    become_ask_pass=options.become_ask_pass,
+                                                    ask_vault_pass=options.ask_vault_pass,
+                                                    become_method=prompt_method)
 
     # read vault_pass from a file
     if not options.ask_vault_pass and options.vault_password_file:
@@ -197,20 +195,18 @@ def main(args):
             stats=stats,
             timeout=options.timeout,
             transport=options.connection,
-            sudo=options.sudo,
-            sudo_user=options.sudo_user,
-            sudo_pass=sudopass,
+            become=options.become,
+            become_method=options.become_method,
+            become_user=options.become_user,
+            become_pass=becomepass,
             extra_vars=extra_vars,
             private_key_file=options.private_key_file,
             only_tags=only_tags,
             skip_tags=skip_tags,
             check=options.check,
             diff=options.diff,
-            su=options.su,
-            su_pass=su_pass,
-            su_user=options.su_user,
             vault_password=vault_pass,
-            force_handlers=options.force_handlers
+            force_handlers=options.force_handlers,
         )
 
         if options.flush_cache:

--- a/docsite/rst/become.rst
+++ b/docsite/rst/become.rst
@@ -1,0 +1,83 @@
+Ansible Privilege Escalation
+++++++++++++++++++++++++++++
+
+Ansible can use existing privilege escalation systems to allow a user to execute tasks as another.
+
+.. contents:: Topics
+
+Become
+``````
+Before 1.9 Ansible mostly allowed the use of sudo and a limited use of su to allow a login/remote user to become a different user
+and execute tasks, create resources with the 2nd user's permissions. As of 1.9 'become' supersedes the old sudo/su, while still
+being backwards compatible. This new system also makes it easier to add other privilege escalation tools like pbrun (Powerbroker),
+pfexec and others.
+
+
+New directives
+--------------
+
+become
+    equivalent to adding sudo: or su: to a play or task, set to true/yes to activate privilege escalation
+
+become_user
+    equivalent to adding sudo_user: or su_user: to a play or task
+
+become_method
+    at play or task level overrides the default method set in ansibile.cfg
+
+
+New ansible_ variables
+----------------------
+Each allows you to set an option per group and/or host
+
+ansible_become
+    equivalent to ansible_sudo or ansbile_su, allows to force privilege escalation
+
+ansible_become_method
+    allows to set privilege escalation method
+
+ansible_become_user
+    equivalent to ansible_sudo_user or ansbile_su_user, allows to set the user you become through privilege escalation
+
+ansible_become_pass
+    equivalent to ansible_sudo_pass or ansbile_su_pass, allows you to set the privilege escalation password
+
+
+New command line options
+-----------------------
+
+--ask-become-pass
+    ask for privilege escalation password
+
+-b, --become
+    run operations with become (no passorwd implied)
+
+--become-method=BECOME_METHOD
+    privilege escalation method to use (default=sudo),
+    valid choices: [ sudo | su | pbrun | pfexec ]
+
+--become-user=BECOME_USER
+    run operations as this user (default=root)
+
+
+sudo and su still work!
+-----------------------
+
+Old playbooks will not need to be changed, even though they are deprecated, sudo and su directives will continue to work though it
+is recommended to move to become as they may be retired at one point. You cannot mix directives on the same object though, ansible
+will complain if you try to.
+
+Become will default to using the old sudo/su configs and variables if they exist, but will override them if you specify any of the
+new ones.
+
+
+
+.. note:: Privilege escalation methods must also be supported by the connection plugin used, most will warn if they do not, some will just ignore it as they always run as root (jail, chroot, etc).
+
+.. seealso::
+
+   `Mailing List <http://groups.google.com/group/ansible-project>`_
+       Questions? Help? Ideas?  Stop by the list on Google Groups
+   `irc.freenode.net <http://irc.freenode.net>`_
+       #ansible IRC chat channel
+

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -159,6 +159,12 @@ fact_caching = memory
 #retry_files_enabled = False
 #retry_files_save_path = ~/.ansible-retry
 
+[privilege_escalation]
+#become=True
+#become_method='sudo'
+#become_user='root'
+#become_ask_pass=False
+
 [paramiko_connection]
 
 # uncomment this line to cause the paramiko connection plugin to not record new host

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -60,15 +60,12 @@ class PlayBook(object):
         timeout          = C.DEFAULT_TIMEOUT,
         remote_user      = C.DEFAULT_REMOTE_USER,
         remote_pass      = C.DEFAULT_REMOTE_PASS,
-        sudo_pass        = C.DEFAULT_SUDO_PASS,
         remote_port      = None,
         transport        = C.DEFAULT_TRANSPORT,
         private_key_file = C.DEFAULT_PRIVATE_KEY_FILE,
         callbacks        = None,
         runner_callbacks = None,
         stats            = None,
-        sudo             = False,
-        sudo_user        = C.DEFAULT_SUDO_USER,
         extra_vars       = None,
         only_tags        = None,
         skip_tags        = None,
@@ -77,11 +74,13 @@ class PlayBook(object):
         check            = False,
         diff             = False,
         any_errors_fatal = False,
-        su               = False,
-        su_user          = False,
-        su_pass          = False,
         vault_password   = False,
         force_handlers   = False,
+        # privelege escalation
+        become           = C.DEFAULT_BECOME,
+        become_method    = C.DEFAULT_BECOME_METHOD,
+        become_user      = C.DEFAULT_BECOME_USER,
+        become_pass      = None,
     ):
 
         """
@@ -92,13 +91,11 @@ class PlayBook(object):
         timeout:          connection timeout
         remote_user:      run as this user if not specified in a particular play
         remote_pass:      use this remote password (for all plays) vs using SSH keys
-        sudo_pass:        if sudo==True, and a password is required, this is the sudo password
         remote_port:      default remote port to use if not specified with the host or play
         transport:        how to connect to hosts that don't specify a transport (local, paramiko, etc)
         callbacks         output callbacks for the playbook
         runner_callbacks: more callbacks, this time for the runner API
         stats:            holds aggregrate data about events occurring to each host
-        sudo:             if not specified per play, requests all plays use sudo mode
         inventory:        can be specified instead of host_list to use a pre-existing inventory object
         check:            don't change anything, just try to detect some potential changes
         any_errors_fatal: terminate the entire execution immediately when one of the hosts has failed
@@ -139,20 +136,19 @@ class PlayBook(object):
         self.callbacks        = callbacks
         self.runner_callbacks = runner_callbacks
         self.stats            = stats
-        self.sudo             = sudo
-        self.sudo_pass        = sudo_pass
-        self.sudo_user        = sudo_user
         self.extra_vars       = extra_vars
         self.global_vars      = {}
         self.private_key_file = private_key_file
         self.only_tags        = only_tags
         self.skip_tags        = skip_tags
         self.any_errors_fatal = any_errors_fatal
-        self.su               = su
-        self.su_user          = su_user
-        self.su_pass          = su_pass
         self.vault_password   = vault_password
         self.force_handlers   = force_handlers
+
+        self.become           = become
+        self.become_method    = become_method
+        self.become_user      = become_user
+        self.become_pass      = become_pass
 
         self.callbacks.playbook = self
         self.runner_callbacks.playbook = self
@@ -416,10 +412,7 @@ class PlayBook(object):
             basedir=task.play.basedir,
             conditional=task.when,
             callbacks=self.runner_callbacks,
-            sudo=task.sudo,
-            sudo_user=task.sudo_user,
             transport=task.transport,
-            sudo_pass=task.sudo_pass,
             is_playbook=True,
             check=self.check,
             diff=self.diff,
@@ -429,13 +422,14 @@ class PlayBook(object):
             accelerate_port=task.play.accelerate_port,
             accelerate_ipv6=task.play.accelerate_ipv6,
             error_on_undefined_vars=C.DEFAULT_UNDEFINED_VAR_BEHAVIOR,
-            su=task.su,
-            su_user=task.su_user,
-            su_pass=task.su_pass,
             vault_pass = self.vault_password,
             run_hosts=hosts,
             no_log=task.no_log,
             run_once=task.run_once,
+            become=task.become,
+            become_method=task.become_method,
+            become_user=task.become_user,
+            become_pass=task.become_pass,
         )
 
         runner.module_vars.update({'play_hosts': hosts})
@@ -616,12 +610,10 @@ class PlayBook(object):
             setup_cache=self.SETUP_CACHE,
             vars_cache=self.VARS_CACHE,
             callbacks=self.runner_callbacks,
-            sudo=play.sudo,
-            sudo_user=play.sudo_user,
-            sudo_pass=self.sudo_pass,
-            su=play.su,
-            su_user=play.su_user,
-            su_pass=self.su_pass,
+            become=play.become,
+            become_method=play.become_method,
+            become_user=play.become_user,
+            become_pass=self.become_pass,
             vault_pass=self.vault_password,
             transport=play.transport,
             is_playbook=True,

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -32,24 +32,25 @@ import uuid
 
 class Play(object):
 
-    __slots__ = [
-       'hosts', 'name', 'vars', 'vars_file_vars', 'role_vars', 'default_vars', 'vars_prompt', 'vars_files',
-       'handlers', 'remote_user', 'remote_port', 'included_roles', 'accelerate',
-       'accelerate_port', 'accelerate_ipv6', 'sudo', 'sudo_user', 'transport', 'playbook',
-       'tags', 'gather_facts', 'serial', '_ds', '_handlers', '_tasks',
-       'basedir', 'any_errors_fatal', 'roles', 'max_fail_pct', '_play_hosts', 'su', 'su_user',
-       'vault_password', 'no_log', 'environment',
+    _pb_common = [
+        'accelerate', 'accelerate_ipv6', 'accelerate_port', 'any_errors_fatal', 'become',
+        'become_method', 'become_user', 'environment', 'gather_facts', 'handlers', 'hosts',
+        'name', 'no_log', 'remote_user', 'roles', 'serial', 'su', 'su_user', 'sudo',
+        'sudo_user', 'tags', 'vars', 'vars_files', 'vars_prompt', 'vault_password',
+    ]
+
+    __slots__ = _pb_common + [
+        '_ds', '_handlers', '_play_hosts', '_tasks', 'any_errors_fatal', 'basedir',
+        'default_vars', 'included_roles', 'max_fail_pct', 'playbook', 'remote_port',
+        'role_vars', 'transport', 'vars_file_vars',
     ]
 
     # to catch typos and so forth -- these are userland names
     # and don't line up 1:1 with how they are stored
-    VALID_KEYS = frozenset((
-       'hosts', 'name', 'vars', 'vars_prompt', 'vars_files',
-       'tasks', 'handlers', 'remote_user', 'user', 'port', 'include', 'accelerate', 'accelerate_port', 'accelerate_ipv6',
-       'sudo', 'sudo_user', 'connection', 'tags', 'gather_facts', 'serial',
-       'any_errors_fatal', 'roles', 'role_names', 'pre_tasks', 'post_tasks', 'max_fail_percentage',
-       'su', 'su_user', 'vault_password', 'no_log', 'environment',
-    ))
+    VALID_KEYS = frozenset(_pb_common + [
+        'connection', 'include', 'max_fail_percentage', 'port', 'post_tasks',
+        'pre_tasks', 'role_names', 'tasks', 'user',
+    ])
 
     # *************************************************
 
@@ -58,7 +59,7 @@ class Play(object):
 
         for x in ds.keys():
             if not x in Play.VALID_KEYS:
-                raise errors.AnsibleError("%s is not a legal parameter at this level in an Ansible Playbook" % x)
+                raise errors.AnsibleError("%s is not a legal parameter of an Ansible Play" % x)
 
         # allow all playbook keys to be set by --extra-vars
         self.vars             = ds.get('vars', {})
@@ -140,8 +141,6 @@ class Play(object):
         self._handlers        = ds.get('handlers', [])
         self.remote_user      = ds.get('remote_user', ds.get('user', self.playbook.remote_user))
         self.remote_port      = ds.get('port', self.playbook.remote_port)
-        self.sudo             = ds.get('sudo', self.playbook.sudo)
-        self.sudo_user        = ds.get('sudo_user', self.playbook.sudo_user)
         self.transport        = ds.get('connection', self.playbook.transport)
         self.remote_port      = self.remote_port
         self.any_errors_fatal = utils.boolean(ds.get('any_errors_fatal', 'false'))
@@ -149,21 +148,39 @@ class Play(object):
         self.accelerate_port  = ds.get('accelerate_port', None)
         self.accelerate_ipv6  = ds.get('accelerate_ipv6', False)
         self.max_fail_pct     = int(ds.get('max_fail_percentage', 100))
-        self.su               = ds.get('su', self.playbook.su)
-        self.su_user          = ds.get('su_user', self.playbook.su_user)
         self.no_log           = utils.boolean(ds.get('no_log', 'false'))
+
+        # Fail out if user specifies conflicting privelege escalations
+        if (ds.get('become') or ds.get('become_user')) and (ds.get('sudo') or ds.get('sudo_user')):
+            raise errors.AnsibleError('sudo params ("become", "become_user") and su params ("sudo", "sudo_user") cannot be used together')
+        if (ds.get('become') or ds.get('become_user')) and (ds.get('su') or ds.get('su_user')):
+            raise errors.AnsibleError('sudo params ("become", "become_user") and su params ("su", "su_user") cannot be used together')
+        if (ds.get('sudo') or ds.get('sudo_user')) and (ds.get('su') or ds.get('su_user')):
+            raise errors.AnsibleError('sudo params ("sudo", "sudo_user") and su params ("su", "su_user") cannot be used together')
+
+        # become settings are inherited and updated normally
+        self.become           = ds.get('become', self.playbook.become)
+        self.become_method    = ds.get('become_method', self.playbook.become_method)
+        self.become_user      = ds.get('become_user', self.playbook.become_user)
+
+        # Make sure current play settings are reflected in become fields
+        if 'sudo' in ds:
+            self.become=ds['sudo']
+            self.become_method='sudo'
+            if 'sudo_user' in ds:
+                self.become_user=ds['sudo_user']
+        elif 'su' in ds:
+            self.become=True
+            self.become=ds['su']
+            if 'su_user' in ds:
+                self.become_user=ds['su_user']
 
         # gather_facts is not a simple boolean, as None means  that a 'smart'
         # fact gathering mode will be used, so we need to be careful here as
         # calling utils.boolean(None) returns False
         self.gather_facts = ds.get('gather_facts', None)
-        if self.gather_facts:
+        if self.gather_facts is not None:
             self.gather_facts = utils.boolean(self.gather_facts)
-
-        # Fail out if user specifies a sudo param with a su param in a given play
-        if (ds.get('sudo') or ds.get('sudo_user')) and (ds.get('su') or ds.get('su_user')):
-            raise errors.AnsibleError('sudo params ("sudo", "sudo_user") and su params '
-                                      '("su", "su_user") cannot be used together')
 
         load_vars['role_names'] = ds.get('role_names', [])
 
@@ -172,9 +189,6 @@ class Play(object):
 
         # apply any missing tags to role tasks
         self._late_merge_role_tags()
-
-        if self.sudo_user != 'root':
-            self.sudo = True
 
         # place holder for the discovered hosts to be used in this play
         self._play_hosts = None
@@ -429,7 +443,7 @@ class Play(object):
 
         for (role, role_path, role_vars, role_params, default_vars) in roles:
             # special vars must be extracted from the dict to the included tasks
-            special_keys = [ "sudo", "sudo_user", "when", "with_items" ]
+            special_keys = [ "sudo", "sudo_user", "when", "with_items", "su", "su_user", "become", "become_user" ]
             special_vars = {}
             for k in special_keys:
                 if k in role_vars:
@@ -531,7 +545,7 @@ class Play(object):
 
     # *************************************************
 
-    def _load_tasks(self, tasks, vars=None, role_params=None, default_vars=None, sudo_vars=None,
+    def _load_tasks(self, tasks, vars=None, role_params=None, default_vars=None, become_vars=None,
                     additional_conditions=None, original_file=None, role_name=None):
         ''' handle task and handler include statements '''
 
@@ -547,8 +561,8 @@ class Play(object):
             role_params = {}
         if default_vars is None:
             default_vars = {}
-        if sudo_vars is None:
-            sudo_vars = {}
+        if become_vars is None:
+            become_vars = {}
 
         old_conditions = list(additional_conditions)
 
@@ -560,14 +574,37 @@ class Play(object):
             if not isinstance(x, dict):
                 raise errors.AnsibleError("expecting dict; got: %s, error in %s" % (x, original_file))
 
-            # evaluate sudo vars for current and child tasks
-            included_sudo_vars = {}
-            for k in ["sudo", "sudo_user"]:
+            # evaluate privilege escalation vars for current and child tasks
+            included_become_vars = {}
+            for k in ["become", "become_user", "become_method", "become_exe"]:
                 if k in x:
-                    included_sudo_vars[k] = x[k]
-                elif k in sudo_vars:
-                    included_sudo_vars[k] = sudo_vars[k]
-                    x[k] = sudo_vars[k]
+                    included_become_vars[k] = x[k]
+                elif k in become_vars:
+                    included_become_vars[k] = become_vars[k]
+                    x[k] = become_vars[k]
+
+            ## backwards compat with old sudo/su directives
+            if 'sudo' in x or 'sudo_user' in x:
+                included_become_vars['become'] = x['sudo']
+                x['become'] = x['sudo']
+                x['become_method'] = 'sudo'
+                del x['sudo']
+
+                if x.get('sudo_user', False):
+                    included_become_vars['become_user'] = x['sudo_user']
+                    x['become_user'] = x['sudo_user']
+                    del x['sudo_user']
+
+            elif 'su' in x or 'su_user' in x:
+                included_become_vars['become'] = x['su']
+                x['become'] = x['su']
+                x['become_method'] = 'su'
+                del x['su']
+
+                if x.get('su_user', False):
+                    included_become_vars['become_user'] = x['su_user']
+                    x['become_user'] = x['su_user']
+                    del x['su_user']
 
             if 'meta' in x:
                 if x['meta'] == 'flush_handlers':
@@ -596,7 +633,7 @@ class Play(object):
                             included_additional_conditions.append(x[k])
                         elif type(x[k]) is list:
                             included_additional_conditions.extend(x[k])
-                    elif k in ("include", "vars", "role_params", "default_vars", "sudo", "sudo_user", "role_name", "no_log"):
+                    elif k in ("include", "vars", "role_params", "default_vars", "sudo", "sudo_user", "role_name", "no_log", "become", "become_user", "su", "su_user"):
                         continue
                     else:
                         include_vars[k] = x[k]
@@ -643,7 +680,7 @@ class Play(object):
                     for y in data:
                         if isinstance(y, dict) and 'include' in y:
                             y['role_name'] = new_role
-                loaded = self._load_tasks(data, mv, role_params, default_vars, included_sudo_vars, list(included_additional_conditions), original_file=include_filename, role_name=new_role)
+                loaded = self._load_tasks(data, mv, role_params, default_vars, included_become_vars, list(included_additional_conditions), original_file=include_filename, role_name=new_role)
                 results += loaded
             elif type(x) == dict:
                 task = Task(

--- a/lib/ansible/runner/action_plugins/assemble.py
+++ b/lib/ansible/runner/action_plugins/assemble.py
@@ -125,7 +125,7 @@ class ActionModule(object):
             xfered = self.runner._transfer_str(conn, tmp, 'src', resultant)
 
             # fix file permissions when the copy is done as a different user
-            if self.runner.sudo and self.runner.sudo_user != 'root' or self.runner.su and self.runner.su_user != 'root':
+            if self.runner.become and self.runner.become_user != 'root':
                 self.runner._remote_chmod(conn, 'a+r', xfered, tmp)
 
             # run the copy module

--- a/lib/ansible/runner/action_plugins/copy.py
+++ b/lib/ansible/runner/action_plugins/copy.py
@@ -234,7 +234,7 @@ class ActionModule(object):
                 self._remove_tempfile_if_content_defined(content, content_tempfile)
 
                 # fix file permissions when the copy is done as a different user
-                if (self.runner.sudo and self.runner.sudo_user != 'root' or self.runner.su and self.runner.su_user != 'root') and not raw:
+                if self.runner.become and self.runner.become_user != 'root' and not raw:
                     self.runner._remote_chmod(conn, 'a+r', tmp_src, tmp_path)
 
                 if raw:

--- a/lib/ansible/runner/action_plugins/fetch.py
+++ b/lib/ansible/runner/action_plugins/fetch.py
@@ -78,7 +78,7 @@ class ActionModule(object):
 
         # use slurp if sudo and permissions are lacking
         remote_data = None
-        if remote_checksum in ('1', '2') or self.runner.sudo:
+        if remote_checksum in ('1', '2') or self.runner.become:
             slurpres = self.runner._execute_module(conn, tmp, 'slurp', 'src=%s' % source, inject=inject)
             if slurpres.is_successful():
                 if slurpres.result['encoding'] == 'base64':

--- a/lib/ansible/runner/action_plugins/patch.py
+++ b/lib/ansible/runner/action_plugins/patch.py
@@ -50,7 +50,7 @@ class ActionModule(object):
         tmp_src = tmp + src
         conn.put_file(src, tmp_src)
 
-        if self.runner.sudo and self.runner.sudo_user != 'root' or self.runner.su and self.runner.su_user != 'root':
+        if self.runner.become and self.runner.become_user != 'root':
             if not self.runner.noop_on_check(inject):
                 self.runner._remote_chmod(conn, 'a+r', tmp_src, tmp)
 

--- a/lib/ansible/runner/action_plugins/script.py
+++ b/lib/ansible/runner/action_plugins/script.py
@@ -113,8 +113,7 @@ class ActionModule(object):
 
         sudoable = True
         # set file permissions, more permissive when the copy is done as a different user
-        if ((self.runner.sudo and self.runner.sudo_user != 'root') or
-                (self.runner.su and self.runner.su_user != 'root')):
+        if self.runner.become and self.runner.become_user != 'root':
             chmod_mode = 'a+rx'
             sudoable = False
         else:

--- a/lib/ansible/runner/action_plugins/template.py
+++ b/lib/ansible/runner/action_plugins/template.py
@@ -133,7 +133,7 @@ class ActionModule(object):
             xfered = self.runner._transfer_str(conn, tmp, 'source', resultant)
 
             # fix file permissions when the copy is done as a different user
-            if self.runner.sudo and self.runner.sudo_user != 'root' or self.runner.su and self.runner.su_user != 'root':
+            if self.runner.become and self.runner.become_user != 'root' or self.runner.su and self.runner.su_user != 'root':
                 self.runner._remote_chmod(conn, 'a+r', xfered, tmp)
 
             # run the copy module

--- a/lib/ansible/runner/action_plugins/unarchive.py
+++ b/lib/ansible/runner/action_plugins/unarchive.py
@@ -99,7 +99,7 @@ class ActionModule(object):
         # handle check mode client side
         # fix file permissions when the copy is done as a different user
         if copy:
-            if self.runner.sudo and self.runner.sudo_user != 'root' or self.runner.su and self.runner.su_user != 'root':
+            if self.runner.become and self.runner.become_user != 'root':
                 if not self.runner.noop_on_check(inject):
                     self.runner._remote_chmod(conn, 'a+r', tmp_src, tmp)
             # Build temporary module_args.

--- a/lib/ansible/runner/action_plugins/win_copy.py
+++ b/lib/ansible/runner/action_plugins/win_copy.py
@@ -230,7 +230,7 @@ class ActionModule(object):
                 self._remove_tempfile_if_content_defined(content, content_tempfile)
 
                 # fix file permissions when the copy is done as a different user
-                if (self.runner.sudo and self.runner.sudo_user != 'root' or self.runner.su and self.runner.su_user != 'root') and not raw:
+                if self.runner.become and self.runner.become_user != 'root' and not raw:
                     self.runner._remote_chmod(conn, 'a+r', tmp_src, tmp_path)
 
                 if raw:

--- a/lib/ansible/runner/action_plugins/win_template.py
+++ b/lib/ansible/runner/action_plugins/win_template.py
@@ -109,7 +109,7 @@ class ActionModule(object):
             xfered = self.runner._transfer_str(conn, tmp, 'source', resultant)
 
             # fix file permissions when the copy is done as a different user
-            if self.runner.sudo and self.runner.sudo_user != 'root' or self.runner.su and self.runner.su_user != 'root':
+            if self.runner.become and self.runner.become_user != 'root':
                 self.runner._remote_chmod(conn, 'a+r', xfered, tmp)
 
             # run the copy module

--- a/lib/ansible/runner/connection_plugins/accelerate.py
+++ b/lib/ansible/runner/connection_plugins/accelerate.py
@@ -50,6 +50,7 @@ class Connection(object):
         self.accport = port[1]
         self.is_connected = False
         self.has_pipelining = False
+        self.become_methods_supported=['sudo']
 
         if not self.port:
             self.port = constants.DEFAULT_REMOTE_PORT
@@ -226,11 +227,11 @@ class Connection(object):
         else:
             return response.get('rc') == 0
 
-    def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False, executable='/bin/sh', in_data=None, su=None, su_user=None):
+    def exec_command(self, cmd, tmp_path, become_user=None, sudoable=False, executable='/bin/sh', in_data=None):
         ''' run a command on the remote host '''
 
-        if su or su_user:
-            raise AnsibleError("Internal Error: this module does not support running commands via su")
+        if sudoable and self.runner.become and self.runner.become_method not in self.become_methods_supported:
+            raise errors.AnsibleError("Internal Error: this module does not support running commands via %s" % self.runner.become_method)
 
         if in_data:
             raise AnsibleError("Internal Error: this module does not support optimized module pipelining")
@@ -238,8 +239,8 @@ class Connection(object):
         if executable == "":
             executable = constants.DEFAULT_EXECUTABLE
 
-        if self.runner.sudo and sudoable and sudo_user:
-            cmd, prompt, success_key = utils.make_sudo_cmd(self.runner.sudo_exe, sudo_user, executable, cmd)
+        if self.runner.become and sudoable:
+            cmd, prompt, success_key = utils.make_become_cmd(cmd, become_user, executable, self.runner.become_method, '', self.runner.become_exe)
 
         vvv("EXEC COMMAND %s" % cmd)
 
@@ -292,8 +293,8 @@ class Connection(object):
                 if fd.tell() >= fstat.st_size:
                     last = True
                 data = dict(mode='put', data=base64.b64encode(data), out_path=out_path, last=last)
-                if self.runner.sudo:
-                    data['user'] = self.runner.sudo_user
+                if self.runner.become:
+                    data['user'] = self.runner.become_user
                 data = utils.jsonify(data)
                 data = utils.encrypt(self.key, data)
 

--- a/lib/ansible/runner/connection_plugins/chroot.py
+++ b/lib/ansible/runner/connection_plugins/chroot.py
@@ -24,6 +24,7 @@ import subprocess
 from ansible import errors
 from ansible import utils
 from ansible.callbacks import vvv
+import ansible.constants as C
 
 class Connection(object):
     ''' Local chroot based connections '''
@@ -31,6 +32,7 @@ class Connection(object):
     def __init__(self, runner, host, port, *args, **kwargs):
         self.chroot = host
         self.has_pipelining = False
+        self.become_methods_supported=C.BECOME_METHODS
 
         if os.geteuid() != 0:
             raise errors.AnsibleError("chroot connection requires running as root")
@@ -60,16 +62,16 @@ class Connection(object):
 
         return self
 
-    def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False, executable='/bin/sh', in_data=None, su=None, su_user=None):
+    def exec_command(self, cmd, tmp_path, become_user=None, sudoable=False, executable='/bin/sh', in_data=None):
         ''' run a command on the chroot '''
 
-        if su or su_user:
-            raise errors.AnsibleError("Internal Error: this module does not support running commands via su")
+        if sudoable and self.runner.become and self.runner.become_method not in self.become_methods_supported:
+            raise errors.AnsibleError("Internal Error: this module does not support running commands via %s" % self.runner.become_method)
 
         if in_data:
             raise errors.AnsibleError("Internal Error: this module does not support optimized module pipelining")
 
-        # We enter chroot as root so sudo stuff can be ignored
+        # We enter chroot as root so we ignore privlege escalation?
 
         if executable:
             local_cmd = [self.chroot_cmd, self.chroot, executable, '-c', cmd]

--- a/lib/ansible/runner/connection_plugins/fireball.py
+++ b/lib/ansible/runner/connection_plugins/fireball.py
@@ -53,6 +53,8 @@ class Connection(object):
         else:
             self.port = port
 
+        self.become_methods_supported=[]
+
     def connect(self):
         ''' activates the connection object '''
 
@@ -64,11 +66,11 @@ class Connection(object):
         socket = self.context.socket(zmq.REQ)
         addr = "tcp://%s:%s" % (self.host, self.port)
         socket.connect(addr)
-        self.socket = socket    
+        self.socket = socket
 
         return self
 
-    def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False, executable='/bin/sh', in_data=None, su_user=None, su=None):
+    def exec_command(self, cmd, tmp_path, become_user, sudoable=False, executable='/bin/sh', in_data=None):
         ''' run a command on the remote host '''
 
         if in_data:
@@ -76,7 +78,7 @@ class Connection(object):
 
         vvv("EXEC COMMAND %s" % cmd)
 
-        if (self.runner.sudo and sudoable) or (self.runner.su and su):
+        if self.runner.become and sudoable:
             raise errors.AnsibleError(
                 "When using fireball, do not specify sudo or su to run your tasks. " +
                 "Instead sudo the fireball action with sudo. " +

--- a/lib/ansible/runner/connection_plugins/funcd.py
+++ b/lib/ansible/runner/connection_plugins/funcd.py
@@ -53,16 +53,14 @@ class Connection(object):
         self.client = fc.Client(self.host)
         return self
 
-    def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False,
-                     executable='/bin/sh', in_data=None, su=None, su_user=None):
+    def exec_command(self, cmd, tmp_path, become_user=None, sudoable=False,
+                     executable='/bin/sh', in_data=None):
         ''' run a command on the remote minion '''
-
-        if su or su_user:
-            raise errors.AnsibleError("Internal Error: this module does not support running commands via su")
 
         if in_data:
             raise errors.AnsibleError("Internal Error: this module does not support optimized module pipelining")
 
+        # totally ignores privlege escalation
         vvv("EXEC %s" % (cmd), host=self.host)
         p = self.client.command.run(cmd)[self.host]
         return (p[0], '', p[1], p[2])

--- a/lib/ansible/runner/connection_plugins/libvirt_lxc.py
+++ b/lib/ansible/runner/connection_plugins/libvirt_lxc.py
@@ -22,6 +22,7 @@ import os
 import subprocess
 from ansible import errors
 from ansible.callbacks import vvv
+import ansible.constants as C
 
 class Connection(object):
     ''' Local lxc based connections '''
@@ -50,6 +51,7 @@ class Connection(object):
         self.host = host
         # port is unused, since this is local
         self.port = port
+        self.become_methods_supported=C.BECOME_METHODS
 
     def connect(self, port=None):
         ''' connect to the lxc; nothing to do here '''
@@ -65,16 +67,16 @@ class Connection(object):
             local_cmd = '%s -q -c lxc:/// lxc-enter-namespace %s -- %s' % (self.cmd, self.lxc, cmd)
         return local_cmd
 
-    def exec_command(self, cmd, tmp_path, sudo_user, sudoable=False, executable='/bin/sh', in_data=None, su=None, su_user=None):
+    def exec_command(self, cmd, tmp_path, become_user, sudoable=False, executable='/bin/sh', in_data=None):
         ''' run a command on the chroot '''
 
-        if su or su_user:
-            raise errors.AnsibleError("Internal Error: this module does not support running commands via su")
+        if sudoable and self.runner.become and self.runner.become_method not in self.become_methods_supported:
+            raise errors.AnsibleError("Internal Error: this module does not support running commands via %s" % self.runner.become_method)
 
         if in_data:
             raise errors.AnsibleError("Internal Error: this module does not support optimized module pipelining")
 
-        # We enter lxc as root so sudo stuff can be ignored
+        # We ignore privelege escalation!
         local_cmd = self._generate_cmd(executable, cmd)
 
         vvv("EXEC %s" % (local_cmd), host=self.lxc)

--- a/lib/ansible/runner/connection_plugins/local.py
+++ b/lib/ansible/runner/connection_plugins/local.py
@@ -26,6 +26,7 @@ from ansible import errors
 from ansible import utils
 from ansible.callbacks import vvv
 
+
 class Connection(object):
     ''' Local based connections '''
 
@@ -33,31 +34,34 @@ class Connection(object):
         self.runner = runner
         self.host = host
         # port is unused, since this is local
-        self.port = port 
+        self.port = port
         self.has_pipelining = False
+
+        # TODO: add su(needs tty), pbrun, pfexec
+        self.become_methods_supported=['sudo']
 
     def connect(self, port=None):
         ''' connect to the local host; nothing to do here '''
 
         return self
 
-    def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False, executable='/bin/sh', in_data=None, su=None, su_user=None):
+    def exec_command(self, cmd, tmp_path, become_user=None, sudoable=False, executable='/bin/sh', in_data=None):
         ''' run a command on the local host '''
 
         # su requires to be run from a terminal, and therefore isn't supported here (yet?)
-        if su or su_user:
-            raise errors.AnsibleError("Internal Error: this module does not support running commands via su")
+        if sudoable and self.runner.become and self.runner.become_method not in self.become_methods_supported:
+            raise errors.AnsibleError("Internal Error: this module does not support running commands via %s" % self.runner.become_method)
 
         if in_data:
             raise errors.AnsibleError("Internal Error: this module does not support optimized module pipelining")
 
-        if not self.runner.sudo or not sudoable:
+        if self.runner.become and sudoable:
+            local_cmd, prompt, success_key = utils.make_become_cmd(cmd, become_user, executable, self.runner.become_method, '-H', self.runner.become_exe)
+        else:
             if executable:
                 local_cmd = executable.split() + ['-c', cmd]
             else:
                 local_cmd = cmd
-        else:
-            local_cmd, prompt, success_key = utils.make_sudo_cmd(self.runner.sudo_exe, sudo_user, executable, cmd)
         executable = executable.split()[0] if executable else None
 
         vvv("EXEC %s" % (local_cmd), host=self.host)
@@ -66,13 +70,19 @@ class Connection(object):
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-        if self.runner.sudo and sudoable and self.runner.sudo_pass:
+        if self.runner.become and sudoable and self.runner.become_pass:
             fcntl.fcntl(p.stdout, fcntl.F_SETFL,
                         fcntl.fcntl(p.stdout, fcntl.F_GETFL) | os.O_NONBLOCK)
             fcntl.fcntl(p.stderr, fcntl.F_SETFL,
                         fcntl.fcntl(p.stderr, fcntl.F_GETFL) | os.O_NONBLOCK)
-            sudo_output = ''
-            while not sudo_output.endswith(prompt) and success_key not in sudo_output:
+            become_output = ''
+            while success_key not in become_output:
+
+                if prompt and become_output.endswith(prompt):
+                    break
+                if utils.su_prompts.check_su_prompt(become_output):
+                    break
+
                 rfd, wfd, efd = select.select([p.stdout, p.stderr], [],
                                               [p.stdout, p.stderr], self.runner.timeout)
                 if p.stdout in rfd:
@@ -81,13 +91,13 @@ class Connection(object):
                     chunk = p.stderr.read()
                 else:
                     stdout, stderr = p.communicate()
-                    raise errors.AnsibleError('timeout waiting for sudo password prompt:\n' + sudo_output)
+                    raise errors.AnsibleError('timeout waiting for %s password prompt:\n' % self.runner.become_method + become_output)
                 if not chunk:
                     stdout, stderr = p.communicate()
-                    raise errors.AnsibleError('sudo output closed while waiting for password prompt:\n' + sudo_output)
-                sudo_output += chunk
-            if success_key not in sudo_output:
-                p.stdin.write(self.runner.sudo_pass + '\n')
+                    raise errors.AnsibleError('%s output closed while waiting for password prompt:\n' % self.runner.become_method + become_output)
+                become_output += chunk
+            if success_key not in become_output:
+                p.stdin.write(self.runner.become_pass + '\n')
             fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
             fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) & ~os.O_NONBLOCK)
 

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -125,6 +125,9 @@ class Connection(object):
         self.private_key_file = private_key_file
         self.has_pipelining = False
 
+        # TODO: add pbrun, pfexec
+        self.become_methods_supported=['sudo', 'su', 'pbrun']
+
     def _cache_key(self):
         return "%s__%s__" % (self.host, self.user)
 
@@ -184,8 +187,11 @@ class Connection(object):
 
         return ssh
 
-    def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False, executable='/bin/sh', in_data=None, su=None, su_user=None):
+    def exec_command(self, cmd, tmp_path, become_user=None, sudoable=False, executable='/bin/sh', in_data=None):
         ''' run a command on the remote host '''
+
+        if self.runner.become and sudoable and self.runner.become_method not in self.become_methods_supported:
+            raise errors.AnsibleError("Internal Error: this module does not support running commands via %s" % self.runner.become_method)
 
         if in_data:
             raise errors.AnsibleError("Internal Error: this module does not support optimized module pipelining")
@@ -206,7 +212,7 @@ class Connection(object):
 
         no_prompt_out = ''
         no_prompt_err = ''
-        if not (self.runner.sudo and sudoable) and not (self.runner.su and su):
+        if not (self.runner.become and sudoable):
 
             if executable:
                 quoted_command = executable + ' -c ' + pipes.quote(cmd)
@@ -224,50 +230,46 @@ class Connection(object):
                 chan.get_pty(term=os.getenv('TERM', 'vt100'),
                              width=int(os.getenv('COLUMNS', 0)),
                              height=int(os.getenv('LINES', 0)))
-            if self.runner.sudo or sudoable:
-                shcmd, prompt, success_key = utils.make_sudo_cmd(self.runner.sudo_exe, sudo_user, executable, cmd)
-            elif self.runner.su or su:
-                shcmd, prompt, success_key = utils.make_su_cmd(su_user, executable, cmd)
+            if self.runner.become and sudoable:
+                shcmd, prompt, success_key = utils.make_become_cmd(cmd, become_user, executable, self.runner.become_method, '', self.runner.become_exe)
 
             vvv("EXEC %s" % shcmd, host=self.host)
-            sudo_output = ''
+            become_output = ''
 
             try:
 
                 chan.exec_command(shcmd)
 
-                if self.runner.sudo_pass or self.runner.su_pass:
+                if self.runner.become_pass:
 
                     while True:
 
-                        if success_key in sudo_output or \
-                            (self.runner.sudo_pass and sudo_output.endswith(prompt)) or \
-                            (self.runner.su_pass and utils.su_prompts.check_su_prompt(sudo_output)):
+                        if success_key in become_output or \
+                            (prompt and become_output.endswith(prompt)) or \
+                            utils.su_prompts.check_su_prompt(become_output)):
                             break
                         chunk = chan.recv(bufsize)
 
                         if not chunk:
-                            if 'unknown user' in sudo_output:
+                            if 'unknown user' in become_output:
                                 raise errors.AnsibleError(
-                                    'user %s does not exist' % sudo_user)
+                                    'user %s does not exist' % become_user)
                             else:
                                 raise errors.AnsibleError('ssh connection ' +
                                     'closed waiting for password prompt')
-                        sudo_output += chunk
+                        become_output += chunk
 
-                    if success_key not in sudo_output:
+                    if success_key not in become_output:
 
                         if sudoable:
-                            chan.sendall(self.runner.sudo_pass + '\n')
-                        elif su:
-                            chan.sendall(self.runner.su_pass + '\n')
+                            chan.sendall(self.runner.become_pass + '\n')
                     else:
-                        no_prompt_out += sudo_output
-                        no_prompt_err += sudo_output
+                        no_prompt_out += become_output
+                        no_prompt_err += become_output
 
             except socket.timeout:
 
-                raise errors.AnsibleError('ssh timed out waiting for sudo.\n' + sudo_output)
+                raise errors.AnsibleError('ssh timed out waiting for privilege escalation.\n' + become_output)
 
         stdout = ''.join(chan.makefile('rb', bufsize))
         stderr = ''.join(chan.makefile_stderr('rb', bufsize))

--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -72,6 +72,10 @@ class Connection(object):
         self.shell_id = None
         self.delegate = None
 
+        # Add runas support
+        #self.become_methods_supported=['runas']
+        self.become_methods_supported=[]
+
     def _winrm_connect(self):
         '''
         Establish a WinRM connection over HTTP/HTTPS.
@@ -143,7 +147,11 @@ class Connection(object):
             self.protocol = self._winrm_connect()
         return self
 
-    def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False, executable=None, in_data=None, su=None, su_user=None):
+    def exec_command(self, cmd, tmp_path, become_user=None, sudoable=False, executable=None, in_data=None):
+
+        if sudoable and self.runner.become and self.runner.become_method not in self.become_methods_supported:
+            raise errors.AnsibleError("Internal Error: this module does not support running commands via %s" % self.runner.become_method)
+
         cmd = cmd.encode('utf-8')
         cmd_parts = shlex.split(cmd, posix=False)
         if '-EncodedCommand' in cmd_parts:

--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -3,6 +3,8 @@
   roles:
     # In destructive because it creates and removes a user
     - { role: test_sudo, tags: test_sudo}
+    #- { role: test_su, tags: test_su} # wait till su support is added to local connection, needs tty
+    - { role: test_become, tags: test_become}
     - { role: test_service, tags: test_service }
     # Current pip unconditionally uses md5.  We can re-enable if pip switches
     # to a different hash or allows us to not check md5

--- a/test/integration/roles/test_become/files/baz.txt
+++ b/test/integration/roles/test_become/files/baz.txt
@@ -1,0 +1,1 @@
+testing tilde expansion with become

--- a/test/integration/roles/test_become/tasks/main.yml
+++ b/test/integration/roles/test_become/tasks/main.yml
@@ -1,0 +1,77 @@
+- include_vars: default.yml
+
+- name: Create test user
+  become: True
+  become_user: root
+  user:
+    name: "{{ become_test_user }}"
+
+- name: test becoming user
+  shell: whoami
+  become: True
+  become_user: "{{ become_test_user }}"
+  register: results
+
+- assert:
+    that:
+      - "results.stdout == '{{ become_test_user }}'"
+
+- name: tilde expansion honors become in file
+  become: True
+  become_user: "{{ become_test_user }}"
+  file:
+    path: "~/foo.txt"
+    state: touch
+
+- name: check that the path in the user's home dir was created
+  stat:
+    path: "~{{ become_test_user }}/foo.txt"
+  register: results
+
+- assert:
+    that:
+      - "results.stat.exists == True"
+      - "results.stat.path|dirname|basename == '{{ become_test_user }}'"
+
+- name: tilde expansion honors become in template
+  become: True
+  become_user: "{{ become_test_user }}"
+  template:
+    src: "bar.j2"
+    dest: "~/bar.txt"
+
+- name: check that the path in the user's home dir was created
+  stat:
+    path: "~{{ become_test_user }}/bar.txt"
+  register: results
+
+- assert:
+    that:
+      - "results.stat.exists == True"
+      - "results.stat.path|dirname|basename == '{{ become_test_user }}'"
+
+- name: tilde expansion honors become in copy
+  become: True
+  become_user: "{{ become_test_user }}"
+  copy:
+    src: baz.txt
+    dest: "~/baz.txt"
+
+- name: check that the path in the user's home dir was created
+  stat:
+    path: "~{{ become_test_user }}/baz.txt"
+  register: results
+
+- assert:
+    that:
+      - "results.stat.exists == True"
+      - "results.stat.path|dirname|basename == '{{ become_test_user }}'"
+
+- name: Remove test user and their home dir
+  become: True
+  become_user: root
+  user:
+    name: "{{ become_test_user }}"
+    state: "absent"
+    remove: "yes"
+

--- a/test/integration/roles/test_become/templates/bar.j2
+++ b/test/integration/roles/test_become/templates/bar.j2
@@ -1,0 +1,1 @@
+{{ become_test_user }}

--- a/test/integration/roles/test_become/vars/default.yml
+++ b/test/integration/roles/test_become/vars/default.yml
@@ -1,0 +1,1 @@
+become_test_user: ansibletest1

--- a/test/integration/roles/test_su/files/baz.txt
+++ b/test/integration/roles/test_su/files/baz.txt
@@ -1,0 +1,1 @@
+testing tilde expansion with su

--- a/test/integration/roles/test_su/tasks/main.yml
+++ b/test/integration/roles/test_su/tasks/main.yml
@@ -1,75 +1,75 @@
 - include_vars: default.yml
 
 - name: Create test user
-  sudo: true
+  su: True
   user:
-    name: "{{ sudo_test_user }}"
+    name: "{{ su_test_user }}"
 
 - name: test becoming user
   shell: whoami
-  sudo: True
-  sudo_user: "{{ sudo_test_user }}"
+  su: True
+  su_user: "{{ su_test_user }}"
   register: results
 
 - assert:
     that:
-      - "results.stdout == '{{ sudo_test_user }}'"
+      - "results.stdout == '{{ su_test_user }}'"
 
-- name: tilde expansion honors sudo in file
-  sudo: True
-  sudo_user: "{{ sudo_test_user }}"
+- name: tilde expansion honors su in file
+  su: True
+  su_user: "{{ su_test_user }}"
   file:
     path: "~/foo.txt"
     state: touch
 
 - name: check that the path in the user's home dir was created
   stat:
-    path: "~{{ sudo_test_user }}/foo.txt"
+    path: "~{{ su_test_user }}/foo.txt"
   register: results
 
 - assert:
     that:
       - "results.stat.exists == True"
-      - "results.stat.path|dirname|basename == '{{ sudo_test_user }}'"
+      - "results.stat.path|dirname|basename == '{{ su_test_user }}'"
 
-- name: tilde expansion honors sudo in template
-  sudo: True
-  sudo_user: "{{ sudo_test_user }}"
+- name: tilde expansion honors su in template
+  su: True
+  su_user: "{{ su_test_user }}"
   template:
     src: "bar.j2"
     dest: "~/bar.txt"
 
 - name: check that the path in the user's home dir was created
   stat:
-    path: "~{{ sudo_test_user }}/bar.txt"
+    path: "~{{ su_test_user }}/bar.txt"
   register: results
 
 - assert:
     that:
       - "results.stat.exists == True"
-      - "results.stat.path|dirname|basename == '{{ sudo_test_user }}'"
+      - "results.stat.path|dirname|basename == '{{ su_test_user }}'"
 
-- name: tilde expansion honors sudo in copy
-  sudo: True
-  sudo_user: "{{ sudo_test_user }}"
+- name: tilde expansion honors su in copy
+  su: True
+  su_user: "{{ su_test_user }}"
   copy:
     src: baz.txt
     dest: "~/baz.txt"
 
 - name: check that the path in the user's home dir was created
   stat:
-    path: "~{{ sudo_test_user }}/baz.txt"
+    path: "~{{ su_test_user }}/baz.txt"
   register: results
 
 - assert:
     that:
       - "results.stat.exists == True"
-      - "results.stat.path|dirname|basename == '{{ sudo_test_user }}'"
+      - "results.stat.path|dirname|basename == '{{ su_test_user }}'"
 
 - name: Remove test user and their home dir
-  sudo: true
+  su: True
   user:
-    name: "{{ sudo_test_user }}"
+    name: "{{ su_test_user }}"
     state: "absent"
     remove: "yes"
 

--- a/test/integration/roles/test_su/templates/bar.j2
+++ b/test/integration/roles/test_su/templates/bar.j2
@@ -1,0 +1,1 @@
+{{ su_test_user }}

--- a/test/integration/roles/test_su/vars/default.yml
+++ b/test/integration/roles/test_su/vars/default.yml
@@ -1,0 +1,1 @@
+su_test_user: ansibletest1

--- a/test/units/TestPlayVarsFiles.py
+++ b/test/units/TestPlayVarsFiles.py
@@ -41,6 +41,9 @@ class FakePlayBook(object):
         self.sudo_user = None
         self.su = None
         self.su_user = None
+        self.become  = None
+        self.become_method  = None
+        self.become_user = None
         self.transport = None
         self.only_tags = None
         self.skip_tags = None

--- a/test/units/TestSynchronize.py
+++ b/test/units/TestSynchronize.py
@@ -18,6 +18,9 @@ class FakeRunner(object):
         self.remote_user = None
         self.private_key_file = None
         self.check = False
+        self.become = False
+        self.become_method = False
+        self.become_user = False
 
     def _execute_module(self, conn, tmp, module_name, args,
         async_jid=None, async_module=None, async_limit=None, inject=None, 
@@ -76,7 +79,7 @@ class TestSynchronize(unittest.TestCase):
         """ verify the synchronize action plugin unsets and then sets sudo """ 
 
         runner = FakeRunner()
-        runner.sudo = True
+        runner.become = True
         runner.remote_user = "root"
         runner.transport = "ssh"
         conn = FakeConn()
@@ -97,7 +100,7 @@ class TestSynchronize(unittest.TestCase):
         assert runner.executed_complex_args == {'dest':'root@el6.lab.net:/tmp/bar',
                                                 'src':'/tmp/foo',
                                                 'rsync_path':'"sudo rsync"'}, "wrong args used"
-        assert runner.sudo == True, "sudo was not reset to True" 
+        assert runner.become == True, "sudo was not reset to True"
 
 
     def test_synchronize_action_local(self):

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -498,7 +498,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(len(cmd), 3)
         self.assertTrue('-u root' in cmd[0])
         self.assertTrue('-p "[sudo via ansible, key=' in cmd[0] and cmd[1].startswith('[sudo via ansible, key'))
-        self.assertTrue('echo SUDO-SUCCESS-' in cmd[0] and cmd[2].startswith('SUDO-SUCCESS-'))
+        self.assertTrue('echo BECOME-SUCCESS-' in cmd[0] and cmd[2].startswith('BECOME-SUCCESS-'))
         self.assertTrue('sudo -k' in cmd[0])
 
     def test_make_su_cmd(self):
@@ -506,7 +506,7 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(isinstance(cmd, tuple))
         self.assertEqual(len(cmd), 3)
         self.assertTrue('root -c "/bin/sh' in cmd[0] or ' root -c /bin/sh' in cmd[0])
-        self.assertTrue('echo SUDO-SUCCESS-' in cmd[0] and cmd[2].startswith('SUDO-SUCCESS-'))
+        self.assertTrue('echo BECOME-SUCCESS-' in cmd[0] and cmd[2].startswith('BECOME-SUCCESS-'))
 
     def test_to_unicode(self):
         uni = ansible.utils.unicode.to_unicode(u'ansible')

--- a/v2/ansible/constants.py
+++ b/v2/ansible/constants.py
@@ -141,15 +141,15 @@ DEFAULT_SU_FLAGS          = get_config(p, DEFAULTS, 'su_flags', 'ANSIBLE_SU_FLAG
 DEFAULT_SU_USER           = get_config(p, DEFAULTS, 'su_user', 'ANSIBLE_SU_USER', 'root')
 DEFAULT_ASK_SU_PASS       = get_config(p, DEFAULTS, 'ask_su_pass', 'ANSIBLE_ASK_SU_PASS', False, boolean=True)
 DEFAULT_GATHERING         = get_config(p, DEFAULTS, 'gathering', 'ANSIBLE_GATHERING', 'implicit').lower()
-
-DEFAULT_ACTION_PLUGIN_PATH     = get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '/usr/share/ansible_plugins/action_plugins')
-DEFAULT_CACHE_PLUGIN_PATH      = get_config(p, DEFAULTS, 'cache_plugins',      'ANSIBLE_CACHE_PLUGINS', '/usr/share/ansible_plugins/cache_plugins')
-DEFAULT_CALLBACK_PLUGIN_PATH   = get_config(p, DEFAULTS, 'callback_plugins',   'ANSIBLE_CALLBACK_PLUGINS', '/usr/share/ansible_plugins/callback_plugins')
-DEFAULT_CONNECTION_PLUGIN_PATH = get_config(p, DEFAULTS, 'connection_plugins', 'ANSIBLE_CONNECTION_PLUGINS', '/usr/share/ansible_plugins/connection_plugins')
-DEFAULT_LOOKUP_PLUGIN_PATH     = get_config(p, DEFAULTS, 'lookup_plugins',     'ANSIBLE_LOOKUP_PLUGINS', '/usr/share/ansible_plugins/lookup_plugins')
-DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       'ANSIBLE_VARS_PLUGINS', '/usr/share/ansible_plugins/vars_plugins')
-DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '/usr/share/ansible_plugins/filter_plugins')
 DEFAULT_LOG_PATH               = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
+
+DEFAULT_ACTION_PLUGIN_PATH     = get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '~/.ansible/plugins/action_plugins:/usr/share/ansible_plugins/action_plugins')
+DEFAULT_CACHE_PLUGIN_PATH      = get_config(p, DEFAULTS, 'cache_plugins',      'ANSIBLE_CACHE_PLUGINS', '~/.ansible/plugins/cache_plugins:/usr/share/ansible_plugins/cache_plugins')
+DEFAULT_CALLBACK_PLUGIN_PATH   = get_config(p, DEFAULTS, 'callback_plugins',   'ANSIBLE_CALLBACK_PLUGINS', '~/.ansible/plugins/callback_plugins:/usr/share/ansible_plugins/callback_plugins')
+DEFAULT_CONNECTION_PLUGIN_PATH = get_config(p, DEFAULTS, 'connection_plugins', 'ANSIBLE_CONNECTION_PLUGINS', '~/.ansible/plugins/connection_plugins:/usr/share/ansible_plugins/connection_plugins')
+DEFAULT_LOOKUP_PLUGIN_PATH     = get_config(p, DEFAULTS, 'lookup_plugins',     'ANSIBLE_LOOKUP_PLUGINS', '~/.ansible/plugins/lookup_plugins:/usr/share/ansible_plugins/lookup_plugins')
+DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       'ANSIBLE_VARS_PLUGINS', '~/.ansible/plugins/vars_plugins:/usr/share/ansible_plugins/vars_plugins')
+DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '~/.ansible/plugins/filter_plugins:/usr/share/ansible_plugins/filter_plugins')
 
 CACHE_PLUGIN                   = get_config(p, DEFAULTS, 'fact_caching', 'ANSIBLE_CACHE_PLUGIN', 'memory')
 CACHE_PLUGIN_CONNECTION        = get_config(p, DEFAULTS, 'fact_caching_connection', 'ANSIBLE_CACHE_PLUGIN_CONNECTION', None)


### PR DESCRIPTION
TODO: add docs and update examples
- become constants inherit existing sudo/su ones
- become command line options, marked sudo/su as deprecated and moved sudo/su passwords to runas group
- changed method signatures as privlege escalation is collapsed to become
- added tests for su and become, diabled su for lack of support in local.py
- updated playbook,play and task objects to become
- added become to runner
- added whoami test for become/sudo/su
- added home override dir for plugins
- removed useless method from ask pass
- forced become pass to always be string also uses to_bytes
- fixed fakerunner for tests
- corrected reference in synchronize action plugin
- added pfexec (needs testing)
- removed unused sudo/su in runner init
- removed deprecated info
- updated pe tests to allow to run under sudo and not need root
- normalized become options into a funciton to avoid duplication and inconsistencies
- pushed suppored list to connection classs property
- updated all connection plugins to latest 'become' pe
