### PR TITLE
v2_final Testing additions and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ language: python
 env:
   - TOXENV=py26
   - TOXENV=py27
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python2.4
 install:
   - pip install tox
 script:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='ansible',
       author_email='michael@ansible.com',
       url='http://ansible.com/',
       license='GPLv3',
-      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
+      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6', 'six'],
       package_dir={ '': 'lib' },
       packages=find_packages('lib'),
       package_data={

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ mock
 passlib
 coverage
 coveralls
+unittest2

--- a/test/units/executor/test_play_iterator.py
+++ b/test/units/executor/test_play_iterator.py
@@ -26,7 +26,7 @@ from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.executor.play_iterator import PlayIterator
 from ansible.playbook import Playbook
 
-from test.mock.loader import DictDataLoader
+from units.mock.loader import DictDataLoader
 
 class TestPlayIterator(unittest.TestCase):
 

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -27,7 +27,7 @@ from ansible.playbook.play import Play
 from ansible.playbook.role import Role
 from ansible.playbook.task import Task
 
-from test.mock.loader import DictDataLoader
+from units.mock.loader import DictDataLoader
 
 class TestPlay(unittest.TestCase):
 

--- a/test/units/playbook/test_playbook.py
+++ b/test/units/playbook/test_playbook.py
@@ -26,7 +26,7 @@ from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.playbook import Playbook
 from ansible.vars import VariableManager
 
-from test.mock.loader import DictDataLoader
+from units.mock.loader import DictDataLoader
 
 class TestPlaybook(unittest.TestCase):
 

--- a/test/units/playbook/test_role.py
+++ b/test/units/playbook/test_role.py
@@ -28,7 +28,7 @@ from ansible.playbook.role import Role
 from ansible.playbook.role.include import RoleInclude
 from ansible.playbook.task import Task
 
-from test.mock.loader import DictDataLoader
+from units.mock.loader import DictDataLoader
 
 class TestRole(unittest.TestCase):
 

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -24,7 +24,7 @@ from ansible.compat.tests.mock import patch, MagicMock
 
 from ansible.vars import VariableManager
 
-from test.mock.loader import DictDataLoader
+from units.mock.loader import DictDataLoader
 
 class TestVariableManager(unittest.TestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,31 @@
 [tox]
-envlist = {py26,py27}-v{1}
+envlist = {py26,py27}
 
 [testenv]
 commands = make tests
 deps = -r{toxinidir}/test-requirements.txt
 whitelist_externals = make
 
-[testenv:py26-v1]
+[testenv:py26]
+commands =
+    python -m compileall -fq -x 'test|samples' .
+    python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce).py' lib/ansible/module_utils
+    make tests
+deps = -r{toxinidir}/test-requirements.txt
+whitelist_externals =
+    make
+    python2.4
 
-[testenv:py27-v1]
+[testenv:py27]
+commands =
+    python -m compileall -fq -x 'test|samples' .
+    make tests
+deps = -r{toxinidir}/test-requirements.txt
+whitelist_externals = make
 
-[testenv:py26-v2]
-deps = -r{toxinidir}/v2/test-requirements.txt
-commands = make newtests
-
-[testenv:py27-v2]
-deps = -r{toxinidir}/v2/test-requirements.txt
-commands = make newtests
-
-[testenv:py34-v2]
-deps = -r{toxinidir}/v2/test-requirements.txt
-commands = make newtests
+[testenv:py34]
+commands =
+    python -m compileall -fq -x 'lib/ansible/module_utils' lib
+    make tests
+deps = -r-r{toxinidir}/test-requirements.txt
+whitelist_externals = make


### PR DESCRIPTION
- Fix import pathing for units.mock
- Add some additional requirements
- Use compileall to test compatiblity with different python versions

Along with the PRs listed later, this PR attempts to validate python version compatibility amongst the code base.  Helping ensure `module_utils` are python24 compatible, as well as the rest of the code being python 2.6, 2.7 and optionally 3.4 compatible.  Currently the python 34 environment in `tox.ini` is not specified to run automatically.

The python 2.6 environment, is the environment used to run the python24 compileall command.

https://github.com/ansible/ansible-modules-core/pull/1293
https://github.com/ansible/ansible-modules-extras/pull/465
