### PR TITLE
Documentation for retry_files_enabled and retry_files_save_path

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -544,6 +544,27 @@ Additional paths can be provided separated by colon characters, in the same way 
 Roles will be first searched for in the playbook directory.  Should a role not be found, it will indicate all the possible paths
 that were searched.
 
+.. _retry_files_enabled:
+
+retry_files_enabled
+===================
+
+This controls whether a failed Ansible playbook should create a .retry file. The default setting is True::
+
+    retry_files_enabled = False
+
+.. _retry_files_save_path:
+
+retry_files_save_path
+=====================
+
+The retry files save path is where Ansible will save .retry files when a playbook fails and retry_files_enabled is True (the default).
+The default location is ~/ and can be changed to any writeable path::
+
+    retry_files_save_path = ~/.ansible-retry
+
+The directory will be created if it does not already exist.
+
 .. _sudo_exe:
 
 sudo_exe

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -170,6 +170,10 @@ fact_caching = memory
 
 
 # retry files
+# When a playbook fails by default a .retry file will be created in ~/
+# You can disable this feature by setting retry_files_enabled to False
+# and you can change the location of the files by setting retry_files_save_path
+
 #retry_files_enabled = False
 #retry_files_save_path = ~/.ansible-retry
 


### PR DESCRIPTION
These two commits add documentation for retry_files_enabled and retry_files_save path to the main documentation and some comments to the example configuration file. 
