### PR TITLE
Add hash_merge and hash_merge_recursive filters with documentation

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -334,6 +334,11 @@ official examples repos do not use this setting::
 
 The valid values are either 'replace' (the default) or 'merge'.
 
+.. versionadded: '2.0'
+
+If you want to merge hashes without changing the global settings, use
+the `combine` filter described in :doc:`playbooks_filters`.
+
 .. _hostfile:
 
 hostfile

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -316,6 +316,41 @@ To get a sha256 password hash with a specific salt::
 Hash types available depend on the master system running ansible,
 'hash' depends on hashlib password_hash depends on crypt.
 
+.. _combine_filter:
+
+Combining hashes/dictionaries
+-----------------------------
+
+.. versionadded:: 2.0
+
+The `combine` filter allows hashes to be merged. For example, the
+following would override keys in one hash:
+
+    {{ {'a':1, 'b':2}|combine({'b':3}) }}
+
+The resulting hash would be:
+
+    {'a':1, 'b':3}
+
+The filter also accepts an optional `recursive=True` parameter to not
+only override keys in the first hash, but also recurse into nested
+hashes and merge their keys too:
+
+    {{ {'a':{'foo':1, 'bar':2}, 'b':2}|combine({'a':{'bar':3, 'baz':4}}, recursive=True) }}
+
+This would result in:
+
+    {'a':{'foo':1, 'bar':3, 'baz':4}, 'b':2}
+
+The filter can also take multiple arguments to merge:
+
+    {{ a|combine(b, c, d) }}
+
+In this case, keys in `d` would override those in `c`, which would
+override those in `b`, and so on.
+
+This behaviour does not depend on the value of the `hash_behaviour`
+setting in `ansible.cfg`.
 
 .. _other_useful_filters:
 


### PR DESCRIPTION
This PR implements the most-requested subset of the earlier (closed) PR
largely unchanged from PR #7872 by @darkk (but the filters are named
differently to address the fact that hash_behaviour=replace doesn't
actually do a shallow merge, as the earlier PR implied).

Closes #7872 by @darkk (hash_merge/hash_replace filters)
Closes #11153 by @telbizov (merged_dicts lookup plugin)

cc: @evanccnyc
