### PR TITLE
Get v2_playbook_on_start working

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -82,6 +82,10 @@ class PlaybookExecutor:
                 if self._tqm is None: # we are doing a listing
                     entry = {'playbook': playbook_path}
                     entry['plays'] = []
+                else:
+                    # make sure the tqm has callbacks loaded
+                    self._tqm.load_callbacks()
+                    self._tqm.send_callback('v2_playbook_on_start', pb)
 
                 i = 1
                 plays = pb.get_plays()
@@ -130,8 +134,6 @@ class PlaybookExecutor:
                         entry['plays'].append(new_play)
 
                     else:
-                        # make sure the tqm has callbacks loaded
-                        self._tqm.load_callbacks()
                         self._tqm._unreachable_hosts.update(self._unreachable_hosts)
 
                         # we are actually running plays

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -44,6 +44,7 @@ class Playbook:
         self._entries = []
         self._basedir = os.getcwd()
         self._loader  = loader
+        self._file_name = None
 
     @staticmethod
     def load(file_name, variable_manager=None, loader=None):
@@ -60,6 +61,8 @@ class Playbook:
 
         # set the loaders basedir
         self._loader.set_basedir(self._basedir)
+
+        self._file_name = file_name
 
         # dynamically load any plugins from the playbook directory
         for name, obj in get_all_plugin_loaders():

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -246,7 +246,7 @@ class CallbackBase:
     def v2_runner_on_file_diff(self, result, diff):
         pass #no v1 correspondance
 
-    def v2_playbook_on_start(self):
+    def v2_playbook_on_start(self, playbook):
         self.playbook_on_start()
 
     def v2_playbook_on_notify(self, result, handler):


### PR DESCRIPTION
This PR does the following:
- Move self._tqm.load_callbacks() earlier to ensure that v2_on_playbook_start can fire
- Pass the playbook instance to v2_on_playbook_start
- Add a _file_name instance attribute to the playbook

As it stands, `v2_on_playbook_start` is never run.  This change ensures that it will, and also changes it's signature to pass in the playbook instance.

Additionally, due to how I plan on using this, it would be nice to also have the filename associated with the playbook instance available to the callback.
