### PR TITLE
Ensure provided mode is compared on equal grounds with existing mode

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -884,6 +884,7 @@ class AnsibleModule(object):
                                    details=str(e))
 
         prev_mode = stat.S_IMODE(path_stat.st_mode)
+        mode = stat.S_IMODE(mode)
 
         if prev_mode != mode:
 


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Bugfix Pull Request

This fixes #14771 for Ansible 2.x
##### Ansible Version:

```
ansible 2.0.1.0
  config file = /home/dag/home-made/ansible.testing/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

<!--- Please describe the change and the reason for it -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

We noticed that doing template/copy on files with a slightly different octal mode than expected, check-mode would result in a change, while a real run would return ok.

We traced this to the fact that Ansible converts existing permissions using sstat.S_IMODE(), however it doesn't do so with the provided mode. So when we provided '0100755', it compared '0755' with '0100755'. In a real run this would be equal, but in check-mode it would be considered a change.
