### PR TITLE
Fixed import typo for memcache module in tests.

### DIFF
--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -26,7 +26,7 @@ from ansible.plugins.cache.memory import CacheModule as MemoryCache
 
 HAVE_MEMCACHED = True
 try:
-    import memcached
+    import memcache
 except ImportError:
     HAVE_MEMCACHED = False
 else:


### PR DESCRIPTION
The typo caused the test for the memcached cache plugin to be skipped
even when the necessary memcache python module was installed.
