### PR TITLE
Update synchronize module plugin to work on OS X

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -47,10 +47,13 @@ class ActionModule(ActionBase):
     def _process_origin(self, host, path, user):
 
         if host not in C.LOCALHOST:
+            userPart = ''
             if user:
-                return '%s@[%s]:%s' % (user, host, path)
+                userPart = '%s@' % (user, )
+            if ":" in host:
+                return '[%s%s]:%s' % (userPart, host, path)
             else:
-                return '[%s]:%s' % (host, path)
+                return '%s%s:%s' % (userPart, host, path)
 
         if ':' not in path and not path.startswith('/'):
             path = self._get_absolute_path(path=path)
@@ -59,10 +62,13 @@ class ActionModule(ActionBase):
     def _process_remote(self, host, path, user):
         transport = self._play_context.connection
         if host not in C.LOCALHOST or transport != "local":
+            userPart = ''
             if user:
-                return '%s@[%s]:%s' % (user, host, path)
+                userPart = '%s@' % (user, )
+            if ":" in host:
+                return '[%s%s]:%s' % (userPart, host, path)
             else:
-                return '[%s]:%s' % (host, path)
+                return '%s%s:%s' % (userPart, host, path)
 
         if ':' not in path and not path.startswith('/'):
             path = self._get_absolute_path(path=path)

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -44,17 +44,17 @@ class ActionModule(ActionBase):
 
         return path
 
+    def _host_is_ipv6_address(self, host):
+        return ':' in host
+
     def _format_rsync_rsh_target(self, host, path, user):
         ''' formats rsync rsh target, escaping ipv6 addresses if needed '''
-
-        def _needs_ipv6_brackets(host):
-            return ':' in host
 
         user_prefix = ''
         if user:
             user_prefix = '%s@' % (user, )
 
-        if _needs_ipv6_brackets(host):
+        if self._host_is_ipv6_address(host):
             return '[%s%s]:%s' % (user_prefix, host, path)
         else:
             return '%s%s:%s' % (user_prefix, host, path)


### PR DESCRIPTION
As discussed at the commit @6c107258fad96fca53bea5a74960f54ac0d7b45e Those changes broke synchronize module functionality on OS X, where the built in rsync is 2.6.9 and has some issues parsing the user@[hostname-or-ipv4-or-ipv6] format in destination.

Main issue is that it completely breaks the synchronize functionality even for IPv4 on current OS X.

The hack below seems to be working on both OS X and Linux (with newer rsync) and with IPv4/6 addresses and A and AAAA DNS names.

The rsync, especially on OS X, is quite picky about the format of SRC and DEST, so some independent testing would be good. Still, this allows for using the synchronize module again on a stock OS X without having to reinstall rsync on all the servers and clients.

Thanks for consideration!
