### PR TITLE
Add support for nested hostgroups in FreeIPA

### DIFF
--- a/contrib/inventory/freeipa.py
+++ b/contrib/inventory/freeipa.py
@@ -23,7 +23,7 @@ def initialize():
 
 def list_groups(api):
     '''
-    This function returns a list of all host groups. This function requires
+    This function prints a list of all host groups. This function requires
     one argument, the FreeIPA/IPA API object.
     '''
 
@@ -34,10 +34,16 @@ def list_groups(api):
     result = api.Command.hostgroup_find()['result']
 
     for hostgroup in result:
-        inventory[hostgroup['cn'][0]] = { 'hosts': [host for host in  hostgroup['member_host']]}
+        # Get direct and indirect members (nested hostgroups) of hostgroup
+        members = []
+        if 'member_host' in hostgroup:
+            members = [host for host in hostgroup['member_host']]
+        if 'memberindirect_host' in hostgroup:
+            members += (host for host in  hostgroup['memberindirect_host'])
+        inventory[hostgroup['cn'][0]] = {'hosts': [host for host in members]}
 
-        for host in  hostgroup['member_host']:
-            hostvars[host] = {}
+        for member in members:
+            hostvars[member] = {}
 
     inventory['_meta'] = {'hostvars': hostvars}
     inv_string = json.dumps(inventory, indent=1, sort_keys=True)


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel 8c8cfa4d7d) last updated 2016/02/28 14:41:03 (GMT -600)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

In FreeIPA it's possible to create nested hostgroups.  This change will make freeipa.py return the members of both the parent and child hostgroups.
Note: This pull request replaces the previous one I messed up (#14023) and closed.
