### PR TITLE
--diff: don't truncate local source file

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -613,7 +613,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                     diff['src_larger'] = C.MAX_FILE_SIZE_FOR_DIFF
                 else:
                     diff['after_header'] = source
-                    diff['after'] = src_contents
+                    diff['after'] = src_contents + src.read()
             else:
                 display.debug("source of file passed in")
                 diff['after_header'] = 'dynamically generated'


### PR DESCRIPTION
While it makes sense not to read multi-gigabyte binary files into RAM,
it's not nice to show spurious diffs when text files also get truncated
to the first 8 KB.

Fixes #14406.
