### PR TITLE
fix docsite ad placement on safari

### DIFF
--- a/docsite/_themes/srtd/static/css/theme.css
+++ b/docsite/_themes/srtd/static/css/theme.css
@@ -4727,18 +4727,28 @@ span[id*='MathJax-Span'] {
 .DocSiteBanner {
     width: 100%;
     display: flex;
+    display: -webkit-flex;
     flex-wrap: wrap;
+    -webkit-flex-wrap: wrap;
     justify-content: space-between;
+    -webkit-justify-content: space-between;
     background-color: #ff5850;
     margin-bottom: 25px;
+}
+
+.DocSiteBanner-imgWrapper {
+    max-width: 100%;
 }
 
 @media screen and (max-width: 1403px) {
     .DocSiteBanner {
         width: 100%;
         display: flex;
+        display: -webkit-flex;
         flex-wrap: wrap;
+        -webkit-flex-wrap: wrap;
         justify-content: center;
+        -webkit-justify-content: center;
         background-color: #fff;
         margin-bottom: 25px;
     }


### PR DESCRIPTION
The previous fix needed some attributes added to safari (as well as one max-width attribute added for firefox) to display ads correctly in all browsers
