### PR TITLE
Updated Azure inventory script to reflect changes in azure python package

### DIFF
--- a/contrib/inventory/windows_azure.py
+++ b/contrib/inventory/windows_azure.py
@@ -48,7 +48,7 @@ except ImportError:
 
 try:
     import azure
-    from azure import WindowsAzureError
+    from azure.common import AzureException, AzureHttpError
     from azure.servicemanagement import ServiceManagementService
 except ImportError as e:
     print("failed=True msg='`azure` library required for this script'")
@@ -194,7 +194,7 @@ class AzureInventory(object):
         try:
             for cloud_service in self.sms.list_hosted_services():
                 self.add_deployments(cloud_service)
-        except WindowsAzureError as e:
+        except AzureHttpError as e:
             print("Looks like Azure's API is down:")
             print("")
             print(e)
@@ -207,7 +207,7 @@ class AzureInventory(object):
         try:
             for deployment in self.sms.get_hosted_service_properties(cloud_service.service_name,embed_detail=True).deployments.deployments:
                 self.add_deployment(cloud_service, deployment)
-        except WindowsAzureError as e:
+        except AzureHttpError as e:
             print("Looks like Azure's API is down:")
             print("")
             print(e)


### PR DESCRIPTION
##### Issue Type:
- Bug Report
- Bugfix Pull Request
##### Ansible Version:

ansible 1.9.3

The [devel/contrib/inventory/windows_azure.py](https://github.com/ansible/ansible/blob/devel/contrib/inventory/windows_azure.py) file used was the latest version from the `devel` branch.
##### Ansible Configuration:

N/A
##### Environment:

The `azure` Python package has been installed through `pip install azure` and is at version 1.0.1.
##### Summary:

The `WindowsAzureError` exception has been changed to an `AzureException` child, named`AzureHttpError` (see [changelog](https://github.com/Azure/azure-sdk-for-python/blob/fa3119c497e98343c7f789e07d108d1d2d457bd2/ChangeLog.txt#L47)). This fix gets the Windows Azure inventory file up to speed on that change.
##### Steps To Reproduce:

Any call that attempts to run the python script breaks, the simplest version being `python contrib/inventory/windows_azure.py`.
##### Expected Results:

Expected result to `python contrib/inventory/windows_azure.py` is a JSON payload.
##### Actual Results:

Actual result is the following output:

```
failed=True msg='`azure` library required for this script'
```
