### PR TITLE
Add support for AWS_SESSION_TOKEN environment variable. (trivial patch)

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -153,6 +153,8 @@ def get_aws_connection_info(module, boto3=False):
     if not security_token:
         if 'AWS_SECURITY_TOKEN' in os.environ:
             security_token = os.environ['AWS_SECURITY_TOKEN']
+        elif 'AWS_SESSION_TOKEN' in os.environ:
+            security_token = os.environ['AWS_SESSION_TOKEN']
         elif 'EC2_SECURITY_TOKEN' in os.environ:
             security_token = os.environ['EC2_SECURITY_TOKEN']
         else:


### PR DESCRIPTION
According to http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs
the "official" environment variables that should be used for AWS credentials are:
`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`
This patch adds support for the latter (the first two vars are already supported).
