### PR TITLE
Releases are named after Led Zeppelin songs as of 2.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Get Involved
 Branch Info
 ===========
 
-   * Releases are named after Van Halen songs.
+   * Releases are named after Led Zeppelin songs.
    * The devel branch corresponds to the release actively under development.
    * As of 1.8, modules are kept in different repos, you'll want to follow [core](https://github.com/ansible/ansible-modules-core) and [extras](https://github.com/ansible/ansible-modules-extras)
    * Various release-X.Y branches exist for previous releases.


### PR DESCRIPTION
According to the [2.0.0 alpha release announcment](https://groups.google.com/forum/#!topic/ansible-announce/3e1pohu1XlQ), Ansible releases will now be named after Led Zeppelin songs:

> One thing you might notice is the release name - as of the 2.0 release we will now be tracking Led Zeppelin songs, with the first release being "Over the Hills and Far Away". Michael and I had discussed this all the way back in December of 2014, so it's nice being able to make it official :)

Let's reflect that in the main README that welcomes everyone to the project!
