### PR TITLE
Correct the ternary example. Fixes #10763

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -301,7 +301,7 @@ Other Useful Filters
 
 To use one value on true and another on false (since 1.9)::
 
-   {{ name == "John" | ternary('Mr','Ms') }}
+   {{ (name == "John") | ternary('Mr','Ms') }}
 
 To concatenate a list into a string::
 


### PR DESCRIPTION
The `ternary` filter example in the docs is slightly wrong.  In the example the filter is being applied to the string `"John"` instead of the evaluation of `name == "John"`.

To solve this, the evaluation must be wrapped in `()`.
