### PR TITLE
Fix confusing wording about aliases

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -46,7 +46,7 @@ To make things explicit, it is suggested that you set them if things are not run
 
     badwolf.example.com:5309
 
-Suppose you have just static IPs and want to set up some aliases that don't live in your host file, or you are connecting through tunnels.  You can do things like this::
+Suppose you have just static IPs and want to set up some aliases that live in your host file, or you are connecting through tunnels.  You can also describe hosts like this::
 
     jumper ansible_ssh_port=5555 ansible_ssh_host=192.168.1.50
 


### PR DESCRIPTION
I'm new to Ansible. When reading through this section of the install docs, I was confused about what file the `jumper ansible_ssh_port=5555 ansible_ssh_host=192.168.1.50` line was supposed to be an example of, because the "aliases that don't live in your host file" wording made it sound like the aliases were supposed to live elsewhere. I tried putting an equivalent line in the hosts file of the toy project I'm playing with, and it worked, so I'm pretty sure it actually does go there? 

Please double check that the new wording is factually accurate; all I did was test that the code runs. 
