### PR TITLE
Enforce `state='file'` in `copy` module

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -257,7 +257,8 @@ class ActionModule(ActionBase):
                     dict(
                         src=source_rel,
                         dest=dest,
-                        original_basename=source_rel
+                        original_basename=source_rel,
+                        state='file'
                     )
                 )
 

--- a/test/integration/roles/test_copy/tasks/main.yml
+++ b/test/integration/roles/test_copy/tasks/main.yml
@@ -63,6 +63,12 @@
       - "copy_result.md5sum == 'c47397529fe81ab62ba3f85e9f4c71f2'"
   when: ansible_fips != True
 
+- name: create a hardlink to the file
+  file: src={{ output_file }} dest={{ output_dir }}/hard.lnk state=hard
+
+- name: copy the same file to the same place
+  copy: src=foo.txt dest={{output_file}} mode=0444
+
 - name: check the stat results of the file
   stat: path={{output_file}}
   register: stat_results


### PR DESCRIPTION
This was causing wrong behaviour when `prev_state` was `hard`-link,
since the `file` module tried to apply the same `state` on the new
file, causing unexpected errors.

Fixes ansible/ansible#10834.
Depends on ansible/ansible-modules-core#2827.
