### PR TITLE
Only show diff when the task actually induced a change

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -150,11 +150,11 @@ class CallbackModule(CallbackBase):
     def v2_on_file_diff(self, result):
         if result._task.loop and 'results' in result._result:
             for res in result._result['results']:
-                if 'diff' in res and res['diff']:
+                if 'diff' in res and res['diff'] and res.get('changed', False):
                     diff = self._get_diff(res['diff'])
                     if diff:
                         self._display.display(diff)
-        elif 'diff' in result._result and result._result['diff']:
+        elif 'diff' in result._result and result._result['diff'] and result._result.get('changed', False):
             diff = self._get_diff(result._result['diff'])
             if diff:
                 self._display.display(diff)


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Feature Pull Request 
##### Summary:

<!--- Please describe the change and the reason for it -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This implements solution 1 in the proposal #14860.

It only shows the diff if the task induced a change, which means that if the changed_when control overrides the task, no diff will be displayed.

See #14860 for a rationale and the use-case.
