### PR TITLE
don't set user to current user

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -20,7 +20,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import pwd
 from string import ascii_letters, digits
 
 from ansible.compat.six import string_types
@@ -108,8 +107,6 @@ def load_config_file():
 
 p, CONFIG_FILE = load_config_file()
 
-active_user   = pwd.getpwuid(os.geteuid())[0]
-
 # check all of these extensions when looking for yaml files for things like
 # group variables -- really anything we can load
 YAML_FILENAME_EXTENSIONS = [ "", ".yml", ".yaml", ".json" ]
@@ -138,7 +135,7 @@ DEFAULT_MODULE_ARGS       = get_config(p, DEFAULTS, 'module_args',      'ANSIBLE
 DEFAULT_MODULE_LANG       = get_config(p, DEFAULTS, 'module_lang',      'ANSIBLE_MODULE_LANG',      'en_US.UTF-8')
 DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE_TIMEOUT',          10, integer=True)
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15, integer=True)
-DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      active_user)
+DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      None)
 DEFAULT_ASK_PASS          = get_config(p, DEFAULTS, 'ask_pass',  'ANSIBLE_ASK_PASS',    False, boolean=True)
 DEFAULT_PRIVATE_KEY_FILE  = get_config(p, DEFAULTS, 'private_key_file', 'ANSIBLE_PRIVATE_KEY_FILE', None, ispath=True)
 DEFAULT_REMOTE_PORT       = get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      None, integer=True)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -23,7 +23,6 @@ import fcntl
 import os
 import pipes
 import pty
-import pwd
 import select
 import shlex
 import subprocess
@@ -188,7 +187,7 @@ class Connection(ConnectionBase):
             )
 
         user = self._play_context.remote_user
-        if user and user != pwd.getpwuid(os.geteuid())[0]:
+        if user:
             self._add_args(
                 "ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set",
                 ("-o", "User={0}".format(self._play_context.remote_user))

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -19,7 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import pwd
 import os
 
 from ansible.compat.tests import unittest
@@ -55,7 +54,7 @@ class TestPlayContext(unittest.TestCase):
         play_context = PlayContext(options=options)
         self.assertEqual(play_context.connection, 'smart')
         self.assertEqual(play_context.remote_addr, None)
-        self.assertEqual(play_context.remote_user, pwd.getpwuid(os.geteuid())[0])
+        self.assertEqual(play_context.remote_user, None)
         self.assertEqual(play_context.password, '')
         self.assertEqual(play_context.port, None)
         self.assertEqual(play_context.private_key_file, C.DEFAULT_PRIVATE_KEY_FILE)


### PR DESCRIPTION
also remove condition to bypass setting user if user matches current user
this enables forcing user when set to the same user as current user and ignoring .ssh/config
while keeping .ssh/config with current user if nothing is specified.

fixes #10962
fixes #9079
