### PR TITLE
Fix typo: "name" to "role"

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -782,7 +782,7 @@ Parameterized roles are useful.
 If you are using a role and want to override a default, pass it as a parameter to the role like so::
 
     roles:
-       - { name: apache, http_port: 8080 }
+       - { role: apache, http_port: 8080 }
 
 This makes it clear to the playbook reader that you've made a conscious choice to override some default in the role, or pass in some
 configuration that the role can't assume by itself.  It also allows you to pass something site-specific that isn't really part of the


### PR DESCRIPTION
I hit this problem running through the doc examples in ansible 1.9.1:

```
ERROR: expected a role name in dictionary: {'name': 'apache', 'http_port': 8080 }
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```
