### PR TITLE
Fix Windows paths containing spaces

### DIFF
--- a/lib/ansible/runner/action_plugins/fetch.py
+++ b/lib/ansible/runner/action_plugins/fetch.py
@@ -94,7 +94,7 @@ class ActionModule(object):
 
         # calculate the destination name
         if os.path.sep not in conn.shell.join_path('a', ''):
-            source_local = source.replace('\\', '/')
+            source_local = source.strip('"').replace('\\', '/')
         else:
             source_local = source
 


### PR DESCRIPTION
Wrap windows paths with quotes to handle paths containing spaces.  Updates to execution policy fix from #10664 so that parameters passed via splatting will work.  Fixes #9999.

Windows integration tests pass for raw/script/ping/slurp/fetch.
