### PR TITLE
Ansible installation from source needs to install MarkupSafe.

### DIFF
--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -145,7 +145,7 @@ If you don't have pip installed in your version of Python, install pip::
 
 Ansible also uses the following Python modules that need to be installed [1]_::
 
-    $ sudo pip install paramiko PyYAML Jinja2 httplib2 six
+    $ sudo pip install paramiko PyYAML Jinja2 httplib2 six MarkupSafe
 
 Note when updating ansible, be sure to not only update the source tree, but also the "submodules" in git
 which point at Ansible's own modules (not the same kind of modules, alas).


### PR DESCRIPTION
Ansible installation from source needs to install MarkupSafe:

```
ansible-playbook -i hosts site.yml 
Unexpected Exception: No module named markupsafe
the full traceback was:

Traceback (most recent call last):
  File "/root/ansible/bin/ansible-playbook", line 72, in <module>
    mycli = getattr(__import__("ansible.cli.%s" % sub, fromlist=[myclass]), myclass)
  File "/root/ansible/lib/ansible/cli/playbook.py", line 30, in <module>
    from ansible.executor.playbook_executor import PlaybookExecutor
  File "/root/ansible/lib/ansible/executor/playbook_executor.py", line 30, in <module>
    from ansible.executor.task_queue_manager import TaskQueueManager
  File "/root/ansible/lib/ansible/executor/task_queue_manager.py", line 29, in <module>
    from ansible.executor.play_iterator import PlayIterator
  File "/root/ansible/lib/ansible/executor/play_iterator.py", line 29, in <module>
    from ansible.playbook.block import Block
  File "/root/ansible/lib/ansible/playbook/__init__.py", line 25, in <module>
    from ansible.playbook.play import Play
  File "/root/ansible/lib/ansible/playbook/play.py", line 27, in <module>
    from ansible.playbook.base import Base
  File "/root/ansible/lib/ansible/playbook/base.py", line 32, in <module>
    from jinja2.exceptions import UndefinedError
  File "/usr/local/lib/python2.7/dist-packages/jinja2/__init__.py", line 33, in <module>
    from jinja2.environment import Environment, Template
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 13, in <module>
    from jinja2 import nodes
  File "/usr/local/lib/python2.7/dist-packages/jinja2/nodes.py", line 19, in <module>
    from jinja2.utils import Markup
  File "/usr/local/lib/python2.7/dist-packages/jinja2/utils.py", line 531, in <module>
    from markupsafe import Markup, escape, soft_unicode
ImportError: No module named markupsafe
```
