### PR TITLE
Delete unused import glob

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-from glob import glob
 
 sys.path.insert(0, os.path.abspath('lib'))
 from ansible import __version__, __author__


### PR DESCRIPTION
glob modules does not seem to be reference any where in the setup.py file. Removed it.
