### PR TITLE
Don't override ansible_ssh_host with inventory_hostname

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -371,7 +371,6 @@ class TaskExecutor:
         # FIXME: delegate_to calculation should be done here
         # FIXME: calculation of connection params/auth stuff should be done here
 
-        self._connection_info.remote_addr = self._host.ipv4_address
         if self._task.delegate_to is not None:
             self._compute_delegate(variables)
 


### PR DESCRIPTION
This PR addresses #11130 

It seems that this line was added before ConnectionInformation was fully functional, and does not appear to be needed any longer. 
