### PR TITLE
Fix race-condition in prepare_writeable_dir

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -312,11 +312,15 @@ def prepare_writeable_dir(tree,mode=0777):
     # and normalized and free of symlinks
     tree = unfrackpath(tree)
 
-    if not os.path.exists(tree):
-        try:
-            os.makedirs(tree, mode)
-        except (IOError, OSError), e:
+    try:
+        os.makedirs(tree, mode)
+    except IOError, e:
+        # has no errno
+        raise errors.AnsibleError("Could not make dir %s: %s" % (tree, e))
+    except OSError, e:
+        if e.errno != errno.EEXIST:
             raise errors.AnsibleError("Could not make dir %s: %s" % (tree, e))
+
     if not os.access(tree, os.W_OK):
         raise errors.AnsibleError("Cannot write to path %s" % tree)
     return tree


### PR DESCRIPTION
All ansible invocations will try to create `$HOME/.ansible/cp`. When two runs are triggered at the exact same moment, they will both see `os.path.exists` return `False` and then try to create the dir. They will then collide and one run will fail with `errno.EEXIST`.

We can fix this by simplifying the code: just create the dir and accept failure because of preexistence. This is what the original code intended anyway.
