### PR TITLE
Allow Ansible to return error with unicode within it.

### DIFF
--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -54,7 +54,7 @@ class AnsibleError(Exception):
         if obj and isinstance(obj, AnsibleBaseYAMLObject):
             extended_error = self._get_extended_error()
             if extended_error:
-                self.message = 'ERROR! %s\n\n%s' % (message, to_str(extended_error))
+                self.message = 'ERROR! %s\n\n%s' % (to_str(message), to_str(extended_error))
         else:
             self.message = 'ERROR! %s' % message
 


### PR DESCRIPTION
Fix for https://github.com/ansible/ansible/issues/13899
