### PR TITLE
Include more info when a task fails

### DIFF
--- a/lib/ansible/callbacks.py
+++ b/lib/ansible/callbacks.py
@@ -487,6 +487,10 @@ class PlaybookRunnerCallbacks(DefaultRunnerCallbacks):
         stdout = results2.pop('stdout', None)
         returned_msg = results2.pop('msg', None)
 
+        results2['task'] = self.task.name
+        results2['role'] = self.task.role_name
+        results2['playbook'] = self.playbook.filename
+
         if item:
             msg = "failed: [%s] => (item=%s) => %s" % (host, item, utils.jsonify(results2))
         else:


### PR DESCRIPTION
Adds "playbook", "role", and "task" fields to the output when a task fails.

This makes it easier to pinpoint where the problem is, especially
when you have a lot of roles and playbooks.

e.g.:

```
failed: [vagrant] => {..."playbook": "/Users/marca/dev/ansible/vagrant.yml",
                      ..."role": "pythonapp",
                      ..."task": "pip install -r /opt/src/{{ sm_app_role }}/requirements.txt"...}
```

Cc: @sontek, @sudarkoff
