### PR TITLE
fixed docsite rail ad

### DIFF
--- a/docsite/_themes/srtd/layout.html
+++ b/docsite/_themes/srtd/layout.html
@@ -166,16 +166,9 @@
 <!-- changeable widget -->
 <center>
 <br/>
-<span class="hs-cta-wrapper" id="hs-cta-wrapper-71d47584-8ef5-4b06-87ae-8d25bc2a837e">
-    <span class="hs-cta-node hs-cta-71d47584-8ef5-4b06-87ae-8d25bc2a837e" id="hs-cta-71d47584-8ef5-4b06-87ae-8d25bc2a837e">
-        <!--[if lte IE 8]><div id="hs-cta-ie-element"></div><![endif]-->
-        <a href="http://cta-redirect.hubspot.com/cta/redirect/330046/71d47584-8ef5-4b06-87ae-8d25bc2a837e"><img class="hs-cta-img" id="hs-cta-img-71d47584-8ef5-4b06-87ae-8d25bc2a837e" style="border-width:0px;" src="https://cdn2.hubspot.net/hubfs/330046/docs-graphics/ASB-docs-left-rail.png" /></a>
-    </span>
-    <script charset="utf-8" src="https://js.hscta.net/cta/current.js"></script>
-        <script type="text/javascript">
-            hbspt.cta.load(330046, '71d47584-8ef5-4b06-87ae-8d25bc2a837e');
-        </script>
-</span>
+<a href="http://www.ansible.com/tower?utm_source=docs">
+    <img style="border-width:0px;" src="https://cdn2.hubspot.net/hubfs/330046/docs-graphics/ASB-docs-left-rail.png" />
+</a>
 </center>
 
 


### PR DESCRIPTION
Removes the hubspot id's that were making the ad image be replaced.
