### PR TITLE
Update Lookups documentation regarding a possible pitfall with password plugin

### DIFF
--- a/docsite/rst/playbooks_lookups.rst
+++ b/docsite/rst/playbooks_lookups.rst
@@ -69,6 +69,8 @@ This length can be changed by passing an extra parameter::
 
 .. note:: If the file already exists, no data will be written to it. If the file has contents, those contents will be read in as the password. Empty files cause the password to return as an empty string        
 
+Caution: Because this runs on the ansible host as the user running the playbook, if the file does not exist, and is not writeable by that user, the playbook will just loop.
+
 Starting in version 1.4, password accepts a "chars" parameter to allow defining a custom character set in the generated passwords. It accepts comma separated list of names that are either string module attributes (ascii_letters,digits, etc) or are used literally::
 
     ---

--- a/docsite/rst/playbooks_lookups.rst
+++ b/docsite/rst/playbooks_lookups.rst
@@ -67,9 +67,9 @@ This length can be changed by passing an extra parameter::
 
         (...)
 
-.. note:: If the file already exists, no data will be written to it. If the file has contents, those contents will be read in as the password. Empty files cause the password to return as an empty string        
+.. note:: If the file already exists, no data will be written to it. If the file has contents, those contents will be read in as the password. Empty files cause the password to return as an empty string.
 
-Caution: Because this runs on the ansible host as the user running the playbook, if the file does not exist, and is not writeable by that user, the playbook will just loop.
+Caution: Since this runs on the ansible host as the user running the playbook, and "become" does not apply, the target file must be readable by the playbook user, or, if it does not exist, the playbook user must have sufficient privileges to create it. (So, for example, attempts to write into areas such as /etc will fail unless the entire playbook is being run as root).
 
 Starting in version 1.4, password accepts a "chars" parameter to allow defining a custom character set in the generated passwords. It accepts comma separated list of names that are either string module attributes (ascii_letters,digits, etc) or are used literally::
 


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Ansible Version:

```
ansible 2.0.0.2
  config file = /home/uds/provisioning/buildbootiso/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:
##### Example output:

```

```

Added a warning regarding attempting to create a local password file when the user the playbook is running as cannot create it... causes Ansible to loop at that task.

This might be considered a bug also in that Ansible never recovers from this user error...
