### PR TITLE
Always define error before using it

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -382,6 +382,8 @@ class Ec2Inventory(object):
                 for instance in instances:
                     self.add_rds_instance(instance, region)
         except boto.exception.BotoServerError, e:
+            error = e.reason
+            
             if e.error_code == 'AuthFailure':
                 error = self.get_auth_error_message()
             if not e.reason == "Forbidden":


### PR DESCRIPTION
When the error reason is "Forbidden", the code throws a Python exception
rather than simply outputting the exception reason.

It's not nice to throw a Python exception when all the info to display
a proper message is available.
