### PR TITLE
Update intro_windows.rst

### DIFF
--- a/docsite/rst/intro_windows.rst
+++ b/docsite/rst/intro_windows.rst
@@ -28,6 +28,10 @@ On a Linux control machine::
 
    pip install https://github.com/diyan/pywinrm/archive/master.zip#egg=pywinrm
 
+On arch-linux:
+   
+   Please make sure to target the python installation ansible is using. pip will target python3, use pip2.7 instead. 
+
 Active Directory Support
 ++++++++++++++++++++++++
 


### PR DESCRIPTION
Arch linux contains python2 and python3. Using the standard pip command will target python3.
