### PR TITLE
Revert to standard port if non-standard port not open.

### DIFF
--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -34,6 +34,8 @@ from ansible.callbacks import vvv
 from ansible import errors
 from ansible import utils
 
+import socket
+
 
 class Connection(object):
     ''' ssh based connections '''
@@ -48,6 +50,12 @@ class Connection(object):
         self.private_key_file = private_key_file
         self.HASHED_KEY_MAGIC = "|1|"
         self.has_pipelining = True
+
+        crlb_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        crlb_rc = crlb_socket.connect_ex((self.host, self.port))
+        crlb_socket.close()
+        if crlb_rc != 0:
+            self.port = C.DEFAULT_REMOTE_PORT
 
         # TODO: add pbrun, pfexec
         self.become_methods_supported=['sudo', 'su', 'pbrun']


### PR DESCRIPTION
If a host is to be built and use a non-standard ssh port, it is reasonable that changes to its' configuration (ssh, iptables, firewall, etc.) be accomplished through ansible. Consider the following playbook which modifies the ssh port in the common role:

> > ---
> > # file: cloud.yaml - Build an OpenStack cloud.
> > - hosts: osctl:oscmp
> >   roles:
> >   - common
> > - hosts: osctl
> >   roles:
> >   - osctl
> > - hosts: oscmp
> >   roles:
> >   - oscmp
> > - hosts: osctl
> >   tasks:
> >   - include: roles/oscmp/tasks/verify.yaml

The playbook fails after the second play with an ssh port error. The inventory has to be changed for both hosts and the playbook rerun.

This commit tests the non-standard port on the target and if it is not open sets the standard ssh port. The inventory can then be created with all non-standard ports defined, and will execute correctly even on the first execution. This is particularly useful when repetitively rebuilding Virtual Machines.

This was developed and tested  on ansible 1.9, and a second fix/pull request submitted for version 2.
