### PR TITLE
Fix Unexpected Exception: global name 'os' is not defined

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -21,13 +21,13 @@ __metaclass__ = type
 
 import getpass
 import locale
+import os
 import signal
 import sys
 
 from six import string_types
 
 from ansible import constants as C
-from ansible.errors import *
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook import Playbook
 from ansible.template import Templar


### PR DESCRIPTION
I inadvertently introduced it in ca826508d992f99ab6cba75d03a34b804448dfef and didn't notice, because there are no unit tests for playbook_executor.py.  Sorry!

(The `from ansible.errors import *` was used _only_ to get the 'os' module, which makes me go "what?")
