### PR TITLE
Provides more complete fix for unverified ctx

### DIFF
--- a/lib/ansible/module_utils/f5.py
+++ b/lib/ansible/module_utils/f5.py
@@ -63,7 +63,15 @@ def disable_ssl_cert_validation():
     # You probably only want to do this for testing and never in production.
     # From https://www.python.org/dev/peps/pep-0476/#id29
     import ssl
-    ssl._create_default_https_context = ssl._create_unverified_context
+
+    try:
+        _create_unverified_https_context = ssl._create_unverified_context
+    except AttributeError:
+        # Legacy Python that doesn't verify HTTPS certificates by default
+        pass
+    else:
+        # Handle target environment that doesn't support HTTPS verification
+        ssl._create_default_https_context = _create_unverified_https_context
 
 # Fully Qualified name (with the partition)
 def fq_name(partition,name):


### PR DESCRIPTION
Noted in the code is this link

  https://www.python.org/dev/peps/pep-0476/#opting-out

Which, upon further looking provides a more complete example of how to opt-out
of SSL verification.

I noted that on a system with the following attributes
- Debian wheezy
- python 2.7.3
- python-openssl 0.13-2+deb7u1

The following error is raised if attempting to disable SSL verification

```
    ssl._create_default_https_context = ssl._create_unverified_context
    AttributeError: 'module' object has no attribute '_create_unverified_context'
```

Completing the workaround using the code at python.org dismisses this error.
