### PR TITLE
Allow setup of docker remote connections

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -50,6 +50,8 @@ except ImportError:
 
 MAGIC_VARIABLE_MAPPING = dict(
    connection       = ('ansible_connection',),
+   connection_command   = ('ansible_connection_command',),
+   connection_args  = ('ansible_connection_args',),
    remote_addr      = ('ansible_ssh_host', 'ansible_host'),
    remote_user      = ('ansible_ssh_user', 'ansible_user'),
    port             = ('ansible_ssh_port', 'ansible_port'),
@@ -136,6 +138,8 @@ class PlayContext(Base):
 
     # connection fields, some are inherited from Base:
     # (connection, port, remote_user, environment, no_log)
+    _connection_command = FieldAttribute(isa='string')
+    _connection_args  = FieldAttribute(isa='string')
     _remote_addr      = FieldAttribute(isa='string')
     _password         = FieldAttribute(isa='string')
     _private_key_file = FieldAttribute(isa='string', default=C.DEFAULT_PRIVATE_KEY_FILE)
@@ -242,6 +246,12 @@ class PlayContext(Base):
 
         if options.connection:
             self.connection = options.connection
+
+        if hasattr(options, 'connection_command') and options.connection_command:
+            self.connection_command = options.connection_command
+
+        if hasattr(options, 'connection_args') and options.connection_args:
+            self.connection_args = options.connection_args
 
         self.remote_user = options.remote_user
         self.private_key_file = options.private_key_file


### PR DESCRIPTION
This PR replaces #13356, because I switched to a new branch. Sorry for inconvenience.

This pull request is a proposal for solving issue #13294. Maybe the changes in the `play_context.py` are not compliant to the current standard of this file and should be seen as a proposal. My intention was to introduce the ability to set the connection command and additional connection arguments independent of the connection type (ssh, local, docker, ...). Besides solving issue #13294 the changes within the `connection/docker.py` show the use of the two new variables in the play_context.

I hope those changes will be merged in the one or another form. I rely hardly on them and currently there is no other possibility to deploy playbooks to remote Docker daemons. Here an example how to use the Docker connection remotely:

_inventory_

```
mycontainer ansible_connection=docker ansible_connections_args="--tlsverify --tlscacert=/path/to/ca.pem --tlscert=/path/to/client-cert.pem --tlskey=/path/to/client-key.pem -H=tcp://myserver.org:4243"
```
