### PR TITLE
Backport combine_vars() logic from Ansible v2.0

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -1485,12 +1485,13 @@ def listify_lookup_plugin_terms(terms, basedir, inject):
 
 def combine_vars(a, b):
 
-    _validate_both_dicts(a, b)
-
     if C.DEFAULT_HASH_BEHAVIOUR == "merge":
         return merge_hash(a, b)
     else:
-        return dict(a.items() + b.items())
+        _validate_both_dicts(a, b)
+        result = a.copy()
+        result.update(b)
+        return result
 
 def random_password(length=20, chars=C.DEFAULT_PASSWORD_CHARS):
     '''Return a random password string of length containing only chars.'''


### PR DESCRIPTION
While debugging I noticed that _validate_both_dicts() was evaluated twice through combine_vars (when merge_hash). Looking at v2.0 the logic was improved to not do _validate_both_dicts() twice in this case.

I also backported the 'update' behaviour as it looks more pythonic.
