### PR TITLE
Removed deletion of salt by 'password' lookup

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -150,11 +150,6 @@ class LookupModule(LookupBase):
                     with open(path, 'w') as f:
                         os.chmod(path, 0o600)
                         f.write(content + '\n')
-                # crypt not requested, remove salt if present
-                elif (params['encrypt'] is None and salt):
-                    with open(path, 'w') as f:
-                        os.chmod(path, 0o600)
-                        f.write(password + '\n')
 
             if params['encrypt']:
                 password = do_encrypt(password, params['encrypt'], salt=salt)


### PR DESCRIPTION
Rebased version of #10872, #11734

Removed deletion of salt param from lookup file by 'password' lookup_filter.
Old behaviour leads to constant changed status when two tasks uses same lookup,
one with 'encrypt' parameter, and other without.

For example:

```
tasks:
  - name: Create user
    user:
      password: "{{ lookup('password', inventory_dir + '/creds/user/pass' encrypt=sha512_crypt) }}"
      ...
# Lookup file 'creds/user/pass' now contain password with salt
  - name: Create htpasswd
    htpasswd:
      password: "{{ lookup('password', inventory_dir + '/creds/user/pass') }}"
      ...
# Salt gets deleted from lookup file 'creds/user/pass'
# Next run of "Create user" task will create it again and will have 'changed' status
```
