### PR TITLE
More meaningful string representation for meta tasks (like 'noop' and 'flush_handlers')

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -133,7 +133,10 @@ class Task(Base, Conditional, Taggable, Become):
 
     def __repr__(self):
         ''' returns a human readable representation of the task '''
-        return "TASK: %s" % self.get_name()
+        if self.get_name() == 'meta ':
+            return "TASK: meta (%s)" % self.args['_raw_params']
+        else:
+            return "TASK: %s" % self.get_name()
 
     def _preprocess_loop(self, ds, new_ds, k, v):
         ''' take a lookup plugin name and store it correctly '''


### PR DESCRIPTION
Makes debug log messages more helpful — consider

>  31457 1449326406.09388: done getting next task for host localhost
>  31457 1449326406.09392:  ^ task is: TASK: meta 

vs

>  31457 1449326406.09388: done getting next task for host localhost
>  31457 1449326406.09392:  ^ task is: TASK: meta (flush_handlers)
