### PR TITLE
Fix rm call in hacking/env-setup. Since it is sourced from a user shell,

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -43,7 +43,7 @@ expr "$MANPATH" : "${PREFIX_MANPATH}.*" > /dev/null || export MANPATH="$PREFIX_M
 gen_egg_info()
 {
     if [ -e "$PREFIX_PYTHONPATH/ansible.egg-info" ] ; then
-        rm -r "$PREFIX_PYTHONPATH/ansible.egg-info"
+        \rm -r "$PREFIX_PYTHONPATH/ansible.egg-info"
     fi
     python setup.py egg_info
 }


### PR DESCRIPTION
rm can have an alias to 'rm -i', which will make sourcing hang when '-q'
is enabled.
Squashing went wrong, so I redid the PR.

Closes #11951.
