### PR TITLE
Make "{{ lookup('file','nonexistent') }}" issue a sensible error again

### DIFF
--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -53,9 +53,10 @@ class LookupModule(LookupBase):
 
             for path in (basedir_path, relative_path, playbook_path):
                 try:
-                    contents, show_data = self._loader._get_file_contents(path)
-                    ret.append(contents.rstrip())
-                    break
+                    if path:
+                        contents, show_data = self._loader._get_file_contents(path)
+                        ret.append(contents.rstrip())
+                        break
                 except AnsibleParserError:
                     continue
             else:


### PR DESCRIPTION
When run from a playbook without roles, 'role_path' was unset, so
relative_path was never set, so the lookup broke while trying to coerce
None to a string, and the expected 'could not locate file' message was
never reached.
