### PR TITLE
ansible manpage: document that the 'command' module is used by default

### DIFF
--- a/docs/man/man1/ansible.1
+++ b/docs/man/man1/ansible.1
@@ -151,7 +151,10 @@ Outputs a list of matching hosts; does not execute anything else\&.
 \fB\-m\fR \fINAME\fR, \fB\-\-module\-name=\fR\fINAME\fR
 .RS 4
 Execute the module called
-\fINAME\fR\&.
+\fINAME\fR\&
+, defaults to the
+\fIcommand\fR\&
+module
 .RE
 .PP
 \fB\-M\fR \fIDIRECTORY\fR, \fB\-\-module\-path=\fR\fIDIRECTORY\fR


### PR DESCRIPTION
The change documents that when '-m module_name' is not given, then the module 'command' is used by default.

Please pull
