### PR TITLE
update ansible_test_service checksum

### DIFF
--- a/test/integration/roles/test_service/tasks/main.yml
+++ b/test/integration/roles/test_service/tasks/main.yml
@@ -6,7 +6,7 @@
   assert:
     that:
     - "install_result.dest == '/usr/sbin/ansible_test_service'"
-    - "install_result.checksum == 'baaa79448a976922c080f1971321d203c6df0961'"
+    - "install_result.checksum == '4e0164ceb9a5aeab76b38483ffd27fe791baa9f4'"
     - "install_result.state == 'file'"
     - "install_result.mode == '0755'"
 


### PR DESCRIPTION
August 27, 2015 commit https://github.com/ansible/ansible/commit/9ae66a7f5cf18498d7cd1860dba17e5c24dc35df#diff-218310efbfeca3002e4ef2732e7d0fdc made changes to `ansible_test_service` without updating the testing checksum. This commit updates the checksum.
