### PR TITLE
Update playbooks_intro.rst - hosts separated by semi-colon

### DIFF
--- a/docsite/rst/playbooks_intro.rst
+++ b/docsite/rst/playbooks_intro.rst
@@ -149,7 +149,7 @@ For each play in a playbook, you get to choose which machines in your infrastruc
 to target and what remote user to complete the steps (called tasks) as.
 
 The `hosts` line is a list of one or more groups or host patterns,
-separated by colons, as described in the :doc:`intro_patterns`
+separated by semi-colons, as described in the :doc:`intro_patterns`
 documentation.  The `remote_user` is just the name of the user account::
 
     ---


### PR DESCRIPTION
Issue Type:
Documentation Report

Ansible Version:
Devel

Summary:
Small tweak that a list of hosts in a playbook should be separated by a semi-colon, not a colon as described.
