### PR TITLE
Vault: Remove tmp decrypted file when experiencing error while writing

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -387,11 +387,11 @@ class VaultEditor:
         # Create a tempfile
         _, tmp_path = tempfile.mkstemp()
 
-        if existing_data:
-            self.write_data(existing_data, tmp_path, shred=False)
-
-        # drop the user into an editor on the tmp file
         try:
+            if existing_data:
+                self.write_data(existing_data, tmp_path, shred=False)
+
+            # drop the user into an editor on the tmp file
             call(self._editor_shell_command(tmp_path))
         except:
             # whatever happens, destroy the decrypted file

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -385,7 +385,8 @@ class VaultEditor:
     def _edit_file_helper(self, filename, existing_data=None, force_save=False):
 
         # Create a tempfile
-        _, tmp_path = tempfile.mkstemp()
+        fd, tmp_path = tempfile.mkstemp()
+        os.close(fd)
 
         try:
             if existing_data:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
$ ansible --version
ansible 2.1.0 (devel 4e6158d06c) last updated 2016/03/06 20:58:29 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 0bbb7ba38d) last updated 2016/03/06 20:46:40 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 39e4040685) last updated 2016/03/06 20:47:12 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

The `ansible-vault edit` command may exit with an error and leave (some or all of the) sensitive, decrypted data in the undeleted temporary file.

This happens when an exception is raised when writing the data to the temporary file. This may happen for many reasons, such as the tmp filesystem running out of space.

Demonstration with a tiny tmpfs:

```
$ mkdir tmpdir
$ sudo mount -t tmpfs -o size=1 tmpfs tmpdir/ # size=1 means 1 page, that is 4kB
$ python -c "print('A'*5000)" > test.yml 
$ ansible-vault encrypt test.yml 
New Vault password: 
Confirm New Vault password: 
Encryption successful
$ TMPDIR=tmpdir ansible-vault edit test.yml 
Vault password: 
ERROR! Unexpected Exception: [Errno 28] No space left on device
to see the full traceback, use -vvv
$ ls tmpdir/
tmp7LwPMH
$ cat tmpdir/tmp7LwPMH
AAAAAAA[...]
```

The fix is easy, simply move the write into the try/except that follows.

Also, I'm closing the unused file descriptors returned by mkstemp(), just for good measure, because it's not good practice to have file descriptors pointing to sensitive data just lying around for no reason.
