### PR TITLE
Fix a typo in man1/ansible

### DIFF
--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -104,7 +104,7 @@ Alternatively you can use a comma separated list of hosts or single host with tr
 *-l* 'SUBSET', *--limit=*'SUBSET'::
 
 Further limits the selected host/group patterns.
-You can prefix it with '~' to indicate that the patter in a regex.
+You can prefix it with '~' to indicate that the pattern is a regex.
 
 *--list-hosts*::
 


### PR DESCRIPTION
Just a small typo fix in the manpage (1) for ansible itself.
