### PR TITLE
Python 3: fix AnsibleError formatting

### DIFF
--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -20,15 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors.yaml_strings import *
-from ansible.utils.unicode import to_unicode, to_bytes
-
-
-if str is bytes:
-    # Python 2
-    to_str = to_bytes
-else:
-    # Python 3
-    to_str = to_unicode
+from ansible.utils.unicode import to_unicode, to_str
 
 
 class AnsibleError(Exception):

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -19,10 +19,17 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os
-
 from ansible.errors.yaml_strings import *
 from ansible.utils.unicode import to_unicode, to_bytes
+
+
+if str is bytes:
+    # Python 2
+    to_str = to_bytes
+else:
+    # Python 3
+    to_str = to_unicode
+
 
 class AnsibleError(Exception):
     '''
@@ -49,7 +56,7 @@ class AnsibleError(Exception):
         if obj and isinstance(obj, AnsibleBaseYAMLObject):
             extended_error = self._get_extended_error()
             if extended_error:
-                self.message = 'ERROR! %s\n\n%s' % (message, to_bytes(extended_error))
+                self.message = 'ERROR! %s\n\n%s' % (message, to_str(extended_error))
         else:
             self.message = 'ERROR! %s' % message
 

--- a/lib/ansible/utils/unicode.py
+++ b/lib/ansible/utils/unicode.py
@@ -251,3 +251,10 @@ def to_bytes(obj, encoding='utf-8', errors='replace', nonstring=None):
 # ensure that a filter will return unicode values.
 def unicode_wrap(func, *args, **kwargs):
     return to_unicode(func(*args, **kwargs), nonstring='passthru')
+
+
+# Alias for converting to native strings.
+if PY3:
+    to_str = to_unicode
+else:
+    to_str = to_bytes


### PR DESCRIPTION
If you convert the error string to bytes and embed it inside another error
string, you get

  Prefix:

  b'Embedded\nerror\nstring'

which is not what we want.

But we also don't want Unicode in error messages causing unexpected 
UnicodeEncodeErrors when on Python 2.

So let's convert the error message into the native string type (bytes on 
Python 2, unicode on Python 3).

This fixes two failing tests on Python 3.
