### PR TITLE
Update GCE module to use JSON credentials

### DIFF
--- a/docsite/rst/guide_gce.rst
+++ b/docsite/rst/guide_gce.rst
@@ -11,11 +11,11 @@ Introduction
 Ansible contains modules for managing Google Compute Engine resources, including creating instances, controlling network access, working with persistent disks, and managing
 load balancers.  Additionally, there is an inventory plugin that can automatically suck down all of your GCE instances into Ansible dynamic inventory, and create groups by tag and other properties.
 
-The GCE modules all require the apache-libcloud module version 0.17.0 or higher, which you can install from pip:
+The GCE modules all require the apache-libcloud module which you can install from pip:
 
 .. code-block:: bash
 
-    $ pip install apache-libcloud>=0.17.0
+    $ pip install apache-libcloud
 
 .. note:: If you're using Ansible on Mac OS X, libcloud also needs to access a CA cert chain. You'll need to download one (you can get one for `here <http://curl.haxx.se/docs/caextract.html>`_.)
 
@@ -29,6 +29,8 @@ JSON format:
 2. `Download JSON credentials <https://support.google.com/cloud/answer/6158849?hl=en&ref_topic=6262490#serviceaccounts>`_
 
 There are three different ways to provide credentials to Ansible so that it can talk with Google Cloud for provisioning and configuration actions:
+
+.. note:: If you would like to use JSON credentials you must have libcloud >= 0.17.0
 
 * by providing to the modules directly
 * by populating a ``secrets.py`` file

--- a/docsite/rst/guide_gce.rst
+++ b/docsite/rst/guide_gce.rst
@@ -11,27 +11,28 @@ Introduction
 Ansible contains modules for managing Google Compute Engine resources, including creating instances, controlling network access, working with persistent disks, and managing
 load balancers.  Additionally, there is an inventory plugin that can automatically suck down all of your GCE instances into Ansible dynamic inventory, and create groups by tag and other properties.
 
-The GCE modules all require the apache-libcloud module, which you can install from pip:
+The GCE modules all require the apache-libcloud module version 0.17.0 or higher, which you can install from pip:
 
 .. code-block:: bash
 
-    $ pip install apache-libcloud
+    $ pip install apache-libcloud>=0.17.0
 
 .. note:: If you're using Ansible on Mac OS X, libcloud also needs to access a CA cert chain. You'll need to download one (you can get one for `here <http://curl.haxx.se/docs/caextract.html>`_.)
 
 Credentials
 -----------
 
-To work with the GCE modules, you'll first need to get some credentials. You can create new one from the `console <https://console.developers.google.com/>`_ by going to the "APIs and Auth" section and choosing to create a new client ID for a service account. Once you've created a new client ID and downloaded (you must click **Generate new P12 Key**) the generated private key (in the `pkcs12 format <http://en.wikipedia.org/wiki/PKCS_12>`_), you'll need to convert the key by running the following command:
+To work with the GCE modules, you'll first need to get some credentials in the
+JSON format:
 
-.. code-block:: bash
+1. `Create a Service Account <https://developers.google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount>`_
+2. `Download JSON credentials <https://support.google.com/cloud/answer/6158849?hl=en&ref_topic=6262490#serviceaccounts>`_
 
-    $ openssl pkcs12 -in pkey.pkcs12 -passin pass:notasecret -nodes -nocerts | openssl rsa -out pkey.pem
-
-There are two different ways to provide credentials to Ansible so that it can talk with Google Cloud for provisioning and configuration actions:
+There are three different ways to provide credentials to Ansible so that it can talk with Google Cloud for provisioning and configuration actions:
 
 * by providing to the modules directly
 * by populating a ``secrets.py`` file
+* by setting environment variables
 
 Calling Modules By Passing Credentials
 ``````````````````````````````````````
@@ -39,7 +40,7 @@ Calling Modules By Passing Credentials
 For the GCE modules you can specify the credentials as arguments:
 
 * ``service_account_email``: email associated with the project
-* ``pem_file``: path to the pem file
+* ``credentials_file``: path to the JSON credentials file
 * ``project_id``: id of the project
 
 For example, to create a new instance using the cloud module, you can use the following configuration:
@@ -48,12 +49,12 @@ For example, to create a new instance using the cloud module, you can use the fo
 
    - name: Create instance(s)
      hosts: localhost
-     connection: local 
+     connection: local
      gather_facts: no
 
      vars:
        service_account_email: unique-id@developer.gserviceaccount.com
-       pem_file: /path/to/project.pem
+       credentials_file: /path/to/project.json
        project_id: project-id
        machine_type: n1-standard-1
        image: debian-7
@@ -61,27 +62,49 @@ For example, to create a new instance using the cloud module, you can use the fo
      tasks:
 
       - name: Launch instances
-        gce: 
-            instance_names: dev 
+        gce:
+            instance_names: dev
             machine_type: "{{ machine_type }}"
             image: "{{ image }}"
             service_account_email: "{{ service_account_email }}"
-            pem_file: "{{ pem_file }}" 
+            credentials_file: "{{ credentials_file }}"
             project_id: "{{ project_id }}"
 
-Calling Modules with secrets.py
-```````````````````````````````
+When running Ansible inside a GCE VM you can use the service account credentials from the local metadata server by
+setting both ``service_account_email`` and ``credentials_file`` to a blank string.
+
+Configuring Modules with secrets.py
+```````````````````````````````````
 
 Create a file ``secrets.py`` looking like following, and put it in some folder which is in your ``$PYTHONPATH``:
 
 .. code-block:: python
 
-    GCE_PARAMS = ('i...@project.googleusercontent.com', '/path/to/project.pem')
+    GCE_PARAMS = ('i...@project.googleusercontent.com', '/path/to/project.json')
     GCE_KEYWORD_PARAMS = {'project': 'project_id'}
 
 Ensure to enter the email address from the created services account and not the one from your main account.
 
 Now the modules can be used as above, but the account information can be omitted.
+
+If you are running Ansible from inside a GCE VM with an authorized service account you can set the email address and
+credentials path as follows so that get automatically picked up:
+
+.. code-block:: python
+
+    GCE_PARAMS = ('', '')
+    GCE_KEYWORD_PARAMS = {'project': 'project_id'}
+
+Configuring Modules with Environment Variables
+``````````````````````````````````````````````
+
+Set the following environment variables before running Ansible in order to configure your credentials:
+
+.. code-block:: bash
+
+    GCE_EMAIL
+    GCE_PROJECT
+    GCE_CREDENTIALS_FILE_PATH
 
 GCE Dynamic Inventory
 ---------------------
@@ -171,7 +194,7 @@ A playbook would looks like this:
        machine_type: n1-standard-1 # default
        image: debian-7
        service_account_email: unique-id@developer.gserviceaccount.com
-       pem_file: /path/to/project.pem
+       credentials_file: /path/to/project.json
        project_id: project-id
 
      tasks:
@@ -181,7 +204,7 @@ A playbook would looks like this:
              machine_type: "{{ machine_type }}"
              image: "{{ image }}"
              service_account_email: "{{ service_account_email }}"
-             pem_file: "{{ pem_file }}"
+             credentials_file: "{{ credentials_file }}"
              project_id: "{{ project_id }}"
              tags: webserver
          register: gce
@@ -224,7 +247,7 @@ a basic example of what is possible::
         machine_type: n1-standard-1 # default
         image: debian-7
         service_account_email: unique-id@developer.gserviceaccount.com
-        pem_file: /path/to/project.pem
+        credentials_file: /path/to/project.json
         project_id: project-id
 
       roles:
@@ -238,13 +261,12 @@ a basic example of what is possible::
           args:
             fwname: "all-http"
             name: "default"
-            allowed: "tcp:80" 
-            state: "present" 
-            service_account_email: "{{ service_account_email }}" 
-            pem_file: "{{ pem_file }}" 
+            allowed: "tcp:80"
+            state: "present"
+            service_account_email: "{{ service_account_email }}"
+            credentials_file: "{{ credentials_file }}"
             project_id: "{{ project_id }}"
 
 By pointing your browser to the IP of the server, you should see a page welcoming you.
 
-Upgrades to this documentation are welcome, hit the github link at the top right of this page if you would like to make additions!  
-
+Upgrades to this documentation are welcome, hit the github link at the top right of this page if you would like to make additions!


### PR DESCRIPTION
This fixes issue https://github.com/ansible/ansible/issues/13515 in a backwards compatible way.

GCP now recommends using JSON credentials files rather than P12 files. Using JSON files also simplifies the onboarding process for Ansible as it no longer requires openssl-foo in order to get started.

This PR updates includes the following:
- Bumps the required libcloud version to 0.17.0 which allows for JSON credentials
- Adds a parameter `credentials_file` that supplants `pem_file`
- Adds documentation for configuring via environment variables
- Adds documentation for using GCE service accounts rather than JSON files
- Updates the examples to use the new `credentials_file` parameter

This PR has a counterpart in the ansible-modules-core repository that enables this functionality in the modules themselves. That one should be merged first or at the same time.

cc @erjohnso 
