### PR TITLE
Don't try to run "ssh -O stop" in Connection.close()

### DIFF
--- a/lib/ansible/plugins/connections/ssh.py
+++ b/lib/ansible/plugins/connections/ssh.py
@@ -517,15 +517,4 @@ class Connection(ConnectionBase):
     def close(self):
         ''' not applicable since we're executing openssh binaries '''
 
-        if self._connected:
-
-            if 'ControlMaster' in self._common_args:
-                cmd = ['ssh','-O','stop']
-                cmd.extend(self._common_args)
-                cmd.append(self._play_context.remote_addr)
-
-                p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                stdout, stderr = p.communicate()
-
-            self._connected = False
-
+        self._connected = False


### PR DESCRIPTION
The TaskExecutor calls connection.close() after it finishes executing
each task. Running "ssh -O stop" here would defeat ControlPersist and
force each task to create a new connection.

That this didn't actually happen was merely a happy accident: what was
in self._common_args was actually 'ControlMaster=yes', while the test
only looked for 'ControlMaster'.
