### PR TITLE
Fix openstack auth type

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -74,7 +74,7 @@ def openstack_full_argument_spec(**kwargs):
     spec = dict(
         cloud=dict(default=None),
         auth_type=dict(default=None),
-        auth=dict(default=None, no_log=True),
+        auth=dict(default=None, type='dict', no_log=True),
         region_name=dict(default=None),
         availability_zone=dict(default=None),
         verify=dict(default=True, aliases=['validate_certs']),


### PR DESCRIPTION
PR #14417 defaults undefined types to 'str'.
"auth" type defaults to 'str' and shade fails.

> failed: [localhost] => (item=debugjob-yfried-irtest-data) => {"failed": true, "invocation": {"module_name": "os_network"}, "item": "debugjob-yfried-irtest-data", "parsed": false}
> An exception occurred during task execution. The full traceback is:
> Traceback (most recent call last):
>   File "/home/yfried/.ansible/tmp/ansible-tmp-1455611353.42-182748332084098/os_network", line 2317, in <module>
>     main()
>   File "/home/yfried/.ansible/tmp/ansible-tmp-1455611353.42-182748332084098/os_network", line 144, in main
>     cloud = shade.openstack_cloud(**module.params)
>   File "/home/yfried/.virtualenvs/ansible_devel/lib/python2.7/site-packages/shade/**init**.py", line 75, in openstack_cloud
>     cloud_config = config.get_one_cloud(**kwargs)
>   File "/home/yfried/.virtualenvs/ansible_devel/lib/python2.7/site-packages/os_client_config/config.py", line 880, in get_one_cloud
>     config[key] = _auth_update(config[key], val)
>   File "/home/yfried/.virtualenvs/ansible_devel/lib/python2.7/site-packages/os_client_config/config.py", line 129, in _auth_update
>     for (k, v) in new_dict.items():
> AttributeError: 'str' object has no attribute 'items'
