### PR TITLE
synchronize: First cut at not doing sudo on the control machine but on the remote machine instead.

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1788,7 +1788,9 @@ class AnsibleModule(object):
         elif isinstance(args, basestring) and use_unsafe_shell:
             shell = True
         elif isinstance(args, basestring):
-            args = shlex.split(args.encode('utf-8'))
+            if isinstance(args, unicode):
+                args = args.encode('utf-8')
+            args = shlex.split(args)
         else:
             msg = "Argument 'args' to run_command must be list or string"
             self.fail_json(rc=257, cmd=args, msg=msg)


### PR DESCRIPTION
In 2.0.0.x become wa sreversed for synchronize.  Happening on the local machine instead of the remote machine.  This restores the ansible-1.9.x behaviour.  it does become on the remote machine.  However, there's aspects of this that are hacky (no hackier than ansible-1.9 but not using 2.0 features).  The big problem is that it does not understand any become method except sudo.  I'm willing to use a partial fix now because we don't want people to get used to the reversed semantics in their playbooks.
