### PR TITLE
fix gce module error reporting

### DIFF
--- a/lib/ansible/module_utils/gce.py
+++ b/lib/ansible/module_utils/gce.py
@@ -28,7 +28,7 @@
 #
 
 import os
-import pprint
+import traceback
 from libcloud.compute.providers import get_driver
 
 USER_AGENT_PRODUCT="Ansible-gce"
@@ -92,4 +92,4 @@ def gce_connect(module, provider=None):
 
 def unexpected_error_msg(error):
     """Create an error string based on passed in error."""
-    return 'Unexpected response: ' + pprint.pformat(vars(error))
+    return 'Unexpected response: (%s). Detail: %s' % (str(error), traceback.format_exc(error))


### PR DESCRIPTION
Error reporting was broken for GCE modules- pprint didn't work with exceptions, so you'd always get "Unexpected response: {}" instead of the real error.
