### PR TITLE
Introduce new 'filetree' lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -18,7 +18,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import glob
 import pwd
 import grp
 import stat

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -24,6 +24,8 @@ import grp
 import stat
 
 from ansible.plugins.lookup import LookupBase
+from __main__ import display
+warning = display.warning
 
 HAVE_SELINUX=False
 try:
@@ -31,12 +33,6 @@ try:
     HAVE_SELINUX=True
 except ImportError:
     pass
-
-try:
-    from __main__.display import warning
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 def _to_filesystem_str(path):
     '''Returns filesystem path as a str, if it wasn't already.
@@ -66,12 +62,12 @@ def selinux_context(path):
     return context
 
 def file_props(root, path):
-    ''' Returns dictionary with file properties, or return None on failure'''
+    ''' Returns dictionary with file properties, or return None on failure '''
     abspath = os.path.join(root, path)
 
     try:
         st = os.lstat(abspath)
-    except OSError, e:
+    except OSError as e:
         warning('filetree: Error using stat() on path %s (%s)' % (abspath, e))
         return None
 
@@ -86,7 +82,7 @@ def file_props(root, path):
         ret['state'] = 'file'
         ret['src'] = abspath
     else:
-        warning('filetree: Error file type of %s not support' % abspath)
+        warning('filetree: Error file type of %s is not supported' % abspath)
         return None
 
     ret['uid'] = st.st_uid

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -22,7 +22,6 @@ import glob
 import pwd
 import grp
 
-from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
 HAVE_SELINUX=False
@@ -79,13 +78,13 @@ def file_props(root, path):
         elif os.path.isfile(abspath):
             ret['state'] = 'file'
             ret['src'] = abspath
-    except OSError, e:
+    except OSError as e:
         display.warning('filetree: Error querying path %s  (%s)' % (abspath, e))
         return None
 
     try:
         stat = os.stat(abspath)
-    except OSError, e:
+    except OSError as e:
         display.warning('filetree: Error using stat() on path %s  (%s)' % (abspath, e))
         return None
 

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -86,8 +86,14 @@ def file_props(root, path):
 
     ret['uid'] = st.st_uid
     ret['gid'] = st.st_gid
-    ret['owner'] = pwd.getpwuid(st.st_uid).pw_name
-    ret['group'] = grp.getgrgid(st.st_gid).gr_name
+    try:
+        ret['owner'] = pwd.getpwuid(st.st_uid).pw_name
+    except KeyError:
+        ret['owner'] = st.st_uid
+    try:
+        ret['group'] = grp.getgrgid(st.st_gid).gr_name
+    except KeyError:
+        ret['group'] = st.st_gid
     ret['mode'] = str(oct(stat.S_IMODE(st.st_mode)))
     ret['size'] = st.st_size
     ret['mtime'] = st.st_mtime

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -1,0 +1,127 @@
+# (c) 2016 Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import glob
+import pwd
+import grp
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+HAVE_SELINUX=False
+try:
+    import selinux
+    HAVE_SELINUX=True
+except ImportError:
+    pass
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+def _to_filesystem_str(path):
+    '''Returns filesystem path as a str, if it wasn't already.
+
+    Used in selinux interactions because it cannot accept unicode
+    instances, and specifying complex args in a playbook leaves
+    you with unicode instances.  This method currently assumes
+    that your filesystem encoding is UTF-8.
+
+    '''
+    if isinstance(path, unicode):
+        path = path.encode("utf-8")
+    return path
+
+# If selinux fails to find a default, return an array of None
+def selinux_context(path):
+    context = [None, None, None, None]
+    if HAVE_SELINUX and selinux.is_selinux_enabled():
+        try:
+            ret = selinux.lgetfilecon_raw(_to_filesystem_str(path))
+        except OSError:
+            return context
+        if ret[0] != -1:
+            # Limit split to 4 because the selevel, the last in the list,
+            # may contain ':' characters
+            context = ret[1].split(':', 3)
+    return context
+
+def file_props(root, path):
+    ''' Returns dictionary with file properties, or return None on failure'''
+    abspath = os.path.join(root, path)
+    ret = dict(root=root, path=path, exists=True)
+
+    try:
+        if os.path.islink(abspath):
+            ret['state'] = 'link'
+            ret['src'] = os.readlink(abspath)
+        elif os.path.isdir(abspath):
+            ret['state'] = 'directory'
+        elif os.path.isfile(abspath):
+            ret['state'] = 'file'
+            ret['src'] = abspath
+    except OSError, e:
+        display.warning('filetree: Error querying path %s  (%s)' % (abspath, e))
+        return None
+
+    try:
+        stat = os.stat(abspath)
+    except OSError, e:
+        display.warning('filetree: Error using stat() on path %s  (%s)' % (abspath, e))
+        return None
+
+    ret['uid'] = stat.st_uid
+    ret['gid'] = stat.st_gid
+    ret['owner'] = pwd.getpwuid(stat.st_uid).pw_name
+    ret['group'] = grp.getgrgid(stat.st_gid).gr_name
+    ret['mode'] = str(oct(stat.st_mode))
+    ret['size'] = stat.st_size
+    ret['mtime'] = stat.st_mtime
+    ret['ctime'] = stat.st_ctime
+
+    if HAVE_SELINUX and selinux.is_selinux_enabled() == 1:
+        context = selinux_context(abspath)
+        ret['seuser'] = context[0]
+        ret['serole'] = context[1]
+        ret['setype'] = context[2]
+        ret['selevel'] = context[3]
+
+    return ret
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+        basedir = self.get_basedir(variables)
+
+        ret = []
+        for term in terms:
+            term_file = os.path.basename(term)
+            dwimmed_path = self._loader.path_dwim_relative(basedir, 'files', os.path.dirname(term))
+            path = os.path.join(dwimmed_path, term_file)
+            for root, dirs, files in os.walk(path, topdown=True):
+                for entry in dirs + files:
+                    relpath = os.path.relpath(os.path.join(root, entry), path)
+                    props = file_props(path, relpath)
+                    if props != None:
+                        ret.append(props)
+
+        return ret

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -122,8 +122,11 @@ class LookupModule(LookupBase):
             for root, dirs, files in os.walk(path, topdown=True):
                 for entry in dirs + files:
                     relpath = os.path.relpath(os.path.join(root, entry), path)
-                    props = file_props(path, relpath)
-                    if props is not None:
-                        ret.append(props)
+
+                    # Skip if relpath was already processed (from another root)
+                    if relpath not in [ entry['path'] for entry in ret ]:
+                        props = file_props(path, relpath)
+                        if props is not None:
+                            ret.append(props)
 
         return ret

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -102,6 +102,7 @@ def file_props(root, path):
 
     return ret
 
+
 class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
@@ -116,7 +117,7 @@ class LookupModule(LookupBase):
                 for entry in dirs + files:
                     relpath = os.path.relpath(os.path.join(root, entry), path)
                     props = file_props(path, relpath)
-                    if props != None:
+                    if props is not None:
                         ret.append(props)
 
         return ret

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -84,7 +84,7 @@ def file_props(root, path):
         return None
 
     try:
-        st = os.stat(abspath)
+        st = os.lstat(abspath)
     except OSError as e:
         display.warning('filetree: Error using stat() on path %s  (%s)' % (abspath, e))
         return None


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

v2.0
##### SUMMARY

The new "filetree" lookup plugin makes it possible to recurse over a tree of files within the task loop. This makes it possible to e.g. template a complete tree of files to a target system with little effort while retaining permissions and ownership.

The module supports directories, files and symlinks. And also SELinux.

If you provide more than one path, it will implement a `with_first_found` logic, and will not process entries it already processed in previous paths. This enables the user to merge different trees in order of importance, or add e.g. role_vars specific paths to influence different instances of the same role.

The item dictionary consists of:
- src
- root
- path
- mode
- state
- owner
- group
- seuser
- serole
- setype
- selevel
- uid
- gid
- size
- mtime
- ctime
##### EXAMPLES

Here is an example of how we use with_filetree within a role.
The `web/` path is relative to either `roles/<role>/files/` or `files/`.

``` yaml
 - name: Create directories
   file:
     path: /web/{{ item.path }}
     state: directory
     mode: '{{ item.mode }}'
   with_filetree: web/
   when: item.state == 'directory'

 - name: Template files
   template:
     src: '{{ item.src }}'
     dest: /web/{{ item.path }}
     mode: '{{ item.mode }}'
   with_filetree: web/
   when: item.state == 'file'

 - name: Recreate symlinks
   file:
     src: '{{ item.src }}'
     dest: /web/{{ item.path }}
     state: link
     force: yes
     mode: '{{ item.mode }}'
   with_filetree: web/
   when: item.state == 'link'
```
##### SPECIAL USE

The following properties also have its special use:
- root: Makes it possible to filter by original location
- path: Is the relative path to root
- uid, gid: Makes it possible to force-create by exact id, rather than by name
- size, mtime, ctime: Makes it possible to filter out files by size, mtime or ctime
