### PR TITLE
Better "conflicting action statements" message

### DIFF
--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -287,7 +287,7 @@ class ModuleArgsParser:
             if item in module_loader or item == 'meta' or item == 'include':
                 # finding more than one module name is a problem
                 if action is not None:
-                    raise AnsibleParserError("conflicting action statements", obj=self._task_ds)
+                    raise AnsibleParserError("conflicting action statements (%s, %s)" % (action, item), obj=self._task_ds)
                 action = item
                 thing = value
                 action, args = self._normalize_parameters(value, action=action, additional_args=additional_args)


### PR DESCRIPTION
I had a tasks file including a snippet twice to create and set up two users.

``` yaml
# Set up the sync user
- include: user.yml
  mode: sync
  user: "{{ssh_user_sync}}"

# Set up the async user
- include: user.yml
  mode: async
  user: "{{ssh_user_async}}"
```

In ansible 2.0 it started failing with the error "conflicting action statements". It is not clear that the problem is that there cannot be an `user` variable, because `user` also happens to be a role. This worked ok in Ansible 1.9.

I think this is brittle (an include may fail in the future because a new action will be implemented...). Anyway I'm not up for a painful discussion about Ansible choices. This patch just provides a better error message:

```
ERROR! conflicting action statements (include, user)
```

which hopefully may lead an user to understand they have to rename a variable.
