### PR TITLE
Deduplicate true duplicate entries in the openstack inventory

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -112,6 +112,14 @@ def get_host_groups(inventory, refresh=False):
     return groups
 
 
+def append_hostvars(hostvars, groups, key, server, namegroup=False):
+    hostvars[key] = dict(
+        ansible_ssh_host=server['interface_ip'],
+        openstack=server)
+    for group in get_groups_from_server(server, namegroup=namegroup):
+        groups[group].append(key)
+
+
 def get_host_groups_from_cloud(inventory):
     groups = collections.defaultdict(list)
     firstpass = collections.defaultdict(list)
@@ -130,20 +138,19 @@ def get_host_groups_from_cloud(inventory):
         firstpass[server['name']].append(server)
     for name, servers in firstpass.items():
         if len(servers) == 1 and use_hostnames:
-            server = servers[0]
-            hostvars[name] = dict(
-                ansible_ssh_host=server['interface_ip'],
-                openstack=server)
-            for group in get_groups_from_server(server, namegroup=False):
-                groups[group].append(server['name'])
+            append_hostvars(hostvars, groups, name, servers[0])
         else:
+            server_ids = set()
+            # Trap for duplicate results
             for server in servers:
-                server_id = server['id']
-                hostvars[server_id] = dict(
-                    ansible_ssh_host=server['interface_ip'],
-                    openstack=server)
-                for group in get_groups_from_server(server, namegroup=True):
-                    groups[group].append(server_id)
+                server_ids.add(server['id'])
+            if len(server_ids) == 1 and use_hostnames:
+                append_hostvars(hostvars, groups, name, servers[0])
+            else:
+                for server in servers:
+                    append_hostvars(
+                        hostvars, groups, server['id'], servers[0],
+                        namegroup=True)
     groups['_meta'] = {'hostvars': hostvars}
     return groups
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

ansible 2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
##### Summary:

If a user has a clouds.yaml file and then runs ansible inventory with OS_ environment variables also set, it can cause the same hosts to get registered twice, which triggers the logic of "I have two of the same cloud host, I will list them by UUID instead of name" - Except it's actually the same host, so you wind up with an unreadable inventory for no reason.

We now de-dup servers that have the same UUID (since that is actually unique) before trying to see if there are duplicate servers for a given name.
##### Example output:

Without patch:

``` json
{
  "_meta": {
    "hostvars": {
      "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46": {
        "ansible_ssh_host": "199.19.213.17", 
        "openstack": {
          "HUMAN_ID": true, 
          "NAME_ATTR": "name", 
          "OS-DCF:diskConfig": "MANUAL", 
          "OS-EXT-AZ:availability_zone": "ca-ymq-2", 
          "OS-EXT-STS:power_state": 1, 
          "OS-EXT-STS:task_state": null, 
          "OS-EXT-STS:vm_state": "active", 
          "OS-SRV-USG:launched_at": "2016-02-18T13:13:07.000000", 
          "OS-SRV-USG:terminated_at": null, 
          "accessIPv4": "199.19.213.17", 
          "accessIPv6": "", 
          "addresses": {
            "public": [
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:d7:0a:6f", 
                "OS-EXT-IPS:type": "fixed", 
                "addr": "199.19.213.17", 
                "version": 4
              }
            ]
          }, 
          "az": "ca-ymq-2", 
          "cloud": "envvars", 
          "config_drive": "True", 
          "created": "2016-02-18T13:12:53Z", 
          "flavor": {
            "id": "bbcb7eb5-5c8d-498f-9d7e-307c575d3566", 
            "name": "v1-standard-1"
          }, 
          "hostId": "e2a357e41aac2b0f870aceeb5938778c6593c3f4fd1b2ad9ab80f861", 
          "human_id": "test-xenial", 
          "id": "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
          "image": {
            "id": "af080d46-1044-4529-98d5-c5a36d0bdb8b", 
            "name": "ubuntu-xenial"
          }, 
          "interface_ip": "199.19.213.17", 
          "key_name": "mordred", 
          "metadata": {}, 
          "name": "test-xenial", 
          "networks": {
            "public": [
              "199.19.213.17"
            ]
          }, 
          "os-extended-volumes:volumes_attached": [], 
          "private_v4": "", 
          "progress": 0, 
          "public_v4": "199.19.213.17", 
          "public_v6": "", 
          "region": "ca-ymq-1", 
          "security_groups": [
            {
              "description": "default", 
              "id": "22f8104a-2359-4091-aa61-9a4c48d6df3f", 
              "name": "default", 
              "security_group_rules": [
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "2172daaa-e402-4cf0-b353-1a7cb7dae184", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": "0.0.0.0/0", 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "47fb6b4c-2f9b-4279-a77c-a645f7fc964f", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": null, 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "8287f9be-614b-4145-9f00-62fa9c856362", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": null, 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "fdd91863-c19b-4b4b-a1bc-822cb8b0adf7", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": "0.0.0.0/0", 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }
              ]
            }
          ], 
          "status": "ACTIVE", 
          "tenant_id": "db92b20496ae4fbda850a689ea9d563f", 
          "updated": "2016-02-18T13:13:07Z", 
          "user_id": "e9b21dc437d149858faee0898fb08e92", 
          "volumes": []
        }
      }, 
      "811c5197-dba7-4d3a-a3f6-68ca5328b9a7": {
        "ansible_ssh_host": "162.253.54.192", 
        "openstack": {
          "HUMAN_ID": true, 
          "NAME_ATTR": "name", 
          "OS-DCF:diskConfig": "MANUAL", 
          "OS-EXT-AZ:availability_zone": "ca-ymq-1", 
          "OS-EXT-STS:power_state": 1, 
          "OS-EXT-STS:task_state": null, 
          "OS-EXT-STS:vm_state": "active", 
          "OS-SRV-USG:launched_at": "2015-08-01T19:52:02.000000", 
          "OS-SRV-USG:terminated_at": null, 
          "accessIPv4": "162.253.54.192", 
          "accessIPv6": "", 
          "addresses": {
            "public": [
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:9f:46:3e", 
                "OS-EXT-IPS:type": "fixed", 
                "addr": "162.253.54.192", 
                "version": 4
              }
            ]
          }, 
          "az": "ca-ymq-1", 
          "cloud": "envvars", 
          "config_drive": "True", 
          "created": "2015-08-01T19:52:16Z", 
          "flavor": {
            "id": "bbcb7eb5-5c8d-498f-9d7e-307c575d3566", 
            "name": "v1-standard-1"
          }, 
          "hostId": "d998a94193237f8d12111cfdc856b83559e3a5b2e7716326ff46ad65", 
          "human_id": "mordred-irc", 
          "id": "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
          "image": {
            "id": "69c99b45-cd53-49de-afdc-f24789eb8f83", 
            "name": "Ubuntu 14.04.2 LTS (2015-06-17)"
          }, 
          "interface_ip": "162.253.54.192", 
          "key_name": "mordred", 
          "metadata": {
            "group": "irc", 
            "groups": "irc,enabled"
          }, 
          "name": "mordred-irc", 
          "networks": {
            "public": [
              "162.253.54.192"
            ]
          }, 
          "os-extended-volumes:volumes_attached": [], 
          "private_v4": "", 
          "progress": 0, 
          "public_v4": "162.253.54.192", 
          "public_v6": "", 
          "region": "ca-ymq-1", 
          "security_groups": [
            {
              "description": "default", 
              "id": "22f8104a-2359-4091-aa61-9a4c48d6df3f", 
              "name": "default", 
              "security_group_rules": [
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "2172daaa-e402-4cf0-b353-1a7cb7dae184", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": "0.0.0.0/0", 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "47fb6b4c-2f9b-4279-a77c-a645f7fc964f", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": null, 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "8287f9be-614b-4145-9f00-62fa9c856362", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": null, 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "fdd91863-c19b-4b4b-a1bc-822cb8b0adf7", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": "0.0.0.0/0", 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }
              ]
            }
          ], 
          "status": "ACTIVE", 
          "tenant_id": "db92b20496ae4fbda850a689ea9d563f", 
          "updated": "2015-08-01T19:52:02Z", 
          "user_id": "e9b21dc437d149858faee0898fb08e92", 
          "volumes": []
        }
      }
    }
  }, 
  "ca-ymq-1": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46"
  ], 
  "ca-ymq-1_ca-ymq-1": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7"
  ], 
  "ca-ymq-1_ca-ymq-2": [
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46"
  ], 
  "ca-ymq-2": [
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46"
  ], 
  "enabled": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7"
  ], 
  "envvars": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46"
  ], 
  "envvars_ca-ymq-1": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46"
  ], 
  "envvars_ca-ymq-1_ca-ymq-1": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7"
  ], 
  "envvars_ca-ymq-1_ca-ymq-2": [
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46"
  ], 
  "flavor-v1-standard-1": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46"
  ], 
  "image-Ubuntu 14.04.2 LTS (2015-06-17)": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7"
  ], 
  "image-ubuntu-xenial": [
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46"
  ], 
  "instance-4ee2b771-36c8-48f4-bc26-5c9a8dbeda46": [
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46"
  ], 
  "instance-811c5197-dba7-4d3a-a3f6-68ca5328b9a7": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7"
  ], 
  "irc": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7"
  ], 
  "meta-group_irc": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7"
  ], 
  "meta-groups_irc,enabled": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7"
  ], 
  "mordred-irc": [
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
    "811c5197-dba7-4d3a-a3f6-68ca5328b9a7"
  ], 
  "test-xenial": [
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
    "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46"
  ]
}
```

With Patch:

``` json
{
  "_meta": {
    "hostvars": {
      "mordred-irc": {
        "ansible_ssh_host": "162.253.54.192", 
        "openstack": {
          "HUMAN_ID": true, 
          "NAME_ATTR": "name", 
          "OS-DCF:diskConfig": "MANUAL", 
          "OS-EXT-AZ:availability_zone": "ca-ymq-1", 
          "OS-EXT-STS:power_state": 1, 
          "OS-EXT-STS:task_state": null, 
          "OS-EXT-STS:vm_state": "active", 
          "OS-SRV-USG:launched_at": "2015-08-01T19:52:02.000000", 
          "OS-SRV-USG:terminated_at": null, 
          "accessIPv4": "162.253.54.192", 
          "accessIPv6": "", 
          "addresses": {
            "public": [
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:9f:46:3e", 
                "OS-EXT-IPS:type": "fixed", 
                "addr": "162.253.54.192", 
                "version": 4
              }
            ]
          }, 
          "az": "ca-ymq-1", 
          "cloud": "envvars", 
          "config_drive": "True", 
          "created": "2015-08-01T19:52:16Z", 
          "flavor": {
            "id": "bbcb7eb5-5c8d-498f-9d7e-307c575d3566", 
            "name": "v1-standard-1"
          }, 
          "hostId": "d998a94193237f8d12111cfdc856b83559e3a5b2e7716326ff46ad65", 
          "human_id": "mordred-irc", 
          "id": "811c5197-dba7-4d3a-a3f6-68ca5328b9a7", 
          "image": {
            "id": "69c99b45-cd53-49de-afdc-f24789eb8f83", 
            "name": "Ubuntu 14.04.2 LTS (2015-06-17)"
          }, 
          "interface_ip": "162.253.54.192", 
          "key_name": "mordred", 
          "metadata": {
            "group": "irc", 
            "groups": "irc,enabled"
          }, 
          "name": "mordred-irc", 
          "networks": {
            "public": [
              "162.253.54.192"
            ]
          }, 
          "os-extended-volumes:volumes_attached": [], 
          "private_v4": "", 
          "progress": 0, 
          "public_v4": "162.253.54.192", 
          "public_v6": "", 
          "region": "ca-ymq-1", 
          "security_groups": [
            {
              "description": "default", 
              "id": "22f8104a-2359-4091-aa61-9a4c48d6df3f", 
              "name": "default", 
              "security_group_rules": [
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "2172daaa-e402-4cf0-b353-1a7cb7dae184", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": "0.0.0.0/0", 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "47fb6b4c-2f9b-4279-a77c-a645f7fc964f", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": null, 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "8287f9be-614b-4145-9f00-62fa9c856362", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": null, 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "fdd91863-c19b-4b4b-a1bc-822cb8b0adf7", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": "0.0.0.0/0", 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }
              ]
            }
          ], 
          "status": "ACTIVE", 
          "tenant_id": "db92b20496ae4fbda850a689ea9d563f", 
          "updated": "2015-08-01T19:52:02Z", 
          "user_id": "e9b21dc437d149858faee0898fb08e92", 
          "volumes": []
        }
      }, 
      "test-xenial": {
        "ansible_ssh_host": "199.19.213.17", 
        "openstack": {
          "HUMAN_ID": true, 
          "NAME_ATTR": "name", 
          "OS-DCF:diskConfig": "MANUAL", 
          "OS-EXT-AZ:availability_zone": "ca-ymq-2", 
          "OS-EXT-STS:power_state": 1, 
          "OS-EXT-STS:task_state": null, 
          "OS-EXT-STS:vm_state": "active", 
          "OS-SRV-USG:launched_at": "2016-02-18T13:13:07.000000", 
          "OS-SRV-USG:terminated_at": null, 
          "accessIPv4": "199.19.213.17", 
          "accessIPv6": "", 
          "addresses": {
            "public": [
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:d7:0a:6f", 
                "OS-EXT-IPS:type": "fixed", 
                "addr": "199.19.213.17", 
                "version": 4
              }
            ]
          }, 
          "az": "ca-ymq-2", 
          "cloud": "envvars", 
          "config_drive": "True", 
          "created": "2016-02-18T13:12:53Z", 
          "flavor": {
            "id": "bbcb7eb5-5c8d-498f-9d7e-307c575d3566", 
            "name": "v1-standard-1"
          }, 
          "hostId": "e2a357e41aac2b0f870aceeb5938778c6593c3f4fd1b2ad9ab80f861", 
          "human_id": "test-xenial", 
          "id": "4ee2b771-36c8-48f4-bc26-5c9a8dbeda46", 
          "image": {
            "id": "af080d46-1044-4529-98d5-c5a36d0bdb8b", 
            "name": "ubuntu-xenial"
          }, 
          "interface_ip": "199.19.213.17", 
          "key_name": "mordred", 
          "metadata": {}, 
          "name": "test-xenial", 
          "networks": {
            "public": [
              "199.19.213.17"
            ]
          }, 
          "os-extended-volumes:volumes_attached": [], 
          "private_v4": "", 
          "progress": 0, 
          "public_v4": "199.19.213.17", 
          "public_v6": "", 
          "region": "ca-ymq-1", 
          "security_groups": [
            {
              "description": "default", 
              "id": "22f8104a-2359-4091-aa61-9a4c48d6df3f", 
              "name": "default", 
              "security_group_rules": [
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "2172daaa-e402-4cf0-b353-1a7cb7dae184", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": "0.0.0.0/0", 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "47fb6b4c-2f9b-4279-a77c-a645f7fc964f", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": null, 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "8287f9be-614b-4145-9f00-62fa9c856362", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": null, 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }, 
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "fdd91863-c19b-4b4b-a1bc-822cb8b0adf7", 
                  "port_range_max": null, 
                  "port_range_min": null, 
                  "protocol": null, 
                  "remote_ip_prefix": "0.0.0.0/0", 
                  "security_group_id": "22f8104a-2359-4091-aa61-9a4c48d6df3f"
                }
              ]
            }
          ], 
          "status": "ACTIVE", 
          "tenant_id": "db92b20496ae4fbda850a689ea9d563f", 
          "updated": "2016-02-18T13:13:07Z", 
          "user_id": "e9b21dc437d149858faee0898fb08e92", 
          "volumes": []
        }
      }
    }
  }, 
  "ca-ymq-1": [
    "mordred-irc", 
    "mordred-irc", 
    "test-xenial"
  ], 
  "ca-ymq-1_ca-ymq-1": [
    "mordred-irc"
  ], 
  "ca-ymq-1_ca-ymq-2": [
    "test-xenial"
  ], 
  "ca-ymq-2": [
    "test-xenial"
  ], 
  "enabled": [
    "mordred-irc"
  ], 
  "envvars": [
    "mordred-irc", 
    "test-xenial"
  ], 
  "envvars_ca-ymq-1": [
    "mordred-irc", 
    "test-xenial"
  ], 
  "envvars_ca-ymq-1_ca-ymq-1": [
    "mordred-irc"
  ], 
  "envvars_ca-ymq-1_ca-ymq-2": [
    "test-xenial"
  ], 
  "flavor-v1-standard-1": [
    "mordred-irc", 
    "test-xenial"
  ], 
  "image-Ubuntu 14.04.2 LTS (2015-06-17)": [
    "mordred-irc"
  ], 
  "image-ubuntu-xenial": [
    "test-xenial"
  ], 
  "instance-4ee2b771-36c8-48f4-bc26-5c9a8dbeda46": [
    "test-xenial"
  ], 
  "instance-811c5197-dba7-4d3a-a3f6-68ca5328b9a7": [
    "mordred-irc"
  ], 
  "irc": [
    "mordred-irc", 
    "mordred-irc"
  ], 
  "meta-group_irc": [
    "mordred-irc"
  ], 
  "meta-groups_irc,enabled": [
    "mordred-irc"
  ]
}
```
