### PR TITLE
Clarify reason for failure

### DIFF
--- a/docsite/rst/playbooks_async.rst
+++ b/docsite/rst/playbooks_async.rst
@@ -77,7 +77,7 @@ following::
 .. note::
    If the value of ``async:`` is not high enough, this will cause the 
    "check on it later" task to fail because the temporary status file that
-   the ``async_status:`` is looking for will not have been written 
+   the ``async_status:`` is looking for will no longer exist 
 
 .. seealso::
 


### PR DESCRIPTION
Saying "will not have been written" is misleading as the file probably existed before the "sync:" timeout value elapsed.
