### PR TITLE
Introduce new 'filetree' lookup plugin (Ansible v1.9)

### DIFF
--- a/lib/ansible/runner/lookup_plugins/filetree.py
+++ b/lib/ansible/runner/lookup_plugins/filetree.py
@@ -76,7 +76,7 @@ def file_props(root, path):
         return None
 
     try:
-        st = os.stat(abspath)
+        st = os.lstat(abspath)
     except OSError, e:
         warning('filetree: Error using stat() on path %s (%s)' % (abspath, e))
         return None

--- a/lib/ansible/runner/lookup_plugins/filetree.py
+++ b/lib/ansible/runner/lookup_plugins/filetree.py
@@ -1,0 +1,123 @@
+# (c) 2016 Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import glob
+import pwd
+import grp
+
+from ansible.utils import (listify_lookup_plugin_terms, path_dwim, warning)
+
+HAVE_SELINUX=False
+try:
+    import selinux
+    HAVE_SELINUX=True
+except ImportError:
+    pass
+
+def _to_filesystem_str(path):
+    '''Returns filesystem path as a str, if it wasn't already.
+
+    Used in selinux interactions because it cannot accept unicode
+    instances, and specifying complex args in a playbook leaves
+    you with unicode instances.  This method currently assumes
+    that your filesystem encoding is UTF-8.
+
+    '''
+    if isinstance(path, unicode):
+        path = path.encode("utf-8")
+    return path
+
+# If selinux fails to find a default, return an array of None
+def selinux_context(path):
+    context = [None, None, None, None]
+    if HAVE_SELINUX and selinux.is_selinux_enabled():
+        try:
+            ret = selinux.lgetfilecon_raw(_to_filesystem_str(path))
+        except OSError:
+            return context
+        if ret[0] != -1:
+            # Limit split to 4 because the selevel, the last in the list,
+            # may contain ':' characters
+            context = ret[1].split(':', 3)
+    return context
+
+def file_props(root, path):
+    ''' Returns dictionary with file properties, or return None on failure'''
+    abspath = os.path.join(root, path)
+    ret = dict(root=root, path=path, exists=True)
+
+    try:
+        if os.path.islink(abspath):
+            ret['state'] = 'link'
+            ret['src'] = os.readlink(abspath)
+        elif os.path.isdir(abspath):
+            ret['state'] = 'directory'
+        elif os.path.isfile(abspath):
+            ret['state'] = 'file'
+            ret['src'] = abspath
+    except OSError, e:
+        warning('filetree: Error querying path %s (%s)' % (abspath, e))
+        return None
+
+    try:
+        stat = os.stat(abspath)
+    except OSError, e:
+        warning('filetree: Error using stat() on path %s (%s)' % (abspath, e))
+        return None
+
+    ret['uid'] = stat.st_uid
+    ret['gid'] = stat.st_gid
+    ret['owner'] = pwd.getpwuid(stat.st_uid).pw_name
+    ret['group'] = grp.getgrgid(stat.st_gid).gr_name
+    ret['mode'] = str(oct(stat.st_mode))
+    ret['size'] = stat.st_size
+    ret['mtime'] = stat.st_mtime
+    ret['ctime'] = stat.st_ctime
+
+    if HAVE_SELINUX and selinux.is_selinux_enabled() == 1:
+        context = selinux_context(abspath)
+        ret['seuser'] = context[0]
+        ret['serole'] = context[1]
+        ret['setype'] = context[2]
+        ret['selevel'] = context[3]
+
+    return ret
+
+class LookupModule(object):
+
+    def __init__(self, basedir=None, runner=None, **kwargs):
+        self.runner = runner
+        self.basedir = self.runner.basedir
+
+    def run(self, terms, inject=None, **kwargs):
+
+        terms = listify_lookup_plugin_terms(terms, self.basedir, inject)
+
+        ret = []
+        for term in terms:
+            term_file = os.path.basename(term)
+            dwimmed_path = path_dwim(self.basedir, os.path.dirname(term))
+            path = os.path.join(dwimmed_path, term_file)
+            for root, dirs, files in os.walk(path, topdown=True):
+                for entry in dirs + files:
+                    relpath = os.path.relpath(os.path.join(root, entry), path)
+                    props = file_props(path, relpath)
+                    if props != None:
+                        ret.append(props)
+
+        return ret

--- a/lib/ansible/runner/lookup_plugins/filetree.py
+++ b/lib/ansible/runner/lookup_plugins/filetree.py
@@ -58,27 +58,27 @@ def selinux_context(path):
     return context
 
 def file_props(root, path):
-    ''' Returns dictionary with file properties, or return None on failure'''
+    ''' Returns dictionary with file properties, or return None on failure '''
     abspath = os.path.join(root, path)
-    ret = dict(root=root, path=path)
-
-    try:
-        if os.path.islink(abspath):
-            ret['state'] = 'link'
-            ret['src'] = os.readlink(abspath)
-        elif os.path.isdir(abspath):
-            ret['state'] = 'directory'
-        elif os.path.isfile(abspath):
-            ret['state'] = 'file'
-            ret['src'] = abspath
-    except OSError, e:
-        warning('filetree: Error querying path %s (%s)' % (abspath, e))
-        return None
 
     try:
         st = os.lstat(abspath)
-    except OSError, e:
+    except OSError as e:
         warning('filetree: Error using stat() on path %s (%s)' % (abspath, e))
+        return None
+
+    ret = dict(root=root, path=path)
+
+    if stat.S_ISLNK(st.st_mode):
+        ret['state'] = 'link'
+        ret['src'] = os.readlink(abspath)
+    elif stat.S_ISDIR(st.st_mode):
+        ret['state'] = 'directory'
+    elif stat.S_ISREG(st.st_mode):
+        ret['state'] = 'file'
+        ret['src'] = abspath
+    else:
+        warning('filetree: Error file type of %s is not supported' % abspath)
         return None
 
     ret['uid'] = st.st_uid

--- a/lib/ansible/runner/lookup_plugins/filetree.py
+++ b/lib/ansible/runner/lookup_plugins/filetree.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import glob
 import pwd
 import grp
 import stat

--- a/lib/ansible/runner/lookup_plugins/filetree.py
+++ b/lib/ansible/runner/lookup_plugins/filetree.py
@@ -19,6 +19,7 @@ import os
 import glob
 import pwd
 import grp
+import stat
 
 from ansible.utils import (listify_lookup_plugin_terms, path_dwim, warning)
 
@@ -59,7 +60,7 @@ def selinux_context(path):
 def file_props(root, path):
     ''' Returns dictionary with file properties, or return None on failure'''
     abspath = os.path.join(root, path)
-    ret = dict(root=root, path=path, exists=True)
+    ret = dict(root=root, path=path)
 
     try:
         if os.path.islink(abspath):
@@ -75,19 +76,19 @@ def file_props(root, path):
         return None
 
     try:
-        stat = os.stat(abspath)
+        st = os.stat(abspath)
     except OSError, e:
         warning('filetree: Error using stat() on path %s (%s)' % (abspath, e))
         return None
 
-    ret['uid'] = stat.st_uid
-    ret['gid'] = stat.st_gid
-    ret['owner'] = pwd.getpwuid(stat.st_uid).pw_name
-    ret['group'] = grp.getgrgid(stat.st_gid).gr_name
-    ret['mode'] = str(oct(stat.st_mode))
-    ret['size'] = stat.st_size
-    ret['mtime'] = stat.st_mtime
-    ret['ctime'] = stat.st_ctime
+    ret['uid'] = st.st_uid
+    ret['gid'] = st.st_gid
+    ret['owner'] = pwd.getpwuid(st.st_uid).pw_name
+    ret['group'] = grp.getgrgid(st.st_gid).gr_name
+    ret['mode'] = str(oct(stat.S_IMODE(st.st_mode)))
+    ret['size'] = st.st_size
+    ret['mtime'] = st.st_mtime
+    ret['ctime'] = st.st_ctime
 
     if HAVE_SELINUX and selinux.is_selinux_enabled() == 1:
         context = selinux_context(abspath)


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Feature Pull Request
##### Ansible Version:

```
ansible 1.9.4
  configured module search path = None
```
##### Summary:

<!--- Please describe the change and the reason for it -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This is a backport of the v2 plugin in PR #14332

The new "filetree" lookup plugin makes it possible to recurse over a tree of files within the task loop. This makes it possible to e.g. template a complete tree of files to a target system with little effort while retaining permissions and ownership.

The module supports directories, files and symlinks. And also SELinux.

The item dictionary consists of:
- src
- root
- path
- mode
- state
- owner
- group
- seuser
- serole
- setype
- selevel
- uid
- gid
- size
- mtime
- ctime

EXAMPLES:
Here is an example of how we use with_filetree within a role.
The `web/` path is relative to either `roles/<role>/files/` or `files/`.

``` yaml
 - name: Create directories
   file:
     path: /web/{{ item.path }}
     state: directory
     mode: '{{ item.mode }}'
     owner: '{{ item.owner }}'
     group: '{{ item.group }}'
     force: yes
   with_filetree: web/
   when: item.state == 'directory'

 - name: Template complete tree
   file:
     src: '{{ item.src }}'
     dest: /web/{{ item.path }}
     state: 'link'
     mode: '{{ item.mode }}'
     owner: '{{ item.owner }}'
     group: '{{ item.group }}'
   with_filetree: web/
   when: item.state == 'link'

 - name: Template complete tree
   template:
     src: '{{ item.src }}'
     dest: /web/{{ item.path }}
     mode: '{{ item.mode }}'
     owner: '{{ item.owner }}'
     group: '{{ item.group }}'
     force: yes
   with_filetree: web/
   when: item.state == 'file'
```

SPECIAL USE:
The following properties also have its special use:
- root: Makes it possible to filter by original location
- path: Is the relative path to root
- uid, gid: Makes it possible to force-create by exact id, rather than by name
- size, mtime, ctime: Makes it possible to filter out files by size, mtime or ctime
