### PR TITLE
DOC: in yum examples, 'pkg' arg renamed to 'name'

### DIFF
--- a/docsite/rst/playbooks_best_practices.rst
+++ b/docsite/rst/playbooks_best_practices.rst
@@ -205,7 +205,7 @@ Below is an example tasks file that explains how a role works.  Our common role 
     # file: roles/common/tasks/main.yml
 
     - name: be sure ntp is installed
-      yum: pkg=ntp state=installed
+      yum: name=ntp state=installed
       tags: ntp
 
     - name: be sure ntp is configured

--- a/docsite/rst/playbooks_intro.rst
+++ b/docsite/rst/playbooks_intro.rst
@@ -62,7 +62,7 @@ For starters, here's a playbook that contains just one play::
       remote_user: root
       tasks:
       - name: ensure apache is at the latest version
-        yum: pkg=httpd state=latest
+        yum: name=httpd state=latest
       - name: write the apache config file
         template: src=/srv/httpd.j2 dest=/etc/httpd.conf
         notify:
@@ -88,7 +88,7 @@ YAML dictionaries to supply the modules with their ``key=value`` arguments.::
       tasks:
       - name: ensure apache is at the latest version
         yum:
-          pkg: httpd
+          name: httpd
           state: latest
       - name: write the apache config file
         template:
@@ -115,7 +115,7 @@ the web servers, and then the database servers. For example::
 
       tasks:
       - name: ensure apache is at the latest version
-        yum: pkg=httpd state=latest
+        yum: name=httpd state=latest
       - name: write the apache config file
         template: src=/srv/httpd.j2 dest=/etc/httpd.conf
 


### PR DESCRIPTION
- alternating both pkg/name in examples might be confusing
- even if pkg= is working, it is not documented in
  module's refrence guide
