### PR TITLE
ability to specify any combination of EC2 instance states to return

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -58,6 +58,11 @@ route53 = False
 # 'all_instances' to True to return all instances regardless of state.
 all_instances = False
 
+# By default, only EC2 instances in the 'running' state are returned. Specify
+# EC2 instance states to return as a comma-separated list. This
+# option is overriden when 'all_instances' is True.
+# instance_states = pending, running, shutting-down, terminated, stopping, stopped
+
 # By default, only RDS instances in the 'available' state are returned.  Set
 # 'all_rds_instances' to True return all RDS instances regardless of state.
 all_rds_instances = False

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -244,6 +244,28 @@ class Ec2Inventory(object):
         else:
             self.all_instances = False
 
+        # Instance states to be gathered in inventory. Default is 'running'.
+        # Setting 'all_instances' to 'yes' overrides this option.
+        ec2_valid_instance_states = [
+            'pending',
+            'running',
+            'shutting-down',
+            'terminated',
+            'stopping',
+            'stopped'
+        ]
+        self.ec2_instance_states = []
+        if self.all_instances:
+            self.ec2_instance_states = ec2_valid_instance_states
+        elif config.has_option('ec2', 'instance_states'):
+          for instance_state in config.get('ec2', 'instance_states').split(','):
+            instance_state = instance_state.strip()
+            if instance_state not in ec2_valid_instance_states:
+              continue
+            self.ec2_instance_states.append(instance_state)
+        else:
+          self.ec2_instance_states = ['running']
+
         # Return all RDS instances? (if RDS is enabled)
         if config.has_option('ec2', 'all_rds_instances') and self.rds_enabled:
             self.all_rds_instances = config.getboolean('ec2', 'all_rds_instances')
@@ -531,8 +553,8 @@ class Ec2Inventory(object):
         ''' Adds an instance to the inventory and index, as long as it is
         addressable '''
 
-        # Only want running instances unless all_instances is True
-        if not self.all_instances and instance.state != 'running':
+        # Only return instances with desired instance states
+        if instance.state not in self.ec2_instance_states:
             return
 
         # Select the best destination address


### PR DESCRIPTION
This addition to the ec2.py inventory script allows for specifying any valid combination of EC2 instance states to return, rather than just all or 'running.' This introduces a new, optional configuration option in ec2.ini called `instance_states`. The default state is still 'running' and if `all_instances` is True, `instance_states` will be ignored, making this backward-compatible.

As an example, we have run into scenarios where we'd like to retrieve inventory information about hosts in either 'running', 'stopped', or 'shutting-down' states, but not 'pending' or 'terminated.' 
