### PR TITLE
Add integration test to verify #10073

### DIFF
--- a/test/integration/roles/test_lookups/tasks/main.yml
+++ b/test/integration/roles/test_lookups/tasks/main.yml
@@ -129,3 +129,26 @@
   debug: msg={{item}}
   with_items: things2
 
+
+# BUG #10073 nested template handling
+
+- name: set variable that clashes
+  set_fact:
+      LOGNAME: foobar
+
+
+- name: get LOGNAME environment var value
+  shell: echo {{ '$LOGNAME' }}
+  register: known_var_value
+
+- name: do the lookup for env LOGNAME
+  set_fact:
+    test_val: "{{ lookup('env', 'LOGNAME') }}"
+
+- debug: var=test_val
+
+- name: compare values
+  assert:
+    that:
+        - "test_val == known_var_value.stdout"
+


### PR DESCRIPTION
In issue #10073 a misbehaviour in literal handling for inline lookup
arguments that can cause unexpected behaviur was reported. This
integration testcase reproduce the problem.

After applying pull request #10991 the issue is fixed and the test
passes.

Signed-off-by: Jan Losinski losinski@wh2.tu-dresden.de
