### PR TITLE
Get tests passing

### DIFF
--- a/test/units/plugins/strategies/test_strategy_base.py
+++ b/test/units/plugins/strategies/test_strategy_base.py
@@ -55,15 +55,15 @@ class TestStrategyBase(unittest.TestCase):
 
         mock_conn_info = MagicMock()
 
-        mock_tqm._failed_hosts = []
-        mock_tqm._unreachable_hosts = []
+        mock_tqm._failed_hosts = dict()
+        mock_tqm._unreachable_hosts = dict()
         strategy_base = StrategyBase(tqm=mock_tqm)
 
-	self.assertEqual(strategy_base.run(iterator=mock_iterator, connection_info=mock_conn_info), 0)
+        self.assertEqual(strategy_base.run(iterator=mock_iterator, connection_info=mock_conn_info), 0)
         self.assertEqual(strategy_base.run(iterator=mock_iterator, connection_info=mock_conn_info, result=False), 1)
-        mock_tqm._failed_hosts = ["host1"]
+        mock_tqm._failed_hosts = dict(host1=True)
         self.assertEqual(strategy_base.run(iterator=mock_iterator, connection_info=mock_conn_info, result=False), 2)
-        mock_tqm._unreachable_hosts = ["host1"]
+        mock_tqm._unreachable_hosts = dict(host1=True)
         self.assertEqual(strategy_base.run(iterator=mock_iterator, connection_info=mock_conn_info, result=False), 3)
 
     def test_strategy_base_get_hosts(self):


### PR DESCRIPTION
The largest failure in the tests was due to selinux not being installed.
The tests don't require it to be installed, so mock the import.

This PR is likely to fail, due to the fix needed in #11186 

However, in my earlier test, here is the success: https://travis-ci.org/sivel/ansible/jobs/65631561

Additional fixes:
1. use the correct data type for `_failed_hosts` and `_unreachable_hosts`
1. use the correct fixture data when comparing distributions
