### PR TITLE
adds new device argument to nxapi command arguments

### DIFF
--- a/lib/ansible/module_utils/nxapi.py
+++ b/lib/ansible/module_utils/nxapi.py
@@ -32,16 +32,16 @@ from ansible.module_utils.nxapi import *
 
 The nxapi module provides the following common argument spec:
 
-    * host (str) - [Required] The IPv4 address or FQDN of the network device
+    * host (str) - The IPv4 address or FQDN of the network device
 
     * port (str) - Overrides the default port to use for the HTTP/S
         connection.  The default values are 80 for HTTP and
         443 for HTTPS
 
-    * url_username (str) - [Required] The username to use to authenticate
+    * username (str) - The username to use to authenticate
         the HTTP/S connection.  Aliases: username
 
-    * url_password (str) - [Required] The password to use to authenticate
+    * password (str) - The password to use to authenticate
         the HTTP/S connection.  Aliases: password
 
     * use_ssl (bool) - Specifies whether or not to use an encrypted (HTTPS)
@@ -51,6 +51,10 @@ The nxapi module provides the following common argument spec:
         device.  Valid values in `cli_show`, `cli_show_ascii`, 'cli_conf`
         and `bash`.  The default value is `cli_show_ascii`
 
+    * device (dict) - Used to send the entire set of connection parameters
+        as a dict object.  This argument is mutually exclusive with the
+        host argument
+
 In order to communicate with Cisco NXOS devices, the NXAPI feature
 must be enabled and configured on the device.
 
@@ -58,34 +62,52 @@ must be enabled and configured on the device.
 
 NXAPI_COMMAND_TYPES = ['cli_show', 'cli_show_ascii', 'cli_conf', 'bash']
 
-def nxapi_argument_spec(spec=None):
-    """Creates an argument spec for working with NXAPI
-    """
-    arg_spec = url_argument_spec()
-    arg_spec.update(dict(
-        host=dict(required=True),
-        port=dict(),
-        url_username=dict(required=True, aliases=['username']),
-        url_password=dict(required=True, aliases=['password']),
-        use_ssl=dict(default=False, type='bool'),
-        command_type=dict(default='cli_show_ascii', choices=NXAPI_COMMAND_TYPES)
-    ))
-    if spec:
-        arg_spec.update(spec)
-    return arg_spec
+NXAPI_COMMON_ARGS = dict(
+    host=dict(),
+    port=dict(),
+    username=dict(),
+    password=dict(),
+    use_ssl=dict(default=False, type='bool'),
+    device=dict(),
+    command_type=dict(default='cli_show_ascii', choices=NXAPI_COMMAND_TYPES)
+)
 
-def nxapi_url(module):
+def nxapi_module(**kwargs):
+    """Append the common args to the argument_spec
+    """
+    spec = kwargs.get('argument_spec') or dict()
+
+    argument_spec = url_argument_spec()
+    argument_spec.update(NXAPI_COMMON_ARGS)
+    if kwargs.get('argument_spec'):
+        argument_spec.update(kwargs['argument_spec'])
+    kwargs['argument_spec'] = argument_spec
+
+    module = AnsibleModule(**kwargs)
+
+    device = module.params.get('device') or dict()
+    for key, value in device.iteritems():
+        if key in NXAPI_COMMON_ARGS:
+            module.params[key] = value
+
+    params = json_dict_unicode_to_bytes(json.loads(MODULE_COMPLEX_ARGS))
+    for key, value in params.iteritems():
+        if key != 'device':
+            module.params[key] = value
+
+    return module
+
+def nxapi_url(params):
     """Constructs a valid NXAPI url
     """
-    if module.params['use_ssl']:
+    if params['use_ssl']:
         proto = 'https'
     else:
         proto = 'http'
-    host = module.params['host']
+    host = params['host']
     url = '{}://{}'.format(proto, host)
-    port = module.params['port']
-    if module.params['port']:
-        url = '{}:{}'.format(url, module.params['port'])
+    if params['port']:
+        url = '{}:{}'.format(url, params['port'])
     url = '{}/ins'.format(url)
     return url
 
@@ -109,7 +131,7 @@ def nxapi_body(commands, command_type, **kwargs):
 def nxapi_command(module, commands, command_type=None, **kwargs):
     """Sends the list of commands to the device over NXAPI
     """
-    url = nxapi_url(module)
+    url = nxapi_url(module.params)
 
     command_type = command_type or module.params['command_type']
 
@@ -117,6 +139,9 @@ def nxapi_command(module, commands, command_type=None, **kwargs):
     data = module.jsonify(data)
 
     headers = {'Content-Type': 'text/json'}
+
+    module.params['url_username'] = module.params['username']
+    module.params['url_password'] = module.params['password']
 
     response, headers = fetch_url(module, url, data=data, headers=headers,
                                   method='POST')


### PR DESCRIPTION
The device argument allows a dict of nxapi parameters to be passed to
the module to simplify passing the nxapi parameters
