### PR TITLE
Fix get_file_lines on inexistent file

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2983,11 +2983,13 @@ def get_file_content(path, default=None, strip=True):
 
 def get_file_lines(path):
     '''file.readlines() that closes the file'''
-    datafile = open(path)
-    try:
-        return datafile.readlines()
-    finally:
-        datafile.close()
+    if os.path.exists(path) and os.access(path, os.R_OK):
+        try:
+            datafile = open(path)
+            return datafile.readlines()
+        finally:
+            datafile.close()
+    return []
 
 def ansible_facts(module):
     facts = {}


### PR DESCRIPTION
Noticed an error when /etc/resolv.conf does not exist and tracked it down to the open call in get_file_lines. This patch fixes the error by checking for the file and read access, moving the open call inside the try block and returning an empty list.
