### PR TITLE
Make the example somewhat more feature complete

### DIFF
--- a/docsite/rst/playbooks_intro.rst
+++ b/docsite/rst/playbooks_intro.rst
@@ -67,8 +67,8 @@ For starters, here's a playbook that contains just one play::
         template: src=/srv/httpd.j2 dest=/etc/httpd.conf
         notify:
         - restart apache
-      - name: ensure apache is running
-        service: name=httpd state=started
+      - name: ensure apache is running (and enable it at boot)
+        service: name=httpd state=started enabled=yes
       handlers:
         - name: restart apache
           service: name=httpd state=restarted


### PR DESCRIPTION
New users might think that "state=started" implies that the service is also started at boot-time, which isn't. By adding it, this change makes a clear distinction between the service state, and whether it is enabled (at boot). And it makes the example more feature-complete as this is what most people would be doing anyway.
