### PR TITLE
Git integration test: remove test for ambiguous .git/branches dir

### DIFF
--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -65,16 +65,11 @@
   stat: path={{ checkout_dir }}/.git/HEAD
   register: head
 
-- name: check for remotes
-  stat: path={{ checkout_dir }}/.git/branches
-  register: branches
-
 - name: assert presence of tags/trunk/branches
   assert:
     that:
       - "tags.stat.isdir"
       - "head.stat.isreg"
-      - "branches.stat.isdir"
 
 - name: verify on a reclone things are marked unchanged
   assert:


### PR DESCRIPTION
I have `.git/branches` in some of my cloned repos but not most of them. A bit more digging suggests that they get created under certain conditions but not always, so I don't think the test should always test they exist. I don't see any explicit references to this directory in `git.py` - the way the module lists branches is simply calling `git branch -a`.

More info: http://stackoverflow.com/questions/10398225/what-is-the-git-branches-folder-used-for
