### PR TITLE
Simplify FactCache.copy()

### DIFF
--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -60,7 +60,7 @@ class FactCache(MutableMapping):
 
     def copy(self):
         """ Return a primitive copy of the keys and values from the cache. """
-        return dict([(k, v) for (k, v) in iteritems(self)])
+        return dict(self)
 
     def keys(self):
         return self._plugin.keys()

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -19,7 +19,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.compat.tests import unittest
+from ansible.compat.tests import unittest, mock
+from ansible.plugins.cache import FactCache
 from ansible.plugins.cache.base import BaseCacheModule
 from ansible.plugins.cache.memory import CacheModule as MemoryCache
 
@@ -40,6 +41,20 @@ except ImportError:
     HAVE_REDIS = False
 else:
     from ansible.plugins.cache.redis import CacheModule as RedisCache
+
+
+class TestFactCache(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch('ansible.constants.CACHE_PLUGIN', 'memory'):
+            self.cache = FactCache()
+
+    def test_copy(self):
+        self.cache['avocado'] = 'fruit'
+        self.cache['daisy'] = 'flower'
+        a_copy = self.cache.copy()
+        self.assertEqual(type(a_copy), dict)
+        self.assertEqual(a_copy, dict(avocado='fruit', daisy='flower'))
 
 
 class TestAbstractClass(unittest.TestCase):


### PR DESCRIPTION
Also fix the bug (missing from six import iteritems) I introduced in 
823677b490d3ddc3bcfe8fa2f215d9d9c2167b14 (sorry!).
