### PR TITLE
HTTPError can also function as a non-exceptional file-like return value

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -849,7 +849,11 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     except (ConnectionError, ValueError), e:
         module.fail_json(msg=str(e))
     except urllib2.HTTPError, e:
-        info.update(dict(msg=str(e), status=e.code, response=e.read(), **e.info()))
+        try:
+            body = e.read()
+        except AttributeError:
+            body = ''
+        info.update(dict(msg=str(e), status=e.code, body=body, **e.info()))
     except urllib2.URLError, e:
         code = int(getattr(e, 'code', -1))
         info.update(dict(msg="Request failed: %s" % str(e), status=code))

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -849,6 +849,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     except (ConnectionError, ValueError), e:
         module.fail_json(msg=str(e))
     except urllib2.HTTPError, e:
+        r = e #useful when handling exotic HTTP errors, such as requests for authentication
         info.update(dict(msg=str(e), status=e.code, **e.info()))
     except urllib2.URLError, e:
         code = int(getattr(e, 'code', -1))

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -849,7 +849,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     except (ConnectionError, ValueError), e:
         module.fail_json(msg=str(e))
     except urllib2.HTTPError, e:
-        info.update(dict(msg=str(e), status=e.code, response=e, **e.info()))
+        info.update(dict(msg=str(e), status=e.code, response=e.read(), **e.info()))
     except urllib2.URLError, e:
         code = int(getattr(e, 'code', -1))
         info.update(dict(msg="Request failed: %s" % str(e), status=code))

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -849,8 +849,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     except (ConnectionError, ValueError), e:
         module.fail_json(msg=str(e))
     except urllib2.HTTPError, e:
-        r = e #useful when handling exotic HTTP errors, such as requests for authentication
-        info.update(dict(msg=str(e), status=e.code, **e.info()))
+        info.update(dict(msg=str(e), status=e.code, response=e, **e.info()))
     except urllib2.URLError, e:
         code = int(getattr(e, 'code', -1))
         info.update(dict(msg="Request failed: %s" % str(e), status=code))


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel 5946fe8a6c) last updated 2016/03/11 07:09:57 (GMT +200)
  lib/ansible/modules/core: (detached HEAD c86a0ef84a) last updated 2016/03/11 07:03:51 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 33a557cc59) last updated 2016/03/11 07:03:54 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = /root/ansible.CaaS/library
```
##### Summary:

ansible/lib/ansible/module_utils/urls.py
fetch_url

Fix : Return file content on HTTPError exception.

[Quote from https://docs.python.org/2/library/urllib2.html]
exception urllib2.HTTPError

```
Though being an exception (a subclass of URLError), an HTTPError can also function as a non-exceptional file-like return value (the same thing that urlopen() returns). This is useful when handling exotic HTTP errors, such as requests for authentication.
```

[/Quote]
##### Example output:

```
```
