### PR TITLE
change check for GCE auth parameters to allow empty strings- "".  This…

### DIFF
--- a/lib/ansible/module_utils/gce.py
+++ b/lib/ansible/module_utils/gce.py
@@ -41,11 +41,11 @@ def gce_connect(module, provider=None):
 
     # If any of the values are not given as parameters, check the appropriate
     # environment variables.
-    if not service_account_email:
+    if service_account_email is None:
         service_account_email = os.environ.get('GCE_EMAIL', None)
-    if not project_id:
+    if project_id is None:
         project_id = os.environ.get('GCE_PROJECT', None)
-    if not pem_file:
+    if pem_file is None:
         pem_file = os.environ.get('GCE_PEM_FILE_PATH', None)
 
     # If we still don't have one or more of our credentials, attempt to


### PR DESCRIPTION
Currently you can't run the GCE cloud modules using instance service accounts on GCE instances.  This requires initializing the libcloud auth with empty strings for the positional arguments.  The `if not value` checks were not allowing empty strings through.  I changed the checks to `if val not None`, which still catches unset values, but lets empty strings work.

… allows service accounts on GCE instances to authenticate through libcloud by setting the email and pem files to empty strings
