### PR TITLE
fix issue that win_stat fails while another process opens the target file

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -211,7 +211,7 @@ Function Get-FileChecksum($path)
     If (Test-Path -PathType Leaf $path)
     {
         $sp = new-object -TypeName System.Security.Cryptography.SHA1CryptoServiceProvider;
-        $fp = [System.IO.File]::Open($path, [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read);
+        $fp = [System.IO.File]::Open($path, [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite);
         $hash = [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
         $fp.Dispose();
     }


### PR DESCRIPTION
win_stat fails to calculate checksum of the file which is opened by another process, because [System.IO.File]::Open() without FileShare parameter can't open such a file.
