### PR TITLE
Revert connection vars to being undefined

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -40,13 +40,17 @@ from ansible.utils.unicode import to_unicode
 
 BASE_ATTRIBUTES = {}
 
+class Undefined:
+    def __len__(self):
+        return 0
+UNDEFINED = Undefined()
 
 class Base:
 
     # connection/transport
     _connection          = FieldAttribute(isa='string')
-    _port                = FieldAttribute(isa='int')
-    _remote_user         = FieldAttribute(isa='string')
+    _port                = FieldAttribute(isa='int', default=UNDEFINED)
+    _remote_user         = FieldAttribute(isa='string', default=UNDEFINED)
 
     # variables
     _vars                = FieldAttribute(isa='dict', priority=100)
@@ -313,7 +317,7 @@ class Base:
                     continue
 
                 # and make sure the attribute is of the type it should be
-                if value is not None:
+                if value not in [None, UNDEFINED]:
                     if attribute.isa == 'string':
                         value = to_unicode(value)
                     elif attribute.isa == 'int':

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -111,7 +111,7 @@ class Base:
             return getattr(self, method)()
 
         value = self._attributes[prop_name]
-        if value is None and hasattr(self, '_get_parent_attribute'):
+        if value in [None, UNDEFINED] and hasattr(self, '_get_parent_attribute'):
             value = self._get_parent_attribute(prop_name)
         return value
 

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -379,7 +379,7 @@ class PlayContext(Base):
                     attrs_considered.append(attr)
 
         # make sure we get port defaults if needed
-        if new_info.port is None and C.DEFAULT_REMOTE_PORT is not None:
+        if new_info.port in [None, UNDEFINED] and C.DEFAULT_REMOTE_PORT is not None:
             new_info.port = int(C.DEFAULT_REMOTE_PORT)
 
         # become legacy updates

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -30,7 +30,7 @@ from ansible.compat.six import iteritems, string_types
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.playbook.attribute import Attribute, FieldAttribute
-from ansible.playbook.base import Base
+from ansible.playbook.base import Base, UNDEFINED
 from ansible.template import Templar
 from ansible.utils.boolean import boolean
 from ansible.utils.unicode import to_unicode
@@ -148,8 +148,8 @@ class PlayContext(Base):
 
     # connection fields, some are inherited from Base:
     # (connection, port, remote_user, environment, no_log)
-    _remote_addr      = FieldAttribute(isa='string')
-    _password         = FieldAttribute(isa='string')
+    _remote_addr      = FieldAttribute(isa='string', default=UNDEFINED)
+    _password         = FieldAttribute(isa='string', default=UNDEFINED)
     _private_key_file = FieldAttribute(isa='string', default=C.DEFAULT_PRIVATE_KEY_FILE)
     _timeout          = FieldAttribute(isa='int', default=C.DEFAULT_TIMEOUT)
     _shell            = FieldAttribute(isa='string')
@@ -531,4 +531,6 @@ class PlayContext(Base):
             if special_var not in variables:
                 for prop, varnames in MAGIC_VARIABLE_MAPPING.items():
                     if special_var in varnames:
-                        variables[special_var] = getattr(self, prop)
+                        value = getattr(self, prop)
+                        if value is not UNDEFINED:
+                            variables[special_var] = getattr(self, prop)

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -27,7 +27,7 @@ from ansible.compat.tests.mock import patch, MagicMock
 from ansible import constants as C
 from ansible.cli import CLI
 from ansible.errors import AnsibleError, AnsibleParserError
-from ansible.playbook.play_context import PlayContext
+from ansible.playbook.play_context import PlayContext, UNDEFINED
 
 from units.mock.loader import DictDataLoader
 
@@ -53,10 +53,10 @@ class TestPlayContext(unittest.TestCase):
         (options, args) = self._parser.parse_args(['-vv', '--check'])
         play_context = PlayContext(options=options)
         self.assertEqual(play_context.connection, 'smart')
-        self.assertEqual(play_context.remote_addr, None)
-        self.assertEqual(play_context.remote_user, None)
-        self.assertEqual(play_context.password, '')
-        self.assertEqual(play_context.port, None)
+        self.assertEqual(play_context.remote_addr, UNDEFINED)
+        self.assertEqual(play_context.remote_user, UNDEFINED)
+        self.assertEqual(play_context.password, UNDEFINED)
+        self.assertEqual(play_context.port, UNDEFINED)
         self.assertEqual(play_context.private_key_file, C.DEFAULT_PRIVATE_KEY_FILE)
         self.assertEqual(play_context.timeout, C.DEFAULT_TIMEOUT)
         self.assertEqual(play_context.shell, None)


### PR DESCRIPTION
This is not necessarily ready to ship.  This is kind of a proof of concept.  There may be a different way we want to handle this.

See #14310 

Before v2, vars such as `ansible_ssh_port` were undefined, allowing the `default` filter to work on them without issue.  In v2, these values are set to `None` when not defined, preventing the basic usage of default.

This approach creates an "UNDEFINED" constant, that is then used to determine if we should define the connection var or not.
