### PR TITLE
cloudstack: add tests for cs_portforward

### DIFF
--- a/test/integration/cloudstack.yml
+++ b/test/integration/cloudstack.yml
@@ -11,4 +11,5 @@
     - { role: test_cs_securitygroup_rule,   tags: test_cs_securitygroup_rule }
     - { role: test_cs_instance,             tags: test_cs_instance }
     - { role: test_cs_instancegroup,        tags: test_cs_instancegroup }
+    - { role: test_cs_portforward,          tags: test_cs_portforward }
     - { role: test_cs_account,              tags: test_cs_account }

--- a/test/integration/roles/test_cs_portforward/defaults/main.yml
+++ b/test/integration/roles/test_cs_portforward/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+cs_portforward_public_ip: "10.100.212.5"
+cs_portforward_vm: "{{ cs_resource_prefix }}-vm"

--- a/test/integration/roles/test_cs_portforward/meta/main.yml
+++ b/test/integration/roles/test_cs_portforward/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - test_cs_common

--- a/test/integration/roles/test_cs_portforward/tasks/main.yml
+++ b/test/integration/roles/test_cs_portforward/tasks/main.yml
@@ -1,0 +1,111 @@
+---
+- name: setup
+  cs_portforward:
+    ip_address: "{{ cs_portforward_public_ip }}"
+    public_port: 80
+    private_port: 8080
+    state: absent
+  register: pf
+- name: verify setup
+  assert:
+    that:
+    - pf|success
+
+- name: test fail if missing params
+  action: cs_portforward
+  register: pf
+  ignore_errors: true
+- name: verify results of fail if missing params
+  assert:
+    that:
+    - pf|failed
+    - 'pf.msg == "missing required arguments: private_port,ip_address,public_port"'
+
+- name: test present port forwarding
+  cs_portforward:
+    ip_address: "{{ cs_portforward_public_ip }}"
+    public_port: 80
+    vm: "{{ cs_portforward_vm }}"
+    private_port: 8080
+  register: pf
+- name: verify results of present port forwarding
+  assert:
+    that:
+    - pf|success
+    - pf|changed
+    - pf.vm_name == "{{ cs_portforward_vm }}"
+    - pf.ip_address == "{{ cs_portforward_public_ip }}"
+    - pf.public_port == 80
+    - pf.public_end_port == 80
+    - pf.private_port == 8080
+    - pf.private_end_port == 8080
+
+- name: test present port forwarding idempotence
+  cs_portforward:
+    ip_address: "{{ cs_portforward_public_ip }}"
+    public_port: 80
+    vm: "{{ cs_portforward_vm }}"
+    private_port: 8080
+  register: pf
+- name: verify results of present port forwarding idempotence
+  assert:
+    that:
+    - pf|success
+    - not pf|changed
+    - pf.vm_name == "{{ cs_portforward_vm }}"
+    - pf.ip_address == "{{ cs_portforward_public_ip }}"
+    - pf.public_port == 80
+    - pf.public_end_port == 80
+    - pf.private_port == 8080
+    - pf.private_end_port == 8080
+
+- name: test change port forwarding
+  cs_portforward:
+    ip_address: "{{ cs_portforward_public_ip }}"
+    public_port: 80
+    vm: "{{ cs_portforward_vm }}"
+    private_port: 8888
+  register: pf
+- name: verify results of change port forwarding
+  assert:
+    that:
+    - pf|success
+    - pf|changed
+    - pf.vm_name == "{{ cs_portforward_vm }}"
+    - pf.ip_address == "{{ cs_portforward_public_ip }}"
+    - pf.public_port == 80
+    - pf.public_end_port == 80
+    - pf.private_port == 8888
+    - pf.private_end_port == 8888
+
+- name: test absent port forwarding
+  cs_portforward:
+    ip_address: "{{ cs_portforward_public_ip }}"
+    public_port: 80
+    private_port: 8888
+    state: absent
+  register: pf
+- name: verify results of absent port forwarding
+  assert:
+    that:
+    - pf|success
+    - pf|changed
+    - pf.vm_name == "{{ cs_portforward_vm }}"
+    - pf.ip_address == "{{ cs_portforward_public_ip }}"
+    - pf.public_port == 80
+    - pf.public_end_port == 80
+    - pf.private_port == 8888
+    - pf.private_end_port == 8888
+
+- name: test absent port forwarding idempotence
+  cs_portforward:
+    ip_address: "{{ cs_portforward_public_ip }}"
+    public_port: 80
+    private_port: 8888
+    state: absent
+  register: pf
+- name: verify results of absent port forwarding idempotence
+  assert:
+    that:
+    - pf|success
+    - not pf|changed


### PR DESCRIPTION
Depends on https://github.com/ansible/ansible-modules-extras/pull/511

```
PLAY [localhost] ************************************************************** 

TASK: [test_cs_portforward | setup] ******************************************* 
ok: [localhost] => {"changed": false}

TASK: [test_cs_portforward | verify setup] ************************************ 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_portforward | test fail if missing params] ********************* 
failed: [localhost] => {"failed": true}
msg: missing required arguments: private_port,ip_address,public_port
...ignoring

TASK: [test_cs_portforward | verify results of fail if missing params] ******** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_portforward | test present port forwarding] ******************** 
changed: [localhost] => {"changed": true, "id": "9bb712cb-0a35-410b-a0cf-0e97be82261b", "ip_address": "10.100.212.5", "private_end_port": 8080, "private_port": 8080, "protocol": "tcp", "public_end_port": 80, "public_port": 80, "tags": [], "vm_display_name": "test-4", "vm_guest_ip": "10.101.68.201", "vm_name": "test-4"}

TASK: [test_cs_portforward | verify results of present port forwarding] ******* 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_portforward | test present port forwarding idempotence] ******** 
ok: [localhost] => {"changed": false, "id": "9bb712cb-0a35-410b-a0cf-0e97be82261b", "ip_address": "10.100.212.5", "private_end_port": 8080, "private_port": 8080, "protocol": "tcp", "public_end_port": 80, "public_port": 80, "tags": [], "vm_display_name": "test-4", "vm_guest_ip": "10.101.68.201", "vm_name": "test-4"}

TASK: [test_cs_portforward | verify results of present port forwarding idempotence] *** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_portforward | test change port forwarding] ********************* 
changed: [localhost] => {"changed": true, "id": "81ac52cf-63e1-4477-8381-1194ca3f8137", "ip_address": "10.100.212.5", "private_end_port": 8888, "private_port": 8888, "protocol": "tcp", "public_end_port": 80, "public_port": 80, "tags": [], "vm_display_name": "test-4", "vm_guest_ip": "10.101.68.201", "vm_name": "test-4"}

TASK: [test_cs_portforward | verify results of change port forwarding] ******** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_portforward | test absent port forwarding] ********************* 
changed: [localhost] => {"changed": true, "id": "81ac52cf-63e1-4477-8381-1194ca3f8137", "ip_address": "10.100.212.5", "private_end_port": 8888, "private_port": 8888, "protocol": "tcp", "public_end_port": 80, "public_port": 80, "tags": [], "vm_display_name": "test-4", "vm_guest_ip": "10.101.68.201", "vm_name": "test-4"}

TASK: [test_cs_portforward | verify results of absent port forwarding] ******** 
ok: [localhost] => {"msg": "all assertions passed"}

TASK: [test_cs_portforward | test absent port forwarding idempotence] ********* 
ok: [localhost] => {"changed": false}

TASK: [test_cs_portforward | verify results of absent port forwarding idempotence] *** 
ok: [localhost] => {"msg": "all assertions passed"}

PLAY RECAP ******************************************************************** 
localhost                  : ok=14   changed=3    unreachable=0    failed=0 
```
