### PR TITLE
Remove mysterious old cruft

### DIFF
--- a/lib/ansible/plugins/lookup/nested.py
+++ b/lib/ansible/plugins/lookup/nested.py
@@ -26,8 +26,6 @@ from ansible.utils.listify import listify_lookup_plugin_terms
 class LookupModule(LookupBase):
 
     def _lookup_variables(self, terms, variables):
-        foo = variables.copy()
-        foo.pop('vars', None)
         results = []
         for x in terms:
             try:


### PR DESCRIPTION
The two lines were added in 2673eb0a and modified in 60e1a1f8, but foo
is completely unused. Removing it doesn't break anything: out it goes!
