### PR TITLE
support utf-8 error messages

### DIFF
--- a/v1/ansible/callbacks.py
+++ b/v1/ansible/callbacks.py
@@ -17,6 +17,8 @@
 
 import utils
 import sys
+reload(sys)
+sys.setdefaultencoding("utf-8")
 import getpass
 import os
 import subprocess


### PR DESCRIPTION
By no means the only solution.. but it works. And fixes bugs reporting errors.

Fixes this: https://github.com/ansible/ansible/issues/10960#issuecomment-112344083
