### PR TITLE
ansible-galaxy force install with dependencies

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -759,6 +759,7 @@ def execute_install(args, options, parser):
     api_server = get_opt(options, "api_server", "galaxy.ansible.com")
     no_deps    = get_opt(options, "no_deps", False)
     roles_path = get_opt(options, "roles_path")
+    force = get_opt(options, "force", False)
 
     roles_done = []
     if role_file:
@@ -769,10 +770,14 @@ def execute_install(args, options, parser):
             # roles listed in a file, one per line
             roles_left = map(ansible.utils.role_spec_parse, f.readlines())
         f.close()
+        role_root = os.path.basename(role_file)
     else:
         # roles were specified directly, so we'll just go out grab them
         # (and their dependencies, unless the user doesn't want us to).
         roles_left = map(ansible.utils.role_spec_parse, args)
+        role_root = roles_left[0].get('name',args[0])
+
+    roles_installed = {}
 
     while len(roles_left) > 0:
         # query the galaxy API for the role data
@@ -835,6 +840,7 @@ def execute_install(args, options, parser):
         installed = False
         if tmp_file:
             installed = install_role(role.get("name"), role.get("version"), tmp_file, options)
+            roles_installed[role.get("name")] = dict(version=role.get("version", "LATEST"), dependent=role.get("dependent", role_root))
             # we're done with the temp file, clean it up
             if tmp_file != role_src:
                 os.unlink(tmp_file)
@@ -850,6 +856,7 @@ def execute_install(args, options, parser):
                         dep = ansible.utils.role_spec_parse(dep)
                     else:
                         dep = ansible.utils.role_yaml_parse(dep)
+                    dep['dependent'] = role.get("name")
                     if not get_role_metadata(dep["name"], options):
                         if dep not in roles_left:
                             print '- adding dependency: %s' % dep["name"]
@@ -857,7 +864,16 @@ def execute_install(args, options, parser):
                         else:
                             print '- dependency %s already pending installation.' % dep["name"]
                     else:
-                        print '- dependency %s is already installed, skipping.' % dep["name"]
+                        if force and dep not in roles_left and dep["name"] not in roles_installed:
+                            print '- adding dependency of role %s: %s' % (role["name"], dep["name"])
+                            roles_left.append(dep)
+                        else:
+                            if dep["name"] in roles_installed:
+                                print '- dependency %s is already installed, skipping.' % dep["name"]
+                            if dep.get("version", "LATEST") != roles_installed[dep["name"]]['version']:
+                                previous = roles_installed[dep["name"]]
+                                print '- WARN: version mismatch for %s=>%s (%s) and %s=>%s (%s)' % (dep['dependent'], dep["name"],
+                                        dep["version"], previous['dependent'], dep['name'], previous['version'])
         if not tmp_file or not installed:
             print "- %s was NOT installed successfully." % role.get("name")
             exit_without_ignore(options)


### PR DESCRIPTION
##### Issue Type:

Bugfix pull request
##### Ansible Version:

ansible 1.9 (devel 3b6102e9a2) last updated 2015/03/11 14:38:19 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD bd997b1066) last updated 2015/03/09 15:37:21 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD e60b2167f5) last updated 2015/03/09 15:36:08 (GMT +1000)
  v2/ansible/modules/core: (detached HEAD 34784b7a61) last updated 2015/03/05 14:11:54 (GMT +1000)
  v2/ansible/modules/extras: (detached HEAD 46e316a20a) last updated 2015/03/05 14:11:54 (GMT +1000)
  configured module search path = None
##### Environment:

N/A
##### Summary:

`ansible-galaxy install --force` does not work correctly with dependencies - it just says they are already installed rather than reinstalling them as expected

Also, warn if the same role with different versions is installed
##### Steps To Reproduce:

Create a role with a dependency. Run `ansible-galaxy install -r rolesfile -p roles` to install the role and then `ansible-galaxy install -r rolesfile -p roles --force` to reinstall. 
While the top level roles in the rolesfile will be reinstalled, the dependencies will not be. 
##### Expected Results:

Dependencies are force reinstalled too. 
##### Actual Results:
- dependency xyz is already installed, skipping.
