### PR TITLE
Add regex_capture jinja2 filter.

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -528,6 +528,11 @@ To escape special characters within a regex, use the "regex_escape" filter::
     # convert '^f.*o(.*)$' to '\^f\.\*o\(\.\*\)\$'
     {{ '^f.*o(.*)$' | regex_escape() }}
 
+To get the value of capturing group within a regex, use the "regex_capture" filter::
+
+    # get the version number
+    {{ 'myapp-1.0' | regex_capture('^[a-zA-Z]+-([0-9]+\.[0-9]+)$') }}
+
 A few useful filters are typically added with each new Ansible release.  The development documentation shows
 how to extend Ansible filters by writing your own as plugins, though in general, we encourage new ones
 to be added to core so everyone can make use of them.

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -324,6 +324,19 @@ def comment(text, style='plain', **kw):
         str_postfix,
         str_end)
 
+def regex_capture(value='', pattern=''):
+    ''' return first capturing group from matched pattern '''
+
+    re_pattern = re.compile(pattern)
+    re_match = re_pattern.match(value)
+
+    if re_match:
+        try:
+            return re_match.group(1)
+        except IndexError:
+            raise errors.AnsibleFilterError('No capture group matched')
+    else:
+        raise errors.AnsibleFilterError('No match found')
 
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
@@ -381,6 +394,7 @@ class FilterModule(object):
             # regex
             'regex_replace': regex_replace,
             'regex_escape': regex_escape,
+            'regex_capture': regex_capture,
 
             # ? : ;
             'ternary': ternary,

--- a/test/integration/roles/test_filters/files/foo.txt
+++ b/test/integration/roles/test_filters/files/foo.txt
@@ -52,6 +52,10 @@ files to exist and are passthrus to the python os.path functions
 /etc/motd with basename = motd
 /etc/motd with dirname  = /etc
 
+Regex capturing group
+
+capturing group = 1.0
+
 TODO: realpath follows symlinks.  There isn't a test for this just now.
 
 TODO: add tests for set theory operations like union

--- a/test/integration/roles/test_filters/templates/foo.j2
+++ b/test/integration/roles/test_filters/templates/foo.j2
@@ -46,6 +46,10 @@ files to exist and are passthrus to the python os.path functions
 /etc/motd with basename = {{ '/etc/motd' | basename }}
 /etc/motd with dirname  = {{ '/etc/motd' | dirname }}
 
+Regex capturing group
+
+capturing group = {{ 'myapp-1.0' | regex_capture('^[a-zA-Z]+-([0-9]+\.[0-9]+)$') }}
+
 TODO: realpath follows symlinks.  There isn't a test for this just now.
 
 TODO: add tests for set theory operations like union


### PR DESCRIPTION
##### SUMMARY
This pull request adds a Jinja2 filter to get the value of the first capturing group within a regular expression.
The use case is reusing variables and command returns directly while being more flexible and limiting the number of grep/sed/awk workarounds.

I wrote an integration test in this pull request, but integration tests for filters do not seem to be currently enabled. I think this issue belongs to another pull request.

Sincerely,


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
docsite/rst/playbooks_filters.rst
lib/ansible/plugins/filter/core.py
test/integration/roles/test_filters/files/foo.txt
test/integration/roles/test_filters/templates/foo.j2

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


