### PR TITLE
Adds 'ansible_check_mode' boolean magic variable

### DIFF
--- a/docsite/rst/playbooks_checkmode.rst
+++ b/docsite/rst/playbooks_checkmode.rst
@@ -38,7 +38,25 @@ Example::
 
 As a reminder, a task with a `when` clause evaluated to false, will
 still be skipped even if it has a `always_run` clause evaluated to
-true.
+true. 
+
+Also if you want to skip, or ignore errors on some tasks in check mode
+you can use a boolean magic variable `ansible_check_mode` (added in version 2.1)
+which will be set to `True` during check mode.
+
+Example::
+
+    tasks:
+
+      - name: this task will be skipped in check mode
+        git: repo=ssh://git@github.com/mylogin/hello.git dest=/home/mylogin/hello
+        when: not ansible_check_mode
+
+      - name: this task will ignore errors in check mode
+        git: repo=ssh://git@github.com/mylogin/hello.git dest=/home/mylogin/hello
+        ignore_errors: "{{ ansible_check_mode }}"
+
+
 
 .. _diff_mode:
 

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -674,7 +674,9 @@ Don't worry about any of this unless you think you need it.  You'll know when yo
 
 Also available, ``inventory_dir`` is the pathname of the directory holding Ansible's inventory host file, ``inventory_file`` is the pathname and the filename pointing to the Ansible's inventory host file.
 
-And finally, ``role_path`` will return the current role's pathname (since 1.8). This will only work inside a role.
+We then have ``role_path`` which will return the current role's pathname (since 1.8). This will only work inside a role.
+
+And finally, ``ansible_check_mode`` (added in version 2.1), a boolean magic variable which will be set to ``True`` if you run Ansible with ``--check``.
 
 .. _variable_file_separation_details:
 

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -32,6 +32,7 @@ from ansible.parsing.splitter import parse_kv
 from ansible.playbook.play import Play
 from ansible.plugins import get_all_plugin_loaders
 from ansible.utils.vars import load_extra_vars
+from ansible.utils.vars import load_options_vars
 from ansible.utils.unicode import to_unicode
 from ansible.vars import VariableManager
 
@@ -122,6 +123,8 @@ class AdHocCLI(CLI):
 
         variable_manager = VariableManager()
         variable_manager.extra_vars = load_extra_vars(loader=loader, options=self.options)
+
+        variable_manager.options_vars = load_options_vars(self.options)
 
         inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=self.options.inventory)
         variable_manager.set_inventory(inventory)

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -33,6 +33,7 @@ from ansible.parsing.dataloader import DataLoader
 from ansible.playbook.block import Block
 from ansible.playbook.play_context import PlayContext
 from ansible.utils.vars import load_extra_vars
+from ansible.utils.vars import load_options_vars
 from ansible.vars import VariableManager
 
 try:
@@ -124,6 +125,8 @@ class PlaybookCLI(CLI):
         # the code, ensuring a consistent view of global variables
         variable_manager = VariableManager()
         variable_manager.extra_vars = load_extra_vars(loader=loader, options=self.options)
+
+        variable_manager.options_vars = load_options_vars(self.options)
 
         # create the inventory, and filter it based on the subset specified (if any)
         inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=self.options.inventory)

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -111,6 +111,13 @@ def load_extra_vars(loader, options):
         extra_vars = combine_vars(extra_vars, data)
     return extra_vars
 
+def load_options_vars(options):
+    options_vars = {}
+    # For now only return check mode, but we can easily return more
+    # options if we need variables for them
+    options_vars['ansible_check_mode'] = options.check
+    return options_vars
+
 def isidentifier(ident):
     """
     Determines, if string is valid Python identifier using the ast module.

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -49,6 +49,8 @@ class TestVariableManager(unittest.TestCase):
             del vars['vars']
         if 'ansible_version' in vars:
             del vars['ansible_version']
+        if 'ansible_check_mode' in vars:
+            del vars['ansible_check_mode']
 
         self.assertEqual(vars, dict(playbook_dir='.'))
 


### PR DESCRIPTION
Adds a boolean magic variable `ansible_check_mode` which will be set to `True` if run with `--check`, otherwise it will be `False`. This allows for an easy way to skip, or ignore tasks in check mode if it doesn't make sense to run them, e.g. need to run git module, but git is not installed yet (since we are running check mode).

``` yaml
tasks:
  - name: install git
    yum: name=git

  - name: this task will be skipped in check mode
    git: repo=ssh://git@github.com/mylogin/hello.git dest=/home/mylogin/hello
    when: not ansible_check_mode

  - name: this task will ignore errors in check mode
    git: repo=ssh://git@github.com/mylogin/hello.git dest=/home/mylogin/hello
    ignore_errors: "{{ ansible_check_mode }}"
```

This also closes https://github.com/ansible/ansible/issues/10696
