### PR TITLE
Add LVM facts to setup module

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -724,6 +724,7 @@ class LinuxHardware(Hardware):
         self.get_dmi_facts()
         self.get_device_facts()
         self.get_uptime_facts()
+        self.get_lvm_facts()
         try:
             self.get_mount_facts()
         except TimeoutError:
@@ -1066,6 +1067,37 @@ class LinuxHardware(Hardware):
     def get_uptime_facts(self):
         uptime_seconds_string = get_file_content('/proc/uptime').split(' ')[0]
         self.facts['uptime_seconds'] = int(float(uptime_seconds_string))
+
+    def get_lvm_facts(self):
+        """ Get LVM Facts if running as root and lvm utils are available """
+
+        if os.getuid() == 0 and module.get_bin_path('vgs'):
+            lvm_util_options = '--noheadings --nosuffix --units g'
+
+            #vgs fields: VG #PV #LV #SN Attr VSize VFree
+            vgs={}
+            rc, vg_lines, err = module.run_command(
+                'vgs %s' % lvm_util_options)
+            for vg_line in vg_lines.splitlines():
+                items = vg_line.split()
+                vgs[items[0]] = {'size_g':items[-2],
+                                 'free_g':items[-1],
+                                 'num_lvs': items[2],
+                                 'num_pvs': items[1]}
+
+            #lvs fields:
+            #LV VG Attr LSize Pool Origin Data% Move Log Copy% Convert
+            lvs = {}
+            rc, lv_lines, err = module.run_command(
+                'lvs %s' % lvm_util_options)
+            for lv_line in lv_lines.splitlines():
+                items = lv_line.split()
+                lvs[items[0]] = {'size_g': items[3],
+                                 'vg': items[1]}
+
+            self.facts['lvm'] = {'lvs': lvs,
+                                 'vgs': vgs}
+
 
 class SunOSHardware(Hardware):
     """


### PR DESCRIPTION
This commit adds LinuxHardware.get_device_facts() and calls that from
.populate().

LVM facts are only gathered if the setup module is running as root and
the lvm utilities are available (tested by searching for 'vgs').

If the conditions are met, facts are set for each volume group and
logical volume.

Rebase of #9795.
