### PR TITLE
Merge properties instead of reading only the first cfg file found

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -62,12 +62,12 @@ def load_config_file():
 
     p = ConfigParser.ConfigParser()
 
-    path0 = os.getenv("ANSIBLE_CONFIG", None)
-    if path0 is not None:
-        path0 = os.path.expanduser(path0)
-    path1 = os.getcwd() + "/ansible.cfg"
-    path2 = os.path.expanduser("~/.ansible.cfg")
-    path3 = "/etc/ansible/ansible.cfg"
+    path0 = "/etc/ansible/ansible.cfg"
+    path1 = os.path.expanduser("~/.ansible.cfg")
+    path2 = os.getcwd() + "/ansible.cfg"
+    path3 = os.getenv("ANSIBLE_CONFIG", None)
+    if path3 is not None:
+        path3 = os.path.expanduser(path0)
 
     for path in [path0, path1, path2, path3]:
         if path is not None and os.path.exists(path):
@@ -76,8 +76,7 @@ def load_config_file():
             except ConfigParser.Error as e:
                 print "Error reading config file: \n%s" % e
                 sys.exit(1)
-            return p
-    return None
+    return p
 
 def shell_expand_path(path):
     ''' shell_expand_path is needed as os.path.expanduser does not work


### PR DESCRIPTION
Use case :

I have a personal ansible.cfg where I configure some optims (ssh_args = -o ControlPersist=30m and pipelining = True); there is an ansible.cfg in my repo that configures some structural patterns (roles_path=public/roles:private/roles).

For such setup, I would have to copy my personal configuration on the cfg of the project or create an environment variable with all the values for the cfg files.

If settings were overridden respecting the order of precedence that is describe in the doc, I can have settings splitted between files and override only what I need.
