### PR TITLE
Make sudo+requiretty and ANSIBLE_PIPELINING work together

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -245,7 +245,7 @@ MAX_FILE_SIZE_FOR_DIFF         = get_config(p, DEFAULTS, 'max_diff_size', 'ANSIB
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', '-o ControlMaster=auto -o ControlPersist=60s')
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
-ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
+ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', True, boolean=True)
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, integer=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
 PARAMIKO_PROXY_COMMAND         = get_config(p, 'paramiko_connection', 'proxy_command', 'ANSIBLE_PARAMIKO_PROXY_COMMAND', None)

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -145,7 +145,7 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
 
     @ensure_connect
     @abstractmethod
-    def exec_command(self, cmd, in_data=None, sudoable=True):
+    def exec_command(self, cmd, in_data=None, sudoable=True, tty=False):
         """Run a command on the remote host.
 
         :arg cmd: byte string containing the command
@@ -156,6 +156,8 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
             a command via a privilege escalation mechanism.  This may affect
             how the connection plugin returns data.  Note that not all
             connections can handle privilege escalation.
+        :kwarg tty: Tell the connection plugin whether or not to allocate a
+            terminal to run this command. Used only by the ssh plugin.
         :returns: a tuple of (return code, stdout, stderr)  The return code is
             an int while stdout and stderr are both byte strings.
 

--- a/lib/ansible/plugins/connection/accelerate.py
+++ b/lib/ansible/plugins/connection/accelerate.py
@@ -165,11 +165,11 @@ class Connection(ConnectionBase):
         else:
             return response.get('rc') == 0
 
-    def exec_command(self, cmd, in_data=None, sudoable=True):
+    def exec_command(self, cmd, in_data=None, sudoable=True, tty=False):
 
         ''' run a command on the remote host '''
 
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable, tty=tty)
 
         if in_data:
             raise AnsibleError("Internal Error: this module does not support optimized module pipelining")

--- a/lib/ansible/plugins/connection/chroot.py
+++ b/lib/ansible/plugins/connection/chroot.py
@@ -97,9 +97,9 @@ class Connection(ConnectionBase):
 
         return p
 
-    def exec_command(self, cmd, in_data=None, sudoable=False):
+    def exec_command(self, cmd, in_data=None, sudoable=False, tty=False):
         ''' run a command on the chroot '''
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable, tty=tty)
 
         p = self._buffered_exec_command(cmd)
 

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -118,9 +118,9 @@ class Connection(ConnectionBase):
             )
             self._connected = True
 
-    def exec_command(self, cmd, in_data=None, sudoable=False):
+    def exec_command(self, cmd, in_data=None, sudoable=False, tty=False):
         """ Run a command on the docker host """
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable, tty=tty)
 
         executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else '/bin/sh'
         # -i is needed to keep stdin open which allows pipelining to work

--- a/lib/ansible/plugins/connection/funcd.py
+++ b/lib/ansible/plugins/connection/funcd.py
@@ -56,7 +56,7 @@ class Connection(object):
         return self
 
     def exec_command(self, cmd, become_user=None, sudoable=False,
-                     executable='/bin/sh', in_data=None):
+                     executable='/bin/sh', in_data=None, tty=False):
         ''' run a command on the remote minion '''
 
         if in_data:

--- a/lib/ansible/plugins/connection/jail.py
+++ b/lib/ansible/plugins/connection/jail.py
@@ -117,9 +117,9 @@ class Connection(ConnectionBase):
 
         return p
 
-    def exec_command(self, cmd, in_data=None, sudoable=False):
+    def exec_command(self, cmd, in_data=None, sudoable=False, tty=False):
         ''' run a command on the jail '''
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable, tty=tty)
 
         # TODO: Check whether we can send the command to stdin via
         # p.communicate(in_data)

--- a/lib/ansible/plugins/connection/libvirt_lxc.py
+++ b/lib/ansible/plugins/connection/libvirt_lxc.py
@@ -97,9 +97,9 @@ class Connection(ConnectionBase):
 
         return p
 
-    def exec_command(self, cmd, in_data=None, sudoable=False):
+    def exec_command(self, cmd, in_data=None, sudoable=False, tty=False):
         ''' run a command on the chroot '''
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable, tty=tty)
 
         p = self._buffered_exec_command(cmd)
 

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -61,10 +61,10 @@ class Connection(ConnectionBase):
             self._connected = True
         return self
 
-    def exec_command(self, cmd, in_data=None, sudoable=True):
+    def exec_command(self, cmd, in_data=None, sudoable=True, tty=False):
         ''' run a command on the local host '''
 
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable, tty=tty)
 
         display.debug("in local.exec_command()")
 

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -248,10 +248,10 @@ class Connection(ConnectionBase):
 
         return ssh
 
-    def exec_command(self, cmd, in_data=None, sudoable=True):
+    def exec_command(self, cmd, in_data=None, sudoable=True, tty=False):
         ''' run a command on the remote host '''
 
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable, tty=tty)
 
         if in_data:
             raise AnsibleError("Internal Error: this module does not support optimized module pipelining")

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -232,7 +232,7 @@ class Connection(ConnectionBase):
 
         return self._command
 
-    def _send_initial_data(self, fh, in_data):
+    def _send_initial_data(self, fh, in_data, tty=False):
         '''
         Writes initial data to the stdin filehandle of the subprocess and closes
         it. (The handle must be closed; otherwise, for example, "sftp -b -" will
@@ -243,6 +243,8 @@ class Connection(ConnectionBase):
 
         try:
             fh.write(in_data)
+            if tty:
+                fh.write("__EOF__942d747a0772c3284ffb5920e234bd57__\n")
             fh.close()
         except (OSError, IOError):
             raise AnsibleConnectionFailure('SSH Error: data could not be sent to the remote host. Make sure this host can be reached over ssh')
@@ -305,7 +307,7 @@ class Connection(ConnectionBase):
 
         return ''.join(output), remainder
 
-    def _run(self, cmd, in_data, sudoable=True):
+    def _run(self, cmd, in_data, sudoable=True, tty=False):
         '''
         Starts the command and communicates with it until it ends.
         '''
@@ -313,31 +315,15 @@ class Connection(ConnectionBase):
         display_cmd = map(to_unicode, map(pipes.quote, cmd))
         display.vvv(u'SSH: EXEC {0}'.format(u' '.join(display_cmd)), host=self.host)
 
-        # Start the given command. If we don't need to pipeline data, we can try
-        # to use a pseudo-tty (ssh will have been invoked with -tt). If we are
-        # pipelining data, or can't create a pty, we fall back to using plain
-        # old pipes.
-
-        p = None
+        # Start the given command.
 
         if isinstance(cmd, (text_type, binary_type)):
             cmd = to_bytes(cmd)
         else:
             cmd = map(to_bytes, cmd)
 
-        if not in_data:
-            try:
-                # Make sure stdin is a proper pty to avoid tcgetattr errors
-                master, slave = pty.openpty()
-                p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                stdin = os.fdopen(master, 'w', 0)
-                os.close(slave)
-            except (OSError, IOError):
-                p = None
-
-        if not p:
-            p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdin = p.stdin
+        p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdin = p.stdin
 
         # If we are using SSH password authentication, write the password into
         # the pipe we opened in _build_command.
@@ -400,7 +386,7 @@ class Connection(ConnectionBase):
         # before we call select.
 
         if states[state] == 'ready_to_send' and in_data:
-            self._send_initial_data(stdin, in_data)
+            self._send_initial_data(stdin, in_data, tty)
             state += 1
 
         while True:
@@ -498,7 +484,7 @@ class Connection(ConnectionBase):
 
             if states[state] == 'ready_to_send':
                 if in_data:
-                    self._send_initial_data(stdin, in_data)
+                    self._send_initial_data(stdin, in_data, tty)
                 state += 1
 
             # Now we're awaiting_exit: has the child process exited? If it has,
@@ -547,10 +533,10 @@ class Connection(ConnectionBase):
 
         return (p.returncode, stdout, stderr)
 
-    def _exec_command(self, cmd, in_data=None, sudoable=True):
+    def _exec_command(self, cmd, in_data=None, sudoable=True, tty=True):
         ''' run a command on the remote host '''
 
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable, tty=tty)
 
         display.vvv(u"ESTABLISH SSH CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self._play_context.remote_addr)
 
@@ -559,12 +545,12 @@ class Connection(ConnectionBase):
         # python interactive-mode but the modules are not compatible with the
         # interactive-mode ("unexpected indent" mainly because of empty lines)
 
-        if in_data:
-            cmd = self._build_command('ssh', self.host, cmd)
-        else:
+        if tty:
             cmd = self._build_command('ssh', '-tt', self.host, cmd)
+        else:
+            cmd = self._build_command('ssh', self.host, cmd)
 
-        (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
+        (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable, tty=tty)
 
         return (returncode, stdout, stderr)
 

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -217,8 +217,8 @@ class Connection(ConnectionBase):
             self._connected = True
         return self
 
-    def exec_command(self, cmd, in_data=None, sudoable=True):
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+    def exec_command(self, cmd, in_data=None, sudoable=True, tty=False):
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable, tty=tty)
         cmd_parts = shlex.split(to_bytes(cmd), posix=False)
         cmd_parts = map(to_unicode, cmd_parts)
         script = None

--- a/lib/ansible/plugins/connection/zone.py
+++ b/lib/ansible/plugins/connection/zone.py
@@ -122,9 +122,9 @@ class Connection(ConnectionBase):
 
         return p
 
-    def exec_command(self, cmd, in_data=None, sudoable=False):
+    def exec_command(self, cmd, in_data=None, sudoable=False, tty=False):
         ''' run a command on the zone '''
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable, tty=tty)
 
         p = self._buffered_exec_command(cmd)
 

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -115,7 +115,7 @@ class ShellModule(object):
         ''' % dict(path=path)
         return self._encode_script(script)
 
-    def build_module_command(self, env_string, shebang, cmd, arg_path=None, rm_tmp=None):
+    def build_module_command(self, env_string, shebang, cmd, arg_path=None, rm_tmp=None, python_interpreter=None):
         cmd_parts = shlex.split(to_bytes(cmd), posix=False)
         cmd_parts = map(to_unicode, cmd_parts)
         if shebang and shebang.lower() == '#!powershell':


### PR DESCRIPTION
Pipelining is a _significant_ performance benefit, because each task can
be completed with a single SSH connection (vs. one ssh connection at the
start to mkdir, plus one sftp and one ssh per task).

Pipelining is disabled by default in Ansible because it conflicts with
the use of sudo if 'Defaults requiretty' is set in /etc/sudoers (as it
is on Red Hat) and su (which always requires a tty).

We can (and already do) make sudo/su happy by using "ssh -t" to allocate
a tty, but then the python interpreter goes into interactive mode and is
unhappy with module source being written to its stdin, per the following
comment from connections/ssh.py:

```
    # we can only use tty when we are not pipelining the modules.
    # piping data into /usr/bin/python inside a tty automatically
    # invokes the python interactive-mode but the modules are not
    # compatible with the interactive-mode ("unexpected indent"
    # mainly because of empty lines)
```

Instead of the (current) drastic solution of turning off pipelining when
we use a tty, we can instead use a tty but suppress the behaviour of the
Python interpreter to switch to interactive mode. The easiest way to do
this is to make its stdin _not_ be a tty, e.g. with cat|python.

This works, but there's a problem: ssh will ignore -t if its input isn't
really a tty. So we could open a pseudo-tty and use that as ssh's stdin,
but if we then write Python source into it, it's all echoed back to us
(because we're a tty). So we have to use -tt to force tty allocation; in
that case, however, ssh puts the tty into "raw" mode (~ICANON), so there
is no good way for the process on the other end to detect EOF on stdin.
So if we do:

```
echo -e "print('hello world')\n"|ssh -tt someho.st "cat|python"
```

…it hangs forever, because cat keeps on reading input even after we've
closed our pipe into ssh's stdin. We can get around this by writing a
special **EOF** marker after writing in_data, and doing this:

```
echo -e "print('hello world')\n__EOF__\n"|ssh -tt someho.st "sed -ne '/__EOF__/q' -e p|python"
```

This works fine, but in fact I use a clever python one-liner by mgedmin
to achieve the same effect without depending on sed (at the expense of a
much longer command line, alas; Python really isn't one-liner-friendly).

There are two things to be careful of: that we use the new pipelining
behaviour only for _execute_module (and not, say, _remote_checksum),
and that we use it only with the ssh plugin (because the others don't
know to write the magic EOF marker). But the ssh plugin can't just do
the pipelining entirely by itself, because the build_module_command()
output may be wrapped by make_become_cmd().

We also enable pipelining by default as a consequence.
