### PR TITLE
Update playbooks_tags.rst

### DIFF
--- a/docsite/rst/playbooks_tags.rst
+++ b/docsite/rst/playbooks_tags.rst
@@ -60,7 +60,9 @@ Example::
             - tag1
 
 There are another 3 special keywords for tags, 'tagged', 'untagged' and 'all', which run only tagged, only untagged
-and all tasks respectively. By default ansible runs as if '--tags all' had been specified.
+and all tasks respectively.
+
+By default ansible runs as if '--tags all' had been specified.
 
 
 .. seealso::


### PR DESCRIPTION
This important point gets lost in the fixed width word wrap of the docs site. Separating it out to it's own line stops it being lost in the noise of the previous sentence.
