### PR TITLE
Have paramiko use /etc/ssh_known_hosts (#7730 rebase)

### DIFF
--- a/lib/ansible/plugins/connections/paramiko_ssh.py
+++ b/lib/ansible/plugins/connections/paramiko_ssh.py
@@ -152,6 +152,7 @@ class Connection(ConnectionBase):
         self.keyfile = os.path.expanduser("~/.ssh/known_hosts")
 
         if C.HOST_KEY_CHECKING:
+            ssh.load_system_host_keys("/etc/ssh/ssh_known_hosts")
             ssh.load_system_host_keys()
 
         ssh.set_missing_host_key_policy(MyAddPolicy(self._new_stdin))


### PR DESCRIPTION
Fixes an issue with a confusing error: "paramiko: The authenticity of host '[host]' can't be established" when ssh on the command line doesn't complain

Closes PR #7730
