### PR TITLE
Modifications to ignored files in inventory directories (v2)

### DIFF
--- a/docsite/rst/intro_dynamic_inventory.rst
+++ b/docsite/rst/intro_dynamic_inventory.rst
@@ -218,12 +218,20 @@ to include it in the project.
 
 .. _using_multiple_sources:
 
-Using Multiple Inventory Sources
-````````````````````````````````
+Using Inventory Directories and Multiple Inventory Sources
+``````````````````````````````````````````````````````````
 
 If the location given to -i in Ansible is a directory (or as so configured in ansible.cfg), Ansible can use multiple inventory sources
 at the same time.  When doing so, it is possible to mix both dynamic and statically managed inventory sources in the same ansible run.  Instant
 hybrid cloud!
+
+In an inventory directory, executable files will be treated as dynamic inventory sources and most other files as static sources. Files which end with any of the following will be ignored::
+
+    ~, .orig, .bak, .ini, .retry, .pyc, .pyo
+
+You can replace this list with your own selection by configuring an ``inventory_ignore_extensions`` list in ansible.cfg, or setting the ANSIBLE_INVENTORY_IGNORE environment variable. The value in either case should be a comma-separated list of patterns, as shown above.
+
+Any ``group_vars`` and ``host_vars`` subdirectories in and inventory directory will be interpreted as expected, making inventory directories a powerful way to organize different sets of configurations.
 
 .. _static_groups_of_dynamic:
 

--- a/docsite/rst/intro_dynamic_inventory.rst
+++ b/docsite/rst/intro_dynamic_inventory.rst
@@ -231,7 +231,7 @@ In an inventory directory, executable files will be treated as dynamic inventory
 
 You can replace this list with your own selection by configuring an ``inventory_ignore_extensions`` list in ansible.cfg, or setting the ANSIBLE_INVENTORY_IGNORE environment variable. The value in either case should be a comma-separated list of patterns, as shown above.
 
-Any ``group_vars`` and ``host_vars`` subdirectories in and inventory directory will be interpreted as expected, making inventory directories a powerful way to organize different sets of configurations.
+Any ``group_vars`` and ``host_vars`` subdirectories in an inventory directory will be interpreted as expected, making inventory directories a powerful way to organize different sets of configurations.
 
 .. _static_groups_of_dynamic:
 


### PR DESCRIPTION
_A replacement for the old pull request #8830._

This adds README\* to the list of file patterns ignored in inventory directories, and adds an 'ignored_inventory_files' configuration option which can be used to override the list.  

The environment variable ANSIBLE_IGNORED_INVENTORY_FILES can also be used.

I've tested this by hand, but I didn't know if there's a good place to test this yet in the new v2 test system.

All the best, 
Quentin
