### PR TITLE
Default hosts file on homebrew installation

### DIFF
--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -254,6 +254,10 @@ To install on a Mac, make sure you have Homebrew, then run:
     $ brew update
     $ brew install ansible
 
+by default ansible will be looking for your host file in "/usr/local/etc/ansible/hosts", check the `Inventory Configuration 
+<http://docs.ansible.com/intro_configuration.html#inventory>`_ on how to change this.
+
+
 .. _from_pkgutil:
 
 Latest Releases Via OpenCSW (Solaris)


### PR DESCRIPTION
Specify on the Docs what's the default location for the hosts file where ansible will be looking if installed with homebrew.
