### PR TITLE
Fix AWS EC2 inventory script instance_filters read

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -389,7 +389,7 @@ class Ec2Inventory(object):
         self.ec2_instance_filters = defaultdict(list)
         if config.has_option('ec2', 'instance_filters'):
 
-            filters = [tag for tag in config.get('ec2', 'instance_filters').split(',') if tag]
+            filters = [f for f in config.get('ec2', 'instance_filters').split(',') if f]
 
             for instance_filter in filters:
                 instance_filter = instance_filter.strip()

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -388,7 +388,10 @@ class Ec2Inventory(object):
         # Instance filters (see boto and EC2 API docs). Ignore invalid filters.
         self.ec2_instance_filters = defaultdict(list)
         if config.has_option('ec2', 'instance_filters'):
-            for instance_filter in config.get('ec2', 'instance_filters', '').split(','):
+
+            filters = [tag for tag in config.get('ec2', 'instance_filters').split(',') if tag]
+
+            for instance_filter in filters:
                 instance_filter = instance_filter.strip()
                 if not instance_filter or '=' not in instance_filter:
                     continue


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0
```
##### Summary:

Ansible supports external AWS EC2 inventory system with the EC2 inventory script. For more details please visit [Ansible docs](http://docs.ansible.com/ansible/intro_dynamic_inventory.html#example-aws-ec2-external-inventory-script). The EC2 inventory scripts reads the configuration from an INI file. The `instance_filters` option controls which EC2 instances are retrieved for inventory. Filling this option and running the inventory script with Python 3 crashes with the following error:

``` python
Traceback (most recent call last):
  File "./contrib/inventory/ec2.py", line 1328, in <module>
    Ec2Inventory()
  File "./contrib/inventory/ec2.py", line 163, in __init__
    self.read_settings()
  File "./contrib/inventory/ec2.py", line 393, in read_settings
    for instance_filter in config.get('ec2', 'instance_filters', '').split(','):
TypeError: get() takes 3 positional arguments but 4 were given
```

The problem is the last parameter of config.get() call, because `fallback` keyword argument is not specified. Please check [Python docs](https://docs.python.org/3.5/library/configparser.html#configparser.ConfigParser.get)

The fix handles `instance_filters` in the right way in case of Python 2&3.
