### PR TITLE
Added --check-first parameter to ansible executable

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -161,6 +161,7 @@ class Cli(object):
             become_pass=becomepass,
             become_user=options.become_user,
             extra_vars=extra_vars,
+            check_first=options.check_first,
         )
 
         if options.seconds:

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -153,6 +153,7 @@ class Runner(object):
         no_log=False,                       # option to enable/disable logging for a given task
         run_once=False,                     # option to enable/disable host bypass loop for a given task
         become=False,                       # whether to run privilege escalation or not
+        check_first=False,
         become_method=C.DEFAULT_BECOME_METHOD,
         become_user=C.DEFAULT_BECOME_USER,      # ex: 'root'
         become_pass=C.DEFAULT_BECOME_PASS,      # ex: 'password123' or None
@@ -217,6 +218,7 @@ class Runner(object):
         self.vault_pass       = vault_pass
         self.no_log           = no_log
         self.run_once         = run_once
+        self.check_first      = check_first
 
         if self.transport == 'smart':
             # If the transport is 'smart', check to see if certain conditions
@@ -1482,7 +1484,7 @@ class Runner(object):
 
         elif self.forks > 1:
             try:
-                if self.become:
+                if self.become and self.check_first:
                     test_result = self._executor(hosts.pop(), None)
                     if test_result.is_successful():
                         results = self._parallel_exec(hosts)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1482,7 +1482,15 @@ class Runner(object):
 
         elif self.forks > 1:
             try:
-                results = self._parallel_exec(hosts)
+                if self.become:
+                    test_result = self._executor(hosts.pop(), None)
+                    if test_result.is_successful():
+                        results = self._parallel_exec(hosts)
+                        results.append(test_result)
+                    else:
+                        return self._partition_results([test_result])
+
+                return self._partition_results(self._parallel_exec(hosts))
             except IOError, ie:
                 print ie.errno
                 if ie.errno == 32:

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1007,6 +1007,8 @@ def base_parser(constants=C, usage="", output_opts=False, runas_opts=False,
     parser.add_option('-M', '--module-path', dest='module_path',
         help="specify path(s) to module library (default=%s)" % constants.DEFAULT_MODULE_PATH,
         default=None)
+    parser.add_option('--check-first', dest='check_first', action='store_true', default=False,
+        help="When running as another user, first run the command 1 time to prevent locking of users.")
 
     if subset_opts:
         parser.add_option('-l', '--limit', default=constants.DEFAULT_SUBSET, dest='subset',


### PR DESCRIPTION
Added an optional --check-first option when running ansible. When this is set and the command is run using elevevated or different privileges, the command is first run on 1 host. If that host fails, ansible considers that the only host and skips the rest.
The reason I did this was because we have a pretty rigorous security policy, so when we try to execute a command as root on 100+ servers, the account is immediately locked because of all the failed login attempts. 
