### PR TITLE
Use a decorator to perform just in time connection

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -210,7 +210,6 @@ class TaskExecutor:
         # get the connection and the handler for this execution
         self._connection = self._get_connection(variables)
         self._connection.set_host_overrides(host=self._host)
-        self._connection._connect()
 
         self._handler = self._get_action_handler(connection=self._connection, templar=templar)
 

--- a/lib/ansible/plugins/connections/__init__.py
+++ b/lib/ansible/plugins/connections/__init__.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 
+from functools import wraps
 from six import add_metaclass
 
 from ansible import constants as C
@@ -32,7 +33,16 @@ from ansible.errors import AnsibleError
 #        which may want to output display/logs too
 from ansible.utils.display import Display
 
-__all__ = ['ConnectionBase']
+__all__ = ['ConnectionBase', 'ensure_connect']
+
+
+def ensure_connect(func):
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        self._connect()
+        return func(self, *args, **kwargs)
+    return wrapped
+
 
 @add_metaclass(ABCMeta)
 class ConnectionBase:

--- a/lib/ansible/plugins/connections/paramiko_ssh.py
+++ b/lib/ansible/plugins/connections/paramiko_ssh.py
@@ -41,7 +41,7 @@ from binascii import hexlify
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.plugins.connections import ConnectionBase
+from ansible.plugins.connections import ConnectionBase, ensure_connect
 
 AUTHENTICITY_MSG="""
 paramiko: The authenticity of host '%s' can't be established.
@@ -59,6 +59,7 @@ with warnings.catch_warnings():
         logging.getLogger("paramiko").setLevel(logging.WARNING)
     except ImportError:
         pass
+
 
 class MyAddPolicy(object):
     """
@@ -187,6 +188,7 @@ class Connection(ConnectionBase):
 
         return ssh
 
+    @ensure_connect
     def exec_command(self, cmd, tmp_path, executable='/bin/sh', in_data=None):
         ''' run a command on the remote host '''
 
@@ -247,6 +249,7 @@ class Connection(ConnectionBase):
 
         return (chan.recv_exit_status(), '', no_prompt_out + stdout, no_prompt_out + stderr)
 
+    @ensure_connect
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''
 
@@ -271,9 +274,10 @@ class Connection(ConnectionBase):
         if cache_key in SFTP_CONNECTION_CACHE:
             return SFTP_CONNECTION_CACHE[cache_key]
         else:
-            result = SFTP_CONNECTION_CACHE[cache_key] = self.connect().ssh.open_sftp()
+            result = SFTP_CONNECTION_CACHE[cache_key] = self._connect().ssh.open_sftp()
             return result
 
+    @ensure_connect
     def fetch_file(self, in_path, out_path):
         ''' save a remote file to the specified path '''
 

--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -34,7 +34,8 @@ from hashlib import sha1
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.plugins.connections import ConnectionBase
+from ansible.plugins.connections import ConnectionBase, ensure_connect
+
 
 class Connection(ConnectionBase):
     ''' ssh based connections '''
@@ -269,6 +270,7 @@ class Connection(ConnectionBase):
             self._display.vvv("EXEC previous known host file not found for {0}".format(host))
         return True
 
+    @ensure_connect
     def exec_command(self, cmd, tmp_path, executable='/bin/sh', in_data=None):
         ''' run a command on the remote host '''
 
@@ -390,6 +392,7 @@ class Connection(ConnectionBase):
 
         return (p.returncode, '', no_prompt_out + stdout, no_prompt_err + stderr)
 
+    @ensure_connect
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''
         self._display.vvv("PUT {0} TO {1}".format(in_path, out_path), host=self._connection_info.remote_addr)
@@ -425,6 +428,7 @@ class Connection(ConnectionBase):
         if returncode != 0:
             raise AnsibleError("failed to transfer file to {0}:\n{1}\n{2}".format(out_path, stdout, stderr))
 
+    @ensure_connect
     def fetch_file(self, in_path, out_path):
         ''' fetch a file from remote to local '''
         self._display.vvv("FETCH {0} TO {1}".format(in_path, out_path), host=self._connection_info.remote_addr)

--- a/lib/ansible/plugins/connections/winrm.py
+++ b/lib/ansible/plugins/connections/winrm.py
@@ -42,8 +42,9 @@ except ImportError:
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.plugins.connections import ConnectionBase
+from ansible.plugins.connections import ConnectionBase, ensure_connect
 from ansible.plugins import shell_loader
+
 
 class Connection(ConnectionBase):
     '''WinRM connections over HTTP/HTTPS.'''
@@ -150,6 +151,7 @@ class Connection(ConnectionBase):
             self.protocol = self._winrm_connect()
         return self
 
+    @ensure_connect
     def exec_command(self, cmd, tmp_path, executable='/bin/sh', in_data=None):
 
         cmd = cmd.encode('utf-8')
@@ -171,6 +173,7 @@ class Connection(ConnectionBase):
             raise AnsibleError("failed to exec cmd %s" % cmd)
         return (result.status_code, '', result.std_out.encode('utf-8'), result.std_err.encode('utf-8'))
 
+    @ensure_connect
     def put_file(self, in_path, out_path):
         self._display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._connection_info.remote_addr)
         if not os.path.exists(in_path):
@@ -209,6 +212,7 @@ class Connection(ConnectionBase):
                     traceback.print_exc()
                     raise AnsibleError("failed to transfer file to %s" % out_path)
 
+    @ensure_connect
     def fetch_file(self, in_path, out_path):
         out_path = out_path.replace('\\', '/')
         self._display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self._connection_info.remote_addr)


### PR DESCRIPTION
This PR adds a new `ensure_connect` decorator for connection plugins.  It's function is to decorate a method requiring a connection to be open.  The replaces the explicit call to `_connect`.

WHY:  Calling `_connect` explicitly as it is, causes the connection plugin to connect to a remote host, sometimes needlessly such as when running an action plugin that does not need a connection, such as `set_fact`.

This change will ensure that a connection is not forcefully established when not needed, but still establish it just in time for the operation.

The following connection plugins have been updated due to them being ready for v2:
- ssh
- paramiko
- winrm

Additional plugins will need to have this decorator applied to `exec_command`, `put_file` and `fetch_file`.

I've tested a handful of scenarios and did not encounter any issues.

Addresses #10997
