### PR TITLE
Check for closing sequence before templating

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -119,7 +119,7 @@ def template(basedir, varname, templatevars, lookup_fatal=True, depth=0, expand_
                 varname = "{{%s}}" % varname
 
         if isinstance(varname, basestring):
-            if '{{' in varname or '{%' in varname:
+            if ('{{' in varname and '}}' in varname ) or ( '{%' in varname and '%}' in varname ):
                 try:
                     varname = template_from_string(basedir, varname, templatevars, fail_on_undefined)
                 except errors.AnsibleError, e:


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Ansible Version:

```
ansible 1.9.4
  configured module search path = None
```

But also with

```
ansible 1.9.4 (stable-1.9 a05df837aa) last updated 2016/02/23 11:51:36 (GMT +200)
  lib/ansible/modules/core: (detached HEAD f22df78345) last updated 2015/02/21 17:07:41 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 23190986fd) last updated 2015/02/21 17:07:41 (GMT +200)
  configured module search path = None
```
##### Summary:

This fixes #14573 for Ansible v1.9.
