### PR TITLE
Add --offline option to galaxy install

### DIFF
--- a/docs/man/man1/ansible-galaxy.1.asciidoc.in
+++ b/docs/man/man1/ansible-galaxy.1.asciidoc.in
@@ -79,6 +79,10 @@ configured in your *ansible.cfg* file (/etc/ansible/roles if not configured)
 A file containing a list of roles to be imported, as specified above. This
 option cannot be used if a rolename or .tar.gz have been specified.
 
+*--offline*::
+
+Don't query the galaxy API unless it's needed when installing roles
+
 REMOVE
 ------
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -95,6 +95,9 @@ class GalaxyCLI(CLI):
                 help='Don\'t download roles listed as dependencies')
             self.parser.add_option('-r', '--role-file', dest='role_file',
                 help='A file containing a list of roles to be imported')
+            self.parser.add_option(
+                '--offline', dest='offline', default=False, action='store_true',
+                help="Don't query the galaxy API unless it's needed when installing roles")
         elif self.action == "remove":
             self.parser.set_usage("usage: %prog remove role1 role2 ...")
         elif self.action == "list":
@@ -146,7 +149,8 @@ class GalaxyCLI(CLI):
         super(GalaxyCLI, self).run()
 
         # if not offline, get connect to galaxy api
-        if self.action in ("import","info","install","search","login","setup","delete") or \
+        if self.action in ("import","info","search","login","setup","delete") or \
+            (self.action == 'install' and not self.options.offline) or \
             (self.action == 'init' and not self.options.offline):
             self.api = GalaxyAPI(self.galaxy)
 


### PR DESCRIPTION
I have part of infrastructure without internet access. This option helps to install roles form local mirror using the ansible-galaxy tool. 
The problem is described and discussed in issue #9687
