### PR TITLE
New method template_no_cache for template object.

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -256,7 +256,7 @@ class TaskExecutor:
                     variables['item'] = item
                     if self._task.evaluate_conditional(templar, variables):
                         if templar._contains_vars(name):
-                            new_item = templar.template(name)
+                            new_item = templar.template(name, cache=False)
                             final_items.append(new_item)
                         else:
                             final_items.append(item)


### PR DESCRIPTION
This method do not compute hash and is used when you know that the result does not need to be cached (like with_items loop).
It also result in a small speed improvement.

Here's some numbers:

| playbook | before 7e04947 | last devel | after |
| --- | --- | --- | --- |
| issue-vars.yml | 3.2s | 6.1s | 2.64s |
| no-vars-mapping.yml | 2.5s | 1.8s | 1.9s |
| real-playbook.yml | 11.5s | 25.4s | 8.9s |

And of course, the yum module with item is working :)
