### PR TITLE
Avoid the ignore_errors statement in the introduction

### DIFF
--- a/docsite/rst/playbooks_intro.rst
+++ b/docsite/rst/playbooks_intro.rst
@@ -213,7 +213,7 @@ them work as simply as you would expect::
 
 The command and shell module care about return codes, so if you have a command
 whose successful exit code is not zero, you may wish to explicitely tell it
-that it should ignore return code:
+that it should ignore the return code:
 
    tasks:
      - name: run this command and ignore the return code

--- a/docsite/rst/playbooks_intro.rst
+++ b/docsite/rst/playbooks_intro.rst
@@ -212,7 +212,7 @@ them work as simply as you would expect::
        command: /sbin/setenforce 0
 
 The command and shell module care about return codes, so if you have a command
-whose successful exit code is not zero, you may wish to explicitely tell it
+whose successful exit code is not zero, you may wish to explicitly tell it
 that it should ignore the return code:
 
    tasks:

--- a/docsite/rst/playbooks_intro.rst
+++ b/docsite/rst/playbooks_intro.rst
@@ -212,19 +212,31 @@ them work as simply as you would expect::
        command: /sbin/setenforce 0
 
 The command and shell module care about return codes, so if you have a command
-whose successful exit code is not zero, you may wish to do this::
+whose successful exit code is not zero, you may wish to explicitely tell it
+that it should ignore return code:
 
    tasks:
-     - name: run this command and ignore the result
-       shell: /usr/bin/somecommand || /bin/true
+     - name: run this command and ignore the return code
+       command: /usr/bin/somecommand
+       failed_when: False
 
-Or this::
+The `failed_when` statement accepts a boolean expression and you can make it fail
+on different conditions::
 
    tasks:
-     - name: run this command and ignore the result
-       shell: /usr/bin/somecommand
-       ignore_errors: True
+     - name: run this command and fail when return code is greater than 5
+       command: /usr/bin/somecommand
+       register: cmd
+       failed_when: cmd.rc > 5
 
+There is also a `changed_when` statement that you can use to influence when a task
+causes a real change. Since `command` and `shell` modules assume that every command
+indicates a change, you can override this default behaviour:
+
+   tasks:
+     - name: run this command and indicate there is no change
+       command: /bin/hostname
+       changed_when: False
 
 If the action line is getting too long for comfort you can break it on
 a space and indent any continuation lines::


### PR DESCRIPTION
The `ignore_errors` statement is a legacy statement that in most cases is superseded by the `failed_when` statement. To not encourage to use ignore_errors, I replaced it by the `failed_when` statement. I also provided an example of the `changed_when` statement.
