### PR TITLE
Don't wrap text for AnsibleParserError

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -80,7 +80,7 @@ if __name__ == '__main__':
         display.error(str(e))
         sys.exit(5)
     except AnsibleParserError as e:
-        display.error(str(e))
+        display.error(str(e), wrap_text=False)
         sys.exit(4)
 # TQM takes care of these, but leaving comment to reserve the exit codes
 #    except AnsibleHostUnreachable as e:

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -182,10 +182,13 @@ class Display:
         (out, err) = cmd.communicate()
         self.display("%s\n" % out, color=color)
 
-    def error(self, msg):
-        new_msg = "\n[ERROR]: %s" % msg
-        wrapped = textwrap.wrap(new_msg, 79)
-        new_msg = "\n".join(wrapped) + "\n"
+    def error(self, msg, wrap_text=True):
+        if wrap_text:
+            new_msg = "\n[ERROR]: %s" % msg
+            wrapped = textwrap.wrap(new_msg, 79)
+            new_msg = "\n".join(wrapped) + "\n"
+        else:
+            new_msg = msg
         if new_msg not in self._errors:
             self.display(new_msg, color='red', stderr=True)
             self._errors[new_msg] = 1


### PR DESCRIPTION
This allows not messing up the wonderful error reporting that is carefully created. Instead of:

```
$ ansible-playbook foo.yml
 [ERROR]: ERROR! 'foo' is not a valid attribute for a Task  The error appears
to have been in '/Users/marca/dev/git-repos/ansible/foo.yml': line 4, column 7,
but may be elsewhere in the file depending on the exact syntax problem.  The
offending line appears to be:    tasks:     - name: do something       ^ here
```

we get:

```
$ ansible-playbook foo.yml
ERROR! 'foo' is not a valid attribute for a Task

The error appears to have been in '/Users/marca/dev/git-repos/ansible/foo.yml': line 4, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
    - name: do something
      ^ here
```

which is much nicer.
