### PR TITLE
Make credstash lookup plugin support encryption contexts

### DIFF
--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -38,7 +38,11 @@ class LookupModule(LookupBase):
         ret = []
         for term in terms:
             try:
-                val = credstash.getSecret(term, **kwargs)
+                version = kwargs.pop('version', '')
+                region = kwargs.pop('region', None)
+                table = kwargs.pop('table', 'credential-store')
+                val = credstash.getSecret(term, version, region, table,
+                                          context=kwargs)
             except credstash.ItemNotFound:
                 raise AnsibleError('Key {0} not found'.format(term))
             except Exception as e:


### PR DESCRIPTION
Previously, the lookup plugin passes all its keyword arguments to
credstash's `getSecret`; while this works for passing the standard
parameters (version, region and table), this does not allow passing
a dictionary of key-value pairs as `getSecret`'s context parameter.

Instead, pop `version`, `region` and `table` from `kwargs`, supplying
the default value if they are not defined, and pass the rest of the `kwargs`
as the `context` parameter.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/13709)

<!-- Reviewable:end -->
