### PR TITLE
Update smart transport to handle Sun_SSH_1.5 on SmartOS

### DIFF
--- a/v1/ansible/runner/__init__.py
+++ b/v1/ansible/runner/__init__.py
@@ -232,7 +232,7 @@ class Runner(object):
                 # see if SSH can support ControlPersist if not use paramiko
                 cmd = subprocess.Popen(['ssh','-o','ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 (out, err) = cmd.communicate()
-                if "Bad configuration option" in err:
+                if "Bad configuration option" in err or "Usage:" in err:
                     self.transport = "paramiko"
 
         # save the original transport, in case it gets


### PR DESCRIPTION
On SmartOS the smart transport's check for the ControlPersist option doesn't behave as intended.  In the Sun_SSH implementation, the usage information is returned instead of "Bad configuration option".
