### PR TITLE
Ensure english dates are generated in debian/changelog placeholder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ DEBUILD_BIN ?= debuild
 DEBUILD_OPTS = --source-option="-I"
 DPUT_BIN ?= dput
 DPUT_OPTS ?=
-DEB_DATE := $(shell date +"%a, %d %b %Y %T %z")
+DEB_DATE := $(LC_TIME=C shell date +"%a, %d %b %Y %T %z")
 ifeq ($(OFFICIAL),yes)
     DEB_RELEASE = $(RELEASE)ppa
     # Sign OFFICIAL builds using 'DEBSIGN_KEYID'


### PR DESCRIPTION
Running `make deb` the script failed with error: 

> Error parsing time at /usr/lib/x86_64-linux-gnu/perl/5.20/Time/Piece.pm line 469, <$filehandle> line 5.
> Makefile:228: recipe for target 'deb' failed

That's because `dpkg-parsechangelog` couldn't parse the changelog anymore. 

I found that deb package changelog has a placeholder for a date and it's getting replaced during the build. 

My `LC_TIME` is set to polish as default so the first item of the changelog looks like:

```
abu@abu:~/src/ansible$ head -5 deb-build/unstable/ansible-2.0.0/debian/changelog
ansible (2.0.0-0.git201511011823.2ee5bb5.devel~unstable) unstable; urgency=low

  * 2.0.0 release

-- Ansible, Inc. <support@ansible.com>  nie, 01 lis 2015 21:53:49 +0100
```
