### PR TITLE
Implement AND'd filters in ec2.py/ini

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -97,7 +97,8 @@ group_by_rds_parameter_group = True
 # inventory. For the full list of possible filters, please read the EC2 API
 # docs: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeInstances.html#query-DescribeInstances-filters
 # Filters are key/value pairs separated by '=', to list multiple filters use
-# a list separated by commas. See examples below.
+# a list separated by commas. To "AND" criteria together, use "&".
+# See examples below.
 
 # Retrieve only instances with (key=value) env=stage tag
 # instance_filters = tag:env=stage
@@ -112,3 +113,12 @@ group_by_rds_parameter_group = True
 # tag Name value matches webservers1*
 # (ex. webservers15, webservers1a, webservers123 etc) 
 # instance_filters = tag:Name=webservers1*
+
+# Retrieve only instances of type t1.micro that also have tag env=stage
+# instance_filters = instance-type=t1.micro&tag:env=stage
+
+# Retrieve instances of type t1.micro AND tag env=stage, as well as any instance
+# that are of type m3.large, regardless of env tag
+# instance_filters = instance-type=t1.micro&tag:env=stage,instance-type=m3.large
+
+

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -296,16 +296,20 @@ class Ec2Inventory(object):
             self.pattern_exclude = None
 
         # Instance filters (see boto and EC2 API docs). Ignore invalid filters.
-        self.ec2_instance_filters = defaultdict(list)
+        self.ec2_instance_filters = []
         if config.has_option('ec2', 'instance_filters'):
-            for instance_filter in config.get('ec2', 'instance_filters', '').split(','):
-                instance_filter = instance_filter.strip()
-                if not instance_filter or '=' not in instance_filter:
-                    continue
-                filter_key, filter_value = [x.strip() for x in instance_filter.split('=', 1)]
-                if not filter_key:
-                    continue
-                self.ec2_instance_filters[filter_key].append(filter_value)
+            for filter_set in config.get('ec2', 'instance_filters', '').split(','):
+                filters = {}
+                filter_set = filter_set.strip()
+                for instance_filter in filter_set.split("&"):
+                    instance_filter = instance_filter.strip()
+                    if not instance_filter or '=' not in instance_filter:
+                        continue
+                    filter_key, filter_value = [x.strip() for x in instance_filter.split('=', 1)]
+                    if not filter_key:
+                        continue
+                    filters[filter_key] = filter_value
+                self.ec2_instance_filters.append(filters.copy())
 
     def parse_cli_args(self):
         ''' Command line argument processing '''
@@ -354,8 +358,8 @@ class Ec2Inventory(object):
             conn = self.connect(region)
             reservations = []
             if self.ec2_instance_filters:
-                for filter_key, filter_values in self.ec2_instance_filters.iteritems():
-                    reservations.extend(conn.get_all_instances(filters = { filter_key : filter_values }))
+                for filters in self.ec2_instance_filters:
+                    reservations.extend(conn.get_all_instances(filters = filters))
             else:
                 reservations = conn.get_all_instances()
 


### PR DESCRIPTION
##### SUMMARY
This extends the EC2 inventory source filtering syntax to include "&" for ANDing filters together, as suggested by @cchurch a few days ago: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/ansible-project/CV4kOYyw6oU/-SHNI0_hSs0J


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
plugins/inventory/ec2.ini
plugins/inventory/ec2.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


