### PR TITLE
Remove unused (copied) _before_comment method

### DIFF
--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -53,11 +53,3 @@ class InventoryIniParser(InventoryAggregateParser):
 
     def parse(self):
         return super(InventoryDirectoryParser, self).parse()
-
-    def _before_comment(self, msg):
-        ''' what's the part of a string before a comment? '''
-        msg = msg.replace("\#","**NOT_A_COMMENT**")
-        msg = msg.split("#")[0]
-        msg = msg.replace("**NOT_A_COMMENT**","#")
-        return msg
-


### PR DESCRIPTION
This was copied from inventory/ini.py, but the rewritten version doesn't
use it, and shows that it isn't needed.
