### PR TITLE
Fix issue when var name is the same as content.

### DIFF
--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -45,8 +45,12 @@ class ActionModule(ActionBase):
                 # If var is a list or dict, use the type as key to display
                 result[to_unicode(type(self._task.args['var']))] = results
             else:
+                # If var name is same as result, try to template it
                 if results == self._task.args['var']:
-                    results = "VARIABLE IS NOT DEFINED!"
+                    try:
+                        results = self._templar.template("{{" + results + "}}", convert_bare=True, fail_on_undefined=True)
+                    except:
+                        results = "VARIABLE IS NOT DEFINED!"
                 result[self._task.args['var']] = results
         else:
             result['msg'] = 'here we are'


### PR DESCRIPTION
See https://github.com/ansible/ansible/issues/13453 for more details.

Here is a simple example:
- Without test variable defined:

``` yaml
ansible -m debug -a var=test localhost
localhost | SUCCESS => {
    "changed": false, 
    "test": "VARIABLE IS NOT DEFINED!"
}
```
- Now with test variable:

``` yaml
ansible -m debug -a var=test -e test=test localhost
localhost | SUCCESS => {
    "changed": false, 
    "test": "test"
}
```
- Same without the patch:

``` yaml
ansible -m debug -a var=test -e test=test localhost
localhost | SUCCESS => {
    "changed": false, 
    "test": "VARIABLE IS NOT DEFINED!"
}
```
