### PR TITLE
Small change so the YAML renders as code.

### DIFF
--- a/docsite/rst/playbooks_error_handling.rst
+++ b/docsite/rst/playbooks_error_handling.rst
@@ -108,7 +108,7 @@ Aborting the play
 
 Sometimes it's desirable to abort the entire play on failure, not just skip remaining tasks for a host.
 
-The ``any_errors_fatal`` play option will mark all hosts as failed if any fails, causing an immediate abort.
+The ``any_errors_fatal`` play option will mark all hosts as failed if any fails, causing an immediate abort::
 
      - hosts: somehosts
        any_errors_fatal: true


### PR DESCRIPTION
The line above the last YAML code block in this document did not have the requisite :: characters, so the YAML did not render correctly in the docs.
