### PR TITLE
Fix ec2 inventory for potentially inconsistent data

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -460,8 +460,20 @@ class Ec2Inventory(object):
             else:
                 reservations = conn.get_all_instances()
 
+            # Pull the tags back in a second step
+            # AWS are on record as saying that the tags fetched in the first `get_all_instances` request are not
+            # reliable and may be missing, and the only way to guarantee they are there is by calling `get_all_tags`
+            instance_ids = []
+            for reservation in reservations:
+                instance_ids.extend([instance.id for instance in reservation.instances])
+            tags = conn.get_all_tags(filters={'resource-type': 'instance', 'resource-id': instance_ids})
+            tags_by_instance_id = defaultdict(dict)
+            for tag in tags:
+                tags_by_instance_id[tag.res_id][tag.name] = tag.value
+
             for reservation in reservations:
                 for instance in reservation.instances:
+                    instance.tags = tags_by_instance_id[instance.id]
                     self.add_instance(instance, region)
 
         except boto.exception.BotoServerError as e:


### PR DESCRIPTION
Last week one of my Ansible Playbooks decided to terminate ALL instances on our account. Since talking to AWS support I have found that this is due to a bug/potential data inconsistency in the EC2 API.

**Incident**

I have a playbook, as detailed in [this blogpost](http://adamj.eu/tech/2015/04/09/cleaning-up-nameless-ec2-instances-with-ansible/), that terminates all instances without tags that have been running > 1 hour. It is intended to clean up accidental launches from aborted CI builds, and thus runs every 15 minutes on our Jenkins server.

Last week, on the nearly 27,000th run of the playbook, it decided to terminate all instances. This was because the EC2 API, through the ec2.py inventory script, returned the list of instances but no tagging information for them.

**Fix**

When I contacted AWS support (private communication) they confirmed that the EC2 `DescribeInstances` endpoint (boto's `get_all_instances`) makes no guarantees about the tags being returned alongside the instances, and that they have failed to document it. They made two suggestions:
1. Use `DescribeTags` (boto's `get_all_tags`) to fetch tag information in a second request, this is guaranteed to fail if it can't fetch tags
2. Apply a tag filter to `DescribeInstances`

Since number 2 cannot be done and still return untagged instances, number 1 is the only option.

This PR implements number 1 in `ec2.py`. For testing I've run it my own inventory and `diff` of the before & after results produces no output, keen to know if there are other ways of testing.
