### PR TITLE
Net parser

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -195,7 +195,10 @@ class NetworkModule(AnsibleModule):
         self.connection.close()
 
     def parse_config(self, cfg):
-        return parse(cfg, indent=3)
+        try:
+            return parse(cfg, indent=3)
+        except Exception, exc:
+            self.fail_json(msg=exc.message)
 
     def get_config(self):
         cmd = 'show running-config'

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -107,7 +107,10 @@ class NetworkModule(AnsibleModule):
         self.connection.close()
 
     def parse_config(self, cfg):
-        return parse(cfg, indent=1)
+        try:
+            return parse(cfg, indent=1)
+        except Exception, exc:
+            self.fail_json(msg=exc.message)
 
     def get_config(self):
         cmd = 'show running-config'

--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -99,7 +99,10 @@ class NetworkModule(AnsibleModule):
         self.connection.close()
 
     def parse_config(self, cfg):
-        return parse(cfg, indent=1)
+        try:
+            return parse(cfg, indent=1)
+        except Exception, exc:
+            self.fail_json(msg=exc.message)
 
     def get_config(self):
         return self.execute('show running-config')[0]

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -96,7 +96,10 @@ class NetworkModule(AnsibleModule):
         self.connection.close()
 
     def parse_config(self, cfg):
-        return parse(cfg, indent=4)
+        try:
+            return parse(cfg, indent=4)
+        except Exception, exc:
+            self.fail_json(msg=exc.message)
 
     def get_config(self):
         cmd = 'show configuration'

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -194,7 +194,11 @@ class NetworkModule(AnsibleModule):
         self.connection.close()
 
     def parse_config(self, cfg):
-        return parse(cfg, indent=2)
+        try:
+            result = parse(cfg, indent=2)
+            return result
+        except Exception:
+            raise
 
     def get_config(self):
         cmd = 'show running-config'

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -195,10 +195,9 @@ class NetworkModule(AnsibleModule):
 
     def parse_config(self, cfg):
         try:
-            result = parse(cfg, indent=2)
-            return result
-        except Exception:
-            raise
+            return parse(cfg, indent=2)
+        except Exception, exc:
+            self.fail_json(msg=exc.message)
 
     def get_config(self):
         cmd = 'show running-config'

--- a/lib/ansible/module_utils/openswitch.py
+++ b/lib/ansible/module_utils/openswitch.py
@@ -207,7 +207,10 @@ class NetworkModule(AnsibleModule):
         self.connection.close()
 
     def parse_config(self, cfg):
-        return parse(cfg, indent=4)
+        try:
+            return parse(cfg, indent=4)
+        except Exception, exc:
+            self.fail_json(msg=exc.message)
 
     def get_config(self):
         if self.params['transport'] == 'cli':


### PR DESCRIPTION
Throw an error if the incoming config is not indented in a way that can be parsed. Also, use the first child to determine indentation width. This gives some flexibility when creating a config template.
