### PR TITLE
go back to always wrapping commands in shell

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -481,8 +481,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         display.debug("done with _execute_module (%s, %s)" % (module_name, module_args))
         return data
 
-    def _low_level_execute_command(self, cmd, sudoable=True, in_data=None,
-            executable=None, encoding_errors='replace'):
+    def _low_level_execute_command(self, cmd, sudoable=True, in_data=None, executable=C.DEFAULT_EXECUTABLE, encoding_errors='replace'):
         '''
         This is the function which executes the low level shell command, which
         may be commands to create/remove directories for temporary files, or to
@@ -498,7 +497,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         '''
 
         if executable is not None:
-            cmd = executable + ' -c ' + cmd
+            cmd = executable + ' -c ' + pipes.quote(cmd)
 
         display.debug("_low_level_execute_command(): starting")
         if not cmd:

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -49,7 +49,7 @@ class TestActionBase(unittest.TestCase):
 
         play_context.remote_user = 'apo'
         action_base._low_level_execute_command('ECHO', sudoable=True)
-        play_context.make_become_cmd.assert_called_once_with('ECHO', executable=None)
+        play_context.make_become_cmd.assert_called_once_with("/bin/sh -c ECHO", executable='/bin/sh')
 
         play_context.make_become_cmd.reset_mock()
 
@@ -58,6 +58,6 @@ class TestActionBase(unittest.TestCase):
         try:
             play_context.remote_user = 'root'
             action_base._low_level_execute_command('ECHO SAME', sudoable=True)
-            play_context.make_become_cmd.assert_called_once_with('ECHO SAME', executable=None)
+            play_context.make_become_cmd.assert_called_once_with("/bin/sh -c 'ECHO SAME'", executable='/bin/sh')
         finally:
             C.BECOME_ALLOW_SAME_USER = become_allow_same_user


### PR DESCRIPTION
This was taken out in an effort to default to the user's shell but creates issues as this is not known ahead of time and its painful to set executable and shell_type for all servers, it should only be needed for those that restrict the userto specific shells and when /bin/sh is not available.
fixes #13882
