### PR TITLE
Bring groups handling in ini.py up-to-date (trivial fix)

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -38,15 +38,12 @@ class InventoryParser(object):
     with their associated hosts and variable settings.
     """
 
-    def __init__(self, loader, groups=None, filename=C.DEFAULT_HOST_LIST):
-        if groups is None:
-            groups = dict()
-
+    def __init__(self, loader, groups, filename=C.DEFAULT_HOST_LIST):
         self._loader = loader
         self.filename = filename
 
-        # Start with an empty host list and the default 'all' and
-        # 'ungrouped' groups.
+        # Start with an empty host list and whatever groups we're passed in
+        # (which should include the default 'all' and 'ungrouped' groups).
 
         self.hosts = {}
         self.patterns = {}


### PR DESCRIPTION
Since c8f2483d, ini.py expects to always be passed in a pre-created list
of groups, and can no longer deal sensibly with an empty list; this just
makes that expectation clear.
