### PR TITLE
Remove references to v2 codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,12 +97,6 @@ all: clean python
 tests:
 	PYTHONPATH=./lib $(NOSETESTS) -d -w test/units -v --with-coverage --cover-package=ansible --cover-branches
 
-newtests:
-	PYTHONPATH=./v2:./lib $(NOSETESTS) -d -w v2/test -v --with-coverage --cover-package=ansible --cover-branches
-
-newtests-py3:
-	PYTHONPATH=./v2:./lib $(NOSETESTS3) -d -w v2/test -v --with-coverage --cover-package=ansible --cover-branches
-
 authors:
 	sh hacking/authors.sh
 


### PR DESCRIPTION
##### Issue Type:

<!-- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Ansible Version:

```
ansible 1.9.4
  configured module search path = None
```
##### Summary:

<!--- Please describe the change and the reason for it.-->

This change removes old references to the removed `/v2` subdirectory.

<!---
If you're fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
