### PR TITLE
Fix multiple backup

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1596,13 +1596,12 @@ class AnsibleModule(object):
             # backups named basename-YYYY-MM-DD@HH:MM:SS~
             ext = time.strftime("%Y-%m-%d@%H:%M:%S~", time.localtime(time.time()))
             backupdest = '%s.%s' % (fn, ext)
-
-            try:
-                shutil.copy2(fn, backupdest)
-            except (shutil.Error, IOError):
-                e = get_exception()
-                self.fail_json(msg='Could not make backup of %s to %s: %s' % (fn, backupdest, e))
-
+            if not os.path.exists(backupdest):
+                try:
+                    shutil.copy2(fn, backupdest)
+                except (shutil.Error, IOError):
+                    e = get_exception()
+                    self.fail_json(msg='Could not make backup of %s to %s: %s' % (fn, backupdest, e))
         return backupdest
 
     def cleanup(self, tmpfile):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1589,7 +1589,7 @@ class AnsibleModule(object):
         return self.digest_from_file(filename, 'sha256')
 
     def backup_local(self, fn):
-        '''make a date-marked backup of the specified file, return True or False on success or failure'''
+        '''make a date-marked backup of the specified file, return backup file name'''
 
         backupdest = ''
         if os.path.exists(fn):


### PR DESCRIPTION
These commits fix a problem when multiple backup files are created within the same second. Previously the original file contents would be lost.

This changes the behaviour to not overwrite existing backup files. It is better to have only one backup file for a number of related changes than to not have a backup of the original file contents at all.
