### PR TITLE
Raise unexpected exceptions

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -107,7 +107,7 @@ if __name__ == '__main__':
         have_cli_options = cli is not None and cli.options is not None
         display.error("Unexpected Exception: %s" % to_unicode(e), wrap_text=False)
         if not have_cli_options or have_cli_options and cli.options.verbosity > 2:
-            display.display("the full traceback was:\n\n%s" % traceback.format_exc())
+            raise
         else:
             display.display("to see the full traceback, use -vvv")
         sys.exit(250)


### PR DESCRIPTION
This change makes debugging much easier.

When I encounter an unexpected error, the default traceback does not provide a clear clue for debugging, like this:

```
Traceback (most recent call last):
  File "/opt/ansible/ansible/bin/ansible-playbook", line 84, in <module>
    sys.exit(cli.run())
  File "/opt/ansible/ansible/lib/ansible/cli/playbook.py", line 142, in run
    results = pbex.run()
  File "/opt/ansible/ansible/lib/ansible/executor/playbook_executor.py", line 75, in run
    pb = Playbook.load(playbook_path, variable_manager=self._variable_manager, loader=self._loader)
  File "/opt/ansible/ansible/lib/ansible/playbook/__init__.py", line 51, in load
    pb._load_playbook_data(file_name=file_name, variable_manager=variable_manager)
  File "/opt/ansible/ansible/lib/ansible/playbook/__init__.py", line 89, in _load_playbook_data
    entry_obj = Play.load(entry, variable_manager=variable_manager, loader=self._loader)
  File "/opt/ansible/ansible/lib/ansible/playbook/play.py", line 111, in load
    return p.load_data(data, variable_manager=variable_manager, loader=loader)
  File "/opt/ansible/ansible/lib/ansible/playbook/base.py", line 201, in load_data
    self._attributes[name] = method(name, ds[name])
  File "/opt/ansible/ansible/lib/ansible/playbook/play.py", line 212, in _load_roles
    roles.append(Role.load(ri, play=self))
  File "/opt/ansible/ansible/lib/ansible/playbook/role/__init__.py", line 112, in load
    r._load_role_data(role_include, parent_role=parent_role)
  File "/opt/ansible/ansible/lib/ansible/playbook/role/__init__.py", line 174, in _load_role_data
    self._task_blocks = load_list_of_blocks(task_data, play=self._play, role=self, loader=self._loader)
  File "/opt/ansible/ansible/lib/ansible/playbook/helpers.py", line 37, in load_list_of_blocks
    assert isinstance(ds, (list, type(None)))
AssertionError
```

This is the default traceback information. I customize the exception hook using the builtin module `cgitb` in [site customization](https://docs.python.org/3/library/site.html):

```
import cgitb
cgitb.enable(format='text')
```

However, it does not give detailed exception information as expected, because `ansible` script catches the exception and did not raise it. After the modification in the patch, `ansible` leaves unexpected exception as is, and I quickly spot the problem:

```
 /opt/ansible/ansible/lib/ansible/playbook/helpers.py in load_list_of_blocks(ds={u'tasks': [{u'include': u'apollo.yml'}, {u'include': u'ssh_keys.yml'}]}, play=, parent_block=None, role=common, task_include=None, use_handlers=False, variable_manager=None, loader=<ansible.parsing.dataloader.DataLoader object>)
   35     from ansible.playbook.block import Block
   36 
   37     assert isinstance(ds, (list, type(None)))
   38 
   39     block_list = []
builtinisinstance = <built-in function isinstance>
ds = {u'tasks': [{u'include': u'apollo.yml'}, {u'include': u'ssh_keys.yml'}]}
builtinlist = <type 'list'>
builtintype = <type 'type'>
builtinNone = None
<type 'exceptions.AssertionError'>: 
```

What's most helpful is that it prints all the contextual variables. I would like to discuss if this could be the default behavior for the commands.

p.s.: This patch does not introduce new breakage to tests.
