### PR TITLE
adds multiline flag to regex test for search and match

### DIFF
--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -62,26 +62,27 @@ def skipped(*a, **kw):
     skipped = item.get('skipped', False)
     return skipped
 
-def regex(value='', pattern='', ignorecase=False, match_type='search'):
+def regex(value='', pattern='', ignorecase=False, multiline=False, match_type='search'):
     ''' Expose `re` as a boolean filter using the `search` method by default.
         This is likely only useful for `search` and `match` which already
         have their own filters.
     '''
+    flags = 0
     if ignorecase:
-        flags = re.I
-    else:
-        flags = 0
+        flags |= re.I
+    if multiline:
+        flags |= re.M
     _re = re.compile(pattern, flags=flags)
     _bool = __builtins__.get('bool')
     return _bool(getattr(_re, match_type, 'search')(value))
 
-def match(value, pattern='', ignorecase=False):
+def match(value, pattern='', ignorecase=False, multiline=False):
     ''' Perform a `re.match` returning a boolean '''
-    return regex(value, pattern, ignorecase, 'match')
+    return regex(value, pattern, ignorecase, multiline, 'match')
 
-def search(value, pattern='', ignorecase=False):
+def search(value, pattern='', ignorecase=False, multiline=False):
     ''' Perform a `re.search` returning a boolean '''
-    return regex(value, pattern, ignorecase, 'search')
+    return regex(value, pattern, ignorecase, multiline, 'search')
 
 class TestModule(object):
     ''' Ansible core jinja2 tests '''


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

ansible 2.1.0 (plugin_test_regex c0f1e1801b) last updated 2016/03/06 08:11:46 (GMT -400)
  lib/ansible/modules/core: (working 45bcc77c23) last updated 2016/03/01 20:13:10 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f6a7b6dd1f) last updated 2016/01/04 21:53:44 (GMT -400)
  config file = /Users/sprygada/Workspaces/playbooks/network/ansible.cfg
  configured module search path = Default w/o overrides
##### Summary:

This commit adds the multiline flag to the regexp search and match test
plugin.  It defaults to re.M = False for backwards compatibility.  To use
the multiline feature add multiline=True to the test filter
##### Example output:

`{{ config | search('^hostname', multiline=True) }}`
