### PR TITLE
add find_vm_by_name function to vmware utils

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -99,6 +99,15 @@ def find_hostsystem_by_name(content, hostname):
     return None
 
 
+def find_vm_by_name(content, vm_name):
+
+    vms = get_all_objs(content, [vim.VirtualMachine])
+    for vm in vms:
+        if vm.name == vm_name:
+            return vm
+    return None
+
+
 def vmware_argument_spec():
 
     return dict(


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

This is an addition to the vmware module utilities.  It is a simple function that can do a search for a virtual machine, similar to how the other functions are defined.

In many cases, such as when utilizing automation to deploy virtual machines, this is a useful function because it aids in making automation related to virtual machines idempotent.
##### Example output:

```

```
