### PR TITLE
Do not fail when variable is not correct in debug action.

### DIFF
--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -40,7 +40,7 @@ class ActionModule(ActionBase):
                 result['msg'] = self._task.args['msg']
         # FIXME: move the LOOKUP_REGEX somewhere else
         elif 'var' in self._task.args: # and not utils.LOOKUP_REGEX.search(self._task.args['var']):
-            results = self._templar.template(self._task.args['var'], convert_bare=True)
+            results = self._templar.template(self._task.args['var'], convert_bare=True, fail_on_undefined=False)
             if type(self._task.args['var']) in (list, dict):
                 # If var is a list or dict, use the type as key to display
                 result[to_unicode(type(self._task.args['var']))] = results


### PR DESCRIPTION
See https://github.com/ansible/ansible/issues/13484 for more information.

You can retrieve original playbook at the following location: https://github.com/Yannig/ansible-issue-low-speed/blob/master/issue-vars/inconsistent-typing.yml

Without the patch: 

``` yaml
TASK [null evaluation failure] *************************************************
task path: /home/yannig/dev/yannig/ansible-issue-low-speed/issue-vars/inconsistent-typing.yml:37
fatal: [localhost]: FAILED! => {"failed": true, "msg": "ERROR! ERROR! ERROR! 'null' is undefined"}
```

With this patch:

``` yaml
TASK [null evaluation failure] *************************************************
ok: [localhost] => {
    "changed": false, 
    "null2_map": "{{null2_map}}"
}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0   
```
