### PR TITLE
Fix bug 14634: symbolic permissions causes error

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -891,7 +891,7 @@ class AnsibleModule(object):
                                    details=str(e))
 
         # Fixes bug 14771. Ignore upper bits of mode
-        mode = (mode & 07777)
+        mode = (mode & PERM_BITS)
 
         prev_mode = stat.S_IMODE(path_stat.st_mode)
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -890,6 +890,9 @@ class AnsibleModule(object):
                                    msg="mode must be in octal or symbolic form",
                                    details=str(e))
 
+        # Fixes bug 14771. Ignore upper bits of mode
+        mode = (mode & 07777)
+
         prev_mode = stat.S_IMODE(path_stat.st_mode)
 
         if prev_mode != mode:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
2.1.0
```
##### Summary:

Fixes #14634

This fixes the parsing of symbolic chmod strings
##### Example output:

In the original code the symbolic string is parsed with
a rather simple regular expression. This will not
cover all possibilities of the `chmod` command.

This fix parses the complete symbolic string and returns the
new octal mode.

Some test results:

```
Curr  | Symbolic                   | New
---------------------------------------------
0400  | =                          | 0000
0400  | u=,g=rx,o=rx               | 0055
0400  | u=rwx,g=,o=                | 0700
0400  | u=rwx,g=rx,o=rx            | 0755
0400  | u=rw+x,g=r+x,o=r+x         | 0755
0400  | u=rw-x,g=r-x,o=r-x         | 0644
0400  | u=rw-x+X,g=r-x+X,o=r-x+X   | 0755
0400  | a+st                       | 7400
```
