### PR TITLE
Fixed mysql socket connections

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -31,7 +31,6 @@
 
 def mysql_connect(module, login_user=None, login_password=None, config_file='', ssl_cert=None, ssl_key=None, ssl_ca=None, db=None, cursor_class=None):
     config = {
-        'host': module.params['login_host'],
         'ssl': {
             }
     }
@@ -39,6 +38,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if module.params['login_unix_socket']:
         config['unix_socket'] = module.params['login_unix_socket']
     else:
+        config['host'] = module.params['login_host']
         config['port'] = module.params['login_port']
 
     if os.path.exists(config_file):


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
```
##### Summary:

Prefers mysql socket connection instead of ip. 
If a module uses a host module paramater default of 127.0.0.1 (for instance mysql_variables does that), the user can't make the socket connection work like it is documented.
The previous version was prefering host connection instead of socket connections.
##### Example output:

My particular issue:

Task:
mysql_variables: "variable=read_only value=1 login_unix_socket={{ mysql_mysqld_options_socket }} login_user=root login_password={{ mysql_passwords['root'] }}"

Generated the output:
FAILED! => {"changed": false, "failed": true, "msg": "unable to connect to database, check login_user and login_password are correct or /root/.my.cnf has the credentials. Exception message: (1045, \"Access denied for user 'root'@'localhost' (using password: YES)\")"}
