### PR TITLE
cloudstack: fix vm not found by displayname

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -119,7 +119,7 @@ class AnsibleCloudStack:
         vms = self.cs.listVirtualMachines(**args)
         if vms:
             for v in vms['virtualmachine']:
-                if vm in [ v['name'], v['id'] ]:
+                if vm in [ v['displayname'], v['name'], v['id'] ]:
                     self.vm_id = v['id']
                     return self.vm_id
         self.module.fail_json(msg="Virtual machine '%s' not found" % vm)


### PR DESCRIPTION
if a user changes the name of a VM, displayname field is going to be changed, which results in VM can not be found unless we also look for the displayname.
