### PR TITLE
Don't overwrite param variables if already set.

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -47,8 +47,10 @@ class AnsibleAWSError(Exception):
 
 def boto3_conn(module, conn_type=None, resource=None, region=None, endpoint=None, **params):
     profile = params.pop('profile_name', None)
-    params['aws_session_token'] = params.pop('security_token', None)
-    params['verify'] = params.pop('validate_certs', None)
+    if 'aws_session_token' not in params:
+        params['aws_session_token'] = params.pop('security_token', None)
+    if 'verify' not in params:
+        params['verify'] = params.pop('validate_certs', None)
 
     if conn_type not in ['both', 'resource', 'client']:
         module.fail_json(msg='There is an issue in the code of the module. You must specify either both, resource or client to the conn_type parameter in the boto3_conn function call')


### PR DESCRIPTION
Since get_aws_connection_info() correctly sets config parameters
boto_params['aws_session_token'] and boto_params['verify'] when
boto3 is detected we must detect whether these have already
been set in boto3_conn() before overwriting them from old-style
boto (not boto3) parameters ('security_token' and 'validate_certs'
respectively).
