### PR TITLE
Add filters: getgrnam and getpwnam

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -294,6 +294,22 @@ Hash types available depend on the master system running ansible,
 'hash' depends on hashlib password_hash depends on crypt.
 
 
+Unix Group and Passwd filters
+-----------------------------
+.. versionadded:: 1.?
+
+Get the password database entry for a username::
+
+    {{ 'root'|getpwnam('root').pw_uid }}
+
+Get the group database entry for a group::
+
+    {{ 'root'|getgrnam('root').gr_gid }}
+
+These calls are based on the corresponding calls
+in the python pwd and grp modules.
+
+
 .. _other_useful_filters:
 
 Other Useful Filters

--- a/lib/ansible/runner/filter_plugins/core.py
+++ b/lib/ansible/runner/filter_plugins/core.py
@@ -32,6 +32,8 @@ from functools import partial
 import operator as py_operator
 from random import SystemRandom, shuffle
 import uuid
+import pwd
+import grp
 
 import yaml
 from jinja2.filters import environmentfilter
@@ -270,6 +272,12 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
 def to_uuid(string):
     return str(uuid.uuid5(UUID_NAMESPACE_ANSIBLE, str(string)))
 
+def getpwnam(user):
+    return pwd.getpwnam(user)
+
+def getgrnam(group):
+    return grp.getgrnam(group)
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -348,4 +356,8 @@ class FilterModule(object):
             # random stuff
             'random': rand,
             'shuffle': randomize_list,
+
+            # users/groups
+            'getpwnam': getpwnam,
+            'getgrnam': getgrnam,
         }

--- a/test/units/TestFilters.py
+++ b/test/units/TestFilters.py
@@ -189,3 +189,14 @@ class TestFilters(unittest.TestCase):
     def test_max(self):
         a = ansible.runner.filter_plugins.mathstuff.max([3, 2, 5, 4])
         assert a == 5
+
+    def test_getpwnam(self):
+        a = ansible.runner.filter_plugins.core.getpwnam('root')
+        assert(a.pw_name == 'root')
+        assert(a.pw_uid == 0)
+        assert(a.pw_gid == 0)
+
+    def test_getgrnam(self):
+        a = ansible.runner.filter_plugins.core.getgrnam('root')
+        assert(a.gr_name == 'root')
+        assert(a.gr_gid == 0)


### PR DESCRIPTION
I thought these might be useful ... and the docs encouraged submissions of useful filters.

In my particular use case, I need to create a pure-ftpd passwd file but I need the uids of the users.

(Admittedly, I didn't check if the user action returned the uid as a result...)
