### PR TITLE
Remove deprecated and unused VaultAES encryption code

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -465,39 +465,7 @@ class VaultAES:
 
         """ Read plaintext data from in_file and write encrypted to out_file """
 
-        # combine sha + data
-        this_sha = to_bytes(sha256(data).hexdigest())
-        tmp_data = this_sha + b"\n" + data
-
-        in_file = BytesIO(tmp_data)
-        in_file.seek(0)
-        out_file = BytesIO()
-
-        bs = AES.block_size
-
-        # Get a block of random data. EL does not have Crypto.Random.new()
-        # so os.urandom is used for cross platform purposes
-        salt = os.urandom(bs - len(b'Salted__'))
-
-        key, iv = self.aes_derive_key_and_iv(password, salt, key_length, bs)
-        cipher = AES.new(key, AES.MODE_CBC, iv)
-        full = to_bytes(b'Salted__' + salt)
-        out_file.write(full)
-        finished = False
-        while not finished:
-            chunk = in_file.read(1024 * bs)
-            if len(chunk) == 0 or len(chunk) % bs != 0:
-                padding_length = (bs - len(chunk) % bs) or bs
-                chunk += to_bytes(padding_length * chr(padding_length), errors='strict', encoding='ascii')
-                finished = True
-            out_file.write(cipher.encrypt(chunk))
-
-        out_file.seek(0)
-        enc_data = out_file.read()
-        tmp_data = hexlify(enc_data)
-
-        return tmp_data
-
+        raise AnsibleError("Encryption disabled for deprecated VaultAES class")
 
     def decrypt(self, data, password, key_length=32):
 

--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -104,9 +104,10 @@ class TestVaultLib(unittest.TestCase):
             raise SkipTest
         v = VaultLib('ansible')
         v.cipher_name = u'AES'
-        enc_data = v.encrypt("foobar")
+        # AES encryption code has been removed, so this is old output for
+        # AES-encrypted 'foobar' with password 'ansible'.
+        enc_data = '$ANSIBLE_VAULT;1.1;AES\n53616c7465645f5fc107ce1ef4d7b455e038a13b053225776458052f8f8f332d554809d3f150bfa3\nfe3db930508b65e0ff5947e4386b79af8ab094017629590ef6ba486814cf70f8e4ab0ed0c7d2587e\n786a5a15efeb787e1958cbdd480d076c\n'
         dec_data = v.decrypt(enc_data)
-        assert enc_data != "foobar", "encryption failed"
         assert dec_data == "foobar", "decryption failed"
 
     def test_encrypt_decrypt_aes256(self):


### PR DESCRIPTION
Now that VaultLib always decides to use AES256 to encrypt, we don't need
this broken code any more. We need to be able to decrypt this format for
a while longer, but encryption support can be safely dropped.
