### PR TITLE
Support any Mapping for with_dict lookup.

### DIFF
--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -17,6 +17,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import collections
+
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
@@ -24,7 +26,8 @@ class LookupModule(LookupBase):
 
     def run(self, terms, varibles=None, **kwargs):
 
-        if not isinstance(terms, dict):
+        # Expect any type of Mapping, notably hostvars
+        if not isinstance(terms, collections.Mapping):
             raise AnsibleError("with_dict expects a dict")
 
         return self._flatten_hash_to_list(terms)


### PR DESCRIPTION
This resolves 39393482865201532da778f103aef35d35c38026 breaking `with_dict: hostvars`.
