### PR TITLE
Fix pygments lexer name

### DIFF
--- a/docsite/conf.py
+++ b/docsite/conf.py
@@ -100,7 +100,7 @@ exclude_patterns = ['modules']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
-highlight_language = 'YAML'
+highlight_language = 'yaml'
 
 
 # Options for HTML output


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Summary:

When building the docsite on RHEL 7, I see lots of warning about the lexer not found. So I decided to take a look and found out this was likely just a case issue. 

Example of warnings::

```
YAMLSyntax.rst:28: WARNING: Pygments lexer name 'YAML' is not known
```

With this change, it show real warning and consistency issue in the doc.
