### PR TITLE
Update get_virtual_facts for OpenVZ 2.6.32-4-pve

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2670,6 +2670,14 @@ class LinuxVirtual(Virtual):
 
     # For more information, check: http://people.redhat.com/~rjones/virt-what/
     def get_virtual_facts(self):
+    	if os.path.exists('/proc/vz'):
+            self.facts['virtualization_type'] = 'openvz'
+            if os.path.exists('/proc/bc'):
+                self.facts['virtualization_role'] = 'host'
+            else:
+                self.facts['virtualization_role'] = 'guest'
+            return
+
         if os.path.exists('/proc/1/cgroup'):
             for line in get_file_lines('/proc/1/cgroup'):
                 if re.search(r'/docker(/|-[0-9a-f]+\.scope)', line):
@@ -2680,14 +2688,6 @@ class LinuxVirtual(Virtual):
                     self.facts['virtualization_type'] = 'lxc'
                     self.facts['virtualization_role'] = 'guest'
                     return
-
-        if os.path.exists('/proc/vz'):
-            self.facts['virtualization_type'] = 'openvz'
-            if os.path.exists('/proc/bc'):
-                self.facts['virtualization_role'] = 'host'
-            else:
-                self.facts['virtualization_role'] = 'guest'
-            return
 
         systemd_container = get_file_content('/run/systemd/container')
         if systemd_container:


### PR DESCRIPTION
In my old openvz virtual machine, get_virtual_facts failed, `/proc/1/cgroup` exists, but when read it, Operation not permitted. So must check openvz first.

```
43-401-panda:~# uname -a
Linux 43-401-panda 2.6.32-4-pve #1 SMP Thu Oct 21 09:35:29 CEST 2010 x86_64 GNU/Linux
43-401-panda:~# ls -l /proc/1/cgroup 
-r--r--r-- 1 root root 0 Jan 20 16:10 /proc/1/cgroup
43-401-panda:~# more /proc/1/cgroup 
/proc/1/cgroup: Operation not permitted
43-401-panda:~#
```
