### PR TITLE
fix with with_dict, no_log, and --check not hide variables.

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1102,7 +1102,12 @@ class Runner(object):
                 # no callbacks
                 return result
             if 'skipped' in data:
-                self.callbacks.on_skipped(host, inject.get('item',None))
+                if self.no_log:
+                    skipped = dict(changed=False, skipped=True)
+                    skipped = utils.censor_unlogged_data(skipped)
+                    self.callbacks.on_skipped(host, skipped)
+                else:
+                    self.callbacks.on_skipped(host, inject.get('item', None))
 
             if self.no_log:
                 data = utils.censor_unlogged_data(data)


### PR DESCRIPTION
When I use
- no_log: true
- using with_dict (not with_items)
- --check
  , still show sensitive information. Confirmed at 1.9.2-rc2.
#10388 has some fix. but not success to `with_items`
### How to reproduce

```
- hosts: localhost
  connection: local
  vars:
    win_users:
      alice:
        pass: SHHHHH
  tasks:
    - win_user: name=johnd password="{{ item.value.pass }}"
      no_log: True
      with_dict: win_users
```

and run `ansible-playbook -i "localhost," no_log.yml --check` then shows,

```
TASK: [win_user name=johnd password="{{ item.value.pass }}"] ******************
skipping: [localhost] => (item={'key': 'alice', 'value': {'pass': 'SHHHHH'}})
ok: [localhost]
```

This PR fixes this problem with almost same change as #10388.

Thank you.
