### PR TITLE
Integration tests for notify with variable list.

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -72,6 +72,9 @@ test_handlers:
 	# Forcing false in play, which overrides command line
 	[ "$$(ansible-playbook test_force_handlers.yml --force-handlers --tags force_false_in_play -i inventory.handlers -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | egrep -o CALLED_HANDLER_. | sort | uniq | xargs)" = "CALLED_HANDLER_B" ]
 
+test_notify:
+	ansible-playbook test_notify.yml -i inventory.notify -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+
 test_hash:
 	ANSIBLE_HASH_BEHAVIOUR=replace ansible-playbook test_hash.yml -i $(INVENTORY) $(CREDENTIALS_ARG) -v -e '{"test_hash":{"extra_args":"this is an extra arg"}}'
 	ANSIBLE_HASH_BEHAVIOUR=merge ansible-playbook test_hash.yml -i $(INVENTORY) $(CREDENTIALS_ARG) -v -e '{"test_hash":{"extra_args":"this is an extra arg"}}'

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -21,7 +21,7 @@ VAULT_PASSWORD_FILE = vault-password
 
 CONSUL_RUNNING := $(shell python consul_running.py)
 
-all: parsing test_var_precedence unicode test_templating_settings non_destructive destructive includes check_mode test_hash test_handlers test_group_by test_vault test_tags
+all: parsing test_var_precedence unicode test_templating_settings non_destructive destructive includes check_mode test_hash test_handlers test_notify test_group_by test_vault test_tags
 
 parsing:
 	#ansible-playbook bad_parsing.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -vvv $(TEST_FLAGS) --tags prepare,common,scenario1; [ $$? -eq 4 ]

--- a/test/integration/inventory.notify
+++ b/test/integration/inventory.notify
@@ -1,0 +1,5 @@
+A handlers_list='["foo", "bar"]'
+B handlers_list=scalar
+C handlers_list=notify_host_c
+D
+E

--- a/test/integration/roles/test_notify/defaults/main.yml
+++ b/test/integration/roles/test_notify/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+handlers_list:
+  - default_foo

--- a/test/integration/roles/test_notify/handlers/main.yml
+++ b/test/integration/roles/test_notify/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: default_foo
+  command: echo

--- a/test/integration/roles/test_notify/handlers/main.yml
+++ b/test/integration/roles/test_notify/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: default_foo
-  command: echo
+  debug: msg="default_foo handler"

--- a/test/integration/roles/test_notify/handlers/main.yml
+++ b/test/integration/roles/test_notify/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: default_foo
-  debug: msg="default_foo handler"
+  set_fact:
+    called_handler: default_foo

--- a/test/integration/roles/test_notify/tasks/main.yml
+++ b/test/integration/roles/test_notify/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: notify with role default vars
+  command: echo
+  notify: '{{handlers_list}}'

--- a/test/integration/roles/test_notify/tasks/main.yml
+++ b/test/integration/roles/test_notify/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- debug: var=handlers_list
+
 - name: notify with role default vars
   command: echo
   notify: '{{handlers_list}}'

--- a/test/integration/test_notify.yml
+++ b/test/integration/test_notify.yml
@@ -1,0 +1,54 @@
+---
+- name: run notify with host vars
+  hosts: A:B
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: notify with host vars
+      command: echo
+      notify: '{{handlers_list}}'
+  handlers:
+    - name: foo
+      command: echo
+    - name: bar
+      command: echo
+    - name: scalar
+      command: echo
+
+- name: run notify with play vars
+  hosts: A:B
+  vars:
+    handlers_list:
+      - play_foo
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: notify with play vars
+      command: echo
+      notify: '{{handlers_list}}'
+  handlers:
+    - name: play_foo
+      command: echo
+
+- name: run notify with included vars
+  hosts: A:B
+  gather_facts: False
+  connection: local
+  tasks:
+    - include_vars: vars/test_notify_vars.yml
+    - name: notify with included vars
+      command: echo
+      notify: '{{handlers_list}}'
+  handlers:
+    - name: included_foo
+      command: echo
+
+- name: run notify with role default vars
+  hosts: C:D:E
+  gather_facts: False
+  connection: local
+  roles:
+    - role: test_notify
+  handlers:
+    - name: notify_host_c
+      command: echo

--- a/test/integration/test_notify.yml
+++ b/test/integration/test_notify.yml
@@ -4,6 +4,7 @@
   gather_facts: False
   connection: local
   tasks:
+    - debug: var=handlers_list
     - name: notify with host vars
       command: echo
       notify: '{{handlers_list}}'
@@ -23,6 +24,7 @@
   gather_facts: False
   connection: local
   tasks:
+    - debug: var=handlers_list
     - name: notify with play vars
       command: echo
       notify: '{{handlers_list}}'
@@ -49,6 +51,12 @@
   connection: local
   roles:
     - role: test_notify
+  tasks:
+    - meta: flush_handlers
+    - assert:
+        that:
+          called_handler is defined
   handlers:
     - name: notify_host_c
-      debug: msg="notify_host_c handler"
+      set_fact:
+        called_handler: notify_host_c

--- a/test/integration/test_notify.yml
+++ b/test/integration/test_notify.yml
@@ -9,11 +9,11 @@
       notify: '{{handlers_list}}'
   handlers:
     - name: foo
-      command: echo
+      debug: msg="foo handler"
     - name: bar
-      command: echo
+      debug: msg="bar handler"
     - name: scalar
-      command: echo
+      debug: msg="scalar handler"
 
 - name: run notify with play vars
   hosts: A:B
@@ -28,7 +28,7 @@
       notify: '{{handlers_list}}'
   handlers:
     - name: play_foo
-      command: echo
+      debug: msg="play_foo handler"
 
 - name: run notify with included vars
   hosts: A:B
@@ -41,7 +41,7 @@
       notify: '{{handlers_list}}'
   handlers:
     - name: included_foo
-      command: echo
+      debug: msg="included_foo handler"
 
 - name: run notify with role default vars
   hosts: C:D:E
@@ -51,4 +51,4 @@
     - role: test_notify
   handlers:
     - name: notify_host_c
-      command: echo
+      debug: msg="notify_host_c handler"

--- a/test/integration/vars/test_notify_vars.yml
+++ b/test/integration/vars/test_notify_vars.yml
@@ -1,0 +1,3 @@
+---
+handlers_list:
+  - included_foo


### PR DESCRIPTION
##### SUMMARY
  make test_notify -C test/integration

It checks notifications with scalar and dict variables.
It tests the notification resolution use the correct priority on resolution of the variables.


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
test/integration/Makefile
test/integration/inventory.notify
test/integration/roles/test_notify/defaults/main.yml
test/integration/roles/test_notify/handlers/main.yml
test/integration/roles/test_notify/tasks/main.yml
test/integration/test_notify.yml
test/integration/vars/test_notify_vars.yml

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


