### PR TITLE
Update playbooks_vault.rst

### DIFF
--- a/docsite/rst/playbooks_vault.rst
+++ b/docsite/rst/playbooks_vault.rst
@@ -5,7 +5,7 @@ Vault
 
 New in Ansible 1.5, "Vault" is a feature of ansible that allows keeping sensitive data such as passwords or keys in encrypted files, rather than as plaintext in your playbooks or roles. These vault files can then be distributed or placed in source control.
 
-To enable this feature, a command line tool, `ansible-vault` is used to edit files, and a command line flag `--ask-vault-pass` or `--vault-password-file` is used.
+To enable this feature, a command line tool, `ansible-vault` is used to edit files, and a command line flag `--ask-vault-pass` or `--vault-password-file` is used. Alternately, you may specify the location of a password file in your  ansible.cfg file. This option requires no command line flag usage.
 
 .. _what_can_be_encrypted_with_vault:
 


### PR DESCRIPTION
As of 1.9 at least, you may specify a password file in your ansible.cfg and not have to extend your playbook calls with vault flags.
