### PR TITLE
Fixing login for VCD service type in VCA module

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/vca.py
+++ b/lib/ansible/utils/module_docs_fragments/vca.py
@@ -34,7 +34,7 @@ options:
       aliases: ['pass', 'pwd']
     org:
       description:
-        - The org to login to for creating vapp, mostly set when the service_type is vdc.
+        - The org to login to for creating vapp. This option is required when the C(service_type) is I(vdc).
       required: false
       default: None
     instance_id:


### PR DESCRIPTION
Login to vCloud Director Standalone service (`vcd`) fails with the error `Login to VCA failed` because the login routine is missing required `org` parameter. This requirement is documented in the [`pyvcoloud` library](https://github.com/vmware/pyvcloud/blob/master/examples/examples.py#L115).
