### PR TITLE
Fix unicode handling in connection plugins.

### DIFF
--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -25,6 +25,7 @@ from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
 from ansible.utils.hashing import checksum, checksum_s, md5, secure_hash
 from ansible.utils.path import makedirs_safe
+from ansible.utils.unicode import to_bytes
 
 
 class ActionModule(ActionBase):
@@ -158,7 +159,7 @@ class ActionModule(ActionBase):
                 self._connection.fetch_file(source, dest)
             else:
                 try:
-                    f = open(dest, 'w')
+                    f = open(to_bytes(dest, errors='strict'), 'w')
                     f.write(remote_data)
                     f.close()
                 except (IOError, OSError) as e:

--- a/lib/ansible/plugins/connection/chroot.py
+++ b/lib/ansible/plugins/connection/chroot.py
@@ -91,7 +91,7 @@ class Connection(ConnectionBase):
         local_cmd = [self.chroot_cmd, self.chroot, executable, '-c', cmd]
 
         display.vvv("EXEC %s" % (local_cmd), host=self.chroot)
-        local_cmd = map(to_bytes, local_cmd)
+        local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
         p = subprocess.Popen(local_cmd, shell=False, stdin=stdin,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 

--- a/lib/ansible/plugins/connection/jail.py
+++ b/lib/ansible/plugins/connection/jail.py
@@ -111,7 +111,7 @@ class Connection(ConnectionBase):
         local_cmd = [self.jexec_cmd, self.jail, executable, '-c', cmd]
 
         display.vvv("EXEC %s" % (local_cmd,), host=self.jail)
-        local_cmd = map(to_bytes, local_cmd)
+        local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
         p = subprocess.Popen(local_cmd, shell=False, stdin=stdin,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -154,7 +154,7 @@ class Connection(ConnectionBase):
 
         out_path = pipes.quote(self._prefix_login_path(out_path))
         try:
-            with open(in_path, 'rb') as in_file:
+            with open(to_bytes(in_path, errors='strict'), 'rb') as in_file:
                 try:
                     p = self._buffered_exec_command('dd of=%s bs=%s' % (out_path, BUFSIZE), stdin=in_file)
                 except OSError:
@@ -180,7 +180,7 @@ class Connection(ConnectionBase):
         except OSError:
             raise AnsibleError("jail connection requires dd command in the jail")
 
-        with open(out_path, 'wb+') as out_file:
+        with open(to_bytes(out_path, errors='strict'), 'wb+') as out_file:
             try:
                 chunk = p.stdout.read(BUFSIZE)
                 while chunk:

--- a/lib/ansible/plugins/connection/libvirt_lxc.py
+++ b/lib/ansible/plugins/connection/libvirt_lxc.py
@@ -91,7 +91,7 @@ class Connection(ConnectionBase):
         local_cmd = [self.virsh, '-q', '-c', 'lxc:///', 'lxc-enter-namespace', self.lxc, '--', executable , '-c', cmd]
 
         display.vvv("EXEC %s" % (local_cmd,), host=self.lxc)
-        local_cmd = map(to_bytes, local_cmd)
+        local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
         p = subprocess.Popen(local_cmd, shell=False, stdin=stdin,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -127,7 +127,7 @@ class Connection(ConnectionBase):
 
         out_path = pipes.quote(self._prefix_login_path(out_path))
         try:
-            with open(in_path, 'rb') as in_file:
+            with open(to_bytes(in_path, errors='strict'), 'rb') as in_file:
                 try:
                     p = self._buffered_exec_command('dd of=%s bs=%s' % (out_path, BUFSIZE), stdin=in_file)
                 except OSError:
@@ -153,7 +153,7 @@ class Connection(ConnectionBase):
         except OSError:
             raise AnsibleError("chroot connection requires dd command in the chroot")
 
-        with open(out_path, 'wb+') as out_file:
+        with open(to_bytes(out_path, errors='strict'), 'wb+') as out_file:
             try:
                 chunk = p.stdout.read(BUFSIZE)
                 while chunk:

--- a/test/integration/test_connection.inventory
+++ b/test/integration/test_connection.inventory
@@ -12,6 +12,28 @@ chroot-no-pipelining ansible_ssh_pipelining=false
 ansible_host=/
 ansible_connection=chroot
 
+[docker]
+docker-pipelining    ansible_ssh_pipelining=true
+docker-no-pipelining ansible_ssh_pipelining=false
+[docker:vars]
+ansible_host=ubuntu-latest
+ansible_connection=docker
+
+[libvirt_lxc]
+libvirt_lxc-pipelining    ansible_ssh_pipelining=true
+libvirt_lxc-no-pipelining ansible_ssh_pipelining=false
+[libvirt_lxc:vars]
+ansible_host=lv-ubuntu-wily-amd64
+ansible_connection=libvirt_lxc
+
+[jail]
+jail-pipelining    ansible_ssh_pipelining=true
+jail-no-pipelining ansible_ssh_pipelining=false
+[jail:vars]
+ansible_host=freebsd_10_2
+ansible_connection=jail
+ansible_python_interpreter=/usr/local/bin/python
+
 [ssh]
 ssh-pipelining    ansible_ssh_pipelining=true
 ssh-no-pipelining ansible_ssh_pipelining=false
@@ -27,5 +49,8 @@ ansible_host=localhost
 ansible_connection=paramiko_ssh
 
 [skip-during-build:children]
+docker
+libvirt_lxc
+jail
 ssh
 paramiko_ssh


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (plugins-unicode 4e78f2d0f8) last updated 2016/03/08 22:52:08 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 45745424f7) last updated 2016/03/07 20:36:49 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD b51efc51bc) last updated 2016/03/07 20:36:49 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Fix handling of unicode paths in connection plugins:
- chroot
- docker
- jail
- libvirt_lxc

Also added tests for these plugins to the connection test inventory, with the tests set to run manually.
##### Example output:

Tested on Ubuntu 15.10 with:

```
TEST_FLAGS='-l !jail' make test_connection
```

Resulting in a play recap of:

```
PLAY RECAP *********************************************************************
chroot-no-pipelining       : ok=9    changed=6    unreachable=0    failed=0   
chroot-pipelining          : ok=9    changed=6    unreachable=0    failed=0   
docker-no-pipelining       : ok=9    changed=6    unreachable=0    failed=0   
docker-pipelining          : ok=9    changed=6    unreachable=0    failed=0   
libvirt_lxc-no-pipelining  : ok=9    changed=6    unreachable=0    failed=0   
libvirt_lxc-pipelining     : ok=9    changed=6    unreachable=0    failed=0   
local-no-pipelining        : ok=9    changed=6    unreachable=0    failed=0   
local-pipelining           : ok=9    changed=6    unreachable=0    failed=0   
paramiko_ssh-no-pipelining : ok=9    changed=6    unreachable=0    failed=0   
paramiko_ssh-pipelining    : ok=9    changed=6    unreachable=0    failed=0   
ssh-no-pipelining          : ok=9    changed=6    unreachable=0    failed=0   
ssh-pipelining             : ok=9    changed=6    unreachable=0    failed=0   
```

Tested on FreeBSD 10.2 with:

```
TEST_FLAGS='-l jail' gmake test_connection
```

Resulting in a play recap of:

```
PLAY RECAP *********************************************************************
jail-no-pipelining         : ok=9    changed=6    unreachable=0    failed=0   
jail-pipelining            : ok=9    changed=6    unreachable=0    failed=0   
```
