### PR TITLE
do-until loop does not fail

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -477,8 +477,11 @@ class TaskExecutor:
                 # no conditional check, or it failed, so sleep for the specified time
                 time.sleep(delay)
 
-            elif 'failed' not in result:
-                break
+            elif self._task.until is not None:
+                cond = Conditional(loader=self._loader)
+                cond.when = [ self._task.until ]
+                if not cond.evaluate_conditional(templar, vars_copy):
+                    result['failed'] = True
 
         # do the final update of the local variables here, for both registered
         # values and any facts which may have been created


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

Do-until loop does not fail even when until contidion is not met in
the last iteration. Fixes #14461
##### Example output:

The following playbook should fail:

``` yml

---
- hosts: localhost
  gather_facts: False
  tasks:
  - name: this should fail
    command: echo "never be"
    register: test_result
    until: test_result.stdout == 'the same'
```

``` sh
$ ansible-playbook until-test.yml
PLAY ***************************************************************************

TASK [this should fail] ********************************************************
FAILED - RETRYING: TASK: this should fail (2 retries left). Result was: {u'changed': True, u'end': u'2016-02-19 16:45:22.419234', u'stdout': u'never be', u'cmd': [u'echo', u'never be'], u'rc': 0, u'start': u'2016-02-19 16:45:22.417698', u'stderr': u'', u'delta': u'0:00:00.001536', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': False, u'_raw_params': u'echo "never be"', u'removes': None, u'warn': True, u'chdir': None}}, 'stdout_lines': [u'never be'], u'warnings': []}
FAILED - RETRYING: TASK: this should fail (1 retries left). Result was: {u'changed': True, u'end': u'2016-02-19 16:45:27.483985', u'stdout': u'never be', u'cmd': [u'echo', u'never be'], u'rc': 0, u'start': u'2016-02-19 16:45:27.480680', u'stderr': u'', u'delta': u'0:00:00.003305', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': False, u'_raw_params': u'echo "never be"', u'removes': None, u'warn': True, u'chdir': None}}, 'stdout_lines': [u'never be'], u'warnings': []}
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["echo", "never be"], "delta": "0:00:00.001389", "end": "2016-02-19 16:45:32.552888", "failed": true, "rc": 0, "start": "2016-02-19 16:45:32.551499", "stderr": "", "stdout": "never be", "stdout_lines": ["never be"], "warnings": []}

NO MORE HOSTS LEFT *************************************************************
        to retry, use: --limit @until-test.retry

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1  
```
