### PR TITLE
Fix for module role dependency declaration.

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -216,6 +216,8 @@ class Play(object):
             role_name = orig_path.get('role', None)
             if role_name is None:
                 raise errors.AnsibleError("expected a role name in dictionary: %s" % orig_path)
+            if role_name.startswith('git+'):
+                role_name = role_name.split('/')[-1]
             role_vars = orig_path
         else:
             role_name = utils.role_spec_parse(orig_path)["name"]


### PR DESCRIPTION
Fix for module role dependency declaration.

Module dependency declaration of git deps is claimed in the [corresponding ansible documentation](http://docs.ansible.com/playbooks_roles.html#role-dependencies).

However it's not working in real life, as [documented in issue #920](https://github.com/ansible/ansible/issues/9280).

When declaring a `git+` dep, errors like this are produced:

```
ERROR: cannot find role in ~/my-ansible-playbook/roles/https:/github.com/jaytaylor/ansible-docker-registry or ...
```

This simple 2-liner fixes the base-case.
