### PR TITLE
Prefer delegate when getting variables from inventory

### DIFF
--- a/lib/ansible/runner/connection_plugins/accelerate.py
+++ b/lib/ansible/runner/connection_plugins/accelerate.py
@@ -51,6 +51,7 @@ class Connection(object):
         self.is_connected = False
         self.has_pipelining = False
         self.become_methods_supported=['sudo']
+        self.delegate = None
 
         if not self.port:
             self.port = constants.DEFAULT_REMOTE_PORT
@@ -102,7 +103,7 @@ class Connection(object):
         if getattr(self.runner, 'accelerate_inventory_host', False):
             inject = utils.combine_vars(inject, self.runner.inventory.get_variables(self.runner.accelerate_inventory_host))
         else:
-            inject = utils.combine_vars(inject, self.runner.inventory.get_variables(self.host))
+            inject = utils.combine_vars(inject, self.runner.inventory.get_variables(self.delegate or self.host))
         vvvv("attempting to start up the accelerate daemon...")
         self.ssh.connect()
         tmp_path = self.runner._make_tmp_path(self.ssh)


### PR DESCRIPTION
Use self.delegate in preference to self.host in the accelerate
connection plugin for retrieval of variables from inventory.

Without this change setting ansible_ssh_host to an IP address, via the
inventory and configuring transport to accelerate via the configuration
will result in an exception message "host not found: <IP>" on
attempting to connect.

When ansible_ssh_host is defined for a host, the runner will pass
this value, which may be an IP address, to the connection plugin as the
value for 'host' to the connector class connect method, and eventually
it will be used for the host attribute on the requested connection
plugin. Consequently, within the Connnection plugin, using the 'host'
attribute for inventory lookup may try using an IP address instead of
the ansible inventory host name.

To handle this case, Ansible runner will check that the whether the
host is being provided (ansible_ssh_host) is the same as the inventory
host name, and when different, it will set an additional attribute
'delegate' on the connection plugin instance. Switching to use
attribute, if not None, and falling back to host, which would have the
correct value if delegate is not set, ensures inventory lookup uses the
correct host.

Fixes #13994
