### PR TITLE
Displays the absolute path of a given task when verbosity is above level 3

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -101,6 +101,12 @@ class Task(Base, Conditional, Taggable, Become):
 
         super(Task, self).__init__()
 
+    def get_path(self):
+       ''' return the absolute path of the task with its line number '''
+
+       if hasattr(self, '_ds'):
+           return "%s:%s" % (self._ds._data_source, self._ds._line_number)
+
     def get_name(self):
        ''' return the name of the task '''
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -110,6 +110,10 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_task_start(self, task, is_conditional):
         self._display.banner("TASK [%s]" % task.get_name().strip())
+        if self._display.verbosity > 3:
+            path = task.get_path()
+            if path:
+                self._display.display("task path: %s" % path, color='cyan')
 
     def v2_playbook_on_cleanup_task_start(self, task):
         self._display.banner("CLEANUP TASK [%s]" % task.get_name().strip())


### PR DESCRIPTION
One of the main challenges  we face in a project with lots of roles is knowing exactly where a given task is defined, having the absolute task path and its line number would help a lot on the development process.
