### PR TITLE
Make "{{ lookup('file','nonexistent') }}" issue the intended error again

### DIFF
--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -53,9 +53,10 @@ class LookupModule(LookupBase):
 
             for path in (basedir_path, relative_path, playbook_path):
                 try:
-                    contents, show_data = self._loader._get_file_contents(path)
-                    ret.append(contents.rstrip())
-                    break
+                    if path:
+                        contents, show_data = self._loader._get_file_contents(path)
+                        ret.append(contents.rstrip())
+                        break
                 except AnsibleParserError:
                     continue
             else:


### PR DESCRIPTION
When the lookup was run in a playbook without roles, it died with:

ERROR! an unexpected type error occurred. Error was coercing to
Unicode: need string or buffer, NoneType found

Fixes #11668
