### PR TITLE
Fix url lookup plugin HTTPError message not being reachable

### DIFF
--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -36,10 +36,10 @@ class LookupModule(LookupBase):
             self._display.vvvv("url lookup connecting to %s" % term)
             try:
                 response = open_url(term, validate_certs=validate_certs)
-            except urllib2.URLError as e:
-                raise AnsibleError("Failed lookup url for %s : %s" % (term, str(e)))
             except urllib2.HTTPError as e:
                 raise AnsibleError("Received HTTP error for %s : %s" % (term, str(e)))
+            except urllib2.URLError as e:
+                raise AnsibleError("Failed lookup url for %s : %s" % (term, str(e)))
             except SSLValidationError as e:
                 raise AnsibleError("Error validating the server's certificate for %s: %s" % (term, str(e)))
             except ConnectionError as e:


### PR DESCRIPTION
AnsibleError could never be raised with "Received HTTP error ..." since urllib2.HTTPError is a subclass of urllib2.URLError and the exception catching statements tests for URLError first. Instead AnsibleError("Failed lookup url ...") would always be raised regardless of the underlying problem.

This patch swaps the order so that both error messages are reachable.
