### PR TITLE
Changing MD5 checksum code to work against files in use

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -210,10 +210,9 @@ Function Get-FileChecksum($path)
     $hash = ""
     If (Test-Path -PathType Leaf $path)
     {
-        $sp = new-object -TypeName System.Security.Cryptography.SHA1CryptoServiceProvider;
-        $fp = [System.IO.File]::Open($path, [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read);
-        $hash = [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
-        $fp.Dispose();
+        $sp = New-Object -TypeName System.Security.Cryptography.SHA1CryptoServiceProvider
+        $hash = [System.BitConverter]::ToString($sp.ComputeHash(`
+          [System.IO.File]::ReadAllBytes($path))).Replace("-", "").ToLower()
     }
     ElseIf (Test-Path -PathType Container $path)
     {

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -94,10 +94,9 @@ class ShellModule(object):
         script = '''
             If (Test-Path -PathType Leaf "%(path)s")
             {
-                $sp = new-object -TypeName System.Security.Cryptography.SHA1CryptoServiceProvider;
-                $fp = [System.IO.File]::Open("%(path)s", [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read);
-                [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
-                $fp.Dispose();
+                $sp = New-Object -TypeName System.Security.Cryptography.SHA1CryptoServiceProvider;
+                [System.BitConverter]::ToString($sp.ComputeHash(`
+                  [System.IO.File]::ReadAllBytes("%(path)s"))).Replace("-", "").ToLower();
             }
             ElseIf (Test-Path -PathType Container "%(path)s")
             {


### PR DESCRIPTION
Currently when using a module such as "win_stat", it will fail when trying to stat a file that is in use.  This is due to the way the MD5 checksum is being extracted via the current powershell code.  I have changed the code to no longer require locking the file in order to properly read an MD5 checksum.  In return, you can now run "win_stat" against files that are in use.
