### PR TITLE
Fixes #13763 Update connections _play_context on every iteration

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -365,6 +365,9 @@ class TaskExecutor:
         if not self._connection or not getattr(self._connection, 'connected', False):
             self._connection = self._get_connection(variables=variables, templar=templar)
             self._connection.set_host_overrides(host=self._host)
+        #If connection is reused, its _play_context is no longer valid and needs to be replaced
+        #This fixes issues with tasks running sudo in a loop and having the success_key incorrect in the second iteration
+        self._connection._play_context = self._play_context
 
         self._handler = self._get_action_handler(connection=self._connection, templar=templar)
 


### PR DESCRIPTION
If this isnt updated, the _connection is reused, and thus has an outdated `_play_context`
This results in outdated `success_key` and `prompt` causing issues if sudo is run in a loop
Refer to the issue #13763 for more debugging and details
