### PR TITLE
- Added STS support for ec2.py for handling multiple accounts

### DIFF
--- a/plugins/inventory/ec2.ini
+++ b/plugins/inventory/ec2.ini
@@ -42,10 +42,10 @@ vpc_destination_variable = ip_address
 
 # To tag instances on EC2 with the resource records that point to them from
 # Route53, uncomment and set 'route53' to True.
-route53 = False
+route53 = True
 
 # To exclude RDS instances from the inventory, uncomment and set to False.
-#rds = False
+rds = True
 
 # Additionally, you can specify the list of zones to exclude looking up in
 # 'route53_excluded_zones' as a comma-separated list.
@@ -115,3 +115,10 @@ group_by_rds_parameter_group = True
 # tag Name value matches webservers1*
 # (ex. webservers15, webservers1a, webservers123 etc) 
 # instance_filters = tag:Name=webservers1*
+
+[account1]
+arn = arn:aws:iam::<account1id>:role/service/ops-syncer-role
+
+[account2]
+arn = arn:aws:iam::<account2id>:role/service/ops-syncer-role
+


### PR DESCRIPTION
##### SUMMARY
Following is the process to scan multiple accounts via STS:

Step 1: Create a role in the destination account from which we would like to scan the instances from and authorize the user and the account from the source account to AssumeRole
`aws iam create-role --path /service/ --role-name cross-access-role --assume-role-policy-document '{ "Version": "2008-10-17", "Statement": [ { "Sid": "", "Effect": "Allow", "Principal": { "AWS": "arn:aws:iam:::user/" }, "Action": "sts:AssumeRole" } ] }'`

Step 2: Attach a policy to the role to only list instances and describe tags
`aws iam put-role-policy --policy-name 'cross-access-policy' --role-name cross-access-role --policy-document '{ "Statement": [ { "Sid": "", "Action": [ "ec2:DescribeInstances", "ec2:DescribeTags", "route53:Get", "route53:List", "rds:Describe", "elasticloadbalancing:Describe" ], "Effect": "Allow", "Resource": "*" } ] }'`

Step3: `export AWS_ACCESS_KEY_ID=xxxx; export AWS_SECRET_ACCESS_KEY=xxxxxx` for the user present in the master account who has access to perform the cross account access


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
plugins/inventory/ec2.ini
plugins/inventory/ec2.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


