### PR TITLE
Improve ansible-galaxy handling of role versions

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -389,8 +389,13 @@ class GalaxyCLI(CLI):
             # query the galaxy API for the role data
 
             if role.install_info is not None and not force:
-                display.display('- %s is already installed, skipping.' % role.name)
-                continue
+                if role.install_info['version'] != role.version:
+                    display.display('- changing role %s from %s to %s' %
+                            (role.name, role.install_info['version'], role.version or "unspecified"))
+                    role.remove()
+                else:
+                    display.display('- %s is already installed, skipping.' % str(role))
+                    continue
 
             try:
                 installed = role.install()
@@ -411,14 +416,18 @@ class GalaxyCLI(CLI):
                         # we know we can skip this, as it's not going to
                         # be found on galaxy.ansible.com
                         continue
-                    if dep_role.install_info is None or force:
+                    if dep_role.install_info is None:
                         if dep_role not in roles_left:
-                            display.display('- adding dependency: %s' % dep_role.name)
+                            display.display('- adding dependency: %s' % str(dep_role))
                             roles_left.append(dep_role)
                         else:
                             display.display('- dependency %s already pending installation.' % dep_role.name)
                     else:
-                        display.display('- dependency %s is already installed, skipping.' % dep_role.name)
+                        if dep_role.install_info['version'] != dep_role.version:
+                            display.warning('- dependency %s from role %s differs from already installed version (%s), skipping' %
+                                            (str(dep_role), role.name, dep_role.install_info['version']))
+                        else:
+                            display.display('- dependency %s is already installed, skipping.' % dep_role.name)
 
             if not installed:
                 display.warning("- %s was NOT installed successfully." % role.name)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -388,11 +388,16 @@ class GalaxyCLI(CLI):
             display.vvv('Installing role %s ' % role.name)
             # query the galaxy API for the role data
 
-            if role.install_info is not None and not force:
+            if role.install_info is not None:
                 if role.install_info['version'] != role.version:
-                    display.display('- changing role %s from %s to %s' %
-                            (role.name, role.install_info['version'], role.version or "unspecified"))
-                    role.remove()
+                    if force:
+                        display.display('- changing role %s from %s to %s' %
+                                        (role.name, role.install_info['version'], role.version or "unspecified"))
+                        role.remove()
+                    else:
+                        display.warning('- %s (%s) is already installed - use --force to change version to %s' %
+                                        (role.name, role.install_info['version'], role.version or "unspecified"))
+                        continue
                 else:
                     display.display('- %s is already installed, skipping.' % str(role))
                     continue

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -82,6 +82,15 @@ class GalaxyRole(object):
                 self.paths = [x for x in galaxy.roles_paths]
                 self.paths = [os.path.join(x, self.name) for x in self.paths]
 
+    def __repr__(self):
+        """
+        Returns "rolename (version)" if version is not null
+        Returns "rolename" otherwise
+        """
+        if self.version:
+            return "%s (%s)" % (self.name, self.version)
+        else:
+            return self.name
 
     def __eq__(self, other):
         return self.name == other.name
@@ -321,7 +330,7 @@ class GalaxyRole(object):
                             raise AnsibleError("Could not update files in %s: %s" % (self.path, str(e)))
 
                 # return the parsed yaml metadata
-                display.display("- %s was installed successfully" % self.name)
+                display.display("- %s was installed successfully" % str(self))
                 if not local_file:
                     try:
                         os.unlink(tmp_file)


### PR DESCRIPTION
Ensure that role versions are considered when deciding
whether or not to (re-)install a role.

Issue a warning when the version of a dependency conflicts
with the version of an already installed role

Display what version of a role is being installed
Show the versions when upgrading/downgrading a role.

Implements #11266 

```
[will@dingo tmp]$ ansible-galaxy install -r ~/src/ansible/test/integration/galaxy_roles.yml -p roles
- downloading role 'oracle_java7', owned by briancoca
- downloading role from https://github.com/bcoca/ansible-oracle_java7-role/archive/v1.0.tar.gz
- extracting oracle_java7 to roles/oracle_java7
- oracle_java7 (v1.0) was installed successfully
- extracting git-ansible-galaxy to roles/git-ansible-galaxy
- git-ansible-galaxy (v1.6) was installed successfully
- adding dependency: git-gal-dep (v0.2)
- extracting hg-ansible-galaxy to roles/hg-ansible-galaxy
- hg-ansible-galaxy was installed successfully
- downloading role from https://bitbucket.org/willthames/http-ansible-galaxy/get/master.tar.gz
- extracting http-role to roles/http-role
- http-role was installed successfully
- extracting php to roles/php
- php was installed successfully
- extracting git-gal-dep to roles/git-gal-dep
- git-gal-dep (v0.2) was installed successfully
[will@dingo tmp]$ ansible-galaxy install -r ~/src/ansible/test/integration/galaxy_roles.yml -p roles
- changing role oracle_java7 from v1.0 to unspecified
- downloading role 'oracle_java7', owned by briancoca
- downloading role from https://github.com/bcoca/ansible-oracle_java7-role/archive/v1.0.tar.gz
- extracting oracle_java7 to roles/oracle_java7
- oracle_java7 (v1.0) was installed successfully
- git-ansible-galaxy (v1.6) is already installed, skipping.
- hg-ansible-galaxy is already installed, skipping.
- http-role is already installed, skipping.
- php is already installed, skipping.
```

Note that the behaviour with galaxy roles with an unspecified version is a little odd. This is because `meta/.galaxy_install_info` gets told the version of the role that actually gets installed when installing under galaxy. However, if you're not fixing versions in your rolesfile, then it's fine to expect that the role will be reinstalled each time you run ansible-galaxy install. (This is similar to the behaviour of `yum state=latest`, for example). One fix for this would be for `.galaxy_install_info` to be told the version of the role specified, rather than the version of the role installed.
