### PR TITLE
Use same interpreter for test-module and module it runs

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -59,7 +59,8 @@ def parse():
         help="path to python debugger (e.g. /usr/bin/pdb)")
     parser.add_option('-I', '--interpreter', dest='interpreter',
         help="path to interpreter to use for this module (e.g. ansible_python_interpreter=/usr/bin/python)",
-        metavar='INTERPRETER_TYPE=INTERPRETER_PATH')
+        metavar='INTERPRETER_TYPE=INTERPRETER_PATH',
+        default='python={}'.format(sys.executable))
     parser.add_option('-c', '--check', dest='check', action='store_true',
         help="run the module in check mode")
     options, args = parser.parse_args()


### PR DESCRIPTION
Default python interpreter to the same interpreter the test-module
script is executed with.  This is so that the interpreter doesn't have
to be specified twice in the command when using non-default python
(e.g. `/path/to/python ./hacking/test-module -I python=/path/to/python ...`)
