### PR TITLE
Add missing import in vault.py

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -25,6 +25,7 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.parsing.vault import VaultEditor
 from ansible.cli import CLI
 from ansible.utils.display import Display
+from ansible.utils.vault import read_vault_file
 
 class VaultCLI(CLI):
     """ Vault command line class """


### PR DESCRIPTION
This PR adds a missing import `read_vault_file` to fix the following error:

``` shell
$ ansible-vault encrypt --vault-password-file vault-password secrets.vault.yml
Traceback (most recent call last):
  File "/home/edward/git/ansible/bin/ansible-vault", line 66, in <module>
    sys.exit(cli.run())
  File "/home/edward/git/ansible/lib/ansible/cli/vault.py", line 74, in run
    self.vault_pass = read_vault_file(self.options.vault_password_file)
NameError: global name 'read_vault_file' is not defined
```
