### PR TITLE
If a hosts is marked as failed, it seems odd to mark it as complete too.

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -362,8 +362,6 @@ class PlayIterator:
                     state.run_state = self.ITERATING_RESCUE
                 elif state._blocks[state.cur_block].always:
                     state.run_state = self.ITERATING_ALWAYS
-                else:
-                    state.run_state = self.ITERATING_COMPLETE
         elif state.run_state == self.ITERATING_RESCUE:
             if state.rescue_child_state is not None:
                 state.rescue_child_state = self._set_failed_state(state.rescue_child_state)


### PR DESCRIPTION
Referencing the issue:  https://github.com/ansible/ansible/issues/14040

The problem is that if "run_state" is COMPLETE the host is marked as failed, and rescue is not called.
I don't know if there are other implications, but for me it has no sense mark at the same time as completed and failed. If something failed is not really complete, is it?

I only deleted the condition where in case of failed it was marked as completed and now it seems to work.

I tested it without block/rescue (a playn tasks playbook), with block/rescue with and without include and it seems to work.

Again, I am not sure if this condition was there for some special reason, and I only decided to take it off because conceptualy for me something failed is not completed.
