### PR TITLE
Provide git based example

### DIFF
--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -100,6 +100,12 @@ And here's an example showing some specific version downloads from multiple sour
     # from bitbucket, alternative syntax and caveats
     - src: http://bitbucket.org/willthames/hg-ansible-galaxy
       scm: hg
+   
+   # from gitlab or other git-based scm   
+    - src: git@gitlab.company.com:mygroup/ansible-base.git
+      scm: git
+      version: 0.1.0
+      path: roles/
 
 As you can see in the above, there are a large amount of controls available
 to customize where roles can be pulled from, and what to save roles as.     


### PR DESCRIPTION
I found it difficult to find documentation for how to pull from a git-based scm that wasn't github. The only way I could find this option was to dig through the google-group.
