### PR TITLE
Delimiter param must be a string

### DIFF
--- a/lib/ansible/runner/lookup_plugins/csvfile.py
+++ b/lib/ansible/runner/lookup_plugins/csvfile.py
@@ -63,7 +63,10 @@ class LookupModule(object):
                 for param in params[1:]:
                     name, value = param.split('=')
                     assert(name in paramvals)
-                    paramvals[name] = value
+                    if name == 'delimiter':
+                        paramvals[name] = str(value)
+                    else:
+                        paramvals[name] = value
             except (ValueError, AssertionError), e:
                 raise errors.AnsibleError(e)
 


### PR DESCRIPTION
I tried to use ansible_fqdn in the params string, but a string concat with this ansible variable casts the params string to unicode. This results in the following exception: AnsibleError: csvfile: "delimiter" must be string, not unicode. 
This exception is triggered here: https://github.com/ansible/ansible/blob/89fcf078bea08792b9b3da38cc8d359dce634742/lib/ansible/runner/lookup_plugins/csvfile.py#L32

csv.reader expects the delimiter param to be a single char string, according to this documentation: https://docs.python.org/2/library/csv.html#csv.Dialect.delimiter

The lookup call to reproduce:
{{ lookup('csvfile', '%s file=/tmp/test.csv delimiter=, col=2' %ansible_fqdn) }}

This patch casts the delimiter param to a string.
