### PR TITLE
Add splitext filter

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -350,6 +350,11 @@ To get the relative path of a link, from a start point (new in version 1.7)::
 
     {{ path | relpath('/etc') }}
 
+To get the root and extension of a path or filename (new in version 2.0)::
+
+    # with path == 'nginx.conf' the return would be ('nginx', '.conf')
+    {{ path | splitext }}
+
 To work with Base64 encoded strings::
 
     {{ encoded | b64decode }}

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -316,6 +316,7 @@ class FilterModule(object):
             'expanduser': partial(unicode_wrap, os.path.expanduser),
             'realpath': partial(unicode_wrap, os.path.realpath),
             'relpath': partial(unicode_wrap, os.path.relpath),
+            'splitext': partial(unicode_wrap, os.path.splitext),
 
             # failure testing
             'failed'  : failed,


### PR DESCRIPTION
This filter exposed `os.path.splitext`.

I have noticed many times in the ansible IRC channel that someone wanted the root of a file with the extension stripped.

I often give them the following:

```
{{ filename.split('.')[0] }}
```

But that can be ugly and not self explanatory.

The `splitext` filter would make that look like:

```
{{ filename|splitext|first }}
```
