### PR TITLE
Allow meta/main.yml to include roles through spec file

### DIFF
--- a/lib/ansible/playbook/role/include.py
+++ b/lib/ansible/playbook/role/include.py
@@ -27,6 +27,7 @@ from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject
 from ansible.playbook.attribute import Attribute, FieldAttribute
 from ansible.playbook.role.definition import RoleDefinition
+from ansible.playbook.role.requirement import RoleRequirement
 
 
 __all__ = ['RoleInclude']
@@ -47,6 +48,8 @@ class RoleInclude(RoleDefinition):
     def load(data, play, current_role_path=None, parent_role=None, variable_manager=None, loader=None):
 
         assert isinstance(data, string_types) or isinstance(data, dict) or isinstance(data, AnsibleBaseYAMLObject)
+        if isinstance(data, string_types) and ',' in data:
+            data = RoleRequirement.role_spec_parse(data)
 
         ri = RoleInclude(play=play, role_basedir=current_role_path, variable_manager=variable_manager, loader=loader)
         return ri.load_data(data, variable_manager=variable_manager, loader=loader)

--- a/test/integration/galaxy_roles.yml
+++ b/test/integration/galaxy_roles.yml
@@ -3,7 +3,7 @@
   name: oracle_java7
 
 - src: git+http://bitbucket.org/willthames/git-ansible-galaxy
-  version: v1.4
+  version: v1.6
 
 - src: http://bitbucket.org/willthames/hg-ansible-galaxy
   scm: hg

--- a/test/integration/galaxy_rolesfile
+++ b/test/integration/galaxy_rolesfile
@@ -1,4 +1,4 @@
-git+https://bitbucket.org/willthames/git-ansible-galaxy,v1.4
+git+https://bitbucket.org/willthames/git-ansible-galaxy,v1.6
 hg+https://bitbucket.org/willthames/hg-ansible-galaxy
 https://bitbucket.org/willthames/http-ansible-galaxy/get/master.tar.gz,,http-role
 git+git@github.com:geerlingguy/ansible-role-php.git


### PR DESCRIPTION
ansible-playbook now works when run with a playbook
that includes a role that includes another role
specified using csv format

Updated one of the roles used in the tests to fix
broken tests - `make test_galaxy` now works

Fixes #11486. Also addresses the problem alluded to in #10620.
