### PR TITLE
egg_info is now written directly to lib

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -42,11 +42,10 @@ expr "$MANPATH" : "${PREFIX_MANPATH}.*" > /dev/null || export MANPATH="$PREFIX_M
 # Do the work in a function so we don't repeat ourselves later
 gen_egg_info()
 {
-    python setup.py egg_info
     if [ -e "$PREFIX_PYTHONPATH/ansible.egg-info" ] ; then
         rm -r "$PREFIX_PYTHONPATH/ansible.egg-info"
     fi
-    mv "ansible.egg-info" "$PREFIX_PYTHONPATH"
+    python setup.py egg_info
 }
 
 if [ "$ANSIBLE_HOME" != "$PWD" ] ; then


### PR DESCRIPTION
Due to the changes made in  https://github.com/ansible/ansible/commit/597c0f48f53067fa6bce785b86d934d903dd4d1d `ansible.egg_info` is now directly written to `lib`.

As a result, the directory is written, removed, and then the `mv` fails.

This PR, moves the `python setup.py egg_info` after the removal, and eliminates the `mv`.
