### PR TITLE
8935 rebase: add «-o outputfile» and -n(oexec) options to hacking/test-module

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -26,7 +26,7 @@
 #    test-module -m ../library/commands/command -a "/bin/sleep 3"
 #    test-module -m ../library/system/service -a "name=httpd ensure=restarted"
 #    test-module -m ../library/system/service -a "name=httpd ensure=restarted" --debugger /usr/bin/pdb
-#    test-modulr -m ../library/file/lineinfile -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
+#    test-module -m ../library/file/lineinfile -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
 #    test-module -m ../library/commands/command -a "echo hello" -n -o "test_hello"
 
 import sys
@@ -69,7 +69,7 @@ def parse():
         help="run the module in check mode")
     parser.add_option('-n', '--noexecute', dest='execute', action='store_false',
         default=True, help="do not run the resulting module")
-    parser.add_option('-o', '--output', dest='filename', 
+    parser.add_option('-o', '--output', dest='filename',
         help="Filename for resulting module",
         default="~/.ansible_module_generated")
     options, args = parser.parse_args()
@@ -195,7 +195,7 @@ def main():
         else:
             raise Exception("internal error, unexpected module style: %s" % module_style)
     if options.execute:
-        if options.debugger: 
+        if options.debugger:
             rundebug(options.debugger, modfile, argspath)
         else:
             runtest(modfile, argspath)

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -27,6 +27,7 @@
 #    test-module -m ../library/system/service -a "name=httpd ensure=restarted"
 #    test-module -m ../library/system/service -a "name=httpd ensure=restarted" --debugger /usr/bin/pdb
 #    test-modulr -m ../library/file/lineinfile -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
+#    test-module -m ../library/commands/command -a "echo hello" -n -o "test_hello"
 
 import sys
 import base64
@@ -66,6 +67,11 @@ def parse():
         default='python={}'.format(sys.executable))
     parser.add_option('-c', '--check', dest='check', action='store_true',
         help="run the module in check mode")
+    parser.add_option('-n', '--noexecute', dest='execute', action='store_false',
+        default=True, help="do not run the resulting module")
+    parser.add_option('-o', '--output', dest='filename', 
+        help="Filename for resulting module",
+        default="~/.ansible_module_generated")
     options, args = parser.parse_args()
     if not options.module_path:
         parser.print_help()
@@ -84,7 +90,7 @@ def write_argsfile(argstring, json=False):
     argsfile.close()
     return argspath
 
-def boilerplate_module(modfile, args, interpreter, check):
+def boilerplate_module(modfile, args, interpreter, check, destfile):
     """ simulate what ansible does with new style modules """
 
     #module_fh = open(modfile)
@@ -128,7 +134,7 @@ def boilerplate_module(modfile, args, interpreter, check):
         inject 
     )
 
-    modfile2_path = os.path.expanduser("~/.ansible_module_generated")
+    modfile2_path = os.path.expanduser(destfile)
     print "* including generated source, if any, saving to: %s" % modfile2_path
     print "* this may offset any line numbers in tracebacks/debuggers!"
     modfile2 = open(modfile2_path, 'w')
@@ -178,7 +184,7 @@ def rundebug(debugger, modfile, argspath):
 def main(): 
 
     options, args = parse()
-    (modfile, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter, options.check)
+    (modfile, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter, options.check, options.filename)
 
     argspath = None
     if module_style != 'new':
@@ -188,10 +194,11 @@ def main():
             argspath = write_argsfile(options.module_args, json=False)
         else:
             raise Exception("internal error, unexpected module style: %s" % module_style)
-    if options.debugger: 
-        rundebug(options.debugger, modfile, argspath)
-    else:
-        runtest(modfile, argspath)
+    if options.execute:
+        if options.debugger: 
+            rundebug(options.debugger, modfile, argspath)
+        else:
+            runtest(modfile, argspath)
         
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Rebase of #8935 (which merged only with a bit of fuzz) with a couple of trivial edits.
