### PR TITLE
Pass same host value for runner_on_file_diff as runner_on_ok

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1112,7 +1112,7 @@ class Runner(object):
                 self.callbacks.on_failed(host, data, ignore_errors)
             else:
                 if self.diff:
-                    self.callbacks.on_file_diff(conn.host, result.diff)
+                    self.callbacks.on_file_diff(host, result.diff)
                 self.callbacks.on_ok(host, data)
 
         return result


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.0 (devel da6d15d1f9) last updated 2015/05/19 11:31:05 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 7dd9f57e16) last updated 2015/05/19 12:50:34 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 576d94e8d4) last updated 2015/05/19 12:50:39 (GMT -400)
  v2/ansible/modules/core: (detached HEAD 85c8a892c8) last updated 2015/05/19 12:50:42 (GMT -400)
  v2/ansible/modules/extras: (detached HEAD 70ea058563) last updated 2015/05/19 12:50:44 (GMT -400)
  configured module search path = None
```
##### Ansible Configuration:

N/A
##### Environment:

Ubuntu 14.04
##### Summary:

`runner_on_file_diff` uses a different value for `host` than `runner_on_ok` or `runner_on_failed`.

`runner_on_file_diff` uses `conn.host`, all others simply use `host`. What this means is that my callback plugin has to do more work to correlate the diff with the correct host. See the code diff for the very simple fix.
##### Steps To Reproduce:

inventory

```
[all]
some_name_here        ansible_ssh_host=localhost
```

playbook.yml

``` yaml

---
- hosts: all
  tasks:
      - template: src=test.j2 dest=/tmp/bugreport.txt
```

test.j2

``` jinja2
# {{ansible_managed}}
```

callback_plugins/bugreport.py

``` python
class CallbackModule(object):
    def runner_on_file_diff(self, host, diff):
        print("runner_on_file_diff", host)
    def runner_on_ok(self, host, res):
        print("runner_on_ok", host)
```

Run ansible:

```
ansible-playbook -i inventory play.yml --diff
```
##### Expected Results:

I expect the print value to show the same hostname for each callback. I also expect that value to be the one from the inventory file, not the one used for the `ansible_ssh_host` variable. E.g. for the given setup above I'd expect to see `some_name_here` for both.
##### Actual Results:

Instead what I end up seeing is `localhost` for the `runner_on_file_diff` callback, and `some_name_here` for the `runner_on_ok` callback. This pull request makes the very small change from `conn.host` to `host`, which then makes the callback act as expected.

```
TASK: [template src=test.j2 dest=/tmp/bugreport.txt] ************************** 
--- before
+++ after
@@ -0,0 +1 @@
+# Ansible managed: /tmp/ansible-test/test.j2 modified on 2015-05-19 12:57:28 by ubergeek42 on test

('runner_on_file_diff', 'localhost')
changed: [some_name_here]
('runner_on_ok', 'some_name_here')
```
