### PR TITLE
Improve ambiguous statement regarding handler order

### DIFF
--- a/docsite/rst/playbooks_intro.rst
+++ b/docsite/rst/playbooks_intro.rst
@@ -382,7 +382,7 @@ Handlers are best used to restart services and trigger reboots.  You probably
 won't need them for much else.
 
 .. note::
-   * Notify handlers are always run in the same order they are parsed by Ansible, `not` in the order listed in the notify-statement.
+   * Notify handlers are always run in the same order they are defined, `not` in the order listed in the notify-statement.
    * Handler names live in a global namespace.
    * If two handler tasks have the same name, only one will run.
      `* <https://github.com/ansible/ansible/issues/4943>`_

--- a/docsite/rst/playbooks_intro.rst
+++ b/docsite/rst/playbooks_intro.rst
@@ -382,7 +382,7 @@ Handlers are best used to restart services and trigger reboots.  You probably
 won't need them for much else.
 
 .. note::
-   * Notify handlers are always run in the order written.
+   * Notify handlers are always run in the same order they are parsed by Ansible, `not` in the order listed in the notify-statement.
    * Handler names live in a global namespace.
    * If two handler tasks have the same name, only one will run.
      `* <https://github.com/ansible/ansible/issues/4943>`_


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Docs Pull Request
##### Summary:

<!--- Please describe the change and the reason for it -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

If you are confused by Ansible's behavior related to the execution order of handlers, the ambiguous statement in the documentation seems to re-enforce what you believe is the wrong behaviour. But in fact it is not. This hopefully improves it a bit. Alternative wording welcome.

This fixes #10064
