### PR TITLE
Pin modules to the matching stable-1.9 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,16 +1,16 @@
 [submodule "lib/ansible/modules/core"]
 	path = lib/ansible/modules/core
 	url = https://github.com/ansible/ansible-modules-core.git
-	branch = devel
+	branch = stable-1.9
 [submodule "lib/ansible/modules/extras"]
 	path = lib/ansible/modules/extras
 	url = https://github.com/ansible/ansible-modules-extras.git
-	branch = devel
+	branch = stable-1.9
 [submodule "v2/ansible/modules/core"]
 	path = v2/ansible/modules/core
 	url = https://github.com/ansible/ansible-modules-core.git
-	branch = devel
+	branch = stable-1.9
 [submodule "v2/ansible/modules/extras"]
 	path = v2/ansible/modules/extras
 	url = https://github.com/ansible/ansible-modules-extras.git
-	branch = devel
+	branch = stable-1.9


### PR DESCRIPTION
This is to keep module changes on devel from breaking when ran on
stable-1.9 Ansible.
