### PR TITLE
Use a decorator to perform just in time connection

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -210,7 +210,6 @@ class TaskExecutor:
         # get the connection and the handler for this execution
         self._connection = self._get_connection(variables)
         self._connection.set_host_overrides(host=self._host)
-        self._connection._connect()
 
         self._handler = self._get_action_handler(connection=self._connection, templar=templar)
 

--- a/lib/ansible/plugins/connections/__init__.py
+++ b/lib/ansible/plugins/connections/__init__.py
@@ -92,16 +92,19 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
         """Connect to the host we've been initialized with"""
         pass
 
+    @ensure_connect
     @abstractmethod
     def exec_command(self, cmd, tmp_path, executable=None, in_data=None):
         """Run a command on the remote host"""
         pass
 
+    @ensure_connect
     @abstractmethod
     def put_file(self, in_path, out_path):
         """Transfer a file from local to remote"""
         pass
 
+    @ensure_connect
     @abstractmethod
     def fetch_file(self, in_path, out_path):
         """Fetch a file from remote to local"""

--- a/lib/ansible/plugins/connections/__init__.py
+++ b/lib/ansible/plugins/connections/__init__.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 
+from functools import wraps
 from six import with_metaclass
 
 from ansible import constants as C
@@ -32,7 +33,16 @@ from ansible.errors import AnsibleError
 #        which may want to output display/logs too
 from ansible.utils.display import Display
 
-__all__ = ['ConnectionBase']
+__all__ = ['ConnectionBase', 'ensure_connect']
+
+
+def ensure_connect(func):
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        self._connect()
+        return func(self, *args, **kwargs)
+    return wrapped
+
 
 class ConnectionBase(with_metaclass(ABCMeta, object)):
     '''

--- a/lib/ansible/plugins/connections/local.py
+++ b/lib/ansible/plugins/connections/local.py
@@ -49,6 +49,8 @@ class Connection(ConnectionBase):
     def exec_command(self, cmd, tmp_path, executable='/bin/sh', in_data=None):
         ''' run a command on the local host '''
 
+        super(Connection, self).exec_command(cmd, tmp_path, executable=executable, in_data=in_data)
+
         debug("in local.exec_command()")
         # su requires to be run from a terminal, and therefore isn't supported here (yet?)
         #if self._connection_info.su:
@@ -108,6 +110,8 @@ class Connection(ConnectionBase):
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to local '''
 
+        super(Connection, self).put_file(in_path, out_path)
+
         #vvv("PUT {0} TO {1}".format(in_path, out_path), host=self.host)
         self._display.vvv("{0} PUT {1} TO {2}".format(self._connection_info.remote_addr, in_path, out_path))
         if not os.path.exists(in_path):
@@ -123,6 +127,9 @@ class Connection(ConnectionBase):
 
     def fetch_file(self, in_path, out_path):
         ''' fetch a file from local to local -- for copatibility '''
+
+        super(Connection, self).fetch_file(in_path, out_path)
+
         #vvv("FETCH {0} TO {1}".format(in_path, out_path), host=self.host)
         self._display.vvv("{0} FETCH {1} TO {2}".format(self._connection_info.remote_addr, in_path, out_path))
         self.put_file(in_path, out_path)

--- a/lib/ansible/plugins/connections/paramiko_ssh.py
+++ b/lib/ansible/plugins/connections/paramiko_ssh.py
@@ -41,7 +41,7 @@ from binascii import hexlify
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.plugins.connections import ConnectionBase, ensure_connect
+from ansible.plugins.connections import ConnectionBase
 from ansible.utils.path import makedirs_safe
 
 AUTHENTICITY_MSG="""
@@ -189,9 +189,10 @@ class Connection(ConnectionBase):
 
         return ssh
 
-    @ensure_connect
     def exec_command(self, cmd, tmp_path, executable='/bin/sh', in_data=None):
         ''' run a command on the remote host '''
+
+        super(Connection, self).exec_command(cmd, tmp_path, executable=executable, in_data=in_data)
 
         if in_data:
             raise AnsibleError("Internal Error: this module does not support optimized module pipelining")
@@ -250,9 +251,10 @@ class Connection(ConnectionBase):
 
         return (chan.recv_exit_status(), '', no_prompt_out + stdout, no_prompt_out + stderr)
 
-    @ensure_connect
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''
+
+        super(Connection, self).put_file(in_path, out_path)
 
         self._display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._connection_info.remote_addr)
 
@@ -278,9 +280,10 @@ class Connection(ConnectionBase):
             result = SFTP_CONNECTION_CACHE[cache_key] = self._connect().ssh.open_sftp()
             return result
 
-    @ensure_connect
     def fetch_file(self, in_path, out_path):
         ''' save a remote file to the specified path '''
+
+        super(Connection, self).fetch_file(in_path, out_path)
 
         self._display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self._connection_info.remote_addr)
 

--- a/lib/ansible/plugins/connections/paramiko_ssh.py
+++ b/lib/ansible/plugins/connections/paramiko_ssh.py
@@ -41,7 +41,7 @@ from binascii import hexlify
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.plugins.connections import ConnectionBase
+from ansible.plugins.connections import ConnectionBase, ensure_connect
 from ansible.utils.path import makedirs_safe
 
 AUTHENTICITY_MSG="""
@@ -60,6 +60,7 @@ with warnings.catch_warnings():
         logging.getLogger("paramiko").setLevel(logging.WARNING)
     except ImportError:
         pass
+
 
 class MyAddPolicy(object):
     """
@@ -188,6 +189,7 @@ class Connection(ConnectionBase):
 
         return ssh
 
+    @ensure_connect
     def exec_command(self, cmd, tmp_path, executable='/bin/sh', in_data=None):
         ''' run a command on the remote host '''
 
@@ -248,6 +250,7 @@ class Connection(ConnectionBase):
 
         return (chan.recv_exit_status(), '', no_prompt_out + stdout, no_prompt_out + stderr)
 
+    @ensure_connect
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''
 
@@ -272,9 +275,10 @@ class Connection(ConnectionBase):
         if cache_key in SFTP_CONNECTION_CACHE:
             return SFTP_CONNECTION_CACHE[cache_key]
         else:
-            result = SFTP_CONNECTION_CACHE[cache_key] = self.connect().ssh.open_sftp()
+            result = SFTP_CONNECTION_CACHE[cache_key] = self._connect().ssh.open_sftp()
             return result
 
+    @ensure_connect
     def fetch_file(self, in_path, out_path):
         ''' save a remote file to the specified path '''
 

--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -34,7 +34,8 @@ from hashlib import sha1
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.plugins.connections import ConnectionBase
+from ansible.plugins.connections import ConnectionBase, ensure_connect
+
 
 class Connection(ConnectionBase):
     ''' ssh based connections '''
@@ -269,6 +270,7 @@ class Connection(ConnectionBase):
             self._display.vvv("EXEC previous known host file not found for {0}".format(host))
         return True
 
+    @ensure_connect
     def exec_command(self, cmd, tmp_path, executable='/bin/sh', in_data=None):
         ''' run a command on the remote host '''
 
@@ -390,6 +392,7 @@ class Connection(ConnectionBase):
 
         return (p.returncode, '', no_prompt_out + stdout, no_prompt_err + stderr)
 
+    @ensure_connect
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''
         self._display.vvv("PUT {0} TO {1}".format(in_path, out_path), host=self._connection_info.remote_addr)
@@ -425,6 +428,7 @@ class Connection(ConnectionBase):
         if returncode != 0:
             raise AnsibleError("failed to transfer file to {0}:\n{1}\n{2}".format(out_path, stdout, stderr))
 
+    @ensure_connect
     def fetch_file(self, in_path, out_path):
         ''' fetch a file from remote to local '''
         self._display.vvv("FETCH {0} TO {1}".format(in_path, out_path), host=self._connection_info.remote_addr)

--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -34,7 +34,7 @@ from hashlib import sha1
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.plugins.connections import ConnectionBase, ensure_connect
+from ansible.plugins.connections import ConnectionBase
 
 
 class Connection(ConnectionBase):
@@ -270,9 +270,10 @@ class Connection(ConnectionBase):
             self._display.vvv("EXEC previous known host file not found for {0}".format(host))
         return True
 
-    @ensure_connect
     def exec_command(self, cmd, tmp_path, executable='/bin/sh', in_data=None):
         ''' run a command on the remote host '''
+
+        super(Connection, self).exec_command(cmd, tmp_path, executable=executable, in_data=in_data)
 
         ssh_cmd = self._password_cmd()
         ssh_cmd += ("ssh", "-C")
@@ -392,9 +393,11 @@ class Connection(ConnectionBase):
 
         return (p.returncode, '', no_prompt_out + stdout, no_prompt_err + stderr)
 
-    @ensure_connect
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''
+
+        super(Connection, self).put_file(in_path, out_path)
+
         self._display.vvv("PUT {0} TO {1}".format(in_path, out_path), host=self._connection_info.remote_addr)
         if not os.path.exists(in_path):
             raise AnsibleFileNotFound("file or module does not exist: {0}".format(in_path))
@@ -428,9 +431,11 @@ class Connection(ConnectionBase):
         if returncode != 0:
             raise AnsibleError("failed to transfer file to {0}:\n{1}\n{2}".format(out_path, stdout, stderr))
 
-    @ensure_connect
     def fetch_file(self, in_path, out_path):
         ''' fetch a file from remote to local '''
+
+        super(Connection, self).fetch_file(in_path, out_path)
+
         self._display.vvv("FETCH {0} TO {1}".format(in_path, out_path), host=self._connection_info.remote_addr)
         cmd = self._password_cmd()
 

--- a/lib/ansible/plugins/connections/winrm.py
+++ b/lib/ansible/plugins/connections/winrm.py
@@ -42,9 +42,10 @@ except ImportError:
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.plugins.connections import ConnectionBase
+from ansible.plugins.connections import ConnectionBase, ensure_connect
 from ansible.plugins import shell_loader
 from ansible.utils.path import makedirs_safe
+
 
 class Connection(ConnectionBase):
     '''WinRM connections over HTTP/HTTPS.'''
@@ -151,6 +152,7 @@ class Connection(ConnectionBase):
             self.protocol = self._winrm_connect()
         return self
 
+    @ensure_connect
     def exec_command(self, cmd, tmp_path, executable='/bin/sh', in_data=None):
 
         cmd = cmd.encode('utf-8')
@@ -172,6 +174,7 @@ class Connection(ConnectionBase):
             raise AnsibleError("failed to exec cmd %s" % cmd)
         return (result.status_code, '', result.std_out.encode('utf-8'), result.std_err.encode('utf-8'))
 
+    @ensure_connect
     def put_file(self, in_path, out_path):
         self._display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._connection_info.remote_addr)
         if not os.path.exists(in_path):
@@ -210,6 +213,7 @@ class Connection(ConnectionBase):
                     traceback.print_exc()
                     raise AnsibleError("failed to transfer file to %s" % out_path)
 
+    @ensure_connect
     def fetch_file(self, in_path, out_path):
         out_path = out_path.replace('\\', '/')
         self._display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self._connection_info.remote_addr)

--- a/lib/ansible/plugins/connections/winrm.py
+++ b/lib/ansible/plugins/connections/winrm.py
@@ -42,7 +42,7 @@ except ImportError:
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.plugins.connections import ConnectionBase, ensure_connect
+from ansible.plugins.connections import ConnectionBase
 from ansible.plugins import shell_loader
 from ansible.utils.path import makedirs_safe
 
@@ -152,8 +152,8 @@ class Connection(ConnectionBase):
             self.protocol = self._winrm_connect()
         return self
 
-    @ensure_connect
     def exec_command(self, cmd, tmp_path, executable='/bin/sh', in_data=None):
+        super(Connection, self).exec_command(cmd, tmp_path, executable=executable, in_data,in_data)
 
         cmd = cmd.encode('utf-8')
         cmd_parts = shlex.split(cmd, posix=False)
@@ -174,8 +174,9 @@ class Connection(ConnectionBase):
             raise AnsibleError("failed to exec cmd %s" % cmd)
         return (result.status_code, '', result.std_out.encode('utf-8'), result.std_err.encode('utf-8'))
 
-    @ensure_connect
     def put_file(self, in_path, out_path):
+        super(Connection, self).put_file(in_path, out_path)
+
         self._display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._connection_info.remote_addr)
         if not os.path.exists(in_path):
             raise AnsibleFileNotFound("file or module does not exist: %s" % in_path)
@@ -213,8 +214,9 @@ class Connection(ConnectionBase):
                     traceback.print_exc()
                     raise AnsibleError("failed to transfer file to %s" % out_path)
 
-    @ensure_connect
     def fetch_file(self, in_path, out_path):
+        super(Connection, self).fetch_file(in_path, out_path)
+
         out_path = out_path.replace('\\', '/')
         self._display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self._connection_info.remote_addr)
         buffer_size = 2**19 # 0.5MB chunks


### PR DESCRIPTION
Copy of #11002 now against the devel branch

This PR adds a new ensure_connect decorator for connection plugins. It's function is to decorate a method requiring a connection to be open. The replaces the explicit call to _connect.

WHY: Calling _connect explicitly as it is, causes the connection plugin to connect to a remote host, sometimes needlessly such as when running an action plugin that does not need a connection, such as set_fact.

This change will ensure that a connection is not forcefully established when not needed, but still establish it just in time for the operation.

The following connection plugins have been updated due to them being ready for v2:
- ssh
- paramiko
- winrm

Additional plugins will need to have this decorator applied to exec_command, put_file and fetch_file.

I've tested a handful of scenarios and did not encounter any issues.

Addresses #10997
