### PR TITLE
Adding docs help for testing modules

### DIFF
--- a/docsite/rst/developing_test_pr.rst
+++ b/docsite/rst/developing_test_pr.rst
@@ -81,27 +81,35 @@ and destination repositories. It will look something like this::
    Someuser wants to merge 1 commit into ansible:devel from someuser:feature_branch_name
 
 .. note::
-   It is important that the PR request target be ansible:devel, as we do not accept pull requests into any other branch.
-   Dot releases are cherry-picked manually by ansible staff.
+   It is important that the PR request target be ansible:devel, as we do not accept pull requests into any other branch.  Dot releases are cherry-picked manually by ansible staff.
 
 The username and branch at the end are the important parts, which will be turned into git commands as follows::
 
    git checkout -b testing_PRXXXX devel
    git pull https://github.com/someuser/ansible.git feature_branch_name
 
-The first command creates and switches to a new branch named testing_PRXXXX, where the XXXX is the actual issue number associated 
-with the pull request (for example, 1234). This branch is based on the devel branch. The second command pulls the new code from the 
-users feature branch into the newly created branch.
+The first command creates and switches to a new branch named testing_PRXXXX, where the XXXX is the actual issue number associated with the pull request (for example, 1234). This branch is based on the devel branch. The second command pulls the new code from the users feature branch into the newly created branch.
 
 .. note::
-   If the GitHub user interface shows that the pull request will not merge cleanly, we do not recommend proceeding if you
-   are not somewhat familiar with git and coding, as you will have to resolve a merge conflict.  This is the responsibility of
-   the original pull request contributor.
+   If the GitHub user interface shows that the pull request will not merge cleanly, we do not recommend proceeding if you are not somewhat familiar with git and coding, as you will have to resolve a merge conflict.  This is the responsibility of the original pull request contributor.
 
 .. note::
-   Some users do not create feature branches, which can cause problems when they have multiple, un-related commits in
-   their version of `devel`. If the source looks like `someuser:devel`, make sure there is only one commit listed on
-   the pull request.
+   Some users do not create feature branches, which can cause problems when they have multiple, un-related commits in their version of `devel`. If the source looks like `someuser:devel`, make sure there is only one commit listed on the pull request.
+
+Finding a Pull Request for Ansible Modules
+++++++++++++++++++++++++++++++++++++++++++
+Ansible modules are in separate repositories, which are managed as Git submodules. Here's a step by step process for checking out a PR for an Ansible extras module, for instance:
+
+1. git clone https://github.com/ansible/ansible.git
+2. cd ansible
+3. git submodule init
+4. git submodule update --recursive
+5. cd lib/ansible/modules/extras
+6. git fetch origin pull/1234/head:pr/1234
+7. git checkout pr/1234
+[ DO YOUR TESTING HERE ]
+8. cd /path/to/ansible/clone
+9. git submodule update --recursive
 
 For Those About To Test, We Salute You
 ++++++++++++++++++++++++++++++++++++++

--- a/docsite/rst/developing_test_pr.rst
+++ b/docsite/rst/developing_test_pr.rst
@@ -107,9 +107,9 @@ Ansible modules are in separate repositories, which are managed as Git submodule
 5. cd lib/ansible/modules/extras
 6. git fetch origin pull/1234/head:pr/1234
 7. git checkout pr/1234
-[ DO YOUR TESTING HERE ]
-8. cd /path/to/ansible/clone
-9. git submodule update --recursive
+8. [ Do your tests here ]
+9. cd /path/to/ansible/clone
+10. git submodule update --recursive
 
 For Those About To Test, We Salute You
 ++++++++++++++++++++++++++++++++++++++

--- a/docsite/rst/developing_test_pr.rst
+++ b/docsite/rst/developing_test_pr.rst
@@ -103,13 +103,12 @@ Ansible modules are in separate repositories, which are managed as Git submodule
 1. git clone https://github.com/ansible/ansible.git
 2. cd ansible
 3. git submodule init
-4. git submodule update --recursive
+4. git submodule update --recursive [ fetches the submodules ]
 5. cd lib/ansible/modules/extras
-6. git fetch origin pull/1234/head:pr/1234
-7. git checkout pr/1234
-8. [ Do your tests here ]
-9. cd /path/to/ansible/clone
-10. git submodule update --recursive
+6. git fetch origin pull/1234/head:pr/1234 [ fetches the specific PR ]
+7. git checkout pr/1234 [ do your testing here ]
+8. cd /path/to/ansible/clone
+9. git submodule update --recursive
 
 For Those About To Test, We Salute You
 ++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Module testing requires dealing with git submodules. Thanks to @sivel for a quick and dirty HOWTO for pulling a particular PR from module repos for testing. We should definitely flesh this out, but this is a good start.
