### PR TITLE
Avoid duplicate /bin/lsblk calls in the setup module.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1037,6 +1037,7 @@ class LinuxHardware(Hardware):
 
     @timeout(10)
     def get_mount_facts(self):
+        uuids = dict()
         self.facts['mounts'] = []
         mtab = get_file_content('/etc/mtab', '')
         for line in mtab.split('\n'):
@@ -1052,13 +1053,17 @@ class LinuxHardware(Hardware):
                     except OSError:
                         continue
 
-                    uuid = 'NA'
-                    lsblkPath = module.get_bin_path("lsblk")
-                    if lsblkPath:
-                        rc, out, err = module.run_command("%s -ln --output UUID %s" % (lsblkPath, fields[0]), use_unsafe_shell=True)
+                    if fields[0] in uuids:
+                        uuid = uuids[fields[0]]
+                    else:
+                        uuid = 'NA'
+                        lsblkPath = module.get_bin_path("lsblk")
+                        if lsblkPath:
+                            rc, out, err = module.run_command("%s -ln --output UUID %s" % (lsblkPath, fields[0]), use_unsafe_shell=True)
 
-                        if rc == 0:
-                            uuid = out.strip()
+                            if rc == 0:
+                                uuid = out.strip()
+                                uuids[fields[0]] = uuid
 
                     self.facts['mounts'].append(
                         {'mount': fields[1],


### PR DESCRIPTION
The setup module calls `/bin/lsblk` once for each device appearing in the `/etc/mtab` file. However, the same device appears there mutliple times when the system uses bind-mounts. As a result, `/bin/lsblk` is being called repeatedly to get the _uuid_ of the same device.

On a system with many mounts, this leads to a `TimeoutError` in the `get_mount_facts` function of the setup module as described in #14551.

Fixes #14551
