### PR TITLE
Add complex_args to logging callback data

### DIFF
--- a/v1/ansible/runner/__init__.py
+++ b/v1/ansible/runner/__init__.py
@@ -1078,7 +1078,8 @@ class Runner(object):
 
             result.result['invocation'] = dict(
                 module_args=module_args,
-                module_name=module_name
+                module_name=module_name,
+                module_complex_args=complex_args,
             )
 
             changed_when = self.module_vars.get('changed_when')


### PR DESCRIPTION
Callback plugins don't get given any complex module arguments on task invocation, this fixes that.
