### PR TITLE
use to_unicode() in _jinja2_vars if type is str.

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -184,8 +184,7 @@ class _jinja2_vars(object):
         var = self.vars[varname]
         # HostVars is special, return it as-is, as is the special variable
         # 'vars', which contains the vars structure
-        if type(var) == str:
-            var = to_unicode(var)
+        var = to_unicode(var, nonstring="passthru")
         if isinstance(var, dict) and varname == "vars" or isinstance(var, HostVars):
             return var
         else:

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -33,7 +33,7 @@ import ast
 import traceback
 
 from ansible.utils.string_functions import count_newlines_from_end
-from ansible.utils import to_bytes
+from ansible.utils import to_bytes, to_unicode
 
 class Globals(object):
 
@@ -184,6 +184,8 @@ class _jinja2_vars(object):
         var = self.vars[varname]
         # HostVars is special, return it as-is, as is the special variable
         # 'vars', which contains the vars structure
+        if type(var) == str:
+            var = to_unicode(var)
         if isinstance(var, dict) and varname == "vars" or isinstance(var, HostVars):
             return var
         else:


### PR DESCRIPTION
if hostvars has unicode value, UnicodeDecodeError occured. This PR will fix it.
### How to reproduce

```
localhost uni="Ă"
```

```
- hosts: localhost
  connection: local
  tasks:
  - debug: msg="{{ uni }}"
```
### error

```
fatal: [localhost] => Traceback (most recent call last):
  File "/Users/shirou/Works/VEnvs/ansible/lib/python2.7/site-packages/ansible/runner/__init__.py", line 590, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/Users/shirou/Works/VEnvs/ansible/lib/python2.7/site-packages/ansible/runner/__init__.py", line 792, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/Users/shirou/Works/VEnvs/ansible/lib/python2.7/site-packages/ansible/runner/__init__.py", line 995, in _executor_internal_inner
    module_args = template.template(self.basedir, module_args, inject, fail_on_undefined=self.error_on_undefined_vars)
  File "/Users/shirou/Works/VEnvs/ansible/lib/python2.7/site-packages/ansible/utils/template.py", line 119, in template
    varname = template_from_string(basedir, varname, templatevars, fail_on_undefined)
  File "/Users/shirou/Works/VEnvs/ansible/lib/python2.7/site-packages/ansible/utils/template.py", line 365, in template_from_string
    res = jinja2.utils.concat(rf)
  File "<template>", line 9, in root
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe3 in position 0: ordinal not in range(128)
```
