### PR TITLE
Set theory dict support

### DIFF
--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -33,19 +33,22 @@ def unique(a):
                 c.append(x)
     return c
 
-def intersect(a, b):
+def intersect(a, b, strict=False):
     if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) & set(b)
     elif isinstance(a, Mapping) and isinstance(b, Mapping):
         c = {}
         for k in intersect(a.keys(),b.keys()):
-            if a[k] == b[k]:
+            if strict:
+                if a[k] == b[k]:
+                    c[k] = a[k]
+            else:
                 c[k] = a[k]
     else:
         c = unique(filter(lambda x: x in b, a))
     return c
 
-def difference(a, b):
+def difference(a, b, strict=False):
     if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) - set(b)
     elif isinstance(a, Mapping) and isinstance(b, Mapping):
@@ -53,15 +56,17 @@ def difference(a, b):
         # get keys that are different
         for k in difference(a.keys(),b.keys()):
             c[k] = a[k]
-        # get values that are different
-        for k in intersect(a.keys(), b.keys()):
-            if a[k] != b[k]:
-                c[k] = a[k]
+
+        if strict:
+            # get values that are different
+            for k in intersect(a.keys(), b.keys()):
+                if a[k] != b[k]:
+                    c[k] = a[k]
     else:
         c = unique(filter(lambda x: x not in b, a))
     return c
 
-def symmetric_difference(a, b):
+def symmetric_difference(a, b, strict=False):
     if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) ^ set(b)
     elif isinstance(a, Mapping) and isinstance(b, Mapping):
@@ -72,10 +77,12 @@ def symmetric_difference(a, b):
                 c[k] = b[k]
             else:
                 c[k] = a[k]
-        # get values that are different
-        for k in intersect(a.keys(), b.keys()):
-            if a[k] != b[k]:
-                c[k] = a[k]
+
+        if strict:
+            # get values that are different
+            for k in intersect(a.keys(), b.keys()):
+                if a[k] != b[k]:
+                    c[k] = a[k]
     else:
         c = unique(filter(lambda x: x not in intersect(a,b), union(a,b)))
     return c

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -39,7 +39,8 @@ def intersect(a, b):
     elif isinstance(a, Mapping) and isinstance(b, Mapping):
         c = {}
         for k in intersect(a.keys(),b.keys()):
-            c[k] = a[k]
+            if a[k] == b[k]:
+                c[k] = a[k]
     else:
         c = unique(filter(lambda x: x in b, a))
     return c
@@ -83,8 +84,8 @@ def union(a, b):
     if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) | set(b)
     elif isinstance(a, Mapping) and isinstance(b, Mapping):
-        c = a.copy()
-        c.update(b)
+        c = b.copy()
+        c.update(a)
     else:
         c = unique(a + b)
     return c

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -18,12 +18,14 @@
 from __future__ import absolute_import
 
 import math
-import collections
+from collections import Hashable, Mapping
 from ansible import errors
 
 def unique(a):
-    if isinstance(a,collections.Hashable):
+    if isinstance(a, Hashable):
         c = set(a)
+    elif isinstance(a, Mapping):
+        c = a
     else:
         c = []
         for x in a:
@@ -32,29 +34,57 @@ def unique(a):
     return c
 
 def intersect(a, b):
-    if isinstance(a,collections.Hashable) and isinstance(b,collections.Hashable):
+    if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) & set(b)
+    elif isinstance(a, Mapping) and isinstance(b, Mapping):
+        c = {}
+        for k in intersect(a.keys(),b.keys()):
+            c[k] = a[k]
     else:
         c = unique(filter(lambda x: x in b, a))
     return c
 
 def difference(a, b):
-    if isinstance(a,collections.Hashable) and isinstance(b,collections.Hashable):
+    if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) - set(b)
+    elif isinstance(a, Mapping) and isinstance(b, Mapping):
+        c = {}
+        # get keys that are different
+        for k in difference(a.keys(),b.keys()):
+            c[k] = a[k]
+        # get values that are different
+        for k in intersect(a.keys(), b.keys()):
+            if a[k] != b[k]:
+                c[k] = a[k]
     else:
         c = unique(filter(lambda x: x not in b, a))
     return c
 
 def symmetric_difference(a, b):
-    if isinstance(a,collections.Hashable) and isinstance(b,collections.Hashable):
+    if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) ^ set(b)
+    elif isinstance(a, Mapping) and isinstance(b, Mapping):
+        c={}
+        # get keys that are different
+        for k in symmetric_difference(a.keys(),b.keys()):
+            if k in b:
+                c[k] = b[k]
+            else:
+                c[k] = a[k]
+        # get values that are different
+        for k in intersect(a.keys(), b.keys()):
+            if a[k] != b[k]:
+                c[k] = a[k]
     else:
         c = unique(filter(lambda x: x not in intersect(a,b), union(a,b)))
     return c
 
 def union(a, b):
-    if isinstance(a,collections.Hashable) and isinstance(b,collections.Hashable):
+    if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) | set(b)
+    elif isinstance(a, Mapping) and isinstance(b, Mapping):
+        c = a.copy()
+        c.update(b)
     else:
         c = unique(a + b)
     return c


### PR DESCRIPTION
Incorporated #10483 and added support to the rest of the set theory functions

test play:

```
- hosts: localhost
  gather_facts: False
  vars:
    dicta:
        a: 1
        b: 2
        c: 3
        d: 4
    dictb:
        c: 3
        d: 2
        e: 3
        f: 4
    union: "{{dicta|union(dictb)}}"
    inter: "{{dicta|intersect(dictb)}}"
    diff: "{{dicta|difference(dictb)}}"
    symdiff: "{{dicta|symmetric_difference(dictb)}}"
  tasks:
    - debug: var=union
    - debug: var=inter
    - debug: var=diff
    - debug: var=symdiff
```

results:

```
PLAY [localhost] ************************************************************** 

TASK: [debug var=union] ******************************************************* 
ok: [localhost] => {
    "var": {
        "union": {
            "a": 1,
            "b": 2,
            "c": 3,
            "d": 2,
            "e": 3,
            "f": 4
        }
    }
}

TASK: [debug var=inter] ******************************************************* 
ok: [localhost] => {
    "var": {
        "inter": {
            "c": 3,
            "d": 4
        }
    }
}

TASK: [debug var=diff] ******************************************************** 
ok: [localhost] => {
    "var": {
        "diff": {
            "a": 1,
            "b": 2
        }
    }
}

TASK: [debug var=symdiff] ***************************************************** 
ok: [localhost] => {
    "var": {
        "symdiff": {
            "a": 1,
            "b": 2,
            "e": 3,
            "f": 4
        }
    }
}

PLAY RECAP ******************************************************************** 
localhost                  : ok=4    changed=0    unreachable=0    failed=0   
```
