### PR TITLE
fix for issue #11885 - allowing json in lookup template calls

### DIFF
--- a/docsite/rst/playbooks_lookups.rst
+++ b/docsite/rst/playbooks_lookups.rst
@@ -271,6 +271,10 @@ Here are some examples::
 
          - debug: msg="{{ lookup('template', './some_template.j2') }} is a value from evaluation of this template"
 
+         # loading a json file from a template as a string
+         - debug: msg="{{ lookup('template', './some_json.json.j2', convert_data=False) }} is a value from evaluation of this template"
+
+
          - debug: msg="{{ lookup('etcd', 'foo') }} is a value from a locally running etcd"
 
          # shelvefile lookup retrieves a string value corresponding to a key inside a Python shelve file

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -27,6 +27,7 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables, **kwargs):
 
+        convert_data_p = kwargs.get('convert_data', True)
         basedir = self.get_basedir(variables)
 
         ret = []
@@ -46,7 +47,7 @@ class LookupModule(LookupBase):
                         searchpath.insert(1, variables['role_path'])
 
                     self._templar.environment.loader.searchpath = searchpath
-                    res = self._templar.template(template_data, preserve_trailing_newlines=True)
+                    res = self._templar.template(template_data, preserve_trailing_newlines=True,convert_data=convert_data_p)
                     ret.append(res)
             else:
                 raise AnsibleError("the template file %s could not be found for the lookup" % term)


### PR DESCRIPTION
fix for issue #11885.
When a json template is loaded via lookup('template' ... ), ansible tries to understand it as python dictionary by default, as the convert_data flag is by default true.
This commit allows to pass the convert_data flag to the 'template' plugin in lookup and therefore allow to load json templates.
