### PR TITLE
allow for sshpass support for `synchronize`

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1609,7 +1609,7 @@ class AnsibleModule(object):
             # rename might not preserve context
             self.set_context_if_different(dest, context, False)
 
-    def run_command(self, args, check_rc=False, close_fds=True, executable=None, data=None, binary_data=False, path_prefix=None, cwd=None, use_unsafe_shell=False, prompt_regex=None):
+    def run_command(self, args, check_rc=False, close_fds=True, executable=None, data=None, binary_data=False, path_prefix=None, cwd=None, use_unsafe_shell=False, prompt_regex=None, shell_env=None):
         '''
         Execute a command, returns rc, stdout, and stderr.
         args is the command to run
@@ -1658,10 +1658,14 @@ class AnsibleModule(object):
         msg = None
         st_in = None
 
-        # Set a temporary env path if a prefix is passed
         env=os.environ
+        # Set a temporary env path if a prefix is passed
         if path_prefix:
             env['PATH']="%s:%s" % (path_prefix, env['PATH'])
+
+        # setup shell env if passed
+        if shell_env:
+           env.update(shell_env)
 
         # create a printable version of the command for use
         # in reporting later, which strips out things like
@@ -1705,7 +1709,7 @@ class AnsibleModule(object):
             stderr=subprocess.PIPE
         )
 
-        if path_prefix:
+        if path_prefix or shell_env:
             kwargs['env'] = env
         if cwd and os.path.isdir(cwd):
             kwargs['cwd'] = cwd

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -173,6 +173,10 @@ class ActionModule(ActionBase):
         if self._task.args.get('mode', 'push') == 'pull':
             (dest_host, src_host) = (src_host, dest_host)
 
+        # MUNGE SSH_PASSWD INFO
+        if self._task.args.get('login_password', None):
+            self._task.args['login_password'] = task_vars.get('ansible_ssh_pass') or self._play_context.password
+
         # MUNGE SRC AND DEST PER REMOTE_HOST INFO
         src = self._task.args.get('src', None)
         dest = self._task.args.get('dest', None)


### PR DESCRIPTION
Needs: https://github.com/ansible/ansible-modules-core/pull/2244
- sshpass support
- env support for run_command

delegate_to fix - https://github.com/ansible/ansible/pull/12752
##### Security consideration
- /proc/pid/environ are only readable by owner, or root. root can read almost everything based on selinux/security policies (including /proc/kcore)
- ssh client tends to strip out env variables, SSHPASS will not be seen by client process (SendEnv ssh config bit)
##### reasons to opt for env var
- module.run_command does not support passing an fd to command module.
- ssh and sshpass do not support reading password from stdin pipe ( data arg of run_command)
- passing fd number to sshpass will not work, as fd no can be random.
- adding support for setting up env was the least invasive and most reliable change
