### PR TITLE
Part fix for https://github.com/ansible/ansible-modules-core/issues/1404 (replaces #11086)

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -151,7 +151,7 @@ Function Get-FileChecksum($path)
     {
         $sp = new-object -TypeName System.Security.Cryptography.SHA1CryptoServiceProvider;
         $fp = [System.IO.File]::Open($path, [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read);
-        [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
+        $hash = [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
         $fp.Dispose();
     }
     ElseIf (Test-Path -PathType Container $path)

--- a/test/integration/roles/test_win_copy/tasks/main.yml
+++ b/test/integration/roles/test_win_copy/tasks/main.yml
@@ -62,7 +62,7 @@
 - name: verify that the file checksum is correct
   assert: 
     that: 
-      - "copy_result.checksum[0] == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'"
+      - "copy_result.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'"
 
 - name: check the stat results of the file
   win_stat: path={{output_file}}
@@ -78,7 +78,7 @@
 #      - "stat_results.stat.isfifo == false"
 #      - "stat_results.stat.isreg == true"
 #      - "stat_results.stat.issock == false"
-      - "stat_results.stat.checksum[0] == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'"
+      - "stat_results.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'"
 
 - name: overwrite the file via same means
   win_copy: src=foo.txt dest={{output_file}}


### PR DESCRIPTION
Replacement for previous attempt at this https://github.com/ansible/ansible/pull/11086 which accidentally included some unwanted changes.

Get-FileChecksum always returns a string now and the test_win_copy integration tests that depend on the checksum
have been updated in this change too.

Also requires https://github.com/ansible/ansible-modules-core/pull/1438
