### PR TITLE
Replace categories with tags.

### DIFF
--- a/docsite/rst/developing_plugins.rst
+++ b/docsite/rst/developing_plugins.rst
@@ -19,7 +19,7 @@ in playbooks and with /usr/bin/ansible to decide how you want to talk to remote 
 are covered in the :doc:`intro_getting_started` section.  Should you want to extend Ansible to support other transports (SNMP? Message bus?
 Carrier Pigeon?) it's as simple as copying the format of one of the existing modules and dropping it into the connection plugins
 directory.   The value of 'smart' for a connection allows selection of paramiko or openssh based on system capabilities, and chooses
-'ssh' if OpenSSH supports ControlPersist, in Ansible 1.2.1 an later.  Previous versions did not support 'smart'.
+'ssh' if OpenSSH supports ControlPersist, in Ansible 1.2.1 and later.  Previous versions did not support 'smart'.
 
 More documentation on writing connection plugins is pending, though you can jump into `lib/ansible/plugins/connection <https://github.com/ansible/ansible/tree/devel/lib/ansible/plugins/connection>`_ and figure things out pretty easily.
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -85,9 +85,9 @@ class GalaxyCLI(CLI):
         elif self.action == "search":
             self.parser.add_option('-P', '--platforms', dest='platforms',
                 help='list of OS platforms to filter by')
-            self.parser.add_option('-C', '--categories', dest='categories',
-                help='list of categories to filter by')
-            self.parser.set_usage("usage: %prog search [<search_term>] [-C <category1,category2>] [-P platform]")
+            self.parser.add_option('-T', '--tags', dest='tags',
+                help='list of tags to filter by')
+            self.parser.set_usage("usage: %prog search [<search_term>] [-T <tag1,tag2>] [-P platform]")
 
         # options that apply to more than one action
         if self.action != "init":
@@ -99,6 +99,8 @@ class GalaxyCLI(CLI):
         if self.action in ("info","init","install","search"):
             self.parser.add_option('-s', '--server', dest='api_server', default="https://galaxy.ansible.com",
                 help='The API server destination')
+            self.parser.add_option('-c', '--ignore-certs', action='store_false', dest='validate_certs', default=True,
+                help='Ignore SSL certificate validation errors.')
 
         if self.action in ("init","install"):
             self.parser.add_option('-f', '--force', dest='force', action='store_true', default=False,
@@ -251,9 +253,6 @@ class GalaxyCLI(CLI):
                 platforms = []
                 if not offline and self.api:
                     platforms = self.api.get_list("platforms") or []
-                categories = []
-                if not offline and self.api:
-                    categories = self.api.get_list("categories") or []
 
                 # group the list of platforms from the api based
                 # on their names, with the release field being
@@ -270,7 +269,6 @@ class GalaxyCLI(CLI):
                     issue_tracker_url = 'http://example.com/issue/tracker',
                     min_ansible_version = '1.2',
                     platforms = platform_groups,
-                    categories = categories,
                 )
                 rendered_meta = Environment().from_string(self.galaxy.default_meta).render(inject)
                 f = open(main_yml_path, 'w')
@@ -543,7 +541,7 @@ class GalaxyCLI(CLI):
         elif len(self.args) == 1:
             search = self.args.pop()
 
-        response = self.api.search_roles(search, self.options.platforms, self.options.categories)
+        response = self.api.search_roles(search, self.options.platforms, self.options.tags)
 
         if 'count' in response:
             self.galaxy.display.display("Found %d roles matching your search:\n" % response['count'])

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -85,9 +85,9 @@ class GalaxyCLI(CLI):
         elif self.action == "search":
             self.parser.add_option('-P', '--platforms', dest='platforms',
                 help='list of OS platforms to filter by')
-            self.parser.add_option('-T', '--tags', dest='tags',
-                help='list of tags to filter by')
-            self.parser.set_usage("usage: %prog search [<search_term>] [-T <tag1,tag2>] [-P platform]")
+            self.parser.add_option('-T', '--galaxy-tags', dest='tags',
+                help='list of galaxy tags to filter by')
+            self.parser.set_usage("usage: %prog search [<search_term>] [-T <galaxy_tag1,galaxy_tag2>] [-P platform]")
 
         # options that apply to more than one action
         if self.action != "init":
@@ -248,8 +248,8 @@ class GalaxyCLI(CLI):
             if dir == "meta":
                 # create a skeleton meta/main.yml with a valid galaxy_info
                 # datastructure in place, plus with all of the available
-                # tags/platforms included (but commented out) and the
-                # dependencies section
+                # platforms included (but commented out), the galaxy_tags
+                # list, and the dependencies section
                 platforms = []
                 if not offline and self.api:
                     platforms = self.api.get_list("platforms") or []

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -62,7 +62,7 @@ class GalaxyAPI(object):
         return 'v1'
 
         try:
-            data = json.load(open_url(api_server))
+            data = json.load(open_url(api_server, validate_certs=self.galaxy.options.validate_certs))
             return data.get("current_version", 'v1')
         except Exception as e:
             # TODO: report error
@@ -86,7 +86,7 @@ class GalaxyAPI(object):
         url = '%s/roles/?owner__username=%s&name=%s' % (self.baseurl, user_name, role_name)
         self.galaxy.display.vvvv("- %s" % (url))
         try:
-            data = json.load(open_url(url))
+            data = json.load(open_url(url, validate_certs=self.galaxy.options.validate_certs))
             if len(data["results"]) != 0:
                 return data["results"][0]
         except:
@@ -103,13 +103,13 @@ class GalaxyAPI(object):
 
         try:
             url = '%s/roles/%d/%s/?page_size=50' % (self.baseurl, int(role_id), related)
-            data = json.load(open_url(url))
+            data = json.load(open_url(url, validate_certs=self.galaxy.options.validate_certs))
             results = data['results']
             done = (data.get('next', None) == None)
             while not done:
                 url = '%s%s' % (self.baseurl, data['next'])
                 self.galaxy.display.display(url)
-                data = json.load(open_url(url))
+                data = json.load(open_url(url, validate_certs=self.galaxy.options.validate_certs))
                 results += data['results']
                 done = (data.get('next', None) == None)
             return results
@@ -123,7 +123,7 @@ class GalaxyAPI(object):
 
         try:
             url = '%s/%s/?page_size' % (self.baseurl, what)
-            data = json.load(open_url(url))
+            data = json.load(open_url(url, validate_certs=self.galaxy.options.validate_certs))
             if "results" in data:
                 results = data['results']
             else:
@@ -134,27 +134,27 @@ class GalaxyAPI(object):
             while not done:
                 url = '%s%s' % (self.baseurl, data['next'])
                 self.galaxy.display.display(url)
-                data = json.load(open_url(url))
+                data = json.load(open_url(url, validate_certs=self.galaxy.options.validate_certs))
                 results += data['results']
                 done = (data.get('next', None) == None)
             return results
         except Exception as error:
             raise AnsibleError("Failed to download the %s list: %s" % (what, str(error)))
 
-    def search_roles(self, search, platforms=None, categories=None):
+    def search_roles(self, search, platforms=None, tags=None):
 
         search_url = self.baseurl + '/roles/?page=1'
 
         if search:
             search_url += '&search=' + urlquote(search)
 
-        if categories is None:
-            categories = []
-        elif isinstance(categories, basestring):
-            categories = categories.split(',')
+        if tags is None:
+            tags = []
+        elif isinstance(tags, basestring):
+            tags = tags.split(',')
 
-        for cat in categories:
-            search_url += '&chain__categories__name=' + urlquote(cat)
+        for tag in tags:
+            search_url += '&chain__tags__name=' + urlquote(tag)
 
         if platforms is None:
             platforms = []
@@ -166,7 +166,7 @@ class GalaxyAPI(object):
 
         self.galaxy.display.debug("Executing query: %s" % search_url)
         try:
-            data = json.load(open_url(search_url))
+            data = json.load(open_url(search_url, validate_certs=self.galaxy.options.validate_certs))
         except HTTPError as e:
             raise AnsibleError("Unsuccessful request to server: %s" % str(e))
 

--- a/lib/ansible/galaxy/data/metadata_template.j2
+++ b/lib/ansible/galaxy/data/metadata_template.j2
@@ -32,8 +32,7 @@ galaxy_info:
     # List tags for your role here, one per line. A tag is
     # a keyword that describes and categorizes the role.
     # Users find roles by searching for tags. Be sure to
-    # remove the '[]' above if you add dependencies
-    # to this list.
+    # remove the '[]' above if you add tags to this list.
     #
     # NOTE: A tag is limited to a single word comprised of
     # alphanumeric characters. Maximum 20 tags per role.

--- a/lib/ansible/galaxy/data/metadata_template.j2
+++ b/lib/ansible/galaxy/data/metadata_template.j2
@@ -28,14 +28,14 @@ galaxy_info:
   #  - {{ version }}
     {%- endfor %}
   {%- endfor %}
-  tags: []
+  galaxy_tags: []
     # List tags for your role here, one per line. A tag is
     # a keyword that describes and categorizes the role.
     # Users find roles by searching for tags. Be sure to
     # remove the '[]' above if you add dependencies
     # to this list.
     #
-    # NOTE: A tag is limted to a single word comprised of
+    # NOTE: A tag is limited to a single word comprised of
     # alphanumeric characters. Maximum 20 tags per role.
 dependencies: []
   # List your role dependencies here, one per line.

--- a/lib/ansible/galaxy/data/metadata_template.j2
+++ b/lib/ansible/galaxy/data/metadata_template.j2
@@ -28,14 +28,15 @@ galaxy_info:
   #  - {{ version }}
     {%- endfor %}
   {%- endfor %}
-  #
-  # Below are all categories currently available. Just as with
-  # the platforms above, uncomment those that apply to your role.
-  #
-  #categories:
-  {%- for category in categories %}
-  #- {{ category.name }}
-  {%- endfor %}
+  tags: []
+    # List tags for your role here, one per line. A tag is
+    # a keyword that describes and categorizes the role.
+    # Users find roles by searching for tags. Be sure to
+    # remove the '[]' above if you add dependencies
+    # to this list.
+    #
+    # NOTE: A tag is limted to a single word comprised of
+    # alphanumeric characters. Maximum 20 tags per role.
 dependencies: []
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -80,7 +80,7 @@ def boto_supports_profile_name():
     return hasattr(boto.ec2.EC2Connection, 'profile_name')
 
 
-def get_aws_connection_info(module):
+def get_aws_connection_info(module, boto3=False):
 
     # Check module args for credentials, then check environment vars
     # access_key
@@ -141,7 +141,7 @@ def get_aws_connection_info(module):
             # in case security_token came in as empty string
             security_token = None
 
-    if HAS_BOTO3:
+    if HAS_BOTO3 and boto3:
         boto_params = dict(aws_access_key_id=access_key,
                            aws_secret_access_key=secret_key,
                            aws_session_token=security_token)


### PR DESCRIPTION
Galaxy is deprecating categories in favor of tags. Each tag is a single word that describes or categorizes a role. Role authors can supply a set of tags that best describes their role. In the next Galaxy release users will be able to search roles by tags.

This PR is intended to update the metadata template and ansible-galaxy 'search' command to reflect this change.

To aid testing added --ignore-certs option for use with install and search commands. Helpful when
using --server to point to a server with a self signed cert.
