### PR TITLE
Document mysql connect_timeout and update tests.

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/mysql.py
+++ b/lib/ansible/utils/module_docs_fragments/mysql.py
@@ -47,6 +47,12 @@ options:
       - The path to a Unix domain socket for local connections
     required: false
     default: null
+  connect_timeout:
+    description:
+      - The connection timeout when connecting to the MySQL server.
+    required: false
+    default: 30
+    version_added: "2.1"
   config_file:
     description:
       - Specify a config file from which user and password are to be read

--- a/test/integration/roles/test_mysql_variables/tasks/main.yml
+++ b/test/integration/roles/test_mysql_variables/tasks/main.yml
@@ -194,11 +194,8 @@
 #============================================================
 # Verify mysql_variable fails with an incorrect login_host parameter
 #
-- name: lower mysql connect timeout
-  ini_file: dest="{{ansible_env.HOME}}/.my.cnf" section=client option=connect_timeout value=5
-
 - name: query mysql_variable using incorrect login_host
-  mysql_variables: variable=wait_timeout login_host=12.0.0.9
+  mysql_variables: variable=wait_timeout login_host=12.0.0.9 connect_timeout=5
   register: result
   ignore_errors: true
 


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (mysql-connect-timeout 07d71f040f) last updated 2016/03/10 13:33:12 (GMT -700)
  lib/ansible/modules/core: (detached HEAD c86a0ef84a) last updated 2016/03/10 13:04:45 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 33a557cc59) last updated 2016/03/10 09:27:07 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Update documentation for mysql\* modules to include the connect_timeout option. Modules which include the updated docs fragment are:
- mysql_db
- mysql_user
- mysql_variables
- mysql_replication

This option has been added to these modules in the following PRs:
- https://github.com/ansible/ansible-modules-core/pull/3224
- https://github.com/ansible/ansible-modules-extras/pull/1832

This also updates test_mysql_variables to use the new connect_timeout option.
##### Example output:

Running this test:

```
TEST_FLAGS='--tags=test_mysql_variables' make destructive
```

Results in the output:

```
TASK [test_mysql_variables : query mysql_variable using incorrect login_host] **
fatal: [testhost]: FAILED! => {"changed": false, "failed": true, "msg": "unable to find /root/.my.cnf. Exception message: (2003, \"Can't connect to MySQL server on '12.0.0.9' (110)\")"}
...ignoring
```
