### PR TITLE
add cobbler api authentication options

### DIFF
--- a/plugins/inventory/cobbler.ini
+++ b/plugins/inventory/cobbler.ini
@@ -5,6 +5,10 @@
 
 host = http://PATH_TO_COBBLER_SERVER/cobbler_api
 
+# If API needs authentication add 'username' and 'password' options here.
+#username = foo
+#password = bar
+
 # API calls to Cobbler can be slow. For this reason, we cache the results of an API
 # call. Set this to the path you want cache files to be written to. Two files
 # will be written to this directory:


### PR DESCRIPTION
add cobbler api authentication options: username and password, which
can be provided if authentication is enabled or cobbler api is behind
a proxy that needs authentication.
