### PR TITLE
Handle unreachable hosts second-last

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -110,12 +110,12 @@ class StrategyBase:
         unreachable_hosts = set(unreachable_hosts).union(self._tqm._unreachable_hosts.keys())
 
         # return the appropriate code, depending on the status hosts after the run
-        if len(unreachable_hosts) > 0:
-            return 3
-        elif len(failed_hosts) > 0:
+        if len(failed_hosts) > 0:
             return 2
         elif not result:
             return 1
+        elif len(unreachable_hosts) > 0:
+            return 3
         else:
             return 0
 

--- a/test/units/plugins/strategies/test_strategy_base.py
+++ b/test/units/plugins/strategies/test_strategy_base.py
@@ -65,11 +65,11 @@ class TestStrategyBase(unittest.TestCase):
         strategy_base = StrategyBase(tqm=mock_tqm)
 
         self.assertEqual(strategy_base.run(iterator=mock_iterator, play_context=mock_play_context), 0)
+        mock_tqm._unreachable_hosts = dict(host1=True)
+        self.assertEqual(strategy_base.run(iterator=mock_iterator, play_context=mock_play_context), 3)
         self.assertEqual(strategy_base.run(iterator=mock_iterator, play_context=mock_play_context, result=False), 1)
         mock_tqm._failed_hosts = dict(host1=True)
         self.assertEqual(strategy_base.run(iterator=mock_iterator, play_context=mock_play_context, result=False), 2)
-        mock_tqm._unreachable_hosts = dict(host1=True)
-        self.assertEqual(strategy_base.run(iterator=mock_iterator, play_context=mock_play_context, result=False), 3)
 
     def test_strategy_base_get_hosts(self):
         mock_hosts = []


### PR DESCRIPTION
This change brings the behaviour back in line with 1.9.

Without this change, an unreachable host will always mask hosts that have had a task failure, allowing the playbook to continue running instead of aborting when all hosts have finished executing the current play.

A simple playbook illustrating this is as follows:

``` yaml

---

- name: A
  hosts: all

- name: B
  hosts: all
  tasks:
    - name: fail
      fail:

- name: C
  hosts: all
```

If all hosts are reachable, this playbook will fail as expected when each host hits `B`. At present, if there are any unreachable hosts, the failures will be masked and all hosts will also execute `C`.
