### PR TITLE
hostvars should return j2 undefined as instance, not type

### DIFF
--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -77,7 +77,7 @@ class HostVars(collections.Mapping):
     def __getitem__(self, host_name):
 
         if host_name not in self._lookup:
-            return j2undefined
+            return j2undefined()
 
         host = self._lookup.get(host_name)
         data = self._variable_manager.get_vars(loader=self._loader, host=host, play=self._play, include_hostvars=False)


### PR DESCRIPTION
v1.9->v2 regression. Looks like someone forgot to create an instance of undefined here- we were returning the j2 undefined type object on a bogus host lookup in hostvars (eg, `hostvars['bogushost']`), which broke all the undefined checks (eg, `some_obj is undefined`). Changed it to return an instance instead (which I assume was the intended behavior, based on the downstream checks)

Added an integration test around add_host that will catch this (separate PR to follow).
