### PR TITLE
Add a new "on_exception" callback method.

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -145,6 +145,12 @@ class PlaybookExecutor:
             if entrylist:
                 return entrylist
 
+        except Exception as e:
+            # Notify callback plugins of catastrophe
+            if self._tqm is not None:
+                self._tqm.send_callback('v2_playbook_on_exception', e)
+            # And re-raise our exception in its original context
+            raise
         finally:
             if self._tqm is not None:
                 self._cleanup()

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -100,3 +100,5 @@ class CallbackBase:
     def playbook_on_stats(self, stats):
         pass
 
+    def playbook_on_exception(self, exception):
+        pass

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -134,3 +134,5 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_stats(self, stats):
         pass
 
+    def v2_playbook_on_exception(self, exception):
+        pass

--- a/lib/ansible/plugins/callback/minimal.py
+++ b/lib/ansible/plugins/callback/minimal.py
@@ -102,3 +102,6 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_stats(self, stats):
         pass
 
+    def v2_playbook_on_exception(self, exception):
+        pass
+


### PR DESCRIPTION
There are two separate commits.  One adds the feature to ansible v2 and the other to v1.

This can be used to catch and log a 'KeyboardInterrupt' when a user cancels a playbook run.

We use callback plugins to log the start and stop of our playbook runs to another system ([fedmsg](http://fedmsg.com) for [Fedora Infrastructure](https://fedoraproject.org/wiki/Infrastructure)).  I sat down to try and build a dashboard showing what admins were running what playbooks at any given time.  We have logs indicating when playbooks start and stop, but _not_ when they are interrupted by control-c or some other internal exception.  Adding this callback would let us expose that kind of information.
