### PR TITLE
Remove an unwanted FIXME annotation

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -288,8 +288,7 @@ class InventoryParser(object):
 
         # Note that we decide whether or not to create a Host based solely on
         # the (non-)existence of its hostname in self.hosts. This means that one
-        # cannot add both "foo:22" and "foo:23" to the inventory. This behaviour
-        # is preserved for now, but this may be an easy FIXME.
+        # cannot add both "foo:22" and "foo:23" to the inventory.
 
         for hn in hostnames:
             if hn not in self.hosts:


### PR DESCRIPTION
<crab> jimi|ansible: do you think it should be possible to add both
       foo:22 and foo:23 to the inventory?
<jimi|ansible> no

…so we don't want an invitation to FIXME.
