### PR TITLE
Add facts for datetime 8601 basic and basic short.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -601,6 +601,8 @@ class Facts(object):
         self.facts['date_time']['time'] = now.strftime('%H:%M:%S')
         self.facts['date_time']['iso8601_micro'] = now.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.facts['date_time']['iso8601'] = now.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        self.facts['date_time']['iso8601_basic'] = now.strftime("%Y%m%dT%H%M%S%f")
+        self.facts['date_time']['iso8601_basic_short'] = now.strftime("%Y%m%dT%H%M%S")
         self.facts['date_time']['tz'] = time.strftime("%Z")
         self.facts['date_time']['tz_offset'] = time.strftime("%z")
 


### PR DESCRIPTION
This PR adds facts for the date time in the official basic format of iso8601 and a short version without fractions of a second.

<strong>Basic</strong>
Notation: yyyymmddThhmmssffffff
Example: 20150705T160037761485

<strong>Basic Short</strong>
Notation: yyyymmddThhmmss
Example: 20150705T160037

This is useful for datetime stamping a file, AWS AMI name, etc. without all of the separators and without having to chain a number of calls, i.e.
`{{ ansible_date_time.year }}{{ ansible_date_time.month }}{{ ansible_date_time.day }}T{{ ansible_date_time.hour }}{{ ansible_date_time.minute }}{{ ansible_date_time.second }}`

Intentionally not using UTC with offset for brevity and as it can be appended by adding the existing tz/tz_offset facts.
