### PR TITLE
add missing ansible galaxy data files to package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,13 @@ setup(name='ansible',
       package_dir={ '': 'lib' },
       packages=find_packages('lib'),
       package_data={
-         '': ['module_utils/*.ps1', 'modules/core/windows/*.ps1', 'modules/extras/windows/*.ps1'],
+          '': [
+              'galaxy/data/metadata_template.j2',
+              'galaxy/data/readme',
+              'module_utils/*.ps1',
+              'modules/core/windows/*.ps1',
+              'modules/extras/windows/*.ps1',
+          ],
       },
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Trying to run `ansible-galaxy` install command fails with error:

```
ERROR! Could not open readme: [Errno 2] No such file or directory: '/Users/benjixx/src/sandbox/.tox/py27-ansible20/lib/python2.7/site-packages/ansible/galaxy/data/readme'
```

This is caused by ansible data files not being explicitly listed in `setup.py`.
