### PR TITLE
moved WinRM setup script test after config

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -105,31 +105,6 @@ Else
     Write-Verbose "PS Remoting is already enabled."
 }
 
-
-# Test a remoting connection to localhost, which should work.
-$httpResult = Invoke-Command -ComputerName "localhost" -ScriptBlock {$env:COMPUTERNAME} -ErrorVariable httpError -ErrorAction SilentlyContinue
-$httpsOptions = New-PSSessionOption -SkipCACheck -SkipCNCheck -SkipRevocationCheck
-
-$httpsResult = New-PSSession -UseSSL -ComputerName "localhost" -SessionOption $httpsOptions -ErrorVariable httpsError -ErrorAction SilentlyContinue
-
-If ($httpResult -and $httpsResult)
-{
-    Write-Verbose "HTTP and HTTPS sessions are enabled."
-}
-ElseIf ($httpsResult -and !$httpResult)
-{
-    Write-Verbose "HTTP sessions are disabled, HTTPS session are enabled."
-}
-ElseIf ($httpResult -and !$httpsResult)
-{
-    Write-Verbose "HTTPS sessions are disabled, HTTP session are enabled."
-}
-Else
-{
-    Throw "Unable to establish an HTTP or HTTPS remoting session."
-}
-
-
 # Make sure there is a SSL listener.
 $listeners = Get-ChildItem WSMan:\localhost\Listener
 If (!($listeners | Where {$_.Keys -like "TRANSPORT=HTTPS"}))
@@ -194,5 +169,27 @@ Else
     Write-Verbose "Firewall rule already exists to allow WinRM HTTPS."
 }
 
+# Test a remoting connection to localhost, which should work.
+$httpResult = Invoke-Command -ComputerName "localhost" -ScriptBlock {$env:COMPUTERNAME} -ErrorVariable httpError -ErrorAction SilentlyContinue
+$httpsOptions = New-PSSessionOption -SkipCACheck -SkipCNCheck -SkipRevocationCheck
+
+$httpsResult = New-PSSession -UseSSL -ComputerName "localhost" -SessionOption $httpsOptions -ErrorVariable httpsError -ErrorAction SilentlyContinue
+
+If ($httpResult -and $httpsResult)
+{
+    Write-Verbose "HTTP and HTTPS sessions are enabled."
+}
+ElseIf ($httpsResult -and !$httpResult)
+{
+    Write-Verbose "HTTP sessions are disabled, HTTPS session are enabled."
+}
+ElseIf ($httpResult -and !$httpsResult)
+{
+    Write-Verbose "HTTPS sessions are disabled, HTTP session are enabled."
+}
+Else
+{
+    Throw "Unable to establish an HTTP or HTTPS remoting session."
+}
 
 Write-Verbose "PS Remoting has been successfully configured for Ansible."


### PR DESCRIPTION
The original placement of the connectivity test prevents the HTTPS configuration from being applied on machines that weren't previously configured for HTTPS, and where HTTP is disabled by default. Moving the test to the end ensures the highest probability of success.
