### PR TITLE
Handle when the lookup-plugin is used in jinja-style

### DIFF
--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -171,7 +171,7 @@ class LookupModule(LookupBase):
                 else:
                     total_search.append(term)
         else:
-            total_search = terms
+            total_search = self._flatten(terms)
 
         roledir = variables.get('roledir')
         for fn in total_search:


### PR DESCRIPTION
This fixes #14190.

Terms provided in this case is a list inside a list, which is not handled correctly.
It bails out trying to handle the list as a filename instead.
