### PR TITLE
Add noseclabel support to libvirt_lxc plugin.

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -952,6 +952,17 @@ The default list is: nfs,vboxsf,fuse,ramfs::
 
     special_context_filesystems = nfs,vboxsf,fuse,ramfs,myspecialfs
 
+libvirt_lxc_noseclabel
+======================
+
+.. versionadded:: 2.1
+
+This setting causes libvirt to connect to lxc containers by passing --noseclabel to virsh.
+This is necessary when running on systems which do not have SELinux.
+The default behavior is no::
+
+    libvirt_lxc_noseclabel = True
+
 Galaxy Settings
 ---------------
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -278,6 +278,9 @@
 # needs to be changed to use the file system dependent context.
 #special_context_filesystems=nfs,vboxsf,fuse,ramfs
 
+# Set this to yes to allow libvirt_lxc connections to work without SELinux.
+#libvirt_lxc_noseclabel = yes
+
 [colors]
 #higlight = white
 #verbose = blue

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -167,6 +167,7 @@ DEFAULT_NO_TARGET_SYSLOG   = get_config(p, DEFAULTS, 'no_target_syslog', 'ANSIBL
 
 # selinux
 DEFAULT_SELINUX_SPECIAL_FS = get_config(p, 'selinux', 'special_context_filesystems', None, 'fuse, nfs, vboxsf, ramfs', islist=True)
+DEFAULT_LIBVIRT_LXC_NOSECLABEL = get_config(p, 'selinux', 'libvirt_lxc_noseclabel', 'LIBVIRT_LXC_NOSECLABEL', False, boolean=True)
 
 ### PRIVILEGE ESCALATION ###
 # Backwards Compat

--- a/lib/ansible/plugins/connection/libvirt_lxc.py
+++ b/lib/ansible/plugins/connection/libvirt_lxc.py
@@ -88,7 +88,12 @@ class Connection(ConnectionBase):
         return the process's exit code immediately.
         '''
         executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else '/bin/sh'
-        local_cmd = [self.virsh, '-q', '-c', 'lxc:///', 'lxc-enter-namespace', self.lxc, '--', executable , '-c', cmd]
+        local_cmd = [self.virsh, '-q', '-c', 'lxc:///', 'lxc-enter-namespace']
+
+        if C.DEFAULT_LIBVIRT_LXC_NOSECLABEL:
+            local_cmd += ['--noseclabel']
+
+        local_cmd += [self.lxc, '--', executable, '-c', cmd]
 
         display.vvv("EXEC %s" % (local_cmd,), host=self.lxc)
         local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (libvirt-no-selinux ba1bcdfc17) last updated 2016/03/10 15:35:05 (GMT -700)
  lib/ansible/modules/core: (detached HEAD c86a0ef84a) last updated 2016/03/10 14:54:36 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 33a557cc59) last updated 2016/03/10 14:54:36 (GMT -700)
  config file = /root/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

Resolves issue #10450 by adding a new configuration option, libvirt_lxc_noseclabel.

This option, if enabled, will pass the --noseclabel option to virsh,
which allows a non-SELinux system to access lxc containers through virsh.
##### Example output:

Assuming you have an lxc container configured in libvirt and listed in test_connection.inventory:

Running as root on Ubuntu 15.10 without the new setting:

```
TEST_FLAGS='-l libvirt_lxc' make test_connection
```

Results in an error:

```
TASK [raw with unicode arg and output] *****************************************
fatal: [libvirt_lxc-pipelining]: FAILED! => {"changed": false, "failed": true, "rc": 1, "stderr": "libvirt:  error : argument unsupported: Security model none cannot be entered\nerror: internal error: Child process (13033) unexpected exit status 125\n", "stdout": "", "stdout_lines": []}
```

Running as root on Ubuntu 15.10 with the new setting:

```
LIBVIRT_LXC_NOSECLABEL=true TEST_FLAGS='-l libvirt_lxc' make test_connection
```

Results in a play recap of:

```
PLAY RECAP *********************************************************************
libvirt_lxc-no-pipelining  : ok=9    changed=6    unreachable=0    failed=0   
libvirt_lxc-pipelining     : ok=9    changed=6    unreachable=0    failed=0   
```
