### PR TITLE
removed the "wy-side-nav-search" element

### DIFF
--- a/docsite/_themes/srtd/layout.html
+++ b/docsite/_themes/srtd/layout.html
@@ -150,11 +150,6 @@
         </a>
       </div>
 
-      <div class="wy-side-nav-search" style="background-color:#5bbdbf;height=80px;margin:'auto auto auto auto'">
-        <!-- <a href="{{ pathto(master_doc) }}" class="icon icon-home"> {{ project }}</a> -->
-        {% include "searchbox.html" %}
-      </div>
-
       <div id="menu-id" class="wy-menu wy-menu-vertical" data-spy="affix">
         {% set toctree = toctree(maxdepth=2, collapse=False) %}
         {% if toctree %}


### PR DESCRIPTION
this is so we can use the new swiftype search and it's search input
