### PR TITLE
updates the ops_template plugin action backup key

### DIFF
--- a/lib/ansible/plugins/action/ops_template.py
+++ b/lib/ansible/plugins/action/ops_template.py
@@ -35,15 +35,15 @@ class ActionModule(NetActionModule, ActionBase):
         if isinstance(self._task.args['src'], basestring):
             self._handle_template()
 
-        self._task.args['config'] = task_vars.get('config')
-
         result.update(self._execute_module(module_name=self._task.action,
             module_args=self._task.args, task_vars=task_vars))
 
-        if self._task.args.get('backup') and '_config' in result:
-            contents = json.dumps(result['_config'], indent=4)
+        if self._task.args.get('backup') and result.get('_backup'):
+            contents = json.dumps(result['_backup'], indent=4)
             self._write_backup(task_vars['inventory_hostname'], contents)
-            del result['_config']
+
+        if '_backup' in result:
+            del result['_backup']
 
         return result
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (plugin_action_ops_template f67bf3f775) last updated 2016/02/28 23:40:05 (GMT -400)
  lib/ansible/modules/core: (working b2047047f2) last updated 2016/02/28 11:32:44 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f6a7b6dd1f) last updated 2016/01/04 21:53:44 (GMT -400)
  config file =
  configured module search path = Default w/o overrides

```
##### Summary:

This commit changes the key the ops_template will search for in order
to backup the current configuration to local disk on the Ansible control
host.  This change was made to make ops_template consistent with the
other network template modules.
