### PR TITLE
Fix an issue where cache plugins weren't updated in certain scenarios

### DIFF
--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -68,3 +68,8 @@ class FactCache(MutableMapping):
     def flush(self):
         """ Flush the fact cache of all keys. """
         self._plugin.flush()
+
+    def update(self, key, value):
+        host_cache = self._plugin.get(key)
+        host_cache.update(value)
+        self._plugin.set(key, host_cache)

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -546,7 +546,7 @@ class VariableManager:
             self._fact_cache[host.name] = facts
         else:
             try:
-                self._fact_cache[host.name].update(facts)
+                self._fact_cache.update(host.name, facts)
             except KeyError:
                 self._fact_cache[host.name] = facts
 


### PR DESCRIPTION
The first call to persisting facts would work due to the assignment of a
MutableMapping calling **setitem** but subsequent module fact data would
not be propogated to the fact cache plugins because update() doesn't
invoke **setitem**.  This changes the behavior a little bit and ensures
set() is called on cache plugins.
