### PR TITLE
Update playbooks_lookups.rst

### DIFF
--- a/docsite/rst/playbooks_lookups.rst
+++ b/docsite/rst/playbooks_lookups.rst
@@ -10,6 +10,8 @@ in Ansible, and are typically used to load variables or templates with informati
 
 .. note:: Lookups occur on the local computer, not on the remote computer.
 
+.. note:: Lookups are executed with a cwd relative to the role or play, as opposed to local tasks which are executed with the cwd of the executed script.
+
 .. note:: Since 1.9 you can pass wantlist=True to lookups to use in jinja2 template "for" loops.
 
 .. contents:: Topics


### PR DESCRIPTION
I was caught out by the different behaviour of lookups & local tasks, and could not find the difference documented anywhere at all, so I took the liberty of proposing this change.

Lookups are always relative to the role or play.
Local tasks are relative to the cwd from which you execute.
