### PR TITLE
avoid path issues by determining the path of ansible-pull and using its ...

### DIFF
--- a/bin/ansible-pull
+++ b/bin/ansible-pull
@@ -186,9 +186,12 @@ def main(args):
     if path is None:
         sys.stderr.write("module '%s' not found.\n" % options.module_name)
         return 1
-    cmd = 'ansible localhost -i "%s" %s -m %s -a "%s"' % (
-            inv_opts, base_opts, options.module_name, repo_opts
+
+    bin_path = os.path.dirname(os.path.abspath(__file__))
+    cmd = '%s/ansible localhost -i "%s" %s -m %s -a "%s"' % (
+            bin_path, inv_opts, base_opts, options.module_name, repo_opts
             )
+
     for ev in options.extra_vars:
         cmd += ' -e "%s"' % ev
 
@@ -221,7 +224,7 @@ def main(args):
         print >>sys.stderr, "Could not find a playbook to run."
         return 1
 
-    cmd = 'ansible-playbook %s %s' % (base_opts, playbook)
+    cmd = '%s/ansible-playbook %s %s' % (bin_path, base_opts, playbook)
     if options.vault_password_file:
         cmd += " --vault-password-file=%s" % options.vault_password_file
     if options.inventory:


### PR DESCRIPTION
Issue Type:

Bugfix Pull Request

Ansible Version:
1.9

Environment:
Linux Ubuntu 14.04 Trusty Tahr

Summary:
Running ansible pull as a cron job by root can fail calling ansible and ansible-playbook due path issues. This reports itself as a file not found error.

ar 17 20:32:01 ip-172-31-8-221 CRON[9295]: (root) CMD (/usr/local/bin/ansible-pull -U ssh://bootstrap@bootstrap.xyz.com:/opt/bootstrap -d bootstrap -i hosts test.yml >> /tmp/cronlog 2>&1)
Starting ansible-pull at 2015-03-17 20:21:01
Traceback (most recent call last):
  File "/usr/local/bin/ansible-pull", line 237, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/usr/local/bin/ansible-pull", line 193, in main
    rc, out, err = cmd_functions.run_cmd(cmd, live=True)
  File "/usr/local/lib/python2.7/dist-packages/ansible/utils/cmd_functions.py", line 29, in run_cmd
    p = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib/python2.7/subprocess.py", line 710, in **init**
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

Steps To Reproduce:

Add the following to the root crontab

/1 \* \* \* \* /usr/local/bin/ansible-pull -U ssh://bootstrap@bootstrap.xyz.com:/opt/bootstrap-repo -d bootstrap -i hosts test.yml >> /tmp/cronlog 2>&1

Fix:

Avoids path issues by determining the path of ansible-pull and using its path to run ansible and ansible-playbook.
