### PR TITLE
Use CLI.expand_tilde also for the vault --output file

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -250,7 +250,8 @@ class CLI(object):
             parser.add_option('--new-vault-password-file', dest='new_vault_password_file',
                 help="new vault password file for rekey", action="callback", callback=CLI.expand_tilde, type=str)
             parser.add_option('--output', default=None, dest='output_file',
-                help='output file name for encrypt or decrypt; use - for stdout')
+                help='output file name for encrypt or decrypt; use - for stdout',
+                action="callback", callback=CLI.expand_tilde, type=str)
 
         if subset_opts:
             parser.add_option('-t', '--tags', dest='tags', default='all',


### PR DESCRIPTION
This was just a minor oversight in the initial submission which makes the newly-added --output option fail to work with a filename like ~/foo. Please merge into devel and stable-2.0.
