### PR TITLE
adhoc: allow -i * to use all hosts as-is

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -100,7 +100,10 @@ class AdHocCLI(CLI):
         loader = DataLoader(vault_password=vault_pass)
         variable_manager = VariableManager()
 
-        inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=self.options.inventory)
+        if self.options.inventory == '*':
+            inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=pattern + ',')
+        else:
+            inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=self.options.inventory)
         variable_manager.set_inventory(inventory)
 
         hosts = inventory.list_hosts(pattern)


### PR DESCRIPTION
Sometimes I want to do something quick against a brand new host that I
haven't yet added to the inventory. This is essentially a more flexible
version of the "comma trick". This allows passing `-i '*'`, which means
basically don't look at inventory files and just try to operate against
any host that I specify verbatim. E.g.:

```
# remotehost is not in any ansible inventory file or dynamic inventory
# but I can target it anyway
$ ansible -i '*' myuser@remotehost -a 'lsb_release -a'
myuser@remotehost | SUCCESS => {
    ...
    "stdout": "Distributor ID:\tUbuntu\nDescription:\tUbuntu 12.04.5 LTS\nRelease:\t12.04\nCodename:\tprecise",
    "cmd": [
        "lsb_release",
        "-a"
    ],
    ...
    "stdout_lines": [
        "Distributor ID:\tUbuntu",
        "Description:\tUbuntu 12.04.5 LTS",
        "Release:\t12.04",
        "Codename:\tprecise"
    ],
    "warnings": []
}
```

Note that this also makes the experience easier for new users and means that
the "Getting started" docs
(http://docs.ansible.com/intro_getting_started.html#your-first-commands) don't
need to cover inventory right away.

If one has an `ansible.cfg` with:

```
[defaults]
inventory = *
```

then it becomes even easier and `-i '*'` can be omitted -- e.g.:

```
ansible myuser@remotehost -a date
```
