### PR TITLE
Improve message content to get more hint about the raised error.

### DIFF
--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 
 from ansible.compat.six import iteritems
 from jinja2.utils import missing
+from ansible.utils.unicode import to_unicode
 
 __all__ = ['AnsibleJ2Vars']
 
@@ -83,7 +84,12 @@ class AnsibleJ2Vars:
         if isinstance(variable, dict) and varname == "vars" or isinstance(variable, HostVars):
             return variable
         else:
-            return self._templar.template(variable)
+            value = None
+            try:
+                value = self._templar.template(variable)
+            except Exception as e:
+                raise type(e)(to_unicode(variable) + ': ' + e.message)
+            return value
 
     def add_locals(self, locals):
         '''


### PR DESCRIPTION
This PR is a little improvement in messages returned by Ansible when you have an error. Here's an example:

``` yaml
- name: "Error report"
  hosts: localhost
  gather_facts: no
  vars:
    some_hash:
      undefined_value: "{{groups['empty-group'][0]}}"
      known_value: "something"
  tasks:
    - name: "This is working"
      debug: var=some_hash.known_value
    - name: "This is not (but it's fine)"
      debug: msg={{some_hash.known_value}}
```

In this playbook, we try to access value of variable named **some_hash['known_value']** but in a hash map which is partialy invalid (list **groups['empty-group']** is empty and does not have '0' element).

In previous version of Ansible, we get the following error while trying to access some_hash.known_value:

```
fatal: [localhost]: FAILED! => {"failed": true, "msg": "list object has no element 0"}
```

The problem is that when I try to access **some_hash.known_value**, there's no list I'm trying to access and can be quite confusing to sort things out (it take me half an hour this day to figure out the problem with a huge hash map). This commit is giving hints about the last template context and help the user figure out more easily the problem. With this PR applied, the message is the following:

```
fatal: [localhost]: FAILED! => {"failed": true, "msg": "{u'known_value': u'something', u'undefined_value': u\"{{groups['empty-group'][0]}}\"}: 'list object has no element 0"}
```
