### PR TITLE
Note previous versions usage of colon delimiter

### DIFF
--- a/docsite/rst/intro_patterns.rst
+++ b/docsite/rst/intro_patterns.rst
@@ -37,6 +37,8 @@ This means the host may be in either one group or the other::
     webservers
     webservers,dbservers
 
+.. note:: Prior to version 2, the notation for listing multiple selectors was a colon, ":", instead of a comma
+
 You can exclude groups as well, for instance, all machines must be in the group webservers but not in the group phoenix::
 
     webservers,!phoenix


### PR DESCRIPTION
Doc site talks about the use of a comma as the host group delimiter for and/or/not hosts patterns.  The comma does not work in version 1.9, but I only found out about the use of colon from a closed Github issue.

PLEASE CHECK VERSION CLAIM!!

I have no idea which version introduced the change, and simply wrote that it was version 2.  Please correct before merging.
