### PR TITLE
Python 3: print function in a shell oneliner in Makefile

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -3,7 +3,7 @@ VARS_FILE ?= integration_config.yml
 
 # Create a semi-random string for use when testing cloud-based resources
 ifndef CLOUD_RESOURCE_PREFIX
-CLOUD_RESOURCE_PREFIX := $(shell python -c "import string,random; print 'ansible-testing-' + ''.join(random.choice(string.ascii_letters + string.digits) for _ in xrange(8));")
+CLOUD_RESOURCE_PREFIX := $(shell python -c "import string,random; print('ansible-testing-' + ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(8)));")
 endif
 
 CREDENTIALS_FILE = credentials.yml


### PR DESCRIPTION
Fixes

```
  File "<string>", line 1
    import string,random; print 'ansible-testing-' + ''.join(random.choice(string.ascii_letters + string.digits) for _ in xrange(8));
                                                 ^
SyntaxError: invalid syntax
```

when running integration tests with

```
. hacking/env-setup
. .tox/py35/bin/activate
make -C test/integration test_var_precedence
```
