### PR TITLE
Fix for get_interfaces_info with AIX #12434

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2355,7 +2355,7 @@ class AIXNetwork(GenericBsdIfconfigNetwork, Network):
         return interface['v4'], interface['v6']
 
     # AIX 'ifconfig -a' does not have three words in the interface line
-    def get_interfaces_info(self, ifconfig_path, ifconfig_options):
+    def get_interfaces_info(self, ifconfig_path, ifconfig_options='-a'):
         interfaces = {}
         current_if = {}
         ips = dict(


### PR DESCRIPTION
This patch fix gathering fact problem against AIX host.
- **test-aix.yml**::

``` yaml
- name: "Test AIX fact gathering"
  gather_facts: yes
  hosts: aix[0]
  tasks:
    - debug: var=ansible_system
```
- Test **ansible-playbook test-aix.yml**::

``` yaml
PLAY [Test AIX fact gathering] ************************************************

GATHERING FACTS ***************************************************************
ok: [aix0]

TASK: [debug var=ansible_system] ******************************************
ok: [aix0] => {
    "ansible_system": "AIX",
    "changed": false
}
```
