### PR TITLE
Fix missing to_bytes on directory path.

### DIFF
--- a/lib/ansible/utils/path.py
+++ b/lib/ansible/utils/path.py
@@ -19,6 +19,7 @@ __metaclass__ = type
 
 import os
 from errno import EEXIST
+from ansible.utils.unicode import to_bytes
 
 __all__ = ['unfrackpath']
 
@@ -33,7 +34,7 @@ def unfrackpath(path):
 
 def makedirs_safe(path, mode=None):
     '''Safe way to create dirs in muliprocess/thread environments'''
-    if not os.path.exists(path):
+    if not os.path.exists(to_bytes(path, errors='strict')):
         try:
             if mode:
                 os.makedirs(path, mode)

--- a/test/integration/test_connection.yml
+++ b/test/integration/test_connection.yml
@@ -14,18 +14,20 @@
   ### copy local file with unicode filename and content
 
   - name: create local file with unicode filename and content
-    local_action: lineinfile dest=/tmp/ansible-local-汉语 create=true line=汉语
+    local_action: lineinfile dest=/tmp/ansible-local-汉语/汉语.txt create=true line=汉语
   - name: remove remote file with unicode filename and content
-    file: path=/tmp/ansible-remote-汉语 state=absent
+    file: path=/tmp/ansible-remote-汉语/汉语.txt state=absent
+  - name: create remote directory with unicode name
+    file: path=/tmp/ansible-remote-汉语 state=directory
   - name: copy local file with unicode filename and content
-    copy: src=/tmp/ansible-local-汉语 dest=/tmp/ansible-remote-汉语
+    copy: src=/tmp/ansible-local-汉语/汉语.txt dest=/tmp/ansible-remote-汉语/汉语.txt
 
   ### fetch remote file with unicode filename and content
 
   - name: remove local file with unicode filename and content
-    local_action: file path=/tmp/ansible-local-汉语 state=absent
+    local_action: file path=/tmp/ansible-local-汉语/汉语.txt state=absent
   - name: fetch remote file with unicode filename and content
-    fetch: src=/tmp/ansible-remote-汉语 dest=/tmp/ansible-local-汉语 fail_on_missing=true validate_checksum=true flat=true
+    fetch: src=/tmp/ansible-remote-汉语/汉语.txt dest=/tmp/ansible-local-汉语/汉语.txt fail_on_missing=true validate_checksum=true flat=true
 
   ### remove local and remote temp files
 


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 2.1.0 (unicode-dir 1e1852c34d) last updated 2016/03/11 16:59:33 (GMT -700)
  lib/ansible/modules/core: (detached HEAD c86a0ef84a) last updated 2016/03/11 16:43:37 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 33a557cc59) last updated 2016/03/11 16:43:37 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
##### Summary:

Add a unicode directory to connection tests, then fix the bug it exposes 
by adding a missing call to to_bytes on a directory path in: utils/path.py

Without this fix a UnicodeEncodeError is thrown when performing some remote file operations which involve a path with unicode characters in a directory name.
##### Example output:

Running the updated `make test_connection` exposes a missing call to to_bytes.

Tested on Ubuntu 15.10 using the command:

```
TEST_FLAGS='-l local-pipelining -vvv' make test_connection
```

Without to_bytes a UnicodeEncodeError is thrown:

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/root/mattclay/ansible/lib/ansible/executor/task_executor.py", line 122, in run
    res = self._execute()
  File "/root/mattclay/ansible/lib/ansible/executor/task_executor.py", line 424, in _execute
    result = self._handler.run(task_vars=variables)
  File "/root/mattclay/ansible/lib/ansible/plugins/action/fetch.py", line 155, in run
    makedirs_safe(os.path.dirname(dest))
  File "/root/mattclay/ansible/lib/ansible/utils/path.py", line 36, in makedirs_safe
    if not os.path.exists(path):
  File "/usr/lib/python2.7/genericpath.py", line 26, in exists
    os.stat(path)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 19-20: ordinal not in range(128)
```

With to_bytes the tests pass, resulting in a play recap of:

```
PLAY RECAP *********************************************************************
local-pipelining           : ok=10   changed=7    unreachable=0    failed=0   
```

Full connection tests also pass on Ubuntu 15.10 with:

```
LIBVIRT_LXC_NOSECLABEL=true TEST_FLAGS='-l "!jail" -e ansible_user=local-user' make test_connection
```

Resulting in a play recap of:

```
PLAY RECAP *********************************************************************
chroot-no-pipelining       : ok=10   changed=7    unreachable=0    failed=0   
chroot-pipelining          : ok=10   changed=7    unreachable=0    failed=0   
docker-no-pipelining       : ok=10   changed=7    unreachable=0    failed=0   
docker-pipelining          : ok=10   changed=7    unreachable=0    failed=0   
libvirt_lxc-no-pipelining  : ok=10   changed=7    unreachable=0    failed=0   
libvirt_lxc-pipelining     : ok=10   changed=7    unreachable=0    failed=0   
local-no-pipelining        : ok=10   changed=7    unreachable=0    failed=0   
local-pipelining           : ok=10   changed=7    unreachable=0    failed=0   
paramiko_ssh-no-pipelining : ok=10   changed=7    unreachable=0    failed=0   
paramiko_ssh-pipelining    : ok=10   changed=7    unreachable=0    failed=0   
ssh-no-pipelining          : ok=10   changed=7    unreachable=0    failed=0   
ssh-pipelining             : ok=10   changed=7    unreachable=0    failed=0   
```

Testing jail on FreeBSD 10.2 also passes with:

```
TEST_FLAGS='-l jail' gmake test_connection
```

Resulting in a play recap of:

```
PLAY RECAP *********************************************************************
jail-no-pipelining         : ok=10   changed=7    unreachable=0    failed=0   
jail-pipelining            : ok=10   changed=7    unreachable=0    failed=0   
```
