### PR TITLE
Fix lookup() plugin

### DIFF
--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -53,7 +53,7 @@ class LookupModule(LookupBase):
 
             for path in (basedir_path, relative_path, playbook_path):
                 try:
-                    contents = self._loader._get_file_contents(path)
+                    contents, show_data = self._loader._get_file_contents(path)
                     ret.append(contents.rstrip())
                     break
                 except AnsibleParserError:


### PR DESCRIPTION
lookup() plugin is currently broken because _get_file_contents() now
returns a tuple: (contents, show_data).

This patch fix that issue.
