### PR TITLE
Make the wait_timeout for rax tests a configurable default

### DIFF
--- a/test/integration/roles/prepare_rax_tests/defaults/main.yml
+++ b/test/integration/roles/prepare_rax_tests/defaults/main.yml
@@ -14,3 +14,5 @@ rackspace_alt_image_name: "CentOS 6 (PVHVM)"
 rackspace_alt_image_human_id: "centos-6-pvhvm"
 
 rackspace_alt_flavor: "general1-1"
+
+rackspace_wait_timeout: 600

--- a/test/integration/roles/test_rax/tasks/main.yml
+++ b/test/integration/roles/test_rax/tasks/main.yml
@@ -119,6 +119,7 @@
     name: "{{ resource_prefix }}-1"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete integration 1"
@@ -141,6 +142,7 @@
     flavor: "{{ rackspace_flavor }}"
     name: "{{ resource_prefix }}-2"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax basic idepmpotency 1
@@ -163,6 +165,7 @@
     flavor: "{{ rackspace_flavor }}"
     name: "{{ resource_prefix }}-2"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax basic idempotency 2
@@ -185,6 +188,7 @@
     name: "{{ resource_prefix }}-2"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete integration 2"
@@ -211,6 +215,7 @@
     meta:
       foo: bar
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax basic idepmpotency with meta 1
@@ -236,6 +241,7 @@
     meta:
       foo: bar
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax basic idempotency with meta 2
@@ -260,6 +266,7 @@
     meta:
       foo: bar
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete integration 3"
@@ -285,6 +292,7 @@
     name: "{{ resource_prefix }}-4"
     count: 2
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax basic idepmpotency multi server 1
@@ -306,6 +314,7 @@
     name: "{{ resource_prefix }}-4"
     count: 2
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax basic idempotency multi server 2
@@ -327,6 +336,7 @@
     name: "{{ resource_prefix }}-4"
     count: 3
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax basic idempotency multi server 3
@@ -349,6 +359,7 @@
     count: 3
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete integration 4"
@@ -375,6 +386,7 @@
     count: 2
     group: "{{ resource_prefix }}-5"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax multi server group without exact_count 1
@@ -398,6 +410,7 @@
     count: 2
     group: "{{ resource_prefix }}-5"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
     state: absent
   register: rax
 
@@ -425,6 +438,7 @@
     count: 2
     group: "{{ resource_prefix }}-6"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax multi server group without exact_count non-idempotency 1
@@ -448,6 +462,7 @@
     count: 2
     group: "{{ resource_prefix }}-6"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax multi server group without exact_count non-idempotency 2
@@ -470,6 +485,7 @@
     count: 4
     group: "{{ resource_prefix }}-6"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
     state: absent
   register: rax
 
@@ -498,6 +514,7 @@
     exact_count: true
     group: "{{ resource_prefix }}-7"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax multi server group with exact_count 1
@@ -522,6 +539,7 @@
     exact_count: true
     group: "{{ resource_prefix }}-7"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax multi server group with exact_count 2
@@ -545,6 +563,7 @@
     exact_count: true
     group: "{{ resource_prefix }}-7"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax multi server group with exact_count 3
@@ -570,6 +589,7 @@
     exact_count: true
     group: "{{ resource_prefix }}-7"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete integration 7"
@@ -597,6 +617,7 @@
     group: "{{ resource_prefix }}-8"
     auto_increment: false
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax multi server group without exact_count and disabled auto_increment 1
@@ -621,6 +642,7 @@
     group: "{{ resource_prefix }}-8"
     auto_increment: false
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
     state: absent
   register: rax
 
@@ -649,6 +671,7 @@
     exact_count: true
     group: "{{ resource_prefix }}-9"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax multi server group with exact_count and no printf 1
@@ -673,6 +696,7 @@
     exact_count: true
     group: "{{ resource_prefix }}-9"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete integration 9"
@@ -701,6 +725,7 @@
     exact_count: true
     group: "{{ resource_prefix }}-10"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax multi server group with exact_count and offset 1
@@ -726,6 +751,7 @@
     exact_count: true
     group: "{{ resource_prefix }}-10"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete integration 10"
@@ -754,6 +780,7 @@
     exact_count: true
     group: "{{ resource_prefix }}-11"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax multi server group with exact_count and offset 1
@@ -779,6 +806,7 @@
     exact_count: true
     group: "{{ resource_prefix }}-11"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete integration 11"
@@ -803,6 +831,7 @@
     flavor: "{{ rackspace_flavor }}"
     name: "{{ resource_prefix }}-12"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate rax instance_ids absent 1 (create)
@@ -827,6 +856,7 @@
       - "{{ rax.success.0.rax_id }}"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax2
 
 - name: Validate rax instance_ids absent 2 (delete)

--- a/test/integration/roles/test_rax_cbs/tasks/main.yml
+++ b/test/integration/roles/test_rax_cbs/tasks/main.yml
@@ -55,6 +55,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-1"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cbs
 
 - name: Validate rax_cbs creds, region and name
@@ -116,6 +117,7 @@
     name: "{{ resource_prefix }}-2"
     size: 150
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cbs
 
 - name: Validate rax_cbs creds, region and valid size
@@ -177,6 +179,7 @@
     name: "{{ resource_prefix }}-3"
     volume_type: SSD
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cbs
 
 - name: Validate rax_cbs creds, region and valid volume_size
@@ -218,6 +221,7 @@
     name: "{{ resource_prefix }}-4"
     description: "{{ resource_prefix }}-4 description"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cbs
 
 - name: Validate rax_cbs creds, region and description
@@ -261,6 +265,7 @@
     meta:
       foo: bar
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cbs
 
 - name: Validate rax_cbs creds, region and meta
@@ -302,6 +307,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-6"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cbs_1
 
 - name: Validate rax_cbs with idempotency 1

--- a/test/integration/roles/test_rax_cbs_attachments/tasks/main.yml
+++ b/test/integration/roles/test_rax_cbs_attachments/tasks/main.yml
@@ -80,6 +80,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-rax_cbs_attachments"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cbs
 
 - name: Validate volume build
@@ -102,6 +103,7 @@
     flavor: "{{ rackspace_flavor }}"
     name: "{{ resource_prefix }}-rax_cbs_attachments"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate CloudServer build
@@ -147,6 +149,7 @@
     volume: "{{ rax_cbs.volume.id }}"
     device: /dev/xvde
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cbs_attachments
 
 - name: Validate rax_cbs_attachments creds, region, server, volume and device (valid)
@@ -166,6 +169,7 @@
     volume: "{{ rax_cbs.volume.id }}"
     device: /dev/xvde
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cbs_attachments
 
 - name: Validate idempotent present test
@@ -183,6 +187,7 @@
     volume: "{{ rax_cbs.volume.id }}"
     device: /dev/xvde
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
     state: absent
   register: rax_cbs_attachments
 
@@ -202,6 +207,7 @@
     volume: "{{ rax_cbs.volume.id }}"
     device: /dev/xvde
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
     state: absent
   register: rax_cbs_attachments
 
@@ -242,6 +248,7 @@
     instance_ids: "{{ rax.instances[0].id }}"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete"

--- a/test/integration/roles/test_rax_cdb/tasks/main.yml
+++ b/test/integration/roles/test_rax_cdb/tasks/main.yml
@@ -73,6 +73,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-1"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: Validate rax_cdb with creds, region and name
@@ -92,6 +93,7 @@
     name: "{{ resource_prefix }}-1"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: "Validate delete integration 1"
@@ -113,6 +115,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-2"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: Validate rax_cdb idempotent test 1
@@ -130,6 +133,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-2"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: Validate rax_cdb idempotent test 2
@@ -148,6 +152,7 @@
     name: "{{ resource_prefix }}-2"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: "Validate delete integration 2"
@@ -167,6 +172,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-3"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: Validate rax_cdb resize volume 1
@@ -185,6 +191,7 @@
     name: "{{ resource_prefix }}-3"
     volume: 3
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
     wait_timeout: 600
   register: rax_cdb
 
@@ -204,6 +211,7 @@
     name: "{{ resource_prefix }}-3"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: "Validate delete integration 3"
@@ -223,6 +231,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-4"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: Validate rax_cdb resize flavor 1
@@ -241,6 +250,7 @@
     name: "{{ resource_prefix }}-4"
     flavor: 2
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
     wait_timeout: 600
   register: rax_cdb
 
@@ -260,6 +270,7 @@
     name: "{{ resource_prefix }}-4"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: "Validate delete integration 4"

--- a/test/integration/roles/test_rax_cdb_database/tasks/main.yml
+++ b/test/integration/roles/test_rax_cdb_database/tasks/main.yml
@@ -92,6 +92,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-rax_cdb_database"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: Validate build
@@ -204,6 +205,7 @@
     name: "{{ resource_prefix }}-rax_cdb_database"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_cdb
 
 - name: Validate Delete

--- a/test/integration/roles/test_rax_clb/tasks/main.yml
+++ b/test/integration/roles/test_rax_clb/tasks/main.yml
@@ -73,6 +73,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-1"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: Validate rax_clb with creds, region and name
@@ -95,6 +96,7 @@
     name: "{{ resource_prefix }}-1"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 1"
@@ -116,6 +118,7 @@
     name: "{{ resource_prefix }}-2"
     protocol: TCP
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: Validate rax_clb with creds, region, name and protocol
@@ -137,6 +140,7 @@
     name: "{{ resource_prefix }}-2"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 2"
@@ -158,6 +162,7 @@
     protocol: TCP
     port: 8080
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: Validate rax_clb with creds, region, name, protocol and port
@@ -179,6 +184,7 @@
     name: "{{ resource_prefix }}-3"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 3"
@@ -201,6 +207,7 @@
     port: 8080
     type: SERVICENET
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: Validate rax_clb with creds, region, name, protocol and type
@@ -222,6 +229,7 @@
     name: "{{ resource_prefix }}-4"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 4"
@@ -245,6 +253,7 @@
     type: SERVICENET
     timeout: 1
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   ignore_errors: true
   register: rax_clb
 
@@ -269,6 +278,7 @@
     type: SERVICENET
     timeout: 60
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: Validate rax_clb with creds, region, name, protocol, type and timeout
@@ -290,6 +300,7 @@
     name: "{{ resource_prefix }}-5"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 5"
@@ -314,6 +325,7 @@
     timeout: 60
     algorithm: RANDOM
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: Validate rax_clb with creds, region, name, protocol, type, timeout and algorithm
@@ -336,6 +348,7 @@
     name: "{{ resource_prefix }}-6"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 6"
@@ -357,6 +370,7 @@
     type: BAD
     timeout: 1
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   ignore_errors: true
   register: rax_clb
 
@@ -379,6 +393,7 @@
     protocol: BAD
     timeout: 1
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   ignore_errors: true
   register: rax_clb
 
@@ -401,6 +416,7 @@
     algorithm: BAD
     timeout: 1
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   ignore_errors: true
   register: rax_clb
 
@@ -428,6 +444,7 @@
     meta:
       foo: bar
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: Validate rax_clb with creds, region, name, protocol, type, timeout, algorithm and metadata
@@ -451,6 +468,7 @@
     name: "{{ resource_prefix }}-7"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 7"
@@ -470,6 +488,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-8-HTTP"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_http
 
 - name: Validate rax_clb with shared VIP HTTP
@@ -489,6 +508,7 @@
     protocol: HTTPS
     port: 443
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
     vip_id: "{{ (rax_clb_http.balancer.virtual_ips|first).id }}"
   register: rax_clb_https
 
@@ -508,6 +528,7 @@
     name: "{{ resource_prefix }}-8-HTTP"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_http
 
 - name: "Delete integration 8 HTTPS"
@@ -518,6 +539,7 @@
     name: "{{ resource_prefix }}-8-HTTPS"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_http
 
 - name: "Validate delete integration 8"
@@ -537,6 +559,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-9"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_p1
 
 - name: Validate rax_clb with updated protocol 1
@@ -555,6 +578,7 @@
     name: "{{ resource_prefix }}-9"
     protocol: TCP
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_p2
 
 - name: Validate rax_clb with updated protocol 2
@@ -574,6 +598,7 @@
     name: "{{ resource_prefix }}-9"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 9"
@@ -592,6 +617,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-10"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_a1
 
 - name: Validate rax_clb with updated algorithm 1
@@ -609,6 +635,7 @@
     name: "{{ resource_prefix }}-10"
     algorithm: RANDOM
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_a2
 
 - name: Validate rax_clb with updated algorithm 2
@@ -628,6 +655,7 @@
     name: "{{ resource_prefix }}-10"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 10"
@@ -647,6 +675,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-11"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_1
 
 - name: Validate rax_clb with updated port 1
@@ -664,6 +693,7 @@
     name: "{{ resource_prefix }}-11"
     port: 8080
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_2
 
 - name: Validate rax_clb with updated port 2
@@ -683,6 +713,7 @@
     name: "{{ resource_prefix }}-11"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 11"
@@ -702,6 +733,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-12"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_1
 
 - name: Validate rax_clb with updated timeout 1
@@ -719,6 +751,7 @@
     name: "{{ resource_prefix }}-12"
     timeout: 60
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_2
 
 - name: Validate rax_clb with updated timeout 2
@@ -738,6 +771,7 @@
     name: "{{ resource_prefix }}-12"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 12"
@@ -757,6 +791,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-13"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_1
 
 - name: Validate rax_clb with invalid updated type 1
@@ -773,6 +808,7 @@
     name: "{{ resource_prefix }}-13"
     type: SERVICENET
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_2
   ignore_errors: true
 
@@ -790,6 +826,7 @@
     name: "{{ resource_prefix }}-13"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 13"
@@ -809,6 +846,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-14"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_1
 
 - name: Validate rax_clb with updated meta 1
@@ -827,6 +865,7 @@
     meta:
       foo: bar
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_2
 
 - name: Validate rax_clb with updated meta 2
@@ -847,6 +886,7 @@
     name: "{{ resource_prefix }}-14"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 14"

--- a/test/integration/roles/test_rax_clb_nodes/tasks/main.yml
+++ b/test/integration/roles/test_rax_clb_nodes/tasks/main.yml
@@ -74,6 +74,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-clb"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: Validate rax_clb creation
@@ -158,6 +159,7 @@
     address: '172.16.0.1'
     port: 80
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_nodes
 
 - name: Validate rax_clb_nodes creds, region, load_balancer_id, address and port
@@ -180,6 +182,7 @@
     node_id: "{{ rax_clb_nodes.node.id }}"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb_nodes
 
 - name: Validate delete integration 1
@@ -201,6 +204,7 @@
     port: 80
     type: secondary
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   ignore_errors: true
   register: rax_clb_nodes
 
@@ -222,6 +226,7 @@
     name: "{{ rax_clb.balancer.name }}"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 3"

--- a/test/integration/roles/test_rax_facts/tasks/main.yml
+++ b/test/integration/roles/test_rax_facts/tasks/main.yml
@@ -122,6 +122,7 @@
     flavor: "{{ rackspace_flavor }}"
     name: "{{ resource_prefix }}-rax_facts"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate build
@@ -267,6 +268,7 @@
     name: "{{ resource_prefix }}-rax_facts"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete"

--- a/test/integration/roles/test_rax_meta/tasks/main.yml
+++ b/test/integration/roles/test_rax_meta/tasks/main.yml
@@ -119,6 +119,7 @@
     meta:
       foo: bar
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: Validate build
@@ -322,6 +323,7 @@
       - "{{ rax.success.0.rax_id }}"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax
 
 - name: "Validate delete"

--- a/test/integration/roles/test_rax_scaling_group/tasks/main.yml
+++ b/test/integration/roles/test_rax_scaling_group/tasks/main.yml
@@ -269,6 +269,7 @@
     region: "{{ rackspace_region }}"
     name: "{{ resource_prefix }}-clb"
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: Validate rax_clb creation
@@ -867,6 +868,7 @@
     name: "{{ rax_clb.balancer.name }}"
     state: absent
     wait: true
+    wait_timeout: "{{ rackspace_wait_timeout }}"
   register: rax_clb
 
 - name: "Validate delete integration 3"


### PR DESCRIPTION
I've started trying to run the integration tests for the rax modules on a regular basis.  While the default values for `wait_timeout` in each module are sane values, I am seeing some timeouts in my integration tests on an infrequent basis.

This PR sets a default of 600 seconds, which can be overridden to allow for the tests to successfully complete.
