### PR TITLE
A better error message for «ansible playbook.yml»

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -116,7 +116,10 @@ class AdHocCLI(CLI):
             return 0
 
         if self.options.module_name in C.MODULE_REQUIRE_ARGS and not self.options.module_args:
-            raise AnsibleOptionsError("No argument passed to %s module" % self.options.module_name)
+            err = "No argument passed to %s module" % self.options.module_name
+            if pattern.endswith(".yml"):
+                err = err + ' (did you mean to run ansible-playbook?)'
+            raise AnsibleOptionsError(err)
 
         #TODO: implement async support
         #if self.options.seconds:


### PR DESCRIPTION
This is a very conservative change: we add the hint only if we're definitely going to die already.

We could do better, e.g. suppress the "empty host list" error and make this raise an AnsibleError rather than an AnsibleOptionsError, so that the error isn't obscured at the end of the usage message (which I've never personally found to be useful behaviour anyway). But this is the smallest, most self-contained change that I could come up with in the interests of making it easier to merge.
