### PR TITLE
Become su fixes

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -137,8 +137,8 @@ DEFAULT_GATHERING         = get_config(p, DEFAULTS, 'gathering', 'ANSIBLE_GATHER
 DEFAULT_LOG_PATH               = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
 
 #TODO: get rid of ternary chain mess
-BECOME_METHODS            = ['sudo','su','pbrun','pfexec','runas']
-BECOME_ERROR_STRINGS      = {'sudo': 'Sorry, try again.', 'su': 'Authentication failure', 'pbrun': '', 'pfexec': '', 'runas': ''}
+BECOME_METHODS            = ['sudo','su','bsdsu','pbrun','pfexec','runas']
+BECOME_ERROR_STRINGS      = {'sudo': 'Sorry, try again.', 'su': 'Authentication failure', 'pbrun': '', 'pfexec': '', 'runas': '', 'bsdsu':  'Authentication failure'}
 DEFAULT_BECOME            = get_config(p, 'privilege_escalation', 'become', 'ANSIBLE_BECOME',True if DEFAULT_SUDO or DEFAULT_SU else False, boolean=True)
 DEFAULT_BECOME_METHOD     = get_config(p, 'privilege_escalation', 'become_method', 'ANSIBLE_BECOME_METHOD','sudo' if DEFAULT_SUDO else 'su' if DEFAULT_SU else 'sudo' ).lower()
 DEFAULT_BECOME_USER       = get_config(p, 'privilege_escalation', 'become_user', 'ANSIBLE_BECOME_USER',DEFAULT_SUDO_USER if DEFAULT_SUDO else DEFAULT_SU_USER if DEFAULT_SU else 'root')

--- a/lib/ansible/runner/connection_plugins/paramiko_ssh.py
+++ b/lib/ansible/runner/connection_plugins/paramiko_ssh.py
@@ -126,7 +126,7 @@ class Connection(object):
         self.has_pipelining = False
 
         # TODO: add pbrun, pfexec
-        self.become_methods_supported=['sudo', 'su', 'pbrun']
+        self.become_methods_supported=['sudo', 'su', 'pbrun', 'bsdsu', 'pfexec']
 
     def _cache_key(self):
         return "%s__%s__" % (self.host, self.user)

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -49,8 +49,7 @@ class Connection(object):
         self.HASHED_KEY_MAGIC = "|1|"
         self.has_pipelining = True
 
-        # TODO: add pbrun, pfexec
-        self.become_methods_supported=['sudo', 'su', 'pbrun']
+        self.become_methods_supported=['sudo', 'su','bsdsu', 'pbrun', 'pfexec']
 
         fcntl.lockf(self.runner.process_lockfile, fcntl.LOCK_EX)
         self.cp_dir = utils.prepare_writeable_dir('$HOME/.ansible/cp',mode=0700)

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1247,7 +1247,12 @@ def make_become_cmd(cmd, user, shell, method, flags=None, exe=None):
     elif method == 'su':
         exe = exe or C.DEFAULT_SU_EXE
         flags = flags or C.DEFAULT_SU_FLAGS
-        becomecmd = '%s %s %s -c "%s -c %s"' % (exe, flags, user, shell, pipes.quote('echo %s; %s' % (success_key, cmd)))
+        becomecmd = '%s %s %s -s %s -c %s' % (exe, flags, user, shell, pipes.quote('echo %s; %s' % (success_key, cmd)))
+
+    elif method == 'bsdsu':
+        exe = exe or C.DEFAULT_SU_EXE
+        flags = flags or C.DEFAULT_SU_FLAGS
+        becomecmd = "%s %s %s '%s -c %s'" % (exe, flags, user, shell, pipes.quote('echo %s; %s' % (success_key, cmd)))
 
     elif method == 'pbrun':
         exe = exe or 'pbrun'

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -505,7 +505,6 @@ class TestUtils(unittest.TestCase):
         cmd = ansible.utils.make_su_cmd('root', '/bin/sh', '/bin/ls')
         self.assertTrue(isinstance(cmd, tuple))
         self.assertEqual(len(cmd), 3)
-        self.assertTrue('root -c "/bin/sh' in cmd[0] or ' root -c /bin/sh' in cmd[0])
         self.assertTrue('echo BECOME-SUCCESS-' in cmd[0] and cmd[2].startswith('BECOME-SUCCESS-'))
 
     def test_to_unicode(self):


### PR DESCRIPTION
- added missing inventory override for become_method
- created new pe class bsdsu due to big differences in su options (need to check aix/solaris)
- for Linux fixes issues seen with su now that checksums do use it when present
