### PR TITLE
ec2.py Add the feature of combining Autoscaling groups Tags

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -65,6 +65,10 @@ route53 = False
 # To exclude ElastiCache instances from the inventory, uncomment and set to False.
 #elasticache = False
 
+# Not to combine tags of Autoscaling group with the rest of instances in the
+# same Autoscaling group
+#autoscaling = False
+
 # Additionally, you can specify the list of zones to exclude looking up in
 # 'route53_excluded_zones' as a comma-separated list.
 # route53_excluded_zones = samplezone1.com, samplezone2.com

--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -67,7 +67,7 @@ route53 = False
 
 # Not to combine tags of Autoscaling group with the rest of instances in the
 # same Autoscaling group
-#autoscaling = False
+autoscaling = False
 
 # Additionally, you can specify the list of zones to exclude looking up in
 # 'route53_excluded_zones' as a comma-separated list.

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -666,29 +666,30 @@ class Ec2Inventory(object):
                 reservations = []
                 autoscale_groups = conn_autoscale.get_all_groups()
                 for autoscale_group in autoscale_groups:
-                  tags = {}
-                  for tag in autoscale_group.tags:
-                    if tag.propagate_at_launch:
-                        tags[tag.key] = tag.value
+                  if autoscale_group.name:
+                    tags = {}
+                    for tag in autoscale_group.tags:
+                      if tag.propagate_at_launch:
+                          tags[tag.key] = tag.value
 
-                  for autoscale_group_instance in autoscale_group.instances:
+                    for autoscale_group_instance in autoscale_group.instances:
 
-                    if self.ec2_instance_filters:
-                        for filter_key, filter_values in self.ec2_instance_filters.items():
-                            reservations.extend(conn_ec2.get_all_instances(
-                                filters = {
-                                    filter_key : filter_values,
-                                    'instance-id': [ autoscale_group_instance.instance_id ]
-                                }
-                            ))
-                    else:
-                        reservations = conn_ec2.get_all_instances(
-                            filters = { 'instance-id': [ autoscale_group_instance.instance_id ] })
+                      if self.ec2_instance_filters:
+                          for filter_key, filter_values in self.ec2_instance_filters.items():
+                              reservations.extend(conn_ec2.get_all_instances(
+                                  filters = {
+                                      filter_key : filter_values,
+                                      'instance-id': [ autoscale_group_instance.instance_id ]
+                                  }
+                              ))
+                      else:
+                          reservations = conn_ec2.get_all_instances(
+                              filters = { 'instance-id': [ autoscale_group_instance.instance_id ] })
 
-                    for reservation in reservations:
-                      for reservation_instance in reservation.instances:
-                        reservation_instance.tags = tags
-                        self.add_instance(reservation_instance, region)
+                      for reservation in reservations:
+                        for reservation_instance in reservation.instances:
+                          reservation_instance.tags = tags
+                          self.add_instance(reservation_instance, region)
 
         except boto.exception.BotoServerError as e:
             if e.error_code == 'AuthFailure':

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -37,7 +37,6 @@ When run against a specific host, this script returns the following variables:
  - ec2_attachTime
  - ec2_attachment
  - ec2_attachmentId
- - ec2_block_devices
  - ec2_client_token
  - ec2_deleteOnTermination
  - ec2_description
@@ -131,15 +130,6 @@ from boto import rds
 from boto import elasticache
 from boto import route53
 import six
-
-from ansible.module_utils import ec2 as ec2_utils
-
-HAS_BOTO3 = False
-try:
-    import boto3
-    HAS_BOTO3 = True
-except ImportError:
-    pass
 
 from six.moves import configparser
 from collections import defaultdict
@@ -285,6 +275,11 @@ class Ec2Inventory(object):
         self.elasticache_enabled = True
         if config.has_option('ec2', 'elasticache'):
             self.elasticache_enabled = config.getboolean('ec2', 'elasticache')
+
+        # Combine with Autoscaling groups tags?
+        self.autoscaling_enabled = True
+        if config.has_option('ec2', 'autoscaling'):
+            self.autoscaling_enabled = config.getboolean('ec2', 'autoscaling')
 
         # Return all EC2 instances?
         if config.has_option('ec2', 'all_instances'):
@@ -492,6 +487,8 @@ class Ec2Inventory(object):
                 self.get_elasticache_replication_groups_by_region(region)
             if self.include_rds_clusters:
                 self.include_rds_clusters_by_region(region)
+            if self.autoscaling_enabled:
+                self.get_autoscaling_instances_by_region(region)
 
         self.write_to_cache(self.inventory, self.cache_path_cache)
         self.write_to_cache(self.index, self.cache_path_index)
@@ -545,12 +542,7 @@ class Ec2Inventory(object):
             instance_ids = []
             for reservation in reservations:
                 instance_ids.extend([instance.id for instance in reservation.instances])
-
-            max_filter_value = 199
-            tags = []
-            for i in range(0, len(instance_ids), max_filter_value):
-                tags.extend(conn.get_all_tags(filters={'resource-type': 'instance', 'resource-id': instance_ids[i:i+max_filter_value]}))
-
+            tags = conn.get_all_tags(filters={'resource-type': 'instance', 'resource-id': instance_ids})
             tags_by_instance_id = defaultdict(dict)
             for tag in tags:
                 tags_by_instance_id[tag.res_id][tag.name] = tag.value
@@ -592,65 +584,6 @@ class Ec2Inventory(object):
                 error = "Looks like AWS RDS is down:\n%s" % e.message
             self.fail_with_error(error, 'getting RDS instances')
 
-    def include_rds_clusters_by_region(self, region):
-        if not HAS_BOTO3:
-            self.fail_with_error("Working with RDS clusters requires boto3 - please install boto3 and try again",
-                                 "getting RDS clusters")
-
-        client = ec2_utils.boto3_inventory_conn('client', 'rds', region, **self.credentials)
-
-        marker, clusters = '', []
-        while marker is not None:
-            resp = client.describe_db_clusters(Marker=marker)
-            clusters.extend(resp["DBClusters"])
-            marker = resp.get('Marker', None)
-
-        account_id = boto.connect_iam().get_user().arn.split(':')[4]
-        c_dict = {}
-        for c in clusters:
-            # remove these datetime objects as there is no serialisation to json
-            # currently in place and we don't need the data yet
-            if 'EarliestRestorableTime' in c:
-                del c['EarliestRestorableTime']
-            if 'LatestRestorableTime' in c:
-                del c['LatestRestorableTime']
-
-            if self.ec2_instance_filters == {}:
-                matches_filter = True
-            else:
-                matches_filter = False
-
-            try:
-                # arn:aws:rds:<region>:<account number>:<resourcetype>:<name>
-                tags = client.list_tags_for_resource(
-                    ResourceName='arn:aws:rds:' + region + ':' + account_id + ':cluster:' + c['DBClusterIdentifier'])
-                c['Tags'] = tags['TagList']
-
-                if self.ec2_instance_filters:
-                    for filter_key, filter_values in self.ec2_instance_filters.items():
-                        # get AWS tag key e.g. tag:env will be 'env'
-                        tag_name = filter_key.split(":", 1)[1]
-                        # Filter values is a list (if you put multiple values for the same tag name)
-                        matches_filter = any(d['Key'] == tag_name and d['Value'] in filter_values for d in c['Tags'])
-
-                        if matches_filter:
-                            # it matches a filter, so stop looking for further matches
-                            break
-
-            except Exception as e:
-                if e.message.find('DBInstanceNotFound') >= 0:
-                    # AWS RDS bug (2016-01-06) means deletion does not fully complete and leave an 'empty' cluster.
-                    # Ignore errors when trying to find tags for these
-                    pass
-
-            # ignore empty clusters caused by AWS bug
-            if len(c['DBClusterMembers']) == 0:
-                continue
-            elif matches_filter:
-                c_dict[c['DBClusterIdentifier']] = c
-
-        self.inventory['db_clusters'] = c_dict
-
     def get_elasticache_clusters_by_region(self, region):
         ''' Makes an AWS API call to the list of ElastiCache clusters (with
         nodes' info) in a particular region.'''
@@ -676,7 +609,7 @@ class Ec2Inventory(object):
 
         try:
             # Boto also doesn't provide wrapper classes to CacheClusters or
-            # CacheNodes. Because of that we can't make use of the get_list
+            # CacheNodes. Because of that wo can't make use of the get_list
             # method in the AWSQueryConnection. Let's do the work manually
             clusters = response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['CacheClusters']
 
@@ -720,6 +653,49 @@ class Ec2Inventory(object):
 
         for replication_group in replication_groups:
             self.add_elasticache_replication_group(replication_group, region)
+
+    def get_autoscaling_instances_by_region(self, region):
+        ''' Makes an AWS API call to the list of Autoscale instances
+         in a particular region with tags of their Autoscale group
+         if the "propagate_at_launch" is set '''
+
+        try:
+            conn_autoscale = self.connect_to_aws(autoscale, region)
+            conn_ec2 = self.connect_to_aws(ec2, region)
+            if conn_autoscale and conn_ec2:
+                autoscale_groups = conn_autoscale.get_all_groups()
+                for autoscale_group in autoscale_groups:
+                  tags = {}
+                  for tag in autoscale_group.tags:
+                    if tag.propagate_at_launch:
+                        tags[tag.key] = tag.value
+
+                  for autoscale_group_instance in autoscale_group.instances:
+
+                    if self.ec2_instance_filters:
+                        for filter_key, filter_values in self.ec2_instance_filters.items():
+                            reservations.extend(conn_ec2.get_all_instances(
+                                filters = {
+                                    filter_key : filter_values,
+                                    'instance-id': [ autoscale_group_instance.instance_id ]
+                                }
+                            ))
+                    else:
+                        reservations = conn_ec2.get_all_instances(
+                            filters = { 'instance-id': [ autoscale_group_instance.instance_id ] })
+
+                    for reservation in reservations:
+                      for reservation_instance in reservation.instances:
+                        reservation_instance.tags = tags
+                        self.add_instance(reservation_instance, region)
+
+        except boto.exception.BotoServerError as e:
+            if e.error_code == 'AuthFailure':
+                error = self.get_auth_error_message()
+            else:
+                backend = 'Eucalyptus' if self.eucalyptus else 'AWS'
+                error = "Error connecting to %s backend.\n%s" % (backend, e.message)
+            self.fail_with_error(error, 'getting Autoscaling Group instances')
 
     def get_auth_error_message(self):
         ''' create an informative error message if there is an issue authenticating'''
@@ -1313,7 +1289,7 @@ class Ec2Inventory(object):
             elif key == 'ec2_tags':
                 for k, v in value.items():
                     if self.expand_csv_tags and ',' in v:
-                        v = list(map(lambda x: x.strip(), v.split(',')))
+                        v = map(lambda x: x.strip(), v.split(','))
                     key = self.to_safe('ec2_tag_' + k)
                     instance_vars[key] = v
             elif key == 'ec2_groups':
@@ -1324,10 +1300,6 @@ class Ec2Inventory(object):
                     group_names.append(group.name)
                 instance_vars["ec2_security_group_ids"] = ','.join([str(i) for i in group_ids])
                 instance_vars["ec2_security_group_names"] = ','.join([str(i) for i in group_names])
-            elif key == 'ec2_block_device_mapping':
-                instance_vars["ec2_block_devices"] = {}
-                for k, v in value.items():
-                    instance_vars["ec2_block_devices"][ os.path.basename(k) ] = v.volume_id
             else:
                 pass
                 # TODO Product codes if someone finds them useful

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -37,7 +37,7 @@ When run against a specific host, this script returns the following variables:
  - ec2_attachTime
  - ec2_attachment
  - ec2_attachmentId
- - ec2_block_device
+ - ec2_block_devices
  - ec2_client_token
  - ec2_deleteOnTermination
  - ec2_description
@@ -553,10 +553,10 @@ class Ec2Inventory(object):
             for reservation in reservations:
                 instance_ids.extend([instance.id for instance in reservation.instances])
 
-                max_filter_value = 199
-                tags = []
-                for i in range(0, len(instance_ids), max_filter_value):
-                  tags.extend(conn.get_all_tags(filters={'resource-type': 'instance', 'resource-id': instance_ids[i:i+max_filter_value]}))
+            max_filter_value = 199
+            tags = []
+            for i in range(0, len(instance_ids), max_filter_value):
+                tags.extend(conn.get_all_tags(filters={'resource-type': 'instance', 'resource-id': instance_ids[i:i+max_filter_value]}))
 
             tags_by_instance_id = defaultdict(dict)
             for tag in tags:

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -663,6 +663,7 @@ class Ec2Inventory(object):
             conn_autoscale = self.connect_to_aws(autoscale, region)
             conn_ec2 = self.connect_to_aws(ec2, region)
             if conn_autoscale and conn_ec2:
+                reservations = []
                 autoscale_groups = conn_autoscale.get_all_groups()
                 for autoscale_group in autoscale_groups:
                   tags = {}

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -762,8 +762,8 @@ class Ec2Inventory(object):
 
                             for reservation in reservations:
                                 for reservation_instance in reservation.instances:
-                                  reservation_instance.tags = tags
-                                  self.add_instance(reservation_instance, region)
+                                    reservation_instance.tags = tags
+                                    self.add_instance(reservation_instance, region)
 
         except boto.exception.BotoServerError as e:
             if e.error_code == 'AuthFailure':

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -287,7 +287,7 @@ class Ec2Inventory(object):
             self.elasticache_enabled = config.getboolean('ec2', 'elasticache')
 
         # Combine with Autoscaling groups tags?
-        self.autoscaling_enabled = True
+        self.autoscaling_enabled = False
         if config.has_option('ec2', 'autoscaling'):
             self.autoscaling_enabled = config.getboolean('ec2', 'autoscaling')
 


### PR DESCRIPTION
If there're Autoscaling groups, fetch their tags set as propagate_at_launch and combine with the tags of these Autoscaling groups.

This is specially useful for this: https://forums.aws.amazon.com/thread.jspa?messageID=588978&#588978

So you can provision EC2 instances launched from Autoscaling groups with CodeDeploy, **before** the CodeDeploy, using the tags from the Autoscaling group (as the Ansible Dynamic Inventory requires: http://docs.ansible.com/ansible/intro_dynamic_inventory.html#example-aws-ec2-external-inventory-script)
