### PR TITLE
Make the debug module accept and dump arbitrary arguments

### DIFF
--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -38,6 +38,7 @@ RAW_PARAM_MODULES = ([
     'set_fact',
     'raw',
     'meta',
+    'debug',
 ])
 
 class ModuleArgsParser:

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -27,20 +27,23 @@ class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=dict()):
 
+        result = {}
+
         if 'msg' in self._task.args:
-            if 'fail' in self._task.args and boolean(self._task.args['fail']):
-                result = dict(failed=True, msg=self._task.args['msg'])
-            else:
-                result = dict(msg=self._task.args['msg'])
+            result['msg'] = self._task.args['msg']
         # FIXME: move the LOOKUP_REGEX somewhere else
         elif 'var' in self._task.args: # and not utils.LOOKUP_REGEX.search(self._task.args['var']):
             results = self._templar.template(self._task.args['var'], convert_bare=True)
             if results == self._task.args['var']:
                 results = "VARIABLE IS NOT DEFINED!"
-            result = dict()
             result[self._task.args['var']] = results
+        elif len(self._task.args) > 0:
+            result['msg'] = str(self._task.args)
         else:
-            result = dict(msg='here we are')
+            result['msg'] = 'here we are'
+
+        if 'fail' in self._task.args and boolean(self._task.args['fail']):
+            result['failed'] = True
 
         # force flag to make debug output module always verbose
         result['_ansible_verbose_always'] = True


### PR DESCRIPTION
This makes it possible to debug a complex module invocation by adding
"debug":

```
- debug: somemod
    arg1: {{...expression...}}
    arg2: ...original arguments...
```

You have to remove the : after somemod (or quote the whole thing),
otherwise it won't parse as valid YAML.

You can also add "fail: yes" to make the task fail.
