### PR TITLE
Remove mention of 'apache example'

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/validate.py
+++ b/lib/ansible/utils/module_docs_fragments/validate.py
@@ -25,7 +25,7 @@ options:
       required: false
       description:
        - The validation command to run before copying into place. The path to the file to
-         validate is passed in via '%s' which must be present as in the apache example below.
+         validate is passed in via '%s' which must be present as in the example below.
          The command is passed securely so shell features like expansion and pipes won't work.
       default: None
 '''


### PR DESCRIPTION
Removed explicit mention of 'apache'. Not all of the file modules that use this doc fragment have an apache example, some give a visudo example instead. Rather than changing the examples, the simplest thing seems to be to remove the explicit mention of apache and just refer to a generic 'example below' 

For more details, see https://github.com/ansible/ansible-modules-core/pull/1455
