### PR TITLE
filters: Make it simple to get the next or previous element of a list

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -113,6 +113,17 @@ To get the maximum value from a list of numbers::
 
     {{ [3, 4, 2] | max }}
 
+To get the next element after a certain element in a list::
+
+    {{ [3, 4, 2] | next_elem(4) }}
+
+To get the previous element before a certain element in a list::
+
+    {{ [3, 4, 2] | pref_elem(4) }}
+
+Asking for an element after the last or before the first one will
+return undefined.
+
 .. _set_theory_filters:
 
 Set Theory Filters

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -193,6 +193,33 @@ def regex_escape(string):
     '''Escape all regular expressions special characters from STRING.'''
     return re.escape(string)
 
+
+def next_elem(alist, elem):
+    from jinja2 import Undefined
+
+    try:
+        i = alist.index(elem)
+        return alist[i+1]
+    except ValueError:
+        raise errors.AnsibleFilterError('%s not in %s' % (elem, alist))
+    except IndexError:
+        return Undefined()
+
+
+def prev_elem(alist, elem):
+    from jinja2 import Undefined
+
+    try:
+        i = alist.index(elem)
+        if i == 0:
+            return Undefined()
+        return alist[i-1]
+    except ValueError:
+        raise errors.AnsibleFilterError('%s not in %s' % (elem, alist))
+    except IndexError:
+        return Undefined()
+
+
 @environmentfilter
 def rand(environment, end, start=None, step=None):
     r = SystemRandom()
@@ -442,6 +469,9 @@ class FilterModule(object):
             'ternary': ternary,
 
             # list
+            'prev_elem': prev_elem,
+            'next_elem': next_elem,
+
             # random stuff
             'random': rand,
             'shuffle': randomize_list,

--- a/test/integration/roles/test_filters/tasks/main.yml
+++ b/test/integration/roles/test_filters/tasks/main.yml
@@ -110,3 +110,11 @@
     that:
       - "users | json_query('[*].hosts[].host') == ['host_a', 'host_b', 'host_c', 'host_d']"
 
+- name: previous and next element of a list
+  assert:
+    that:
+        - "'a' == [ 'a', 'b', 'c' ]|prev_elem('b')"
+        - "'c' == [ 'a', 'b', 'c' ]|next_elem('b')"
+        - "[ 'a', 'b', 'c' ]|prev_elem('a') is undefined"
+        - "[ 'a', 'b', 'c' ]|next_elem('c') is undefined"
+


### PR DESCRIPTION
The usecase here is to build links between e.g. Jenkins jobs in
different stages:

stages:
- test
- qa
- produdction

and then in the job be able to trigger s.th. in the next stage:

   stages|next_elem('current_stage')

but not trigger anything e.g. after the production stage.
