### PR TITLE
Change the output of ansible --list-hosts to be separated by spaces

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -110,8 +110,7 @@ class AdHocCLI(CLI):
             self.display.warning("provided hosts list is empty, only localhost is available")
 
         if self.options.listhosts:
-            for host in hosts:
-                self.display.display('    %s' % host)
+            self.display.display(' '.join([str(x) for x in hosts]))
             return 0
 
         if self.options.module_name in C.MODULE_REQUIRE_ARGS and not self.options.module_args:


### PR DESCRIPTION
Change the output of ansible --list-hosts to be separated by spaces instead of newlines

This way it can be readily used in `.clusterssh/config`:

```
external_cluster_command=/path/to/ansible/bin/ansible --list-hosts
```
