### PR TITLE
added hmc.py and hmc.ini in plugins/inventory

### DIFF
--- a/plugins/inventory/hmc.ini
+++ b/plugins/inventory/hmc.ini
@@ -1,0 +1,10 @@
+# Ansible HMC inventory script
+#
+
+[hmc]
+
+# HMC Hostname
+hostname = hmchost.example.com
+
+# Username
+username = hscroot

--- a/plugins/inventory/hmc.py
+++ b/plugins/inventory/hmc.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+# This file requests lpar inventory information from an IBM frame via the
+# Hardware Management Console. You are not required to have ssh keys set
+# up but you will need to supply a username on the command line.
+# 
+# usage: hmc.py --host <hmc> --user <username>
+#
+# Written by Kate McDonald <https://github.com/katishna>
+# 2015
+# With thanks to Melissa Donohue for all the python help
+
+from subprocess import Popen,PIPE
+import os, sys
+import ConfigParser
+import json
+
+result = {}
+
+class HMCinventory(object):
+
+# read some settings from the .ini
+    def read_settings(self):
+        config = ConfigParser.SafeConfigParser()
+        config.read(os.path.dirname(os.path.realpath(__file__)) + '/hmc.ini')
+
+        # server
+        if config.has_option('hmc', 'hostname'):
+            self.hmcname = config.get('hmc', 'hostname')
+
+        # login
+        if config.has_option('hmc', 'username'):
+            self.hmc_username = config.get('hmc', 'username')
+
+
+# gets a list of frames on the HMC
+    def get_frames(self, hmcname, username):
+        data = {}
+        pipe = Popen(['ssh', '-l', username, hmcname, 'lssyscfg', '-r', 'sys', '-F', 'name'], stdout=PIPE, universal_newlines=False)
+        data = [x[:-1] for x in pipe.stdout.readlines()]
+        return data
+
+# gets a list of LPARs on a given frame
+    def get_lpars(self, hmcname, username, frame):
+        data = {}
+        lparData = Popen(['ssh', '-l', username, hmcname, 'lssyscfg', '-r', 'lpar', '-m', frame, '-F', 'name'], stdout=PIPE)
+        data  = [x[:-1] for x in lparData.stdout.readlines()]
+        return data
+
+        
+    def __init__(self):
+
+        self.hmcname = None
+        self.hmc_username = None
+
+        self.read_settings()
+
+        if self.hmcname and self.hmc_username:
+
+            HMC = self.hmcname
+            USER = self.hmc_username
+            framelist = self.get_frames(HMC, USER)
+            for frame in framelist:
+                print frame
+                data = self.get_lpars(HMC, USER, frame)
+                print json.dumps(data)
+
+        else:
+            print >> sys.stderr, "Error: Configuration of server and username are required in hmc.ini."
+            sys.exit(1)
+
+HMCinventory()
+


### PR DESCRIPTION
This inventory plugin pulls data from an IBM Hardware Management Console (HMC) about the physical frames attached to that HMC and the logical partitions (individual servers) on that frame. It provides a picture of what is accessible via that HMC. This version of the plugin uses ssh based commands to pull the data, which allows it to work on older HMCs. A future rewrite of the code will use the RESTful API, but will remove the backward compatibility that using ssh provides. The frames run AIX, IBMi, and Power Linux logical partitions.

I need this information regularly at work but couldn't find anything currently in Ansible to provide the data. This is my first PR and I've tried to rebase it against the 2.0 devel branch, so if I've done that wrong please let me know and I'll fix it.
