### PR TITLE
Fix for PowerShell unquote method when passed None.

### DIFF
--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -126,6 +126,7 @@ class ShellModule(object):
 
     def _unquote(self, value):
         '''Remove any matching quotes that wrap the given value.'''
+        value = to_unicode(value or '')
         m = re.match(r'^\s*?\'(.*?)\'\s*?$', value)
         if m:
             return m.group(1)

--- a/test/integration/roles/test_win_template/tasks/main.yml
+++ b/test/integration/roles/test_win_template/tasks/main.yml
@@ -39,6 +39,17 @@
     that: 
       - "template_result.changed == true"
 
+- name: fill in a basic template again
+  win_template:
+    src: foo.j2
+    dest: "{{win_output_dir}}/foo.templated"
+  register: template_result2
+
+- name: verify that the template was not changed
+  assert: 
+    that: 
+      - "not template_result2|changed" 
+
 # VERIFY CONTENTS
 
 - name: copy known good into place


### PR DESCRIPTION
Fix for a bug that surfaces when a template is unchanged and `src=None` is passed to the `win_file` module.
