### PR TITLE
Add win_splitdrive filter for windows users

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -342,6 +342,18 @@ To get the last name of a windows style file path (new in version 2.0)::
 
     {{ path | win_basename }}
 
+To separate the windows drive letter from the rest of a file path (new in version 2.0)::
+
+    {{ path | win_splitdrive }}
+
+To get only the windows drive letter
+
+    {{ path | win_splitdrive | first }} 
+    
+To get the rest of the path without the drive letter
+
+    {{ path | win_splitdrive | last }} 
+
 To get the directory from a path::
 
     {{ path | dirname }}

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -254,6 +254,7 @@ class FilterModule(object):
             'splitext': partial(unicode_wrap, os.path.splitext),
             'win_basename': partial(unicode_wrap, ntpath.basename),
             'win_dirname': partial(unicode_wrap, ntpath.dirname),
+            'win_splitdrive': partial(unicode_wrap, ntpath.splitdrive),
 
             # value as boolean
             'bool': bool,


### PR DESCRIPTION
Another little filter addition of use to those targeting windows.

Its more advanced usage than other similar filters as it returns a list of 2 items, but I put example usage in the docs so hopefully not too confusing.
