### PR TITLE
assert password or ssh key provided on new image creation

### DIFF
--- a/test/integration/credentials.template
+++ b/test/integration/credentials.template
@@ -14,8 +14,8 @@ pem_file:
 project_id:
 
 # Azure Credentials
-azure_subscription_id:
-azure_cert_path:
+azure_subscription_id: "{{ lookup('env', 'AZURE_SUBSCRIPTION_ID') }}"
+azure_cert_path: "{{ lookup('env', 'AZURE_CERT_PATH') }}"
 
 # GITHUB SSH private key - a path to a SSH private key for use with github.com
 github_ssh_private_key: "{{ lookup('env','HOME') }}/.ssh/id_rsa"

--- a/test/integration/roles/test_azure/tasks/main.yml
+++ b/test/integration/roles/test_azure/tasks/main.yml
@@ -6,6 +6,9 @@
   azure:
   register: result
   ignore_errors: true
+  environment:
+    AZURE_SUBSCRIPTION_ID: ""
+    AZURE_CERT_PATH: ""
 
 - name: assert failure when called with no credentials
   assert:
@@ -14,6 +17,7 @@
        - 'result.msg == "No subscription_id provided. Please set ''AZURE_SUBSCRIPTION_ID'' or use the ''subscription_id'' parameter"'
 
 # ============================================================
+
 - name: test credentials
   azure:
     subscription_id: "{{ subscription_id }}"
@@ -26,6 +30,27 @@
     that:
        - 'result.failed'
        - 'result.msg == "name parameter is required for new instance"'
+
+# ============================================================
+- name: test with no password or ssh cert
+  azure:
+    subscription_id: "{{ subscription_id }}"
+    management_cert_path: "{{ cert_path }}"
+    name: "{{ instance_name }}"
+    image: "b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-12_04_4-LTS-amd64-server-20140514-en-us-30GB"
+    storage_account: "{{ storage_account }}"
+    user: "{{ user }}"
+    role_size: "{{ role_size }}"
+    location: "{{ location }}"
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: assert failure when called with no password or ssh cert
+  assert:
+    that:
+       - 'result.failed'
+       - 'result.msg == "password or ssh_cert_path parameter is required for new instance"'
 
 # ============================================================
 - name: test status=Running (expected changed=true)
@@ -41,6 +66,7 @@
     location: "{{ location }}"
     wait: yes
     state: present
+    wait_timeout: 1200
   register: result
 
 - name: assert state=Running (expected changed=true)
@@ -56,8 +82,14 @@
     subscription_id: "{{ subscription_id }}"
     management_cert_path: "{{ cert_path }}"
     name: "{{ instance_name }}"
-    #storage_account: "{{ storage_account }}"
-    #location: "{{ location }}"
     wait: yes
     state: absent
+    wait_timeout: 1200
   register: result
+
+- name: assert named deployment changed (expected changed=true)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.deployment.name == "{{ instance_name }}"'
+


### PR DESCRIPTION
- grab azure credentials from env by default in example credential template
- Remove environmental variables that define azure credentials when performing undefined credentials test
- add test for no password or ssh key early fail
