### PR TITLE
If remote_addr isn't set, set to ipv4_address

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -371,6 +371,9 @@ class TaskExecutor:
         # FIXME: delegate_to calculation should be done here
         # FIXME: calculation of connection params/auth stuff should be done here
 
+        if not self._connection_info.remote_addr:
+            self._connection_info.remote_addr = self._host.ipv4_address
+
         if self._task.delegate_to is not None:
             self._compute_delegate(variables)
 


### PR DESCRIPTION
I wasn't able to previously determine what exactly the re-assignment to the `ipv4_address` was needed for.

After more playing, it seems there are some circumstances where `remote_addr` is not set, and should be set to the `ipv4_address`.

This PR adds the line back in, but under an if statement to first check if it is not set.
