### PR TITLE
Make pipelining work with su/sudo+requiretty

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -237,7 +237,7 @@ DEFAULT_NULL_REPRESENTATION    = get_config(p, DEFAULTS, 'null_representation', 
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', '-o ControlMaster=auto -o ControlPersist=60s')
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
-ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
+ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', True, boolean=True)
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, integer=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -177,7 +177,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if tmp and "tmp" in tmp:
             # tmp has already been created
             return False
-        if not self._connection.has_pipelining or not self._play_context.pipelining or C.DEFAULT_KEEP_REMOTE_FILES or self._play_context.become_method == 'su':
+        if not self._connection.has_pipelining or not self._play_context.pipelining or C.DEFAULT_KEEP_REMOTE_FILES:
             # tmp is necessary to store the module source code
             # or we want to keep the files on the target system
             return True
@@ -438,7 +438,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 # not sudoing or sudoing to root, so can cleanup files in the same step
                 rm_tmp = tmp
 
-        cmd = self._connection._shell.build_module_command(environment_string, shebang, cmd, arg_path=args_file_path, rm_tmp=rm_tmp)
+        python_interp = task_vars.get('ansible_python_interpreter', 'python')
+
+        cmd = self._connection._shell.build_module_command(environment_string, shebang, cmd, arg_path=args_file_path, rm_tmp=rm_tmp, python_interpreter=python_interp)
         cmd = cmd.strip()
 
         sudoable = True

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -103,7 +103,7 @@ class ShellModule(object):
         ''' % dict(path=path)
         return self._encode_script(script)
 
-    def build_module_command(self, env_string, shebang, cmd, arg_path=None, rm_tmp=None):
+    def build_module_command(self, env_string, shebang, cmd, arg_path=None, rm_tmp=None, python_interpreter=None):
         cmd_parts = shlex.split(to_bytes(cmd), posix=False)
         cmd_parts = map(to_unicode, cmd_parts)
         if shebang and shebang.lower() == '#!powershell':

--- a/lib/ansible/plugins/shell/sh.py
+++ b/lib/ansible/plugins/shell/sh.py
@@ -134,12 +134,17 @@ class ShellModule(object):
         cmd = "%s; %s || (echo \'0  \'%s)" % (test, cmd, shell_escaped_path)
         return cmd
 
-    def build_module_command(self, env_string, shebang, cmd, arg_path=None, rm_tmp=None):
+    def build_module_command(self, env_string, shebang, cmd, arg_path=None, rm_tmp=None, python_interpreter='python'):
         # don't quote the cmd if it's an empty string, because this will
         # break pipelining mode
-        if cmd.strip() != '':
+        env = env_string.strip()
+        exe = shebang.replace("#!", "").strip()
+        if cmd.strip() == '':
+            reader = "%s -uc 'import sys; [sys.stdout.write(s) for s in iter(sys.stdin.readline, \"__EOF__942d747a0772c3284ffb5920e234bd57__\\n\")]'|" % python_interpreter
+            cmd_parts = [env, reader, env, exe]
+        else:
             cmd = pipes.quote(cmd)
-        cmd_parts = [env_string.strip(), shebang.replace("#!", "").strip(), cmd]
+            cmd_parts = [env, exe, cmd]
         if arg_path is not None:
             cmd_parts.append(arg_path)
         new_cmd = " ".join(cmd_parts)


### PR DESCRIPTION
While writing http://toroid.org/ansible-ssh-pipelining it occurred to me that it's possible to make pipelining work with su and sudo+requiretty. Here's a working solution. I've been using this for several days now, and I can say that it's **very** pleasant to use this with pipelining and the recently-speeded-up v2.

Thanks to @mgedmin for coming up with the Python one-liner that I substituted for sed. (If the maintainers consider sed an acceptable dependency—as I do—the sed version in the commit message is shorter and easier to understand. Note that this is a change to the sh/ssh plugins, so it's not relevant to Windows.)

cc: @abadger
