### PR TITLE
quit plays with an error if there were failed tasks and handler execu…

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -826,6 +826,11 @@ class PlayBook(object):
                 # if there were failed tasks and handler execution
                 # is not forced, quit the play with an error
                 return False
+            elif task_errors:
+                # if there were failed tasks and handler execution is forced,
+                # execute all handlers and quit the play with an error
+                self.run_handlers(play)
+                return False
             else:
                 # no errors, go ahead and execute all handlers
                 if not self.run_handlers(play):


### PR DESCRIPTION
this pull request is to fix the below bug:

force handler is set to true for ansible
any_errors_fatal is set to true for some play

when some task fails, plays for other hosts will still continue to execute.
