### PR TITLE
Add ansible_ssh_extra_args inventory variable

### DIFF
--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -151,6 +151,11 @@ run operations with su as this user (default=root)
 
 Run operations with sudo (nopasswd) (deprecated, use become)
 
+*--ssh-extra-args=*''-o ProxyCommand="ssh -W %h:%p ..." ...''::
+
+Add the specified arguments to any ssh command-line. Useful to set a
+ProxyCommand to use a jump host, but any arguments may be specified.
+
 *-U*, 'SUDO_USER', *--sudo-user=*'SUDO_USER'::
 
 Desired sudo user (default=root) (deprecated, use become).

--- a/docs/man/man1/ansible-pull.1.asciidoc.in
+++ b/docs/man/man1/ansible-pull.1.asciidoc.in
@@ -105,6 +105,11 @@ Purge the checkout after the playbook is run.
 
 Sleep for random interval (between 0 and SLEEP number of seconds) before starting.  This is a useful way ot disperse git requests.
 
+*--ssh-extra-args=*''-o ProxyCommand="ssh -W %h:%p ..." ...''::
+
+Add the specified arguments to any ssh command-line. Useful to set a
+ProxyCommand to use a jump host, but any arguments may be specified.
+
 *-t* 'TAGS', *--tags=*'TAGS'::
 
 Only run plays and tasks tagged with these values.

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -143,6 +143,11 @@ Run operations with su as this user (default=root)
 
 Run the command as the user given by -u and sudo to root.
 
+*--ssh-extra-args=*''-o ProxyCommand="ssh -W %h:%p ..." ...''::
+
+Add the specified arguments to any ssh command-line. Useful to set a
+ProxyCommand to use a jump host, but any arguments may be specified.
+
 *-U* 'SUDO_USERNAME', *--sudo-user=*'SUDO_USERNAME'::
 
 Sudo to 'SUDO_USERNAME' instead of root.  Implies --sudo.

--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -55,6 +55,37 @@ consider managing from a Fedora or openSUSE client even though you are managing 
 We keep paramiko as the default as if you are first installing Ansible on an EL box, it offers a better experience
 for new users.
 
+.. _use_ssh_jump_hosts:
+
+How do I configure a jump host to access servers that I have no direct access to?
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+With Ansible version 2, it's possible to set `ansible_ssh_extra_args` as
+an inventory variable. Any arguments specified this way are added to the
+ssh command line when connecting to the relevant host(s), so it's a good
+way to set a `ProxyCommand`. Consider the following inventory group:
+
+    [gatewayed]
+    foo ansible_ssh_host=192.0.2.1
+    bar ansible_ssh_host=192.0.2.2
+
+You can create `group_vars/gatewayed.yml` with the following contents:
+
+    ansible_ssh_extra_args: '-o ProxyCommand="ssh -W %h:%p -q user@gateway.example.com"'
+
+Ansible will then add these arguments when trying to connect to any host
+in the group `gatewayed`. (These arguments are added to any `ssh_args`
+that may be configured, so it isn't necessary to repeat the default
+`ControlPath` settings in `ansible_ssh_extra_args`.)
+
+Note that `ssh -W` is available only with OpenSSH 5.4 or later. With
+older versions, it's necessary to execute `nc %h:%p` or some equivalent
+command on the bastion host.
+
+With earlier versions of Ansible, it was necessary to configure a
+suitable `ProxyCommand` for one or more hosts in `~/.ssh/config`,
+or globally by setting `ssh_args` in `ansible.cfg`.
+
 .. _ec2_cloud_performance:
 
 How do I speed up management inside EC2?

--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -211,9 +211,11 @@ SSH connection::
       The ssh password to use (this is insecure, we strongly recommend using --ask-pass or SSH keys)
     ansible_ssh_private_key_file
       Private key file used by ssh.  Useful if using multiple keys and you don't want to use SSH agent.
+    ansible_ssh_args
+      This setting overrides any ``ssh_args`` configured in ``ansible.cfg``.
     ansible_ssh_extra_args
       Additional arguments for ssh. Useful to configure a ``ProxyCommand`` for a certain host (or group).
-      This is used in addition to any ``ssh_args`` configured in ``ansible.cfg``.
+      This is used in addition to any ``ssh_args`` configured in ``ansible.cfg`` or the inventory.
 
 Privilege escalation (see :doc:`Ansible Privilege Escalation<become>` for further details)::
 

--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -211,6 +211,9 @@ SSH connection::
       The ssh password to use (this is insecure, we strongly recommend using --ask-pass or SSH keys)
     ansible_ssh_private_key_file
       Private key file used by ssh.  Useful if using multiple keys and you don't want to use SSH agent.
+    ansible_ssh_extra_args
+      Additional arguments for ssh. Useful to configure a ``ProxyCommand`` for a certain host (or group).
+      This is used in addition to any ``ssh_args`` configured in ``ansible.cfg``.
 
 Privilege escalation (see :doc:`Ansible Privilege Escalation<become>` for further details)::
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -315,6 +315,8 @@ class CLI(object):
                 help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
             parser.add_option('-T', '--timeout', default=C.DEFAULT_TIMEOUT, type='int', dest='timeout',
                 help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
+            parser.add_option('--ssh-extra-args', default='', dest='ssh_extra_args',
+                help="specify extra arguments to pass to ssh (e.g. ProxyCommand)")
 
         if async_opts:
             parser.add_option('-P', '--poll', default=C.DEFAULT_POLL_INTERVAL, type='int', dest='poll_interval',

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -163,6 +163,7 @@ class PlayContext(Base):
     _private_key_file = FieldAttribute(isa='string', default=C.DEFAULT_PRIVATE_KEY_FILE)
     _timeout          = FieldAttribute(isa='int', default=C.DEFAULT_TIMEOUT)
     _shell            = FieldAttribute(isa='string')
+    _ssh_extra_args   = FieldAttribute(isa='string')
     _connection_lockfd= FieldAttribute(isa='int')
 
     # privilege escalation fields
@@ -252,6 +253,7 @@ class PlayContext(Base):
 
         self.remote_user = options.remote_user
         self.private_key_file = options.private_key_file
+        self.ssh_extra_args = options.ssh_extra_args
 
         # privilege escalation
         self.become        = options.become

--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -121,9 +121,10 @@ class Connection(ConnectionBase):
         self._common_args += ("-o", "ConnectTimeout={0}".format(self._play_context.timeout))
 
         # If any extra SSH arguments are specified in the inventory for
-        # this host, add them in.
-        if self.ssh_extra_args is not None:
-            extra_args = self.ssh_extra_args
+        # this host, or specified as an override on the command line,
+        # add them in.
+        extra_args = self._play_context.ssh_extra_args or self.ssh_extra_args
+        if extra_args is not None:
             self._common_args += [x.strip() for x in shlex.split(extra_args) if x.strip()]
 
         self._connected = True

--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -59,11 +59,14 @@ class Connection(ConnectionBase):
 
         self.host = self._play_context.remote_addr
         self.ssh_extra_args = ''
+        self.ssh_args = ''
 
     def set_host_overrides(self, host):
         v = host.get_vars()
         if 'ansible_ssh_extra_args' in v:
             self.ssh_extra_args = v['ansible_ssh_extra_args']
+        if 'ansible_ssh_args' in v:
+            self.ssh_args = v['ansible_ssh_args']
 
     @property
     def transport(self):
@@ -78,10 +81,10 @@ class Connection(ConnectionBase):
         if self._connected:
             return self
 
-        extra_args = C.ANSIBLE_SSH_ARGS
-        if extra_args is not None:
+        ssh_args = self.ssh_args or C.ANSIBLE_SSH_ARGS
+        if ssh_args is not None:
             # make sure there is no empty string added as this can produce weird errors
-            self._common_args += [x.strip() for x in shlex.split(extra_args) if x.strip()]
+            self._common_args += [x.strip() for x in shlex.split(ssh_args) if x.strip()]
         else:
             self._common_args += (
                 "-o", "ControlMaster=auto",

--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -150,14 +150,7 @@ class Connection(ConnectionBase):
                 ("-o", "IdentityFile=\"{0}\"".format(os.path.expanduser(key)))
             )
 
-        if self._play_context.password:
-            self.add_args(
-                "ansible_password/ansible_ssh_pass set", (
-                    "-o", "GSSAPIAuthentication=no",
-                    "-o", "PubkeyAuthentication=no"
-                )
-            )
-        else:
+        if not self._play_context.password:
             self.add_args(
                 "ansible_password/ansible_ssh_pass not set", (
                     "-o", "KbdInteractiveAuthentication=no",


### PR DESCRIPTION
This PR does two things: (1) adds an `ansible_ssh_extra_args` inventory variable, and (2) makes it possible to override on the command-line. When it's set, the specified arguments are added to the ssh command for a host/group/everyone. This is applied in addition to any `ssh_args` configured in `ansible.cfg`, so there's no need to repeat the default `ControlPath` settings. (Note that `ssh_args` **cannot** be set as an inventory variable, so it's all hosts or nothing.)

The primary use of this feature is to specify a per-host or per-group `ProxyCommand` in the inventory to use a "jump host". Of course, it may have other uses as well, depending on the complexity of the ssh configuration.

This is an oft-requested feature, and it's the minimum common feature to both PRs #9122 (by @sivel) and #9477 (by @nitzmahone), which seek to make it easier to use by assembling the proxy command from simpler settings. Both of those PRs are currently outdated, not being worked on actively, and complex enough that they seem unlikely to make it to v2. In contrast, this PR is very low-impact, and I've tested that it's sufficient to set a jump host. It also will not conflict with the more user-friendly change attempted in the PRs referenced above, should they be resurrected in future.

I consulted @bcoca on the implementation via IRC, and he seemed to agree that this was the least intrusive way to implement the desired feature.
