### PR TITLE
Bugfix: win_checksum

### DIFF
--- a/v1/ansible/module_utils/powershell.ps1
+++ b/v1/ansible/module_utils/powershell.ps1
@@ -151,7 +151,7 @@ Function Get-FileChecksum($path)
     {
         $sp = new-object -TypeName System.Security.Cryptography.SHA1CryptoServiceProvider;
         $fp = [System.IO.File]::Open($path, [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read);
-        [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
+        $hash = [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
         $fp.Dispose();
     }
     ElseIf (Test-Path -PathType Container $path)


### PR DESCRIPTION
Win checksum had some errors causing it to output an array of strings instead of a string. This caused depending module such as win_file and win_copy to throw errors.
