### PR TITLE
Hide 'include' tasks when not in verbose mode

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -114,23 +114,24 @@ class CallbackModule(CallbackBase):
         self._display.banner("NO MORE HOSTS LEFT")
 
     def v2_playbook_on_task_start(self, task, is_conditional):
-        args = ''
-        # args can be specified as no_log in several places: in the task or in
-        # the argument spec.  We can check whether the task is no_log but the
-        # argument spec can't be because that is only run on the target
-        # machine and we haven't run it thereyet at this time.
-        #
-        # So we give people a config option to affect display of the args so
-        # that they can secure this if they feel that their stdout is insecure
-        # (shoulder surfing, logging stdout straight to a file, etc).
-        if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
-            args = ', '.join(('%s=%s' % a for a in task.args.items()))
-            args = ' %s' % args
-        self._display.banner("TASK [%s%s]" % (task.get_name().strip(), args))
-        if self._display.verbosity >= 2:
-            path = task.get_path()
-            if path:
-                self._display.display("task path: %s" % path, color=C.COLOR_DEBUG)
+        if self._display.verbosity > 1 or task.get_name() != 'include':
+            args = ''
+            # args can be specified as no_log in several places: in the task or in
+            # the argument spec.  We can check whether the task is no_log but the
+            # argument spec can't be because that is only run on the target
+            # machine and we haven't run it thereyet at this time.
+            #
+            # So we give people a config option to affect display of the args so
+            # that they can secure this if they feel that their stdout is insecure
+            # (shoulder surfing, logging stdout straight to a file, etc).
+            if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
+                args = ', '.join(('%s=%s' % a for a in task.args.items()))
+                args = ' %s' % args
+            self._display.banner("TASK [%s%s]" % (task.get_name().strip(), args))
+            if self._display.verbosity >= 2:
+                path = task.get_path()
+                if path:
+                    self._display.display("task path: %s" % path, color=C.COLOR_DEBUG)
 
     def v2_playbook_on_cleanup_task_start(self, task):
         self._display.banner("CLEANUP TASK [%s]" % task.get_name().strip())
@@ -212,8 +213,9 @@ class CallbackModule(CallbackBase):
         self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_include(self, included_file):
-        msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
-        self._display.display(msg, color=C.COLOR_SKIP)
+        if self._display.verbosity > 1:
+            msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
+            self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_stats(self, stats):
         self._display.banner("PLAY RECAP")

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -114,7 +114,7 @@ class CallbackModule(CallbackBase):
         self._display.banner("NO MORE HOSTS LEFT")
 
     def v2_playbook_on_task_start(self, task, is_conditional):
-        if self._display.verbosity > 1 or task.get_name() != 'include':
+        if self._display.verbosity > 1 or task.action != 'include':
             args = ''
             # args can be specified as no_log in several places: in the task or in
             # the argument spec.  We can check whether the task is no_log but the


### PR DESCRIPTION
This implements #14285 by default.

It will hide all include-tasks by default and in verbosity 1 (-v), but will show all details when verbosty 2 or higher (-vv).

It is quite annoying and confusing that Ansible emits all include tasks. Also because the color is the same color as skipping.
