### PR TITLE
Trigger v2_on_file_diff callback if 'diff' in results

### DIFF
--- a/lib/ansible/executor/process/result.py
+++ b/lib/ansible/executor/process/result.py
@@ -115,6 +115,10 @@ class ResultProcess(multiprocessing.Process):
                         self._send_result(('v2_playbook_item_on_skipped', result))
                     else:
                         self._send_result(('v2_playbook_item_on_ok', result))
+
+                    if 'diff' in result._result:
+                        self._send_result(('emit_diff', result))
+
                     continue
 
                 clean_copy = strip_internal_keys(result._result)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -251,6 +251,9 @@ class StrategyBase:
 
                     ret_results.append(task_result)
 
+                elif result[0] == 'emit_diff':
+                    self._tqm.send_callback('v2_on_file_diff', result[1])
+
                 elif result[0] == 'add_host':
                     result_item = result[1]
                     new_host_info = result_item.get('add_host', dict())


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (fix-diff-for-task-items c85c3c2673) last updated 2016/03/07 15:07:05 (GMT +200)
  lib/ansible/modules/core: (devel c998730152) last updated 2016/03/07 09:10:44 (GMT +200)
  lib/ansible/modules/extras: (devel c439cc9ca6) last updated 2016/03/01 09:59:08 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

Attempt at fixing Issue #14843 

Diff mode for itemized tasks broke in the reworking of the result handling for itemized tasks.
##### Example output:

```
TASK [copy file itemized] ******************************************************
changed: [localhost] => (item=foo)
--- before
+++ after: /tmp/foo
@@ -0,0 +1,1 @@
+foo bar

changed: [localhost] => (item=bar)
@@ -0,0 +1,1 @@
+foo bar
```
