### PR TITLE
Check sys.modules before loading modules

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -304,6 +304,9 @@ class PluginLoader:
     __contains__ = has_plugin
 
     def _load_module_source(self, name, path):
+        if name in sys.modules:
+            # See https://github.com/ansible/ansible/issues/13110
+            return sys.modules[name]
         with open(path, 'r') as module_file:
             module = imp.load_source(name, path, module_file)
         return module


### PR DESCRIPTION
Code for a plugin is usually loaded by a PluginLoader(), and henceforth
available from self._module_cache, which prevents duplicate loading.
However there are situations (e.g. where one action plugin imports code
from another one) where the plugin module might be already imported (and
resident in sys.modules), but not present in the PluginLoader's
_module_cache, which causes imp.load_source() to effectively reload the
module, overwriting global class declarations and causing subtle latent
bugs.

Fixes #13110.
Fixes #12979.
