### PR TITLE
Fix kerberos transport when no password supplied

### DIFF
--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -84,6 +84,9 @@ class Connection(object):
         vvv("ESTABLISH WINRM CONNECTION FOR USER: %s on PORT %s TO %s" % \
             (self.user, port, self.host), host=self.host)
         netloc = '%s:%d' % (self.host, port)
+        # If user has kerberos, and password is blank set it to 'kerberos'
+        if not self.password and HAVE_KERBEROS:
+            self.password = 'kerberos'
         cache_key = '%s:%s@%s:%d' % (self.user, hashlib.md5(self.password).hexdigest(), self.host, port)
         if cache_key in _winrm_cache:
             vvvv('WINRM REUSE EXISTING CONNECTION: %s' % cache_key, host=self.host)


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.9.0.1
  configured module search path = /opt/ansible-library
##### Environment:

Red Hat Enterprise Linux Server release 6.6 (Santiago)
##### Summary:

If using kerberos transport on winrm, and you don't specify a password, winrm connection fails
##### Steps To Reproduce:
- get a kerberos ticket
- attempt to connect to a windows host 

`ansible windows_host -m win_ping  -eansible_connection=winrm -eansible_ssh_port=5986`
##### Expected Results:

win_ping returns pong 
##### Actual Results:

`File "/usr/lib/python2.6/site-packages/ansible/runner/connection_plugins/winrm.py", line 87, in _winrm_connect
    cache_key = '%s:%s@%s:%d' % (self.user, hashlib.md5(self.password).hexdigest(), self.host, port)
TypeError: md5() argument 1 must be string or read-only buffer, not None`
