### PR TITLE
Allow grouping two EC2 tags to allow more specific configuration

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -121,6 +121,23 @@ group_by_elasticache_cluster = True
 group_by_elasticache_parameter_group = True
 group_by_elasticache_replication_group = True
 
+# Special grouping based on joining two AWS tags.
+# For example, suppose you tag your AWS resources by environment and role.
+# Instances might have Env=dev/prod and Role=web/db etc. While the above
+# "group_by_tag_keys" will give groups "tag_Env_prod" and "tag_Role_db", there
+# is no group that contains only the "db" servers in "prod". This option
+# creates groupings such as:
+#   tags_Env_dev_Role_db
+#   tags_Env_dev_Role_web
+#   tags_Env_prod_Role_db
+#   tags_Env_prod_Role_web
+# If you need these very specific groupings, uncomment the lines below and
+# change the parent/child tags to your preferred tag names (case-sensitive).
+# (note: parent/child just refers to the grouping/sorting).
+#group_by_joined_tags = True
+#joined_parent_tag = Env
+#joined_child_tag = Role
+
 # If you only want to include hosts that match a certain regular expression
 # pattern_include = staging-*
 


### PR DESCRIPTION
This PR is intended to help with multi-stage environments (dev, staging, prod etc.)

ec2.py creates groups for tags, so if you have for example the tags Env=prod,Role=web then you will see groupings:

```
tag_Env_prod
tag_Role_web
```

This change allows the creation of a more specific group based on two tags. In the above example, you can also get the group:

```
tags_Env_prod_Role_web
```

so that configuration can be targeted to 'all prod web servers'.

Which tag names to join are configurable.

This is needed in more complex setups because Ansible group names are unique, even when nested. In other words, if we put the group tag_Role_web inside tag_Env_prod, we can't also put a group tag_Role_web inside tag_Env_dev - tag_Role_web is a single group with a mix of dev and prod instances.

In considering if this is a standard/recommended way of working, I've looked at [How to Differentiate Staging vs Production](http://docs.ansible.com/ansible/playbooks_best_practices.html#how-to-differentiate-staging-vs-production), [variable precedence](http://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) and [this related issue](https://github.com/ansible/ansible/issues/9877).

While it's possible to use per-environment inventory, the variable precedence can be error prone. e.g. if you specify a variable in the main group_vars directory, it will overwrite the inventory-specific ones. Therefore for any per-environment variable, it can not have a default value, and you need to remember to put it in each inventory file, and remember _not_ to put it in the main group_vars.

Grouping tags together such as Env and Role I believe is a fairly common use case, although it can be used with any pair of tags.
