### PR TITLE
Reintroduce documented colon-split ranges

### DIFF
--- a/test/units/TestInventory.py
+++ b/test/units/TestInventory.py
@@ -212,7 +212,12 @@ class TestInventory(unittest.TestCase):
         inventory.subset('greek[0-2];norse[0]')
         self.assertEqual(sorted(inventory.list_hosts()),  sorted(['zeus','hera','thor']))
 
-    def test_subet_range_empty_group(self):
+    def test_subset_range_pattern(self):
+        inventory = self.simple_inventory()
+        inventory.subset('greek[0:1];norse[0]')
+        self.assertEqual(sorted(inventory.list_hosts()),  sorted(['zeus','hera','thor']))
+
+    def test_subset_range_empty_group(self):
         inventory = self.simple_inventory()
         inventory.subset('missing[0]')
         self.assertEqual(sorted(inventory.list_hosts()), sorted([]))


### PR DESCRIPTION
Allow `webservers[0:25]` as documented in
http://docs.ansible.com/intro_patterns.html

That's the first 26 webservers (so behaves differently
to `webservers[0-25]` which is 25 hosts)

Works for both `--limit` and `hosts`
(the test documented in #9670 now works)

Fixes #9670
