### PR TITLE
Adds utf-8 encoding to f5 module_utils

### DIFF
--- a/lib/ansible/module_utils/f5.py
+++ b/lib/ansible/module_utils/f5.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 # This code is part of Ansible, but is an independent component.
 # This particular file snippet, and this file snippet only, is BSD licensed.
 # Modules you write using this snippet, which is embedded dynamically by Ansible


### PR DESCRIPTION
The contributor's name on line 10 (originally line 7) includes a character
that the default Python encoding (ASCII) raises an error on when interpreting
the file.

Specifying the utf-8 encoding, as is done in other modules, resolves
the error.

The error being raised is

SyntaxError: Non-ASCII character '\xc3' in file /.../lib/ansible/module_utils/f5.py
on line 7, but no encoding declared; see http://www.python.org/peps/pep-0263.html
for details
