### PR TITLE
prevent local logging of module args under -vv when no_log specified

### DIFF
--- a/lib/ansible/runner/action_plugins/normal.py
+++ b/lib/ansible/runner/action_plugins/normal.py
@@ -53,7 +53,12 @@ class ActionModule(object):
             module_name = 'command'
             module_args += " #USE_SHELL"
 
-        vv("REMOTE_MODULE %s %s" % (module_name, module_args), host=conn.host)
+        if self.runner.no_log:
+            module_display_args = "(no_log enabled, args censored)"
+        else:
+            module_display_args = module_args
+
+        vv("REMOTE_MODULE %s %s" % (module_name, module_display_args), host=conn.host)
         return self.runner._execute_module(conn, tmp, module_name, module_args, inject=inject, complex_args=complex_args)
 
 


### PR DESCRIPTION
Module args were getting logged with -vv even when no_log was set; this caused sensitive data to be logged (eg, under Tower w/ Verbose setting).
