### PR TITLE
Don't recommend installing ansible via homebrew

### DIFF
--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -242,17 +242,14 @@ You may also wish to install from ports, run:
 
     $ sudo make -C /usr/ports/sysutils/ansible install
 
-.. _from_brew:
+.. _on_macos:
 
-Latest Releases Via Homebrew (Mac OSX)
+Latest Releases on Mac OSX
 ++++++++++++++++++++++++++++++++++++++
 
-To install on a Mac, make sure you have Homebrew, then run:
+The preferred way to install ansible on a Mac is via pip.
 
-.. code-block:: bash
-
-    $ brew update
-    $ brew install ansible
+The instructions can be found in `Latest Releases Via Pip`_ section.
 
 .. _from_pkgutil:
 


### PR DESCRIPTION
We should not recommend installing ansible via homebrew.  In my experience it is more trouble than it is worth, and many "support" questions in #ansible are a result of homebrew.

Some bad things that homebrew does in my opinion:
1. By default causes you to use `/usr/local/bin/python` but without much explanation of such
2. Replaces the ansible "bin" scripts with shell scripts that manipulate `PYTHONPATH`
3. The `PYTHONPATH` and above referenced shell scripts are specific to the installation of ansible via homebrew, and pip does not install python dependencies in a location inclusive to the modified `PYTHONPATH`
4. Patches the source of ansible on the fly to reference non-standard paths, such as `/usr/local/etc/ansible`

This PR simply removes the homebrew reference, and recommends using pip to install ansible on Mac.
