### PR TITLE
only set ansible_ssh_host if not already set

### DIFF
--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -121,7 +121,9 @@ class Host:
         results = combine_vars(results, self.vars)
         results['inventory_hostname'] = self.name
         results['inventory_hostname_short'] = self.name.split('.')[0]
-        results['ansible_ssh_host'] = self.ipv4_address
+
+        if 'ansible_ssh_host' not in results:
+            results['ansible_ssh_host'] = self.ipv4_address
 
         if 'ansible_ssh_port' not in results:
             results['ansible_ssh_port'] = C.DEFAULT_REMOTE_PORT


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 2.0.0 (devel 5b5ba35111) last updated 2015/07/20 20:08:15 (GMT -400)
##### Ansible Configuration:

[defaults]
inventory = hosts.py (test script for this bug report)
##### Environment:

OS X
##### Summary:

When using dynamic inventory that sets ansible_ssh_host as a hostvar, ansible will set ansible_ssh_host = to ipv4_address, which earlier gets defaulted to name -- so, ansible will connect to 'name' instead of ansible_ssh_host
##### Steps To Reproduce:

set ansible.cfg to a dynamic hosts file. I made a super basic inventory script for testing. I've tested with both _meta vars, and hostvars supplied with --host 
here is a sample script I used for testing:

``` python
#!/usr/bin/python
import json
import argparse

parser = argparse.ArgumentParser(description='test')
parser.add_argument('--list', action='store_true', default=False)
parser.add_argument('--host', action='store')
args = parser.parse_args()

inventory = {}

if args.list:
    inventory['all'] = {}
    inventory['all']['hosts'] = []
    inventory['all']['hosts'].append("bluefish")
    print json.dumps(inventory)
elif args.host:
    if args.host == 'bluefish':
        inventory['ansible_ssh_host'] = '192.168.1.4'
        inventory['ansible_ssh_port'] = '22'
    print json.dumps(inventory)


##### Expected Results:

     ansible bluefish -m ping -vvv                                                              
    <192.168.1.4> ESTABLISH SSH CONNECTION FOR USER: whereismyjetpack
    <192.168.1.4> EXEC ssh -C -tt -q -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/tmp/ansible-ssh-%h-%p-%r" -o Port=22 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 192.168.1.4 mkdir -p "$HOME/.ansible/tmp/ansible-tmp-1437441884.36-23031124330564" && chmod a+rx "$HOME/.ansible/tmp/ansible-tmp-1437441884.36-23031124330564" && echo "$HOME/.ansible/tmp/ansible-tmp-1437441884.36-23031124330564"

##### Actual Results:

     ansible bluefish -m ping -vvv                                                       
    <bluefish> ESTABLISH SSH CONNECTION FOR USER: whereismyjetpack
    <bluefish> EXEC ssh -C -tt -q -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/tmp/ansible-ssh-%h-%p-%r" -o Port=22 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 bluefish mkdir -p "$HOME/.ansible/tmp/ansible-tmp-1437441672.46-233732641996366" && chmod a+rx "$HOME/.ansible/tmp/ansible-tmp-1437441672.46-233732641996366" && echo "$HOME/.ansible/tmp/ansible-tmp-1437441672.46-233732641996366"

```
