### PR TITLE
explain source of EC2 inventory error

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -514,11 +514,11 @@ class Ec2Inventory(object):
 
         return '\n'.join(errors)
 
-    def fail_with_error(self, err_msg, err_operation_context=None):
+    def fail_with_error(self, err_msg, err_operation=None):
         '''log an error to std err for ansible-playbook to consume and exit'''
-        if err_operation_context:
+        if err_operation:
             err_msg = 'ERROR: "{err_msg}", while: {err_operation}'.format(
-                err_msg=err_msg, err_operation=err_operation_context)
+                err_msg=err_msg, err_operation=err_operation)
         sys.stderr.write(err_msg)
         sys.exit(1)
 

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -406,7 +406,9 @@ class Ec2Inventory(object):
             else:
                 backend = 'Eucalyptus' if self.eucalyptus else 'AWS' 
                 error = "Error connecting to %s backend.\n%s" % (backend, e.message)
-            self.fail_with_error(error)
+            self.fail_with_error(
+                'ERROR: "{error}", while: {err_operation}'.format(
+                     error=error, err_operation='getting EC2 instances'))
 
     def get_rds_instances_by_region(self, region):
         ''' Makes an AWS API call to the list of RDS instances in a particular
@@ -425,7 +427,9 @@ class Ec2Inventory(object):
                 error = self.get_auth_error_message()
             if not e.reason == "Forbidden":
                 error = "Looks like AWS RDS is down:\n%s" % e.message
-            self.fail_with_error(error)
+            self.fail_with_error(
+                'ERROR: "{error}", while: {err_operation}'.format(
+                     error=error, err_operation='getting RDS instances'))
 
     def get_elasticache_clusters_by_region(self, region):
         ''' Makes an AWS API call to the list of ElastiCache clusters (with


### PR DESCRIPTION
addresses part of https://github.com/ansible/ansible/issues/10840
@edrozenberg 

I ran into this while creating a more limited IAM role for some users.

Before
RDS: `ERROR: Inventory script (ec2.py) had an execution error: Forbidden`
EC2: `ERROR: Inventory script (ec2.py) had an execution error: Error connecting to AWS backend.
You are not authorized to perform this operation.`
ElastiCache: `ERROR: Inventory script (ec2.py) had an execution error: Forbidden`

After
RDS: `ERROR: Inventory script (ec2.py) had an execution error: ERROR: "Forbidden", while: getting RDS instances`
EC2: `ERROR: Inventory script (ec2.py) had an execution error: ERROR: "Error connecting to AWS backend.
You are not authorized to perform this operation.", while: getting EC2 instances`
ElastiCache: `ERROR: Inventory script (ec2.py) had an execution error: ERROR: "Forbidden", while: getting ElastiCache clusters`

Thanks
