### PR TITLE
Use AWS_DEFAULT_REGION env var if none specified

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -124,6 +124,8 @@ def get_aws_connection_info(module, boto3=False):
     if not region:
         if 'AWS_REGION' in os.environ:
             region = os.environ['AWS_REGION']
+        elif 'AWS_DEFAULT_REGION' in os.environ:
+            region = os.environ['AWS_DEFAULT_REGION']
         elif 'EC2_REGION' in os.environ:
             region = os.environ['EC2_REGION']
         else:


### PR DESCRIPTION
Since boto3 and aws cli expect AWS_DEFAULT_REGION env var, it would be good if it would be supported in get_aws_connection_info() as well.

http://boto3.readthedocs.org/en/latest/guide/configuration.html
http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment
