### PR TITLE
Fix copy module handling of symlinks

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -252,6 +252,14 @@ class ActionModule(ActionBase):
                     self._remove_tmp_path(tmp)
                     continue
 
+                # Fix for https://github.com/ansible/ansible-modules-core/issues/1568.
+                # If checksums match, and follow = True, find out if 'dest' is a link. If so,
+                # change it to point to the source of the link.
+                if follow:
+                    dest_status_nofollow = self._execute_remote_stat(dest_file, all_vars=task_vars, follow=False)
+                    if dest_status_nofollow['islnk'] and 'lnk_source' in dest_status_nofollow.keys():
+                        dest = dest_status_nofollow['lnk_source']
+
                 # Build temporary module_args.
                 new_module_args = self._task.args.copy()
                 new_module_args.update(


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (modules_issue_1568 2f74f6738d) last updated 2016/02/23 13:47:53 (GMT -600)
  lib/ansible/modules/core: (detached HEAD 8d126bd877) last updated 2016/02/23 10:35:32 (GMT -600)
  lib/ansible/modules/extras: (detached HEAD f6c5ed987f) last updated 2016/02/23 10:35:42 (GMT -600)
  config file =
  configured module search path = Default w/o overrides
```

Verified same issue existed in:

```
ansible 2.0.0.2
  config file =
  configured module search path = Default w/o overrides
```
##### Summary:

Fixes ansible/ansible-modules-core#1568. See the comments in that issue for several example runs which demonstrate the issue.

When checksums of local and remote files match, and when follow = True,
determine if remote destination is a symlink. If so, find out what path the link is
pointing to, and pass that path to the file module as 'dest' instead.

This change fixes an edge case in file copy behavior when:
- 'dest' is a symlink to some other file ('realdest')
- follow = True
- the checksums of the source file, 'src', and the symlink target, 'realdest',
  match.

Because the checksums match, the copy module is skipped and the file module
is invoked directly with 'dest' = the symlink, and 'src' = the source of the
copy module, whether that source is present on the target machine or not.

When 'src' doesn't exist on the target machine, this leads to an error that
looks like this because it can't change the target of the symlink:

```
TASK [copy] ********************************************************************
fatal: [192.168.56.101]: FAILED! => {"changed": false, "checksum": "f572d396fae9206628714fb2ce00f72e94f2258f", "failed": true, "gid": 1000, "group": "ajdecon", "mode": "0777", "msg": "src file does not exist, use \"force=yes\" if you really want to create the link: /tmp/issue1568/dest_dir/source", "owner": "ajdecon", "path": "/tmp/issue1568/dest_dir/dest", "size": 8, "src": "source", "state": "link", "uid": 1000}
```

When the path 'src' _does_ exist on the target machine, the file module makes
this the symlink "dest -> src" instead of "dest -> realdest"... even if the
checksum of 'src' on the target machine is different from the checksum of 'src'
on the machine where Ansible is running.
