### PR TITLE
Update "smart" transport to handle Sun_SSH_1.5 on SmartOS

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -452,7 +452,7 @@ class TaskExecutor:
                 try:
                     cmd = subprocess.Popen(['ssh','-o','ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                     (out, err) = cmd.communicate()
-                    if "Bad configuration option" in err:
+                    if "Bad configuration option" in err or "Usage:" in err:
                         conn_type = "paramiko"
                 except OSError:
                     conn_type = "paramiko"


### PR DESCRIPTION
On SmartOS the smart transport's check for the ControlPersist option doesn't behave as intended. In the Sun_SSH implementation, the usage information is returned instead of "Bad configuration option".

My original, incorrect PR: https://github.com/ansible/ansible/pull/12093
