### PR TITLE
Add no_syslog option in order to prevent ansible syslog its actions on the remote host

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -401,6 +401,17 @@ it to 'shell'::
 
     module_name = command
 
+.. _no_syslog:
+
+no_syslog
+=======
+
+.. versionadded: 'v2'
+
+By default ansible will log actions to the remote syslog, this turns off this behaviour.
+
+   no_syslog=False
+
 .. _nocolor:
 
 nocolor

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -58,6 +58,9 @@ timeout = 10
 # if so defined, consider logrotate
 #log_path = /var/log/ansible.log
 
+# this turns off ansible logging on the remote machine
+#no_syslog = True
+
 # default module name for /usr/bin/ansible
 #module_name = command
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -298,6 +298,8 @@ class CLI(object):
                 help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
             parser.add_option('-T', '--timeout', default=C.DEFAULT_TIMEOUT, type='int', dest='timeout',
                 help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
+            parser.add_option('-n', '--no-syslog', dest='no_syslog', action='store_true',
+                help='disable syslogging on remote machine')
 
         if async_opts:
             parser.add_option('-P', '--poll', default=C.DEFAULT_POLL_INTERVAL, type='int',

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -135,6 +135,7 @@ DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBL
 DEFAULT_EXECUTABLE        = get_config(p, DEFAULTS, 'executable', 'ANSIBLE_EXECUTABLE', '/bin/sh')
 DEFAULT_GATHERING         = get_config(p, DEFAULTS, 'gathering', 'ANSIBLE_GATHERING', 'implicit').lower()
 DEFAULT_LOG_PATH          = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
+DEFAULT_NO_SYSLOG         = get_config(p, DEFAULTS, 'no_syslog', 'ANSIBLE_NO_SYSLOG', False, boolean=True)
 
 # selinux
 DEFAULT_SELINUX_SPECIAL_FS = get_config(p, 'selinux', 'special_context_filesystems', None, 'fuse, nfs, vboxsf, ramfs', islist=True)

--- a/lib/ansible/executor/connection_info.py
+++ b/lib/ansible/executor/connection_info.py
@@ -173,6 +173,7 @@ class ConnectionInformation:
         self.only_tags   = set()
         self.skip_tags   = set()
         self.no_log      = False
+        self.no_syslog   = C.DEFAULT_NO_SYSLOG
         self.check_mode  = False
 
         #TODO: just pull options setup to above?
@@ -232,6 +233,8 @@ class ConnectionInformation:
             self.verbosity  = options.verbosity
         #if options.no_log:
         #    self.no_log     = boolean(options.no_log)
+        if options.no_syslog:
+            self.no_syslog  = boolean(options.no_syslog)
         if options.check:
             self.check_mode = boolean(options.check)
 
@@ -281,7 +284,7 @@ class ConnectionInformation:
 
         # loop through a subset of attributes on the task object and set
         # connection fields based on their values
-        for attr in ('connection', 'remote_user', 'become', 'become_user', 'become_pass', 'become_method', 'environment', 'no_log'):
+        for attr in ('connection', 'remote_user', 'become', 'become_user', 'become_pass', 'become_method', 'environment', 'no_log', 'no_syslog'):
             if hasattr(task, attr):
                 attr_val = getattr(task, attr)
                 if attr_val is not None:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -335,7 +335,7 @@ def heuristic_log_sanitize(data):
 
 class AnsibleModule(object):
 
-    def __init__(self, argument_spec, bypass_checks=False, no_log=False,
+    def __init__(self, argument_spec, bypass_checks=False, no_log=False, no_syslog=False,
         check_invalid_arguments=True, mutually_exclusive=None, required_together=None,
         required_one_of=None, add_file_common_args=False, supports_check_mode=False,
         required_if=None):
@@ -350,6 +350,7 @@ class AnsibleModule(object):
         self.supports_check_mode = supports_check_mode
         self.check_mode = False
         self.no_log = no_log
+        self.no_syslog = no_syslog
         self.cleanup_files = []
 
         self.aliases = {}
@@ -365,7 +366,7 @@ class AnsibleModule(object):
 
         self.params = self._load_params()
 
-        self._legal_inputs = ['_ansible_check_mode', '_ansible_no_log']
+        self._legal_inputs = ['_ansible_check_mode', '_ansible_no_log', '_ansible_no_syslog']
 
         self.aliases = self._handle_aliases()
 
@@ -373,8 +374,9 @@ class AnsibleModule(object):
             self._check_invalid_arguments()
         self._check_for_check_mode()
         self._check_for_no_log()
+        self._check_for_no_syslog()
 
-        # check exclusive early 
+        # check exclusive early
         if not bypass_checks:
             self._check_mutually_exclusive(mutually_exclusive)
 
@@ -399,7 +401,7 @@ class AnsibleModule(object):
             self._check_required_if(required_if)
 
         self._set_defaults(pre=False)
-        if not self.no_log:
+        if not (self.no_log or self.no_syslog):
             self._log_invocation()
 
         # finally, make sure we're in a sane working dir
@@ -918,6 +920,11 @@ class AnsibleModule(object):
         for (k,v) in self.params.iteritems():
             if k == '_ansible_no_log':
                 self.no_log = self.boolean(v)
+
+    def _check_for_no_syslog(self):
+        for (k,v) in self.params.iteritems():
+            if k == '_ansible_no_syslog':
+                self.no_syslog = self.boolean(v)
 
     def _check_invalid_arguments(self):
         for (k,v) in self.params.iteritems():

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -323,6 +323,9 @@ class ActionBase:
         if self._connection_info.no_log:
             module_args['_ansible_no_log'] = True
 
+        if self._connection_info.no_syslog:
+            module_args['_ansible_no_syslog'] = True
+
         debug("in _execute_module (%s, %s)" % (module_name, module_args))
 
         (module_style, shebang, module_data) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)

--- a/lib/ansible/plugins/action/async.py
+++ b/lib/ansible/plugins/action/async.py
@@ -40,8 +40,12 @@ class ActionModule(ActionBase):
 
         env_string = self._compute_environment_string()
 
+        module_args = self._task.args.copy()
+        if self._connection_info.no_syslog:
+            module_args['_ansible_no_syslog'] = True
+
         # configure, upload, and chmod the target module
-        (module_style, shebang, module_data) = self._configure_module(module_name=module_name, module_args=self._task.args, task_vars=task_vars)
+        (module_style, shebang, module_data) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)
         self._transfer_data(remote_module_path, module_data)
         self._remote_chmod(tmp, 'a+rx', remote_module_path)
 
@@ -50,7 +54,7 @@ class ActionModule(ActionBase):
         self._transfer_data(async_module_path, async_module_data)
         self._remote_chmod(tmp, 'a+rx', async_module_path)
 
-        argsfile = self._transfer_data(self._connection._shell.join_path(tmp, 'arguments'), json.dumps(self._task.args))
+        argsfile = self._transfer_data(self._connection._shell.join_path(tmp, 'arguments'), json.dumps(module_args))
 
         async_limit = self._task.async
         async_jid   = str(random.randint(0, 999999999999))


### PR DESCRIPTION
Add no_syslog option in order to prevent ansible syslog its actions
on the remote host.

Syslog on remote hosts can be turned off by:
- no_syslog option inside ansible.cfg.
- -n --no_syslog command line options (ansible and ansible-playbook).
