### PR TITLE
Allow AdHocCLI to be more flexible for overriding

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -65,6 +65,13 @@ class AdHocCLI(CLI):
 
         return True
 
+    def _play_ds(self, pattern):
+        return dict(
+            name = "Ansible Ad-Hoc",
+            hosts = pattern,
+            gather_facts = 'no',
+            tasks = [ dict(action=dict(module=self.options.module_name, args=parse_kv(self.options.module_args))), ]
+        )
 
     def run(self):
         ''' use Runner lib to do SSH things '''
@@ -117,13 +124,7 @@ class AdHocCLI(CLI):
         #    results = runner.run()
 
         # create a pseudo-play to execute the specified module via a single task
-        play_ds = dict(
-            name = "Ansible Ad-Hoc",
-            hosts = pattern,
-            gather_facts = 'no',
-            tasks = [ dict(action=dict(module=self.options.module_name, args=parse_kv(self.options.module_args))), ]
-        )
-
+        play_ds = self._play_ds(pattern)
         play = Play().load(play_ds, variable_manager=variable_manager, loader=loader)
 
         # now create a task queue manager to execute the play

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -128,9 +128,9 @@ class AdHocCLI(CLI):
         play = Play().load(play_ds, variable_manager=variable_manager, loader=loader)
 
         # now create a task queue manager to execute the play
-        tqm = None
+        self._tqm = None
         try:
-            tqm = TaskQueueManager(
+            self._tqm = TaskQueueManager(
                     inventory=inventory,
                     variable_manager=variable_manager,
                     loader=loader,
@@ -139,10 +139,10 @@ class AdHocCLI(CLI):
                     passwords=passwords,
                     stdout_callback='minimal',
                 )
-            result = tqm.run(play)
+            result = self._tqm.run(play)
         finally:
-            if tqm:
-                tqm.cleanup()
+            if self._tqm:
+                self._tqm.cleanup()
 
         return result
 


### PR DESCRIPTION
In one of our applications we mimic the `AdHocCLI` functionality.  Now that this class exists we are attempting to reuse more of it's code without having to copy paste.

The following changes are part of this PR:
1. Add a `_play_ds` method that can be easily overridden. We already have a dictionary for the args for a module, this allows us to overwrite building the play ds to pass in our already structured data.
2. Make `TaskQueueManager` an instance attribute of `AdHocCLI`.  We also produce a "recap" for adhoc commands to make it easier to see where things change and fail.

Both of these changes make it easier for us to inherit from `AdHocCLI` and only override small pieces of code without having to copy paste into our project.

The only thing I question, is whether it would be beneficial for ad-hoc commands to have a recap in ansible itself.
