### PR TITLE
Recommend using pywinrm >= 0.1.1 from PyPI instead of GitHub version.

### DIFF
--- a/docsite/rst/intro_windows.rst
+++ b/docsite/rst/intro_windows.rst
@@ -26,7 +26,7 @@ Installing on the Control Machine
 
 On a Linux control machine::
 
-   pip install https://github.com/diyan/pywinrm/archive/master.zip#egg=pywinrm
+   pip install "pywinrm>=0.1.1"
 
 Active Directory Support
 ++++++++++++++++++++++++


### PR DESCRIPTION
With @nitzmahone's recent updates to pywinrm (https://github.com/diyan/pywinrm/pull/74 and https://github.com/diyan/pywinrm/pull/76) included in pywinrm 0.1.1, I think we should now recommend using pywinrm from PyPI instead of GitHub.
