### PR TITLE
Python 3: fix TypeError: unorderable types in test

### DIFF
--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -220,6 +220,10 @@ class TestTaskExecutor(unittest.TestCase):
         mock_task.changed_when = None
         mock_task.failed_when = None
         mock_task.post_validate.return_value = None
+        # mock_task.async cannot be left unset, because on Python 3 MagicMock()
+        # > 0 raises a TypeError   There are two reasons for using the value 1
+        # here: on Python 2 comparing MagicMock() > 0 returns True, and the
+        # other reason is that if I specify 0 here, the test fails. ;)
         mock_task.async = 1
 
         mock_play_context = MagicMock()

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -220,6 +220,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_task.changed_when = None
         mock_task.failed_when = None
         mock_task.post_validate.return_value = None
+        mock_task.async = 1
 
         mock_play_context = MagicMock()
         mock_play_context.post_validate.return_value = None


### PR DESCRIPTION
The full error was

```
======================================================================
ERROR: test_task_executor_execute (units.executor.test_task_executor.TestTaskExecutor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mg/src/ansible/test/units/executor/test_task_executor.py", line 252, in test_task_executor_execute
    mock_action.run.return_value = dict(ansible_facts=dict())
  File "/home/mg/src/ansible/lib/ansible/executor/task_executor.py", line 317, in _execute
    if self._task.async > 0:
TypeError: unorderable types: MagicMock() > int()

----------------------------------------------------------------------
```

Experiments show that Python 2 MagicMock() > 0 is true, so I'm setting the
async property on mock_task to 1.  (If I set it to 0, the test fails anyway.)
