### PR TITLE
Handle the key 'custom' in the 'diff' result from modules

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -131,6 +131,8 @@ class CallbackBase:
                         differ = difflib.unified_diff(to_unicode(diff['before']).splitlines(True), to_unicode(diff['after']).splitlines(True), before_header, after_header, '', '', 10)
                         ret.extend(list(differ))
                         ret.append('\n')
+                    if 'prepared' in diff:
+                        ret.append(to_unicode(diff['prepared']))
                     return u"".join(ret)
             except UnicodeDecodeError:
                 ret.append(">> the files are different, but the diff library cannot compare unicode strings\n\n")


### PR DESCRIPTION
So far, when a 'diff' dict is returned with module results, it is
checked for 'before' and 'after' texts, which are processed in
_get_diff() by python difflib.  This generates the changes to display
when CLI users specify --diff.

However, some modules will generate changes that cannot easily be
expressed in a conventional diff. One example is the output of the
synchronize module, which presents changed files in a common log format
as in `rsync --itemize-changes`.

Add a check for a diff['custom'] key, which can contain custom diff text
from modules.
