### PR TITLE
Fix: add missing import 'locale'

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import getpass
+import locale
 import signal
 import sys
 


### PR DESCRIPTION
This file appears to be missing an 'import locale'.
FWIW, this fixed a real issue i encountered while using rpi-cross.
