### PR TITLE
Allow InventoryScript JSON with childgroups only

### DIFF
--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -103,7 +103,7 @@ class InventoryScript:
             if not isinstance(data, dict):
                 data = {'hosts': data}
             # is not those subkeys, then simplified syntax, host with vars
-            elif not any(k in data for k in ('hosts','vars')):
+            elif not any(k in data for k in ('hosts','vars','children')):
                 data = {'hosts': [group_name], 'vars': data}
 
             if 'hosts' in data:


### PR DESCRIPTION
and without hosts and vars

Without this patch, the simplified syntax is triggered when a group
is defined like this:

```
"platforms": {
    "children": [
        "cloudstack"
    ]
}
```

Which results in a group 'platforms' with 1 host 'platforms'.

This is basically only a redo of this commit: https://github.com/ansible/ansible/commit/69740b86e8b8ce7e0407bbe6f8eb9d97dd93022c
that got nullified by this commit: https://github.com/ansible/ansible/commit/ce3ef7f4c16e47d5a0b5600e1c56c177b7c93f0d#diff-a4d695beaa410b22bfeb22749cdaa210R99

more details in issue: https://github.com/ansible/ansible/issues/13655
