### PR TITLE
Correct emphasis markup nit in playbooks_vault.rst

### DIFF
--- a/docsite/rst/playbooks_vault.rst
+++ b/docsite/rst/playbooks_vault.rst
@@ -77,7 +77,7 @@ If you have existing files that you no longer want to keep encrypted, you can pe
 Viewing Encrypted Files
 ```````````````````````
 
-_Available since Ansible 1.8_
+*Available since Ansible 1.8*
 
 If you want to view the contents of an encrypted file without editing it, you can use the `ansible-vault view` command::
 


### PR DESCRIPTION
It looks like the original intention was to italicize, but someone was used to another markup language. I have switched the wrapped tags so we're showing italics and not a broken link.
