### PR TITLE
Handle URLs in meta/main.yml dependencies

### DIFF
--- a/lib/ansible/playbook/role/include.py
+++ b/lib/ansible/playbook/role/include.py
@@ -34,7 +34,7 @@ from ansible.module_utils._text import to_native
 __all__ = ['RoleInclude']
 
 
-class RoleInclude(RoleDefinition):
+class RoleInclude(RoleRequirement):
 
     """
     A derivative of RoleDefinition, used by playbook code when a role


### PR DESCRIPTION
e.g

```
dependencies:
- git+https://github.com/blah/blah.git,v1.2
```

```
$ ansible-playbook playbook.yml
Using /home/wthames/src/ansible-playbooks/ansible.cfg as config file
ERROR! the role 'git+https://github.com/blah/blah.git,v1.2' was not found in /home/wthames/src/ansible-playbooks/roles:./roles:...
```

Use `RoleRequirement` rather than `RoleDefinition` for handling role inclusions

Handle of comma separated specified versions

Allow old style string role specifications (no need for `{ role: rolespecification }` when `rolespecification` will suffice.

This is for backward compatibility with 1.8 style rolesfiles and meta/main.yml files
