### PR TITLE
Fix handling of difflist containing multiple before/after pairs

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -106,7 +106,6 @@ class CallbackBase:
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore')
-                    ret = []
                     if 'dst_binary' in diff:
                         ret.append("diff skipped: destination file appears to be binary\n")
                     if 'src_binary' in diff:
@@ -133,9 +132,9 @@ class CallbackBase:
                         ret.append('\n')
                     if 'prepared' in diff:
                         ret.append(to_unicode(diff['prepared']))
-                    return u"".join(ret)
             except UnicodeDecodeError:
                 ret.append(">> the files are different, but the diff library cannot compare unicode strings\n\n")
+        return u"".join(ret)
 
     def _get_item(self, result):
         if result.get('_ansible_no_log', False):

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -127,14 +127,22 @@ class CallbackBase:
                             after_header = "after: %s" % diff['after_header']
                         else:
                             after_header = 'after'
-                        differ = difflib.unified_diff(to_unicode(diff['before']).splitlines(True), to_unicode(diff['after']).splitlines(True), before_header, after_header, '', '', 10)
-                        ret.extend(list(differ))
-                        ret.append('\n')
+                        differ = difflib.unified_diff(to_unicode(diff['before']).splitlines(True),
+                                                      to_unicode(diff['after']).splitlines(True),
+                                                      fromfile=before_header,
+                                                      tofile=after_header,
+                                                      fromfiledate='',
+                                                      tofiledate='',
+                                                      n=10)
+                        difflines = list(differ)
+                        if difflines:
+                            ret.extend(difflines)
+                            ret.append('\n')
                     if 'prepared' in diff:
                         ret.append(to_unicode(diff['prepared']))
             except UnicodeDecodeError:
                 ret.append(">> the files are different, but the diff library cannot compare unicode strings\n\n")
-        return u"".join(ret)
+        return u''.join(ret)
 
     def _get_item(self, result):
         if result.get('_ansible_no_log', False):

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -138,9 +138,13 @@ class CallbackModule(CallbackBase):
         if result._task.loop and 'results' in result._result:
             for res in result._result['results']:
                 if 'diff' in res and res['diff']:
-                    self._display.display(self._get_diff(res['diff']))
+                    diff = self._get_diff(res['diff'])
+                    if diff:
+                        self._display.display(diff)
         elif 'diff' in result._result and result._result['diff']:
-            self._display.display(self._get_diff(result._result['diff']))
+            diff = self._get_diff(result._result['diff'])
+            if diff:
+                self._display.display(diff)
 
     def v2_playbook_item_on_ok(self, result):
 


### PR DESCRIPTION
Commit ansible/ansible@c337293 introduced a difflist feature. The return
value however was not adequately outdented to append any diff after the first.

Fix this logic problem.
