### PR TITLE
Possible fix for the first newline and triple newline problems

### DIFF
--- a/v2/ansible/parsing/splitter.py
+++ b/v2/ansible/parsing/splitter.py
@@ -211,7 +211,7 @@ def split_args(args):
                 params.append(token)
                 appended = True
             elif print_depth or block_depth or comment_depth or inside_quotes or was_inside_quotes:
-                if idx == 0 and not inside_quotes and was_inside_quotes:
+                if idx == 0 and was_inside_quotes:
                     params[-1] = "%s%s" % (params[-1], token)
                 elif len(tokens) > 1:
                     spacer = ''
@@ -251,8 +251,7 @@ def split_args(args):
         # one item (meaning we split on newlines), add a newline back here
         # to preserve the original structure
         if len(items) > 1 and itemidx != len(items) - 1 and not line_continuation:
-            if not params[-1].endswith('\n'):
-                params[-1] += '\n'
+            params[-1] += '\n'
 
         # always clear the line continuation flag
         line_continuation = False


### PR DESCRIPTION
Potential fix for failing unittests.  Currently if we give parse_kv `u'a="multiline\nmessage1\\\n" b="multiline\nmessage2\\\n"'`

We get this failure:

```
======================================================================
FAIL: test.parsing.test_splitter.TestSplitter_Gen.test_split_args(u'a="multiline\nmessage1\\\n" b="multiline\nmessage2\\\n"', [u'a="multiline\nmessage1\\\n"', u'b="multiline\nmessage2\\\n"'])
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/srv/ansible/ansible-friday/v2/test/parsing/test_splitter.py", line 96, in check_split_args
    tools.eq_(split_args(args), expected)
AssertionError: [u'a="multiline\n\nmessage1\\\n"', u'b="multiline\n\nmessage2\\\n"'] != [u'a="multiline\nmessage1\\\n"', u'b="multiline\nmessage2\\\n"']
----------------------------------------------------------------------
```

The modification to line 214 logically seems to be the fix for that (when we go through the next item, do not append a newline because we already did that when we exited the previous token loop.

However, that creates a different failure with this input `u'a="blank\n\n\nlines"'`:

```
======================================================================
FAIL: test.parsing.test_splitter.TestSplitter_Gen.test_split_args(u'a="blank\n\n\nlines"', [u'a="blank\n\n\nlines"'])
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/srv/ansible/ansible-friday/v2/test/parsing/test_splitter.py", line 96, in check_split_args
    tools.eq_(split_args(args), expected)
AssertionError: [u'a="blank\nlines"'] != [u'a="blank\n\n\nlines"']
----------------------------------------------------------------------
```

Since we just messed with Line 214, it seems like modifying line 254 so that we are allowed to append newlines right after another newline is the right fix.

After these two fixes all the current unittests pass.
