### PR TITLE
added --pass-limit-to-inventory as discussed in https://groups.google.com/forum/#!topic/ansible-devel/ZGwvE7RgWTc

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -230,6 +230,8 @@ class CLI(object):
                 help='outputs a list of matching hosts; does not execute anything else')
             parser.add_option('-l', '--limit', default=C.DEFAULT_SUBSET, dest='subset',
                 help='further limit selected hosts to an additional pattern')
+            parser.add_option('--pass-limit-to-inventory', default=False, dest='passlimit', action='store_true',
+                help='pass the --limit argument to the inventory script')
 
         if module_opts:
             parser.add_option('-M', '--module-path', dest='module_path', default=None,

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -124,7 +124,7 @@ class PlaybookCLI(CLI):
         variable_manager.extra_vars = load_extra_vars(loader=loader, options=self.options)
 
         # create the inventory, and filter it based on the subset specified (if any)
-        inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=self.options.inventory)
+        inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=self.options.inventory,limit=self.options.subset if self.options.passlimit else None)
         variable_manager.set_inventory(inventory)
 
         # (which is not returned in list_hosts()) is taken into account for

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -51,7 +51,7 @@ class Inventory(object):
     Host inventory for ansible.
     """
 
-    def __init__(self, loader, variable_manager, host_list=C.DEFAULT_HOST_LIST):
+    def __init__(self, loader, variable_manager, host_list=C.DEFAULT_HOST_LIST, limit=None):
 
         # the host file file, or script path, or list of hosts
         # if a list, inventory data will NOT be loaded
@@ -78,7 +78,7 @@ class Inventory(object):
         self._restriction = None
         self._subset = None
 
-        self.parse_inventory(host_list)
+        self.parse_inventory(host_list,limit=limit)
 
     def serialize(self):
         data = dict()
@@ -87,7 +87,7 @@ class Inventory(object):
     def deserialize(self, data):
         pass
 
-    def parse_inventory(self, host_list):
+    def parse_inventory(self, host_list,limit=None):
 
         if isinstance(host_list, string_types):
             if "," in host_list:
@@ -118,7 +118,7 @@ class Inventory(object):
                 host_list = os.path.join(self.host_list, "")
                 self.parser = InventoryDirectory(loader=self._loader, groups=self.groups, filename=host_list)
             else:
-                self.parser = get_file_parser(host_list, self.groups, self._loader)
+                self.parser = get_file_parser(host_list, self.groups, self._loader, limit=limit)
                 vars_loader.add_directory(self.basedir(), with_subdir=True)
 
             if not self.parser:

--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -34,7 +34,7 @@ from ansible.inventory.script import InventoryScript
 
 __all__ = ['get_file_parser']
 
-def get_file_parser(hostsfile, groups, loader):
+def get_file_parser(hostsfile, groups, loader,limit=None):
     # check to see if the specified file starts with a
     # shebang (#!/), so if an error is raised by the parser
     # class we can show a more apropos error
@@ -55,7 +55,7 @@ def get_file_parser(hostsfile, groups, loader):
 
     if loader.is_executable(hostsfile):
         try:
-            parser = InventoryScript(loader=loader, groups=groups, filename=hostsfile)
+            parser = InventoryScript(loader=loader, groups=groups, filename=hostsfile, limit=limit)
             processed = True
         except Exception as e:
             myerr.append("The file %s is marked as executable, but failed to execute correctly. " % hostsfile + \


### PR DESCRIPTION
##### SUMMARY
the idea is simple, if  --pass-limit-to-inventory is used when running ansible-playbook, then when the inventory is called, it will have the arguments --list --limit BLABLA 

so you can use it to narrow the scope of the inventory


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/__init__.py
lib/ansible/cli/playbook.py
lib/ansible/inventory/__init__.py
lib/ansible/inventory/dir.py
lib/ansible/inventory/script.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


