### PR TITLE
safe_item filter plugin to safely get from deep dicts

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -95,6 +95,20 @@ Jinja2 provides a useful 'default' filter, that is often a better approach to fa
 In the above example, if the variable 'some_variable' is not defined, the value used will be 5, rather than an error
 being raised.
 
+Defaulting Undefined Variables in Deep Expressions
+--------------------------------------------------
+
+Ansible provides a filter for a more complex case, where one wishes to set a default value for an expression such as::
+
+    {{ some.deep.item.in.object }}
+
+In this case, the 'default' value will still fail if the parent objects ('some', 'deep', 'item', 'in') are undefined.
+To do this safely::
+
+    {{ some | safe_item('deep.item.in.object', 'default_value') }}
+    {{ some | safe_item(['deep', 'item', 'in', 'object'])}}
+
+If 'default_value' is omitted, the filter returns null.
 
 .. _omitting_undefined_variables:
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -40,6 +40,7 @@ import uuid
 
 import yaml
 from jinja2.filters import environmentfilter
+from jinja2.runtime import StrictUndefined
 from distutils.version import LooseVersion, StrictVersion
 from ansible.compat.six import iteritems, string_types
 
@@ -176,6 +177,19 @@ def version_compare(value, version, operator='eq', strict=False):
 def regex_escape(string):
     '''Escape all regular expressions special characters from STRING.'''
     return re.escape(string)
+
+def safe_item(d, items, default=None):
+    try:
+        value = d
+        if isinstance(items, basestring):
+            items = items.split('.')
+        for item in items:
+            value = value.get(item, default)
+        if isinstance(value, StrictUndefined):
+            return default
+        return value
+    except:
+        return default
 
 @environmentfilter
 def rand(environment, end, start=None, step=None):
@@ -436,4 +450,5 @@ class FilterModule(object):
 
             # array and dict lookups
             'extract': extract,
+            'safe_item': safe_item,
         }


### PR DESCRIPTION
It's currently very hard to use values from possibly nested dicts where each component can be undefined.

Example expression: `ansible_local.my_fact_file.my_fact`.

Using `default` or `is defined` will still fail if `ansible_local` or `my_fact_file` are undefined. My filter allows one to do this:

`ansible_local | safe_item('my_fact_file.my_fact')`

And not throw an error if any of these values are undefined or isn't a dictionary. A custom default value can be passed:

`ansible_local | safe_item('my_fact_file.my_fact', 'default')`

And the string expression can be expressed more safely as a list:

`ansible_local | safe_item(['my_fact_file', 'my_fact'], 'default')`
