### PR TITLE
Fix YAML formatting issue for rax integration tests

### DIFF
--- a/test/integration/roles/test_rax_cbs/tasks/main.yml
+++ b/test/integration/roles/test_rax_cbs/tasks/main.yml
@@ -8,7 +8,7 @@
   assert:
     that:
       - rax_cbs|failed
-      - rax_cbs.msg == 'missing required arguments: name'
+      - 'rax_cbs.msg == "missing required arguments: name"'
 # ============================================================
 
 
@@ -165,7 +165,7 @@
   assert:
     that:
       - rax_cbs|failed
-      - "rax_cbs.msg == 'value of volume_type must be one of: SSD,SATA, got: fail'"
+      - 'rax_cbs.msg == "value of volume_type must be one of: SSD,SATA, got: fail"'
 # ============================================================
 
 

--- a/test/integration/roles/test_rax_cbs_attachments/tasks/main.yml
+++ b/test/integration/roles/test_rax_cbs_attachments/tasks/main.yml
@@ -8,7 +8,7 @@
   assert:
     that:
       - rax_cbs_attachments|failed
-      - rax_cbs_attachments.msg == 'missing required arguments: server,volume,device'
+      - 'rax_cbs_attachments.msg == "missing required arguments: server,volume,device"'
 # ============================================================
 
 

--- a/test/integration/roles/test_rax_cdb/tasks/main.yml
+++ b/test/integration/roles/test_rax_cdb/tasks/main.yml
@@ -8,7 +8,7 @@
   assert:
     that:
       - rax_cdb|failed
-      - rax_cdb.msg == 'missing required arguments: name'
+      - 'rax_cdb.msg == "missing required arguments: name"'
 # ============================================================
 
 
@@ -60,7 +60,7 @@
   assert:
     that:
       - rax_cdb|failed
-      - rax_cdb.msg == 'missing required arguments: name'
+      - 'rax_cdb.msg == "missing required arguments: name"'
 # ============================================================
 
 

--- a/test/integration/roles/test_rax_cdb_database/tasks/main.yml
+++ b/test/integration/roles/test_rax_cdb_database/tasks/main.yml
@@ -8,7 +8,7 @@
   assert:
     that:
       - rax_cdb_database|failed
-      - rax_cdb_database.msg == 'missing required arguments: name,cdb_id'
+      - 'rax_cdb_database.msg == "missing required arguments: name,cdb_id"'
 # ============================================================
 
 
@@ -24,7 +24,7 @@
   assert:
     that:
       - rax_cdb_database|failed
-      - rax_cdb_database.msg == 'missing required arguments: cdb_id'
+      - 'rax_cdb_database.msg == "missing required arguments: cdb_id"'
 # ============================================================
 
 

--- a/test/integration/roles/test_rax_clb/tasks/main.yml
+++ b/test/integration/roles/test_rax_clb/tasks/main.yml
@@ -8,7 +8,7 @@
   assert:
     that:
       - rax_clb|failed
-      - rax_clb.msg == 'missing required arguments: name'
+      - 'rax_clb.msg == "missing required arguments: name"'
 # ============================================================
 
 
@@ -60,7 +60,7 @@
   assert:
     that:
       - rax_clb|failed
-      - rax_clb.msg == 'missing required arguments: name'
+      - 'rax_clb.msg == "missing required arguments: name"'
 # ============================================================
 
 
@@ -378,7 +378,7 @@
   assert:
     that:
       - rax_clb|failed
-      - "rax_clb.msg == 'value of type must be one of: PUBLIC,SERVICENET, got: BAD'"
+      - 'rax_clb.msg == "value of type must be one of: PUBLIC,SERVICENET, got: BAD"'
 # ============================================================
 
 
@@ -401,7 +401,7 @@
   assert:
     that:
       - rax_clb|failed
-      - "rax_clb.msg == 'value of protocol must be one of: DNS_TCP,DNS_UDP,FTP,HTTP,HTTPS,IMAPS,IMAPv4,LDAP,LDAPS,MYSQL,POP3,POP3S,SMTP,TCP,TCP_CLIENT_FIRST,UDP,UDP_STREAM,SFTP, got: BAD'"
+      - 'rax_clb.msg == "value of protocol must be one of: DNS_TCP,DNS_UDP,FTP,HTTP,HTTPS,IMAPS,IMAPv4,LDAP,LDAPS,MYSQL,POP3,POP3S,SMTP,TCP,TCP_CLIENT_FIRST,UDP,UDP_STREAM,SFTP, got: BAD"'
 # ============================================================
 
 
@@ -424,7 +424,7 @@
   assert:
     that:
       - rax_clb|failed
-      - "rax_clb.msg == 'value of algorithm must be one of: RANDOM,LEAST_CONNECTIONS,ROUND_ROBIN,WEIGHTED_LEAST_CONNECTIONS,WEIGHTED_ROUND_ROBIN, got: BAD'"
+      - 'rax_clb.msg == "value of algorithm must be one of: RANDOM,LEAST_CONNECTIONS,ROUND_ROBIN,WEIGHTED_LEAST_CONNECTIONS,WEIGHTED_ROUND_ROBIN, got: BAD"'
 # ============================================================
 
 

--- a/test/integration/roles/test_rax_clb_nodes/tasks/main.yml
+++ b/test/integration/roles/test_rax_clb_nodes/tasks/main.yml
@@ -8,7 +8,7 @@
   assert:
     that:
       - rax_clb_nodes|failed
-      - rax_clb_nodes.msg == 'missing required arguments: load_balancer_id'
+      - 'rax_clb_nodes.msg == "missing required arguments: load_balancer_id"'
 # ============================================================
 
 

--- a/test/integration/roles/test_rax_facts/tasks/main.yml
+++ b/test/integration/roles/test_rax_facts/tasks/main.yml
@@ -8,7 +8,7 @@
   assert:
     that:
       - rax_facts|failed
-      - rax_facts.msg == 'one of the following is required: address,id,name'
+      - 'rax_facts.msg == "one of the following is required: address,id,name"'
 # ============================================================
 
 

--- a/test/integration/roles/test_rax_keypair/tasks/main.yml
+++ b/test/integration/roles/test_rax_keypair/tasks/main.yml
@@ -8,7 +8,7 @@
   assert:
     that:
       - rax_keypair|failed
-      - rax_keypair.msg == 'missing required arguments: name'
+      - 'rax_keypair.msg == "missing required arguments: name"'
 # ============================================================
 
 

--- a/test/integration/roles/test_rax_meta/tasks/main.yml
+++ b/test/integration/roles/test_rax_meta/tasks/main.yml
@@ -8,7 +8,7 @@
   assert:
     that:
       - rax_meta|failed
-      - rax_meta.msg == 'one of the following is required: address,id,name'
+      - 'rax_meta.msg == "one of the following is required: address,id,name"'
 # ============================================================
 
 

--- a/test/integration/roles/test_rax_network/tasks/main.yml
+++ b/test/integration/roles/test_rax_network/tasks/main.yml
@@ -8,7 +8,7 @@
   assert:
     that:
       - rax_network|failed
-      - rax_network.msg == 'missing required arguments: label'
+      - 'rax_network.msg == "missing required arguments: label"'
 # ============================================================
 
 
@@ -61,7 +61,7 @@
   assert:
     that:
       - rax_network|failed
-      - rax_network.msg == 'missing required arguments: cidr'
+      - 'rax_network.msg == "missing required arguments: cidr"'
 # ============================================================
 
 

--- a/test/integration/roles/test_rax_scaling_group/tasks/main.yml
+++ b/test/integration/roles/test_rax_scaling_group/tasks/main.yml
@@ -622,7 +622,7 @@
     that:
       - rax_scaling_group|success
       - not rax_scaling_group|changed
-      - rax_scaling_group.autoscale_group.launchConfiguration.args.server['OS-DCF:diskConfig'] == 'AUTO'
+      - "rax_scaling_group.autoscale_group.launchConfiguration.args.server['OS-DCF:diskConfig'] == 'AUTO'"
 
 - name: Change disk_config 2
   rax_scaling_group:
@@ -644,7 +644,7 @@
     that:
       - rax_scaling_group|success
       - rax_scaling_group|changed
-      - rax_scaling_group.autoscale_group.launchConfiguration.args.server['OS-DCF:diskConfig'] == 'MANUAL'
+      - "rax_scaling_group.autoscale_group.launchConfiguration.args.server['OS-DCF:diskConfig'] == 'MANUAL'"
 # ============================================================
 
 


### PR DESCRIPTION
The `yaml.CSafeLoader` is more strict on parsing, and as such, causes some poorly formatted YAML in the rax integration tests to parse unexpectedly.

This PR fixes the parsing issues by wrapping the full line in quotes to prevent the YAML parser from thinking that a `:` in the line separates a key/value pair.
