### PR TITLE
docsite/rst/intro_configuration.rst: reword Title.

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -1,5 +1,5 @@
-The Ansible Configuration File
-++++++++++++++++++++++++++++++
+Configuration file
+++++++++++++++++++
 
 .. contents:: Topics
 


### PR DESCRIPTION
Make Configuration the first word, so that it is in line with other documents
and that system administrators/devops people don't lose the tab when having
many browser tabs open.

Discussed wording with bcoca on IRC.
