### PR TITLE
docsite: add missing closing square bracket

### DIFF
--- a/docsite/rst/playbooks_delegation.rst
+++ b/docsite/rst/playbooks_delegation.rst
@@ -147,7 +147,7 @@ In 2.0, the directive `delegate_facts` may be set to `True` to assign the task's
           setup:
           delegate_to: "{{item}}"
           delegate_facts: True
-          with_items: "{{groups['dbservers'}}"
+          with_items: "{{groups['dbservers']}}"
 
 The above will gather facts for the machines in the dbservers group and assign the facts to those machines and not to app_servers.
 This way you can lookup `hostvars['dbhost1']['default_ipv4_addresses'][0]` even though dbservers were not part of the play, or left out by using `--limit`.


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel e35b1cf154) last updated 2016/02/22 16:13:14 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 0508a4a4b8) last updated 2016/02/12 19:20:00 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD f40fe33648) last updated 2016/02/12 19:20:00 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Correct a minor typo in code in the delegate_facts documentation.
##### Example output:

Not applicable
