### PR TITLE
Add missing import in ansible.cli

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -33,6 +33,7 @@ from ansible import __version__
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.utils.unicode import to_bytes
+from ansible.utils.display import Display
 
 class SortedOptParser(optparse.OptionParser):
     '''Optparser which sorts the options by opt before outputting --help'''


### PR DESCRIPTION
This PR adds a missing import in `ansible.cli`.

If `display` is `None` in the `CLI` class, display will need to be initialized with `Display` which hasn't been imported
