### PR TITLE
Make combine_vars() compatible with Python 3

### DIFF
--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -32,7 +32,9 @@ def combine_vars(a, b):
     if C.DEFAULT_HASH_BEHAVIOUR == "merge":
         return merge_hash(a, b)
     else:
-        return dict(a.items() + b.items())
+        result = a.copy()
+        result.update(b)
+        return result
 
 def merge_hash(a, b):
     ''' recursively merges hash b into a

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -121,7 +121,9 @@ class VariableManager:
         if C.DEFAULT_HASH_BEHAVIOUR == "merge":
             return self._merge_dicts(a, b)
         else:
-            return dict(a.items() + b.items())
+            result = a.copy()
+            result.update(b)
+            return result
 
     def _merge_dicts(self, a, b):
         '''


### PR DESCRIPTION
Fixes

  TypeError: unsupported operand type(s) for +: 'dict_items' and 'dict_items'

on Python 3.

(I'm making very small pull requests to make review easier.  Please tell
me if you find that inconvenient.)
