### PR TITLE
Pass windows command as-is without splitting/rejoining parameters.

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -159,18 +159,18 @@ class Connection(ConnectionBase):
         cmd_ext = cmd_parts and self._shell._unquote(cmd_parts[0]).lower()[-4:] or ''
         # Support running .ps1 files (via script/raw).
         if cmd_ext == '.ps1':
-            script = ' '.join(['&'] + cmd_parts)
+            script = '& %s' % cmd
         # Support running .bat/.cmd files; change back to the default system encoding instead of UTF-8.
         elif cmd_ext in ('.bat', '.cmd'):
-            script = ' '.join(['[System.Console]::OutputEncoding = [System.Text.Encoding]::Default;', '&'] + cmd_parts)
+            script = '[System.Console]::OutputEncoding = [System.Text.Encoding]::Default; & %s' % cmd
         # Encode the command if not already encoded; supports running simple PowerShell commands via raw.
         elif '-EncodedCommand' not in cmd_parts:
-            script = ' '.join(cmd_parts)
+            script = cmd
         if script:
             cmd_parts = self._shell._encode_script(script, as_list=True)
         if '-EncodedCommand' in cmd_parts:
             encoded_cmd = cmd_parts[cmd_parts.index('-EncodedCommand') + 1]
-            decoded_cmd = to_unicode(base64.b64decode(encoded_cmd))
+            decoded_cmd = to_unicode(base64.b64decode(encoded_cmd).decode('utf-16-le'))
             self._display.vvv("EXEC %s" % decoded_cmd, host=self._play_context.remote_addr)
         else:
             self._display.vvv("EXEC %s" % cmd, host=self._play_context.remote_addr)

--- a/test/integration/roles/test_win_raw/tasks/main.yml
+++ b/test/integration/roles/test_win_raw/tasks/main.yml
@@ -92,3 +92,12 @@
   assert:
     that:
       - "raw_result.stdout_lines[0] == 'wwe=raw'"
+
+- name: run a raw command with unicode chars and quoted args (from https://github.com/ansible/ansible-modules-core/issues/1929)
+  raw: Write-Host --% icacls D:\somedir\ /grant "! ЗАО. Руководство":F
+  register: raw_result2
+
+- name: make sure raw passes command as-is and doesn't split/rejoin args
+  assert:
+    that:
+      - "raw_result2.stdout_lines[0] == '--% icacls D:\\\\somedir\\\\ /grant \"! ЗАО. Руководство\":F'"

--- a/test/integration/roles/test_win_script/files/test_script_bool.ps1
+++ b/test/integration/roles/test_win_script/files/test_script_bool.ps1
@@ -1,0 +1,6 @@
+Param(
+[bool]$boolvariable
+)
+
+Write-Host $boolvariable.GetType()
+Write-Host $boolvariable

--- a/test/integration/roles/test_win_script/tasks/main.yml
+++ b/test/integration/roles/test_win_script/tasks/main.yml
@@ -171,3 +171,13 @@
       - "not test_cmd_result.stderr"
       - "not test_cmd_result|failed"
       - "test_cmd_result|changed"
+
+- name: run test script that takes a boolean parameter
+  script: test_script_bool.ps1 $true
+  register: test_script_bool_result
+
+- name: check that the script ran and the parameter was treated as a boolean
+  assert:
+    that:
+      - "test_script_bool_result.stdout_lines[0] == 'System.Boolean'"
+      - "test_script_bool_result.stdout_lines[1] == 'True'"


### PR DESCRIPTION
- Fixes extra spaces added between parameters from https://github.com/ansible/ansible-modules-core/issues/1929
- Correctly decode PowerShell command encoded as UTF-16-LE so that it displays correctly in debug messages, fixes the other issue from https://github.com/ansible/ansible-modules-core/issues/1929
- Add test to verify that script parameters are passed as-is, so $true is interpreted as a boolean, fixes https://github.com/ansible/ansible/issues/10947
