### PR TITLE
FIXME in host range parsing

### DIFF
--- a/docsite/rst/intro_patterns.rst
+++ b/docsite/rst/intro_patterns.rst
@@ -72,9 +72,9 @@ As an advanced usage, you can also select the numbered server in a group::
    
     webservers[0]
 
-Or a portion of servers in a group::
+Or a range of servers in a group::
 
-    webservers[0-25]
+    webservers[0:25]
 
 Most people don't specify patterns as regular expressions, but you can.  Just start the pattern with a '~'::
 

--- a/lib/ansible/inventory/expand_hosts.py
+++ b/lib/ansible/inventory/expand_hosts.py
@@ -75,7 +75,6 @@ def expand_hostname_range(line = None):
         #   of hosts and then repeat until none left.
         # - also add an optional third parameter which contains the step. (Default: 1)
         #   so range can be [01:10:2] -> 01 03 05 07 09
-        # FIXME: make this work for alphabetic sequences too.
 
         (head, nrange, tail) = line.replace('[','|',1).replace(']','|',1).split('|')
         bounds = nrange.split(":")
@@ -104,7 +103,7 @@ def expand_hostname_range(line = None):
             i_end = string.ascii_letters.index(end)
             if i_beg > i_end:
                 raise errors.AnsibleError("host range format incorrectly specified!")
-            seq = string.ascii_letters[i_beg:i_end+1]
+            seq = [string.ascii_letters[i] for i in range(i_beg, i_end+1, int(step))]
         except ValueError:  # not an alpha range
             seq = range(int(beg), int(end)+1, int(step))
 

--- a/lib/ansible/inventory/expand_hosts.py
+++ b/lib/ansible/inventory/expand_hosts.py
@@ -103,7 +103,7 @@ def expand_hostname_range(line = None):
             i_end = string.ascii_letters.index(end)
             if i_beg > i_end:
                 raise errors.AnsibleError("host range must have begin <= end")
-            seq = [string.ascii_letters[i] for i in range(i_beg, i_end+1, int(step))]
+            seq = list(string.ascii_letters[i_beg:i_end+1:int(step)])
         except ValueError:  # not an alpha range
             seq = range(int(beg), int(end)+1, int(step))
 

--- a/lib/ansible/inventory/expand_hosts.py
+++ b/lib/ansible/inventory/expand_hosts.py
@@ -79,7 +79,7 @@ def expand_hostname_range(line = None):
         (head, nrange, tail) = line.replace('[','|',1).replace(']','|',1).split('|')
         bounds = nrange.split(":")
         if len(bounds) != 2 and len(bounds) != 3:
-            raise errors.AnsibleError("host range incorrectly specified")
+            raise errors.AnsibleError("host range must be begin:end or begin:end:step")
         beg = bounds[0]
         end = bounds[1]
         if len(bounds) == 2:
@@ -89,11 +89,11 @@ def expand_hostname_range(line = None):
         if not beg:
             beg = "0"
         if not end:
-            raise errors.AnsibleError("host range end value missing")
+            raise errors.AnsibleError("host range must specify end value")
         if beg[0] == '0' and len(beg) > 1:
             rlen = len(beg) # range length formatting hint
             if rlen != len(end):
-                raise errors.AnsibleError("host range format incorrectly specified!")
+                raise errors.AnsibleError("host range must specify equal-length begin and end formats")
             fill = lambda _: str(_).zfill(rlen)  # range sequence
         else:
             fill = str
@@ -102,7 +102,7 @@ def expand_hostname_range(line = None):
             i_beg = string.ascii_letters.index(beg)
             i_end = string.ascii_letters.index(end)
             if i_beg > i_end:
-                raise errors.AnsibleError("host range format incorrectly specified!")
+                raise errors.AnsibleError("host range must have begin <= end")
             seq = [string.ascii_letters[i] for i in range(i_beg, i_end+1, int(step))]
         except ValueError:  # not an alpha range
             seq = range(int(beg), int(end)+1, int(step))


### PR DESCRIPTION
1. Make the `step` argument work for alphabetic sequences: `[a:e:2]` means a,c,e (this was the `FIXME`).
2. Improved error messages for host range parsing errors: we say "host range must …something…" now
3. Mention `x:y` ranges in `intro_patterns.rst`.
