### PR TITLE
Print error message when no_log is True

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1636,9 +1636,12 @@ def censor_unlogged_data(data):
     '''
     new_data = {}
     for (x,y) in data.iteritems():
-       if x in [ 'skipped', 'changed', 'failed', 'rc' ]:
-           new_data[x] = y
+        if x in [ 'skipped', 'changed', 'failed', 'rc', 'msg' ]:
+            new_data[x] = y
     new_data['censored'] = 'results hidden due to no_log parameter'
+    # retain msg on failure as diagnosis is difficult otherwise
+    if 'failed' in data and 'msg' in data:
+        new_data['msg'] = data['msg']
     return new_data
 
 def check_mutually_exclusive_privilege(options, parser):

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -780,7 +780,7 @@ class TestUtils(unittest.TestCase):
         assert 'failed' in data
         assert 'changed' in data
         assert 'skipped' in data
-        assert 'msg' not in data
+        assert 'msg' in data
         assert data['censored'] == 'results hidden due to no_log parameter'
 
     def test_repo_url_to_role_name(self):


### PR DESCRIPTION
Without an error message, many conditions are impossible to
further diagnose.

There is a risk that the error message might contain sensitive
data but this information is more likely to be contained in
other parts of the data structure.

As an example, the current postgresql_user module errors when a DB is readonly (even if there is no change to the user - but that's a separate PR)

no_log unset: 

```
$ ansible-playbook change_db_user.yml -l db-host

PLAY [db-host] ************************************************* 

GATHERING FACTS *************************************************************** 
ok: [db-host]

TASK: [add postgresql user] *************************************************** 
failed: [db-host] => {"failed": true}
msg: ERROR:  cannot execute ALTER ROLE in a read-only transaction
```

no_log set:

```
$ ansible-playbook change_db_user.yml -l db-host

PLAY [db-host] ************************************************* 

GATHERING FACTS *************************************************************** 
ok: [db-host]

TASK: [add postgresql user] *************************************************** 
failed: [db-host] => {"censored": "results hidden due to no_log parameter", "failed": true}
```

with this change

```
$ ansible-playbook change_db_user.yml -l db-host

PLAY [db-host] ************************************************* 

GATHERING FACTS *************************************************************** 
ok: [db-host]

TASK: [add postgresql user] *************************************************** 
failed: [db-host] => {"censored": "results hidden due to no_log parameter", "failed": true}
msg: ERROR:  cannot execute ALTER ROLE in a read-only transaction
```

Note that most of the censorship still occurs (which is really important when using with_items, otherwise the items, including passwords, get displayed)
