### PR TITLE
Path of group_vars and host_vars were getting the basedir added twice.

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -640,6 +640,7 @@ class Inventory(object):
         else:
             basedirs = [self._playbook_basedir]
 
+        cur_loader_basedir = self._loader.get_basedir()
         for basedir in basedirs:
 
             # this can happen from particular API usages, particularly if not run
@@ -660,13 +661,16 @@ class Inventory(object):
             # FIXME: these should go to VariableManager
             if group and host is None:
                 # load vars in dir/group_vars/name_of_group
-                base_path = os.path.join(basedir, "group_vars/%s" % group.name)
+                self._loader.set_basedir(basedir)
+                base_path = os.path.join("group_vars", group.name)
                 results = self._variable_manager.add_group_vars_file(base_path, self._loader)
             elif host and group is None:
                 # same for hostvars in dir/host_vars/name_of_host
-                base_path = os.path.join(basedir, "host_vars/%s" % host.name)
+                self._loader.set_basedir(basedir)
+                base_path = os.path.join("host_vars", host.name)
                 results = self._variable_manager.add_host_vars_file(base_path, self._loader)
 
+        self._loader.set_basedir(cur_loader_basedir)
         # all done, results is a dictionary of variables for this particular host.
         return results
 

--- a/lib/ansible/parsing/__init__.py
+++ b/lib/ansible/parsing/__init__.py
@@ -112,15 +112,19 @@ class DataLoader():
         return parsed_data
 
     def path_exists(self, path):
+        path = self.path_dwim(path)
         return os.path.exists(path)
 
     def is_file(self, path):
+        path = self.path_dwim(path)
         return os.path.isfile(path)
 
     def is_directory(self, path):
+        path = self.path_dwim(path)
         return os.path.isdir(path)
 
     def list_directory(self, path):
+        path = self.path_dwim(path)
         return os.listdir(path)
 
     def _safe_load(self, stream, file_name=None):

--- a/test/units/mock/loader.py
+++ b/test/units/mock/loader.py
@@ -29,10 +29,10 @@ class DictDataLoader(DataLoader):
     def __init__(self, file_mapping=dict()):
         assert type(file_mapping) == dict
 
+        super(DictDataLoader, self).__init__()
+
         self._file_mapping = file_mapping
         self._build_known_directories()
-
-        super(DictDataLoader, self).__init__()
 
     def load_from_file(self, path):
         if path in self._file_mapping:


### PR DESCRIPTION
Fix inventory so this won't happen and fix DataLoader so that it will
test relative paths relative to self._basedir

Fixes #11789
