### PR TITLE
Python 3: don't convert module arguments to bytes

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1240,10 +1240,7 @@ class AnsibleModule(object):
 
     def _load_params(self):
         ''' read the input and return a dictionary and the arguments string '''
-        params = json.loads(MODULE_COMPLEX_ARGS)
-        if str is bytes:
-            # Python 2
-            params = json_dict_unicode_to_bytes(params)
+        params = json_dict_unicode_to_bytes(json.loads(MODULE_COMPLEX_ARGS))
         if params is None:
             params = dict()
         return params

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1240,7 +1240,10 @@ class AnsibleModule(object):
 
     def _load_params(self):
         ''' read the input and return a dictionary and the arguments string '''
-        params = json_dict_unicode_to_bytes(json.loads(MODULE_COMPLEX_ARGS))
+        params = json.loads(MODULE_COMPLEX_ARGS)
+        if str is bytes:
+            # Python 2
+            params = json_dict_unicode_to_bytes(params)
         if params is None:
             params = dict()
         return params

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -21,6 +21,7 @@ from __future__ import (absolute_import, division)
 __metaclass__ = type
 
 import errno
+import sys
 
 from six.moves import builtins
 
@@ -220,7 +221,8 @@ class TestModuleUtilsBasic(unittest.TestCase):
         from ansible.module_utils.basic import get_module_path
         with patch('os.path.realpath', return_value='/path/to/foo/'):
             self.assertEqual(get_module_path(), '/path/to/foo')
- 
+
+    @unittest.skipIf(sys.version_info[0] >= 3, "Python 3 is not supported on targets (yet)")
     def test_module_utils_basic_ansible_module_creation(self):
         from ansible.module_utils import basic
 


### PR DESCRIPTION
Fixes a test failure:

```
======================================================================
ERROR: test_module_utils_basic_ansible_module_creation (units.module_utils.test_basic.TestModuleUtilsBasic)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mg/src/ansible/test/units/module_utils/test_basic.py", line 250, in test_module_utils_basic_ansible_module_creation
    supports_check_mode=True,
  File "/home/mg/src/ansible/lib/ansible/module_utils/basic.py", line 470, in __init__
    self._check_required_arguments()
  File "/home/mg/src/ansible/lib/ansible/module_utils/basic.py", line 1050, in _check_required_arguments
    self.fail_json(msg="missing required arguments: %s" % ",".join(missing))
  File "/home/mg/src/ansible/lib/ansible/module_utils/basic.py", line 1445, in fail_json
    sys.exit(1)
SystemExit: 1
-------------------- >> begin captured stdout << ---------------------
{"msg": "missing required arguments: foo", "failed": true}
```

because converting 'foo' to bytes yields b'foo' on Python 3, which doesn't match the native-unicode 'foo' argument spec.
