### PR TITLE
Update with_items + variable example to remove unnecessary quotes

### DIFF
--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -23,7 +23,7 @@ To save some typing, repeated tasks can be written in short-hand like so::
 
 If you have defined a YAML list in a variables file, or the 'vars' section, you can also do::
 
-    with_items: "{{somelist}}"
+    with_items: somelist
 
 The above would be the equivalent of::
 


### PR DESCRIPTION
If you use the example as written it does work fine, but you're given a warning message:

```
[WARNING]: It is unnecessary to use '{{' in loops, leave variables in loop expressions bare.
```

As pointed out in https://github.com/ansible/ansible/issues/6407#issuecomment-37362386 it's preferable to drop the quotes in this case, for simplicity and elegance. It'd be good to follow that in the docs too, rather than lead people into confusing warning messages.
