### PR TITLE
Unicode and other fixes for vault

### DIFF
--- a/lib/ansible/parsing/__init__.py
+++ b/lib/ansible/parsing/__init__.py
@@ -151,12 +151,15 @@ class DataLoader():
 
         show_content = True
         try:
-            with open(file_name, 'r') as f:
+            with open(file_name, 'rb') as f:
                 data = f.read()
                 if self._vault.is_encrypted(data):
                     data = self._vault.decrypt(data)
                     show_content = False
+
+            data = to_unicode(data, errors='strict')
             return (data, show_content)
+
         except (IOError, OSError) as e:
             raise AnsibleParserError("an error occurred while trying to read the file '%s': %s" % (file_name, str(e)))
 

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -29,7 +29,6 @@ from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
 from ansible.utils.hashing import checksum
 from ansible.utils.unicode import to_bytes
-from ansible.parsing.vault import VaultLib
 
 class ActionModule(ActionBase):
 

--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -64,7 +64,7 @@ class TestVaultLib(unittest.TestCase):
         slots = ['is_encrypted',
                  'encrypt',
                  'decrypt',
-                 '_add_header',
+                 '_format_output',
                  '_split_header',]
         for slot in slots:
             assert hasattr(v, slot), "VaultLib is missing the %s method" % slot
@@ -75,11 +75,11 @@ class TestVaultLib(unittest.TestCase):
         data = u"$ANSIBLE_VAULT;9.9;TEST\n%s" % hexlify(b"ansible")
         assert v.is_encrypted(data), "encryption check on headered text failed"
 
-    def test_add_header(self):
+    def test_format_output(self):
         v = VaultLib('ansible')
         v.cipher_name = "TEST"
         sensitive_data = "ansible"
-        data = v._add_header(sensitive_data)
+        data = v._format_output(sensitive_data)
         lines = data.split(b'\n')
         assert len(lines) > 1, "failed to properly add header"
         header = to_unicode(lines[0])
@@ -87,7 +87,7 @@ class TestVaultLib(unittest.TestCase):
         header_parts = header.split(';')
         assert len(header_parts) == 3, "header has the wrong number of parts"
         assert header_parts[0] == '$ANSIBLE_VAULT', "header does not start with $ANSIBLE_VAULT"
-        assert header_parts[1] == v.version, "header version is incorrect"
+        assert header_parts[1] == v.b_version, "header version is incorrect"
         assert header_parts[2] == 'TEST', "header does end with cipher name"
 
     def test_split_header(self):
@@ -97,7 +97,7 @@ class TestVaultLib(unittest.TestCase):
         lines = rdata.split(b'\n')
         assert lines[0] == b"ansible"
         assert v.cipher_name == 'TEST', "cipher name was not set"
-        assert v.version == "9.9"
+        assert v.b_version == "9.9"
 
     def test_encrypt_decrypt_aes(self):
         if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:


### PR DESCRIPTION
The python3 work on vault broke vault's handling of unicode.  This patch fixes vault so that it only deals in byte strings inside of the Ciphers.  VaultLib and VaultEditor can take in either byte strings or unicode strings and will convert (using utf-8) before passing the data on to the ciphers.

Nonessential changes include
- prefixing variables in VaultLib containing byte strings with b_ so that it's easier to tell what the contents of a var are.  VaultLib is the only class that needs to know whether its dealing with bytes or unicode (the other classes should only be given byte strings by VaultLib or else pass their data on to VaultLib to do the conversion) so it seemed like the class most in need of this.
- Make sure that when we read in a file in parsing/**init**.py that it is read as a byte string nad then we convert it to a unicode type (either via VaultLib or inside of that method if it's paintext).
- Convert lists to frozensets since they are only being used to do containment tests.
- Correct a few typos in the to-be-used-in-the-future VaultFile code
- Fix the optimization that does not resave unchanged vault files to still resave the file if the old vault was VaultAES instead of VaultAES256.
- Made conversions from bytes to unicode throw errors instead of replacing unknown chars with "?".  In this case we're dealing with very precise formats so we don't want to mess those up here. 
- Set padding bytes to encode in the ascii encoding... this should never matter (I believe that the character can only be codepoint 0-16 here) but the code will definitely do the wrong thing if the padding is a multibyte character so doing this may catch future coding errors.
