### PR TITLE
Fix UnicodeEncodeError when writing tree files (1.9.x)

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -22,6 +22,7 @@ import os
 import shlex
 import yaml
 import copy
+import codecs
 import optparse
 import operator
 from ansible import errors
@@ -229,7 +230,7 @@ def write_tree_file(tree, hostname, buf):
     # TODO: might be nice to append playbook runs per host in a similar way
     # in which case, we'd want append mode.
     path = os.path.join(tree, hostname)
-    fd = open(path, "w+")
+    fd = codecs.open(path, "w+", "utf-8")
     fd.write(buf)
     fd.close()
 


### PR DESCRIPTION
This is the very same fix as in #10630. The fix there applies to writing the json fact files to the cache. 

The same error occurs when you write the facts explicitly to a directory with `--tree some/directory`.

Using `--tree` is no longer really needed now that there's a json fact cache, but as long as the code is still there I thought it best to fix it.

**Note:** I based it off the stable-1.9 branch as that looked like the 1.9 bugfixes branch. The devel branch looks to be for 2.0 (and the file I fixed isn't in there anymore).
