### PR TITLE
Disallow --forks 0

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -186,7 +186,7 @@ class CLI(object):
             self.options.become_method = 'su'
 
 
-    def validate_conflicts(self, vault_opts=False, runas_opts=False):
+    def validate_conflicts(self, vault_opts=False, runas_opts=False, fork_opts=False):
         ''' check for conflicting options '''
 
         op = self.options
@@ -210,6 +210,10 @@ class CLI(object):
                                   "and su arguments ('-su', '--su-user', and '--ask-su-pass') "
                                   "and become arguments ('--become', '--become-user', and '--ask-become-pass')"
                                   " are exclusive of each other")
+
+        if fork_opts:
+            if op.forks < 1:
+                self.parser.error("The number of processes (--forks) must be >= 1")
 
     @staticmethod
     def expand_tilde(option, opt, value, parser):

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -60,7 +60,7 @@ class AdHocCLI(CLI):
             raise AnsibleOptionsError("Missing target hosts")
 
         self.display.verbosity = self.options.verbosity
-        self.validate_conflicts(runas_opts=True, vault_opts=True)
+        self.validate_conflicts(runas_opts=True, vault_opts=True, fork_opts=True)
 
         return True
 

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -76,7 +76,7 @@ class PlaybookCLI(CLI):
             raise AnsibleOptionsError("You must specify a playbook file to run")
 
         self.display.verbosity = self.options.verbosity
-        self.validate_conflicts(runas_opts=True, vault_opts=True)
+        self.validate_conflicts(runas_opts=True, vault_opts=True, fork_opts=True)
 
     def run(self):
 


### PR DESCRIPTION
Without at least one worker process, things break:

Traceback (most recent call last):
  File "/home/ams/extern/ansible/ansible/lib/ansible/executor/process/result.py", line 103, in run
    result = self._read_worker_result()
  File "/home/ams/extern/ansible/ansible/lib/ansible/executor/process/result.py", line 69, in _read_worker_result
    (worker_prc, main_q, rslt_q) = self._workers[self._cur_worker]
IndexError: list index out of range
