### PR TITLE
ansible-galaxy: forgive meta/main.yml mishaps

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -414,10 +414,9 @@ def get_role_metadata(role_name, options):
             f.close()
             return meta_data
         else:
-            print '- WARN: role %s does not contain a meta/main.yml' % role_name
             return None
     except:
-        print '- WARN: cannot access or parse role %s meta/main.yml' % role_name
+        ansible.utils.warning('cannot access or parse meta/main.yml for role %s' % role_name)
         return None
 
 def get_galaxy_install_info(role_name, options):
@@ -515,20 +514,6 @@ def install_role(role_name, role_version, role_filename, options):
         # verify the role's meta file
         meta_file = None
         members = role_tar_file.getmembers()
-        # next find the metadata file
-        for member in members:
-            if "/meta/main.yml" in member.name:
-                meta_file = member
-                break
-        if not meta_file:
-            print "- error: this role does not appear to have a meta/main.yml file."
-            return False
-        else:
-            try:
-                meta_file_data = yaml.safe_load(role_tar_file.extractfile(meta_file))
-            except:
-                print "- error: this role does not appear to have a valid meta/main.yml file."
-                return False
 
         # we strip off the top-level directory for all of the files contained within
         # the tar file here, since the default is 'github_repo-target', and change it 
@@ -547,7 +532,7 @@ def install_role(role_name, role_version, role_filename, options):
                 else:
                     # using --force, remove the old path
                     if not remove_role(role_name, options):
-                        print "- error: %s doesn't appear to contain a role." % role_path
+                        print "- error: %s doesn't appear to contain a role with meta/main.yml." % role_path
                         print "  please remove this directory manually if you really want to put the role here."
                         return False
             else:
@@ -575,7 +560,7 @@ def install_role(role_name, role_version, role_filename, options):
 
         # return the parsed yaml metadata
         print "- %s was installed successfully" % role_name
-        return meta_file_data
+        return True
 
 #-------------------------------------------------------------------------------------
 # Action functions
@@ -847,8 +832,6 @@ def execute_install(args, options, parser):
                     if not role_data:
                         role_dependencies = []
                     else:
-                        if role_data.get('dependencies') is None:
-                            print '- WARN: %s meta/main.yml does not contain a dependencies list' % role.get('name')
                         # cater for `dependencies: `
                         role_dependencies = role_data.get('dependencies') or []
                 else:

--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -414,9 +414,11 @@ def get_role_metadata(role_name, options):
             f.close()
             return meta_data
         else:
+            print '- WARN: role %s does not contain a meta/main.yml' % role_name
             return None
     except:
-        return None    
+        print '- WARN: cannot access or parse role %s meta/main.yml' % role_name
+        return None
 
 def get_galaxy_install_info(role_name, options):
     """
@@ -842,9 +844,16 @@ def execute_install(args, options, parser):
             if not no_deps and installed:
                 if not role_data:
                     role_data = get_role_metadata(role.get("name"), options)
-                    role_dependencies = role_data['dependencies']
+                    if not role_data:
+                        role_dependencies = []
+                    else:
+                        if role_data.get('dependencies') is None:
+                            print '- WARN: %s meta/main.yml does not contain a dependencies list' % role.get('name')
+                        # cater for `dependencies: `
+                        role_dependencies = role_data.get('dependencies') or []
                 else:
                     role_dependencies = role_data['summary_fields']['dependencies'] # api_fetch_role_related(api_server, 'dependencies', role_data['id'])
+
                 for dep in role_dependencies:
                     if isinstance(dep, basestring):
                         dep = ansible.utils.role_spec_parse(dep)


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

[wthames@wthames ansible (devel)]$ ansible --version
ansible 1.9 (devel c8de03d516) last updated 2015/03/13 11:14:59 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD 31cc5f543f) last updated 2015/03/13 11:15:44 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD 8baba98ebe) last updated 2015/03/13 11:15:06 (GMT +1000)
  v2/ansible/modules/core: (detached HEAD 34784b7a61) last updated 2015/03/05 14:11:54 (GMT +1000)
  v2/ansible/modules/extras: (detached HEAD 46e316a20a) last updated 2015/03/05 14:11:54 (GMT +1000)
  configured module search path = None
##### Environment:

N/A
##### Summary:

For roles not created through ansible-galaxy init, but
manually, meta/main.yml may not exist or contain
dependency information. Handle such cases gracefully
- warn but cope when meta/main.yml is missing
- warn but cope when meta/main.yml is inaccessible or unparseable
- warn but cope when meta/main.yml contains no dependencies data
- warn but cope when meta/main.yml effectively has dependencies: None

The latter case looks like:

```
dependencies:
```

All of the above cases are treated as an empty dependency list.
##### Steps To Reproduce:

Create a role without a meta/main.yml file and try to install it
Create a role with a meta/main.yml but with no dependencies section and try to install it

Cope with other general problems like inaccessible or unparseable meta/main.yml or a null dependencies section
##### Expected Results:

A warning is generated but role installation continues
##### Actual Results:

Currently ansible-galaxy install bombs out when meta/main.yml is missing or broken with a NoneType error

```
Traceback (most recent call last):
  File "/home/wthames/src/ansible/bin/ansible-galaxy", line 973, in <module>
    main()
  File "/home/wthames/src/ansible/bin/ansible-galaxy", line 967, in main
    fn(args, options, parser)
  File "/home/wthames/src/ansible/bin/ansible-galaxy", line 854, in execute_install
    for dep in role_dependencies:
TypeError: 'NoneType' object is not iterable
```
