### PR TITLE
Add RedirectHandler class for controlling redirects in urllib2

### DIFF
--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -153,6 +153,28 @@
     that:
       - 'result.location|default("") == "http://httpbin.org/relative-redirect/1"'
 
+- name: Check SSL with redirect
+  uri:
+    url: 'https://httpbin.org/redirect/2'
+  register: result
+
+- name: Assert SSL with redirect
+  assert:
+    that:
+      - 'result.url|default("") == "https://httpbin.org/get"'
+
+- name: redirect to bad SSL site
+  uri:
+    url: 'http://wrong.host.badssl.com'
+  register: result
+  ignore_errors: true
+
+- name: Ensure bad SSL site reidrect fails
+  assert:
+    that:
+      - result|failed
+      - '"wrong.host.badssl.com" in result.msg'
+
 - name: test basic auth
   uri:
     url: 'http://httpbin.org/basic-auth/user/passwd'

--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -113,7 +113,7 @@
   assert:
     that:
       - "result.failed == true"
-      - "'certificate does not match ' in result.msg"
+      - "'SSL Certificate does not belong' in result.msg"
       - "stat_result.stat.exists == false"
 
 - name: Clean up any cruft from the results directory
@@ -140,3 +140,45 @@
     that:
       - "stat_result.stat.exists == true"
       - "result.changed == true"
+
+- name: test redirect without follow_redirects
+  uri:
+    url: 'http://httpbin.org/redirect/2'
+    follow_redirects: 'none'
+    status_code: 302
+  register: result
+
+- name: Assert location header
+  assert:
+    that:
+      - 'result.location|default("") == "http://httpbin.org/relative-redirect/1"'
+
+- name: test basic auth
+  uri:
+    url: 'http://httpbin.org/basic-auth/user/passwd'
+    user: user
+    password: passwd
+
+- name: test basic forced auth
+  uri:
+    url: 'http://httpbin.org/hidden-basic-auth/user/passwd'
+    force_basic_auth: true
+    user: user
+    password: passwd
+
+- name: test PUT
+  uri:
+    url: 'http://httpbin.org/put'
+    method: PUT
+    body: 'foo=bar'
+
+- name: test OPTIONS
+  uri:
+    url: 'http://httpbin.org/'
+    method: OPTIONS
+  register: result
+
+- name: Assert we got an allow header
+  assert:
+    that:
+      - 'result.allow|default("") == "HEAD, OPTIONS, GET"'


### PR DESCRIPTION
This PR adds new functionality to `ansible.module_utils.urls` to control redirects in urllib2.

This is added to provide missing functionality to `urls.py` that will enable us to drop the `httplib2` dependency in the `uri` module.

PR for the `uri` module incoming.
