### PR TITLE
Ansible-galaxy requirements support a include directive

### DIFF
--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -68,6 +68,28 @@ To request specific versions (tags) of a role, use this syntax in the roles file
 
 Available versions will be listed on the Ansible Galaxy webpage for that role.
 
+Installing Multiple Roles From Multiple Files
+=============================================
+
+At a basic level, including requirements files allows you to break up bits of configuration policy into smaller files. Role includes pull in roles from other files.
+
+    ansible-galaxy install -r requirements.yml
+
+    # from galaxy
+    - src: yatesr.timezone
+
+    - include: webserver.yml
+
+
+Content of the webserver.yml file.
+
+    # from github
+    - src: https://github.com/bennojoy/nginx
+
+    # from github installing to a relative path
+    - src: https://github.com/bennojoy/nginx
+      path: vagrant/roles/
+
 Advanced Control over Role Requirements Files
 =============================================
 
@@ -383,21 +405,5 @@ Use the --remove option to disable and remove a Travis integration:
     $ ansible-galaxy setup --remove ID
 
 Provide the ID of the integration you want disabled. Use the --list option to get the ID.
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
 
 


### PR DESCRIPTION
## Context

As the tasks file, the first goal of this directive is to include files and combine them to form clean, reusable abstractions.
## Tests

``` yaml
# nginx.yaml

---
- src: https://github.com/bennojoy/nginx
  path: roles/
  name: nginx_server1
```

``` yaml
# requirements.yaml

---
- include: nginx.yml

- src: https://github.com/bennojoy/nginx
  path: roles/
  name: nginx_server2
```

``` bash
$ ansible-galaxy install -r requirements.yaml
```
## update

`2015-11-16`: rebase + add a test part
`2016-02-08`: rebase

Thanks
