### PR TITLE
Fix DataLoader's docstring

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -52,9 +52,7 @@ class DataLoader():
     Usage:
 
         dl = DataLoader()
-        (or)
-        dl = DataLoader(vault_password='foo')
-
+        # optionally: dl.set_vault_password('foo')
         ds = dl.load('...')
         ds = dl.load_from_file('/path/to/file')
     '''


### PR DESCRIPTION
`DataLoader.__init__` doesn't take an argument named `vault_password`
