### PR TITLE
Add ProxyCommand support to the paramiko connection plugin

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -739,6 +739,17 @@ instead.  Setting it to False will improve performance and is recommended when h
 
     record_host_keys=True
 
+.. _paramiko_proxy_command
+
+proxy_command
+=============
+
+.. versionadded:: 2.1
+
+Use an OpenSSH like ProxyCommand for proxying all Paramiko SSH connections through a bastion or jump host. Requires a minimum of Paramiko version 1.9.0. On Enterprise Linux 6 this is provided by ``python-paramiko1.10`` in the EPEL repository::
+
+    proxy_command = ssh -W "%h:%p" bastion
+
 .. _openssh_settings:
 
 OpenSSH Specific Settings

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -244,6 +244,7 @@ ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path',
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, integer=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
+PARAMIKO_PROXY_COMMAND         = get_config(p, 'paramiko_connection', 'proxy_command', 'ANSIBLE_PARAMIKO_PROXY_COMMAND', None)
 
 
 # obsolete -- will be formally removed

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -23,6 +23,7 @@ __metaclass__ = type
 import fcntl
 import gettext
 import os
+import shlex
 from abc import ABCMeta, abstractmethod, abstractproperty
 
 from functools import wraps
@@ -31,6 +32,7 @@ from ansible.compat.six import with_metaclass
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.plugins import shell_loader
+from ansible.utils.unicode import to_bytes, to_unicode
 
 try:
     from __main__ import display
@@ -111,6 +113,15 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
         variables which may be used to set those attributes in this method.
         '''
         pass
+
+    @staticmethod
+    def _split_ssh_args(argstring):
+        """
+        Takes a string like '-o Foo=1 -o Bar="foo bar"' and returns a
+        list ['-o', 'Foo=1', '-o', 'Bar=foo bar'] that can be added to
+        the argument list. The list will not contain any empty elements.
+        """
+        return [to_unicode(x.strip()) for x in shlex.split(to_bytes(argstring)) if x.strip()]
 
     @abstractproperty
     def transport(self):

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -32,6 +32,7 @@ import tempfile
 import traceback
 import fcntl
 import sys
+import re
 
 from termios import tcflush, TCIFLUSH
 from binascii import hexlify
@@ -54,6 +55,9 @@ paramiko: The authenticity of host '%s' can't be established.
 The %s key fingerprint is %s.
 Are you sure you want to continue connecting (yes/no)?
 """
+
+# SSH Options Regex
+SETTINGS_REGEX = re.compile(r'(\w+)(?:\s*=\s*|\s+)(.+)')
 
 # prevent paramiko warning noise -- see http://stackoverflow.com/questions/3920502/
 HAVE_PARAMIKO=False
@@ -158,14 +162,34 @@ class Connection(ConnectionBase):
                 pass # file was not found, but not required to function
             ssh.load_system_host_keys()
 
+        proxy_command = None
+        # Parse ansible_ssh_common_args, specifically looking for ProxyCommand
+        ssh_common_args = getattr(self._play_context, 'ssh_common_args', None)
+        if ssh_common_args is not None:
+            args = self._split_ssh_args(ssh_common_args)
+            for i, arg in enumerate(args):
+                if arg.lower() == 'proxycommand':
+                    # _split_ssh_args split ProxyCommand from the command itself
+                    proxy_command = args[i + 1]
+                else:
+                    # ProxyCommand and the command itself are a single string
+                    match = SETTINGS_REGEX.match(arg)
+                    if match:
+                        if match.group(1).lower() == 'proxycommand':
+                            proxy_command = match.group(2)
+
+                if proxy_command:
+                    break
+
+        proxy_command = proxy_command or C.PARAMIKO_PROXY_COMMAND
+
         sock_kwarg = {}
-        if C.PARAMIKO_PROXY_COMMAND:
+        if proxy_command:
             replacers = {
                 '%h': self._play_context.remote_addr,
                 '%p': port,
                 '%r': self._play_context.remote_user
             }
-            proxy_command = C.PARAMIKO_PROXY_COMMAND
             for find, replace in replacers.items():
                 proxy_command = proxy_command.replace(find, str(replace))
             try:

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -144,9 +144,13 @@ class Connection(ConnectionBase):
     def _parse_proxy_command(self, port=22):
         proxy_command = None
         # Parse ansible_ssh_common_args, specifically looking for ProxyCommand
-        ssh_common_args = getattr(self._play_context, 'ssh_common_args', None)
+        ssh_args = [
+            getattr(self._play_context, 'ssh_extra_args', ''),
+            getattr(self._play_context, 'ssh_common_args', ''),
+            getattr(self._play_context, 'ssh_args', ''),
+        ]
         if ssh_common_args is not None:
-            args = self._split_ssh_args(ssh_common_args)
+            args = self._split_ssh_args(' '.join(ssh_args))
             for i, arg in enumerate(args):
                 if arg.lower() == 'proxycommand':
                     # _split_ssh_args split ProxyCommand from the command itself

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -24,7 +24,6 @@ import os
 import pipes
 import pty
 import select
-import shlex
 import subprocess
 import time
 
@@ -100,15 +99,6 @@ class Connection(ConnectionBase):
 
         return controlpersist, controlpath
 
-    @staticmethod
-    def _split_args(argstring):
-        """
-        Takes a string like '-o Foo=1 -o Bar="foo bar"' and returns a
-        list ['-o', 'Foo=1', '-o', 'Bar=foo bar'] that can be added to
-        the argument list. The list will not contain any empty elements.
-        """
-        return [to_unicode(x.strip()) for x in shlex.split(to_bytes(argstring)) if x.strip()]
-
     def _add_args(self, explanation, args):
         """
         Adds the given args to self._command and displays a caller-supplied
@@ -157,7 +147,7 @@ class Connection(ConnectionBase):
         # Next, we add [ssh_connection]ssh_args from ansible.cfg.
 
         if self._play_context.ssh_args:
-            args = self._split_args(self._play_context.ssh_args)
+            args = self._split_ssh_args(self._play_context.ssh_args)
             self._add_args("ansible.cfg set ssh_args", args)
 
         # Now we add various arguments controlled by configuration file settings
@@ -210,7 +200,7 @@ class Connection(ConnectionBase):
         for opt in ['ssh_common_args', binary + '_extra_args']:
             attr = getattr(self._play_context, opt, None)
             if attr is not None:
-                args = self._split_args(attr)
+                args = self._split_ssh_args(attr)
                 self._add_args("PlayContext set %s" % opt, args)
 
         # Check if ControlPersist is enabled and add a ControlPath if one hasn't


### PR DESCRIPTION
This PR adds OpenSSH like `ProxyCommand` support to the paramiko connection plugin.

This is one problem that I have at work, as we have to use a bastion to access all devices, which forces us to use the `ssh` connection plugin, regardless of whether the version of OpenSSH supports `ControlPersist`, which requires us to configure `ssh_args` to an empty string, or even supply `ControlPath` and such, without `ControlPersist`.

Now you can set up your `ansible.cfg` to have your ProxyCommand such as:

```
[paramiko_connection]
proxy_command = ssh -W "%h:%p" bastion
```

or

```
[paramiko_connection]
proxy_command = ssh bastion "nc %h %p"
```

This functionality requires `paramiko>=1.9.0`, which is included in the documentation and in the code.
##### What this PR does not address
- ~~an inventory variable for supplying this configuration~~
