### PR TITLE
fix for datetime exception in ecs_tasks

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -65,6 +65,7 @@ import grp
 import pwd
 import platform
 import errno
+import datetime
 from itertools import repeat, chain
 
 try:
@@ -423,9 +424,12 @@ def remove_values(value, no_log_strings):
         for omit_me in no_log_strings:
             if omit_me in stringy_value:
                 return 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
+    elif isinstance(value, datetime.datetime):
+        value = value.isoformat()
     else:
         raise TypeError('Value of unknown type: %s, %s' % (type(value), value))
     return value
+
 
 def heuristic_log_sanitize(data, no_log_values=None):
     ''' Remove strings that look like passwords from log messages '''


### PR DESCRIPTION
Proposed fix for https://github.com/ansible/ansible-modules-extras/issues/1348 in ansible-module-extras as remove_values() function is does not have an option to match the datetime.datetime type and throws an error. Also seen in other boto3 modules - in the ones I've written I popped a date_handler function but with this, that can be removed.
