### PR TITLE
Add quote to a variable following a colon

### DIFF
--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -11,7 +11,7 @@ How can I set the PATH or any other environment variable for a task or entire pl
 Setting environment variables can be done with the `environment` keyword. It can be used at task or playbook level::
 
     environment:
-      PATH: "{{ ansible_env.PATH }}":/thingy/bin
+      PATH: "{{ ansible_env.PATH }}:/thingy/bin"
       SOME: value
 
 

--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -11,7 +11,7 @@ How can I set the PATH or any other environment variable for a task or entire pl
 Setting environment variables can be done with the `environment` keyword. It can be used at task or playbook level::
 
     environment:
-      PATH: {{ ansible_env.PATH }}:/thingy/bin
+      PATH: "{{ ansible_env.PATH }}":/thingy/bin
       SOME: value
 
 


### PR DESCRIPTION
A value after a colon, such as an ansible variable, has to be quoted. Otherwise YAML will interpret it as a dictionary.
