### PR TITLE
Don't blow up on directory access denied when lookng for plugins.

### DIFF
--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -173,7 +173,13 @@ class PluginLoader(object):
         found = None
         for path in [p for p in self._get_paths() if p not in self._searched_paths]:
             if os.path.isdir(path):
-                full_paths = (os.path.join(path, f) for f in os.listdir(path))
+                try:
+                    full_paths = (os.path.join(path, f) for f in os.listdir(path))
+                except OSError as e:
+                    if e.errno == 13:   # Permission denied; skip this directory
+                        continue
+                    else:
+                        raise
                 for full_path in (f for f in full_paths if os.path.isfile(f)):
                     for suffix in suffixes:
                         if full_path.endswith(suffix):


### PR DESCRIPTION
When recursing through subdirectires looking for plugins, don't blow up
if we hit a subdirectory we're not permitted to list, just move on.

This is particularly annoying when running ansible from $HOME under OS X,
as ansible will recurse into $HOME/Library/, where there are almost always
directories the regular user may not list.

My first experience with running ansible (version 1.9.0.1), having followed
the intro to the point of doing 'ansible all -m ping' , was to get a screenful of
exceptions.  Not a good start for a novice ansible user.
