### PR TITLE
Stops using _groups_list to check for host when using 'add_host'

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -457,7 +457,10 @@ class Inventory(object):
         return matching_host
 
     def get_group(self, groupname):
-        return self.groups[groupname]
+        if groupname in self.groups:
+            return self.groups[groupname]
+        else:
+            return None
 
     def get_group_variables(self, groupname, update_cached=False, vault_password=None):
         if groupname not in self._vars_per_group or update_cached:

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -356,10 +356,10 @@ class StrategyBase:
             new_group.add_host(new_host)
 
             # add this host to the group cache
-            if self._inventory._groups_list is not None:
-                if group_name in self._inventory._groups_list:
-                    if new_host.name not in self._inventory._groups_list[group_name]:
-                        self._inventory._groups_list[group_name].append(new_host.name)
+            if self._inventory.groups is not None:
+                if group_name in self._inventory.groups:
+                    if new_host not in self._inventory.get_group(group_name).hosts:
+                        self._inventory.get_group(group_name).hosts.append(new_host.name)
 
         # clear pattern caching completely since it's unpredictable what
         # patterns may have referenced the group


### PR DESCRIPTION
May be related to https://github.com/ansible/ansible/issues/11957

Using the 'add_host' function in current devel branch causes playbooks to return exceptions stating 

Inventory has no attribute '_groups_list'

This PR aims to use the existing attribute in the inventory and groups objects to work around this issue.

[EDIT]
For context, I am using 'add_host' in the following manner

```
- name: Add instance IP to new hosts group
  add_host: name=192.168.30.31 groupname=my_host_ip
```
