### PR TITLE
Evaluate lookup terms only in with_* contexts

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -712,7 +712,9 @@ class Runner(object):
             try:
                 items_terms = self.module_vars.get('items_lookup_terms', '')
                 items_terms = template.template(basedir, items_terms, inject)
-                items = utils.plugins.lookup_loader.get(items_plugin, runner=self, basedir=basedir).run(items_terms, inject=inject)
+                context_inject = dict(inject)
+                context_inject['_lookup_context'] = "with"
+                items = utils.plugins.lookup_loader.get(items_plugin, runner=self, basedir=basedir).run(items_terms, inject=context_inject)
             except errors.AnsibleUndefinedVariable, e:
                 if 'has no attribute' in str(e):
                     # the undefined variable was an attribute of a variable that does

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1449,6 +1449,9 @@ def safe_eval(expr, locals={}, include_exceptions=False):
 
 def listify_lookup_plugin_terms(terms, basedir, inject):
 
+    if inject.get('_lookup_context') != "with":
+        return terms
+
     from ansible.utils import template
 
     if isinstance(terms, basestring):

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1450,6 +1450,10 @@ def safe_eval(expr, locals={}, include_exceptions=False):
 def listify_lookup_plugin_terms(terms, basedir, inject):
 
     if inject.get('_lookup_context') != "with":
+
+        if isinstance(terms, basestring):
+            terms = [ terms ]
+        
         return terms
 
     from ansible.utils import template

--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -94,12 +94,16 @@ def lookup(name, *args, **kwargs):
     from ansible import utils
     instance = utils.plugins.lookup_loader.get(name.lower(), basedir=kwargs.get('basedir',None))
     tvars = kwargs.get('vars', None)
+    inject = dict()
+    if tvars is not None:
+        inject.update(tvars)
+    inject['_lookup_context'] = 'inline'
 
     wantlist = kwargs.pop('wantlist', False)
 
     if instance is not None:
         try:
-            ran = instance.run(*args, inject=tvars, **kwargs)
+            ran = instance.run(*args, inject=inject, **kwargs)
         except errors.AnsibleError:
             raise
         except jinja2.exceptions.UndefinedError, e:


### PR DESCRIPTION
As mentioned in Issue #10073 there is a problem when evaluation lookup
terms in inline {{ lookup( ... ) }} statements. The problem is, that
the template engine dies not know that the term was a literal even if
it was quoted, because the "outer" tempalte engine have already
stripped the quotes when the templating in listify_lookup_plugin_terms
see the term.

The term will then be evaluated as template variables and if a part
of the term evaluates to the "parent" variable of the current scope it
will cause an endless recursion.

This patch fixes the issue by introducing a new inject property that
tells in whick context we are currently. So listify_lookup_plugin_terms
can skip term evaluation if we are not within a "with_*" context.
