### PR TITLE
strip BECOME-SUCCESS at lower level

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -544,6 +544,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if rc is None:
             rc = 0
 
+        out = self._strip_success_message(out)
+
         display.debug("_low_level_execute_command() done: rc=%d, stdout=%s, stderr=%s" % (rc, stdout, stderr))
 
         return dict(rc=rc, stdout=out, stdout_lines=out.splitlines(), stderr=err)


### PR DESCRIPTION
script (and probably others) still has BECOME-SUCESS in stdout
