### PR TITLE
LXC inventory scripts: fix libvirt_lxc

### DIFF
--- a/contrib/inventory/libvirt_lxc.py
+++ b/contrib/inventory/libvirt_lxc.py
@@ -27,11 +27,11 @@ result['all'] = {}
 pipe = Popen(['virsh', '-q', '-c', 'lxc:///', 'list', '--name', '--all'], stdout=PIPE, universal_newlines=True)
 result['all']['hosts'] = [x[:-1] for x in pipe.stdout.readlines()]
 result['all']['vars'] = {}
-result['all']['vars']['ansible_connection'] = 'lxc'
+result['all']['vars']['ansible_connection'] = 'libvirt_lxc'
 
 if len(sys.argv) == 2 and sys.argv[1] == '--list':
     print(json.dumps(result))
 elif len(sys.argv) == 3 and sys.argv[1] == '--host':
-    print(json.dumps({'ansible_connection': 'lxc'}))
+    print(json.dumps({'ansible_connection': 'libvirt_lxc'}))
 else:
     print("Need an argument, either --list or --host <host>")


### PR DESCRIPTION
This is a minor fix to the `libvirt_lxc.py` inventory script, which now correctly sets `ansible_connection` to `libvirt_lxc` instead of just `lxc`.
