### PR TITLE
Add Nagios livestatus inventory plugin.

### DIFF
--- a/contrib/inventory/nagios_livestatus.ini
+++ b/contrib/inventory/nagios_livestatus.ini
@@ -1,5 +1,9 @@
 # Ansible Nagios external inventory script settings
 #
+# To get all available possibilities, check following URL:
+# http://www.naemon.org/documentation/usersguide/livestatus.html
+# https://mathias-kettner.de/checkmk_livestatus.html
+#
 
 [local]
 # Livestatus URI
@@ -7,12 +11,31 @@
 # livestatus_uri=unix:/var/cache/naemon/live
 
 [remote]
+
+# default field name for host: name
+# Uncomment to override:
+# host_field=address
+#
+# default field group for host: groups
+# Uncomment to override:
+# group_field=state
 # default fields retrieved: address, alias, display_name, childs, parents
 # To override, uncomment the following line
 # fields_to_retrieve=address,alias,display_name
 #
-# default prefix: livestatus_
+# default variable prefix: livestatus_
 # To override, uncomment the following line
-# prefix=naemon_
+# var_prefix=naemon_
+#
+# default filter: None
+#
+# Uncomment to override
+#
+# All host with state = OK
+# host_filter=state = 0
+# Warning: for the moment, you can use only one filter at a time. You cannot combine various conditions.
+#
+# All host in groups Linux
+# host_filter=groups >= Linux
 #
 livestatus_uri=tcp:192.168.66.137:6557

--- a/contrib/inventory/nagios_livestatus.ini
+++ b/contrib/inventory/nagios_livestatus.ini
@@ -1,0 +1,18 @@
+# Ansible Nagios external inventory script settings
+#
+
+[local]
+# Livestatus URI
+# Example for default naemon livestatus unix socket :
+# livestatus_uri=unix:/var/cache/naemon/live
+
+[remote]
+# default fields retrieved: address, alias, display_name, childs, parents
+# To override, uncomment the following line
+# fields_to_retrieve=address,alias,display_name
+#
+# default prefix: livestatus_
+# To override, uncomment the following line
+# prefix=naemon_
+#
+livestatus_uri=tcp:192.168.66.137:6557

--- a/contrib/inventory/nagios_livestatus.py
+++ b/contrib/inventory/nagios_livestatus.py
@@ -158,18 +158,18 @@ class NagiosLivestatusInventory(object):
             self.json_indent = 2
 
         if len(self.backends) == 0:
-            print "Error: Livestatus configuration is missing. See nagios_livestatus.ini."
+            print("Error: Livestatus configuration is missing. See nagios_livestatus.ini.")
             exit(1)
 
         for backend in self.backends:
             self.query_backend(backend, self.options.host)
 
         if self.options.host:
-            print json.dumps(self.result['_meta']['hostvars'][self.options.host[0]], indent = self.json_indent)
+            print(json.dumps(self.result['_meta']['hostvars'][self.options.host[0]], indent = self.json_indent))
         elif self.options.list:
-            print json.dumps(self.result, indent = self.json_indent)
+            print(json.dumps(self.result, indent = self.json_indent))
         else:
-            print "usage: --list or --host HOSTNAME [--pretty]"
+            print("usage: --list or --host HOSTNAME [--pretty]")
             exit(1)
 
 NagiosLivestatusInventory()

--- a/contrib/inventory/nagios_livestatus.py
+++ b/contrib/inventory/nagios_livestatus.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+# (c) 2015, Yannig Perre <yannig.perre@gmail.com>
+#
+# This file is part of Ansible,
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+'''
+Nagios livestatus inventory script. Before using this script, please
+update nagios_livestatus.ini file.
+
+Livestatus is a nagios/naemon/shinken module which let you retrieve
+informations stored in the monitoring core.
+
+This plugin inventory need livestatus API for python. Please install it
+before using this script (apt/pip/yum/...).
+
+'''
+
+import os
+import re
+import argparse
+try:
+    import configparser
+except ImportError:
+    import ConfigParser
+    configparser = ConfigParser
+import json
+
+try:
+    from mk_livestatus import Socket
+except ImportError:
+    print("Error: mk_livestatus is needed. Try something like: pip install python-mk-livestatus")
+    exit(1)
+
+class NagiosLivestatusInventory(object):
+
+    def parse_ini_file(self):
+        config = configparser.SafeConfigParser()
+        config.read(os.path.dirname(os.path.realpath(__file__)) + '/nagios_livestatus.ini')
+        for section in config.sections():
+            if not config.has_option(section, 'livestatus_uri'): continue
+
+            # If fields_to_retrieve is not set, using default fields
+            fields_to_retrieve = self.default_fields_to_retrieve
+            if config.has_option(section, 'fields_to_retrieve'):
+                fields_to_retrieve = [field.strip() for field in config.get(section, 'fields_to_retrieve').split(',')]
+                fields_to_retrieve = tuple(fields_to_retrieve)
+
+            # If prefix is not set, using livestatus_
+            prefix = "livestatus_"
+            if config.has_option(section, 'prefix'):
+                prefix = config.get(section, 'prefix').strip()
+
+            # Retrieving livestatus string connection
+            livestatus_uri = config.get(section, 'livestatus_uri')
+            # Local unix socket
+            unix_match = re.match('unix:(.*)', livestatus_uri)
+            if unix_match is not None:
+                self.backends.append({
+                  'connection': unix_match.group(1),
+                  'fields':     fields_to_retrieve,
+                  'name':       section,
+                  'prefix':     prefix,
+                })
+                return
+            # Remote tcp connection
+            tcp_match = re.match('tcp:(.*):([^:]*)', livestatus_uri)
+            if tcp_match is not None:
+                self.backends.append({
+                  'connection': (tcp_match.group(1), int(tcp_match.group(2))),
+                  'fields':     fields_to_retrieve,
+                  'name':       section,
+                  'prefix':     prefix,
+                })
+                return
+            raise Exception('livestatus_uri field is invalid (%s). Expected: unix:/path/to/live or tcp:host:port' % livestatus_uri)
+
+    def parse_options(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--host',   nargs=1)
+        parser.add_argument('--list',   action='store_true')
+        parser.add_argument('--pretty', action='store_true')
+        self.options = parser.parse_args()
+
+    def add_host(self, hostname, group):
+        if group not in self.result:
+            self.result[group] = {}
+            self.result[group]['hosts'] = []
+        if hostname not in self.result[group]:
+            self.result[group]['hosts'].append(hostname)
+
+    def query_backend(self, backend, host = None):
+        '''Query a livestatus backend'''
+        hosts_request = Socket(backend['connection']).hosts.columns('name', 'groups')
+        if host is not None:
+            hosts_request = hosts_request.filter('name = ' + host[0])
+        hosts_request._columns += backend['fields']
+
+        hosts = hosts_request.call()
+        for host in hosts:
+            self.add_host(host['name'], 'all')
+            self.add_host(host['name'], backend['name'])
+            for group in host['groups']:
+                self.add_host(host['name'], group)
+            for field in backend['fields']:
+                var_name = backend['prefix'] + field
+                if host['name'] not in self.result['_meta']['hostvars']:
+                    self.result['_meta']['hostvars'][host['name']] = {}
+                self.result['_meta']['hostvars'][host['name']][var_name] = host[field]
+
+    def __init__(self):
+
+        self.defaultgroup = 'group_all'
+        self.default_fields_to_retrieve = ('address', 'alias', 'display_name', 'childs', 'parents')
+        self.backends = []
+        self.options = None
+
+        self.parse_ini_file()
+        self.parse_options()
+
+        self.result = {}
+        self.result['_meta'] = {}
+        self.result['_meta']['hostvars'] = {}
+        self.json_indent = None
+        if self.options.pretty:
+            self.json_indent = 2
+
+        if len(self.backends) == 0:
+            print "Error: Livestatus configuration is missing. See nagios_livestatus.ini."
+            exit(1)
+
+        for backend in self.backends:
+            self.query_backend(backend, self.options.host)
+
+        if self.options.host:
+            print json.dumps(self.result['_meta']['hostvars'][self.options.host[0]], indent = self.json_indent)
+        elif self.options.list:
+            print json.dumps(self.result, indent = self.json_indent)
+        else:
+            print "usage: --list or --host HOSTNAME [--pretty]"
+            exit(1)
+
+NagiosLivestatusInventory()


### PR DESCRIPTION
This plugin can retrieve information from livestatus module and use it as an inventory script.

Here is some examples:
- Calling inventory script: ./nagios_livestatus.py --list

```
{"all": {"hosts": ["hplj2605dn", "linksys-srw224p", "localhost", "test", "test2", "winserver"]}, "remote": {"hosts": ["hplj2605dn", "linksys-srw224p", "localhost", "test", "test2", "winserver"]}, "_meta": {"hostvars": {"test2": {"livestatus_parents": [], "livestatus_alias": "Serveur de test2", "livestatus_childs": [], "livestatus_display_name": "test2", "livestatus_address": "127.0.0.1"}, "winserver": {"livestatus_parents": [], "livestatus_alias": "My Windows Server", "livestatus_childs": [], "livestatus_display_name": "winserver", "livestatus_address": "192.168.1.2"}, "linksys-srw224p": {"livestatus_parents": [], "livestatus_alias": "Linksys SRW224P Switch", "livestatus_childs": [], "livestatus_display_name": "linksys-srw224p", "livestatus_address": "192.168.1.253"}, "hplj2605dn": {"livestatus_parents": [], "livestatus_alias": "HP LaserJet 2605dn", "livestatus_childs": [], "livestatus_display_name": "hplj2605dn", "livestatus_address": "192.168.1.30"}, "test": {"livestatus_parents": [], "livestatus_alias": "Serveur de test", "livestatus_childs": [], "livestatus_display_name": "test", "livestatus_address": "127.0.0.1"}, "localhost": {"livestatus_parents": [], "livestatus_alias": "localhost", "livestatus_childs": [], "livestatus_display_name": "localhost", "livestatus_address": "127.0.0.1"}}}, "windows-servers": {"hosts": ["winserver"]}, "switches": {"hosts": ["linksys-srw224p"]}, "linux-servers": {"hosts": ["localhost"]}, "Linux": {"hosts": ["test", "test2"]}, "network-printers": {"hosts": ["hplj2605dn"]}, "Linux-SNMP": {"hosts": ["test", "test2"]}}
```
- display livestatus address from nagios group **Linux**: **$ ansible -m debug -a var=livestatus_address -i ./nagios_livestatus.py Linux**

``` json
test2 | success >> {
    "var": {
        "livestatus_address": "127.0.0.1"
    }
}

test | success >> {
    "var": {
        "livestatus_address": "127.0.0.1"
    }
}
```
