### PR TITLE
fix for include in handlers

### DIFF
--- a/lib/ansible/playbook/handler.py
+++ b/lib/ansible/playbook/handler.py
@@ -20,8 +20,14 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors import AnsibleError
-#from ansible.inventory.host import Host
+from ansible.playbook.helpers import load_list_of_tasks
 from ansible.playbook.task import Task
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
 
 class Handler(Task):
 
@@ -35,9 +41,21 @@ class Handler(Task):
         return "HANDLER: %s" % self.get_name()
 
     @staticmethod
-    def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
-        t = Handler(block=block, role=role, task_include=task_include)
-        return t.load_data(data, variable_manager=variable_manager, loader=loader)
+    def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None, play=None):
+        h = Handler(block=block, role=role, task_include=task_include)
+        h.load_data(data, variable_manager=variable_manager, loader=loader)
+        if h.get_name() == 'include':
+            filename = data[u'include']
+            display.debug('loading handlers from %s' % filename)
+            ds = loader.load_from_file(filename)
+            if ds is None:
+                return []
+            elif not isinstance(ds, list):
+                raise AnsibleError("included task files must contain a list of tasks")
+            handlers = load_list_of_tasks(ds, play=play, use_handlers=True, loader=loader)
+            return handlers
+
+        return h
 
     def flag_for_host(self, host):
         #assert instanceof(host, Host)

--- a/lib/ansible/playbook/handler.py
+++ b/lib/ansible/playbook/handler.py
@@ -44,16 +44,19 @@ class Handler(Task):
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None, play=None):
         h = Handler(block=block, role=role, task_include=task_include)
         h.load_data(data, variable_manager=variable_manager, loader=loader)
-        if h.get_name() == 'include':
-            filename = data[u'include']
-            display.debug('loading handlers from %s' % filename)
-            ds = loader.load_from_file(filename)
-            if ds is None:
-                return []
-            elif not isinstance(ds, list):
-                raise AnsibleError("included task files must contain a list of tasks")
-            handlers = load_list_of_tasks(ds, play=play, use_handlers=True, loader=loader)
-            return handlers
+        if h.action == 'include':
+            filenames = h.args['_raw_params'].strip().split()
+            retval = []
+            for filename in filenames:
+                display.debug('loading handlers from %s' % filename)
+                ds = loader.load_from_file(filename)
+                if ds is None:
+                    continue
+                elif not isinstance(ds, list):
+                    raise AnsibleError("included task files must contain a list of tasks")
+                handlers = load_list_of_tasks(ds, play=play, use_handlers=True, loader=loader)
+                retval.extend(handlers)
+            return retval
 
         return h
 

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -92,11 +92,14 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
             )
         else:
             if use_handlers:
-                t = Handler.load(task, block=block, role=role, task_include=task_include, variable_manager=variable_manager, loader=loader)
+                t = Handler.load(task, block=block, role=role, task_include=task_include, variable_manager=variable_manager, loader=loader, play=play)
             else:
                 t = Task.load(task, block=block, role=role, task_include=task_include, variable_manager=variable_manager, loader=loader)
 
-        task_list.append(t)
+        if isinstance(t, list):
+            task_list.extend(t)
+        else:
+            task_list.append(t)
 
     return task_list
 

--- a/test/integration/handlers/direct1.yml
+++ b/test/integration/handlers/direct1.yml
@@ -1,0 +1,3 @@
+- name: set_handler_fact_3
+  set_fact:
+    handler3_called: True

--- a/test/integration/handlers/direct2.yml
+++ b/test/integration/handlers/direct2.yml
@@ -1,0 +1,3 @@
+- name: set_handler_fact_4
+  set_fact:
+    handler4_called: True

--- a/test/integration/test_handlers.yml
+++ b/test/integration/test_handlers.yml
@@ -24,3 +24,29 @@
   connection: local
   roles:
   - { role: test_handlers }
+
+- name: test included handler
+  hosts: A
+  gather_facts: False
+  connection: local
+  tasks:
+   - name: notify included handler
+     shell: echo
+     notify:
+      - set_handler_fact_3
+      - set_handler_fact_4
+     tags: ['scenario1']
+  handlers:
+   - action: include handlers/direct1.yml handlers/direct2.yml
+
+- name: verify included handler was run
+  hosts: A
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: verify handlers 3 and 4 ran
+      assert:
+        that:
+            - "'handler3_called' in hostvars[inventory_hostname]"
+            - "'handler4_called' in hostvars[inventory_hostname]"
+      tags: ['scenario1']


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (detached HEAD handler_in) last updated 2016/02/24 16:43:16 (GMT -600)
  lib/ansible/modules/core: (detached HEAD e9454fa44f) last updated 2016/02/24 16:44:11 (GMT -600)
  lib/ansible/modules/extras: (detached HEAD fade5b7936) last updated 2016/02/24 16:44:11 (GMT -600)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Potential fix for including files in Handlers. At the moment, if you have a play such as

```

---
- hosts: all
  user: "{{ssh_user}}"
  handlers:
   - include: handler.yml
  tasks:
   - name: bar
     shell: echo bar
     notify: barrr
```

and handlers.yml

```

---
- name: barrr
  shell: echo barrr
```

The Handler object that gets created has a get_name() of 'include'.  The handler will get notified, but ansible will not load the included file and will silently not run the notified handler.
##### Example output:

```
$ ansible-playbook -i hosts playbook.yml 

PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [matt-lab-db]

TASK [bar] *********************************************************************
changed: [matt-lab-db]

RUNNING HANDLER [barrr] ********************************************************
changed: [matt-lab-db]

PLAY RECAP *********************************************************************
matt-lab-db                : ok=3    changed=2    unreachable=0    failed=0   
```
