### PR TITLE
Don't override stdout_callback in adhoc

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -161,7 +161,7 @@ class AdHocCLI(CLI):
         if self.options.one_line:
             cb = 'oneline'
         else:
-            cb = 'minimal'
+            cb = C.DEFAULT_STDOUT_CALLBACK
 
         if self.options.tree:
             C.DEFAULT_CALLBACK_WHITELIST.append('tree')


### PR DESCRIPTION
The fallback condition for --oneline totally overrides the
stdout_callback setting from ansible.cfg.
