### PR TITLE
Deprecate groupname[x-y] syntax in favour of groupname[x:y]

### DIFF
--- a/docsite/rst/intro_patterns.rst
+++ b/docsite/rst/intro_patterns.rst
@@ -68,13 +68,19 @@ It's also ok to mix wildcard patterns and groups at the same time::
 
     one*.com:dbservers
 
-As an advanced usage, you can also select the numbered server in a group::
-   
-    webservers[0]
+You can select a host or subset of hosts from a group by their position. For example, given the following group::
 
-Or a range of servers in a group::
+    [webservers]
+    cobweb
+    webbing
+    weber
 
-    webservers[0:25]
+You can refer to hosts within the group by adding a subscript to the group name:
+
+    webservers[0]       # == cobweb
+    webservers[-1]      # == weber
+    webservers[0:1]     # == webservers[0]:webservers[1]
+                        # == cobweb:webbing
 
 Most people don't specify patterns as regular expressions, but you can.  Just start the pattern with a '~'::
 

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -229,9 +229,12 @@ class Inventory(object):
     def _match_one_pattern(self, pattern):
         """ 
         Takes a single pattern (i.e., not "p1:p2") and returns a list of
-        matching hosts names. Does not take negatives or intersections
+        matching host names. Does not take negatives or intersections
         into account.
         """
+
+        if pattern.startswith("&") or pattern.startswith("!"):
+            pattern = pattern[1:]
 
         if pattern in self._pattern_cache:
             return self._pattern_cache[pattern]
@@ -307,9 +310,6 @@ class Inventory(object):
         results = []
         hosts = []
         hostnames = set()
-
-        # ignore any negative checks here, this is handled elsewhere
-        pattern = pattern.replace("!","").replace("&", "")
 
         def __append_host_to_results(host):
             if host.name not in hostnames:

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -228,9 +228,40 @@ class Inventory(object):
 
     def _match_one_pattern(self, pattern):
         """ 
-        Takes a single pattern (i.e., not "p1:p2") and returns a list of
-        matching host names. Does not take negatives or intersections
-        into account.
+        Takes a single pattern and returns a list of matching host names.
+        Ignores intersection (&) and exclusion (!) specifiers.
+
+        The pattern may be:
+
+            1. A regex starting with ~, e.g. '~[abc]*'
+            2. A shell glob pattern with ?/*/[chars]/[!chars], e.g. 'foo'
+            3. An ordinary word that matches itself only, e.g. 'foo'
+
+        The pattern is matched using the following rules:
+
+            1. If it's 'all', it matches all hosts in all groups.
+            2. Otherwise, for each known group name:
+                (a) if it matches the group name, the results include all hosts
+                    in the group or any of its children.
+                (b) otherwise, if it matches any hosts in the group, the results
+                    include the matching hosts.
+
+        This means that 'foo*' may match one or more groups (thus including all
+        hosts therein) but also hosts in other groups.
+
+        The built-in groups 'all' and 'ungrouped' are special. No pattern can
+        match these group names (though 'all' behaves as though it matches, as
+        described above). The word 'ungrouped' can match a host of that name,
+        and patterns like 'ungr*' and 'al*' can match either hosts or groups
+        other than all and ungrouped.
+
+        If the pattern matches one or more group names according to these rules,
+        it may have an optional range suffix to select a subset of the results.
+        This is allowed only if the pattern is not a regex, i.e. '~foo[1]' does
+        not work (the [1] is interpreted as part of the regex), but 'foo*[1]'
+        would work if 'foo*' matched the name of one or more groups.
+
+        Duplicate matches are always eliminated from the results.
         """
 
         if pattern.startswith("&") or pattern.startswith("!"):


### PR DESCRIPTION
This series of PRs cleans up and documents various aspects of the parsing of `hosts: groupname[x:y]` and deprecates the earlier `[x-y]` subscript syntax in favour of the inclusive `[x:y]` syntax. That's the only real functional change, though there are various simplifications/improvements to the code. This is based on extensive discussion on IRC.

I had originally planned to make it possible to use `nongroupname[x:y]` range syntax to match hostnames the way they can be specified when defining the inventory, but it became clear that the ambiguities introduced by the change in light of the existing slicing syntax as well as the `fnmatch` character classes made this more complicated than I wanted.

This finally supersedes #10543 by @willthames.

cc: @bcoca @abadger 
