### PR TITLE
Python 3: avoid iteritems() in a template

### DIFF
--- a/lib/ansible/galaxy/data/metadata_template.j2
+++ b/lib/ansible/galaxy/data/metadata_template.j2
@@ -20,7 +20,7 @@ galaxy_info:
   # platform on this list, let us know and we'll get it added!
   #
   #platforms:
-  {%- for platform,versions in platforms.iteritems() %}
+  {%- for platform,versions in platforms.items() %}
   #- name: {{ platform }}
   #  versions:
   #  - all


### PR DESCRIPTION
I don't think six.iteritems is available here, but I also don't expect there
to be enough platforms to ever make the speed difference between
.items() and .iteritems() noticeable.
