### PR TITLE
Minor tweaks to winrm integration tests

### DIFF
--- a/test/integration/roles/prepare_win_tests/meta/main.yml
+++ b/test/integration/roles/prepare_win_tests/meta/main.yml
@@ -1,0 +1,3 @@
+---
+
+allow_duplicates: yes

--- a/test/integration/test_winrm.yml
+++ b/test/integration/test_winrm.yml
@@ -18,6 +18,7 @@
 
 - hosts: windows
   gather_facts: false
+  max_fail_percentage: 1
   roles: 
     - { role: test_win_raw, tags: test_win_raw }
     - { role: test_win_script, tags: test_win_script }


### PR DESCRIPTION
- Allow prepare_win_tests role to run multiple times.
- Fail play when any host fails.
