### PR TITLE
Adds support for converting a MAC address to an integer

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -228,6 +228,9 @@ def _bool_hwaddr_query(v):
     if v:
         return True
 
+def _int_hwaddr_query(v):
+    return int(v)
+
 def _cisco_query(v):
     v.dialect = netaddr.mac_cisco
     return str(v)
@@ -637,6 +640,7 @@ def hwaddr(value, query = '', alias = 'hwaddr'):
             '': _empty_hwaddr_query,
             'bare': _bare_query,
             'bool': _bool_hwaddr_query,
+            'int': _int_hwaddr_query,
             'cisco': _cisco_query,
             'eui48': _win_query,
             'linux': _linux_query,


### PR DESCRIPTION
Adds an "int" format to the MAC address filter of ipaddr.py. Useful for doing math with MAC addresses, such as ensuring a series of MAC addresses are in a specific order when configuring VMs.

Example:

``` ---
- hosts: local
  tasks:
    - set_fact: mac_str="52:54:00:00:00:00"
    - set_fact: base_mac="{{ mac_str | macaddr('int') }}"
    - debug: msg="{{ (base_mac|int + 257) | macaddr('linux') }}" # 52:54:00:00:01:01
    - debug: msg="{{ (base_mac|int + 258) | macaddr('linux') }}" # 52:54:00:00:01:02
```

Separate from but useful with "[Adds the int_hash filter](https://github.com/ansible/ansible/pull/13473)" to generate MAC addresses on NICs in an ascending order on a host.
