### PR TITLE
Allow debug var parameter to accept a list or dict.

### DIFF
--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -19,7 +19,7 @@ __metaclass__ = type
 
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
-
+from ansible.utils.unicode import to_unicode
 
 class ActionModule(ActionBase):
     ''' Print statements during execution '''
@@ -43,7 +43,7 @@ class ActionModule(ActionBase):
             results = self._templar.template(self._task.args['var'], convert_bare=True)
             if type(self._task.args['var']) in (list, dict):
                 # If var is a list or dict, use the type as key to display
-                result[str(type(self._task.args['var']))] = results
+                result[to_unicode(type(self._task.args['var']))] = results
             else:
                 if results == self._task.args['var']:
                     results = "VARIABLE IS NOT DEFINED!"

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -41,9 +41,13 @@ class ActionModule(ActionBase):
         # FIXME: move the LOOKUP_REGEX somewhere else
         elif 'var' in self._task.args: # and not utils.LOOKUP_REGEX.search(self._task.args['var']):
             results = self._templar.template(self._task.args['var'], convert_bare=True)
-            if results == self._task.args['var']:
-                results = "VARIABLE IS NOT DEFINED!"
-            result[self._task.args['var']] = results
+            if type(self._task.args['var']) in (list, dict):
+                # If var is a list or dict, use the type as key to display
+                result[str(type(self._task.args['var']))] = results
+            else:
+                if results == self._task.args['var']:
+                    results = "VARIABLE IS NOT DEFINED!"
+                result[self._task.args['var']] = results
         else:
             result['msg'] = 'here we are'
 


### PR DESCRIPTION
This PR is a proposal to fix the following bug report: https://github.com/ansible/ansible/issues/13252

Let's take the following playbook:

``` yaml

---
- hosts: localhost
  gather_facts: no
  tasks:
    - name: Setting fact
      set_fact:
        testing_dictionary:
          - name: number_one
            value: one
          - name: number_two
            value: two

    - name: Debugging
      debug:
        var: "{{item}}"
      with_items: "{{ testing_dictionary | default({}) }}"

    - debug: var="{{testing_dictionary}}"

```

With this patch, Ansible is producing the following output:

``` yaml
PLAY ***************************************************************************

TASK [Setting fact] ************************************************************
ok: [localhost]

TASK [Debugging] ***************************************************************
ok: [localhost] => (item={u'name': u'number_one', u'value': u'one'}) => {
    "<type 'dict'>": {
        "name": "number_one",
        "value": "one"
    },
    "item": {
        "name": "number_one",
        "value": "one"
    }
}
ok: [localhost] => (item={u'name': u'number_two', u'value': u'two'}) => {
    "<type 'dict'>": {
        "name": "number_two",
        "value": "two"
    },
    "item": {
        "name": "number_two",
        "value": "two"
    }
}

TASK [debug var={{testing_dictionary}}] ****************************************
ok: [localhost] => {
    "<type 'list'>": [
        {
            "name": "number_one",
            "value": "one"
        },
        {
            "name": "number_two",
            "value": "two"
        }
    ],
    "changed": false
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0
```
