### PR TITLE
Connection function for boto3

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -46,6 +46,19 @@ AWS_REGIONS = [
     'us-gov-west-1',
 ]
 
+def boto3_conn(module, conn_type=None, resource=None, region=None, endpoint=None, **params):
+    if conn_type not in ['both', 'resource', 'client']:
+        module.fail_json(msg='There is an issue in the code of the module. You must specify either both, resource or client to the conn_type parameter in the boto3_conn function call')
+
+    resource = boto3.session.Session().resource(resource, region_name=region, endpoint_url=endpoint, **params)
+    client = resource.meta.client
+
+    if conn_type == 'resource':
+        return resource
+    elif conn_type == 'client':
+        return client
+    else:
+        return client, resource
 
 def aws_common_argument_spec():
     return dict(
@@ -72,7 +85,7 @@ def boto_supports_profile_name():
     return hasattr(boto.ec2.EC2Connection, 'profile_name')
 
 
-def get_aws_connection_info(module):
+def get_aws_connection_info(module, boto3=False):
 
     # Check module args for credentials, then check environment vars
     # access_key
@@ -131,19 +144,31 @@ def get_aws_connection_info(module):
             # in case security_token came in as empty string
             security_token = None
 
-    boto_params = dict(aws_access_key_id=access_key,
-                       aws_secret_access_key=secret_key,
-                       security_token=security_token)
+    if boto3:
+        boto_params = dict(aws_access_key_id=access_key,
+                           aws_secret_access_key=secret_key,
+                           aws_session_token=security_token)
+        if validate_certs:
+            boto_params['verify'] = validate_certs
 
-    # profile_name only works as a key in boto >= 2.24
-    # so only set profile_name if passed as an argument
-    if profile_name:
-        if not boto_supports_profile_name():
-            module.fail_json("boto does not support profile_name before 2.24")
-        boto_params['profile_name'] = profile_name
+        if profile_name:
+            boto_params['profile_name'] = profile_name
 
-    if validate_certs and HAS_LOOSE_VERSION and LooseVersion(boto.Version) >= LooseVersion("2.6.0"):
-        boto_params['validate_certs'] = validate_certs
+
+    else:
+        boto_params = dict(aws_access_key_id=access_key,
+                           aws_secret_access_key=secret_key,
+                           security_token=security_token)
+
+       # profile_name only works as a key in boto >= 2.24
+        # so only set profile_name if passed as an argument
+        if profile_name:
+            if not boto_supports_profile_name():
+                module.fail_json("boto does not support profile_name before 2.24")
+            boto_params['profile_name'] = profile_name
+
+        if validate_certs and HAS_LOOSE_VERSION and LooseVersion(boto.Version) >= LooseVersion("2.6.0"):
+            boto_params['validate_certs'] = validate_certs
 
     return region, ec2_url, boto_params
 


### PR DESCRIPTION
This is adding a simple connection function for boto3.

Inside of a module's code, it would be used like:

``` python
region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

ec2_client, ec2_res = boto3_conn(module, conn_type='both', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_kwargs)

all_vpcs = ec2_client.describe_vpcs()
```

There are two noticeable pieces that make it functionally different than the current connection functions:
- `conn_type`: refers to the type of session you want, whether a high level resource session or a low level client session, or both.  The boto3 docs regarding sessions are [here](http://boto3.readthedocs.org/en/latest/reference/core/session.html)
- `resource`: this is the AWS resource you want to communicate such as ec2, s3, autoscaling, etc. Full list is [here](http://boto3.readthedocs.org/en/latest/reference/services/index.html)

This should allow everyone to start using boto3 for module development/enhancement right away.
