### PR TITLE
Fix for https://github.com/ansible/ansible/issues/13221

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -202,6 +202,7 @@ class TaskQueueManager:
             #        to do this with a proper BaseProxy/DictProxy derivative
             exposed=(
                 'set_variable_manager', 'set_inventory', '__contains__', '__delitem__',
+                'set_nonpersistent_facts', 'set_host_facts', 'set_host_variable',
                 '__getitem__', '__len__', '__setitem__', 'clear', 'copy', 'get', 'has_key',
                 'items', 'keys', 'pop', 'popitem', 'setdefault', 'update', 'values'
             ),

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -275,7 +275,7 @@ class StrategyBase:
                     var_value = wrap_var(result[3])
 
                     self._variable_manager.set_nonpersistent_facts(host, {var_name: var_value})
-                    self._tqm._hostvars_manager.hostvars().set_variable_manager(self._variable_manager)
+                    self._tqm._hostvars_manager.hostvars().set_nonpersistent_facts(host, {var_name: var_value})
 
                 elif result[0] in ('set_host_var', 'set_host_facts'):
                     host = result[1]
@@ -300,13 +300,15 @@ class StrategyBase:
                         var_value = result[5]
 
                         self._variable_manager.set_host_variable(target_host, var_name, var_value)
+                        self._tqm._hostvars_manager.hostvars().set_host_variable(target_host, var_name, var_value)
                     elif result[0] == 'set_host_facts':
                         facts = result[4]
                         if task.action == 'set_fact':
                             self._variable_manager.set_nonpersistent_facts(target_host, facts)
+                            self._tqm._hostvars_manager.hostvars().set_nonpersistent_facts(target_host, facts)
                         else:
                             self._variable_manager.set_host_facts(target_host, facts)
-                    self._tqm._hostvars_manager.hostvars().set_variable_manager(self._variable_manager)
+                            self._tqm._hostvars_manager.hostvars().set_host_facts(target_host, facts)
 
                 else:
                     raise AnsibleError("unknown result message received: %s" % result[0])

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -79,6 +79,15 @@ class HostVars(collections.Mapping):
             self._cached_result[sha1_hash] = result
         return result
 
+    def set_host_variable(self, host, varname, value):
+        self._variable_manager.set_host_variable(host, varname, value)
+
+    def set_nonpersistent_facts(self, host, facts):
+        self._variable_manager.set_nonpersistent_facts(host, facts)
+
+    def set_host_facts(self, host, facts):
+        self._variable_manager.set_host_facts(host, facts)
+
     def __contains__(self, host_name):
         return self._find_host(host_name) is not None
 


### PR DESCRIPTION
Do not call set_variable_manager each time but only at the end of _process_pending_results.

With the playbook described in https://github.com/ansible/ansible/issues/13221 applied on 20 hosts, Ansible takes 35s vs 4 minutes without this patch.
