### PR TITLE
Undefined names found by pyflakes in plugins/inventory/

### DIFF
--- a/plugins/inventory/consul_io.py
+++ b/plugins/inventory/consul_io.py
@@ -125,6 +125,7 @@ import os
 import re
 import argparse
 from time import time
+import sys
 import ConfigParser
 import urllib, urllib2, base64
 

--- a/plugins/inventory/softlayer.py
+++ b/plugins/inventory/softlayer.py
@@ -55,7 +55,7 @@ class SoftLayerInventory(object):
             self.get_all_servers()
             print self.json_format_dict(self.inventory, True)
         elif self.args.host:
-            self.get_virtual_servers(client)
+            self.get_virtual_servers()
             print self.json_format_dict(self.inventory["_meta"]["hostvars"][self.args.host], True)
 
     def to_safe(self, word):


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.0 (devel f4172fb9da) last updated 2015/04/18 19:42:59 (GMT +200)
  lib/ansible/modules/core: (detached HEAD a19fa6ba48) last updated 2015/04/18 19:43:07 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD df7fcc90d9) last updated 2015/04/18 19:43:15 (GMT +200)
  v2/ansible/modules/core: (detached HEAD 34784b7a61) last updated 2015/04/18 19:43:24 (GMT +200)
  v2/ansible/modules/extras: (detached HEAD df7fcc90d9) last updated 2015/04/18 19:43:35 (GMT +200)
  configured module search path = None
```
##### Environment:

Irrevelant (Slackware GNU/Linux).
##### Summary:

Fix missing names found by @pyflakes for
- plugins/inventory/consul_io.py (c02f114967bb3d0d63ba20a0a93854ee986541c7)
- plugins/inventory/softlayer.py (79f2dca60a80839ab656eef656522fbef002e7af)
