### PR TITLE
allow include: directive to work during exception processing

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -47,8 +47,6 @@ class IncludedFile:
         included_files = []
 
         for res in results:
-            if res._host.name in tqm._failed_hosts:
-                continue
 
             if res._task.action == 'include':
                 if res._task.loop:


### PR DESCRIPTION
prior to this commit, an attempt to use the `include:` directive would
fail in a `rescue:` or `always:` block if there were failures in the
main block task list.

Resolves #12876.
