### PR TITLE
add win_basename and win_dirname filters

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -338,9 +338,17 @@ To get the last name of a file path, like 'foo.txt' out of '/etc/asdf/foo.txt'::
 
     {{ path | basename }}
 
+To get the last name of a windows style file path (new in version 2.0)::
+
+    {{ path | win_basename }}
+
 To get the directory from a path::
 
     {{ path | dirname }}
+
+To get the directory from a windows path (new version 2.0)::
+
+    {{ path | win_dirname }}
 
 To expand a path containing a tilde (`~`) character (new in version 1.5)::
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -21,6 +21,7 @@ import sys
 import base64
 import json
 import os.path
+import ntpath
 import types
 import pipes
 import glob
@@ -251,6 +252,8 @@ class FilterModule(object):
             'realpath': partial(unicode_wrap, os.path.realpath),
             'relpath': partial(unicode_wrap, os.path.relpath),
             'splitext': partial(unicode_wrap, os.path.splitext),
+            'win_basename': partial(unicode_wrap, ntpath.basename),
+            'win_dirname': partial(unicode_wrap, ntpath.dirname),
 
             # value as boolean
             'bool': bool,


### PR DESCRIPTION
I'd like to add these two filters which users who are targetting windows hosts might find useful.
