### PR TITLE
Remove trailing newline from default meta template

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -86,9 +86,9 @@ dependencies: []
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-  {% for dependency in dependencies %}
+  {%- for dependency in dependencies %}
   #- {{ dependency }}
-  {% endfor %}
+  {%- endfor %}
 
 """
 


### PR DESCRIPTION
`ansible-galaxy init` does not add trailing newlines to any of the
other files it generates.  Correcting the meta template to behave.
