### PR TITLE
Make test module work in v2

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -35,6 +35,7 @@ import subprocess
 import traceback
 import optparse
 import ansible.utils as utils
+from ansible.parsing.utils.jsonify import jsonify
 import ansible.module_common as module_common
 import ansible.constants as C
 
@@ -75,7 +76,7 @@ def write_argsfile(argstring, json=False):
     argsfile = open(argspath, 'w')
     if json:
         args = utils.parse_kv(argstring)
-        argstring = utils.jsonify(args)
+        argstring = jsonify(args)
     argsfile.write(argstring)
     argsfile.close()
     return argspath
@@ -150,7 +151,7 @@ def runtest( modfile, argspath):
         print "RAW OUTPUT"
         print out
         print err
-        results = utils.parse_json(out)
+        results = json.loads(out)
     except:
         print "***********************************"
         print "INVALID OUTPUT FORMAT"
@@ -160,7 +161,7 @@ def runtest( modfile, argspath):
 
     print "***********************************"
     print "PARSED OUTPUT"
-    print utils.jsonify(results,format=True)
+    print jsonify(results,format=True)
 
 def rundebug(debugger, modfile, argspath):
     """Run interactively with console debugger."""

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -36,6 +36,7 @@ import traceback
 import optparse
 import ansible.utils as utils
 from ansible.parsing.utils.jsonify import jsonify
+from ansible.parsing.splitter import parse_kv
 import ansible.module_common as module_common
 import ansible.constants as C
 
@@ -75,7 +76,7 @@ def write_argsfile(argstring, json=False):
     argspath = os.path.expanduser("~/.ansible_test_module_arguments")
     argsfile = open(argspath, 'w')
     if json:
-        args = utils.parse_kv(argstring)
+        args = parse_kv(argstring)
         argstring = jsonify(args)
     argsfile.write(argstring)
     argsfile.close()

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -177,7 +177,7 @@ def main():
     options, args = parse()
     (modfile, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter, options.check)
 
-    argspath=None
+    argspath = None
     if module_style != 'new':
         if module_style == 'non_native_want_json':
             argspath = write_argsfile(options.module_args, json=True)


### PR DESCRIPTION
Wasn't working because some utility functions have moved around:
- `jsonify` moved from `ansible.utils` to `ansible.parsing.utils.jsonify`
- I don't see `ansible.utils.parse_json` anymore so I used `json.loads`.

```
$ hacking/test-module -m lib/ansible/modules/core/packaging/os/apt_repository.py
* including generated source, if any, saving to: /Users/marca/.ansible_module_generated
* this may offset any line numbers in tracebacks/debuggers!
***********************************
RAW OUTPUT
{"msg": "missing required arguments: repo", "failed": true}


***********************************
PARSED OUTPUT
{
    "failed": true,
    "msg": "missing required arguments: repo"
}
```
