### PR TITLE
add filter_plugins.mathstuff.to_bytes + tests

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -257,6 +257,13 @@ Square root, or the 5th::
     {{ myvar | root }}
     {{ myvar | root(5) }}
 
+Convert memory units to number of bytes, standard by default, or SI with an optional arg
+
+    {{ '64kb' | to_bytes }} => 65536
+    {{ '8 GB' | to_bytes }} => 8589934592.0
+    {{ '64kb' | to_bytes(True) }} => 64000
+    {{ '8 GB' | to_bytes(True) }} => 8000000000.0
+
 Note that jinja2 already provides some like abs() and round().
 
 .. _ipaddr_filter:

--- a/test/units/plugins/filter/test_to_bytes.py
+++ b/test/units/plugins/filter/test_to_bytes.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# (c) 2015, Benjamin Morris <ben@rooted.systems>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+from __future__ import unicode_literals
+__metaclass__ = type
+
+import math
+from nose.tools import assert_raises
+
+from ansible.compat.tests import unittest
+from ansible.plugins.filter.mathstuff import to_bytes
+from ansible import errors
+
+class TestToBytes(unittest.TestCase):
+
+    def get_multipliers(self, multi_factor):
+        return {
+            'b': 1,
+            'kb': multi_factor,
+            'mb': math.pow(multi_factor, 2),
+            'gb': math.pow(multi_factor, 3),
+            'tb': math.pow(multi_factor, 4),
+            'pb': math.pow(multi_factor, 5),
+        }
+
+    def test_to_bytes_good_input(self):
+        units = (
+            'b',
+            'kb',
+            'mb',
+            'gb',
+            'tb',
+            'pb',
+        )
+
+        # test non-si
+        multi_factor = 1024
+        for unit in units:
+            byte_val = 0
+            rc = to_bytes('%s%s' % (byte_val, unit))
+            self.assertTrue(rc == byte_val * self.get_multipliers(multi_factor).get(unit),
+                    'should have returned %s bytes for prefix %s' % (byte_val, unit))
+
+            byte_val = 10
+            rc = to_bytes('%s%s' % (byte_val, unit))
+            self.assertTrue(rc == byte_val * self.get_multipliers(multi_factor).get(unit),
+                    'should have returned %s bytes for prefix %s' % (byte_val, unit))
+
+            byte_val = 10431987413
+            rc = to_bytes('%s%s' % (byte_val, unit))
+            self.assertTrue(rc == byte_val * self.get_multipliers(multi_factor).get(unit),
+                    'should have returned %s bytes for prefix %s' % (byte_val, unit))
+
+        # test si
+        multi_factor = 1000
+        for unit in units:
+            byte_val = 0
+            rc = to_bytes('%s%s' % (byte_val, unit), True)
+            self.assertTrue(rc == byte_val * self.get_multipliers(multi_factor).get(unit),
+                    'should have returned %s bytes for prefix %s' % (byte_val, unit))
+
+            byte_val = 10
+            rc = to_bytes('%s%s' % (byte_val, unit), True)
+            self.assertTrue(rc == byte_val * self.get_multipliers(multi_factor).get(unit),
+                    'should have returned %s bytes for prefix %s' % (byte_val, unit))
+
+            byte_val = 10431987413
+            rc = to_bytes('%s%s' % (byte_val, unit), True)
+            self.assertTrue(rc == byte_val * self.get_multipliers(multi_factor).get(unit),
+                    'should have returned %s bytes for prefix %s' % (byte_val, unit))
+
+    def test_to_bytes_negative_input(self):
+        assert_raises(errors.AnsibleFilterError, to_bytes, '-10kb')
+
+    def test_to_bytes_non_str_input(self):
+        assert_raises(errors.AnsibleFilterError, to_bytes, 0.0)
+        assert_raises(errors.AnsibleFilterError, to_bytes, None)
+
+    def test_to_bytes_invalid_format_input(self):
+        assert_raises(errors.AnsibleFilterError, to_bytes, "kb10")
+        assert_raises(errors.AnsibleFilterError, to_bytes, "10")
+        assert_raises(errors.AnsibleFilterError, to_bytes, "kb")
+        assert_raises(errors.AnsibleFilterError, to_bytes, "q")
+        assert_raises(errors.AnsibleFilterError, to_bytes, "")
+        assert_raises(errors.AnsibleFilterError, to_bytes, "1010b10")
+
+    def test_to_bytes_unicode_input(self):
+        assert_raises(errors.AnsibleFilterError, to_bytes, '\x00\x00\x00\x00\x00')
+        assert_raises(errors.AnsibleFilterError, to_bytes, 'ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ')


### PR DESCRIPTION
I ran into a problem where I needed to convert a memory unit string such
as "8GB" into a number of bytes to do some calculations and set vars
based on these calculations. I couldn't find a simple way to do this
without resorting to multiple variables and complicated stuff, so I
wrote this filter_plugin to do the conversion. Also wrote unit tests to ensure
bad input is handled and the logic is robust.

```
In [6]: from ansible.plugins.filter.mathstuff import human_readable, to_bytes

In [7]: human_readable(to_bytes('8 GB'))
Out[7]: '8.00 GB'
```

~~~start git commit msg

the to_bytes filter plugin allows you to convert
memory unit strings such as "8GB", "64kb", etc.

ex setting a variable:

```
postgres_shared_buffers = "8GB"
postgres_nr_huge_pages = "{{ ( postgres_shared_buffers|to_bytes / 1024 / 2048 * 1.05 ) |round |int }}"
```

the filter plugin works with any string in the format

VALUE UNIT

where valid VALUE can be any positive integer 0-max, [0-9]+

where valid UNIT can be lower or uppercase (the UNIT is parsed with .lower()) in the form:

```
basebytes = ('b', )
kilobytes = ('k', 'kb', 'kib', )
megabytes = ('m', 'mb', 'mib', )
gigabytes = ('g', 'gb', 'gib', )
terabytes = ('t', 'tb', 'tib', )
petabytes = ('p', 'pb', 'pib', )
```

the VALUE and UNIT can be seperated by any number of whitespace, including no space.

Some example formats are:

```
    "64kb"
    "64 kb"
    "64       kb"
    "64kib"
    "64KB"
    "64Kb"
    "64k b"
```

There is also an optional si flag for the filter, allowing you to
convert the input value into bytes with the SI units for memory.
ex:

```
    "8KB" | to_bytes(True) = 8 * (1000 ** 1)
    "8MB" | to_bytes(True) = 8 * (1000 ** 2)
```
