### PR TITLE
s/rpmbuild/rpm-build

### DIFF
--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -192,7 +192,7 @@ You can also build an RPM yourself.  From the root of a checkout or tarball, use
     $ git clone git://github.com/ansible/ansible.git --recursive
     $ cd ./ansible
     $ make rpm
-    $ sudo rpm -Uvh ./rpmbuild/ansible-*.noarch.rpm
+    $ sudo rpm -Uvh ./rpm-build/ansible-*.noarch.rpm
 
 .. _from_apt:
 


### PR DESCRIPTION
When I followed these instructions, the generated path was 'rpm-build', not 'rpmbuild'. My rpm-build version is rpm-build-4.11.1-25.el7.x86_64 if that's relevant. Maybe this is 'just me', but wanted to feed back in case it's the same for everyone.
