### PR TITLE
Fix command building for scp if ssh

### DIFF
--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -407,12 +407,12 @@ class Connection(ConnectionBase):
 
         if C.DEFAULT_SCP_IF_SSH:
             cmd.append('scp')
-            cmd += self._common_args
-            cmd.append(in_path,host + ":" + pipes.quote(out_path))
+            cmd.extend(self._common_args)
+            cmd.extend([in_path, '{0}:{1}'.format(host, pipes.quote(out_path))])
             indata = None
         else:
             cmd.append('sftp')
-            cmd += self._common_args
+            cmd.extend(self._common_args)
             cmd.append(host)
             indata = "put {0} {1}\n".format(pipes.quote(in_path), pipes.quote(out_path))
 
@@ -440,12 +440,12 @@ class Connection(ConnectionBase):
 
         if C.DEFAULT_SCP_IF_SSH:
             cmd.append('scp')
-            cmd += self._common_args
-            cmd += ('{0}:{1}'.format(host, in_path), out_path)
+            cmd.extend(self._common_args)
+            cmd.extend(['{0}:{1}'.format(host, in_path), out_path])
             indata = None
         else:
             cmd.append('sftp')
-            cmd += self._common_args
+            cmd.extend(self._common_args)
             cmd.append(host)
             indata = "get {0} {1}\n".format(in_path, out_path)
 


### PR DESCRIPTION
Currently with `scp_if_ssh` set to `True` you will get the following traceback:

```
Traceback (most recent call last):
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/executor/process/worker.py", line 118, in run
    executor_result = TaskExecutor(host, task, job_vars, new_connection_info, self._new_stdin, self._loader, shared_loader_obj).run()
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/executor/task_executor.py", line 107, in run
    res = self._execute()
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/executor/task_executor.py", line 263, in _execute
    result = self._handler.run(task_vars=variables)
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/plugins/action/normal.py", line 27, in run
    return self._execute_module(tmp)
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/plugins/action/__init__.py", line 355, in _execute_module
    self._transfer_data(remote_module_path, module_data)
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/plugins/action/__init__.py", line 221, in _transfer_data
    self._connection.put_file(afile, remote_path)
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/plugins/connections/ssh.py", line 411, in put_file
    cmd.append(in_path,host + ":" + pipes.quote(out_path))
TypeError: append() takes exactly one argument (2 given)
```

This PR fixes this by error and additionally, normalizes "appending" to the command.
