### PR TITLE
allow shell plugin to affect remote module filename

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -400,7 +400,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             tmp = self._make_tmp_path()
 
         if tmp:
-            remote_module_path = self._connection._shell.join_path(tmp, module_name)
+            remote_module_filename = self._connection._shell.get_remote_filename(module_name)
+            remote_module_path = self._connection._shell.join_path(tmp, remote_module_filename)
             if module_style == 'old':
                 # we'll also need a temp file to hold our module arguments
                 args_file_path = self._connection._shell.join_path(tmp, 'args')

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -301,11 +301,6 @@ class Connection(ConnectionBase):
             }}
         '''
 
-        # FUTURE: this sucks- why can't the module/shell stuff do this?
-        with open(in_path, 'r') as temp_file:
-            if temp_file.read(15).lower().startswith('#!powershell') and not out_path.lower().endswith('.ps1'):
-                out_path = out_path + '.ps1'
-
         script = script_template.format(self._shell._escape(out_path))
         cmd_parts = self._shell._encode_script(script, as_list=True, strict_mode=False)
 

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -49,6 +49,13 @@ class ShellModule(object):
             return path
         return '"%s"' % path
 
+    # powershell requires that script files end with .ps1
+    def get_remote_filename(self, base_name):
+        if not base_name.strip().lower().endswith('.ps1'):
+            return base_name.strip() + '.ps1'
+
+        return base_name.strip()
+
     def path_has_trailing_slash(self, path):
         # Allow Windows paths to be specified using either slash.
         path = self._unquote(path)

--- a/lib/ansible/plugins/shell/sh.py
+++ b/lib/ansible/plugins/shell/sh.py
@@ -47,6 +47,10 @@ class ShellModule(object):
     def join_path(self, *args):
         return os.path.join(*args)
 
+    # some shells (eg, powershell) are snooty about filenames/extensions, this lets the shell plugin have a say
+    def get_remote_filename(self, base_name):
+        return base_name.strip()
+
     def path_has_trailing_slash(self, path):
         return path.endswith('/')
 


### PR DESCRIPTION
Fix for #13368, added get_remote_filename to shell plugins, powershell version appends .ps1 if necessary, base shell plugin no-ops

CC @jimi-c 
