### PR TITLE
Update add_host example in AWS Guide

### DIFF
--- a/docsite/rst/guide_aws.rst
+++ b/docsite/rst/guide_aws.rst
@@ -107,7 +107,7 @@ From this, we'll use the add_host module to dynamically create a host group cons
           register: ec2
     
        - name: Add all instance public IPs to host group
-         add_host: hostname={{ item.public_ip }} groupname=ec2hosts
+         add_host: hostname={{ item.public_ip }} groups=ec2hosts
          with_items: ec2.instances
 
 With the host group now created, a second play at the bottom of the the same provisioning playbook file might now have some configuration steps::


### PR DESCRIPTION
The add_host module now uses "groups" instead of "groupname" to allow for specifying more than one group.
