### PR TITLE
Replace - in ec2 inventory as well

### DIFF
--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -787,7 +787,7 @@ class Ec2Inventory(object):
         ''' Converts 'bad' characters in a string to underscores so they can be
         used as Ansible groups '''
 
-        return re.sub("[^A-Za-z0-9\-]", "_", word)
+        return re.sub("[^A-Za-z0-9\_]", "_", word)
 
 
     def json_format_dict(self, data, pretty=False):


### PR DESCRIPTION
Dash (-) is not a variable ansible group name, so it needs to be replaced as well.

Without this, you end up with things like tags including a - so you can't refer to those variables in the plays. Even worst, the error message when using it in conditions is ba^Wdoesn't even exist, see: #5356
