### PR TITLE
'bytes' object has no attribute 'encode' on ansible-vault view

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -459,7 +459,7 @@ class CLI(object):
             os.environ['LESS'] = CLI.LESS_OPTS
         try:
             cmd = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=sys.stdout)
-            cmd.communicate(input=text.encode(sys.stdout.encoding))
+            cmd.communicate(input=text.decode('utf-8').encode(sys.stdout.encoding))
         except IOError:
             pass
         except KeyboardInterrupt:


### PR DESCRIPTION
Encode cannot be applied to a 'bytes' string so we either assume utf-8 encoding for de original vault file or a config parameter is required for the viewer. We'll assume utf-8 for this fix
