### PR TITLE
Delete all compiled python files when running hacking/env-setup

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -57,8 +57,10 @@ fi
 	cd "$ANSIBLE_HOME"
 	if [ "$verbosity" = silent ] ; then
 	    gen_egg_info > /dev/null 2>&1
+            rm **/*.pyc > /dev/null 2>&1
 	else
 	    gen_egg_info
+            rm **/*.pyc
 	fi
 	cd "$current_dir"
 )

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -57,10 +57,10 @@ fi
 	cd "$ANSIBLE_HOME"
 	if [ "$verbosity" = silent ] ; then
 	    gen_egg_info > /dev/null 2>&1
-            rm **/*.pyc > /dev/null 2>&1
+            find . -type f -name "*.pyc" -delete > /dev/null 2>&1
 	else
 	    gen_egg_info
-            rm **/*.pyc
+            find . -type f -name "*.pyc" -delete
 	fi
 	cd "$current_dir"
 )

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -43,6 +43,7 @@ if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
     rm -r $PREFIX_PYTHONPATH/ansible*.egg-info
 end
 mv ansible*egg-info $PREFIX_PYTHONPATH
+rm **/*.pyc
 popd
 
 

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -43,7 +43,7 @@ if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
     rm -r $PREFIX_PYTHONPATH/ansible*.egg-info
 end
 mv ansible*egg-info $PREFIX_PYTHONPATH
-rm **/*.pyc
+find . -type f -name "*.pyc" -delete
 popd
 
 


### PR DESCRIPTION
Switching between branches, I got errors about modules missing error classes - I think this is because the errors module in lib/ansible was moved to its own directory. This clears our any compiled artifacts that shouldn't be there.
