### PR TITLE
Make ansible-galaxy work with galaxy.ansible.com

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -318,9 +318,6 @@ class GalaxyCLI(CLI):
 
         roles_done = []
         roles_left = []
-        role_name = self.args.pop(0).strip()
-
-        gr = GalaxyRole(self.galaxy, role_name)
         if role_file:
             f = open(role_file, 'r')
             if role_file.endswith('.yaml') or role_file.endswith('.yml'):
@@ -328,20 +325,18 @@ class GalaxyCLI(CLI):
             else:
                 # roles listed in a file, one per line
                 for rname in f.readlines():
-                    roles_left.append(GalaxyRole(self.galaxy, rname))
+                    roles_left.append(GalaxyRole(self.galaxy, rname.strip()))
             f.close()
         else:
             # roles were specified directly, so we'll just go out grab them
             # (and their dependencies, unless the user doesn't want us to).
             for rname in self.args:
-                roles_left.append(GalaxyRole(self.galaxy, rname))
+                roles_left.append(GalaxyRole(self.galaxy, rname.strip()))
 
         while len(roles_left) > 0:
             # query the galaxy API for the role data
             role_data = None
             role = roles_left.pop(0)
-            role_src = role.src
-            role_scm = role.scm
             role_path = role.path
 
             if role_path:
@@ -350,21 +345,19 @@ class GalaxyCLI(CLI):
                 self.options.roles_path = roles_path
 
             tmp_file = None
-            if role_src and os.path.isfile(role_src):
+            installed = False
+            if role.src and os.path.isfile(role.src):
                 # installing a local tar.gz
-                tmp_file = role_src
+                tmp_file = role.src
             else:
-                if role_scm:
+                if role.scm:
                     # create tar file from scm url
-                    tmp_file = scm_archive_role(role_scm, role_src, role.version, role.name)
-                if role_src:
-                    if '://' in role_src:
-                        # just download a URL - version will probably be in the URL
-                        tmp_file = gr.fetch()
-                    else:
-                        role_data = self.api.lookup_role_by_name(role_src)
+                    tmp_file = scm_archive_role(role.scm, role.src, role.version, role.name)
+                if role.src:
+                    if '://' not in role.src:
+                        role_data = self.api.lookup_role_by_name(role.src)
                         if not role_data:
-                            self.display.warning("- sorry, %s was not found on %s." % (role_src, self.options.api_server))
+                            self.display.warning("- sorry, %s was not found on %s." % (role.src, self.options.api_server))
                             self.exit_without_ignore()
                             continue
 
@@ -377,24 +370,23 @@ class GalaxyCLI(CLI):
                             if len(role_versions) > 0:
                                 loose_versions = [LooseVersion(a.get('name',None)) for a in role_versions]
                                 loose_versions.sort()
-                                role["version"] = str(loose_versions[-1])
+                                role.version = str(loose_versions[-1])
                             else:
-                                role["version"] = 'master'
-                        elif role['version'] != 'master':
+                                role.version = 'master'
+                        elif role.version != 'master':
                             if role_versions and role.version not in [a.get('name', None) for a in role_versions]:
                                 self.display.warning('role is %s' % role)
                                 self.display.warning("- the specified version (%s) was not found in the list of available versions (%s)." % (role.version, role_versions))
                                 self.exit_without_ignore()
                                 continue
 
-                        # download the role. if --no-deps was specified, we stop here,
-                        # otherwise we recursively grab roles and all of their deps.
-                        tmp_file = gr.fetch(role_data)
-            installed = False
+                    # download the role. if --no-deps was specified, we stop here,
+                    # otherwise we recursively grab roles and all of their deps.
+                    tmp_file = role.fetch(role_data)
             if tmp_file:
-                installed = install_role(role.name, role.version, tmp_file, options)
+                installed = role.install(tmp_file)
                 # we're done with the temp file, clean it up
-                if tmp_file != role_src:
+                if tmp_file != role.src:
                     os.unlink(tmp_file)
                 # install dependencies, if we want them
 

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -49,7 +49,7 @@ class GalaxyRole(object):
 
         self.name = name
         self.version = version
-        self.src = src
+        self.src = src or name
         self.scm = scm
 
         self.path = (os.path.join(galaxy.roles_path, self.name))
@@ -178,17 +178,16 @@ class GalaxyRole(object):
 
         return False
 
-    def fetch(self, target, role_data):
+    def fetch(self, role_data):
         """
-        Downloads the archived role from github to a temp location, extracts
-        it, and then copies the extracted role to the role library path.
+        Downloads the archived role from github to a temp location
         """
 
         # first grab the file and save it to a temp location
-        if self.src:
-            archive_url = self.src
+        if "github_user" in role_data and "github_repo" in role_data:
+            archive_url = 'https://github.com/%s/%s/archive/%s.tar.gz' % (role_data["github_user"], role_data["github_repo"], self.version)
         else:
-            archive_url = 'https://github.com/%s/%s/archive/%s.tar.gz' % (role_data["github_user"], role_data["github_repo"], target)
+            archive_url = self.src
         self.display.display("- downloading role from %s" % archive_url)
 
         try:


### PR DESCRIPTION
##### Issue Type:

Bugfix pull request
##### Ansible Version:

```
ansible 2.0.0 (devel 956937b110) last updated 2015/06/15 14:54:16 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD e84392b14b) last updated 2015/07/07 11:27:31 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD 62caf8806a) last updated 2015/07/07 11:27:31 (GMT +1000)
  v1/ansible/modules/core: (detached HEAD f8d8af17cd) last updated 2015/06/15 15:23:40 (GMT +1000)
  v1/ansible/modules/extras: (detached HEAD 495ad450e5) last updated 2015/06/15 15:23:47 (GMT +1000)
  configured module search path = None
```
##### Ansible Configuration:

Nothing relevant
##### Environment:

N/A
##### Summary:

Update v2 ansible-galaxy to work with galaxy.ansible.com
##### Steps To Reproduce:

Run ansible-galaxy install galaxy.role. Fails
##### Expected Results:

```
ansible-galaxy install -r rolesfile -p roles
```

should work with a rolesfile containing roles using galaxy.ansible.com
##### Actual Results:

```
Traceback (most recent call last):
  File "/home/wthames/src/ansible/bin/ansible-galaxy", line 66, in <module>
    sys.exit(cli.run())
  File "/home/wthames/src/ansible/lib/ansible/cli/galaxy.py", line 134, in run
    self.execute()
  File "/home/wthames/src/ansible/lib/ansible/cli/__init__.py", line 96, in execute
    fn()
  File "/home/wthames/src/ansible/lib/ansible/cli/galaxy.py", line 321, in execute_install
    role_name = self.args.pop(0).strip()
IndexError: pop from empty list
```
