### PR TITLE
Fixed docs typo

### DIFF
--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -125,10 +125,6 @@ environment variable.
 
 Use this file to authenticate the connection
 
-*--skip-tages=*'SKIP_TAGS'::
-
-Only run plays and tasks whose tags do not match these values.
-
 *--start-at-task=*'START_AT'::
 
 Start the playbook at the task matching this name.


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Docs Pull Request
##### Ansible Version:

```
ansible 2.0.0.2
```
##### Summary:

incorrect documents.

``` bash
$ man ansible-playbook
       --skip-tages=SKIP_TAGS
           Only run plays and tasks whose tags do not match these values.
```

Of course, `--skip-tages` does not exist.
(correct option is `--skip-tags`.)

``` bash
$ ansible-playbook -i inventory playbook.yml --skip-tages nginx
Usage: ansible-playbook playbook.yml

ansible-playbook: error: no such option: --skip-tages
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/14760)

<!-- Reviewable:end -->
