### PR TITLE
Allow roles to use dictionary spec in dependencies

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -213,7 +213,7 @@ class Play(object):
         role_vars = {}
         if type(orig_path) == dict:
             # what, not a path?
-            role_name = orig_path.get('role', None)
+            role_name = utils.role_yaml_parse(orig_path)["name"]
             if role_name is None:
                 raise errors.AnsibleError("expected a role name in dictionary: %s" % orig_path)
             role_vars = orig_path


### PR DESCRIPTION
The docs suggest that the following dependencies
specification may be used in meta/main.yml

```
dependencies:
- { role: "git+https://gitserver/rolename.git" }
```

This change makes that work

Fixes #9280
