### PR TITLE
Prefer dnf to yum.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -106,6 +106,7 @@ class Facts(object):
     # package manager, put the preferred one last.  If there is an
     # ansible module, use that as the value for the 'name' key.
     PKG_MGRS = [ { 'path' : '/usr/bin/yum',         'name' : 'yum' },
+                 { 'path' : '/usr/bin/dnf',         'name' : 'dnf' },
                  { 'path' : '/usr/bin/apt-get',     'name' : 'apt' },
                  { 'path' : '/usr/bin/zypper',      'name' : 'zypper' },
                  { 'path' : '/usr/sbin/urpmi',      'name' : 'urpmi' },

--- a/v2/ansible/module_utils/facts.py
+++ b/v2/ansible/module_utils/facts.py
@@ -105,6 +105,7 @@ class Facts(object):
     # package manager, put the preferred one last.  If there is an
     # ansible module, use that as the value for the 'name' key.
     PKG_MGRS = [ { 'path' : '/usr/bin/yum',         'name' : 'yum' },
+                 { 'path' : '/usr/bin/dnf',         'name' : 'dnf' },
                  { 'path' : '/usr/bin/apt-get',     'name' : 'apt' },
                  { 'path' : '/usr/bin/zypper',      'name' : 'zypper' },
                  { 'path' : '/usr/sbin/urpmi',      'name' : 'urpmi' },


### PR DESCRIPTION
On Fedora 22 and later, yum is deprecated and dnf is installed by
default. However, the detection do not seems to take this in account,
and always use yum, even when yum cli is just a wrapper to tell "use
dnf", as this is the case on F22 and later ( see package dnf-yum ).

As dnf is not installed by default, except on F22, this shouldn't
break anything.
