### PR TITLE
Add missing $

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -25,7 +25,7 @@ fi
 # The below is an alternative to readlink -fn which doesn't exist on OS X
 # Source: http://stackoverflow.com/a/1678636
 FULL_PATH=$(python -c "import os; print(os.path.realpath('$HACKING_DIR'))")
-export ANSIBLE_HOME=(dirname "$FULL_PATH")
+export ANSIBLE_HOME=$(dirname "$FULL_PATH")
 
 PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
 PREFIX_PATH="$ANSIBLE_HOME/bin"


### PR DESCRIPTION
I'm not sure how this was lost, but `env-setup` is broken without it:

```
$ source hacking/env-setup -q               
hacking/env-setup:28: number expected
```
