### PR TITLE
v2: Fixing delegate_to when using a variable

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -455,18 +455,18 @@ class TaskExecutor:
         # get the vars for the delegate by its name
         try:
             this_info = variables['hostvars'][self._task.delegate_to]
+
+            # get the real ssh_address for the delegate and allow ansible_ssh_host to be templated
+            #self._play_context.remote_user      = self._compute_delegate_user(self.delegate_to, delegate['inject'])
+            self._play_context.remote_addr      = this_info.get('ansible_ssh_host', self._task.delegate_to)
+            self._play_context.port             = this_info.get('ansible_ssh_port', self._play_context.port)
+            self._play_context.password         = this_info.get('ansible_ssh_pass', self._play_context.password)
+            self._play_context.private_key_file = this_info.get('ansible_ssh_private_key_file', self._play_context.private_key_file)
+            self._play_context.connection       = this_info.get('ansible_connection', C.DEFAULT_TRANSPORT)
+            self._play_context.become_pass      = this_info.get('ansible_sudo_pass', self._play_context.become_pass)
         except:
             # make sure the inject is empty for non-inventory hosts
             this_info = {}
-
-        # get the real ssh_address for the delegate and allow ansible_ssh_host to be templated
-        #self._play_context.remote_user      = self._compute_delegate_user(self.delegate_to, delegate['inject'])
-        self._play_context.remote_addr      = this_info.get('ansible_ssh_host', self._task.delegate_to)
-        self._play_context.port             = this_info.get('ansible_ssh_port', self._play_context.port)
-        self._play_context.password         = this_info.get('ansible_ssh_pass', self._play_context.password)
-        self._play_context.private_key_file = this_info.get('ansible_ssh_private_key_file', self._play_context.private_key_file)
-        self._play_context.connection       = this_info.get('ansible_connection', C.DEFAULT_TRANSPORT)
-        self._play_context.become_pass      = this_info.get('ansible_sudo_pass', self._play_context.become_pass)
 
         if self._play_context.remote_addr in ('127.0.0.1', 'localhost'):
              self._play_context.connection = 'local'


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible --version                                                                                                                                                                                                             ?[0] !11341
ansible 2.0.0 (devel d412bc72ef) last updated 2015/07/22 14:40:40 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 222927256d) last updated 2015/07/22 14:40:49 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 167cad99fa) last updated 2015/07/22 14:40:49 (GMT -700)
  v1/ansible/modules/core: (detached HEAD f8d8af17cd) last updated 2015/06/09 16:52:46 (GMT -700)
  v1/ansible/modules/extras: (detached HEAD 495ad450e5) last updated 2015/06/09 16:52:49 (GMT -700)
  configured module search path = /Users/andrew/workspace/ops/deploy/modules/
```
##### Ansible Configuration:

Nothing. Just updating with the latest `devel` branch.
##### Environment:

Mac OS X 10.10.4
##### Summary:

When using `delegate_to` with a variable and the hostname does not have an entry in `variables['hostvars']` an AttributeError exception is thrown. This is because jinja2 returns backed an instance of the jinja2.Undefined class. When the `get` method is used to find a variable inside of the UndefinedClass the exception is thrown.

The fix just wraps the entire group of calls in the try, except block to pass over these exceptions.
##### Steps To Reproduce:
###### test.yml

``` yaml

---
- hosts: tag_group_test
  gather_facts: false
  vars_files:
    - group_vars/test
  tasks:
    - debug: msg="{{ bastion }}"
      delegate_to: "{{ bastion }}"
```
###### group_vars/test

``` yaml

---
bastion: bastion-staging
```

```
% ansible-playbook -i deploy_conf/ec2.py -vvvv test.yml
```
##### Expected Results:

```
% ansible-playbook -i deploy_conf/ec2.py -vvvv test.yml
Using /Users/andrew/workspace/ops/deploy/deploy_conf/ansible.cfg as config file
1 plays in test.yml
Loaded callback default of type stdout, v2.0

PLAY ****************************************************************************

TASK [debug msg=bastion-staging] ************************************************
{}
bastion-staging
ok: [ip-172-31-9-206.us-west-1.compute.internal] => {
    "changed": false,
    "msg": "bastion-staging"
}
{}
bastion-staging
ok: [ip-172-31-8-71.us-west-1.compute.internal] => {
    "changed": false,
    "msg": "bastion-staging"
}

PLAY RECAP **********************************************************************
ip-172-31-8-71.us-west-1.compute.internal : ok=1    changed=0    unreachable=0    failed=0
ip-172-31-9-206.us-west-1.compute.internal : ok=1    changed=0    unreachable=0    failed=0
```
##### Actual Results:

```
% ansible-playbook -i deploy_conf/ec2.py -vvvv test.yml              
Using /Users/andrew/workspace/ops/deploy/deploy_conf/ansible.cfg as config file
1 plays in test.yml
Loaded callback default of type stdout, v2.0

PLAY ****************************************************************************

TASK [debug msg=bastion-staging] ************************************************
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/Users/andrew/workspace/ansible/lib/ansible/executor/process/worker.py", line 118, in run
    executor_result = TaskExecutor(host, task, job_vars, new_play_context, self._new_stdin, self._loader, shared_loader_obj).run()
  File "/Users/andrew/workspace/ansible/lib/ansible/executor/task_executor.py", line 110, in run
    res = self._execute()
  File "/Users/andrew/workspace/ansible/lib/ansible/executor/task_executor.py", line 245, in _execute
    self._connection = self._get_connection(variables)
  File "/Users/andrew/workspace/ansible/lib/ansible/executor/task_executor.py", line 398, in _get_connection
    self._compute_delegate(variables)
  File "/Users/andrew/workspace/ansible/lib/ansible/executor/task_executor.py", line 464, in _compute_delegate
    self._play_context.remote_addr      = this_info.get('ansible_ssh_host', self._task.delegate_to)
AttributeError: type object 'Undefined' has no attribute 'get'

fatal: [ip-172-31-9-206.us-west-1.compute.internal]: FAILED! => {
    "failed": true,
    "stdout": ""
}
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/Users/andrew/workspace/ansible/lib/ansible/executor/process/worker.py", line 118, in run
    executor_result = TaskExecutor(host, task, job_vars, new_play_context, self._new_stdin, self._loader, shared_loader_obj).run()
  File "/Users/andrew/workspace/ansible/lib/ansible/executor/task_executor.py", line 110, in run
    res = self._execute()
  File "/Users/andrew/workspace/ansible/lib/ansible/executor/task_executor.py", line 245, in _execute
    self._connection = self._get_connection(variables)
  File "/Users/andrew/workspace/ansible/lib/ansible/executor/task_executor.py", line 398, in _get_connection
    self._compute_delegate(variables)
  File "/Users/andrew/workspace/ansible/lib/ansible/executor/task_executor.py", line 464, in _compute_delegate
    self._play_context.remote_addr      = this_info.get('ansible_ssh_host', self._task.delegate_to)
AttributeError: type object 'Undefined' has no attribute 'get'

fatal: [ip-172-31-8-71.us-west-1.compute.internal]: FAILED! => {
    "failed": true,
    "stdout": ""
}

PLAY RECAP **********************************************************************
ip-172-31-8-71.us-west-1.compute.internal : ok=0    changed=0    unreachable=0    failed=1
ip-172-31-9-206.us-west-1.compute.internal : ok=0    changed=0    unreachable=0    failed=1
```
