### PR TITLE
Add example callback plugin: no_hosts_matched_fail

### DIFF
--- a/plugins/callbacks/no_hosts_matched_fail.py
+++ b/plugins/callbacks/no_hosts_matched_fail.py
@@ -1,0 +1,11 @@
+# plugins/no_hosts_matched_fail.py
+
+from ansible.errors import AnsibleError
+
+
+class CallbackModule(object):
+    def playbook_on_start(self):
+        print('|---> plugin activated: %s' % __file__)
+
+    def playbook_on_no_hosts_matched(self):
+        raise AnsibleError("FATAL: no hosts matched or all hosts have already failed -- aborting\n")


### PR DESCRIPTION
This example callback plugin makes `ansible-playbook` return a non-zero exit code if the playbook matches no hosts.

A stab at a solution to
https://groups.google.com/forum/#!topic/ansible-project/9QlUer83zA0

E.g.:

```
[marca@marca-mac2 test]$ cat foo.yml

---
- hosts: a-host-that-does-not-exist
  tasks:
    - debug: var=ansible_env

[marca@marca-mac2 test]$ ansible-playbook foo.yml
|---> plugin activated: /private/tmp/test/plugins/no_hosts_matched_fail.pyc

PLAY [a-host-that-does-not-exist] *********************************************
skipping: no hosts matched
ERROR: FATAL: no hosts matched or all hosts have already failed -- aborting


[marca@marca-mac2 test]$ echo $?
1
```

Cc: @sudarkoff, @sontek, @djeebus
