### PR TITLE
bugfix: serial keyword can be specified as a percentage

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -87,7 +87,7 @@ class Play(Base, Taggable, Become):
     _any_errors_fatal    = FieldAttribute(isa='bool', default=False, always_post_validate=True)
     _force_handlers      = FieldAttribute(isa='bool', always_post_validate=True)
     _max_fail_percentage = FieldAttribute(isa='percent', always_post_validate=True)
-    _serial              = FieldAttribute(isa='string', default='0', always_post_validate=True)
+    _serial              = FieldAttribute(isa='percent', default=0, always_post_validate=True)
     _strategy            = FieldAttribute(isa='string', default='linear', always_post_validate=True)
 
     # =================================================================================

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -87,7 +87,7 @@ class Play(Base, Taggable, Become):
     _any_errors_fatal    = FieldAttribute(isa='bool', default=False, always_post_validate=True)
     _force_handlers      = FieldAttribute(isa='bool', always_post_validate=True)
     _max_fail_percentage = FieldAttribute(isa='percent', always_post_validate=True)
-    _serial              = FieldAttribute(isa='int', default=0, always_post_validate=True)
+    _serial              = FieldAttribute(isa='string', default='0', always_post_validate=True)
     _strategy            = FieldAttribute(isa='string', default='linear', always_post_validate=True)
 
     # =================================================================================


### PR DESCRIPTION
The serial keyword can be specified as a percentage, e.g '30%' or a number e.g. '3'; therefore it needs to be a string to allow both types
