### PR TITLE
v2: Fixed delegation when using a host that is not in the inventory

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -472,17 +472,21 @@ class TaskExecutor:
         try:
             this_info = variables['hostvars'][self._task.delegate_to]
 
-            # get the real ssh_address for the delegate and allow ansible_ssh_host to be templated
-            #self._play_context.remote_user      = self._compute_delegate_user(self.delegate_to, delegate['inject'])
+            # If the delegate_to host does not exist in the inventory then the get should thrown an exception
+            # and make sure that this_info is an empty dict so that the defaults are properly used
             self._play_context.remote_addr      = this_info.get('ansible_ssh_host', self._task.delegate_to)
-            self._play_context.port             = this_info.get('ansible_ssh_port', self._play_context.port)
-            self._play_context.password         = this_info.get('ansible_ssh_pass', self._play_context.password)
-            self._play_context.private_key_file = this_info.get('ansible_ssh_private_key_file', self._play_context.private_key_file)
-            self._play_context.connection       = this_info.get('ansible_connection', C.DEFAULT_TRANSPORT)
-            self._play_context.become_pass      = this_info.get('ansible_sudo_pass', self._play_context.become_pass)
         except:
             # make sure the inject is empty for non-inventory hosts
             this_info = {}
+
+        # get the real ssh_address for the delegate and allow ansible_ssh_host to be templated
+        #self._play_context.remote_user      = self._compute_delegate_user(self.delegate_to, delegate['inject'])
+        self._play_context.remote_addr      = this_info.get('ansible_ssh_host', self._task.delegate_to)
+        self._play_context.port             = this_info.get('ansible_ssh_port', self._play_context.port)
+        self._play_context.password         = this_info.get('ansible_ssh_pass', self._play_context.password)
+        self._play_context.private_key_file = this_info.get('ansible_ssh_private_key_file', self._play_context.private_key_file)
+        self._play_context.connection       = this_info.get('ansible_connection', C.DEFAULT_TRANSPORT)
+        self._play_context.become_pass      = this_info.get('ansible_sudo_pass', self._play_context.become_pass)
 
         if self._play_context.remote_addr in ('127.0.0.1', 'localhost'):
              self._play_context.connection = 'local'


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
% ansible --version                                                                                                             ?[0] !10366
ansible 2.0.0 (devel 614463e899) last updated 2015/07/29 13:30:11 (GMT -700)
  lib/ansible/modules/core: (detached HEAD a46b3a4dc4) last updated 2015/07/29 13:34:14 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD e30d8b84fe) last updated 2015/07/29 13:34:14 (GMT -700)
  v1/ansible/modules/core: (detached HEAD f8d8af17cd) last updated 2015/06/09 16:52:46 (GMT -700)
  v1/ansible/modules/extras: (detached HEAD 495ad450e5) last updated 2015/06/09 16:52:49 (GMT -700)
  config file = /Users/andrew/workspace/ops/deploy/deploy_conf/ansible.cfg
  configured module search path = /Users/andrew/workspace/ops/deploy/modules/
```
##### Ansible Configuration:

Nothing has changed and worked fine before the v2 update.
##### Environment:

Local: Mac OS X 10.10.4
##### Summary:

Currently when using a host with the `delegate_to` option that is not in the inventory the host is skipped over. This is due to an earlier commit of mine (7f45c9edf) that jumps over the hosts instead of setting the defaults. This commit fixes this so that if a set of variables don't exist for the specified `delegate_to` host then defaults a used.
##### Steps To Reproduce:

test.yml

``` yaml

---
- hosts: tag_group_test
  gather_facts: false
  vars:
    bastion: bastion-staging
  tasks:
    - name: Print the hostname of the delegate host
      command: hostname
      delegate_to: "{{ bastion }}"
```

```
%  ansible-playbook -i deploy_conf/ec2.py -vvvv test.yml
```
##### Expected Results:

Notice here that the hostname for each system is the same and different from the host it's being run for. These results are actually delegated.

```
Using /Users/andrew/workspace/ops/deploy/deploy_conf/ansible.cfg as config file
1 plays in test.yml
Loaded callback default of type stdout, v2.0

PLAY ****************************************************************************

TASK [Print the hostname of the delegate host] **********************************
<bastion-staging> ESTABLISH SSH CONNECTION FOR USER: ec2-user
<bastion-staging> ESTABLISH SSH CONNECTION FOR USER: ec2-user
<bastion-staging> EXEC ssh -C -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/tmp/%h-%r" -o StrictHostKeyChecking=no -o IdentityFile="/Users/andrew/.ssh/test.pem" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=ec2-user -o ConnectTimeout=10 bastion-staging LANG=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python
<bastion-staging> EXEC ssh -C -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/tmp/%h-%r" -o StrictHostKeyChecking=no -o IdentityFile="/Users/andrew/.ssh/test.pem" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=ec2-user -o ConnectTimeout=10 bastion-staging LANG=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python
changed: [ip-172-31-9-206.us-west-1.compute.internal] => {"changed": true, "cmd": ["hostname"], "delta": "0:00:00.201191", "end": "2015-07-30 00:28:20.925431", "rc": 0, "start": "2015-07-30 00:28:20.724240", "stderr": "", "stdout": "ip-172-31-0-232", "stdout_lines": ["ip-172-31-0-232"], "warnings": []}
changed: [ip-172-31-8-71.us-west-1.compute.internal] => {"changed": true, "cmd": ["hostname"], "delta": "0:00:00.186944", "end": "2015-07-30 00:28:20.785483", "rc": 0, "start": "2015-07-30 00:28:20.598539", "stderr": "", "stdout": "ip-172-31-0-232", "stdout_lines": ["ip-172-31-0-232"], "warnings": []}

PLAY RECAP **********************************************************************
ip-172-31-8-71.us-west-1.compute.internal : ok=1    changed=1    unreachable=0    failed=0
ip-172-31-9-206.us-west-1.compute.internal : ok=1    changed=1    unreachable=0    failed=0
```
##### Actual Results:

In the actual results the actual hosts hostname is shown in both the SSH output as well as the output of the `hostname` command sent to the hosts.

```
Using /Users/andrew/workspace/ops/deploy/deploy_conf/ansible.cfg as config file
1 plays in test.yml
Loaded callback default of type stdout, v2.0

PLAY ****************************************************************************

TASK [Print the hostname of the delegate host] **********************************
<ip-172-31-9-206.us-west-1.compute.internal> ESTABLISH SSH CONNECTION FOR USER: ec2-user
<ip-172-31-8-71.us-west-1.compute.internal> ESTABLISH SSH CONNECTION FOR USER: ec2-user
<ip-172-31-8-71.us-west-1.compute.internal> EXEC ssh -C -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/tmp/%h-%r" -o StrictHostKeyChecking=no -o IdentityFile="/Users/andrew/.ssh/test.pem" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=ec2-user -o ConnectTimeout=10 ip-172-31-8-71.us-west-1.compute.internal LANG=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python
<ip-172-31-9-206.us-west-1.compute.internal> EXEC ssh -C -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/tmp/%h-%r" -o StrictHostKeyChecking=no -o IdentityFile="/Users/andrew/.ssh/test.pem" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=ec2-user -o ConnectTimeout=10 ip-172-31-9-206.us-west-1.compute.internal LANG=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python
changed: [ip-172-31-9-206.us-west-1.compute.internal] => {"changed": true, "cmd": ["hostname"], "delta": "0:00:00.056842", "end": "2015-07-30 00:27:54.970215", "rc": 0, "start": "2015-07-30 00:27:54.913373", "stderr": "", "stdout": "ip-172-31-9-206", "stdout_lines": ["ip-172-31-9-206"], "warnings": []}
changed: [ip-172-31-8-71.us-west-1.compute.internal] => {"changed": true, "cmd": ["hostname"], "delta": "0:00:00.055844", "end": "2015-07-30 00:27:55.003505", "rc": 0, "start": "2015-07-30 00:27:54.947661", "stderr": "", "stdout": "ip-172-31-8-71", "stdout_lines": ["ip-172-31-8-71"], "warnings": []}

PLAY RECAP **********************************************************************
ip-172-31-8-71.us-west-1.compute.internal : ok=1    changed=1    unreachable=0    failed=0
ip-172-31-9-206.us-west-1.compute.internal : ok=1    changed=1    unreachable=0    failed=0
```
