### PR TITLE
Change ec2 instance filtering to allow for AND

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -131,7 +131,11 @@ group_by_elasticache_replication_group = True
 # inventory. For the full list of possible filters, please read the EC2 API
 # docs: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeInstances.html#query-DescribeInstances-filters
 # Filters are key/value pairs separated by '=', to list multiple filters use
-# a list separated by commas. See examples below.
+# a list separated by commas.
+# In general, a line with multiple filters of the same name is combined with
+# OR, a line with different filters is combined with AND. See the section named
+# "Combining Search Filters" at //docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html
+# and the examples below.
 
 # Retrieve only instances with (key=value) env=staging tag
 # instance_filters = tag:env=staging
@@ -139,8 +143,15 @@ group_by_elasticache_replication_group = True
 # Retrieve only instances with role=webservers OR role=dbservers tag
 # instance_filters = tag:role=webservers,tag:role=dbservers
 
-# Retrieve only t1.micro instances OR instances with tag env=staging
+# Retrieve only t1.micro instances AND instances with tag env=staging
 # instance_filters = instance-type=t1.micro,tag:env=staging
+
+# Retrieve only instances with app=myproject AND env=prod
+# instance_filters = tag:app=myproject,tag:env=prod
+
+# Retrieve only instances with app=myproject AND instances with role=web OR job
+# e.g. app=myproject AND (role=web OR role=job)
+# instance_filters = tag:app=myproject,tag:role=web,tag:role=job
 
 # You can use wildcards in filter values also. Below will list instances which
 # tag Name value matches webservers1*

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -467,8 +467,7 @@ class Ec2Inventory(object):
             conn = self.connect(region)
             reservations = []
             if self.ec2_instance_filters:
-                for filter_key, filter_values in self.ec2_instance_filters.items():
-                    reservations.extend(conn.get_all_instances(filters = { filter_key : filter_values }))
+                reservations.extend(conn.get_all_instances(filters = self.ec2_instance_filters.items()))
             else:
                 reservations = conn.get_all_instances()
 


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.0.0.2
  config file = /Users/ross/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

This modifies the ec2 inventory script to hand-off the instance-filter combination to AWS's API, as described under ["Combining Search Filters"](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html).

Currently a request is made for each filter and the results combined - this change combines the filters into a single request. These filters are combined with AND for differing key names and OR for similar keys.

I appreciate this is something that we would (and have) customised in our own setups, but I spent a bit of time searching for this and thought it might help save some time for others, even if it isn't merged.
##### Example output:

This allows for filters like:

```
tag:app=MyApp,tag:env=stage,tag:role=web,tag:role=job
becomes (tag:app==MyApp AND tag:env==stage AND (tag:role==web OR tag:role=job))
```

This will change the result of one of the examples:

```
instance_filters = instance-type=t1.micro,tag:env=staging
before: (instance-type==t1.micro OR tag:env==staging)
after: (instance-type==t1.micro AND tag:env==staging)
```
