### PR TITLE
Check for `_data_source` and `_line_number` properties on `task._ds` before accessing them

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -97,7 +97,7 @@ class Task(Base, Conditional, Taggable, Become):
     def get_path(self):
         ''' return the absolute path of the task with its line number '''
 
-        if hasattr(self, '_ds'):
+        if hasattr(self, '_ds') and hasattr(self._ds, '_data_source') and hasattr(self._ds, '_line_number'):
             return "%s:%s" % (self._ds._data_source, self._ds._line_number)
 
     def get_name(self):


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.0.2
  config file =
  configured module search path = Default w/o overrides
```

(but present on `devel` also)
##### Summary:

I'm attempting to use ansible programmatically and am passing in a non-default Callback Module in order to get a higher verbosity level. In `task.py`, it sees that the verbosity level is higher and tries to get the file path and line number for each task, but since I'm passing in tasks via the API they don't (and IMO shouldn't?) have these properties. 

This PR adds more check to ensure `task._ds` has `_data_source` and `_line_number` properties before attempting to access them.
##### Example output:

```
 [WARNING]: Failure when attempting to use callback plugin
(<ansible.plugins.callback.default.CallbackModule object at 0x10ae2c050>): 'dict' object
has no attribute '_data_source'
```

Note that the problem isn't actually in the CallbackModule here – it's the task that's throwing, but it's getting caught and logged as a callback plugin error in `task_queue_manager.py`.
