### PR TITLE
Update playbooks_tags.rst

### DIFF
--- a/docsite/rst/playbooks_tags.rst
+++ b/docsite/rst/playbooks_tags.rst
@@ -59,7 +59,7 @@ Example::
             - tag1
 
 There are another 3 special keywords for tags, 'tagged', 'untagged' and 'all', which run only tagged, only untagged
-and all tasks respectively. By default ansible runs as if --tags all had been specified.
+and all tasks respectively. By default ansible runs as if '--tags all' had been specified.
 
 
 .. seealso::


### PR DESCRIPTION
Minor clarity edit. Highlight the command part of the sentence to clarify use of 'all' tag.
