### PR TITLE
Add OpenStack Inventory configuration

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -94,9 +94,9 @@ def get_groups_from_server(server_vars):
     return groups
 
 
-def get_host_groups(inventory):
+def get_host_groups(inventory, refresh=False):
     (cache_file, cache_expiration_time) = get_cache_settings()
-    if is_cache_stale(cache_file, cache_expiration_time):
+    if is_cache_stale(cache_file, cache_expiration_time, refresh=refresh):
         groups = to_json(get_host_groups_from_cloud(inventory))
         open(cache_file, 'w').write(groups)
     else:
@@ -121,8 +121,10 @@ def get_host_groups_from_cloud(inventory):
     return groups
 
 
-def is_cache_stale(cache_file, cache_expiration_time):
+def is_cache_stale(cache_file, cache_expiration_time, refresh=False):
     ''' Determines if cache file has expired, or if it is still valid '''
+    if refresh:
+        return True
     if os.path.isfile(cache_file):
         mod_time = os.path.getmtime(cache_file)
         current_time = time.time()
@@ -176,7 +178,7 @@ def main():
         )
 
         if args.list:
-            output = get_host_groups(inventory)
+            output = get_host_groups(inventory, refresh=args.refresh)
         elif args.host:
             output = to_json(inventory.get_host(args.host))
         print(output)

--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -32,6 +32,13 @@
 # all of them and present them as one contiguous inventory.
 #
 # See the adjacent openstack.yml file for an example config file
+# There are two ansible inventory specific options that can be set in
+# the inventory section.
+# expand_hostvars controls whether or not the inventory will make extra API
+#                 calls to fill out additional information about each server
+# use_hostnames changes the behavior from registering every host with its UUID
+#               and making a group of its hostname to only doing this if the
+#               hostname in question has more than one server
 
 import argparse
 import collections
@@ -51,7 +58,7 @@ import shade.inventory
 CONFIG_FILES = ['/etc/ansible/openstack.yaml']
 
 
-def get_groups_from_server(server_vars):
+def get_groups_from_server(server_vars, namegroup=True):
     groups = []
 
     region = server_vars['region']
@@ -76,7 +83,8 @@ def get_groups_from_server(server_vars):
             groups.append(extra_group)
 
     groups.append('instance-%s' % server_vars['id'])
-    groups.append(server_vars['name'])
+    if namegroup:
+        groups.append(server_vars['name'])
 
     for key in ('flavor', 'image'):
         if 'name' in server_vars[key]:
@@ -106,17 +114,36 @@ def get_host_groups(inventory, refresh=False):
 
 def get_host_groups_from_cloud(inventory):
     groups = collections.defaultdict(list)
+    firstpass = collections.defaultdict(list)
     hostvars = {}
-    for server in inventory.list_hosts():
+    list_args = {}
+    if hasattr(inventory, 'extra_config'):
+        use_hostnames = inventory.extra_config['use_hostnames']
+        list_args['expand'] = inventory.extra_config['expand_hostvars']
+    else:
+        use_hostnames = False
+
+    for server in inventory.list_hosts(**list_args):
 
         if 'interface_ip' not in server:
             continue
-        for group in get_groups_from_server(server):
-            groups[group].append(server['id'])
-        hostvars[server['id']] = dict(
-            ansible_ssh_host=server['interface_ip'],
-            openstack=server,
-        )
+        firstpass[server['name']].append(server)
+    for name, servers in firstpass.items():
+        if len(servers) == 1 and use_hostnames:
+            server = servers[0]
+            hostvars[name] = dict(
+                ansible_ssh_host=server['interface_ip'],
+                openstack=server)
+            for group in get_groups_from_server(server, namegroup=False):
+                groups[group].append(server['name'])
+        else:
+            for server in servers:
+                server_id = server['id']
+                hostvars[server_id] = dict(
+                    ansible_ssh_host=server['interface_ip'],
+                    openstack=server)
+                for group in get_groups_from_server(server, namegroup=True):
+                    groups[group].append(server_id)
     groups['_meta'] = {'hostvars': hostvars}
     return groups
 
@@ -171,11 +198,21 @@ def main():
     try:
         config_files = os_client_config.config.CONFIG_FILES + CONFIG_FILES
         shade.simple_logging(debug=args.debug)
-        inventory = shade.inventory.OpenStackInventory(
+        inventory_args = dict(
             refresh=args.refresh,
             config_files=config_files,
             private=args.private,
         )
+        if hasattr(shade.inventory.OpenStackInventory, 'extra_config'):
+            inventory_args.update(dict(
+                config_key='ansible',
+                config_defaults={
+                    'use_hostnames': False,
+                    'expand_hostvars': True,
+                }
+            ))
+
+        inventory = shade.inventory.OpenStackInventory(**inventory_args)
 
         if args.list:
             output = get_host_groups(inventory, refresh=args.refresh)

--- a/contrib/inventory/openstack.yml
+++ b/contrib/inventory/openstack.yml
@@ -26,3 +26,6 @@ clouds:
       username: stack
       password: stack
       project_name: stack
+ansible:
+  use_hostnames: True
+  expand_hostvars: False


### PR DESCRIPTION
There are two behaviors which want to be configurable for OpenStack Inventory. This adds the ability to configure them, but defaults the behavior to the existing behavior.

This requires https://review.openstack.org/#/c/246587 and https://review.openstack.org/#/c/257437/ to land and release before it's useful, but it should fail safely to current behavior without them.
