### PR TITLE
Replace pipes.quote for shlex_quote

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -21,12 +21,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import pipes
 import random
 import re
 import string
 
 from ansible.compat.six import iteritems, string_types
+from ansible.compat.six.moves import shlex_quote
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.playbook.attribute import Attribute, FieldAttribute
@@ -383,7 +383,7 @@ class PlayContext(Base):
             becomecmd   = None
             randbits    = ''.join(random.choice(string.ascii_lowercase) for x in range(32))
             success_key = 'BECOME-SUCCESS-%s' % randbits
-            success_cmd = pipes.quote('echo %s; %s' % (success_key, cmd))
+            success_cmd = shlex_quote('echo %s; %s' % (success_key, cmd))
 
             # set executable to use for the privilege escalation method, with various overrides
             exe = self.become_exe or \
@@ -405,7 +405,7 @@ class PlayContext(Base):
                 # it fail if it would have prompted for a password.
                 #
                 # Passing a quoted compound command to sudo (or sudo -s)
-                # directly doesn't work, so we shellquote it with pipes.quote()
+                # directly doesn't work, so we shellquote it with shlex_quote()
                 # and pass the quoted string to the user's shell.
 
                 # force quick error if password is required but not supplied, should prevent sudo hangs.
@@ -461,7 +461,7 @@ class PlayContext(Base):
             if self.become_pass:
                 self.prompt = prompt
             self.success_key = success_key
-            return ('%s -c %s' % (executable, pipes.quote(becomecmd)))
+            return ('%s -c %s' % (executable, shlex_quote(becomecmd)))
 
         return cmd
 

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -427,6 +427,7 @@ class PlayContext(Base):
 
             elif self.become_method == 'pbrun':
 
+                # NOTE: this is 'assword' on purpose as diff versions does not capitalize it the same way.
                 prompt='assword:'
                 becomecmd = '%s -b %s -u %s %s' % (exe, flags, self.become_user, success_cmd)
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -22,13 +22,13 @@ __metaclass__ = type
 import base64
 import json
 import os
-import pipes
 import random
 import stat
 import tempfile
 import time
 
 from ansible.compat.six import binary_type, text_type, iteritems
+from ansible.compat.six.moves import shlex_quote
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure
@@ -379,7 +379,7 @@ class ActionBase:
                 # the remote system, which can be read and parsed by the module
                 args_data = ""
                 for k,v in iteritems(module_args):
-                    args_data += '%s="%s" ' % (k, pipes.quote(v))
+                    args_data += '%s="%s" ' % (k, shlex_quote(v))
                 self._transfer_data(args_file_path, args_data)
             self._display.debug("done transferring module to remote")
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -21,13 +21,14 @@ __metaclass__ = type
 
 import fcntl
 import os
-import pipes
 import pty
 import pwd
 import select
 import shlex
 import subprocess
 import time
+
+from ansible.compat.six.moves import shlex_quote
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
@@ -317,7 +318,7 @@ class Connection(ConnectionBase):
         Starts the command and communicates with it until it ends.
         '''
 
-        display_cmd = map(pipes.quote, cmd[:-1]) + [cmd[-1]]
+        display_cmd = map(shlex_quote, cmd[:-1]) + [cmd[-1]]
         self._display.vvv('SSH: EXEC {0}'.format(' '.join(display_cmd)), host=self.host)
 
         # Start the given command. If we don't need to pipeline data, we can try
@@ -618,11 +619,11 @@ class Connection(ConnectionBase):
         host = '[%s]' % self.host
 
         if C.DEFAULT_SCP_IF_SSH:
-            cmd = self._build_command('scp', in_path, '{0}:{1}'.format(host, pipes.quote(out_path)))
+            cmd = self._build_command('scp', in_path, '{0}:{1}'.format(host, shlex_quote(out_path)))
             in_data = None
         else:
             cmd = self._build_command('sftp', host)
-            in_data = "put {0} {1}\n".format(pipes.quote(in_path), pipes.quote(out_path))
+            in_data = "put {0} {1}\n".format(shlex_quote(in_path), shlex_quote(out_path))
 
         (returncode, stdout, stderr) = self._run(cmd, in_data)
 
@@ -641,11 +642,11 @@ class Connection(ConnectionBase):
         host = '[%s]' % self.host
 
         if C.DEFAULT_SCP_IF_SSH:
-            cmd = self._build_command('scp', '{0}:{1}'.format(host, pipes.quote(in_path)), out_path)
+            cmd = self._build_command('scp', '{0}:{1}'.format(host, shlex_quote(in_path)), out_path)
             in_data = None
         else:
             cmd = self._build_command('sftp', host)
-            in_data = "get {0} {1}\n".format(pipes.quote(in_path), pipes.quote(out_path))
+            in_data = "get {0} {1}\n".format(shlex_quote(in_path), shlex_quote(out_path))
 
         (returncode, stdout, stderr) = self._run(cmd, in_data)
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -304,10 +304,11 @@ class Connection(ConnectionBase):
         # have removed from the output), we retain it to be processed with the
         # next chunk.
 
-        remainder = ''
         if output and not output[-1].endswith('\n'):
             remainder = output[-1]
             output = output[:-1]
+        else:
+            remainder = ''
 
         return ''.join(output), remainder
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -24,7 +24,6 @@ import json
 import os.path
 import ntpath
 import types
-import pipes
 import glob
 import re
 import crypt
@@ -39,6 +38,7 @@ import yaml
 from jinja2.filters import environmentfilter
 from distutils.version import LooseVersion, StrictVersion
 from ansible.compat.six import iteritems
+from ansible.compat.six.moves import shlex_quote
 
 from ansible import errors
 from ansible.parsing.yaml.dumper import AnsibleDumper
@@ -114,7 +114,7 @@ def bool(a):
 
 def quote(a):
     ''' return its argument quoted for shell usage '''
-    return pipes.quote(a)
+    return shlex_quote(a)
 
 def fileglob(pathname):
     ''' return list of matched files for glob '''


### PR DESCRIPTION
pipes.quote is considered deprecated (https://docs.python.org/2/library/pipes.html#pipes.quote) so I think using six here is a fitting compromise.

Also this is a step for bringing python3 compatibility to the ansible codebase.
