### PR TITLE
pybook: Python syntax to write playbooks

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -35,7 +35,9 @@ from ansible.module_utils.splitter import split_args, unquote
 from ansible.module_utils.basic import heuristic_log_sanitize
 from ansible.utils.unicode import to_bytes, to_unicode
 import ansible.constants as C
+from . import pybook
 import ast
+import pprint
 import time
 import StringIO
 import stat
@@ -774,10 +776,17 @@ def parse_yaml_from_file(path, vault_password=None):
         data = vault.decrypt(data)
         show_content = False
 
-    try:
-        return parse_yaml(data, path_hint=path)
-    except yaml.YAMLError, exc:
-        process_yaml_error(exc, data, path, show_content)
+    if re.match("#!.*python", data):
+        result = pybook.run_pybook(path)
+    else:
+        try:
+            result = parse_yaml(data, path_hint=path)
+        except yaml.YAMLError, exc:
+            process_yaml_error(exc, data, path, show_content)
+            
+    if VERBOSITY >= 3:
+        display("""Structure of file "%s":\n%s\n""" % (path, pprint.pformat(result)), color='yellow')
+    return result
 
 def parse_kv(args):
     ''' convert a string of key/value items to a dict '''

--- a/lib/ansible/utils/pybook.py
+++ b/lib/ansible/utils/pybook.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import yaml
+
+block_stack = []
+
+def append_impl(new_co, current_name, populate):
+    if not block_stack:
+        block_stack.append({} if current_name else [])
+        
+    
+    current_object = block_stack[-1]
+    is_seq = type(current_object) == list
+    
+    if is_seq:
+        if populate:
+            current_object.extend(new_co)
+        else:
+            current_object.append(new_co)
+    else:
+        if populate:
+            current_object.update(new_co)
+        else:
+            current_object[current_name] = new_co
+
+class Block:
+    def __init__(self, is_sequence):
+        self.is_sequence = is_sequence
+        self.current_name = None
+        
+    def __enter__(self):
+        new_co = [] if self.is_sequence else {}
+        append_impl(new_co, self.current_name, False)
+        
+        block_stack.append(new_co)
+        self.current_name = None
+
+        return None
+    
+    def __exit__(self, type, value, traceback):
+        if type:
+            raise
+
+        block_stack.pop()
+
+        return True
+    
+    def __call__(self, name):
+        self.current_name = name
+        return self
+
+mapping  = Block(False)
+sequence = Block(True)
+
+def append_by_args(args, is_yaml, populate=False):
+    ln = len(args)
+    if ln == 1:
+        current_name, new_co = None, args[0]
+    else:
+        current_name, new_co = args
+        
+    if is_yaml:
+        new_co = yaml.load(new_co)
+    append_impl(new_co, current_name, populate)
+    
+
+def append(*args):
+    append_by_args(args, False)
+
+def append_yaml(*args):
+    append_by_args(args, True)
+
+def populate_yaml(*args):
+    append_by_args(args, True, populate=True)
+
+book_globals = {
+    "mapping":  mapping,
+    "sequence": sequence,
+    "append":   append,
+    "append_yaml":   append_yaml,
+    "populate_yaml": populate_yaml
+}
+
+#__all__ = book_globals.keys()
+
+def run_pybook_file(f):
+    # :TRICKY: supposed to be empty
+    assert not block_stack
+
+    exec(f, book_globals)
+    return block_stack.pop()
+
+def run_pybook(fname):
+    with open(fname) as f:
+        return run_pybook_file(f)
+
+def main():
+    import sys
+    fname = sys.argv[1]
+
+    try:
+        result = run_pybook(fname)
+    except Exception, e:
+        raise
+    import pprint
+    pprint.pprint(result)
+    
+if __name__ == '__main__':
+    main()

--- a/test/units/TestPybook.py
+++ b/test/units/TestPybook.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import unittest
+import yaml
+from ansible.utils import pybook
+import pprint
+
+def check_text(text, supposed_res):
+    res = pybook.run_pybook_file(text)
+    
+    assert res == supposed_res, pprint.pprint(res)
+
+class TestPybook(unittest.TestCase):
+
+    def test_list(self):
+        text = """
+with mapping:
+    pass
+"""
+        check_text(text, [{}])
+
+    def test_map(self):
+        text = """
+with sequence("key"):
+    pass
+"""
+        check_text(text, {"key": []})
+
+    def test_append(self):
+        text = """
+with sequence("key"):
+    append(True)
+"""
+        check_text(text, {"key": [True]})
+
+    def test_populate_yaml(self):
+        text = """
+populate_yaml('''
+---
+  - name: create user
+    user: name=user shell=/bin/bash
+''')
+"""
+        check_text(text, [{
+            "name": "create user",
+            "user": "name=user shell=/bin/bash"
+        }])


### PR DESCRIPTION
Now Ansible suggests to write playbooks in YAML and JSON.

This patch adds a possibility to write playbooks in Python language for greater flexibility. A Python playbook use a simple API to generate YAML like structures, like so:

In YAML:

```

---

- hosts: web
  vars:
    build_cbo: false

  tasks:
  - include: web-tasks.yml
```

In Python:

```
#!python

with mapping:
    append("hosts", "web")
    with mapping("vars"):
        append("build_cbo", False)

    with sequence("tasks"):
        with mapping:
            append("include", "web-tasks.py")
```

Python API consists of `<with mapping>` for starting dictionaries, `<with sequence>` for starting lists, `<append>` for appending whole Python objects and `<append_yaml>`/`<populate_yaml>` for mixing Python and YAML notation.

This patch also includes tests in test/unit/TestPybook.py .
