### PR TITLE
Make sanitze_output function catch other forms of passwords

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -283,6 +283,7 @@ def heuristic_log_sanitize(data):
     ''' Remove strings that look like passwords from log messages '''
     # Currently filters:
     # user:pass@foo/whatever and http://username:pass@wherever/foo
+    # and strings like -p foo and password=foo
     # This code has false positives and consumes parts of logs that are
     # not passwds
 
@@ -293,6 +294,8 @@ def heuristic_log_sanitize(data):
     #   a passwd
     # sep_search_end: where in the string to end a search for the sep
     output = []
+    PASSWORD_RE = re.compile(r"""((password| -p)[= ]?)['"]?([^ ]*)""")
+    data = PASSWORD_RE.sub(r'\1VALUE_HIDDEN', data)
     begin = len(data)
     prev_begin = begin
     sep = 1

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -941,26 +941,7 @@ def getch():
 def sanitize_output(arg_string):
     ''' strips private info out of a string '''
 
-    private_keys = ('password', 'login_password')
-
-    output = []
-    for part in arg_string.split():
-        try:
-            (k, v) = part.split('=', 1)
-        except ValueError:
-            v = heuristic_log_sanitize(part)
-            output.append(v)
-            continue
-
-        if k in private_keys:
-            v = 'VALUE_HIDDEN'
-        else:
-            v = heuristic_log_sanitize(v)
-        output.append('%s=%s' % (k, v))
-
-    output = ' '.join(output)
-    return output
-
+    return heuristic_log_sanitize(arg_string)
 
 ####################################################################
 # option handling code for /usr/bin/ansible and ansible-playbook

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -409,6 +409,10 @@ class TestUtils(unittest.TestCase):
 
     def test_sanitize_output(self):
         self.assertEqual(ansible.utils.sanitize_output('password=foo'), 'password=VALUE_HIDDEN')
+        self.assertEqual(ansible.utils.sanitize_output('password="foo"'), 'password=VALUE_HIDDEN')
+        self.assertEqual(ansible.utils.sanitize_output('--password=foo'), '--password=VALUE_HIDDEN')
+        self.assertEqual(ansible.utils.sanitize_output('password foo'), 'password VALUE_HIDDEN')
+        self.assertEqual(ansible.utils.sanitize_output(' -p foo'), ' -p VALUE_HIDDEN')
         self.assertEqual(ansible.utils.sanitize_output('foo=user:pass@foo/whatever'),
                          'foo=user:********@foo/whatever')
         self.assertEqual(ansible.utils.sanitize_output('foo=http://username:pass@wherever/foo'),


### PR DESCRIPTION
##### SUMMARY
The motivation for this change is that we have some shell commands that contain passwords in the arguments and when running ansible with verbosity -vv in a build environment like Jenkins those passwords would then get captured in the logs. This change detects some other common password keys that one might find in a cli tool argument like those passed to the mongo shell.

Includes strings like
-p foo
password=foo
--password=foo
--password 'foo'


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py
lib/ansible/utils/__init__.py
test/units/TestUtils.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


