### PR TITLE
inventory.refresh_inventory does not refresh inventory._restriction

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -759,3 +759,12 @@ class Inventory(object):
         self.groups          = {}
 
         self.parse_inventory(self.host_list)
+
+        # refresh plain host list
+        new_hosts = []
+        for host in self._restriction:
+            name = host.get_name()
+            new_host = self.get_host(name)
+            new_hosts.append(new_host)
+
+        self._restriction = new_hosts


### PR DESCRIPTION
If we are updating the inventory with the meta action refresh_inventory, the internal list of the inventory will be refreshed and new objects will be inserted into the new list.
but since the following code does equal check via memory address of host1 == memory address of host2, further checks will fail and the host will not be returned. see L204

refresh should search for restrition hosts on the new list and replace the old restriction host list
