### PR TITLE
Documenting default path for hosts file - Ansible homebrew installation

### DIFF
--- a/docsite/rst/intro_getting_started.rst
+++ b/docsite/rst/intro_getting_started.rst
@@ -55,6 +55,8 @@ public SSH key should be located in ``authorized_keys`` on those systems::
 
 This is an inventory file, which is also explained in greater depth here:  :doc:`intro_inventory`.
 
+.. NOTE:: Mac users who have installed Ansible using Homebrew, should edit (or create) /usr/local/etc/ansible/hosts instead of /etc/ansible/hosts mentioned above.
+
 We'll assume you are using SSH keys for authentication.  To set up SSH agent to avoid retyping passwords, you can
 do:
 


### PR DESCRIPTION
While following the Getting Started, I had trouble running the first command since I installed Ansible via `brew`. And by doing that, the default path for the **hosts** file is `/usr/local/etc/ansible/hosts` instead of `/etc/ansible/hosts` as the doc says. There is an issue from another repository which helped me: https://github.com/skyl/ansible-sandbox/issues/1

Thanks! : )
