### PR TITLE
Fix ansible/ansible#10937

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -293,7 +293,7 @@ class Facts(object):
             for (path, name) in Facts.OSDIST_LIST:
                 if os.path.exists(path):
                     if os.path.getsize(path) > 0:
-                        if self.facts['distribution'] in ('Fedora', ):
+                        if self.facts['distribution'] in ('Fedora', 'Centos', ):
                             # Once we determine the value is one of these distros
                             # we trust the values are always correct
                             break


### PR DESCRIPTION
As i see python.dist() find correct distribution_name, but next code rewrite it to RedHat. I think we can add Centos to exception like Fedora.
