### PR TITLE
hacking/test-module, updated to new location and non-classness of module_common

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -37,7 +37,7 @@ import optparse
 import ansible.utils as utils
 from ansible.parsing.utils.jsonify import jsonify
 from ansible.parsing.splitter import parse_kv
-import ansible.module_common as module_common
+import ansible.executor.module_common as module_common
 import ansible.constants as C
 
 try:
@@ -89,7 +89,7 @@ def boilerplate_module(modfile, args, interpreter, check):
     #module_data = module_fh.read()
     #module_fh.close()
 
-    replacer = module_common.ModuleReplacer()
+    #replacer = module_common.ModuleReplacer()
 
     #included_boilerplate = module_data.find(module_common.REPLACER) != -1 or module_data.find("import ansible.module_utils") != -1
 
@@ -118,7 +118,7 @@ def boilerplate_module(modfile, args, interpreter, check):
     if check:
          complex_args['CHECKMODE'] = True
 
-    (module_data, module_style, shebang) = replacer.modify_module(
+    (module_data, module_style, shebang) = module_common.modify_module(
         modfile, 
         complex_args,
         args,


### PR DESCRIPTION
before change

```
$ hacking/test-module -m ~/dev/ansible-modules-core/system/ping.py 
Traceback (most recent call last):
  File "hacking/test-module", line 40, in <module>
    import ansible.module_common as module_common
ImportError: No module named module_common
```

after change

```
$ hacking/test-module -m ~/dev/ansible-modules-core/system/ping.py 
* including generated source, if any, saving to: /Users/glynch/.ansible_module_generated
* this may offset any line numbers in tracebacks/debuggers!
***********************************
RAW OUTPUT
{"changed": false, "ping": "pong"}


***********************************
PARSED OUTPUT
{
    "changed": false, 
    "ping": "pong"
}
```
