### PR TITLE
Display the string which is causing an exception to be raised.

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -464,7 +464,7 @@ class Templar:
             try:
                 t = myenv.from_string(data)
             except TemplateSyntaxError as e:
-                raise AnsibleError("template error while templating string: %s" % str(e))
+                raise AnsibleError("template error while templating string: %s. String: %s" % (str(e), data))
             except Exception as e:
                 if 'recursion' in str(e):
                     raise AnsibleError("recursive loop detected in template string: %s" % data)


### PR DESCRIPTION
In the ansible template module, when there is an error while
expanding a templated string, displaying the string causing the
exception is very useful.

I had a missing closing } in a string from the group_vars/all file. The error only happened when I was trying to access a hostvars variable in a playbook. With this error message, I found the problem right away.
