### PR TITLE
fix for fork_late nuking host data in task_results

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -185,6 +185,11 @@ class StrategyBase:
                 result = self._final_q.get()
                 display.debug("got result from result worker: %s" % ([text_type(x) for x in result],))
 
+                # patch up hollowed-out hosts in any task_result objects
+                for r in result:
+                    if isinstance(r, TaskResult):
+                        r._host = self._inventory.get_host(r._host.name)
+
                 # all host status messages contain 2 entries: (msg, task_result)
                 if result[0] in ('host_task_ok', 'host_task_failed', 'host_task_skipped', 'host_unreachable'):
                     task_result = result[1]


### PR DESCRIPTION
Because so many things in the result chain expect task_result._host to be populated, we can't just get rid of it. So we always repopulate it with a local one from inventory as soon as we get the result object from the results queue.

@jimi-c @abadger 

Should fix #13526 and #13564 
