### PR TITLE
Fix build failure: Use 2.4-compatible exception syntax

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -122,9 +122,9 @@ def connect_to_api(module, disconnect_atexit=True):
         if disconnect_atexit:
             atexit.register(connect.Disconnect, service_instance)
         return service_instance.RetrieveContent()
-    except vim.fault.InvalidLogin as invalid_login:
+    except vim.fault.InvalidLogin, invalid_login:
         module.fail_json(msg=invalid_login.msg, apierror=str(invalid_login))
-    except requests.ConnectionError as connection_error:
+    except requests.ConnectionError, connection_error:
         module.fail_json(msg="Unable to connect to vCenter or ESXi API on TCP/443.", apierror=str(connection_error))
 
 


### PR DESCRIPTION
This is intended to address the build failure at
https://travis-ci.org/ansible/ansible/jobs/73507390

py26 runtests: commands[1] | python2.4 -m compileall -fq -x module_utils/(a10|rax|openstack|ec2|gce).py lib/ansible/module_utils
Compiling lib/ansible/module_utils/vmware.py ...
  File "lib/ansible/module_utils/vmware.py", line 125
    except vim.fault.InvalidLogin as invalid_login:
                                   ^
SyntaxError: invalid syntax
ERROR: InvocationError: '/usr/bin/python2.4 -m compileall -fq -x module_utils/(a10|rax|openstack|ec2|gce).py lib/ansible/module_utils'
