### PR TITLE
Allow _get_hostgroup_vars to properly return

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -736,11 +736,15 @@ class Inventory(object):
             if group and host is None:
                 # load vars in dir/group_vars/name_of_group
                 base_path = os.path.realpath(os.path.join(basedir, "group_vars/%s" % group.name))
-                results = self._variable_manager.add_group_vars_file(base_path, self._loader)
+                r = self._variable_manager.add_group_vars_file(base_path, self._loader)
+                if bool(r):
+                    results = r
             elif host and group is None:
                 # same for hostvars in dir/host_vars/name_of_host
                 base_path = os.path.realpath(os.path.join(basedir, "host_vars/%s" % host.name))
-                results = self._variable_manager.add_host_vars_file(base_path, self._loader)
+                r = self._variable_manager.add_host_vars_file(base_path, self._loader)
+                if bool(r):
+                    results = r
 
         # all done, results is a dictionary of variables for this particular host.
         return results


### PR DESCRIPTION
When iterating over `basedirs`, and the playbook base directory
does not contain inventory, an empty dict is returned to the caller
instead of the inventory found.

For further details see the bug report #13873.
