### PR TITLE
Fixes for synchronize with delegate_to

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -134,6 +134,18 @@ SU_PROMPT_LOCALIZATIONS = [
     '密碼',
 ]
 
+TASK_ATTRIBUTE_OVERRIDES = (
+    'become',
+    'become_user',
+    'become_pass',
+    'become_method',
+    'connection',
+    'delegate_to',
+    'no_log',
+    'remote_user',
+)
+
+
 class PlayContext(Base):
 
     '''
@@ -285,7 +297,7 @@ class PlayContext(Base):
 
         # loop through a subset of attributes on the task object and set
         # connection fields based on their values
-        for attr in ('connection', 'remote_user', 'become', 'become_user', 'become_pass', 'become_method', 'no_log'):
+        for attr in TASK_ATTRIBUTE_OVERRIDES:
             if hasattr(task, attr):
                 attr_val = getattr(task, attr)
                 if attr_val is not None:

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -132,9 +132,12 @@ class ActionModule(ActionBase):
             new_connection = connection_loader.get('local', self._play_context, new_stdin)
             self._connection = new_connection
             transport_overridden = True
+            ### FIXME: We think that this was here for v1 because the local
+            # connection didn't support sudo.  In v2 it does so we think it's
+            # safe to remove this now.
+
             # Also disable sudo
-            ### FIXME: Why exactly?
-            self._play_context.become = False
+            #self._play_context.become = False
 
         # MUNGE SRC AND DEST PER REMOTE_HOST INFO
         src  = self._task.args.get('src', None)


### PR DESCRIPTION
There's several things wrong with the synchronize module's detection of delegate_to being used.  This patch fixes them.

With this applied, pushing and pulling works both from localhost to a remote host and from a delegate_to  host and a remote host.  (provided that you can ssh between all of the hosts appropriately.)
