### PR TITLE
remove module param quotes

### DIFF
--- a/test/integration/roles/test_mysql_user/tasks/test_privs.yml
+++ b/test/integration/roles/test_mysql_user/tasks/test_privs.yml
@@ -23,9 +23,9 @@
 
 - include: assert_user.yml user_name={{user_name_2}} priv='SELECT'
   when: current_append_privs ==  "yes"
-  
+ 
 - name: create user with current privileges (expect changed=true)
-  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} priv=*.*:'{{current_privilege}}' append_privs={{current_append_privs}} state=present
+  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} priv=*.*:{{current_privilege}} append_privs={{current_append_privs}} state=present
   register: result
 
 - name: assert output message for current privileges 


### PR DESCRIPTION
Fixes 

```
TASK [test_mysql_user : create user with current privileges (expect changed=true)] ***
fatal: [testhost]: FAILED! => {"changed": false, "failed": true, "msg": "invalid privileges string: Invalid privileges specified: frozenset([\"'SELECT'\"])"}
```
