### PR TITLE
Fix rsync connections to IPv6 addresses

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -48,9 +48,9 @@ class ActionModule(ActionBase):
 
         if host not in C.LOCALHOST:
             if user:
-                return '%s@%s:%s' % (user, host, path)
+                return '%s@[%s]:%s' % (user, host, path)
             else:
-                return '%s:%s' % (host, path)
+                return '[%s]:%s' % (host, path)
 
         if ':' not in path and not path.startswith('/'):
             path = self._get_absolute_path(path=path)
@@ -60,9 +60,9 @@ class ActionModule(ActionBase):
         transport = self._play_context.connection
         if host not in C.LOCALHOST or transport != "local":
             if user:
-                return '%s@%s:%s' % (user, host, path)
+                return '%s@[%s]:%s' % (user, host, path)
             else:
-                return '%s:%s' % (host, path)
+                return '[%s]:%s' % (host, path)
 
         if ':' not in path and not path.startswith('/'):
             path = self._get_absolute_path(path=path)


### PR DESCRIPTION
Similar to https://github.com/ansible/ansible/pull/11816 we can unconditionally
wrap the host address in square brackets. This is required by rsync for IPv6
addresses.

If this patch is acceptable, I would greatly appreciate it being back ported to the stable-1.9 branch
