### PR TITLE
add resolv and resolv_all filters

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -284,6 +284,27 @@ in :doc:`playbooks_filters_ipaddr`.
 
 .. _hash_filters:
 
+Hostname lookup filter
+----------------------
+.. versionadded:: 2.0
+
+To resolve a hostname to an ip address::
+
+    {{ my_var | resolv }}
+
+To resolve a hostname to a list of ip addresses (e.g., for a hostname that
+has multiple `A` records in DNS)::
+
+    {{ myvar | resolv_all }}
+
+For example, to show a list of all ``google.com`` addresses::
+
+    google.com is available at:
+
+    {% for addr in 'google.com' | resolv_all %}
+    - {{addr}}
+    {% endfor %}
+
 Hashing filters
 --------------------
 .. versionadded:: 1.9

--- a/lib/ansible/plugins/filter/resolv.py
+++ b/lib/ansible/plugins/filter/resolv.py
@@ -1,0 +1,59 @@
+# (c) 2015 Ansible Project Contributors
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import socket
+
+from ansible import errors
+
+
+def _resolv(v):
+    '''resolv a hostname, properly transforming exceptions from the
+    socket module into AnsibleFilterError exceptions.'''
+    try:
+        r = socket.gethostbyname_ex(v)
+    except socket.gaierror as exc:
+        raise errors.AnsibleFilterError(
+            'failed to resolv hostname "%s": %s' % (v, exc))
+    else:
+        return r
+
+
+def filter_resolv(v):
+    '''Return the first available address for the given hostname.'''
+    r = _resolv(v)
+    return r[2][0]
+
+
+def filter_resolv_all(v):
+    '''Return all available addresses for the given hostname.'''
+    r = _resolv(v)
+    return r[2]
+
+
+class FilterModule(object):
+    '''Provides resolv and resolv_all filters.'''
+    filter_map = {
+        'resolv': filter_resolv,
+        'resolv_all': filter_resolv_all,
+    }
+
+    def filters(self):
+        return self.filter_map


### PR DESCRIPTION
This commit adds two filters to Ansible that permit translating a
hostname into one (or more) ip addresses:
- `resolv` resolves a hostname into a single ip address:
  
  ```
  The ip of {{hostname}} is {{hostname|resolv}}.
  ```
- `resolv_all` provides access to all the available addresses associated
  with a hostname:
  
  ```
    {{hostname}} is available as:
  
    {% for addr in hostname|resolv_all %}
    - {{addr}}
    {% endfor %}
  ```
