### PR TITLE
custom callbacks with adhoc cli

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -66,7 +66,7 @@ class CLI(object):
     LESS_OPTS = 'FRSX'  # -F (quit-if-one-screen) -R (allow raw ansi control chars)
                         # -S (chop long lines) -X (disable termcap init and de-init)
 
-    def __init__(self, args):
+    def __init__(self, args, callback=None):
         """
         Base init method for all command line programs
         """
@@ -75,6 +75,7 @@ class CLI(object):
         self.options = None
         self.parser = None
         self.action = None
+        self.callback = callback
 
     def set_action(self):
         """

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -158,7 +158,9 @@ class AdHocCLI(CLI):
         play_ds = self._play_ds(pattern, self.options.seconds, self.options.poll_interval)
         play = Play().load(play_ds, variable_manager=variable_manager, loader=loader)
 
-        if self.options.one_line:
+        if self.callback: 
+            cb = self.callback
+        elif self.options.one_line:
             cb = 'oneline'
         else:
             cb = 'minimal'


### PR DESCRIPTION
Tested by adapting this script:

```
#!/usr/bin/python -tt
# Author: Toshio Kuratomi <toshio@fedoraproject.org>
# Copyright: December, 2015
# License: LGPLv3+
import sys

from ansible import plugins
from ansible.plugins.callback import CallbackBase
from ansible.plugins.callback import default

class CallbackModule(CallbackBase):
    _original_path = ''
    def v2_runner_on_unreachable(self, result):
        self._display.display("%s: down" % result._host.get_name())

    def v2_runner_on_ok(self, result, *args, **kwargs):
        if result._result.get('stdout', None):
            self._display.display('%s: yes' % result._host.get_name())
        else:
            self._display.display('%s: no' % result._host.get_name())

    def v2_runner_on_failed(self, result, *args, **kwargs):
        self._display.display('%s: command failed on host' % result._host.get_name())

from ansible.cli.adhoc import AdHocCLI

if __name__ == '__main__':
    pattern = 'builders'
    if len(sys.argv) > 1:
        pattern = ';'.join(sys.argv[1:])

    print(pattern)
    args = [sys.argv[0], pattern, '-f', '30', '-T', '20', '-u', 'badger']
    #args.extend(['-m', 'shell', '-a', 'whoami | wc -c'])
    args.extend(['-m', 'shell', '-a', 'ps -opid\\\\=  --ppid $(pidof -s -x kojid) || echo -n none || ps -u mock -u mockbuilder -opid\\\\=', '-vvvv'])
    cli = AdHocCLI(args, callback=CallbackModule())
    cli.parse()
    result = cli.run()

```
