### PR TITLE
add releases 1.9.2 and 1.9.3

### DIFF
--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -9,6 +9,8 @@ Active Development
 Released
 ++++++++
 
+1.9.3  09-04-2015
+1.9.2  06-25-2015
 1.9.1  "Dancing In the Streets" 04-27-2015
 1.9.0  "Dancing In the Streets" 03-25-2015
 1.8.4  "You Really Got Me" ---- 02-19-2015


### PR DESCRIPTION
for some reason the last stable releases don't show up in the releases list. Please add them.
