### PR TITLE
[security] shred ansible-vault tmp_file. Also when editor is interruped

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -235,9 +235,10 @@ class VaultEditor:
         passes = 3
         with open(tmp_path,  "w") as fh:
             for _ in range(int(passes)):
+                fh.seek(0,  0)
                 data = generate_data(ld)
                 fh.write(data)
-                fh.seek(0,  0)
+                os.fsync(fh)
         os.remove(tmp_path)
         
     def _edit_file_helper(self, filename, existing_data=None, force_save=False):


### PR DESCRIPTION
The implementation of ansible-vault has two problems when you do `ansible-vault edit my-encrypted-secrets.yml`: 

1) if ansible-vault receives a keyboard-interrupt during editing, the file is not deleted and the secrets are left plain, unencrypted on disk (chmod 600, granted). This keyboard interrupt is not likely when you are using vim, but it is when you are using gedit or meld (you have an attached terminal then, because you gave in the password there). 
2) with or without interrupt, the unencrypted file is not shredded by ansible-vault, just deleted. 

This patch fixes both issues. 
