### PR TITLE
Adding the inventory_file var back

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -356,6 +356,7 @@ class VariableManager:
 
         if self._inventory is not None:
             variables['inventory_dir'] = self._inventory.basedir()
+            variables['inventory_file'] = self._inventory.src()
             if play:
                 # add the list of hosts in the play, as adjusted for limit/filters
                 # DEPRECATED: play_hosts should be deprecated in favor of ansible_play_hosts,


### PR DESCRIPTION
This fixes the formerly fixed https://github.com/ansible/ansible/issues/8534 where `vars_files` won't expand the `inventory_file` variable.
