### PR TITLE
test_hg fix: remove reference to "head"

### DIFF
--- a/test/integration/roles/test_hg/tasks/main.yml
+++ b/test/integration/roles/test_hg/tasks/main.yml
@@ -66,7 +66,6 @@
   assert:
     that:
       - "tags.stat.isreg"
-      - "head.stat.isreg"
       - "branches.stat.isreg"
 
 - name: verify on a reclone things are marked unchanged


### PR DESCRIPTION
```
TASK [test_hg : assert presence of tags/trunk/branches] ************************
task path: /home/ubuntu/ansible/test/integration/roles/test_hg/tasks/main.yml:65
fatal: [testhost]: FAILED! => {"failed": true, "msg": "ERROR! The conditional check 'head.stat.isreg' failed. The error was: ERROR! error while evaluating conditional: head.stat.isreg ({% if head.stat.isreg %} True {% else %} False {% endif %})"}
```

This is remnant from earlier change 50e5d81777e6228cc90b982c111e5f51e78e965d which removed stat on head file..
