### PR TITLE
GCE tag prefix for creating ansible group.

### DIFF
--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -257,7 +257,10 @@ class GceInventory(object):
 
             tags = node.extra['tags']
             for t in tags:
-                tag = 'tag_%s' % t
+                if t.startswith('group-'):
+                    tag = t[6:]
+                else:
+                    tag = 'tag_%s' % t
                 if groups.has_key(tag): groups[tag].append(name)
                 else: groups[tag] = [name]
 


### PR DESCRIPTION
When you migrate your old hosting to GCE, you want to keep your beloved groups. It can be done with a simple name convention : a GCE tag beginning with group-, like "group-toto" becomes a group named "toto".
