### PR TITLE
Update list of prerequisites for 'make tests'

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,7 @@ mock interfaces rather than producing side effects.
 
 Playbook engine code is better suited for integration tests.
 
-Requirements: sudo pip install paramiko PyYAML jinja2 httplib2 passlib nose mock
+Requirements: sudo pip install paramiko PyYAML jinja2 httplib2 passlib nose mock patch funcsigs coverage
 
 integration
 -----------


### PR DESCRIPTION
I had to install these additional modules to get 'make tests' to run without complaint: patch, funcsigs, and coverage
