### PR TITLE
Including diff in Runner results return so the PlayBook, PlayBook callba...

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -102,6 +102,7 @@ DEFAULT_HOST_LIST         = shell_expand_path(get_config(p, DEFAULTS, 'inventory
 DEFAULT_MODULE_PATH       = get_config(p, DEFAULTS, 'library',          'ANSIBLE_LIBRARY',          None)
 DEFAULT_ROLES_PATH        = shell_expand_path(get_config(p, DEFAULTS, 'roles_path',       'ANSIBLE_ROLES_PATH',       '/etc/ansible/roles'))
 DEFAULT_REMOTE_TMP        = get_config(p, DEFAULTS, 'remote_tmp',       'ANSIBLE_REMOTE_TEMP',      '$HOME/.ansible/tmp')
+DEFAULT_REMOTE_CP         = get_config(p, DEFAULTS, 'remote_cp',        'ANSIBLE_REMOTE_CP',        '$HOME/.ansible/cp')
 DEFAULT_MODULE_NAME       = get_config(p, DEFAULTS, 'module_name',      None,                       'command')
 DEFAULT_PATTERN           = get_config(p, DEFAULTS, 'pattern',          None,                       '*')
 DEFAULT_FORKS             = get_config(p, DEFAULTS, 'forks',            'ANSIBLE_FORKS',            5, integer=True)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1412,6 +1412,7 @@ class Runner(object):
                 raise Exception("internal error, host not set")
             if result.communicated_ok():
                 results2["contacted"][host] = result.result
+                results2["contacted"][host].update({'diff': result.diff})
             else:
                 results2["dark"][host] = result.result
 

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -53,7 +53,7 @@ class Connection(object):
         self.become_methods_supported=['sudo', 'su', 'pbrun']
 
         fcntl.lockf(self.runner.process_lockfile, fcntl.LOCK_EX)
-        self.cp_dir = utils.prepare_writeable_dir('$HOME/.ansible/cp',mode=0700)
+        self.cp_dir = utils.prepare_writeable_dir(C.DEFAULT_REMOTE_CP, mode=0700)
         fcntl.lockf(self.runner.process_lockfile, fcntl.LOCK_UN)
 
     def connect(self):


### PR DESCRIPTION
1: PlayBook callbacks or plugins can deal with it.

If you run Ansible with "diff", the diff content is created in the subthreads of the multiprocess execution, then is passed back to the Runner but the runner in the _partition_results method is ignoring the "diff" so it never gets back to the PlayBook and cannot be used by the callbacks or stats modules.
That means that nothing can use the diff to deal with it (plugins, diff analysis, storing in a db, printing in an specific format, sending by email).

With this pull request that just adds a line to the code, the "diff" content is passed back to the PlayBook so the PlayBook callbacks, stats or plugins can use it to perform extra operations.

It doesn't add extra load to the network because the "diff" is already being passed to the main thread (Runner)

2: Allowing configuration of remote_cp the same as remote_tmp is allowed instead of being hardcoded in the code
