### PR TITLE
sanatize results

### DIFF
--- a/lib/ansible/executor/process/result.py
+++ b/lib/ansible/executor/process/result.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 
 from ansible.compat.six.moves import queue
 from ansible.compat.six import iteritems, text_type
+from ansible.vars import strip_internal_keys
 
 import multiprocessing
 import time
@@ -105,7 +106,7 @@ class ResultProcess(multiprocessing.Process):
 
                 # if this task is registering a result, do it now
                 if result._task.register:
-                    self._send_result(('register_host_var', result._host, result._task.register, result._result))
+                    self._send_result(('register_host_var', result._host, result._task.register, strip_internal_keys(result._result)))
 
                 # send callbacks, execute other options based on the result status
                 # TODO: this should all be cleaned up and probably moved to a sub-function.

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -27,6 +27,7 @@ from copy import deepcopy
 from ansible.compat.six import string_types
 
 from ansible import constants as C
+from ansible.vars import strip_internal_keys
 from ansible.utils.unicode import to_unicode
 
 __all__ = ["CallbackBase"]
@@ -56,10 +57,7 @@ class CallbackBase:
             indent = 4
 
         # All result keys stating with _ansible_ are internal, so remove them from the result before we output anything.
-        abridged_result = result.copy()
-        for k in abridged_result.keys():
-            if isinstance(k, string_types) and k.startswith('_ansible_'):
-                del abridged_result[k]
+        abridged_result = strip_internal_keys(result)
 
         # Remove invocation unless verbosity is turned up or the specific
         # callback wants to keep it

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -34,6 +34,7 @@ except ImportError:
 
 from ansible import constants as C
 from ansible.cli import CLI
+from ansible.compat.six import string_types
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleFileNotFound
 from ansible.inventory.host import Host
 from ansible.parsing import DataLoader

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -69,6 +69,17 @@ def preprocess_vars(a):
 
     return data
 
+def strip_internal_keys(dirty):
+    '''
+    All keys stating with _ansible_ are internal, so create a copy of the 'dirty' dict
+    and remove them from the clean one before returning it
+    '''
+    clean = dirty.copy()
+    for k in dirty.keys():
+        if isinstance(k, string_types) and k.startswith('_ansible_'):
+            del clean[k]
+    return clean
+
 class VariableManager:
 
     def __init__(self):


### PR DESCRIPTION
centralize the sanitation function, now both callback output and registered vars are properly sanitized 
