### PR TITLE
Allow PATCH to list of valid HTTP methods

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -669,7 +669,7 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
     urllib2.install_opener(opener)
 
     if method:
-        if method.upper() not in ('OPTIONS','GET','HEAD','POST','PUT','DELETE','TRACE','CONNECT'):
+        if method.upper() not in ('OPTIONS','GET','HEAD','POST','PUT','DELETE','TRACE','CONNECT','PATCH'):
             raise ConnectionError('invalid HTTP request method; %s' % method.upper())
         request = RequestWithMethod(url, method.upper(), data)
     else:


### PR DESCRIPTION
I'm working on the kubernetes module[1] and in order to cover the full kubernetes API, [patch operations](http://kubernetes.io/v1.0/docs/devel/api-conventions.html#patch-operations) need to be supported. For the REST calls, I'm using `ansible.module_utils.urls` and `PATCH` is not supported.

This PR adds the `PATCH` to the list of allowed HTTP methods.

[1] https://github.com/ansible/ansible-modules-extras/issues/1139 
