### PR TITLE
fix for dynamic (add_host) hosts not available in hostvars

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -455,6 +455,8 @@ class Inventory(object):
 
     def clear_pattern_cache(self):
         ''' called exclusively by the add_host plugin to allow patterns to be recalculated '''
+        global HOSTS_PATTERNS_CACHE
+        HOSTS_PATTERNS_CACHE = {}
         self._pattern_cache = {}
 
     def groups_for_host(self, host):

--- a/test/integration/non_destructive.yml
+++ b/test/integration/non_destructive.yml
@@ -41,6 +41,7 @@
     - { role: test_get_url, tags: test_get_url }
     - { role: test_embedded_module, tags: test_embedded_module }
     - { role: test_uri, tags: test_uri }
+    - { role: test_add_host, tags: test_add_host }
     # Turn on test_binary when we start testing v2
     #- { role: test_binary, tags: test_binary }
 

--- a/test/integration/roles/test_add_host/tasks/main.yml
+++ b/test/integration/roles/test_add_host/tasks/main.yml
@@ -1,0 +1,39 @@
+# test code for the add_host action
+# (c) 2015, Matt Davis <mdavis@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: add a host to the runtime inventory
+  add_host:
+    name: newdynamichost
+    groups: newdynamicgroup
+    a_var: from add_host
+
+- debug: msg={{hostvars['newdynamichost'].group_names}}
+
+- name: ensure that dynamically-added host is visible via hostvars, groups, etc (there are several caches that could break this)
+  assert:
+    that:
+    - hostvars['bogushost'] is not defined # there was a bug where an undefined host was a "type" instead of an instance- ensure this works before we rely on it
+    - hostvars['newdynamichost'] is defined
+    - hostvars['newdynamichost'].group_names is defined
+    - "'newdynamicgroup' in hostvars['newdynamichost'].group_names"
+    - hostvars['newdynamichost']['bogusvar'] is not defined
+    - hostvars['newdynamichost']['a_var'] is defined
+    - hostvars['newdynamichost']['a_var'] == 'from add_host'
+    - groups['bogusgroup'] is not defined # same check as above to ensure that bogus groups are undefined...
+    - groups['newdynamicgroup'] is defined
+    - "'newdynamichost' in groups['newdynamicgroup']"


### PR DESCRIPTION
Looks like there are two pattern caches that need to be cleared for this to work- added the second one.
Added integration tests for add_host to prevent future regressions.

If this PR runs its own tests, they may fail until #13184 is merged.
