### PR TITLE
Support strategy_plugins setting in a configuration file

### DIFF
--- a/docsite/rst/developing_plugins.rst
+++ b/docsite/rst/developing_plugins.rst
@@ -112,6 +112,7 @@ to /usr/share/ansible/plugins, in a subfolder for each plugin type::
     * connection_plugins
     * filter_plugins
     * vars_plugins
+    * strategy_plugins
 
 To change this path, edit the ansible configuration file.
 

--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -600,6 +600,20 @@ Additional paths can be provided separated by colon characters, in the same way 
 Roles will be first searched for in the playbook directory.  Should a role not be found, it will indicate all the possible paths
 that were searched.
 
+.. _strategy_plugins:
+
+strategy_plugins
+==================
+
+Strategy plugin allow users to change the way in which Ansible runs tasks on targeted hosts.
+
+This is a developer-centric feature that allows low-level extensions around Ansible to be loaded from
+different locations::
+
+    strategy_plugins = ~/.ansible/plugins/strategy_plugins/:/usr/share/ansible_plugins/strategy_plugins
+
+Most users will not need to use this feature.  See :doc:`developing_plugins` for more details
+
 .. _sudo_exe:
 
 sudo_exe

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -141,6 +141,7 @@
 #vars_plugins       = /usr/share/ansible/plugins/vars
 #filter_plugins     = /usr/share/ansible/plugins/filter
 #test_plugins       = /usr/share/ansible/plugins/test
+#strategy_plugins   = /usr/share/ansible/plugins/strategy
 
 # by default callbacks are not loaded for /bin/ansible, enable this if you
 # want, for example, a notification or logging callback to also apply to

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -212,6 +212,7 @@ DEFAULT_INVENTORY_PLUGIN_PATH  = get_config(p, DEFAULTS, 'inventory_plugins',  '
 DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       'ANSIBLE_VARS_PLUGINS', '~/.ansible/plugins/vars:/usr/share/ansible/plugins/vars', ispath=True)
 DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '~/.ansible/plugins/filter:/usr/share/ansible/plugins/filter', ispath=True)
 DEFAULT_TEST_PLUGIN_PATH       = get_config(p, DEFAULTS, 'test_plugins',       'ANSIBLE_TEST_PLUGINS', '~/.ansible/plugins/test:/usr/share/ansible/plugins/test', ispath=True)
+DEFAULT_STRATEGY_PLUGIN_PATH   = get_config(p, DEFAULTS, 'strategy_plugins',   'ANSIBLE_STRATEGY_PLUGINS', '~/.ansible/plugins/strategy:/usr/share/ansible/plugins/strategy', ispath=True)
 DEFAULT_STDOUT_CALLBACK        = get_config(p, DEFAULTS, 'stdout_callback',    'ANSIBLE_STDOUT_CALLBACK', 'default')
 # cache
 CACHE_PLUGIN                   = get_config(p, DEFAULTS, 'fact_caching', 'ANSIBLE_CACHE_PLUGIN', 'memory')

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -444,7 +444,7 @@ fragment_loader = PluginLoader(
 strategy_loader = PluginLoader(
     'StrategyModule',
     'ansible.plugins.strategy',
-    None,
+    C.DEFAULT_STRATEGY_PLUGIN_PATH,
     'strategy_plugins',
     required_base_class='StrategyBase',
 )


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (support-strategy_plugins-setting-in-config-file 299c18d700) last updated 2016/03/05 20:15:04 (GMT +900)
  lib/ansible/modules/core: (detached HEAD 0bbb7ba38d) last updated 2016/03/05 20:21:36 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD 39e4040685) last updated 2016/03/05 20:21:59 (GMT +900)
  config file =
  configured module search path = Default w/o overrides
```
##### Summary:

Support 'strategy_plugins' setting in a configuration file.

I've asked about this in ansible-devel group. Here is the link.
https://groups.google.com/forum/#!topic/ansible-devel/0BfaxfNB_-0
##### Example output:

Move linear strategy plugin to /tmp/strategy_plugins directory (just for this test!)
Then, specify the directory using 'strategy_plugins' setting in ansible.cfg.
Even in this case, ansible-playbook successfully runs.

```
$ mv lib/ansible/plugins/strategy/linear.py* /tmp/strategy_plugins
$ cat ansible.cfg
[defaults]
strategy_plugins=/tmp/strategy_plugins
$ cat example.yml
- hosts: all
  strategy: linear
  tasks:
    - ping:
$ ansible-playbook -i inventory example.yml

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
ok: [54.238.185.1]

TASK [ping] ********************************************************************
ok: [54.238.185.1]

PLAY RECAP *********************************************************************
54.238.185.1             : ok=2    changed=0    unreachable=0    failed=0
```
