### PR TITLE
profile_tasks.py requires CALLBACK_ constants or the v2 code doesn't pass the …

### DIFF
--- a/lib/ansible/plugins/callback/profile_tasks.py
+++ b/lib/ansible/plugins/callback/profile_tasks.py
@@ -58,7 +58,14 @@ def tasktime():
 
 
 class CallbackModule(CallbackBase):
-
+    """
+    This callback module provides per-task timing, ongoing playbook elapsed time 
+    and ordered list of top 20 longest running tasks at end.
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'profile_tasks'
+ 
     def __init__(self, display):
         self.stats = {}
         self.current = None


### PR DESCRIPTION
…display param and it gives an error

relates to #11625 and commit a09f6236a5f9ace208e7b17893e67c386abaa802
fixes #11627 

before change

```
$ ansible-playbook plays/test_to_json.yml -vvv
Using /Users/glynch/vagrant/ansible_foo/ansible.cfg as config file
1 plays in plays/test_to_json.yml
 [ERROR]: Unexpected Exception: __init__() takes exactly 2 arguments (1 given)

the full traceback was:

Traceback (most recent call last):
  File "/Users/glynch/dev/ansible/bin/ansible-playbook", line 77, in <module>
    sys.exit(cli.run())
  File "/Users/glynch/dev/ansible/lib/ansible/cli/playbook.py", line 162, in run
    results = pbex.run()
  File "/Users/glynch/dev/ansible/lib/ansible/executor/playbook_executor.py", line 128, in run
    self._tqm.load_callbacks()
  File "/Users/glynch/dev/ansible/lib/ansible/executor/task_queue_manager.py", line 154, in load_callbacks
    self._callback_plugins.append(callback_plugin())
TypeError: __init__() takes exactly 2 arguments (1 given)
```

after change

```
$ ansible-playbook plays/test_to_json.yml -vvv
Using /Users/glynch/vagrant/ansible_foo/ansible.cfg as config file
1 plays in plays/test_to_json.yml

PLAY: ***************************************************************************

TASK [debug msg={"bob": "bar", "fox": "jumped over"}] ***************************
ok: [centos66] => {
    "changed": false, 
    "msg": {
        "bob": "bar", 
        "fox": "jumped over"
    }
}
```
