### PR TITLE
fixes issue where hostvars are not loaded in the Host object

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -661,10 +661,16 @@ class Inventory(object):
             if group and host is None:
                 # load vars in dir/group_vars/name_of_group
                 base_path = os.path.join(basedir, "group_vars/%s" % group.name)
+                #The variables also needs to go into the Host objects vars key
+                if self._loader.path_exists(base_path):
+                    results = self._loader.load_from_file(base_path)
                 self._variable_manager.add_group_vars_file(base_path, self._loader)
             elif host and group is None:
                 # same for hostvars in dir/host_vars/name_of_host
                 base_path = os.path.join(basedir, "host_vars/%s" % host.name)
+                #The variables also needs to go into the Host objects vars key
+                if self._loader.path_exists(base_path):
+                    results = self._loader.load_from_file(base_path)
                 self._variable_manager.add_host_vars_file(base_path, self._loader)
 
         # all done, results is a dictionary of variables for this particular host.


### PR DESCRIPTION
A proposed fix for #11217 which actually happens because the hostvars are not loaded into the host object but loaded only into varialblemanagers.host_vars_files. 
The connection object uses host.get_vars() method to set the connection variables and since the hostvars are not available there it uses the default values.
