### PR TITLE
Specify the correct default options for sudo_flags

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -587,9 +587,10 @@ the sudo implementation is matching CLI flags with the standard sudo::
 sudo_flags
 ==========
 
-Additional flags to pass to sudo when engaging sudo support.  The default is '-H' which preserves the $HOME environment variable
-of the original user.  In some situations you may wish to add or remove flags, but in general most users
-will not need to change this setting::
+Additional flags to pass to sudo when engaging sudo support. The default is '-H -S -n' which sets the HOME environment
+variable, prompts for passwords via STDIN, and avoids prompting the user for input of any kind. Note that '-n' will conflict
+with using password-less sudo auth, such as pam_ssh_agent_auth. In some situations you may wish to add or remove flags, but
+in general most users will not need to change this setting:::
 
    sudo_flags=-H -S -n
 

--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -591,7 +591,7 @@ Additional flags to pass to sudo when engaging sudo support.  The default is '-H
 of the original user.  In some situations you may wish to add or remove flags, but in general most users
 will not need to change this setting::
 
-   sudo_flags=-H
+   sudo_flags=-H -S -n
 
 .. _sudo_user:
 


### PR DESCRIPTION
The correct default options for sudo_flags can be found at: https://github.com/ansible/ansible/blob/devel/lib/ansible/constants.py#L181

Slightly alter explanation of '-H' so as not to confuse it with -E, --preserve-env (which preserves existing environment variables).

When adding the two other options, include short explanations of those options.

Add note about '-n', which did not appear in 1.x I believe, and which bit me.
