### PR TITLE
Python 3: fix vault tests

### DIFF
--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -106,9 +106,9 @@ class TestVaultLib(unittest.TestCase):
         v.cipher_name = u'AES'
         # AES encryption code has been removed, so this is old output for
         # AES-encrypted 'foobar' with password 'ansible'.
-        enc_data = '$ANSIBLE_VAULT;1.1;AES\n53616c7465645f5fc107ce1ef4d7b455e038a13b053225776458052f8f8f332d554809d3f150bfa3\nfe3db930508b65e0ff5947e4386b79af8ab094017629590ef6ba486814cf70f8e4ab0ed0c7d2587e\n786a5a15efeb787e1958cbdd480d076c\n'
+        enc_data = b'$ANSIBLE_VAULT;1.1;AES\n53616c7465645f5fc107ce1ef4d7b455e038a13b053225776458052f8f8f332d554809d3f150bfa3\nfe3db930508b65e0ff5947e4386b79af8ab094017629590ef6ba486814cf70f8e4ab0ed0c7d2587e\n786a5a15efeb787e1958cbdd480d076c\n'
         dec_data = v.decrypt(enc_data)
-        assert dec_data == "foobar", "decryption failed"
+        assert dec_data == b"foobar", "decryption failed"
 
     def test_encrypt_decrypt_aes256(self):
         if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:

--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -115,10 +115,10 @@ class TestVaultLib(unittest.TestCase):
             raise SkipTest
         v = VaultLib('ansible')
         v.cipher_name = 'AES256'
-        enc_data = v.encrypt("foobar")
+        enc_data = v.encrypt(b"foobar")
         dec_data = v.decrypt(enc_data)
-        assert enc_data != "foobar", "encryption failed"
-        assert dec_data == "foobar", "decryption failed"
+        assert enc_data != b"foobar", "encryption failed"
+        assert dec_data == b"foobar", "decryption failed"
 
     def test_encrypt_encrypted(self):
         if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:

--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -97,7 +97,7 @@ class TestVaultLib(unittest.TestCase):
         lines = rdata.split(b'\n')
         assert lines[0] == b"ansible"
         assert v.cipher_name == 'TEST', "cipher name was not set"
-        assert v.b_version == "9.9"
+        assert v.b_version == b"9.9"
 
     def test_encrypt_decrypt_aes(self):
         if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:

--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -78,17 +78,17 @@ class TestVaultLib(unittest.TestCase):
     def test_format_output(self):
         v = VaultLib('ansible')
         v.cipher_name = "TEST"
-        sensitive_data = "ansible"
+        sensitive_data = b"ansible"
         data = v._format_output(sensitive_data)
         lines = data.split(b'\n')
         assert len(lines) > 1, "failed to properly add header"
-        header = to_unicode(lines[0])
-        assert header.endswith(';TEST'), "header does end with cipher name"
-        header_parts = header.split(';')
+        header = to_bytes(lines[0])
+        assert header.endswith(b';TEST'), "header does end with cipher name"
+        header_parts = header.split(b';')
         assert len(header_parts) == 3, "header has the wrong number of parts"
-        assert header_parts[0] == '$ANSIBLE_VAULT', "header does not start with $ANSIBLE_VAULT"
+        assert header_parts[0] == b'$ANSIBLE_VAULT', "header does not start with $ANSIBLE_VAULT"
         assert header_parts[1] == v.b_version, "header version is incorrect"
-        assert header_parts[2] == 'TEST', "header does end with cipher name"
+        assert header_parts[2] == b'TEST', "header does end with cipher name"
 
     def test_split_header(self):
         v = VaultLib('ansible')

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ commands =
     py27: python -m compileall -fq -x 'test|samples' lib test contrib
     py{34,35}: python -m compileall -fq -x 'lib/ansible/module_utils|lib/ansible/modules' lib test contrib
     # Unittests need lots of work to make code python3 compatible
-    py{26,27}: make tests
+    py{26,27,35}: make tests


### PR DESCRIPTION
This fixes all four remaining unit test failures on Python 3.5 and
enables Python 3.5 tests in Travis.

Python 3.4 still has four failures in vault code due to %-formatting of
byte strings.

Note that passing tests don't mean that Ansible itself can already be
used with Python 3.5: test coverage is only 53%.
