### PR TITLE
add ansible_cmdline variable so that notify plugins can obtain the actual command run

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -191,6 +191,8 @@ class Play(object):
 
         load_vars['role_names'] = ds.get('role_names', [])
 
+        load_vars['ansible_cmdline'] = " ".join(sys.argv)
+
         self._tasks      = self._load_tasks(self._ds.get('tasks', []), load_vars)
         self._handlers   = self._load_tasks(self._ds.get('handlers', []), load_vars)
 


### PR DESCRIPTION
The driver behind this change is to allow notify plugins to be able to inject the Ansible command line into their messages.  Not sure if this is the right place in the code, but it works for me.
