### PR TITLE
rax module ultis: Prevent an empty error message

### DIFF
--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -315,7 +315,11 @@ def setup_rax_module(module, rax_module, region_required=True):
         else:
             raise Exception('No credentials supplied!')
     except Exception, e:
-        module.fail_json(msg='%s' % e.message)
+        if e.message:
+            msg = str(e.message)
+        else:
+            msg = repr(e)
+        module.fail_json(msg=msg)
 
     if region_required and region not in rax_module.regions:
         module.fail_json(msg='%s is not a valid region, must be one of: %s' %


### PR DESCRIPTION
It appears that not all of the exceptions that can be caught while authenticating contain a message.  In such a case, we'll at least repr the exception class to provide an error message.

See https://github.com/ansible/ansible-modules-core/issues/919
