### PR TITLE
ansible-playbook: Add option to exit with an error if no plays were m…

### DIFF
--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -72,6 +72,9 @@ class PlaybookCLI(CLI):
             help="one-step-at-a-time: confirm each task before running")
         parser.add_option('--start-at-task', dest='start_at_task',
             help="start the playbook at the task matching this name")
+        parser.add_option('--error-if-no-plays-matched',
+            dest='error_if_no_plays_matched', action='store_true',
+            help="exit with a non-zero status code if no plays were matched by any host")
 
         self.options, self.args = parser.parse_args(self.args[1:])
 


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Summary:

Fixes: #14693

I have a "deploy" job in Jenkins. When I mistype a hostname in the
_group_ definitions, the call to ansible-playbook will happily print "No
hosts matched" and return with an exit code of zero. The CI system will
then believe everything was deployed successfully.

This seems to violate some kind of UNIX principle to me and now requires
parsing of the Jenkins log file for this particular string, which is
rather ugly.

The current default behaviour is correct - the no hosts matched message
occurs at the _play_ level and not at the playbook level, hence making
this an option that is disabled by default
##### Example output:

```
  $ ansible-playbook [..] --error-if-no-plays-matched
  <snip>

  PLAY [deploy] *************************************************
  skipping: no hosts matched

  PLAY RECAP ****************************************************

  [ERROR]: No plays were matched by any host.

  $ echo $?
  1
```
