### PR TITLE
Catch additional assertion errors for load_list_of_blocks

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -34,10 +34,7 @@ def load_list_of_blocks(ds, play, parent_block=None, role=None, task_include=Non
     # we import here to prevent a circular dependency with imports
     from ansible.playbook.block import Block
 
-    try:
-        assert isinstance(ds, (list, type(None)))
-    except AssertionError:
-        raise AnsibleParserError("Task list is not a list, invalid format provided: %s" % ds)
+    assert isinstance(ds, (list, type(None)))
 
     block_list = []
     if ds:

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -171,11 +171,17 @@ class Role(Base, Become, Conditional, Taggable):
 
         task_data = self._load_role_yaml('tasks')
         if task_data:
-            self._task_blocks = load_list_of_blocks(task_data, play=self._play, role=self, loader=self._loader)
+            try:
+                self._task_blocks = load_list_of_blocks(task_data, play=self._play, role=self, loader=self._loader)
+            except:
+                raise AnsibleParserError("The tasks/main.yml file for role '%s' must contain a list of tasks" % self._role_name , obj=task_data)
 
         handler_data = self._load_role_yaml('handlers')
         if handler_data:
-            self._handler_blocks = load_list_of_blocks(handler_data, play=self._play, role=self, use_handlers=True, loader=self._loader)
+            try:
+                self._handler_blocks = load_list_of_blocks(handler_data, play=self._play, role=self, use_handlers=True, loader=self._loader)
+            except:
+                raise AnsibleParserError("The handlers/main.yml file for role '%s' must contain a list of tasks" % self._role_name , obj=task_data)
 
         # vars and default vars are regular dictionaries
         self._role_vars  = self._load_role_yaml('vars')


### PR DESCRIPTION
This PR addresses a few locations where `load_list_of_blocks` was used, but we were not catching the `AssertionError`.

This was partially addressed in https://github.com/ansible/ansible/commit/53cd80225143d0011416041f4cd815a07c650772 however, due to changing the exception that is raised, the existing `except AssertionError:` statements are no longer useful, and we are potentially losing additional useful data.

This PR brings the code into alignment with how it is done elsewhere in the codebase.
