### PR TITLE
Python 3: there's no basestring

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -118,7 +118,7 @@ class Task(Base, Conditional, Taggable, Become):
     def _merge_kv(self, ds):
         if ds is None:
             return ""
-        elif isinstance(ds, basestring):
+        elif isinstance(ds, string_types):
             return ds
         elif isinstance(ds, dict):
             buf = ""


### PR DESCRIPTION
Fixes another failing test.

(I don't want to do a global search/replace for 'basestring' because I want to
have unit tests covering each occurrence.  When I run out of existing failing
tests, I'll try to write new ones.)
