### PR TITLE
corrected role path search order

### DIFF
--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -135,46 +135,44 @@ class RoleDefinition(Base, Become, Conditional, Taggable):
         append it to the default role path
         '''
 
-        role_path = unfrackpath(role_name)
+        # we always start the search for roles in the base directory of the playbook
+        role_search_paths = [
+            os.path.join(self._loader.get_basedir(), u'roles'),
+            self._loader.get_basedir(),
+        ]
 
+        # also search in the configured roles path
+        if C.DEFAULT_ROLES_PATH:
+            configured_paths = C.DEFAULT_ROLES_PATH.split(os.pathsep)
+            role_search_paths.extend(configured_paths)
+
+        # finally, append the roles basedir, if it was set, so we can
+        # search relative to that directory for dependent roles
+        if self._role_basedir:
+            role_search_paths.append(self._role_basedir)
+
+        # create a templar class to template the dependency names, in
+        # case they contain variables
+        if self._variable_manager is not None:
+            all_vars = self._variable_manager.get_vars(loader=self._loader, play=self._play)
+        else:
+            all_vars = dict()
+
+        templar = Templar(loader=self._loader, variables=all_vars)
+        role_name = templar.template(role_name)
+
+        # now iterate through the possible paths and return the first one we find
+        for path in role_search_paths:
+            path = templar.template(path)
+            role_path = unfrackpath(os.path.join(path, role_name))
+            if self._loader.path_exists(role_path):
+                return (role_name, role_path)
+
+        # if not found elsewhere try to extract path from name
+        role_path = unfrackpath(role_name)
         if self._loader.path_exists(role_path):
             role_name = os.path.basename(role_name)
             return (role_name, role_path)
-        else:
-            # we always start the search for roles in the base directory of the playbook
-            role_search_paths = [
-                os.path.join(self._loader.get_basedir(), u'roles'),
-                u'./roles',
-                self._loader.get_basedir(),
-                u'./'
-            ]
-
-            # also search in the configured roles path
-            if C.DEFAULT_ROLES_PATH:
-                configured_paths = C.DEFAULT_ROLES_PATH.split(os.pathsep)
-                role_search_paths.extend(configured_paths)
-
-            # finally, append the roles basedir, if it was set, so we can
-            # search relative to that directory for dependent roles
-            if self._role_basedir:
-                role_search_paths.append(self._role_basedir)
-
-            # create a templar class to template the dependency names, in
-            # case they contain variables
-            if self._variable_manager is not None:
-                all_vars = self._variable_manager.get_vars(loader=self._loader, play=self._play)
-            else:
-                all_vars = dict()
-
-            templar = Templar(loader=self._loader, variables=all_vars)
-            role_name = templar.template(role_name)
-
-            # now iterate through the possible paths and return the first one we find
-            for path in role_search_paths:
-                path = templar.template(path)
-                role_path = unfrackpath(os.path.join(path, role_name))
-                if self._loader.path_exists(role_path):
-                    return (role_name, role_path)
 
         raise AnsibleError("the role '%s' was not found in %s" % (role_name, ":".join(role_search_paths)), obj=self._ds)
 


### PR DESCRIPTION
the unfraking was matching roles in current dir as it always returns a full path,
pushed to the bottom as match of last resort
fixes #13645
