### PR TITLE
Python 3: make test_variable_manager_precedence pass

### DIFF
--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -41,6 +41,9 @@ class Host:
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return hash(self.name)
+
     def serialize(self):
         groups = []
         for group in self.groups:

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -38,6 +38,9 @@ class Host:
     def __eq__(self, other):
         return self.name == other.name
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def serialize(self):
         groups = []
         for group in self.groups:

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -20,7 +20,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import ast
-import shlex
 import re
 
 from ansible import constants as C
@@ -30,7 +29,8 @@ from ansible.inventory.group import Group
 from ansible.inventory.expand_hosts import detect_range
 from ansible.inventory.expand_hosts import expand_hostname_range
 from ansible.parsing.utils.addresses import parse_address
-from ansible.utils.unicode import to_unicode, to_bytes
+from ansible.utils.shlex import shlex_split
+from ansible.utils.unicode import to_unicode
 
 class InventoryParser(object):
     """
@@ -231,13 +231,11 @@ class InventoryParser(object):
         # beta:2345 user=admin      # we'll tell shlex
         # gamma sudo=True user=root # to ignore comments
 
-        line = to_bytes(line)
         try:
-            tokens = shlex.split(line, comments=True)
+            tokens = shlex_split(line, comments=True)
         except ValueError as e:
             self._raise_error("Error parsing host definition '%s': %s" % (varstring, e))
 
-        tokens = [ to_unicode(t) for t in tokens]
         (hostnames, port) = self._expand_hostpattern(tokens[0])
         hosts = self._Hosts(hostnames, port)
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import ast
 import re
 
-from six import string_types
+from six import string_types, text_type, binary_type
 from jinja2 import Environment
 from jinja2.loaders import FileSystemLoader
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError
@@ -217,10 +217,10 @@ class Templar:
         # Don't template unsafe variables, instead drop them back down to
         # their constituent type.
         if hasattr(variable, '__UNSAFE__'):
-            if isinstance(variable, unicode):
-                return unicode(variable)
-            elif isinstance(variable, str):
-                return str(variable)
+            if isinstance(variable, text_type):
+                return text_type(variable)
+            elif isinstance(variable, binary_type):
+                return bytes(variable)
             else:
                 return variable
 

--- a/lib/ansible/utils/shlex.py
+++ b/lib/ansible/utils/shlex.py
@@ -1,0 +1,33 @@
+# (c) 2015, Marius Gedminas <marius@gedmin.as>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# alongwith Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+
+import shlex
+from six import PY3
+
+from ansible.utils.unicode import to_bytes, to_unicode
+
+
+if PY3:
+    # shlex.split() wants Unicode (i.e. ``str``) input on Python 3
+    shlex_split = shlex.split
+else:
+    # shlex.split() wants bytes (i.e. ``str``) input on Python 2
+    def shlex_split(s, comments=False, posix=True):
+        return map(to_unicode, shlex.split(to_bytes(s), comments, posix))
+    shlex_split.__doc__ = shlex.split.__doc__

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -24,6 +24,7 @@ import os
 from collections import defaultdict
 from collections import MutableMapping
 
+from six import iteritems
 from jinja2.exceptions import UndefinedError
 
 try:
@@ -285,7 +286,7 @@ class VariableManager:
 
             if self._inventory is not None:
                 all_vars['groups']  = dict()
-                for (group_name, group) in self._inventory.groups.iteritems():
+                for (group_name, group) in iteritems(self._inventory.groups):
                     all_vars['groups'][group_name] = [h.name for h in group.get_hosts()]
 
                 if include_hostvars:

--- a/test/units/inventory/test_host.py
+++ b/test/units/inventory/test_host.py
@@ -33,3 +33,6 @@ class TestHost(unittest.TestCase):
         # __ne__ is a separate method
         self.assertFalse(self.hostA != Host('a'))
 
+    def test_hashability(self):
+        # equality implies the hash values are the same
+        self.assertEqual(hash(self.hostA), hash(Host('a')))

--- a/test/units/inventory/test_host.py
+++ b/test/units/inventory/test_host.py
@@ -1,0 +1,35 @@
+# Copyright 2015 Marius Gedminas <marius@gedmin.as>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from ansible.inventory.host import Host
+
+
+class TestHost(unittest.TestCase):
+
+    def setUp(self):
+        self.hostA = Host('a')
+        self.hostB = Host('b')
+
+    def test_equality(self):
+        self.assertEqual(self.hostA, self.hostA)
+        self.assertNotEqual(self.hostA, self.hostB)
+        self.assertEqual(self.hostA, Host('a'))
+        # __ne__ is a separate method
+        self.assertFalse(self.hostA != Host('a'))
+

--- a/test/units/utils/test_shlex.py
+++ b/test/units/utils/test_shlex.py
@@ -1,0 +1,39 @@
+# (c) 2015, Marius Gedminas <marius@gedmin.as>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from ansible.utils.shlex import shlex_split
+
+
+class TestSplit(unittest.TestCase):
+
+    def test_trivial(self):
+        self.assertEqual(shlex_split("a b c"), ["a", "b", "c"])
+
+    def test_unicode(self):
+        self.assertEqual(shlex_split(u"a b \u010D"), [u"a", u"b", u"\u010D"])
+
+    def test_quoted(self):
+        self.assertEqual(shlex_split('"a b" c'), ["a b", "c"])
+
+    def test_comments(self):
+        self.assertEqual(shlex_split('"a b" c # d', comments=True), ["a b", "c"])
+
+    def test_error(self):
+        self.assertRaises(ValueError, shlex_split, 'a "b')
+


### PR DESCRIPTION
I'm going through failing unit tests one by one and making them pass.
This PR fixes test_variable_manager_precedence from
test/units/vars/test_variable_manager.py, which was failing due to
several unrelated issues:
- shlex.split() cannot deal with bytes on Python 3
- ansible.inventory.host.Host needs to be (correctly) hashable
- one count of dict.iteritems()
- one count of 'unicode' in a module I thought I'd already
  Python-3-ified (this is why I focus on making the tests pass on Python
  3, so I can submit a PR to enable them in the default tox.ini/Travis
  run).
