### PR TITLE
Remove the range part while parsing hostname and port

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -110,7 +110,7 @@ class InventoryParser(object):
                     continue
                 hostname = tokens[0]
                 port = C.DEFAULT_REMOTE_PORT
-                hostname_norange = re.sub(r'\[(.+:)+.+\]', '', hostname)
+                hostname_norange = re.sub(r'\[.+\]', '', hostname)
                 # Three cases to check:
                 # 0. A hostname that contains a range pesudo-code and a port
                 # 1. A hostname that contains just a port

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -110,20 +110,17 @@ class InventoryParser(object):
                     continue
                 hostname = tokens[0]
                 port = C.DEFAULT_REMOTE_PORT
+                hostname_norange = re.sub(r'\[(.+:)+.+\]', '', hostname)
                 # Three cases to check:
                 # 0. A hostname that contains a range pesudo-code and a port
                 # 1. A hostname that contains just a port
-                if hostname.count(":") > 1:
+                if hostname_norange.count(":") > 1:
                     # Possible an IPv6 address, or maybe a host line with multiple ranges
                     # IPv6 with Port  XXX:XXX::XXX.port
                     # FQDN            foo.example.com
                     if hostname.count(".") == 1:
                         (hostname, port) = hostname.rsplit(".", 1)
-                elif ("[" in hostname and
-                    "]" in hostname and
-                    ":" in hostname and
-                    (hostname.rindex("]") < hostname.rindex(":")) or
-                    ("]" not in hostname and ":" in hostname)):
+                elif ":" in hostname_norange:
                         (hostname, port) = hostname.rsplit(":", 1)
 
                 hostnames = []

--- a/test/units/inventory_test_data/complex_hosts
+++ b/test/units/inventory_test_data/complex_hosts
@@ -94,3 +94,5 @@ blade-[a:c]-[1:16]
 blade-[d:z]-[01:16].example.com
 blade-[1:10]-[1:16]
 host-e-[10:16].example.net:1234
+server-[01:09].dc1
+server-[01:09].dc1:5678

--- a/test/units/inventory_test_data/complex_hosts
+++ b/test/units/inventory_test_data/complex_hosts
@@ -96,3 +96,5 @@ blade-[1:10]-[1:16]
 host-e-[10:16].example.net:1234
 server-[01:09].dc1
 server-[01:09].dc1:5678
+server-[01:09:2].dc1
+server-[01:09:2].dc1:5678


### PR DESCRIPTION
Fix the issue that the INI parser treat the hosts with range in `/etc/ansible/hosts` as a IPv6 address with port, which causes exception at runtime
For example: `server-[01:99:2].dc1`
