### PR TITLE
Create different cache dir for AWS_PROFILE

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -315,6 +315,10 @@ class Ec2Inventory(object):
         cache_dir = os.path.expanduser(config.get('ec2', 'cache_path'))
         if self.boto_profile:
             cache_dir = os.path.join(cache_dir, 'profile_' + self.boto_profile)
+        if not None in [os.environ.get('AWS_PROFILE')]:
+            cache_dir = os.path.join(cache_dir, 'aws_profile_' + os.environ.get('AWS_PROFILE'))
+        else:
+            cache_dir = os.path.join(cache_dir, 'aws_profile_default')
         if not os.path.exists(cache_dir):
             os.makedirs(cache_dir)
 
@@ -480,7 +484,7 @@ class Ec2Inventory(object):
             if e.error_code == 'AuthFailure':
                 error = self.get_auth_error_message()
             else:
-                backend = 'Eucalyptus' if self.eucalyptus else 'AWS' 
+                backend = 'Eucalyptus' if self.eucalyptus else 'AWS'
                 error = "Error connecting to %s backend.\n%s" % (backend, e.message)
             self.fail_with_error(error, 'getting EC2 instances')
 
@@ -696,7 +700,7 @@ class Ec2Inventory(object):
                     if self.nested_groups:
                         self.push_group(self.inventory, 'security_groups', key)
             except AttributeError:
-                self.fail_with_error('\n'.join(['Package boto seems a bit older.', 
+                self.fail_with_error('\n'.join(['Package boto seems a bit older.',
                                             'Please upgrade boto >= 2.3.0.']))
 
         # Inventory: Group by tag keys
@@ -800,7 +804,7 @@ class Ec2Inventory(object):
                         self.push_group(self.inventory, 'security_groups', key)
 
             except AttributeError:
-                self.fail_with_error('\n'.join(['Package boto seems a bit older.', 
+                self.fail_with_error('\n'.join(['Package boto seems a bit older.',
                                             'Please upgrade boto >= 2.3.0.']))
 
 


### PR DESCRIPTION
If don't create different cache dir, there will be some risk when
user use AWS_PROFILE switch in different production environments.
