### PR TITLE
Fix example formatting in the documentation

### DIFF
--- a/docsite/rst/intro_patterns.rst
+++ b/docsite/rst/intro_patterns.rst
@@ -75,7 +75,7 @@ You can select a host or subset of hosts from a group by their position. For exa
     webbing
     weber
 
-You can refer to hosts within the group by adding a subscript to the group name:
+You can refer to hosts within the group by adding a subscript to the group name::
 
     webservers[0]       # == cobweb
     webservers[-1]      # == weber


### PR DESCRIPTION
A missing `:` makes [this example](http://docs.ansible.com/ansible/intro_patterns.html) render badly:
![ekrano nuotrauka is 2015-09-17 11-05-43](https://cloud.githubusercontent.com/assets/159967/9928085/150fd1da-5d2c-11e5-8849-afde6778b1b6.png)
