### PR TITLE
skipping unused modules to avoid false positive

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2514,7 +2514,9 @@ class LinuxVirtual(Virtual):
         if os.path.exists("/proc/modules") and os.access('/proc/modules', os.R_OK):
             modules = []
             for line in get_file_lines("/proc/modules"):
-                data = line.split(" ", 1)
+                data = line.split(" ")
+                if len(data) > 2 and data[2] == '0':
+                    continue # skip unused modules
                 modules.append(data[0])
 
             if 'kvm' in modules:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request: #14938
##### Ansible Version:

```
ansible 1.9.4
```
##### Summary:

Some OS preload the 'kvm' module even if it's not actually used.
Skipping unused modules allows to avoid false positive.
Note that the third column contains the module usage count.
