### PR TITLE
Expand 'become' after variable merging

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -163,7 +163,7 @@ class Task(object):
         if (ds.get('sudo') or ds.get('sudo_user') or ds.get('sudo_pass')) and (ds.get('su') or ds.get('su_user') or ds.get('su_pass')):
             raise errors.AnsibleError('incompatible parameters ("su", "su_user", "su_pass") and sudo params "sudo", "sudo_user", "sudo_pass" in task: %s' % self.name)
 
-        self.become        = utils.boolean(ds.get('become', play.become))
+        self.become        = ds.get('become', play.become)
         self.become_method = ds.get('become_method', play.become_method)
         self.become_user   = ds.get('become_user', play.become_user)
         self.become_pass   = ds.get('become_pass', play.playbook.become_pass)

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -199,7 +199,8 @@ class Runner(object):
         self.remote_port      = remote_port
         self.private_key_file = private_key_file
         self.background       = background
-        self.become           = become
+        self.become_var       = become
+        self.become           = None
         self.become_method    = become_method
         self.become_user_var  = become_user
         self.become_user      = None
@@ -841,7 +842,9 @@ class Runner(object):
     def _executor_internal_inner(self, host, module_name, module_args, inject, port, is_chained=False, complex_args=None):
         ''' decides how to invoke a module '''
 
-        # late processing of parameterized become_user (with_items,..)
+        # late processing of parameterized become and become_user (with_items,..)
+        if self.become_var is not None:
+            self.become = utils.boolean(template.template(self.basedir, self.become_var, inject))
         if self.become_user_var is not None:
             self.become_user = template.template(self.basedir, self.become_user_var, inject)
 


### PR DESCRIPTION
The 'become' variable still cannot take variables as its value.
This has been fixed long time ago for 'become_user' (PR #3217)

This commit applies variable expansion to 'become' the same way it is already applied to 'become_user'.

Addresses #10667 #2526
