### PR TITLE
Meta inventory and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Major Changes:
  * template code now retains types for bools and numbers instead of turning them into strings.
    If you need the old behaviour, quote the value and it will get passed around as a string
  * Consolidated code from modules using urllib2 to normalize features, TLS and SNI support
+ * Consiidated code from modules using urllib2 to normalize features, TLS and SNI support
+ * added meta: refresh_inventory to force rereading the inventory in a play
 
 Deprecated Modules (new ones in parens):
   * ec2_ami_search (ec2_ami_find)

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -143,6 +143,7 @@ DEFAULT_EXECUTABLE        = get_config(p, DEFAULTS, 'executable', 'ANSIBLE_EXECU
 DEFAULT_GATHERING         = get_config(p, DEFAULTS, 'gathering', 'ANSIBLE_GATHERING', 'implicit').lower()
 DEFAULT_LOG_PATH          = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
 DEFAULT_FORCE_HANDLERS    = get_config(p, DEFAULTS, 'force_handlers', 'ANSIBLE_FORCE_HANDLERS', False, boolean=True)
+DEFAULT_INVENTORY_IGNORE  = get_config(p, DEFAULTS, 'inventory_ignore_extensions', 'ANSIBLE_INVENTORY_IGNORE', ["~", ".orig", ".bak", ".ini", ".cfg", ".retry", ".pyc", ".pyo"], islist=True)
 
 # selinux
 DEFAULT_SELINUX_SPECIAL_FS = get_config(p, 'selinux', 'special_context_filesystems', None, 'fuse, nfs, vboxsf, ramfs', islist=True)
@@ -197,7 +198,7 @@ HOST_KEY_CHECKING              = get_config(p, DEFAULTS, 'host_key_checking',  '
 SYSTEM_WARNINGS                = get_config(p, DEFAULTS, 'system_warnings', 'ANSIBLE_SYSTEM_WARNINGS', True, boolean=True)
 DEPRECATION_WARNINGS           = get_config(p, DEFAULTS, 'deprecation_warnings', 'ANSIBLE_DEPRECATION_WARNINGS', True, boolean=True)
 DEFAULT_CALLABLE_WHITELIST     = get_config(p, DEFAULTS, 'callable_whitelist', 'ANSIBLE_CALLABLE_WHITELIST', [], islist=True)
-COMMAND_WARNINGS               = get_config(p, DEFAULTS, 'command_warnings', 'ANSIBLE_COMMAND_WARNINGS', False, boolean=True)
+COMMAND_WARNINGS               = get_config(p, DEFAULTS, 'command_warnings', 'ANSIBLE_COMMAND_WARNINGS', True, boolean=True)
 DEFAULT_LOAD_CALLBACK_PLUGINS  = get_config(p, DEFAULTS, 'bin_ansible_callbacks', 'ANSIBLE_LOAD_CALLBACK_PLUGINS', False, boolean=True)
 DEFAULT_CALLBACK_WHITELIST     = get_config(p, DEFAULTS, 'callback_whitelist', 'ANSIBLE_CALLBACK_WHITELIST', [], islist=True)
 RETRY_FILES_ENABLED            = get_config(p, DEFAULTS, 'retry_files_enabled', 'ANSIBLE_RETRY_FILES_ENABLED', True, boolean=True)

--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -27,10 +27,57 @@ from ansible.errors import AnsibleError
 
 from ansible.inventory.host import Host
 from ansible.inventory.group import Group
-from ansible.inventory.ini import InventoryParser
-from ansible.inventory.script import InventoryScript
-from ansible.utils.path import is_executable
 from ansible.utils.vars import combine_vars
+
+from ansible.utils.path import is_executable
+from ansible.inventory.ini import InventoryParser as InventoryINIParser
+from ansible.inventory.script import InventoryScript
+
+__all__ = ['get_file_parser']
+
+def get_file_parser(hostsfile, loader):
+    # check to see if the specified file starts with a
+    # shebang (#!/), so if an error is raised by the parser
+    # class we can show a more apropos error
+
+    shebang_present = False
+    processed = False
+    myerr = []
+    parser = None
+
+    try:
+        inv_file = open(hostsfile)
+        first_line = inv_file.readlines()[0]
+        inv_file.close()
+        if first_line.startswith('#!'):
+            shebang_present = True
+    except:
+        pass
+
+    if is_executable(hostsfile):
+        try:
+            parser = InventoryScript(loader=loader, filename=hostsfile)
+            processed = True
+        except Exception as e:
+            myerr.append("The file %s is marked as executable, but failed to execute correctly. " % hostsfile + \
+                            "If this is not supposed to be an executable script, correct this with `chmod -x %s`." % hostsfile)
+            myerr.append(str(e))
+
+    if not processed:
+        try:
+            parser = InventoryINIParser(filename=hostsfile)
+            processed = True
+        except Exception as e:
+            if shebang_present and not is_executable(hostsfile):
+                myerr.append("The file %s looks like it should be an executable inventory script, but is not marked executable. " % hostsfile + \
+                              "Perhaps you want to correct this with `chmod +x %s`?" % hostsfile)
+            else:
+                myerr.append(str(e))
+
+    if not processed and myerr:
+        raise AnsibleError( '\n'.join(myerr) )
+
+    return parser
 
 class InventoryDirectory(object):
     ''' Host inventory parser for ansible using a directory of inventories. '''
@@ -48,7 +95,7 @@ class InventoryDirectory(object):
         for i in self.names:
 
             # Skip files that end with certain extensions or characters
-            if any(i.endswith(ext) for ext in ("~", ".orig", ".bak", ".ini", ".cfg", ".retry", ".pyc", ".pyo")):
+            if any(i.endswith(ext) for ext in C.DEFAULT_INVENTORY_IGNORE):
                 continue
             # Skip hidden files
             if i.startswith('.') and not i.startswith('./'):
@@ -59,10 +106,14 @@ class InventoryDirectory(object):
             fullpath = os.path.join(self.directory, i)
             if os.path.isdir(fullpath):
                 parser = InventoryDirectory(loader=loader, filename=fullpath)
-            elif is_executable(fullpath):
-                parser = InventoryScript(loader=loader, filename=fullpath)
             else:
-                parser = InventoryParser(filename=fullpath)
+                parser = get_file_parser(fullpath, loader)
+                if parser is None:
+                    #FIXME: needs to use display
+                    import warnings
+                    warnings.warning("Could not find parser for %s, skipping" % fullpath)
+                    continue
+
             self.parsers.append(parser)
 
             # retrieve all groups and hosts form the parser and add them to

--- a/lib/ansible/plugins/inventory/README.md
+++ b/lib/ansible/plugins/inventory/README.md
@@ -1,0 +1,1 @@
+These are not currently in use, but this is what the future of inventory will become after 2.0

--- a/lib/ansible/plugins/inventory/directory.py
+++ b/lib/ansible/plugins/inventory/directory.py
@@ -22,10 +22,13 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+from ansible import constants as C
 
 from . aggregate import InventoryAggregateParser
 
 class InventoryDirectoryParser(InventoryAggregateParser):
+
+    CONDITION="is_dir(%s)"
 
     def __init__(self, inven_directory):
         directory = inven_directory
@@ -35,7 +38,7 @@ class InventoryDirectoryParser(InventoryAggregateParser):
         # Clean up the list of filenames
         for filename in names:
             # Skip files that end with certain extensions or characters
-            if any(filename.endswith(ext) for ext in ("~", ".orig", ".bak", ".ini", ".retry", ".pyc", ".pyo")):
+            if any(filename.endswith(ext) for ext in C.DEFAULT_INVENTORY_IGNORE):
                 continue
             # Skip hidden files
             if filename.startswith('.') and not filename.startswith('.{0}'.format(os.path.sep)):

--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -23,9 +23,12 @@ __metaclass__ = type
 
 import os
 
+from ansible import constants as C
 from . import InventoryParser
 
 class InventoryIniParser(InventoryAggregateParser):
+
+    CONDITION="is_file(%s)"
 
     def __init__(self, inven_directory):
         directory = inven_directory
@@ -35,7 +38,7 @@ class InventoryIniParser(InventoryAggregateParser):
         # Clean up the list of filenames
         for filename in names:
             # Skip files that end with certain extensions or characters
-            if any(filename.endswith(ext) for ext in ("~", ".orig", ".bak", ".ini", ".retry", ".pyc", ".pyo")):
+            if any(filename.endswith(ext) for ext in C.DEFAULT_INVENTORY_IGNORE):
                 continue
             # Skip hidden files
             if filename.startswith('.') and not filename.startswith('.{0}'.format(os.path.sep)):

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -1,0 +1,31 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+#############################################
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+from ansible import constants as C
+from . import InventoryParser
+
+class InventoryScriptParser(InventoryParser):
+
+    CONDITION="is_file(%s) and is_executable(%s)"

--- a/lib/ansible/plugins/strategies/__init__.py
+++ b/lib/ansible/plugins/strategies/__init__.py
@@ -506,3 +506,21 @@ class StrategyBase:
         self._display.banner(msg)
 
         return ret
+
+    def _execute_meta(self, task, play_context, iterator):
+
+        # meta tasks store their args in the _raw_params field of args,
+        # since they do not use k=v pairs, so get that
+        meta_action = task.args.get('_raw_params')
+
+        if meta_action == 'noop':
+            # FIXME: issue a callback for the noop here?
+            pass
+        elif meta_action == 'flush_handlers':
+            self.run_handlers(iterator, play_context)
+        elif meta_action == 'refresh_inventory':
+            self._inventory.refresh_inventory()
+        #elif meta_action == 'reset_connection':
+        #    connection_info.connection.close()
+        else:
+            raise AnsibleError("invalid meta action requested: %s" % meta_action, obj=task._ds)

--- a/lib/ansible/plugins/strategies/linear.py
+++ b/lib/ansible/plugins/strategies/linear.py
@@ -178,16 +178,7 @@ class StrategyModule(StrategyBase):
                             continue
 
                     if task.action == 'meta':
-                        # meta tasks store their args in the _raw_params field of args,
-                        # since they do not use k=v pairs, so get that
-                        meta_action = task.args.get('_raw_params')
-                        if meta_action == 'noop':
-                            # FIXME: issue a callback for the noop here?
-                            continue
-                        elif meta_action == 'flush_handlers':
-                            self.run_handlers(iterator, play_context)
-                        else:
-                            raise AnsibleError("invalid meta action requested: %s" % meta_action, obj=task._ds)
+                        self._execute_meta(task, play_context, iterator)
                     else:
                         # handle step if needed, skip meta actions as they are used internally
                         if self._step and choose_step:


### PR DESCRIPTION
added meta: refresh_inventory
cleaned up AnsibleError to match general style
now dir and single file share same logic on dealing with files
if executable fails, we try ini aftewards and only then really fail
inventory ignored files are now configurable
added note to plugins/inventory that it is not currently used code

fixes  #8830,  #10068, #10369 and some cases of #9526
