### PR TITLE
Allow specifying Vault password from the environment.

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -165,9 +165,12 @@ class CLI(with_metaclass(ABCMeta, object)):
         ''' prompt for vault password and/or password change '''
 
         vault_pass = None
-        try:
-            vault_pass = getpass.getpass(prompt="Vault password: ")
 
+        try:
+            try:
+                vault_pass = os.environ['ANSIBLE_VAULT_PASSWORD']
+            except KeyError:
+                vault_pass = getpass.getpass(prompt="Vault password: ")
         except EOFError:
             pass
 


### PR DESCRIPTION
This would be extremely useful for CI systems such as travis-ci.org - I am
currently having to take the Vault password from the environment it
provides,, save it to a secure file and then finally pass
`--vault-password-file` which all seems a waste and a lot of busywork.

I could replace this secure file with a script that will echo the proposed
environment variable, but this turns out to be actually even _more_ work and
perhaps even uglier. (ie. echo "#!/bin/sh\necho \$ANSIBLE_VAULT_PASSWORD"..)

This patch factors out the calls to `getpass.getpass` so we are not
duplicating the the logic in all combinations of `ask_new_vault_pass`
and `rekey`.

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
