### PR TITLE
Python 3: there's no xrange

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -24,8 +24,10 @@ __metaclass__ = type
 import pipes
 import random
 import re
+import string
 
 from six import iteritems, string_types
+from six.moves import range
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
@@ -317,7 +319,7 @@ class PlayContext(Base):
         if self.become:
 
             becomecmd   = None
-            randbits    = ''.join(chr(random.randint(ord('a'), ord('z'))) for x in xrange(32))
+            randbits    = ''.join(random.choice(string.ascii_lowercase) for x in range(32))
             success_key = 'BECOME-SUCCESS-%s' % randbits
             success_cmd = pipes.quote('echo %s; %s' % (success_key, cmd))
 


### PR DESCRIPTION
Use six.moves.range instead (aliased to xrange on Python 2, aliased to range
on Python 3).

Also I couldn't resist replacing the elaborate chr/ord/randrange dance with
the simpler random.choice(string.ascii_lowercase) that was already used
elsewhere in the Ansible codebase.
