### PR TITLE
Remove check of hardcoded AWS region list.

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -32,20 +32,6 @@ try:
 except:
     HAS_LOOSE_VERSION = False
 
-AWS_REGIONS = [
-    'ap-northeast-1',
-    'ap-southeast-1',
-    'ap-southeast-2',
-    'cn-north-1',
-    'eu-central-1',
-    'eu-west-1',
-    'eu-central-1',
-    'sa-east-1',
-    'us-east-1',
-    'us-west-1',
-    'us-west-2',
-    'us-gov-west-1',
-]
 
 
 def aws_common_argument_spec():
@@ -63,7 +49,7 @@ def ec2_argument_spec():
     spec = aws_common_argument_spec()
     spec.update(
         dict(
-            region=dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
+            region=dict(aliases=['aws_region', 'ec2_region']),
         )
     )
     return spec
@@ -170,7 +156,7 @@ def connect_to_aws(aws_module, region, **params):
     conn = aws_module.connect_to_region(region, **params)
     if not conn:
         if region not in [aws_module_region.name for aws_module_region in aws_module.regions()]:
-            raise StandardError("Region %s does not seem to be available for aws module %s. If the region definitely exists, you may need to upgrade boto" % (region, aws_module.__name__))
+            raise StandardError("Region %s does not seem to be available for aws module %s. If the region definitely exists, you may need to upgrade boto or extend with endpoints_path" % (region, aws_module.__name__))
         else:
             raise StandardError("Unknown problem connecting to region %s for aws module %s." % (region, aws_module.__name__))
     if params.get('profile_name'):

--- a/v2/ansible/module_utils/ec2.py
+++ b/v2/ansible/module_utils/ec2.py
@@ -32,21 +32,6 @@ try:
 except:
     HAS_LOOSE_VERSION = False
 
-AWS_REGIONS = [
-    'ap-northeast-1',
-    'ap-southeast-1',
-    'ap-southeast-2',
-    'cn-north-1',
-    'eu-central-1',
-    'eu-west-1',
-    'eu-central-1',
-    'sa-east-1',
-    'us-east-1',
-    'us-west-1',
-    'us-west-2',
-    'us-gov-west-1',
-]
-
 
 def aws_common_argument_spec():
     return dict(
@@ -63,7 +48,7 @@ def ec2_argument_spec():
     spec = aws_common_argument_spec()
     spec.update(
         dict(
-            region=dict(aliases=['aws_region', 'ec2_region'], choices=AWS_REGIONS),
+            region=dict(aliases=['aws_region', 'ec2_region']),
         )
     )
     return spec
@@ -168,7 +153,7 @@ def connect_to_aws(aws_module, region, **params):
     conn = aws_module.connect_to_region(region, **params)
     if not conn:
         if region not in [aws_module_region.name for aws_module_region in aws_module.regions()]:
-            raise StandardError("Region %s does not seem to be available for aws module %s. If the region definitely exists, you may need to upgrade boto" % (region, aws_module.__name__))
+            raise StandardError("Region %s does not seem to be available for aws module %s. If the region definitely exists, you may need to upgrade boto or extend with endpoints_path" % (region, aws_module.__name__))
         else:
             raise StandardError("Unknown problem connecting to region %s for aws module %s." % (region, aws_module.__name__))
     if params.get('profile_name'):


### PR DESCRIPTION
You can extend boto to point at other regions that are defined in a
private cloud by defining `BOTO_ENDPOINTS` or `endpoints_path` in
the `~/.boto` file.

Ansible was doing a premature check against a hard-coded list of regions
that interrupted this possibility.  This commit removes that and
clarifies what the user can do if they specify a non-AWS region.
