### PR TITLE
Ansible executable does not detect/report unsupported invocation

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -21,6 +21,7 @@ from __future__ import (absolute_import,
                         print_function)
 
 __requires__ = ['ansible']
+
 try:
     import pkg_resources
 except Exception:
@@ -35,7 +36,9 @@ import os
 import sys
 import traceback
 
-from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
+from ansible.errors import (AnsibleError,
+                            AnsibleOptionsError,
+                            AnsibleParserError)
 from ansible.utils.display import Display
 from ansible.utils.unicode import to_unicode
 

--- a/bin/ansible
+++ b/bin/ansible
@@ -23,13 +23,13 @@ from __future__ import (absolute_import,
 __requires__ = ['ansible']
 
 try:
+    # Use pkg_resources to find the correct versions of libraries and set
+    # sys.path appropriately when there are multiversion installs...
     import pkg_resources
 except Exception:
-    # Use pkg_resources to find the correct versions of libraries and set
-    # sys.path appropriately when there are multiversion installs.  But we
-    # have code that better expresses the errors in the places where the code
-    # is actually used (the deps are optional for many code paths) so we don't
-    # want to fail here.
+    # ... we have code that better expresses the errors in the places where the
+    # code is actually used (the deps are optional for many code paths) so we
+    # don't want to fail here.
     pass
 
 import os

--- a/bin/ansible
+++ b/bin/ansible
@@ -45,11 +45,13 @@ from ansible.utils.unicode import to_unicode
 class LastResort(object):
     """Output of last resort."""
 
+    OUTPUT_FILE = sys.stderr
+
     def display(self, msg):
-        print(msg, file=sys.stderr)
+        print(msg, file=LastResort.OUTPUT_FILE)
 
     def error(self, msg, wrap_text=None):
-        print(msg, file=sys.stderr)
+        print(msg, file=LastResort.OUTPUT_FILE)
 
 if __name__ == '__main__':
 

--- a/bin/ansible
+++ b/bin/ansible
@@ -61,19 +61,19 @@ if __name__ == '__main__':
         display = Display()
 
         if executed_as == 'ansible-playbook':
-            from ansible.cli.playbook import PlaybookCLI as mycli
+            from ansible.cli.playbook import PlaybookCLI as requested_cli
         elif executed_as == 'ansible':
-            from ansible.cli.adhoc import AdHocCLI as mycli
+            from ansible.cli.adhoc import AdHocCLI as requested_cli
         elif executed_as == 'ansible-pull':
-            from ansible.cli.pull import PullCLI as mycli
+            from ansible.cli.pull import PullCLI as requested_cli
         elif executed_as == 'ansible-doc':
-            from ansible.cli.doc import DocCLI as mycli
+            from ansible.cli.doc import DocCLI as requested_cli
         elif executed_as == 'ansible-vault':
-            from ansible.cli.vault import VaultCLI as mycli
+            from ansible.cli.vault import VaultCLI as requested_cli
         elif executed_as == 'ansible-galaxy':
-            from ansible.cli.galaxy import GalaxyCLI as mycli
+            from ansible.cli.galaxy import GalaxyCLI as requested_cli
 
-        cli = mycli(sys.argv, display=display)
+        cli = requested_cli(sys.argv, display=display)
         if cli:
             cli.parse()
             sys.exit(cli.run())

--- a/bin/ansible
+++ b/bin/ansible
@@ -60,6 +60,7 @@ if __name__ == '__main__':
     try:
         display = Display()
 
+        requested_cli = None
         if executed_as == 'ansible-playbook':
             from ansible.cli.playbook import PlaybookCLI as requested_cli
         elif executed_as == 'ansible':
@@ -73,12 +74,12 @@ if __name__ == '__main__':
         elif executed_as == 'ansible-galaxy':
             from ansible.cli.galaxy import GalaxyCLI as requested_cli
 
-        cli = requested_cli(sys.argv, display=display)
-        if cli:
-            cli.parse()
-            sys.exit(cli.run())
-        else:
+        if requested_cli is None:
             raise AnsibleError("Program not implemented: %s" % executed_as)
+
+        cli = requested_cli(sys.argv, display=display)
+        cli.parse()
+        sys.exit(cli.run())
 
     except AnsibleOptionsError as e:
         cli.parser.print_help()

--- a/bin/ansible
+++ b/bin/ansible
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-########################################################
 from __future__ import (absolute_import, print_function)
 __metaclass__ = type
 
@@ -40,17 +39,12 @@ from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.utils.display import Display
 from ansible.utils.unicode import to_unicode
 
-########################################
-### OUTPUT OF LAST RESORT ###
 class LastResort(object):
     def display(self, msg):
         print(msg, file=sys.stderr)
 
     def error(self, msg, wrap_text=None):
         print(msg, file=sys.stderr)
-
-
-########################################
 
 if __name__ == '__main__':
 

--- a/bin/ansible
+++ b/bin/ansible
@@ -18,7 +18,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 ########################################################
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, print_function)
 __metaclass__ = type
 
 __requires__ = ['ansible']

--- a/bin/ansible
+++ b/bin/ansible
@@ -45,13 +45,11 @@ from ansible.utils.unicode import to_unicode
 class LastResort(object):
     """Output of last resort."""
 
-    OUTPUT_FILE = sys.stderr
-
-    def display(self, msg):
-        print(msg, file=LastResort.OUTPUT_FILE)
+    def display(self, msg, **kwargs):
+        print(msg, file=sys.stderr)
 
     def error(self, msg, **kwargs):
-        print(msg, file=LastResort.OUTPUT_FILE)
+        self.display(msg)
 
 if __name__ == '__main__':
 

--- a/bin/ansible
+++ b/bin/ansible
@@ -74,7 +74,7 @@ def specialised_cli(executed_as):
     elif executed_as == 'ansible-galaxy':
         from ansible.cli.galaxy import GalaxyCLI as requested_cli
     if requested_cli is None:
-        raise AnsibleError("Program not implemented: %s" % executed_as)
+        raise AnsibleError('Program not implemented: %s' % executed_as)
     return requested_cli
 
 def report_exception(exception, display):
@@ -107,14 +107,14 @@ if __name__ == '__main__':
         sys.exit(ERROR_GENERIC)
 
     except KeyboardInterrupt:
-        display.error("User interrupted execution")
+        display.error('User interrupted execution')
         sys.exit(ERROR_EXECUTION_INTERRUPTED)
 
     except Exception as e:
         have_cli_options = cli is not None and cli.options is not None
-        display.error("Unexpected Exception: %s" % to_unicode(e), wrap_text=False)
+        display.error('Unexpected Exception: %s' % to_unicode(e), wrap_text=False)
         if not have_cli_options or have_cli_options and cli.options.verbosity > 2:
-            display.display("the full traceback was:\n\n%s" % traceback.format_exc())
+            display.display('the full traceback was:\n\n%s' % traceback.format_exc())
         else:
-            display.display("to see the full traceback, use -vvv")
+            display.display('to see the full traceback, use -vvv')
         sys.exit(ERROR_UNEXPECTED)

--- a/bin/ansible
+++ b/bin/ansible
@@ -42,6 +42,14 @@ from ansible.errors import (AnsibleError,
 from ansible.utils.display import Display
 from ansible.utils.unicode import to_unicode
 
+ERROR_GENERIC = 1
+ERROR_HOST_FAILED = 2 # Reserved. Returned by TaskQueueManager
+ERROR_HOST_UNREACHABLE = 3 # Reserved. Returned by TaskQueueManager
+ERROR_PARSING = 4
+ERROR_COMMAND_OPTIONS = 5
+ERROR_EXECUTION_INTERRUPTED = 99
+ERROR_UNEXPECTED = 250
+
 class LastResort(object):
     """Output of last resort."""
 
@@ -69,6 +77,9 @@ def specialised_cli(executed_as):
         raise AnsibleError("Program not implemented: %s" % executed_as)
     return requested_cli
 
+def report_exception(exception, display):
+    display.error(to_unicode(e), wrap_text=False)
+
 if __name__ == '__main__':
 
     display = LastResort()
@@ -84,24 +95,21 @@ if __name__ == '__main__':
 
     except AnsibleOptionsError as e:
         cli.parser.print_help()
-        display.error(to_unicode(e), wrap_text=False)
-        sys.exit(5)
+        report_exception(e, display)
+        sys.exit(ERROR_COMMAND_OPTIONS)
+
     except AnsibleParserError as e:
-        display.error(to_unicode(e), wrap_text=False)
-        sys.exit(4)
-# TQM takes care of these, but leaving comment to reserve the exit codes
-#    except AnsibleHostUnreachable as e:
-#        display.error(str(e))
-#        sys.exit(3)
-#    except AnsibleHostFailed as e:
-#        display.error(str(e))
-#        sys.exit(2)
+        report_exception(e, display)
+        sys.exit(ERROR_PARSING)
+
     except AnsibleError as e:
-        display.error(to_unicode(e), wrap_text=False)
-        sys.exit(1)
+        report_exception(e, display)
+        sys.exit(ERROR_GENERIC)
+
     except KeyboardInterrupt:
         display.error("User interrupted execution")
-        sys.exit(99)
+        sys.exit(ERROR_EXECUTION_INTERRUPTED)
+
     except Exception as e:
         have_cli_options = cli is not None and cli.options is not None
         display.error("Unexpected Exception: %s" % to_unicode(e), wrap_text=False)
@@ -109,4 +117,4 @@ if __name__ == '__main__':
             display.display("the full traceback was:\n\n%s" % traceback.format_exc())
         else:
             display.display("to see the full traceback, use -vvv")
-        sys.exit(250)
+        sys.exit(ERROR_UNEXPECTED)

--- a/bin/ansible
+++ b/bin/ansible
@@ -112,9 +112,12 @@ if __name__ == '__main__':
 
     except Exception as e:
         have_cli_options = cli is not None and cli.options is not None
-        display.error('Unexpected Exception: %s' % to_unicode(e), wrap_text=False)
-        if not have_cli_options or have_cli_options and cli.options.verbosity > 2:
-            display.display('the full traceback was:\n\n%s' % traceback.format_exc())
+        display.error('Unexpected Exception: %s' % to_unicode(e),
+                      wrap_text=False)
+        if (not have_cli_options
+                or have_cli_options and cli.options.verbosity > 2):
+            full_traceback = traceback.format_exc()
+            display.display('the full traceback was:\n\n%s' % full_traceback)
         else:
             display.display('to see the full traceback, use -vvv')
         sys.exit(ERROR_UNEXPECTED)

--- a/bin/ansible
+++ b/bin/ansible
@@ -50,7 +50,7 @@ class LastResort(object):
     def display(self, msg):
         print(msg, file=LastResort.OUTPUT_FILE)
 
-    def error(self, msg, wrap_text=None):
+    def error(self, msg, **kwargs):
         print(msg, file=LastResort.OUTPUT_FILE)
 
 if __name__ == '__main__':

--- a/bin/ansible
+++ b/bin/ansible
@@ -40,6 +40,8 @@ from ansible.utils.display import Display
 from ansible.utils.unicode import to_unicode
 
 class LastResort(object):
+    """Output of last resort."""
+
     def display(self, msg):
         print(msg, file=sys.stderr)
 

--- a/bin/ansible
+++ b/bin/ansible
@@ -20,8 +20,6 @@
 from __future__ import (absolute_import,
                         print_function)
 
-__metaclass__ = type
-
 __requires__ = ['ansible']
 try:
     import pkg_resources

--- a/bin/ansible
+++ b/bin/ansible
@@ -55,22 +55,22 @@ if __name__ == '__main__':
 
     display = LastResort()
     cli = None
-    me = os.path.basename(sys.argv[0])
+    executed_as = os.path.basename(sys.argv[0])
 
     try:
         display = Display()
 
-        if me == 'ansible-playbook':
+        if executed_as == 'ansible-playbook':
             from ansible.cli.playbook import PlaybookCLI as mycli
-        elif me == 'ansible':
+        elif executed_as == 'ansible':
             from ansible.cli.adhoc import AdHocCLI as mycli
-        elif me == 'ansible-pull':
+        elif executed_as == 'ansible-pull':
             from ansible.cli.pull import PullCLI as mycli
-        elif me == 'ansible-doc':
+        elif executed_as == 'ansible-doc':
             from ansible.cli.doc import DocCLI as mycli
-        elif me == 'ansible-vault':
+        elif executed_as == 'ansible-vault':
             from ansible.cli.vault import VaultCLI as mycli
-        elif me == 'ansible-galaxy':
+        elif executed_as == 'ansible-galaxy':
             from ansible.cli.galaxy import GalaxyCLI as mycli
 
         cli = mycli(sys.argv, display=display)
@@ -78,7 +78,7 @@ if __name__ == '__main__':
             cli.parse()
             sys.exit(cli.run())
         else:
-            raise AnsibleError("Program not implemented: %s" % me)
+            raise AnsibleError("Program not implemented: %s" % executed_as)
 
     except AnsibleOptionsError as e:
         cli.parser.print_help()

--- a/bin/ansible
+++ b/bin/ansible
@@ -17,7 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function)
+from __future__ import (absolute_import,
+                        print_function)
+
 __metaclass__ = type
 
 __requires__ = ['ansible']

--- a/bin/ansible
+++ b/bin/ansible
@@ -51,6 +51,24 @@ class LastResort(object):
     def error(self, msg, **kwargs):
         self.display(msg)
 
+def specialised_cli(executed_as):
+    requested_cli = None
+    if executed_as == 'ansible-playbook':
+        from ansible.cli.playbook import PlaybookCLI as requested_cli
+    elif executed_as == 'ansible':
+        from ansible.cli.adhoc import AdHocCLI as requested_cli
+    elif executed_as == 'ansible-pull':
+        from ansible.cli.pull import PullCLI as requested_cli
+    elif executed_as == 'ansible-doc':
+        from ansible.cli.doc import DocCLI as requested_cli
+    elif executed_as == 'ansible-vault':
+        from ansible.cli.vault import VaultCLI as requested_cli
+    elif executed_as == 'ansible-galaxy':
+        from ansible.cli.galaxy import GalaxyCLI as requested_cli
+    if requested_cli is None:
+        raise AnsibleError("Program not implemented: %s" % executed_as)
+    return requested_cli
+
 if __name__ == '__main__':
 
     display = LastResort()
@@ -59,24 +77,7 @@ if __name__ == '__main__':
 
     try:
         display = Display()
-
-        requested_cli = None
-        if executed_as == 'ansible-playbook':
-            from ansible.cli.playbook import PlaybookCLI as requested_cli
-        elif executed_as == 'ansible':
-            from ansible.cli.adhoc import AdHocCLI as requested_cli
-        elif executed_as == 'ansible-pull':
-            from ansible.cli.pull import PullCLI as requested_cli
-        elif executed_as == 'ansible-doc':
-            from ansible.cli.doc import DocCLI as requested_cli
-        elif executed_as == 'ansible-vault':
-            from ansible.cli.vault import VaultCLI as requested_cli
-        elif executed_as == 'ansible-galaxy':
-            from ansible.cli.galaxy import GalaxyCLI as requested_cli
-
-        if requested_cli is None:
-            raise AnsibleError("Program not implemented: %s" % executed_as)
-
+        requested_cli = specialised_cli(executed_as)
         cli = requested_cli(sys.argv, display=display)
         cli.parse()
         sys.exit(cli.run())


### PR DESCRIPTION
The core of this Pull Request is a plain bug fix.

The `ansible` executable (i.e. bin/ansible) is symlinked to in various forms from the bin/ directory:
- ansible-doc -> ansible
- ansible-galaxy -> ansible
- ansible-playbook -> ansible
- ansible-pull -> ansible
- ansible-vault -> ansible

Inside `ansible`, which form to take is determined by looking at sys.argv[0].

When the executable is invoked in an unsupported form, an exception "should" be raised:

```
raise AnsibleError("Program not implemented: %s" % me)
```

The code that does that is broken, as proven by creating a new symlink (e.g.: "unsupported"):

```
$ cd bin
$ ln -s ansible unsupported
$ ./unsupported
```

The resulting exception shows that the "unsupported" check is implemented incorrectly:

```
Unexpected Exception: name 'mycli' is not defined
the full traceback was:

Traceback (most recent call last):
  File "./unsupported", line 77, in <module>
    cli = mycli(sys.argv, display=display)
NameError: name 'mycli' is not defined
```

This pull request contains multiple commits, which not only fix the problem, but also
improve the executable's readability.

Examples:

The core bug fix commit is:
https://github.com/ansible/ansible/commit/3133f442ae1d32ef2ae40bdf96b2f8ad40561c90

Explicit exit/error codes:
https://github.com/Maroloccio/ansible/commit/c1d816053b6cc268eafaed28041178bacb027cd2

... for a subjectively more readable final version of:

https://github.com/Maroloccio/ansible/blob/devel/bin/ansible
