### PR TITLE
Adds ElastiCache to ec2 dynamic inventory plugin

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -65,6 +65,7 @@ all_rds_instances = False
 # By default, only ElastiCache clusters and nodes in the 'available' state
 # are returned. Set 'all_elasticache_clusters' and/or 'all_elastic_nodes'
 # to True return all ElastiCache clusters and nodes, regardless of state.
+all_elasticache_replication_groups = False
 all_elasticache_clusters = False
 all_elasticache_nodes = False
 
@@ -101,6 +102,7 @@ group_by_rds_parameter_group = True
 group_by_elasticache_engine = True
 group_by_elasticache_cluster = True
 group_by_elasticache_parameter_group = True
+group_by_elasticache_replication_group = True
 
 # If you only want to include hosts that match a certain regular expression
 # pattern_include = stage-*

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -65,6 +65,11 @@ all_rds_instances = False
 # By default, only ElastiCache clusters and nodes in the 'available' state
 # are returned. Set 'all_elasticache_clusters' and/or 'all_elastic_nodes'
 # to True return all ElastiCache clusters and nodes, regardless of state.
+#
+# Note that all_elasticache_nodes only applies to listed clusters. That means
+# if you set all_elastic_clusters to false, no node will be return from
+# unavailable clusters, regardless of the state and to what you set for
+# all_elasticache_nodes.
 all_elasticache_replication_groups = False
 all_elasticache_clusters = False
 all_elasticache_nodes = False

--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -47,6 +47,9 @@ route53 = False
 # To exclude RDS instances from the inventory, uncomment and set to False.
 #rds = False
 
+# To exclude ElastiCache instances from the inventory, uncomment and set to False.
+#elasticache = False
+
 # Additionally, you can specify the list of zones to exclude looking up in
 # 'route53_excluded_zones' as a comma-separated list.
 # route53_excluded_zones = samplezone1.com, samplezone2.com
@@ -58,6 +61,12 @@ all_instances = False
 # By default, only RDS instances in the 'available' state are returned.  Set
 # 'all_rds_instances' to True return all RDS instances regardless of state.
 all_rds_instances = False
+
+# By default, only ElastiCache clusters and nodes in the 'available' state
+# are returned. Set 'all_elasticache_clusters' and/or 'all_elastic_nodes'
+# to True return all ElastiCache clusters and nodes, regardless of state.
+all_elasticache_clusters = False
+all_elasticache_nodes = False
 
 # API calls to EC2 are slow. For this reason, we cache the results of an API
 # call. Set this to the path you want cache files to be written to. Two files
@@ -89,6 +98,9 @@ group_by_tag_none = True
 group_by_route53_names = True
 group_by_rds_engine = True
 group_by_rds_parameter_group = True
+group_by_elasticache_engine = True
+group_by_elasticache_cluster = True
+group_by_elasticache_parameter_group = True
 
 # If you only want to include hosts that match a certain regular expression
 # pattern_include = stage-*

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -786,12 +786,8 @@ class Ec2Inventory(object):
             if self.nested_groups:
                 self.push_group(self.inventory, 'types', type_name)
 
-        # Inventory: Group by VPC
-        # if self.group_by_vpc_id and instance.subnet_group and instance.subnet_group.vpc_id:
-        #     vpc_id_name = self.to_safe('vpc_id_' + instance.subnet_group.vpc_id)
-        #     self.push(self.inventory, vpc_id_name, dest)
-        #     if self.nested_groups:
-        #         self.push_group(self.inventory, 'vpcs', vpc_id_name)
+        # Inventory: Group by VPC (information not available in the current
+        # AWS API version for ElastiCache)
 
         # Inventory: Group by security group
         if self.group_by_security_group and not is_redis:
@@ -878,12 +874,8 @@ class Ec2Inventory(object):
             if self.nested_groups:
                 self.push_group(self.inventory, 'types', type_name)
 
-        # Inventory: Group by VPC
-        # if self.group_by_vpc_id and instance.subnet_group and instance.subnet_group.vpc_id:
-        #     vpc_id_name = self.to_safe('vpc_id_' + instance.subnet_group.vpc_id)
-        #     self.push(self.inventory, vpc_id_name, dest)
-        #     if self.nested_groups:
-        #         self.push_group(self.inventory, 'vpcs', vpc_id_name)
+        # Inventory: Group by VPC (information not available in the current
+        # AWS API version for ElastiCache)
 
         # Inventory: Group by security group
         if self.group_by_security_group:
@@ -900,17 +892,9 @@ class Ec2Inventory(object):
             if self.nested_groups:
                 self.push_group(self.inventory, 'elasticache_engines', self.to_safe("elasticache_" + cluster['Engine']))
 
-        # Inventory: Group by parameter group
-        # if self.group_by_elasticache_parameter_group:
-        #     self.push(self.inventory, self.to_safe("elasticache_parameter_group_" + cluster['CacheParameterGroup']['CacheParameterGroupName']), dest)
-        #     if self.nested_groups:
-        #         self.push_group(self.inventory, 'elasticache_parameter_groups', self.to_safe("elasticache_parameter_group_" + cluster['CacheParameterGroup']['CacheParameterGroupName']))
+        # Inventory: Group by parameter group (done at cluster level)
 
-        # Inventory: Group by replication group
-        # if self.group_by_elasticache_replication_group and 'ReplicationGroupId' in cluster and cluster['ReplicationGroupId']:
-        #     self.push(self.inventory, self.to_safe("elasticache_replication_group_" + cluster['ReplicationGroupId']), dest)
-        #     if self.nested_groups:
-        #         self.push_group(self.inventory, 'elasticache_replication_groups', self.to_safe("elasticache_" + cluster['ReplicationGroupId']))
+        # Inventory: Group by replication group (done at cluster level)
 
         # Inventory: Group by ElastiCache Cluster
         if self.group_by_elasticache_cluster:

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -1096,11 +1096,17 @@ class Ec2Inventory(object):
             if key == 'ec2_node_groups' and value:
                 host_info['ec2_endpoint_address'] = value[0]['PrimaryEndpoint']['Address']
                 host_info['ec2_endpoint_port'] = value[0]['PrimaryEndpoint']['Port']
+                replica_count = 0
                 for node in value[0]['NodeGroupMembers']:
                     if node['CurrentRole'] == 'primary':
                         host_info['ec2_primary_cluster_address'] = node['ReadEndpoint']['Address']
                         host_info['ec2_primary_cluster_port'] = node['ReadEndpoint']['Port']
                         host_info['ec2_primary_cluster_id'] = node['CacheClusterId']
+                    elif node['CurrentRole'] == 'replica':
+                        host_info['ec2_replica_cluster_address_'+ str(replica_count)] = node['ReadEndpoint']['Address']
+                        host_info['ec2_replica_cluster_port_'+ str(replica_count)] = node['ReadEndpoint']['Port']
+                        host_info['ec2_replica_cluster_id_'+ str(replica_count)] = node['CacheClusterId']
+                        replica_count += 1
             if key == 'ec2_member_clusters' and value:
                 host_info['ec2_member_clusters'] = ','.join([str(i) for i in value])
             elif key == 'ec2_cache_parameter_group':

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -1117,10 +1117,14 @@ class Ec2Inventory(object):
 
             # Target: Almost everything
             elif key == 'ec2_security_groups':
-                sg_ids = []
-                for sg in value:
-                    sg_ids.append(sg['SecurityGroupId'])
-                host_info["ec2_security_group_ids"] = ','.join([str(i) for i in sg_ids])
+
+                # Skip if SecurityGroups is None
+                # (it is possible to have the key defined but no value in it).
+                if value is not None:
+                    sg_ids = []
+                    for sg in value:
+                        sg_ids.append(sg['SecurityGroupId'])
+                    host_info["ec2_security_group_ids"] = ','.join([str(i) for i in sg_ids])
 
             # Target: Everything
             # Preserve booleans and integers

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -1088,6 +1088,11 @@ class Ec2Inventory(object):
             if key == 'ec2_endpoint' and value:
                 host_info['ec2_endpoint_address'] = value['Address']
                 host_info['ec2_endpoint_port'] = value['Port']
+            if key == 'ec2_node_groups' and value:
+                host_info['ec2_endpoint_address'] = value[0]['PrimaryEndpoint']['Address']
+                host_info['ec2_endpoint_port'] = value[0]['PrimaryEndpoint']['Port']
+            if key == 'ec2_member_clusters' and value:
+                host_info['ec2_member_clusters'] = ','.join([str(i) for i in value])
             elif key == 'ec2_cache_parameter_group':
                 host_info['ec2_cache_parameter_group_name'] = value['CacheParameterGroupName']
                 host_info['ec2_cache_parameter_apply_status'] = value['ParameterApplyStatus']

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -1096,6 +1096,11 @@ class Ec2Inventory(object):
             if key == 'ec2_node_groups' and value:
                 host_info['ec2_endpoint_address'] = value[0]['PrimaryEndpoint']['Address']
                 host_info['ec2_endpoint_port'] = value[0]['PrimaryEndpoint']['Port']
+                for node in value[0]['NodeGroupMembers']:
+                    if node['CurrentRole'] == 'primary':
+                        host_info['ec2_primary_cluster_address'] = node['ReadEndpoint']['Address']
+                        host_info['ec2_primary_cluster_port'] = node['ReadEndpoint']['Port']
+                        host_info['ec2_primary_cluster_id'] = node['CacheClusterId']
             if key == 'ec2_member_clusters' and value:
                 host_info['ec2_member_clusters'] = ','.join([str(i) for i in value])
             elif key == 'ec2_cache_parameter_group':

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -121,6 +121,7 @@ from time import time
 import boto
 from boto import ec2
 from boto import rds
+from boto import elasticache
 from boto import route53
 import six
 
@@ -232,6 +233,11 @@ class Ec2Inventory(object):
         if config.has_option('ec2', 'rds'):
             self.rds_enabled = config.getboolean('ec2', 'rds')
 
+        # Include ElastiCache instances?
+        self.elasticache_enabled = True
+        if config.has_option('ec2', 'elasticache'):
+            self.elasticache_enabled = config.getboolean('ec2', 'elasticache')
+
         # Return all EC2 and RDS instances (if RDS is enabled)
         if config.has_option('ec2', 'all_instances'):
             self.all_instances = config.getboolean('ec2', 'all_instances')
@@ -241,6 +247,18 @@ class Ec2Inventory(object):
             self.all_rds_instances = config.getboolean('ec2', 'all_rds_instances')
         else:
             self.all_rds_instances = False
+
+        # Return all ElastiCache clusters? (if ElastiCache is enabled)
+        if config.has_option('ec2', 'all_elasticache_clusters') and self.elasticache_enabled:
+            self.all_elasticache_clusters = config.getboolean('ec2', 'all_elasticache_clusters')
+        else:
+            self.all_elasticache_clusters = False
+
+        # Return all ElastiCache nodes? (if ElastiCache is enabled)
+        if config.has_option('ec2', 'all_elasticache_nodes') and self.elasticache_enabled:
+            self.all_elasticache_nodes = config.getboolean('ec2', 'all_elasticache_nodes')
+        else:
+            self.all_elasticache_nodes = False
 
         # Cache related
         cache_dir = os.path.expanduser(config.get('ec2', 'cache_path'))
@@ -272,6 +290,9 @@ class Ec2Inventory(object):
             'group_by_route53_names',
             'group_by_rds_engine',
             'group_by_rds_parameter_group',
+            'group_by_elasticache_engine',
+            'group_by_elasticache_cluster',
+            'group_by_elasticache_parameter_group',
         ]
         for option in group_by_options:
             if config.has_option('ec2', option):

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -1076,6 +1076,11 @@ class Ec2Inventory(object):
             of parameters. This method should be used only when 'describe' is
             used directly because Boto doesn't provide specific classes. '''
 
+        # I really don't agree with prefixing everything with 'ec2'
+        # because EC2, RDS and ElastiCache are different services.
+        # I'm just following the pattern used until now to not break any
+        # compatibility.
+
         host_info = {}
         for key in describe_dict:
             value = describe_dict[key]

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -1099,6 +1099,7 @@ class Ec2Inventory(object):
             if key == 'ec2_member_clusters' and value:
                 host_info['ec2_member_clusters'] = ','.join([str(i) for i in value])
             elif key == 'ec2_cache_parameter_group':
+                host_info["ec2_cache_node_ids_to_reboot"] = ','.join([str(i) for i in value['CacheNodeIdsToReboot']])
                 host_info['ec2_cache_parameter_group_name'] = value['CacheParameterGroupName']
                 host_info['ec2_cache_parameter_apply_status'] = value['ParameterApplyStatus']
             elif key == 'ec2_security_groups':

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -791,7 +791,11 @@ class Ec2Inventory(object):
 
         # Inventory: Group by security group
         if self.group_by_security_group and not is_redis:
-            if 'SecurityGroups' in cluster:
+
+            # Check for the existance of the 'SecurityGroups' key and also if
+            # this key has some value. When the cluster is not placed in a SG
+            # the query can return None here and cause an error.
+            if 'SecurityGroups' in cluster and cluster['SecurityGroups'] is not None:
                 for security_group in cluster['SecurityGroups']:
                     key = self.to_safe("security_group_" + security_group['SecurityGroupId'])
                     self.push(self.inventory, key, dest)
@@ -879,7 +883,11 @@ class Ec2Inventory(object):
 
         # Inventory: Group by security group
         if self.group_by_security_group:
-            if 'SecurityGroups' in cluster:
+
+            # Check for the existance of the 'SecurityGroups' key and also if
+            # this key has some value. When the cluster is not placed in a SG
+            # the query can return None here and cause an error.
+            if 'SecurityGroups' in cluster and cluster['SecurityGroups'] is not None:
                 for security_group in cluster['SecurityGroups']:
                     key = self.to_safe("security_group_" + security_group['SecurityGroupId'])
                     self.push(self.inventory, key, dest)

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -447,7 +447,7 @@ class Ec2Inventory(object):
             if e.error_code == 'AuthFailure':
                 error = self.get_auth_error_message()
             if not e.reason == "Forbidden":
-                error = "Looks like AWS RDS is down:\n%s" % e.message
+                error = "Looks like AWS ElastiCache is down:\n%s" % e.message
             self.fail_with_error(error)
 
         try:
@@ -481,7 +481,7 @@ class Ec2Inventory(object):
             if e.error_code == 'AuthFailure':
                 error = self.get_auth_error_message()
             if not e.reason == "Forbidden":
-                error = "Looks like AWS RDS is down:\n%s" % e.message
+                error = "Looks like AWS ElastiCache [Replication Groups] is down:\n%s" % e.message
             self.fail_with_error(error)
 
         try:
@@ -491,7 +491,7 @@ class Ec2Inventory(object):
             replication_groups = response['DescribeReplicationGroupsResponse']['DescribeReplicationGroupsResult']['ReplicationGroups']
 
         except KeyError as e:
-            error = "ElastiCache query to AWS failed (unexpected format)."
+            error = "ElastiCache [Replication Groups] query to AWS failed (unexpected format)."
             self.fail_with_error(error)
 
         for replication_group in replication_groups:

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -250,6 +250,12 @@ class Ec2Inventory(object):
         else:
             self.all_rds_instances = False
 
+        # Return all ElastiCache replication groups? (if ElastiCache is enabled)
+        if config.has_option('ec2', 'all_elasticache_replication_groups') and self.elasticache_enabled:
+            self.all_elasticache_replication_groups = config.getboolean('ec2', 'all_elasticache_replication_groups')
+        else:
+            self.all_elasticache_replication_groups = False
+
         # Return all ElastiCache clusters? (if ElastiCache is enabled)
         if config.has_option('ec2', 'all_elasticache_clusters') and self.elasticache_enabled:
             self.all_elasticache_clusters = config.getboolean('ec2', 'all_elasticache_clusters')
@@ -295,6 +301,7 @@ class Ec2Inventory(object):
             'group_by_elasticache_engine',
             'group_by_elasticache_cluster',
             'group_by_elasticache_parameter_group',
+            'group_by_elasticache_replication_group',
         ]
         for option in group_by_options:
             if config.has_option('ec2', option):

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -420,7 +420,7 @@ class Ec2Inventory(object):
                     self.add_rds_instance(instance, region)
         except boto.exception.BotoServerError as e:
             error = e.reason
-            
+
             if e.error_code == 'AuthFailure':
                 error = self.get_auth_error_message()
             if not e.reason == "Forbidden":
@@ -513,7 +513,7 @@ class Ec2Inventory(object):
             errors.append(" - No Boto config found at any expected location '%s'" % ', '.join(boto_paths))
 
         return '\n'.join(errors)
-        
+
     def fail_with_error(self, err_msg):
         '''log an error to std err for ansible-playbook to consume and exit'''
         sys.stderr.write(err_msg)
@@ -1025,7 +1025,6 @@ class Ec2Inventory(object):
 
         return list(name_list)
 
-
     def get_host_info_dict_from_instance(self, instance):
         instance_vars = {}
         for key in vars(instance):
@@ -1224,7 +1223,6 @@ class Ec2Inventory(object):
         used as Ansible groups '''
 
         return re.sub("[^A-Za-z0-9\_]", "_", word)
-
 
     def json_format_dict(self, data, pretty=False):
         ''' Converts a dict to a JSON object and dumps it as a formatted

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -420,8 +420,8 @@ class Ec2Inventory(object):
             self.fail_with_error(error)
 
     def get_elasticache_clusters_by_region(self, region):
-        ''' Makes an AWS API call to the list of ElastiCache clusters in a
-            particular region.'''
+        ''' Makes an AWS API call to the list of ElastiCache clusters (with
+        nodes' info) in a particular region.'''
 
         # ElastiCache boto module doesn't provide a get_all_intances method,
         # that's why we need to call describe directly (it would be called by
@@ -429,7 +429,9 @@ class Ec2Inventory(object):
         try:
             conn = elasticache.connect_to_region(region)
             if conn:
-                response = conn.describe_cache_clusters()
+                # show_cache_node_info = True
+                # because we also want nodes' information
+                response = conn.describe_cache_clusters(None, None, None, True)
 
         except boto.exception.BotoServerError as e:
             error = e.reason

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -880,19 +880,19 @@ class Ec2Inventory(object):
         host_info = {}
         for key in describe_dict:
             value = describe_dict[key]
-            key = self.to_safe('ec2_' + key)
+            key = self.to_safe('ec2_' + self.uncammelize(key))
 
             # Handle complex types
-            if key == 'ec2_ConfigurationEndpoint' and value:
+            if key == 'ec2_configuration_endpoint' and value:
                 host_info['ec2_configuration_endpoint_address'] = value['Address']
                 host_info['ec2_configuration_endpoint_port'] = value['Port']
-            if key == 'ec2_Endpoint' and value:
+            if key == 'ec2_endpoint' and value:
                 host_info['ec2_endpoint_address'] = value['Address']
                 host_info['ec2_endpoint_port'] = value['Port']
-            elif key == 'ec2_CacheParameterGroup':
+            elif key == 'ec2_cache_parameter_group':
                 host_info['ec2_cache_parameter_group_name'] = value['CacheParameterGroupName']
                 host_info['ec2_cache_parameter_apply_status'] = value['ParameterApplyStatus']
-            elif key == 'ec2_SecurityGroups':
+            elif key == 'ec2_security_groups':
                 sg_ids = []
                 for sg in value:
                     sg_ids.append(sg['SecurityGroupId'])
@@ -972,6 +972,9 @@ class Ec2Inventory(object):
         cache.write(json_data)
         cache.close()
 
+    def uncammelize(self, key):
+        temp = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', key)
+        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', temp).lower()
 
     def to_safe(self, word):
         ''' Converts 'bad' characters in a string to underscores so they can be

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -366,6 +366,7 @@ class Ec2Inventory(object):
                 self.get_rds_instances_by_region(region)
             if self.elasticache_enabled:
                 self.get_elasticache_clusters_by_region(region)
+                self.get_elasticache_replication_groups_by_region(region)
 
         self.write_to_cache(self.inventory, self.cache_path_cache)
         self.write_to_cache(self.index, self.cache_path_index)
@@ -461,6 +462,40 @@ class Ec2Inventory(object):
 
         for cluster in clusters:
             self.add_elasticache_cluster(cluster, region)
+
+    def get_elasticache_replication_groups_by_region(self, region):
+        ''' Makes an AWS API call to the list of ElastiCache replication groups
+        in a particular region.'''
+
+        # ElastiCache boto module doesn't provide a get_all_intances method,
+        # that's why we need to call describe directly (it would be called by
+        # the shorthand method anyway...)
+        try:
+            conn = elasticache.connect_to_region(region)
+            if conn:
+                response = conn.describe_replication_groups()
+
+        except boto.exception.BotoServerError as e:
+            error = e.reason
+
+            if e.error_code == 'AuthFailure':
+                error = self.get_auth_error_message()
+            if not e.reason == "Forbidden":
+                error = "Looks like AWS RDS is down:\n%s" % e.message
+            self.fail_with_error(error)
+
+        try:
+            # Boto also doesn't provide wrapper classes to ReplicationGroups
+            # Because of that wo can't make use of the get_list method in the
+            # AWSQueryConnection. Let's do the work manually
+            replication_groups = response['DescribeReplicationGroupsResponse']['DescribeReplicationGroupsResult']['ReplicationGroups']
+
+        except KeyError as e:
+            error = "ElastiCache query to AWS failed (unexpected format)."
+            self.fail_with_error(error)
+
+        for replication_group in replication_groups:
+            self.add_elasticache_replication_group(replication_group, region)
 
     def get_auth_error_message(self):
         ''' create an informative error message if there is an issue authenticating'''

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -926,6 +926,58 @@ class Ec2Inventory(object):
         else:
             self.inventory["_meta"]["hostvars"][dest] = host_info
 
+    def add_elasticache_replication_group(self, replication_group, region):
+        ''' Adds an ElastiCache replication group to the inventory and index '''
+
+        # Only want available clusters unless all_elasticache_replication_groups is True
+        if not self.all_elasticache_replication_groups and replication_group['Status'] != 'available':
+            return
+
+        # Select the best destination address (PrimaryEndpoint)
+        dest = replication_group['NodeGroups'][0]['PrimaryEndpoint']['Address']
+
+        if not dest:
+            # Skip clusters we cannot address (e.g. private VPC subnet)
+            return
+
+        # Add to index
+        self.index[dest] = [region, replication_group['ReplicationGroupId']]
+
+        # Inventory: Group by ID (always a group of 1)
+        if self.group_by_instance_id:
+            self.inventory[replication_group['ReplicationGroupId']] = [dest]
+            if self.nested_groups:
+                self.push_group(self.inventory, 'instances', replication_group['ReplicationGroupId'])
+
+        # Inventory: Group by region
+        if self.group_by_region:
+            self.push(self.inventory, region, dest)
+            if self.nested_groups:
+                self.push_group(self.inventory, 'regions', region)
+
+        # Inventory: Group by availability zone (doesn't apply to replication groups)
+
+        # Inventory: Group by node type (doesn't apply to replication groups)
+
+        # Inventory: Group by VPC (information not available in the current
+        # AWS API version for replication groups
+
+        # Inventory: Group by security group (doesn't apply to replication groups)
+        # Check this value in cluster level
+
+        # Inventory: Group by engine (replication groups are always Redis)
+        if self.group_by_elasticache_engine:
+            self.push(self.inventory, 'elasticache_redis', dest)
+            if self.nested_groups:
+                self.push_group(self.inventory, 'elasticache_engines', 'redis')
+
+        # Global Tag: all ElastiCache clusters
+        self.push(self.inventory, 'elasticache_replication_groups', replication_group['ReplicationGroupId'])
+
+        host_info = self.get_host_info_dict_from_describe_dict(replication_group)
+
+        self.inventory["_meta"]["hostvars"][dest] = host_info
+
     def get_route53_records(self):
         ''' Get and store the map of resource records to domain names that
         point to them. '''

--- a/plugins/inventory/ec2.py
+++ b/plugins/inventory/ec2.py
@@ -238,11 +238,13 @@ class Ec2Inventory(object):
         if config.has_option('ec2', 'elasticache'):
             self.elasticache_enabled = config.getboolean('ec2', 'elasticache')
 
-        # Return all EC2 and RDS instances (if RDS is enabled)
+        # Return all EC2 instances?
         if config.has_option('ec2', 'all_instances'):
             self.all_instances = config.getboolean('ec2', 'all_instances')
         else:
             self.all_instances = False
+
+        # Return all RDS instances? (if RDS is enabled)
         if config.has_option('ec2', 'all_rds_instances') and self.rds_enabled:
             self.all_rds_instances = config.getboolean('ec2', 'all_rds_instances')
         else:


### PR DESCRIPTION
Adds support to AWS ElastiCache services (Clusters, Nodes and Replication Groups) to ec2.py dynamic inventory plugin.

The new functionality follows the architecture used for the previous services (EC2 and RDS) supported by the script, with some obvious differences due to lack of dedicated classes in Boto.

The added code follows the pattern used until now, regarding to grouping, naming and keys (although I think it should be subject of refactoring in the future).

I hope you appreciate the addition! It'll be very useful to everybody out there using ElastiCache services!!

If you have any doubts or suggestion, I'm entirely at your disposal.

Live long and prosper \\//_

Ah, by the way, today is my birthday!! :)
