### PR TITLE
Specify supported RHEL7's six version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='ansible',
       author_email='support@ansible.com',
       url='http://ansible.com/',
       license='GPLv3',
-      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6', 'six'],
+      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6', 'six >= 1.3.0'],
       package_dir={ '': 'lib' },
       packages=find_packages('lib'),
       package_data={


### PR DESCRIPTION
As expressed by @abadger here: 4f6f2c21e877cd15300edea1a1ef3b4ab9edf6a1

Because Ansible is stuck with six 1.3.0 for now, I suggested on IRC to create a branch just for "when RHEL updates six" to put some python3 compatibility commits there. Lines like this (https://github.com/ansible/ansible/blob/e6d3c6745f6ab7f04c18dfe4fda21fcd6a98e909/lib/ansible/plugins/connection/winrm.py#L28), my PR #12617 and I believe some other stuff by @mgedmin only works for newer versions of six.
