### PR TITLE
Explictly set the version of strict mode to use for powershell modules.

### DIFF
--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -509,7 +509,7 @@ Windows modules checklist
 * Favour native powershell and .net ways of doing things over calls to COM libraries or calls to native executables which may or may not be present in all versions of windows
 * modules are in powershell (.ps1 files) but the docs reside in same name python file (.py)
 * look at ansible/lib/ansible/module_utils/powershell.ps1 for common code, avoid duplication
-* Ansible uses strictmode so be sure to test with that enabled
+* Ansible uses strictmode version 2.0 so be sure to test with that enabled
 * start with::
 
     #!powershell

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -26,7 +26,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-Set-StrictMode -Version Latest
+Set-StrictMode -Version 2.0
 
 # Ansible v2 will insert the module arguments below as a string containing
 # JSON; assign them to an environment variable and redefine $args so existing


### PR DESCRIPTION
I'd like the version of strict mode to be set explicitly in case next update to powershell comes with a new version of strict mode that.

Also updated the module development windows modules checklist to state the version of strict mode in use.
