### PR TITLE
New version of VaultAES256: no padding, base64 output (plus some cleanups)

### DIFF
--- a/lib/ansible/parsing/__init__.py
+++ b/lib/ansible/parsing/__init__.py
@@ -167,7 +167,7 @@ class DataLoader():
             with open(file_name, 'rb') as f:
                 data = f.read()
                 if self._vault.is_encrypted(data):
-                    data = self._vault.decrypt(data)
+                    data = self._vault.decrypt(data)[-1]
                     show_content = False
 
             data = to_unicode(data, errors='strict')

--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -138,17 +138,17 @@ class TestVaultLib(unittest.TestCase):
         # AES encryption code has been removed, so this is old output for
         # AES-encrypted 'foobar' with password 'ansible'.
         enc_data = '$ANSIBLE_VAULT;1.1;AES\n53616c7465645f5fc107ce1ef4d7b455e038a13b053225776458052f8f8f332d554809d3f150bfa3\nfe3db930508b65e0ff5947e4386b79af8ab094017629590ef6ba486814cf70f8e4ab0ed0c7d2587e\n786a5a15efeb787e1958cbdd480d076c\n'
-        dec_data = v.decrypt(enc_data)
-        assert dec_data == "foobar", "decryption failed"
+        dec_data = v.decrypt(enc_data)[-1]
+        self.assertEqual(dec_data, "foobar", msg="decryption failed")
 
     def test_encrypt_decrypt_aes256(self):
         if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:
             raise SkipTest
         v = VaultLib('ansible')
         enc_data = v.encrypt("foobar", 'AES256')
-        dec_data = v.decrypt(enc_data)
-        assert enc_data != "foobar", "encryption failed"
-        assert dec_data == "foobar", "decryption failed"
+        dec_data = v.decrypt(enc_data)[-1]
+        self.assertNotEqual(enc_data, "foobar", msg="encryption failed")
+        self.assertEqual(dec_data, "foobar", msg="decryption failed")
 
     def test_encrypt_encrypted(self):
         if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:

--- a/test/units/parsing/vault/test_vault_editor.py
+++ b/test/units/parsing/vault/test_vault_editor.py
@@ -207,7 +207,7 @@ class TestVaultEditor(unittest.TestCase):
 
         os.unlink(v10_file.name)
 
-        assert vl.cipher_name == "AES256", "wrong cipher name set after rekey: %s" % vl.cipher_name
+        assert ';AES256' in fdata, "wrong cipher name set after rekey"
         assert error_hit == False, "error decrypting migrated 1.0 file"
         assert dec_data.strip() == "foo", "incorrect decryption of rekeyed/migrated file: %s" % dec_data
 

--- a/test/units/parsing/vault/test_vault_editor.py
+++ b/test/units/parsing/vault/test_vault_editor.py
@@ -194,21 +194,21 @@ class TestVaultEditor(unittest.TestCase):
         fdata = f.read()
         f.close()
 
-        assert error_hit == False, "error rekeying 1.0 file to 1.1"
+        self.assertEqual(error_hit, False, msg="error rekeying 1.0 file to 1.1")
 
         # ensure filedata can be decrypted, is 1.1 and is AES256
         vl = VaultLib("ansible2")
         dec_data = None
         error_hit = False
         try:
-            dec_data = vl.decrypt(fdata)
+            dec_data = vl.decrypt(fdata)[-1]
         except errors.AnsibleError as e:
             error_hit = True
 
         os.unlink(v10_file.name)
 
-        assert ';AES256' in fdata, "wrong cipher name set after rekey"
-        assert error_hit == False, "error decrypting migrated 1.0 file"
-        assert dec_data.strip() == "foo", "incorrect decryption of rekeyed/migrated file: %s" % dec_data
+        self.assertIn(';AES256', fdata, msg="wrong cipher name set after rekey")
+        self.assertEqual(error_hit, False, msg="error decrypting migrated 1.0 file")
+        self.assertEqual(dec_data.strip(), "foo", msg="incorrect decryption of rekeyed/migrated file: %s" % dec_data)
 
 


### PR DESCRIPTION
These don't alter any functionality, but they set the stage for comprehensive improvements in the AES256 cipher while maintaining backwards compatibility more easily than was possible before. These simplifications will eventually also make it simpler to complete the `VaultFile` prototype and enable transparent vault usage from playbooks.
