### PR TITLE
test_filters fix: add expanduser and test data for fileglob test

### DIFF
--- a/test/integration/roles/test_filters/files/foo.txt
+++ b/test/integration/roles/test_filters/files/foo.txt
@@ -44,7 +44,7 @@ quoted = quoted
 
 The fileglob module returns the list of things matching a pattern.
 
-fileglob = []
+fileglob = a,b,d
 
 There are also various string operations that work on paths.  These do not require
 files to exist and are passthrus to the python os.path functions

--- a/test/integration/roles/test_filters/tasks/main.yml
+++ b/test/integration/roles/test_filters/tasks/main.yml
@@ -44,6 +44,19 @@
     that: 
         - 'diff_result_9851.stdout == ""'
 
+- name: cleanup test data for fileglob
+  file: path={{output_dir}}/foo state=absent
+
+- name: create subdir for fileglob test data
+  file: path={{output_dir}}/foo state=directory
+
+- name: prep test data for fileglob
+  file: path={{output_dir}}/foo/{{ item }} state=touch
+  with_items:
+    - a
+    - b
+    - d
+
 - name: fill in a basic template
   template: src=foo.j2 dest={{output_dir}}/foo.templated mode=0644
   register: template_result

--- a/test/integration/roles/test_filters/templates/foo.j2
+++ b/test/integration/roles/test_filters/templates/foo.j2
@@ -38,7 +38,7 @@ quoted = {{ 'quoted' | quote }}
 
 The fileglob module returns the list of things matching a pattern.
 
-fileglob = {{ (output_dir + '/*') | fileglob }}
+fileglob = {{ (output_dir + '/foo/*') | expanduser | fileglob | map('basename') | sort | join(',') }}
 
 There are also various string operations that work on paths.  These do not require
 files to exist and are passthrus to the python os.path functions


### PR DESCRIPTION
jinja2 fileglob filter does not support user expansion ("~").
Existing test is always returning empty list [] when output_dir
contains "~". As soon as you change output_dir to absolute path,
test will fail because fileglob actually starts working..

This change will add clean subdirectory with known content
for fileglob to work on. The glob is passed through "expanduser"
filter, so that it would work even with default "~/ansible_testing"
output_dir.
#### Test

After the change, test is still passing. With or without absolute `output_dir`.

```
ansible-playbook non_destructive.yml -i inventory -e @integration_config.yml -t test_filters
...
TASK [test_filters : cleanup test data for fileglob] ***************************
ok: [testhost]

TASK [test_filters : create subdir for fileglob test data] *********************
changed: [testhost]

TASK [test_filters : prep test data for fileglob] ******************************
changed: [testhost] => (item=a)
changed: [testhost] => (item=b)
changed: [testhost] => (item=d)

TASK [test_filters : fill in a basic template] *********************************
changed: [testhost]

TASK [test_filters : copy known good into place] *******************************
changed: [testhost]

TASK [test_filters : compare templated file to known good] *********************
changed: [testhost]

TASK [test_filters : verify templated file matches known good] *****************
ok: [testhost]
```
