### PR TITLE
Corrected group separator

### DIFF
--- a/docsite/rst/intro_patterns.rst
+++ b/docsite/rst/intro_patterns.rst
@@ -31,7 +31,7 @@ It is also possible to address a specific host or set of hosts by name::
     192.168.1.50
     192.168.1.*
 
-The following patterns address one or more groups.  Groups separated by a comma indicate an "OR" configuration.
+The following patterns address one or more groups.  Groups separated by a colon indicate an "OR" configuration.
 This means the host may be in either one group or the other::
 
     webservers


### PR DESCRIPTION
The text said comma, but the examples were all colons.
