### PR TITLE
Restore ability for a module to specify WANT_JSON

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -397,7 +397,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if tmp:
             remote_module_filename = self._connection._shell.get_remote_filename(module_name)
             remote_module_path = self._connection._shell.join_path(tmp, remote_module_filename)
-            if module_style == 'old':
+            if module_style in ['old', 'non_native_want_json']:
                 # we'll also need a temp file to hold our module arguments
                 args_file_path = self._connection._shell.join_path(tmp, 'args')
 
@@ -411,6 +411,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 for k,v in iteritems(module_args):
                     args_data += '%s="%s" ' % (k, pipes.quote(text_type(v)))
                 self._transfer_data(args_file_path, args_data)
+            elif module_style == 'non_native_want_json':
+                self._transfer_data(args_file_path, json.dumps(module_args))
             display.debug("done transferring module to remote")
 
         environment_string = self._compute_environment_string()


### PR DESCRIPTION
IN 2.0/devel it appears that `WANT_JSON` functionality has been broken.

Nowhere did we inspect `module_style` for `non_native_want_json` and upload a JSON args file.

This change should fix this.

This should likely be cherry picked in stable-2.0 as well.
