### PR TITLE
Adding support for scm-based role source urls (ansible-galaxy)

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -385,7 +385,8 @@ class GalaxyCLI(CLI):
             # roles were specified directly, so we'll just go out grab them
             # (and their dependencies, unless the user doesn't want us to).
             for rname in self.args:
-                roles_left.append(GalaxyRole(self.galaxy, rname.strip()))
+                role = RoleRequirement.role_yaml_parse(rname.strip())
+                roles_left.append(GalaxyRole(self.galaxy, **role))
 
         for role in roles_left:
             display.vvv('Installing role %s ' % role.name)
@@ -681,4 +682,3 @@ class GalaxyCLI(CLI):
         display.display(resp['status'])
 
         return True
-

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -168,7 +168,7 @@ else
 	@echo "Consul agent is not running locally. To run a cluster locally see http://github.com/sgargan/consul-vagrant"
 endif
 
-test_galaxy: test_galaxy_spec test_galaxy_yaml
+test_galaxy: test_galaxy_spec test_galaxy_yaml test_galaxy_git
 
 test_galaxy_spec:
 	mytmpdir=$(MYTMPDIR) ; \
@@ -188,10 +188,18 @@ test_galaxy_yaml:
     rm -rf $$mytmpdir ; \
     exit $$RC
 
+test_galaxy_git:
+	mytmpdir=$(MYTMPDIR) ; \
+	ansible-galaxy install git+https://bitbucket.org/willthames/git-ansible-galaxy,v1.6 -p $$mytmpdir/roles -vvvv; \
+    cp galaxy_playbook_git.yml $$mytmpdir ; \
+    ansible-playbook -i $(INVENTORY) $$mytmpdir/galaxy_playbook_git.yml -v $(TEST_FLAGS) ; \
+    RC=$$? ; \
+    rm -rf $$mytmpdir ; \
+    exit $$RC
+
 test_lookup_paths:
 	ansible-playbook lookup_paths/play.yml -i $(INVENTORY) -v $(TEST_FLAGS)
 
 no_log:
 	# This test expects 7 loggable vars and 0 non loggable ones, if either mismatches it fails, run the ansible-playbook command to debug
 	[ "$$(ansible-playbook no_log_local.yml -i $(INVENTORY) -vvvvv | awk --source 'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "6/0" ]
-

--- a/test/integration/galaxy_playbook_git.yml
+++ b/test/integration/galaxy_playbook_git.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  connection: local
+
+  roles:
+  - "git-ansible-galaxy"


### PR DESCRIPTION
Fix for #13910 (incl. integration test to cover it)
