### PR TITLE
Replace -delete with portable -exec rm {} \;

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -57,10 +57,10 @@ fi
 	cd "$ANSIBLE_HOME"
 	if [ "$verbosity" = silent ] ; then
 	    gen_egg_info > /dev/null 2>&1
-            find . -type f -name "*.pyc" -delete > /dev/null 2>&1
+            find . -type f -name "*.pyc" -exec rm {} \; > /dev/null 2>&1
 	else
 	    gen_egg_info
-            find . -type f -name "*.pyc" -delete
+            find . -type f -name "*.pyc" -exec rm {} \;
 	fi
 	cd "$current_dir"
 )


### PR DESCRIPTION
Needed on OpenBSD which does not support -delete.

Running ". hacking/env-setup" on OpenBSD with current devel prints the following error message:

> find: -delete: unknown option
