### PR TITLE
Vagrant inventory: exit 0 on success

### DIFF
--- a/plugins/inventory/vagrant.py
+++ b/plugins/inventory/vagrant.py
@@ -107,7 +107,7 @@ if options.list:
         hosts['vagrant'].append(data['HostName'])
 
     print json.dumps(hosts)
-    sys.exit(1)
+    sys.exit(0)
 
 # Get out the host details
 #------------------------------
@@ -122,11 +122,11 @@ elif options.host:
         result['ansible_ssh_port'] = result['Port']
 
     print json.dumps(result)
-    sys.exit(1)
+    sys.exit(0)
 
 
 # Print out help
 #------------------------------
 else:
     parser.print_help()
-    sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
Current code has sys.exit(1) at the end of the codepath for the options --help, --list and --host. These are not error conditions so should be returning 0 for success, not 1 which is EPERM "Operation not permitted". Newer Vagrant versions examine the exit codes from subprocesses and interpret this as a failure, as do external scripts.
