### PR TITLE
Pass boto_profile to get_route53_records

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -1243,7 +1243,7 @@ class Ec2Inventory(object):
         ''' Get and store the map of resource records to domain names that
         point to them. '''
 
-        r53_conn = route53.Route53Connection()
+        r53_conn = route53.Route53Connection(profile_name=self.boto_profile)
         all_zones = r53_conn.get_zones()
 
         route53_zones = [ zone for zone in all_zones if zone.name[:-1]

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -1243,7 +1243,10 @@ class Ec2Inventory(object):
         ''' Get and store the map of resource records to domain names that
         point to them. '''
 
-        r53_conn = route53.Route53Connection(profile_name=self.boto_profile)
+        if self.boto_profile:
+            r53_conn = route53.Route53Connection(profile_name=self.boto_profile)
+        else:
+            r53_conn = route53.Route53Connection()
         all_zones = r53_conn.get_zones()
 
         route53_zones = [ zone for zone in all_zones if zone.name[:-1]


### PR DESCRIPTION
If a boto profile is supplied on the command line it will not be used for the new route 53 connection object. This ensures that the new connection uses the profile that was specified.