### PR TITLE
setup.py: do not require pycrypto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='ansible',
       license='GPLv3',
       # Ansible will also make use of a system copy of python-six if installed but use a
       # Bundled copy if it's not.
-      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
+      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools'],
       package_dir={ '': 'lib' },
       packages=find_packages('lib'),
       package_data={


### PR DESCRIPTION
PyCrypto is not available for Windows as installable package
