### PR TITLE
Add complex_args to logging callback data

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1078,7 +1078,8 @@ class Runner(object):
 
             result.result['invocation'] = dict(
                 module_args=module_args,
-                module_name=module_name
+                module_name=module_name,
+                module_complex_args=complex_args,
             )
 
             changed_when = self.module_vars.get('changed_when')


### PR DESCRIPTION
Following on from #11512: Callback plugins don't get given any complex module arguments on task completion, this fixes that.
