### PR TITLE
Display a warning when using a deprecated module

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -247,6 +247,14 @@ class PluginLoader:
             for alias_name in ('_%s' % n for n in potential_names):
                 # We've already cached all the paths at this point
                 if alias_name in self._plugin_path_cache:
+                    if not os.path.islink(self._plugin_path_cache[alias_name]):
+                        d = Display()
+                        d.warning('%s has been deprecated, which means '
+                                  'it is kept for backwards compatibility '
+                                  'but usage is discouraged. The module '
+                                  'documentation details page may explain '
+                                  'more about this rationale.' %
+                                  name.lstrip('_'))
                     return self._plugin_path_cache[alias_name]
 
         return None


### PR DESCRIPTION
This PR adds a warning when using a deprecated module.  Currently a user would never know the module was deprecated unless they looked at the docs.

This should help users identify that they are using a deprecated module, to enable us to eventually remove those modules.

Example output:

```
TASK [glance_image] *************************************************************
 [WARNING]: glance_image has been deprecated, which means it is kept for
backwards compatibility but usage is discouraged.  The module documentation
details page may explain more about this rationale.
```

The text there is largely taken from the text used on docs.ansible.com.

If desired we could also get the docs and display the specific module deprecation string.
