### PR TITLE
Ignore EPIPE when flushing stdout stderr

### DIFF
--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -129,11 +129,12 @@ class Display:
                 msg2 = to_unicode(msg2, self._output_encoding(stderr=stderr))
 
             if not stderr:
-                sys.stdout.write(msg2)
-                sys.stdout.flush()
+                fileobj = sys.stdout
             else:
-                sys.stderr.write(msg2)
-                sys.stderr.flush()
+                fileobj = sys.stderr
+
+            fileobj.write(msg2)
+            fileobj.flush()
 
         if logger and not screen_only:
             msg2 = nocolor.lstrip(u'\n')

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -28,6 +28,7 @@ import time
 import locale
 import logging
 import getpass
+import errno
 from struct import unpack, pack
 from termios import TIOCGWINSZ
 from multiprocessing import Lock
@@ -134,7 +135,14 @@ class Display:
                 fileobj = sys.stderr
 
             fileobj.write(msg2)
-            fileobj.flush()
+
+            try:
+                fileobj.flush()
+            except IOError as e:
+                # Ignore EPIPE in case fileobj has been prematurely closed, eg.
+                # when piping to "head -n1"
+                if e.errno != errno.EPIPE:
+                    raise
 
         if logger and not screen_only:
             msg2 = nocolor.lstrip(u'\n')


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

2.1.0 (git)
##### Summary:

Ignore EPIPE to avoid tracebacks when piping output to other commands. For example:

```
  $ ansible web --list-hosts | head -n1
```

Such a pipe target will close up shop early when its seen enough input,
causing ansible to print an ugly traceback.
##### Example output:

```
  $ ansible web --list-hosts | head -n1
  hosts (7):
  ERROR! Unexpected Exception: [Errno 32] Broken pipe
  Traceback (most recent call last):
    File "/home/lamby/git/private/lamby-ansible2/.venv/bin/ansible", line 114, in <module>
      display.display("to see the full traceback, use -vvv")
    File "/home/lamby/git/private/lamby-ansible2/.venv/local/lib/python2.7/site-packages/ansible/utils/display.py", line 133, in display
      sys.stdout.flush()
  IOError: [Errno 32] Broken pipe
  $

  $ ansible web --list-hosts | head -n1 # with patch applied
  hosts (7):
  $
```
