### PR TITLE
make ansible-galaxy version work for branches as well as tree-ish

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -36,8 +36,7 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.galaxy import Galaxy
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.role import GalaxyRole
-from ansible.playbook.role.requirement import RoleRequirement
-from ansible.playbook.role.requirement import role_spec_parse
+from ansible.playbook.role.requirement import RoleRequirement, role_spec_parse
 
 class GalaxyCLI(CLI):
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -418,7 +418,7 @@ class GalaxyCLI(CLI):
                 if role.scm:
                     # create tar file from scm url
                     tmp_file = GalaxyRole.scm_archive_role(role.scm, role.src, role.version, role.name)
-                if role.src:
+                elif role.src:
                     if '://' not in role.src:
                         role_data = self.api.lookup_role_by_name(role.src)
                         if not role_data:
@@ -448,6 +448,10 @@ class GalaxyCLI(CLI):
                         # download the role. if --no-deps was specified, we stop here,
                         # otherwise we recursively grab roles and all of their deps.
                         tmp_file = role.fetch(role_data)
+                    else:
+                        # just download a URL - version will probably be in the URL
+                        role_data={"dummy": True} # must not be empty for role.fetch()
+                        tmp_file = role.fetch(role_data)
 
             if tmp_file:
                 installed = role.install(tmp_file)
@@ -461,11 +465,11 @@ class GalaxyCLI(CLI):
                         self.display.debug('Installing dep %s' % dep)
                         dep_req = RoleRequirement()
                         __, dep_name, __ = dep_req.parse(dep)
-                        dep_role = GalaxyRole(self.galaxy, name=dep_name)
+                        dep_role = self.create_role_from_spec(dep_name)
                         if dep_role.install_info is None or force:
                             if dep_role not in roles_left:
                                 self.display.display('- adding dependency: %s' % dep_name)
-                                roles_left.append(GalaxyRole(self.galaxy, name=dep_name))
+                                roles_left.append(self.create_role_from_spec(dep_name))
                             else:
                                 self.display.display('- dependency %s already pending installation.' % dep_name)
                         else:

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -306,7 +306,7 @@ class GalaxyRole(object):
             with open('/dev/null', 'w') as devnull:
                 try:
                     display.display("- executing: %s" % " ".join(checkout_cmd))
-                    popen = subprocess.Popen(checkout_cmd, cwd=tempdir, stdout=devnull, stderr=devnull)
+                    popen = subprocess.Popen(checkout_cmd, cwd=os.path.join(tempdir, role_name), stdout=devnull, stderr=devnull)
                 except IOError, OSError:
                     raise AnsibleError("error executing: %s" % " ".join(checkout_cmd))
                 rc = popen.wait()

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -65,9 +65,9 @@ class GalaxyRole(object):
                 if os.path.exists(role_path):
                     self.path = role_path
                     break
-            else:
-                # use the first path by default
-                self.path = os.path.join(galaxy.roles_paths[0], self.name)
+                else:
+                    # use the first path by default
+                    self.path = os.path.join(galaxy.roles_paths[0], self.name)
 
     def __eq__(self, other):
         return self.name == other.name

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -293,7 +293,7 @@ class GalaxyRole(object):
             try:
                 display.display("- executing: %s" % " ".join(clone_cmd))
                 popen = subprocess.Popen(clone_cmd, cwd=tempdir, stdout=devnull, stderr=devnull)
-            except:
+            except IOError, OSError:
                 raise AnsibleError("error executing: %s" % " ".join(clone_cmd))
             rc = popen.wait()
         if rc != 0:
@@ -307,13 +307,13 @@ class GalaxyRole(object):
                 try:
                     display.display("- executing: %s" % " ".join(checkout_cmd))
                     popen = subprocess.Popen(checkout_cmd, cwd=tempdir, stdout=devnull, stderr=devnull)
-                except:
+                except IOError, OSError:
                     raise AnsibleError("error executing: %s" % " ".join(checkout_cmd))
-                    rc = popen.wait()
-                    if rc != 0:
-                        display.display("- command %s failed" % ' '.join(clone_cmd))
-                        display.display("  in directory %s" % tempdir)
-                        return False
+                rc = popen.wait()
+            if rc != 0:
+                display.display("- command %s failed" % ' '.join(checkout_cmd))
+                display.display("  in directory %s" % tempdir)
+                return False
 
         temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.tar')
         if scm == 'hg':

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -293,7 +293,7 @@ class GalaxyRole(object):
             try:
                 display.display("- executing: %s" % " ".join(clone_cmd))
                 popen = subprocess.Popen(clone_cmd, cwd=tempdir, stdout=devnull, stderr=devnull)
-            except IOError, OSError:
+            except (IOError, OSError):
                 raise AnsibleError("error executing: %s" % " ".join(clone_cmd))
             rc = popen.wait()
         if rc != 0:
@@ -307,7 +307,7 @@ class GalaxyRole(object):
                 try:
                     display.display("- executing: %s" % " ".join(checkout_cmd))
                     popen = subprocess.Popen(checkout_cmd, cwd=os.path.join(tempdir, role_name), stdout=devnull, stderr=devnull)
-                except IOError, OSError:
+                except (IOError, OSError):
                     raise AnsibleError("error executing: %s" % " ".join(checkout_cmd))
                 rc = popen.wait()
             if rc != 0:


### PR DESCRIPTION
Squashes WIP merges and replaces https://github.com/ansible/ansible/pull/10478

Version can now be a branch, a tag, or any <tree-ish> supported by git including specific commit IDs.
