### PR TITLE
Use custom download url if supplied by galaxy

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -219,6 +219,10 @@ class GalaxyRole(object):
                     if role_versions and self.version not in [a.get('name', None) for a in role_versions]:
                         raise AnsibleError("- the specified version (%s) of %s was not found in the list of available versions (%s)." % (self.version, self.name, role_versions))
 
+                matched_version = filter( lambda v : v['name'] == self.version , role_versions )
+                if len(matched_version) == 1 :
+                    self.src = matched_version[0].get('url', self.src) or self.src
+
                 tmp_file = self.fetch(role_data)
 
         else:

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -221,7 +221,7 @@ class GalaxyRole(object):
 
                 matched_version = filter( lambda v : v['name'] == self.version , role_versions )
                 if len(matched_version) == 1 :
-                    self.src = matched_version[0].get('url', self.src) or self.src
+                    self.src = matched_version[0].get('download', self.src) or self.src
 
                 tmp_file = self.fetch(role_data)
 


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Summary:

This change enables installing roles which are not github produced tarballs. It searchs the (currently unused) url field returned by galaxy on queries like https://galaxy.ansible.com/api/v1/roles/7595/versions/, and if it is not empty for the selected role, it use that value to download the role.
