### PR TITLE
(TRIVIAL) Fail if the vault password script returns non-zero.

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -501,6 +501,8 @@ class CLI(object):
             except OSError as e:
                 raise AnsibleError("Problem running vault password script %s (%s). If this is not a script, remove the executable bit from the file." % (' '.join(this_path), e))
             stdout, stderr = p.communicate()
+            if p.returncode != 0:
+                raise AnsibleError("Vault password script %s returned non-zero (%s)." % (this_path, p.returncode))
             vault_pass = stdout.strip('\r\n')
         else:
             try:


### PR DESCRIPTION
Fixes #12673

Not checking the error code could potentially lead to encrypting the data with the error message as the password.

Before:

```
$ ansible-vault --vault-password-file=~/.secrets/.vaultpw encrypt group_vars/prod
Error reading secret/ansible/vault: Get https://vault:8200/v1/secret/ansible/vault: net/http: TLS handshake timeout
Encryption successful
```

After:

```
$ ansible-vault --vault-password-file=~/.secrets/.vaultpw encrypt group_vars/prod
Error reading secret/ansible/vault: Get https://vault:8200/v1/secret/ansible/vault: net/http: TLS handshake timeout
ERROR! Vault password script /Users/georges/.secrets/.vaultpw returned non-zero (1).
```

(If this looks acceptable, I'll add tests.)

/cc @msabramo @0x9900
