### PR TITLE
Fixed documentation for host pattern portions

### DIFF
--- a/docsite/rst/intro_patterns.rst
+++ b/docsite/rst/intro_patterns.rst
@@ -74,7 +74,7 @@ As an advanced usage, you can also select the numbered server in a group::
 
 Or a portion of servers in a group::
 
-    webservers[0:25]
+    webservers[0-25]
 
 Most people don't specify patterns as regular expressions, but you can.  Just start the pattern with a '~'::
 


### PR DESCRIPTION
The documentation for patterns http://docs.ansible.com/intro_patterns.html says:

> Or a portion of servers in a group:

```
webservers[0:25]
```

But this doesn't work. Instead of colon, a dash should be used:

```
webservers[0-25]
```
