### PR TITLE
Fix pause module when ansible output is piped

### DIFF
--- a/v1/ansible/runner/action_plugins/pause.py
+++ b/v1/ansible/runner/action_plugins/pause.py
@@ -24,6 +24,7 @@ from termios import tcflush, TCIFLUSH
 import datetime
 import sys
 import time
+import locale
 
 
 class ActionModule(object):
@@ -101,7 +102,7 @@ class ActionModule(object):
                 # Clear out any unflushed buffered input which would
                 # otherwise be consumed by raw_input() prematurely.
                 tcflush(sys.stdin, TCIFLUSH)
-                self.result['user_input'] = raw_input(self.prompt.encode(sys.stdout.encoding))
+                self.result['user_input'] = raw_input(self.prompt.encode(sys.stdout.encoding or locale.getpreferredencoding()))
         except KeyboardInterrupt:
             while True:
                 print '\nAction? (a)bort/(c)ontinue: '


### PR DESCRIPTION
Fixes traceback when pause module is used and ansible output is piped into another process (== no sys.stdout.encoding is set).

```
$ ansible -i '127.0.0.1,' '*' -m pause -a "prompt='test'"| cat
127.0.0.1 | FAILED => Traceback (most recent call last):
  File "/home/mivanov/repos/nap/golive/.pyenv/lib/python2.7/site-packages/ansible/runner/__init__.py", line 582, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/home/mivanov/repos/nap/golive/.pyenv/lib/python2.7/site-packages/ansible/runner/__init__.py", line 785, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/home/mivanov/repos/nap/golive/.pyenv/lib/python2.7/site-packages/ansible/runner/__init__.py", line 1032, in _executor_internal_inner
    result = handler.run(conn, tmp, module_name, module_args, inject, complex_args)
  File "/home/mivanov/repos/nap/golive/.pyenv/lib/python2.7/site-packages/ansible/runner/action_plugins/pause.py", line 105, in run
    self.result['user_input'] = raw_input(self.prompt.encode(sys.stdout.encoding))
TypeError: encode() argument 1 must be string, not None
```
