### PR TITLE
Fix ansible-vault rekey

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -35,6 +35,7 @@ class VaultCLI(CLI):
     def __init__(self, args, display=None):
 
         self.vault_pass = None
+        self.new_vault_pass = None
         super(VaultCLI, self).__init__(args, display)
 
     def parse(self):


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.0 (devel d91b3c6b9d) last updated 2015/10/05 15:41:58 (GMT -500)
  lib/ansible/modules/core: (detached HEAD 144291120e) last updated 2015/10/05 15:42:05 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD da426da308) last updated 2015/10/05 15:42:05 (GMT -500)
  config file =
 configured module search path = None
```
##### Ansible Configuration:

None.
##### Environment:

Mac OS X 10.10.5
##### Summary:

Running ansible-vault rekey without the --new-vault-password-file option throws an exception
##### Steps To Reproduce:

Run ansible-vault rekey secrets.yaml. After inputing the Vault password it will throw an exception.
##### Expected Results:

After asking for the Vault password it should ask for the new vault password without exception.
##### Actual Results:

```
mbp:group_vars user$ ansible-vault rekey secrets.yaml -vvv
No config file found; using defaults
Vault password: **********
Unexpected Exception: 'VaultCLI' object has no attribute 'new_vault_pass'
the full traceback was:

Traceback (most recent call last):
  File "/Users/rcleere/code/ansible/ansible/bin/ansible-vault", line 79, in <module>
    sys.exit(cli.run())
  File "/Users/rcleere/code/ansible/ansible/lib/ansible/cli/vault.py", line 103, in run
    self.execute()
  File "/Users/rcleere/code/ansible/ansible/lib/ansible/cli/__init__.py", line 96, in execute
    fn()
  File "/Users/rcleere/code/ansible/ansible/lib/ansible/cli/vault.py", line 148, in execute_rekey
    if self.new_vault_pass:
AttributeError: 'VaultCLI' object has no attribute 'new_vault_pass'
```
