### PR TITLE
Fix filtering by project in Cloudstask inventory

### DIFF
--- a/contrib/inventory/cloudstack.py
+++ b/contrib/inventory/cloudstack.py
@@ -109,11 +109,11 @@ class CloudStackInventory(object):
             project_id = self.get_project_id(options.project)
 
         if options.host:
-            data = self.get_host(options.host)
+            data = self.get_host(options.host, project_id)
             print(json.dumps(data, indent=2))
 
         elif options.list:
-            data = self.get_list()
+            data = self.get_list(project_id)
             print(json.dumps(data, indent=2))
         else:
             print("usage: --list | --host <hostname> [--project <project>]",


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.0.2
```
##### Summary:

The local variable `project_id` was defined but unused. Now pass it to the `get_host` and `get_list` methods to filter results by project, as mentioned in the usage reference.
