### PR TITLE
Improve module doc template and module return value doc

### DIFF
--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -401,6 +401,37 @@ like this::
 The EXAMPLES section, just like the documentation section, is required in
 all module pull requests for new modules.
 
+Possible return values from the module should also be documented
+in addition to :doc:`common_return_values`.
+The fields unique to the module must be written in plain text
+in a ``RETURN`` string within the module like this::
+
+    RETURN = '''
+    field_name:
+      description: field description
+      returned: success, changed, or more detailed conditions
+      type: boolean, integer, string, list, etc.
+      sample: sample field value
+    dict_field_name:
+      description: dict field description
+      returned: success, changed, or more detailed conditions
+      type: dictionary
+      sample: sample dict field value
+      contains:
+        dict_key:
+          description: dict description
+          returned: success, changed, or more detailed conditions
+          type: boolean, integer, string, list, etc.
+          sample: sample dict value
+    '''
+
+If the module has no special fields other than :doc:`common_return_values`,
+``RETURN`` should explicitly have an empty dictionary::
+
+    RETURN = '''
+    {}
+    '''
+
 .. _module_dev_testing:
 
 Building & Testing

--- a/hacking/templates/rst.j2
+++ b/hacking/templates/rst.j2
@@ -102,11 +102,17 @@ Examples
 {% endif %}
 
 
-{% if returndocs -%}
 Return Values
 -------------
 
-Common return values are documented here :doc:`common_return_values`, the following are the fields unique to this module:
+Common return values are documented here :doc:`common_return_values`.
+
+{% if returndocs is not mapping -%}
+There is no documentation on fields unique to this module.
+{% elif not returndocs -%}
+There are no fields unique to this module.
+{% else -%}
+The following are the fields unique to this module:
 
 .. raw:: html
 


### PR DESCRIPTION
In ansible/ansible-modules-extras#832 I was requested from a reviewer to document module return values as per [module checklist](http://docs.ansible.com/ansible/developing_modules.html#module-checklist).

Actually, my module has no special values to document, however, I couldn't find a good way or a good reason to mention it in an individual module doc, and felt it would be better to fix the module doc template instead.  So I made this PR.

This makes every module doc include a mention to [Common Return Values](http://docs.ansible.com/ansible/common_return_values.html), which improves doc usability.  Developers can easily declare there are no return values unique to their modules by putting `{}` in `RETURN` variable, so they are encouraged to document `RETURN` in every module.
