### PR TITLE
Do not set 'changed' to True when using group_by

### DIFF
--- a/lib/ansible/plugins/action/group_by.py
+++ b/lib/ansible/plugins/action/group_by.py
@@ -40,6 +40,6 @@ class ActionModule(ActionBase):
         group_name = self._task.args.get('key')
         group_name = group_name.replace(' ','-')
 
-        result['changed'] = True
+        result['changed'] = False
         result['add_group'] = group_name
         return result


### PR DESCRIPTION
Since group_by is not changing in any way to the remote
system, there is no change. This also make things more consistent
with the set_fact plugin.
