### PR TITLE
[contrib] Add option to define group vars in DigitalOcean dynamic inventory script

### DIFF
--- a/contrib/inventory/digital_ocean.ini
+++ b/contrib/inventory/digital_ocean.ini
@@ -26,3 +26,9 @@ cache_max_age = 300
 # Use the private network IP address instead of the public when available.
 #
 use_private_network = False
+
+# Pass variables to every group, e.g.:
+#
+#   group_variables = { 'ansible_user': 'root' }
+#
+group_variables = {}


### PR DESCRIPTION
Hi!

This patch adds support for `group_vars` to the DigitalOcean dynamic inventory script, so that one can pass `ansible_*` parameters (or any other variables). For example, my use case is that I have one SSH key for DO, which is different than my other hosts:

``` ini
# Ansible DigitalOcean external inventory script settings
#
[digital_ocean]

# The module needs your DigitalOcean API Token.
# It may also be specified on the command line via --api-token
# or via the environment variables DO_API_TOKEN or DO_API_KEY
#
api_token = token

# Pass variables to every group
#
group_variables = { 'ansible_user': 'root', 'ansible_private_key_file': '/path/to/do_key' }
```

No BC break involved with this patch, but the JSON structure has changed to fit Ansible expectations (cf. https://docs.ansible.com/ansible/developing_inventory.html#script-conventions):

Before:

``` json
{
    "foo": [ "x.x.x.x" ]
}
```

After:

``` json
{
    "foo": {
        "hosts": [ "x.x.x.x" ],
        "vars": {}
    }
}
```

Regards,
William
