### PR TITLE
Fix the lexer used, jinja2 is not valid, jinja is

### DIFF
--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -177,7 +177,7 @@ How do I loop over a list of hosts in a group, inside of a template?
 A pretty common pattern is to iterate over a list of hosts inside of a host group, perhaps to populate a template configuration
 file with a list of servers. To do this, you can just access the "$groups" dictionary in your template, like this:
 
-.. code-block:: jinja2
+.. code-block:: jinja
 
     {% for host in groups['db_servers'] %}
         {{ host }}


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Summary:

With #14948 merged, I see a warning on jinja2, lexer not found. A quick verification in the source code show that indeed, the name is jinja, not jinja2, hence this pull request.

See the code here:
https://bitbucket.org/birkenfeld/pygments-main/src/32fc01cbd18cf835c947d9451b1f1838aac133bd/pygments/lexers/templates.py?at=default&fileviewer=file-view-default#templates.py-333
