### PR TITLE
Add splitpart filter for template string splitting

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -428,6 +428,14 @@ To add quotes for shell usage::
 
     - shell: echo {{ string_value | quote }} 
 
+To split a comma-delimited string and return the first element:
+
+    {{ string | splitpart(0) }}
+
+To split a string with another delimiter, and return the second element:
+
+    {{ string | splitpart(1, ':') }}
+
 To use one value on true and another on false (new in version 1.9)::
 
    {{ (name == "John") | ternary('Mr','Ms') }}

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -116,6 +116,10 @@ def quote(a):
     ''' return its argument quoted for shell usage '''
     return pipes.quote(a)
 
+def splitpart(input, index, delimiter = ','):
+    ''' split input string on delimiter, returning element with given index '''
+    return input.split(delimiter)[index]
+
 def fileglob(pathname):
     ''' return list of matched files for glob '''
     return glob.glob(pathname)
@@ -375,6 +379,9 @@ class FilterModule(object):
 
             # quote string for shell usage
             'quote': quote,
+
+            # split string and return one element
+            'splitpart': splitpart,
 
             # hash filters
             # md5 hex digest of string


### PR DESCRIPTION
This adds an additional Jinja filter for splitting delimited strings and returning an individual element by index number.

I have added this (trivial) filter to address a need to split input data in a template. The data are delimited by colon characters (":"), and it seems prudent to split this natively in Ansible rather than rely on forking out to other commands in a shell environment.

Example usage:

```
- hosts: localhost
  vars:
    to_split: my:example:colon:delimited:data
  tasks:
    - name: split data in variable to_split on a colon, returning element at index 3
      debug: msg="{{ to_split | splitpart(3, ':') }}"
```

Output:

```
username-pc:ansible username$ ansible-playbook test.yml -c local
 [WARNING]: provided hosts list is empty, only localhost is available


PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [localhost -> localhost]

TASK [split data in variable to_split on a colon, returning element at index 3] 
ok: [localhost -> localhost] => {
    "changed": false, 
    "msg": "delimited"
}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0   
```
