### PR TITLE
Option to override playbook hosts parameter with 'all' hosts

### DIFF
--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -102,6 +102,8 @@ def main(args):
         help="run handlers even if a task fails")
     parser.add_option('--flush-cache', dest='flush_cache', action='store_true',
         help="clear the fact cache")
+    parser.add_option('--all-hosts', dest='all_hosts', action='store_true',
+        help="override playbook hosts to use all")
 
     options, args = parser.parse_args(args)
 
@@ -223,6 +225,11 @@ def main(args):
                 playnum += 1
                 play = ansible.playbook.Play(pb, play_ds, play_basedir,
                                               vault_password=pb.vault_password)
+
+                if options.all_hosts:
+                    print '  play ALL hosts'
+                    play.hosts = 'all'
+
                 label = play.name
                 hosts = pb.inventory.list_hosts(play.hosts)
 

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -210,6 +210,7 @@ def main(args):
             diff=options.diff,
             vault_password=vault_pass,
             force_handlers=options.force_handlers,
+            all_hosts=options.all_hosts
         )
 
         if options.flush_cache:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -76,6 +76,7 @@ class PlayBook(object):
         any_errors_fatal = False,
         vault_password   = False,
         force_handlers   = False,
+        all_hosts        = False,
         # privilege escalation
         become           = C.DEFAULT_BECOME,
         become_method    = C.DEFAULT_BECOME_METHOD,
@@ -144,6 +145,7 @@ class PlayBook(object):
         self.any_errors_fatal = any_errors_fatal
         self.vault_password   = vault_password
         self.force_handlers   = force_handlers
+        self.all_hosts        = all_hosts
 
         self.become           = become
         self.become_method    = become_method
@@ -317,6 +319,9 @@ class PlayBook(object):
 
             # Remove tasks we wish to skip
             matched_tags = matched_tags - set(self.skip_tags)
+
+            if self.all_hosts:
+                play.hosts = 'all'
 
             # if we have matched_tags, the play must be run.
             # if the play contains no tasks, assume we just want to gather facts


### PR DESCRIPTION
Sometimes when maintaining servers, I need to run playbooks against hosts there are in different groups from the one specified in the playbook's hosts definition. To avoid having to set all my playbooks to `hosts: all` and use `--limit` to decide which hosts to migrate, a better option would be to leave the hosts definition with the "normal" groups and use the proposed parameter `--all-hosts` combined with `--limit` to migrate to different groups when necessary.

It can be useful when running ad-hoc without inventory:
`ansible-playbooks --all-hosts -i rogue_webserver.hostname, configure_webservers.yml`

Or when running against dynamic groups or just created (ungrouped) servers:
`ansible-playbooks --all-hosts -i ec2.py --limit "tag_Type_webservers" configure_webservers.yml`
