### PR TITLE
devel breaks «gathering=explicit» setting in ansible.cfg

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -58,7 +58,7 @@ class Play(Base, Taggable, Become):
     _accelerate_port     = FieldAttribute(isa='int', default=5099) # should be alias of port
 
     # Connection
-    _gather_facts        = FieldAttribute(isa='string', default='smart')
+    _gather_facts        = FieldAttribute(isa='bool', default=None)
     _hosts               = FieldAttribute(isa='list', default=[], required=True, listof=string_types)
     _name                = FieldAttribute(isa='string', default='')
 


### PR DESCRIPTION
Issue Type:

Bugfix Pull Request

Ansible Version:

devel@d70c88bf

Ansible Configuration:

gathering=explicit

Environment:

N/A

Summary:

Setting gathering=explicit in ansible.cfg has no effect: plays without gather_facts: True still gathered facts.

There was a confusion between the valid values for defaults.gathering (explicit/implicit/smart) and a play's gather_facts setting (boolean), which resulted in gathering=explicit being ignored.

Steps To Reproduce:

Set gathering=explicit. Run a play that doesn't set gather_facts: True.

Expected Results:

Doesn't gather facts.

Actual Results:

Does gather facts.
