### PR TITLE
Improved function Get-AnsibleParam now has aliasing support

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -105,7 +105,8 @@ Function Fail-Json($obj, $message = $null)
 #Get-AnsibleParam also supports Parameter validation to save you from coding that manually:
 #Example: Get-AnsibleParam -obj $params -name "State" -default "Present" -ValidateSet "Present","Absent" -resultobj $resultobj -failifempty $true
 #Note that if you use the failifempty option, you do need to specify resultobject as well.
-Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempty=$false, $emptyattributefailmessage, $ValidateSet, $ValidateSetErrorMessage, [string[]]$aliases, [Parameter(DontShow)]$OriginalName)
+#Also note that the "OriginalName" parameter is used for keeping internal state while recursing and must not be used when invoking the function.
+Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempty=$false, $emptyattributefailmessage, $ValidateSet, $ValidateSetErrorMessage, [string[]]$aliases, $OriginalName)
 {
     if (!$originalname)
     {

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -133,7 +133,15 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempt
                     if ($ValidateSetErrorMessage -eq $null)
                     {
                         #Auto-generated error should be sufficient in most use cases
-                        $ValidateSetErrorMessage = "Argument $name needs to be one of $($ValidateSet -join ",") but was $($obj.$name)."
+                        if ($originalname -eq $name)
+                        {
+                            $ValidateSetErrorMessage = "Argument $originalname needs to be one of $($ValidateSet -join ",") but was $($obj.$name)."
+                        }
+                        Else
+                        {
+                            $ValidateSetErrorMessage = "Argument $originalname (you were using the alias $name) needs to be one of $($ValidateSet -join ",") but was $($obj.$name)."
+                        }
+                        
                     }
                     Fail-Json -obj $resultobj -message $ValidateSetErrorMessage
                 }


### PR DESCRIPTION
This commit adds support for aliases in the Get-Attr/Get-AnsibleParam function. Usage:
simple usage:

``` powershell
Get-AnsibleParam -obj $params -name State -aliases Ensure
```

or multi-aliasing:

``` powershell
Get-AnsibleParam -obj $params -name State -aliases Ensure,Status
```

or with mandatory params:

``` powershell
Get-AnsibleParam -obj $params -name State -aliases Ensure -failifempty $true -ValidateSet "present","absent" -resultobj $returnobj
```

We need to to some very thorough testing of this function, since so many things depend on it. I've tested it every way I can using strictmode, but there's probably some scenario I haven't thought of.
