### PR TITLE
now show full callback stacktrace when vvv+

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -290,8 +290,13 @@ class TaskQueueManager:
                     try:
                         method(*args, **kwargs)
                     except Exception as e:
+                        import traceback
+                        orig_tb = traceback.format_exc()
                         try:
                             v1_method = method.replace('v2_','')
                             v1_method(*args, **kwargs)
                         except Exception:
-                            display.warning('Error when using %s: %s' % (method, str(e)))
+                            if display.verbosity >= 3:
+                                display.warning(orig_tb, formatted=True)
+                            else:
+                                display.warning('Error when using %s: %s' % (method, str(e)))

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -202,10 +202,15 @@ class Display:
             self.display(new_msg.strip(), color=C.COLOR_DEPRECATE, stderr=True)
             self._deprecations[new_msg] = 1
 
-    def warning(self, msg):
-        new_msg = "\n[WARNING]: %s" % msg
-        wrapped = textwrap.wrap(new_msg, self.columns)
-        new_msg = "\n".join(wrapped) + "\n"
+    def warning(self, msg, formatted=False):
+
+        if not formatted:
+            new_msg = "\n[WARNING]: %s" % msg
+            wrapped = textwrap.wrap(new_msg, self.columns)
+            new_msg = "\n".join(wrapped) + "\n"
+        else:
+            new_msg = "\n[WARNING]: \n%s" % msg
+
         if new_msg not in self._warns:
             self.display(new_msg, color=C.COLOR_WARN, stderr=True)
             self._warns[new_msg] = 1


### PR DESCRIPTION
still is a warning as we don't want to repeat it multiple times nor additional callbacks to stop ansible execution. Hopefully we can avoid shipping w/o exceptions in the default/minimal callbacks...

fixes #13713
