### PR TITLE
Allow the use of HTTP on custom ports in the fetch_url function

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -377,6 +377,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
                 netloc = netloc.split('@', 1)[1]
             if ':' in netloc:
                 hostname, port = netloc.split(':', 1)
+                port = int(port)
             else:
                 hostname = netloc
                 port = 443


### PR DESCRIPTION
Currently if you try to use fetch_url on a URL when specifying https and a custom port the port doesn't get converted to an int.
