### PR TITLE
Display config file read when -v provided

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -79,6 +79,8 @@ def load_config_file():
     for path in [path0, path1, path2, path3]:
         if path is not None and os.path.exists(path):
             try:
+                if '-v' in sys.argv:
+                    print('Reading config file: {0}'.format(path))
                 p.read(path)
             except configparser.Error as e:
                 print("Error reading config file: \n{0}".format(e))


### PR DESCRIPTION
Because I sometimes get confused because I don't know which config file is being picked up.

```
$ ansible foo -m ping -v
Reading config file: /Users/msabramo/smstack/ansible.cfg
...
```
