### PR TITLE
We should give pipes.quote() a string every time

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -409,7 +409,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 # the remote system, which can be read and parsed by the module
                 args_data = ""
                 for k,v in iteritems(module_args):
-                    args_data += '%s="%s" ' % (k, pipes.quote(v))
+                    args_data += '%s="%s" ' % (k, pipes.quote(text_type(v)))
                 self._transfer_data(args_file_path, args_data)
             display.debug("done transferring module to remote")
 


### PR DESCRIPTION
This fixes an issue in `_execute_module` where we end up passing boolean values (i.e. `module_args['_ansible_check_mode']`, `module_args['_ansible_no_log']`, and `module_args['_ansible_debug']`) to `pipes.quote()` which expects a string.

This happens when executing an "old style" module and enabling either the "check_mode", "no_log", or "debug" options.
