### PR TITLE
Fixes #13010 by updating boto3 methods

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -41,19 +41,24 @@ except:
 
 
 def boto3_conn(module, conn_type=None, resource=None, region=None, endpoint=None, **params):
+    profile = params.pop('profile_name', None)
+    params['aws_session_token'] = params.pop('security_token', None)
+    params['verify'] = params.pop('validate_certs', None)
+
     if conn_type not in ['both', 'resource', 'client']:
         module.fail_json(msg='There is an issue in the code of the module. You must specify either both, resource or client to the conn_type parameter in the boto3_conn function call')
 
     if conn_type == 'resource':
-        resource = boto3.session.Session().resource(resource, region_name=region, endpoint_url=endpoint, **params)
+        resource = boto3.session.Session(profile_name=profile).resource(resource, region_name=region, endpoint_url=endpoint, **params)
         return resource
     elif conn_type == 'client':
-        client = boto3.session.Session().client(resource, region_name=region, endpoint_url=endpoint, **params)
+        client = boto3.session.Session(profile_name=profile).client(resource, region_name=region, endpoint_url=endpoint, **params)
         return client
     else:
-        resource = boto3.session.Session().resource(resource, region_name=region, endpoint_url=endpoint, **params)
-        client = boto3.session.Session().client(resource, region_name=region, endpoint_url=endpoint, **params)
+        resource = boto3.session.Session(profile_name=profile).resource(resource, region_name=region, endpoint_url=endpoint, **params)
+        client = boto3.session.Session(profile_name=profile).client(resource, region_name=region, endpoint_url=endpoint, **params)
         return client, resource
+
 
 def aws_common_argument_spec():
     return dict(
@@ -152,7 +157,6 @@ def get_aws_connection_info(module, boto3=False):
 
         if profile_name:
             boto_params['profile_name'] = profile_name
-
 
     else:
         boto_params = dict(aws_access_key_id=access_key,


### PR DESCRIPTION
Fixes #13010 by updating boto3 methods to update boto3_conn to check for profile_name and if detected, remove from params and set a new variable of profile which is passed into Session separately. 

Resubmission of PR #13012 as it was easier to just recreate a new branch with 1 commit and the latest devel commits.
