### PR TITLE
Handle unexpected database presence

### DIFF
--- a/test/integration/roles/test_mysql_db/tasks/main.yml
+++ b/test/integration/roles/test_mysql_db/tasks/main.yml
@@ -19,8 +19,9 @@
 # ============================================================
 
 - name: make sure the test database is not there
-  command: mysql "-e drop database '{{db_name}}';"
-  ignore_errors: True
+  command: mysql {{db_name}}
+  register: mysql_db_check
+  failed_when: "'1049' not in mysql_db_check.stderr"
 
 - name: test state=present for a database name (expect changed=true)
   mysql_db: name={{ db_name }} state=present


### PR DESCRIPTION
Check for database presence in a nice way, rather than
dropping the database.

Thankfully there was a syntax error in the previous
version, so no database would have been dropped.
There was no check for whether it succeeded or not.
