### PR TITLE
Fix bug where extra vars highest precedence is violated when used ins…

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -611,6 +611,7 @@ class Runner(object):
         # since some of the variables we'll be replacing may be contained there too
         module_vars_inject = utils.combine_vars(host_variables, combined_cache.get(host, {}))
         module_vars_inject = utils.combine_vars(self.module_vars, module_vars_inject)
+        module_vars_inject = utils.combine_vars(module_vars_inject, self.extra_vars)
         module_vars = template.template(self.basedir, self.module_vars, module_vars_inject)
 
         # remove bad variables from the module vars, which may be in there due


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 1.9.4
  configured module search path = None
```
##### Summary:

Fixes a regression issue that seems to have appeared in version > 1.7 but fixed in 2.0.

Extra vars precedence is not respected when they overwrite a variable within another variable interpolation used inside a role.
#### Example:

Assuming the following

 `group_vars/apis`

```
apis_haproxy_frontends:
   - name: keystone-public-api-frontend
     bind:
       - "{{ network_vip_frontend }}:5000"
     default_backend: keystone-public-api
```

`group_vars/region`

```
network_vip_frontend: 10.230.254.235 
```

`playbook.yml`:

```
- hosts: apis
  sudo: True
  roles:
    - role: haproxy
      haproxy_frontends: "{{ apis_haproxy_frontends }}"
      haproxy_backends: "{{ apis_haproxy_backends }}"
      tags: haproxy
```

When calling the playbook with the extra vars like this:

```
ansible-playbook playbook.yml -e "network_vip_frontend=172.21.128.229"
```

This incorrectly gives this output (using debug inside the role):

```
ok: [ctrl01] => {
    "var": {
        "haproxy_frontends": [
            {
                "bind": [
                    "10.230.254.235:5000"
                ],
                "default_backend": "keystone-public-api",
                "name": "keystone-public-api-frontend"
            }
}
```

This fix gives the intended result:

```
ok: [ctrl01] => {
    "var": {
        "haproxy_frontends": [
            {
                "bind": [
                    "172.21.128.229:5000"
                ],
                "default_backend": "keystone-public-api",
                "name": "keystone-public-api-frontend"
            }
}
```

I have noticed that the incorrect interpolation happens after the first include task in the role.
If you use debug as the first task(s), then this problem doesn't appear strangely in the previous example.

Should also fix #10896
