### PR TITLE
quotes removed from become_method

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -161,7 +161,7 @@ fact_caching = memory
 
 [privilege_escalation]
 #become=True
-#become_method='sudo'
+#become_method=sudo
 #become_user='root'
 #become_ask_pass=False
 


### PR DESCRIPTION
just experimented that with quotes it does not work (ansible 1.9.1)
