### PR TITLE
allow multiple vCenter/ESXi servers in single inventory

### DIFF
--- a/plugins/inventory/vmware.ini
+++ b/plugins/inventory/vmware.ini
@@ -29,9 +29,9 @@ guests_only = True
 
 [auth]
 
-# Specify hostname or IP address of vCenter/ESXi server.  A port may be
-# included with the hostname, e.g.: vcenter.example.com:8443.  This setting
-# may also be defined via the VMWARE_HOST environment variable.
+# Specify comma seperated hostnames or IP addresses of vCenter/ESXi servers.
+# A port may be included with the hostname, e.g.: vcenter.example.com:8443.
+# This setting may also be defined via the VMWARE_HOST environment variable.
 host = vcenter.example.com
 
 # Specify a username to access the vCenter host.  This setting may also be

--- a/plugins/inventory/vmware.py
+++ b/plugins/inventory/vmware.py
@@ -87,8 +87,10 @@ class VMwareInventory(object):
         if not auth_password and self.config.has_option('auth', 'password'):
             auth_password = self.config.get('auth', 'password')
 
+        self.client = []
         # Create the VMware client connection.
-        self.client = Client(auth_host, auth_user, auth_password)
+        for host in auth_host.split(","):
+            self.client.append(Client(host, auth_user, auth_password))
 
     def _put_cache(self, name, value):
         '''
@@ -310,60 +312,61 @@ class VMwareInventory(object):
         else:
             prefix_filter = None
 
-        # Loop through physical hosts:
-        for host in HostSystem.all(self.client):
+        for vm_client in self.client:
+            # Loop through physical hosts:
+            for host in HostSystem.all(vm_client):
 
-            if not self.guests_only:
-                self._add_host(inv, 'all', host.name)
-                self._add_host(inv, hw_group, host.name)
-                host_info = self._get_host_info(host)
-                if meta_hostvars:
-                    inv['_meta']['hostvars'][host.name] = host_info
-                self._put_cache(host.name, host_info)
+                if not self.guests_only:
+                    self._add_host(inv, 'all', host.name)
+                    self._add_host(inv, hw_group, host.name)
+                    host_info = self._get_host_info(host)
+                    if meta_hostvars:
+                        inv['_meta']['hostvars'][host.name] = host_info
+                    self._put_cache(host.name, host_info)
 
-            # Loop through all VMs on physical host.
-            for vm in host.vm:
-                if prefix_filter:
-                    if vm.name.startswith( prefix_filter ):
-                        continue
-                self._add_host(inv, 'all', vm.name)
-                self._add_host(inv, vm_group, vm.name)
-                vm_info = self._get_vm_info(vm)
-                if meta_hostvars:
-                    inv['_meta']['hostvars'][vm.name] = vm_info
-                self._put_cache(vm.name, vm_info)
+                # Loop through all VMs on physical host.
+                for vm in host.vm:
+                    if prefix_filter:
+                        if vm.name.startswith( prefix_filter ):
+                            continue
+                    self._add_host(inv, 'all', vm.name)
+                    self._add_host(inv, vm_group, vm.name)
+                    vm_info = self._get_vm_info(vm)
+                    if meta_hostvars:
+                        inv['_meta']['hostvars'][vm.name] = vm_info
+                    self._put_cache(vm.name, vm_info)
 
-                # Group by resource pool.
-                vm_resourcePool = vm_info.get('vmware_resourcePool', None)
-                if vm_resourcePool:
-                    self._add_child(inv, vm_group, 'resource_pools')
-                    self._add_child(inv, 'resource_pools', vm_resourcePool)
-                    self._add_host(inv, vm_resourcePool, vm.name)
+                    # Group by resource pool.
+                    vm_resourcePool = vm_info.get('vmware_resourcePool', None)
+                    if vm_resourcePool:
+                        self._add_child(inv, vm_group, 'resource_pools')
+                        self._add_child(inv, 'resource_pools', vm_resourcePool)
+                        self._add_host(inv, vm_resourcePool, vm.name)
 
-                # Group by datastore.
-                for vm_datastore in vm_info.get('vmware_datastores', []):
-                    self._add_child(inv, vm_group, 'datastores')
-                    self._add_child(inv, 'datastores', vm_datastore)
-                    self._add_host(inv, vm_datastore, vm.name)
+                    # Group by datastore.
+                    for vm_datastore in vm_info.get('vmware_datastores', []):
+                        self._add_child(inv, vm_group, 'datastores')
+                        self._add_child(inv, 'datastores', vm_datastore)
+                        self._add_host(inv, vm_datastore, vm.name)
 
-                # Group by network.
-                for vm_network in vm_info.get('vmware_networks', []):
-                    self._add_child(inv, vm_group, 'networks')
-                    self._add_child(inv, 'networks', vm_network)
-                    self._add_host(inv, vm_network, vm.name)
+                    # Group by network.
+                    for vm_network in vm_info.get('vmware_networks', []):
+                        self._add_child(inv, vm_group, 'networks')
+                        self._add_child(inv, 'networks', vm_network)
+                        self._add_host(inv, vm_network, vm.name)
 
-                # Group by guest OS.
-                vm_guestId = vm_info.get('vmware_guestId', None)
-                if vm_guestId:
-                    self._add_child(inv, vm_group, 'guests')
-                    self._add_child(inv, 'guests', vm_guestId)
-                    self._add_host(inv, vm_guestId, vm.name)
+                    # Group by guest OS.
+                    vm_guestId = vm_info.get('vmware_guestId', None)
+                    if vm_guestId:
+                        self._add_child(inv, vm_group, 'guests')
+                        self._add_child(inv, 'guests', vm_guestId)
+                        self._add_host(inv, vm_guestId, vm.name)
 
-                # Group all VM templates.
-                vm_template = vm_info.get('vmware_template', False)
-                if vm_template:
-                    self._add_child(inv, vm_group, 'templates')
-                    self._add_host(inv, 'templates', vm.name)
+                    # Group all VM templates.
+                    vm_template = vm_info.get('vmware_template', False)
+                    if vm_template:
+                        self._add_child(inv, vm_group, 'templates')
+                        self._add_host(inv, 'templates', vm.name)
 
         self._put_cache(cache_name, inv)
         return inv


### PR DESCRIPTION
Allow multiple vCenter/ESXi servers to be scanned from single inventory/ini combo, removing the need to have multiple sets of vmware inventory files when managing a large deployment.
