### PR TITLE
Update DigitalOcean dynamic inventory to API v2

### DIFF
--- a/plugins/inventory/digital_ocean.ini
+++ b/plugins/inventory/digital_ocean.ini
@@ -3,12 +3,11 @@
 
 [digital_ocean]
 
-# The module needs your DigitalOcean Client ID and API Key.
-# These may also be specified on the command line via --client-id and --api-key
-# or via the environment variables DO_CLIENT_ID and DO_API_KEY
+# The module needs your DigitalOcean API Token.
+# It may also be specified on the command line via --api-token
+# or via the environment variables DO_API_TOKEN or DO_API_KEY
 #
-#client_id = abcdefg123456
-#api_key = 123456abcdefg
+#api_token = 123456abcdefg
 
 
 # API calls to DigitalOcean may be slow. For this reason, we cache the results

--- a/plugins/inventory/digital_ocean.py
+++ b/plugins/inventory/digital_ocean.py
@@ -226,6 +226,9 @@ or environment variables (DO_API_TOKEN)'''
             self.build_inventory()
             json_data = self.inventory
 
+        if self.cache_refreshed:
+            self.write_to_cache()
+
         if self.args.pretty:
             print json.dumps(json_data, sort_keys=True, indent=2)
         else:
@@ -309,23 +312,30 @@ or environment variables (DO_API_TOKEN)'''
         '''Get JSON from DigitalOcean API'''
         if self.args.force_cache:
             return
+        # We always get fresh droplets
+        if self.is_cache_valid() and not (resource=='droplets' or resource is None):
+            return
         if self.args.refresh_cache:
             resource=None
 
         if resource == 'droplets' or resource is None:
             self.data['droplets'] = self.manager.all_active_droplets()
+            self.cache_refreshed = True
         if resource == 'regions' or resource is None:
             self.data['regions'] = self.manager.all_regions()
+            self.cache_refreshed = True
         if resource == 'images' or resource is None:
             self.data['images'] = self.manager.all_images(filter=None)
+            self.cache_refreshed = True
         if resource == 'sizes' or resource is None:
             self.data['sizes'] = self.manager.sizes()
+            self.cache_refreshed = True
         if resource == 'ssh_keys' or resource is None:
             self.data['ssh_keys'] = self.manager.all_ssh_keys()
+            self.cache_refreshed = True
         if resource == 'domains' or resource is None:
             self.data['domains'] = self.manager.all_domains()
-
-        self.write_to_cache()
+            self.cache_refreshed = True
 
 
     def build_inventory(self):


### PR DESCRIPTION
Update to API version 2.
In API v 2 to get inventory is done in one request, so there is no need to cache any more.
