### PR TITLE
Listify terms for file and template lookup plugins

### DIFF
--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -22,6 +22,7 @@ import codecs
 
 from ansible.errors import *
 from ansible.plugins.lookup import LookupBase
+from ansible.utils.listify import listify_lookup_plugin_terms
 
 class LookupModule(LookupBase):
 
@@ -30,6 +31,7 @@ class LookupModule(LookupBase):
         ret = []
 
         basedir = self.get_basedir(variables)
+        terms = listify_lookup_plugin_terms(terms, templar=self._templar, loader=self._loader)
 
         for term in terms:
             self._display.debug("File lookup term: %s" % term)

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -22,6 +22,7 @@ import os
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
+from ansible.utils.listify import listify_lookup_plugin_terms
 
 class LookupModule(LookupBase):
 
@@ -30,6 +31,7 @@ class LookupModule(LookupBase):
         basedir = self.get_basedir(variables)
 
         ret = []
+        terms = listify_lookup_plugin_terms(terms, templar=self._templar, loader=self._loader)
 
         for term in terms:
             self._display.debug("File lookup term: %s" % term)


### PR DESCRIPTION
As of 6338c3b28cd37479ecb666feb7b54088a83c7094, the file and template lookup plugins break because the supplied string is treated as a list. It appears `listify_lookup_plugin_terms()` is meant to handle this (and indeed did in v1). This implements this in v2. Let me know if I've missed something here...
