### PR TITLE
adhoc does not load plugins by default

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -163,6 +163,9 @@ class AdHocCLI(CLI):
         else:
             cb = 'minimal'
 
+        if not C.DEFAULT_LOAD_CALLBACK_PLUGINS:
+            C.DEFAULT_CALLBACK_WHITELIST = []
+
         if self.options.tree:
             C.DEFAULT_CALLBACK_WHITELIST.append('tree')
             C.TREE_DIR = self.options.tree


### PR DESCRIPTION
reimplemented feature from 1.x which kept additional callbacks from
poluting adhoc unless specifically asked for through configuration.
