### PR TITLE
Get-FileChecksum doesn't calculate hash for files

### DIFF
--- a/v1/ansible/module_utils/powershell.ps1
+++ b/v1/ansible/module_utils/powershell.ps1
@@ -151,7 +151,7 @@ Function Get-FileChecksum($path)
     {
         $sp = new-object -TypeName System.Security.Cryptography.SHA1CryptoServiceProvider;
         $fp = [System.IO.File]::Open($path, [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read);
-        [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
+        $hash = [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
         $fp.Dispose();
     }
     ElseIf (Test-Path -PathType Container $path)


### PR DESCRIPTION
missing update of the checksum value before returning the result - $hash is never updated in case file exists
