### PR TITLE
local and ssh connection plugin fixes

### DIFF
--- a/lib/ansible/plugins/connections/local.py
+++ b/lib/ansible/plugins/connections/local.py
@@ -51,7 +51,7 @@ class Connection(ConnectionBase):
     def exec_command(self, cmd, tmp_path, in_data=None, sudoable=True):
         ''' run a command on the local host '''
 
-        super(Connection, self).exec_command(cmd, tmp_path, in_data=in_data)
+        super(Connection, self).exec_command(cmd, tmp_path, in_data=in_data, sudoable=sudoable)
 
         debug("in local.exec_command()")
         # su requires to be run from a terminal, and therefore isn't supported here (yet?)

--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -176,7 +176,7 @@ class Connection(ConnectionBase):
                 if self._connection_info.become_pass:
                     self.check_incorrect_password(stdout, prompt)
                 elif self.check_password_prompt(stdout, prompt):
-                    raise AnsibleError('Missing %s password', self._connection_info.become_method)
+                    raise AnsibleError('Missing %s password' % self._connection_info.become_method)
 
             if p.stdout in rfd:
                 dat = os.read(p.stdout.fileno(), 9000)


### PR DESCRIPTION
This PR addresses a few things:
1. On the `ssh` connection plugin, use `%` for printf formatting to replace `%s`
2. Make sure we accept kwarg `sudoable` for the `local` connection plugin and pass it when calling `exec_command` via `super`
