### PR TITLE
Inject existing groups at InventoryDir initialization

### DIFF
--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -107,7 +107,7 @@ class InventoryDirectory(object):
                 continue
             fullpath = os.path.join(self.directory, i)
             if os.path.isdir(fullpath):
-                parser = InventoryDirectory(loader=loader, filename=fullpath)
+                parser = InventoryDirectory(loader=loader, groups=groups, filename=fullpath)
             else:
                 parser = get_file_parser(fullpath, self.groups, loader)
                 if parser is None:


### PR DESCRIPTION
This fixes a corner case where ini files live in a subdir
of the main inventory directory.

Reproducing the original error:

mkdir -p inventory/ini
cat > inventory/ini/hosts << EOF
[www]
www1
EOF

$ ansible -i inventory/ all -m ping
ERROR! 'all'

(or without the [www] group, it would complain about 'ungrouped')
