### PR TITLE
allow ConfigureRemotingForAnsible.ps1 script from public zone

### DIFF
--- a/docsite/rst/intro_windows.rst
+++ b/docsite/rst/intro_windows.rst
@@ -8,7 +8,7 @@ Windows Support
 Windows: How Does It Work
 `````````````````````````
 
-As you may have already read, Ansible manages Linux/Unix machines using SSH by default.  
+As you may have already read, Ansible manages Linux/Unix machines using SSH by default.
 
 Starting in version 1.7, Ansible also contains support for managing Windows machines.  This uses
 native PowerShell remoting, rather than SSH.
@@ -40,22 +40,22 @@ Installing python-kerberos dependencies
 
    # Via Yum
    yum -y install python-devel krb5-devel krb5-libs krb5-workstation
-   
+
    # Via Apt (Ubuntu)
    sudo apt-get install python-dev libkrb5-dev
-   
+
    # Via Portage (Gentoo)
-   emerge -av app-crypt/mit-krb5 
+   emerge -av app-crypt/mit-krb5
    emerge -av dev-python/setuptools
 
    # Via pkg (FreeBSD)
    sudo pkg install security/krb5
-   
+
    # Via OpenCSW (Solaris)
    pkgadd -d http://get.opencsw.org/now
    /opt/csw/bin/pkgutil -U
-   /opt/csw/bin/pkgutil -y -i libkrb5_3 
-   
+   /opt/csw/bin/pkgutil -y -i libkrb5_3
+
    # Via Pacman (Arch Linux)
    pacman -S krb5
 
@@ -115,18 +115,23 @@ Windows System Prep
 
 In order for Ansible to manage your windows machines, you will have to enable PowerShell remoting configured.
 
-To automate setup of WinRM, you can run `this PowerShell script <https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1>`_ on the remote machine. 
+To automate setup of WinRM, you can run `this PowerShell script <https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1>`_ on the remote machine.
 
-Admins may wish to modify this setup slightly, for instance to increase the timeframe of
-the certificate.
+The example script accepts a few arguments which Admins may choose to use to modify the default setup slightly, which might be appropriate in some cases.
+
+Pass the -CertValidityDays option to customize the expiration date of the generated certificate.
+  powershell.exe -File ConfigureRemotingForAnsible.ps1 -CertValidityDays 100
+
+Pass the -SkipNetworkProfileCheck switch to configure winrm to listen on PUBLIC zone interfaces.  (Without this option, the script will fail if any network interface on device is in PUBLIC zone)
+  powershell.exe -File ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
 
 .. note::
-   On Windows 7 and Server 2008 R2 machines, due to a bug in Windows 
+   On Windows 7 and Server 2008 R2 machines, due to a bug in Windows
    Management Framework 3.0, it may be necessary to install this
    hotfix http://support.microsoft.com/kb/2842230 to avoid receiving
    out of memory and stack overflow exceptions.  Newly-installed Server 2008
    R2 systems which are not fully up to date with windows updates are known
-   to have this issue.   
+   to have this issue.
 
    Windows 8.1 and Server 2012 R2 are not affected by this issue as they
    come with Windows Management Framework 4.0.
@@ -145,8 +150,8 @@ Looking at an ansible checkout, copy the `examples/scripts/upgrade_to_ps3.ps1 <h
 What modules are available
 ``````````````````````````
 
-Most of the Ansible modules in core Ansible are written for a combination of Linux/Unix machines and arbitrary web services, though there are various 
-Windows modules as listed in the `"windows" subcategory of the Ansible module index <http://docs.ansible.com/list_of_windows_modules.html>`_.  
+Most of the Ansible modules in core Ansible are written for a combination of Linux/Unix machines and arbitrary web services, though there are various
+Windows modules as listed in the `"windows" subcategory of the Ansible module index <http://docs.ansible.com/list_of_windows_modules.html>`_.
 
 Browse this index to see what is available.
 
@@ -275,5 +280,3 @@ form of new modules, tweaks to existing modules, documentation, or something els
        Questions? Help? Ideas?  Stop by the list on Google Groups
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
-
-

--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -7,6 +7,10 @@
 #
 # Set $VerbosePreference = "Continue" before running the script in order to
 # see the output messages.
+# Set $SkipNetworkProfileCheck to skip the network profile check.  Without
+# specifying this the script will only run if the device's interfaces are in
+# DOMAIN or PRIVATE zones.  Provide this switch if you want to enable winrm on
+# a device with an interface in PUBLIC zone.
 #
 # Written by Trond Hindenes <trond@hindenes.com>
 # Updated by Chris Church <cchurch@ansible.com>


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible/issues/12362

The current script fails on machines which have network interfaces designated as connected to "Public" networks (choices for network designation being Private, Domain, Public).  This commit adds the optional switch "SkipNetworkProfileCheck" to ConfigureRemotingForAnsible.ps1 -- when passed the switch causes the script to skip the check which enforces that only devices on Private/Domain zones can have winrm initialized.
