### PR TITLE
Force success_key value against play_context and connection play_context

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -505,6 +505,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if sudoable and self._play_context.become and (allow_same_user or not same_user):
             display.debug("_low_level_execute_command(): using become for this command")
             cmd = self._play_context.make_become_cmd(cmd, executable=executable)
+            # Updating connection context to share same success_key
+            self._connection._play_context.success_key = self._play_context.success_key
 
         display.debug("_low_level_execute_command(): executing: %s" % (cmd,))
         rc, stdout, stderr = self._connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -206,7 +206,10 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
         pass
 
     def check_become_success(self, output):
-        return self._play_context.success_key == output.rstrip()
+        for line in output.splitlines(True):
+            if self._play_context.success_key == line.rstrip():
+                return True
+        return False
 
     def check_password_prompt(self, output):
         if self._play_context.prompt is None:


### PR DESCRIPTION
Do not look for sudo prompt on second item run (using with_items for exemple) for the same task.

Fix https://github.com/ansible/ansible/issues/13624
