### PR TITLE
plugins/inventory/serf.py: Use SERF_RPC_* env vars

### DIFF
--- a/plugins/inventory/serf.py
+++ b/plugins/inventory/serf.py
@@ -20,10 +20,18 @@
 # Dynamic inventory script which lets you use nodes discovered by Serf
 # (https://serfdom.io/).
 #
-# Requires host to be a member of a Serf cluster and the `serfclient` Python
-# module from https://pypi.python.org/pypi/serfclient
+# Requires the `serfclient` Python module from
+# https://pypi.python.org/pypi/serfclient
+#
+# Environment variables
+# ---------------------
+#   - `SERF_RPC_ADDR`
+#   - `SERF_RPC_AUTH`
+#
+# These variables are described at https://www.serfdom.io/docs/commands/members.html#_rpc_addr
 
 import argparse
+import os
 import sys
 
 # https://pypi.python.org/pypi/serfclient
@@ -37,9 +45,22 @@ except ImportError:
 _key = 'serf'
 
 
+def _serf_client():
+    kwargs = {}
+
+    rpc_addr = os.getenv('SERF_RPC_ADDR')
+    if rpc_addr:
+        kwargs['host'], kwargs['port'] = rpc_addr.split(':')
+
+    rpc_auth = os.getenv('SERF_RPC_AUTH')
+    if rpc_auth:
+        kwargs['rpc_auth'] = rpc_auth
+
+    return SerfClient(**kwargs)
+
+
 def get_serf_members_data():
-    serf = SerfClient()
-    return serf.members().body['Members']
+    return _serf_client().members().body['Members']
 
 
 def get_nodes(data):


### PR DESCRIPTION
This makes the Serf inventory plugin use the `SERF_RPC_ADDR` and `SERF_RPC_AUTH` environment variables that the `serf` command-line tool already uses (see https://www.serfdom.io/docs/commands/members.html#_rpc_addr).

These can be used to get Serf data from a remote node instead of requiring the ansible control host to be running a serf agent and to be a member of the serf cluster. E.g.:

```
$ SERF_RPC_ADDR=serf.company.com:7373 SERF_RPC_AUTH="secret" /Users/marca/dev/git-repos/ansible/plugins/inventory/serf.py --list
{"serf": ["mt5-pyweb01", "mt3-pyweb01", "mt2-pyweb02", "mt1-pyweb01", ...
```

Cc: @bcoca, @KushalP, @sudarkoff
