### PR TITLE
Backport of the jsonfile cache fix for filepath substitution

### DIFF
--- a/lib/ansible/cache/jsonfile.py
+++ b/lib/ansible/cache/jsonfile.py
@@ -37,7 +37,7 @@ class CacheModule(BaseCacheModule):
 
         self._timeout = float(C.CACHE_PLUGIN_TIMEOUT)
         self._cache = {}
-        self._cache_dir = C.CACHE_PLUGIN_CONNECTION # expects a dir path
+        self._cache_dir = os.path.expandvars(os.path.expanduser(C.CACHE_PLUGIN_CONNECTION)) # expects a dir path
         if not self._cache_dir:
             utils.exit("error, fact_caching_connection is not set, cannot use fact cache")
 


### PR DESCRIPTION
As wished by @davidfischer-ch in pr #13142
