### PR TITLE
Change syslog (priority) level from LOG_NOTICE to LOG_INFO

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1161,10 +1161,10 @@ class AnsibleModule(object):
             except IOError, e:
                 # fall back to syslog since logging to journal failed
                 syslog.openlog(str(module), 0, syslog.LOG_USER)
-                syslog.syslog(syslog.LOG_NOTICE, msg) #1
+                syslog.syslog(syslog.LOG_INFO, msg) #1
         else:
             syslog.openlog(str(module), 0, syslog.LOG_USER)
-            syslog.syslog(syslog.LOG_NOTICE, msg) #2
+            syslog.syslog(syslog.LOG_INFO, msg) #2
 
     def _set_cwd(self):
         try:


### PR DESCRIPTION
If you look at the meaning of the different syslog levels, NOTICE means that the event is unusual and may need someone to look at it. Whereas INFO is pure informational and expected.

Since module invocations are in fact requested (deliberate) actions, they shouldn't need any additional post-processing, and therefore should not be logged as NOTICE.

This may seem like hairsplitting, but correctly categorizing system events helps weeding through the noise downhill. (e.g. we don't do any specific post-processing of DEBUG or INFO events)

According to Wikipedia: https://en.wikipedia.org/wiki/Syslog

5   Notice      notice  Events that are unusual but not error conditions .
6   Informational   info        Normal operational messages -no action required. Example an application has started, paused or ended successfully.
