### PR TITLE
Show a nice error if the role name is missing.

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -167,8 +167,8 @@ class GalaxyCLI(CLI):
         force      = self.get_opt('force', False)
         offline    = self.get_opt('offline', False)
 
-        role_name = self.args.pop(0).strip()
-        if role_name == "":
+        role_name = self.args.pop(0).strip() if self.args else None
+        if not role_name:
             raise AnsibleOptionsError("- no role name specified for init")
         role_path = os.path.join(init_path, role_name)
         if os.path.exists(role_path):


### PR DESCRIPTION
without the patch:

```
Traceback (most recent call last):
  File "/home/florian/sources/ansible/bin/ansible-galaxy", line 79, in <module>
    sys.exit(cli.run())
  File "/home/florian/sources/ansible/lib/ansible/cli/galaxy.py", line 125, in run
    self.execute()
  File "/home/florian/sources/ansible/lib/ansible/cli/__init__.py", line 96, in execute
    fn()
  File "/home/florian/sources/ansible/lib/ansible/cli/galaxy.py", line 170, in execute_init
    role_name = self.args.pop(0).strip()
IndexError: pop from empty list
```
