### PR TITLE
Fix blind override in failed_when

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -465,7 +465,7 @@ class TaskExecutor:
                     result['failed_when_result'] = result['failed'] = failed_when_result
                 else:
                     failed_when_result = False
-                    result['failed'] = False
+                    result['failed'] = result.get('failed', False)
                 return failed_when_result
 
             if 'ansible_facts' in result:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (fix_failed_when_blind_override dbff3a6bbc) last updated 2016/03/09 17:48:59 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 816bd42b07) last updated 2016/03/09 15:27:12 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD e0be11da08) last updated 2016/03/09 15:27:12 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```
##### Summary:

Fixes blind override in failed_when that causes all task failures to be successes.
##### Example output:
