### PR TITLE
Don't break out of plays loop when some hosts fail

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -165,10 +165,10 @@ class PlaybookExecutor:
                             self._unreachable_hosts.update(self._tqm._unreachable_hosts)
                             self._tqm.clear_failed_hosts()
 
-                        # if the last result wasn't zero or 3 (some hosts were unreachable),
-                        # break out of the serial batch loop
-                        if result not in (0, 3):
-                            break
+                            # if the last result wasn't zero or 3 (some hosts were unreachable),
+                            # break out of the serial batch loop
+                            if result not in (0, 3):
+                                break
 
                     i = i + 1 # per play
 


### PR DESCRIPTION
##### SUMMARY
It used to break out of the wrong loop - first play with failed hosts silently stopped running the playbook, instead of just skipping the current play.

##### ISSUE TYPE
Feature Pull Request

##### ANSIBLE VERSION
N/A
