### PR TITLE
In reference to Issue #10850.  This passes the current hostname of the d...

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -361,7 +361,7 @@ class AnsibleModule(object):
 
         (self.params, self.args) = self._load_params()
 
-        self._legal_inputs = ['CHECKMODE', 'NO_LOG']
+        self._legal_inputs = ['CHECKMODE', 'NO_LOG', 'HOSTNAME']
         
         self.aliases = self._handle_aliases()
 

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1351,6 +1351,7 @@ class Runner(object):
             else:
                 raise errors.AnsibleFileNotFound("module %s not found in configured module paths.  Additionally, core modules are missing. If this is a checkout, run 'git submodule update --init --recursive' to correct this problem." % (module_name))
 
+        module_args = '%s HOSTNAME=%s' % (module_args, conn.host)
 
         # insert shared code and arguments into the module
         (module_data, module_style, module_shebang) = module_replacer.modify_module(


### PR DESCRIPTION
...evice under execution to the module by injecting it into the module_args.

Info:
When developing an ansible module that should be run as connection=local, we may need the hostname of the device that is "technically" under execution by Ansible (even if we aren't actually connecting to it with ansible).  As of right now, I don't believe there are any injection points where the hostname is actually accessible from within a Python module (other than through explicit module_args, which then means we have the requirement of a contrived 'host' argument for the module, and will have to execute the module through a Playbook to keep the benefits of concurrency), or through action_plugins.

I think the hostname of the device under execution is general enough to warrant being passed into the Ansible Modules without forcing us to rely on action plugins or playbooks.

It should be noted that this can also be useful for non connection=local modules, but I bring that up as it's easier to see why I'd need the hostname (e.g. to spin up my own subsystem SSH session to the device, if Ansible doesn't support it).
