### PR TITLE
Make SSH binary path a configurable variable

### DIFF
--- a/contrib/inventory/openvz.py
+++ b/contrib/inventory/openvz.py
@@ -26,6 +26,7 @@
 # Groups are determined by the description field of openvz guests
 # multiple groups can be seperated by commas: webserver,dbserver
 
+from ansible import constants as C
 from subprocess import Popen,PIPE
 import sys
 import json
@@ -42,7 +43,7 @@ def get_guests():
     #Loop through vzhosts
     for h in vzhosts:
         #SSH to vzhost and get the list of guests in json
-        pipe = Popen(['ssh', h,'vzlist','-j'], stdout=PIPE, universal_newlines=True)
+        pipe = Popen([C.ANSIBLE_SSH_BINARY, h,'vzlist','-j'], stdout=PIPE, universal_newlines=True)
 
         #Load Json info of guests
         json_data = json.loads(pipe.stdout.read())

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -226,6 +226,10 @@ fact_caching = memory
 # only be disabled if your sftp version has problems with batch mode
 #sftp_batch_mode = False
 
+# can be used to set the path to SSH binary. Can be useful if SSH is not in
+# the system path, or if a customized version of SSH is meant to be used.
+#ssh_bin = ssh
+
 [accelerate]
 accelerate_port = 5099
 accelerate_timeout = 30

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -208,6 +208,7 @@ RETRY_FILES_SAVE_PATH          = get_config(p, DEFAULTS, 'retry_files_save_path'
 
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', None)
+ANSIBLE_SSH_BINARY             = get_config(p, 'ssh_connection', 'ssh_binary', 'ANSIBLE_SSH_BINARY', 'ssh')
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, integer=True)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -450,7 +450,7 @@ class TaskExecutor:
             else:
                 # see if SSH can support ControlPersist if not use paramiko
                 try:
-                    cmd = subprocess.Popen(['ssh','-o','ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    cmd = subprocess.Popen([C.ANSIBLE_SSH_BINARY, '-o', 'ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                     (out, err) = cmd.communicate()
                     if "Bad configuration option" in err:
                         conn_type = "paramiko"

--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -326,7 +326,7 @@ class Connection(ConnectionBase):
         super(Connection, self).exec_command(cmd, tmp_path, in_data=in_data, sudoable=sudoable)
 
         ssh_cmd = self._password_cmd()
-        ssh_cmd += ("ssh", "-C")
+        ssh_cmd += (C.ANSIBLE_SSH_BINARY, "-C")
         if not in_data:
             # we can only use tty when we are not pipelining the modules. piping data into /usr/bin/python
             # inside a tty automatically invokes the python interactive-mode but the modules are not
@@ -449,11 +449,15 @@ class Connection(ConnectionBase):
 
         if C.DEFAULT_SCP_IF_SSH:
             cmd.append('scp')
+            cmd.append('-S')
+            cmd.append(C.ANSIBLE_SSH_BINARY)
             cmd.extend(self._common_args)
             cmd.extend([in_path, '{0}:{1}'.format(host, pipes.quote(out_path))])
             indata = None
         else:
             cmd.append('sftp')
+            cmd.append('-S')
+            cmd.append(C.ANSIBLE_SSH_BINARY)
             cmd.extend(self._common_args)
             cmd.append(host)
             indata = "put {0} {1}\n".format(pipes.quote(in_path), pipes.quote(out_path))
@@ -478,11 +482,15 @@ class Connection(ConnectionBase):
 
         if C.DEFAULT_SCP_IF_SSH:
             cmd.append('scp')
+            cmd.append('-S')
+            cmd.append(C.ANSIBLE_SSH_BINARY)
             cmd.extend(self._common_args)
             cmd.extend(['{0}:{1}'.format(self.host, in_path), out_path])
             indata = None
         else:
             cmd.append('sftp')
+            cmd.append('-S')
+            cmd.append(C.ANSIBLE_SSH_BINARY)
             # sftp batch mode allows us to correctly catch failed transfers,
             # but can be disabled if for some reason the client side doesn't
             # support the option
@@ -506,7 +514,7 @@ class Connection(ConnectionBase):
         if self._connected:
 
             if 'ControlMaster' in self._common_args:
-                cmd = ['ssh','-O','stop']
+                cmd = [C.ANSIBLE_SSH_BINARY,'-O','stop']
                 cmd.extend(self._common_args)
                 cmd.append(self._play_context.remote_addr)
 


### PR DESCRIPTION
##### SUMMARY
Add SSH binary path to the list of configuration variables and make the existing code respect its value.


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
contrib/inventory/openvz.py
examples/ansible.cfg
lib/ansible/constants.py
lib/ansible/executor/task_executor.py
lib/ansible/plugins/connections/ssh.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


