### PR TITLE
Add tox and travis-ci support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ deb-build
 credentials.yml
 # test output
 .coverage
+.tox
 results.xml
 coverage.xml
 /test/units/cover-html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: python
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+install:
+  - pip install tox
+script:
+  - tox
+after_success:
+  - coveralls

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ NOSETESTS3 ?= nosetests-3.3
 all: clean python
 
 tests:
-	PYTHONPATH=./lib $(NOSETESTS) -d -w test/units -v # Could do: --with-coverage --cover-package=ansible
+	PYTHONPATH=./lib $(NOSETESTS) -d -w test/units -v --with-coverage --cover-package=ansible --cover-branches
 
 newtests:
 	PYTHONPATH=./v2:./lib $(NOSETESTS) -d -w v2/test -v --with-coverage --cover-package=ansible --cover-branches

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![PyPI version](https://badge.fury.io/py/ansible.png)](http://badge.fury.io/py/ansible) [![PyPI downloads](https://pypip.in/d/ansible/badge.png)](https://pypi.python.org/pypi/ansible)
+[![PyPI version](https://badge.fury.io/py/ansible.png)](http://badge.fury.io/py/ansible)
+[![PyPI downloads](https://pypip.in/d/ansible/badge.png)](https://pypi.python.org/pypi/ansible)
+[![Build Status](https://travis-ci.org/ansible/ansible.svg?branch=tox_and_travis)](https://travis-ci.org/ansible/ansible)
 
 
 Ansible

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,5 @@
 nose
 mock
 passlib
+coverage
+coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py26,py27
+
+[testenv]
+deps = -r{toxinidir}/test-requirements.txt
+whitelist_externals = make
+commands = make tests


### PR DESCRIPTION
Add tox integration to run unittests in supported python releases.  Travis-CI is used for test execution.  

Additionally, the unittest `TestQuotePgIdentifier` was updated to support using `assert_raises_regexp` on python-2.6.

Sample travis-ci output available at https://travis-ci.org/ansible/ansible/builds/54189977
