### PR TITLE
non-destructive says we should run test_binary at v2

### DIFF
--- a/test/integration/non_destructive.yml
+++ b/test/integration/non_destructive.yml
@@ -42,6 +42,5 @@
     - { role: test_embedded_module, tags: test_embedded_module }
     - { role: test_uri, tags: test_uri }
     - { role: test_add_host, tags: test_add_host }
-    # Turn on test_binary when we start testing v2
-    #- { role: test_binary, tags: test_binary }
+    - { role: test_binary, tags: test_binary }
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.0.2
  config file = /home/johnb/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

When I was looking at non_destructive.yml I saw that test_binary was disabled.

This appears to run correctly on Ubuntu 14.04
##### Example output:

```

~/git/ansible-inc/test/integration (test_binary)$ ansible-playbook non_destructive.yml -i inventory -e @integration_config.yml  -v --tags=test_binary

snip

testhost                   : ok=31   changed=11   unreachable=0    failed=0   
```

We are now using Ansible v2 and these tests pass, so run them.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/14614)

<!-- Reviewable:end -->
