### PR TITLE
integration tests; windows; change win_setup asserts as 0Mb is a legal amount of physical memory

### DIFF
--- a/test/integration/roles/test_win_setup/tasks/main.yml
+++ b/test/integration/roles/test_win_setup/tasks/main.yml
@@ -33,7 +33,7 @@
       - "setup_result.ansible_facts.ansible_hostname"
       - "setup_result.ansible_facts.ansible_ip_addresses"
       - "setup_result.ansible_facts.ansible_system"
-      - "setup_result.ansible_facts.ansible_totalmem"
+      - "setup_result.ansible_facts.ansible_totalmem > -1"
       - "setup_result.ansible_facts.ansible_interfaces"
       - "setup_result.ansible_facts.ansible_interfaces[0]"
       - "setup_result.ansible_facts.ansible_interfaces[0].interface_name"


### PR DESCRIPTION
ansible currently reports 0 for totalmem when running inside a virtual machine.  This is because it is currently using wmi to retrieve the total physical ram.  

This change just changes the test so the assert checks the amount of ram is greater than -1 

I attempted to find a way to retrieve the base memory allocation from the vm but could not find a wmi class that reports the base ram (although a lot of other memory information appears available from 

Get-WmiObject -Class Win32_OperatingSystem -Namespace root/cimv2 -ComputerName . | Format-Table -Property TotalVirtualMemorySize,TotalVisibleMemorySize,FreePhysicalMemory,FreeVirtualMemory,FreeSpaceInPagingFiles

see (https://technet.microsoft.com/en-us/library/dd315379.aspx)
