### PR TITLE
Treat generators like lists and tuples

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -16,6 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 from functools import partial
+import types
 
 try:
     import netaddr
@@ -319,7 +320,7 @@ def ipaddr(value, query = '', version = False, alias = 'ipaddr'):
         return False
 
     # Check if value is a list and parse each element
-    elif isinstance(value, (list, tuple)):
+    elif isinstance(value, (list, tuple, types.GeneratorType)):
 
         _ret = []
         for element in value:
@@ -457,7 +458,7 @@ def ipaddr(value, query = '', version = False, alias = 'ipaddr'):
 
 def ipwrap(value, query = ''):
     try:
-        if isinstance(value, (list, tuple)):
+        if isinstance(value, (list, tuple, types.GeneratorType)):
             _ret = []
             for element in value:
                 if ipaddr(element, query, version = False, alias = 'ipwrap'):


### PR DESCRIPTION
Fix for #11434. Jinja2 filters use generators extensively, so anyone doing something like

```
{{ ansible_interface.ipv6|map(attribute='address')|ipwrap }}
```

is liable to get in trouble, otherwise.
