### PR TITLE
Have ec2.py expand tilde and vars when looking up the EC2_INI_PATH env variable

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -192,7 +192,7 @@ class Ec2Inventory(object):
         else:
             config = configparser.ConfigParser()
         ec2_default_ini_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ec2.ini')
-        ec2_ini_path = os.environ.get('EC2_INI_PATH', ec2_default_ini_path)
+        ec2_ini_path = os.path.expanduser(os.path.expandvars(os.environ.get('EC2_INI_PATH', ec2_default_ini_path)))
         config.read(ec2_ini_path)
 
         # is eucalyptus?


### PR DESCRIPTION
Rebase of #7485 to target `contrib/inventory` rather than `plugins/inventory`
