### PR TITLE
Fix indentation

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2452,7 +2452,7 @@ class LinuxVirtual(Virtual):
             self.facts['virtualization_role'] = 'guest'
             return
 
-	if sys_vendor == 'oVirt':
+        if sys_vendor == 'oVirt':
             self.facts['virtualization_type'] = 'kvm'
             self.facts['virtualization_role'] = 'guest'
             return


### PR DESCRIPTION
Incorrect indentation on line 2455 in lib/ansible/module_utils.facts.py causes any custom modules that import module_utils.facts.py to fail with an error similar to this:

```
RAW OUTPUT

  File "/home/jdetiber/.ansible_module_generated", line 4525
    if os.path.exists('/proc/self/status'):
                                          ^
IndentationError: unindent does not match any outer indentation level
```

This was introduced with: https://github.com/ansible/ansible/commit/29cca0191b19b5b4e5d6cc84992dc9a53b19c837

Any 1.9 ansible binaries suffer from this issue currently.
