### PR TITLE
Fix regression in max byte limit for --diff source files

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -613,7 +613,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                     diff['src_larger'] = C.MAX_FILE_SIZE_FOR_DIFF
                 else:
                     diff['after_header'] = source
-                    diff['after'] = src_contents
+                    diff['after'] = src_contents + src.read()
             else:
                 display.debug("source of file passed in")
                 diff['after_header'] = 'dynamically generated'


### PR DESCRIPTION
```
› ansible-playbook --version
ansible-playbook 2.0.0.2
  config file = /Users/george/.ansible.cfg
  configured module search path = Default w/o overrides
```

Came across an issue where running `ansible-playbook` with the `--check --diff` parameters would suggest that the dest file would be truncated, even though it wouldn't. Ran the same test with `1.9.4` and the diff produced was correct (i.e. no truncation).

I traced the error back to this line and removed the limit and all's well.

Note a similar fix was made for https://github.com/ansible/ansible/pull/8442
