### PR TITLE
Delegation: use connection=local only if using the standard SSH port

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -357,9 +357,10 @@ class PlayContext(Base):
                 if connection_type in delegated_vars:
                     break
             else:
-                if new_info.remote_addr in C.LOCALHOST:
+                delegated_to_localhost = new_info.remote_addr in C.LOCALHOST
+                if delegated_to_localhost:
                     new_info.connection = 'local'
-                elif getattr(new_info, 'connection', None) == 'local' and new_info.remote_addr not in C.LOCALHOST:
+                elif getattr(new_info, 'connection', None) == 'local' and not delegated_to_localhost:
                     new_info.connection = C.DEFAULT_TRANSPORT
 
         # set no_log to default if it was not previouslly set

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -357,7 +357,11 @@ class PlayContext(Base):
                 if connection_type in delegated_vars:
                     break
             else:
-                delegated_to_localhost = new_info.remote_addr in C.LOCALHOST
+                if C.DEFAULT_REMOTE_PORT is not None:
+                    using_default_port = new_info.port is None or new_info.port == int(C.DEFAULT_REMOTE_PORT)
+                else:
+                    using_default_port = new_info.port is None
+                delegated_to_localhost = new_info.remote_addr in C.LOCALHOST and using_default_port
                 if delegated_to_localhost:
                     new_info.connection = 'local'
                 elif getattr(new_info, 'connection', None) == 'local' and not delegated_to_localhost:

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -358,9 +358,9 @@ class PlayContext(Base):
                     break
             else:
                 if new_info.remote_addr in C.LOCALHOST:
-                    setattr(new_info, 'connection', 'local')
+                    new_info.connection = 'local'
                 elif getattr(new_info, 'connection', None) == 'local' and new_info.remote_addr not in C.LOCALHOST:
-                    setattr(new_info, 'connection', C.DEFAULT_TRANSPORT)
+                    new_info.connection = C.DEFAULT_TRANSPORT
 
         # set no_log to default if it was not previouslly set
         if new_info.no_log is None:


### PR DESCRIPTION
Fixes #12817.

I've tested with this playbook:

``` yml
- hosts: vagrant
  gather_facts: no
  tasks:
    - command: hostname
      register: direct

- hosts: localhost
  gather_facts: no
  tasks:
    - command: hostname
      delegate_to: vagrant
      register: indirect

    - assert:
        that: indirect.stdout != "platonas"

- hosts: vagrant
  gather_facts: no
  tasks:
    - command: hostname
      delegate_to: localhost
      register: cmd

    - assert:
        that: cmd.stdout == "platonas"
```

The first two commands correctly use SSH into my Vagrant VM, after
applying my fix.  The third command correctly uses connection=local.
