### PR TITLE
Fix getting name of container, so links work

### DIFF
--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -276,7 +276,7 @@ def list_groups():
             id = container.get('Id')
             short_id = id[:13]
             try:
-                name = container.get('Names', list()).pop(0).lstrip('/')
+                name = container.get('Names', list()).pop().lstrip('/')
             except IndexError:
                 name = short_id
 


### PR DESCRIPTION
##### SUMMARY
This commit fixes getting names of docker-inventory. When using linked containers the containers will end up getting the name of the links, instead of the name given with --name. Therefore pop() the last item in the array, not the first.


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
plugins/inventory/docker.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


