### PR TITLE
added package to special 'squashable' fields

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -269,7 +269,12 @@ class TaskExecutor:
         if len(items) > 0 and task_action in self.SQUASH_ACTIONS:
             if all(isinstance(o, string_types) for o in items):
                 final_items = []
-                name = self._task.args.pop('name', None) or self._task.args.pop('pkg', None)
+
+                name = None
+                for allowed in ['name', 'pkg', 'package']:
+                    name = self._task.args.pop(allowed, None)
+                    if name is not None:
+                        break
 
                 # This gets the information to check whether the name field
                 # contains a template that we can squash for


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
2.0.1
```
##### Summary:

Fixes issue with special 'squashing' for apt by adding existing alias to 'name' that currently errors out.
fixes https://github.com/ansible/ansible-modules-core/issues/3145
fixes https://github.com/ansible/ansible-modules-core/issues/2300
