### PR TITLE
Devel fix bomb shell

### DIFF
--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -159,7 +159,7 @@ class ModuleArgsParser:
         # we don't allow users to set them directy in arguments
         if action not in ('command', 'shell', 'script', 'raw'):
             for arg in args:
-                if arg.startswith('_') and arg not in ('_raw_params'):
+                if arg.startswith('_ansible_'):
                     raise AnsibleError("invalid parameter specified for action '%s': '%s'" % (action, arg))
 
         # finally, update the args we're going to return with the ones

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 from ansible.compat.six import iteritems, string_types
 
-from ansible.errors import AnsibleParserError
+from ansible.errors import AnsibleParserError,AnsibleError
 from ansible.plugins import module_loader
 from ansible.parsing.splitter import parse_kv, split_args
 from ansible.template import Templar
@@ -154,6 +154,13 @@ class ModuleArgsParser:
                 if isinstance(tmp_args, string_types):
                     tmp_args = parse_kv(tmp_args)
                 args.update(tmp_args)
+
+        # only internal variables can start with an underscore, so
+        # we don't allow users to set them directy in arguments
+        if action not in ('command', 'shell', 'script', 'raw'):
+            for arg in args:
+                if arg.startswith('_') and arg not in ('_raw_params'):
+                    raise AnsibleError("invalid parameter specified for action '%s': '%s'" % (action, arg))
 
         # finally, update the args we're going to return with the ones
         # which were normalized above

--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -83,11 +83,6 @@ def parse_kv(args, check_raw=False):
                 k = x[:pos]
                 v = x[pos + 1:]
 
-                # only internal variables can start with an underscore, so
-                # we don't allow users to set them directy in arguments
-                if k.startswith('_'):
-                    raise AnsibleError("invalid parameter specified: '%s'" % k)
-
                 # FIXME: make the retrieval of this list of shell/command
                 #        options a function, so the list is centralized
                 if check_raw and k not in ('creates', 'removes', 'chdir', 'executable', 'warn'):


### PR DESCRIPTION
Fix for https://github.com/ansible/ansible/issues/13269

Consistent behaviour between old and new style notation and allow variables starting with `_`. Now only variables starting with `_ansible_` are not allowed at all.
