### PR TITLE
add option to ansible-vault to read new password from file for rekey

### DIFF
--- a/docs/man/man1/ansible-vault.1
+++ b/docs/man/man1/ansible-vault.1
@@ -2,12 +2,12 @@
 .\"     Title: ansible-vault
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 12/09/2014
+.\"      Date: 07/28/2015
 .\"    Manual: System administration commands
-.\"    Source: Ansible 1.9
+.\"    Source: Ansible 2.0.0
 .\"  Language: English
 .\"
-.TH "ANSIBLE\-VAULT" "1" "12/09/2014" "Ansible 1\&.9" "System administration commands"
+.TH "ANSIBLE\-VAULT" "1" "07/28/2015" "Ansible 2\&.0\&.0" "System administration commands"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -43,7 +43,12 @@ The following options are available to all sub\-commands:
 .PP
 \fB\-\-vault\-password\-file=\fR\fIFILE\fR
 .RS 4
-A file containing the vault password to be used during the encryption/decryption steps\&. Be sure to keep this file secured if it is used\&.
+A file containing the vault password to be used during the encryption/decryption steps\&. Be sure to keep this file secured if it is used\&. If the file is executable, it will be run and its standard output will be used as the password\&.
+.RE
+.PP
+\fB\-\-new\-vault\-password\-file=\fR\fIFILE\fR
+.RS 4
+A file containing the new vault password to be used when rekeying a file\&. Be sure to keep this file secured if it is used\&. If the file is executable, it will be run and its standard output will be used as the password\&.
 .RE
 .PP
 \fB\-h\fR, \fB\-\-help\fR

--- a/docs/man/man1/ansible-vault.1.asciidoc.in
+++ b/docs/man/man1/ansible-vault.1.asciidoc.in
@@ -36,7 +36,15 @@ The following options are available to all sub-commands:
 *--vault-password-file=*'FILE'::
 
 A file containing the vault password to be used during the encryption/decryption
-steps. Be sure to keep this file secured if it is used.
+steps. Be sure to keep this file secured if it is used. If the file is executable,
+it will be run and its standard output will be used as the password.
+
+*--new-vault-password-file=*'FILE'::
+
+A file containing the new vault password to be used when rekeying a
+file. Be sure to keep this file secured if it is used. If the file
+is executable, it will be run and its standard output will be used as
+the password.
 
 *-h*, *--help*::
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -258,6 +258,10 @@ class CLI(object):
             parser.add_option('--vault-password-file', default=C.DEFAULT_VAULT_PASSWORD_FILE,
                 dest='vault_password_file', help="vault password file", action="callback",
                 callback=CLI.expand_tilde, type=str)
+            parser.add_option('--new-vault-password-file',
+			    dest='new_vault_password_file', help="new vault password file for rekey", action="callback",
+			    callback=CLI.expand_tilde, type=str)
+
 
         if subset_opts:
             parser.add_option('-t', '--tags', dest='tags', default='all',

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -77,6 +77,10 @@ class VaultCLI(CLI):
         else:
             self.vault_pass, _= self.ask_vault_passwords(ask_vault_pass=True, ask_new_vault_pass=False, confirm_new=False)
 
+        if self.options.new_vault_password_file:
+            # for rekey only
+            self.new_vault_pass = CLI.read_vault_password_file(self.options.new_vault_password_file)
+
         if not self.vault_pass:
             raise AnsibleOptionsError("A password is required to use Ansible's Vault")
 
@@ -125,7 +129,11 @@ class VaultCLI(CLI):
         for f in self.args:
             if not (os.path.isfile(f)):
                 raise AnsibleError(f + " does not exist")
-        __, new_password = self.ask_vault_passwords(ask_vault_pass=False, ask_new_vault_pass=True, confirm_new=True)
+
+        if self.new_vault_pass:
+            new_password = self.new_vault_pass
+        else:
+            __, new_password = self.ask_vault_passwords(ask_vault_pass=False, ask_new_vault_pass=True, confirm_new=True)
 
         for f in self.args:
             this_editor = VaultEditor(None, self.vault_pass, f)


### PR DESCRIPTION
The --new-vault-password-file option works the same as
--vault-password-file but applies only to rekeying (when
--vault-password-file sets the old password). Also update the manpage
to document these options more fully.
