### PR TITLE
Removed deletion of salt by 'password' lookup Issue #10871

### DIFF
--- a/lib/ansible/runner/lookup_plugins/password.py
+++ b/lib/ansible/runner/lookup_plugins/password.py
@@ -114,11 +114,6 @@ class LookupModule(object):
                     with open(path, 'w') as f:
                         os.chmod(path, 0600)
                         f.write(content + '\n')
-                # crypt not requested, remove salt if present
-                elif (encrypt is None and salt):
-                    with open(path, 'w') as f:
-                        os.chmod(path, 0600)
-                        f.write(password + '\n')
 
             if encrypt:
                 password = utils.do_encrypt(password, encrypt, salt=salt)


### PR DESCRIPTION
Removed deletion of salt param from lookup file by 'password'
lookup_filter.
When two dependent roles use single password lookup, with encrypt parameter and without it leads to constant 'changed' status of the one task.
