### PR TITLE
Error messages from a CLI should be sent to stderr

### DIFF
--- a/plugins/inventory/consul_io.py
+++ b/plugins/inventory/consul_io.py
@@ -124,6 +124,7 @@ be used to access the machine.
 import os
 import re
 import argparse
+import sys
 from time import time
 import ConfigParser
 import urllib, urllib2, base64
@@ -136,8 +137,8 @@ except ImportError:
 try:
   import consul
 except ImportError, e:
-  print """failed=True msg='python-consul required for this module. see
-  http://python-consul.readthedocs.org/en/latest/#installation'"""
+  sys.stderr.write("""failed=True msg='python-consul required for this module. see
+  http://python-consul.readthedocs.org/en/latest/#installation'\n""")
   sys.exit(1)
 
 

--- a/plugins/inventory/digital_ocean.py
+++ b/plugins/inventory/digital_ocean.py
@@ -140,7 +140,7 @@ except ImportError:
 try:
     from dopy.manager import DoError, DoManager
 except ImportError, e:
-    print "failed=True msg='`dopy` library required for this script'"
+    sys.stderr.write("failed=True msg='`dopy` library required for this script'\n")
     sys.exit(1)
 
 
@@ -170,9 +170,9 @@ class DigitalOceanInventory(object):
 
         # Verify credentials were set
         if not hasattr(self, 'client_id') or not hasattr(self, 'api_key'):
-            print '''Could not find values for DigitalOcean client_id and api_key.
+            sys.stderr.write('''Could not find values for DigitalOcean client_id and api_key.
 They must be specified via either ini file, command line argument (--client-id and --api-key),
-or environment variables (DO_CLIENT_ID and DO_API_KEY)'''
+or environment variables (DO_CLIENT_ID and DO_API_KEY)\n''')
             sys.exit(-1)
 
         # env command, show DigitalOcean credentials
@@ -190,7 +190,7 @@ or environment variables (DO_CLIENT_ID and DO_API_KEY)'''
             self.load_from_cache()
             if len(self.data) == 0:
                 if self.args.force_cache:
-                    print '''Cache is empty and --force-cache was specified'''
+                    sys.stderr.write('''Cache is empty and --force-cache was specified\n''')
                     sys.exit(-1)
                 self.load_all_data_from_digital_ocean()
             else:

--- a/plugins/inventory/docker.py
+++ b/plugins/inventory/docker.py
@@ -152,7 +152,7 @@ for path in [os.getcwd(), '', os.path.dirname(os.path.abspath(__file__))]:
 try:
     import docker
 except ImportError:
-    print('docker-py is required for this module')
+    sys.stderr.write('docker-py is required for this module\n')
     sys.exit(1)
 
 

--- a/plugins/inventory/gce.py
+++ b/plugins/inventory/gce.py
@@ -90,7 +90,7 @@ try:
     from libcloud.compute.providers import get_driver
     _ = Provider.GCE
 except:
-    print("GCE inventory script requires libcloud >= 0.13")
+    sys.stderr.write("GCE inventory script requires libcloud >= 0.13\n")
     sys.exit(1)
 
 
@@ -150,7 +150,7 @@ class GceInventory(object):
             if not secrets_path.endswith('secrets.py'):
                 err = "Must specify libcloud secrets file as "
                 err += "/absolute/path/to/secrets.py"
-                print(err)
+                sys.stderr.write(err + '\n')
                 sys.exit(1)
             sys.path.append(os.path.dirname(secrets_path))
             try:

--- a/plugins/inventory/jail.py
+++ b/plugins/inventory/jail.py
@@ -34,4 +34,4 @@ if len(sys.argv) == 2 and sys.argv[1] == '--list':
 elif len(sys.argv) == 3 and sys.argv[1] == '--host':
     print json.dumps({'ansible_connection': 'jail'})
 else:
-    print "Need an argument, either --list or --host <host>"
+    sys.stderr.write("Need an argument, either --list or --host <host>\n")

--- a/plugins/inventory/libvirt_lxc.py
+++ b/plugins/inventory/libvirt_lxc.py
@@ -34,4 +34,4 @@ if len(sys.argv) == 2 and sys.argv[1] == '--list':
 elif len(sys.argv) == 3 and sys.argv[1] == '--host':
     print json.dumps({'ansible_connection': 'lxc'})
 else:
-    print "Need an argument, either --list or --host <host>"
+    sys.stderr.write("Need an argument, either --list or --host <host>\n")

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -185,9 +185,8 @@ class LinodeInventory(object):
             for node in Linode.search(status=Linode.STATUS_RUNNING):
                 self.add_node(node)
         except chube_api.linode_api.ApiError, e:
-            print "Looks like Linode's API is down:"
-            print
-            print e
+            sys.stderr.write("Looks like Linode's API is down:\n\n")
+            sys.stderr.write(e + '\n')
             sys.exit(1)
 
     def get_node(self, linode_id):
@@ -195,9 +194,8 @@ class LinodeInventory(object):
         try:
             return Linode.find(api_id=linode_id)
         except chube_api.linode_api.ApiError, e:
-            print "Looks like Linode's API is down:"
-            print
-            print e
+            sys.stderr.write("Looks like Linode's API is down:\n\n")
+            sys.stderr.write(e + '\n')
             sys.exit(1)
 
     def populate_datacenter_cache(self):

--- a/plugins/inventory/nova.py
+++ b/plugins/inventory/nova.py
@@ -218,5 +218,4 @@ elif len(sys.argv) == 3 and (sys.argv[1] == '--host'):
     sys.exit(0)
 
 else:
-    print "usage: --list  ..OR.. --host <hostname>"
-    sys.exit(1)
+    sys.exit("usage: --list  ..OR.. --host <hostname>")

--- a/plugins/inventory/openshift.py
+++ b/plugins/inventory/openshift.py
@@ -61,7 +61,7 @@ def get_config(env_var, config_var):
     if not result:
         result = get_from_rhc_config(config_var)
     if not result:
-        print "failed=True msg='missing %s'" % env_var
+        sys.stderr.write("failed=True msg='missing %s'\n" % env_var)
         sys.exit(1)
     return result
 

--- a/plugins/inventory/openstack.py
+++ b/plugins/inventory/openstack.py
@@ -152,8 +152,7 @@ def main():
         elif args.host:
             inventory.get_host(args.host)
     except shade.OpenStackCloudException as e:
-        print(e.message)
-        sys.exit(1)
+        sys.exit(e.message)
     sys.exit(0)
 
 

--- a/plugins/inventory/rax.py
+++ b/plugins/inventory/rax.py
@@ -164,7 +164,7 @@ try:
     import pyrax
     from pyrax.utils import slugify
 except ImportError:
-    print('pyrax is required for this module')
+    sys.stderr.write('pyrax is required for this module\n')
     sys.exit(1)
 
 NON_CALLABLES = (basestring, bool, dict, int, list, type(None))

--- a/plugins/inventory/windows_azure.py
+++ b/plugins/inventory/windows_azure.py
@@ -51,7 +51,7 @@ try:
     from azure import WindowsAzureError
     from azure.servicemanagement import ServiceManagementService
 except ImportError as e:
-    print "failed=True msg='`azure` library required for this script'"
+    sys.stderr.write("failed=True msg='`azure` library required for this script'\n")
     sys.exit(1)
 
 
@@ -157,9 +157,8 @@ class AzureInventory(object):
             for cloud_service in self.sms.list_hosted_services():
                 self.add_deployments(cloud_service)
         except WindowsAzureError as e:
-            print "Looks like Azure's API is down:"
-            print
-            print e
+            sys.stderr.write("Looks like Azure's API is down:\n\n")
+            sys.stderr.write(e + '\n')
             sys.exit(1)
 
     def add_deployments(self, cloud_service):
@@ -169,9 +168,8 @@ class AzureInventory(object):
                 if deployment.deployment_slot == "Production":
                     self.add_deployment(cloud_service, deployment)
         except WindowsAzureError as e:
-            print "Looks like Azure's API is down:"
-            print
-            print e
+            sys.stderr.write("Looks like Azure's API is down:\n\n")
+            sys.stderr.write(e + '\n')
             sys.exit(1)
 
     def add_deployment(self, cloud_service, deployment):

--- a/plugins/inventory/zone.py
+++ b/plugins/inventory/zone.py
@@ -40,4 +40,4 @@ if len(sys.argv) == 2 and sys.argv[1] == '--list':
 elif len(sys.argv) == 3 and sys.argv[1] == '--host':
     print json.dumps({'ansible_connection': 'zone'})
 else:
-    print "Need an argument, either --list or --host <host>"
+    sys.stderr.write("Need an argument, either --list or --host <host>\n")


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

```
ansible 2.0.0 (devel f4172fb9da) last updated 2015/04/18 19:42:59 (GMT +200)
  lib/ansible/modules/core: (detached HEAD a19fa6ba48) last updated 2015/04/18 19:43:07 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD df7fcc90d9) last updated 2015/04/18 19:43:15 (GMT +200)
  v2/ansible/modules/core: (detached HEAD 34784b7a61) last updated 2015/04/18 19:43:24 (GMT +200)
  v2/ansible/modules/extras: (detached HEAD df7fcc90d9) last updated 2015/04/18 19:43:35 (GMT +200)
  configured module search path = None
```
##### Environment:

Irrevelant (Slackware GNU/Linux).
##### Summary:

The CLI in the inventory plugins directory should write their errors to `stderr`, especially if they are meant to be called by [InventoryScript()](https://github.com/ansible/ansible/blob/c3d34a538613eea3d6db03a700211887f697b443/lib/ansible/inventory/script.py#L48) as the [docker script does](https://github.com/ansible/ansible/blob/8c4161d4a12849afd46dea7c63b540b0437e03c3/plugins/inventory/docker.py#L178).

Note this is replacing the issue #10764 i opened after my misunderstanding.
##### Steps To Reproduce:

Execute incorrectly most of the scripts from the [plugins/inventory/](https://github.com/ansible/ansible/blob/devel/plugins/inventory/) directory, ie:

``` sh-session
$ /path/to/ansible/plugins/inventory/digital_ocean.py --all >/dev/null ; echo $?
1
$ ansible -m ping -u root -i digital_ocean.py all
ERROR: Inventory script (digital_ocean.py) had an execution error:
```
##### Expected Results:

``` sh-session
$ /path/to/ansible/plugins/inventory/digital_ocean.py --all >/dev/null
Could not find values for DigitalOcean client_id and api_key.
They must be specified via either ini file, command line argument (--client-id and --api-key),
or environment variables (DO_CLIENT_ID and DO_API_KEY)
$ ansible -m ping -u root -i digital_ocean.py all
ERROR: Inventory script (digital_ocean.py) had an execution error: Could not find values for DigitalOcean client_id and api_key.
They must be specified via either ini file, command line argument (--client-id and --api-key),
or environment variables (DO_CLIENT_ID and DO_API_KEY)

```
##### Actual Results:

Error message is sent to `stdout`.
##### Further notes:
- some scripts use `sys.exit("error message")`, which write the message to `stderr` and exit with code 1 (which is totally valid)
- some scripts use `sys.exit(-1)` which would probably give a exit status of 255 if the platform limit the exit code to 8 bits ([wikipedia](http://en.wikipedia.org/wiki/Exit_status), [shell page](http://tldp.org/LDP/abs/html/exit-status.html))
- i chose to use `sys.stderr.write()` as it is the more portable Python syntax accross versions, but i didn't change the scripts using the `print >> sys.stderr,` form
