### PR TITLE
using loops: notify didn't work when the notify value is a single string (and not a list)

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -148,6 +148,9 @@ class TaskExecutor:
         # the variables and re-validate the task with the item variable
         task_vars = self._job_vars.copy()
 
+        templar = Templar(loader=self._loader, shared_loader_obj=self._shared_loader_obj, variables=task_vars)
+        self._task.post_validate(templar=templar)
+
         items = self._squash_items(items, task_vars)
         for item in items:
             task_vars['item'] = item

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -27,6 +27,9 @@ parsing:
 	ansible-playbook bad_parsing.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -vvv $(TEST_FLAGS) --tags prepare,common,scenario5
 	ansible-playbook good_parsing.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
+notify_loop:
+	[ "$$(ansible-playbook test_notify_loop.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | grep -Po 'RUNNING HANDLER \[\K[^\]]+')" = "test handler" ]
+
 includes:
 	ansible-playbook test_includes.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) $(TEST_FLAGS)
 

--- a/test/integration/test_notify_loop.yml
+++ b/test/integration/test_notify_loop.yml
@@ -1,0 +1,12 @@
+- hosts: testhost
+  tasks:
+    - name: 'debug'
+      debug: msg='a task'
+      changed_when: item == 1
+      notify: test handler
+      with_items:
+          - 1
+          - 2
+  handlers: 
+    - name: test handler
+      debug: msg="handler called"


### PR DESCRIPTION
[Task.post_validate](https://github.com/pilou-/ansible/blob/notify_with_items/lib/ansible/playbook/base.py#L242) was called for each [included task](https://github.com/pilou-/ansible/blob/notify_with_items/lib/ansible/executor/task_executor.py#L238) but [wasn't](https://github.com/pilou-/ansible/blob/notify_with_items/lib/ansible/executor/task_executor.py#L164) for the 'include' task. post_validate needs to be called because this method [modifies](https://github.com/pilou-/ansible/blob/notify_with_items/lib/ansible/playbook/base.py#L290) the task, for example the 'notify' attribute becomes a list if it's a string.

Without this patch, using an handler named 'test', [`_notified_handlers`](https://github.com/pilou-/ansible/blob/notify_with_items/lib/ansible/plugins/strategies/__init__.py#L403) looks like `{u'test': [], u's': [testhost], u'e': [testhost], u't': [testhost]}` when it should be `{u'test': [testhost]}`.
