### PR TITLE
Remove install_requires dependency on setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='ansible',
       author_email='michael@ansible.com',
       url='http://ansible.com/',
       license='GPLv3',
-      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6', 'six'],
+      install_requires=['paramiko', 'jinja2', "PyYAML", 'pycrypto >= 2.6', 'six'],
       package_dir={ '': 'lib' },
       packages=find_packages('lib'),
       package_data={


### PR DESCRIPTION
Ansible does not `install_require`  setuptools, setuptools is a build / setup-time requirement, one that if it wasn't present, would make the `setup.py` not even importable.

Putting setuptools in install_requires means that because pip has only a full-upgrade mode where all dependencies are upgraded, if someone tries to `pip install -U ansible` and is not on the latest setuptools, pip will try to upgrade it, which isn't desirable unless it's specifically intended, not to mention that there are means of installing ansible that do not require setuptools to be installed at all.
