### PR TITLE
Document route53's requirement for boto >=2.28.0

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/aws.py
+++ b/lib/ansible/utils/module_docs_fragments/aws.py
@@ -63,7 +63,7 @@ options:
     version_added: "1.6"
 requirements:
   - "python >= 2.6"
-  - boto
+  - "boto (>= 2.28.0 for Ansible 2's route53 module)"
 notes:
   - If parameters are not set within the module, the following
     environment variables can be used in decreasing order of precedence


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
```
##### Summary:

route53 creates Record objects using `health check` and `failover`
parameters. Those parameters only became available in boto 2.28.0.
As some prominent LTS Linux releases (e.g.: Ubuntu 14.04) only ship
older boto versions (e.g.: 2.20.1 for Ubuntu 14.04), users are getting
unhelpful error messages like

```
TypeError: __init__() got an unexpected keyword argument 'health_check'
```

when running with their LTS install's default boto. To guide LTS
users, we mark the boto 2.28.0 requirement also in the documentation.

See ansible/ansible#13646
