### PR TITLE
temporarily disable strictmode

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -26,7 +26,8 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-Set-StrictMode -Version Latest
+#Temporarily removed strictmode as it breaks a lot of modules
+#Set-StrictMode -Version Latest
 
 # Ansible v2 will insert the module arguments below as a string containing
 # JSON; assign them to an environment variable and redefine $args so existing


### PR DESCRIPTION
Strictmode introdoces a number of errors in various modules, for instance modules which are testing if an argument exists outside of get-attr. We need to (possibly temporarily) disable strictmode checking.
