### PR TITLE
allow for non standard hostnames

### DIFF
--- a/docsite/rst/playbooks_roles.rst
+++ b/docsite/rst/playbooks_roles.rst
@@ -191,11 +191,8 @@ This designates the following behaviors, for each role 'x':
 - If roles/x/handlers/main.yml exists, handlers listed therein will be added to the play
 - If roles/x/vars/main.yml exists, variables listed therein will be added to the play
 - If roles/x/meta/main.yml exists, any role dependencies listed therein will be added to the list of roles (1.3 and later)
-- Any copy tasks can reference files in roles/x/files/ without having to path them relatively or absolutely
-- Any script tasks can reference scripts in roles/x/files/ without having to path them relatively or absolutely
-- Any template tasks can reference files in roles/x/templates/ without having to path them relatively or absolutely
-- Any include tasks can reference files in roles/x/tasks/ without having to path them relatively or absolutely
-   
+- Any copy, script, template or include tasks (in the role) can reference files in roles/x/files/ without having to path them relatively or absolutely
+
 In Ansible 1.4 and later you can configure a roles_path to search for roles.  Use this to check all of your common roles out to one location, and share
 them easily between multiple playbook projects.  See :doc:`intro_configuration` for details about how to set this up in ansible.cfg.
 

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -23,7 +23,7 @@ import ast
 import re
 
 from ansible import constants as C
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.inventory.host import Host
 from ansible.inventory.group import Group
 from ansible.inventory.expand_hosts import detect_range
@@ -264,9 +264,12 @@ class InventoryParser(object):
         # Can the given hostpattern be parsed as a host with an optional port
         # specification?
 
-        (pattern, port) = parse_address(hostpattern, allow_ranges=True)
-        if not pattern:
-            self._raise_error("Can't parse '%s' as host[:port]" % hostpattern)
+        try:
+            (pattern, port) = parse_address(hostpattern, allow_ranges=True)
+        except:
+            # not a recognizable host pattern
+            pattern = hostpattern
+            port = None
 
         # Once we have separated the pattern, we expand it into list of one or
         # more hostnames, depending on whether it contains any [x:y] ranges.

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -265,6 +265,12 @@ class Role(Base, Become, Conditional, Taggable):
                 inherited_vars = combine_vars(inherited_vars, parent._role_params)
         return inherited_vars
 
+    def get_role_params(self):
+        params = {}
+        for dep in self.get_all_dependencies():
+            params = combine_vars(params, dep._role_params)
+        return params
+
     def get_vars(self, dep_chain=[], include_params=True):
         all_vars = self.get_inherited_vars(dep_chain, include_params=include_params)
 

--- a/lib/ansible/plugins/action/add_host.py
+++ b/lib/ansible/plugins/action/add_host.py
@@ -53,9 +53,13 @@ class ActionModule(ActionBase):
         new_name = self._task.args.get('name', self._task.args.get('hostname', None))
         display.vv("creating host via 'add_host': hostname=%s" % new_name)
 
-        name, port = parse_address(new_name, allow_ranges=False)
-        if not name:
-            raise AnsibleError("Invalid inventory hostname: %s" % new_name)
+        try:
+            name, port = parse_address(new_name, allow_ranges=False)
+        except:
+            # not a parsable hostname, but might still be usable
+            name = new_name
+            port = None
+
         if port:
             self._task.args['ansible_ssh_port'] = port
 

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -308,6 +308,7 @@ class VariableManager:
 
             if not C.DEFAULT_PRIVATE_ROLE_VARS:
                 for role in play.get_roles():
+                    all_vars = combine_vars(all_vars, role.get_role_params())
                     all_vars = combine_vars(all_vars, role.get_vars(include_params=False))
 
         if task:

--- a/test/units/parsing/test_addresses.py
+++ b/test/units/parsing/test_addresses.py
@@ -71,7 +71,12 @@ class TestParseAddress(unittest.TestCase):
         for t in self.tests:
             test = self.tests[t]
 
-            (host, port) = parse_address(t)
+            try:
+                (host, port) = parse_address(t)
+            except:
+                host = None
+                port = None
+
             assert host == test[0]
             assert port == test[1]
 
@@ -79,6 +84,11 @@ class TestParseAddress(unittest.TestCase):
         for t in self.range_tests:
             test = self.range_tests[t]
 
-            (host, port) = parse_address(t, allow_ranges=True)
+            try:
+                (host, port) = parse_address(t, allow_ranges=True)
+            except:
+                host = None
+                port = None
+
             assert host == test[0]
             assert port == test[1]

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -26,7 +26,7 @@ from ansible.plugins.cache.memory import CacheModule as MemoryCache
 
 HAVE_MEMCACHED = True
 try:
-    import memcached
+    import memcache
 except ImportError:
     HAVE_MEMCACHED = False
 else:


### PR DESCRIPTION
- Changed parse_addresses to throw exceptions instead of passing None
- Switched callers to trap and pass through the original values.
- Look at deprecating this and possibly validate at plugin instead
  fixes #13608
