### PR TITLE
Don't compile .py files under .tox/

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ whitelist_externals = make
 [testenv:py26]
 commands =
     python --version
-    python -m compileall -fq -x 'test|samples|contrib/inventory/vagrant.py' .
+    python -m compileall -fq -x 'test|samples|contrib/inventory/vagrant.py|.tox' .
     make tests
 deps = -r{toxinidir}/test-requirements.txt
 whitelist_externals =
@@ -18,7 +18,7 @@ whitelist_externals =
 [testenv:py27]
 commands =
     python --version
-    python -m compileall -fq -x 'test|samples' .
+    python -m compileall -fq -x 'test|samples|.tox' .
     make tests
 deps = -r{toxinidir}/test-requirements.txt
 whitelist_externals = make
@@ -26,7 +26,7 @@ whitelist_externals = make
 [testenv:py34]
 commands =
     python --version
-    python -m compileall -fq -x 'lib/ansible/module_utils' lib
+    python -m compileall -fq -x 'lib/ansible/module_utils|.tox' lib
     make tests
 deps = -r{toxinidir}/test-requirements.txt
 whitelist_externals = make


### PR DESCRIPTION
'tox -e py26' would fail for me because python -m compileall would crawl under
.tox/py27 and, unsurprisingly, get SyntaxErrors on files from the Python 2.7
standard library using syntax features not supported by Python 2.6.
