### PR TITLE
Note that version 3.11 of PyYAML is now required.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,7 @@ allowed in future versions:
     ```
     - debug: msg="The error message was: {{error_code |default('') }}"
     ```
+* Version 3.11 of PyYAML is now required.
 
 ## 1.9.4 "Dancing In the Street" - Oct 9, 2015
 


### PR DESCRIPTION
Solaris 11.3 still ships PyYAML 3.09, resulting in the following error
being issued by Ansible:

```
ERROR! Unexpected Exception: 'AnsibleLoader' object has no attribute 'dispose'
```
