### PR TITLE
[feature] add src_path to galaxy requirements spec

### DIFF
--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -88,6 +88,12 @@ And here's an example showing some specific version downloads from multiple sour
     - src: https://github.com/bennojoy/nginx
       version: master
       name: nginx_role
+
+    # from github, specifying a subdirectory (ansible/role) that
+    # contains the role
+    - src: https://github.com/auser/test-project
+      name: test
+      src_path: ansible/role
     
     # from a webserver, where the role is packaged in a tar.gz
     - src: https://some.webserver.example.com/files/master.tar.gz

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -49,7 +49,7 @@ class GalaxyRole(object):
     ROLE_DIRS = ('defaults','files','handlers','meta','tasks','templates','vars')
 
 
-    def __init__(self, galaxy, name, src=None, version=None, scm=None, path=None):
+    def __init__(self, galaxy, name, src=None, version=None, scm=None, path=None, src_path=None):
 
         self._metadata = None
         self._install_info = None
@@ -61,6 +61,10 @@ class GalaxyRole(object):
         self.version = version
         self.src = src or name
         self.scm = scm
+        if src_path:
+            self.src_path = src_path.split('/')
+        else:
+            self.src_path = None
 
         if path is not None:
             if self.name not in path:
@@ -276,6 +280,10 @@ class GalaxyRole(object):
                         # and drop the leading directory, as mentioned above
                         if member.isreg() or member.issym():
                             parts = member.name.split(os.sep)[1:]
+                            if self.src_path:
+                                if parts[:len(self.src_path)] != self.src_path:
+                                    continue
+                                parts = parts[len(self.src_path):]
                             final_parts = []
                             for part in parts:
                                 if part != '..' and '~' not in part and '$' not in part:
@@ -286,7 +294,7 @@ class GalaxyRole(object):
                     # write out the install info file for later use
                     self._write_galaxy_install_info()
                 except OSError as e:
-                   raise AnsibleError("Could not update files in %s: %s" % (self.path, str(e)))
+                    raise AnsibleError("Could not update files in %s: %s" % (self.path, str(e)))
 
                 # return the parsed yaml metadata
                 display.display("- %s was installed successfully" % self.name)

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -37,6 +37,7 @@ VALID_SPEC_KEYS = [
     'role',
     'scm',
     'src',
+    'src_path',
     'version',
 ]
 


### PR DESCRIPTION
This feature makes it possible to require a role that is a subdirectory within `src`. For example, a role that is embedded in a larger project:

```
example-project/
├── extra
│   └── ansible-role
│       ├── defaults
│       │   └── main.yml
│       ├── files
│       ├── handlers
│       │   └── main.yml
│       ├── meta
│       │   └── main.yml
│       ├── README.md
│       ├── tasks
│       │   └── main.yml
│       ├── templates
│       └── vars
│           └── main.yml
├── README.md
└── src
    └── ...
├── ...
```

The following entry in `requirements.yml` would then install the above `ansible-role` as `example`:

```
- src: https://github.com/auser/example-project
  name: example
  src_path: extra/ansible-role
```
