### PR TITLE
Adding comment filter

### DIFF
--- a/v1/ansible/runner/filter_plugins/core.py
+++ b/v1/ansible/runner/filter_plugins/core.py
@@ -270,6 +270,83 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
 def to_uuid(string):
     return str(uuid.uuid5(UUID_NAMESPACE_ANSIBLE, str(string)))
 
+def comment(text, style='plain', **kw):
+    # Predefined comment types
+    comment_styles = {
+        'plain': {
+            'decoration': '# '
+        },
+        'erlang': {
+            'decoration': '% '
+        },
+        'c': {
+            'decoration': '// '
+        },
+        'cblock': {
+            'beginning': '/*',
+            'decoration': ' * ',
+            'end': ' */'
+        },
+        'xml': {
+            'beginning': '<!--',
+            'decoration': ' - ',
+            'end': '-->'
+        }
+    }
+
+    # Pointer to the right comment type
+    style_params = comment_styles[style]
+
+    if 'decoration' in kw:
+        prepostfix = kw['decoration']
+    else:
+        prepostfix = style_params['decoration']
+
+    # Default params
+    p = {
+        'newline': '\n',
+        'beginning': '',
+        'prefix': (prepostfix).rstrip(),
+        'prefix_count': 1,
+        'decoration': '',
+        'postfix': (prepostfix).rstrip(),
+        'postfix_count': 1,
+        'end': ''
+    }
+
+    # Update default params
+    p.update(style_params)
+    p.update(kw)
+
+    # Compose substrings for the final string
+    str_beginning = ''
+    if p['beginning']:
+        str_beginning = "%s%s" % (p['beginning'], p['newline'])
+    str_prefix = str(
+        "%s%s" % (p['prefix'], p['newline'])) * int(p['prefix_count'])
+    str_text = ("%s%s" % (
+        p['decoration'],
+        # Prepend each line of the text with the decorator
+        text.replace(
+            p['newline'], "%s%s" % (p['newline'], p['decoration'])))).replace(
+                # Remove trailing spaces when only decorator is on the line
+                "%s%s" % (p['decoration'], p['newline']),
+                "%s%s" % (p['decoration'].rstrip(), p['newline']))
+    str_postfix = p['newline'].join(
+        [''] + [p['postfix'] for x in range(p['postfix_count'])])
+    str_end = ''
+    if p['end']:
+        str_end = "%s%s" % (p['newline'], p['end'])
+
+    # Return the final string
+    return "%s%s%s%s%s" % (
+        str_beginning,
+        str_prefix,
+        str_text,
+        str_postfix,
+        str_end)
+
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -348,4 +425,7 @@ class FilterModule(object):
             # random stuff
             'random': rand,
             'shuffle': randomize_list,
+
+            # comment-style decoration of string
+            'comment': comment,
         }


### PR DESCRIPTION
This patch is adding a new Jinja2 filter called `comment` which allows to decorate the text with a chosen comment style. The main motivation behind it is to be able to have nicer `ansible_managed` string. The current `ansible_managed` string is one and very long line. The `comment` filter allows to split the string on multiple lines and decorate it with a desired comment style.

For example, if we override the `ansible_managed` string in `ansible.conf` like this:

```
[defaults]

ansible_managed = This file is managed by Ansible.%n
  template: {file}
  date: %Y-%m-%d %H:%M:%S
  user: {uid}
  host: {host}
```

Then we can decorate the text with the `comment` filter like this:

```
{{ ansible_managed | comment }}
```

That will create the following output:

```
#
# This file is managed by Ansible.
# 
# template: /home/jtyr/ansible/env/dev/ansible_managed/roles/role1/templates/test.j2
# date: 2015-03-18 11:02:58
# user: jtyr
# host: myhost
#
```

The filter has couple of predefined comment styles and it also allows to define completely new styles inline. Here is couple of examples of how to use it:

```
Plain style (default):
{{ ansible_managed | comment }}

Erlang style:
{{ ansible_managed | comment('erlang') }}

C style:
{{ ansible_managed | comment('c') }}

C block style:
{{ ansible_managed | comment('cblock') }}

XML style:
{{ ansible_managed | comment('xml') }}

Custom style:
{{ ansible_managed | comment('plain', prefix='#######\n#', postfix='#\n#######\n   ###\n    #') }}
```

That will produce the following output:

```
Plain style (default):
#
# This file is managed by Ansible.
# 
# template: /home/jtyr/ansible/env/dev/ansible_managed/roles/role1/templates/test.j2
# date: 2015-03-18 11:02:58
# user: jtyr
# host: myhost
#

Erlang style:
%
% This file is managed by Ansible.
% 
% template: /home/jtyr/ansible/env/dev/ansible_managed/roles/role1/templates/test.j2
% date: 2015-03-18 11:02:58
% user: jtyr
% host: myhost
%

C style:
//
// This file is managed by Ansible.
// 
// template: /home/jtyr/ansible/env/dev/ansible_managed/roles/role1/templates/test.j2
// date: 2015-03-18 11:02:58
// user: jtyr
// host: myhost
//

C block style:
/*
 *
 * This file is managed by Ansible.
 * 
 * template: /home/jtyr/ansible/env/dev/ansible_managed/roles/role1/templates/test.j2
 * date: 2015-03-18 11:02:58
 * user: jtyr
 * host: myhost
 *
 */

XML style:
<!--
 -
 - This file is managed by Ansible.
 - 
 - template: /home/jtyr/ansible/env/dev/ansible_managed/roles/role1/templates/test.j2
 - date: 2015-03-18 11:02:58
 - user: jtyr
 - host: myhost
 -
-->

Custom style:
#######
#
# This file is managed by Ansible.
# 
# template: /home/jtyr/ansible/env/dev/ansible_managed/roles/role1/templates/test.j2
# date: 2015-03-18 11:02:58
# user: jtyr
# host: myhost
#
#######
   ###
    #
```
