### PR TITLE
added playbook and options info to callbacks

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -39,6 +39,11 @@ except ImportError:
 
 __all__ = ["CallbackBase"]
 
+try:
+    from __main__ import cli
+except ImportError:
+    # using API w/o cli 
+    cli = False
 
 class CallbackBase:
 
@@ -53,6 +58,11 @@ class CallbackBase:
             self._display = display
         else:
             self._display = global_display
+
+        if cli:
+            self._options = cli.options
+        else:
+            self._options = None
 
         if self._display.verbosity >= 4:
             name = getattr(self, 'CALLBACK_NAME', 'unnamed')

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -230,3 +230,16 @@ class CallbackModule(CallbackBase):
 
         self._display.display("", screen_only=True)
 
+    def v2_playbook_on_start(self, playbook):
+        if self._display.verbosity > 1:
+            from os.path import basename
+            self._display.banner("PLAYBOOK: %s" % basename(playbook._file_name))
+
+        if self._display.verbosity > 3:
+            if self._options is not None:
+                for option in dir(self._options):
+                    if option.startswith('_') or option in ['read_file', 'ensure_value', 'read_module']:
+                        continue
+                    val =  getattr(self._options,option)
+                    if val:
+                        self._display.vvvv('%s: %s' % (option,val))


### PR DESCRIPTION
will display on certain verbosity levels, both playbook/file info
and non empty options with which it's running.
