### PR TITLE
Speed up execution

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -96,7 +96,7 @@ class Base:
     @staticmethod
     def _generic_g(prop_name, self):
         method = "_get_attr_%s" % prop_name
-        if method in dir(self):
+        if hasattr(self, method):
             return getattr(self, method)()
 
         return self._attributes[prop_name]


### PR DESCRIPTION
`if method in dir(self):` is very inefficient:
- it must construct a list object listing all the object attributes & methods
- it must then perform a O(N) linear scan of that list

Replace it with the idiomatic `if hasattr(self, method):`, which is a
O(1) expected time hash lookup.

Should fix #11981.  Or at least a part of it.
