### PR TITLE
initial add of action plugin ops_template

### DIFF
--- a/lib/ansible/plugins/action/ops_template.py
+++ b/lib/ansible/plugins/action/ops_template.py
@@ -1,0 +1,50 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_template import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        if self._connection.transport == 'local':
+            return super(ActionModule, self).run(tmp, task_vars)
+
+        result = dict(changed=False)
+
+        if isinstance(self._task.args['src'], basestring):
+            self._handle_template()
+
+        self._task.args['config'] = task_vars.get('config')
+
+        result.update(self._execute_module(module_name=self._task.action,
+            module_args=self._task.args, task_vars=task_vars))
+
+        if self._task.args.get('backup') and '_config' in result:
+            contents = json.dumps(result['_config'], indent=4)
+            self._write_backup(task_vars['inventory_hostname'], contents)
+            del result['_config']
+
+        return result
+
+


### PR DESCRIPTION
Adds new local action ops_config for handling openswitch configurations using
either dc or cli based configurations.  Implements the common net_config
local action.
