### PR TITLE
 Add no_syslog option in order to prevent ansible syslog its actions on the remote host (rebase  #11502)

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -436,6 +436,17 @@ it to 'shell'::
 
     module_name = command
 
+.. _no_syslog:
+
+no_syslog
+=======
+
+.. versionadded: 'v2'
+
+By default ansible will log actions to the remote syslog, this turns off this behaviour.
+
+   no_syslog=False
+
 .. _nocolor:
 
 nocolor

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -61,6 +61,9 @@ timeout = 10
 # if so defined, consider logrotate
 #log_path = /var/log/ansible.log
 
+# this turns off ansible logging on the remote machine
+#no_syslog = True
+
 # default module name for /usr/bin/ansible
 #module_name = command
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -315,6 +315,8 @@ class CLI(object):
                 help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
             parser.add_option('-T', '--timeout', default=C.DEFAULT_TIMEOUT, type='int', dest='timeout',
                 help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
+            parser.add_option('-n', '--no-syslog', default=C.DEFAULT_NO_SYSLOG, dest='no_syslog', action='store_true',
+                help='disable syslogging on remote machine')
 
         if async_opts:
             parser.add_option('-P', '--poll', default=C.DEFAULT_POLL_INTERVAL, type='int', dest='poll_interval',

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -149,6 +149,7 @@ DEFAULT_GATHERING         = get_config(p, DEFAULTS, 'gathering', 'ANSIBLE_GATHER
 DEFAULT_LOG_PATH          = shell_expand_path(get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', ''))
 DEFAULT_FORCE_HANDLERS    = get_config(p, DEFAULTS, 'force_handlers', 'ANSIBLE_FORCE_HANDLERS', False, boolean=True)
 DEFAULT_INVENTORY_IGNORE  = get_config(p, DEFAULTS, 'inventory_ignore_extensions', 'ANSIBLE_INVENTORY_IGNORE', ["~", ".orig", ".bak", ".ini", ".cfg", ".retry", ".pyc", ".pyo"], islist=True)
+DEFAULT_NO_SYSLOG         = get_config(p, DEFAULTS, 'no_syslog', 'ANSIBLE_NO_SYSLOG', False, boolean=True)
 
 # selinux
 DEFAULT_SELINUX_SPECIAL_FS = get_config(p, 'selinux', 'special_context_filesystems', None, 'fuse, nfs, vboxsf, ramfs', islist=True)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -344,7 +344,7 @@ def heuristic_log_sanitize(data):
 
 class AnsibleModule(object):
 
-    def __init__(self, argument_spec, bypass_checks=False, no_log=False,
+    def __init__(self, argument_spec, bypass_checks=False, no_log=False, no_syslog=False,
         check_invalid_arguments=True, mutually_exclusive=None, required_together=None,
         required_one_of=None, add_file_common_args=False, supports_check_mode=False,
         required_if=None):
@@ -359,6 +359,7 @@ class AnsibleModule(object):
         self.supports_check_mode = supports_check_mode
         self.check_mode = False
         self.no_log = no_log
+        self.no_syslog = no_syslog
         self.cleanup_files = []
 
         self.aliases = {}
@@ -374,7 +375,7 @@ class AnsibleModule(object):
 
         self.params = self._load_params()
 
-        self._legal_inputs = ['_ansible_check_mode', '_ansible_no_log']
+        self._legal_inputs = ['_ansible_check_mode', '_ansible_no_log', '_ansible_no_syslog']
 
         self.aliases = self._handle_aliases()
 
@@ -382,8 +383,9 @@ class AnsibleModule(object):
             self._check_invalid_arguments()
         self._check_for_check_mode()
         self._check_for_no_log()
+        self._check_for_no_syslog()
 
-        # check exclusive early 
+        # check exclusive early
         if not bypass_checks:
             self._check_mutually_exclusive(mutually_exclusive)
 
@@ -408,7 +410,7 @@ class AnsibleModule(object):
             self._check_required_if(required_if)
 
         self._set_defaults(pre=False)
-        if not self.no_log:
+        if not (self.no_log or self.no_syslog):
             self._log_invocation()
 
         # finally, make sure we're in a sane working dir
@@ -927,6 +929,11 @@ class AnsibleModule(object):
         for (k,v) in self.params.iteritems():
             if k == '_ansible_no_log':
                 self.no_log = self.boolean(v)
+
+    def _check_for_no_syslog(self):
+        for (k,v) in self.params.iteritems():
+            if k == '_ansible_no_syslog':
+                self.no_syslog = self.boolean(v)
 
     def _check_invalid_arguments(self):
         for (k,v) in self.params.iteritems():

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -53,6 +53,7 @@ class Base:
     # flags and misc. settings
     _environment         = FieldAttribute(isa='list')
     _no_log              = FieldAttribute(isa='bool')
+    _no_syslog           = FieldAttribute(isa='bool')
 
     def __init__(self):
 

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -142,6 +142,7 @@ TASK_ATTRIBUTE_OVERRIDES = (
     'connection',
     'delegate_to',
     'no_log',
+    'no_syslog',
     'remote_user',
 )
 
@@ -155,7 +156,7 @@ class PlayContext(Base):
     '''
 
     # connection fields, some are inherited from Base:
-    # (connection, port, remote_user, environment, no_log)
+    # (connection, port, remote_user, environment, no_log, no_syslog)
     _remote_addr      = FieldAttribute(isa='string')
     _password         = FieldAttribute(isa='string')
     _private_key_file = FieldAttribute(isa='string', default=C.DEFAULT_PRIVATE_KEY_FILE)
@@ -257,6 +258,8 @@ class PlayContext(Base):
             self.verbosity  = options.verbosity
         #if options.no_log:
         #    self.no_log     = boolean(options.no_log)
+        if options.no_syslog:
+            self.no_syslog  = boolean(options.no_syslog)
         if options.check:
             self.check_mode = boolean(options.check)
         if hasattr(options, 'force_handlers') and options.force_handlers:

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -347,6 +347,9 @@ class ActionBase:
         if self._play_context.no_log:
             module_args['_ansible_no_log'] = True
 
+        if self._play_context.no_syslog:
+            module_args['_ansible_no_syslog'] = True
+
         self._display.debug("in _execute_module (%s, %s)" % (module_name, module_args))
 
         (module_style, shebang, module_data) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)

--- a/lib/ansible/plugins/action/async.py
+++ b/lib/ansible/plugins/action/async.py
@@ -40,8 +40,12 @@ class ActionModule(ActionBase):
 
         env_string = self._compute_environment_string()
 
+        module_args = self._task.args.copy()
+        if self._play_context.no_syslog:
+            module_args['_ansible_no_syslog'] = True
+
         # configure, upload, and chmod the target module
-        (module_style, shebang, module_data) = self._configure_module(module_name=module_name, module_args=self._task.args, task_vars=task_vars)
+        (module_style, shebang, module_data) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)
         self._transfer_data(remote_module_path, module_data)
         self._remote_chmod(tmp, 'a+rx', remote_module_path)
 
@@ -50,7 +54,7 @@ class ActionModule(ActionBase):
         self._transfer_data(async_module_path, async_module_data)
         self._remote_chmod(tmp, 'a+rx', async_module_path)
 
-        argsfile = self._transfer_data(self._connection._shell.join_path(tmp, 'arguments'), json.dumps(self._task.args))
+        argsfile = self._transfer_data(self._connection._shell.join_path(tmp, 'arguments'), json.dumps(module_args))
 
         async_limit = self._task.async
         async_jid   = str(random.randint(0, 999999999999))


### PR DESCRIPTION
Add no_syslog option in order to prevent ansible syslog its actions
on the remote host.

Syslog on remote hosts can be turned off by:

```
no_syslog option inside ansible.cfg.
-n --no_syslog command line options (ansible and ansible-playbook).
```

Rebased version of #11502
