### PR TITLE
Make jsonfile fact cache handle fancy paths properly

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -50,7 +50,7 @@ class CacheModule(BaseCacheModule):
 
         self._timeout = float(C.CACHE_PLUGIN_TIMEOUT)
         self._cache = {}
-        self._cache_dir = C.CACHE_PLUGIN_CONNECTION # expects a dir path
+        self._cache_dir = os.path.expandvars(os.path.expanduser(C.CACHE_PLUGIN_CONNECTION)) # expects a dir path
         if not self._cache_dir:
             raise AnsibleError("error, fact_caching_connection is not set, cannot use fact cache")
 


### PR DESCRIPTION
Basically fixes #13094

os.path.expanduser as well as s.path.expandvars is applied before before storing C.CACHE_PLUGIN_CONNECTION as instance attribute.
