### PR TITLE
fix 'coveralls' code coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     packages:
       - python2.4
 install:
-  - pip install tox PyYAML Jinja2 sphinx
+  - pip install tox PyYAML Jinja2 sphinx coveralls
 script:
 # urllib2's defaults are not secure enough for us
 - ./test/code-smell/replace-urlopen.sh .

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ script:
 - if test x"$TOXENV" != x'py24' ; then tox ; fi
 - if test x"$TOXENV" = x'py24' ; then python2.4 -V && python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce).py' lib/ansible/module_utils ; fi
   #- make -C docsite all
-- if test x"$INTEGRATION" = x'yes' ; then source ./hacking/env-setup && cd test/integration/ && make parsing && make test_var_precedence && make unicode ; fi
+- if test x"$INTEGRATION" = x'yes' ; then ( source ./hacking/env-setup && cd test/integration/ && make parsing && make test_var_precedence && make unicode ) ; fi
 after_success:
   - coveralls


### PR DESCRIPTION
Submitting code-coverage report to `coveralls.io` probably never worked. This is adding the necessary command. Integration tests were also breaking this feature. Either because they 'cd' to different directory or hack PATH/PYTHONPATH. I didn't look into it too deep. Instead, I've put them into sub-shell for protection.

While working on this change, it occurred to me that it would be prudent to separate unittest and integration tests into separate jobs.. just an idea.

_Note_: To enabled coverage reports, someone with admin rights to `ansible/ansible` would need to enable it on https://coveralls.io/repos/new.
