### PR TITLE
Fix verbose output with module 'script'

### DIFF
--- a/v1/ansible/runner/connection_plugins/ssh.py
+++ b/v1/ansible/runner/connection_plugins/ssh.py
@@ -272,7 +272,7 @@ class Connection(object):
         if utils.VERBOSITY > 3:
             ssh_cmd += ["-vvv"]
         else:
-            if self.runner.module_name == 'raw':
+            if self.runner.module_name == 'raw' or self.runner.module_name == 'script':
                 ssh_cmd += ["-q"]
             else:
                 ssh_cmd += ["-v"]


### PR DESCRIPTION
Fix verbose output with module 'script' (same as mentioned in cf3313b).
