### PR TITLE
Add environment-handling to roles.

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -425,6 +425,7 @@ class Play(object):
         new_handlers    = []
         role_vars_files = []
         defaults_files  = []
+        new_environment = {}
 
         pre_tasks = ds.get('pre_tasks', None)
         if type(pre_tasks) != list:
@@ -454,23 +455,25 @@ class Play(object):
                 if k in role_vars:
                     special_vars[k] = role_vars[k]
 
-            task_basepath     = utils.path_dwim(self.basedir, os.path.join(role_path, 'tasks'))
-            handler_basepath  = utils.path_dwim(self.basedir, os.path.join(role_path, 'handlers'))
-            vars_basepath     = utils.path_dwim(self.basedir, os.path.join(role_path, 'vars'))
-            meta_basepath     = utils.path_dwim(self.basedir, os.path.join(role_path, 'meta'))
-            defaults_basepath = utils.path_dwim(self.basedir, os.path.join(role_path, 'defaults'))
+            task_basepath        = utils.path_dwim(self.basedir, os.path.join(role_path, 'tasks'))
+            handler_basepath     = utils.path_dwim(self.basedir, os.path.join(role_path, 'handlers'))
+            vars_basepath        = utils.path_dwim(self.basedir, os.path.join(role_path, 'vars'))
+            meta_basepath        = utils.path_dwim(self.basedir, os.path.join(role_path, 'meta'))
+            defaults_basepath    = utils.path_dwim(self.basedir, os.path.join(role_path, 'defaults'))
+            environment_basepath = utils.path_dwim(self.basedir, os.path.join(role_path, 'environment'))
 
-            task      = self._resolve_main(task_basepath)
-            handler   = self._resolve_main(handler_basepath)
-            vars_file = self._resolve_main(vars_basepath)
-            meta_file = self._resolve_main(meta_basepath)
-            defaults_file = self._resolve_main(defaults_basepath)
+            task             = self._resolve_main(task_basepath)
+            handler          = self._resolve_main(handler_basepath)
+            vars_file        = self._resolve_main(vars_basepath)
+            meta_file        = self._resolve_main(meta_basepath)
+            defaults_file    = self._resolve_main(defaults_basepath)
+            environment_file = self._resolve_main(environment_basepath)
 
             library   = utils.path_dwim(self.basedir, os.path.join(role_path, 'library'))
 
             missing = lambda f: not os.path.isfile(f)
-            if missing(task) and missing(handler) and missing(vars_file) and missing(defaults_file) and missing(meta_file) and not os.path.isdir(library):
-                raise errors.AnsibleError("found role at %s, but cannot find %s or %s or %s or %s or %s or %s" % (role_path, task, handler, vars_file, defaults_file, meta_file, library))
+            if missing(task) and missing(handler) and missing(vars_file) and missing(defaults_file) and missing(meta_file) and missing(environment_file) and not os.path.isdir(library):
+                raise errors.AnsibleError("found role at %s, but cannot find %s or %s or %s or %s or %s or %s or %s" % (role_path, task, handler, vars_file, defaults_file, meta_file, environment_file, library))
 
             if isinstance(role, dict):
                 role_name = role['role']
@@ -494,6 +497,10 @@ class Play(object):
                 role_vars_files.append(vars_file)
             if os.path.isfile(defaults_file):
                 defaults_files.append(defaults_file)
+            if os.path.isfile(environment_file):
+                environment = utils.parse_yaml_from_file(environment_file, vault_password=self.vault_password)
+                if type(environment) == dict:
+                    new_environment.update(environment)
             if os.path.isdir(library):
                 utils.plugins.module_finder.add_directory(library)
 
@@ -526,6 +533,10 @@ class Play(object):
 
         self.role_vars = self._load_role_vars_files(role_vars_files)
         self.default_vars = self._load_role_defaults(defaults_files)
+
+        # play environment overrides role environment
+        new_environment.update(self.environment)
+        self.environment = new_environment
 
         return ds
 
@@ -846,7 +857,7 @@ class Play(object):
             """ Render the raw filename into 3 forms """
 
             # filename2 is the templated version of the filename, which will
-            # be fully rendered if any variables contained within it are 
+            # be fully rendered if any variables contained within it are
             # non-inventory related
             filename2 = template(self.basedir, filename, self.vars)
 


### PR DESCRIPTION
[See also #8878.]

A new subdirectory, 'environment', is available for roles. The dictionary elements from the main.yml file within are merged with those from previous roles. (Later roles override previous ones.) Finally, the play's environment is merged into the roles' environment variables.

Thus, the (lowest-to-highest) precedence for any environment variable specified in multiple places is: roles (in role-load order) - play - task.
