### PR TITLE
Consul kv lookup super invocation fix

### DIFF
--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -75,7 +75,7 @@ class LookupModule(LookupBase):
 
     def __init__(self, loader=None, templar=None, **kwargs):
 
-        super(LookupBase, self).__init__(loader, templar, **kwargs)
+        super(LookupModule, self).__init__(loader, templar, **kwargs)
 
         self.agent_url = 'http://localhost:8500'
         if os.getenv('ANSIBLE_CONSUL_URL') is not None:


### PR DESCRIPTION
I was getting this error with the latest devel build:
 `File "/usr/local/lib/python2.7/dist-packages/ansible-2.0.0-py2.7.egg/ansible/plugins/__init__.py", line 331, in get
    obj = getattr(self._module_cache[path], self.class_name)(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/ansible-2.0.0-py2.7.egg/ansible/plugins/lookup/consul_kv.py", line 78, in __init__
    super(LookupBase, self).__init__(loader, templar, **kwargs)
TypeError: object.__init__() takes no parameters`

 This PR fixes it
