### PR TITLE
use pulled ansible.cfg for inventory

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -210,8 +210,23 @@ class CLI(object):
         setattr(parser.values, option.dest, os.path.expanduser(value))
 
     @staticmethod
-    def base_parser(usage="", output_opts=False, runas_opts=False, meta_opts=False, runtask_opts=False, vault_opts=False, module_opts=False,
-            async_opts=False, connect_opts=False, subset_opts=False, check_opts=False, inventory_opts=False, epilog=None, fork_opts=False, runas_prompt_opts=False):
+    def base_parser(usage="",
+                    output_opts=False,
+                    runas_opts=False,
+                    meta_opts=False,
+                    runtask_opts=False,
+                    vault_opts=False,
+                    module_opts=False,
+                    async_opts=False,
+                    connect_opts=False,
+                    subset_opts=False,
+                    check_opts=False,
+                    inventory_opts=False,
+                    inventory_default=C.DEFAULT_HOST_LIST,
+                    epilog=None,
+                    fork_opts=False,
+                    runas_prompt_opts=False,
+                    ):
         ''' create an options parser for most ansible scripts '''
 
         # TODO: implement epilog parsing
@@ -225,7 +240,7 @@ class CLI(object):
         if inventory_opts:
             parser.add_option('-i', '--inventory-file', dest='inventory',
                 help="specify inventory host path (default=%s) or comma separated host list" % C.DEFAULT_HOST_LIST,
-                default=C.DEFAULT_HOST_LIST, action="callback", callback=CLI.expand_tilde, type=str)
+                default=inventory_default, action="callback", callback=CLI.expand_tilde, type=str)
             parser.add_option('--list-hosts', dest='listhosts', action='store_true',
                 help='outputs a list of matching hosts; does not execute anything else')
             parser.add_option('-l', '--limit', default=C.DEFAULT_SUBSET, dest='subset',

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -63,6 +63,7 @@ class PullCLI(CLI):
             runtask_opts=True,
             subset_opts=True,
             inventory_opts=True,
+            inventory_default=None,
             module_opts=True,
             runas_prompt_opts=True,
         )


### PR DESCRIPTION
- restore 1.9 behavior
- only give `-i` option to ansible-playbook if explicitly given to ansible-pull
  this then allows ansible-playbook to use the pulled ansible.cfg for the inventory
- leave behavior of all other tools unchanged
- fixes #13688
