### PR TITLE
make compression support for ssh, scp, sftp connection configurable

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -208,6 +208,10 @@ fact_caching = memory
 # (default is sftp)
 #scp_if_ssh = True
 
+# if True, make ssh use compression for connection
+#compression=True
+
+
 [accelerate]
 accelerate_port = 5099
 accelerate_timeout = 30

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -209,8 +209,7 @@ fact_caching = memory
 #scp_if_ssh = True
 
 # if True, make ssh use compression for connection
-#compression=True
-
+#compression=False
 
 [accelerate]
 accelerate_port = 5099

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -208,7 +208,7 @@ fact_caching = memory
 # (default is sftp)
 #scp_if_ssh = True
 
-# if True, make ssh use compression for connection
+# if True, make ssh use compression for connection. Compression enabled by default.
 #compression=False
 
 [accelerate]

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -183,6 +183,7 @@ RETRY_FILES_SAVE_PATH          = get_config(p, DEFAULTS, 'retry_files_save_path'
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
+ANSIBLE_SSH_COMPRESSION        = get_config(p, 'ssh_connection', 'compression', 'ANSIBLE_SSH_COMPRESSION', False, boolean=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
 # obsolete -- will be formally removed
 ZEROMQ_PORT                    = get_config(p, 'fireball_connection', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099, integer=True)

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -183,7 +183,7 @@ RETRY_FILES_SAVE_PATH          = get_config(p, DEFAULTS, 'retry_files_save_path'
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
-ANSIBLE_SSH_COMPRESSION        = get_config(p, 'ssh_connection', 'compression', 'ANSIBLE_SSH_COMPRESSION', False, boolean=True)
+ANSIBLE_SSH_COMPRESSION        = get_config(p, 'ssh_connection', 'compression', 'ANSIBLE_SSH_COMPRESSION', True, boolean=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
 # obsolete -- will be formally removed
 ZEROMQ_PORT                    = get_config(p, 'fireball_connection', 'zeromq_port', 'ANSIBLE_ZEROMQ_PORT', 5099, integer=True)

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -266,7 +266,7 @@ class Connection(object):
             raise errors.AnsibleError("Internal Error: this module does not support running commands via %s" % self.runner.become_method)
 
         ssh_cmd = self._password_cmd()
-        ssh_cmd += ["ssh", "-C"]
+        ssh_cmd += ["ssh"]
         if not in_data:
             # we can only use tty when we are not pipelining the modules. piping data into /usr/bin/python
             # inside a tty automatically invokes the python interactive-mode but the modules are not

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -85,6 +85,9 @@ class Connection(object):
         if not C.HOST_KEY_CHECKING:
             self.common_args += ["-o", "StrictHostKeyChecking=no"]
 
+        if C.ANSIBLE_SSH_COMPRESSION:
+            self.common_args += ["-o", "Compression=yes"]
+
         if self.port is not None:
             self.common_args += ["-o", "Port=%d" % (self.port)]
         if self.private_key_file is not None:


### PR DESCRIPTION
I notice that compression used only for command execution via ssh, but not for scp or sftp file transfers. Patch will set compression=yes by default for ssh, scp and sftp. User can switch off compression via cfg file.
