### PR TITLE
Set serialization of hostvars to pickle all the object attributes

### DIFF
--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -17,6 +17,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 import collections
@@ -27,16 +28,17 @@ from ansible.template import Templar
 
 __all__ = ['HostVars']
 
+
 # Note -- this is a Mapping, not a MutableMapping
 class HostVars(collections.Mapping):
     ''' A special view of vars_cache that adds values from the inventory when needed. '''
 
     def __init__(self, vars_manager, play, inventory, loader):
         self._vars_manager = vars_manager
-        self._play         = play
-        self._inventory    = inventory
-        self._loader       = loader
-        self._lookup       = {}
+        self._play = play
+        self._inventory = inventory
+        self._loader = loader
+        self._lookup = {}
 
     def __getitem__(self, host_name):
 
@@ -62,7 +64,18 @@ class HostVars(collections.Mapping):
         raise NotImplementedError('HostVars does not support len.  hosts entries are discovered dynamically as needed')
 
     def __getstate__(self):
-        return self._lookup
+        to_pickle = {
+            'vars_manager': self._vars_manager,
+            'play': self._play,
+            'inventory': self._inventory,
+            'loader': self._loader,
+            'lookup': self._lookup
+        }
+        return to_pickle
 
-    def __setstate__(self, data):
-        self._lookup = data
+    def __setstate__(self, to_unpickle):
+        self._vars_manager = to_unpickle['vars_manager']
+        self._play = to_unpickle['play']
+        self._inventory = to_unpickle['inventory']
+        self._loader = to_unpickle['loader']
+        self._lookup = to_unpickle['lookup']


### PR DESCRIPTION
Set serialization of hostvars to pickle all the object attributes to fix issue #12005, about the raising of the exception:

```
AttributeError: 'HostVars' object has no attribute '_inventory'
```

Here I copy my last comment in that issue describing the problem and the solutions.

In this Pull Request I'm implementing what I described as "**Option to fix it B**".

---

As @Pallokala said, the issue was introduced in commit e7b2308, specifically, in the file:

```
ansible/lib/ansible/vars/hostvars.py
```

In the last section of the class `HostVars`:

``` python
    def __getstate__(self):
        return self._lookup

    def __setstate__(self, data):
        self._lookup = data
```

starting from [this line](https://github.com/ansible/ansible/blob/e7b2308b66c7930df87d77232d5e48769ab03f58/lib/ansible/vars/hostvars.py#L64).

Those methods are [meant to be used by Pickle](https://docs.python.org/2/library/pickle.html#object.__getstate__) to generate the data to pickle and then unpickle it.

**Description of the error**:

I'm not an expert in Ansible internals, but it seems that that object is being created, then pickled and then unpickled, and after being unpickled, by the `__getstate__` and `__setstate__` methods, it only preserves its `_lookup` attribute and it doesn't have the other attributes that are created in the `__init__`.

Thereafter the object is being consulted for a host, calling the `__getitem__` method, that method checks if the host is in the `_lookup` dictionary, and as it doesn't find it, it looks for it in `host = self._inventory.get_host(host_name)`, and there is when the attribute error is raised.

**Option to fix it A**:

Remove the section for pickling and unpickling (`__getstate__` and `__setstate__`).

**Option to fix it B**:

Add all the other attributes to the return of the `__getstate__` and use them in the `__setstate__` to generate the new unpiclked object, as all the other objects are used in the method `__getitem__`.

The initial commit says that the intention was to "Speed up serialization of hostvars by simply using the internal" but I'm not sure how much this would help now, as the only thing that wouldn't be pickled would be the methods, I'm not sure that the speed up would be as much as originally intended since all the other attributes would also be pickled.

I plan on submitting a PR with the option B which is the more complex, in case the maintainers don't want it, the other option will be simpler to implement.
