### PR TITLE
Include's tags argument allows only one tag to be specified.

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -489,7 +489,7 @@ class StrategyBase:
             # error so that users know not to specify them both ways
             tags = temp_vars.pop('tags', [])
             if isinstance(tags, string_types):
-                tags = [ tags ]
+                tags = tags.split(',')
             if len(tags) > 0:
                 if len(b._task_include.tags) > 0:
                     raise AnsibleParserError("Include tasks should not specify tags in more than one way (both via args and directly on the task). Mixing tag specify styles is prohibited for whole import hierarchy, not only for single import statement",


### PR DESCRIPTION
I have an Ansible 1.9 playbook which uses an `include` role with multiple tags:

```
tasks:
 - include: a.yml tags=b,c
```

When I try to run task `b` with Ansible 2.0 (`ansible-playbook foo.yml -t b`), no task is executed.
The problem seems to be that in `lib/ansible/plugins/strategy/__init__.py`, the `tags` argument is not split by `,` when it is a string, but simply put into a list. This PR fixes this so that `ansible-playbook foo.yml -t b` will continue to work as with Ansible 1.9.
