### PR TITLE
v2 breakage: lookupfile should lookup the given file=xxx

### DIFF
--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -75,7 +75,7 @@ class LookupModule(LookupBase):
             if paramvals['delimiter'] == 'TAB':
                 paramvals['delimiter'] = "\t"
 
-            lookupfile = self._loader.path_dwim_relative(basedir, 'files', term)
+            lookupfile = self._loader.path_dwim_relative(basedir, 'files', paramvals['file'])
             var = self.read_csv(lookupfile, key, paramvals['delimiter'], paramvals['default'], paramvals['col'])
             if var is not None:
                 if type(var) is list:

--- a/v1/ansible/runner/lookup_plugins/csvfile.py
+++ b/v1/ansible/runner/lookup_plugins/csvfile.py
@@ -63,7 +63,10 @@ class LookupModule(object):
                 for param in params[1:]:
                     name, value = param.split('=')
                     assert(name in paramvals)
-                    paramvals[name] = value
+                    if name == 'delimiter':
+                        paramvals[name] = str(value)
+                    else:
+                        paramvals[name] = value
             except (ValueError, AssertionError), e:
                 raise errors.AnsibleError(e)
 


### PR DESCRIPTION
Without this patch, if you do:

```
lookup('csvfile', 'xxx file=foo.csv')
```

you get an error like:

```
"msg": "ERROR! csvfile: [Errno 2] No such file or directory: u'/home/ams/xxx file=foo.csv'"
```

This was because we used the pre-split `term` for the `self._loader.path_dwim_relative` call.
