### PR TITLE
add systemd-nspawn connection driver

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -286,6 +286,8 @@ class CLI(object):
                 help="specify extra arguments to pass to scp only (e.g. -l)")
             connect_group.add_option('--ssh-extra-args', default='', dest='ssh_extra_args',
                 help="specify extra arguments to pass to ssh only (e.g. -R)")
+            connect_group.add_option('--nspawn-extra-args', default='', dest='nspawn_extra_args',
+                help="specify extra arguments to pass to systemd-nspawn only (e.g. --bind)")
 
             parser.add_option_group(connect_group)
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -244,6 +244,7 @@ ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path',
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, integer=True)
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
+ANSIBLE_NSPAWN_ARGS            = get_config(p, 'nspawn_connection', 'nspawn_args', 'ANSIBLE_NSPAWN_ARGS', '-q')
 
 
 # obsolete -- will be formally removed

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -49,35 +49,36 @@ except ImportError:
 # in variable names.
 
 MAGIC_VARIABLE_MAPPING = dict(
-   connection       = ('ansible_connection',),
-   remote_addr      = ('ansible_ssh_host', 'ansible_host'),
-   remote_user      = ('ansible_ssh_user', 'ansible_user'),
-   port             = ('ansible_ssh_port', 'ansible_port'),
-   accelerate_port  = ('ansible_accelerate_port',),
-   password         = ('ansible_ssh_pass', 'ansible_password'),
-   private_key_file = ('ansible_ssh_private_key_file', 'ansible_private_key_file'),
-   pipelining       = ('ansible_ssh_pipelining', 'ansible_pipelining'),
-   shell            = ('ansible_shell_type',),
-   become           = ('ansible_become',),
-   become_method    = ('ansible_become_method',),
-   become_user      = ('ansible_become_user',),
-   become_pass      = ('ansible_become_password','ansible_become_pass'),
-   become_exe       = ('ansible_become_exe',),
-   become_flags     = ('ansible_become_flags',),
-   ssh_common_args  = ('ansible_ssh_common_args',),
-   sftp_extra_args  = ('ansible_sftp_extra_args',),
-   scp_extra_args   = ('ansible_scp_extra_args',),
-   ssh_extra_args   = ('ansible_ssh_extra_args',),
-   sudo             = ('ansible_sudo',),
-   sudo_user        = ('ansible_sudo_user',),
-   sudo_pass        = ('ansible_sudo_password', 'ansible_sudo_pass'),
-   sudo_exe         = ('ansible_sudo_exe',),
-   sudo_flags       = ('ansible_sudo_flags',),
-   su               = ('ansible_su',),
-   su_user          = ('ansible_su_user',),
-   su_pass          = ('ansible_su_password', 'ansible_su_pass'),
-   su_exe           = ('ansible_su_exe',),
-   su_flags         = ('ansible_su_flags',),
+   connection        = ('ansible_connection',),
+   remote_addr       = ('ansible_ssh_host', 'ansible_host'),
+   remote_user       = ('ansible_ssh_user', 'ansible_user'),
+   port              = ('ansible_ssh_port', 'ansible_port'),
+   accelerate_port   = ('ansible_accelerate_port',),
+   password          = ('ansible_ssh_pass', 'ansible_password'),
+   private_key_file  = ('ansible_ssh_private_key_file', 'ansible_private_key_file'),
+   pipelining        = ('ansible_ssh_pipelining', 'ansible_pipelining'),
+   shell             = ('ansible_shell_type',),
+   become            = ('ansible_become',),
+   become_method     = ('ansible_become_method',),
+   become_user       = ('ansible_become_user',),
+   become_pass       = ('ansible_become_password','ansible_become_pass'),
+   become_exe        = ('ansible_become_exe',),
+   become_flags      = ('ansible_become_flags',),
+   ssh_common_args   = ('ansible_ssh_common_args',),
+   sftp_extra_args   = ('ansible_sftp_extra_args',),
+   scp_extra_args    = ('ansible_scp_extra_args',),
+   ssh_extra_args    = ('ansible_ssh_extra_args',),
+   nspawn_extra_args = ('ansible_nspawn_extra_args',),
+   sudo              = ('ansible_sudo',),
+   sudo_user         = ('ansible_sudo_user',),
+   sudo_pass         = ('ansible_sudo_password', 'ansible_sudo_pass'),
+   sudo_exe          = ('ansible_sudo_exe',),
+   sudo_flags        = ('ansible_sudo_flags',),
+   su                = ('ansible_su',),
+   su_user           = ('ansible_su_user',),
+   su_pass           = ('ansible_su_password', 'ansible_su_pass'),
+   su_exe            = ('ansible_su_exe',),
+   su_flags          = ('ansible_su_flags',),
 )
 
 SU_PROMPT_LOCALIZATIONS = [
@@ -148,21 +149,23 @@ class PlayContext(Base):
 
     # connection fields, some are inherited from Base:
     # (connection, port, remote_user, environment, no_log)
-    _remote_addr      = FieldAttribute(isa='string')
-    _password         = FieldAttribute(isa='string')
-    _private_key_file = FieldAttribute(isa='string', default=C.DEFAULT_PRIVATE_KEY_FILE)
-    _timeout          = FieldAttribute(isa='int', default=C.DEFAULT_TIMEOUT)
-    _shell            = FieldAttribute(isa='string')
-    _ssh_args         = FieldAttribute(isa='string', default=C.ANSIBLE_SSH_ARGS)
-    _ssh_common_args  = FieldAttribute(isa='string')
-    _sftp_extra_args  = FieldAttribute(isa='string')
-    _scp_extra_args   = FieldAttribute(isa='string')
-    _ssh_extra_args   = FieldAttribute(isa='string')
-    _connection_lockfd= FieldAttribute(isa='int')
-    _pipelining       = FieldAttribute(isa='bool', default=C.ANSIBLE_SSH_PIPELINING)
-    _accelerate       = FieldAttribute(isa='bool', default=False)
-    _accelerate_ipv6  = FieldAttribute(isa='bool', default=False, always_post_validate=True)
-    _accelerate_port  = FieldAttribute(isa='int', default=C.ACCELERATE_PORT, always_post_validate=True)
+    _remote_addr       = FieldAttribute(isa='string')
+    _password          = FieldAttribute(isa='string')
+    _private_key_file  = FieldAttribute(isa='string', default=C.DEFAULT_PRIVATE_KEY_FILE)
+    _timeout           = FieldAttribute(isa='int', default=C.DEFAULT_TIMEOUT)
+    _shell             = FieldAttribute(isa='string')
+    _nspawn_args       = FieldAttribute(isa='string', default=C.ANSIBLE_NSPAWN_ARGS)
+    _nspawn_extra_args = FieldAttribute(isa='string')
+    _ssh_args          = FieldAttribute(isa='string', default=C.ANSIBLE_SSH_ARGS)
+    _ssh_common_args   = FieldAttribute(isa='string')
+    _sftp_extra_args   = FieldAttribute(isa='string')
+    _scp_extra_args    = FieldAttribute(isa='string')
+    _ssh_extra_args    = FieldAttribute(isa='string')
+    _connection_lockfd = FieldAttribute(isa='int')
+    _pipelining        = FieldAttribute(isa='bool', default=C.ANSIBLE_SSH_PIPELINING)
+    _accelerate        = FieldAttribute(isa='bool', default=False)
+    _accelerate_ipv6   = FieldAttribute(isa='bool', default=False, always_post_validate=True)
+    _accelerate_port   = FieldAttribute(isa='int', default=C.ACCELERATE_PORT, always_post_validate=True)
 
     # privilege escalation fields
     _become           = FieldAttribute(isa='bool')
@@ -261,6 +264,7 @@ class PlayContext(Base):
         self.sftp_extra_args = options.sftp_extra_args
         self.scp_extra_args = options.scp_extra_args
         self.ssh_extra_args = options.ssh_extra_args
+        self.nspawn_extra_args = options.nspawn_extra_args
 
         # privilege escalation
         self.become        = options.become

--- a/lib/ansible/plugins/connection/nspawn.py
+++ b/lib/ansible/plugins/connection/nspawn.py
@@ -1,0 +1,154 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import pipes
+import subprocess
+import traceback
+import shlex
+
+from ansible import constants as C
+from ansible.errors import AnsibleError
+from ansible.plugins.connection import ConnectionBase
+from ansible.module_utils.basic import is_executable
+from ansible.utils.unicode import to_bytes
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+BUFSIZE = 65536
+
+
+class Connection(ConnectionBase):
+    ''' Local nspawn based connections '''
+
+    transport = 'nspawn'
+    has_pipelining = True
+    become_methods = frozenset(C.BECOME_METHODS)
+
+    def __init__(self, play_context, new_stdin, *args, **kwargs):
+        super(Connection, self).__init__(play_context, new_stdin,
+                *args, **kwargs)
+
+        display.vvv("NSPAWN ARGS %s" % self._play_context.nspawn_args)
+        display.vvv("NSPAWN EXTRA ARGS %s" % self._play_context.nspawn_extra_args)
+
+        self.chroot = self._play_context.remote_addr
+
+        if os.geteuid() != 0:
+            raise AnsibleError("nspawn connection requires running as root")
+
+        # we're running as root on the local system so do some
+        # trivial checks for ensuring 'host' is actually a chroot'able dir
+        if not os.path.isdir(self.chroot):
+            raise AnsibleError("%s is not a directory" % self.chroot)
+
+        chrootsh = os.path.join(self.chroot, 'bin/sh')
+        if not is_executable(chrootsh):
+            raise AnsibleError("%s does not look like a chrootable dir (/bin/sh missing)" % self.chroot)
+
+        self.nspawn_cmd = 'systemd-nspawn'
+
+    def _connect(self):
+      pass
+
+    def _buffered_exec_command(self, cmd, stdin=subprocess.PIPE):
+        ''' run a command on the chroot.  This is only needed for
+        implementing put_file() get_file() so that we don't have to
+        read the whole file into memory.
+
+        compared to exec_command() it looses some niceties like being
+        able to return the process's exit code immediately.
+        '''
+        executable = (
+                C.DEFAULT_EXECUTABLE.split()[0]
+                if C.DEFAULT_EXECUTABLE
+                else '/bin/sh')
+
+        nspawn_args = shlex.split(self._play_context.nspawn_args)
+        nspawn_extra_args = shlex.split(self._play_context.nspawn_extra_args)
+        local_cmd = [self.nspawn_cmd, '-D', self.chroot ] + nspawn_args + nspawn_extra_args + [
+                '--', executable, '-c', cmd]
+
+        display.vvv("EXEC %s" % (local_cmd), host=self.chroot)
+        local_cmd = map(to_bytes, local_cmd)
+        p = subprocess.Popen(local_cmd, shell=False, stdin=stdin,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        return p
+
+    def exec_command(self, cmd, in_data=None, sudoable=False):
+        ''' run a command on the chroot '''
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+
+        p = self._buffered_exec_command(cmd)
+        stdout, stderr = p.communicate(in_data)
+        return (p.returncode, stdout, stderr)
+
+    def _prefix_login_path(self, remote_path):
+        ''' Make sure that we put files into a standard path
+
+            If a path is relative, then we need to choose where to put it.
+            ssh chooses $HOME but we aren't guaranteed that a home dir will
+            exist in any given chroot.  So for now we're choosing "/" instead.
+            This also happens to be the former default.
+
+            Can revisit using $HOME instead if it's a problem
+        '''
+        if not remote_path.startswith(os.path.sep):
+            remote_path = os.path.join(os.path.sep, remote_path)
+        return os.path.normpath(remote_path)
+
+    def put_file(self, in_path, out_path):
+        ''' transfer a file from local to chroot '''
+        super(Connection, self).put_file(in_path, out_path)
+        display.vvv("PUT %s TO %s" % (in_path, out_path), host=self.chroot)
+
+        out_path = pipes.quote(self._prefix_login_path(out_path))
+        try:
+            with open(in_path, 'rb') as in_file:
+                try:
+                    p = self._buffered_exec_command('dd of=%s bs=%s' % (out_path, BUFSIZE), stdin=in_file)
+                except OSError:
+                    raise AnsibleError("chroot connection requires dd command in the chroot")
+                try:
+                    stdout, stderr = p.communicate()
+                except:
+                    traceback.print_exc()
+                    raise AnsibleError("failed to transfer file %s to %s" % (in_path, out_path))
+                if p.returncode != 0:
+                    raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" % (in_path, out_path, stdout, stderr))
+        except IOError:
+            raise AnsibleError("file or module does not exist at: %s" % in_path)
+
+    def fetch_file(self, in_path, out_path):
+        ''' fetch a file from chroot to local '''
+        super(Connection, self).fetch_file(in_path, out_path)
+        display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self.chroot)
+
+        in_path = pipes.quote(self._prefix_login_path(in_path))
+        try:
+            p = self._buffered_exec_command('dd if=%s bs=%s' % (in_path, BUFSIZE))
+        except OSError:
+            raise AnsibleError("chroot connection requires dd command in the chroot")
+
+        with open(out_path, 'wb+') as out_file:
+            try:
+                chunk = p.stdout.read(BUFSIZE)
+                while chunk:
+                    out_file.write(chunk)
+                    chunk = p.stdout.read(BUFSIZE)
+            except:
+                traceback.print_exc()
+                raise AnsibleError("failed to transfer file %s to %s" % (in_path, out_path))
+            stdout, stderr = p.communicate()
+            if p.returncode != 0:
+                raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" % (in_path, out_path, stdout, stderr))
+
+    def close(self):
+        ''' terminate the connection; nothing to do here '''
+        super(Connection, self).close()
+        self._connected = False


### PR DESCRIPTION
This commit adds a connection driver built on top of systemd-nspawn.
This is similar to the existing `chroot` driver, except that nspawn
offers a variety of additional services. For example, it takes care of
automatically mounting `/proc` and `/sys` inside the chroot environment,
which will make a variety of tools work correctly that would otherwise
fail.

You can take advantage of other system-nspawn features to perform more
complicated tasks.  For example, on my x86_64 system I have a Raspberry
Pi disk image mounted on `/rpi`.  I can't use `chroot` with this because
the binaries contained in the image are for the wrong architecture.
However, I can use the systemd-nspawn `--bind` option to automatically
insert the appropriate qemu-arm binary into the container using an
inventory file like this:

```
pi ansible_host=/rpi ansible_nspawn_extra_args='--bind /usr/bin/qemu-arm --bind /lib64'
```

See http://www.freedesktop.org/software/systemd/man/systemd-nspawn.html
for more information about systemd-nspawn itself.
