### PR TITLE
$SubjectName variable unused; clean up

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -1,4 +1,4 @@
-﻿# Configure a Windows host for remote management with Ansible
+# Configure a Windows host for remote management with Ansible
 # -----------------------------------------------------------
 #
 # This script checks the current WinRM/PSRemoting configuration and makes the
@@ -10,16 +10,17 @@
 #
 # Written by Trond Hindenes <trond@hindenes.com>
 # Updated by Chris Church <cchurch@ansible.com>
+# Updated by Michael Crilly <mike@autologic.cm>
 #
 # Version 1.0 - July 6th, 2014
 # Version 1.1 - November 11th, 2014
+# Version 1.2 - May 15th, 2015
 
 Param (
     [string]$SubjectName = $env:COMPUTERNAME,
     [int]$CertValidityDays = 365,
     $CreateSelfSignedCert = $true
 )
-
 
 Function New-LegacySelfSignedCert
 {
@@ -60,10 +61,11 @@ Function New-LegacySelfSignedCert
     $certdata = $enrollment.CreateRequest(0)
     $enrollment.InstallResponse(2, $certdata, 0, "")
 
-    # Return the thumbprint of the last installed cert.
+    # Return the thumbprint of the last installed certificate;
+    # This is needed for the new HTTPS WinRM listerner we're
+    # going to create further down.
     Get-ChildItem "Cert:\LocalMachine\my"| Sort-Object NotBefore -Descending | Select -First 1 | Select -Expand Thumbprint
 }
-
 
 # Setup error handling.
 Trap
@@ -73,13 +75,11 @@ Trap
 }
 $ErrorActionPreference = "Stop"
 
-
 # Detect PowerShell version.
 If ($PSVersionTable.PSVersion.Major -lt 3)
 {
     Throw "PowerShell version 3 or higher is required."
 }
-
 
 # Find and start the WinRM service.
 Write-Verbose "Verifying WinRM service."
@@ -93,7 +93,6 @@ ElseIf ((Get-Service "WinRM").Status -ne "Running")
     Start-Service -Name "WinRM" -ErrorAction Stop
 }
 
-
 # WinRM should be running; check that we have a PS session config.
 If (!(Get-PSSessionConfiguration -Verbose:$false) -or (!(Get-ChildItem WSMan:\localhost\Listener)))
 {
@@ -105,30 +104,27 @@ Else
     Write-Verbose "PS Remoting is already enabled."
 }
 
-
 # Test a remoting connection to localhost, which should work.
 $httpResult = Invoke-Command -ComputerName "localhost" -ScriptBlock {$env:COMPUTERNAME} -ErrorVariable httpError -ErrorAction SilentlyContinue
 $httpsOptions = New-PSSessionOption -SkipCACheck -SkipCNCheck -SkipRevocationCheck
-
 $httpsResult = New-PSSession -UseSSL -ComputerName "localhost" -SessionOption $httpsOptions -ErrorVariable httpsError -ErrorAction SilentlyContinue
 
 If ($httpResult -and $httpsResult)
 {
-    Write-Verbose "HTTP and HTTPS sessions are enabled."
+    Write-Verbose "HTTP: Enabled | HTTPS: Enabled"
 }
 ElseIf ($httpsResult -and !$httpResult)
 {
-    Write-Verbose "HTTP sessions are disabled, HTTPS session are enabled."
+    Write-Verbose "HTTP: Disabled | HTTPS: Enabled"
 }
 ElseIf ($httpResult -and !$httpsResult)
 {
-    Write-Verbose "HTTPS sessions are disabled, HTTP session are enabled."
+    Write-Verbose "HTTP: Enabled | HTTPS: Disabled"
 }
 Else
 {
     Throw "Unable to establish an HTTP or HTTPS remoting session."
 }
-
 
 # Make sure there is a SSL listener.
 $listeners = Get-ChildItem WSMan:\localhost\Listener
@@ -137,17 +133,19 @@ If (!($listeners | Where {$_.Keys -like "TRANSPORT=HTTPS"}))
     # HTTPS-based endpoint does not exist.
     If (Get-Command "New-SelfSignedCertificate" -ErrorAction SilentlyContinue)
     {
-        $cert = New-SelfSignedCertificate -DnsName $env:COMPUTERNAME -CertStoreLocation "Cert:\LocalMachine\My"
+        $cert = New-SelfSignedCertificate -DnsName $SubjectName -CertStoreLocation "Cert:\LocalMachine\My"
         $thumbprint = $cert.Thumbprint
+        Write-Host "Self-signed SSL certificate generated; thumbprint: $thumbprint"
     }
     Else
     {
-        $thumbprint = New-LegacySelfSignedCert -SubjectName $env:COMPUTERNAME
+        $thumbprint = New-LegacySelfSignedCert -SubjectName $SubjectName
+        Write-Host "(Legacy) Self-signed SSL certificate generated; thumbprint: $thumbprint"
     }
 
     # Create the hashtables of settings to be used.
     $valueset = @{}
-    $valueset.Add('Hostname', $env:COMPUTERNAME)
+    $valueset.Add('Hostname', $SubjectName)
     $valueset.Add('CertificateThumbprint', $thumbprint)
 
     $selectorset = @{}
@@ -162,7 +160,6 @@ Else
     Write-Verbose "SSL listener is already active."
 }
 
-
 # Check for basic authentication.
 $basicAuthSetting = Get-ChildItem WSMan:\localhost\Service\Auth | Where {$_.Name -eq "Basic"}
 If (($basicAuthSetting.Value) -eq $false)
@@ -174,7 +171,6 @@ Else
 {
     Write-Verbose "Basic auth is already enabled."
 }
-
 
 # Configure firewall to allow WinRM HTTPS connections.
 $fwtest1 = netsh advfirewall firewall show rule name="Allow WinRM HTTPS"
@@ -193,6 +189,5 @@ Else
 {
     Write-Verbose "Firewall rule already exists to allow WinRM HTTPS."
 }
-
 
 Write-Verbose "PS Remoting has been successfully configured for Ansible."


### PR DESCRIPTION
Having used this script several times today, I came to notice the $SubjectName variable, being passed in via the CLI, is essentially ignored when generating the SSL certificates, rendering it useless. I believe it's a good idea to have it in place, so I've updated the script to reflect this.

I also cleaned up some random new lines throughout the file, and expanded on a comment.

It might be worth going a step further and commenting the file fully, as most people reviewing this file won't be familiar with PowerShell (like I wasn't until a few days ago). It could be helpful.
