### PR TITLE
Fix __repr__ for meta tasks

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -133,7 +133,7 @@ class Task(Base, Conditional, Taggable, Become):
 
     def __repr__(self):
         ''' returns a human readable representation of the task '''
-        if self.get_name() == 'meta ':
+        if self.get_name() == 'meta':
             return "TASK: meta (%s)" % self.args['_raw_params']
         else:
             return "TASK: %s" % self.get_name()


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
2.1.0
```
##### Summary:

`__repr__` in Task model is not working properly. From the code we can suspect that we should provide a detailed _raw_params for meta tasks in repr, but the space after the 'meta' ruined this.

Steps to reproduce the problem:

```
> from ansible.playbook.task import Task
> noop_task = Task()
> noop_task.action = 'meta'
> noop_task.args['_raw_params'] = 'noop'
> noop_task
TASK: meta
```

Expect behavior:

```
> from ansible.playbook.task import Task
> noop_task = Task()
> noop_task.action = 'meta'
> noop_task.args['_raw_params'] = 'noop'
> noop_task
TASK: meta (noop)
```
