### PR TITLE
comment to ec2.ini inventory instances grouping 

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -35,6 +35,9 @@ destination_variable = public_dns_name
 # private subnet, this should be set to 'private_ip_address', and Ansible must
 # be run from within EC2. The key of an EC2 tag may optionally be used; however
 # the boto instance variables hold precedence in the event of a collision.
+# WARNING: - instances that are in the private vpc, _without_ public ip address 
+# will not be listed in the inventory untill You set: 
+# vpc_destination_variable = 'private_ip_address'
 vpc_destination_variable = ip_address
 
 # To tag instances on EC2 with the resource records that point to them from


### PR DESCRIPTION
Warning about usage boto+ec2.ini

I had a problem, that mine instances were not presented in 
ec2.py --refresh-cache

It did appear, that instances without "key_variable" (in my case instances in vps did not have 'ip_address', they only have 'private_ip_address')  won't be presented on the list, so be Warned
This comment should help to clarify the issue. 
