### PR TITLE
add support for SSH ports in git repository URLs, allows git to auth with non standard ports

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -19,3 +19,4 @@
     - { role: test_mysql_variables, tags: test_mysql_variables}
     - { role: test_docker, tags: test_docker, when: ansible_distribution != "Fedora" }
     - { role: test_zypper, tags: test_zypper}
+    - { role: test_git, tags: test_git }

--- a/test/integration/non_destructive.yml
+++ b/test/integration/non_destructive.yml
@@ -28,7 +28,6 @@
     - { role: test_synchronize, tags: test_synchronize }
     - { role: test_assemble, tags: test_assemble }
     - { role: test_subversion, tags: test_subversion }
-    - { role: test_git, tags: test_git }
     - { role: test_hg, tags: test_hg }
     - { role: test_lineinfile, tags: test_lineinfile }
     - { role: test_unarchive, tags: test_unarchive }

--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -140,13 +140,21 @@
   when: not git_result|skipped
 
 # Test checkout with non-standard port
-# requires prior acceptance of ssh.github.com hostkey for port 443, and requires
-# that no hostkey was accepted for ssh.github.com port 22
+
+- name: checkout git@[ssh.github.com:443] repo (expected pass)
+  git:
+    repo: '{{ repo_format4 }}'
+    dest: '{{ checkout_dir }}'
+    version: 'master'
+    accept_hostkey: true
+    key_file: '{{ github_ssh_private_key }}'
+  register: git_result
+  when: github_ssh_private_key is defined
 
 - name: clear checkout_dir
   file: state=absent path={{ checkout_dir }}
 
-- name: checkout git@[ssh.github.com:443] repo with accept_hostkey (expected pass)
+- name: checkout git@[ssh.github.com:443] repo (expected pass)
   git:
     repo: '{{ repo_format4 }}'
     dest: '{{ checkout_dir }}'
@@ -162,8 +170,6 @@
   when: not git_result|skipped
 
 # Test checkout with non-standard port (alternate URL format)
-# requires prior acceptance of ssh.github.com hostkey for port 443, and requires
-# that no hostkey was accepted for ssh.github.com port 22
 
 - name: clear checkout_dir
   file: state=absent path={{ checkout_dir }}

--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -22,6 +22,8 @@
     repo_format1: 'https://github.com/jimi-c/test_role'
     repo_format2: 'git@github.com:jimi-c/test_role.git'
     repo_format3: 'ssh://git@github.com/jimi-c/test_role.git'
+    repo_format4: 'git@[ssh.github.com:443]:jimi-c/test_role.git'
+    repo_format5: 'git+ssh://git@ssh.github.com:443/jimi-c/test_role.git'
     repo_submodules: 'https://github.com/abadger/test_submodules.git'
     repo_submodules_newer: 'https://github.com/abadger/test_submodules_newer.git'
     repo_submodule1: 'https://github.com/abadger/test_submodules_subm1.git'
@@ -125,6 +127,50 @@
 - name: checkout ssh://git@github.com repo with accept_hostkey (expected pass)
   git:
     repo: '{{ repo_format3 }}'
+    dest: '{{ checkout_dir }}'
+    version: 'master'
+    accept_hostkey: false # should already have been accepted
+    key_file: '{{ github_ssh_private_key }}'
+  register: git_result
+  when: github_ssh_private_key is defined
+
+- assert:
+    that:
+      - 'git_result.changed'
+  when: not git_result|skipped
+
+# Test checkout with non-standard port
+# requires prior acceptance of ssh.github.com hostkey for port 443, and requires
+# that no hostkey was accepted for ssh.github.com port 22
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
+
+- name: checkout git@[ssh.github.com:443] repo with accept_hostkey (expected pass)
+  git:
+    repo: '{{ repo_format4 }}'
+    dest: '{{ checkout_dir }}'
+    version: 'master'
+    accept_hostkey: false # should already have been accepted
+    key_file: '{{ github_ssh_private_key }}'
+  register: git_result
+  when: github_ssh_private_key is defined
+
+- assert:
+    that:
+      - 'git_result.changed'
+  when: not git_result|skipped
+
+# Test checkout with non-standard port (alternate URL format)
+# requires prior acceptance of ssh.github.com hostkey for port 443, and requires
+# that no hostkey was accepted for ssh.github.com port 22
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
+
+- name: checkout git+ssh://git@ssh.github.com:443 repo with accept_hostkey (expected pass)
+  git:
+    repo: '{{ repo_format5 }}'
     dest: '{{ checkout_dir }}'
     version: 'master'
     accept_hostkey: false # should already have been accepted

--- a/test/units/module_utils/basic/test_known_hosts.py
+++ b/test/units/module_utils/basic/test_known_hosts.py
@@ -19,28 +19,37 @@
 from ansible.compat.tests import unittest
 from ansible.module_utils import known_hosts
 
+
 class TestAnsibleModuleKnownHosts(unittest.TestCase):
     urls = {
         'ssh://one.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'one.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'one.example.org', 'get_port': None},
         'ssh+git://two.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'two.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'two.example.org', 'get_port': None},
         'rsync://three.example.org/user/example.git':
-            {'is_ssh_url': False, 'get_fqdn': 'three.example.org'},
+            {'is_ssh_url': False, 'get_fqdn': 'three.example.org', 'get_port': None},
         'git@four.example.org:user/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'four.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'four.example.org', 'get_port': None},
         'git+ssh://five.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'five.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'five.example.org', 'get_port': None},
         'ssh://six.example.org:21/example.org':
-            {'is_ssh_url': True, 'get_fqdn': 'six.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'six.example.org', 'get_port': '21'},
+        'git@[seven.example.org:443]/example.git':
+            {'is_ssh_url': True, 'get_fqdn': 'seven.example.org', 'get_port': '443'},
+        'git+ssh://git@eight.example.org:443/example.git':
+            {'is_ssh_url': True, 'get_fqdn': 'eight.example.org', 'get_port': '443'},
+        'git+ssh://git@[nine.example.org:443]/example.git':
+            {'is_ssh_url': True, 'get_fqdn': 'nine.example.org', 'get_port': '443'},
+        'git+ssh://git@[ten.example.org]/example.git':
+            {'is_ssh_url': True, 'get_fqdn': 'ten.example.org', 'get_port': None},
         'ssh://[2001:DB8::abcd:abcd]/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'get_port': None},
         'ssh://[2001:DB8::abcd:abcd]:22/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'get_port': '22'},
+        'ssh://[2001:DB8::abcd:abcd]:21/example.git':
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'get_port': '21'},
         'username@[2001:DB8::abcd:abcd]/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
-        'username@[2001:DB8::abcd:abcd]:22/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'get_port': None},
     }
 
     def test_is_ssh_url(self):
@@ -51,5 +60,7 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
         for u in self.urls:
             self.assertEqual(known_hosts.get_fqdn(u), self.urls[u]['get_fqdn'])
 
-
-
+    def test_get_port(self):
+        for u in self.urls:
+            self.assertEqual(known_hosts.get_port(u), self.urls[u]['get_port'], "%s != %s for %s"
+                             % (known_hosts.get_port(u), self.urls[u]['get_port'], u))


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Summary:

This pull requests fixes #14574 

It adds support in `ansible.module_utils.known_hosts` for repository URLs in the following formats, as understood by git itself:

```
user@[host:port]/path.git
user@[host]/path.git
ssh://user@host:port/repo.git
ssh://[ipv6-addr]:port/path.git
```

(including git+ssh variants)

Because SSH stores host and port definitions in known_hosts as `[host]:port`, a function `get_port` was added that extracts the SSH port from the given repository URL.

It also removes repository URLs in the form

`'username@[2001:DB8::abcd:abcd]:22/example.git'`

from the test suite, as in my testing, they did not work in git (the port was not recognized). 

The git integration tests were moved to `destructive.yml`, because they remove the `known_hosts` file.
##### Example output:

The example from the bug report now works:

```

---
- hosts: 127.0.0.1
  connection: local
  tasks:
    - name: try to clone something 1
      git: repo=git+ssh://git@ssh.github.com:443/jimi-c/test_role.git dest=/tmp/test_role_1
      ignore_errors: yes

    - name: try to clone something 2
      git: repo=git@[ssh.github.com:443]:jimi-c/test_role.git dest=/tmp/test_role_2
      ignore_errors: yes
```

It gives the following output:

```
 _________________________________
< TASK [try to clone something 1] >
 ---------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

changed: [127.0.0.1]
 _________________________________
< TASK [try to clone something 2] >
 ---------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

changed: [127.0.0.1]
```
