### PR TITLE
change ec2 util to create only requested objects

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -25,6 +25,7 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import os, boto3
 
 try:
     from distutils.version import LooseVersion
@@ -37,14 +38,15 @@ def boto3_conn(module, conn_type=None, resource=None, region=None, endpoint=None
     if conn_type not in ['both', 'resource', 'client']:
         module.fail_json(msg='There is an issue in the code of the module. You must specify either both, resource or client to the conn_type parameter in the boto3_conn function call')
 
-    resource = boto3.session.Session().resource(resource, region_name=region, endpoint_url=endpoint, **params)
-    client = resource.meta.client
-
     if conn_type == 'resource':
+        resource = boto3.session.Session().resource(resource, region_name=region, endpoint_url=endpoint, **params)
         return resource
     elif conn_type == 'client':
+        client = boto3.session.Session().client(resource, region_name=region, endpoint_url=endpoint, **params)
         return client
     else:
+        resource = boto3.session.Session().resource(resource, region_name=region, endpoint_url=endpoint, **params)
+        client = boto3.session.Session().client(resource, region_name=region, endpoint_url=endpoint, **params)
         return client, resource
 
 def aws_common_argument_spec():


### PR DESCRIPTION
In anticipation of upcoming ECS modules, I have the following issue with ec2.py as it exists.  I run this command:
`EC2_INI_PATH=$ANSIBLE_HOME/contrib/inventory/ec2.ini AWS_REGION=us-west-2 ANSIBLE_LIBRARY=ansible-modules-core:J1G-ansible-modules-extras ansible -i test/inventory.ini -vvv -m ecs_cluster_facts localhost -a "details=true”`

The ecs_cluster_facts uses this code to connect to boto3:
`self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)`

But gets errors:
`File "/Users/mchance/Projects/47Lining/Customers/Ansible/ansible/lib/ansible/module_utils/ec2.py", line 89, in get_aws_connection_info
    if 'AWS_URL' in os.environ:
NameError: global name 'os' is not defined`

Similarly for boto3.. but more problematic:
`File "/Users/mchance/Projects/47Lining/Customers/Ansible/ansible/lib/ansible/module_utils/ec2.py", line 41, in boto3_conn
    resource = boto3.session.Session().resource(resource, region_name=region, endpoint_url=endpoint, **params)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/boto3/session.py", line 257, in resource 
    service_name, 'resources-1')
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/botocore/loaders.py", line 119, in _wrapper
    data = func(self, *args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/botocore/loaders.py", line 280, in determine_latest_version
    return max(self.list_api_versions(service_name, type_name))
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/botocore/loaders.py", line 119, in _wrapper
    data = func(self, *args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/botocore/loaders.py", line 309, in list_api_versions
    raise DataNotFoundError(data_path=service_name)
    botocore.exceptions.DataNotFoundError: Unable to load data for: ecs`

Because botocore doesn't in fact have a resources-1.json file:
`ls /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/botocore/data/ecs/2014-11-13
    paginators-1.json service-2.json    waiters-2.json`
