### PR TITLE
Fix for task_executor on OS X

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -380,7 +380,7 @@ class TaskExecutor:
         conn_type = self._connection_info.connection
         if conn_type == 'smart':
             conn_type = 'ssh'
-            if sys.platform.startswith('darwin') and self._connection_info.remote_pass:
+            if sys.platform.startswith('darwin') and self._connection_info.password:
                 # due to a current bug in sshpass on OSX, which can trigger
                 # a kernel panic even for non-privileged users, we revert to
                 # paramiko on that OS when a SSH password is specified


### PR DESCRIPTION
I get this exception during the setup task:

AttributeError: 'ConnectionInformation' object has no attribute 'remote_pass'

I believe it is supposed to be looking at the password attribute. Either that
or we should create a remote_pass attribute in ConnectionInformation.
