### PR TITLE
Avoid merging dict and unicode

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -647,7 +647,8 @@ class Runner(object):
         # vars_files which had host-specific templating done)
         inject = utils.combine_vars(inject, self.vars_cache.get(host, {}))
         # role parameters next
-        inject = utils.combine_vars(inject, self.role_params)
+        role_params = template.template(self.basedir, self.role_params, inject)
+        inject = utils.combine_vars(inject, role_params)
         # and finally -e vars are the highest priority
         inject = utils.combine_vars(inject, self.extra_vars)
         # and then special vars


### PR DESCRIPTION
This fixes #12915

~~Since combine_vars() is being run directly on role_params through get_inject_vars(), we have to avoid merge_hash() to complain about merging a dict with a string (i.e. jinja template).~~
