### PR TITLE
doc: add cloudstack guide to the guides

### DIFF
--- a/docsite/rst/guides.rst
+++ b/docsite/rst/guides.rst
@@ -9,8 +9,8 @@ This section is new and evolving.  The idea here is explore particular use cases
    guide_aws
    guide_rax
    guide_gce
+   guide_cloudstack
    guide_vagrant
    guide_rolling_upgrade
 
 Pending topics may include: Docker, Jenkins, Google Compute Engine, Linode/DigitalOcean, Continuous Deployment, and more.
-


### PR DESCRIPTION
 I am not really aware how rst works but this looks like it does what it should.
