### PR TITLE
doc: we need GPLv3 license headers

### DIFF
--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -464,7 +464,7 @@ Module checklist
     * Requirements should  be documented, using the `requirements=[]` field
     * Author should be set, name and github id at least
     * Made use of U() for urls, C() for files and options, I() for params, M() for modules?
-    * GPL License header
+    * GPL 3 License header
     * Does module use check_mode? Could it be modified to use it? Document it
     * Examples: make sure they are reproducible
     * Return: document the return structure of the module


### PR DESCRIPTION
GPLv2 only headers are incompatible with GPLv3
