### PR TITLE
Only use become if the target user difers from the current remote user.

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -678,6 +678,18 @@ Ask for privilege escalation password, the default is False::
 
     become_ask_pass=True
 
+.. _become_allow_same_user:
+
+become_allow_same_user
+======================
+
+Most of the time, using *sudo* to run a command as the same user who is running
+*sudo* itself is unnecessary overhead, so Ansible does not allow it. However,
+depending on the *sudo* configuration, it may be necessary to run a command as
+the same user through *sudo*, such as to switch SELinux contexts. For this
+reason, you can set ``become_allow_same_user`` to ``True`` and disable this
+optimization.
+
 .. _paramiko_settings:
 
 Paramiko Specific Settings

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -173,6 +173,7 @@ DEFAULT_ASK_SUDO_PASS     = get_config(p, DEFAULTS, 'ask_sudo_pass',    'ANSIBLE
 # Become
 BECOME_ERROR_STRINGS      = {'sudo': 'Sorry, try again.', 'su': 'Authentication failure', 'pbrun': '', 'pfexec': '', 'runas': '', 'doas': 'Permission denied'} #FIXME: deal with i18n
 BECOME_METHODS            = ['sudo','su','pbrun','pfexec','runas','doas']
+BECOME_ALLOW_SAME_USER    = get_config(p, 'privilege_escalation', 'become_allow_same_user', 'ANSIBLE_BECOME_ALLOW_SAME_USER', False, boolean=True)
 DEFAULT_BECOME_METHOD     = get_config(p, 'privilege_escalation', 'become_method', 'ANSIBLE_BECOME_METHOD','sudo' if DEFAULT_SUDO else 'su' if DEFAULT_SU else 'sudo' ).lower()
 DEFAULT_BECOME            = get_config(p, 'privilege_escalation', 'become', 'ANSIBLE_BECOME',False, boolean=True)
 DEFAULT_BECOME_USER       = get_config(p, 'privilege_escalation', 'become_user', 'ANSIBLE_BECOME_USER', 'root')

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -453,7 +453,9 @@ class ActionBase:
             self._display.debug("no command, exiting _low_level_execute_command()")
             return dict(stdout='', stderr='')
 
-        if sudoable and self._play_context.become and self._play_context.become_user != self._play_context.remote_user:
+        allow_same_user = C.BECOME_ALLOW_SAME_USER
+        same_user = self._play_context.become_user == self._play_context.remote_user
+        if sudoable and self._play_context.become and (allow_same_user or not same_user):
             self._display.debug("using become for this command")
             cmd = self._play_context.make_become_cmd(cmd, executable=executable)
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -453,7 +453,7 @@ class ActionBase:
             self._display.debug("no command, exiting _low_level_execute_command()")
             return dict(stdout='', stderr='')
 
-        if sudoable and self._play_context.become:
+        if sudoable and self._play_context.become and self._play_context.become_user != self._play_context.remote_user:
             self._display.debug("using become for this command")
             cmd = self._play_context.make_become_cmd(cmd, executable=executable)
 

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -1,0 +1,45 @@
+# (c) 2015, Florian Apolloner <florian@apolloner.eu>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import Mock
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.action import ActionBase
+
+
+class TestActionBase(unittest.TestCase):
+
+    def test_sudo_only_if_user_differs(self):
+        play_context = PlayContext()
+        action_base = ActionBase(None, None, play_context, None, None, None)
+        action_base._connection = Mock(exec_command=Mock(return_value=(0, '', '', '')))
+
+        play_context.become = True
+        play_context.become_user = play_context.remote_user = 'root'
+        play_context.make_become_cmd = Mock(return_value='CMD')
+
+        action_base._low_level_execute_command('ECHO', '/tmp', sudoable=True)
+        play_context.make_become_cmd.assert_not_called()
+
+        play_context.remote_user = 'apo'
+        action_base._low_level_execute_command('ECHO', '/tmp', sudoable=True)
+        play_context.make_become_cmd.assert_called_once_with('ECHO', executable=None)

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
+from ansible import constants as C
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.playbook.play_context import PlayContext
@@ -43,3 +44,14 @@ class TestActionBase(unittest.TestCase):
         play_context.remote_user = 'apo'
         action_base._low_level_execute_command('ECHO', '/tmp', sudoable=True)
         play_context.make_become_cmd.assert_called_once_with('ECHO', executable=None)
+
+        play_context.make_become_cmd.reset_mock()
+
+        become_allow_same_user = C.BECOME_ALLOW_SAME_USER
+        C.BECOME_ALLOW_SAME_USER = True
+        try:
+            play_context.remote_user = 'root'
+            action_base._low_level_execute_command('ECHO SAME', '/tmp', sudoable=True)
+            play_context.make_become_cmd.assert_called_once_with('ECHO SAME', executable=None)
+        finally:
+            C.BECOME_ALLOW_SAME_USER = become_allow_same_user


### PR DESCRIPTION
The idea behind this change is as follows: Usually I have bootstrap script which require sudo, but if someone already has access as root there is no need for a switch… While this could be implemented in the playbook itself using something like `become: "{{ ansible_ssh_user != 'root' }}"` (which is currently not possible either), it seems way nicer to to that in ansible itself. Personally I cannot see any reason to use sudo if the target user is already the current user. Thoughts?
