### PR TITLE
Document using the `raw` module to install a py2.X and simplejson

### DIFF
--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -93,7 +93,7 @@ Also you need Python 2.4 or later, but if you are running less than Python 2.5 o
 
    If you need to bootstrap these remote systems by installing Python 2.X,
    using the 'raw' module will be able to do it remotely. For example,
-   ``ansible myhost --sudo -m raw -a "yum install python2 python-simplejson"``
+   ``ansible myhost --sudo -m raw -a "yum install -y python2 python-simplejson"``
    would install Python 2.X and the simplejson module needed to run ansible and its modules.
 
 .. _installing_the_control_machine:

--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -89,8 +89,12 @@ Also you need Python 2.4 or later, but if you are running less than Python 2.5 o
    the 'ansible_python_interpreter' variable in inventory (see :doc:`intro_inventory`) to point at your 2.X Python.  Distributions
    like Red Hat Enterprise Linux, CentOS, Fedora, and Ubuntu all have a 2.X interpreter installed
    by default and this does not apply to those distributions.  This is also true of nearly all
-   Unix systems.  If you need to bootstrap these remote systems by installing Python 2.X, 
-   using the 'raw' module will be able to do it remotely.
+   Unix systems.
+
+   If you need to bootstrap these remote systems by installing Python 2.X,
+   using the 'raw' module will be able to do it remotely. For example,
+   ``ansible myhost --sudo -m raw -a "yum install python2 python-simplejson"``
+   would install Python 2.X and the simplejson module needed to run ansible and its modules.
 
 .. _installing_the_control_machine:
 


### PR DESCRIPTION
In the installation guide, the raw module is mentioned as an option for installing Python or simplejson on managed nodes that don't have them. This change adds an example for users that may already be familiar with using ansible but are checking install docs because they don't know the requirements for managed nodes, or are using a distribution that doesn't include Python 2 by default.
