### PR TITLE
Make it easier to read error message

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -414,7 +414,7 @@ class Base:
         def _validate_variable_keys(ds):
             for key in ds:
                 if not isidentifier(key):
-                    raise TypeError("%s is not a valid variable name" % key)
+                    raise TypeError("'%s' is not a valid variable name" % key)
 
         try:
             if isinstance(ds, dict):


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible-playbook --version
ansible-playbook 2.0.0.2
  config file = /home/johnb/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

Quoting the bad variable name makes it a lot easier to read
##### Example output:

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/14847)

<!-- Reviewable:end -->
