### PR TITLE
fix sorting of groups for host vars

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -234,7 +234,7 @@ class VariableManager:
                 for item in data:
                     all_vars = combine_vars(all_vars, item)
 
-            for group in host.get_groups():
+            for group in sorted(host.get_groups(), key=lambda g: g.depth):
                 if group.name in self._group_vars_files and group.name != 'all':
                     for data in self._group_vars_files[group.name]:
                         data = preprocess_vars(data)
@@ -415,7 +415,7 @@ class VariableManager:
         items = []
         if task.loop is not None:
             if task.loop in lookup_loader:
-                #TODO: remove convert_bare true and deprecate this in with_ 
+                #TODO: remove convert_bare true and deprecate this in with_
                 try:
                     loop_terms = listify_lookup_plugin_terms(terms=task.loop_args, templar=templar, loader=loader, fail_on_undefined=True, convert_bare=True)
                 except AnsibleUndefinedVariable as e:
@@ -615,4 +615,3 @@ class VariableManager:
         if host_name not in self._vars_cache:
             self._vars_cache[host_name] = dict()
         self._vars_cache[host_name][varname] = value
-

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -232,7 +232,7 @@ class VariableManager:
             if 'all' in self._group_vars_files:
                 data = preprocess_vars(self._group_vars_files['all'])
                 for item in data:
-                    all_vars = combine_vars(all_vars, item)
+                    all_vars = combine_vars(item, all_vars)
 
             for group in sorted(host.get_groups(), key=lambda g: g.depth):
                 if group.name in self._group_vars_files and group.name != 'all':

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -232,7 +232,7 @@ class VariableManager:
             if 'all' in self._group_vars_files:
                 data = preprocess_vars(self._group_vars_files['all'])
                 for item in data:
-                    all_vars = combine_vars(item, all_vars)
+                    all_vars = combine_vars(all_vars, item)
 
             for group in sorted(host.get_groups(), key=lambda g: g.depth):
                 if group.name in self._group_vars_files and group.name != 'all':


### PR DESCRIPTION
found this issue because we're using the hierarchy of groups to specify values on different levels.

how to validate fix:

```
cat >inventory <<EOF
[top:children]
lower

[lower]
host01
EOF

mkdir group_vars
cat >group_vars/top <<EOF

---
my_var: "shouldn't be used"
EOF

cat >group_vars/lower <<EOF

---
my_var: "this one should be used"
EOF

cat >playbook.yml <<EOF
- hosts: all
  connection: local
  sudo: no
  tasks:
    - debug: msg="{{ my_var }}"
EOF

ansible-playbook -i inventory playbook.yml
```

compare result from ansible 2.0 devel and my fork to see difference

log:

```
(venv)$ pip install git+https://github.com/ansible/ansible.git
Collecting git+https://github.com/ansible/ansible.git
  Cloning https://github.com/ansible/ansible.git to /var/folders/y_/l6hg282s1636jt3ggm75dlrr0000gn/T/pip-72FUSu-build
Collecting paramiko (from ansible==2.0.0)
/Users/lars/tmp/ver/venv/lib/python2.7/site-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:90: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#in
secureplatformwarning.
  InsecurePlatformWarning
  Using cached paramiko-1.16.0-py2.py3-none-any.whl
Collecting jinja2 (from ansible==2.0.0)
  Using cached Jinja2-2.8-py2.py3-none-any.whl
Collecting PyYAML (from ansible==2.0.0)
Requirement already satisfied (use --upgrade to upgrade): setuptools in ./venv/lib/python2.7/site-packages (from ansible==2.0.0)
Collecting pycrypto>=2.6 (from ansible==2.0.0)
Collecting ecdsa>=0.11 (from paramiko->ansible==2.0.0)
  Using cached ecdsa-0.13-py2.py3-none-any.whl
Collecting MarkupSafe (from jinja2->ansible==2.0.0)
Installing collected packages: ecdsa, pycrypto, paramiko, MarkupSafe, jinja2, PyYAML, ansible
  Running setup.py install for ansible
Successfully installed MarkupSafe-0.23 PyYAML-3.11 ansible-2.0.0 ecdsa-0.13 jinja2-2.8 paramiko-1.16.0 pycrypto-2.6.1
/Users/lars/tmp/ver/venv/lib/python2.7/site-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:90: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#in
secureplatformwarning.
  InsecurePlatformWarning
(venv)$ ansible-playbook -i inventory playbook.yml
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default). This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [host01]

TASK [debug msg={{ my_var }}] **************************************************
ok: [host01] => {
    "changed": false,
    "msg": "shouldn't be used"
}

PLAY RECAP *********************************************************************
host01                     : ok=2    changed=0    unreachable=0    failed=0

(venv)$ pip install -U git+https://github.com/larsla/ansible.git
Collecting git+https://github.com/larsla/ansible.git
  Cloning https://github.com/larsla/ansible.git to /var/folders/y_/l6hg282s1636jt3ggm75dlrr0000gn/T/pip-Zn8Aay-build
Requirement already up-to-date: paramiko in ./venv/lib/python2.7/site-packages (from ansible==2.0.0)
Requirement already up-to-date: jinja2 in ./venv/lib/python2.7/site-packages (from ansible==2.0.0)
Requirement already up-to-date: PyYAML in ./venv/lib/python2.7/site-packages (from ansible==2.0.0)
/Users/lars/tmp/ver/venv/lib/python2.7/site-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:90: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
Collecting setuptools (from ansible==2.0.0)
  Using cached setuptools-18.7-py2.py3-none-any.whl
Requirement already up-to-date: pycrypto>=2.6 in ./venv/lib/python2.7/site-packages (from ansible==2.0.0)
Requirement already up-to-date: ecdsa>=0.11 in ./venv/lib/python2.7/site-packages (from paramiko->ansible==2.0.0)
Requirement already up-to-date: MarkupSafe in ./venv/lib/python2.7/site-packages (from jinja2->ansible==2.0.0)
Installing collected packages: setuptools, ansible
  Found existing installation: setuptools 18.2
    Uninstalling setuptools-18.2:
      Successfully uninstalled setuptools-18.2
  Found existing installation: ansible 2.0.0
    Uninstalling ansible-2.0.0:
      Successfully uninstalled ansible-2.0.0
  Running setup.py install for ansible
Successfully installed ansible-2.0.0 setuptools-18.7

(venv)$ ansible-playbook -i inventory playbook.yml
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default). This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [host01]

TASK [debug msg={{ my_var }}] **************************************************
ok: [host01] => {
    "changed": false,
    "msg": "this one should be used"
}

PLAY RECAP *********************************************************************
host01                     : ok=2    changed=0    unreachable=0    failed=0
```
