### PR TITLE
Fix fetch to not fail for missing file when fail_if_missing=False

### DIFF
--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -62,6 +62,8 @@ class ActionModule(ActionBase):
         if remote_checksum in ('1', '2') or self._play_context.become:
             slurpres = self._execute_module(module_name='slurp', module_args=dict(src=source), task_vars=task_vars, tmp=tmp)
             if slurpres.get('failed'):
+                if remote_checksum == '1' and not fail_on_missing:
+                   return dict(msg="the remote file does not exist, not transferring, ignored", file=source, changed=False)
                 return slurpres
             else:
                 if slurpres['encoding'] == 'base64':

--- a/test/integration/roles/test_fetch/tasks/main.yml
+++ b/test/integration/roles/test_fetch/tasks/main.yml
@@ -38,5 +38,34 @@
     that:
       'diff.stdout == ""'
 
- 
+- name: attempt to fetch a non-existent file - do not fail on missing
+  fetch: src={{ output_dir }}/doesnotexist dest={{ output_dir }}/fetched
+  register: fetch_missing_nofail
 
+- name: check fetch missing no fail result
+  assert:
+    that:
+      - "fetch_missing_nofail.msg"
+      - "not fetch_missing_nofail|changed"
+
+- name: attempt to fetch a non-existent file - fail on missing
+  fetch: src={{ output_dir }}/doesnotexist dest={{ output_dir }}/fetched fail_on_missing=yes
+  register: fetch_missing
+  ignore_errors: true
+
+- name: check fetch missing with failure
+  assert:
+    that:
+      - "fetch_missing|failed"
+      - "fetch_missing.msg"
+      - "not fetch_missing|changed"
+
+- name: attempt to fetch a directory - should not fail but return a message
+  fetch: src={{ output_dir }} dest={{ output_dir }}/somedir
+  register: fetch_dir
+
+- name: check fetch directory result
+  assert:
+    that:
+      - "not fetch_dir|changed"
+      - "fetch_dir.msg"


### PR DESCRIPTION
Fixes `fetch` action plugin to not fail if file is missing and `fail_if_missing=False` (the default).  Add tests to `test_fetch` role to verify it works as expected.  Also fixes an integration test failure from th `test_win_fetch` role.
