### PR TITLE
Add tests for connection plugins.

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -73,18 +73,17 @@ environment: setup
 non_destructive: setup
 	ansible-playbook non_destructive.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
-test_connection: setup
-ifeq ($(EUID),0)
-	# Test connection plugins when running as root (lang unspecified).
-	                ansible-playbook test_connection.yml -i test_connection.inventory -l '!skip-during-build' $(TEST_FLAGS)
-	# Test connection plugins when running as root (lang=C).
-	LC_ALL=C LANG=C ansible-playbook test_connection.yml -i test_connection.inventory -l '!skip-during-build' $(TEST_FLAGS)
-else
-	# Test connection plugins when not running as root (lang unspecified).
-	                ansible-playbook test_connection.yml -i test_connection.inventory -l '!skip-during-build !chroot' $(TEST_FLAGS)
-	# Test connection plugins when not running as root (lang=C).
-	LC_ALL=C LANG=C ansible-playbook test_connection.yml -i test_connection.inventory -l '!skip-during-build !chroot' $(TEST_FLAGS)
+# Skip connection plugins which require root when not running as root.
+ifneq ($(EUID),0)
+TEST_CONNECTION_FILTER := !chroot
 endif
+
+# Connection plugin test command to repeat with each locale setting.
+TEST_CONNECTION_CMD = $(1) ansible-playbook test_connection.yml -i test_connection.inventory -l '!skip-during-build $(TEST_CONNECTION_FILTER)' $(TEST_FLAGS)
+
+test_connection: setup
+	$(call TEST_CONNECTION_CMD)
+	$(call TEST_CONNECTION_CMD, LC_ALL=C LANG=C)
 
 destructive: setup
 	ansible-playbook destructive.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -21,8 +21,9 @@ MYTMPDIR = $(shell mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 VAULT_PASSWORD_FILE = vault-password
 
 CONSUL_RUNNING := $(shell python consul_running.py)
+EUID := $(shell id -u -r)
 
-all: setup parsing test_var_precedence unicode test_templating_settings environment non_destructive destructive includes blocks pull check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log
+all: setup parsing test_var_precedence unicode test_templating_settings environment non_destructive destructive includes blocks pull check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_connection
 
 setup:
 	rm -rf $(TEST_DIR)
@@ -71,6 +72,19 @@ environment: setup
 
 non_destructive: setup
 	ansible-playbook non_destructive.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+
+test_connection: setup
+ifeq ($(EUID),0)
+	# Test connection plugins when running as root (lang unspecified).
+	                ansible-playbook test_connection.yml -i test_connection.inventory -l '!skip-during-build' $(TEST_FLAGS)
+	# Test connection plugins when running as root (lang=C).
+	LC_ALL=C LANG=C ansible-playbook test_connection.yml -i test_connection.inventory -l '!skip-during-build' $(TEST_FLAGS)
+else
+	# Test connection plugins when not running as root (lang unspecified).
+	                ansible-playbook test_connection.yml -i test_connection.inventory -l '!skip-during-build !chroot' $(TEST_FLAGS)
+	# Test connection plugins when not running as root (lang=C).
+	LC_ALL=C LANG=C ansible-playbook test_connection.yml -i test_connection.inventory -l '!skip-during-build !chroot' $(TEST_FLAGS)
+endif
 
 destructive: setup
 	ansible-playbook destructive.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)

--- a/test/integration/test_connection.inventory
+++ b/test/integration/test_connection.inventory
@@ -1,0 +1,31 @@
+[local]
+local-pipelining    ansible_ssh_pipelining=true
+local-no-pipelining ansible_ssh_pipelining=false
+[local:vars]
+ansible_host=localhost
+ansible_connection=local
+
+[chroot]
+chroot-pipelining    ansible_ssh_pipelining=true
+chroot-no-pipelining ansible_ssh_pipelining=false
+[chroot:vars]
+ansible_host=/
+ansible_connection=chroot
+
+[ssh]
+ssh-pipelining    ansible_ssh_pipelining=true
+ssh-no-pipelining ansible_ssh_pipelining=false
+[ssh:vars]
+ansible_host=localhost
+ansible_connection=ssh
+
+[paramiko_ssh]
+paramiko_ssh-pipelining    ansible_ssh_pipelining=true
+paramiko_ssh-no-pipelining ansible_ssh_pipelining=false
+[paramiko_ssh:vars]
+ansible_host=localhost
+ansible_connection=paramiko_ssh
+
+[skip-during-build:children]
+ssh
+paramiko_ssh

--- a/test/integration/test_connection.yml
+++ b/test/integration/test_connection.yml
@@ -1,0 +1,35 @@
+- hosts: all
+  gather_facts: no
+  serial: 1
+  tasks:
+
+  ### raw with unicode arg and output
+
+  - name: raw with unicode arg and output
+    raw: echo 汉语
+    register: command
+  - name: check output of raw with unicode arg and output
+    assert: { that: "'汉语' in command.stdout" }
+
+  ### copy local file with unicode filename and content
+
+  - name: create local file with unicode filename and content
+    local_action: lineinfile dest=/tmp/ansible-local-汉语 create=true line=汉语
+  - name: remove remote file with unicode filename and content
+    file: path=/tmp/ansible-remote-汉语 state=absent
+  - name: copy local file with unicode filename and content
+    copy: src=/tmp/ansible-local-汉语 dest=/tmp/ansible-remote-汉语
+
+  ### fetch remote file with unicode filename and content
+
+  - name: remove local file with unicode filename and content
+    local_action: file path=/tmp/ansible-local-汉语 state=absent
+  - name: fetch remote file with unicode filename and content
+    fetch: src=/tmp/ansible-remote-汉语 dest=/tmp/ansible-local-汉语 fail_on_missing=true validate_checksum=true flat=true
+
+  ### remove local and remote temp files
+
+  - name: remove local temp file
+    local_action: file path=/tmp/ansible-local-汉语 state=absent
+  - name: remove remote temp file
+    file: path=/tmp/ansible-remote-汉语 state=absent


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (test-connection ca62bc5db3) last updated 2016/03/04 13:16:31 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 0bbb7ba38d) last updated 2016/03/03 15:34:52 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 39e4040685) last updated 2016/03/03 15:34:52 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Add connection plugin integration tests for:
- local
- chroot
- ssh
- paramiko_ssh

The same tests run for each connection plugin, with both the default locale and the C locale, with and without pipelining enabled.

These tests were used to find the bugs fixed by ansible/ansible#14797 and then test those fixes.

The local and chroot plugin tests will run as part of the build. If these tests are merged I can work on adding support for testing ssh and paramiko_ssh in docker containers with a local SSH server.
##### Example output:

Assuming root and a local SSH server, full tests can be run manually with:

```
TEST_FLAGS='-l "" -e ansible_user=some-local-user' make test_connection
```

Resulting in a play recap like this (twice, once for the default locale and once for LANG=C):

```
PLAY RECAP *********************************************************************
chroot-no-pipelining       : ok=9    changed=6    unreachable=0    failed=0   
chroot-pipelining          : ok=9    changed=6    unreachable=0    failed=0   
local-no-pipelining        : ok=9    changed=6    unreachable=0    failed=0   
local-pipelining           : ok=9    changed=6    unreachable=0    failed=0   
paramiko_ssh-no-pipelining : ok=9    changed=6    unreachable=0    failed=0   
paramiko_ssh-pipelining    : ok=9    changed=6    unreachable=0    failed=0   
ssh-no-pipelining          : ok=9    changed=6    unreachable=0    failed=0   
ssh-pipelining             : ok=9    changed=6    unreachable=0    failed=0   
```
