### PR TITLE
Defined JSON booleans in global context for python eval()

### DIFF
--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -41,6 +41,13 @@ def safe_eval(expr, locals={}, include_exceptions=False):
     http://stackoverflow.com/questions/12523516/using-ast-and-whitelists-to-make-pythons-eval-safe
     '''
 
+    # define certain JSON types
+    # eg. JSON booleans are unknown to python eval()
+    JSON_TYPES = {
+        'false': False,
+        'true': True,
+    }
+
     # this is the whitelist of AST nodes we are going to
     # allow in the evaluation. Any node type other than
     # those listed here will raise an exception in our custom
@@ -116,7 +123,7 @@ def safe_eval(expr, locals={}, include_exceptions=False):
         parsed_tree = ast.parse(expr, mode='eval')
         cnv.visit(parsed_tree)
         compiled = compile(parsed_tree, expr, 'eval')
-        result = eval(compiled, {}, dict(locals))
+        result = eval(compiled, JSON_TYPES, dict(locals))
 
         if include_exceptions:
             return (result, None)

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -45,6 +45,7 @@ def safe_eval(expr, locals={}, include_exceptions=False):
     # eg. JSON booleans are unknown to python eval()
     JSON_TYPES = {
         'false': False,
+        'null': None,
         'true': True,
     }
 


### PR DESCRIPTION
We define 'false' and 'true' as variables so that python eval() recognizes them as False and True.

This fixes #14291.
