### PR TITLE
Use rich comparisons for Attribute and FieldAttribute

### DIFF
--- a/lib/ansible/playbook/attribute.py
+++ b/lib/ansible/playbook/attribute.py
@@ -19,6 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+
 class Attribute:
 
     def __init__(self, isa=None, private=False, default=None, required=False, listof=None, priority=0, always_post_validate=False):
@@ -31,8 +32,26 @@ class Attribute:
         self.priority = priority
         self.always_post_validate = always_post_validate
 
-    def __cmp__(self, other):
-       return cmp(other.priority, self.priority)
+    def __eq__(self, other):
+        return other.priority == self.priority
+
+    def __ne__(self, other):
+        return other.priority != self.priority
+
+    # NB: higher priority numbers sort first
+
+    def __lt__(self, other):
+        return other.priority < self.priority
+
+    def __gt__(self, other):
+        return other.priority > self.priority
+
+    def __le__(self, other):
+        return other.priority <= self.priority
+
+    def __ge__(self, other):
+        return other.priority >= self.priority
+
 
 class FieldAttribute(Attribute):
     pass

--- a/lib/ansible/playbook/attribute.py
+++ b/lib/ansible/playbook/attribute.py
@@ -23,13 +23,13 @@ class Attribute:
 
     def __init__(self, isa=None, private=False, default=None, required=False, listof=None, priority=0, always_post_validate=False):
 
-       self.isa = isa
-       self.private = private
-       self.default = default
-       self.required = required
-       self.listof = listof
-       self.priority = priority
-       self.always_post_validate = always_post_validate
+        self.isa = isa
+        self.private = private
+        self.default = default
+        self.required = required
+        self.listof = listof
+        self.priority = priority
+        self.always_post_validate = always_post_validate
 
     def __cmp__(self, other):
        return cmp(other.priority, self.priority)

--- a/test/units/playbook/test_attribute.py
+++ b/test/units/playbook/test_attribute.py
@@ -1,0 +1,55 @@
+# (c) 2015, Marius Gedminas <marius@gedmin.as>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.compat.tests import unittest
+from ansible.playbook.attribute import Attribute
+
+
+class TestAttribute(unittest.TestCase):
+
+    def setUp(self):
+        self.one = Attribute(priority=100)
+        self.two = Attribute(priority=0)
+
+    def test_eq(self):
+        self.assertTrue(self.one == self.one)
+        self.assertFalse(self.one == self.two)
+
+    def test_ne(self):
+        self.assertFalse(self.one != self.one)
+        self.assertTrue(self.one != self.two)
+
+    def test_lt(self):
+        self.assertFalse(self.one < self.one)
+        self.assertTrue(self.one < self.two)
+        self.assertFalse(self.two < self.one)
+
+    def test_gt(self):
+        self.assertFalse(self.one > self.one)
+        self.assertFalse(self.one > self.two)
+        self.assertTrue(self.two > self.one)
+
+    def test_le(self):
+        self.assertTrue(self.one <= self.one)
+        self.assertTrue(self.one <= self.two)
+        self.assertFalse(self.two <= self.one)
+
+    def test_ge(self):
+        self.assertTrue(self.one >= self.one)
+        self.assertFalse(self.one >= self.two)
+        self.assertTrue(self.two >= self.one)
+


### PR DESCRIPTION
Because **cmp** is not supported on Python 3.

Fixes

  TypeError: unorderable types: FieldAttribute() < FieldAttribute()

on Python 3.
