### PR TITLE
fix no_log leakages to local output, add tests

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -346,8 +346,11 @@ class ActionBase:
         # set no log in the module arguments, if required
         if self._play_context.no_log:
             module_args['_ansible_no_log'] = True
+            module_display_args = "(no_log enabled, args censored)"
+        else:
+            module_display_args = module_args
 
-        self._display.vvv("Module: %s, args: %s" % (module_name, module_args))
+        self._display.vvv("Module: %s, args: %s" % (module_name, module_display_args))
 
         (module_style, shebang, module_data) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)
         if not shebang:

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -53,6 +53,9 @@ check_mode:
 test_group_by:
 	ansible-playbook test_group_by.yml -i inventory.group_by -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
+no_log:
+	[ "$$(ansible-playbook no_log_local.yml -i $(INVENTORY) -vvvvv | grep DO_NOT_LOG)" = "" ]
+
 test_handlers:
 	ansible-playbook test_handlers.yml --tags scenario1 -i inventory.handlers -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 	[ "$$(ansible-playbook test_handlers.yml --tags scenario2 -l A -i inventory.handlers -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | grep -Po 'RUNNING HANDLER \[test_handlers : \K[^\]]+')" = "test handler" ]

--- a/test/integration/no_log_local.yml
+++ b/test/integration/no_log_local.yml
@@ -1,0 +1,68 @@
+# TODO: add include tests with args
+# TODO: test against real connection plugins to ensure they're not leaking module args
+
+- name: normal play
+  hosts: testhost
+  gather_facts: no
+  tasks:
+  - name: args should be logged in the absence of no_log
+    shell: echo "LOG_ME_TASK_SUCCEEDED"
+  - name: item args/results should be logged in the absence of no_log
+    shell: echo {{ item }}
+    with_items: [ "LOG_ME_ITEM_SUCCEEDED" ]
+  - name: failed args should be logged in the absence of no_log
+    shell: echo "LOG_ME_TASK_FAILED"
+    failed_when: true
+    ignore_errors: true
+  - name: failed item args should be logged in the absence of no_log
+    shell: echo {{ item }}
+    with_items: [ "LOG_ME_ITEM_FAILED" ]
+    failed_when: true
+    ignore_errors: true
+  - name: args should not be logged when task-level no_log set 
+    shell: echo "DO_NOT_LOG_TASK_SUCCEEDED"
+    no_log: true
+  - name: item args should be suppressed with no_log
+    shell: echo {{ item }}
+    no_log: true
+    with_items: [ "DO_NOT_LOG_ITEM_SUCCEEDED" ]
+  - name: failed args should not be logged when task-level no_log set
+    shell: echo "DO_NOT_LOG_TASK_FAILED"
+    no_log: true
+    failed_when: true
+    ignore_errors: true
+  - name: failed item args should be suppressed with no_log
+    shell: echo {{ item }}
+    no_log: true
+    with_items: [ "DO_NOT_LOG_ITEM_FAILED" ]
+    failed_when: true
+    ignore_errors: true
+  - name: skipped task args should be suppressed with no_log
+    shell: echo "DO_NOT_LOG_TASK_SKIPPED"
+    no_log: true
+    when: false
+  - name: skipped item args should be suppressed with no_log
+    shell: echo {{ item }}
+    no_log: true
+    with_items: [ "normal", "DO_NOT_LOG_ITEM_SKIPPED" ]
+    when: item != "DO_NOT_LOG_ITEM_SKIPPED"
+  - name: async task args should suppressed with no_log
+    async: 10
+    poll: 1
+    shell: echo "DO_NOT_LOG_ASYNC_TASK_SUCCEEDED"
+    no_log: true
+ 
+- name: play-level no_log set
+  hosts: testhost
+  gather_facts: no
+  no_log: true
+  tasks:
+  - name: args should not be logged when play-level no_log set
+    shell: echo "DO_NOT_LOG_PLAY"
+  - name: args should not be logged when both play- and task-level no_log set
+    shell: echo "DO_NOT_LOG_TASK_AND_PLAY"
+    no_log: true
+  - name: args should be logged when task-level no_log overrides play-level
+    shell: echo "LOG_ME_OVERRIDE"
+    no_log: false
+

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -323,5 +323,5 @@ class TestTaskExecutor(unittest.TestCase):
         with patch.object(action_loader, 'get', _get):
             mock_templar = MagicMock()
             res = te._poll_async_result(result=dict(ansible_job_id=1), templar=mock_templar)
-            self.assertEqual(res, dict(finished=1))
+            self.assertTrue(('finished', 1) in res.items())
 


### PR DESCRIPTION
Re-fixes #11946 for 2.0 after #12188 re-introduced the issue. Also fixes a number of other leakages introduced with 2.0, and adds integration tests to check most cases fixed herein.
