### PR TITLE
Fixes for FreeBSD get_memory_facts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1264,13 +1264,14 @@ class FreeBSDHardware(Hardware):
         # Device          1M-blocks     Used    Avail Capacity
         # /dev/ada0p3        314368        0   314368     0%
         #
-        rc, out, err = module.run_command("/usr/sbin/swapinfo -m")
+        rc, out, err = module.run_command("/usr/sbin/swapinfo -k")
         lines = out.split('\n')
         if len(lines[-1]) == 0:
             lines.pop()
         data = lines[-1].split()
-        self.facts['swaptotal_mb'] = data[1]
-        self.facts['swapfree_mb'] = data[3]
+        if data[0] != 'Device':
+            self.facts['swaptotal_mb'] = int(data[1]) / 1024
+            self.facts['swapfree_mb'] = int(data[3]) / 1024
 
     @timeout(10)
     def get_mount_facts(self):


### PR DESCRIPTION
- swapinfo on FreeBSD 6 (maybe 7 too?) doesn't support the "-m" flag for
  fetching amounts in megabytes. This patch fetches amounts in kilobytes
  and divides by 1024 (and also returns the result as an int instead of
  a string).
- When no swap is configured, swapinfo prints a header line and nothing
  else:

```
    $ swapinfo
    Device         1K-blocks     Used    Avail Capacity
```

  The old version unexpectedly parsed that header line and emitted
  nonsense values like:

```
    "ansible_swapfree_mb": "Avail"
    "ansible_swaptotal_mb": "1K-blocks"
```

  This version emits those items altogether when no swap is configured.
