### PR TITLE
Support querying systemd container information

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2394,6 +2394,12 @@ class LinuxVirtual(Virtual):
                 self.facts['virtualization_role'] = 'guest'
             return
 
+        systemd_container = get_file_content('/run/systemd/container')
+        if systemd_container:
+            self.facts['virtualization_type'] = systemd_container
+            self.facts['virtualization_role'] = 'guest'
+            return
+
         if os.path.exists('/proc/1/cgroup'):
             for line in get_file_lines('/proc/1/cgroup'):
                 if re.search(r'/docker(/|-[0-9a-f]+\.scope)', line):


### PR DESCRIPTION
systemd writes a /run/systemd/container file in any container it starts to make it really easy to detect the container type.

This adds support for detecting systemd-nspawn containers (and any other container format that will write data there for compatibility). Otherwise we have to look for  `1:name=systemd:/system.slice/` in `/proc/1/cgroup`, which I'm not confident will be unique enough.
