### PR TITLE
Fix misplaced paren.

### DIFF
--- a/lib/ansible/plugins/connection/jail.py
+++ b/lib/ansible/plugins/connection/jail.py
@@ -71,7 +71,7 @@ class Connection(ConnectionBase):
     def _search_executable(executable):
         cmd = distutils.spawn.find_executable(executable)
         if not cmd:
-            raise AnsibleError("%s command not found in PATH") % executable
+            raise AnsibleError("%s command not found in PATH" % executable)
         return cmd
 
     def list_jails(self):


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (misplaced-paren 33f93f9241) last updated 2016/03/08 22:16:23 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 45745424f7) last updated 2016/03/07 20:36:49 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD b51efc51bc) last updated 2016/03/07 20:36:49 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Using the jail connection plugin when a required executable is missing will try to raise an exception, but due to a misplaced paren a different exception is raised instead.
##### Example output:

Before the fix:

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/home/matt/mattclay/ansible/lib/ansible/executor/task_executor.py", line 122, in run
    res = self._execute()
  File "/home/matt/mattclay/ansible/lib/ansible/executor/task_executor.py", line 389, in _execute
    self._connection = self._get_connection(variables=variables, templar=templar)
  File "/home/matt/mattclay/ansible/lib/ansible/executor/task_executor.py", line 612, in _get_connection
    connection = self._shared_loader_obj.connection_loader.get(conn_type, self._play_context, self._new_stdin)
  File "/home/matt/mattclay/ansible/lib/ansible/plugins/__init__.py", line 331, in get
    obj = getattr(self._module_cache[path], self.class_name)(*args, **kwargs)
  File "/home/matt/mattclay/ansible/lib/ansible/plugins/connection/jail.py", line 64, in __init__
    self.jls_cmd = self._search_executable('jls')
  File "/home/matt/mattclay/ansible/lib/ansible/plugins/connection/jail.py", line 74, in _search_executable
    raise AnsibleError("%s command not found in PATH") % executable
TypeError: unsupported operand type(s) for %: 'AnsibleError' and 'str'

fatal: [jail-pipelining]: FAILED! => {"failed": true, "msg": "Unexpected failure during module execution.", "stdout": ""}
```

After the fix:

```
fatal: [jail-pipelining]: FAILED! => {"failed": true, "msg": "jls command not found in PATH"}
```
