### PR TITLE
EC2 Inventory: Add instance metadata and additional groups based on VPC and subnet info

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -105,8 +105,15 @@ group_by_availability_zone = True
 group_by_ami_id = True
 group_by_instance_type = True
 group_by_key_pair = True
+group_by_vpc_cidr = True
 group_by_vpc_id = True
+group_by_vpc_name = True
+group_by_vpc_tags = True
 group_by_security_group = True
+group_by_subnet_cidr = True
+group_by_subnet_id = True
+group_by_subnet_name = True
+group_by_subnet_tags = True
 group_by_tag_keys = True
 group_by_tag_none = True
 group_by_route53_names = True
@@ -116,6 +123,8 @@ group_by_elasticache_engine = True
 group_by_elasticache_cluster = True
 group_by_elasticache_parameter_group = True
 group_by_elasticache_replication_group = True
+# Note: grouping by VPC or subnet cidr, name or tags will require querying
+#       the AWS API for VPC data
 
 # If you only want to include hosts that match a certain regular expression
 # pattern_include = staging-*


### PR DESCRIPTION
Adds around VPC/subnet CIDR, name, ID and tags.  Also incorporates another branch that consolidates the inventory push calls.
