### PR TITLE
doc: wrong parameter "succeeded" in when statement

### DIFF
--- a/docsite/rst/playbooks_conditionals.rst
+++ b/docsite/rst/playbooks_conditionals.rst
@@ -47,7 +47,7 @@ decide to do something conditionally based on success or failure::
       - command: /bin/something
         when: result|failed
       - command: /bin/something_else
-        when: result|succeeded
+        when: result|success
       - command: /bin/still/something_else
         when: result|skipped
 


### PR DESCRIPTION
In **when** statement, the documentation states the use of "_succeeded_", when it should be "_success_".

Using "succeeded" will not work and return this error:

```
Failed to template {% if mobile_status|succeeded %} True {% else %} False {% endif %}: template error while templating string: no filter named 'succeeded'
```

version: ansible==1.9.4
