### PR TITLE
Darwin uptime_seconds fact

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1592,6 +1592,7 @@ class Darwin(Hardware):
         self.get_mac_facts()
         self.get_cpu_facts()
         self.get_memory_facts()
+        self.get_uptime_facts()
         return self.facts
 
     def get_sysctl(self):
@@ -1639,6 +1640,17 @@ class Darwin(Hardware):
         if rc == 0:
             self.facts['memfree_mb'] = long(out.splitlines()[-1].split()[1]) / 1024 / 1024
 
+    def get_uptime_facts(self):
+        kern_boottime = self.sysctl['kern.boottime']
+        match = re.search('(Mon|Tue|Wed|Thu|Fri|Sat|Sun).*$', kern_boottime)
+        if match:
+            boottime_string = match.group(0)
+            try:
+                boottime = datetime.datetime.strptime(boottime_string, "%a %b %d %H:%M:%S %Y")
+                delta = datetime.datetime.now() - boottime
+                self.facts['uptime_seconds'] = int(delta.total_seconds())
+            except ValueError:
+                pass
 
 class Network(Facts):
     """


### PR DESCRIPTION
Another try for darwin platform with the uptime_seconds fact.  Using the get_sysctl method returns the following for boottime:

```
derecho:~ cblument$ /usr/sbin/sysctl hw machdep kern|grep boottime
kern.boottime: { sec = 1426005997, usec = 0 } Tue Mar 10 11:46:37 2015
kern.boottime = Tue Mar 10 11:46:37 2015
```

I am guessing, depending on the version of mac os x, that the order of what is returned is different or one or the other is returned.  Maybe it changes after reboots.  This commit should handle any of those cases.

Wrapping this up in a try/except seems yucky but not sure how else to handle it.
