### PR TITLE
Change Solaris packaging module from pkg to pkg5

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -142,7 +142,7 @@ class Facts(object):
                  { 'path' : '/usr/sbin/swlist',     'name' : 'SD-UX' },
                  { 'path' : '/usr/bin/emerge',      'name' : 'portage' },
                  { 'path' : '/usr/sbin/pkgadd',     'name' : 'svr4pkg' },
-                 { 'path' : '/usr/bin/pkg',         'name' : 'pkg' },
+                 { 'path' : '/usr/bin/pkg',         'name' : 'pkg5' },
                  { 'path' : '/usr/bin/xbps-install','name' : 'xbps' },
                  { 'path' : '/usr/local/sbin/pkg',  'name' : 'pkgng' },
     ]


### PR DESCRIPTION
The Solaris package managing module in Ansible managing packages via the program '/usr/bin/pkg' is named "pkg5", not "pkg": http://docs.ansible.com/ansible/pkg5_module.html

Additionally, there is no packaging module in Ansible named 'pkg'.
