### PR TITLE
Galaxy 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Ansible Changes By Release
   by setting the `ANSIBLE_NULL_REPRESENTATION` environment variable.
 * Added `meta: refresh_inventory` to force rereading the inventory in a play.
   This re-executes inventory scripts, but does not force them to ignore any cache they might use.
-* Now when you delegate an action that returns ansible_facts, these facts will be applied to the delegated host, unlike before when they were applied to the current host.
+* New delegate_facts directive, a boolean that allows you to apply facts to the delegated host (true/yes) instead of the inventory_hostname (no/false) which is the default and previous behaviour.
 * local connections now work with 'su' as a privilege escalation method
 * New ssh configuration variables(`ansible_ssh_common_args`, `ansible_ssh_extra_args`) can be used to configure a
   per-group or per-host ssh ProxyCommand or set any other ssh options.

--- a/docsite/build-site.py
+++ b/docsite/build-site.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import print_function
 
 __docformat__ = 'restructuredtext'
 
@@ -24,9 +25,9 @@ import traceback
 try:
     from sphinx.application import Sphinx
 except ImportError:
-    print "#################################"
-    print "Dependency missing: Python Sphinx"
-    print "#################################"
+    print("#################################")
+    print("Dependency missing: Python Sphinx")
+    print("#################################")
     sys.exit(1)
 import os
 
@@ -40,7 +41,7 @@ class SphinxBuilder(object):
         """
         Run the DocCommand.
         """
-        print "Creating html documentation ..."
+        print("Creating html documentation ...")
 
         try:
             buildername = 'html'
@@ -69,10 +70,10 @@ class SphinxBuilder(object):
 
             app.builder.build_all()
 
-        except ImportError, ie:
+        except ImportError:
             traceback.print_exc()
-        except Exception, ex:
-            print >> sys.stderr, "FAIL! exiting ... (%s)" % ex
+        except Exception as ex:
+            print("FAIL! exiting ... (%s)" % ex, file=sys.stderr)
 
     def build_docs(self):
         self.app.builder.build_all()
@@ -83,9 +84,9 @@ def build_rst_docs():
 
 if __name__ == '__main__':
     if '-h' in sys.argv or '--help' in sys.argv:
-        print "This script builds the html documentation from rst/asciidoc sources.\n"
-        print "    Run 'make docs' to build everything."
-        print "    Run 'make viewdocs' to build and then preview in a web browser."
+        print("This script builds the html documentation from rst/asciidoc sources.\n")
+        print("    Run 'make docs' to build everything.")
+        print("    Run 'make viewdocs' to build and then preview in a web browser.")
         sys.exit(0)
 
     build_rst_docs()
@@ -93,4 +94,4 @@ if __name__ == '__main__':
     if "view" in sys.argv:
         import webbrowser
         if not webbrowser.open('htmlout/index.html'):
-            print >> sys.stderr, "Could not open on your webbrowser."
+            print("Could not open on your webbrowser.", file=sys.stderr)

--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -318,7 +318,7 @@ This only removes the role from Galaxy. It does not impact the actual GitHub rep
 Setup Travis Integerations
 --------------------------
 
-Using the setup command you can enable notifications from `travis <http://travis-ci.org>`. The setup command expects that the user previously authenticated with Galaxy using the login command.
+Using the setup command you can enable notifications from `travis <http://travis-ci.org>`_. The setup command expects that the user previously authenticated with Galaxy using the login command.
 
 ::
 
@@ -326,11 +326,11 @@ Using the setup command you can enable notifications from `travis <http://travis
 
     Added integration for travis chouseknecht/ansible-role-sendmail 
 
-The setup command requires your Travis token. The Travis token is not stored in Galaxy. It is used along with the GitHub username and repo to create a hash as described in `the Travis documentation <https://docs.travis-ci.com/user/notifications/>`. The calculated hash is stored in Galaxy and use to verify notifications received from Travis.
+The setup command requires your Travis token. The Travis token is not stored in Galaxy. It is used along with the GitHub username and repo to create a hash as described in `the Travis documentation <https://docs.travis-ci.com/user/notifications/>`_. The calculated hash is stored in Galaxy and used to verify notifications received from Travis.
 
-The setup command enables Galaxy to respond to notifications. Follow the `Travis getting started guide <https://docs.travis-ci.com/user/getting-started/>` to enable the Travis build process for the role repository.
+The setup command enables Galaxy to respond to notifications. Follow the `Travis getting started guide <https://docs.travis-ci.com/user/getting-started/>`_ to enable the Travis build process for the role repository.
 
-When you create your .travis.yml file add the following to cause Travis to notify Galaxy when build has completed:
+When you create your .travis.yml file add the following to cause Travis to notify Galaxy when a build completes:
 
 ::
 

--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -24,7 +24,7 @@ Installing Roles
 
 The most obvious is downloading roles from the Ansible Galaxy website::
 
-   ansible-galaxy install username.rolename
+   $ ansible-galaxy install username.rolename
 
 .. _galaxy_cli_roles_path:
 
@@ -33,23 +33,16 @@ roles_path
 
 You can specify a particular directory where you want the downloaded roles to be placed::
 
-   ansible-galaxy install username.role -p ~/Code/ansible_roles/
+   $ ansible-galaxy install username.role -p ~/Code/ansible_roles/
    
 This can be useful if you have a master folder that contains ansible galaxy roles shared across several projects. The default is the roles_path configured in your ansible.cfg file (/etc/ansible/roles if not configured).
 
-Building out Role Scaffolding
------------------------------
-
-It can also be used to initialize the base structure of a new role, saving time on creating the various directories and main.yml files a role requires::
-
-   ansible-galaxy init rolename
-
 Installing Multiple Roles From A File
--------------------------------------
+=====================================
 
 To install multiple roles, the ansible-galaxy CLI can be fed a requirements file.  All versions of ansible allow the following syntax for installing roles from the Ansible Galaxy website::
 
-   ansible-galaxy install -r requirements.txt
+   $ ansible-galaxy install -r requirements.txt
 
 Where the requirements.txt looks like::
 
@@ -64,7 +57,7 @@ To request specific versions (tags) of a role, use this syntax in the roles file
 Available versions will be listed on the Ansible Galaxy webpage for that role.
 
 Advanced Control over Role Requirements Files
----------------------------------------------
+=============================================
 
 For more advanced control over where to download roles from, including support for remote repositories, Ansible 1.8 and later support a new YAML format for the role requirements file, which must end in a 'yml' extension.  It works like this::
 
@@ -120,4 +113,276 @@ Roles pulled from galaxy work as with other SCM sourced roles above. To download
        Questions? Help? Ideas?  Stop by the list on Google Groups
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
+
+Building Role Scaffolding
+-------------------------
+
+Use the init command to initialize the base structure of a new role, saving time on creating the various directories and main.yml files a role requires::
+
+   $ ansible-galaxy init rolename
+
+The above will create the following directory structure in the current working directory:
+  
+::
+
+   README.md
+   .travsis.yml
+   defaults/
+       main.yml
+   files/
+   handlers/
+       main.yml
+   meta/
+       main.yml
+   templates/
+   tests/
+       inventory
+       test.yml
+   vars/
+       main.yml
+
+.. note::
+
+    .travis.yml and tests/ are new in Ansible 2.0
+
+If a directory matching the name of the role already exists in the current working directory, the init command will result in an error. To ignore the error use the --force option. Force will create the above subdirectories and files, replacing anything that matches.
+
+Search for Roles
+----------------
+
+The search command provides for querying the Galaxy database, allowing for searching by tags, platforms, author and multiple keywords. For example:
+
+::
+
+    $ ansible-galaxy search elasticsearch --author geerlingguy
+
+The search command will return a list of the first 1000 results matching your search:
+
+::
+    
+    Found 2 roles matching your search:
+
+    Name                              Description
+    ----                              -----------
+    geerlingguy.elasticsearch         Elasticsearch for Linux.
+    geerlingguy.elasticsearch-curator Elasticsearch curator for Linux.
+
+.. note::
+
+    The format of results pictured here is new in Ansible 2.0.
+
+Get More Information About a Role
+---------------------------------
+
+Use the info command To view more detail about a specific role:
+
+::
+
+    $ ansible-galaxy info username.role_name
+
+This returns everything found in Galaxy for the role:
+
+::
+
+    Role: username.rolename
+        description: Installs and configures a thing, a distributed, highly available NoSQL thing.
+        active: True
+        commit: c01947b7bc89ebc0b8a2e298b87ab416aed9dd57
+        commit_message: Adding travis
+        commit_url: https://github.com/username/repo_name/commit/c01947b7bc89ebc0b8a2e298b87ab
+        company: My Company, Inc.
+        created: 2015-12-08T14:17:52.773Z
+        download_count: 1
+        forks_count: 0
+        github_branch:
+        github_repo: repo_name
+        github_user: username
+        id: 6381
+        is_valid: True
+        issue_tracker_url:
+        license: Apache
+        min_ansible_version: 1.4
+        modified: 2015-12-08T18:43:49.085Z
+        namespace: username
+        open_issues_count: 0
+        path: /Users/username/projects/roles
+        scm: None
+        src: username.repo_name
+        stargazers_count: 0
+        travis_status_url: https://travis-ci.org/username/repo_name.svg?branch=master
+        version:
+        watchers_count: 1
+
+.. note::
+
+    The format of results pictured here is new in Ansible 2.0.
+
+
+List Installed Roles
+--------------------
+
+The list command shows the names of roles installed in roles_path.
+
+::
+
+    $ ansible-galaxy list
+
+The list of roles includes the installed version as well:
+
+::
+
+- chouseknecht.role-install_mongod, master
+- chouseknecht.test-role-1, v1.0.2
+- chrismeyersfsu.role-iptables, master
+- chrismeyersfsu.role-required_vars, master
+
+Remove an Installed Role
+------------------------
+
+The remove command will delete a role from roles_path:
+
+::
+
+    $ ansible-galaxy remove username.rolename
+
+Authenticate with Galaxy
+------------------------
+
+To use the import, delete and setup commands authentication with Galaxy is required. The login command will authenticate the user,retrieve a token from Galaxy, and store it in the user's home directory.
+
+::
+
+    $ ansible-galaxy login
+
+    We need your Github login to identify you.
+    This information will not be sent to Galaxy, only to api.github.com.
+    The password will not be displayed.
+
+    Use --github-token if you do not want to enter your password.
+
+    Github Username: dsmith
+    Password for dsmith:
+    Succesfully logged into Galaxy as dsmith
+
+As depicted above, the login command prompts for a GitHub username and password. It does not send this information to Galaxy. It actually authenticates with GitHub and creates a personal access token. It then sends the personal access token to Galaxy, which in turn verifies that you are you and returns an access token. The personal access token is then destroyed. No GitHub passwords or token are stored in Galaxy. 
+
+If you do not wish to use your GitHub password, or if you have two-factor authentication enabled with GitHub, use the --github-token option to pass a personal access token that you create. Log into GitHub, go to Settings and click on Personal Access Token to create a token. 
+
+Import a Role
+-------------
+
+New in Ansible 2.0 roles can be imported using ansible-galaxy. The import command expects that the user previously authenticated with Galaxy using the login command.
+
+Import any GitHub repo you have access to:
+
+::
+
+    $ ansible-galaxy import github_user github_repo
+
+By default the command will wait for the role to be imported by Galaxy, displaying the results as the import progresses:
+
+::
+
+    Successfully submitted import request 41
+    Starting import 41: role_name=myrole repo=githubuser/ansible-role-repo ref=
+    Retrieving Github repo githubuser/ansible-role-repo
+    Accessing branch: master
+    Parsing and validating meta/main.yml
+    Parsing galaxy_tags
+    Parsing platforms
+    Adding dependencies
+    Parsing and validating README.md
+    Adding repo tags as role versions
+    Import completed
+    Status SUCCESS : warnings=0 errors=0
+
+Use the --branch option to import a specific branch. If not specified, the default branch for the repo will be used.
+
+If the --no-wait option is present, the command will not wait for results. Results of the most recent import for any of your roles is available on the Galaxy web site under My Imports.
+
+.. note::
+
+    The import command is only available in Ansible 2.0.
+
+Delete a Role
+-------------
+
+Remove a role from the Galaxy web site using the delete command.  You can delete any role that you have access to in GitHub.
+
+::
+
+    ansible-galaxy delete github_user github_repo
+
+This only removes the role from Galaxy. It does not impact the actual GitHub repo.
+
+.. note::
+
+    The delete command is only available in Ansible 2.0.
+
+Setup Travis Integerations
+--------------------------
+
+Using the setup command you can enable notifications from `travis <http://travis-ci.org>`.
+
+::
+
+    $ ansible-galaxy setup travis github_user github_repo xxxtravistokenxxx
+
+    Added integration for travis chouseknecht/ansible-role-sendmail 
+
+The setup command requires your Travis token. The Travis token is not stored in Galaxy. It is used along with the GitHub username and repo to create a hash as described in `the Travis documentation <https://docs.travis-ci.com/user/notifications/>`. The calculated hash is stored in Galaxy and use to verify notifications received from Travis.
+
+The setup command enables Galaxy to respond to notifications. Follow the `Travis getting started guide <https://docs.travis-ci.com/user/getting-started/>` to enable the Travis build process for the role repository.
+
+When you create your .travis.yml file add the following to cause Travis to notify Galaxy when build has completed:
+
+::
+
+    notifications:
+        webhooks: https://galaxy.ansible.com/api/v1/notifications/
+
+.. note::
+
+    The setup command is only available in Ansible 2.0.
+
+
+List Travis Integrtions
+=======================
+
+Use the --list option to display your Travis integrations:
+
+    $ ansible-galaxy setup --list
+
+
+    ID         Source     Repo
+    ---------- ---------- ----------
+    2          travis     github_user/github_repo
+    1          travis     github_user/github_repo
+
+
+Remove Travis Integrations
+==========================
+
+Use the --remove option to disable a Travis integration:
+
+    $ ansible-galaxy setup --remove ID
+
+Provide the ID of the integration you want disabled. Use the --list option to get the ID.
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+
 

--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -221,20 +221,16 @@ This returns everything found in Galaxy for the role:
 List Installed Roles
 --------------------
 
-The list command shows the names of roles installed in roles_path.
+The list command shows the name and version of each role installed in roles_path.
 
 ::
 
     $ ansible-galaxy list
 
-The list of roles includes the installed version as well:
-
-::
-
-- chouseknecht.role-install_mongod, master
-- chouseknecht.test-role-1, v1.0.2
-- chrismeyersfsu.role-iptables, master
-- chrismeyersfsu.role-required_vars, master
+    - chouseknecht.role-install_mongod, master
+    - chouseknecht.test-role-1, v1.0.2
+    - chrismeyersfsu.role-iptables, master
+    - chrismeyersfsu.role-required_vars, master
 
 Remove an Installed Role
 ------------------------
@@ -264,14 +260,14 @@ To use the import, delete and setup commands authentication with Galaxy is requi
     Password for dsmith:
     Succesfully logged into Galaxy as dsmith
 
-As depicted above, the login command prompts for a GitHub username and password. It does not send this information to Galaxy. It actually authenticates with GitHub and creates a personal access token. It then sends the personal access token to Galaxy, which in turn verifies that you are you and returns an access token. The personal access token is then destroyed. No GitHub passwords or token are stored in Galaxy. 
+As depicted above, the login command prompts for a GitHub username and password. It does NOT send your password to Galaxy. It actually authenticates with GitHub and creates a personal access token. It then sends the personal access token to Galaxy, which in turn verifies that you are you and returns a Galaxy access token. After authentication completes the GitHub personal access token is destroyed. 
 
 If you do not wish to use your GitHub password, or if you have two-factor authentication enabled with GitHub, use the --github-token option to pass a personal access token that you create. Log into GitHub, go to Settings and click on Personal Access Token to create a token. 
 
 Import a Role
 -------------
 
-New in Ansible 2.0 roles can be imported using ansible-galaxy. The import command expects that the user previously authenticated with Galaxy using the login command.
+Roles can be imported using ansible-galaxy. The import command expects that the user previously authenticated with Galaxy using the login command.
 
 Import any GitHub repo you have access to:
 
@@ -307,7 +303,7 @@ If the --no-wait option is present, the command will not wait for results. Resul
 Delete a Role
 -------------
 
-Remove a role from the Galaxy web site using the delete command.  You can delete any role that you have access to in GitHub.
+Remove a role from the Galaxy web site using the delete command.  You can delete any role that you have access to in GitHub. The delete command expects that the user previously authenticated with Galaxy using the login command.
 
 ::
 
@@ -322,7 +318,7 @@ This only removes the role from Galaxy. It does not impact the actual GitHub rep
 Setup Travis Integerations
 --------------------------
 
-Using the setup command you can enable notifications from `travis <http://travis-ci.org>`.
+Using the setup command you can enable notifications from `travis <http://travis-ci.org>`. The setup command expects that the user previously authenticated with Galaxy using the login command.
 
 ::
 
@@ -351,6 +347,8 @@ List Travis Integrtions
 
 Use the --list option to display your Travis integrations:
 
+::
+
     $ ansible-galaxy setup --list
 
 
@@ -364,6 +362,8 @@ Remove Travis Integrations
 ==========================
 
 Use the --remove option to disable a Travis integration:
+
+::
 
     $ ansible-galaxy setup --remove ID
 

--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -140,7 +140,7 @@ def list_modules(module_dir, depth=0):
             if os.path.isdir(d):
 
                 res = list_modules(d, depth + 1)
-                for key in res.keys():
+                for key in list(res.keys()):
                     if key in categories:
                         categories[key] = merge_hash(categories[key], res[key])
                         res.pop(key, None)
@@ -451,7 +451,7 @@ def main():
 
     categories = list_modules(options.module_dir)
     last_category = None
-    category_names = categories.keys()
+    category_names = list(categories.keys())
     category_names.sort()
 
     category_list_path = os.path.join(options.output_dir, "modules_by_category.rst")

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -163,6 +163,9 @@ class AdHocCLI(CLI):
         else:
             cb = 'minimal'
 
+        if not C.DEFAULT_LOAD_CALLBACK_PLUGINS:
+            C.DEFAULT_CALLBACK_WHITELIST = []
+
         if self.options.tree:
             C.DEFAULT_CALLBACK_WHITELIST.append('tree')
             C.TREE_DIR = self.options.tree

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -22,12 +22,14 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os
 import os.path
 import sys
 import yaml
+import getpass
+import json
+import time
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from jinja2 import Environment
 
 import ansible.constants as C
@@ -36,7 +38,10 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.galaxy import Galaxy
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.role import GalaxyRole
+from ansible.galaxy.login import GalaxyLogin
+from ansible.galaxy.token import GalaxyToken
 from ansible.playbook.role.requirement import RoleRequirement
+from ansible.module_utils.urls import open_url
 
 try:
     from __main__ import display
@@ -44,17 +49,54 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-
 class GalaxyCLI(CLI):
 
-    VALID_ACTIONS = ("init", "info", "install", "list", "remove", "search")
-    SKIP_INFO_KEYS = ("name", "description", "readme_html", "related", "summary_fields", "average_aw_composite", "average_aw_score", "url" )
+    available_commands = OrderedDict([
+        ("delete",    "remove a role from Galaxy"),
+        ("import",    "add a role contained in a GitHub repo to Galaxy"),
+        ("info",      "display details about a particular role"),
+        ("init",      "create a role directory structure in your roles path"),
+        ("install",   "download a role into your roles path"),
+        ("list",      "enumerate roles found in your roles path"),
+        ("login",     "authenticate with Galaxy API and store the token"),
+        ("remove",    "delete a role from your roles path"),
+        ("search",    "query the Galaxy API"),
+        ("setup",     "add a TravisCI integration to Galaxy"),
+    ])
 
+    SKIP_INFO_KEYS = ("name", "description", "readme_html", "related", "summary_fields", "average_aw_composite", "average_aw_score", "url" )
+    
     def __init__(self, args):
+        
+        self.VALID_ACTIONS = []
+        for key in self.available_commands:
+            self.VALID_ACTIONS.append(key)
 
         self.api = None
         self.galaxy = None
         super(GalaxyCLI, self).__init__(args)
+
+    def set_action(self):
+        """
+        Get the action the user wants to execute from the sys argv list.
+        """
+        for i in range(0,len(self.args)):
+            arg = self.args[i]
+            if arg in self.VALID_ACTIONS:
+                self.action = arg
+                del self.args[i]
+                break
+
+        if not self.action:
+            self.show_available_actions()
+
+    def show_available_actions(self):
+        # list available commands
+        display.display(u'\n' + "usage: ansible-galaxy COMMAND [--help] [options] ...")
+        display.display(u'\n' + "availabe commands:" + u'\n\n')
+        for key in self.available_commands:
+            display.display(u'\t' + "%-12s %s" % (key, self.available_commands[key]))
+        display.display(' ')
 
     def parse(self):
         ''' create an options parser for bin/ansible '''
@@ -63,11 +105,21 @@ class GalaxyCLI(CLI):
             usage = "usage: %%prog [%s] [--help] [options] ..." % "|".join(self.VALID_ACTIONS),
             epilog = "\nSee '%s <command> --help' for more information on a specific command.\n\n" % os.path.basename(sys.argv[0])
         )
-
+        
         self.set_action()
 
         # options specific to actions
-        if self.action == "info":
+        if self.action == "delete":
+            self.parser.set_usage("usage: %prog delete [options] github_user github_repo")
+        elif self.action == "import":
+            self.parser.set_usage("usage: %prog import [options] github_user github_repo")
+            self.parser.add_option('-n', '--no-wait', dest='wait', action='store_false', default=True,
+                help='Don\'t wait for import results.')
+            self.parser.add_option('-b', '--branch', dest='reference',
+                help='The name of a branch to import. Defaults to the repository\'s default branch (usually master)')
+            self.parser.add_option('-t', '--status', dest='check_status', action='store_true', default=False,
+                help='Check the status of the most recent import request for given github_user/github_repo.')
+        elif self.action == "info":
             self.parser.set_usage("usage: %prog info [options] role_name[,version]")
         elif self.action == "init":
             self.parser.set_usage("usage: %prog init [options] role_name")
@@ -83,27 +135,40 @@ class GalaxyCLI(CLI):
             self.parser.add_option('-n', '--no-deps', dest='no_deps', action='store_true', default=False,
                 help='Don\'t download roles listed as dependencies')
             self.parser.add_option('-r', '--role-file', dest='role_file',
-                help='A file containing a list of roles to be imported')
+                help='A file containing a list of roles to be imported')    
         elif self.action == "remove":
             self.parser.set_usage("usage: %prog remove role1 role2 ...")
         elif self.action == "list":
             self.parser.set_usage("usage: %prog list [role_name]")
+        elif self.action == "login":
+            self.parser.set_usage("usage: %prog login [options]")
+            self.parser.add_option('-g','--github-token', dest='token', default=None,
+                help='Identify with github token rather than username and password.')
         elif self.action == "search":
             self.parser.add_option('--platforms', dest='platforms',
                 help='list of OS platforms to filter by')
             self.parser.add_option('--galaxy-tags', dest='tags',
                 help='list of galaxy tags to filter by')
-            self.parser.set_usage("usage: %prog search [<search_term>] [--galaxy-tags <galaxy_tag1,galaxy_tag2>] [--platforms platform]")
+            self.parser.add_option('--author', dest='author',
+                help='GitHub username')
+            self.parser.set_usage("usage: %prog search [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] [--author username]")
+        elif self.action == "setup":
+            self.parser.set_usage("usage: %prog setup [options] source github_uer github_repo secret" +
+                u'\n\n' + "Create an integration or web hook from travis.")
+            self.parser.add_option('-r', '--remove', dest='remove_id', default=None,
+                help='Remove the integration matching the provided ID value. Use --list to see ID values.')
+            self.parser.add_option('-l', '--list', dest="setup_list", action='store_true', default=False,
+                help='List all of your integrations.')
 
         # options that apply to more than one action
-        if self.action != "init":
+        if not self.action in ("config","import","init","login","setup"):
             self.parser.add_option('-p', '--roles-path', dest='roles_path', default=C.DEFAULT_ROLES_PATH,
                 help='The path to the directory containing your roles. '
                      'The default is the roles_path configured in your '
                      'ansible.cfg file (/etc/ansible/roles if not configured)')
 
-        if self.action in ("info","init","install","search"):
-            self.parser.add_option('-s', '--server', dest='api_server', default="https://galaxy.ansible.com",
+        if self.action in ("import","info","init","install","login","search","setup","delete"):
+            self.parser.add_option('-s', '--server', dest='api_server', default=C.GALAXY_SERVER,
                 help='The API server destination')
             self.parser.add_option('-c', '--ignore-certs', action='store_false', dest='validate_certs', default=True,
                 help='Ignore SSL certificate validation errors.')
@@ -112,23 +177,25 @@ class GalaxyCLI(CLI):
             self.parser.add_option('-f', '--force', dest='force', action='store_true', default=False,
                 help='Force overwriting an existing role')
 
-        # get options, args and galaxy object
-        self.options, self.args =self.parser.parse_args(self.args[1:])
-        display.verbosity = self.options.verbosity
-        self.galaxy = Galaxy(self.options)
+        if self.action:
+            # get options, args and galaxy object
+            self.options, self.args =self.parser.parse_args()
+            display.verbosity = self.options.verbosity
+            self.galaxy = Galaxy(self.options)
 
         return True
 
     def run(self):
 
+        if not self.action:
+            return True
+
         super(GalaxyCLI, self).run()
 
         # if not offline, get connect to galaxy api
-        if self.action in ("info","install", "search") or (self.action == 'init' and not self.options.offline):
-            api_server = self.options.api_server
-            self.api = GalaxyAPI(self.galaxy, api_server)
-            if not self.api:
-                raise AnsibleError("The API server (%s) is not responding, please try again later." % api_server)
+        if self.action in ("import","info","install","search","login","setup","delete") or \
+            (self.action == 'init' and not self.options.offline):            
+            self.api = GalaxyAPI(self.galaxy)
 
         self.execute()
 
@@ -188,7 +255,7 @@ class GalaxyCLI(CLI):
                             "however it will reset any main.yml files that may have\n"
                             "been modified there already." % role_path)
 
-        # create the default README.md
+        # create default README.md
         if not os.path.exists(role_path):
             os.makedirs(role_path)
         readme_path = os.path.join(role_path, "README.md")
@@ -196,9 +263,16 @@ class GalaxyCLI(CLI):
         f.write(self.galaxy.default_readme)
         f.close()
 
+        # create default .travis.yml
+        travis = Environment().from_string(self.galaxy.default_travis).render()
+        f = open(os.path.join(role_path, '.travis.yml'), 'w')
+        f.write(travis)
+        f.close()
+
         for dir in GalaxyRole.ROLE_DIRS:
             dir_path = os.path.join(init_path, role_name, dir)
             main_yml_path = os.path.join(dir_path, 'main.yml')
+
             # create the directory if it doesn't exist already
             if not os.path.exists(dir_path):
                 os.makedirs(dir_path)
@@ -234,6 +308,20 @@ class GalaxyCLI(CLI):
                 f.write(rendered_meta)
                 f.close()
                 pass
+            elif dir == "tests":
+                # create tests/test.yml
+                inject = dict(
+                    role_name = role_name
+                )
+                playbook = Environment().from_string(self.galaxy.default_test).render(inject)
+                f = open(os.path.join(dir_path, 'test.yml'), 'w')
+                f.write(playbook)
+                f.close()
+
+                # create tests/inventory
+                f = open(os.path.join(dir_path, 'inventory'), 'w')
+                f.write('localhost')
+                f.close()
             elif dir not in ('files','templates'):
                 # just write a (mostly) empty YAML file for main.yml
                 f = open(main_yml_path, 'w')
@@ -325,7 +413,7 @@ class GalaxyCLI(CLI):
 
                     for role in required_roles:
                         role = RoleRequirement.role_yaml_parse(role)
-                        display.debug('found role %s in yaml file' % str(role))
+                        display.vvv('found role %s in yaml file' % str(role))
                         if 'name' not in role and 'scm' not in role:
                             raise AnsibleError("Must specify name or src for role")
                         roles_left.append(GalaxyRole(self.galaxy, **role))
@@ -348,7 +436,7 @@ class GalaxyCLI(CLI):
                 roles_left.append(GalaxyRole(self.galaxy, rname.strip()))
 
         for role in roles_left:
-            display.debug('Installing role %s ' % role.name)
+            display.vvv('Installing role %s ' % role.name)
             # query the galaxy API for the role data
 
             if role.install_info is not None and not force:
@@ -458,21 +546,189 @@ class GalaxyCLI(CLI):
         return 0
 
     def execute_search(self):
-
+        page_size = 1000
         search = None
-        if len(self.args) > 1:
-            raise AnsibleOptionsError("At most a single search term is allowed.")
-        elif len(self.args) == 1:
-            search = self.args.pop()
+        
+        if len(self.args):
+            terms = []
+            for i in range(len(self.args)):
+               terms.append(self.args.pop())
+            search = '+'.join(terms)
 
-        response = self.api.search_roles(search, self.options.platforms, self.options.tags)
+        if not search and not self.options.platforms and not self.options.tags and not self.options.author:
+            raise AnsibleError("Invalid query. At least one search term, platform, galaxy tag or author must be provided.")
 
-        if 'count' in response:
-            display.display("Found %d roles matching your search:\n" % response['count'])
+        response = self.api.search_roles(search, platforms=self.options.platforms,
+            tags=self.options.tags, author=self.options.author, page_size=page_size)
+    
+        if response['count'] == 0:
+            display.display("No roles match your search.", color="yellow")
+            return True
 
         data = ''
-        if 'results' in response:
-            for role in response['results']:
-                data += self._display_role_info(role)
 
+        if response['count'] > page_size:
+            data += ("Found %d roles matching your search. Showing first %s.\n" % (response['count'], page_size))
+        else:
+            data += ("Found %d roles matching your search:\n" % response['count'])
+
+        max_len = []
+        for role in response['results']:
+            max_len.append(len(role['username'] + '.' + role['name']))
+        name_len = max(max_len)
+        format_str = " %%-%ds %%s\n" % name_len
+        data +='\n'
+        data += (format_str % ("Name", "Description"))
+        data += (format_str % ("----", "-----------"))
+        for role in response['results']:
+            data += (format_str % (role['username'] + '.' + role['name'],role['description']))
+            
         self.pager(data)
+
+        return True
+
+    def execute_login(self):
+        """
+        Verify user's identify via Github and retreive an auth token from Galaxy.
+        """
+        # Authenticate with github and retrieve a token
+        if self.options.token is None:
+            login = GalaxyLogin(self.galaxy)
+            github_token = login.create_github_token()
+        else:
+            github_token = self.options.token
+
+        galaxy_response = self.api.authenticate(github_token)
+        
+        if self.options.token is None:
+            # Remove the token we created
+            login.remove_github_token()
+        
+        # Store the Galaxy token 
+        token = GalaxyToken()
+        token.set(galaxy_response['token'])
+
+        display.display("Succesfully logged into Galaxy as %s" % galaxy_response['username'])
+        return 0
+
+    def execute_import(self):
+        """
+        Import a role into Galaxy
+        """
+        
+        colors = {
+            'INFO':    'normal',
+            'WARNING': 'yellow',
+            'ERROR':   'red',
+            'SUCCESS': 'green',
+            'FAILED':  'red'
+        }
+
+        if len(self.args) < 2:
+            raise AnsibleError("Expected a github_username and github_repository. Use --help.")
+
+        github_repo = self.args.pop()
+        github_user = self.args.pop()
+
+        if self.options.check_status:
+            task = self.api.get_import_task(github_user=github_user, github_repo=github_repo)
+        else:
+            # Submit an import request
+            task = self.api.create_import_task(github_user, github_repo, reference=self.options.reference)
+            
+            if len(task) > 1:
+                # found multiple roles associated with github_user/github_repo
+                display.display("WARNING: More than one Galaxy role associated with Github repo %s/%s." % (github_user,github_repo),
+                    color='yellow')
+                display.display("The following Galaxy roles are being updated:" + u'\n', color='yellow')
+                for t in task:
+                    display.display('%s.%s' % (t['summary_fields']['role']['namespace'],t['summary_fields']['role']['name']), color='yellow')
+                display.display(u'\n' + "To properly namespace this role, remove each of the above and re-import %s/%s from scratch" % (github_user,github_repo),
+                    color='yellow')
+                return 0
+            # found a single role as expected
+            display.display("Successfully submitted import request %d" % task[0]['id'])
+            if not self.options.wait:
+                display.display("Role name: %s" % task[0]['summary_fields']['role']['name'])
+                display.display("Repo: %s/%s" % (task[0]['github_user'],task[0]['github_repo']))
+
+        if self.options.check_status or self.options.wait:
+            # Get the status of the import
+            msg_list = []
+            finished = False
+            while not finished:
+                task = self.api.get_import_task(task_id=task[0]['id'])
+                for msg in task[0]['summary_fields']['task_messages']:
+                    if msg['id'] not in msg_list:
+                        display.display(msg['message_text'], color=colors[msg['message_type']])
+                        msg_list.append(msg['id'])
+                if task[0]['state'] in ['SUCCESS', 'FAILED']:
+                    finished = True
+                else:
+                    time.sleep(10)
+
+        return 0
+
+    def execute_setup(self):
+        """
+        Setup an integration from Github or Travis
+        """
+
+        if self.options.setup_list:
+            # List existing integration secrets
+            secrets = self.api.list_secrets()
+            if len(secrets) == 0:
+                # None found
+                display.display("No integrations found.")
+                return 0
+            display.display(u'\n' + "ID         Source     Repo", color="green")
+            display.display("---------- ---------- ----------", color="green")
+            for secret in secrets:
+                display.display("%-10s %-10s %s/%s" % (secret['id'], secret['source'], secret['github_user'],
+                    secret['github_repo']),color="green")
+            return 0
+
+        if self.options.remove_id:
+            # Remove a secret
+            self.api.remove_secret(self.options.remove_id)
+            display.display("Secret removed. Integrations using this secret will not longer work.", color="green")
+            return 0
+
+        if len(self.args) < 4:
+            raise AnsibleError("Missing one or more arguments. Expecting: source github_user github_repo secret")
+            return 0
+            
+        secret = self.args.pop()
+        github_repo = self.args.pop()
+        github_user = self.args.pop()
+        source = self.args.pop()
+
+        resp = self.api.add_secret(source, github_user, github_repo, secret)
+        display.display("Added integration for %s %s/%s" % (resp['source'], resp['github_user'], resp['github_repo']))
+
+        return 0
+
+    def execute_delete(self):
+        """
+        Delete a role from galaxy.ansible.com
+        """
+
+        if len(self.args) < 2:
+            raise AnsibleError("Missing one or more arguments. Expected: github_user github_repo")
+        
+        github_repo = self.args.pop()
+        github_user = self.args.pop()
+        resp = self.api.delete_role(github_user, github_repo)
+
+        if len(resp['deleted_roles']) > 1:
+            display.display("Deleted the following roles:")
+            display.display("ID     User            Name")
+            display.display("------ --------------- ----------")
+            for role in resp['deleted_roles']:
+                display.display("%-8s %-15s %s" % (role.id,role.namespace,role.name))
+        
+        display.display(resp['status'])
+
+        return True
+
+        

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -25,7 +25,6 @@ __metaclass__ = type
 import os.path
 import sys
 import yaml
-import getpass
 import json
 import time
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -152,8 +152,8 @@ class GalaxyCLI(CLI):
                 help='GitHub username')
             self.parser.set_usage("usage: %prog search [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] [--author username]")
         elif self.action == "setup":
-            self.parser.set_usage("usage: %prog setup [options] source github_uer github_repo secret" +
-                u'\n\n' + "Create an integration or web hook from travis.")
+            self.parser.set_usage("usage: %prog setup [options] source github_user github_repo secret" +
+                u'\n\n' + "Create an integration with travis.")
             self.parser.add_option('-r', '--remove', dest='remove_id', default=None,
                 help='Remove the integration matching the provided ID value. Use --list to see ID values.')
             self.parser.add_option('-l', '--list', dest="setup_list", action='store_true', default=False,

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -263,6 +263,7 @@ GALAXY_SCMS                    = get_config(p, 'galaxy', 'scms', 'ANSIBLE_GALAXY
 
 # characters included in auto-generated passwords
 DEFAULT_PASSWORD_CHARS = ascii_letters + digits + ".,:-_"
+STRING_TYPE_FILTERS = get_config(p, 'jinja2', 'dont_type_filters', 'ANSIBLE_STRING_TYPE_FILTERS', ['string', 'to_json', 'to_nice_json', 'to_yaml', 'ppretty', 'json'], islist=True )
 
 # non-configurable things
 MODULE_REQUIRE_ARGS       = ['command', 'shell', 'raw', 'script']

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -255,7 +255,9 @@ ACCELERATE_MULTI_KEY           = get_config(p, 'accelerate', 'accelerate_multi_k
 PARAMIKO_PTY                   = get_config(p, 'paramiko_connection', 'pty', 'ANSIBLE_PARAMIKO_PTY', True, boolean=True)
 
 # galaxy related
-DEFAULT_GALAXY_URI             = get_config(p, 'galaxy', 'server_uri', 'ANSIBLE_GALAXY_SERVER_URI', 'https://galaxy.ansible.com')
+GALAXY_SERVER                  = get_config(p, 'galaxy', 'server', 'ANSIBLE_GALAXY_SERVER', 'https://galaxy.ansible.com')
+GALAXY_IGNORE_CERTS            = get_config(p, 'galaxy', 'ignore_certs', 'ANSIBLE_GALAXY_IGNORE', False, boolean=True)
+
 # this can be configured to blacklist SCMS but cannot add new ones unless the code is also updated
 GALAXY_SCMS                    = get_config(p, 'galaxy', 'scms', 'ANSIBLE_GALAXY_SCMS', 'git, hg', islist=True)
 

--- a/lib/ansible/galaxy/__init__.py
+++ b/lib/ansible/galaxy/__init__.py
@@ -52,6 +52,8 @@ class Galaxy(object):
         #TODO: move to getter for lazy loading
         self.default_readme = self._str_from_data_file('readme')
         self.default_meta = self._str_from_data_file('metadata_template.j2')
+        self.default_test = self._str_from_data_file('test_playbook.j2')
+        self.default_travis = self._str_from_data_file('travis.j2')
 
     def add_role(self, role):
         self.roles[role.name] = role

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -25,11 +25,15 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
+import urllib
+
 from urllib2 import quote as urlquote, HTTPError
 from urlparse import urlparse
 
+import ansible.constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils.urls import open_url
+from ansible.galaxy.token import GalaxyToken
 
 try:
     from __main__ import display
@@ -43,45 +47,113 @@ class GalaxyAPI(object):
 
     SUPPORTED_VERSIONS = ['v1']
 
-    def __init__(self, galaxy, api_server):
+    def __init__(self, galaxy):
 
         self.galaxy = galaxy
+        self.token = GalaxyToken()
+        self._api_server = C.GALAXY_SERVER
+        self._validate_certs = C.GALAXY_IGNORE_CERTS
 
-        try:
-            urlparse(api_server, scheme='https')
-        except:
-            raise AnsibleError("Invalid server API url passed: %s" % api_server)
+        # set validate_certs
+        if galaxy.options.validate_certs == False:
+            self._validate_certs = False
+        display.vvv('Check for valid certs: %s' % self._validate_certs)
 
-        server_version = self.get_server_api_version('%s/api/' % (api_server))
-        if not server_version:
-            raise AnsibleError("Could not retrieve server API version: %s" % api_server)
+        # set the API server
+        if galaxy.options.api_server != C.GALAXY_SERVER:
+            self._api_server = galaxy.options.api_server
+        display.vvv("Connecting to galaxy_server: %s" % self._api_server)
 
+        server_version = self.get_server_api_version()
+       
         if server_version in self.SUPPORTED_VERSIONS:
-            self.baseurl = '%s/api/%s' % (api_server, server_version)
+            self.baseurl = '%s/api/%s' % (self._api_server, server_version)
             self.version = server_version # for future use
-            display.vvvvv("Base API: %s" % self.baseurl)
+            display.vvv("Base API: %s" % self.baseurl)
         else:
             raise AnsibleError("Unsupported Galaxy server API version: %s" % server_version)
 
-    def get_server_api_version(self, api_server):
+    def __auth_header(self):
+        token = self.token.get()
+        if token is None:
+            raise AnsibleError("No access token. You must first use login to authenticate and obtain an access token.")
+        return {'Authorization': 'Token ' + token}
+
+    def __call_galaxy(self, url, args=None, headers=None, method=None):
+        if args and not headers:
+            headers = self.__auth_header()
+        try:
+            display.vvv(url)
+            resp = open_url(url, data=args, validate_certs=self._validate_certs, headers=headers, method=method)
+            data = json.load(resp)
+        except HTTPError as e:
+            res = json.load(e)
+            raise AnsibleError(res['detail'])
+        return data
+
+    @property
+    def api_server(self):
+        return self._api_server    
+    
+    @property
+    def validate_certs(self):
+        return self._validate_certs
+
+    def get_server_api_version(self):
         """
         Fetches the Galaxy API current version to ensure
         the API server is up and reachable.
         """
-        #TODO: fix galaxy server which returns current_version path (/api/v1) vs actual version (v1)
-        # also should set baseurl using supported_versions which has path
-        return 'v1'
-
         try:
-            data = json.load(open_url(api_server, validate_certs=self.galaxy.options.validate_certs))
-            return data.get("current_version", 'v1')
-        except Exception:
-            # TODO: report error
-            return None
+            url = '%s/api/' % self._api_server
+            data = json.load(open_url(url, validate_certs=self._validate_certs))
+            return data['current_version']
+        except Exception as e:
+            raise AnsibleError("The API server (%s) is not responding, please try again later." % url)
+        
+    def authenticate(self, github_token):
+        """
+        Retrieve an authentication token
+        """
+        url = '%s/tokens/' % self.baseurl
+        args = urllib.urlencode({"github_token": github_token})
+        resp = open_url(url, data=args, validate_certs=self._validate_certs, method="POST")
+        data = json.load(resp)
+        return data
 
+    def create_import_task(self, github_user, github_repo, reference=None):
+        """
+        Post an import request
+        """
+        url = '%s/imports/' % self.baseurl
+        args = urllib.urlencode({
+            "github_user": github_user,
+            "github_repo": github_repo,
+            "github_reference": reference if reference else ""
+        })
+        data = self.__call_galaxy(url, args=args)
+        if data.get('results', None):
+            return data['results']
+        return data
+
+    def get_import_task(self, task_id=None, github_user=None, github_repo=None):
+        """
+        Check the status of an import task.
+        """
+        url = '%s/imports/' % self.baseurl
+        if not task_id is None:
+            url = "%s?id=%d" % (url,task_id)
+        elif not github_user is None and not github_repo is None:
+            url = "%s?github_user=%s&github_repo=%s" % (url,github_user,github_repo)
+        else:
+            raise AnsibleError("Expected task_id or github_user and github_repo")
+        
+        data = self.__call_galaxy(url)
+        return data['results']
+       
     def lookup_role_by_name(self, role_name, notify=True):
         """
-        Find a role by name
+        Find a role by name.
         """
         role_name = urlquote(role_name)
 
@@ -92,18 +164,12 @@ class GalaxyAPI(object):
             if notify:
                 display.display("- downloading role '%s', owned by %s" % (role_name, user_name))
         except:
-            raise AnsibleError("- invalid role name (%s). Specify role as format: username.rolename" % role_name)
+            raise AnsibleError("Invalid role name (%s). Specify role as format: username.rolename" % role_name)
 
         url = '%s/roles/?owner__username=%s&name=%s' % (self.baseurl, user_name, role_name)
-        display.vvvv("- %s" % (url))
-        try:
-            data = json.load(open_url(url, validate_certs=self.galaxy.options.validate_certs))
-            if len(data["results"]) != 0:
-                return data["results"][0]
-        except:
-            # TODO: report on connection/availability errors
-            pass
-
+        data = self.__call_galaxy(url)
+        if len(data["results"]) != 0:
+            return data["results"][0]
         return None
 
     def fetch_role_related(self, related, role_id):
@@ -114,13 +180,12 @@ class GalaxyAPI(object):
 
         try:
             url = '%s/roles/%d/%s/?page_size=50' % (self.baseurl, int(role_id), related)
-            data = json.load(open_url(url, validate_certs=self.galaxy.options.validate_certs))
+            data = self.__call_galaxy(url)
             results = data['results']
             done = (data.get('next', None) is None)
             while not done:
                 url = '%s%s' % (self.baseurl, data['next'])
-                display.display(url)
-                data = json.load(open_url(url, validate_certs=self.galaxy.options.validate_certs))
+                data = self.__call_galaxy(url)
                 results += data['results']
                 done = (data.get('next', None) is None)
             return results
@@ -131,10 +196,9 @@ class GalaxyAPI(object):
         """
         Fetch the list of items specified.
         """
-
         try:
             url = '%s/%s/?page_size' % (self.baseurl, what)
-            data = json.load(open_url(url, validate_certs=self.galaxy.options.validate_certs))
+            data = self.__call_galaxy(url)
             if "results" in data:
                 results = data['results']
             else:
@@ -144,41 +208,64 @@ class GalaxyAPI(object):
                 done = (data.get('next', None) is None)
             while not done:
                 url = '%s%s' % (self.baseurl, data['next'])
-                display.display(url)
-                data = json.load(open_url(url, validate_certs=self.galaxy.options.validate_certs))
+                data = self.__call_galaxy(url)
                 results += data['results']
                 done = (data.get('next', None) is None)
             return results
         except Exception as error:
             raise AnsibleError("Failed to download the %s list: %s" % (what, str(error)))
 
-    def search_roles(self, search, platforms=None, tags=None):
+    def search_roles(self, search, **kwargs):
 
-        search_url = self.baseurl + '/roles/?page=1'
+        search_url = self.baseurl + '/search/roles/?'
 
         if search:
-            search_url += '&search=' + urlquote(search)
+            search_url += '&autocomplete=' + urlquote(search)
 
-        if tags is None:
-            tags = []
-        elif isinstance(tags, basestring):
+        tags = kwargs.get('tags',None)
+        platforms = kwargs.get('platforms', None)
+        page_size = kwargs.get('page_size', None)
+        author = kwargs.get('author', None)
+
+        if tags and isinstance(tags, basestring):
             tags = tags.split(',')
-
-        for tag in tags:
-            search_url += '&chain__tags__name=' + urlquote(tag)
-
-        if platforms is None:
-            platforms = []
-        elif isinstance(platforms, basestring):
+            search_url += '&tags_autocomplete=' + '+'.join(tags)
+        
+        if platforms and isinstance(platforms, basestring):
             platforms = platforms.split(',')
+            search_url += '&platforms_autocomplete=' + '+'.join(platforms)
 
-        for plat in platforms:
-            search_url += '&chain__platforms__name=' + urlquote(plat)
+        if page_size:
+            search_url += '&page_size=%s' % page_size
 
-        display.debug("Executing query: %s" % search_url)
-        try:
-            data = json.load(open_url(search_url, validate_certs=self.galaxy.options.validate_certs))
-        except HTTPError as e:
-            raise AnsibleError("Unsuccessful request to server: %s" % str(e))
+        if author:
+            search_url += '&username_autocomplete=%s' % author
+   
+        data = self.__call_galaxy(search_url)
+        return data
 
+    def add_secret(self, source, github_user, github_repo, secret):
+        url = "%s/notification_secrets/" % self.baseurl
+        args = urllib.urlencode({
+            "source": source,
+            "github_user": github_user,
+            "github_repo": github_repo,
+            "secret": secret
+        })
+        data = self.__call_galaxy(url, args=args)
+        return data
+
+    def list_secrets(self):
+        url = "%s/notification_secrets" % self.baseurl
+        data = self.__call_galaxy(url, headers=self.__auth_header())
+        return data
+
+    def remove_secret(self, secret_id):
+        url = "%s/notification_secrets/%s/" % (self.baseurl, secret_id)
+        data = self.__call_galaxy(url, headers=self.__auth_header(), method='DELETE')
+        return data
+
+    def delete_role(self, github_user, github_repo):
+        url = "%s/removerole/?github_user=%s&github_repo=%s" % (self.baseurl,github_user,github_repo)
+        data = self.__call_galaxy(url, headers=self.__auth_header(), method='DELETE')
         return data

--- a/lib/ansible/galaxy/data/metadata_template.j2
+++ b/lib/ansible/galaxy/data/metadata_template.j2
@@ -2,9 +2,11 @@ galaxy_info:
   author: {{ author }}
   description: {{description}}
   company: {{ company }}
+  
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
   # issue_tracker_url: {{ issue_tracker_url }}
+  
   # Some suggested licenses:
   # - BSD (default)
   # - MIT
@@ -13,7 +15,17 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: {{ license }}
+  
   min_ansible_version: {{ min_ansible_version }}
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If travis integration is cofigured, only notification for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+  
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your
@@ -28,6 +40,7 @@ galaxy_info:
   #  - {{ version }}
     {%- endfor %}
   {%- endfor %}
+  
   galaxy_tags: []
     # List tags for your role here, one per line. A tag is
     # a keyword that describes and categorizes the role.
@@ -36,6 +49,7 @@ galaxy_info:
     #
     # NOTE: A tag is limited to a single word comprised of
     # alphanumeric characters. Maximum 20 tags per role.
+
 dependencies: []
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies

--- a/lib/ansible/galaxy/data/test_playbook.j2
+++ b/lib/ansible/galaxy/data/test_playbook.j2
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - {{ role_name }}

--- a/lib/ansible/galaxy/data/travis.j2
+++ b/lib/ansible/galaxy/data/travis.j2
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/lib/ansible/galaxy/login.py
+++ b/lib/ansible/galaxy/login.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+########################################################################
+#
+# (C) 2015, Chris Houseknecht <chouse@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+########################################################################
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import getpass
+import json
+import urllib
+
+from urllib2 import quote as urlquote, HTTPError
+from urlparse import urlparse
+
+from ansible.errors import AnsibleError, AnsibleOptionsError
+from ansible.module_utils.urls import open_url
+from ansible.utils.color import stringc
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+class GalaxyLogin(object):
+    ''' Class to handle authenticating user with Galaxy API prior to performing CUD operations '''
+
+    GITHUB_AUTH = 'https://api.github.com/authorizations'
+    
+    def __init__(self, galaxy, github_token=None):
+        self.galaxy = galaxy
+        self.github_username = None
+        self.github_password = None
+        
+        if github_token == None:
+            self.get_credentials()
+
+    def get_credentials(self):
+        display.display(u'\n\n' + "We need your " + stringc("Github login",'bright cyan') + 
+            " to identify you.", screen_only=True)
+        display.display("This information will " + stringc("not be sent to Galaxy",'bright cyan') + 
+            ", only to " + stringc("api.github.com.","yellow"), screen_only=True)
+        display.display("The password will not be displayed." + u'\n\n', screen_only=True)
+        display.display("Use " + stringc("--github-token",'yellow') + 
+            " if you do not want to enter your password." + u'\n\n', screen_only=True)
+        
+        try:
+            self.github_username = raw_input("Github Username: ")
+        except:
+            pass
+
+        try:
+            self.github_password = getpass.getpass("Password for %s: " % self.github_username)
+        except:
+            pass
+
+        if not self.github_username or not self.github_password:
+            raise AnsibleError("Invalid Github credentials. Username and password are required.")
+
+    def remove_github_token(self):
+        '''
+        If for some reason an ansible-galaxy token was left from a prior login, remove it. We cannot
+        retrieve the token after creation, so we are forced to create a new one.
+        '''
+        try:
+            tokens = json.load(open_url(self.GITHUB_AUTH, url_username=self.github_username,
+                url_password=self.github_password, force_basic_auth=True,))
+        except HTTPError as e:
+            res = json.load(e)
+            raise AnsibleError(res['message'])
+
+        for token in tokens:
+            if token['note'] == 'ansible-galaxy login':
+                display.vvvvv('removing token: %s' % token['token_last_eight'])
+                try: 
+                    open_url('https://api.github.com/authorizations/%d' % token['id'], url_username=self.github_username,
+                        url_password=self.github_password, method='DELETE', force_basic_auth=True,)
+                except HTTPError as e:
+                    res = json.load(e)
+                    raise AnsibleError(res['message'])
+
+    def create_github_token(self):
+        '''
+        Create a personal authorization token with a note of 'ansible-galaxy login'
+        '''
+        self.remove_github_token()
+        args = json.dumps({"scopes":["public_repo"], "note":"ansible-galaxy login"})
+        try:
+            data = json.load(open_url(self.GITHUB_AUTH, url_username=self.github_username,
+                url_password=self.github_password, force_basic_auth=True, data=args))
+        except HTTPError as e:
+            res = json.load(e)
+            raise AnsibleError(res['message'])
+        return data['token']

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -46,7 +46,7 @@ class GalaxyRole(object):
     SUPPORTED_SCMS = set(['git', 'hg'])
     META_MAIN = os.path.join('meta', 'main.yml')
     META_INSTALL = os.path.join('meta', '.galaxy_install_info')
-    ROLE_DIRS = ('defaults','files','handlers','meta','tasks','templates','vars')
+    ROLE_DIRS = ('defaults','files','handlers','meta','tasks','templates','vars','tests')
 
 
     def __init__(self, galaxy, name, src=None, version=None, scm=None, path=None):
@@ -198,10 +198,10 @@ class GalaxyRole(object):
                 role_data = self.src
                 tmp_file = self.fetch(role_data)
             else:
-                api = GalaxyAPI(self.galaxy, self.options.api_server)
+                api = GalaxyAPI(self.galaxy)
                 role_data = api.lookup_role_by_name(self.src)
                 if not role_data:
-                    raise AnsibleError("- sorry, %s was not found on %s." % (self.src, self.options.api_server))
+                    raise AnsibleError("- sorry, %s was not found on %s." % (self.src, api.api_server))
 
                 role_versions = api.fetch_role_related('versions', role_data['id'])
                 if not self.version:
@@ -213,8 +213,10 @@ class GalaxyRole(object):
                         loose_versions = [LooseVersion(a.get('name',None)) for a in role_versions]
                         loose_versions.sort()
                         self.version = str(loose_versions[-1])
+                    elif role_data.get('github_branch', None):
+                        self.version = role_data['github_branch']
                     else:
-                        self.version = 'master'
+                        self.version = 'master' 
                 elif self.version != 'master':
                     if role_versions and self.version not in [a.get('name', None) for a in role_versions]:
                         raise AnsibleError("- the specified version (%s) of %s was not found in the list of available versions (%s)." % (self.version, self.name, role_versions))

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+########################################################################
+#
+# (C) 2015, Chris Houseknecht <chouse@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+########################################################################
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import yaml
+from stat import *
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+class GalaxyToken(object):
+    ''' Class to storing and retrieving token in ~/.ansible_galaxy '''
+
+    def __init__(self):
+        self.file = os.path.expanduser("~") + '/.ansible_galaxy'
+        self.config = yaml.safe_load(self.__open_config_for_read())
+        if not self.config:
+            self.config = {}
+        
+    def __open_config_for_read(self):
+        if os.path.isfile(self.file):
+            display.vvv('Opened %s' % self.file)
+            return open(self.file, 'r')
+        # config.yml not found, create and chomd u+rw
+        f = open(self.file,'w')
+        f.close()
+        os.chmod(self.file,S_IRUSR|S_IWUSR) # owner has +rw
+        display.vvv('Created %s' % self.file) 
+        return open(self.file, 'r')
+
+    def set(self, token): 
+        self.config['token'] = token
+        self.save()
+    
+    def get(self):
+        return self.config.get('token', None)
+    
+    def save(self):
+        with open(self.file,'w') as f:
+            yaml.safe_dump(self.config,f,default_flow_style=False)
+        

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -524,7 +524,10 @@ class Facts(object):
         keytypes = ('dsa', 'rsa', 'ecdsa', 'ed25519')
 
         if self.facts['system'] == 'Darwin':
-            keydir = '/etc'
+            if self.facts['distribution'] == 'MacOSX' and LooseVersion(self.facts['distribution_version']) >= LooseVersion('10.11') :
+                keydir = '/etc/ssh'
+            else:
+                keydir = '/etc'
         else:
             keydir = '/etc/ssh'
 

--- a/lib/ansible/module_utils/nxapi.py
+++ b/lib/ansible/module_utils/nxapi.py
@@ -32,16 +32,16 @@ from ansible.module_utils.nxapi import *
 
 The nxapi module provides the following common argument spec:
 
-    * host (str) - [Required] The IPv4 address or FQDN of the network device
+    * host (str) - The IPv4 address or FQDN of the network device
 
     * port (str) - Overrides the default port to use for the HTTP/S
         connection.  The default values are 80 for HTTP and
         443 for HTTPS
 
-    * url_username (str) - [Required] The username to use to authenticate
+    * username (str) - The username to use to authenticate
         the HTTP/S connection.  Aliases: username
 
-    * url_password (str) - [Required] The password to use to authenticate
+    * password (str) - The password to use to authenticate
         the HTTP/S connection.  Aliases: password
 
     * use_ssl (bool) - Specifies whether or not to use an encrypted (HTTPS)
@@ -51,6 +51,10 @@ The nxapi module provides the following common argument spec:
         device.  Valid values in `cli_show`, `cli_show_ascii`, 'cli_conf`
         and `bash`.  The default value is `cli_show_ascii`
 
+    * device (dict) - Used to send the entire set of connection parameters
+        as a dict object.  This argument is mutually exclusive with the
+        host argument
+
 In order to communicate with Cisco NXOS devices, the NXAPI feature
 must be enabled and configured on the device.
 
@@ -58,34 +62,52 @@ must be enabled and configured on the device.
 
 NXAPI_COMMAND_TYPES = ['cli_show', 'cli_show_ascii', 'cli_conf', 'bash']
 
-def nxapi_argument_spec(spec=None):
-    """Creates an argument spec for working with NXAPI
-    """
-    arg_spec = url_argument_spec()
-    arg_spec.update(dict(
-        host=dict(required=True),
-        port=dict(),
-        url_username=dict(required=True, aliases=['username']),
-        url_password=dict(required=True, aliases=['password']),
-        use_ssl=dict(default=False, type='bool'),
-        command_type=dict(default='cli_show_ascii', choices=NXAPI_COMMAND_TYPES)
-    ))
-    if spec:
-        arg_spec.update(spec)
-    return arg_spec
+NXAPI_COMMON_ARGS = dict(
+    host=dict(),
+    port=dict(),
+    username=dict(),
+    password=dict(),
+    use_ssl=dict(default=False, type='bool'),
+    device=dict(),
+    command_type=dict(default='cli_show_ascii', choices=NXAPI_COMMAND_TYPES)
+)
 
-def nxapi_url(module):
+def nxapi_module(**kwargs):
+    """Append the common args to the argument_spec
+    """
+    spec = kwargs.get('argument_spec') or dict()
+
+    argument_spec = url_argument_spec()
+    argument_spec.update(NXAPI_COMMON_ARGS)
+    if kwargs.get('argument_spec'):
+        argument_spec.update(kwargs['argument_spec'])
+    kwargs['argument_spec'] = argument_spec
+
+    module = AnsibleModule(**kwargs)
+
+    device = module.params.get('device') or dict()
+    for key, value in device.iteritems():
+        if key in NXAPI_COMMON_ARGS:
+            module.params[key] = value
+
+    params = json_dict_unicode_to_bytes(json.loads(MODULE_COMPLEX_ARGS))
+    for key, value in params.iteritems():
+        if key != 'device':
+            module.params[key] = value
+
+    return module
+
+def nxapi_url(params):
     """Constructs a valid NXAPI url
     """
-    if module.params['use_ssl']:
+    if params['use_ssl']:
         proto = 'https'
     else:
         proto = 'http'
-    host = module.params['host']
+    host = params['host']
     url = '{}://{}'.format(proto, host)
-    port = module.params['port']
-    if module.params['port']:
-        url = '{}:{}'.format(url, module.params['port'])
+    if params['port']:
+        url = '{}:{}'.format(url, params['port'])
     url = '{}/ins'.format(url)
     return url
 
@@ -109,7 +131,7 @@ def nxapi_body(commands, command_type, **kwargs):
 def nxapi_command(module, commands, command_type=None, **kwargs):
     """Sends the list of commands to the device over NXAPI
     """
-    url = nxapi_url(module)
+    url = nxapi_url(module.params)
 
     command_type = command_type or module.params['command_type']
 
@@ -117,6 +139,9 @@ def nxapi_command(module, commands, command_type=None, **kwargs):
     data = module.jsonify(data)
 
     headers = {'Content-Type': 'text/json'}
+
+    module.params['url_username'] = module.params['username']
+    module.params['url_password'] = module.params['password']
 
     response, headers = fetch_url(module, url, data=data, headers=headers,
                                   method='POST')

--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -65,8 +65,8 @@ def parse_kv(args, check_raw=False):
                 raise
 
         raw_params = []
-        for x in vargs:
-            x = _decode_escapes(x)
+        for orig_x in vargs:
+            x = _decode_escapes(orig_x)
             if "=" in x:
                 pos = 0
                 try:
@@ -90,7 +90,7 @@ def parse_kv(args, check_raw=False):
                 else:
                     options[k.strip()] = unquote(v.strip())
             else:
-                raw_params.append(x)
+                raw_params.append(orig_x)
 
         # recombine the free-form params, if any were found, and assign
         # them to a special option for use later by the shell/command module

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -34,6 +34,7 @@ class Block(Base, Become, Conditional, Taggable):
     _rescue = FieldAttribute(isa='list', default=[])
     _always = FieldAttribute(isa='list', default=[])
     _delegate_to = FieldAttribute(isa='list')
+    _delegate_facts = FieldAttribute(isa='bool', defalt=False)
 
     # for future consideration? this would be functionally
     # similar to the 'else' clause for exceptions

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -34,7 +34,7 @@ class Block(Base, Become, Conditional, Taggable):
     _rescue = FieldAttribute(isa='list', default=[])
     _always = FieldAttribute(isa='list', default=[])
     _delegate_to = FieldAttribute(isa='list')
-    _delegate_facts = FieldAttribute(isa='bool', defalt=False)
+    _delegate_facts = FieldAttribute(isa='bool', default=False)
 
     # for future consideration? this would be functionally
     # similar to the 'else' clause for exceptions

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -395,6 +395,10 @@ class PlayContext(Base):
         # set become defaults if not previouslly set
         task.set_become_defaults(new_info.become, new_info.become_method, new_info.become_user)
 
+        # have always_run override check mode
+        if task.always_run:
+            new_info.check_mode = False
+
         return new_info
 
     def make_become_cmd(self, cmd, executable=None):

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -61,6 +61,7 @@ def hash_params(params):
 class Role(Base, Become, Conditional, Taggable):
 
     _delegate_to = FieldAttribute(isa='string')
+    _delegate_facts = FieldAttribute(isa='bool', defalt=False)
 
     def __init__(self, play=None):
         self._role_name        = None

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -61,7 +61,7 @@ def hash_params(params):
 class Role(Base, Become, Conditional, Taggable):
 
     _delegate_to = FieldAttribute(isa='string')
-    _delegate_facts = FieldAttribute(isa='bool', defalt=False)
+    _delegate_facts = FieldAttribute(isa='bool', default=False)
 
     def __init__(self, play=None):
         self._role_name        = None

--- a/lib/ansible/playbook/role/include.py
+++ b/lib/ansible/playbook/role/include.py
@@ -40,7 +40,8 @@ class RoleInclude(RoleDefinition):
     is included for execution in a play.
     """
 
-    _delegate_to          = FieldAttribute(isa='string')
+    _delegate_to    = FieldAttribute(isa='string')
+    _delegate_facts = FieldAttribute(isa='bool', defalt=False)
 
     def __init__(self, play=None, role_basedir=None, variable_manager=None, loader=None):
         super(RoleInclude, self).__init__(play=play, role_basedir=role_basedir, variable_manager=variable_manager, loader=loader)

--- a/lib/ansible/playbook/role/include.py
+++ b/lib/ansible/playbook/role/include.py
@@ -41,7 +41,7 @@ class RoleInclude(RoleDefinition):
     """
 
     _delegate_to    = FieldAttribute(isa='string')
-    _delegate_facts = FieldAttribute(isa='bool', defalt=False)
+    _delegate_facts = FieldAttribute(isa='bool', default=False)
 
     def __init__(self, play=None, role_basedir=None, variable_manager=None, loader=None):
         super(RoleInclude, self).__init__(play=play, role_basedir=role_basedir, variable_manager=variable_manager, loader=loader)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -72,7 +72,7 @@ class Task(Base, Conditional, Taggable, Become):
     _changed_when         = FieldAttribute(isa='string')
     _delay                = FieldAttribute(isa='int', default=5)
     _delegate_to          = FieldAttribute(isa='string')
-    _delegate_facts       = FieldAttribute(isa='bool', defalt=False)
+    _delegate_facts       = FieldAttribute(isa='bool', default=False)
     _failed_when          = FieldAttribute(isa='string')
     _first_available_file = FieldAttribute(isa='list')
     _loop                 = FieldAttribute(isa='string', private=True)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -72,6 +72,7 @@ class Task(Base, Conditional, Taggable, Become):
     _changed_when         = FieldAttribute(isa='string')
     _delay                = FieldAttribute(isa='int', default=5)
     _delegate_to          = FieldAttribute(isa='string')
+    _delegate_facts       = FieldAttribute(isa='bool', defalt=False)
     _failed_when          = FieldAttribute(isa='string')
     _first_available_file = FieldAttribute(isa='list')
     _loop                 = FieldAttribute(isa='string', private=True)

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -157,7 +157,7 @@ class ActionModule(ActionBase):
             if self._play_context.diff:
                 diff = self._get_diff_data(dest, resultant, task_vars, source_file=False)
 
-            if not self._play_context.check_mode or self._task.always_run: # do actual work thorugh copy
+            if not self._play_context.check_mode: # do actual work thorugh copy
                 xfered = self._transfer_data(self._connection._shell.join_path(tmp, 'source'), resultant)
 
                 # fix file permissions when the copy is done as a different user

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -157,7 +157,7 @@ class ActionModule(ActionBase):
             if self._play_context.diff:
                 diff = self._get_diff_data(dest, resultant, task_vars, source_file=False)
 
-            if not self._play_context.check_mode: # do actual work thorugh copy
+            if not self._play_context.check_mode or self._task.always_run: # do actual work thorugh copy
                 xfered = self._transfer_data(self._connection._shell.join_path(tmp, 'source'), resultant)
 
                 # fix file permissions when the copy is done as a different user

--- a/lib/ansible/plugins/callback/tree.py
+++ b/lib/ansible/plugins/callback/tree.py
@@ -41,7 +41,8 @@ class CallbackModule(CallbackBase):
 
         self.tree = TREE_DIR
         if not self.tree:
-            self._display.warnings("Disabling tree callback, invalid directory provided to tree option: %s" % self.tree)
+            self.tree = os.path.expanduser("~/.ansible/tree")
+            self._display.warning("Defaulting to ~/.ansible/tree, invalid directory provided to tree option: %s" % self.tree)
 
     def write_tree_file(self, hostname, buf):
         ''' write something into treedir/hostname '''
@@ -53,7 +54,7 @@ class CallbackModule(CallbackBase):
             with open(path, 'wb+') as fd:
                 fd.write(buf)
         except (OSError, IOError) as e:
-            self._display.warnings("Unable to write to %s's file: %s" % (hostname, str(e)))
+            self._display.warning("Unable to write to %s's file: %s" % (hostname, str(e)))
 
     def result_to_tree(self, result):
         if self.tree:

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -289,7 +289,7 @@ class StrategyBase:
 
                     # find the host we're actually refering too here, which may
                     # be a host that is not really in inventory at all
-                    if task.delegate_to is not None:
+                    if task.delegate_to is not None and task.delegate_facts:
                         task_vars = self._variable_manager.get_vars(loader=self._loader, play=iterator._play, host=host, task=task)
                         self.add_tqm_variables(task_vars, play=iterator._play)
                         if item is not None:


### PR DESCRIPTION
Added new commands:
- login - authenticate user prior to performing CRUD operations (i.e. import and delete)
- setup - configure Travis integration
- import - import a role from a GitHub repo into Galaxy
- delete - delete a role from Galaxy

Added .travis.yml - see template in galaxy/data.

Added 'github_branch' to meta/main.yml. If set, travis notifications will be accepted from this branch, installs will come from this branch (unless the repo has tags). If not set, the repo's default branch will be used.

Reworked search to point at search/roles endpoint, provide --author option, and present more usable results.

Defined galaxy_server and galaxy_ignore_certs in constants.py.
