### PR TITLE
Elevate privileges when checking for file existence

### DIFF
--- a/test/integration/roles/test_become/tasks/main.yml
+++ b/test/integration/roles/test_become/tasks/main.yml
@@ -24,6 +24,8 @@
     state: touch
 
 - name: check that the path in the user's home dir was created
+  become: True
+  become_user: "{{ become_test_user }}"
   stat:
     path: "~{{ become_test_user }}/foo.txt"
   register: results
@@ -41,6 +43,8 @@
     dest: "~/bar.txt"
 
 - name: check that the path in the user's home dir was created
+  become: True
+  become_user: "{{ become_test_user }}"
   stat:
     path: "~{{ become_test_user }}/bar.txt"
   register: results
@@ -58,6 +62,8 @@
     dest: "~/baz.txt"
 
 - name: check that the path in the user's home dir was created
+  become: True
+  become_user: "{{ become_test_user }}"
   stat:
     path: "~{{ become_test_user }}/baz.txt"
   register: results

--- a/test/integration/roles/test_sudo/tasks/main.yml
+++ b/test/integration/roles/test_sudo/tasks/main.yml
@@ -23,6 +23,8 @@
     state: touch
 
 - name: check that the path in the user's home dir was created
+  sudo: True
+  sudo_user: "{{ sudo_test_user }}"
   stat:
     path: "~{{ sudo_test_user }}/foo.txt"
   register: results
@@ -40,6 +42,8 @@
     dest: "~/bar.txt"
 
 - name: check that the path in the user's home dir was created
+  sudo: True
+  sudo_user: "{{ sudo_test_user }}"
   stat:
     path: "~{{ sudo_test_user }}/bar.txt"
   register: results
@@ -57,6 +61,8 @@
     dest: "~/baz.txt"
 
 - name: check that the path in the user's home dir was created
+  sudo: True
+  sudo_user: "{{ sudo_test_user }}"
   stat:
     path: "~{{ sudo_test_user }}/baz.txt"
   register: results


### PR DESCRIPTION
Certain OSs default to home directories as 0700
Without elevating privileges, checking for file existence
fails.
