### PR TITLE
Set fail_on_cloud_config in openstack inventory

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2012, Marco Vito Moscaritolo <marco@agavee.com>
 # Copyright (c) 2013, Jesse Keating <jesse.keating@rackspace.com>
 # Copyright (c) 2015, Hewlett-Packard Development Company, L.P.
+# Copyright (c) 2016, Rackspace Australia
 #
 # This module is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -39,12 +40,17 @@
 # use_hostnames changes the behavior from registering every host with its UUID
 #               and making a group of its hostname to only doing this if the
 #               hostname in question has more than one server
+# fail_on_errors causes the inventory to fail and return no hosts if one cloud
+#                has failed (for example, bad credentials or being offline).
+#                When set to False, the inventory will return hosts from
+#                whichever other clouds it can contact. (Default: True)
 
 import argparse
 import collections
 import os
 import sys
 import time
+from distutils.version import StrictVersion
 
 try:
     import json
@@ -128,6 +134,9 @@ def get_host_groups_from_cloud(inventory):
     if hasattr(inventory, 'extra_config'):
         use_hostnames = inventory.extra_config['use_hostnames']
         list_args['expand'] = inventory.extra_config['expand_hostvars']
+        if StrictVersion(shade.__version__) >= StrictVersion("1.6.0"):
+            list_args['fail_on_cloud_config'] = \
+                inventory.extra_config['fail_on_errors']
     else:
         use_hostnames = False
 
@@ -216,6 +225,7 @@ def main():
                 config_defaults={
                     'use_hostnames': False,
                     'expand_hostvars': True,
+                    'fail_on_errors': True,
                 }
             ))
 

--- a/contrib/inventory/openstack.yml
+++ b/contrib/inventory/openstack.yml
@@ -29,3 +29,4 @@ clouds:
 ansible:
   use_hostnames: True
   expand_hostvars: False
+  fail_on_errors: True


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

When managing across multiple openstack clouds, if any one of them is unavailable for whatever reason (the cloud may be down or the credentials misconfigured etc) then no hosts are returned from the dynamic inventory.

In some cases you may still want an inventory returned for whichever clouds are available. This is particularly useful if you're doing CD across multiple clouds for resiliency.

This relies on the recently merged upstream change in shade: https://review.openstack.org/#/c/285882/

From the commit message:

Add support for a new option to the openstack inventory. This is so
should one cloud be unavailable you can still list hosts from any
other openstack clouds you have configured.

This is exposed as an option under the extra config part of ansible
in the openstack clouds.yaml.
