### PR TITLE
Add ability to adhoc apply roles to hosts

### DIFF
--- a/lib/ansible/cli/role_apply.py
+++ b/lib/ansible/cli/role_apply.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# (c) 2015, Marc Abramowitz <msabramo@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division)
+__metaclass__ = type
+
+import os
+import sys
+import tempfile
+
+from ansible.utils.display import Display
+
+
+def role_apply(hosts, roles,
+               show_playbook=False, options=None, display=None):
+    if options is None:
+        options = get_options()
+
+    if display is None:
+        display = Display()
+
+    playbook_content = get_playbook_content(hosts, roles)
+    if show_playbook:
+        display.display(79 * '-')
+        display.display(playbook_content)
+        display.display(79 * '-')
+
+    with tempfile.NamedTemporaryFile(suffix='.yml') as tmpf:
+        tmpf.write(playbook_content)
+        tmpf.flush()
+        cmd = 'ansible-playbook {options_str} {playbook}'.format(
+            options_str=' '.join(options),
+            playbook=tmpf.name)
+        display.display('Executing: {cmd}'.format(cmd=cmd))
+        os.system(cmd)
+
+
+def get_options():
+    options = []
+    for arg in sys.argv[1:]:
+        if not arg.startswith('-'):
+            continue
+        if arg.startswith('--r') or arg.startswith('-r'):
+            continue
+        options.append(arg)
+
+    return options
+
+
+def get_playbook_hosts(hosts):
+    playbook_hosts = '\n'.join([
+        '    - {host}'.format(host=host) for host in hosts])
+    return playbook_hosts
+
+
+def get_playbook_roles(roles):
+    playbook_roles = '\n'.join([
+        '    - {role}'.format(role=role) for role in roles])
+    return playbook_roles
+
+
+def get_playbook_content(hosts, roles):
+    playbook_hosts = get_playbook_hosts(hosts)
+    playbook_roles = get_playbook_roles(roles)
+    playbook_content = """\
+#!/usr/bin/env ansible-playbook
+---
+- hosts:
+{playbook_hosts}
+  roles:
+{playbook_roles}
+        """.format(
+            playbook_hosts=playbook_hosts,
+            playbook_roles=playbook_roles
+        ).rstrip()
+    return playbook_content
+
+

--- a/test/units/cli/test_role_apply.py
+++ b/test/units/cli/test_role_apply.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# (c) 2015, Marc Abramowitz <msabramo@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division)
+__metaclass__ = type
+
+import shlex
+import sys
+import yaml
+
+from ansible.cli.role_apply import role_apply
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch, MagicMock, mock_open, Mock
+
+
+@patch('os.system')
+def test_role_apply(mock_os_system):
+    def os_system_side_effect(cmd):
+        playbook_file = shlex.split(cmd)[-1]
+        os_system_side_effect.playbook_text = open(playbook_file).read()
+
+    mock_os_system.side_effect = os_system_side_effect
+    role_apply(
+        hosts=['somehost'], roles=['somerole'], show_playbook=False)
+    cmd = mock_os_system.call_args[0][0]
+    assert cmd.startswith('ansible-playbook')
+    assert cmd.endswith('.yml')
+    playbook_text = os_system_side_effect.playbook_text
+    assert playbook_text.startswith('#!/usr/bin/env ansible-playbook')
+    playbook = yaml.load(playbook_text)
+    assert len(playbook) == 1
+    assert playbook[0]['hosts'] == ['somehost']
+    assert playbook[0]['roles'] == ['somerole']
+
+
+@patch('ansible.cli.role_apply.Display')
+@patch('os.system')
+def test_role_apply_show_playbook(mock_os_system, mock_Display):
+    def os_system_side_effect(cmd):
+        playbook_file = shlex.split(cmd)[-1]
+        os_system_side_effect.playbook_text = open(playbook_file).read()
+
+    mock_os_system.side_effect = os_system_side_effect
+    role_apply(
+        hosts=['somehost'], roles=['somerole'], show_playbook=True)
+    cmd = mock_os_system.call_args[0][0]
+    assert cmd.startswith('ansible-playbook')
+    assert cmd.endswith('.yml')
+    playbook_text = os_system_side_effect.playbook_text
+    assert playbook_text.startswith('#!/usr/bin/env ansible-playbook')
+    playbook = yaml.load(playbook_text)
+    assert len(playbook) == 1
+    assert playbook[0]['hosts'] == ['somehost']
+    assert playbook[0]['roles'] == ['somerole']
+    mock_Display.return_value.display.assert_any_call(playbook_text)
+
+
+@patch.object(sys, 'argv',
+              ['ansible',
+               '-r', 'somerole', '--timeout', '30', '-u', 'somueser'])
+@patch('os.system')
+def test_role_apply_options(mock_os_system):
+    def os_system_side_effect(cmd):
+        playbook_file = shlex.split(cmd)[-1]
+        os_system_side_effect.playbook_text = open(playbook_file).read()
+
+    mock_os_system.side_effect = os_system_side_effect
+    role_apply(hosts=['somehost'], roles=['somerole'])
+    cmd = mock_os_system.call_args[0][0]
+    assert cmd.startswith('ansible-playbook')
+    assert cmd.endswith('.yml')
+    playbook_text = os_system_side_effect.playbook_text
+    assert playbook_text.startswith('#!/usr/bin/env ansible-playbook')
+    playbook = yaml.load(playbook_text)
+    assert len(playbook) == 1
+    assert playbook[0]['hosts'] == ['somehost']
+    assert playbook[0]['roles'] == ['somerole']


### PR DESCRIPTION
I have often wanted the ability to adhoc apply a role to hosts. Yes, I can write a playbook to do this, but I feel like then I would accumulate a big list of playbooks that are of questionable usefulness and would clutter the repository.

This would also make it easier for people to demo and test and code review roles from galaxy as the user does not need to create a playbook just to try out the role.

I've seen people ask for this before -- e.g.:
- https://groups.google.com/forum/#!topic/ansible-project/h-SGLuPDRrs

E.g.:

```
$ ansible vagrant -r docker --sudo
-------------------------------------------------------------------------------
#!/usr/bin/env ansible-playbook

---
- hosts:
    - vagrant
  roles:
    - docker
-------------------------------------------------------------------------------
Executing: ansible-playbook --sudo /var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmpNimKE4.yml

PLAY: ***************************************************************************

TASK [setup] ********************************************************************
ok: [vagrant]

TASK [angstwad.docker_ubuntu : angstwad.docker_ubuntu : Fail if not a new release of Ubuntu] ***
skipping: [vagrant]
...
```

```
$ ansible vagrant --role-name=docker --sudo -vvvv --timeout=30
-------------------------------------------------------------------------------
#!/usr/bin/env ansible-playbook

---
- hosts:
    - vagrant
  roles:
    - docker
-------------------------------------------------------------------------------
Executing: ansible-playbook --sudo -vvvv --timeout=30 /var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmpW0f6ZX.yml
1 plays in /var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmpW0f6ZX.yml

PLAY: ***************************************************************************
...
```

Applying a role ad hoc seems to me to be quite similar to ad hoc applying a module in that you'd want to do these for the same reasons (e.g.: ability to quickly try things out, ability to do one-off operations, avoid accumulation of tons of trivial little playbooks, make ansible easier to demo and easier to learn). 
Ansible currently allows ad-hoc execution of modules but roles require a playbook but I see them as quite similar; hence this PR. 

Cc: @georges, @sontek, @djeebus
