### PR TITLE
add simple prefix filtering to vmware inventory

### DIFF
--- a/plugins/inventory/vmware.ini
+++ b/plugins/inventory/vmware.ini
@@ -23,6 +23,10 @@ guests_only = True
 # caching will be disabled.
 #cache_dir = ~/.cache/ansible
 
+# Specify a prefix filter. Any VMs with names beginning with this string will
+# not be returned.
+# prefix_filter = test_
+
 [auth]
 
 # Specify hostname or IP address of vCenter/ESXi server.  A port may be

--- a/plugins/inventory/vmware.py
+++ b/plugins/inventory/vmware.py
@@ -55,7 +55,7 @@ from suds.sudsobject import Object as SudsObject
 
 
 class VMwareInventory(object):
-    
+
     def __init__(self, guests_only=None):
         self.config = ConfigParser.SafeConfigParser()
         if os.environ.get('VMWARE_INI', ''):
@@ -305,6 +305,11 @@ class VMwareInventory(object):
         else:
             vm_group = default_group + '_vm'
 
+        if self.config.has_option('defaults', 'prefix_filter'):
+            prefix_filter = self.config.get('defaults', 'prefix_filter')
+        else:
+            prefix_filter = None
+
         # Loop through physical hosts:
         for host in HostSystem.all(self.client):
 
@@ -318,6 +323,9 @@ class VMwareInventory(object):
 
             # Loop through all VMs on physical host.
             for vm in host.vm:
+                if prefix_filter:
+                    if vm.name.startswith( prefix_filter ):
+                        continue
                 self._add_host(inv, 'all', vm.name)
                 self._add_host(inv, vm_group, vm.name)
                 vm_info = self._get_vm_info(vm)


### PR DESCRIPTION
Significantly speeds up inventory collection on systems with many
excluded machines.
