### PR TITLE
Small inventory host-range parsing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,11 @@ Other Notable Changes:
 * play output is now dynamically sized to terminal with a minimal of 80 coluumns (old default)
 * vars_prompt and pause are now skipped with a warning if the play is called non interactively (i.e. pull from cron)
 
+Minor changes:
+
+* The undocumented semicolon-separated "pattern1;pattern2" syntax to
+  match hosts is no longer supported.
+
 ## 1.9.2 "Dancing In the Street" - Jun 26, 2015
 
 * Security fixes to check that hostnames match certificates with https urls (CVE-2015-3908)

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -178,10 +178,11 @@ class Inventory(object):
         applied subsets.
         """
 
-        # process patterns
+        # Enumerate all hosts matching the given pattern (which may be
+        # either a list of patterns or a string like 'pat1:pat2').
         if isinstance(pattern, list):
-            pattern = ';'.join(pattern)
-        patterns = self._split_pattern(pattern.replace(";",":"))
+            pattern = ':'.join(pattern)
+        patterns = self._split_pattern(pattern)
         hosts = self._get_hosts(patterns)
 
         # exclude hosts not in a subset, if defined
@@ -520,8 +521,7 @@ class Inventory(object):
         if subset_pattern is None:
             self._subset = None
         else:
-            subset_pattern = subset_pattern.replace(',',':')
-            subset_patterns = self._split_pattern(subset_pattern.replace(";",":"))
+            subset_patterns = self._split_pattern(subset_pattern)
             results = []
             # allow Unix style @filename data
             for x in subset_patterns:

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -39,7 +39,7 @@ class Inventory(object):
     Host inventory for ansible.
     """
 
-    #__slots__ = [ 'host_list', 'groups', '_restriction', '_also_restriction', '_subset',
+    #__slots__ = [ 'host_list', 'groups', '_restriction', '_subset',
     #              'parser', '_vars_per_host', '_vars_per_group', '_hosts_cache', '_groups_list',
     #              '_pattern_cache', '_vault_password', '_vars_plugins', '_playbook_basedir']
 
@@ -70,7 +70,6 @@ class Inventory(object):
 
         # a list of host(names) to contain current inquiries to
         self._restriction = None
-        self._also_restriction = None
         self._subset = None
 
         self.parse_inventory(host_list)
@@ -176,8 +175,6 @@ class Inventory(object):
         # exclude hosts mentioned in any restriction (ex: failed hosts)
         if self._restriction is not None:
             hosts = [ h for h in hosts if h in self._restriction ]
-        if self._also_restriction is not None:
-            hosts = [ h for h in hosts if h in self._also_restriction ]
 
         return hosts
 
@@ -489,22 +486,13 @@ class Inventory(object):
     def restrict_to_hosts(self, restriction):
         """ 
         Restrict list operations to the hosts given in restriction.  This is used
-        to exclude failed hosts in main playbook code, don't use this for other
+        to batch serial operations in main playbook code, don't use this for other
         reasons.
         """
         if not isinstance(restriction, list):
             restriction = [ restriction ]
         self._restriction = restriction
 
-    def also_restrict_to(self, restriction):
-        """
-        Works like restict_to but offers an additional restriction.  Playbooks use this
-        to implement serial behavior.
-        """
-        if not isinstance(restriction, list):
-            restriction = [ restriction ]
-        self._also_restriction = restriction
-    
     def subset(self, subset_pattern):
         """ 
         Limits inventory results to a subset of inventory that matches a given
@@ -532,10 +520,6 @@ class Inventory(object):
         """ Do not restrict list operations """
         self._restriction = None
     
-    def lift_also_restriction(self):
-        """ Clears the also restriction """
-        self._also_restriction = None
-
     def is_file(self):
         """ did inventory come from a file? """
         if not isinstance(self.host_list, basestring):


### PR DESCRIPTION
This removes some dead code, revises a few comments, and fixes the problem of parsing "foo[1:3]:bar:baz" into a list.
