### PR TITLE
ansible-galaxy: use HTTP for Travis Notifications

### DIFF
--- a/lib/ansible/galaxy/data/travis.j2
+++ b/lib/ansible/galaxy/data/travis.j2
@@ -26,4 +26,4 @@ script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
 
 notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  webhooks: http://galaxy.ansible.com/api/v1/notifications/


### PR DESCRIPTION
The TLS ciphers on our Azure load balancer are not compatible with Travis-ci.  This is a known issue/difficulty with travis notifications. See: https://docs.travis-ci.com/user/notifications/#Note-on-SSL-TLS-Ciphers.

Changing the default .travis.yml created by ansible-galaxy init. It should default to HTTP rather than HTTPS.
