### PR TITLE
Verify that the role_spec is using a comma before warning

### DIFF
--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -83,8 +83,7 @@ class RoleRequirement(RoleDefinition):
         #   'version': 'v1.0',
         #   'name': 'repo'
         # }
-
-        display.deprecated("The comma separated role spec format, use the yaml/explicit format instead.")
+        display.deprecated("The comma separated role spec format, use the yaml/explicit format instead. Line that trigger this: %s" % role_spec)
 
         default_role_versions = dict(git='master', hg='tip')
 
@@ -145,8 +144,13 @@ class RoleRequirement(RoleDefinition):
             return dict(name=name, src=src, scm=scm, version=version)
 
         if 'role' in role:
-            # Old style: {role: "galaxy.role,version,name", other_vars: "here" }
-            role = RoleRequirement.role_spec_parse(role['role'])
+            name = role['role']
+            if ',' in name:
+                # Old style: {role: "galaxy.role,version,name", other_vars: "here" }
+                role = RoleRequirement.role_spec_parse(role['role'])
+            else:
+                del role['role']
+                role['name'] = name
         else:
             role = role.copy()
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (fix_spurious_warning 81f7bfd014) last updated 2016/02/22 19:51:26 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 8d126bd877) last updated 2016/02/13 16:22:31 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD f6c5ed987f) last updated 2016/02/13 16:22:31 (GMT +200)
  config file = /home/misc/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

Since RoleRequirement.role_spec_parse is called even with a role_spec without a comma (see ./lib/ansible/playbook/role/requirement.py), it will always show the warning.

One way to trigger this is having this snippet in meta/main.yml:

```
dependencies:
  - role: foo
    when: "use_foo == True"
```

(see https://github.com/OSAS/ansible-role-httpd for a example of why that's used)

The code in RoleRequirement.role_yaml_parse is wrongly assuming this is using the old spec format, and thus trigger the warning.
