### PR TITLE
Issue 13438

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -524,7 +524,10 @@ class Facts(object):
         keytypes = ('dsa', 'rsa', 'ecdsa', 'ed25519')
 
         if self.facts['system'] == 'Darwin':
-            keydir = '/etc'
+            if self.facts['distribution'] == 'MacOSX' and LooseVersion(self.facts['distribution_version']) >= LooseVersion('10.11') :
+                keydir = '/etc/ssh'
+            else:
+                keydir = '/etc'
         else:
             keydir = '/etc/ssh'
 


### PR DESCRIPTION
@abadger 

OS X El Capitan moved the /etc/ssh_\* files into /etc/ssh/*. So in the get_public_ssh_host_keys() method in lib/ansible/module_utisl/facts.py, I have added an additional check for Darwin systems. If the distribution is MacOSX and the version is >= 10.11, key_dir is set to the new location. Older versions use the old location.

I've tested this fix against systems running El Capitan and Yosemite (previous version). Both find the host keys correctly.  Also tested against Debian Jessie.

Thanks - David
