### PR TITLE
Add judgment to to fix path0 if ANSIBLE_CONFIG is set to a dir

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -65,6 +65,8 @@ def load_config_file():
     path0 = os.getenv("ANSIBLE_CONFIG", None)
     if path0 is not None:
         path0 = os.path.expanduser(path0)
+    if os.path.isdir(path0):
+        path0 += "/ansible.cfg"
     path1 = os.getcwd() + "/ansible.cfg"
     path2 = os.path.expanduser("~/.ansible.cfg")
     path3 = "/etc/ansible/ansible.cfg"


### PR DESCRIPTION
I made a mistake when I set ANSIBLE_CONFIG to a dir contains ansible.cfg and hosts. After digging into the source, I found this variable should direct to ansible.cfg file itself, but I think maybe I'm not the only one who made such mistake, so I pulled this request.
