### PR TITLE
Feature Pull Request: vagrant inventory, bugfixing and refactoring

### DIFF
--- a/contrib/inventory/vagrant.py
+++ b/contrib/inventory/vagrant.py
@@ -13,6 +13,7 @@ Example Vagrant configuration using this script:
 """
 
 # Copyright (C) 2013  Mark Mandel <mark@compoundtheory.com>
+#               2015  Igor Khomyakov <homyakov@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,17 +34,26 @@ Example Vagrant configuration using this script:
 #
 
 import sys
+import os.path
 import subprocess
 import re
-import string
+from paramiko import SSHConfig
+from cStringIO import StringIO
 from optparse import OptionParser
+from collections import defaultdict
 try:
     import json
 except:
     import simplejson as json
 
+_group = 'vagrant'  # a default group
+_ssh_to_ansible = [('user', 'ansible_ssh_user'),
+                   ('hostname', 'ansible_ssh_host'),
+                   ('identityfile', 'ansible_ssh_private_key_file'),
+                   ('port', 'ansible_ssh_port')]
+
 # Options
-#------------------------------
+# ------------------------------
 
 parser = OptionParser(usage="%prog [options] --list | --host <machine>")
 parser.add_option('--list', default=False, dest="list", action="store_true",
@@ -56,19 +66,13 @@ parser.add_option('--host', default=None, dest="host",
 # helper functions
 #
 
+
 # get all the ssh configs for all boxes in an array of dictionaries.
 def get_ssh_config():
-    configs = []
+    return {k: get_a_ssh_config(k) for k in list_running_boxes()}
 
-    boxes = list_running_boxes()
 
-    for box in boxes:
-        config = get_a_ssh_config(box)
-        configs.append(config)
-
-    return configs
-
-#list all the running boxes
+# list all the running boxes
 def list_running_boxes():
     output = subprocess.check_output(["vagrant", "status"]).split('\n')
 
@@ -79,54 +83,47 @@ def list_running_boxes():
         if matcher:
             boxes.append(matcher.group(1))
 
-
     return boxes
 
-#get the ssh config for a single box
+
+# get the ssh config for a single box
 def get_a_ssh_config(box_name):
     """Gives back a map of all the machine's ssh configurations"""
 
-    output = subprocess.check_output(["vagrant", "ssh-config", box_name]).split('\n')
+    output = subprocess.check_output(["vagrant", "ssh-config", box_name])
+    config = SSHConfig()
+    config.parse(StringIO(output))
+    host_config = config.lookup(box_name)
 
-    config = {}
-    for line in output:
-        if line.strip() != '':
-            matcher = re.search("(  )?([a-zA-Z]+) (.*)", line)
-            config[matcher.group(2)] = matcher.group(3)
+    # man 5 ssh_config:
+    # > It is possible to have multiple identity files ...
+    # > all these identities will be tried in sequence.
+    for id in host_config['identityfile']:
+        if os.path.isfile(id):
+            host_config['identityfile'] = id
 
-    return config
-
+    return {v: host_config[k] for k, v in _ssh_to_ansible}
 
 # List out servers that vagrant has running
-#------------------------------
+# ------------------------------
 if options.list:
     ssh_config = get_ssh_config()
-    hosts = { 'vagrant': []}
+    meta = defaultdict(dict)
 
-    for data in ssh_config:
-        hosts['vagrant'].append(data['HostName'])
+    for host in ssh_config:
+        meta['hostvars'][host] = ssh_config[host]
 
-    print json.dumps(hosts)
+    print json.dumps({_group: list(ssh_config.keys()), '_meta': meta})
     sys.exit(0)
 
 # Get out the host details
-#------------------------------
+# ------------------------------
 elif options.host:
-    result = {}
-    ssh_config = get_ssh_config()
-
-    details = filter(lambda x: (x['HostName'] == options.host), ssh_config)
-    if len(details) > 0:
-        #pass through the port, in case it's non standard.
-        result = details[0]
-        result['ansible_ssh_port'] = result['Port']
-
-    print json.dumps(result)
+    print json.dumps(get_a_ssh_config(options.host))
     sys.exit(0)
 
-
 # Print out help
-#------------------------------
+# ------------------------------
 else:
     parser.print_help()
     sys.exit(0)


### PR DESCRIPTION
#### Feature Pull Request:
#### Ansible Version:

1.9.2 and above
#### Summary:

inventory script is not working for multiple VMs
#### Steps To Reproduce:

Here is a simple [Vagrantfile with "db" and "web" virtual machines](https://gist.github.com/hostmaster/92dd34ed9f8830e9f1d0)
#### Expected Results:

Somethink like  

```
$ python vagrant.py --list
{"vagrant": ["db", "web"]}
```
#### Actual Results:

```
$ python vagrant.py --list
{"vagrant": ["127.0.0.1", "127.0.0.1"]}
```
#### Fixed version

produces the output below: 

```
{"vagrant": ["web", "db"], "_meta": {"hostvars": {"web": {"ansible_ssh_host": "127.0.0.1", "ansible_ssh_port": "2222", "ansible_ssh_user": "vagrant", "ansible_ssh_private_key_file": "/home/igor/ansible_vagrant/.vagrant/machines/web/virtualbox/private_key"}, "db": {"ansible_ssh_host": "127.0.0.1", "ansible_ssh_port": "2200", "ansible_ssh_user": "vagrant", "ansible_ssh_private_key_file": "/home/igor/ansible_vagrant/.vagrant/.vagrant/machines/db/virtualbox/private_key"}}}}
```
#### bugfix
- Added support for multiple VMs
#### refactored
- Paramiko module is used to parse ssh_config.
- Added [`_meta`](https://docs.ansible.com/ansible/developing_inventory.html#tuning-the-external-inventory-script) element

@markmandel it would be nice if you could have a look 
