### PR TITLE
fixes 11607, override ansible_ssh_port in group/host_vars

### DIFF
--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -78,8 +78,6 @@ class Host:
 
         if port and port != C.DEFAULT_REMOTE_PORT:
             self.set_variable('ansible_ssh_port', int(port))
-        else:
-            self.set_variable('ansible_ssh_port', C.DEFAULT_REMOTE_PORT)
 
         self._gathered_facts = False
 
@@ -124,6 +122,10 @@ class Host:
         results['inventory_hostname'] = self.name
         results['inventory_hostname_short'] = self.name.split('.')[0]
         results['ansible_ssh_host'] = self.ipv4_address
+
+        if 'ansible_ssh_port' not in results:
+            results['ansible_ssh_port'] = C.DEFAULT_REMOTE_PORT
+
         results['group_names'] = sorted([ g.name for g in groups if g.name != 'all'])
         return results
 


### PR DESCRIPTION
Tested with `ansible myhost -m ping -vvvv`.  It correctly picks up ansible_ssh_port in the following order
- host_vars
- group_vars
- remote_port (default) in ansible.cfg

Full testing can be seen in https://gist.github.com/halberom/2195fe0d6dfa996d9439

Only thing I'm not sure about is whether it should be assigned to a class variable?  Also I took a look at the unit tests and although i could see there's a port test in executor.connection_info, I've no idea how to validate or expand on it.  Any tips appreciated.
