### PR TITLE
Force SSL transport for pywinrm updates, get host+group vars

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -48,6 +48,7 @@ from ansible.plugins.connection import ConnectionBase
 from ansible.plugins import shell_loader
 from ansible.utils.path import makedirs_safe
 from ansible.utils.unicode import to_bytes, to_unicode, to_str
+from ansible.utils.vars import combine_vars
 
 class Connection(ConnectionBase):
     '''WinRM connections over HTTP/HTTPS.'''
@@ -76,7 +77,7 @@ class Connection(ConnectionBase):
         '''
         Override WinRM-specific options from host variables.
         '''
-        host_vars = host.get_vars()
+        host_vars = combine_vars(host.get_group_vars(), host.get_vars())
 
         self._winrm_host = self._play_context.remote_addr
         self._winrm_port = int(self._play_context.port or 5986)
@@ -91,10 +92,12 @@ class Connection(ConnectionBase):
             self._winrm_realm = None
         self._winrm_realm = host_vars.get('ansible_winrm_realm', self._winrm_realm) or None
 
+        transport_selector = 'ssl' if self._winrm_scheme == 'https' else 'plaintext'
+
         if HAVE_KERBEROS and ('@' in self._winrm_user or self._winrm_realm):
-            self._winrm_transport = 'kerberos,plaintext'
+            self._winrm_transport = 'kerberos,%s' % transport_selector
         else:
-            self._winrm_transport = 'plaintext'
+            self._winrm_transport = transport_selector
         self._winrm_transport = host_vars.get('ansible_winrm_transport', self._winrm_transport)
         if isinstance(self._winrm_transport, basestring):
             self._winrm_transport = [x.strip() for x in self._winrm_transport.split(',') if x.strip()]


### PR DESCRIPTION
I PR'd a change to pywinrm to allow server certs to be ignored; but it's only on the SSL transport (which we were previously ignoring). For this to work more generally (eg, when defined as a group_var), we're also now pulling the named ansible_winrm_\* args from the merged set of host/group vars, not just host_vars.
