### PR TITLE
Add support for cmd list to connection plugins.

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -611,10 +611,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             display.debug("_low_level_execute_command(): using become for this command")
             cmd = self._play_context.make_become_cmd(cmd, executable=executable)
 
-        if self._connection.allow_executable:
-            if executable is None:
-                executable = self._play_context.executable
-            cmd = executable + ' -c ' + pipes.quote(cmd)
+        if executable is None:
+            executable = self._play_context.executable
+
+        cmd = self._connection._shell.create_cmd_list(executable, cmd)
 
         display.debug("_low_level_execute_command(): executing: %s" % (cmd,))
         rc, stdout, stderr = self._connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -64,7 +64,6 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
     # as discovered by the specified file extension.  An empty string as the
     # language means any language.
     module_implementation_preferences = ('',)
-    allow_executable = True
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         # All these hasattrs allow subclasses to override these parameters
@@ -159,7 +158,7 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
     def exec_command(self, cmd, in_data=None, sudoable=True):
         """Run a command on the remote host.
 
-        :arg cmd: byte string containing the command
+        :arg cmd: list of byte strings containing the command
         :kwarg in_data: If set, this data is passed to the command's stdin.
             This is used to implement pipelining.  Currently not all
             connection plugins implement pipelining.

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -27,7 +27,6 @@ __metaclass__ = type
 import distutils.spawn
 import os
 import os.path
-import pipes
 import subprocess
 import re
 
@@ -167,7 +166,7 @@ class Connection(ConnectionBase):
         """ Run a command on the docker host """
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        local_cmd = self._build_exec_cmd([self._play_context.executable, '-c', cmd])
+        local_cmd = self._build_exec_cmd(cmd)
 
         display.vvv("EXEC %s" % (local_cmd,), host=self._play_context.remote_addr)
         local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
@@ -201,12 +200,11 @@ class Connection(ConnectionBase):
             raise AnsibleFileNotFound(
                 "file or module does not exist: %s" % in_path)
 
-        out_path = pipes.quote(out_path)
         # Older docker doesn't have native support for copying files into
         # running containers, so we use docker exec to implement this
         # Although docker version 1.8 and later provide support, the
         # owner and group of the files are always set to root
-        args = self._build_exec_cmd([self._play_context.executable, "-c", "dd of=%s bs=%s" % (out_path, BUFSIZE)])
+        args = self._build_exec_cmd(['dd', 'of=%s' % out_path, 'bs=%s' % BUFSIZE])
         args = [to_bytes(i, errors='strict') for i in args]
         with open(to_bytes(in_path, errors='strict'), 'rb') as in_file:
             try:

--- a/lib/ansible/plugins/connection/funcd.py
+++ b/lib/ansible/plugins/connection/funcd.py
@@ -64,6 +64,7 @@ class Connection(object):
 
         # totally ignores privlege escalation
         vvv("EXEC %s" % (cmd), host=self.host)
+        cmd = self._shell.join_cmd_list(cmd)
         p = self.client.command.run(cmd)[self.host]
         return (p[0], p[1], p[2])
 

--- a/lib/ansible/plugins/connection/jail.py
+++ b/lib/ansible/plugins/connection/jail.py
@@ -23,11 +23,9 @@ __metaclass__ = type
 import distutils.spawn
 import os
 import os.path
-import pipes
 import subprocess
 import traceback
 
-from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.unicode import to_bytes
@@ -105,8 +103,7 @@ class Connection(ConnectionBase):
         compared to exec_command() it looses some niceties like being able to
         return the process's exit code immediately.
         '''
-        executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else '/bin/sh'
-        local_cmd = [self.jexec_cmd, self.jail, executable, '-c', cmd]
+        local_cmd = [self.jexec_cmd, self.jail] + cmd
 
         display.vvv("EXEC %s" % (local_cmd,), host=self.jail)
         local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
@@ -143,11 +140,11 @@ class Connection(ConnectionBase):
         super(Connection, self).put_file(in_path, out_path)
         display.vvv("PUT %s TO %s" % (in_path, out_path), host=self.jail)
 
-        out_path = pipes.quote(self._prefix_login_path(out_path))
+        out_path = self._prefix_login_path(out_path)
         try:
             with open(to_bytes(in_path, errors='strict'), 'rb') as in_file:
                 try:
-                    p = self._buffered_exec_command('dd of=%s bs=%s' % (out_path, BUFSIZE), stdin=in_file)
+                    p = self._buffered_exec_command(['dd', 'of=%s' % out_path, 'bs=%s' % BUFSIZE], stdin=in_file)
                 except OSError:
                     raise AnsibleError("jail connection requires dd command in the jail")
                 try:
@@ -165,9 +162,9 @@ class Connection(ConnectionBase):
         super(Connection, self).fetch_file(in_path, out_path)
         display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self.jail)
 
-        in_path = pipes.quote(self._prefix_login_path(in_path))
+        in_path = self._prefix_login_path(in_path)
         try:
-            p = self._buffered_exec_command('dd if=%s bs=%s' % (in_path, BUFSIZE))
+            p = self._buffered_exec_command(['dd', 'if=%s' % in_path, 'bs=%s' % BUFSIZE])
         except OSError:
             raise AnsibleError("jail connection requires dd command in the jail")
 

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -25,10 +25,6 @@ import subprocess
 import fcntl
 import getpass
 
-from ansible.compat.six import text_type, binary_type
-
-import ansible.constants as C
-
 from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.unicode import to_bytes, to_str
@@ -66,21 +62,14 @@ class Connection(ConnectionBase):
 
         display.debug("in local.exec_command()")
 
-        executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else None
-
         display.vvv(u"{0} EXEC {1}".format(self._play_context.remote_addr, cmd))
         # FIXME: cwd= needs to be set to the basedir of the playbook
         display.debug("opening command with Popen()")
 
-        if isinstance(cmd, (text_type, binary_type)):
-            cmd = to_bytes(cmd)
-        else:
-            cmd = map(to_bytes, cmd)
+        cmd = [to_bytes(i, errors='strict') for i in cmd]
 
         p = subprocess.Popen(
             cmd,
-            shell=isinstance(cmd, (text_type, binary_type)),
-            executable=executable, #cwd=...
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -272,6 +272,7 @@ class Connection(ConnectionBase):
 
         display.vvv("EXEC %s" % cmd, host=self._play_context.remote_addr)
 
+        cmd = self._shell.join_cmd_list(cmd)
         cmd = to_bytes(cmd, errors='strict')
 
         no_prompt_out = ''

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -559,6 +559,8 @@ class Connection(ConnectionBase):
         # python interactive-mode but the modules are not compatible with the
         # interactive-mode ("unexpected indent" mainly because of empty lines)
 
+        cmd = self._shell.join_cmd_list(cmd)
+
         if in_data:
             cmd = self._build_command('ssh', self.host, cmd)
         else:

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -64,7 +64,6 @@ class Connection(ConnectionBase):
     transport = 'winrm'
     module_implementation_preferences = ('.ps1', '')
     become_methods = []
-    allow_executable = False
 
     def __init__(self,  *args, **kwargs):
 
@@ -215,6 +214,7 @@ class Connection(ConnectionBase):
 
     def exec_command(self, cmd, in_data=None, sudoable=True):
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        cmd = self._shell.join_cmd_list(cmd)
         cmd_parts = shlex.split(to_bytes(cmd), posix=False)
         cmd_parts = map(to_unicode, cmd_parts)
         script = None

--- a/lib/ansible/plugins/connection/zone.py
+++ b/lib/ansible/plugins/connection/zone.py
@@ -124,6 +124,8 @@ class Connection(ConnectionBase):
         ''' run a command on the zone '''
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
+        cmd = self._shell.join_cmd_list(cmd)
+
         p = self._buffered_exec_command(cmd)
 
         stdout, stderr = p.communicate(in_data)

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -45,6 +45,12 @@ class ShellBase(object):
     def join_path(self, *args):
         return os.path.join(*args)
 
+    def create_cmd_list(self, executable, cmd):
+        return [executable, '-c', cmd]
+
+    def join_cmd_list(self, cmd):
+        return ' '.join([pipes.quote(i) for i in cmd])
+
     # some shells (eg, powershell) are snooty about filenames/extensions, this lets the shell plugin have a say
     def get_remote_filename(self, base_name):
         return base_name.strip()

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -23,6 +23,7 @@ import re
 import shlex
 
 from ansible.utils.unicode import to_bytes, to_unicode
+from ansible.errors import AnsibleError
 
 _common_args = ['PowerShell', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Unrestricted']
 
@@ -53,6 +54,14 @@ class ShellModule(object):
         if path.startswith('~'):
             return path
         return '"%s"' % path
+
+    def create_cmd_list(self, executable, cmd):
+        return cmd
+
+    def join_cmd_list(self, cmd):
+        if len(cmd) != 1:
+            raise AnsibleError('powershell requires len(cmd) = 1, cmd = %s' % cmd)
+        return cmd
 
     # powershell requires that script files end with .ps1
     def get_remote_filename(self, base_name):

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -56,12 +56,12 @@ class ShellModule(object):
         return '"%s"' % path
 
     def create_cmd_list(self, executable, cmd):
-        return cmd
+        return [cmd]
 
     def join_cmd_list(self, cmd):
         if len(cmd) != 1:
             raise AnsibleError('powershell requires len(cmd) = 1, cmd = %s' % cmd)
-        return cmd
+        return cmd[0]
 
     # powershell requires that script files end with .ps1
     def get_remote_filename(self, base_name):


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (cmd-list 6c2e32b046) last updated 2016/03/10 16:27:09 (GMT -700)
  lib/ansible/modules/core: (detached HEAD c86a0ef84a) last updated 2016/03/10 14:54:36 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 33a557cc59) last updated 2016/03/10 14:54:36 (GMT -700)
  config file = /root/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

Some connection plugins require cmd as a list instead of a string.

Previously these plugins converted the cmd string provided to exec_command
to a list by wrapping cmd in another shell. Now they receive cmd as a list
and no longer specify their own shell.

Connection plugins which were changed:
- chroot
- docker
- jail
- libvirt_lxc
- local

These changes were made after discussions with @bcoca over PR #14813 which resulted in the decision to allow passing cmd as a list to plugins which require it.
##### Example output:

Tested as root on Ubuntu 15.10 with:

```
LIBVIRT_LXC_NOSECLABEL=true TEST_FLAGS='-l "!jail" -e ansible_user=local-test-user' make test_connection
```

Resulting a play recap of:

```
PLAY RECAP *********************************************************************
chroot-no-pipelining       : ok=9    changed=6    unreachable=0    failed=0   
chroot-pipelining          : ok=9    changed=6    unreachable=0    failed=0   
docker-no-pipelining       : ok=9    changed=6    unreachable=0    failed=0   
docker-pipelining          : ok=9    changed=6    unreachable=0    failed=0   
libvirt_lxc-no-pipelining  : ok=9    changed=6    unreachable=0    failed=0   
libvirt_lxc-pipelining     : ok=9    changed=6    unreachable=0    failed=0   
local-no-pipelining        : ok=9    changed=6    unreachable=0    failed=0   
local-pipelining           : ok=9    changed=6    unreachable=0    failed=0   
paramiko_ssh-no-pipelining : ok=9    changed=6    unreachable=0    failed=0   
paramiko_ssh-pipelining    : ok=9    changed=6    unreachable=0    failed=0   
ssh-no-pipelining          : ok=9    changed=6    unreachable=0    failed=0   
ssh-pipelining             : ok=9    changed=6    unreachable=0    failed=0 
```

Tested as root on FreeBSD 10.2 with:

```
TEST_FLAGS='-l jail' gmake test_connection
```

Resulting a play recap of:

```
PLAY RECAP *********************************************************************
jail-no-pipelining         : ok=9    changed=6    unreachable=0    failed=0   
jail-pipelining            : ok=9    changed=6    unreachable=0    failed=0   
```
