### PR TITLE
Fix formatting of Groups of Groups

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -106,7 +106,7 @@ Variables can also be applied to an entire group at once::
 Groups of Groups, and Group Variables
 +++++++++++++++++++++++++++++++++++++
 
-It is also possible to make groups of groups using the ``:children`` suffix. Just like above, you can apply variables using ``:vars``.
+It is also possible to make groups of groups using the ``:children`` suffix. Just like above, you can apply variables using ``:vars``::
 
    [atlanta]
    host1


### PR DESCRIPTION
The example in the Groups of Groups section was being rendered as a quote.
Switching to the `::` notation causes it to render as preformatted text instead.
This could have also been done with a `.. code:` block, but I chose to be
consistent with other sections in the document.
