### PR TITLE
Update consul_io.py to support HTTPS endpoints

### DIFF
--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -410,6 +410,7 @@ class ConsulConfig(dict):
       '''get an instance of the api based on the supplied configuration'''
       host = 'localhost'
       port =  8500
+      scheme = 'http'
       token = None
 
       if hasattr(self, 'url'):
@@ -419,11 +420,13 @@ class ConsulConfig(dict):
               host = o.hostname
           if o.port:
               port = o.port
+          if o.scheme:
+              scheme = o.scheme
 
       if hasattr(self, 'token'):
           token = self.token
           if not token:
               token = 'anonymous'
-      return consul.Consul(host=host, port=port, token=token)
+      return consul.Consul(host=host, port=port, scheme=scheme, token=token)
 
 ConsulInventory()


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.0.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

Adds HTTPS support to the consul_io.py
