### PR TITLE
Document and test 'is undefined' rather than 'is not defined'

### DIFF
--- a/docsite/rst/playbooks_conditionals.rst
+++ b/docsite/rst/playbooks_conditionals.rst
@@ -90,7 +90,7 @@ If a required variable has not been set, you can skip or fail using Jinja2's
           when: foo is defined
 
         - fail: msg="Bailing out. this play requires 'bar'"
-          when: bar is not defined
+          when: bar is undefined
 
 This is especially useful in combination with the conditional import of vars
 files (see below).

--- a/test/integration/roles/test_conditionals/tasks/main.yml
+++ b/test/integration/roles/test_conditionals/tasks/main.yml
@@ -148,6 +148,16 @@
     that:
     - "result.skipped == true"
 
+- name: test bad conditional 'is undefined'
+  shell: echo 'testing'
+  when: test_bare is undefined
+  register: result
+
+- name: assert bad conditional 'is undefined' did NOT run
+  assert:
+    that:
+    - "result.skipped == true"
+
 - name: test bare conditional
   shell: echo 'testing'
   when: test_bare


### PR DESCRIPTION
According to https://github.com/ansible/ansible/issues/10273,
this syntax should work better for nested dicts.
