### PR TITLE
Set executable to None, fixes issue #13696

### DIFF
--- a/lib/ansible/runner/action_plugins/raw.py
+++ b/lib/ansible/runner/action_plugins/raw.py
@@ -34,7 +34,7 @@ class ActionModule(object):
             # in --check mode, always skip this module execution
             return ReturnData(conn=conn, comm_ok=True, result=dict(skipped=True))
 
-        executable = ''
+        executable = None
         # From library/command, keep in sync
         r = re.compile(r'(^|\s)(executable)=(?P<quote>[\'"])?(.*?)(?(quote)(?<!\\)(?P=quote))((?<!\\)\s|$)')
         for m in r.finditer(module_args):


### PR DESCRIPTION
See issue #13696 for a detailed description of the problem.
`executable = None` will be picked up in [`_low_level_exec_command`](https://github.com/ansible/ansible/blob/stable-1.9/lib/ansible/runner/__init__.py#L1161) and set to C.DEFAULT_EXECUTABLE if it is None.
