### PR TITLE
capture error when smoeone puts a list or some other complex type in

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -403,6 +403,9 @@ class Runner(object):
             # the hostname was not found in the inventory, so
             # we just ignore this and try the next method
             pass
+        except TypeError, e:
+            # Someone is trying to pass a list or some other 'non string' as a host.
+            raise errors.AnsibleError("Invalid type for delegate_to: %s" % str(e))
 
         if thisuser is None and self.remote_user:
             # user defined by play/runner


### PR DESCRIPTION
note that this is a fix for stable-1.9, fixes reported traceback:

```
    - name: Create facts.d directory on ops-control
      file:
        state: directory
        path: /etc/ansible/facts.d
      sudo: yes
      delegate_to: "{{groups.control}}"
```

produces

```
TASK: [debug var=groups.control] ********************************************** 
ok: [127.0.0.1] => {
    "var": {
        "groups.control": [
            "10.0.196.112"
        ]
    }
}


TASK: [Create facts.d directory on ops-control] ******************************* 
fatal: [127.0.0.1 -> [u'10.0.196.112']] => Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 582, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 785, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 923, in _executor_internal_inner
    delegate = self._compute_delegate(actual_pass, inject)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 363, in _compute_delegate
    delegate['user'] = self._compute_delegate_user(self.delegate_to, delegate['inject'])
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 393, in _compute_delegate_user
    if host in inject['hostvars']:
TypeError: unhashable type: 'list'
```
