### PR TITLE
Add an expand_csv_tags setting to ec2.ini

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -97,6 +97,10 @@ nested_groups = False
 # Replace - tags when creating groups to avoid issues with ansible
 replace_dash_in_groups = True
 
+# If set to true, any tag of the form "a,b,c" is expanded into a list
+# and the results are used to create additional tag_* inventory groups.
+expand_csv_tags = False
+
 # The EC2 inventory output can become very large. To manage its size,
 # configure which groups should be created.
 group_by_instance_id = True


### PR DESCRIPTION
If enabled, this will convert tags of the form "a,b,c" to a list and use
the results to create additional inventory groups.

This is based on PR #8676 by nickpeck (but not a straight rebase—both
the code and the nomenclature have been changed here).

Closes #8676

cc: @willthames @bcoca 
