### PR TITLE
assertRaises should be given an exception type. Fixes 11441

### DIFF
--- a/test/units/parsing/yaml/test_loader.py
+++ b/test/units/parsing/yaml/test_loader.py
@@ -29,6 +29,11 @@ from ansible.compat.tests.mock import patch
 
 from ansible.parsing.yaml.loader import AnsibleLoader
 
+try:
+    from _yaml import ParserError
+except ImportError:
+    from yaml.parser import ParserError
+
 
 class TestAnsibleLoaderBasic(unittest.TestCase):
 
@@ -123,7 +128,7 @@ class TestAnsibleLoaderBasic(unittest.TestCase):
     def test_error_conditions(self):
         stream = StringIO("""{""")
         loader = AnsibleLoader(stream, 'myfile.yml')
-        self.assertRaises(loader.get_single_data)
+        self.assertRaises(ParserError, loader.get_single_data)
 
     def test_front_matter(self):
         stream = StringIO("""---\nfoo: bar""")


### PR DESCRIPTION
This PR addresses an issue where `assertRaises` was not given an exception type to look for.  This gets unit tests passing again.
