### PR TITLE
Makes AnsibleModule.fail_json() write to stderr

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1245,7 +1245,7 @@ class AnsibleModule(object):
         assert 'msg' in kwargs, "implementation error -- msg to explain the error is required"
         kwargs['failed'] = True
         self.do_cleanup_files()
-        print self.jsonify(kwargs)
+        sys.stderr.write(self.jsonify(kwargs) + '\n')
         sys.exit(1)
 
     def is_executable(self, path):


### PR DESCRIPTION
Suggestion to fix bug #10764.

I strongly suggest error messages to be sent to `stderr`.
