### PR TITLE
Don't check for existence of failed key, check it's value. Fixes #11172

### DIFF
--- a/lib/ansible/plugins/strategies/__init__.py
+++ b/lib/ansible/plugins/strategies/__init__.py
@@ -149,7 +149,7 @@ class StrategyBase:
                     task_result = result[1]
                     host = task_result._host
                     task = task_result._task
-                    if result[0] == 'host_task_failed' or 'failed' in task_result._result:
+                    if result[0] == 'host_task_failed' or task_result._result.get('failed', False):
                         if not task.ignore_errors:
                             debug("marking %s as failed" % host.name)
                             iterator.mark_host_failed(host)


### PR DESCRIPTION
This PR addresses #11172 

Instead of just checking if the key `failed` is in the result, check the actual value of `failed`.
