### PR TITLE
Fix all permission/mode examples to use strings for octal representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,8 +99,8 @@ allowed in future versions:
       gather_facts: false
       vars:
         my_dirs:
-          - { path: /tmp/3a, state: directory, mode: 0755 }
-          - { path: /tmp/3b, state: directory, mode: 0700 }
+          - { path: /tmp/3a, state: directory, mode: '0755' }
+          - { path: /tmp/3b, state: directory, mode: '0700' }
       tasks:
         - file:
           args: "{{item}}"

--- a/docsite/rst/guide_rax.rst
+++ b/docsite/rst/guide_rax.rst
@@ -691,7 +691,7 @@ Using Ansible Pull
             state: touch
             owner: root
             group: root
-            mode: 0400
+            mode: '0400'
     
     - name: Base Configure Servers
       hosts: all
@@ -761,7 +761,7 @@ Using Ansible Pull with XenStore
             state: touch
             owner: root
             group: root
-            mode: 0400
+            mode: '0400'
     
     - name: Base Configure Servers
       hosts: all

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -110,7 +110,7 @@ As of Ansible 1.8, it is possible to use the default filter to omit variables an
         - path: /tmp/foo
         - path: /tmp/bar
         - path: /tmp/baz
-          mode: "0444"
+          mode: '0444'
 
 For the first two files in the list, the default mode will be determined by the umask of the system as the `mode=`
 parameter will not be sent to the file module while the final file will receive the `mode=0444` option.

--- a/docsite/rst/porting_guide_2.0.rst
+++ b/docsite/rst/porting_guide_2.0.rst
@@ -66,8 +66,8 @@ uses key=value escaping which has not changed.  The other option is to check for
       gather_facts: false
       vars:
         my_dirs:
-          - { path: /tmp/3a, state: directory, mode: 0755 }
-          - { path: /tmp/3b, state: directory, mode: 0700 }
+          - { path: /tmp/3a, state: directory, mode: '0755' }
+          - { path: /tmp/3b, state: directory, mode: '0700' }
       tasks:
         - file:
           args: "{{item}}" # <- args here uses the full variable syntax

--- a/test/integration/roles/test_template/tasks/main.yml
+++ b/test/integration/roles/test_template/tasks/main.yml
@@ -115,7 +115,7 @@
   template:
     src: foo.j2
     dest: '{{output_dir}}/foo.symlink'
-    mode: 0600
+    mode: '0600'
     follow: True
   register: template_result
 
@@ -135,7 +135,7 @@
   template:
     src: foo.j2
     dest: '{{output_dir}}/foo.symlink'
-    mode: 0600
+    mode: '0600'
     follow: True
   register: template_result
 

--- a/test/integration/roles/test_unarchive/tasks/main.yml
+++ b/test/integration/roles/test_unarchive/tasks/main.yml
@@ -308,7 +308,7 @@
 - name: Change the mode of the toplevel dir
   file:
     path: "{{ output_dir }}/test-unarchive-tar-gz/unarchive-dir"
-    mode: 0701
+    mode: "0701"
 
 - name: Remove a file from the extraction point
   file:


### PR DESCRIPTION
This is required because yaml and ansible v2 represents this as decimal values internally. And as such it fails with an incorrect value when run.
