### PR TITLE
Removed deletion of salt by 'password' lookup (#10871 rebase)

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -133,11 +133,6 @@ class LookupModule(LookupBase):
                     with open(path, 'w') as f:
                         os.chmod(path, 0o600)
                         f.write(content + '\n')
-                # crypt not requested, remove salt if present
-                elif (encrypt is None and salt):
-                    with open(path, 'w') as f:
-                        os.chmod(path, 0o600)
-                        f.write(password + '\n')
 
             if encrypt:
                 password = do_encrypt(password, encrypt, salt=salt)


### PR DESCRIPTION
Otherwise two tasks that lookup the same password, one with the encrypt
parameter and one without, it always considers the latter "changed".

Rebased version of #10872 
