### PR TITLE
cloudstack: add tests for cs_firewall

### DIFF
--- a/test/integration/cloudstack.yml
+++ b/test/integration/cloudstack.yml
@@ -12,3 +12,4 @@
     - { role: test_cs_instance,             tags: test_cs_instance }
     - { role: test_cs_instancegroup,        tags: test_cs_instancegroup }
     - { role: test_cs_account,              tags: test_cs_account }
+    - { role: test_cs_firewall,             tags: test_cs_firewall }

--- a/test/integration/roles/test_cs_firewall/defaults/main.yml
+++ b/test/integration/roles/test_cs_firewall/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+cs_firewall_ip_address: 10.100.212.5
+cs_firewall_network: test

--- a/test/integration/roles/test_cs_firewall/meta/main.yml
+++ b/test/integration/roles/test_cs_firewall/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - test_cs_common

--- a/test/integration/roles/test_cs_firewall/tasks/main.yml
+++ b/test/integration/roles/test_cs_firewall/tasks/main.yml
@@ -1,0 +1,271 @@
+---
+- name: setup 80
+  cs_firewall:
+    port: 80
+    ip_address: "{{ cs_firewall_ip_address }}"
+    state: absent
+  register: fw
+- name: verify setup
+  assert:
+    that:
+    - fw|success
+
+- name: setup 5300
+  cs_firewall:
+    ip_address: "{{ cs_firewall_ip_address }}"
+    protocol: udp
+    start_port: 5300
+    end_port: 5333
+    cidr: 1.2.3.4/24
+    state: absent
+  register: fw
+- name: verify setup
+  assert:
+    that:
+    - fw|success
+
+- name: setup all
+  cs_firewall:
+    network: "{{ cs_firewall_network }}"
+    protocol: all
+    type: egress
+    state: absent
+  register: fw
+- name: verify setup
+  assert:
+    that:
+    - fw|success
+
+- name: test fail if missing params
+  action: cs_firewall
+  register: fw
+  ignore_errors: true
+- name: verify results of fail if missing params
+  assert:
+    that:
+    - fw|failed
+    - fw.msg == "missing required argument for protocol 'tcp': start_port or end_port"
+
+- name: test fail if missing params ip_address ingress
+  cs_firewall:
+    port: 80
+  register: fw
+  ignore_errors: true
+- name: verify results of fail if missing params ip_address
+  assert:
+    that:
+    - fw|failed
+    - fw.msg == "missing required argument for type ingress: ip_address"
+
+- name: test fail if missing params network egress
+  cs_firewall:
+    type: egress
+  register: fw
+  ignore_errors: true
+- name: verify results of fail if missing params ip_address
+  assert:
+    that:
+    - fw|failed
+    - fw.msg == "missing required argument for type egress: network"
+
+- name: test present firewall rule ingress 80
+  cs_firewall:
+    port: 80
+    ip_address: "{{ cs_firewall_ip_address }}"
+  register: fw
+- name: verify results of present firewall rule ingress 80
+  assert:
+    that:
+    - fw|success
+    - fw|changed
+    - fw.cidr == "0.0.0.0/0"
+    - fw.ip_address == "{{ cs_firewall_ip_address }}"
+    - fw.protocol == "tcp"
+    - fw.start_port == 80
+    - fw.end_port == 80
+    - fw.type == "ingress"
+
+- name: test present firewall rule ingress 80 idempotence
+  cs_firewall:
+    port: 80
+    ip_address: "{{ cs_firewall_ip_address }}"
+  register: fw
+- name: verify results of present firewall rule ingress 80 idempotence
+  assert:
+    that:
+    - fw|success
+    - not fw|changed
+    - fw.cidr == "0.0.0.0/0"
+    - fw.ip_address == "{{ cs_firewall_ip_address }}"
+    - fw.protocol == "tcp"
+    - fw.start_port == 80
+    - fw.end_port == 80
+    - fw.type == "ingress"
+
+- name: test present firewall rule ingress 5300
+  cs_firewall:
+    ip_address: "{{ cs_firewall_ip_address }}"
+    protocol: udp
+    start_port: 5300
+    end_port: 5333
+    cidr: 1.2.3.4/24
+  register: fw
+- name: verify results of present firewall rule ingress 5300
+  assert:
+    that:
+    - fw|success
+    - fw|changed
+    - fw.cidr == "1.2.3.4/24"
+    - fw.ip_address == "{{ cs_firewall_ip_address }}"
+    - fw.protocol == "udp"
+    - fw.start_port == 5300
+    - fw.end_port == 5333
+    - fw.type == "ingress"
+
+- name: test present firewall rule ingress 5300 idempotence
+  cs_firewall:
+    ip_address: "{{ cs_firewall_ip_address }}"
+    protocol: udp
+    start_port: 5300
+    end_port: 5333
+    cidr: 1.2.3.4/24
+  register: fw
+- name: verify results of present firewall rule ingress 5300 idempotence
+  assert:
+    that:
+    - fw|success
+    - not fw|changed
+    - fw.cidr == "1.2.3.4/24"
+    - fw.ip_address == "{{ cs_firewall_ip_address }}"
+    - fw.protocol == "udp"
+    - fw.start_port == 5300
+    - fw.end_port == 5333
+    - fw.type == "ingress"
+
+- name: test present firewall rule egress all
+  cs_firewall:
+    network: "{{ cs_firewall_network }}"
+    protocol: all
+    type: egress
+  register: fw
+- name: verify results of present firewall rule egress all
+  assert:
+    that:
+    - fw|success
+    - fw|changed
+    - fw.cidr == "0.0.0.0/0"
+    - fw.network == "{{ cs_firewall_network }}"
+    - fw.protocol == "all"
+    - fw.type == "egress"
+
+- name: test present firewall rule egress all idempotence
+  cs_firewall:
+    network: "{{ cs_firewall_network }}"
+    protocol: all
+    type: egress
+  register: fw
+- name: verify results of present firewall rule egress all idempotence
+  assert:
+    that:
+    - fw|success
+    - not fw|changed
+    - fw.cidr == "0.0.0.0/0"
+    - fw.network == "{{ cs_firewall_network }}"
+    - fw.protocol == "all"
+    - fw.type == "egress"
+
+- name: test absent firewall rule ingress 80
+  cs_firewall:
+    port: 80
+    ip_address: "{{ cs_firewall_ip_address }}"
+    state: absent
+  register: fw
+- name: verify results of absent firewall rule ingress 80
+  assert:
+    that:
+    - fw|success
+    - fw|changed
+    - fw.cidr == "0.0.0.0/0"
+    - fw.ip_address == "{{ cs_firewall_ip_address }}"
+    - fw.protocol == "tcp"
+    - fw.start_port == 80
+    - fw.end_port == 80
+    - fw.type == "ingress"
+
+- name: test absent firewall rule ingress 80 idempotence
+  cs_firewall:
+    port: 80
+    ip_address: "{{ cs_firewall_ip_address }}"
+    state: absent
+  register: fw
+- name: verify results of absent firewall rule ingress 80 idempotence
+  assert:
+    that:
+    - fw|success
+    - not fw|changed
+
+- name: test absent firewall rule ingress 5300
+  cs_firewall:
+    ip_address: "{{ cs_firewall_ip_address }}"
+    protocol: udp
+    start_port: 5300
+    end_port: 5333
+    cidr: 1.2.3.4/24
+    state: absent
+  register: fw
+- name: verify results of absent firewall rule ingress 5300
+  assert:
+    that:
+    - fw|success
+    - fw|changed
+    - fw.cidr == "1.2.3.4/24"
+    - fw.ip_address == "{{ cs_firewall_ip_address }}"
+    - fw.protocol == "udp"
+    - fw.start_port == 5300
+    - fw.end_port == 5333
+    - fw.type == "ingress"
+
+- name: test absent firewall rule ingress 5300 idempotence
+  cs_firewall:
+    ip_address: "{{ cs_firewall_ip_address }}"
+    protocol: udp
+    start_port: 5300
+    end_port: 5333
+    cidr: 1.2.3.4/24
+    state: absent
+  register: fw
+- name: verify results of absent firewall rule ingress 5300 idempotence
+  assert:
+    that:
+    - fw|success
+    - not fw|changed
+
+- name: test absent firewall rule egress all
+  cs_firewall:
+    network: "{{ cs_firewall_network }}"
+    protocol: all
+    type: egress
+    state: absent
+  register: fw
+- name: verify results of absent firewall rule egress all
+  assert:
+    that:
+    - fw|success
+    - fw|changed
+    - fw.cidr == "0.0.0.0/0"
+    - fw.network == "{{ cs_firewall_network }}"
+    - fw.protocol == "all"
+    - fw.type == "egress"
+
+- name: test absent firewall rule egress all idempotence
+  cs_firewall:
+    network: "{{ cs_firewall_network }}"
+    protocol: all
+    type: egress
+    state: absent
+  register: fw
+- name: verify results of absent firewall rule egress all idempotence
+  assert:
+    that:
+    - fw|success
+    - not fw|changed


### PR DESCRIPTION
Depends on https://github.com/ansible/ansible-modules-extras/pull/510

```
PLAY [localhost] ************************************************************** 

TASK: [test_cs_firewall | setup 80] ******************************************* 
ok: [localhost] => {"changed": false}

TASK: [test_cs_firewall | verify setup] *************************************** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | setup 5300] ***************************************** 
ok: [localhost] => {"changed": false}

TASK: [test_cs_firewall | verify setup] *************************************** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | setup all] ****************************************** 
changed: [localhost] => {"changed": true, "cidr": "0.0.0.0/0", "network": "test", "protocol": "all", "type": "egress"}

TASK: [test_cs_firewall | verify setup] *************************************** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test fail if missing params] ************************ 
failed: [localhost] => {"failed": true}
msg: missing required argument for protocol 'tcp': start_port or end_port
...ignoring

TASK: [test_cs_firewall | verify results of fail if missing params] *********** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test fail if missing params ip_address ingress] ***** 
failed: [localhost] => {"failed": true}
msg: IP address param 'ip_address' is required
...ignoring

TASK: [test_cs_firewall | verify results of fail if missing params ip_address] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test fail if missing params network egress] ********* 
failed: [localhost] => {"failed": true}
msg: missing required argument for protocol 'tcp': start_port or end_port
...ignoring

TASK: [test_cs_firewall | verify results of fail if missing params ip_address] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test present firewall rule ingress 80] ************** 
changed: [localhost] => {"changed": true, "cidr": "0.0.0.0/0", "end_port": 80, "ip_address": "10.100.212.5", "protocol": "tcp", "start_port": 80, "type": "ingress"}

TASK: [test_cs_firewall | verify results of present firewall rule ingress 80] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test present firewall rule ingress 80 idempotence] *** 
ok: [localhost] => {"changed": false, "cidr": "0.0.0.0/0", "end_port": 80, "ip_address": "10.100.212.5", "protocol": "tcp", "start_port": 80, "type": "ingress"}

TASK: [test_cs_firewall | verify results of present firewall rule ingress 80 idempotence] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test present firewall rule ingress 5300] ************ 
changed: [localhost] => {"changed": true, "cidr": "1.2.3.4/24", "end_port": 5333, "ip_address": "10.100.212.5", "protocol": "udp", "start_port": 5300, "type": "ingress"}

TASK: [test_cs_firewall | verify results of present firewall rule ingress 5300] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test present firewall rule ingress 5300 idempotence] *** 
ok: [localhost] => {"changed": false, "cidr": "1.2.3.4/24", "end_port": 5333, "ip_address": "10.100.212.5", "protocol": "udp", "start_port": 5300, "type": "ingress"}

TASK: [test_cs_firewall | verify results of present firewall rule ingress 5300 idempotence] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test present firewall rule egress all] ************** 
changed: [localhost] => {"changed": true, "cidr": "0.0.0.0/0", "network": "test", "protocol": "all", "type": "egress"}

TASK: [test_cs_firewall | verify results of present firewall rule egress all] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test present firewall rule egress all idempotence] *** 
ok: [localhost] => {"changed": false, "cidr": "0.0.0.0/0", "network": "test", "protocol": "all", "type": "egress"}

TASK: [test_cs_firewall | verify results of present firewall rule egress all idempotence] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test absent firewall rule ingress 80] *************** 
changed: [localhost] => {"changed": true, "cidr": "0.0.0.0/0", "end_port": 80, "ip_address": "10.100.212.5", "protocol": "tcp", "start_port": 80, "type": "ingress"}

TASK: [test_cs_firewall | verify results of absent firewall rule ingress 80] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test absent firewall rule ingress 80 idempotence] *** 
ok: [localhost] => {"changed": false}

TASK: [test_cs_firewall | verify results of absent firewall rule ingress 80 idempotence] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test absent firewall rule ingress 5300] ************* 
changed: [localhost] => {"changed": true, "cidr": "1.2.3.4/24", "end_port": 5333, "ip_address": "10.100.212.5", "protocol": "udp", "start_port": 5300, "type": "ingress"}

TASK: [test_cs_firewall | verify results of absent firewall rule ingress 5300] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test absent firewall rule ingress 5300 idempotence] *** 
ok: [localhost] => {"changed": false}

TASK: [test_cs_firewall | verify results of absent firewall rule ingress 5300 idempotence] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test absent firewall rule egress all] *************** 
changed: [localhost] => {"changed": true, "cidr": "0.0.0.0/0", "network": "test", "protocol": "all", "type": "egress"}

TASK: [test_cs_firewall | verify results of absent firewall rule egress all] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_firewall | test absent firewall rule egress all idempotence] *** 
ok: [localhost] => {"changed": false}

TASK: [test_cs_firewall | verify results of absent firewall rule egress all idempotence] *** 
ok: [localhost] => {"msg": "all assertions passed"}

PLAY RECAP ******************************************************************** 
localhost                  : ok=36   changed=7    unreachable=0    failed=0 
```
