### PR TITLE
Fix #14702, restore previous documented behavior for precedence

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -311,9 +311,6 @@ class VariableManager:
                     all_vars = combine_vars(all_vars, role.get_vars(include_params=False))
 
         if task:
-            if task._role:
-                all_vars = combine_vars(all_vars, task._role.get_vars())
-                all_vars = combine_vars(all_vars, task._role.get_role_params(task._block._dep_chain))
             all_vars = combine_vars(all_vars, task.get_vars())
 
         if host:
@@ -325,6 +322,9 @@ class VariableManager:
         # have higher precedence than the vars/np facts above
         if task:
             all_vars = combine_vars(all_vars, task.get_include_params())
+            if task._role:
+                all_vars = combine_vars(all_vars, task._role.get_vars())
+                all_vars = combine_vars(all_vars, task._role.get_role_params(task._block._dep_chain))
 
         all_vars = combine_vars(all_vars, self._extra_vars)
         all_vars = combine_vars(all_vars, magic_variables)


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
$ ansible --version
ansible 2.0.0.2
  config file = /home/misc/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

In v2.0, the precedence of variable set when declaring a role seems to have been changed in a non documented nor backward compatible way.

So with this trivial playbook:

```
$ cat mail.yml

---
- hosts: all
  connection: local
  roles:
  - role: test
    var: foo
  - role: test
    var: bar
```

and this role:

```
$ cat roles/test/tasks/main.yml 

---
- debug: var=var
- set_fact: var=plop
```

I have a different output in v1.9 than in v2.0

Ansible 1.9.4:

```
$ ansible-playbook   -i '127.0.0.1,' main.yml

PLAY [all] ******************************************************************** 

GATHERING FACTS *************************************************************** 
ok: [127.0.0.1]

TASK: [test | debug var=var] ************************************************** 
ok: [127.0.0.1] => {
    "var": {
        "var": "foo"
    }
}

TASK: [test | set_fact var=plop] ********************************************** 
ok: [127.0.0.1]

TASK: [test | debug var=var] ************************************************** 
ok: [127.0.0.1] => {
    "var": {
        "var": "bar"
    }
}

TASK: [test | set_fact var=plop] ********************************************** 
ok: [127.0.0.1]

PLAY RECAP ******************************************************************** 
127.0.0.1                  : ok=5    changed=0    unreachable=0    failed=0   

```

Ansible devel 

```
$ ansible-playbook   -i '127.0.0.1,' main.yml

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
ok: [127.0.0.1]

TASK [test : debug] ************************************************************
ok: [127.0.0.1] => {
    "var": "foo"
}

TASK [test : set_fact] *********************************************************
ok: [127.0.0.1]

TASK [test : debug] ************************************************************
ok: [127.0.0.1] => {
    "var": "plop"
}

TASK [test : set_fact] *********************************************************
ok: [127.0.0.1]

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=5    changed=0    unreachable=0    failed=0   

```

According to the doc, there is protection to avoid
the need to namespace variable in roles. That's documented in the variable precedence list ( since role and include vars is below set_facts ), and there is a explicit part of the doc dedicated to that specific example ( see the last part of the "Variable example" paragraph ).

So this PR revert back to the bahavior of the previous version ( as it broke a few of my playbooks/role, who depended on that behavior ), and since the change was not documented on https://github.com/ansible/ansible/blob/devel/docsite/rst/porting_guide_2.0.rst, I assume that this was not on purpose. 

I have also been looking at adding a test for that, but for now, i am trying to understand the Play object to write a test.
