### PR TITLE
module_utils.basic: set LC_ALL=C in command_run()

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1479,8 +1479,9 @@ class AnsibleModule(object):
         msg = None
         st_in = None
 
-        # Set a temporart env path if a prefix is passed
         env=os.environ
+        env['LC_ALL'] = "C"
+        # Set a temporart env path if a prefix is passed
         if path_prefix:
             env['PATH']="%s:%s" % (path_prefix, env['PATH'])
 

--- a/v2/ansible/module_utils/basic.py
+++ b/v2/ansible/module_utils/basic.py
@@ -1448,8 +1448,9 @@ class AnsibleModule(object):
         msg = None
         st_in = None
 
-        # Set a temporary env path if a prefix is passed
         env=os.environ
+        env['LC_ALL'] = "C"
+        # Set a temporary env path if a prefix is passed
         if path_prefix:
             env['PATH']="%s:%s" % (path_prefix, env['PATH'])
 


### PR DESCRIPTION
Instead of passing the env into the command_run(), it should be defaulted to LC_ALL=C.
Closes https://github.com/ansible/ansible-modules-extras/pull/529
