### PR TITLE
Add a configuration setting that allows the user to specify printing …

### DIFF
--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -304,8 +304,6 @@ How do I keep secret data in my playbook?
 
 If you would like to keep secret data in your Ansible content and still share it publicly or keep things in source control, see :doc:`playbooks_vault`.
 
-.. _i_dont_see_my_question:
-
 In Ansible 1.8 and later, if you have a task that you don't want to show the results or command given to it when using -v (verbose) mode, the following task or playbook attribute can be useful::
 
     - name: secret task
@@ -322,6 +320,8 @@ The no_log attribute can also apply to an entire play::
 Though this will make the play somewhat difficult to debug.  It's recommended that this
 be applied to single tasks only, once a playbook is completed.   
 
+
+.. _i_dont_see_my_question:
 
 I don't see my question here
 ++++++++++++++++++++++++++++

--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -228,6 +228,34 @@ Allows disabling of deprecating warnings in ansible-playbook output::
 
 Deprecation warnings indicate usage of legacy features that are slated for removal in a future release of Ansible.
 
+.. _display_args_to_stdout
+
+display_args_to_stdout
+======================
+
+.. versionadded:: 2.1.0
+
+By default, ansible-playbook will print a header for each task that is run to
+stdout.  These headers will contain the ``name:`` field from the task if you
+specified one.  If you didn't then ansible-playbook uses the task's action to
+help you tell which task is presently running.  Sometimes you run many of the
+same action and so you want more information about the task to differentiate
+it from others of the same action.  If you set this variable to ``True`` in
+the config then ansible-playbook will also include the task's arguments in the
+header.
+
+This setting defaults to ``False`` because there is a chance that you have
+sensitive values in your parameters and do not want those to be printed to
+stdout::
+
+    display_args_to_stdout=False
+
+If you set this to ``True`` you should be sure that you have secured your
+environment's stdout (no one can shoulder surf your screen and you aren't
+saving stdout to an insecure file) or made sure that all of your playbooks
+explicitly added the ``no_log: True`` parameter to tasks which have sensistive
+values   See :ref:`keep_secret_data` for more information.
+
 .. _display_skipped_hosts:
 
 display_skipped_hosts

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -98,6 +98,16 @@
 # task is skipped.
 #display_skipped_hosts = True
 
+# by default, if a task in a playbook does not include a name: field then
+# ansible-playbook will construct a header that includes the task's action but
+# not the task's args.  This is a security feature because ansible cannot know
+# if the *module* considers an argument to be no_log at the time that the
+# header is printed.  If your environment doesn't have a problem securing
+# stdout from ansible-playbook (or you have manually specified no_log in your
+# playbook on all of the tasks where you have secret information) then you can
+# safely set this to True to get more informative messages.
+#display_args_to_stdout = False
+
 # by default (as of 1.3), Ansible will raise errors when attempting to dereference 
 # Jinja2 variables that are not set in templates or action lines. Uncomment this line
 # to revert the behavior to pre-1.3.

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -113,7 +113,19 @@ class CallbackModule(CallbackBase):
         self._display.banner("NO MORE HOSTS LEFT")
 
     def v2_playbook_on_task_start(self, task, is_conditional):
-        self._display.banner("TASK [%s]" % task.get_name().strip())
+        args = ''
+        # args can be specified as no_log in several places: in the task or in
+        # the argument spec.  We can check whether the task is no_log but the
+        # argument spec can't be because that is only run on the target
+        # machine and we haven't run it thereyet at this time.
+        #
+        # So we give people a config option to affect display of the args so
+        # that they can secure this if they feel that their stdout is insecure
+        # (shoulder surfing, logging stdout straight to a file, etc).
+        if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
+            args = ', '.join(('%s=%s' % a for a in task.args.items()))
+            args = ' %s' % args
+        self._display.banner("TASK [%s%s]" % (task.get_name().strip(), args))
         if self._display.verbosity > 2:
             path = task.get_path()
             if path:


### PR DESCRIPTION
…of task arguments in the header.

Fixes #14554
