### PR TITLE
stdout_callback instead of callback_stdout

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -39,7 +39,7 @@ gathering = implicit
 #host_key_checking = False
 
 # change the default callback
-#callback_stdout = skippy
+#stdout_callback = skippy
 # enable additional callbacks
 #callback_whitelist = timer, mail
 


### PR DESCRIPTION
The correct setting name is stdout_callback
