### PR TITLE
Extending union filter for dictionaries

### DIFF
--- a/lib/ansible/runner/filter_plugins/mathstuff.py
+++ b/lib/ansible/runner/filter_plugins/mathstuff.py
@@ -53,7 +53,10 @@ def symmetric_difference(a, b):
     return c
 
 def union(a, b):
-    if isinstance(a,collections.Hashable) and isinstance(b,collections.Hashable):
+    if isinstance(a, dict) and isinstance(b, dict):
+        c = a.copy()
+        c.update(b)
+    elif isinstance(a,collections.Hashable) and isinstance(b,collections.Hashable):
         c = set(a) | set(b)
     else:
         c = unique(a + b)


### PR DESCRIPTION
This patch allows to use the `union` filter for dictionaries. The possible use case is as follows:

```
my_var1:
  option1: val1
  option2: val2

my_var2:
  option3: val3

my_var3: "{{ my_var1 | union(my_var2) }}"
```
