### PR TITLE
[subelements lookup] allow subelement property to be nested and add optional 'skip_missing' flag

### DIFF
--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -189,6 +189,12 @@ Given the mysql hosts and privs subkey lists, you can also iterate over a list i
 Subelements walks a list of hashes (aka dictionaries) and then traverses a list with a given (nested sub-)key inside of those
 records.
 
+Optionally,  you can add a third element to the subelements list, that holds a
+dictionary of flags. Currently you can add the 'skip_missing' flag. If set to
+True, the lookup plugin will skip the lists items that do not contain the given
+subkey. Without this flag, or if that flag is set to False, the plugin will
+yield an error and complain about the missing subkey.
+
 The authorized_key pattern is exactly where it comes up most.
 
 .. _looping_over_integer_sequences:

--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -147,9 +147,26 @@ How might that be accomplished?  Let's assume you had the following defined and 
         authorized: 
           - /tmp/alice/onekey.pub
           - /tmp/alice/twokey.pub
+        mysql:
+            password: mysql-password
+            hosts:
+              - "%"
+              - "127.0.0.1"
+              - "::1"
+              - "localhost"
+            privs:
+              - "*.*:SELECT"
+              - "DB1.*:ALL"
       - name: bob
         authorized:
           - /tmp/bob/id_rsa.pub
+        mysql:
+            password: other-mysql-password
+            hosts:
+              - "db1"
+            privs:
+              - "*.*:SELECT"
+              - "DB2.*:ALL"
 
 It might happen like so::
 
@@ -161,7 +178,15 @@ It might happen like so::
          - users
          - authorized
 
-Subelements walks a list of hashes (aka dictionaries) and then traverses a list with a given key inside of those
+Given the mysql hosts and privs subkey lists, you can also iterate over a list in a nested subkey::
+
+    - name: Setup MySQL users
+      mysql_user: name={{ item.0.user }} password={{ item.0.mysql.password }} host={{ item.1 }} priv={{ item.0.mysql.privs | join('/') }}
+      with_subelements:
+        - users
+        - mysql.hosts
+
+Subelements walks a list of hashes (aka dictionaries) and then traverses a list with a given (nested sub-)key inside of those
 records.
 
 The authorized_key pattern is exactly where it comes up most.

--- a/lib/ansible/runner/lookup_plugins/subelements.py
+++ b/lib/ansible/runner/lookup_plugins/subelements.py
@@ -18,6 +18,8 @@
 import ansible.utils as utils
 import ansible.errors as errors
 
+FLAGS = ('skip_missing',)
+
 
 class LookupModule(object):
 
@@ -26,16 +28,21 @@ class LookupModule(object):
 
 
     def run(self, terms, inject=None, **kwargs):
+        def _raise_terms_error(msg=""):
+            raise errors.AnsibleError(
+                "subelements lookup expects a list of two or three items, "
+                + msg)
         terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
         terms[0] = utils.listify_lookup_plugin_terms(terms[0], self.basedir, inject)
 
-        if not isinstance(terms, list) or not len(terms) == 2:
-            raise errors.AnsibleError(
-                "subelements lookup expects a list of two items, first a dict or a list, and second a string")
-        terms[0] = utils.listify_lookup_plugin_terms(terms[0], self.basedir, inject)
+        # check lookup terms - check number of terms
+        if not isinstance(terms, list) or not 2 <= len(terms) <= 3:
+            _raise_terms_error()
+
+        # first term should be a list (or dict), second a string holding the subkey
         if not isinstance(terms[0], (list, dict)) or not isinstance(terms[1], basestring):
-            raise errors.AnsibleError(
-                "subelements lookup expects a list of two items, first a dict or a list, and second a string")
+            _raise_terms_error("first a dict or a list, second a string pointing to the subkey")
+        subelements = terms[1].split(".")
 
         if isinstance(terms[0], dict): # convert to list:
             if terms[0].get('skipped',False) != False:
@@ -46,8 +53,16 @@ class LookupModule(object):
                 elementlist.append(terms[0][key])
         else:
             elementlist = terms[0]
-        subelements = terms[1].split(".")
 
+        # check for optional flags in third term
+        flags = {}
+        if len(terms) == 3:
+            flags = terms[2]
+        if not isinstance(flags, dict) and not all([isinstance(key, basestring) and key in FLAGS for key in flags]):
+            _raise_terms_error("the optional third item must be a dict with flags %s" % FLAGS)
+
+
+        # build_items
         ret = []
         for item0 in elementlist:
             if not isinstance(item0, dict):
@@ -56,16 +71,24 @@ class LookupModule(object):
                 # this particular item is to be skipped
                 continue
 
+            skip_missing = utils.boolean(flags.get('skip_missing', False))
             subvalue = item0
             lastsubkey = False
+            sublist = []
             for subkey in subelements:
                 if subkey == subelements[-1]:
                     lastsubkey = True
                 if not subkey in subvalue:
-                    raise errors.AnsibleError("could not find '%s' key in iterated item '%s'" % (subkey, subvalue))
+                    if skip_missing:
+                        continue
+                    else:
+                        raise errors.AnsibleError("could not find '%s' key in iterated item '%s'" % (subkey, subvalue))
                 if not lastsubkey:
                     if not isinstance(subvalue[subkey], dict):
-                        raise errors.AnsibleError("the key %s should point to a dictionary, got '%s'" % (subkey, subvalue[subkey]))
+                        if skip_missing:
+                            continue
+                        else:
+                            raise errors.AnsibleError("the key %s should point to a dictionary, got '%s'" % (subkey, subvalue[subkey]))
                     else:
                         subvalue = subvalue[subkey]
                 else: # lastsubkey

--- a/lib/ansible/runner/lookup_plugins/subelements.py
+++ b/lib/ansible/runner/lookup_plugins/subelements.py
@@ -44,22 +44,35 @@ class LookupModule(object):
             elementlist = []
             for key in terms[0].iterkeys():
                 elementlist.append(terms[0][key])
-        else: 
+        else:
             elementlist = terms[0]
-        subelement = terms[1]
+        subelements = terms[1].split(".")
 
         ret = []
         for item0 in elementlist:
             if not isinstance(item0, dict):
                 raise errors.AnsibleError("subelements lookup expects a dictionary, got '%s'" %item0)
-            if item0.get('skipped',False) != False:
+            if item0.get('skipped', False) != False:
                 # this particular item is to be skipped
-                continue 
-            if not subelement in item0:
-                raise errors.AnsibleError("could not find '%s' key in iterated item '%s'" % (subelement, item0))
-            if not isinstance(item0[subelement], list):
-                raise errors.AnsibleError("the key %s should point to a list, got '%s'" % (subelement, item0[subelement]))
-            sublist = item0.pop(subelement, [])
+                continue
+
+            subvalue = item0
+            lastsubkey = False
+            for subkey in subelements:
+                if subkey == subelements[-1]:
+                    lastsubkey = True
+                if not subkey in subvalue:
+                    raise errors.AnsibleError("could not find '%s' key in iterated item '%s'" % (subkey, subvalue))
+                if not lastsubkey:
+                    if not isinstance(subvalue[subkey], dict):
+                        raise errors.AnsibleError("the key %s should point to a dictionary, got '%s'" % (subkey, subvalue[subkey]))
+                    else:
+                        subvalue = subvalue[subkey]
+                else: # lastsubkey
+                    if not isinstance(subvalue[subkey], list):
+                        raise errors.AnsibleError("the key %s should point to a list, got '%s'" % (subkey, subvalue[subkey]))
+                    else:
+                        sublist = subvalue.pop(subkey, [])
             for item1 in sublist:
                 ret.append((item0, item1))
 

--- a/test/integration/roles/test_iterators/tasks/main.yml
+++ b/test/integration/roles/test_iterators/tasks/main.yml
@@ -39,7 +39,7 @@
   set_fact: "{{ item.0 + item.1 }}=x"
   with_nested:
     - [ 'a', 'b' ]
-    - [ 'c', 'd' ]        
+    - [ 'c', 'd' ]
 
 - debug: var=ac
 - debug: var=ad
@@ -110,6 +110,25 @@
         - "_xr == 'r'"
         - "_yi == 'i'"
         - "_yo == 'o'"
+
+- name: test with_subelements with missing key or subkey
+  set_fact: "{{ '_'+ item.0.id + item.1 }}={{ item.1 }}"
+  with_subelements:
+    - element_data_missing
+    - the.sub.key.list
+    - skip_missing: yes
+  register: _subelements_missing_subkeys
+
+- debug: var=_subelements_missing_subkeys.skipped
+- debug: var=_subelements_missing_subkeys.results|length
+- name: verify with_subelements in subkeys results
+  assert:
+    that:
+        - _subelements_missing_subkeys.skipped is not defined
+        - _subelements_missing_subkeys.results|length == 2
+        - "_xk == 'k'"
+        - "_xl == 'l'"
+
 
 # WITH_TOGETHER        
 

--- a/test/integration/roles/test_iterators/tasks/main.yml
+++ b/test/integration/roles/test_iterators/tasks/main.yml
@@ -97,6 +97,20 @@
         - "_ye == 'e'"
         - "_yf == 'f'"
 
+- name: test with_subelements in subkeys
+  set_fact: "{{ '_'+ item.0.id + item.1 }}={{ item.1 }}"
+  with_subelements:
+    - element_data
+    - the.sub.key.list
+
+- name: verify with_subelements in subkeys results
+  assert:
+    that:
+        - "_xq == 'q'"
+        - "_xr == 'r'"
+        - "_yi == 'i'"
+        - "_yo == 'o'"
+
 # WITH_TOGETHER        
 
 - name: test with_together

--- a/test/integration/roles/test_iterators/vars/main.yml
+++ b/test/integration/roles/test_iterators/vars/main.yml
@@ -19,3 +19,25 @@ element_data:
           list:
             - "i"
             - "o"
+element_data_missing:
+  - id: x
+    the_list:
+      - "f"
+      - "d"
+    the:
+      sub:
+        key:
+          list:
+            - "k"
+            - "l"
+  - id: y
+    the_list:
+      - "f"
+      - "d"
+  - id: z
+    the_list:
+      - "e"
+      - "f"
+    the:
+      sub:
+        key:

--- a/test/integration/roles/test_iterators/vars/main.yml
+++ b/test/integration/roles/test_iterators/vars/main.yml
@@ -3,7 +3,19 @@ element_data:
     the_list:
       - "f"
       - "d"
+    the:
+      sub:
+        key:
+          list:
+            - "q"
+            - "r"
   - id: y
     the_list:
       - "e"
       - "f"
+    the:
+      sub:
+        key:
+          list:
+            - "i"
+            - "o"


### PR DESCRIPTION
Allow the subelement property to the subelements lookup plugin to be nested:

```

---
users:
  - user: bob
    password: system-password
    mysql:
      password: mysql-password
      hosts:
        - "%"
        - "{{ ansible_hostname }}"
        - "127.0.0.1"
        - "::1"
        - "localhost"
      privs:
        - "*.*:SELECT"
        - "DB1.*:ALL"
```

you can now refer to the mysql.hosts subkey 

```
- name: Setup MySQL users
  mysql_user: name={{ item.0.user }} password={{ item.0.mysql.password }} host={{ item.1 }} priv={{ item.0.mysql.privs | join('/') }}
  with_subelements:
    - users
    - mysql.hosts
```

closes #9863 

A second set of patches addresses and closes #9827 by implementing an optional third list item, holding a dictionary of flags, allowing 'skip_missing: yes' to be set, which will let the plugin just skip list items that do not contain the given subkey, instead of raising an error.
