### PR TITLE
Bugfix Pull Request: hostvars is not JSON serializable

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -427,6 +427,8 @@ class VariableManager:
 
         if 'hostvars' in all_vars and host:
             all_vars['vars'] = all_vars['hostvars'][host.get_name()]
+            all_vars['hostvars'] = dict(
+                [(host.get_name(), UnsafeProxy(all_vars['hostvars'][host.get_name()]))])
 
         #VARIABLE_CACHE[cache_entry] = all_vars
 


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 2.0.0 (devel a1f6de8745) last updated 2015/10/02 20:50:10 (GMT +100)
  lib/ansible/modules/core: (detached HEAD dbc860daaa) last updated 2015/10/02 19:45:58 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 9f5420e459) last updated 2015/10/02 19:45:58 (GMT +100)
  config file =
  configured module search path = None
##### Environment:

N/A
(tested on Mac OS X 10.10.5 Python 2.7.10)
##### Summary:

As reported in https://github.com/ansible/ansible/issues/11877#issuecomment-140049113 `hostvars` is not JSON serializable. Is this intentional?
##### Steps To Reproduce:

```
ansible localhost -m debug -a 'var={{hostvars | to_json}}'
```
##### Expected Results:

```
localhost | SUCCESS => {
    "changed": false,
    "{{hostvars | to_json}}": "{\"localhost\": {\"inventory_hostname\": \"localhost\", \"inventory_hostname_short\": \"localhost\", \"playbook_dir\": \".\", \"omit\": \"__omit_place_holder__e07edb72d3da2b6446cb59291fa944b6161d4c4b\", \"ansible_python_interpreter\": \"/Users/simon/venvs/ansible/bin/python\", \"inventory_dir\": null, \"ansible_play_hosts\": [], \"ansible_connection\": \"local\", \"groups\": {\"ungrouped\": [\"localhost\"], \"all\": [\"localhost\"]}, \"group_names\": [], \"play_hosts\": [], \"ansible_version\": {\"major\": 2, \"full\": \"2.0.0\", \"string\": \"2.0.0\", \"minor\": 0, \"revision\": 0}}}"
}
```
##### Actual Results:

```
localhost | FAILED! => {
    "failed": true,
    "msg": "ERROR! an unexpected type error occurred. Error was <ansible.vars.hostvars.HostVars object at 0x10fc30610> is not JSON serializable"
}
```
##### Additional infomation

The root cause appears to be the use of the `ansible.vars.hostvars.HostVars` object which isn't serialisable by `to_json`:

```
$ ansible localhost -m debug -a 'var={{hostvars}}'
localhost | SUCCESS => {
    "changed": false,
    "{{hostvars}}": "<ansible.vars.hostvars.HostVars object at 0x1067875d0>"
}
```

This PR replaces the `all_vars['hostvars']` object with a dict, and gives the "expected output" shown above. However I'm not familiar enough with the code to know whether this is correct or not. Is hostvars ever used without a host context?

Without `to_json` the hostvars for the current host is output instead of an object reference:

```
$ ansible localhost -m debug -a 'var={{hostvars}}'
localhost | SUCCESS => {
    "changed": false,
    "{{hostvars}}": {
        "localhost": {
            "ansible_connection": "local",
            "ansible_play_hosts": [],
            "ansible_python_interpreter": "/Users/simon/venvs/ansible/bin/python",
            "ansible_version": {
                "full": "2.0.0",
                "major": 2,
                "minor": 0,
                "revision": 0,
                "string": "2.0.0"
            },
            "group_names": [],
            "groups": {
                "all": [
                    "localhost"
                ],
                "ungrouped": [
                    "localhost"
                ]
            },
            "inventory_dir": null,
            "inventory_hostname": "localhost",
            "inventory_hostname_short": "localhost",
            "omit": "__omit_place_holder__3aadc5376db27eaee74ed0f68b95a9a599d78c5e",
            "play_hosts": [],
            "playbook_dir": "."
        }
    }
}
```
