### PR TITLE
If ssh died, it's an error, not a timeout

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -411,6 +411,10 @@ class Connection(ConnectionBase):
 
             if not rfd:
                 if state <= states.index('awaiting_escalation'):
+                    # If the process has already exited, then it's not really a
+                    # timeout; we'll let the normal error handling deal with it.
+                    if p.poll() is not None:
+                        break
                     self._terminate_process(p)
                     raise AnsibleError('Timeout (%ds) waiting for privilege escalation prompt: %s' % (timeout, stdout))
 


### PR DESCRIPTION
See discussion in #12916 and #13147.
