### PR TITLE
Make main include files format more permissive.

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -34,7 +34,11 @@ def load_list_of_blocks(ds, play, parent_block=None, role=None, task_include=Non
     # we import here to prevent a circular dependency with imports
     from ansible.playbook.block import Block
 
-    assert isinstance(ds, (list, type(None)))
+    try:
+        assert isinstance(ds, (list, type(None)))
+    except AssertionError:
+        assert isinstance(ds['tasks'], (list, type(None)))
+        ds = ds['tasks']
 
     block_list = []
     if ds:


### PR DESCRIPTION
Ansible assumes that `roles/x/tasks/main.yml` is a plain list of tasks, but when the file is in the format:

```
tasks:
  - xxx
...
```

it fails with unexpected exception (AssertionError).

This patch tolerates both format. The other way would be to raise an Ansible-specifc exception for this unexpected include file format.
