### PR TITLE
Only run win_feature tests when the host has the ServerManager module.

### DIFF
--- a/test/integration/roles/test_win_feature/tasks/main.yml
+++ b/test/integration/roles/test_win_feature/tasks/main.yml
@@ -17,10 +17,16 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 
+- name: check whether servermanager module is available (windows 2008 r2 or later)
+  raw: PowerShell -Command Import-Module ServerManager
+  register: win_feature_has_servermanager
+  ignore_errors: true
+
 - name: start with feature absent
   win_feature:
     name: "{{ test_win_feature_name }}"
     state: absent
+  when: win_feature_has_servermanager|success
 
 - name: install feature
   win_feature:
@@ -30,6 +36,7 @@
     include_sub_features: yes
     include_management_tools: yes
   register: win_feature_install_result
+  when: win_feature_has_servermanager|success
 
 - name: check result of installing feature
   assert:
@@ -45,6 +52,7 @@
       - "win_feature_install_result.feature_result[0].restart_needed is defined"
       - "win_feature_install_result.feature_result[0].skip_reason"
       - "win_feature_install_result.feature_result[0].success is defined"
+  when: win_feature_has_servermanager|success
 
 - name: install feature again
   win_feature:
@@ -54,6 +62,7 @@
     include_sub_features: yes
     include_management_tools: yes
   register: win_feature_install_again_result
+  when: win_feature_has_servermanager|success
 
 - name: check result of installing feature again
   assert:
@@ -63,12 +72,14 @@
       - "win_feature_install_again_result.exitcode == 'NoChangeNeeded'"
       - "not win_feature_install_again_result.restart_needed"
       - "win_feature_install_again_result.feature_result == []"
+  when: win_feature_has_servermanager|success
 
 - name: remove feature
   win_feature:
     name: "{{ test_win_feature_name }}"
     state: absent
   register: win_feature_remove_result
+  when: win_feature_has_servermanager|success
 
 - name: check result of removing feature
   assert:
@@ -84,12 +95,14 @@
       - "win_feature_remove_result.feature_result[0].restart_needed is defined"
       - "win_feature_remove_result.feature_result[0].skip_reason"
       - "win_feature_remove_result.feature_result[0].success is defined"
+  when: win_feature_has_servermanager|success
 
 - name: remove feature again
   win_feature:
     name: "{{ test_win_feature_name }}"
     state: absent
   register: win_feature_remove_again_result
+  when: win_feature_has_servermanager|success
 
 - name: check result of removing feature again
   assert:
@@ -99,6 +112,7 @@
       - "win_feature_remove_again_result.exitcode == 'NoChangeNeeded'"
       - "not win_feature_remove_again_result.restart_needed"
       - "win_feature_remove_again_result.feature_result == []"
+  when: win_feature_has_servermanager|success
 
 - name: try to install an invalid feature name
   win_feature:
@@ -106,6 +120,7 @@
     state: present
   register: win_feature_install_invalid_result
   ignore_errors: true
+  when: win_feature_has_servermanager|success
 
 - name: check result of installing invalid feature name
   assert:
@@ -114,6 +129,7 @@
       - "not win_feature_install_invalid_result|changed"
       - "win_feature_install_invalid_result.msg"
       - "win_feature_install_invalid_result.exitcode == 'InvalidArgs'"
+  when: win_feature_has_servermanager|success
 
 - name: try to remove an invalid feature name
   win_feature:
@@ -121,6 +137,7 @@
     state: absent
   register: win_feature_remove_invalid_result
   ignore_errors: true
+  when: win_feature_has_servermanager|success
 
 - name: check result of removing invalid feature name
   assert:
@@ -129,3 +146,4 @@
       - "not win_feature_remove_invalid_result|changed"
       - "win_feature_remove_invalid_result.msg"
       - "win_feature_remove_invalid_result.exitcode == 'InvalidArgs'"
+  when: win_feature_has_servermanager|success


### PR DESCRIPTION
Skips remaining win_feature tests on unsupported OS versions (e.g. Windows Server 2008 non-R2).
