### PR TITLE
Use PBKDF2HMAC() from cryptography for vault keys.

### DIFF
--- a/docsite/rst/playbooks_vault.rst
+++ b/docsite/rst/playbooks_vault.rst
@@ -108,5 +108,11 @@ This is something you may wish to do if using Ansible from a continuous integrat
 
 (The `--vault-password-file` option can also be used with the :ref:`ansible-pull` command if you wish, though this would require distributing the keys to your nodes, so understand the implications -- vault is more intended for push mode).
 
+.. _speeding_up_vault:
 
+Speeding Up Vault Operations
+````````````````````````````
 
+By default, Ansible uses PyCrypto to encrypt and decrypt vault files. If you have many encrypted files, decrypting them at startup may cause a perceptible delay. To speed this up, install the cryptography package::
+
+    pip install cryptography


### PR DESCRIPTION
When stretching the key for vault files, use PBKDF2HMAC() from the
cryptography package instead of pycrypto. This will speed up the opening
of vault files by ~10x.

The problem is here in lib/ansible/utils/vault.py:

```
hash_function = SHA256

# make two keys and one iv
pbkdf2_prf = lambda p, s: HMAC.new(p, s, hash_function).digest()

derivedkey = PBKDF2(password, salt, dkLen=(2 * keylength) + ivlength,
                    count=10000, prf=pbkdf2_prf)
```

`PBKDF2()` calls a Python callback function (`pbkdf2_pr()`) 10000 times.
If one has several vault files, this will cause excessive start times
with `ansible` or `ansible-playbook` (we experience ~15 second startup
times).

Testing the original implementation in 1.9.2 with a vault file:

In [2]: %timeit v.decrypt(encrypted_data)
1 loops, best of 3: 265 ms per loop

Having a recent OpenSSL version and using the vault.py changes in this commit:

In [2]: %timeit v.decrypt(encrypted_data)
10 loops, best of 3: 23.2 ms per loop
