### PR TITLE
6238 rebase: add ssh_specific_args config option

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -703,6 +703,18 @@ If set, this will pass a specific set of options to Ansible rather than Ansible'
 In particular, users may wish to raise the ControlPersist time to encourage performance.  A value of 30 minutes may
 be appropriate. If `ssh_args` is set, the default ``control_path`` setting is not used.
 
+.. _ssh_specific_args:
+
+ssh_specific_args
+=================
+
+If set, this will pass additional options to ssh, but not scp or sftp::
+
+    ssh_specific_args = -R 12346:localhost:12345
+
+This can be used if you need to use ssh options that aren't valid for
+scp. You won't ordinarily need this setting.
+
 .. _control_path:
 
 control_path

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -201,6 +201,7 @@ RETRY_FILES_SAVE_PATH          = get_config(p, DEFAULTS, 'retry_files_save_path'
 
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
+ANSIBLE_SSH_SPECIFIC_ARGS      = get_config(p, 'ssh_connection', 'ssh_specific_args', 'ANSIBLE_SSH_SPECIFIC_ARGS', None)
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, integer=True)

--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -88,6 +88,10 @@ class Connection(ConnectionBase):
                 "-o", "ControlPath=\"{0}\"".format(C.ANSIBLE_SSH_CONTROL_PATH % dict(directory=self._cp_dir)),
             )
 
+        self.ssh_specific_args = []
+        if C.ANSIBLE_SSH_SPECIFIC_ARGS:
+            self.ssh_specific_args += shlex.split(C.ANSIBLE_SSH_SPECIFIC_ARGS)
+
         cp_in_use = False
         cp_path_set = False
         for arg in self._common_args:
@@ -340,6 +344,7 @@ class Connection(ConnectionBase):
         else:
             ssh_cmd.append("-q")
         ssh_cmd += self._common_args
+        ssh_cmd += self.ssh_specific_args
 
         if self._ipv6:
             ssh_cmd += ['-6']


### PR DESCRIPTION
This is a trivial rebase of #6238 from @jeremyherbert with an added doc patch. Note that I don't particularly like the name `ssh_specific_args`, and I've not done anything about the linked-from-#8637 request to make sftp vars configurable. But I figured it would be easier to pick up discussion after nearly a year if there were a documented, rebased PR available.

(I tested that setting the variable does actually add the arguments to ssh.)
