### PR TITLE
Do not combine group_vars with an empty file

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -308,7 +308,8 @@ class VariableManager:
             paths = [os.path.join(path, name) for name in names if not name.startswith('.')]
             for p in paths:
                 _found, results = self._load_inventory_file(path=p, loader=loader)
-                data = self._combine_vars(data, results)
+                if results is not None:
+                    data = self._combine_vars(data, results)
 
         else:
             file_name, ext = os.path.splitext(path)


### PR DESCRIPTION
This addresses a specific case with multiple vars files
in a group_vars/${groupname}/ directory where one of those files
is empty, which returns None instead of an empty dict.

This then triggers an error in the combine_vars utility function.
