### PR TITLE
Default task retries to 3 like it was in previous releases. Fixes #12928

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -81,7 +81,7 @@ class Task(Base, Conditional, Taggable, Become):
     _notify               = FieldAttribute(isa='list')
     _poll                 = FieldAttribute(isa='int')
     _register             = FieldAttribute(isa='string')
-    _retries              = FieldAttribute(isa='int', default=1)
+    _retries              = FieldAttribute(isa='int', default=3)
     _until                = FieldAttribute(isa='list') # ?
 
     def __init__(self, block=None, role=None, task_include=None):


### PR DESCRIPTION
In previous releases, `retries` was defaulted to 3 for do-until loops (https://github.com/ansible/ansible/blob/stable-1.9/lib/ansible/playbook/task.py#L141).  This is also documented at http://docs.ansible.com/ansible/playbooks_loops.html#do-until-loops

This PR updates the default in devel from 1 to 3.
