### PR TITLE
Import missing MutableMapping class for module_docs

### DIFF
--- a/lib/ansible/utils/module_docs.py
+++ b/lib/ansible/utils/module_docs.py
@@ -23,6 +23,7 @@ import ast
 import yaml
 import traceback
 
+from collections import MutableMapping
 from ansible.plugins import fragment_loader
 
 # modules that are ok that they do not have documentation strings


### PR DESCRIPTION
Currently building the docs is failing right now due to a missing import:

```
Traceback (most recent call last):
  File "/home/sivel/.virtualenvs/ansible/ansible/lib/ansible/utils/module_docs.py", line 89, in get_docstring
    if isinstance(doc[key], MutableMapping):
NameError: global name 'MutableMapping' is not defined
```

This PR addresses this by importing `MutableMapping`.
