### PR TITLE
use remote_user or become_user in docker connection

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -122,9 +122,8 @@ class Connection(ConnectionBase):
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
         executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else '/bin/sh'
-        exec_user = self._play_context.become_user if self._play_context.become else self._play_context.remote_user
         # -i is needed to keep stdin open which allows pipelining to work
-        local_cmd = [self.docker_cmd, "exec", '-u', exec_user, '-i', self._play_context.remote_addr, executable, '-c', cmd]
+        local_cmd = [self.docker_cmd, "exec", '-u', self._play_context.remote_user, '-i', self._play_context.remote_addr, executable, '-c', cmd]
 
         display.vvv("EXEC %s" % (local_cmd), host=self._play_context.remote_addr)
         p = subprocess.Popen(local_cmd, shell=False, stdin=subprocess.PIPE,
@@ -169,8 +168,7 @@ class Connection(ConnectionBase):
             # Older docker doesn't have native support for copying files into
             # running containers, so we use docker exec to implement this
             executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else '/bin/sh'
-            exec_user = self._play_context.become_user if self._play_context.become else self._play_context.remote_user
-            args = [self.docker_cmd, "exec", '-u', exec_user, "-i", self._play_context.remote_addr, executable, "-c",
+            args = [self.docker_cmd, "exec", '-u', self._play_context.remote_user, "-i", self._play_context.remote_addr, executable, "-c",
                     "dd of={0} bs={1}".format(out_path, BUFSIZE)]
             with open(in_path, 'rb') as in_file:
                 try:


### PR DESCRIPTION
This commit makes Ansible using the `remote user` (aka `ansible_user`) when executing tasks against a Docker container with the Docker connection plugin. Alternatively the `become_user` is used when `become` is true.

This PR would solve issue #13388

**Side effect:** The `docker exec` way does not need a `become_method`, because Docker has its own user management. Thus the user is set by Docker when starting the process with `docker exec`. Using an additional become method then is not just unnescessary but also a disadvantage, because the Docker image needs to provide the become method. I don't know how to disable the `become_method` for the Docker connection plugin. Anybody with enough knowledge could to that after merging this PR, because then the `become_method` becomes obsolete like described.
