### PR TITLE
Output proper JSON from vbox dynamic inventory contrib script

### DIFF
--- a/contrib/inventory/vbox.py
+++ b/contrib/inventory/vbox.py
@@ -23,6 +23,11 @@ try:
 except ImportError:
     import simplejson as json
 
+class SetEncoder(json.JSONEncoder):
+   def default(self, obj):
+      if isinstance(obj, set):
+         return list(obj)
+      return json.JSONEncoder.default(self, obj)
 
 VBOX="VBoxManage"
 
@@ -110,5 +115,4 @@ if __name__ == '__main__':
     else:
         inventory = get_hosts()
 
-    import pprint
-    pprint.pprint(inventory)
+    sys.stdout.write(json.dumps(inventory, indent=2, cls=SetEncoder))


### PR DESCRIPTION
The vbox.py dynamic inventory contrib script outputs invalid JSON:

```
    {'Base machines': set(['dev local',
```

Not only should JSON string values be enclosed in double quotes, "set(" is also not valid JSON. This currently prohibits Ansible (v1.9.1) from being able to use the output of the script:

```
$ ansible -m ping -i ./vbox.py all
simplejson.scanner.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```

The cause is the use of `pprint` to dump the gathered output. `pprint` does not produce proper JSON output. 

This pull request fixes these issues by using the `json.dumps()` method with a custom JSONEncoder to cast sets to lists. It has been tested on ansible v1.9.1 and found to work on that version:

```
$ ansible -m ping -i ./vbox.py all
dev local | success >> {
    "changed": false,
    "ping": "pong"
}
```
