### PR TITLE
Get AWS access and secret keys from boto config

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -86,8 +86,9 @@ def get_aws_connection_info(module):
         elif 'EC2_ACCESS_KEY' in os.environ:
             access_key = os.environ['EC2_ACCESS_KEY']
         else:
-            # in case access_key came in as empty string
-            access_key = None
+            access_key = boto.config.get('Credentials', 'aws_access_key_id')
+            if not access_key:
+                access_key = boto.config.get('default', 'aws_access_key_id')
 
     if not secret_key:
         if 'AWS_SECRET_ACCESS_KEY' in os.environ:
@@ -97,8 +98,9 @@ def get_aws_connection_info(module):
         elif 'EC2_SECRET_KEY' in os.environ:
             secret_key = os.environ['EC2_SECRET_KEY']
         else:
-            # in case secret_key came in as empty string
-            secret_key = None
+            secret_key = boto.config.get('Credentials', 'aws_secret_access_key')
+            if not secret_key:
+                secret_key = boto.config.get('default', 'aws_secret_access_key')
 
     if not region:
         if 'AWS_REGION' in os.environ:
@@ -117,8 +119,9 @@ def get_aws_connection_info(module):
         elif 'EC2_SECURITY_TOKEN' in os.environ:
             security_token = os.environ['EC2_SECURITY_TOKEN']
         else:
-            # in case security_token came in as empty string
-            security_token = None
+            security_token = boto.config.get('Credentials', 'aws_security_token')
+            if not security_token:
+                security_token = boto.config.get('default', 'aws_security_token')
 
     boto_params = dict(aws_access_key_id=access_key,
                        aws_secret_access_key=secret_key,


### PR DESCRIPTION
##### SUMMARY
I noticed when I was trying to manage my AWS servers using the ec2 module I was getting the following error: 

```
msg: No handler was ready to authenticate. 1 handlers were checked. ['HmacAuthV4Handler'] Check your credentials
```

This is caused when the credentials are not configured properly. However, I have a valid ${HOME}/.boto with the '[Credentials]' section correctly configured. The ec2 dynamic inventory script and connecting  with plain boto work fine.

I googled the problem and found this issue: https://github.com/ansible/ansible/issues/9984 was having a similar problem.

I fixed the problem by adding a boto config lookup to the ec2 module utils.


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


