### PR TITLE
Fix bug 14715: Galaxy CLI paging error

### DIFF
--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -180,12 +180,12 @@ class GalaxyAPI(object):
             url = '%s/roles/%d/%s/?page_size=50' % (self.baseurl, int(role_id), related)
             data = self.__call_galaxy(url)
             results = data['results']
-            done = (data.get('next', None) is None)
+            done = (data.get('next_link', None) is None)
             while not done:
-                url = '%s%s' % (self.baseurl, data['next'])
+                url = '%s%s' % (self._api_server, data['next_link'])
                 data = self.__call_galaxy(url)
                 results += data['results']
-                done = (data.get('next', None) is None)
+                done = (data.get('next_link', None) is None)
             return results
         except:
             return None
@@ -203,12 +203,12 @@ class GalaxyAPI(object):
                 results = data
             done = True
             if "next" in data:
-                done = (data.get('next', None) is None)
+                done = (data.get('next_link', None) is None)
             while not done:
-                url = '%s%s' % (self.baseurl, data['next'])
+                url = '%s%s' % (self._api_server, data['next_link'])
                 data = self.__call_galaxy(url)
                 results += data['results']
-                done = (data.get('next', None) is None)
+                done = (data.get('next_link', None) is None)
             return results
         except Exception as error:
             raise AnsibleError("Failed to download the %s list: %s" % (what, str(error)))


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (galaxy2_paging a7eb9592d9) last updated 2016/02/29 19:26:36 (GMT -400)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file =
  configured module search path = Default w/o overrides
```
##### Summary:

Fix for https://github.com/ansible/galaxy-issues/issues/134.  Galaxy API now returns correct URL in `next_link` data attribute. It no longer contains the protocol and server, and begins with '/api/v1'.
##### Example output:

```
```
