### PR TITLE
Ansible inventory

### DIFF
--- a/docs/man/man1/ansible-galaxy.1
+++ b/docs/man/man1/ansible-galaxy.1
@@ -2,12 +2,12 @@
 .\"     Title: ansible-galaxy
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 12/09/2014
+.\"      Date: 05/05/2015
 .\"    Manual: System administration commands
-.\"    Source: Ansible 1.9
+.\"    Source: Ansible 2.0.0
 .\"  Language: English
 .\"
-.TH "ANSIBLE\-GALAXY" "1" "12/09/2014" "Ansible 1\&.9" "System administration commands"
+.TH "ANSIBLE\-GALAXY" "1" "05/05/2015" "Ansible 2\&.0\&.0" "System administration commands"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/docs/man/man1/ansible-playbook.1
+++ b/docs/man/man1/ansible-playbook.1
@@ -2,12 +2,12 @@
 .\"     Title: ansible-playbook
 .\"    Author: :doctype:manpage
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 12/09/2014
+.\"      Date: 05/05/2015
 .\"    Manual: System administration commands
-.\"    Source: Ansible 1.9
+.\"    Source: Ansible 2.0.0
 .\"  Language: English
 .\"
-.TH "ANSIBLE\-PLAYBOOK" "1" "12/09/2014" "Ansible 1\&.9" "System administration commands"
+.TH "ANSIBLE\-PLAYBOOK" "1" "05/05/2015" "Ansible 2\&.0\&.0" "System administration commands"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -66,7 +66,7 @@ search path to load modules from\&. The default is
 .PP
 \fB\-e\fR \fIVARS\fR, \fB\-\-extra\-vars=\fR\fIVARS\fR
 .RS 4
-Extra variables to inject into a playbook, in key=value key=value format or as quoted JSON (hashes and arrays)\&.
+Extra variables to inject into a playbook, in key=value key=value format or as quoted JSON (hashes and arrays)\&. To load variables from a file, specify the file preceded by @ (e\&.g\&. @vars\&.yml)\&.
 .RE
 .PP
 \fB\-f\fR \fINUM\fR, \fB\-\-forks=\fR\fINUM\fR
@@ -156,7 +156,7 @@ Outputs a list of matching hosts; does not execute anything else\&.
 .sp
 The following environment variables may be specified\&.
 .sp
-ANSIBLE_HOSTS  \(em Override the default ansible hosts file
+ANSIBLE_INVENTORY  \(em Override the default ansible inventory file
 .sp
 ANSIBLE_LIBRARY \(em Override the default ansible module library path
 .SH "FILES"
@@ -181,3 +181,9 @@ Ansible is released under the terms of the GPLv3 License\&.
 \fBansible\fR(1), \fBansible\-pull\fR(1), \fBansible\-doc\fR(1)
 .sp
 Extensive documentation is available in the documentation site: http://docs\&.ansible\&.com\&. IRC and mailing list info can be found in file CONTRIBUTING\&.md, available in: https://github\&.com/ansible/ansible
+.SH "AUTHOR"
+.PP
+\fB:doctype:manpage\fR
+.RS 4
+Author.
+.RE

--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -133,7 +133,7 @@ ENVIRONMENT
 
 The following environment variables may be specified.
 
-ANSIBLE_HOSTS  -- Override the default ansible hosts file
+ANSIBLE_INVENTORY  -- Override the default ansible inventory file
 
 ANSIBLE_LIBRARY -- Override the default ansible module library path
 

--- a/docs/man/man1/ansible-pull.1
+++ b/docs/man/man1/ansible-pull.1
@@ -2,12 +2,12 @@
 .\"     Title: ansible
 .\"    Author: :doctype:manpage
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 12/09/2014
+.\"      Date: 05/05/2015
 .\"    Manual: System administration commands
-.\"    Source: Ansible 1.9
+.\"    Source: Ansible 2.0.0
 .\"  Language: English
 .\"
-.TH "ANSIBLE" "1" "12/09/2014" "Ansible 1\&.9" "System administration commands"
+.TH "ANSIBLE" "1" "05/05/2015" "Ansible 2\&.0\&.0" "System administration commands"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -104,3 +104,9 @@ Ansible is released under the terms of the GPLv3 License\&.
 \fBansible\fR(1), \fBansible\-playbook\fR(1), \fBansible\-doc\fR(1)
 .sp
 Extensive documentation is available in the documentation site: http://docs\&.ansible\&.com\&. IRC and mailing list info can be found in file CONTRIBUTING\&.md, available in: https://github\&.com/ansible/ansible
+.SH "AUTHOR"
+.PP
+\fB:doctype:manpage\fR
+.RS 4
+Author.
+.RE

--- a/docs/man/man1/ansible.1
+++ b/docs/man/man1/ansible.1
@@ -2,12 +2,12 @@
 .\"     Title: ansible
 .\"    Author: :doctype:manpage
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 12/09/2014
+.\"      Date: 05/05/2015
 .\"    Manual: System administration commands
-.\"    Source: Ansible 1.9
+.\"    Source: Ansible 2.0.0
 .\"  Language: English
 .\"
-.TH "ANSIBLE" "1" "12/09/2014" "Ansible 1\&.9" "System administration commands"
+.TH "ANSIBLE" "1" "05/05/2015" "Ansible 2\&.0\&.0" "System administration commands"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -89,19 +89,14 @@ The
 to pass to the module\&.
 .RE
 .PP
-\fB\-k\fR, \fB\-\-ask\-pass\fR  
+\fB\-k\fR, \fB\-\-ask\-pass\fR
 .RS 4
 Prompt for the SSH password instead of assuming key\-based authentication with ssh\-agent\&.
 .RE
 .PP
-\fB--ask-su-pass\fR
-.RS 4
-Prompt for the su password instead of assuming key\-based authentication with ssh\-agent\&.
-.RE
-.PP
 \fB\-K\fR, \fB\-\-ask\-sudo\-pass\fR
 .RS 4
-Prompt for the password to use with \-\-sudo, if any\&.
+Prompt for the password to use with \-\-sudo, if any
 .RE
 .PP
 \fB\-o\fR, \fB\-\-one\-line\fR
@@ -111,12 +106,7 @@ Try to output everything on one line\&.
 .PP
 \fB\-s\fR, \fB\-\-sudo\fR
 .RS 4
-Run the command as the user given by \-u and sudo to root.
-.RE
-.PP
-\fB\-S\fR, \fB\-\-su\fR
-.RS 4
-Run operations with su\&.
+Run the command as the user given by \-u and sudo to root\&.
 .RE
 .PP
 \fB\-t\fR \fIDIRECTORY\fR, \fB\-\-tree=\fR\fIDIRECTORY\fR
@@ -203,7 +193,7 @@ Ranges of hosts are also supported\&. For more information and additional option
 .sp
 The following environment variables may be specified\&.
 .sp
-ANSIBLE_HOSTS  \(em Override the default ansible hosts file
+ANSIBLE_INVENTORY  \(em Override the default ansible inventory file
 .sp
 ANSIBLE_LIBRARY \(em Override the default ansible module library path
 .sp
@@ -221,3 +211,9 @@ Ansible is released under the terms of the GPLv3 License\&.
 \fBansible\-playbook\fR(1), \fBansible\-pull\fR(1), \fBansible\-doc\fR(1)
 .sp
 Extensive documentation is available in the documentation site: http://docs\&.ansible\&.com\&. IRC and mailing list info can be found in file CONTRIBUTING\&.md, available in: https://github\&.com/ansible/ansible
+.SH "AUTHOR"
+.PP
+\fB:doctype:manpage\fR
+.RS 4
+Author.
+.RE

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -153,7 +153,7 @@ ENVIRONMENT
 
 The following environment variables may be specified.
 
-ANSIBLE_HOSTS  -- Override the default ansible hosts file
+ANSIBLE_INVENTORY  -- Override the default ansible inventory file
 
 ANSIBLE_LIBRARY -- Override the default ansible module library path
 


### PR DESCRIPTION
Support for ANSIBLE_HOSTS is broken due to commit
c73254543a9fc66bf2a22f978c6e979ae361221c, therefore do not mention it in
the man pages.
