### PR TITLE
added conda recipe for v2 latest

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -2,10 +2,15 @@ package:
   name: ansible
   version: "2.0.0.2"
 
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', '0') }}
+
 source:
-  fn: ansible-2.0.0.2.tar.gz
-  url: https://pypi.python.org/packages/source/a/ansible/ansible-2.0.0.2.tar.gz
-  md5: 816d0c49e084383e47a725c761a0e413
+  path: ../
+#  fn: ansible-2.0.0.2.tar.gz
+#  url: https://pypi.python.org/packages/source/a/ansible/ansible-2.0.0.2.tar.gz
+#  md5: 816d0c49e084383e47a725c761a0e413
 #  patches:
    # List any patch files here
    # - fix.patch

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,170 @@
+package:
+  name: ansible
+  version: "2.0.0.2"
+
+source:
+  fn: ansible-2.0.0.2.tar.gz
+  url: https://pypi.python.org/packages/source/a/ansible/ansible-2.0.0.2.tar.gz
+  md5: 816d0c49e084383e47a725c761a0e413
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # noarch_python: True
+  preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - ansible = ansible:main
+    #
+    # Would create an entry point called ansible that calls ansible.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - paramiko
+    - jinja2
+    - pyyaml
+    - setuptools
+    - pycrypto >=2.6
+
+  run:
+    - python
+    - paramiko
+    - jinja2
+    - pyyaml
+    - setuptools
+    - pycrypto >=2.6
+
+test:
+  # Python imports
+  imports:
+    - ansible
+    - ansible.cli
+    - ansible.compat
+    - ansible.compat.six
+    - ansible.compat.tests
+    - ansible.config
+    - ansible.errors
+    - ansible.executor
+    - ansible.executor.process
+    - ansible.galaxy
+    - ansible.inventory
+    - ansible.inventory.vars_plugins
+    - ansible.module_utils
+    - ansible.modules
+    - ansible.modules.core
+    - ansible.modules.core.cloud
+    - ansible.modules.core.cloud.amazon
+    - ansible.modules.core.cloud.azure
+    - ansible.modules.core.cloud.digital_ocean
+    - ansible.modules.core.cloud.docker
+    - ansible.modules.core.cloud.google
+    - ansible.modules.core.cloud.linode
+    - ansible.modules.core.cloud.openstack
+    - ansible.modules.core.cloud.rackspace
+    - ansible.modules.core.cloud.vmware
+    - ansible.modules.core.commands
+    - ansible.modules.core.database
+    - ansible.modules.core.database.mysql
+    - ansible.modules.core.database.postgresql
+    - ansible.modules.core.files
+    - ansible.modules.core.inventory
+    - ansible.modules.core.network
+    - ansible.modules.core.network.basics
+    - ansible.modules.core.packaging
+    - ansible.modules.core.packaging.language
+    - ansible.modules.core.packaging.os
+    - ansible.modules.core.source_control
+    - ansible.modules.core.system
+    - ansible.modules.core.utilities
+    - ansible.modules.core.utilities.helper
+    - ansible.modules.core.utilities.logic
+    - ansible.modules.core.web_infrastructure
+    - ansible.modules.core.windows
+    - ansible.modules.extras
+    - ansible.modules.extras.cloud
+    - ansible.modules.extras.cloud.amazon
+    - ansible.modules.extras.cloud.centurylink
+    - ansible.modules.extras.cloud.cloudstack
+    - ansible.modules.extras.cloud.docker
+    - ansible.modules.extras.cloud.google
+    - ansible.modules.extras.cloud.lxc
+    - ansible.modules.extras.cloud.misc
+    - ansible.modules.extras.cloud.openstack
+    - ansible.modules.extras.cloud.profitbricks
+    - ansible.modules.extras.cloud.rackspace
+    - ansible.modules.extras.cloud.vmware
+    - ansible.modules.extras.cloud.webfaction
+    - ansible.modules.extras.clustering
+    - ansible.modules.extras.commands
+    - ansible.modules.extras.database
+    - ansible.modules.extras.database.misc
+    - ansible.modules.extras.database.mysql
+    - ansible.modules.extras.database.postgresql
+    - ansible.modules.extras.database.vertica
+    - ansible.modules.extras.files
+    - ansible.modules.extras.messaging
+    - ansible.modules.extras.monitoring
+    - ansible.modules.extras.network
+    - ansible.modules.extras.network.a10
+    - ansible.modules.extras.network.citrix
+    - ansible.modules.extras.network.f5
+    - ansible.modules.extras.notification
+    - ansible.modules.extras.packaging
+    - ansible.modules.extras.packaging.language
+    - ansible.modules.extras.packaging.os
+    - ansible.modules.extras.source_control
+    - ansible.modules.extras.system
+    - ansible.modules.extras.web_infrastructure
+    - ansible.modules.extras.windows
+    - ansible.parsing
+    - ansible.parsing.utils
+    - ansible.parsing.vault
+    - ansible.parsing.yaml
+    - ansible.playbook
+    - ansible.playbook.role
+    - ansible.plugins
+    - ansible.plugins.action
+    - ansible.plugins.cache
+    - ansible.plugins.callback
+    - ansible.plugins.connection
+    - ansible.plugins.filter
+    - ansible.plugins.inventory
+    - ansible.plugins.lookup
+    - ansible.plugins.shell
+    - ansible.plugins.strategy
+    - ansible.plugins.test
+    - ansible.plugins.vars
+    - ansible.template
+    - ansible.utils
+    - ansible.utils.module_docs_fragments
+    - ansible.vars
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://ansible.com/
+  license: GNU General Public License v3 or later (GPLv3+)
+  summary: 'Radically simple IT automation'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
This conda recipe can be used with http://conda.pydata.org to build a conda package that can be installed with `conda install ansible` which will sandbox ansible versions.  Those conda packages can be put on Anaconda Cloud (http://anaconda.org) in user namespaces and with tags.

This helps ansible live in conda software sandboxes.
