### PR TITLE
Strip proc_1 before testing it. Fixes #14858

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -581,13 +581,16 @@ class Facts(object):
         else:
             proc_1 = os.path.basename(proc_1)
 
+        if proc_1 is not None:
+            proc_1 = proc_1.strip()
+
         if proc_1 == 'init' or proc_1.endswith('sh'):
             # many systems return init, so this cannot be trusted, if it ends in 'sh' it probalby is a shell in a container
             proc_1 = None
 
         # if not init/None it should be an identifiable or custom init, so we are done!
         if proc_1 is not None:
-            self.facts['service_mgr'] = proc_1.strip()
+            self.facts['service_mgr'] = proc_1
 
         # start with the easy ones
         elif  self.facts['distribution'] == 'MacOSX':


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0
```
##### Summary:

It looks like we should be stripping the result for `proc_1` before testing it's value.  This should fix #14858.

In my tests this does change the outcome on a rhel5 system
##### Example output:
###### Old

```
rhel5.sivel.net | SUCCESS => {
    "ansible_facts": {
        "ansible_service_mgr": "init"
    },
    "changed": false
}
```
###### New

```
rhel5.sivel.net | SUCCESS => {
    "ansible_facts": {
        "ansible_service_mgr": "sysvinit"
    },
    "changed": false
}
```

This should also be cherry picked into stable-2.0.
