### PR TITLE
implement folding of long lines in inventory

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -80,6 +80,23 @@ You can also select the connection type and user on a per host basis:
 As mentioned above, setting these in the inventory file is only a shorthand, and we'll discuss how to store them in individual files
 in the 'host_vars' directory a bit later on.
 
+Extending long lines
+~~~~~~~~~~~~~~~~~~~~
+
+Long lines can be extended using the INI-style convention of indenting
+subsequent lines, so the above could also be written like this::
+
+   [targets]
+
+   localhost
+     ansible_connection=local
+   other1.example.com
+     ansible_connection=ssh
+     ansible_user=mpdehaan
+   other2.example.com
+     ansible_connection=ssh
+     ansible_user=mdehaan
+
 .. _host_variables:
 
 Host Variables

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -189,8 +189,10 @@ class TestVariableManager(unittest.TestCase):
         v._fact_cache = defaultdict(dict)
 
         fake_loader = DictDataLoader({
-            # inventory1
-            '/etc/ansible/inventory1': """
+            # inventory1 (we need to remove the indenting here
+            # in order to support the line extension feature
+            # implemented in #14358).
+            '/etc/ansible/inventory1': '\n'.join(x.strip() for x in """
             [group2:children]
             group1
 
@@ -202,7 +204,7 @@ class TestVariableManager(unittest.TestCase):
 
             [group2:vars]
             group_var = group_var_from_inventory_group2
-            """,
+            """.splitlines()),
 
             # role defaults_only1
             '/etc/ansible/roles/defaults_only1/defaults/main.yml': """


### PR DESCRIPTION
This commit permits entries in an inventory file to be extended
over multiple lines by indenting subsequent lines, as in
https://docs.python.org/3/library/configparser.html#supported-ini-file-structure.

For example, this example from the docs:

```
other1.example.com  ansible_connection=ssh ansible_user=mpdehaan
```

Can be written as:

```
other1.example.com
  ansible_connection=ssh
  ansible_user=mpdehaan
```

This commit includes doc and test updates.

Resolves #14358.
