### PR TITLE
Raise AnsibleParserError instead of AssertionError

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -36,7 +36,8 @@ def load_list_of_blocks(ds, play, parent_block=None, role=None, task_include=Non
     # we import here to prevent a circular dependency with imports
     from ansible.playbook.block import Block
 
-    assert ds is None or isinstance(ds, list), 'block has bad type: %s' % type(ds)
+    if not isinstance(ds, (list, type(None))):
+        raise AnsibleParserError('block has bad type: "%s". Expecting "list"' % type(ds).__name__, obj=ds)
 
     block_list = []
     if ds:
@@ -67,12 +68,13 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
     from ansible.playbook.handler import Handler
     from ansible.playbook.task import Task
 
-    assert isinstance(ds, list), 'task has bad type: %s' % type(ds)
+    if not isinstance(ds, list):
+        raise AnsibleParserError('task has bad type: "%s". Expected "list"' % type(ds).__name__, obj=ds)
 
     task_list = []
     for task in ds:
         if not isinstance(task, dict):
-            raise AnsibleParserError("task/handler entries must be dictionaries (got a %s)" % type(task), obj=ds)
+            raise AnsibleParserError('task/handler has bad type: "%s". Expected "dict"' % type(task).__name__, obj=task)
 
         if 'block' in task:
             t = Block.load(
@@ -105,7 +107,8 @@ def load_list_of_roles(ds, current_role_path=None, variable_manager=None, loader
     # we import here to prevent a circular dependency with imports
     from ansible.playbook.role.include import RoleInclude
 
-    assert isinstance(ds, list), 'roles has bad type: %s' % type(ds)
+    if not isinstance(ds, list):
+        raise AnsibleParserError('roles has bad type: "%s". Expectes "list"' % type(ds).__name__, obj=ds)
 
     roles = []
     for role_def in ds:


### PR DESCRIPTION
Currently if there is a parser error, we raise an AssertionError in several functions instead of AnsibleParserError.

This causes a traceback, and doesn't cause ansible to print a useful message.

This PR converts the AssertionError to AnsibleParserError
##### Traceback

```
Traceback (most recent call last):
  File "/Users/matt/python_venvs/ansibledev/ansible/bin/ansible-playbook", line 66, in <module>
    sys.exit(cli.run())
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/cli/playbook.py", line 160, in run
    results = pbex.run()
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/executor/playbook_executor.py", line 68, in run
    pb = Playbook.load(playbook_path, variable_manager=self._variable_manager, loader=self._loader)
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/playbook/__init__.py", line 47, in load
    pb._load_playbook_data(file_name=file_name, variable_manager=variable_manager)
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/playbook/__init__.py", line 78, in _load_playbook_data
    entry_obj = Play.load(entry, variable_manager=variable_manager, loader=self._loader)
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/playbook/play.py", line 98, in load
    return p.load_data(data, variable_manager=variable_manager, loader=loader)
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/playbook/base.py", line 175, in load_data
    self._attributes[name] = method(name, ds[name])
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/playbook/play.py", line 151, in _load_tasks
    return load_list_of_blocks(ds=ds, play=self, variable_manager=self._variable_manager, loader=self._loader)
  File "/Users/matt/python_venvs/ansibledev/ansible/lib/ansible/playbook/helpers.py", line 39, in load_list_of_blocks
    assert ds is None or isinstance(ds, list), 'block has bad type: %s' % type(ds)
AssertionError: block has bad type: <class 'ansible.parsing.yaml.objects.AnsibleMapping'>
```
##### Helpful Error

```
ERROR! block has bad type: "AnsibleMapping". Expecting "list"

The error appears to have been in '/Users/matt/python_venvs/ansibledev/playbooks/ds_error.yml': line 4, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
    command: whoami
    ^ here
```
