### PR TITLE
Add simple --diff colour support

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -278,6 +278,9 @@ COLOR_SKIP        = get_config(p, 'colors', 'skip', 'ANSIBLE_COLOR_SKIP', 'cyan'
 COLOR_UNREACHABLE = get_config(p, 'colors', 'unreachable', 'ANSIBLE_COLOR_UNREACHABLE', 'bright red')
 COLOR_OK          = get_config(p, 'colors', 'ok', 'ANSIBLE_COLOR_OK', 'green')
 COLOR_CHANGED     = get_config(p, 'colors', 'ok', 'ANSIBLE_COLOR_CHANGED', 'yellow')
+COLOR_DIFF_ADD    = get_config(p, 'colors', 'diff_add', 'ANSIBLE_COLOR_DIFF_ADD', 'green')
+COLOR_DIFF_REMOVE = get_config(p, 'colors', 'diff_remove', 'ANSIBLE_COLOR_DIFF_REMOVE', 'red')
+COLOR_DIFF_LINES  = get_config(p, 'colors', 'diff_lines', 'ANSIBLE_COLOR_DIFF_LINES', 'cyan')
 
 # non-configurable things
 MODULE_REQUIRE_ARGS       = ['command', 'shell', 'raw', 'script']

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -138,12 +138,12 @@ class CallbackBase:
                         has_diff = False
                         for line in differ:
                             has_diff = True
-                            if line.startswith('-'):
-                                line = stringc(line, 'red')
-                            elif line.startswith('+'):
-                                line = stringc(line, 'green')
+                            if line.startswith('+'):
+                                line = stringc(line, C.COLOR_DIFF_ADD)
+                            elif line.startswith('-'):
+                                line = stringc(line, C.COLOR_DIFF_REMOVE)
                             elif line.startswith('@@'):
-                                line = stringc(line, 'cyan')
+                                line = stringc(line, C.COLOR_DIFF_LINES)
                             ret.append(line)
                         if has_diff:
                             ret.append('\n')

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -28,6 +28,7 @@ from ansible.compat.six import string_types
 
 from ansible import constants as C
 from ansible.vars import strip_internal_keys
+from ansible.utils.color import stringc
 from ansible.utils.unicode import to_unicode
 
 try:
@@ -134,9 +135,17 @@ class CallbackBase:
                                                       fromfiledate='',
                                                       tofiledate='',
                                                       n=10)
-                        difflines = list(differ)
-                        if difflines:
-                            ret.extend(difflines)
+                        has_diff = False
+                        for line in differ:
+                            has_diff = True
+                            if line.startswith('-'):
+                                line = stringc(line, 'red')
+                            elif line.startswith('+'):
+                                line = stringc(line, 'green')
+                            elif line.startswith('@@'):
+                                line = stringc(line, 'cyan')
+                            ret.append(line)
+                        if has_diff:
                             ret.append('\n')
                     if 'prepared' in diff:
                         ret.append(to_unicode(diff['prepared']))


### PR DESCRIPTION
Happy to extend this to make diff output more smart/configurable in future, but wanted to get the ball rolling with hardcoded colours as this (in my opinion!) makes `--diff` output considerably easier to visually parse.

Since it uses `stringc` from `ansible.utils.color`, it naturally obeys the standard `ANSIBLE_[NO|FORCE]COLOR` constants.

I note there's currently another PR open (https://github.com/ansible/ansible/pull/14434) which modifies the surrounding code, so if you'd like me to rebase this on top of that to make things easier, let me know.

---
#### Screenshot

<img width="680" alt="diff colours" src="https://cloud.githubusercontent.com/assets/7656560/13062190/9124c3d2-d434-11e5-834f-02e21afb4265.png">
