### PR TITLE
fix cache reading code, add refresh-cache and instance_filters

### DIFF
--- a/contrib/inventory/vmware.ini
+++ b/contrib/inventory/vmware.ini
@@ -27,6 +27,10 @@ guests_only = True
 # not be returned.
 # prefix_filter = test_
 
+# For consistency with with ec2, use instance_filters in the positive sense
+# returning instances starting with any instance_filter. Comma-separated, no spaces
+# instance_filters = prefix_1,prefix_2
+
 [auth]
 
 # Specify hostname or IP address of vCenter/ESXi server.  A port may be


### PR DESCRIPTION
vmware.ini has the line
# cache_dir = ~/.cache/ansible

However, the code that reads the cache_dir does not expand the ~.  Added os.path.expanduser to fix.

To make this dynamic inventory similar to ec2.py I added
instance_filters
and a --refresh-cache flag.

To test, install jq.  Customize your vmware.ini and source your vars into the shell environment.
 note '' is two single quotes in the lines below
    $ ./vmware.py | jq ''
    Note now long it takes
    $ ./vmware.py | jq '' 
    The second time should be much faster if you uncomment cache_dir
    $ ./vmware.py --refresh-cache | jq ''
    This should return almost instantly
