### PR TITLE
Docs: Fix bracket expansion in targetting pattern

### DIFF
--- a/docsite/rst/intro_patterns.rst
+++ b/docsite/rst/intro_patterns.rst
@@ -79,9 +79,8 @@ You can refer to hosts within the group by adding a subscript to the group name:
 
     webservers[0]       # == cobweb
     webservers[-1]      # == weber
-    webservers[0:1]     # == webservers[0],webservers[1]
+    webservers[0-1]     # == webservers[0],webservers[1]
                         # == cobweb,webbing
-    webservers[1:]      # == webbing,weber
 
 Most people don't specify patterns as regular expressions, but you can.  Just start the pattern with a '~'::
 


### PR DESCRIPTION
Doc fix.

See #13044 

Syntax `group[0:1]` has changed to `group[0-1]`, and `group[0:]` does not work anymore.
