### PR TITLE
Groups naming convention in vagrant hosts provider

### DIFF
--- a/contrib/inventory/vagrant.ini
+++ b/contrib/inventory/vagrant.ini
@@ -1,0 +1,2 @@
+[vagrant]
+#host_match_regex = '(.*?)(?:-[0-9]+)?$' #host name to group convention (Name: <BLA>-N => Group: <BLA>)


### PR DESCRIPTION
### Add Grouping by naming convention capabilities:

If the file `vagrant.ini` is present, and contains a regex:

``` ini
[vagrant]
host_match_regex = '(.*?)(?:-[0-9]+)?$'
```

Then any vagrant machine with the following naming convention will be grouped:

Machine: `<NAME>-X` => Group: `<NAME>`

This is in addition to the previously used `vagrant` group.

If the `vagrant.ini` file doesn't exist (or the needed option) then the vagrant host provider will continue as before.

Any group caught in the regex will be used as a host group.
