### PR TITLE
Merge properties instead of reading only the first cfg file found

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -10,6 +10,15 @@ for most users, but there may be reasons you would want to change them.
 
 Changes can be made and used in a configuration file which will be processed in the following order::
 
+    * /etc/ansible/ansible.cfg
+    * .ansible.cfg (in the home directory)
+    * ansible.cfg (in the current directory)
+    * ANSIBLE_CONFIG (an environment variable)
+
+Ansible will process the above list and merge settings, overriding values from top to bottom of the list.
+
+Prior to 2.3, settings where not merged. Ansible processing files in the following order and using the first file found::
+
     * ANSIBLE_CONFIG (an environment variable)
     * ansible.cfg (in the current directory)
     * .ansible.cfg (in the home directory)

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -138,7 +138,7 @@ def _get_config(p, section, key, env_var, default):
 
 
 def load_config_file():
-    ''' Load Config File order(first found is used): ENV, CWD, HOME, /etc/ansible '''
+    ''' Load Config File order(merging): /etc/ansible, HOME, CWD, ENV '''
 
     p = configparser.ConfigParser()
 
@@ -153,15 +153,16 @@ def load_config_file():
         path1 = None
     path2 = os.path.expanduser("~/.ansible.cfg")
     path3 = "/etc/ansible/ansible.cfg"
+    final_path = ''
 
-    for path in [path0, path1, path2, path3]:
+    for path in [path3, path2, path1, path0]:
         if path is not None and os.path.exists(path):
             try:
+                final_path = path
                 p.read(path)
             except configparser.Error as e:
                 raise AnsibleOptionsError("Error reading config file: \n{0}".format(e))
-            return p, path
-    return None, ''
+    return p, final_path
 
 
 p, CONFIG_FILE = load_config_file()

--- a/test/units/configuration/resources/01-etc.cfg
+++ b/test/units/configuration/resources/01-etc.cfg
@@ -1,0 +1,3 @@
+[defaults]
+etc_only=1
+etc=1

--- a/test/units/configuration/resources/02-user.cfg
+++ b/test/units/configuration/resources/02-user.cfg
@@ -1,0 +1,3 @@
+[defaults]
+etc=2
+user=2

--- a/test/units/configuration/resources/03-cwd.cfg
+++ b/test/units/configuration/resources/03-cwd.cfg
@@ -1,0 +1,3 @@
+[defaults]
+etc=3
+cwd=3

--- a/test/units/configuration/resources/04-env.cfg
+++ b/test/units/configuration/resources/04-env.cfg
@@ -1,0 +1,3 @@
+[defaults]
+etc=4
+env=4

--- a/test/units/configuration/test_load_configuration.py
+++ b/test/units/configuration/test_load_configuration.py
@@ -1,0 +1,67 @@
+# (c) 2016, Pierre-Gildas MILLON <pgmillon@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from ansible import constants
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch
+
+original_open = open
+original_getenv = os.getenv
+
+
+def open(path):
+    if "/etc/ansible/ansible.cfg" == path:
+        return TestLoadConfiguration.open_resource("resources/01-etc.cfg")
+    if os.path.expanduser("~/.ansible.cfg") == path:
+        return TestLoadConfiguration.open_resource("resources/02-user.cfg")
+    if os.getcwd() + "/ansible.cfg" == path:
+        return TestLoadConfiguration.open_resource("resources/03-cwd.cfg")
+    if "resources/ansible.cfg" == path:
+        return TestLoadConfiguration.open_resource("resources/04-env.cfg")
+
+
+def getenv(key, default=None):
+    if "ANSIBLE_CONFIG" == key:
+        return "resources/ansible.cfg"
+    return original_getenv(key, default)
+
+
+def exists(_):
+    return True
+
+
+class TestLoadConfiguration(unittest.TestCase):
+
+    @staticmethod
+    def open_resource(path):
+        path = os.path.dirname(os.path.abspath(__file__)) + '/' + path
+        return original_open(path)
+
+    @patch('__builtin__.open', open)
+    @patch('os.getenv', getenv)
+    @patch('os.path.exists', exists)
+    def test_load_config(self):
+        p, config_file = constants.load_config_file()
+
+        self.assertEqual(1, p.getint("defaults", "etc_only"))
+        self.assertEqual(2, p.getint("defaults", "user"))
+        self.assertEqual(3, p.getint("defaults", "cwd"))
+        self.assertEqual(4, p.getint("defaults", "etc"))
+        self.assertEqual(4, p.getint("defaults", "env"))
+
+        self.assertEqual("resources/ansible.cfg", config_file)


### PR DESCRIPTION
Use case :

I have a personal ansible.cfg where I configure some optims (ssh_args = -o ControlPersist=30m and pipelining = True); there is an ansible.cfg in my repo that configures some structural patterns (roles_path=public/roles:private/roles).

For such setup, I would have to copy my personal configuration on the cfg of the project or create an environment variable with all the values for the cfg files.

If settings were overridden respecting the order of precedence that is describe in the doc, I can have settings splitted between files and override only what I need.

Replaces #12523 with rebased on devel, with tests and doc updated.
