### PR TITLE
Added hyphen (-) as a valid character for permissions

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -929,7 +929,7 @@ class AnsibleModule(object):
     def _symbolic_mode_to_octal(self, path_stat, symbolic_mode):
         new_mode = stat.S_IMODE(path_stat.st_mode)
 
-        mode_re = re.compile(r'^(?P<users>[ugoa]+)(?P<operator>[-+=])(?P<perms>[rwxXst]*|[ugo])$')
+        mode_re = re.compile(r'^(?P<users>[ugoa]+)(?P<operator>[-+=])(?P<perms>[rwxXst-]*|[ugo])$')
         for mode in symbolic_mode.split(','):
             match = mode_re.match(mode)
             if match:


### PR DESCRIPTION
Here's an example of its usage:

```
fake@fake  /tmp  chmod 777 bar

fake@fake  /tmp  ls -ld bar
drwxrwxrwx  2 fake  fake  68 Jan 28 13:09 bar

fake@fake  /tmp  chmod go=- bar

fake@fake  /tmp  ls -ld bar
drwx------  2 fake  fake  68 Jan 28 13:09 bar
```
