### PR TITLE
When var name is the same as var content, try to template it before reporting that var is not defined.

### DIFF
--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -54,6 +54,9 @@ class ActionModule(ActionBase):
                 try:
                     results = self._templar.template(self._task.args['var'], convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
                     if results == self._task.args['var']:
+                        # if results is not str/unicode type, raise an exception
+                        if type(results) not in [str, unicode]:
+                            raise AnsibleUndefinedVariable
                         # If var name is same as result, try to template it
                         results = self._templar.template("{{" + results + "}}", convert_bare=True, fail_on_undefined=True)
                 except AnsibleUndefinedVariable:

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -54,7 +54,8 @@ class ActionModule(ActionBase):
                 try:
                     results = self._templar.template(self._task.args['var'], convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
                     if results == self._task.args['var']:
-                        raise AnsibleUndefinedVariable
+                        # If var name is same as result, try to template it
+                        results = self._templar.template("{{" + results + "}}", convert_bare=True, fail_on_undefined=True)
                 except AnsibleUndefinedVariable:
                     results = "VARIABLE IS NOT DEFINED!"
 

--- a/test/integration/roles/test_var_blending/tasks/main.yml
+++ b/test/integration/roles/test_var_blending/tasks/main.yml
@@ -34,3 +34,15 @@
     that: 
         - 'diff_result.stdout == ""' 
 
+- name: check debug variable with same name as var content
+  debug: var=same_value_as_var_name_var
+  register: same_value_as_var_name
+
+- name: check debug variable output when variable is undefined
+  debug: var=undefined_variable
+  register: var_undefined
+
+- assert:
+    that:
+      - var_undefined.undefined_variable == 'VARIABLE IS NOT DEFINED!'
+      - same_value_as_var_name.same_value_as_var_name_var == 'same_value_as_var_name_var'

--- a/test/integration/roles/test_var_blending/vars/more_vars.yml
+++ b/test/integration/roles/test_var_blending/vars/more_vars.yml
@@ -1,1 +1,3 @@
 badwolf: badwolf
+
+same_value_as_var_name_var: "same_value_as_var_name_var"


### PR DESCRIPTION
Add asserts in test_var_blending to check this special corner case.
