### PR TITLE
Enable use of non standard hostname in inventory

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -110,7 +110,10 @@ class Inventory(object):
         elif isinstance(host_list, list):
             for h in host_list:
                 (host, port) = parse_address(h, allow_ranges=False)
-                all.add_host(Host(host, port))
+                if host is not None:
+                    all.add_host(Host(host, port))
+                else:
+                    all.add_host(Host(h))
         elif self._loader.path_exists(host_list):
             #TODO: switch this to a plugin loader and a 'condition' per plugin on which it should be tried, restoring 'inventory pllugins'
             if self.is_directory(host_list):


### PR DESCRIPTION
If the host given cannot be parsed in hostnae:port tuple,
then it might be a different format and used by a alternative
connexion plugin.

Fixes #13608
