### PR TITLE
Don't empty out become_pass. See #11169

### DIFF
--- a/lib/ansible/executor/connection_info.py
+++ b/lib/ansible/executor/connection_info.py
@@ -109,8 +109,6 @@ class ConnectionInformation:
             self.become_method = play.become_method
         if play.become_user:
             self.become_user   = play.become_user
-        if play.become_pass:
-            self.become_pass   = play.become_pass
 
         # non connection related
         self.no_log      = play.no_log

--- a/lib/ansible/executor/connection_info.py
+++ b/lib/ansible/executor/connection_info.py
@@ -109,7 +109,8 @@ class ConnectionInformation:
             self.become_method = play.become_method
         if play.become_user:
             self.become_user   = play.become_user
-        self.become_pass   = play.become_pass
+        if play.become_pass:
+            self.become_pass   = play.become_pass
 
         # non connection related
         self.no_log      = play.no_log
@@ -132,7 +133,6 @@ class ConnectionInformation:
         self.become        = options.become
         self.become_method = options.become_method
         self.become_user   = options.become_user
-        self.become_pass   = ''
 
         # general flags (should we move out?)
         if options.verbosity:


### PR DESCRIPTION
This PR ensures that the `become_pass` supplied via the CLI (prompt) does not get emptied out.

become_pass is not part of `options` so we don't need to try to set it in `set_options`, and only set it from the play if it is actually set.

There is still more work to do to solve #11169, but this is a start.
