### PR TITLE
Add support for no-expiration to jsonfile cache

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -102,6 +102,9 @@ class CacheModule(BaseCacheModule):
 
     def has_expired(self, key):
 
+        if self._timeout == 0:
+            return False
+
         cachefile = "%s/%s" % (self._cache_dir, key)
         try:
             st = os.stat(cachefile)


### PR DESCRIPTION
## Issue

When using `fact_caching = jsonfile` to cache facts, setting `fact_caching_timeout = 0` does not disable cache expiration (as it does with `fact_caching = redis`).
## Steps to Reproduce
1. Configure Ansible to cache facts to a JSON file
   
   ```
   $ export ANSIBLE_CONFIG=~/ansible/config 
   $ cat ~/ansible/config 
   [defaults]
   gathering = smart
   fact_caching = jsonfile
   fact_caching_connection = /tmp/ansible_cache
   fact_caching_timeout = 0
   ```
2. Create a simple playbook
   
   ```
   $ cat ~/ansible/playbook.yml
   ---
   - hosts: all
     tasks:
     - ping:
   ```
3. Execute playbook multiple times
   
   ```
   $ for run in {1..2}; do ansible-playbook ~/ansible/playbook.yml; done
   ```
## Expected Result

NOTE: The setup task should only run on the first playbook execution; it should be cached for the second execution.

```
PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [127.0.0.1]

TASK [ping] ********************************************************************
ok: [127.0.0.1]

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=2    changed=0    unreachable=0    failed=0   


PLAY ***************************************************************************

TASK [ping] ********************************************************************
ok: [127.0.0.1]

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=1    changed=0    unreachable=0    failed=0   
```
## Actual Result

NOTE: The setup task is run for both executions.

```
PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [127.0.0.1]

TASK [ping] ********************************************************************
ok: [127.0.0.1]

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=2    changed=0    unreachable=0    failed=0   


PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [127.0.0.1]

TASK [ping] ********************************************************************
ok: [127.0.0.1]

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=2    changed=0    unreachable=0    failed=0   
``
```
