### PR TITLE
Preserve OLDPWD in hacking/env-setup

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -53,13 +53,15 @@ if [ "$ANSIBLE_HOME" != "$PWD" ] ; then
 else
     current_dir="$ANSIBLE_HOME"
 fi
-cd "$ANSIBLE_HOME"
-if [ "$verbosity" = silent ] ; then
-    gen_egg_info > /dev/null 2>&1
-else
-    gen_egg_info
-fi
-cd "$current_dir"
+(
+	cd "$ANSIBLE_HOME"
+	if [ "$verbosity" = silent ] ; then
+	    gen_egg_info > /dev/null 2>&1
+	else
+	    gen_egg_info
+	fi
+	cd "$current_dir"
+)
 
 if [ "$verbosity" != silent ] ; then
     cat <<- EOF


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.0 (env-setup-preserve-oldpwd c800a1c68a) last updated 2015/07/23 11:24:38 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 222927256d) last updated 2015/07/23 09:28:47 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 167cad99fa) last updated 2015/07/23 09:28:47 (GMT +200)
  v1/ansible/modules/core: (detached HEAD f8d8af17cd) last updated 2015/07/17 15:26:48 (GMT +200)
  v1/ansible/modules/extras: (detached HEAD 495ad450e5) last updated 2015/07/17 15:26:52 (GMT +200)
  configured module search path = None
```
##### Ansible Configuration:

None
##### Environment:

N/A
##### Summary:

Preserve `OLDPWD` when sourcing hacking/env-setup. Clobbering `OLDPWD` is particularly annoying when I cd into the ansible source tree before sourcing (force of habit).
##### Steps To Reproduce:

``` shell
mkdir -p foo bar
cd foo
cd ../bar
source ~/git/ansible/hacking/env-setup
cd -
pwd
```
##### Expected Results:

```
/home/sheldonh/foo
```
##### Actual Results:

```
/home/sheldonh/git/ansible
```
