### PR TITLE
Fix bug in ipaddr netmask filter when cidr is 32

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -162,7 +162,7 @@ def _net_query(v):
             return str(v.network) + '/' + str(v.prefixlen)
 
 def _netmask_query(v):
-    if v.size > 1:
+    if v.size >= 1:
         return str(v.netmask)
 
 def _network_query(v):

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -1,0 +1,35 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests import unittest
+from ansible.plugins.filter.ipaddr import ipaddr, _netmask_query
+
+
+class TestNetmask(unittest.TestCase):
+    def test_whole_octets(self):
+        address = '1.1.1.1/24'
+        self.assertEqual(ipaddr(address, 'netmask'), '255.255.255.0')
+
+    def test_partial_octet(self):
+        address = '1.1.1.1/25'
+        self.assertEqual(ipaddr(address, 'netmask'), '255.255.255.128')
+
+    def test_32_cidr(self):
+        address = '1.12.1.34/32'
+        self.assertEqual(ipaddr(address, 'netmask'), '255.255.255.255')

--- a/test/utils/tox/requirements-py3.txt
+++ b/test/utils/tox/requirements-py3.txt
@@ -11,3 +11,4 @@ unittest2
 redis
 python3-memcached
 python-systemd
+netaddr

--- a/test/utils/tox/requirements.txt
+++ b/test/utils/tox/requirements.txt
@@ -12,3 +12,4 @@ redis
 python-memcached
 python-systemd
 pycrypto
+netaddr


### PR DESCRIPTION
##### SUMMARY
Fixes #12065 


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/ipaddr.py
test/units/plugins/filter/test_ipaddr.py
test/utils/tox/requirements-py3.txt
test/utils/tox/requirements.txt

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


