### PR TITLE
Add ability to specify using ssh_args in synchronize for v2

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -22,6 +22,8 @@ import os.path
 
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
+from ansible import constants
+
 
 class ActionModule(ActionBase):
 
@@ -81,6 +83,7 @@ class ActionModule(ActionBase):
 
         src  = self._task.args.get('src', None)
         dest = self._task.args.get('dest', None)
+        use_ssh_args = self._task.args.pop('use_ssh_args', None)
 
         # FIXME: this doesn't appear to be used anywhere?
         local_rsync_path = task_vars.get('ansible_rsync_path')
@@ -161,6 +164,9 @@ class ActionModule(ActionBase):
         # make sure rsync path is quoted.
         if rsync_path:
             self._task.args['rsync_path'] = '"%s"' % rsync_path
+
+        if use_ssh_args:
+            self._task.args['ssh_args'] = constants.ANSIBLE_SSH_ARGS
 
         # run the module and store the result
         result = self._execute_module('synchronize')


### PR DESCRIPTION
This PR brings the changes from #10612 into the v2_final branch.

In addition to the changes needed to get `use_ssh_args` to work, there is an additional commit to just get the synchronize action plugin to work at all.

Of important note.  Automatically delegating to localhost is _not_ fixed in this PR.  I did not have the time to get that functionality working.
