### PR TITLE
10x performance increase; remove uneeded deepcopy field

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import json
 import difflib
 import warnings
-from copy import deepcopy
+from copy import copy, deepcopy
 
 from ansible.compat.six import string_types
 
@@ -128,9 +128,18 @@ class CallbackBase:
 
         return item
 
+    def deepcopy_exclude(self, copyme, exclude=[]):
+        res = copy(copyme)
+        try:
+            setattr(res, exclude, None)
+        except TypeError:
+            for e in exclude:
+                setattr(res, e, None)
+        return deepcopy(res)
+
     def _process_items(self, result):
         for res in result._result['results']:
-            newres = self._copy_result(result)
+            newres = self.deepcopy_exclude(result, '_result')
             res['item'] = self._get_item(res)
             newres._result = res
             if 'failed' in res and res['failed']:

--- a/test/units/plugins/callback/test_callback.py
+++ b/test/units/plugins/callback/test_callback.py
@@ -1,0 +1,81 @@
+# (c) 2012-2014, Chris Meyers <chris.meyers.fsu@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from six import PY3
+from copy import deepcopy
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch, mock_open
+
+from ansible.plugins.callback import CallbackBase
+import ansible.plugins.callback as callish
+
+class TestCopyResultExclude(unittest.TestCase):
+    def setUp(self):
+        class DummyClass():
+            def __init__(self):
+                self.bar = [ 1, 2, 3 ]
+                self.a = {
+                    "b": 2,
+                    "c": 3,
+                }
+                self.b = {
+                    "c": 3,
+                    "d": 4,
+                }
+        self.foo = DummyClass()
+        self.cb = CallbackBase()
+
+    def tearDown(self):
+        pass
+
+    def test_copy_logic(self):
+        res = self.cb._copy_result_exclude(self.foo, ())
+        self.assertEqual(self.foo.bar, res.bar)
+    
+    def test_copy_deep(self):
+        res = self.cb._copy_result_exclude(self.foo, ())
+        self.assertNotEqual(id(self.foo.bar), id(res.bar))
+
+    def test_no_exclude(self):
+        res = self.cb._copy_result_exclude(self.foo, ())
+        self.assertEqual(self.foo.bar, res.bar)
+        self.assertEqual(self.foo.a, res.a)
+        self.assertEqual(self.foo.b, res.b)
+    
+    def test_exclude(self):
+        res = self.cb._copy_result_exclude(self.foo, ['bar', 'b'])
+        self.assertIsNone(res.bar)
+        self.assertIsNone(res.b)
+        self.assertEqual(self.foo.a, res.a)
+
+    def test_result_unmodified(self):
+        bar_id = id(self.foo.bar)
+        a_id = id(self.foo.a)
+        res = self.cb._copy_result_exclude(self.foo, ['bar', 'a'])
+
+        self.assertEqual(self.foo.bar, [ 1, 2, 3 ])
+        self.assertEqual(bar_id, id(self.foo.bar))
+
+        self.assertEqual(self.foo.a, dict(b=2, c=3))
+        self.assertEqual(a_id, id(self.foo.a))
+
+


### PR DESCRIPTION
```
#./main.yml

---
- hosts: all
  gather_facts: false
  vars:
    hello: "Hello World"
  tasks:
    - debug: msg="Hello world {{ hello }}"
      with_sequence: count=1000
```

```
time ansible-playbook -i inventory main.yml
...

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0


real    0m29.533s
user    0m29.919s
sys 0m1.436s
```

Hmm, that "feels" slow. Let's take a deeper look as to why.

```
python -m cProfile -o outme /Users/meyers/ansible/ansible/bin/ansible-playbook -i inventory main.yml >> stdout
pyprof2calltree -i outme
qcachegrind outme.log
```

**Note:** replace `qcachegrind` with `kcachegrind` if on Linux.

![image](https://cloud.githubusercontent.com/assets/722880/12005209/c527236e-ab5d-11e5-8b79-15ba846725cb.png)

`deepcopy` is costly. What is calling it and what can we do about it? 
![image](https://cloud.githubusercontent.com/assets/722880/12005225/87b469e6-ab5e-11e5-8fdf-2eb34fd47494.png)
`lib/ansible/plugins/callback/__init__.py _process_items()` is costly.

```
    def _process_items(self, result):
        for res in result._result['results']:
            newres = self._copy_result(result)
            res['item'] = self._get_item(res)
            newres._result = res
            if 'failed' in res and res['failed']:
                self.v2_playbook_item_on_failed(newres)
            elif 'skipped' in res and res['skipped']:
                self.v2_playbook_item_on_skipped(newres)
            else:
                self.v2_playbook_item_on_ok(newres)
```

`_copy_result()` is basically a wrapper for `deepcopy()`. The copy of `result._result` is being overwritten in `newres._result = res`. What happens if we don't deep copy `_result`?
![image](https://cloud.githubusercontent.com/assets/722880/12005233/0757231e-ab5f-11e5-80a8-994906ab6c69.png)
Wowzers!

```
time ansible-playbook -i inventory main.yml
...
PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0


real    0m4.617s
user    0m4.518s
sys 0m0.458s
```

**=~ 10x speedup**
### Implementation Thoughts

Instead of creating a `deepcopy_exclude()` method, instead modify `_copy_result()` to accept the `exclude` parameter. If exclude parameter included in the call then behave like `deepcopy_exclude()`
