### PR TITLE
cloudstack: add error result handling in async job

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -185,8 +185,10 @@ class AnsibleCloudStack:
         if 'jobid' in job:
             while True:
                 res = self.cs.queryAsyncJobResult(jobid=job['jobid'])
-                if res['jobstatus'] != 0:
-                    if 'jobresult' in res and key is not None and key in res['jobresult']:
+                if res['jobstatus'] != 0 and 'jobresult' in res:
+                    if 'errortext' in res['jobresult']:
+                        self.module.fail_json(msg="Failed: '%s'" % res['jobresult']['errortext'])
+                    if key and key in res['jobresult']:
                         job = res['jobresult'][key]
                     break
                 time.sleep(2)


### PR DESCRIPTION
The async job polling did not handle error state returned by the API.
