### PR TITLE
Handle blank lines and comments in galaxy spec files

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -774,6 +774,9 @@ def execute_install(args, options, parser):
         # (and their dependencies, unless the user doesn't want us to).
         roles_left = map(ansible.utils.role_spec_parse, args)
 
+    # roles_spec_parse returns None for comments or blank lines
+    roles_left = filter(lambda x: x is not None, roles_left)
+
     while len(roles_left) > 0:
         # query the galaxy API for the role data
         role_data = None

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -392,7 +392,7 @@ def role_spec_parse(role_spec):
     role_version = ''
     default_role_versions = dict(git='master', hg='tip')
     if role_spec == "" or role_spec.startswith("#"):
-        return (None, None, None, None)
+        return None
 
     tokens = [s.strip() for s in role_spec.split(',')]
     

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -848,6 +848,16 @@ class TestUtils(unittest.TestCase):
                     'version' : '', 
                     'name' : 'master'
                 }
+            ),
+            (
+                # test comment
+                "# this is a comment",
+                None
+            ),
+            (
+                # test blank line
+                "",
+                None
             )
             ]
         for (spec, result) in tests:

--- a/v2/ansible/playbook/role/requirement.py
+++ b/v2/ansible/playbook/role/requirement.py
@@ -135,7 +135,7 @@ class RoleRequirement(RoleDefinition):
         role_spec = role_spec.strip()
         role_version = ''
         if role_spec == "" or role_spec.startswith("#"):
-            return (None, None, None, None)
+            return None
 
         tokens = [s.strip() for s in role_spec.split(',')]
 


### PR DESCRIPTION
`ansible.utils.role_spec_parse` (and v2 equivalent) already
handle when the roles file contains blank lines or comments

Make `ansible.utils.role_spec_parse` and
`ansible.playbook.role.requirement._role_spec_parse`
return a more appropriate result

Fix ansible-galaxy to make use of that information
