### PR TITLE
now ansible ignores tempate errors on passwords

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -934,8 +934,12 @@ class Runner(object):
 
         # user/pass may still contain variables at this stage
         actual_user = template.template(self.basedir, actual_user, inject)
-        actual_pass = template.template(self.basedir, actual_pass, inject)
-        self.become_pass = template.template(self.basedir, self.become_pass, inject)
+        try:
+            actual_pass = template.template(self.basedir, actual_pass, inject)
+            self.become_pass = template.template(self.basedir, self.become_pass, inject)
+        except:
+            # ignore password template errors, could be triggered by password charaters #10468
+            pass
 
         # make actual_user available as __magic__ ansible_ssh_user variable
         inject['ansible_ssh_user'] = actual_user


### PR DESCRIPTION
they could be caused by random character combinations, fixes #10468
