### PR TITLE
improve handling of embedded shell scripts

### DIFF
--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -96,9 +96,14 @@ def parse_kv(args, check_raw=False):
             else:
                 raw_params.append(x)
 
-        # recombine the free-form params, if any were found, and assign
-        # them to a special option for use later by the shell/command module
-        if len(raw_params) > 0:
+        if len(options) == 0:
+            # if there were no keyword arguments, simply return the raw
+            # arguments verbatim in the _raw_params parameter for use by
+            # the shell/command modules.
+            options[u'_raw_params'] = args
+        elif len(raw_params) > 0:
+            # if there were keyword arguments, then recombine the remaining
+            # raw parameters into the _raw_params parameter.
             options[u'_raw_params'] = ' '.join(raw_params)
 
     return options


### PR DESCRIPTION
This commit addresses #12856, in which shell scripts passed to the
`shell` module are corrupted to the split-and-rejoin approach taken in
`lib/anslibe/parsing/splitter.py`.

This commit modifies the behavior of `parse_kv` such that if there are
no keyword arguments the raw arguments are returned verbatim, rather
than going through the split-and-rejoin process.
