### PR TITLE
Unarchrefactor

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -674,6 +674,4 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             ),
         )
 
-    # execute the unarchive module now, with the updated args
-    result.update(self._execute_module(module_args=new_module_args, task_vars=task_vars))
     return result

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -605,7 +605,6 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         source  = self._task.args.get('src', None)
         dest    = self._task.args.get('dest', None)
-#        creates = self._task.args.get('creates', None)
 
         if source is None or dest is None:
             result['failed'] = True
@@ -615,16 +614,6 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if not tmp:
             tmp = self._make_tmp_path()
 
-        #if creates:
-#             # do not run the command if the line contains creates=filename
-#             # and the filename already exists. This allows idempotence
-#             # of command executions.
-#             result = self._execute_module(module_name='stat', module_args=dict(path=creates), task_vars=task_vars)
-#             stat = result.get('stat', None)
-#             if stat and stat.get('exists', False):
-#                 result['skipped'] = True
-#                 result['msg'] = "skipped, since %s exists" % creates
-#                 return result
 
         dest = self._remote_expand_user(dest) # CCTODO: Fix path for Windows hosts.
         source = os.path.expanduser(source)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -599,3 +599,81 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 diff['after'] = source
 
         return diff
+
+    def _copy(self,tmp=None):
+        result = []
+
+        source  = self._task.args.get('src', None)
+        dest    = self._task.args.get('dest', None)
+        #copy    = boolean(self._task.args.get('copy', True))
+        creates = self._task.args.get('creates', None)
+
+        if source is None or dest is None:
+            result['failed'] = True
+            result['msg'] = "src (or content) and dest are required"
+            return result
+
+        if not tmp:
+            tmp = self._make_tmp_path()
+
+        if creates:
+            # do not run the command if the line contains creates=filename
+            # and the filename already exists. This allows idempotence
+            # of command executions.
+            result = self._execute_module(module_name='stat', module_args=dict(path=creates), task_vars=task_vars)
+            stat = result.get('stat', None)
+            if stat and stat.get('exists', False):
+                result['skipped'] = True
+                result['msg'] = "skipped, since %s exists" % creates
+                return result
+
+        dest = self._remote_expand_user(dest) # CCTODO: Fix path for Windows hosts.
+        source = os.path.expanduser(source)
+
+        #if copy:
+        if self._task._role is not None:
+            source = self._loader.path_dwim_relative(self._task._role._role_path, 'files', source)
+        else:
+            source = self._loader.path_dwim_relative(self._loader.get_basedir(), 'files', source)
+
+        remote_checksum = self._remote_checksum(dest, all_vars=task_vars)
+        if remote_checksum == '4':
+            result['failed'] = True
+            result['msg'] = "python isn't present on the system.  Unable to compute checksum"
+            return result
+        elif remote_checksum != '3':
+            result['failed'] = True
+            result['msg'] = "dest '%s' must be an existing dir" % dest
+            return result
+
+        # transfer the file to a remote tmp location
+        tmp_src = tmp + 'source'
+        self._connection.put_file(source, tmp_src)
+
+        # handle diff mode client side
+        # handle check mode client side
+        # fix file permissions when the copy is done as a different user
+        if self._play_context.become and self._play_context.become_user != 'root':
+            if not self._play_context.check_mode:
+                self._remote_chmod('a+r', tmp_src)
+
+        # Build temporary module_args.
+        new_module_args = self._task.args.copy()
+        new_module_args.update(
+            dict(
+                src=tmp_src,
+                original_basename=os.path.basename(source),
+            ),
+        )
+
+    else:
+        new_module_args = self._task.args.copy()
+        new_module_args.update(
+            dict(
+                original_basename=os.path.basename(source),
+            ),
+        )
+
+    # execute the unarchive module now, with the updated args
+    result.update(self._execute_module(module_args=new_module_args, task_vars=task_vars))
+    return result

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -23,13 +23,12 @@ import os
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
 
-
 class ActionModule(ActionBase):
 
     TRANSFERS_FILES = True
 
     def run(self, tmp=None, task_vars=None):
-        ''' handler for unarchive operations '''
+        ''' orchestrates determining appropriate unarchive module and calling it '''
         if task_vars is None:
             task_vars = dict()
 

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -71,6 +71,28 @@ class ActionModule(ActionBase):
         # source may have been upated by _copy
         new_module_args['original_basename'] = os.path.basename(source)
     
-        # execute the unarchive module now, with the updated args
+        # execute the unarchive module and get archive type
         result.update(self._execute_module(module_args=new_module_args, task_vars=task_vars))
+        if result.get('failed') or result.get('skipped'):
+            return result
+        if result.get('archive_type'):
+            handler_for = {
+                'TarArchive':     'untar',
+                'TarBzipArchive': 'untar',
+                'TarXzArchive':   'untar',
+                'TgzArchive':     'untar',
+                'ZipArchive':     'unzip',
+            }
+            if result['archive_type'] not in handler_for:
+                result['failed'] = True
+                result['msg'] = "No handler for archive type '%s'" % result['archive_type']
+                return result
+                
+            new_module_args['archive_type'] = result['archive_type']
+            result.update(self._execute_module(module_name=handler_for[result['archive_type']], module_args=new_module_args, task_vars=task_vars))
+        else:
+            result['failed'] = True
+            result['msg'] = "Failed to determine archive type for '%s'" %  source
+            return result
+        
         return result

--- a/lib/ansible/plugins/action/untar.py
+++ b/lib/ansible/plugins/action/untar.py
@@ -23,13 +23,12 @@ import os
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
 
-
 class ActionModule(ActionBase):
 
     TRANSFERS_FILES = True
 
     def run(self, tmp=None, task_vars=None):
-        ''' handler for unarchive operations '''
+        ''' handler for untar operations '''
         if task_vars is None:
             task_vars = dict()
 
@@ -39,6 +38,9 @@ class ActionModule(ActionBase):
         copy    = boolean(self._task.args.get('copy', True))
         creates = self._task.args.get('creates', None)
 
+
+        # we need this is untar is called directly, but not if unarchive already checked
+        # it's inefficent but dependable for now
         if creates:
             # do not run the command if the line contains creates=filename
             # and the filename already exists. This allows idempotence

--- a/lib/ansible/plugins/action/untar.py
+++ b/lib/ansible/plugins/action/untar.py
@@ -1,0 +1,64 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2013, Dylan Martin <dmartin@seattlecentral.edu>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+from ansible.plugins.action import ActionBase
+from ansible.utils.boolean import boolean
+
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = True
+
+    def run(self, tmp=None, task_vars=None):
+        ''' handler for unarchive operations '''
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        source  = self._task.args.get('src', None)
+        copy    = boolean(self._task.args.get('copy', True))
+
+        if tmp is None:
+            tmp = self._make_tmp_path()
+
+        new_module_args = self._task.args.copy()
+        
+        if copy:
+            result.update(self._copy(tmp,task_vars))
+            if result.get('failed') or result.get('skipped'):
+                if result.get('passback'):
+                    del result['passback']
+                return result    
+        
+            # how I got some values from _copy
+            source = result['passback']['source']
+            tmp_src = result['passback']['tmp_src']
+            del result['passback']
+            new_module_args['src'] = tmp_src
+    
+        # source may have been upated by _copy
+        new_module_args['original_basename'] = os.path.basename(source)
+    
+        # execute the unarchive module now, with the updated args
+        result.update(self._execute_module(module_args=new_module_args, task_vars=task_vars))
+        return result

--- a/lib/ansible/plugins/action/unzip.py
+++ b/lib/ansible/plugins/action/unzip.py
@@ -23,13 +23,12 @@ import os
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
 
-
 class ActionModule(ActionBase):
 
     TRANSFERS_FILES = True
 
     def run(self, tmp=None, task_vars=None):
-        ''' handler for unarchive operations '''
+        ''' handler for unzip operations '''
         if task_vars is None:
             task_vars = dict()
 

--- a/lib/ansible/plugins/action/unzip.py
+++ b/lib/ansible/plugins/action/unzip.py
@@ -1,0 +1,64 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2013, Dylan Martin <dmartin@seattlecentral.edu>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+from ansible.plugins.action import ActionBase
+from ansible.utils.boolean import boolean
+
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = True
+
+    def run(self, tmp=None, task_vars=None):
+        ''' handler for unarchive operations '''
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        source  = self._task.args.get('src', None)
+        copy    = boolean(self._task.args.get('copy', True))
+
+        if tmp is None:
+            tmp = self._make_tmp_path()
+
+        new_module_args = self._task.args.copy()
+        
+        if copy:
+            result.update(self._copy(tmp,task_vars))
+            if result.get('failed') or result.get('skipped'):
+                if result.get('passback'):
+                    del result['passback']
+                return result    
+        
+            # how I got some values from _copy
+            source = result['passback']['source']
+            tmp_src = result['passback']['tmp_src']
+            del result['passback']
+            new_module_args['src'] = tmp_src
+    
+        # source may have been upated by _copy
+        new_module_args['original_basename'] = os.path.basename(source)
+    
+        # execute the unarchive module now, with the updated args
+        result.update(self._execute_module(module_args=new_module_args, task_vars=task_vars))
+        return result


### PR DESCRIPTION
This is the plugin side of a refactor to allow untar and unzip (and any future unarchivers) to have their own modules, thus allowing their own arguments.  There will be a corresponding PR for ansible-modules-core in just a moment.  Don't accept one without the other!

This PR only refactors and does not add new arguments.  

After doing it, I realized a lot of ways to make it better.  I added a _copy method to the ActionBase class, thinking this would be good because other future modules could use it.  However, it might be better to make an unarchive subclass of ActionBase and stick stuff in thier.  Also, I wound up duplicating a fair amount of code between the unarchive module and the untar and unzip modules.  I would like to separate out some of the logic.  Possibly into ansible.module_utils somewhere... sigh... 

So, basically, if you aren't picky, take this PR.  It should allow folks who want to submit PRs for new tar/zip features to be able to do so.  If you're even remotely picky, fire it back with comments and I'll unscrew whatever parts you don't like.

There will be a nearly identical sounding PR for ansible-modules-core in just a moment.  One doesn't work without the other.
