### PR TITLE
Correct default plugin search path

### DIFF
--- a/docsite/rst/developing_plugins.rst
+++ b/docsite/rst/developing_plugins.rst
@@ -104,7 +104,7 @@ Distributing Plugins
 --------------------
 
 Plugins are loaded from both Python's site_packages (those that ship with ansible) and a configured plugins directory, which defaults
-to /usr/share/ansible/plugins, in a subfolder for each plugin type::
+to /usr/share/ansible_plugins, in a subfolder for each plugin type::
 
     * action_plugins
     * lookup_plugins


### PR DESCRIPTION
I have ansible 1.9.3 installed, and the configuration file in `/etc/ansible/ansible.cfg`
defines default plugin search paths as
    /usr/share/ansible_plugins/...
rather than
    /usr/share/ansible/plugins/...
