### PR TITLE
Fix re import failure in templates module when running unit tests.

### DIFF
--- a/v2/ansible/template/__init__.py
+++ b/v2/ansible/template/__init__.py
@@ -19,6 +19,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import re
+
 from jinja2 import Environment
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 from jinja2.utils import concat as j2_concat


### PR DESCRIPTION
Fix the 're' import error that occurs when running `make newtests`.
