### PR TITLE
Windows: Added parameter validation to the get-attr function

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -101,11 +101,11 @@ Function Fail-Json($obj, $message = $null)
 # Helper function to get an "attribute" from a psobject instance in powershell.
 # This is a convenience to make getting Members from an object easier and
 # slightly more pythonic
-# Example: $attr = Get-Attr $response "code" -default "1"
-#Get-attr also supports Parameter validation to save you from coding that manually:
-#Example: Get-attr -obj $params -name "State" -default "Present" -ValidateSet "Present","Absent" -resultobj $resultobj -failifempty $true
+# Example: $attr = Get-AnsibleParam $response "code" -default "1"
+#Get-AnsibleParam also supports Parameter validation to save you from coding that manually:
+#Example: Get-AnsibleParam -obj $params -name "State" -default "Present" -ValidateSet "Present","Absent" -resultobj $resultobj -failifempty $true
 #Note that if you use the failifempty option, you do need to specify resultobject as well.
-Function Get-Attr($obj, $name, $default = $null, $resultobj, $failifempty=$false, $emptyattributefailmessage, $ValidateSet, $ValidateSetErrorMessage)
+Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempty=$false, $emptyattributefailmessage, $ValidateSet, $ValidateSetErrorMessage)
 {
     # Check if the provided Member $name exists in $obj and return it or the default. 
     Try
@@ -154,6 +154,7 @@ Function Get-Attr($obj, $name, $default = $null, $resultobj, $failifempty=$false
     }
 }
 
+#Alias Get-attr-->Get-AnsibleParam for backwards compat.New-Alias -Name Get-attr -Value Get-AnsibleParam
 
 # Helper filter/pipeline function to convert a value to boolean following current
 # Ansible practices

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -101,11 +101,11 @@ Function Fail-Json($obj, $message = $null)
 # Helper function to get an "attribute" from a psobject instance in powershell.
 # This is a convenience to make getting Members from an object easier and
 # slightly more pythonic
-# Example: $attr = Get-Attr $response "code" -default "1"
-#Get-attr also supports Parameter validation to save you from coding that manually:
-#Example: Get-attr -obj $params -name "State" -default "Present" -ValidateSet "Present","Absent" -resultobj $resultobj -failifempty $true
+# Example: $attr = Get-AnsibleParam $response "code" -default "1"
+#Get-AnsibleParam also supports Parameter validation to save you from coding that manually:
+#Example: Get-AnsibleParam -obj $params -name "State" -default "Present" -ValidateSet "Present","Absent" -resultobj $resultobj -failifempty $true
 #Note that if you use the failifempty option, you do need to specify resultobject as well.
-Function Get-Attr($obj, $name, $default = $null, $resultobj, $failifempty=$false, $emptyattributefailmessage, $ValidateSet, $ValidateSetErrorMessage)
+Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempty=$false, $emptyattributefailmessage, $ValidateSet, $ValidateSetErrorMessage)
 {
     # Check if the provided Member $name exists in $obj and return it or the default. 
     Try
@@ -153,6 +153,9 @@ Function Get-Attr($obj, $name, $default = $null, $resultobj, $failifempty=$false
         }
     }
 }
+
+#Alias Get-attr-->Get-AnsibleParam for backwards compat.
+New-Alias -Name Get-attr -Value Get-AnsibleParam
 
 
 # Helper filter/pipeline function to convert a value to boolean following current


### PR DESCRIPTION
Improved get-attr so that it also enables parameter validation (this will implement a standardizer way of validating params instead of each module having to implement it itself)

Example: If a module requires the option "state" to be either "present" or "absent" this can be expressed like:
`Get-attr -obj $params -name "State" -default "Present" -ValidateSet "Present","Absent" -resultobj $resultobj -failifempty $true`
This will fail calling `fail-json` automatically if the option is anything other than "present" or "absent" and should save module devs some coding.
