### PR TITLE
Modified files to use single quotes rather than double for file path.…

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -274,7 +274,7 @@ class Connection(ConnectionBase):
 
         script_template = u'''
             begin {{
-                $path = "{0}"
+                $path = '{0}'
 
                 $DebugPreference = "Continue"
                 $ErrorActionPreference = "Stop"

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -52,7 +52,7 @@ class ShellModule(object):
         path = '\\'.join(parts)
         if path.startswith('~'):
             return path
-        return '"%s"' % path
+        return '\'%s\'' % path
 
     # powershell requires that script files end with .ps1
     def get_remote_filename(self, base_name):


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Ansible Version:

ansible 2.0.1.0
  config file = 
  configured module search path = Default w/o overrides
##### Summary:

Modified files to use single quotes rather than double for file path. Powershell does not process $ variables in strings that are single quoted. Powershell DOES process $ variables that are in double quoted strings. 

Using single quotes enables ansible to  handle file paths that contain folders that start with $. (i.e. C:/Users/$admin/...)
