### PR TITLE
Update docs (playbooks_loops.rst, playbooks_filters.rst)

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -450,11 +450,11 @@ To separate the windows drive letter from the rest of a file path (new in versio
 
 To get only the windows drive letter::
 
-    {{ path | win_splitdrive | first }} 
-    
+    {{ path | win_splitdrive | first }}
+
 To get the rest of the path without the drive letter::
 
-    {{ path | win_splitdrive | last }} 
+    {{ path | win_splitdrive | last }}
 
 To get the directory from a path::
 

--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -181,7 +181,7 @@ It might happen like so::
 Given the mysql hosts and privs subkey lists, you can also iterate over a list in a nested subkey::
 
     - name: Setup MySQL users
-      mysql_user: name={{ item.0.user }} password={{ item.0.mysql.password }} host={{ item.1 }} priv={{ item.0.mysql.privs | join('/') }}
+      mysql_user: name={{ item.0.name }} password={{ item.0.mysql.password }} host={{ item.1 }} priv={{ item.0.mysql.privs | join('/') }}
       with_subelements:
         - users
         - mysql.hosts


### PR DESCRIPTION
- playbooks_filters.rst

The example for `first` and `last` filter shows [its bare strings](http://docs.ansible.com/ansible/playbooks_filters.html#other-useful-filters).
- playbooks_loops.rst

The example for `subelements` might be [typo](http://docs.ansible.com/ansible/playbooks_loops.html#looping-over-subelements).
