### PR TITLE
Fix race in accelerate connection plugin

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -50,6 +50,8 @@ import getpass
 import sys
 import subprocess
 import contextlib
+import threading
+import tempfile
 
 from vault import VaultLib
 
@@ -63,6 +65,7 @@ LOOKUP_REGEX = re.compile(r'lookup\s*\(')
 PRINT_CODE_REGEX = re.compile(r'(?:{[{%]|[%}]})')
 CODE_REGEX = re.compile(r'(?:{%|%})')
 
+_LOCK = threading.Lock()
 
 try:
     # simplejson can be much faster if it's available
@@ -128,8 +131,15 @@ def key_for_hostname(hostname):
 
     key_path = os.path.expanduser(C.ACCELERATE_KEYS_DIR)
     if not os.path.exists(key_path):
-        os.makedirs(key_path, mode=0700)
-        os.chmod(key_path, int(C.ACCELERATE_KEYS_DIR_PERMS, 8))
+        # avoid race with multiple forks trying to create paths on host
+        # but limit when locking is needed to creation only
+        with(_LOCK):
+            if not os.path.exists(key_path):
+                # use a temp directory and rename to ensure the directory
+                # searched for only appears after permissions applied.
+                tmp_dir = tempfile.mkdtemp(dir=os.path.dirname(key_path))
+                os.chmod(tmp_dir, int(C.ACCELERATE_KEYS_DIR_PERMS, 8))
+                os.rename(tmp_dir, key_path)
     elif not os.path.isdir(key_path):
         raise errors.AnsibleError('ACCELERATE_KEYS_DIR is not a directory.')
 
@@ -140,19 +150,25 @@ def key_for_hostname(hostname):
 
     # use new AES keys every 2 hours, which means fireball must not allow running for longer either
     if not os.path.exists(key_path) or (time.time() - os.path.getmtime(key_path) > 60*60*2):
-        key = AesKey.Generate(size=256)
-        fd = os.open(key_path, os.O_WRONLY | os.O_CREAT, int(C.ACCELERATE_KEYS_FILE_PERMS, 8))
-        fh = os.fdopen(fd, 'w')
-        fh.write(str(key))
-        fh.close()
-        return key
-    else:
-        if stat.S_IMODE(os.stat(key_path).st_mode) != int(C.ACCELERATE_KEYS_FILE_PERMS, 8):
-            raise errors.AnsibleError('Incorrect permissions on the key file for this host. Use `chmod 0%o %s` to correct this issue.' % (int(C.ACCELERATE_KEYS_FILE_PERMS, 8), key_path))
-        fh = open(key_path)
-        key = AesKey.Read(fh.read())
-        fh.close()
-        return key
+        # avoid race with multiple forks trying to create key
+        # but limit when locking is needed to creation only
+        with(_LOCK):
+            if not os.path.exists(key_path) or (time.time() - os.path.getmtime(key_path) > 60*60*2):
+                key = AesKey.Generate()
+                # use temp file to ensure file only appears once it has
+                # desired contents and permissions
+                with tempfile.NamedTemporaryFile(mode='w', dir=os.path.dirname(key_path), delete=False) as fh:
+                    tmp_key_path = fh.name
+                    fh.write(str(key))
+                os.chmod(tmp_key_path, int(C.ACCELERATE_KEYS_FILE_PERMS, 8))
+                os.rename(tmp_key_path, key_path)
+                return key
+
+    if stat.S_IMODE(os.stat(key_path).st_mode) != int(C.ACCELERATE_KEYS_FILE_PERMS, 8):
+        raise errors.AnsibleError('Incorrect permissions on the key file for this host. Use `chmod 0%o %s` to correct this issue.' % (int(C.ACCELERATE_KEYS_FILE_PERMS, 8), key_path))
+
+    with open(key_path) as fh:
+        return AesKey.Read(fh.read())
 
 def encrypt(key, msg):
     return key.Encrypt(msg.encode('utf-8'))


### PR DESCRIPTION
First commit fixes #13850 which is two races on the controller
1. Is if the ansible keys directory for accelerate/fireball doesn't exist, it can be attempted to be created by multiple threads, where some may spot it exists but has the wrong permissions, while others throw an exception on trying to create the directory a second time.
2. In creating the credentials and storing them, multiple forks may try to regenerate the keys for the same host where using delegate_to, or attempt to read the file before it's contents are written.

In both cases the solution is a combination of checking if the file exists, and then locking and rechecking if it still doesn't in case something acquired the lock before the current thread but after the exists test, followed by using temporary file names under the desired path and only moving the files once they have the correct permissions and contents to ensure if the exists test returns true and we just created them, they are guaranteed to be correct.

Second commit builds on a corner case of the 2nd part of the first commit. It is limited to where executing against multiple hosts, with a task using the delegate_to option (or potentially where ansible_ssh_hosts references the same underlying machine for multiple hosts), where the delegate_to references the same host for each task. If the accelerate daemon has not been already started, multiple forks may each attempt to start it resulting in collisions and exceptions where multiple instances try to bind to the same port, resulting in only one of the creating forks and other subsequent tasks that picked up the correctly generated key in succeeded.

It is probably possible to improve the performance around this second commit to avoid the locking where you are not targeting the same underlying host via delegate_to or ansible_ssh_host settings, but as this would only improve the initial connection set up time, it should be relatively negligible except where running a very small number tasks against many hosts with a very high number of forks and using the accelerate transport.
