### PR TITLE
Consistently use "OracleLinux" in OS detection.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -87,7 +87,7 @@ class Facts(object):
     _I386RE = re.compile(r'i([3456]86|86pc)')
     # For the most part, we assume that platform.dist() will tell the truth.
     # This is the fallback to handle unknowns or exceptions
-    OSDIST_LIST = ( ('/etc/oracle-release', 'Oracle Linux'),
+    OSDIST_LIST = ( ('/etc/oracle-release', 'OracleLinux'),
                     ('/etc/redhat-release', 'RedHat'),
                     ('/etc/vmware-release', 'VMwareESX'),
                     ('/etc/openwrt_release', 'OpenWrt'),
@@ -297,7 +297,7 @@ class Facts(object):
                             # Once we determine the value is one of these distros
                             # we trust the values are always correct
                             break
-                        elif name == 'Oracle Linux':
+                        elif name == 'OracleLinux':
                             data = get_file_content(path)
                             if 'Oracle Linux' in data:
                                 self.facts['distribution'] = name


### PR DESCRIPTION
Previously, a mixture of "OracleLinux" and "Oracle Linux" was used,
causing the `ansible_os_family` fact not to be set to `RedHat`.

Fixes #10742.
