### PR TITLE
Accept both " import *" and " import AnsibleModule"

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -94,7 +94,7 @@ def _find_snippet_imports(module_data, module_path, strip_comments):
             import_error = False
             if len(tokens) != 3:
                 import_error = True
-            if b" import *" not in line:
+            if (b" import *" not in line) and not (b" import AnsibleModule" in line):
                 import_error = True
             if import_error:
                 raise AnsibleError("error importing module in %s, expecting format like 'from ansible.module_utils.<lib name> import *'" % module_path)


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.0.2
  config file =
  configured module search path = Default w/o overrides
```
##### Summary:

When developing an ansible module ansible forces you to import the AnsibleModule with the line:

`from ansible.module_utils.<lib name> import *`

which breaks PEP8. But there is no real reason to do not this instead:

`from ansible.module_utils.<lib name> import AnsibleModule`

which doesn't break anything.
##### Example output:

N/A
