### PR TITLE
Updated fetch_url to actually use the parameters being passed in.

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -504,8 +504,8 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     r = None
     info = dict(url=url)
     try:
-        r = open_url(url, data=None, headers=None, method=None,
-                use_proxy=True, force=False, last_mod_time=None, timeout=10,
+        r = open_url(url, data=data, headers=headers, method=method,
+                use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout,
                 validate_certs=validate_certs, url_username=username,
                 url_password=password, http_agent=http_agent)
         info.update(r.info())


### PR DESCRIPTION
I was trying to use the dnsmadeeasy module but the changes were not be reflected in DNS Made Easy and I noticed I was getting back some obscure error message. I tracked the issue down to the parameters being passed into the fetch_url method were not being used particularly the headers parameter.
