### PR TITLE
Avoid too broad except in Inventory

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -105,19 +105,18 @@ class Inventory(object):
                 # class we can show a more apropos error
                 shebang_present = False
                 try:
-                    inv_file = open(host_list)
-                    first_line = inv_file.readlines()[0]
-                    inv_file.close()
-                    if first_line.startswith('#!'):
-                        shebang_present = True
-                except:
+                    with open(host_list, "r") as inv_file:
+                        first_line = inv_file.readline()
+                        if first_line.startswith("#!"):
+                            shebang_present = True
+                except IOError:
                     pass
 
                 if utils.is_executable(host_list):
                     try:
                         self.parser = InventoryScript(filename=host_list)
                         self.groups = self.parser.groups.values()
-                    except:
+                    except errors.AnsibleError:
                         if not shebang_present:
                             raise errors.AnsibleError("The file %s is marked as executable, but failed to execute correctly. " % host_list + \
                                                       "If this is not supposed to be an executable script, correct this with `chmod -x %s`." % host_list)
@@ -127,7 +126,7 @@ class Inventory(object):
                     try:
                         self.parser = InventoryParser(filename=host_list)
                         self.groups = self.parser.groups.values()
-                    except:
+                    except errors.AnsibleError:
                         if shebang_present:
                             raise errors.AnsibleError("The file %s looks like it should be an executable inventory script, but is not marked executable. " % host_list + \
                                                       "Perhaps you want to correct this with `chmod +x %s`?" % host_list)


### PR DESCRIPTION
Capture only IOError when reading shebang from inventory file, to avoid ignoring other possible exceptions like timeouts from a task.
We are using Celery to manage different tasks and if eventually a task times out at this part of the code, it will not rollback as expected and will keep on executing the rest of the code, leading it to a hard timeout
