### PR TITLE
Synchronize fix error

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -77,7 +77,7 @@ class ActionModule(ActionBase):
         # connection to the remote host
         if 'ansible_syslog_facility' in task_vars:
             del task_vars['ansible_syslog_facility']
-        for key in task_vars:
+        for key in task_vars.keys():
             if key.startswith("ansible_") and key.endswith("_interpreter"):
                 del task_vars[key]
 


### PR DESCRIPTION
Ran into an error using synchronize.

It is not valid to delete dictionary elements while iterating it.

```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/ansible/executor/process/worker.py", line 118, in run
    executor_result = TaskExecutor(host, task, job_vars, new_play_context, self._new_stdin, self._loader, shared_loader_obj).run()
  File "/usr/lib64/python2.7/site-packages/ansible/executor/task_executor.py", line 117, in run
    res = self._execute()
  File "/usr/lib64/python2.7/site-packages/ansible/executor/task_executor.py", line 317, in _execute
    result = self._handler.run(task_vars=variables)
  File "/usr/lib64/python2.7/site-packages/ansible/plugins/action/synchronize.py", line 150, in run
    self._override_module_replaced_vars(task_vars)
  File "/usr/lib64/python2.7/site-packages/ansible/plugins/action/synchronize.py", line 80, in _override_module_replaced_vars
    for key in task_vars:
RuntimeError: dictionary changed size during iteration
```
