### PR TITLE
Fix envvars support in openstack modules

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -93,11 +93,7 @@ def openstack_full_argument_spec(**kwargs):
 
 
 def openstack_module_kwargs(**kwargs):
-    ret = dict(
-        required_one_of=[
-            ['cloud', 'auth'],
-        ],
-    )
+    ret = {}
     for key in ('mutually_exclusive', 'required_together', 'required_one_of'):
         if key in kwargs:
             if key in ret:

--- a/lib/ansible/utils/module_docs_fragments/openstack.py
+++ b/lib/ansible/utils/module_docs_fragments/openstack.py
@@ -23,7 +23,9 @@ class ModuleDocFragment(object):
 options:
   cloud:
     description:
-      - Named cloud to operate against. Provides default values for I(auth) and I(auth_plugin)
+      - Named cloud to operate against. Provides default values for I(auth) and
+        I(auth_type). This parameter is not needed if I(auth) is provided or if
+        OpenStack OS_* environment variables are present.
     required: false
   auth:
     description:
@@ -32,7 +34,8 @@ options:
         I(auth_url), I(username), I(password), I(project_name) and any
         information about domains if the cloud supports them. For other plugins,
         this param will need to contain whatever parameters that auth plugin
-        requires. This parameter is not needed if a named cloud is provided.
+        requires. This parameter is not needed if a named cloud is provided or
+        OpenStack OS_* environment variables are present.
     required: false
   auth_type:
     description:

--- a/lib/ansible/utils/module_docs_fragments/openstack.py
+++ b/lib/ansible/utils/module_docs_fragments/openstack.py
@@ -80,14 +80,17 @@ options:
       - A path to a CA Cert bundle that can be used as part of verifying
         SSL API requests.
     required: false
+    default: None
   cert:
     description:
       - A path to a client certificate to use as part of the SSL transaction
     required: false
+    default: None
   key:
     description:
       - A path to a client key to use as part of the SSL transaction
     required: false
+    default: None
   endpoint_type:
     description:
         - Endpoint URL type to fetch from the service catalog.
@@ -103,5 +106,6 @@ notes:
     can come from a yaml config file in /etc/ansible/openstack.yaml,
     /etc/openstack/clouds.yaml or ~/.config/openstack/clouds.yaml, then from
     standard environment variables, then finally by explicit parameters in
-    plays.
+    plays. More information can be found at
+    U(http://docs.openstack.org/developer/os-client-config)
 '''

--- a/v2/ansible/module_utils/openstack.py
+++ b/v2/ansible/module_utils/openstack.py
@@ -93,11 +93,7 @@ def openstack_full_argument_spec(**kwargs):
 
 
 def openstack_module_kwargs(**kwargs):
-    ret = dict(
-        required_one_of=[
-            ['cloud', 'auth'],
-        ],
-    )
+    ret = {}
     for key in ('mutually_exclusive', 'required_together', 'required_one_of'):
         if key in kwargs:
             if key in ret:


### PR DESCRIPTION
We were being too strict in the openstack_module_kwargs utility function, requiring either cloud or auth to be defined. However, a user can also reasonably decide that they want to use OpenStack environment variables instead. Remove the restriction so that passthrough values work properly.

Also - while we're in here, add a link to where documentation can be found, and add a few defaults to the docs.
