### PR TITLE
ssh port not working as the if clause is wrong

### DIFF
--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -104,7 +104,7 @@ class Connection(ConnectionBase):
         if not C.HOST_KEY_CHECKING:
             self._common_args += ("-o", "StrictHostKeyChecking=no")
 
-        if self._connection_info.port is not None:
+        if self._connection_info.port is None:
             self._common_args += ("-o", "Port={0}".format(self._connection_info.port))
         if self._connection_info.private_key_file is not None:
             self._common_args += ("-o", "IdentityFile=\"{0}\"".format(os.path.expanduser(self._connection_info.private_key_file)))


### PR DESCRIPTION
The ssh port always results in port 22 as the if clause is never executed, this means that hosts on non-standard ssh port cannot be accessed
