### PR TITLE
Allow S3 urls in requirements.yml files

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -57,7 +57,7 @@ def parse_s3_url(url):
     if match:
         return match.group(1), match.group(2)
     return None, None
-    
+
 class GalaxyRole(object):
 
     SUPPORTED_SCMS = set(['git', 'hg'])

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -22,17 +22,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-
 import re
-
-def parse_s3_url(url):
-    "Return bucket and prefix from a s3://bucket/key type AWS S3 URL"
-    match =  re.search('^s3://([^\/]+)/?(.*)', url)
-    if match:
-        return match.group(1), match.group(2)
-
-    return None, None
-
 import datetime
 import os
 import tarfile
@@ -61,7 +51,13 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-
+def parse_s3_url(url):
+    "Return bucket and prefix from a s3://bucket/key type AWS S3 URL"
+    match =  re.search('^s3://([^\/]+)/?(.*)', url)
+    if match:
+        return match.group(1), match.group(2)
+    return None, None
+    
 class GalaxyRole(object):
 
     SUPPORTED_SCMS = set(['git', 'hg'])

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -51,12 +51,14 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
+
 def parse_s3_url(url):
     "Return bucket and prefix from a s3://bucket/key type AWS S3 URL"
-    match =  re.search('^s3://([^\/]+)/?(.*)', url)
+    match = re.search('^s3://([^\/]+)/?(.*)', url)
     if match:
         return match.group(1), match.group(2)
     return None, None
+
 
 class GalaxyRole(object):
 
@@ -204,14 +206,14 @@ class GalaxyRole(object):
                 temp_file = tempfile.NamedTemporaryFile(delete=False)
                 if archive_url.startswith('s3:'):
                     bucket, prefix = parse_s3_url(archive_url)
-                    try: # attempt to use boto3
+                    try:  # attempt to use boto3
                         s3 = boto3.resource('s3')
                         s3_file = s3.Object(bucket, prefix).get()
-                        chunk = s3_file['Body'].read(1024*8)
+                        chunk = s3_file['Body'].read(1024 * 8)
                         while chunk:
                             temp_file.write(chunk)
-                            chunk = s3_file['Body'].read(1024*8)
-                    except NameError: # try using boto instead
+                            chunk = s3_file['Body'].read(1024 * 8)
+                    except NameError:  # try using boto instead
                         try:
                             s3 = boto.connect_s3()
                             bucket = s3.lookup(bucket)


### PR DESCRIPTION
##### SUMMARY

Provide a means of grabbing roles from S3 files. Without this capability, there's no clean way to put a packaged role file behind an authentication system.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ansible-galaxy

##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /Users/doug/.ansible.cfg
  configured module search path = Default w/o overrides
```
