### PR TITLE
make executable setting connection dependant

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -505,7 +505,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             replacement strategy (python3 could use surrogateescape)
         '''
 
-        if executable is not None:
+        if executable is not None and self._connection.allow_executable:
             cmd = executable + ' -c ' + pipes.quote(cmd)
 
         display.debug("_low_level_execute_command(): starting")

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -60,6 +60,7 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
     # as discovered by the specified file extension.  An empty string as the
     # language means any language.
     module_implementation_preferences = ('',)
+    allow_executable = True
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         # All these hasattrs allow subclasses to override these parameters

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -63,6 +63,7 @@ class Connection(ConnectionBase):
 
     module_implementation_preferences = ('.ps1', '')
     become_methods = []
+    allow_executable = False
 
     def __init__(self,  *args, **kwargs):
 


### PR DESCRIPTION
winrm shoudl not use executable, rest should?
fixes #14233
