### PR TITLE
Improve efficiency of merge_hash (Ansible v2.0)

### DIFF
--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -74,6 +74,12 @@ def merge_hash(a, b):
     """
 
     _validate_mutable_mappings(a, b)
+
+    # if a is empty or equal to b, return b
+    if a == {} or a == b:
+        return b.copy()
+
+    # if b is empty the below unfolds quickly
     result = a.copy()
 
     # next, iterate over b keys and values


### PR DESCRIPTION
This is related to PR #14559, but only the part for Ansible v2.0

This commit makes merging empty dicts, or equal dicts more efficient.

I noticed that while debugging merge_hash a lot of merges related to empty dictionaries and sometimes also identical dictionaries.
