### PR TITLE
Allow multiple interpreters to be specified

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -251,13 +251,9 @@ ansible_shell_type
     By default commands are formatted using ``sh``-style syntax.
     Setting this to ``csh`` or ``fish`` will cause commands executed on target systems to follow those shell's syntax instead.
 ansible_python_interpreter
-    The target host python path. This is useful for systems with more
-    than one Python or not located at :command:`/usr/bin/python` such as \*BSD, or where :command:`/usr/bin/python`
-    is not a 2.X series Python.  We do not use the :command:`/usr/bin/env` mechanism as that requires the remote user's
-    path to be set right and also assumes the :program:`python` executable is named python, where the executable might
-    be named something like :program:`python2.6`.
+    The target host Python path. A colon separated list of candidate paths can be supplied.
 ansible_*_interpreter
-    Works for anything such as ruby or perl and works just like ``ansible_python_interpreter``.
+    Similar variables are supported for other interpreted languages such as Perl or Ruby.
     This replaces shebang of modules which will run on that host.
 
 .. versionadded:: 2.1
@@ -275,6 +271,10 @@ Examples from a host file::
   aws_host          ansible_ssh_private_key_file=/home/example/.ssh/aws.pem
   freebsd_host      ansible_python_interpreter=/usr/local/bin/python
   ruby_module_host  ansible_ruby_interpreter=/usr/bin/ruby.1.9.3
+
+  [all:vars]
+  # by default try some usual locations, and fall back to searching PATH
+  ansible_python_interpreter=/usr/local/bin/python2.6:/usr/bin/python:python
 
 Non-SSH connection types
 ++++++++++++++++++++++++

--- a/docsite/rst/playbooks_interpreters.rst
+++ b/docsite/rst/playbooks_interpreters.rst
@@ -44,12 +44,14 @@ command will be searched in PATH.
 Specifying multiple interpreters
 --------------------------------
 
-In the context of managing farms of heterogeneous hosts, it may be impractical
-to maintain an up-to-date record of what exact interpreter path is to
-be used on a given machine. In such a context, Ansible can be configured
-to look for the interpreter from a set of possible candidates given as a
-colon-separated list.  Each item is either a full name, or just a base name
-that will be resolved from PATH:
+In general it is best to specify the exact location of the correct
+interpreter for each machine in the inventory. However, in the
+context of managing farms of heterogeneous hosts, it may be impractical
+to maintain an up-to-date record of what exact interpreter path is
+to be used on a given machine. In such a context, Ansible can be
+configured to look for the interpreter from a set of possible
+candidates given as a colon-separated list. Each item is either a
+full name, or just a base name that will be resolved from PATH:
 
 Example::
 
@@ -62,7 +64,9 @@ This indicates that Ansible should try the following Python interpreters in orde
 - '/usr/bin/python'
 - a 'python' binary from PATH
 
-Ansible stops the search as soon as a matching executable is found.
+Ansible stops the search as soon as a matching executable is found. Note that
+this is not supported for machines using a release of the fish shell older than
+2.2.0.
 
 Interpreter caching
 -------------------

--- a/docsite/rst/playbooks_interpreters.rst
+++ b/docsite/rst/playbooks_interpreters.rst
@@ -1,0 +1,83 @@
+Specifying Interpreters
++++++++++++++++++++++++
+
+.. contents:: Topics
+
+Ansible modules are written in Python, or other interpreted languages such as Perl or Ruby.
+Following UNIX convention, the implementation language of a given module is identified
+by its shebang line, such as '#! /usr/bin/python'. This indicates the default interpreter
+to be used when running the module.
+
+However, the actual location of the appropriate interpreter may vary
+from host to host. For instance, on \*BSD systems, it is usually
+'/usr/local/bin/python'; on some machines, the default Python binary
+may be a 3.X one, whereas Ansible modules require a Python 2.X
+interpreter, which could be installed as '/usr/bin/python2'.
+
+
+Inventory variables
+-------------------
+
+The interpreter for a given language can be set using inventory variables named
+after the base name of the default interpreter. So, for Python, the default interpreter
+is '/usr/bin/python', so the variable is 'ansible_python_interpreter'. Likewise
+for other languages, the variable is 'ansible_*_interpreter'.
+
+Examples from a host file::
+
+    [linux_group]
+    python3_host ansible_python_interpreter=/usr/bin/python2
+    ruby_host  ansible_ruby_interpreter=/usr/bin/ruby.1.9.3
+
+    [freebsd_group:vars]
+    ansible_python_interpreter=/usr/local/bin/python
+
+Relying on PATH
+---------------
+
+Ansible by default requires the full path of interpreters to be set in inventory,
+if you want to override the default path. This ensures that the result of
+executing a playbook is independent of environment settings. However, if
+'ansible_*_interpreter' is set to just a base name, then the corresponding
+command will be searched in PATH.
+
+Specifying multiple interpreters
+--------------------------------
+
+In the context of managing farms of heterogeneous hosts, it may be impractical
+to maintain an up-to-date record of what exact interpreter path is to
+be used on a given machine. In such a context, Ansible can be configured
+to look for the interpreter from a set of possible candidates given as a
+colon-separated list.  Each item is either a full name, or just a base name
+that will be resolved from PATH:
+
+Example::
+
+    ansible_python_interpreter=/usr/local/bin/python2.7:python2:/usr/bin/python:python
+
+This indicates that Ansible should try the following Python interpreters in order:
+
+- '/usr/local/bin/python2.7'
+- a 'python2' binary from PATH
+- '/usr/bin/python'
+- a 'python' binary from PATH
+
+Ansible stops the search as soon as a matching executable is found.
+
+Interpreter caching
+-------------------
+
+In the case where an interpreter is looked up from PATH, or from a list of possible
+candidates, the lookup is done only once per playbook for each host. The result
+is stored as a host fact so that it remains in effect for the whole playbook.
+
+If fact caching is used, the setting is also part of the cached information, and
+the lookup is not performed again until the cache is flushed.
+
+.. seealso::
+
+   `Mailing List <http://groups.google.com/group/ansible-project>`_
+       Questions? Help? Ideas?  Stop by the list on Google Groups
+   `irc.freenode.net <http://irc.freenode.net>`_
+       #ansible IRC chat channel
+

--- a/docsite/rst/playbooks_special_topics.rst
+++ b/docsite/rst/playbooks_special_topics.rst
@@ -22,3 +22,4 @@ and adopt these only if they seem relevant or useful to your environment.
    playbooks_vault
    playbooks_startnstep
    playbooks_directives
+   playbooks_interpreters

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -67,6 +67,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         self._cleanup_remote_tmp  = False
         self._supports_check_mode = True
+        self._module_facts        = dict()
 
     @abstractmethod
     def run(self, tmp=None, task_vars=None):
@@ -146,7 +147,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                                    "run 'git submodule update --init --recursive' to correct this problem." % (module_name))
 
         # insert shared code and arguments into the module
-        (module_data, module_style, module_shebang) = modify_module(module_name, module_path, module_args, task_vars=task_vars, module_compression=self._play_context.module_compression)
+        (module_data, module_style, module_shebang) = modify_module(module_name, module_path, module_args,
+            handler=self, task_vars=task_vars, module_compression=self._play_context.module_compression)
 
         return (module_style, module_shebang, module_data, module_path)
 
@@ -178,6 +180,53 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         final_environment = self._templar.template(final_environment)
         return self._connection._shell.env_prefix(**final_environment)
 
+    def _compute_interpreter(self, lang, task_vars):
+        '''
+        Determine a suitable interpreter for lang using ansible_<lang>_interpreter,
+        and return the determined interpreter, or None if not found.
+        '''
+
+        # compute name of configuration variable for this language
+
+        interpreter_config = 'ansible_%s_interpreter' % lang
+
+        # check for previously cached result for this module
+
+        interpreter = self._module_facts.get(interpreter_config, None)
+        if interpreter is not None:
+            return interpreter
+
+        # no cached value found: proceed with determination of suitable interpreter path
+
+        interpreter = None
+
+        if interpreter_config in task_vars:
+            interp_list = to_bytes(task_vars[interpreter_config].strip(), errors='strict').split(':')
+            interpreter = None
+            fallback_interp = interp_list[0]
+
+            # If more than a single interpreter is specified, or if the only
+            # one specified does not have a full path, check each candidate
+            # value until a valid one is found.
+
+            if len(interp_list) > 1 or os.path.sep not in fallback_interp:
+                try:
+                    while interpreter is None:
+                        candidate = interp_list.pop(0).strip()
+                        interpreter = self._remote_check_interp(interpreter_config, candidate)
+                except:
+                    interpreter = None
+
+            # If no interpreter found, fall back to first one specified
+
+            if interpreter is None:
+                interpreter = fallback_interp
+
+            if interpreter is not None and interpreter != task_vars[interpreter_config]:
+                self._module_facts[interpreter_config] = interpreter
+
+        return interpreter
+
     def _early_needs_tmp_path(self):
         '''
         Determines if a temp path should be created before the action is executed.
@@ -200,6 +249,21 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             # even when conn has pipelining, old style modules need tmp to store arguments
             return True
         return False
+
+    def _remote_check_interp(self, var, candidate):
+        '''
+        Check whether candidate (which is either the base name or the
+        full path to an interpreter) is available, and if so return full path.
+        '''
+        cmd = self._connection._shell.check_interp(candidate)
+        self._display.debug("calling _low_level_execute_command to check %s" % var)
+        data = self._low_level_execute_command(cmd, sudoable=True)
+
+        interp_full_path = data['stdout'].strip().splitlines()[-1]
+        if 'NOTFOUND' in interp_full_path:
+            return None
+        else:
+            return interp_full_path
 
     def _make_tmp_path(self, remote_user):
         '''
@@ -680,6 +744,14 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 data['module_stderr'] = res['stderr']
                 if res['stderr'].startswith(u'Traceback'):
                     data['exception'] = res['stderr']
+
+        # merge additional facts provided by the module
+        if self._module_facts:
+            if 'ansible_facts' in data:
+                data['ansible_facts'].update(self._module_facts)
+            else:
+                data['ansible_facts'] = self._module_facts
+
         return data
 
     def _low_level_execute_command(self, cmd, sudoable=True, in_data=None, executable=None, encoding_errors='replace'):

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -57,6 +57,9 @@ class ShellBase(object):
     def path_has_trailing_slash(self, path):
         return path.endswith('/')
 
+    def check_interp(self, interp):
+        return 'command -v "%s" || echo NOTFOUND' % interp
+
     def chmod(self, mode, path, recursive=True):
         path = pipes.quote(path)
         cmd = ['chmod']

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -58,7 +58,7 @@ class ShellBase(object):
         return path.endswith('/')
 
     def check_interp(self, interp):
-        return 'command -v "%s" || echo NOTFOUND' % interp
+        return 'command -v "%s" %s echo NOTFOUND' % (interp, self._SHELL_OR)
 
     def chmod(self, mode, path, recursive=True):
         path = pipes.quote(path)


### PR DESCRIPTION
It may be inconvenient to set a specific ansible_<lang>_interpreter
explicitly for each host in inventory. Instead allow the specification
of a comma-separated list of interpreters, which are tried in turn until
one is found, and cache the value for future use. Interpreters can
be specified either with a full path, or with just a base name,
in which case they are located in PATH.
