### PR TITLE
[subelements lookup] allow subelement property to be nested and add optional 'skip_missing' flag

### DIFF
--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -189,6 +189,12 @@ Given the mysql hosts and privs subkey lists, you can also iterate over a list i
 Subelements walks a list of hashes (aka dictionaries) and then traverses a list with a given (nested sub-)key inside of those
 records.
 
+Optionally,  you can add a third element to the subelements list, that holds a
+dictionary of flags. Currently you can add the 'skip_missing' flag. If set to
+True, the lookup plugin will skip the lists items that do not contain the given
+subkey. Without this flag, or if that flag is set to False, the plugin will
+yield an error and complain about the missing subkey.
+
 The authorized_key pattern is exactly where it comes up most.
 
 .. _looping_over_integer_sequences:

--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -147,9 +147,26 @@ How might that be accomplished?  Let's assume you had the following defined and 
         authorized: 
           - /tmp/alice/onekey.pub
           - /tmp/alice/twokey.pub
+        mysql:
+            password: mysql-password
+            hosts:
+              - "%"
+              - "127.0.0.1"
+              - "::1"
+              - "localhost"
+            privs:
+              - "*.*:SELECT"
+              - "DB1.*:ALL"
       - name: bob
         authorized:
           - /tmp/bob/id_rsa.pub
+        mysql:
+            password: other-mysql-password
+            hosts:
+              - "db1"
+            privs:
+              - "*.*:SELECT"
+              - "DB2.*:ALL"
 
 It might happen like so::
 
@@ -161,7 +178,15 @@ It might happen like so::
          - users
          - authorized
 
-Subelements walks a list of hashes (aka dictionaries) and then traverses a list with a given key inside of those
+Given the mysql hosts and privs subkey lists, you can also iterate over a list in a nested subkey::
+
+    - name: Setup MySQL users
+      mysql_user: name={{ item.0.user }} password={{ item.0.mysql.password }} host={{ item.1 }} priv={{ item.0.mysql.privs | join('/') }}
+      with_subelements:
+        - users
+        - mysql.hosts
+
+Subelements walks a list of hashes (aka dictionaries) and then traverses a list with a given (nested sub-)key inside of those
 records.
 
 The authorized_key pattern is exactly where it comes up most.

--- a/test/integration/roles/test_iterators/tasks/main.yml
+++ b/test/integration/roles/test_iterators/tasks/main.yml
@@ -39,7 +39,7 @@
   set_fact: "{{ item.0 + item.1 }}=x"
   with_nested:
     - [ 'a', 'b' ]
-    - [ 'c', 'd' ]        
+    - [ 'c', 'd' ]
 
 - debug: var=ac
 - debug: var=ad
@@ -110,6 +110,25 @@
         - "_xr == 'r'"
         - "_yi == 'i'"
         - "_yo == 'o'"
+
+- name: test with_subelements with missing key or subkey
+  set_fact: "{{ '_'+ item.0.id + item.1 }}={{ item.1 }}"
+  with_subelements:
+    - element_data_missing
+    - the.sub.key.list
+    - skip_missing: yes
+  register: _subelements_missing_subkeys
+
+- debug: var=_subelements_missing_subkeys.skipped
+- debug: var=_subelements_missing_subkeys.results|length
+- name: verify with_subelements in subkeys results
+  assert:
+    that:
+        - _subelements_missing_subkeys.skipped is not defined
+        - _subelements_missing_subkeys.results|length == 2
+        - "_xk == 'k'"
+        - "_xl == 'l'"
+
 
 # WITH_TOGETHER        
 

--- a/test/integration/roles/test_iterators/tasks/main.yml
+++ b/test/integration/roles/test_iterators/tasks/main.yml
@@ -97,6 +97,20 @@
         - "_ye == 'e'"
         - "_yf == 'f'"
 
+- name: test with_subelements in subkeys
+  set_fact: "{{ '_'+ item.0.id + item.1 }}={{ item.1 }}"
+  with_subelements:
+    - element_data
+    - the.sub.key.list
+
+- name: verify with_subelements in subkeys results
+  assert:
+    that:
+        - "_xq == 'q'"
+        - "_xr == 'r'"
+        - "_yi == 'i'"
+        - "_yo == 'o'"
+
 # WITH_TOGETHER        
 
 - name: test with_together

--- a/test/integration/roles/test_iterators/vars/main.yml
+++ b/test/integration/roles/test_iterators/vars/main.yml
@@ -19,3 +19,25 @@ element_data:
           list:
             - "i"
             - "o"
+element_data_missing:
+  - id: x
+    the_list:
+      - "f"
+      - "d"
+    the:
+      sub:
+        key:
+          list:
+            - "k"
+            - "l"
+  - id: y
+    the_list:
+      - "f"
+      - "d"
+  - id: z
+    the_list:
+      - "e"
+      - "f"
+    the:
+      sub:
+        key:

--- a/test/integration/roles/test_iterators/vars/main.yml
+++ b/test/integration/roles/test_iterators/vars/main.yml
@@ -3,7 +3,19 @@ element_data:
     the_list:
       - "f"
       - "d"
+    the:
+      sub:
+        key:
+          list:
+            - "q"
+            - "r"
   - id: y
     the_list:
       - "e"
       - "f"
+    the:
+      sub:
+        key:
+          list:
+            - "i"
+            - "o"


### PR DESCRIPTION
This is an update PR based on #10880 but reworked on v2_final.

Allow the subelement property to the subelements lookup plugin to be nested:

```

---
users:
  - user: bob
    password: system-password
    mysql:
      password: mysql-password
      hosts:
        - "%"
        - "{{ ansible_hostname }}"
        - "127.0.0.1"
        - "::1"
        - "localhost"
      privs:
        - "*.*:SELECT"
        - "DB1.*:ALL"
```

you can now refer to the mysql.hosts subkey 

```
- name: Setup MySQL users
  mysql_user: name={{ item.0.user }} password={{ item.0.mysql.password }} host={{ item.1 }} priv={{ item.0.mysql.privs | join('/') }}
  with_subelements:
    - users
    - mysql.hosts
```

closes #9863 

A second set of patches addresses and closes #9827 by implementing an optional third list item, holding a dictionary of flags, allowing 'skip_missing: yes' to be set, which will let the plugin just skip list items that do not contain the given subkey, instead of raising an error.
