### PR TITLE
Enable winrm put_file to upload an empty file.

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -206,7 +206,7 @@ class Connection(ConnectionBase):
             # windows command length), divide by 2.67 (UTF16LE base64 command
             # encoding), then by 1.35 again (data base64 encoding).
             buffer_size = int(((8190 - len(cmd)) / 2.67) / 1.35)
-            for offset in xrange(0, in_size, buffer_size):
+            for offset in xrange(0, in_size or 1, buffer_size):
                 try:
                     out_data = in_file.read(buffer_size)
                     if offset == 0:

--- a/test/integration/roles/test_win_copy/tasks/main.yml
+++ b/test/integration/roles/test_win_copy/tasks/main.yml
@@ -19,6 +19,41 @@
 - name: record the output directory
   set_fact: output_file={{win_output_dir}}/foo.txt
 
+- name: copy an empty file
+  win_copy:
+    src: empty.txt
+    dest: "{{win_output_dir}}/empty.txt"
+  register: copy_empty_result
+
+- name: check copy empty result
+  assert:
+    that:
+      - copy_empty_result|changed
+      - copy_empty_result.checksum == 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+
+- name: stat the empty file
+  win_stat:
+    path: "{{win_output_dir}}/empty.txt"
+  register: stat_empty_result
+
+- name: check that empty file really was created
+  assert:
+    that:
+      - stat_empty_result.stat.exists
+      - stat_empty_result.stat.size == 0
+
+- name: copy an empty file again
+  win_copy:
+    src: empty.txt
+    dest: "{{win_output_dir}}/empty.txt"
+  register: copy_empty_again_result
+
+- name: check copy empty again result
+  assert:
+    that:
+      - not copy_empty_again_result|changed
+      - copy_empty_again_result.checksum == 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+
 - name: initiate a basic copy
 #- name: initiate a basic copy, and also test the mode
 #  win_copy: src=foo.txt dest={{output_file}} mode=0444


### PR DESCRIPTION
Found when looking at `win_lineinfile` tests.  `win_copy` and related modules that depend on the `put_file` method in the `winrm` connection plugin would not create a remote file if the source file was empty.
