### PR TITLE
Put the advice to the user as comments in the template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ##### Issue Type:
 
-Please pick one and delete the rest:
+<!--- Please pick one and delete the rest: -->
  - Bug Report
  - Feature Idea
  - Documentation Report
@@ -8,42 +8,48 @@ Please pick one and delete the rest:
 ##### Ansible Version:
 
 ```
-(Paste verbatim output from “ansible --version” here)
+<!--- Paste verbatim output from “ansible --version” here -->
 ```
 
 ##### Ansible Configuration:
 
-Please mention any settings you've changed/added/removed in ansible.cfg
+<!---
+Please mention any settings you have changed/added/removed in ansible.cfg
 (or using the ANSIBLE_* environment variables).
+-->
 
 ##### Environment:
 
+<!---
 Please mention the OS you are running Ansible from, and the OS you are
-managing, or say “N/A” for anything that isn't platform-specific.
+managing, or say “N/A” for anything that is not platform-specific.
+-->
 
 ##### Summary:
 
-Please explain the problem briefly.
+<!--- Please explain the problem briefly -->
 
 ##### Steps To Reproduce:
 
+<!---
 For bugs, please show exactly how to reproduce the problem. For new
 features, show how the feature would be used.
+-->
 
 ```
-(Paste example playbooks or commands here)
+<!--- Paste example playbooks or commands here -->
 ```
 
-You can also paste gist.github.com links for larger files.
+<!--- You can also paste gist.github.com links for larger files -->
 
 ##### Expected Results:
 
-What did you expect to happen when running the steps above?
+<!--- What did you expect to happen when running the steps above? -->
 
 ##### Actual Results:
 
-What actually happened?
+<!--- What actually happened? -->
 
 ```
-(Paste verbatim command output here)
+<!--- Paste verbatim command output here -->
 ```

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ##### Issue Type:
 
-Please pick one and delete the rest:
+<!--- Please pick one and delete the rest: -->
  - Feature Pull Request
  - New Module Pull Request
  - Bugfix Pull Request
@@ -9,19 +9,21 @@ Please pick one and delete the rest:
 ##### Ansible Version:
 
 ```
-(Paste verbatim output from “ansible --version” here)
+<!--- Paste verbatim output from “ansible --version” here -->
 ```
 
 ##### Summary:
 
-Please describe the change and the reason for it.
+<!--- Please describe the change and the reason for it -->
 
-(If you're fixing an existing issue, please include "Fixes #nnn" in your
+<!---
+If you are fixing an existing issue, please include "Fixes #nnn" in your
 commit message and your description; but you should still explain what
-the change does.)
+the change does.
+-->
 
 ##### Example output:
 
 ```
-(Paste verbatim command output here if necessary)
+<!-- Paste verbatim command output here if necessary -->
 ```


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest:-->
- Feature Pull Request
##### Ansible Version:

```
<!--- Paste verbatim output from “ansible --version” here -->
```
##### Summary:

<!--- Please describe the change and the reason for it -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Most issues include parts of the advice from the template, which adds noise to tickets.
E.g. A lot of tickets include the text "Please pick one and delete the rest:"

By adding the advice to the user as comments (<!--- comment -->) we achieve two important things:
1. The advice does not end up in the actual issue ticket or pull request
2. It is easier for the user to differentiate its own input and the original advice
   (And my help them to clean up the advice as well)

I edited this text to include the comments as this PR would change them.
And I left the comments also in the output blocks to see the effect.
##### Example output:

```
<!--- Paste verbatim command output here if necessary -->
Edit this ticket and you will see exactly what I mean :-)
All advice has been left in the ticket as comments.
```
