### PR TITLE
Add a requires on python-six 1.4.0 ( for add_metaclass )

### DIFF
--- a/v2/setup.py
+++ b/v2/setup.py
@@ -18,7 +18,7 @@ setup(name='ansible',
       author_email='michael@ansible.com',
       url='http://ansible.com/',
       license='GPLv3',
-      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
+      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6', 'six >= 1.4.0'],
       # package_dir={ '': 'lib' },
       # packages=find_packages('lib'),
       package_data={


### PR DESCRIPTION
This also mean that this doesn't run on RHEL 7 as of today.
