### PR TITLE
Python 3: use six.text_type instead of unicode

### DIFF
--- a/contrib/inventory/apache-libcloud.py
+++ b/contrib/inventory/apache-libcloud.py
@@ -260,11 +260,11 @@ class LibcloudInventory(object):
             key = self.to_safe('ec2_' + key)
 
             # Handle complex types
-            if type(value) in [int, bool]:
+            if isinstance(value, (int, bool)):
                 instance_vars[key] = value
-            elif type(value) in string_types:
+            elif isinstance(value, string_types):
                 instance_vars[key] = value.strip()
-            elif type(value) == type(None):
+            elif value is None:
                 instance_vars[key] = ''
             elif key == 'ec2_region':
                 instance_vars[key] = value.name

--- a/contrib/inventory/apache-libcloud.py
+++ b/contrib/inventory/apache-libcloud.py
@@ -37,7 +37,7 @@ import re
 from time import time
 import ConfigParser
 
-from six import iteritems
+from six import iteritems, string_types
 from libcloud.compute.types import Provider
 from libcloud.compute.providers import get_driver
 import libcloud.security as sec
@@ -262,7 +262,7 @@ class LibcloudInventory(object):
             # Handle complex types
             if type(value) in [int, bool]:
                 instance_vars[key] = value
-            elif type(value) in [str, unicode]:
+            elif type(value) in string_types:
                 instance_vars[key] = value.strip()
             elif type(value) == type(None):
                 instance_vars[key] = ''

--- a/contrib/inventory/vmware.py
+++ b/contrib/inventory/vmware.py
@@ -39,6 +39,8 @@ import sys
 import time
 import ConfigParser
 
+from six import text_type
+
 # Disable logging message trigged by pSphere/suds.
 try:
     from logging import NullHandler
@@ -149,7 +151,7 @@ class VMwareInventory(object):
         seen = seen or set()
         if isinstance(obj, ManagedObject):
             try:
-                obj_unicode = unicode(getattr(obj, 'name'))
+                obj_unicode = text_type(getattr(obj, 'name'))
             except AttributeError:
                 obj_unicode = ()
             if obj in seen:

--- a/lib/ansible/executor/process/result.py
+++ b/lib/ansible/executor/process/result.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from six.moves import queue
-from six import iteritems
+from six import iteritems, text_type
 
 import multiprocessing
 import os
@@ -62,7 +62,7 @@ class ResultProcess(multiprocessing.Process):
         super(ResultProcess, self).__init__()
 
     def _send_result(self, result):
-        debug(u"sending result: %s" % ([unicode(x) for x in result],))
+        debug(u"sending result: %s" % ([text_type(x) for x in result],))
         self._final_q.put(result, block=False)
         debug("done sending result")
 

--- a/lib/ansible/parsing/__init__.py
+++ b/lib/ansible/parsing/__init__.py
@@ -24,6 +24,7 @@ import json
 import os
 
 from yaml import load, YAMLError
+from six import text_type
 
 from ansible.errors import AnsibleParserError
 from ansible.errors.yaml_strings import YAML_SYNTAX_ERROR
@@ -80,7 +81,7 @@ class DataLoader():
                 # they are unable to cope with our subclass.
                 # Unwrap and re-wrap the unicode so we can keep track of line
                 # numbers
-                new_data = unicode(data)
+                new_data = text_type(data)
             else:
                 new_data = data
             try:

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -27,7 +27,7 @@ from functools import partial
 from inspect import getmembers
 from io import FileIO
 
-from six import iteritems, string_types
+from six import iteritems, string_types, text_type
 
 from jinja2.exceptions import UndefinedError
 
@@ -291,7 +291,7 @@ class Base:
                 # and make sure the attribute is of the type it should be
                 if value is not None:
                     if attribute.isa == 'string':
-                        value = unicode(value)
+                        value = text_type(value)
                     elif attribute.isa == 'int':
                         value = int(value)
                     elif attribute.isa == 'float':

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from jinja2.exceptions import UndefinedError
+from six import text_type
 
 from ansible.errors import *
 from ansible.playbook.attribute import FieldAttribute
@@ -82,7 +83,7 @@ class Conditional:
         if conditional is None or conditional == '':
             return True
 
-        if conditional in all_vars and '-' not in unicode(all_vars[conditional]):
+        if conditional in all_vars and '-' not in text_type(all_vars[conditional]):
             conditional = all_vars[conditional]
 
         # make sure the templar is using the variables specifed to this method

--- a/lib/ansible/plugins/shell/sh.py
+++ b/lib/ansible/plugins/shell/sh.py
@@ -24,6 +24,8 @@ import ansible.constants as C
 import time
 import random
 
+from six import text_type
+
 _USER_HOME_PATH_RE = re.compile(r'^~[_.A-Za-z0-9][-_.A-Za-z0-9]*$')
 
 class ShellModule(object):
@@ -40,7 +42,7 @@ class ShellModule(object):
             LC_MESSAGES = C.DEFAULT_MODULE_LANG,
         )
         env.update(kwargs)
-        return ' '.join(['%s=%s' % (k, pipes.quote(unicode(v))) for k,v in env.items()])
+        return ' '.join(['%s=%s' % (k, pipes.quote(text_type(v))) for k,v in env.items()])
 
     def join_path(self, *args):
         return os.path.join(*args)

--- a/lib/ansible/plugins/strategies/__init__.py
+++ b/lib/ansible/plugins/strategies/__init__.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from six.moves import queue as Queue
-from six import iteritems
+from six import iteritems, text_type
 
 import time
 
@@ -168,7 +168,7 @@ class StrategyBase:
         while not self._final_q.empty() and not self._tqm._terminated:
             try:
                 result = self._final_q.get(block=False)
-                self._display.debug("got result from result worker: %s" % ([unicode(x) for x in result],))
+                self._display.debug("got result from result worker: %s" % ([text_type(x) for x in result],))
 
                 # all host status messages contain 2 entries: (msg, task_result)
                 if result[0] in ('host_task_ok', 'host_task_failed', 'host_task_skipped', 'host_unreachable'):

--- a/lib/ansible/plugins/strategies/linear.py
+++ b/lib/ansible/plugins/strategies/linear.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from six import iteritems
+from six import iteritems, text_type
 
 from ansible.errors import AnsibleError
 from ansible.executor.play_iterator import PlayIterator
@@ -221,7 +221,7 @@ class StrategyModule(StrategyBase):
                             saved_name = task.name
                             display.debug("done copying, going to template now")
                             try:
-                                task.name = unicode(templar.template(task.name, fail_on_undefined=False))
+                                task.name = text_type(templar.template(task.name, fail_on_undefined=False))
                                 display.debug("done templating")
                             except:
                                 # just ignore any errors during task name templating,


### PR DESCRIPTION
Replace 'unicode' with six.text_type, everywhere but in module_utils.
