### PR TITLE
Dynamically add ssl key to the mysql config hash iff needed

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -31,10 +31,11 @@
 
 def mysql_connect(module, login_user=None, login_password=None, config_file='', ssl_cert=None, ssl_key=None, ssl_ca=None, db=None, cursor_class=None, connect_timeout=30):
     config = {
-        'host': module.params['login_host'],
-        'ssl': {
-            }
+        'host': module.params['login_host']
     }
+
+    if ssl_ca is not None or ssl_key is not None or ssl_cert is not None:
+        config['ssl'] = {}
 
     if module.params['login_unix_socket']:
         config['unix_socket'] = module.params['login_unix_socket']


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
```
##### Summary:

module_utils.mysql will throw a "client library does not have SSL support" exception if MySQL SSL support is not available. This occurs even when attempting to use a non-SSL protected connection. 

```
- name: create users
  mysql_user: name='root' host='192.168.1.%' state=present
    password='xxxx' encrypted=no
    priv='*.*:all'
    login_user=root login_password=yyyy login_unix_socket=/opt/local/var/run/mariadb-10.0/mysqld.sock
```
##### Example output:

```
failed: [host] => (item={u'passwd': u'xxxx', u'host': u'192.168.1.%', u'name': u'root', u'priv': u'*.*:all'}) => {"failed": true, "item": {"host": "192.168.1.%", "name": "root", "passwd": "xxxx", "priv": "*.*:all"}, "msg": "unable to connect to database, check login_user and login_password are correct or /Us
ers/mgrimes/.my.cnf has the credentials. Exception message: client library does not have SSL support"}
```
