### PR TITLE
Make «copy content='…'» add a newline if there isn't one

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -274,6 +274,8 @@ class ActionModule(ActionBase):
         content = to_bytes(content)
         try:
             f.write(content)
+            if not content.endswith('\n'):
+                f.write('\n')
         except Exception as err:
             os.remove(content_tempfile)
             raise Exception(err)

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -273,9 +273,9 @@ class ActionModule(ActionBase):
         f = os.fdopen(fd, 'wb')
         content = to_bytes(content)
         try:
-            f.write(content)
             if not content.endswith('\n'):
-                f.write('\n')
+                content = content + '\n'
+            f.write(content)
         except Exception as err:
             os.remove(content_tempfile)
             raise Exception(err)


### PR DESCRIPTION
Fun fact: according to POSIX, a file should end with a newline.
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206

Rebase of #9468
