### PR TITLE
Adds the int_hash filter.

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -309,6 +309,11 @@ Other hashes (platform dependent)::
 
     {{ 'test2'|hash('blowfish') }}
 
+Get a hash in integer form of a string. Takes two arguments where the first
+is the minimum and the second is the maximum possible integer returned.
+
+    {{ 'test3'|int_hash(0, 4294967294) }}
+
 To get a sha512 password hash (random salt)::
 
     {{ 'passwordsaresecret'|password_hash('sha512') }}

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -211,6 +211,20 @@ def get_hash(data, hashtype='sha1'):
     h.update(data)
     return h.hexdigest()
 
+def get_int_hash(data, min=0, max=None):
+    hex_hash = get_hash(data, hashtype='sha512')
+    int_hash = int(hex_hash, 16)
+    if max is None:
+        if min != 0:
+            raise errors.AnsibleFilterError('|int_hash expects a max value to be given together with min')
+        return int_hash
+    else:
+        if min >= max:
+            raise errors.AnsibleFilterError('|int_hash expects max to be higher than min')
+        if min < 0:
+            raise errors.AnsibleFilterError('|int_hash expects min to be a positive integer')
+        return min + int_hash % (max + 1 - min)
+
 def get_encrypted_password(password, hashtype='sha512', salt=None):
 
     # TODO: find a way to construct dynamically from system
@@ -407,6 +421,7 @@ class FilterModule(object):
             # generic hashing
             'password_hash': get_encrypted_password,
             'hash': get_hash,
+            'int_hash': get_int_hash,
 
             # file glob
             'fileglob': fileglob,


### PR DESCRIPTION
int_hash hashes a string and returns the hash in integer form, truncated to a range selected by the user.

It uses sha512 but this detail is not important to the user, it should only promise that the output is indistinguishable from random numbers given that the input changes and that the result is always the same given the same input.

This is meant as an alternative to the random integer filter, giving you a number which is for practical purposes random but allows generation of the numbers in an idempotent way. For example, the name of a host could be used as input to the int_hash to produce the same number between playbook executions in places were the random filter could have been used.

The result should not be trusted to be unique any more than randomly selected number in the same range; it's not. Basic experimentation has shown that the amount of calls to needed Python 2.7 random.randint() before a duplicate number is produced is on average the same as when using int_hash and using an input in the form of "<some_static_string>-<sequentially_increasing_number>". Based on this I conclude that for non crypto purposes it's as "good" as random numbers, as should be expected from a cryptographically secure hash such as sha512 which does all the lifting.

One real world use case for this is generating a MAC address from a hostname.
When letting libvirt select its own MAC addresses it does it from the same range the example task below does. By using int_hash with the inventory host name instead of random the task becomes idempotent and doesn't replace the MAC addresses if the playbook in rerun.

Example:

```
TASK [debug msg={{ 'hostname10-32' | int_hash(90520730730496, 90520747507711) | macaddr('linux') }}] ***
ok: [localhost] => {
    "changed": false,
    "msg": "52:54:00:26:b5:b1"
}
```

Separate from but useful with "[Adds support for converting a MAC address to an integer](https://github.com/ansible/ansible/pull/13460)" to generate MAC addresses on NICs in an ascending order on a host.