### PR TITLE
Make sure combine_vars() returns a dict

### DIFF
--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -56,7 +56,7 @@ def combine_vars(a, b):
     else:
         # HASH_BEHAVIOUR == 'replace'
         _validate_mutable_mappings(a, b)
-        result = a.copy()
+        result = dict(a)
         result.update(b)
         return result
 
@@ -66,7 +66,7 @@ def merge_hash(a, b):
     """
 
     _validate_mutable_mappings(a, b)
-    result = a.copy()
+    result = dict(a)
 
     # next, iterate over b keys and values
     for k, v in iteritems(b):

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -43,7 +43,7 @@ class TestVariableUtils(unittest.TestCase):
             dict(
                 a=defaultdict(a=1, c=defaultdict(foo='bar')),
                 b=dict(b=2, c=dict(baz='bam')),
-                result=defaultdict(a=1, b=2, c=defaultdict(foo='bar', baz='bam'))
+                result=dict(a=1, b=2, c=dict(foo='bar', baz='bam'))
             ),
         )
     test_replace_data = (
@@ -60,7 +60,7 @@ class TestVariableUtils(unittest.TestCase):
             dict(
                 a=defaultdict(a=1, c=dict(foo='bar')),
                 b=dict(b=2, c=defaultdict(baz='bam')),
-                result=defaultdict(a=1, b=2, c=defaultdict(baz='bam'))
+                result=dict(a=1, b=2, c=dict(baz='bam'))
             ),
         )
 
@@ -96,3 +96,12 @@ class TestVariableUtils(unittest.TestCase):
         with mock.patch('ansible.constants.DEFAULT_HASH_BEHAVIOUR', 'merge'):
             for test in self.test_merge_data:
                 self.assertEqual(combine_vars(test['a'], test['b']), test['result'])
+
+    def test_combine_vars_dict_type(self):
+        # Regression test for https://github.com/ansible/ansible/issues/12206
+        with mock.patch('ansible.constants.DEFAULT_HASH_BEHAVIOUR', 'replace'):
+            for test in self.test_replace_data:
+                self.assertEqual(type(combine_vars(test['a'], test['b'])), dict)
+        with mock.patch('ansible.constants.DEFAULT_HASH_BEHAVIOUR', 'merge'):
+            for test in self.test_merge_data:
+                self.assertEqual(type(combine_vars(test['a'], test['b'])), dict)


### PR DESCRIPTION
Prior to commit 54dbfba8f8c83f226eff3ab53a1ec3e099fe1e56 the return value of
combine_vars (and VariableManager._combine_vars) was always the builtin dict
type.  The named commit changed that, by accident, and this introduced a bug
(#12206).  This change reverts to prior behavior where combine_vars() always
returns a builtin dict and fixes #12206.

Note: VariableManager._combine_vars() has been refactored since 54dbfba and
now calls combine_vars().  Yay reduced code duplication!
