### PR TITLE
ansible_firewalld fact

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -43,6 +43,12 @@ except ImportError:
     HAVE_SELINUX=False
 
 try:
+    import firewall.config
+    HAS_FIREWALLD = True
+except ImportError:
+    HAS_FIREWALLD = False
+
+try:
     import json
     # Detect python-json which is incompatible and fallback to simplejson in
     # that case
@@ -145,6 +151,7 @@ class Facts(object):
             self.get_cmdline()
             self.get_public_ssh_host_keys()
             self.get_selinux_facts()
+            self.get_firewalld_facts()
             self.get_fips_facts()
             self.get_pkg_mgr_facts()
             self.get_lsb_facts()
@@ -321,7 +328,7 @@ class Facts(object):
                                 self.facts['distribution'] = name
                             else:
                                 self.facts['distribution'] = data.split()[0]
-                            break  
+                            break
                         elif name == 'Slackware':
                             data = get_file_content(path)
                             if 'Slackware' in data:
@@ -329,7 +336,7 @@ class Facts(object):
                                 version = re.findall('\w+[.]\w+', data)
                                 if version:
                                     self.facts['distribution_version'] = version[0]
-                            break      
+                            break
                         elif name == 'OracleLinux':
                             data = get_file_content(path)
                             if 'Oracle Linux' in data:
@@ -606,6 +613,13 @@ class Facts(object):
                     self.facts['selinux']['type'] = 'unknown'
             except OSError, e:
                 self.facts['selinux']['type'] = 'unknown'
+
+
+    def get_firewalld_facts(self):
+        self.facts['firewalld'] = False
+        if HAS_FIREWALLD:
+            self.facts['firewalld'] = {}
+            self.facts['firewalld']['version'] = firewall.config.VERSION
 
 
     def get_fips_facts(self):
@@ -1975,7 +1989,7 @@ class LinuxNetwork(Network):
 
                         # If this is the default address, update default_ipv4
                         if 'address' in default_ipv4 and default_ipv4['address'] == address:
-                            default_ipv4['broadcast'] = broadcast 
+                            default_ipv4['broadcast'] = broadcast
                             default_ipv4['netmask'] = netmask
                             default_ipv4['network'] = network
                             default_ipv4['macaddress'] = macaddress


### PR DESCRIPTION
##### SUMMARY
This is a proof of concept implementation of a `firewalld` fact. The detection logic is lifted from the firewalld` module in extras.

My Web server deployment playbooks can run on bare-metal setups that include firewalld and on OpenStack VMs, which rely on Neutron for firewalling. The playbooks use Ansible's firewalld module, which (understandably) errors out if no firewalld support is present. In my case, I just want to skip firewalld tasks. 

With this fact, I can use a simple `when` clause, as shown below.

``` yaml
- firewalld: ...
  when: ansible_firewalld != false
```

At the moment, I'm doing exactly the same thing for SElinux, taking advantage of the existing `ansible_selinux` fact. This works quite well for me.

I think this fact should be provided by ansible, because it integrates well with the existing firewalld module.  Without this fact, I need to write my own detection logic. It's not difficult, but it makes the plays a bit less elegant.

I manually tested the code in this PR against a Fedora server installation that has firewalld, and a Fedora cloud installation that does not. I'm willing to put in the time to write automated tests, if a bit of guidance is provided.

Thank you for ansible! :heart:


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


