### PR TITLE
Set type for OpenStack 'verify' param

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -77,7 +77,7 @@ def openstack_full_argument_spec(**kwargs):
         auth=dict(default=None, type='dict', no_log=True),
         region_name=dict(default=None),
         availability_zone=dict(default=None),
-        verify=dict(default=True, aliases=['validate_certs']),
+        verify=dict(default=True, type='bool', aliases=['validate_certs']),
         cacert=dict(default=None),
         cert=dict(default=None),
         key=dict(default=None, no_log=True),


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

ansible 2.1.0
##### Summary:

Ansible will assume 'str' type if a type is not explicitly set. This parameter
is a 'bool', so we need to set it explicitly.

Fixes #14588 
##### Example output:

n/a

The 'verify' param is a bool, so we don't want it to be an assumed
str.
