### PR TITLE
Fix traceback with using GCE on EL6 with python-crypto2.6

### DIFF
--- a/plugins/inventory/gce.py
+++ b/plugins/inventory/gce.py
@@ -72,6 +72,16 @@ Author: Eric Johnson <erjohnso@google.com>
 Version: 0.0.1
 '''
 
+__requires__ = ['pycrypto>=2.6']
+try:
+    import pkg_resources
+except ImportError:
+    # Use pkg_resources to find the correct versions of libraries and set
+    # sys.path appropriately when there are multiversion installs.  We don't
+    # fail here as there is code that better expresses the errors where the
+    # library is used.
+    pass
+
 USER_AGENT_PRODUCT="Ansible-gce_inventory_plugin"
 USER_AGENT_VERSION="v1"
 


### PR DESCRIPTION
This fix resolves an issue on EL6 systems where there may be multiple versions
of pycrypto installed.  EPEL provides both `python-crypto` and
`python-crypto2.6`.  These packages are co-installable.  However, modules
importing the `Crypto` library must specify which version to use, otherwise the
default will be used.  The libcloud `gce` provider relies on the `pycrypto` library,
and needs `2.6` or newer.

This change follows the same pattern established in `bin/ansible` for
specifying python library requirements.
