### PR TITLE
Add become support for OpenBSD doas

### DIFF
--- a/docs/man/man1/ansible-playbook.1
+++ b/docs/man/man1/ansible-playbook.1
@@ -60,7 +60,7 @@ Run operations with become (nopasswd implied)
 .PP
 \fB\-\-become\-method=BECOME_METHOD\fR
 .RS 4
-Privilege escalation method to use (default=sudo), valid choices: [ sudo | su | pbrun | pfexec | runas ]
+Privilege escalation method to use (default=sudo), valid choices: [ sudo | su | pbrun | pfexec | runas | doas ]
 .RE
 .PP
 \fB\-\-become\-user=BECOME_USER\fR

--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -51,7 +51,7 @@ Run operations with become (nopasswd implied)
 *--become-method=BECOME_METHOD*::
 
 Privilege escalation method to use (default=sudo),
-valid choices: [ sudo | su | pbrun | pfexec | runas ]
+valid choices: [ sudo | su | pbrun | pfexec | runas | doas ]
 
 *--become-user=BECOME_USER*::
 

--- a/docs/man/man1/ansible.1
+++ b/docs/man/man1/ansible.1
@@ -84,7 +84,7 @@ seconds\&.
 .PP
 \fB\-\-become\-method=\fR\fIBECOME_METHOD\fR
 .RS 4
-Privilege escalation method to use (default=sudo), valid choices: [ sudo | su | pbrun | pfexec | runas ]
+Privilege escalation method to use (default=sudo), valid choices: [ sudo | su | pbrun | pfexec | runas | doas ]
 .RE
 .PP
 \fB\-\-become\-user=\fR\fIBECOME_USER\fR

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -65,7 +65,7 @@ Run commands in the background, killing the task after 'NUM' seconds.
 *--become-method=*'BECOME_METHOD'::
 
 Privilege escalation method to use (default=sudo),
-valid choices: [ sudo | su | pbrun | pfexec | runas ]
+valid choices: [ sudo | su | pbrun | pfexec | runas | doas ]
 
 *--become-user=*'BECOME_USER'::
 

--- a/docsite/rst/become.rst
+++ b/docsite/rst/become.rst
@@ -23,7 +23,7 @@ become_user
     equivalent to adding 'sudo_user:' or 'su_user:' to a play or task, set to user with desired privileges
 
 become_method
-    at play or task level overrides the default method set in ansible.cfg, set to 'sudo'/'su'/'pbrun'/'pfexec'
+    at play or task level overrides the default method set in ansible.cfg, set to 'sudo'/'su'/'pbrun'/'pfexec'/'doas'
 
 
 New ansible\_ variables
@@ -54,7 +54,7 @@ New command line options
 
 --become-method=BECOME_METHOD
     privilege escalation method to use (default=sudo),
-    valid choices: [ sudo | su | pbrun | pfexec ]
+    valid choices: [ sudo | su | pbrun | pfexec | doas ]
 
 --become-user=BECOME_USER
     run operations as this user (default=root)

--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -651,7 +651,7 @@ The equivalent of adding sudo: or su: to a play or task, set to true/yes to acti
 become_method
 =============
 
-Set the privilege escalation method. The default is ``sudo``, other options are ``su``, ``pbrun``, ``pfexec``::
+Set the privilege escalation method. The default is ``sudo``, other options are ``su``, ``pbrun``, ``pfexec``, ``doas``::
 
     become_method=su
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -162,8 +162,8 @@ DEFAULT_SUDO_FLAGS        = get_config(p, DEFAULTS, 'sudo_flags', 'ANSIBLE_SUDO_
 DEFAULT_ASK_SUDO_PASS     = get_config(p, DEFAULTS, 'ask_sudo_pass',    'ANSIBLE_ASK_SUDO_PASS',    False, boolean=True)
 
 # Become
-BECOME_ERROR_STRINGS      = {'sudo': 'Sorry, try again.', 'su': 'Authentication failure', 'pbrun': '', 'pfexec': '', 'runas': ''} #FIXME: deal with i18n
-BECOME_METHODS            = ['sudo','su','pbrun','pfexec','runas']
+BECOME_ERROR_STRINGS      = {'sudo': 'Sorry, try again.', 'su': 'Authentication failure', 'pbrun': '', 'pfexec': '', 'runas': '', 'doas': 'Permission denied'} #FIXME: deal with i18n
+BECOME_METHODS            = ['sudo','su','pbrun','pfexec','runas','doas']
 DEFAULT_BECOME_METHOD     = get_config(p, 'privilege_escalation', 'become_method', 'ANSIBLE_BECOME_METHOD','sudo' if DEFAULT_SUDO else 'su' if DEFAULT_SU else 'sudo' ).lower()
 DEFAULT_BECOME            = get_config(p, 'privilege_escalation', 'become', 'ANSIBLE_BECOME',False, boolean=True)
 DEFAULT_BECOME_USER       = get_config(p, 'privilege_escalation', 'become_user', 'ANSIBLE_BECOME_USER', 'root')

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -387,6 +387,20 @@ class PlayContext(Base):
                 flags = self.become_flags or ''
                 becomecmd = '%s %s /user:%s "%s"' % (exe, flags, self.become_user, success_cmd)
 
+            elif self.become_method == 'doas':
+
+                prompt = 'Password:'
+                exe = self.become_exe or 'doas'
+                flags = self.become_flags or ''
+
+                if not self.become_pass:
+                    flags += ' -n '
+
+                if self.become_user:
+                    flags += ' -u %s ' % self.become_user
+
+                becomecmd = '%s %s echo %s && %s %s env ANSIBLE=true %s' % (exe, flags, success_key, exe, flags, cmd)
+
             else:
                 raise AnsibleError("Privilege escalation method not found: %s" % self.become_method)
 

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -123,6 +123,8 @@ class TestPlayContext(unittest.TestCase):
         pbrun_flags = ''
         pfexec_exe   = 'pfexec'
         pfexec_flags = ''
+        doas_exe    = 'doas'
+        doas_flags  = ' -n  -u foo '
 
         cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
         self.assertEqual(cmd, default_cmd)
@@ -145,6 +147,10 @@ class TestPlayContext(unittest.TestCase):
         play_context.become_method = 'pfexec'
         cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
         self.assertEqual(cmd, """%s -c '%s %s "'"'"'echo %s; %s'"'"'"'""" % (default_exe, pfexec_exe, pfexec_flags, play_context.success_key, default_cmd))
+
+        play_context.become_method = 'doas'
+        cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
+        self.assertEqual(cmd, """%s -c '%s %s echo %s && %s %s env ANSIBLE=true %s'""" % (default_exe, doas_exe, doas_flags, play_context.success_key, doas_exe, doas_flags, default_cmd))
 
         play_context.become_method = 'bad'
         self.assertRaises(AnsibleError, play_context.make_become_cmd, cmd=default_cmd, executable="/bin/bash")


### PR DESCRIPTION
This adds a new become_method `doas`, to support OpenBSD's `doas`.

There are a few things about this that I'm not a big fan of, but I couldn't see a cleaner way to do this:
1. `doas` treats its first argument as the command to execute, so we can't `doas "FOO=BAR python /path/to/python/script"`; this will fail, as there is no binary called `FOO=BAR python /path/to/python/script`.
2. Similarly, environment variables aren't commands. As far as I can tell, `ansible` always starts a command by setting environment variables, so this patch makes the assumption that this is always the case. This seemed easier and less fragile than trying to parse `cmd` to determine if environment variables were, in fact, being set. Perhaps this can be made safer with `.... env ANSIBLE=TRUE %s`?

Overall, it's pretty rudimentary (and still requires modifications to [ansible-modules-core/commands/command.py](https://github.com/ansible/ansible-modules-core/blob/devel/commands/command.py#L146)), but it's at least functional on my system.

fixes #11972
