### PR TITLE
[FIX] ansible-galaxy missing an exception import

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -31,7 +31,7 @@ import subprocess
 
 from ansible import __version__
 from ansible import constants as C
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.utils.unicode import to_bytes
 
 class SortedOptParser(optparse.OptionParser):


### PR DESCRIPTION
``` bash
# without the fix
$ ansible-galaxy 
Traceback (most recent call last):
  File "./bin/ansible-galaxy", line 38, in <module>
    from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
ImportError: cannot import name AnsibleOptionsError
```

``` bash
# after
$ ansible-galaxy 
Usage: ansible-galaxy [init|info|install|list|remove] [--help] [options] ...

Options:
  -h, --help     show this help message and exit
  -v, --verbose  verbose mode (-vvv for more, -vvvv to enable connection
                 debugging)
  --version      show program's version number and exit
ERROR! Missing required action
```
