### PR TITLE
Fix pyflakes error: use 'msg' variable

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -95,7 +95,7 @@ class Play(Base, Taggable, Become):
 
     def get_name(self):
        ''' return the name of the Play '''
-       return "PLAY: %s" % self._attributes.get('name')
+       return self._attributes.get('name')
 
     @staticmethod
     def load(data, variable_manager=None, loader=None):

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -108,4 +108,4 @@ class CallbackModule(CallbackBase):
         else:
             msg = "PLAY [%s]" % name
 
-        self._display.banner(name)
+        self._display.banner(msg)

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -39,7 +39,7 @@ class TestPlay(unittest.TestCase):
 
     def test_empty_play(self):
         p = Play.load(dict())
-        self.assertEqual(str(p), "PLAY: ")
+        self.assertEqual(str(p), '')
 
     def test_basic_play(self):
         p = Play.load(dict(


### PR DESCRIPTION
1. Error was: local variable 'msg' is assigned to but never used
2. avoid to display "PLAY [PLAY:]" when name of the playbook is undefined
