### PR TITLE
implement jinja2 header overrides

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -19,6 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import ast
 import re
 
 from jinja2 import Environment
@@ -255,6 +256,17 @@ class Templar:
             else:
                 overrides = JINJA2_ALLOWED_OVERRIDES.intersection(set(overrides))
                 myenv = self.environment.overlay(overrides)
+
+            # Get jinja env overrides from template
+            if data.startswith(JINJA2_OVERRIDE):
+                eol = data.find('\n')
+                line = data[len(JINJA2_OVERRIDE):eol]
+                data = data[eol+1:]
+                for pair in line.split(','):
+                    (key,val) = pair.split(':')
+                    key = key.strip()
+                    if key in JINJA2_ALLOWED_OVERRIDES:
+                        setattr(myenv, key, ast.literal_eval(val.strip()))
 
             #FIXME: add tests
             myenv.filters.update(self._get_filters())


### PR DESCRIPTION
Complete 4098e8283e8cf7c13ced8c04796d838caf304c81, the code comes from [v1](https://github.com/ansible/ansible/blob/de98dc2968f312b5c565631a56f4bf153ccd9bec/v1/ansible/utils/template.py#L252).
