### PR TITLE
Make --diff lines of context configurable

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -284,6 +284,9 @@ COLOR_DIFF_ADD    = get_config(p, 'colors', 'diff_add', 'ANSIBLE_COLOR_DIFF_ADD'
 COLOR_DIFF_REMOVE = get_config(p, 'colors', 'diff_remove', 'ANSIBLE_COLOR_DIFF_REMOVE', 'red')
 COLOR_DIFF_LINES  = get_config(p, 'colors', 'diff_lines', 'ANSIBLE_COLOR_DIFF_LINES', 'cyan')
 
+# diff
+DIFF_CONTEXT = get_config(p, 'diff', 'context', 'ANSIBLE_DIFF_CONTEXT', 3, integer=True)
+
 # non-configurable things
 MODULE_REQUIRE_ARGS       = ['command', 'shell', 'raw', 'script']
 MODULE_NO_JSON            = ['command', 'shell', 'raw']

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -144,7 +144,7 @@ class CallbackBase:
                                                       tofile=after_header,
                                                       fromfiledate='',
                                                       tofiledate='',
-                                                      n=10)
+                                                      n=C.DIFF_CONTEXT)
                         has_diff = False
                         for line in differ:
                             has_diff = True


### PR DESCRIPTION
...and reduce the default number of context lines to 3, as this is more consistent with [`diff`](http://man7.org/linux/man-pages/man1/diff.1.html)'s default (and subsequently what most people are accustomed to):

```
   -u -U NUM --unified[=NUM]
   Output NUM (default 3) lines of unified context.
```

I've included this option under a new `[diff]` config section in anticipation of future configurable diff improvements (colours, output format, etc.) that I plan on contributing.

I wasn't sure whether it was worth making this a command line argument as well (e.g. `--diff-context=NUM`), but I think it may be worthwhile, given that the lines of context you'd want to see are largely dependent on the type of change you're making, which varies from deployment to deployment, but I'll leave it up to you guys to advise.
