### PR TITLE
SoftLayer inventory to include private only instances

### DIFF
--- a/contrib/inventory/softlayer.py
+++ b/contrib/inventory/softlayer.py
@@ -202,6 +202,6 @@ class SoftLayerInventory(object):
     def get_all_servers(self):
         self.client = SoftLayer.Client()
         self.get_virtual_servers()
-        #self.get_physical_servers()
+        self.get_physical_servers()
 
 SoftLayerInventory()


### PR DESCRIPTION
##### SUMMARY
The current inventory solution only allows the ability to list instances that have a public interface. These new changes will allow the ability to also list virtual instances that only have a private interface. This uses tags to identify the device group, and prefixes with "private_".


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
contrib/inventory/softlayer.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


