### PR TITLE
Fix doc site ads

### DIFF
--- a/docsite/Makefile
+++ b/docsite/Makefile
@@ -43,4 +43,4 @@ modules: $(FORMATTER) ../hacking/templates/rst.j2
 	PYTHONPATH=../lib $(FORMATTER) -t rst --template-dir=../hacking/templates --module-dir=../lib/ansible/modules -o rst/
 
 staticmin:
-	cat _themes/srtd/static/css/theme.css | sed -e 's/^[ \t]*//g; s/[ \t]*$$//g; s/\([:{;,]\) /\1/g; s/ {/{/g; s/\/\*.*\*\///g; /^$$/d' | sed -e :a -e '$$!N; s/\n\(.\)/\1/; ta' > _themes/srtd/static/css/theme.min.css
+	cat _themes/srtd/static/css/theme.css | sed -e 's/^[ 	]*//g; s/[ 	]*$$//g; s/\([:{;,]\) /\1/g; s/ {/{/g; s/\/\*.*\*\///g; /^$$/d' | sed -e :a -e '$$!N; s/\n\(.\)/\1/; ta' > _themes/srtd/static/css/theme.min.css

--- a/docsite/_themes/srtd/footer.html
+++ b/docsite/_themes/srtd/footer.html
@@ -13,7 +13,7 @@
   <hr/>
 
   <p>
-  &copy; Copyright 2015 <a href="http://ansible.com">Ansible, Inc.</a>.
+  &copy; Copyright 2016 <a href="http://ansible.com">Ansible, Inc.</a>.
 
   {%- if last_updated %}
     {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}

--- a/docsite/_themes/srtd/layout.html
+++ b/docsite/_themes/srtd/layout.html
@@ -166,7 +166,7 @@
 <!-- changeable widget -->
 <center>
 <br/>
-<a href="http://www.ansible.com/tower?utm_source=docs">
+<a href="http://www.ansible.com/docs-left?utm_source=docs">
     <img style="border-width:0px;" src="https://cdn2.hubspot.net/hubfs/330046/docs-graphics/ASB-docs-left-rail.png" />
 </a>
 </center>
@@ -189,15 +189,17 @@
       <div class="wy-nav-content">
         <div class="rst-content">
 
-          <!-- Tower ads -->
-          <a class="DocSiteBanner" href="http://www.ansible.com/tower?utm_source=docs">
-            <div class="DocSiteBanner-imgWrapper">
-              <img src="https://cdn2.hubspot.net/hubfs/330046/docs-graphics/ASB-docs-top-left.png">
-            </div>
-            <div class="DocSiteBanner-imgWrapper">
-              <img src="https://cdn2.hubspot.net/hubfs/330046/docs-graphics/ASB-docs-top-right.png">
-            </div>
-          </a>
+          <!-- Banner ads -->
+          <div class="DocSiteBanner">
+            <a class="DocSiteBanner-imgWrapper"
+                href="http://www.ansible.com/docs-top?utm_source=docs">
+                <img src="https://cdn2.hubspot.net/hubfs/330046/docs-graphics/ASB-docs-top-left.png">
+            </a>
+            <a class="DocSiteBanner-imgWrapper"
+                href="http://www.ansible.com/docs-top?utm_source=docs">
+                <img src="https://cdn2.hubspot.net/hubfs/330046/docs-graphics/ASB-docs-top-right.png">
+            </a>
+        </div>
 
           {% include "breadcrumbs.html" %}
           <div id="page-content">

--- a/docsite/_themes/srtd/static/css/theme.css
+++ b/docsite/_themes/srtd/static/css/theme.css
@@ -4723,33 +4723,16 @@ span[id*='MathJax-Span'] {
     padding: 0.4045em 1.618em;
 }
 
-
 .DocSiteBanner {
-    width: 100%;
     display: flex;
     display: -webkit-flex;
+    justify-content: center;
+    -webkit-justify-content: center;
     flex-wrap: wrap;
     -webkit-flex-wrap: wrap;
-    justify-content: space-between;
-    -webkit-justify-content: space-between;
-    background-color: #ff5850;
     margin-bottom: 25px;
 }
 
 .DocSiteBanner-imgWrapper {
     max-width: 100%;
-}
-
-@media screen and (max-width: 1403px) {
-    .DocSiteBanner {
-        width: 100%;
-        display: flex;
-        display: -webkit-flex;
-        flex-wrap: wrap;
-        -webkit-flex-wrap: wrap;
-        justify-content: center;
-        -webkit-justify-content: center;
-        background-color: #fff;
-        margin-bottom: 25px;
-    }
 }


### PR DESCRIPTION
This fixes the make target (was not escaping just tabs, but also "T's".  This also removes the space between the doc ads and makes the url/img configurable.  Finally, the copyright date on the docsite footer has been updated to 2016.
