### PR TITLE
Missing dependency on markupsafe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='ansible',
       license='GPLv3',
       # Ansible will also make use of a system copy of python-six if installed but use a
       # Bundled copy if it's not.
-      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
+      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6', 'markupsafe'],
       package_dir={ '': 'lib' },
       packages=find_packages('lib'),
       package_data={


### PR DESCRIPTION
My first launch of ansible (installed from pip) throws me an exception on missing markupsafe module, so I guess it just need to be added on the `setup.py`

``` python
~$ ansible
Traceback (most recent call last):
  File "/home/baptistemm/Code/ansible-venv/bin/ansible", line 36, in <module>
    from ansible.runner import Runner
  File "/home/baptistemm/Code/ansible-venv/local/lib/python2.7/site-packages/ansible/runner/__init__.py", line 32, in <module>
    import jinja2
  File "/home/baptistemm/Code/ansible-venv/local/lib/python2.7/site-packages/jinja2/__init__.py", line 33, in <module>
    from jinja2.environment import Environment, Template
  File "/home/baptistemm/Code/ansible-venv/local/lib/python2.7/site-packages/jinja2/environment.py", line 13, in <module>
    from jinja2 import nodes
  File "/home/baptistemm/Code/ansible-venv/local/lib/python2.7/site-packages/jinja2/nodes.py", line 19, in <module>
    from jinja2.utils import Markup
  File "/home/baptistemm/Code/ansible-venv/local/lib/python2.7/site-packages/jinja2/utils.py", line 531, in <module>
    from markupsafe import Markup, escape, soft_unicode
ImportError: No module named markupsafe
```
