### PR TITLE
Use SSH askpass instead of sshpass for password logins

### DIFF
--- a/bin/ansible-pwecho
+++ b/bin/ansible-pwecho
@@ -1,2 +1,1 @@
-#!/bin/sh
-echo $ANSIBLE_SSH_PASS
+ansible

--- a/bin/ansible-pwecho
+++ b/bin/ansible-pwecho
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo $ANSIBLE_SSH_PASS

--- a/lib/ansible/cli/pwecho.py
+++ b/lib/ansible/cli/pwecho.py
@@ -27,12 +27,15 @@ from ansible.cli import CLI
 
 class PwechoCLI(CLI):
 
-    def __init__(self, args):
-        super(PwechoCLI, self).__init__(args)
-
     def run(self):
-        sys.stdout.write(os.getenv("ANSIBLE_SSH_PASS", ""))
+        pw = os.getenv("ANSIBLE_SSH_PASS")
+        if not pw:
+            sys.stderr.write("Environment variable ANSIBLE_SSH_PASS not set\n")
+            sys.stderr.flush()
+            sys.exit(1)
+        sys.stdout.write(pw)
         sys.stdout.flush()
+        sys.exit(0)
 
     def parse(self):
         return

--- a/lib/ansible/cli/pwecho.py
+++ b/lib/ansible/cli/pwecho.py
@@ -1,0 +1,38 @@
+# (c) 2016, Joonas Aunola <joonas@aunola.fi>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ansible-pwecho echoes the content of ANSIBLE_SSH_PASS environment
+# variable.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import sys
+
+from ansible.cli import CLI
+
+
+class PwechoCLI(CLI):
+
+    def __init__(self, args):
+        super(PwechoCLI, self).__init__(args)
+
+    def run(self):
+        sys.stdout.write(os.getenv("ANSIBLE_SSH_PASS", ""))
+        sys.stdout.flush()
+
+    def parse(self):
+        return

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -242,6 +242,7 @@ DEFAULT_NULL_REPRESENTATION    = get_config(p, DEFAULTS, 'null_representation', 
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', '-o ControlMaster=auto -o ControlPersist=60s')
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
+ANSIBLE_SSH_USE_ASKPASS        = get_config(p, 'ssh_connection', 'use_askpass', 'ANSIBLE_SSH_USE_ASKPASS', False, boolean=True)
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, integer=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -134,9 +134,9 @@ class Connection(ConnectionBase):
 
         if self._play_context.password:
             self._command_env.update(dict(
-              DISPLAY=(os.getenv("DISPLAY", ""),
+              DISPLAY=os.getenv("DISPLAY", ""),
               SSH_ASKPASS="/usr/bin/ansible-pwecho",
-              ANSIBLE_SSH_PASS=self._play_context.password)))
+              ANSIBLE_SSH_PASS=self._play_context.password))
 
         self._command += [binary]
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(name='ansible',
          'bin/ansible-doc',
          'bin/ansible-galaxy',
          'bin/ansible-vault',
+         'bin/ansible-pwecho',
       ],
       data_files=[],
 )


### PR DESCRIPTION
## Description

This PR makes OpenSSH to use askpass directly without the need of external sshpass program.

This sets the password to the environment variable called ANSIBLE_SSH_PASS and sets the SSH_ASKPASS enviroment to "/usr/bin/ansible-pwecho". Itse also sets the DISPLAY enviroment variable to empty string, if it's not set. When the ssh needs password, it'll execute the askpass program which simply outputs the password from the enviroment variable.
## Security considerations

The password can be read from the environment variable of the ansible-pwecho program. However, at least in Linux the permissions are limited to the current user.

On the other hand, the pwecho program is very simple.
## TODO
- Does the change to the enviroment variables affect Ansible or other programs?
- I tested this only with simple inventory file containing hostname, ansible_ssh_user and ansible_ssh_pass
- Should the feature be activated by default or with some command line switch?
- Should the sshpass-program be removed completely or left as a fallback
  - Current patch removes support for that program
- Does the fix work with sftp or scp
- Test with other systems (currently tested only in Linux)
