### PR TITLE
Fixup boto3_conn aws_session_token and verify

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -47,8 +47,6 @@ class AnsibleAWSError(Exception):
 
 def boto3_conn(module, conn_type=None, resource=None, region=None, endpoint=None, **params):
     profile = params.pop('profile_name', None)
-    params['aws_session_token'] = params.pop('security_token', None)
-    params['verify'] = params.pop('validate_certs', None)
 
     if conn_type not in ['both', 'resource', 'client']:
         module.fail_json(msg='There is an issue in the code of the module. You must specify either both, resource or client to the conn_type parameter in the boto3_conn function call')


### PR DESCRIPTION
Fixup boto3_conn by removing unnecessary lines since commit https://github.com/ansible/ansible/commit/6ea772931fba2151fb2fb86caab8f7be10cf5769 which overwrote commit https://github.com/ansible/ansible/commit/27398131cf31eb7ca834a30ea2d8a871a937a377

Below snippet under def get_aws_connection_info(module, boto3=False) means it is not required anymore in boto3_conn.

```
if HAS_BOTO3 and boto3:
        boto_params = dict(aws_access_key_id=access_key,
                           aws_secret_access_key=secret_key,
                           aws_session_token=security_token)
```
