### PR TITLE
Updated the tox.ini file to run multiple ansible versions.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,21 @@
 [tox]
-envlist = py26,py27
+envlist = {py26,py27}-v{1}
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
 whitelist_externals = make
+
+[testenv:py26-v1]
 commands = make tests
+
+[testenv:py27-v1]
+commands = make tests
+
+[testenv:py26-v2]
+commands = make newtests
+
+[testenv:py27-v2]
+commands = make newtests
+
+[testenv:py34-v2]
+commands = make newtests


### PR DESCRIPTION
Purpose: so that devs can use tox to run v1 or v2 of ansible with various versions of python.
For example `tox -e py27-v2 will run python2.7 on v2. Currently, only py26 and py27 are run on v1 when
running just`tox` so that we aren't breaking builds.
