### PR TITLE
Make some of the optional requirements optional for testing -- we'll skip the tests instead

### DIFF
--- a/v2/test-requirements.txt
+++ b/v2/test-requirements.txt
@@ -5,8 +5,10 @@ jinja2
 httplib2
 passlib
 six
-python-memcached
-redis
+
+# These are needed for various optional features
+#python-memcached
+#redis
 
 # Test requirements
 unittest2

--- a/v2/test/plugins/test_cache.py
+++ b/v2/test/plugins/test_cache.py
@@ -21,9 +21,25 @@ __metaclass__ = type
 
 from ansible.compat.tests import unittest
 from ansible.plugins.cache.base import BaseCacheModule
-from ansible.plugins.cache.memcached import CacheModule as MemcachedCache
 from ansible.plugins.cache.memory import CacheModule as MemoryCache
-from ansible.plugins.cache.redis import CacheModule as RedisCache
+
+HAVE_MEMCACHED = True
+try:
+    import memcached
+except ImportError:
+    HAVE_MEMCACHED = False
+else:
+    # Use an else so that the only reason we skip this is for lack of
+    # memcached, not errors importing the plugin
+    from ansible.plugins.cache.memcached import CacheModule as MemcachedCache
+
+HAVE_REDIS = True
+try:
+    import redis
+except ImportError:
+    HAVE_REDIS = False
+else:
+    from ansible.plugins.cache.redis import CacheModule as RedisCache
 
 
 class TestAbstractClass(unittest.TestCase):
@@ -72,11 +88,13 @@ class TestAbstractClass(unittest.TestCase):
 
         self.assertIsInstance(CacheModule3(), CacheModule3)
 
+    @unittest.skipUnless(HAVE_MEMCACHED)
     def test_memcached_cachemodule(self):
         self.assertIsInstance(MemcachedCache(), MemcachedCache)
 
     def test_memory_cachemodule(self):
         self.assertIsInstance(MemoryCache(), MemoryCache)
 
+    @unittest.skipUnless(HAVE_REDIS)
     def test_redis_cachemodule(self):
         self.assertIsInstance(RedisCache(), RedisCache)


### PR DESCRIPTION
We don't want to pull in redis and memcached all the time.
