### PR TITLE
adhoc: Allow hosts not in inventory to be targeted

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -54,6 +54,9 @@ class AdHocCLI(CLI):
         self.parser.add_option('-m', '--module-name', dest='module_name',
             help="module name to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
             default=C.DEFAULT_MODULE_NAME)
+        self.parser.add_option('--allow-hosts-not-in-inventory',
+            action='store_true', dest='allow_hosts_not_in_inventory',
+            help="Allow targeting hosts not in inventory", default=True)
 
         self.options, self.args = self.parser.parse_args()
 
@@ -102,6 +105,9 @@ class AdHocCLI(CLI):
 
         inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=self.options.inventory)
         variable_manager.set_inventory(inventory)
+
+        if self.options.allow_hosts_not_in_inventory:
+            inventory.add_ungrouped_host(pattern)
 
         hosts = inventory.list_hosts(pattern)
         if len(hosts) == 0:

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -330,11 +330,14 @@ class Inventory(object):
             raise errors.AnsibleError("no hosts matching the pattern '%s' were found" % pat)
 
     def _create_implicit_localhost(self, pattern):
-        new_host = Host(pattern)
+        new_host = self.add_ungrouped_host(pattern)
         new_host.set_variable("ansible_python_interpreter", sys.executable)
         new_host.set_variable("ansible_connection", "local")
         new_host.ipv4_address = '127.0.0.1'
+        return new_host
 
+    def add_ungrouped_host(self, pattern):
+        new_host = Host(pattern)
         ungrouped = self.get_group("ungrouped")
         if ungrouped is None:
             self.add_group(Group('ungrouped'))


### PR DESCRIPTION
Sometimes I want to do something quick against a brand new host that I haven't yet added to the inventory. This is essentially a more flexible version of the "comma trick".

E.g.:

```
# `somehost` is not in the ansible inventory

$ ansible somehost -m ping --allow-hosts-not-in-inventory
user@host | SUCCESS => {
    "invocation": {
        "module_name": "ping",
        "module_args": {}
    },
    "changed": false,
    "ping": "pong"
}
```

Note that this also makes the experience easier for new users and means that the "Getting started" docs
(http://docs.ansible.com/intro_getting_started.html#your-first-commands) don't need to cover inventory right away, which makes for a more shallow learning curve.

Replaces https://github.com/ansible/ansible/pull/11426
