### PR TITLE
WinRM Connection Fixes

### DIFF
--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -90,13 +90,18 @@ class Connection(object):
             return _winrm_cache[cache_key]
         exc = None
         for transport, scheme in self.transport_schemes['http' if port == 5985 else 'https']:
-            if transport == 'kerberos' and not HAVE_KERBEROS:
+            if transport == 'kerberos' and (not HAVE_KERBEROS or not '@' in self.user):
                 continue
+            if transport == 'kerberos':
+                realm = self.user.split('@', 1)[1].strip() or None
+            else:
+                realm = None
             endpoint = urlparse.urlunsplit((scheme, netloc, '/wsman', '', ''))
             vvvv('WINRM CONNECT: transport=%s endpoint=%s' % (transport, endpoint),
                  host=self.host)
             protocol = Protocol(endpoint, transport=transport,
-                                username=self.user, password=self.password)
+                                username=self.user, password=self.password,
+                                realm=realm)
             try:
                 protocol.send_message('')
                 _winrm_cache[cache_key] = protocol

--- a/lib/ansible/runner/connection_plugins/winrm.py
+++ b/lib/ansible/runner/connection_plugins/winrm.py
@@ -18,8 +18,6 @@
 from __future__ import absolute_import
 
 import base64
-import hashlib
-import imp
 import os
 import re
 import shlex
@@ -43,10 +41,6 @@ try:
     HAVE_KERBEROS = True
 except ImportError:
     pass
-
-_winrm_cache = {
-    # 'user:pwhash@host:port': <protocol instance>
-}
 
 def vvvvv(msg, host=None):
     verbose(msg, host=host, caplevel=4)
@@ -84,10 +78,6 @@ class Connection(object):
         vvv("ESTABLISH WINRM CONNECTION FOR USER: %s on PORT %s TO %s" % \
             (self.user, port, self.host), host=self.host)
         netloc = '%s:%d' % (self.host, port)
-        cache_key = '%s:%s@%s:%d' % (self.user, hashlib.md5(self.password).hexdigest(), self.host, port)
-        if cache_key in _winrm_cache:
-            vvvv('WINRM REUSE EXISTING CONNECTION: %s' % cache_key, host=self.host)
-            return _winrm_cache[cache_key]
         exc = None
         for transport, scheme in self.transport_schemes['http' if port == 5985 else 'https']:
             if transport == 'kerberos' and (not HAVE_KERBEROS or not '@' in self.user):
@@ -104,7 +94,6 @@ class Connection(object):
                                 realm=realm)
             try:
                 protocol.send_message('')
-                _winrm_cache[cache_key] = protocol
                 return protocol
             except WinRMTransportError, exc:
                 err_msg = str(exc)
@@ -116,7 +105,6 @@ class Connection(object):
                     if code == 401:
                         raise errors.AnsibleError("the username/password specified for this server was incorrect")
                     elif code == 411:
-                        _winrm_cache[cache_key] = protocol
                         return protocol
                 vvvv('WINRM CONNECTION ERROR: %s' % err_msg, host=self.host)
                 continue

--- a/lib/ansible/runner/shell_plugins/powershell.py
+++ b/lib/ansible/runner/shell_plugins/powershell.py
@@ -57,7 +57,7 @@ def _build_file_cmd(cmd_parts, quote_args=True):
     '''Build command line to run a file, given list of file name plus args.'''
     if quote_args:
         cmd_parts = ['"%s"' % x for x in cmd_parts]
-    return ' '.join(['&'] + cmd_parts)
+    return ' '.join(_common_args + ['-ExecutionPolicy', 'Unrestricted', '-File'] + cmd_parts)
 
 class ShellModule(object):
 


### PR DESCRIPTION
Fixes ExecutionPolicy issue described in https://groups.google.com/d/topic/ansible-devel/yXqHS6oEBpg/discussion and introduced by #9602.

Fixes auth issues when kerberos is installed but not required for connection.  Described in #10577 and https://groups.google.com/d/topic/ansible-project/NnT-4BwISuM/discussion, alternate implementation to #10644.

Remove winrm connection cache.  Only useful when connecting to a single host.  Fixes issue from #10391.
