### PR TITLE
Make sure potential_names is not dependent on hashing order

### DIFF
--- a/lib/ansible/utils/plugins.py
+++ b/lib/ansible/utils/plugins.py
@@ -165,7 +165,7 @@ class PluginLoader(object):
             else:
                 suffixes = ['.py', '']
 
-        potential_names = frozenset('%s%s' % (name, s) for s in suffixes)
+        potential_names = list('%s%s' % (name, s) for s in suffixes)
         for full_name in potential_names:
             if full_name in self._plugin_path_cache:
                 return self._plugin_path_cache[full_name]


### PR DESCRIPTION
For me, `potential_names` contains this in one run invocation of `find_plugin`:

```
[ u'win_restart_computer.ps1', u'win_restart_computer' ]
```

But in the next invocation of find_plugin, it's as if it contains this:

```
[ u'win_ad_group', u'win_ad_group.ps1' ]
```

This is because the items in a set/frozenset have no defined order, thus the order in which the items are iterated varies based on the hash value of the item. This means that the name without extension is returned, u'win_ad_group', which means that no shebang line will be found, which means that ansible will fail with the error "module is missing interpreter line".

Impact on runtime should be minimal, because the list of suffixes won't contain more than two items.
