### PR TITLE
* v1/bin/ansible-galaxy - add -L / --extract-symlinks option

### DIFF
--- a/v1/bin/ansible-galaxy
+++ b/v1/bin/ansible-galaxy
@@ -192,6 +192,9 @@ def build_option_parser(action):
         parser.add_option(
             '-r', '--role-file', dest='role_file',
             help='A file containing a list of roles to be imported')
+        parser.add_option(
+            '-L', '--extract-symlinks', dest='extract_symlinks', action='store_true', default=False,
+            help='Recreate symlinks as well as regular files')
     elif action == "remove":
         parser.set_usage("usage: %prog remove role1 role2 ...")
     elif action == "list":
@@ -551,12 +554,14 @@ def install_role(role_name, role_version, role_filename, options):
             else:
                 os.makedirs(role_path)
 
+            extract_symlinks = get_opt(options, "extract_symlinks", False)
+
             # now we do the actual extraction to the role_path
             for member in members:
                 # we only extract files, and remove any relative path
                 # bits that might be in the file for security purposes
                 # and drop the leading directory, as mentioned above
-                if member.isreg() or member.issym():
+                if member.isreg() or ( extract_symlinks and member.issym() ):
                     parts = member.name.split("/")[1:]
                     final_parts = []
                     for part in parts:


### PR DESCRIPTION
bin/ansible-galaxy - add -L / --extract-symlinks option that will extract symlinks (duh)

I'm not neglecting security implications, that's why this option is disabled by default. Of course it needs to be disabled in order to preserve current default behaviour.

In my use case, where ansible-galaxy downloads files from local git repos only, it's perfectly valid to have it preserve elaborate config structures in "files" that contain symlinks.

This is in line with pull request #11587.

From what I can see in lib/ansible/galaxy/role.py (2.0 stuff) it's just extracting links, it's not even optional.
