### PR TITLE
Make it possible to access the HTTP response data in fetch_url

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -467,7 +467,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         info['url'] = r.geturl()  # The URL goes in too, because of redirects.
         info.update(dict(msg="OK (%s bytes)" % r.headers.get('Content-Length', 'unknown'), status=200))
     except urllib2.HTTPError, e:
-        info.update(dict(msg=str(e), status=e.code))
+        info.update(dict(msg=str(e), status=e.code, http_error=e))
     except urllib2.URLError, e:
         code = int(getattr(e, 'code', -1))
         info.update(dict(msg="Request failed: %s" % str(e), status=code))


### PR DESCRIPTION
##### SUMMARY
Without this change you would not be able to access the http response data via e.read(). This is useful so that you can display errors to users if the API you're communicating with uses non-standard headers for error indication


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/urls.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


