### PR TITLE
Update example vpc_desitnation_variable example with working settings

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -35,9 +35,9 @@ destination_variable = public_dns_name
 # private subnet, this should be set to 'private_ip_address', and Ansible must
 # be run from within EC2. The key of an EC2 tag may optionally be used; however
 # the boto instance variables hold precedence in the event of a collision.
-# WARNING: - instances that are in the private vpc, _without_ public ip address 
+# WARNING: - instances that are in the private vpc, _without_ public ip address
 # will not be listed in the inventory until You set:
-# vpc_destination_variable = 'private_ip_address'
+# vpc_destination_variable = private_ip_address
 vpc_destination_variable = ip_address
 
 # To tag instances on EC2 with the resource records that point to them from
@@ -144,7 +144,7 @@ group_by_elasticache_replication_group = True
 
 # You can use wildcards in filter values also. Below will list instances which
 # tag Name value matches webservers1*
-# (ex. webservers15, webservers1a, webservers123 etc) 
+# (ex. webservers15, webservers1a, webservers123 etc)
 # instance_filters = tag:Name=webservers1*
 
 # A boto configuration profile may be used to separate out credentials


### PR DESCRIPTION
The stated setting for vpc_destination_variable is quoted, and as such will return zero hosts.

This PR removes those quotes and causes the code to work when uncommenting the supplied line.
