### PR TITLE
Add integration tests for zypper

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -18,3 +18,4 @@
     - { role: test_mysql_user, tags: test_mysql_user}
     - { role: test_mysql_variables, tags: test_mysql_variables}
     - { role: test_docker, tags: test_docker}
+    - { role: test_zypper, tags: test_zypper}

--- a/test/integration/roles/test_zypper/files/empty.spec
+++ b/test/integration/roles/test_zypper/files/empty.spec
@@ -1,0 +1,12 @@
+Summary:   Empty RPM
+Name:      empty
+Version:   1
+Release:   0
+License:   GPLv3
+Group:     Applications/System
+BuildArch: noarch
+
+%description
+Empty RPM
+
+%files

--- a/test/integration/roles/test_zypper/meta/main.yml
+++ b/test/integration/roles/test_zypper/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/roles/test_zypper/tasks/main.yml
+++ b/test/integration/roles/test_zypper/tasks/main.yml
@@ -1,0 +1,26 @@
+# test code for the zyppe module
+#
+# (c) 2015, Guido Günther <agx@sigxcpu.org>
+#
+# heavily based on the yum tests which are
+#
+# (c) 2014, James Tanner <tanner.jc@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- include: 'zypper.yml'
+  when: ansible_distribution in ['SLES', 'openSUSE']
+

--- a/test/integration/roles/test_zypper/tasks/zypper.yml
+++ b/test/integration/roles/test_zypper/tasks/zypper.yml
@@ -1,0 +1,194 @@
+# UNINSTALL
+- name: uninstall hello
+  zypper: name=hello state=removed
+  register: zypper_result
+
+- name: check hello with rpm
+  shell: rpm -q hello
+  failed_when: False
+  register: rpm_result
+
+- debug: var=zypper_result
+- debug: var=rpm_result
+
+- name: verify uninstallation of hello
+  assert:
+    that:
+        - "zypper_result.rc == 0"
+        - "rpm_result.rc == 1"
+
+# UNINSTALL AGAIN
+- name: uninstall hello again
+  zypper: name=hello state=removed
+  register: zypper_result
+
+- name: verify no change on re-uninstall
+  assert:
+    that:
+        - "not zypper_result.changed"
+
+# INSTALL
+- name: install hello
+  zypper: name=hello state=present
+  register: zypper_result
+
+- name: check hello with rpm
+  shell: rpm -q hello
+  failed_when: False
+  register: rpm_result
+
+- debug: var=zypper_result
+- debug: var=rpm_result
+
+- name: verify installation of hello
+  assert:
+    that:
+        - "zypper_result.rc == 0"
+        - "zypper_result.changed"
+        - "rpm_result.rc == 0"
+
+# INSTALL AGAIN
+- name: install hello again
+  zypper: name=hello state=present
+  register: zypper_result
+
+- name: verify no change on second install
+  assert:
+    that:
+        - "not zypper_result.changed"
+
+# Multiple packages
+- name: uninstall hello and metamail
+  zypper:
+    name:
+      - hello
+      - metamail
+    state: removed
+  register: zypper_result
+
+- name: check hello with rpm
+  shell: rpm -q hello
+  failed_when: False
+  register: rpm_hello_result
+
+- name: check metamail with rpm
+  shell: rpm -q metamail
+  failed_when: False
+  register: rpm_metamail_result
+
+- name: verify packages uninstalled
+  assert:
+    that:
+        - "rpm_hello_result.rc != 0"
+        - "rpm_metamail_result.rc != 0"
+
+- name: install hello and metamail
+  zypper:
+    name:
+      - hello
+      - metamail
+    state: present
+  register: zypper_result
+
+- name: check hello with rpm
+  shell: rpm -q hello
+  failed_when: False
+  register: rpm_hello_result
+
+- name: check metamail with rpm
+  shell: rpm -q metamail
+  failed_when: False
+  register: rpm_metamail_result
+
+- name: verify packages installed
+  assert:
+    that:
+        - "zypper_result.rc == 0"
+        - "zypper_result.changed"
+        - "rpm_hello_result.rc == 0"
+        - "rpm_metamail_result.rc == 0"
+
+- name: uninstall hello and metamail
+  zypper:
+    name:
+      - hello
+      - metamail
+    state: removed
+
+# INSTALL nonexistent package
+- name: install hello from url
+  zypper: name=doesnotexist state=present
+  register: zypper_result
+  ignore_errors: yes
+
+- name: verify package installation failed
+  assert:
+    that:
+      - "zypper_result.rc == 104"
+      - "zypper_result.msg.startswith('No provider of')"
+
+# INSTALL broken local package
+- name: create directory
+  file:
+    path: "{{output_dir | expanduser}}/zypper"
+    state: directory
+
+- name: fake rpm package
+  file:
+    path: "{{output_dir | expanduser}}/zypper/broken.rpm"
+    state: touch
+
+- name: install broken rpm
+  zypper:
+    name="{{output_dir | expanduser}}/zypper/broken.rpm"
+    state=present
+  register: zypper_result
+  ignore_errors: yes
+
+- debug: var=zypper_result
+
+- name: verify we failed installation of broken rpm
+  assert:
+    that:
+      - "zypper_result.rc == 1"
+      - "'broken.rpm: not an rpm package' in zypper_result.msg"
+
+# Build and install an empty rpm
+- name: copy spec file
+  copy:
+    src: empty.spec
+    dest: "{{ output_dir | expanduser }}/zypper/empty.spec"
+
+- name: build rpm
+  command: |
+    rpmbuild -bb \
+    --define "_topdir {{output_dir | expanduser }}/zypper/rpm-build"
+    --define "_builddir %{_topdir}" \
+    --define "_rpmdir %{_topdir}" \
+    --define "_srcrpmdir %{_topdir}" \
+    --define "_specdir {{output_dir | expanduser}}/zypper" \
+    --define "_sourcedir %{_topdir}" \
+    {{ output_dir }}/zypper/empty.spec
+  register: rpm_build_result
+
+- name: install empty rpm
+  zypper:
+    name: "{{ output_dir | expanduser }}/zypper/rpm-build/noarch/empty-1-0.noarch.rpm"
+  register: zypper_result
+
+- name: check empty with rpm
+  shell: rpm -q empty
+  failed_when: False
+  register: rpm_result
+
+- name: verify installation of empty
+  assert:
+    that:
+        - "zypper_result.rc == 0"
+        - "zypper_result.changed"
+        - "rpm_result.rc == 0"
+
+- name: uninstall empry
+  zypper:
+    name: empty
+    state: removed


### PR DESCRIPTION
Modeled after the yum tests but also tests local package installations
as fixed with PR#1256.

This depends on PRs #1256, #1261 and #1262 in ansible-modules-extra.
