### PR TITLE
Enable py34 test in travis so we don't regress recent fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   - TOKENV=py24
   - TOXENV=py26
   - TOXENV=py27
+  - TOXENV=py34
 addons:
   apt:
     sources:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27}
+envlist = {py26,py27,py34}
 
 [testenv]
 commands = make tests
@@ -26,7 +26,10 @@ whitelist_externals = make
 [testenv:py34]
 commands =
     python --version
+    # scripts in contrib still need to be ported to python3-compatible syntax
+    #python -m compileall -fq -x 'lib/ansible/module_utils|lib/ansible/modules' lib test contrib
     python -m compileall -fq -x 'lib/ansible/module_utils|lib/ansible/modules' lib test
-    make tests
+    # Unittests need lots of work to make code python3 compatible
+    #make tests
 deps = -r{toxinidir}/test-requirements.txt
 whitelist_externals = make


### PR DESCRIPTION
This is just pycompile tests to catch SyntaxErrors.
