### PR TITLE
You can create private instances in SoftLayer without a primaryIpAddress

### DIFF
--- a/plugins/inventory/softlayer.py
+++ b/plugins/inventory/softlayer.py
@@ -106,9 +106,13 @@ class SoftLayerInventory(object):
 
         # if there's no IP address, we can't reach it
         if 'primaryIpAddress' not in instance:
-            return
+            if 'primaryBackendIpAddress' not in instance:
+                return
 
-        dest = instance['primaryIpAddress']
+        if 'primaryIpAddress' in instance:
+            dest = instance['primaryIpAddress']
+        else:
+            dest = instance['primaryBackendIpAddress']
 
         self.inventory["_meta"]["hostvars"][dest] = instance
 


### PR DESCRIPTION
##### SUMMARY
Currently the SoftLayer inventory script ignores any servers which don't have a public IP address which isn't always ideal


##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
plugins/inventory/softlayer.py

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION


