### PR TITLE
Handle 'include' tasks in handlers

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -90,10 +90,19 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
         else:
             if use_handlers:
                 t = Handler.load(task, block=block, role=role, task_include=task_include, variable_manager=variable_manager, loader=loader)
+                if t.action == 'include':
+                    if t._role is not None:
+                        include_file = loader.path_dwim_relative(t._role._role_path, 'handlers', t.args.get('_raw_params'))
+                    else:
+                        include_file = loader.path_dwim(t.args.get('_raw_params'))
+                    handler_data = loader.load_from_file(include_file)
+                    for included in load_list_of_tasks(handler_data, play, block=block, role=role, task_include=task_include, use_handlers=use_handlers, variable_manager=variable_manager, loader=loader):
+                        task_list.append(included)
+                else:
+                    task_list.append(t)
             else:
                 t = Task.load(task, block=block, role=role, task_include=task_include, variable_manager=variable_manager, loader=loader)
-
-        task_list.append(t)
+                task_list.append(t)
 
     return task_list
 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -21,7 +21,7 @@ VAULT_PASSWORD_FILE = vault-password
 
 CONSUL_RUNNING := $(shell python consul_running.py)
 
-all: parsing test_var_precedence unicode test_templating_settings non_destructive destructive includes check_mode test_hash test_handlers test_group_by test_vault test_tags
+all: parsing test_var_precedence unicode test_templating_settings non_destructive destructive includes handlers_includes check_mode test_hash test_handlers test_group_by test_vault test_tags
 
 parsing:
 	ansible-playbook bad_parsing.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -vvv $(TEST_FLAGS) --tags prepare,common,scenario5
@@ -30,6 +30,9 @@ parsing:
 includes:
 	ansible-playbook test_includes.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) $(TEST_FLAGS)
 
+handlers_includes:
+	[ "$$(ansible-playbook test_handlers_include.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | grep -Po 'RUNNING HANDLER \[\K[^\]]+')" = "test handler" ]
+	[ "$$(ansible-playbook test_handlers_include_role.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | grep -Po 'RUNNING HANDLER \[\K[^\]]+')" = "test_handlers_include : test handler" ]
 unicode:
 	ansible-playbook unicode.yml -i $(INVENTORY) -e @$(VARS_FILE) -v $(TEST_FLAGS) -e 'extra_var=café'
 	# Test the start-at-task flag #9571

--- a/test/integration/handlers.yml
+++ b/test/integration/handlers.yml
@@ -1,0 +1,2 @@
+- name: test handler
+  debug: msg="handler called"

--- a/test/integration/roles/test_handlers_include/handlers/main.yml
+++ b/test/integration/roles/test_handlers_include/handlers/main.yml
@@ -1,0 +1,1 @@
+- include: handlers.yml

--- a/test/integration/roles/test_handlers_include/tasks/main.yml
+++ b/test/integration/roles/test_handlers_include/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: 'main task'
+  debug: msg='main task'
+  changed_when: True
+  notify: test handler

--- a/test/integration/test_handlers_include.yml
+++ b/test/integration/test_handlers_include.yml
@@ -1,0 +1,8 @@
+- name: verify playbook handlers can includes tasks
+  hosts: testhost
+  tasks:
+    - debug: msg="main task"
+      changed_when: True
+      notify: test handler
+  handlers:
+    - include: handlers.yml

--- a/test/integration/test_handlers_include_role.yml
+++ b/test/integration/test_handlers_include_role.yml
@@ -1,0 +1,4 @@
+- name: verify role handlers can includes tasks
+  hosts: testhost
+  roles: 
+    - { role: test_handlers_include }


### PR DESCRIPTION
`include` tasks in handlers must be handled : they were allowed in 1.9.
