### PR TITLE
Fix: #14771

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -891,7 +891,7 @@ class AnsibleModule(object):
                                    details=str(e))
 
         # Fixes bug 14771. Ignore upper bits of mode
-        mode = (mode & 07777)
+        mode = (mode & PERM_BITS)
 
         prev_mode = stat.S_IMODE(path_stat.st_mode)
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -890,6 +890,9 @@ class AnsibleModule(object):
                                    msg="mode must be in octal or symbolic form",
                                    details=str(e))
 
+        # Fixes bug 14771. Ignore upper bits of mode
+        mode = (mode & 07777)
+
         prev_mode = stat.S_IMODE(path_stat.st_mode)
 
         if prev_mode != mode:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
1.9.4 en 2.0.1.0

##### Summary:

See discussion in bugreport #14771

See discussion on Github.

This small patch set mode to ignore all but the lower 4 octal digits.
```
