### PR TITLE
Merge Host.ipv[46]_address into .address

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -460,7 +460,7 @@ class TaskExecutor:
         # FIXME: calculation of connection params/auth stuff should be done here
 
         if not self._play_context.remote_addr:
-            self._play_context.remote_addr = self._host.ipv4_address
+            self._play_context.remote_addr = self._host.address
 
         if self._task.delegate_to is not None:
             self._compute_delegate(variables)

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -390,7 +390,7 @@ class Inventory(object):
         new_host = Host(pattern)
         new_host.set_variable("ansible_python_interpreter", sys.executable)
         new_host.set_variable("ansible_connection", "local")
-        new_host.ipv4_address = '127.0.0.1'
+        new_host.address = '127.0.0.1'
         self.get_group("ungrouped").add_host(new_host)
         return new_host
 

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -46,8 +46,7 @@ class Host:
         return dict(
             name=self.name,
             vars=self.vars.copy(),
-            ipv4_address=self.ipv4_address,
-            ipv6_address=self.ipv6_address,
+            address=self.address,
             gathered_facts=self._gathered_facts,
             groups=groups,
         )
@@ -55,10 +54,9 @@ class Host:
     def deserialize(self, data):
         self.__init__()
 
-        self.name         = data.get('name')
-        self.vars         = data.get('vars', dict())
-        self.ipv4_address = data.get('ipv4_address', '')
-        self.ipv6_address = data.get('ipv6_address', '')
+        self.name    = data.get('name')
+        self.vars    = data.get('vars', dict())
+        self.address = data.get('address', '')
 
         groups = data.get('groups', [])
         for group_data in groups:
@@ -72,11 +70,10 @@ class Host:
         self.vars = {}
         self.groups = []
 
-        self.ipv4_address = name
-        self.ipv6_address = name
+        self.address = name
 
         if port:
-            self.set_variable('ansible_ssh_port', int(port))
+            self.set_variable('ansible_port', int(port))
 
         self._gathered_facts = False
 

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -255,8 +255,8 @@ class InventoryParser(object):
         for h in hosts:
             for k in variables:
                 h.set_variable(k, variables[k])
-                if k == 'ansible_ssh_host':
-                    h.ipv4_address = variables[k]
+                if k in ['ansible_host', 'ansible_ssh_host']:
+                    h.address = variables[k]
 
         return hosts
 

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -62,7 +62,7 @@ class HostVars(collections.Mapping):
             new_host =  Host(name='localhost')
             new_host.set_variable("ansible_python_interpreter", sys.executable)
             new_host.set_variable("ansible_connection", "local")
-            new_host.ipv4_address = '127.0.0.1'
+            new_host.address = '127.0.0.1'
             hosts.append(new_host)
 
         for host in hosts:


### PR DESCRIPTION
The earlier distinction was never used; .ipv6_address was always a copy
of .ipv4_address, and the latter was always used to set the remote_addr
field in the PlayContext.

Also uses the canonical ansible_host/ansible_port names when setting the
address and port from variables.
