### PR TITLE
env-setup: Don't use ${.sh.file} if shell is pdksh

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -16,7 +16,7 @@ if [ -n "$BASH_SOURCE" ] ; then
     HACKING_DIR=$(dirname "$BASH_SOURCE")
 elif [ $(basename -- "$0") = "env-setup" ]; then
     HACKING_DIR=$(dirname "$0")
-elif [ -n "$KSH_VERSION" ]; then
+elif [ -n "$KSH_VERSION" ] && echo $KSH_VERSION | grep -qv '^@(#)PD KSH'; then
     HACKING_DIR=$(dirname "${.sh.file}")
 else
     HACKING_DIR="$PWD/hacking"


### PR DESCRIPTION
The default ksh in OpenBSD throws the following error:
$ . hacking/env-setup
ksh: hacking/env-setup[23]: ${.sh.file}": bad substitution

The same error can be seen on Linux if pdksh is used.
