### PR TITLE
task logging revamp

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -182,7 +182,7 @@ fact_caching = memory
 #no_log = False
 
 # prevents logging of tasks, but only on the targets, data is still logged on the master/controller
-#managed_syslog = True
+#no_target_syslog = True
 
 [privilege_escalation]
 #become=True

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -177,6 +177,13 @@ fact_caching = memory
 #retry_files_enabled = False
 #retry_files_save_path = ~/.ansible-retry
 
+
+# prevents logging of task data, off by default
+#no_log = False
+
+# prevents logging of tasks, but only on the targets, data is still logged on the master/controller
+#managed_syslog = True
+
 [privilege_escalation]
 #become=True
 #become_method=sudo

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -154,6 +154,10 @@ DEFAULT_LOG_PATH          = get_config(p, DEFAULTS, 'log_path',           'ANSIB
 DEFAULT_FORCE_HANDLERS    = get_config(p, DEFAULTS, 'force_handlers', 'ANSIBLE_FORCE_HANDLERS', False, boolean=True)
 DEFAULT_INVENTORY_IGNORE  = get_config(p, DEFAULTS, 'inventory_ignore_extensions', 'ANSIBLE_INVENTORY_IGNORE', ["~", ".orig", ".bak", ".ini", ".cfg", ".retry", ".pyc", ".pyo"], islist=True)
 
+# disclosure
+DEFAULT_NO_LOG           = get_config(p, DEFAULTS, 'no_log', 'ANSIBLE_NO_LOG', False, boolean=True)
+DEFAULT_MANAGED_SYSLOG   = get_config(p, DEFAULTS, 'managed_syslog', 'ANSIBLE_MANAGED_SYSLOG', True, boolean=True)
+
 # selinux
 DEFAULT_SELINUX_SPECIAL_FS = get_config(p, 'selinux', 'special_context_filesystems', None, 'fuse, nfs, vboxsf, ramfs', islist=True)
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -156,7 +156,7 @@ DEFAULT_INVENTORY_IGNORE  = get_config(p, DEFAULTS, 'inventory_ignore_extensions
 
 # disclosure
 DEFAULT_NO_LOG           = get_config(p, DEFAULTS, 'no_log', 'ANSIBLE_NO_LOG', False, boolean=True)
-DEFAULT_MANAGED_SYSLOG   = get_config(p, DEFAULTS, 'managed_syslog', 'ANSIBLE_MANAGED_SYSLOG', True, boolean=True)
+DEFAULT_NO_TARGET_SYSLOG   = get_config(p, DEFAULTS, 'no_target_syslog', 'ANSIBLE_NO_TARGET_SYSLOG', True, boolean=True)
 
 # selinux
 DEFAULT_SELINUX_SPECIAL_FS = get_config(p, 'selinux', 'special_context_filesystems', None, 'fuse, nfs, vboxsf, ramfs', islist=True)

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -206,9 +206,6 @@ class PlayContext(Base):
         if play.become_user:
             self.become_user = play.become_user
 
-        # non connection related
-        self.no_log      = play.no_log
-
         if play.force_handlers is not None:
             self.force_handlers = play.force_handlers
 
@@ -234,8 +231,6 @@ class PlayContext(Base):
         # general flags (should we move out?)
         if options.verbosity:
             self.verbosity  = options.verbosity
-        #if options.no_log:
-        #    self.no_log     = boolean(options.no_log)
         if options.check:
             self.check_mode = boolean(options.check)
         if hasattr(options, 'force_handlers') and options.force_handlers:
@@ -321,6 +316,10 @@ class PlayContext(Base):
         # during some other step in the process
         if task._local_action:
             setattr(new_info, 'connection', 'local')
+
+        # set no_log to default if it was not previouslly set
+        if new_info.no_log is None:
+            new_info.no_log = C.DEFAULT_NO_LOG
 
         return new_info
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -351,7 +351,7 @@ class ActionBase:
             module_args['_ansible_check_mode'] = True
 
         # set no log in the module arguments, if required
-        if self._play_context.no_log or not C.DEFAULT_MANAGED_SYSLOG:
+        if self._play_context.no_log or not C.DEFAULT_NO_TARGET_SYSLOG:
             module_args['_ansible_no_log'] = True
 
         # set debug in the module arguments, if required

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -351,8 +351,12 @@ class ActionBase:
             module_args['_ansible_check_mode'] = True
 
         # set no log in the module arguments, if required
-        if self._play_context.no_log:
+        if self._play_context.no_log or not C.DEFAULT_MANAGED_SYSLOG:
             module_args['_ansible_no_log'] = True
+
+        # set debug in the module arguments, if required
+        if C.DEFAULT_DEBUG:
+            module_args['_ansible_debug'] = True
 
         (module_style, shebang, module_data) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)
         if not shebang:

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -79,7 +79,6 @@ class TestPlayContext(unittest.TestCase):
         self.assertEqual(play_context.remote_user, 'mock')
         self.assertEqual(play_context.password, '')
         self.assertEqual(play_context.port, 1234)
-        self.assertEqual(play_context.no_log, True)
         self.assertEqual(play_context.become, True)
         self.assertEqual(play_context.become_method, "mock")
         self.assertEqual(play_context.become_user, "mockroot")
@@ -87,11 +86,11 @@ class TestPlayContext(unittest.TestCase):
         mock_task = MagicMock()
         mock_task.connection    = 'mocktask'
         mock_task.remote_user   = 'mocktask'
+        mock_task.no_log        =  mock_play.no_log
         mock_task.become        = True
         mock_task.become_method = 'mocktask'
         mock_task.become_user   = 'mocktaskroot'
         mock_task.become_pass   = 'mocktaskpass'
-        mock_task.no_log        = False
         mock_task._local_action = False
 
         all_vars = dict(
@@ -106,11 +105,15 @@ class TestPlayContext(unittest.TestCase):
         self.assertEqual(play_context.connection, 'mock_inventory')
         self.assertEqual(play_context.remote_user, 'mocktask')
         self.assertEqual(play_context.port, 4321)
-        self.assertEqual(play_context.no_log, False)
+        self.assertEqual(play_context.no_log, True)
         self.assertEqual(play_context.become, True)
         self.assertEqual(play_context.become_method, "mocktask")
         self.assertEqual(play_context.become_user, "mocktaskroot")
         self.assertEqual(play_context.become_pass, "mocktaskpass")
+
+        mock_task.no_log        = False
+        play_context = play_context.set_task_and_variable_override(task=mock_task, variables=all_vars, templar=mock_templar)
+        self.assertEqual(play_context.no_log, False)
 
     def test_play_context_make_become_cmd(self):
         (options, args) = self._parser.parse_args([])


### PR DESCRIPTION
- allow global no_log setting, no need to set at play or task level, but can be overriden by them
- allow turning off syslog only on task execution from target host (manage_syslog), overlaps with no_log functionality
- created log function for task modules to use, now we can remove all syslog references, will use systemd journal if present
- added debug flag to modules, so they can make it call new log function conditionally
- added debug logging in module's run_command
