### PR TITLE
Cleans up extra whitespace in ansible.cfg

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -1,7 +1,7 @@
 # config file for ansible -- http://ansible.com/
 # ==============================================
 
-# nearly all parameters can be overridden in ansible-playbook 
+# nearly all parameters can be overridden in ansible-playbook
 # or with command line flags. ansible will read ANSIBLE_CONFIG,
 # ansible.cfg in the current working directory, .ansible.cfg in
 # the home directory or /etc/ansible/ansible.cfg, whichever it
@@ -81,7 +81,7 @@
 # list any Jinja2 extensions to enable here:
 #jinja2_extensions = jinja2.ext.do,jinja2.ext.i18n
 
-# if set, always use this private key file for authentication, same as 
+# if set, always use this private key file for authentication, same as
 # if passing --private-key to ansible or ansible-playbook
 #private_key_file = /path/to/file
 
@@ -93,8 +93,8 @@
 #ansible_managed = Ansible managed: {file} on {host}
 
 # by default, ansible-playbook will display "Skipping [host]" if it determines a task
-# should not be run on a host.  Set this to "False" if you don't want to see these "Skipping" 
-# messages. NOTE: the task header will still be shown regardless of whether or not the 
+# should not be run on a host.  Set this to "False" if you don't want to see these "Skipping"
+# messages. NOTE: the task header will still be shown regardless of whether or not the
 # task is skipped.
 #display_skipped_hosts = True
 
@@ -108,7 +108,7 @@
 # safely set this to True to get more informative messages.
 #display_args_to_stdout = False
 
-# by default (as of 1.3), Ansible will raise errors when attempting to dereference 
+# by default (as of 1.3), Ansible will raise errors when attempting to dereference
 # Jinja2 variables that are not set in templates or action lines. Uncomment this line
 # to revert the behavior to pre-1.3.
 #error_on_undefined_vars = False
@@ -127,7 +127,7 @@
 # (as of 1.8), Ansible can optionally warn when usage of the shell and
 # command module appear to be simplified by using a default Ansible module
 # instead.  These warnings can be silenced by adjusting the following
-# setting or adding warn=yes or warn=no to the end of the command line 
+# setting or adding warn=yes or warn=no to the end of the command line
 # parameter string.  This will for example suggest using the git module
 # instead of shelling out to the git command.
 # command_warnings = False
@@ -143,13 +143,13 @@
 #test_plugins       = /usr/share/ansible/plugins/test
 
 # by default callbacks are not loaded for /bin/ansible, enable this if you
-# want, for example, a notification or logging callback to also apply to 
+# want, for example, a notification or logging callback to also apply to
 # /bin/ansible runs
 #bin_ansible_callbacks = False
 
 
 # don't like cows?  that's unfortunate.
-# set to 1 if you don't want cowsay support or export ANSIBLE_NOCOWS=1 
+# set to 1 if you don't want cowsay support or export ANSIBLE_NOCOWS=1
 #nocows = 1
 
 # set which cowsay stencil you'd like to use by default. When set to 'random',
@@ -218,32 +218,32 @@
 [ssh_connection]
 
 # ssh arguments to use
-# Leaving off ControlPersist will result in poor performance, so use 
+# Leaving off ControlPersist will result in poor performance, so use
 # paramiko on older platforms rather than removing it
 #ssh_args = -o ControlMaster=auto -o ControlPersist=60s
 
 # The path to use for the ControlPath sockets. This defaults to
 # "%(directory)s/ansible-ssh-%%h-%%p-%%r", however on some systems with
-# very long hostnames or very long path names (caused by long user names or 
+# very long hostnames or very long path names (caused by long user names or
 # deeply nested home directories) this can exceed the character limit on
-# file socket names (108 characters for most platforms). In that case, you 
+# file socket names (108 characters for most platforms). In that case, you
 # may wish to shorten the string below.
-# 
-# Example: 
+#
+# Example:
 # control_path = %(directory)s/%%h-%%r
 #control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
 
-# Enabling pipelining reduces the number of SSH operations required to 
-# execute a module on the remote server. This can result in a significant 
-# performance improvement when enabled, however when using "sudo:" you must 
+# Enabling pipelining reduces the number of SSH operations required to
+# execute a module on the remote server. This can result in a significant
+# performance improvement when enabled, however when using "sudo:" you must
 # first disable 'requiretty' in /etc/sudoers
 #
 # By default, this option is disabled to preserve compatibility with
 # sudoers configurations that have requiretty (the default on many distros).
-# 
+#
 #pipelining = False
 
-# if True, make ansible use scp if the connection type is ssh 
+# if True, make ansible use scp if the connection type is ssh
 # (default is sftp)
 #scp_if_ssh = True
 
@@ -259,7 +259,7 @@
 
 # The daemon timeout is measured in minutes. This time is measured
 # from the last activity to the accelerate daemon.
-#accelerate_daemon_timeout = 30 
+#accelerate_daemon_timeout = 30
 
 # If set to yes, accelerate_multi_key will allow multiple
 # private keys to be uploaded to it, though each user must


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel cd51ba7965) last updated 2016/02/24 10:55:55 (GMT -700)
  lib/ansible/modules/core: (detached HEAD e9454fa44f) last updated 2016/02/24 10:55:55 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD fade5b7936) last updated 2016/02/24 10:55:56 (GMT -700)
```
##### Summary:

Extra whitespace can add noise to diffs and commits, especially when a text editor (e.g. Atom) cleans up whitespace by default.
##### Example output:
