### PR TITLE
[v2] template: fix regression bug in template in case force=false

### DIFF
--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -150,7 +150,7 @@ class ActionModule(ActionBase):
         diff = {}
         new_module_args = self._task.args.copy()
 
-        if local_checksum != remote_checksum:
+        if force and local_checksum != remote_checksum:
 
             result['changed'] = True
             # if showing diffs, we need to get the remote value


### PR DESCRIPTION
Fixes regression bug, previously reported in #12844 fixed with
4b2088471909e9f785dc2d52ce3c46c95d54e463 re-introduced with
c64ac90560938811fac4ff32ae69e1e667dddc34

```
 $ cat /tmp/test.yml 

---
- hosts: localhost
  tasks:
  - template: src=/etc/hosts dest=/etc/hostname force=no
```

without patch:

```
 $ ansible-playbook test.yml --check
 [WARNING]: provided hosts list is empty, only localhost is available


PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [template dest=/etc/hostname src=/etc/hosts force=no] *********************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   
```

with patch;

```
 $ ansible-playbook test.yml --check
 [WARNING]: provided hosts list is empty, only localhost is available


PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [template dest=/etc/hostname src=/etc/hosts force=no] *********************
ok: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0   
```
