### PR TITLE
Python 3: use the right PyYAML SafeRepresenter for unicode

### DIFF
--- a/lib/ansible/parsing/yaml/dumper.py
+++ b/lib/ansible/parsing/yaml/dumper.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import yaml
+from six import PY3
 
 from ansible.parsing.yaml.objects import AnsibleUnicode
 
@@ -30,8 +31,13 @@ class AnsibleDumper(yaml.SafeDumper):
     '''
     pass
 
+if PY3:
+    represent_unicode = yaml.representer.SafeRepresenter.represent_str
+else:
+    represent_unicode = yaml.representer.SafeRepresenter.represent_unicode
+
 AnsibleDumper.add_representer(
     AnsibleUnicode,
-    yaml.representer.SafeRepresenter.represent_unicode
+    represent_unicode,
 )
 


### PR DESCRIPTION
PyYAML has a SafeRepresenter in lib/... that defines

```
def represent_unicode(self, data):
   return self.represent_scalar(u'tag:yaml.org,2002:str', data)
```

and a different SafeRepresenter in lib3/... that defines

```
def represent_str(self, data):
   return self.represent_scalar('tag:yaml.org,2002:str', data)
```

so the right thing to do on Python 3 is to use represent_str.

(AnsibleUnicode is a subclass of six.text_type, i.e. 'str' on Python 3.)
