### PR TITLE
Define _callback_plugins in constructor

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -74,6 +74,9 @@ class TaskQueueManager:
 
         self._final_q = multiprocessing.Queue()
 
+        # load callback plugins
+        self._callback_plugins = self._load_callbacks(self._stdout_callback)
+
         # create the pool of worker threads, based on the number of forks specified
         try:
             fileno = sys.stdin.fileno()
@@ -203,9 +206,6 @@ class TaskQueueManager:
         a given task (meaning no hosts move on to the next task until all hosts
         are done with the current task).
         '''
-
-        # load callback plugins
-        self._callback_plugins = self._load_callbacks(self._stdout_callback)
 
         if play.vars_prompt:
             for var in play.vars_prompt:


### PR DESCRIPTION
Fixes #11463.
Since 927072546b4ffb12d6642643d44551de945b390f,
'TaskQueueManager._callback_plugins is defined in
'TaskQueueManager.run()', but it is possible to use
'_callback_plugins' without calling 'TaskQueueManager.run()'.
