### PR TITLE
treat forks config parameter as max value...

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -92,8 +92,14 @@ class TaskQueueManager:
         # plugins for inter-process locking.
         self._connection_lockfile = tempfile.TemporaryFile()
 
+        # Treat "forks" config parameter as max value. Only create number of workers
+        # equal to number of hosts in inventory if less than max value.
+        num_workers = self._options.forks
+        if self._options.forks > len(self._inventory.list_hosts()):
+            num_workers = len(self._inventory.list_hosts())
+
         self._workers = []
-        for i in range(self._options.forks):
+        for i in range(num_workers):
             main_q = multiprocessing.Queue()
             rslt_q = multiprocessing.Queue()
 
@@ -266,4 +272,3 @@ class TaskQueueManager:
                         method(*args, **kwargs)
                     except Exception as e:
                         self._display.warning('Error when using %s: %s' % (method, str(e)))
-


### PR DESCRIPTION
 ... instead of always creating that number of workers.
Otherwise we have a lot of workers with using resources without having any work to do.
This was exhausting resources on our Jenkins server even when the plays were on pretty small inventories.
