### PR TITLE
Fixes authentication error bug when user has rsa keys

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -88,7 +88,8 @@ class Shell(object):
         self.errors.extend(CLI_ERRORS_RE)
 
     def open(self, host, port=22, username=None, password=None,
-            timeout=10, key_filename=None, pkey=None, look_for_keys=None):
+            timeout=10, key_filename=None, pkey=None, look_for_keys=None,
+            allow_agent=False):
 
         self.ssh = paramiko.SSHClient()
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -100,7 +101,7 @@ class Shell(object):
 
         self.ssh.connect(host, port=port, username=username, password=password,
                     timeout=timeout, look_for_keys=look_for_keys, pkey=pkey,
-                    key_filename=key_filename)
+                    key_filename=key_filename, allow_agent=allow_agent)
 
         self.shell = self.ssh.invoke_shell()
         self.shell.settimeout(10)
@@ -199,4 +200,3 @@ def get_cli_connection(module):
         module.fail_json(msg='socket timed out')
 
     return cli
-


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

``````
$ ansible --version
ansible 2.1.0
  config file = /Users/patrick/src/ansible-playbooks/network/ansible.cfg
  configured module search path = /Users/patrick/src/ntc/ntc-ansible/library```

##### Summary:

If a user has rsa keys under .ssh the current Shell class will fail. This is due to the allow_agent parameter of Paramiko.

##### Example output:

``````

patrick at ns2803m in ~/src/ansible-playbooks/network (master●●) (ansible-network)
$ ansible-playbook -i hosts test_ios_config.yml

PLAY ***************************************************************************

TASK [upgrade : Test ios_config] ***********************************************
fatal: [172.29.50.5]: FAILED! => {"changed": false, "failed": true, "msg": "failed to connecto to 172.29.50.5:22 - Authentication failed."}

NO MORE HOSTS LEFT *************************************************************
    to retry, use: --limit @test_ios_config.retry

PLAY RECAP *********************************************************************
172.29.50.5                : ok=0    changed=0    unreachable=0    failed=1

patrick at ns2803m in ~/src/ansible-playbooks/network (master●●) (ansible-network)
$ ls ~/.ssh
config          id_rsa          id_rsa.pub      known_hosts     known_hosts.old

```

```
