### PR TITLE
add credstash lookup plugin

### DIFF
--- a/docsite/rst/playbooks_lookups.rst
+++ b/docsite/rst/playbooks_lookups.rst
@@ -140,6 +140,42 @@ default      empty string   return value if the key is not in the csv file
 .. note:: The default delimiter is TAB, *not* comma.
 
 
+.. _credstash_lookup:
+
+The Credstash Lookup
+````````````````````
+
+Credstash is a small utility for managing secrets using AWS's KMS and DynamoDB: https://github.com/LuminalOSS/credstash
+
+First, you need to store your secrets with credstash::
+
+
+    $ credstash put my-github-password secure123
+
+    my-github-password has been stored
+
+
+Example usage::
+
+
+    ---
+    - name: "Test credstash lookup plugin -- get my github password"
+      debug: msg="Credstash lookup! {{ lookup('credstash', 'my-github-password') }}"
+
+
+You can specify regions or tables to fetch secrets from::
+
+
+    ---
+    - name: "Test credstash lookup plugin -- get my other password from us-west-1"
+      debug: msg="Credstash lookup! {{ lookup('credstash', 'my-other-password', region='us-west-1') }}"
+
+
+    - name: "Test credstash lookup plugin -- get the company's github password"
+      debug: msg="Credstash lookup! {{ lookup('credstash', 'company-github-password', table='company-passwords') }}"
+
+
+
 .. _more_lookups:
 
 More Lookups

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -1,0 +1,42 @@
+# (c) 2015, Ensighten <infra@ensighten.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+import credstash
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+
+        if isinstance(terms, basestring):
+            terms = [terms]
+
+        ret = []
+        for term in terms:
+            try:
+                val = credstash.getSecret(term, **kwargs)
+            except credstash.ItemNotFound:
+                raise AnsibleError('Key {} not found'.format(term))
+            except Exception as e:
+                raise AnsibleError('Encountered exception while fetching {}: {}'.format(term, e.message))
+            ret.append(val)
+
+        return ret

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -29,12 +29,11 @@ except ImportError:
     CREDSTASH_INSTALLED = False
 
 
-if not CREDSTASH_INSTALLED:
-    raise AnsibleError('The credstash lookup plugin requires credstash to be installed.')
-
-
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
+
+        if not CREDSTASH_INSTALLED:
+            raise AnsibleError('The credstash lookup plugin requires credstash to be installed.')
 
         if isinstance(terms, basestring):
             terms = [terms]

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -43,9 +43,9 @@ class LookupModule(LookupBase):
             try:
                 val = credstash.getSecret(term, **kwargs)
             except credstash.ItemNotFound:
-                raise AnsibleError('Key {} not found'.format(term))
+                raise AnsibleError('Key {0} not found'.format(term))
             except Exception, e:
-                raise AnsibleError('Encountered exception while fetching {}: {}'.format(term, e.message))
+                raise AnsibleError('Encountered exception while fetching {0}: {1}'.format(term, e.message))
             ret.append(val)
 
         return ret

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -45,7 +45,7 @@ class LookupModule(LookupBase):
                 val = credstash.getSecret(term, **kwargs)
             except credstash.ItemNotFound:
                 raise AnsibleError('Key {} not found'.format(term))
-            except Exception as e:
+            except Exception, e:
                 raise AnsibleError('Encountered exception while fetching {}: {}'.format(term, e.message))
             ret.append(val)
 

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -20,7 +20,17 @@ __metaclass__ = type
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
-import credstash
+CREDSTASH_INSTALLED = False
+
+try:
+    import credstash
+    CREDSTASH_INSTALLED = True
+except ImportError:
+    CREDSTASH_INSTALLED = False
+
+
+if not CREDSTASH_INSTALLED:
+    raise AnsibleError('The credstash lookup plugin requires credstash to be installed.')
 
 
 class LookupModule(LookupBase):


### PR DESCRIPTION
Credstash is a small utility for managing secrets using AWS's KMS and DynamoDB: https://github.com/LuminalOSS/credstash

Example usage:

```
- name: "Test credstash lookup plugin"
  debug: msg="Credstash lookup! {{ lookup('credstash', 'my-github-password') }}"
```

All credstash options (region, table, etc) are also configurable:

```
- name: "Test credstash lookup plugin"
  debug: msg="Credstash lookup! {{ lookup('credstash', 'my-other-password', region='us-west-1') }}"
```

I have some small questions about contributing. This lookup plugin has a dependency on the `credstash` module. Is there a way for me to add this as a dependency for the plugin? Is there also a good way for me to add documentation?
