### PR TITLE
Python 3: make ansible.template.safe_eval() work

### DIFF
--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -67,8 +67,8 @@ def safe_eval(expr, locals={}, include_exceptions=False):
     )
 
     # AST node types were expanded after 2.6
-    if not sys.version.startswith('2.6'):
-        SAFE_NODES.union(
+    if sys.version_info[:2] >= (2, 7):
+        SAFE_NODES.update(
             set(
                 (ast.Set,)
             )

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -20,6 +20,7 @@ __metaclass__ = type
 import ast
 import sys
 
+from six import string_types
 from six.moves import builtins
 
 from ansible import constants as C
@@ -73,6 +74,14 @@ def safe_eval(expr, locals={}, include_exceptions=False):
             )
         )
 
+    # And in Python 3.4 too
+    if sys.version_info[:2] >= (3, 4):
+        SAFE_NODES.update(
+            set(
+                (ast.NameConstant,)
+            )
+        )
+
     filter_list = []
     for filter in filter_loader.all():
         filter_list.extend(filter.filters().keys())
@@ -96,7 +105,7 @@ def safe_eval(expr, locals={}, include_exceptions=False):
             for child_node in ast.iter_child_nodes(node):
                 self.generic_visit(child_node, inside_call)
 
-    if not isinstance(expr, basestring):
+    if not isinstance(expr, string_types):
         # already templated to a datastructure, perhaps?
         if include_exceptions:
             return (expr, None)

--- a/test/units/template/test_safe_eval.py
+++ b/test/units/template/test_safe_eval.py
@@ -19,6 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import sys
 from collections import defaultdict
 
 from ansible.compat.tests import unittest
@@ -45,3 +46,6 @@ class TestSafeEval(unittest.TestCase):
             self.assertEqual(safe_eval('[]', locals=locals_vars), [])
             self.assertEqual(safe_eval('{}', locals=locals_vars), {})
 
+    @unittest.skipUnless(sys.version_info[:2] >= (2, 7), "Python 2.6 has no set literals")
+    def test_set_literals(self):
+        self.assertEqual(safe_eval('{0}'), set([0]))


### PR DESCRIPTION
Two things changed in Python 3.4:
- 'basestring' is no longer defined, so use six.string_types
- True/False are now special AST node types (NamedConstant) rather than
  just names

(Good thing we had tests, or I wouldn't have noticed the 2nd thing!)

I found only one place where safe_eval() is called inside the ansible
codebase: in lib/template/**init**.py.  The call to safe_eval(result,
...) is protected by result.startswith('...'), which means result cannot
possibly be a byte string on Python 3 (or startswith() would raise, so
six.string_types (which excludes byte strings on Python 3) is fine here.

Also, while fixing this I noticed a bug in the existing code that tried
to support set literals, so I fixed it too.
