### PR TITLE
Lower connect timeout for test_mysql_variables.

### DIFF
--- a/test/integration/roles/test_mysql_variables/tasks/main.yml
+++ b/test/integration/roles/test_mysql_variables/tasks/main.yml
@@ -194,6 +194,9 @@
 #============================================================
 # Verify mysql_variable fails with an incorrect login_host parameter
 #
+- name: lower mysql connect timeout
+  ini_file: dest="{{ansible_env.HOME}}/.my.cnf" section=client option=connect_timeout value=5
+
 - name: query mysql_variable using incorrect login_host
   mysql_variables: variable=wait_timeout login_host=12.0.0.9
   register: result


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (mysql-test-timeout 20eee14a2c) last updated 2016/03/10 20:19:49 (GMT +000)
  lib/ansible/modules/core: (detached HEAD c86a0ef84a) last updated 2016/03/10 17:37:18 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 33a557cc59) last updated 2016/03/10 17:37:23 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Set the connect_timeout value in ~/.my.cnf to 5 seconds in test_mysql_variables before testing "query mysql_variable using incorrect login_host" to speed up the test.
##### Example output:

Tested on Ubuntu 15.10 with the following:

```
TEST_FLAGS='--tags=test_mysql_variables' make destructive
```

Play recap as follows:

```
PLAY RECAP *********************************************************************
testhost                   : ok=125  changed=17   unreachable=0    failed=0   
```
