### PR TITLE
Remove SSL config map when empty

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -59,6 +59,9 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if db is not None:
         config['db'] = db
 
+    if config['ssl'] == {}:
+      config.pop('ssl')
+
     db_connection = MySQLdb.connect(**config)
     if cursor_class is not None:
         return db_connection.cursor(cursorclass=MySQLdb.cursors.DictCursor)


### PR DESCRIPTION
This avoids exceptions when ssl is not available.

See #14594 for details.
