### PR TITLE
Implement cat-like filtering behaviour for encrypt/decrypt

### DIFF
--- a/docs/man/man1/ansible-vault.1
+++ b/docs/man/man1/ansible-vault.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: ansible-vault
 .\"    Author: [see the "AUTHOR" section]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 07/28/2015
+.\" Generator: DocBook XSL Stylesheets v1.76.1 <http://docbook.sf.net/>
+.\"      Date: 08/27/2015
 .\"    Manual: System administration commands
 .\"    Source: Ansible 2.0.0
 .\"  Language: English
 .\"
-.TH "ANSIBLE\-VAULT" "1" "07/28/2015" "Ansible 2\&.0\&.0" "System administration commands"
+.TH "ANSIBLE\-VAULT" "1" "08/27/2015" "Ansible 2\&.0\&.0" "System administration commands"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -80,19 +80,35 @@ The \fBedit\fR sub\-command is used to modify a file which was previously encryp
 This command will decrypt the file to a temporary file and allow you to edit the file, saving it back when done and removing the temporary file\&.
 .SH "REKEY"
 .sp
-*$ ansible\-vault rekey [options] FILE_1 [FILE_2, \&..., FILE_N]
+\fB$ ansible\-vault rekey [options] FILE_1 [FILE_2, \&..., FILE_N]\fR
 .sp
 The \fBrekey\fR command is used to change the password on a vault\-encrypted files\&. This command can update multiple files at once, and will prompt for both the old and new passwords before modifying any data\&.
 .SH "ENCRYPT"
 .sp
-*$ ansible\-vault encrypt [options] FILE_1 [FILE_2, \&..., FILE_N]
+\fB$ ansible\-vault encrypt [options] FILE_1 [FILE_2, \&..., FILE_N]\fR
 .sp
 The \fBencrypt\fR sub\-command is used to encrypt pre\-existing data files\&. As with the \fBrekey\fR command, you can specify multiple files in one command\&.
+.sp
+Starting with version 2\&.0, the \fBencrypt\fR command accepts an \fB\-\-output FILENAME\fR option to determine where encrypted output is stored\&. With this option, input is read from the (at most one) filename given on the command line; if no input file is given, input is read from stdin\&. Either the input or the output file may be given as \fI\-\fR for stdin and stdout respectively\&. If neither input nor output file is given, the command acts as a filter, reading plaintext from stdin and writing it to stdout\&.
+.sp
+Thus any of the following invocations can be used:
+.sp
+\fB$ ansible\-vault encrypt\fR
+.sp
+\fB$ ansible\-vault encrypt \-\-output OUTFILE\fR
+.sp
+\fB$ ansible\-vault encrypt INFILE \-\-output OUTFILE\fR
+.sp
+\fB$ echo secret|ansible\-vault encrypt \-\-output OUTFILE\fR
+.sp
+Reading from stdin and writing only encrypted output is a good way to prevent sensitive data from ever hitting disk (either interactively or from a script)\&.
 .SH "DECRYPT"
 .sp
-*$ ansible\-vault decrypt [options] FILE_1 [FILE_2, \&..., FILE_N]
+\fB$ ansible\-vault decrypt [options] FILE_1 [FILE_2, \&..., FILE_N]\fR
 .sp
 The \fBdecrypt\fR sub\-command is used to remove all encryption from data files\&. The files will be stored as plain\-text YAML once again, so be sure that you do not run this command on data files with active passwords or other sensitive data\&. In most cases, users will want to use the \fBedit\fR sub\-command to modify the files securely\&.
+.sp
+As with \fBencrypt\fR, the \fBdecrypt\fR subcommand also accepts the \fB\-\-output FILENAME\fR option to specify where plaintext output is stored, and stdin/stdout is handled as described above\&.
 .SH "AUTHOR"
 .sp
 Ansible was originally written by Michael DeHaan\&. See the AUTHORS file for a complete list of contributors\&.

--- a/docs/man/man1/ansible-vault.1.asciidoc.in
+++ b/docs/man/man1/ansible-vault.1.asciidoc.in
@@ -84,7 +84,7 @@ file, saving it back when done and removing the temporary file.
 REKEY
 -----
 
-*$ ansible-vault rekey [options] FILE_1 [FILE_2, ..., FILE_N]
+*$ ansible-vault rekey [options] FILE_1 [FILE_2, ..., FILE_N]*
 
 The *rekey* command is used to change the password on a vault-encrypted files.
 This command can update multiple files at once, and will prompt for both the
@@ -93,21 +93,45 @@ old and new passwords before modifying any data.
 ENCRYPT
 -------
 
-*$ ansible-vault encrypt [options] FILE_1 [FILE_2, ..., FILE_N]
+*$ ansible-vault encrypt [options] FILE_1 [FILE_2, ..., FILE_N]*
 
 The *encrypt* sub-command is used to encrypt pre-existing data files. As with the
 *rekey* command, you can specify multiple files in one command.
 
+Starting with version 2.0, the *encrypt* command accepts an *--output FILENAME*
+option to determine where encrypted output is stored. With this option, input is
+read from the (at most one) filename given on the command line; if no input file
+is given, input is read from stdin. Either the input or the output file may be
+given as '-' for stdin and stdout respectively. If neither input nor output file
+is given, the command acts as a filter, reading plaintext from stdin and writing
+it to stdout.
+
+Thus any of the following invocations can be used:
+
+*$ ansible-vault encrypt*
+
+*$ ansible-vault encrypt --output OUTFILE*
+
+*$ ansible-vault encrypt INFILE --output OUTFILE*
+
+*$ echo secret|ansible-vault encrypt --output OUTFILE*
+
+Reading from stdin and writing only encrypted output is a good way to prevent
+sensitive data from ever hitting disk (either interactively or from a script).
+
 DECRYPT
 -------
 
-*$ ansible-vault decrypt [options] FILE_1 [FILE_2, ..., FILE_N]
+*$ ansible-vault decrypt [options] FILE_1 [FILE_2, ..., FILE_N]*
 
 The *decrypt* sub-command is used to remove all encryption from data files. The files
 will be stored as plain-text YAML once again, so be sure that you do not run this
 command on data files with active passwords or other sensitive data. In most cases, 
 users will want to use the *edit* sub-command to modify the files securely.
 
+As with *encrypt*, the *decrypt* subcommand also accepts the *--output FILENAME*
+option to specify where plaintext output is stored, and stdin/stdout is handled
+as described above.
 
 AUTHOR
 ------

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -260,8 +260,8 @@ class CLI(object):
                 dest='vault_password_file', help="vault password file", action="callback",
                 callback=CLI.expand_tilde, type=str)
             parser.add_option('--new-vault-password-file',
-			    dest='new_vault_password_file', help="new vault password file for rekey", action="callback",
-			    callback=CLI.expand_tilde, type=str)
+                dest='new_vault_password_file', help="new vault password file for rekey", action="callback",
+                callback=CLI.expand_tilde, type=str)
 
 
         if subset_opts:

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -262,6 +262,8 @@ class CLI(object):
             parser.add_option('--new-vault-password-file',
                 dest='new_vault_password_file', help="new vault password file for rekey", action="callback",
                 callback=CLI.expand_tilde, type=str)
+            parser.add_option('--output', default=None, dest='output_file',
+                help='output file name for encrypt or decrypt; use - for stdout')
 
 
         if subset_opts:

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -63,20 +63,21 @@ class VaultCLI(CLI):
         self.options, self.args = self.parser.parse_args()
         self.display.verbosity = self.options.verbosity
 
-        if self.options.output_file:
-            if self.action not in ['encrypt','decrypt']:
-                raise AnsibleOptionsError("The --output option can be used only with ansible-vault encrypt/decrypt")
+        can_output = ['encrypt', 'decrypt']
 
+        if self.action not in can_output:
+            if self.options.output_file:
+                raise AnsibleOptionsError("The --output option can be used only with ansible-vault %s" % '/'.join(can_output))
+            if len(self.args) == 0:
+                raise AnsibleOptionsError("Vault requires at least one filename as a parameter")
+        else:
             # This restriction should remain in place until it's possible to
             # load multiple YAML records from a single file, or it's too easy
             # to create an encrypted file that can't be read back in. But in
             # the meanwhile, "cat a b c|ansible-vault encrypt --output x" is
             # a workaround.
-            if len(self.args) > 1:
+            if self.options.output_file and len(self.args) > 1:
                 raise AnsibleOptionsError("At most one input file may be used with the --output option")
-
-        elif len(self.args) == 0:
-            raise AnsibleOptionsError("Vault requires at least one filename as a parameter")
 
     def run(self):
 

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -102,17 +102,25 @@ class VaultCLI(CLI):
 
     def execute_encrypt(self):
 
+        if len(self.args) == 0 and sys.stdin.isatty():
+            self.display.display("Reading plaintext input from stdin", stderr=True)
+
         for f in self.args or ['-']:
             self.editor.encrypt_file(f, output_file=self.options.output_file)
 
-        self.display.display("Encryption successful", stderr=True)
+        if sys.stdout.isatty():
+            self.display.display("Encryption successful", stderr=True)
 
     def execute_decrypt(self):
+
+        if len(self.args) == 0 and sys.stdin.isatty():
+            self.display.display("Reading ciphertext input from stdin", stderr=True)
 
         for f in self.args or ['-']:
             self.editor.decrypt_file(f, output_file=self.options.output_file)
 
-        self.display.display("Decryption successful", stderr=True)
+        if sys.stdout.isatty():
+            self.display.display("Decryption successful", stderr=True)
 
     def execute_create(self):
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -329,25 +329,24 @@ class VaultEditor:
     def read_data(self, filename):
         try:
             if filename == '-':
-                f = sys.stdin
+                data = sys.stdin.read()
             else:
-                f = open(filename, "rb")
-            data = f.read()
-            f.close()
+                with open(filename, "rb") as fh:
+                    data = fh.read()
         except Exception as e:
             raise AnsibleError(str(e))
 
         return data
 
     def write_data(self, data, filename):
+        bytes = to_bytes(data, errors='strict')
         if filename == '-':
-            f = sys.stdout
+            sys.stdout.write(bytes)
         else:
             if os.path.isfile(filename):
                 os.remove(filename)
-            f = open(filename, "wb")
-        f.write(to_bytes(data, errors='strict'))
-        f.close()
+            with open(filename, "wb") as fh:
+                fh.write(bytes)
 
     def shuffle_files(self, src, dest):
         # overwrite dest with src


### PR DESCRIPTION
As discussed on IRC, this includes some minor functionality-preserving cleanups for VaultEditor, and uses this to implement the stdin/stdout encryption/decryption semantics requested by @bcoca and @abadger.
