### PR TITLE
WIP: tag the setup task with always

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -137,6 +137,7 @@ class PlayIterator:
         setup_block = Block(play=self._play)
         setup_task = Task(block=setup_block)
         setup_task.action = 'setup'
+        setup_task.tags   = ['always']
         setup_task.args   = {}
         setup_task.set_loader(self._play._loader)
         setup_block.block = [setup_task]


### PR DESCRIPTION
fixes #14228
but breaks ##13602

Since 5587b08335f223fff64f54ced6f2790b3d6ee6f0, the automatic `setup` created by `gather_facts` inherits all properties from the play, as other tasks, this includes tags. 

In the PR I give it the `always` tag but this can be superseded by additional tags in the play included in `--skip-tags` or by `--skip-tags always`.
