### PR TITLE
Allow lookups to return python data structures

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -420,7 +420,13 @@ class Templar:
                 if wantlist:
                     ran = wrap_var(ran)
                 else:
-                    ran = UnsafeProxy(",".join(ran))
+                    try:
+                        ran = UnsafeProxy(",".join(ran))
+                    except TypeError:
+                        if isinstance(ran, list) and len(ran) == 1:
+                            ran = wrap_var(ran[0])
+                        else:
+                            ran = wrap_var(ran)
 
             return ran
         else:


### PR DESCRIPTION
##### Issue Type:

 Bugfix Pull Request
##### Ansible Version:

```
v2
```
##### Summary:

Fixes #14541.  This change allows a lookup to return python data structures.  As is if a lookup returns a python data structure or a string that evaluates as a python data structure, a TypeError is raised while trying to join the results with a comma.

This change catches that TypeError and will either a single item of the list if the list was only 1 element long, or return the list itself.
##### Example output:

N/A
