### PR TITLE
Allow vault to operate from stdin/to stdout (i.e. plaintext never hits the disk)

### DIFF
--- a/docs/man/man1/ansible-vault.1
+++ b/docs/man/man1/ansible-vault.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: ansible-vault
 .\"    Author: [see the "AUTHOR" section]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 07/28/2015
+.\" Generator: DocBook XSL Stylesheets v1.76.1 <http://docbook.sf.net/>
+.\"      Date: 08/26/2015
 .\"    Manual: System administration commands
 .\"    Source: Ansible 2.0.0
 .\"  Language: English
 .\"
-.TH "ANSIBLE\-VAULT" "1" "07/28/2015" "Ansible 2\&.0\&.0" "System administration commands"
+.TH "ANSIBLE\-VAULT" "1" "08/26/2015" "Ansible 2\&.0\&.0" "System administration commands"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,7 +31,7 @@
 ansible-vault \- manage encrypted YAML data\&.
 .SH "SYNOPSIS"
 .sp
-ansible\-vault [create|decrypt|edit|encrypt|rekey] [\-\-help] [options] file_name
+ansible\-vault [create|decrypt|edit|encrypt|rekey|filter] [\-\-help] [options] file_name
 .SH "DESCRIPTION"
 .sp
 \fBansible\-vault\fR can encrypt any structured data file used by Ansible\&. This can include \fBgroup_vars/\fR or \fBhost_vars/\fR inventory variables, variables loaded by \fBinclude_vars\fR or \fBvars_files\fR, or variable files passed on the ansible\-playbook command line with \fB\-e @file\&.yml\fR or \fB\-e @file\&.json\fR\&. Role variables and defaults are also included!
@@ -80,19 +80,26 @@ The \fBedit\fR sub\-command is used to modify a file which was previously encryp
 This command will decrypt the file to a temporary file and allow you to edit the file, saving it back when done and removing the temporary file\&.
 .SH "REKEY"
 .sp
-*$ ansible\-vault rekey [options] FILE_1 [FILE_2, \&..., FILE_N]
+\fB$ ansible\-vault rekey [options] FILE_1 [FILE_2, \&..., FILE_N]\fR
 .sp
 The \fBrekey\fR command is used to change the password on a vault\-encrypted files\&. This command can update multiple files at once, and will prompt for both the old and new passwords before modifying any data\&.
 .SH "ENCRYPT"
 .sp
-*$ ansible\-vault encrypt [options] FILE_1 [FILE_2, \&..., FILE_N]
+\fB$ ansible\-vault encrypt [options] FILE_1 [FILE_2, \&..., FILE_N]\fR
 .sp
 The \fBencrypt\fR sub\-command is used to encrypt pre\-existing data files\&. As with the \fBrekey\fR command, you can specify multiple files in one command\&.
 .SH "DECRYPT"
 .sp
-*$ ansible\-vault decrypt [options] FILE_1 [FILE_2, \&..., FILE_N]
+\fB$ ansible\-vault decrypt [options] FILE_1 [FILE_2, \&..., FILE_N]\fR
 .sp
 The \fBdecrypt\fR sub\-command is used to remove all encryption from data files\&. The files will be stored as plain\-text YAML once again, so be sure that you do not run this command on data files with active passwords or other sensitive data\&. In most cases, users will want to use the \fBedit\fR sub\-command to modify the files securely\&.
+.SH "FILTER"
+.sp
+\fB$ cat unencrypted\-file|ansible\-vault filter \-\-encrypt > encrypted\-file\fR
+.sp
+\fB$ cat encrypted\-file|ansible\-vault filter \-\-decrypt > unencrypted\-file\fR
+.sp
+The \fBfilter\fR sub\-command accepts text on stdin and writes filtered text (i\&.e\&. encrypted or unencrypted, depending on the option specified) to stdout\&.
 .SH "AUTHOR"
 .sp
 Ansible was originally written by Michael DeHaan\&. See the AUTHORS file for a complete list of contributors\&.

--- a/docs/man/man1/ansible-vault.1.asciidoc.in
+++ b/docs/man/man1/ansible-vault.1.asciidoc.in
@@ -12,7 +12,7 @@ ansible-vault - manage encrypted YAML data.
 
 SYNOPSIS
 --------
-ansible-vault [create|decrypt|edit|encrypt|rekey] [--help] [options] file_name
+ansible-vault [create|decrypt|edit|encrypt|rekey|filter] [--help] [options] file_name
 
 
 DESCRIPTION
@@ -84,7 +84,7 @@ file, saving it back when done and removing the temporary file.
 REKEY
 -----
 
-*$ ansible-vault rekey [options] FILE_1 [FILE_2, ..., FILE_N]
+*$ ansible-vault rekey [options] FILE_1 [FILE_2, ..., FILE_N]*
 
 The *rekey* command is used to change the password on a vault-encrypted files.
 This command can update multiple files at once, and will prompt for both the
@@ -93,7 +93,7 @@ old and new passwords before modifying any data.
 ENCRYPT
 -------
 
-*$ ansible-vault encrypt [options] FILE_1 [FILE_2, ..., FILE_N]
+*$ ansible-vault encrypt [options] FILE_1 [FILE_2, ..., FILE_N]*
 
 The *encrypt* sub-command is used to encrypt pre-existing data files. As with the
 *rekey* command, you can specify multiple files in one command.
@@ -101,13 +101,23 @@ The *encrypt* sub-command is used to encrypt pre-existing data files. As with th
 DECRYPT
 -------
 
-*$ ansible-vault decrypt [options] FILE_1 [FILE_2, ..., FILE_N]
+*$ ansible-vault decrypt [options] FILE_1 [FILE_2, ..., FILE_N]*
 
 The *decrypt* sub-command is used to remove all encryption from data files. The files
 will be stored as plain-text YAML once again, so be sure that you do not run this
 command on data files with active passwords or other sensitive data. In most cases, 
 users will want to use the *edit* sub-command to modify the files securely.
 
+FILTER
+------
+
+*$ cat unencrypted-file|ansible-vault filter --encrypt > encrypted-file*
+
+*$ cat encrypted-file|ansible-vault filter --decrypt > unencrypted-file*
+
+The *filter* sub-command accepts text on stdin and writes filtered text
+(i.e. encrypted or unencrypted, depending on the option specified) to
+stdout.
 
 AUTHOR
 ------

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -262,6 +262,10 @@ class CLI(object):
             parser.add_option('--new-vault-password-file',
 			    dest='new_vault_password_file', help="new vault password file for rekey", action="callback",
 			    callback=CLI.expand_tilde, type=str)
+            parser.add_option('--encrypt', dest='filter_action', action='store_const', const='encrypt',
+                help='encrypt using ansible-vault filter')
+            parser.add_option('--decrypt', dest='filter_action', action='store_const', const='decrypt',
+                help='decrypt using ansible-vault filter')
 
 
         if subset_opts:

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -25,6 +25,7 @@ __metaclass__ = type
 import os
 import shlex
 import shutil
+import sys
 import tempfile
 from io import BytesIO
 from subprocess import call
@@ -235,7 +236,7 @@ class VaultEditor:
     # file I/O, ditto read_file(self, filename) and launch_editor(self, filename)
     # ... "Don't Repeat Yourself", etc.
 
-    def __init__(self, cipher_name, password, filename):
+    def __init__(self, cipher_name, password, filename=None):
         # instantiates a member variable for VaultLib
         self.cipher_name = cipher_name
         self.password = password
@@ -369,6 +370,24 @@ class VaultEditor:
         # re-encrypt data and re-write file
         enc_data = new_vault.encrypt(dec_data)
         self.write_data(enc_data, self.filename)
+
+    def filter(self, action):
+
+        check_prereqs()
+
+        input = sys.stdin.read()
+        vault = VaultLib(self.password)
+
+        if action == 'encrypt':
+            if vault.is_encrypted(input):
+                raise AnsibleError("input is already encrypted")
+            output = vault.encrypt(input)
+        else:
+            if not vault.is_encrypted(input):
+                raise AnsibleError("input is not encrypted")
+            output = vault.decrypt(input)
+
+        sys.stdout.write(to_bytes(output, errors='strict'))
 
     def read_data(self, filename):
         f = open(filename, "rb")


### PR DESCRIPTION
This is something I've mentioned on IRC a few times, but not submitted as a PR before. With this, and the semi-related #11767, it's possible to automate various vault operations without ever leaking plaintext to disk, even in the form of temp files.
