### PR TITLE
Make --list-hosts honor --limit (Fix for #13848)

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -132,6 +132,7 @@ class AdHocCLI(CLI):
 
         if self.options.subset:
             inventory.subset(self.options.subset)
+            hosts = inventory.list_hosts(pattern)
             if len(inventory.list_hosts(pattern)) == 0 and not no_hosts:
                 # Invalid limit
                 raise AnsibleError("Specified --limit does not match any hosts")


### PR DESCRIPTION
Fix for #13848. 

Makes `--list-hosts` honor `--limit` by recomputing `hosts` when `options.subset` is set.

With the fix, the output for @serialdoom's example cases is as follows:

``` bash
ansible all -i hosts --list-hosts
  hosts (10):
    host1
    host2
    host3
    host4
    host5
    host6
    host7
    host8
    host9
    host10

ansible all -i hosts --limit ~host1 --list-hosts
  hosts (2):
    host1
    host10

ansible all -i hosts --limit host4 --list-hosts
  hosts (1):
    host4
```
### Alternative solution

Recomputing `hosts` like this might be a bit smelly -- one might contend that `hosts` should hold _all_ hosts, regardless of whether a subset is selected. Another, possibly cleaner, route is to use two variables `all_hosts` and `selected_hosts`:

``` python
selected_hosts = all_hosts = inventory.list_hosts(pattern)
no_hosts = False
if len(all_hosts) == 0:
    display.warning("provided hosts list is empty, only localhost is available")
    no_hosts = True

if self.options.subset:
    inventory.subset(self.options.subset)
    selected_hosts = inventory.list_hosts(pattern)
    if len(inventory.list_hosts(pattern)) == 0 and not no_hosts:
        # Invalid limit
        raise AnsibleError("Specified --limit does not match any hosts")

if self.options.listhosts:
    display.display('  hosts (%d):' % len(selected_hosts))
    for host in selected_hosts:
        display.display('    %s' % host)
    return 0
```

If you prefer this, or some other variant, let me know, and I'll fix the PR.
