### PR TITLE
Integrate EUI64 SLAAC into ipaddr() Jinja2 filter

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -143,6 +143,18 @@ def _link_local_query(v, value):
         if ipaddr(str(v_ip), 'fe80::/10'):
             return value
 
+def _eui64_query(v, value):
+    v_ip = netaddr.IPAddress(str(v.ip))
+    if v.version != 6:
+        return False
+
+    # RFC 4862, 5.5.3
+    if v.prefixlen != 64:
+        return False
+
+    hw = netaddr.EUI(value);
+    return str(hw.ipv6(v.ip)) + '/64'
+
 def _loopback_query(v, value):
     v_ip = netaddr.IPAddress(str(v.ip))
     if v_ip.is_loopback():
@@ -451,7 +463,10 @@ def ipaddr(value, query = '', version = False, alias = 'ipaddr'):
                 return value
 
         except:
-            raise errors.AnsibleFilterError(alias + ': unknown filter type: %s' % query)
+            if hwaddr(query):
+                return _eui64_query(v,query)
+            else:
+                raise errors.AnsibleFilterError(alias + ': unknown filter type: %s' % query)
 
     return False
 


### PR DESCRIPTION
##### SUMMARY
usage: {{ 2db8::/64 | ipaddr(l2addr) }}
- Enforce RFC 4862 5.5.3 and ignore networks with a prefixlen other than 64
- does not require a separate keyword, acts as if l2addr was an index in the
  subnet
- does not work with bare hwaddr (such as "001122334455") to keep templates
  like {{ 2db8::/32 | ipaddr(32) }} working. Better force hwaddr format as in
  {{ 2db8::/64 | ipaddr(l2addr|hwaddr('eui48')) }} when unsure.


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/ipaddr.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


