### PR TITLE
Fix #12258: don't wrap None in UnsafeProxy.

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -183,7 +183,8 @@ class VariableManager:
             try:
                 host_facts = self._fact_cache.get(host.name, dict())
                 for k in host_facts.keys():
-                    host_facts[k] = UnsafeProxy(host_facts[k])
+                    if host_facts[k] is not None:
+                        host_facts[k] = UnsafeProxy(host_facts[k])
                 all_vars = combine_vars(all_vars, host_facts)
             except KeyError:
                 pass

--- a/lib/ansible/vars/unsafe_proxy.py
+++ b/lib/ansible/vars/unsafe_proxy.py
@@ -72,6 +72,8 @@ class UnsafeProxy(object):
         return bool(object.__getattribute__(self, "_obj"))
     def __str__(self):
         return str(object.__getattribute__(self, "_obj"))
+    def __unicode__(self):
+        return unicode(object.__getattribute__(self, "_obj"))
     def __repr__(self):
         return repr(object.__getattribute__(self, "_obj"))
     
@@ -89,7 +91,7 @@ class UnsafeProxy(object):
         '__long__', '__lshift__', '__lt__', '__mod__', '__mul__', '__ne__', 
         '__neg__', '__oct__', '__or__', '__pos__', '__pow__', '__radd__', 
         '__rand__', '__rdiv__', '__rdivmod__', '__reduce__', '__reduce_ex__', 
-        '__repr__', '__reversed__', '__rfloorfiv__', '__rlshift__', '__rmod__', 
+        '__repr__', '__reversed__', '__rfloordiv__', '__rlshift__', '__rmod__',
         '__rmul__', '__ror__', '__rpow__', '__rrshift__', '__rshift__', '__rsub__', 
         '__rtruediv__', '__rxor__', '__setitem__', '__setslice__', '__sub__', 
         '__truediv__', '__xor__', 'next',
@@ -106,7 +108,7 @@ class UnsafeProxy(object):
         
         namespace = {}
         for name in cls._special_names:
-            if hasattr(theclass, name):
+            if hasattr(theclass, name) and not hasattr(cls, name):
                 namespace[name] = make_method(name)
         return type("%s(%s)" % (cls.__name__, theclass.__name__), (cls,), namespace)
     
@@ -127,6 +129,5 @@ class UnsafeProxy(object):
         except KeyError:
             cache[obj.__class__] = theclass = cls._create_class_proxy(obj.__class__)
         ins = object.__new__(theclass)
-        theclass.__init__(ins, obj, *args, **kwargs)
         return ins
 


### PR DESCRIPTION
The change in `__init__.py` fixes the crash referenced in the bug.

The changes in `unsafe_proxy.py` are lifted from the comments in the article referenced by the file. They all seem very reasonable, based on my limited understanding of Python's type system. I can remove them from this PR if that is desirable.
