### PR TITLE
Another small batch of trivial FIXME removals

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -411,7 +411,6 @@ class TaskExecutor:
         correct connection object from the list of connection plugins
         '''
 
-        # FIXME: delegate_to calculation should be done here
         # FIXME: calculation of connection params/auth stuff should be done here
 
         if not self._play_context.remote_addr:

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -93,7 +93,6 @@ class Role(Base, Become, Conditional, Taggable):
 
     @staticmethod
     def load(role_include, play, parent_role=None):
-        # FIXME: add back in the role caching support
         try:
             # The ROLE_CACHE is a dictionary of role names, with each entry
             # containing another dictionary corresponding to a set of parameters


### PR DESCRIPTION
The first two just needed to be removed, as the required changes have been made already.

The third one involves a small change suggested by @bcoca to make the raw module set in_data because `ssh.py` can't access the `module_name` any more.
