### PR TITLE
If GCE instance not have public ip, set None.

### DIFF
--- a/plugins/inventory/gce.py
+++ b/plugins/inventory/gce.py
@@ -211,7 +211,7 @@ class GceInventory(object):
             'gce_image': inst.image,
             'gce_machine_type': inst.size,
             'gce_private_ip': inst.private_ips[0],
-            'gce_public_ip': inst.public_ips[0],
+            'gce_public_ip': inst.public_ips[0] if inst.public_ips else None,
             'gce_name': inst.name,
             'gce_description': inst.extra['description'],
             'gce_status': inst.extra['status'],
@@ -220,7 +220,7 @@ class GceInventory(object):
             'gce_metadata': md,
             'gce_network': net,
             # Hosts don't have a public name, so we add an IP
-            'ansible_ssh_host': inst.public_ips[0]
+            'ansible_ssh_host': inst.public_ips[0] if inst.public_ips else None
         }
 
     def get_instance(self, instance_name):


### PR DESCRIPTION
Sorry, my english is terrible.

Google Compute Engine's Dynamic Inventory Script (gce.py) does not care about instance not have public ip.

``` console
$ ./gce.py
Traceback (most recent call last):
  File "./bug_gce.py", line 287, in <module>
    GceInventory()
  File "./bug_gce.py", line 111, in __init__
    print(self.json_format_dict(self.group_instances(),
  File "./bug_gce.py", line 242, in group_instances
    meta["hostvars"][name] = self.node_to_dict(node)
  File "./bug_gce.py", line 214, in node_to_dict
    'gce_public_ip': inst.public_ips[0],
IndexError: list index out of range
```

if inst.public_ips is empty array, set None.

``` console
./gce.py | jq .                                                                                                                                                                                                                                [~/.ansible]
{
  "n1-highcpu-2": [
    "instance-2"
  ],
  "tag_internal": [
    "instance-2"
  ],
  "_meta": {
    "hostvars": {
      "instance-1": {
        "gce_uuid": "000000000000000000000000000000",
        "gce_public_ip": "000.000.000.00",
        "ansible_ssh_host": "000.000.000.00",
        "gce_private_ip": "10.10.100.1",
        "gce_id": "0000000000000000",
        "gce_image": null,
        "gce_description": null,
        "gce_machine_type": "f1-micro",
        "gce_tags": [
          "bastion"
        ],
        "gce_name": "instance-1",
        "gce_zone": "asia-east1-a",
        "gce_status": "RUNNING",
        "gce_network": "default",
        "gce_metadata": {}
      },
      "instance-2": {
        "gce_uuid": "00000000000000000000000000000000",
        "gce_public_ip": null,
        "ansible_ssh_host": null,
        "gce_private_ip": "10.10.100.2",
        "gce_id": "0000000000000000",
        "gce_image": null,
        "gce_description": null,
        "gce_machine_type": "n1-highcpu-2",
        "gce_tags": [
          "internal"
        ],
        "gce_name": "instance-2",
        "gce_zone": "asia-east1-a",
        "gce_status": "RUNNING",
        "gce_network": "default",
        "gce_metadata": {}
      }
    }
  },
  "tag_bastion": [
    "instance-1"
  ],
  "asia-east1-a": [
    "instance-2",
    "instance-1"
  ],
  "f1-micro": [
    "instance-1"
  ],
  "status_running": [
    "instance-2",
    "instance-1"
  ],
  "persistent_disk": [
    "instance-2",
    "instance-1"
  ],
  "network_default": [
    "instance-2",
    "instance-1"
  ]
}
```
