### PR TITLE
Uncomment encrypt handling for vars_prompt

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -34,6 +34,7 @@ from ansible.template import Templar
 from ansible.utils.color import colorize, hostcolor
 from ansible.utils.debug import debug
 from ansible.utils.encrypt import do_encrypt
+from ansible.utils.unicode import to_unicode
 
 class PlaybookExecutor:
 
@@ -274,8 +275,7 @@ class PlaybookExecutor:
             result = do_encrypt(result, encrypt, salt_size, salt)
 
         # handle utf-8 chars
-        # FIXME: make this work
-        #result = to_unicode(result, errors='strict')
+        result = to_unicode(result, errors='strict')
         return result
 
 

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -262,7 +262,7 @@ class PlaybookExecutor:
                 second = do_prompt("confirm " + msg, private)
                 if result == second:
                     break
-                display("***** VALUES ENTERED DO NOT MATCH ****")
+                self._display.display("***** VALUES ENTERED DO NOT MATCH ****")
         else:
             result = do_prompt(msg, private)
 

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -33,6 +33,7 @@ from ansible.template import Templar
 
 from ansible.utils.color import colorize, hostcolor
 from ansible.utils.debug import debug
+from ansible.utils.encrypt import do_encrypt
 
 class PlaybookExecutor:
 
@@ -269,9 +270,8 @@ class PlaybookExecutor:
         if not result and default is not None:
             result = default
 
-        # FIXME: make this work with vault or whatever this old method was
-        #if encrypt:
-        #    result = utils.do_encrypt(result, encrypt, salt_size, salt)
+        if encrypt:
+            result = do_encrypt(result, encrypt, salt_size, salt)
 
         # handle utf-8 chars
         # FIXME: make this work


### PR DESCRIPTION
This makes the following work again:

```
vars_prompt:
  - name: varname
    prompt: "password"
    encrypt: "sha512_crypt"
```

It said `FIXME`, but I didn't really have to do much to `FIXIT`.
