### PR TITLE
Explicitly accept become_success in awaiting_prompt state

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -457,12 +457,17 @@ class Connection(ConnectionBase):
                 tmp_stdout = tmp_stderr = ''
 
             # If we see a privilege escalation prompt, we send the password.
+            # (If we're expecting a prompt but the escalation succeeds, we
+            # didn't need the password and can carry on regardless.)
 
-            if states[state] == 'awaiting_prompt' and self._flags['become_prompt']:
-                display.debug('Sending become_pass in response to prompt')
-                stdin.write(self._play_context.become_pass + '\n')
-                self._flags['become_prompt'] = False
-                state += 1
+            if states[state] == 'awaiting_prompt':
+                if self._flags['become_prompt']:
+                    display.debug('Sending become_pass in response to prompt')
+                    stdin.write(self._play_context.become_pass + '\n')
+                    self._flags['become_prompt'] = False
+                    state += 1
+                elif self._flags['become_success']:
+                    state += 1
 
             # We've requested escalation (with or without a password), now we
             # wait for an error message or a successful escalation.


### PR DESCRIPTION
If we request escalation with a password, we start in expecting_prompt
state. If the escalation then succeeds without the password, i.e., the
become_success response arrives, we must explicitly move into the next
state (awaiting_escalation, which immediately goes into ready_to_send),
so that we no longer try to apply the timeout.

Otherwise, if the results of the task don't arrive with become_success
(dependent on the exact timing), we leak the success notification and
eventually timeout. But if the module response did arrive before the
timeout expired, the "process has already exited" test would do the
right thing by accident (which is why it didn't fail more often).

Fixes #13289
