### PR TITLE
Allow real addresses as dig lookup argument

### DIFF
--- a/lib/ansible/plugins/lookup/dig.py
+++ b/lib/ansible/plugins/lookup/dig.py
@@ -201,7 +201,11 @@ class LookupModule(LookupBase):
                         ret.append(str(e))
 
         except dns.resolver.NXDOMAIN:
-            ret.append('NXDOMAIN')
+            try:
+                dns.reversename.from_address(domain)
+                ret.append(domain)
+            except:
+                ret.append('NXDOMAIN')
         except dns.resolver.NoAnswer:
             ret.append("")
         except dns.resolver.Timeout:


### PR DESCRIPTION
This small change allows real IP addresses to be given as arguments to dig lookup. Without this change, `myres.query('127.0.0.1')` will generate "NXDOMAIN" on output. This change verifies whether the given value has inverse resolution, and in that case it returns the IP address given as input.
I know that adding '/PTR' after should solve my issue, but in that case the variable holding the addresses cannot be used anywhere else.
