### PR TITLE
Do not append parent more than once when calling serialize.

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -354,7 +354,7 @@ class Role(Base, Become, Conditional, Taggable):
 
         return block_list
 
-    def serialize(self, include_deps=True):
+    def serialize(self, include_deps=True, already_included_roles=[]):
         res = super(Role, self).serialize()
 
         res['_role_name']    = self._role_name
@@ -376,7 +376,10 @@ class Role(Base, Become, Conditional, Taggable):
 
         parents = []
         for parent in self._parents:
-            parents.append(parent.serialize(include_deps=False))
+            if parent.get_name() not in already_included_roles:
+                already_included_roles.append(parent.get_name())
+                parents.append(parent.serialize(include_deps=False, already_included_roles=already_included_roles))
+
         res['_parents'] = parents
 
         return res


### PR DESCRIPTION
Can result in a 10 time speed improvement when using role with redundant dependencies (check https://github.com/ansible/ansible/issues/14112 for more details).
