### PR TITLE
Fix role task including

### DIFF
--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -153,6 +153,8 @@ class Block(Base, Become, Conditional, Taggable):
         if self._dep_chain is None:
             if self._parent_block:
                 return self._parent_block.get_dep_chain()
+            elif self._task_include:
+                return self._task_include._block.get_dep_chain()
             else:
                 return None
         else:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

This reverted code block prevented running roles with task includes.

The reverted commit is a duplicate, but the changes do not reflect the commit message.

Fixes https://github.com/ansible/ansible/issues/14885
##### Example output:

```
$ cd ansible
$ git checkout stable-2.0
$ git submodule update --init --recursive
$ source hacking/env-setup
$ git clone https://github.com/fvant/ansible-role-debug.git ../ansible-role-debug
$ ansible-playbook -i 'localhost,' ../ansible-role-debug/setup.yml
PLAY [Setup the Foobar service] ************************************************

TASK [testrole : include] ******************************************************
included: /home/pmrlabra/ansible-role-debug/roles/testrole/tasks/docker.yml for localhost

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0
```

With this PR, the role is executed correctly.
