### PR TITLE
Add account ID grouping to ec2.py (dynamic inventory)

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -124,6 +124,7 @@ expand_csv_tags = False
 group_by_instance_id = True
 group_by_region = True
 group_by_availability_zone = True
+group_by_aws_account = False
 group_by_ami_id = True
 group_by_instance_type = True
 group_by_key_pair = True


### PR DESCRIPTION
It's possible to run multiple incarnations of ec2.py to pull in hosts from multiple AWS accounts, but the hosts have no attribute or grouping to distinguish which account they are in. This change adds an AWS account ID attribute to instances and a corresponding group, allowing instances to be identified by account in multi-account environments.
