### PR TITLE
Make inventory-plugin docker.py work on local system, and fix name

### DIFF
--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -286,6 +286,8 @@ def list_groups():
             if not id:
                 continue
 
+            image = container.get('Image').split(':')[0].replace('/','-')
+
             running = inspect.get('State', dict()).get('Running')
 
             groups[id].append(name)
@@ -293,6 +295,7 @@ def list_groups():
             if not short_id in groups.keys():
                 groups[short_id].append(name)
             groups[hostname].append(name)
+            groups[image].append(name)
 
             if running is True:
                 groups['running'].append(name)


### PR DESCRIPTION
##### SUMMARY
Fixes the containers name, by using the name set by --name, or the first name set in names[], rather than preferring the name of links and dynamic_names. Also properly sets the containers IP from NetworkSettings.IPAddress and uses "localhost" as hostname when running on a local unix-socket, so it doesn't break by passing null-values to Host() while parsing YML/JSON.


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
plugins/inventory/docker.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


