### PR TITLE
ipaddr filter properly handle addresses on /31 networks

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -80,7 +80,8 @@ def _ip_query(v):
     if v.size == 1:
         return str(v.ip)
     if v.size > 1:
-        if v.ip != v.network:
+        # /31 networks in netaddr have no broadcast address
+        if v.ip != v.network or not v.broadcast:
             return str(v.ip)
 
 def _gateway_query(v):


### PR DESCRIPTION
fix for https://github.com/ansible/ansible/issues/13716

```
  tasks:
  - debug: msg="100.64.251.2/31 => {{ '100.64.251.2/31' | ipaddr('address') }}"
  - debug: msg="100.64.251.3/31 => {{ '100.64.251.3/31' | ipaddr('address') }}"
  - debug: msg="100.64.251.0/24 => {{ '100.64.251.0/24' | ipaddr('address') }}"
  - debug: msg="100.64.251.0/31 => {{ '100.64.251.0/24' | ipaddr('address') }}"
```

``````
ok: [localhost] => {
    "msg": "100.64.251.2/31 => 100.64.251.2"
}
ok: [localhost] => {
    "msg": "100.64.251.3/31 => 100.64.251.3"
}
ok: [localhost] => {
    "msg": "100.64.251.0/24 => "
}
ok: [localhost] => {
    "msg": "100.64.251.0/31 => "
}```
``````
