### PR TITLE
bugfix: missing path for lvm facts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1073,12 +1073,14 @@ class LinuxHardware(Hardware):
         """ Get LVM Facts if running as root and lvm utils are available """
 
         if os.getuid() == 0 and module.get_bin_path('vgs'):
+            vgs_path = module.get_bin_path('vgs')
+            lvs_path = module.get_bin_path('lvs')
             lvm_util_options = '--noheadings --nosuffix --units g'
 
             #vgs fields: VG #PV #LV #SN Attr VSize VFree
             vgs={}
             rc, vg_lines, err = module.run_command(
-                'vgs %s' % lvm_util_options)
+                '%s %s' % (vgs_path, lvm_util_options))
             for vg_line in vg_lines.splitlines():
                 items = vg_line.split()
                 vgs[items[0]] = {'size_g':items[-2],
@@ -1090,7 +1092,7 @@ class LinuxHardware(Hardware):
             #LV VG Attr LSize Pool Origin Data% Move Log Copy% Convert
             lvs = {}
             rc, lv_lines, err = module.run_command(
-                'lvs %s' % lvm_util_options)
+                '%s %s' % (lvs_path, lvm_util_options))
             for lv_line in lv_lines.splitlines():
                 items = lv_line.split()
                 lvs[items[0]] = {'size_g': items[3],


### PR DESCRIPTION
### Issue Type:

Bugfix Pull Request
### Ansible Version:

ansible 2.0.0 (fix_lvm_facts 1ea1b9fb13) last updated 2015/08/12 16:35:31 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 072c4f38ea) last updated 2015/08/12 15:55:49 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD dcd2f441b5) last updated 2015/08/12 15:55:54 (GMT +200)
  v1/ansible/modules/core:  not found - use git submodule update --init v1/ansible/modules/core
  v1/ansible/modules/extras:  not found - use git submodule update --init v1/ansible/modules/extras
#### Summary:

PR https://github.com/ansible/ansible/pull/11762 works fine on my SLES system but on CentOS vgs can't be found.

This PR adds the binary path.
Please review and give feedback
