### PR TITLE
Run dnf for fedora-rawhide with --allowerasing

### DIFF
--- a/test/utils/docker/fedora-rawhide/Dockerfile
+++ b/test/utils/docker/fedora-rawhide/Dockerfile
@@ -10,6 +10,7 @@ rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 RUN dnf -y install \
+    --allowerasing \
     dbus-python \
     file \
     findutils \


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (travis-docker-dnf d198a05beb) last updated 2016/03/10 17:44:47 (GMT -700)
  lib/ansible/modules/core: (detached HEAD c86a0ef84a) last updated 2016/03/10 14:54:36 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 33a557cc59) last updated 2016/03/10 14:54:36 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Recent PRs on Travis are failing due to package dependency issues for fedora-rawhide when building the docker image:

```
Error: package python2-dnf-1.1.6-2.fc24.noarch requires dnf-conf = 1.1.6-2.fc24, but none of the providers can be installed

(try to add '--allowerasing' to command line to replace conflicting packages)
```

This appears to be occurring because `dnf-conf-1.1.7-2.fc25.noarch` is already installed.

I was not able to reproduce this issue locally because building the docker image locally uses a newer python2-dnf package which matches the installed dnf-conf package.

Getting the newer python2-dnf package seems like the proper fix, but this PR may provide a functional work-around in the meantime.
