### PR TITLE
Don't test for play.become_pass any longer

### DIFF
--- a/test/units/executor/test_connection_information.py
+++ b/test/units/executor/test_connection_information.py
@@ -72,7 +72,6 @@ class TestConnectionInformation(unittest.TestCase):
         mock_play.become        = True
         mock_play.become_method = 'mock'
         mock_play.become_user   = 'mockroot'
-        mock_play.become_pass   = 'mockpass'
         mock_play.no_log        = True
         mock_play.environment   = dict(mock='mockenv')
 
@@ -86,7 +85,6 @@ class TestConnectionInformation(unittest.TestCase):
         self.assertEqual(conn_info.become, True)
         self.assertEqual(conn_info.become_method, "mock")
         self.assertEqual(conn_info.become_user, "mockroot")
-        self.assertEqual(conn_info.become_pass, "mockpass")
 
         mock_task = MagicMock()
         mock_task.connection    = 'mocktask'


### PR DESCRIPTION
In #11183 we removed the ability to set `become_pass` at the play level.

This is now causing tests to fail.  This PR removes those tests.

NOTE: I believe we still allow setting `become_pass` at the task level.  That will need to be addressed in in a separate effort.
