### PR TITLE
update_json for module intermediate comms

### DIFF
--- a/changelogs/fragments/live_from_nj.yml
+++ b/changelogs/fragments/live_from_nj.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - new 'live' keyword allows actions to display intermediate output

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -52,6 +52,7 @@ class AdHocCLI(CLI):
         opt_help.add_module_options(self.parser)
         opt_help.add_basedir_options(self.parser)
         opt_help.add_tasknoplay_options(self.parser)
+        opt_help.add_live_options(self.parser)
 
         # options unique to ansible ad-hoc
         self.parser.add_argument('-a', '--args', dest='module_args',

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -549,3 +549,8 @@ def _tagged_type_factory(name: str, func: t.Callable[[str], object], /) -> t.Cal
     tag_value._name = name  # simplify debugging by attaching the argument name to the function
 
     return tag_value
+
+
+def add_live_options(parser):
+    parser.add_argument('--live', default=False, dest='live', action='store_true',
+                        help="Requests and displays 'live updates' from executing actions and connections that support it.")

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -118,6 +118,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
         opt_help.add_basedir_options(self.parser)
         opt_help.add_runtask_options(self.parser)
         opt_help.add_tasknoplay_options(self.parser)
+        opt_help.add_live_options(self.parser)
 
         # options unique to shell
         self.parser.add_argument('pattern', help='host pattern', metavar='pattern', default='all', nargs='?')
@@ -386,6 +387,14 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
     def help_become(self):
         display.display("Toggle whether the tasks are run with become")
+
+    def do_live(self, arg):
+        """Toggle whether plays run with become"""
+        if arg:
+            self.options.live = boolean(arg, strict=False)
+            display.v("live changed to %s" % self.options.live)
+        else:
+            display.display("Please specify live value, e.g. `live yes`")
 
     def do_remote_user(self, arg):
         """Given a username, set the remote user plays are run by"""

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -987,7 +987,8 @@ def _find_module_utils(
         async_timeout: int,
         become_plugin: BecomeBase | None,
         environment: dict[str, str],
-        remote_is_local: bool = False
+        remote_is_local: bool = False,
+        live_updates: bool = False,
 ) -> _BuiltModule:
     """
     Given the source of the module, convert it to a Jinja2 template to insert
@@ -1164,6 +1165,7 @@ def _find_module_utils(
             params=encoded_params,
             extensions=extension_manager.get_extensions(),
             zip_data=to_text(cached_module.zip_data),
+            live_updates=live_updates,
         )
 
         args_string = '\n'.join(f'{key}={value!r},' for key, value in args.items())
@@ -1280,6 +1282,7 @@ def modify_module(
         become_plugin=None,
         environment=None,
         remote_is_local=False,
+        live_updates=False,
 ) -> _BuiltModule:
     """
     Used to insert chunks of code into modules before transfer rather than
@@ -1321,6 +1324,7 @@ def modify_module(
         become_plugin=become_plugin,
         environment=environment,
         remote_is_local=remote_is_local,
+        live_updates=live_updates,
     )
 
     b_module_data = module_bits.b_module_data

--- a/lib/ansible/keyword_desc.yml
+++ b/lib/ansible/keyword_desc.yml
@@ -36,6 +36,7 @@ handlers: "A section with tasks that are treated as handlers, these won't get ex
 hosts: "A list of groups, hosts or host pattern that translates into a list of hosts that are the play's target."
 ignore_errors: Boolean that allows you to ignore task failures and continue with play. It does not affect connection errors.
 ignore_unreachable: Boolean that allows you to ignore task failures due to an unreachable host and continue with the play. This does not affect other task errors (see :term:`ignore_errors`) but is useful for groups of volatile/ephemeral hosts.
+live: "Signals that a task should return 'live updates' if the module supports it"
 loop: "Takes a list for the task to iterate over, saving each list element into the ``item`` variable (configurable via loop_control)"
 loop_control: Several keys here allow you to modify/set loop behavior in a task. See :ref:`loop_control`.
 max_fail_percentage: can be used to abort the run after a given percentage of hosts in the current batch has failed. This only works on linear or linear-derived strategies.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1456,7 +1456,8 @@ class AnsibleModule(object):
 
         self.add_path_info(kwargs)
 
-        if '_ansible_update' not in kwargs:
+        if '_ansible_update' in kwargs:
+            return kwargs
 
         if 'warnings' in kwargs:
             self.deprecate(  # pylint: disable=ansible-deprecated-unnecessary-collection-name
@@ -1535,11 +1536,10 @@ class AnsibleModule(object):
         print('\n%s' % json.dumps(o, cls=encoder))
         sys.stdout.flush()
 
-        """ return from the module, without error """
+        # Return from the module, without error
         _skip_stackwalk = True
 
         self.do_cleanup_files()
-        self._return_formatted(kwargs)
         sys.exit(0)
 
     def fail_json(self, msg: str, *, exception: BaseException | str | None = _UNSET, **kwargs) -> t.NoReturn:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -380,6 +380,7 @@ class AnsibleModule(object):
         and :ref:`developing_program_flow_modules` for more detailed explanation.
         """
 
+        self._updates = 0
         self._name = os.path.basename(__file__)  # initialize name until we can parse from options
         self.argument_spec = argument_spec
         self.supports_check_mode = supports_check_mode
@@ -399,6 +400,7 @@ class AnsibleModule(object):
         self._shell = None
         self._syslog_facility = 'LOG_USER'
         self._verbosity = 0
+        self._provide_updates = False
         # May be used to set modifications to the environment for any
         # run_command invocation
         self.run_command_environ_update = {}
@@ -1338,6 +1340,10 @@ class AnsibleModule(object):
             else:
                 self._log_to_syslog(journal_msg)
 
+            # TODO: does 'return log data' need diff setting?
+            if self._debug and journal_msg:
+                self.update_json({'log': journal_msg})
+
     def _log_invocation(self):
         """ log that ansible ran the module """
         # TODO: generalize a separate log function and make log_invocation use it
@@ -1450,8 +1456,7 @@ class AnsibleModule(object):
 
         self.add_path_info(kwargs)
 
-        if 'invocation' not in kwargs:
-            kwargs['invocation'] = {'module_args': self.params}
+        if '_ansible_update' not in kwargs:
 
         if 'warnings' in kwargs:
             self.deprecate(  # pylint: disable=ansible-deprecated-unnecessary-collection-name
@@ -1528,8 +1533,8 @@ class AnsibleModule(object):
         """
         encoder = _json.get_module_encoder(_ANSIBLE_PROFILE, _json.Direction.MODULE_TO_CONTROLLER)
         print('\n%s' % json.dumps(o, cls=encoder))
+        sys.stdout.flush()
 
-    def exit_json(self, **kwargs) -> t.NoReturn:
         """ return from the module, without error """
         _skip_stackwalk = True
 
@@ -1599,6 +1604,14 @@ class AnsibleModule(object):
         self._return_formatted(kwargs)
 
         sys.exit(1)
+
+    def update_json(self, data):
+
+        if self._provide_updates:
+            self._updates += 1
+            data['_ansible_update'] = self._updates
+            self._return_formatted(data)
+            self.log('update #%s' % self._updates)
 
     def fail_on_missing_params(self, required_params=None):
         if not required_params:
@@ -1846,6 +1859,14 @@ class AnsibleModule(object):
         except (shutil.Error, OSError) as ex:
             raise Exception(f'Could not write data to file {dest!r} from {src!r}.') from ex
 
+    def _read_from_pipes(self, rpipes, rfds, file_descriptor):
+        data = b''
+        if file_descriptor in rfds:
+            data = os.read(file_descriptor.fileno(), 9000)
+            if data == b'':
+                rpipes.remove(file_descriptor)
+        return data
+
     def _clean_args(self, args):
 
         if not self._clean:
@@ -2051,6 +2072,10 @@ class AnsibleModule(object):
         try:
             if self._debug:
                 self.log('Executing: ' + self._clean_args(args))
+
+            if self._provide_updates:
+                kwargs['bufsize'] = 0
+
             cmd = subprocess.Popen(args, **kwargs)
             if before_communicate_callback:
                 before_communicate_callback(cmd)

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -82,6 +82,7 @@ PASS_VARS: dict[str, t.Any] = {
     'diff': ('_diff', False),
     'keep_remote_files': ('_keep_remote_files', False),
     'ignore_unknown_opts': ('_ignore_unknown_opts', False),
+    'live_updates': ('live', None),
     'module_name': ('_name', None),
     'no_log': ('no_log', False),
     'remote_tmp': ('_remote_tmp', None),
@@ -96,7 +97,7 @@ PASS_VARS: dict[str, t.Any] = {
     'version': ('ansible_version', '0.0'),
 }
 
-PASS_BOOLS = ('check_mode', 'debug', 'diff', 'keep_remote_files', 'ignore_unknown_opts', 'no_log')
+PASS_BOOLS = ('check_mode', 'debug', 'diff', 'keep_remote_files', 'ignore_unknown_opts', 'live', 'no_log')
 
 DEFAULT_TYPE_VALIDATORS = {
     'str': check_type_str,

--- a/lib/ansible/module_utils/json_utils.py
+++ b/lib/ansible/module_utils/json_utils.py
@@ -64,15 +64,34 @@ def _filter_non_json_lines(data, objects_only=False):
     else:
         raise ValueError('No end of json char found')
 
+    trailing_junk = ''
     if reverse_end_offset > 0:
         # Trailing junk is uncommon and can point to things the user might
         # want to change.  So print a warning if we find any
         trailing_junk = lines[len(lines) - reverse_end_offset:]
-        for line in trailing_junk:
-            if line.strip():
-                warnings.append('Module invocation had junk after the JSON data: %s' % '\n'.join(trailing_junk))
-                break
 
     lines = lines[:(len(lines) - reverse_end_offset)]
+    return ('\n'.join(lines), trailing_junk)
 
-    return ('\n'.join(lines), warnings)
+
+# NB: a copy of this function exists in ../../modules/core/async_wrapper.py.
+# Ensure any changes are propagated there.
+def _filter_non_json_lines(data):
+    '''
+    Used to filter unrelated output around module JSON output, like messages from
+    tcagetattr, or where dropbear spews MOTD on every single command (which is nuts).
+
+    Filters leading lines before first line-starting occurrence of '{' or '[', and filter all
+    trailing lines after matching close character (working from the bottom of output).
+    '''
+    warnings = []
+
+    lines, trailing_junk = _consume_json(data)
+    # Trailing junk is uncommon and can point to things the user might want to change.
+    # So print a warning if we find any 'non whitespace' junk
+    for line in trailing_junk:
+        if line.strip():
+            warnings.append('Module invocation had junk after the JSON data: %s' % '\n'.join(trailing_junk))
+            break
+
+    return (lines, warnings)

--- a/lib/ansible/module_utils/json_utils.py
+++ b/lib/ansible/module_utils/json_utils.py
@@ -72,26 +72,3 @@ def _filter_non_json_lines(data, objects_only=False):
 
     lines = lines[:(len(lines) - reverse_end_offset)]
     return ('\n'.join(lines), trailing_junk)
-
-
-# NB: a copy of this function exists in ../../modules/core/async_wrapper.py.
-# Ensure any changes are propagated there.
-def _filter_non_json_lines(data):
-    '''
-    Used to filter unrelated output around module JSON output, like messages from
-    tcagetattr, or where dropbear spews MOTD on every single command (which is nuts).
-
-    Filters leading lines before first line-starting occurrence of '{' or '[', and filter all
-    trailing lines after matching close character (working from the bottom of output).
-    '''
-    warnings = []
-
-    lines, trailing_junk = _consume_json(data)
-    # Trailing junk is uncommon and can point to things the user might want to change.
-    # So print a warning if we find any 'non whitespace' junk
-    for line in trailing_junk:
-        if line.strip():
-            warnings.append('Module invocation had junk after the JSON data: %s' % '\n'.join(trailing_junk))
-            break
-
-    return (lines, warnings)

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -708,6 +708,7 @@ class Base(FieldAttributeBase):
     any_errors_fatal = FieldAttribute(isa='bool', default=C.ANY_ERRORS_FATAL)
     throttle = FieldAttribute(isa='int', default=0)
     timeout = FieldAttribute(isa='int', default=C.TASK_TIMEOUT)
+    live = FieldAttribute(isa='bool')
 
     # explicitly invoke a debugger on tasks
     debugger = FieldAttribute(isa='string')

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -27,7 +27,7 @@ from ansible.executor.interpreter_discovery import discover_interpreter, Interpr
 from ansible.module_utils._internal import _traceback
 from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
 from ansible.module_utils.errors import UnsupportedError
-from ansible.module_utils.json_utils import _filter_non_json_lines
+from ansible.module_utils.json_utils import _consume_json
 from ansible.module_utils.common.json import Direction, get_module_encoder, get_module_decoder
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.release import __version__
@@ -309,6 +309,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         # modify_module will exit early if interpreter discovery is required; re-run after if necessary
         for _dummy in (1, 2):
             try:
+<<<<<<< HEAD
                 module_bits = modify_module(
                     module_name=module_name,
                     module_path=module_path,
@@ -322,6 +323,17 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
                     become_plugin=self._connection.become,
                 )
 
+=======
+                (module_data, module_style, module_shebang) = modify_module(module_name, module_path, module_args, self._templar,
+                                                                            task_vars=use_vars,
+                                                                            module_compression=C.config.get_config_value('DEFAULT_MODULE_COMPRESSION',
+                                                                                                                         variables=task_vars),
+                                                                            async_timeout=self._task.async_val,
+                                                                            environment=final_environment,
+                                                                            remote_is_local=bool(getattr(self._connection, '_remote_is_local', False)),
+                                                                            live_updates=bool(self._task.live),
+                                                                            **become_kwargs)
+>>>>>>> aeb7f9d47f4 (Added ability to modules to emit 'update messsages')
                 break
             except InterpreterDiscoveryRequiredError as idre:
                 self._discovered_interpreter = discover_interpreter(action=self, interpreter_name=idre.interpreter_name,
@@ -949,6 +961,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
             if not self._supports_check_mode:
                 raise AnsibleError("check mode is not supported for this operation")
             module_args['_ansible_check_mode'] = True
+
         else:
             module_args['_ansible_check_mode'] = False
 
@@ -996,6 +1009,9 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
 
         # make sure the remote_tmp value is sent through in case modules needs to create their own
         module_args['_ansible_remote_tmp'] = self.get_shell_option('remote_tmp', default='~/.ansible/tmp')
+
+        # enable live updates
+        module_args['_ansible_live_updates'] = self._task.live
 
         # tells the module to ignore options that are not in its argspec.
         module_args['_ansible_ignore_unknown_opts'] = ignore_unknown_opts
@@ -1159,7 +1175,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
             self._fixup_perms2(remote_files, self._get_remote_user())
 
         # actually execute
-        res = self._low_level_execute_command(cmd, sudoable=sudoable, in_data=in_data)
+        res = self._low_level_execute_command(cmd, sudoable=sudoable, in_data=in_data, live=bool(self._task.live))
 
         # parse the main result
         data = self._parse_returned_data(res, module_bits.serialization_profile)
@@ -1208,8 +1224,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
 
     def _parse_returned_data(self, res: dict[str, t.Any], profile: str) -> dict[str, t.Any]:
         try:
-            filtered_output, warnings = _filter_non_json_lines(res.get('stdout', ''), objects_only=True)
-
+            filtered_output, warnings = _consume_json(res.get('stdout', ''), objects_only=True)
             for w in warnings:
                 display.warning(w)
 
@@ -1266,7 +1281,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         return data
 
     # FIXME: move to connection base
-    def _low_level_execute_command(self, cmd, sudoable=True, in_data=None, executable=None, encoding_errors='surrogate_then_replace', chdir=None):
+    def _low_level_execute_command(self, cmd, sudoable=True, in_data=None, executable=None, encoding_errors='surrogate_then_replace', chdir=None, live=False):
         """
         This is the function which executes the low level shell command, which
         may be commands to create/remove directories for temporary files, or to

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -27,7 +27,7 @@ from ansible.executor.interpreter_discovery import discover_interpreter, Interpr
 from ansible.module_utils._internal import _traceback
 from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
 from ansible.module_utils.errors import UnsupportedError
-from ansible.module_utils.json_utils import _consume_json
+from ansible.module_utils.json_utils import _filter_non_json_lines
 from ansible.module_utils.common.json import Direction, get_module_encoder, get_module_decoder
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.release import __version__
@@ -309,7 +309,6 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         # modify_module will exit early if interpreter discovery is required; re-run after if necessary
         for _dummy in (1, 2):
             try:
-<<<<<<< HEAD
                 module_bits = modify_module(
                     module_name=module_name,
                     module_path=module_path,
@@ -321,19 +320,8 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
                     environment=final_environment,
                     remote_is_local=bool(getattr(self._connection, '_remote_is_local', False)),
                     become_plugin=self._connection.become,
+                    live_updates=bool(self._task.live),
                 )
-
-=======
-                (module_data, module_style, module_shebang) = modify_module(module_name, module_path, module_args, self._templar,
-                                                                            task_vars=use_vars,
-                                                                            module_compression=C.config.get_config_value('DEFAULT_MODULE_COMPRESSION',
-                                                                                                                         variables=task_vars),
-                                                                            async_timeout=self._task.async_val,
-                                                                            environment=final_environment,
-                                                                            remote_is_local=bool(getattr(self._connection, '_remote_is_local', False)),
-                                                                            live_updates=bool(self._task.live),
-                                                                            **become_kwargs)
->>>>>>> aeb7f9d47f4 (Added ability to modules to emit 'update messsages')
                 break
             except InterpreterDiscoveryRequiredError as idre:
                 self._discovered_interpreter = discover_interpreter(action=self, interpreter_name=idre.interpreter_name,
@@ -1224,7 +1212,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
 
     def _parse_returned_data(self, res: dict[str, t.Any], profile: str) -> dict[str, t.Any]:
         try:
-            filtered_output, warnings = _consume_json(res.get('stdout', ''), objects_only=True)
+            filtered_output, warnings = _filter_non_json_lines(res.get('stdout', ''), objects_only=True)
             for w in warnings:
                 display.warning(w)
 

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -17,6 +17,9 @@ from ansible import constants as C
 from ansible.errors import AnsibleValueOmittedError
 from ansible.module_utils.common.text.converters import to_text
 from ansible.playbook.play_context import PlayContext
+from ansible.errors import AnsibleError
+from ansible.module_utils.json_utils import _filter_non_json_lines
+from ansible.module_utils.six import string_types
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.become import BecomeBase
 from ansible.plugins.shell import ShellBase
@@ -229,6 +232,25 @@ class ConnectionBase(AnsiblePlugin):
         f = self._play_context.connection_lockfd
         fcntl.lockf(f, fcntl.LOCK_UN)
         display.vvvv('CONNECTION: pid %d released lock on %d' % (os.getpid(), f), host=self._play_context.remote_addr)
+
+    def _handle_updates(self, data):
+
+        is_update = False
+        rest_data = ''
+        if b'_ansible_update' in data:
+            # consume update data
+            try:
+                updates, rest_data = _filter_non_json_lines(str(data))
+            except ValueError:
+                # improper json, incomplete, ignore try later
+                updates = None
+
+            if updates and updates.strip():
+                is_update = True
+                # TODO: once callbacks are expanded use those instead of restricting
+                display.display('[U]: <%s> %s' % (self._play_context.remote_addr, updates), color=C.COLOR_DEPRECATE, screen_only=True)
+
+        return is_update, to_bytes(rest_data)
 
     def reset(self) -> None:
         display.warning("Reset is not implemented for this connection")

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -19,7 +19,6 @@ from ansible.module_utils.common.text.converters import to_text
 from ansible.playbook.play_context import PlayContext
 from ansible.errors import AnsibleError
 from ansible.module_utils.json_utils import _filter_non_json_lines
-from ansible.module_utils.six import string_types
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.become import BecomeBase
 from ansible.plugins.shell import ShellBase
@@ -250,7 +249,7 @@ class ConnectionBase(AnsiblePlugin):
                 # TODO: once callbacks are expanded use those instead of restricting
                 display.display('[U]: <%s> %s' % (self._play_context.remote_addr, updates), color=C.COLOR_DEPRECATE, screen_only=True)
 
-        return is_update, to_bytes(rest_data)
+        return is_update, rest_data
 
     def reset(self) -> None:
         display.warning("Reset is not implemented for this connection")

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -83,7 +83,7 @@ class Connection(ConnectionBase):
             self._connected = True
         return self
 
-    def exec_command(self, cmd: str, in_data: bytes | None = None, sudoable: bool = True) -> tuple[int, bytes, bytes]:
+    def exec_command(self, cmd: str, in_data: bytes | None = None, sudoable: bool = True, live: bool = False) -> tuple[int, bytes, bytes]:
         """ run a command on the local host """
 
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
@@ -131,11 +131,45 @@ class Connection(ConnectionBase):
             os.close(stdin)
 
         display.debug("done running command with Popen()")
+        selector = selectors.DefaultSelector()
+        selector.register(p.stdout, selectors.EVENT_READ)
+        selector.register(p.stderr, selectors.EVENT_READ)
 
         become_stdout_bytes, become_stderr_bytes = self._ensure_become_success(p, pty_primary, sudoable)
 
-        display.debug("getting output with communicate()")
-        stdout, stderr = p.communicate(in_data)
+        display.debug("starting update loop")
+
+        stdout = b''
+        stdout_done = False
+        stderr = b''
+        stderr_done = False
+
+        while True:
+            events = selector.select(1)
+            for key, event in events:
+                output = b''
+                if key.fileobj == p.stdout:
+                    output = os.read(p.stdout.fileno(), 9000)
+                    if output == b'':
+                        stdout_done = True
+                        selector.unregister(p.stdout)
+                    stdout += output
+                elif key.fileobj == p.stderr:
+                    output = os.read(p.stderr.fileno(), 9000)
+                    if output == b'':
+                        stderr_done = True
+                        selector.unregister(p.stderr)
+                    stderr += output
+
+                is_update, rest = self._handle_updates(output)
+                if is_update:
+                    stdout = rest or b''
+
+            # Exit if the process has closed both fds and the process has
+            # finished
+            if stdout_done and stderr_done and p.poll() is not None:
+                break
+
         display.debug("done communicating")
 
         # preserve output from privilege escalation stage as `bytes`; it may contain actual output (eg `raw`) or error messages

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1102,7 +1102,7 @@ class Connection(ConnectionBase):
         return popen_kwargs
 
     @_clean_shm
-    def _bare_run(self, cmd: list[bytes], in_data: bytes | None, sudoable: bool = True, checkrc: bool = True) -> tuple[int, bytes, bytes]:
+    def _bare_run(self, cmd: list[bytes], in_data: bytes | None, sudoable: bool = True, checkrc: bool = True, live: bool = False) -> tuple[int, bytes, bytes]:
         """
         Starts the command and communicates with it until it ends.
         """
@@ -1131,11 +1131,16 @@ class Connection(ConnectionBase):
         if self.sshpass_pipe:
             popen_kwargs['pass_fds'] = self.sshpass_pipe
 
+        if live:
+            bufsize = 0
+        else:
+            bufsize = -1
+
         if not in_data:
             try:
                 # Make sure stdin is a proper pty to avoid tcgetattr errors
                 master, slave = pty.openpty()
-                p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **popen_kwargs)
+                p = subprocess.Popen(cmd, bufsize=bufsize, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **popen_kwargs)
                 stdin = os.fdopen(master, 'wb', 0)
                 os.close(slave)
             except OSError:
@@ -1268,10 +1273,14 @@ class Connection(ConnectionBase):
                         b_tmp_stderr += b_chunk
                         display.debug("stderr chunk (state=%s):\n>>>%s<<<\n" % (state, to_text(b_chunk)))
 
+                    # check if this was an update message, return remainder if it is
+                    is_update, rest = self._handle_updates(b_tmp_stdout)
+                    if is_update:
+                        b_tmp_stdout = rest or b''
+
                 # We examine the output line-by-line until we have negotiated any
                 # privilege escalation prompt and subsequent success/error message.
                 # Afterwards, we can accumulate output without looking at it.
-
                 if state < states.index('ready_to_send'):
                     if b_tmp_stdout:
                         b_output, b_unprocessed = self._examine_output('stdout', states[state], b_tmp_stdout, sudoable)
@@ -1399,10 +1408,10 @@ class Connection(ConnectionBase):
         return (p.returncode, b_stdout, b_stderr)
 
     @_ssh_retry
-    def _run(self, cmd: list[bytes], in_data: bytes | None, sudoable: bool = True, checkrc: bool = True) -> tuple[int, bytes, bytes]:
+    def _run(self, cmd: list[bytes], in_data: bytes | None, sudoable: bool = True, checkrc: bool = True, live: bool = False) -> tuple[int, bytes, bytes]:
         """Wrapper around _bare_run that retries the connection
         """
-        return self._bare_run(cmd, in_data, sudoable=sudoable, checkrc=checkrc)
+        return self._bare_run(cmd, in_data, sudoable=sudoable, checkrc=checkrc, live=live)
 
     @_ssh_retry
     def _file_transport_command(self, in_path: str, out_path: str, sftp_action: str) -> tuple[int, bytes, bytes]:
@@ -1488,7 +1497,7 @@ class Connection(ConnectionBase):
     #
     # Main public methods
     #
-    def exec_command(self, cmd: str, in_data: bytes | None = None, sudoable: bool = True) -> tuple[int, bytes, bytes]:
+    def exec_command(self, cmd: str, in_data: bytes | None = None, sudoable: bool = True, live: bool = False) -> tuple[int, bytes, bytes]:
         """ run a command on the remote host """
 
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
@@ -1521,7 +1530,7 @@ class Connection(ConnectionBase):
             args = (self.host, cmd)
 
         cmd = self._build_command(ssh_executable, 'ssh', *args)
-        (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
+        (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable, live=live)
 
         # When running on Windows, stderr may contain CLIXML encoded output
         if getattr(self._shell, "_IS_WINDOWS", False):

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -684,6 +684,7 @@ class TestActionBase(unittest.TestCase):
         mock_task.diff = False
         mock_task.check_mode = False
         mock_task.no_log = False
+        mock_task.live = False
 
         # create a mock connection, so we don't actually try and connect to things
         def get_option(option):


### PR DESCRIPTION
- new 'live' keyword to indicate you want intermediate (live) updates from module execution
- added 'live' intelligence to 'run_command' for those modules executing commands using it

TODO:
- displays when -vvvvv ... really should be using callback now that sivel added queuing

implements https://github.com/ansible/proposals/issues/92
