### PR TITLE
ansible_mount_<mount> facts in addition to array of mounts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -889,6 +889,22 @@ class LinuxHardware(Hardware):
                          'uuid': uuid,
                          })
 
+                    if (fields[1] == '/'):
+                        mount_name = "_root"
+                    else:
+                        mount_name = fields[1].replace('/','_')
+
+                    self.facts['mount' + mount_name] = {
+                         'mount': fields[1],
+                         'device':fields[0],
+                         'fstype': fields[2],
+                         'options': fields[3],
+                         # statvfs data
+                         'size_total': size_total,
+                         'size_available': size_available,
+                         'uuid': uuid,
+                         }
+
     def get_device_facts(self):
         self.facts['devices'] = {}
         lspci = module.get_bin_path('lspci')


### PR DESCRIPTION
This change adds enumerated ansible_mount_<mountpoint> with one special case for / as "root" It does not change the existing ansible_mounts array based on the assumption that someone is already using the other facts as they are today.

This allows direct selection of a mount by name instead of looping over the list of all mounted filesystems to find the desired mount.

```
        "ansible_mount_orahome": {
        "device": "/dev/mapper/vg-lv_orahome", 
        "fstype": "ext4", 
        "mount": "/orahome", 
        "options": "rw", 
        "size_available": 200443834368, 
        "size_total": 211378954240, 
        "uuid": ""
    }, 
    "ansible_mount_root": {
        "device": "/dev/mapper/vg-lv_root", 
        "fstype": "ext4", 
        "mount": "/", 
        "options": "rw", 
        "size_available": 10591088640, 
        "size_total": 15919398912, 
        "uuid": ""
    }, 
```

Full example output before and after  https://gist.github.com/shawnferry/0c0cb623495e1f6bc715
