### PR TITLE
Python 3: avoid %-formatting of byte strings

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -194,10 +194,12 @@ class VaultLib:
         if not self.cipher_name:
             raise AnsibleError("the cipher must be set before adding a header")
 
-        tmpdata = [b'%s\n' % b_data[i:i+80] for i in range(0, len(b_data), 80)]
-        tmpdata.insert(0, b'%s;%s;%s\n' % (b_HEADER, self.b_version,
-            to_bytes(self.cipher_name, errors='strict', encoding='utf-8')))
-        tmpdata = b''.join(tmpdata)
+        header = b';'.join([b_HEADER, self.b_version,
+            to_bytes(self.cipher_name, errors='strict', encoding='utf-8')])
+        tmpdata = [header]
+        tmpdata += [b_data[i:i+80] for i in range(0, len(b_data), 80)]
+        tmpdata += [b'']
+        tmpdata = b'\n'.join(tmpdata)
 
         return tmpdata
 
@@ -422,7 +424,7 @@ class VaultAES:
 
         d = d_i = b''
         while len(d) < key_length + iv_length:
-            text = b"%s%s%s" % (d_i, password, salt)
+            text = b''.join([d_i, password, salt])
             d_i = to_bytes(md5(text).digest(), errors='strict')
             d += d_i
 
@@ -568,7 +570,7 @@ class VaultAES256:
 
         # COMBINE SALT, DIGEST AND DATA
         hmac = HMAC.new(key2, cryptedData, SHA256)
-        message = b'%s\n%s\n%s' % (hexlify(salt), to_bytes(hmac.hexdigest()), hexlify(cryptedData))
+        message = b''.join([hexlify(salt), b'\n', to_bytes(hmac.hexdigest()), b'\n', hexlify(cryptedData)])
         message = hexlify(message)
         return message
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -570,7 +570,7 @@ class VaultAES256:
 
         # COMBINE SALT, DIGEST AND DATA
         hmac = HMAC.new(key2, cryptedData, SHA256)
-        message = b''.join([hexlify(salt), b'\n', to_bytes(hmac.hexdigest()), b'\n', hexlify(cryptedData)])
+        message = b'\n'.join([hexlify(salt), to_bytes(hmac.hexdigest()), hexlify(cryptedData)])
         message = hexlify(message)
         return message
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ commands =
     py27: python -m compileall -fq -x 'test|samples' lib test contrib
     py{34,35}: python -m compileall -fq -x 'lib/ansible/module_utils|lib/ansible/modules' lib test contrib
     # Unittests need lots of work to make code python3 compatible
-    py{26,27,35}: make tests
+    py{26,27,34,35}: make tests


### PR DESCRIPTION
This is needed for Python 3.4 compatibility; Python 3.5 can use
`b'%s\n' bytestring` again.

Also enable unit tests on Python 3.4 in tox and Travis, because they now
pass, yay!
