### PR TITLE
Do not sort group_names (Ansible v1.9)

### DIFF
--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -61,7 +61,7 @@ class Host(object):
         results = utils.combine_vars(results, self.vars)
         results['inventory_hostname'] = self.name
         results['inventory_hostname_short'] = self.name.split('.')[0]
-        results['group_names'] = sorted([ g.name for g in groups if g.name != 'all'])
+        results['group_names'] = [ g.name for g in groups if g.name != 'all']
         return results
 
 

--- a/test/units/TestInventory.py
+++ b/test/units/TestInventory.py
@@ -419,7 +419,7 @@ class TestInventory(unittest.TestCase):
 
         assert vars == {'inventory_hostname': 'zeus',
                         'inventory_hostname_short': 'zeus',
-                        'group_names': ['greek', 'major-god']}
+                        'group_names': ['major-god', 'greek']}
 
     def test_allows_equals_sign_in_var(self):
         inventory = self.simple_inventory()
@@ -433,7 +433,7 @@ class TestInventory(unittest.TestCase):
 
         expected_vars = {'inventory_hostname': 'zeus',
                          'inventory_hostname_short': 'zeus',
-                         'group_names': ['greek', 'major-god'],
+                         'group_names': ['major-god', 'greek'],
                          'var_a': '3#4'}
 
         print "HOST     VARS=%s" % host_vars


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Ansible Version:

```
[dag@moria ansible]$ ansible --version
ansible 1.9.4
  configured module search path = None
```

But also tested on `stable-1.9` !
##### Summary:

This fixes #14613

This brings the behaviour back in line with the behaviour of Ansible v2.0.

Computable consistency looks more important than cosmetic output.
Besides if sorting is somehow needed (e.g. for human comparison), that's exactly what Jinja2 is for.
##### Example output:

1.9.4 behaviour:

```
[dag@moria ansible.testing]$ ansible-playbook -i inventory2 test65.yml 

PLAY [regional] *************************************************************** 

TASK: [Print Group Names] ***************************************************** 
ok: [Server1] => {
    "msg": "['regional', 'southwest']"
}
ok: [Server2] => {
    "msg": "['regional', 'southwest']"
}
ok: [Server3] => {
    "msg": "['east', 'regional']"
}

PLAY RECAP ******************************************************************** 
Server1                    : ok=1    changed=0    unreachable=0    failed=0   
Server2                    : ok=1    changed=0    unreachable=0    failed=0   
Server3                    : ok=1    changed=0    unreachable=0    failed=0  
```

New stable-1.9 behaviour:

```

PLAY [regional] *************************************************************** 

TASK: [Print Group Names] ***************************************************** 
ok: [Server1] => {
    "msg": "['regional', 'southwest']"
}
ok: [Server2] => {
    "msg": "['regional', 'southwest']"
}
ok: [Server3] => {
    "msg": "['regional', 'east']"
}

PLAY RECAP ******************************************************************** 
Server1                    : ok=1    changed=0    unreachable=0    failed=0   
Server2                    : ok=1    changed=0    unreachable=0    failed=0   
Server3                    : ok=1    changed=0    unreachable=0    failed=0  
```

Current 2.0.0.2 behaviour:

```
[dag@moria ansible.testing]$ ansible-playbook -i inventory2 test65.yml 

PLAY ***************************************************************************

TASK [Print Group Names] *******************************************************
ok: [Server3] => {
    "msg": [
        "regional", 
        "east"
    ]
}
ok: [Server1] => {
    "msg": [
        "regional", 
        "southwest"
    ]
}
ok: [Server2] => {
    "msg": [
        "regional", 
        "southwest"
    ]
}

PLAY RECAP *********************************************************************
Server1                    : ok=1    changed=0    unreachable=0    failed=0   
Server2                    : ok=1    changed=0    unreachable=0    failed=0   
Server3                    : ok=1    changed=0    unreachable=0    failed=0  
```
