### PR TITLE
Add validate_certs param to skip SSL verification in VMware

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -105,7 +105,7 @@ def vmware_argument_spec():
         hostname=dict(type='str', required=True),
         username=dict(type='str', aliases=['user', 'admin'], required=True),
         password=dict(type='str', aliases=['pass', 'pwd'], required=True, no_log=True),
-        skip_ssl=dict(type='bool', required=False, default=False),
+        validate_certs=dict(type='bool', required=False, default=True),
     )
 
 
@@ -114,15 +114,15 @@ def connect_to_api(module, disconnect_atexit=True):
     hostname = module.params['hostname']
     username = module.params['username']
     password = module.params['password']
-    skip_ssl = module.params['skip_ssl']
+    validate_certs = module.params['validate_certs']
 
     try:
-        if skip_ssl:
+        if validate_certs:
+            service_instance = connect.SmartConnect(host=hostname, user=username, pwd=password)
+	else:
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             context.verify_mode = ssl.CERT_NONE
             service_instance = connect.SmartConnect(host=hostname, user=username, pwd=password, sslContext=context)
-	else:
-            service_instance = connect.SmartConnect(host=hostname, user=username, pwd=password)
 
         # Disabling atexit should be used in special cases only.
         # Such as IP change of the ESXi host which removes the connection anyway.


### PR DESCRIPTION
This is handy when working with development environments using self-signed certificates.
