### PR TITLE
allow ansible to connect to docker containers (without using ssh)

### DIFF
--- a/lib/ansible/plugins/connections/docker.py
+++ b/lib/ansible/plugins/connections/docker.py
@@ -80,6 +80,12 @@ class Connection(ConnectionBase):
 
     def _connect(self, port=None):
         """ Connect to the container. Nothing to do """
+        if not self._connected:
+            self._display.vvv("ESTABLISH LOCAL CONNECTION FOR USER: {0}".format(
+                self._play_context.remote_user, host=self._play_context.remote_addr)
+            )
+            self._connected = True
+
         return self
 
     def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False,
@@ -162,4 +168,4 @@ class Connection(ConnectionBase):
 
     def close(self):
         """ Terminate the connection. Nothing to do for Docker"""
-        pass
+        self._connected = False

--- a/lib/ansible/plugins/connections/docker.py
+++ b/lib/ansible/plugins/connections/docker.py
@@ -24,6 +24,8 @@ import subprocess
 import time
 import re
 
+import ansible.constants as C
+
 from ansible import errors
 from ansible.plugins.connections import ConnectionBase
 
@@ -88,25 +90,16 @@ class Connection(ConnectionBase):
 
         return self
 
-    def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False,
-                     executable='/bin/sh', in_data=None, su=None,
-                     su_user=None):
-
+    def exec_command(self, cmd, tmp_path, in_data=None, sudoable=False):
         """ Run a command on the local host """
+        super(Connection, self).exec_command(cmd, tmp_path, in_data=in_data, sudoable=sudoable)
 
         # Don't currently support su
-        if su or su_user:
-            raise errors.AnsibleError("Internal Error: this module does not "
-                                      "support running commands via su")
-
         if in_data:
             raise errors.AnsibleError("Internal Error: this module does not "
                                       "support optimized module pipelining")
 
-        if sudoable and sudo_user:
-            raise errors.AnsibleError("Internal Error: this module does not "
-                                      "support running commands via sudo")
-
+        executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else None
         if executable:
             local_cmd = [self.docker_cmd, "exec", self._play_context.remote_addr, executable,
                          '-c', cmd]

--- a/lib/ansible/plugins/connections/docker.py
+++ b/lib/ansible/plugins/connections/docker.py
@@ -4,6 +4,8 @@
 # (c) 2014, Lorin Hochstein
 # (c) 2015, Leendert Brouwer
 #
+# Maintainer: Leendert Brouwer (https://github.com/objectified)
+#
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/lib/ansible/plugins/connections/docker.py
+++ b/lib/ansible/plugins/connections/docker.py
@@ -26,6 +26,8 @@ import subprocess
 import time
 import re
 
+from distutils.version import LooseVersion
+
 import ansible.constants as C
 
 from ansible import errors
@@ -46,7 +48,7 @@ class Connection(ConnectionBase):
         self.can_copy_bothways = False
 
         docker_version = self._get_docker_version()
-        if self.compare_versions(docker_version, '1.8.0') >= 0:
+        if LooseVersion(docker_version) >= LooseVersion('1.8.0'):
             self.can_copy_bothways = True
 
     def _get_docker_version(self):
@@ -75,12 +77,6 @@ class Connection(ConnectionBase):
     @property
     def transport(self):
         return 'docker'
-
-    def compare_versions(self, version1, version2):
-        # Source: https://stackoverflow.com/questions/1714027/version-number-comparison
-        def normalize(v):
-            return [int(x) for x in re.sub(r'(\.0+)*$','', v).split(".")]
-        return cmp(normalize(version1), normalize(version2))
 
     def _connect(self, port=None):
         """ Connect to the container. Nothing to do """

--- a/lib/ansible/plugins/connections/docker.py
+++ b/lib/ansible/plugins/connections/docker.py
@@ -1,0 +1,119 @@
+# Based on the chroot connection plugin by Maykel Moya
+#
+# Connection plugin for configuring docker containers
+# (c) 2014, Lorin Hochstein
+# (c) 2015, Leendert Brouwer
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+import time
+
+from ansible import errors
+from ansible.plugins.connections import ConnectionBase
+
+BUFSIZE = 65536
+
+class Connection(ConnectionBase):
+
+    def __init__(self, play_context, new_stdin, *args, **kwargs):
+        super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
+
+        if 'docker_command' in kwargs:
+            self.docker_cmd = kwargs['docker_command']
+        else:
+            self.docker_cmd = 'docker'
+
+    @property
+    def transport(self):
+        return 'docker'
+
+    def _connect(self, port=None):
+        """ Connect to the container. Nothing to do """
+        return self
+
+    def exec_command(self, cmd, tmp_path, sudo_user=None, sudoable=False,
+                     executable='/bin/sh', in_data=None, su=None,
+                     su_user=None):
+
+        """ Run a command on the local host """
+
+        # Don't currently support su
+        if su or su_user:
+            raise errors.AnsibleError("Internal Error: this module does not "
+                                      "support running commands via su")
+
+        if in_data:
+            raise errors.AnsibleError("Internal Error: this module does not "
+                                      "support optimized module pipelining")
+
+        if sudoable and sudo_user:
+            raise errors.AnsibleError("Internal Error: this module does not "
+                                      "support running commands via sudo")
+
+        if executable:
+            local_cmd = [self.docker_cmd, "exec", self._play_context.remote_addr, executable,
+                         '-c', cmd]
+        else:
+            local_cmd = '%s exec "%s" %s' % (self.docker_cmd, self._play_context.remote_addr, cmd)
+
+        self._display.vvv("EXEC %s" % (local_cmd), host=self._play_context.remote_addr)
+        p = subprocess.Popen(local_cmd,
+                             shell=isinstance(local_cmd, basestring),
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        stdout, stderr = p.communicate()
+        return (p.returncode, '', stdout, stderr)
+
+    # Docker doesn't have native support for copying files into running
+    # containers, so we use docker exec to implement this
+    def put_file(self, in_path, out_path):
+        """ Transfer a file from local to container """
+        args = [self.docker_cmd, "exec", "-i", self._play_context.remote_addr, "bash", "-c",
+                "dd of=%s bs=%s" % (format(out_path), BUFSIZE)]
+
+        self._display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr)
+
+        if not os.path.exists(in_path):
+            raise errors.AnsibleFileNotFound(
+                "file or module does not exist: %s" % in_path)
+        p = subprocess.Popen(args, stdin=open(in_path),
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p.communicate()
+
+    def fetch_file(self, in_path, out_path):
+        """ Fetch a file from container to local. """
+        # out_path is the final file path, but docker takes a directory, not a
+        # file path
+        out_dir = os.path.dirname(out_path)
+
+        args = [self.docker_cmd, "cp", "%s:%s" % (self._play_context.remote_addr, in_path), out_dir]
+
+        self._display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr)
+        p = subprocess.Popen(args, stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p.communicate()
+
+        # Rename if needed
+        actual_out_path = os.path.join(out_dir, os.path.basename(in_path))
+        if actual_out_path != out_path:
+            os.rename(actual_out_path, out_path)
+
+    def close(self):
+        """ Terminate the connection. Nothing to do for Docker"""
+        pass


### PR DESCRIPTION
This connection plugin allows Ansible to connect to Docker containers through using `docker exec`, to allow Ansible to configure Docker containers without first copying Ansible and your playbooks to the container (as long as there's Python, you're good to go - just like with regular servers). 

It was largely based on the work done by Lorin Hochstein on his https://github.com/lorin/ansible-docker-connection project.

Some remarks about the implementation:
- it does not use docker-py, but calls the docker CLI through subprocess; I've found that from experience with other projects that use docker-py, it's very much a moving target at the moment, and that tends to break integration (as it did quite recently in Ansible as well I believe). If people insist on using docker-py instead, I can rewrite the code accordingly.
- to copy files over to the container it `cat`s the file and writes them to the stdin of the container; this is because `docker cp` does not actually support copying from the host to the container, only the other way around. This trick/hack seems to work well enough for now, and we can gradually get rid of it once https://github.com/docker/docker/pull/13171 has been integrated into Docker.
