### PR TITLE
Adds 'active_directory_callback' to contrib (replacement PR for https://github.com/ansible/ansible/pull/14476)

### DIFF
--- a/contrib/callback/active_directory_callback.py
+++ b/contrib/callback/active_directory_callback.py
@@ -1,0 +1,100 @@
+# This plugin for ansible is intended to manage acquiring and destroying
+# kerberos / windows domain credentials.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import subprocess
+from subprocess import Popen, PIPE
+from ansible import errors
+
+from ansible.plugins.callback import CallbackBase
+
+class CallbackModule(CallbackBase):
+    """
+    This callback module is intended to manage acquiring and disposing
+    of kerberos / windows domain credentials.
+    A new credential cache is created for each run and the contents
+    of the cache are destroyed when the run completes.
+    It needs to be able to find kinit, klist and kdestroy
+    Because a ticket is good for all machines on a domain,
+    a ticket is cached for the first host found from inventory.
+    
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE= 'aggregate'
+    CALLBACK_NAME = 'active_directory_callback'
+    CALLBACK_NEEDS_WHITELIST = False
+
+    def __init__(self):
+
+        super(CallbackModule, self).__init__()
+
+        self._display.vv('active_directory_callback: plugin activated')
+        self.cache_count = 0
+
+    def __del__(self):
+
+        credential_cache = os.environ['KRB5CCNAME']
+        self._display.vv("active_directory_callback: Leaving domains and removing all tickets from credential cache: %s" % (credential_cache))
+        self._display.vv('active_directory_callback: plugin deactivated')
+        self.destroy_all_tickets(credential_cache)
+
+    def run_kerberos_command(self, command_and_args, password):
+
+        try:
+            cmd = subprocess.Popen(command_and_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if password:
+               stdout, stderr = cmd.communicate('%s\n' % password)
+            else:
+               stdout, stderr = cmd.communicate()
+            if stderr:
+                stderr_lines = stderr.decode('ascii').splitlines()
+                if stderr_lines:
+                    self._display.vv( "active_directory_callback: STDERR Error when running %s - message was: %s" % (command_and_args[0], stderr_lines) )
+            return cmd.returncode
+        except OSError:
+            raise errors.AnsibleError("%s is not installed in %s.  Please check you have installed krb-user/krb5-workstation and can run kinit, klist and kdestroy from the command line" % (command_and_args[0], command_and_args[1]))
+        except IOError:
+            raise errors.AnsibleError("could not authenticate as %s.  Please check winrm group vars are correctly configured." % (command_and_args[1]))
+
+    def cache_new_ticket(self, userAtDomain, password):
+
+        command_and_args = ['kinit', '%s' % (userAtDomain) ]
+        result = self.run_kerberos_command(command_and_args, password)
+        self._display.vv('active_directory_callback: cache new ticket return code was %s' % (result))
+        if result == 0:
+            self.cache_count += 1
+
+    def destroy_all_tickets(self, credential_cache):
+
+        command_and_args = ['kdestroy']
+        self.run_kerberos_command(command_and_args, None)
+
+    def set_ticket_cache(self):
+
+        self.ticket_cache = '/tmp/krb5cc_ansible-%s' % (os.getpid())
+        #print "active_directory_callback: Caching credentials to %s" % (ticket_cache)
+        os.environ['KRB5CCNAME'] = self.ticket_cache
+
+    def v2_playbook_on_play_start(self, *args, **kwargs):
+
+        self._display.vv( "active_directory_callback: Checking for domains to join... " )
+        self.set_ticket_cache()
+        hosts = args[0].get_variable_manager()._inventory.get_hosts()
+        for host in hosts:
+            if self.cache_count > 0:
+                return
+            else:
+                self._display.vv( "active_directory_callback: Considering host: %s" % (host))
+                host_grp_vars = host.get_group_vars()
+                if ('ansible_user' in host_grp_vars):
+                    if ("@" in host_grp_vars['ansible_user']):
+                        self._display.vv( "active_directory_callback: Host %s is configured for windows domain connection.  Looking for ticket for %s ..." % (host, host_grp_vars['ansible_user']))
+                        self.cache_new_ticket(host_grp_vars['ansible_user'], host_grp_vars['ansible_password'])
+
+        self._display.vv( "active_directory_callback: Completed windows domain join checking." )
+

--- a/contrib/callback/active_directory_callback.rst
+++ b/contrib/callback/active_directory_callback.rst
@@ -1,0 +1,36 @@
+active\_directory_callback.py
+=================
+
+Ansible plugin for attaching to a windows domain at runtime.
+It is a wrapper for the tools kinit and kdestroy, so these 
+must be available to the current user.
+
+Usage
+-----
+
+Configure your windows hosts for domain authentication as described 
+here: http://docs.ansible.com/ansible/intro_windows.html#active-directory-support
+Ensure you have used the new names ``ansible_user`` and ``ansible_password``, rather than the older names ``ansible_ssh_user`` and ``ansible_ssh_pass`` as this
+plugin only recognizes the newer style username and password
+Optionally, set ``bin_ansible_callbacks = True win_domain`` in ``ansible.cfg``.
+This will allow automatically connecting to Active Directory domains when using the 
+ ``ansible`` command as well as when using ``ansible-playbook``.
+
+Run playbooks as normal.
+
+Features
+--------
+
+Since a domain login is good for all machines on the domain, the plugin
+will cache a domain login for the first host configured as a windows host
+in the current inventory and then return control to the play / playbook.
+
+This saves caching lots of unnecessary logins for each host, but assumes you 
+only wish to connect to a single domain per inventory.
+
+To view debug messages run with -vv
+
+Compatibility
+-------------
+
+Ansible 2.0+


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Feature Pull Request
##### Ansible Version:

ansible 2.1.0 (active_directory_callback 38b639ac1c) last updated 2016/03/15 05:55:56 (GMT +100)
  lib/ansible/modules/core: (detached HEAD c86a0ef84a) last updated 2016/03/15 05:27:24 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 33a557cc59) last updated 2016/03/15 05:27:24 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides
##### Summary:

Following feedback on https://github.com/ansible/ansible/pull/14476, where it was suggested that because this callback plugin is unlikely to be of long term interest, due to planned changes after Ansbile 2.1, the best place for it would be in contrib, so this PR is a resubmission of https://github.com/ansible/ansible/pull/14476, but with the following changes:

The plugin has been renamed from 'win_domain' to 'active_directory_callback' to avoid confusion with forthcoming windows modules.
The plugin expects only the newer style 'ansible_user' and 'ansible_password' names for specifying the windows domain user and password and does not support the older style names i.e. 'ansible_ssh_user' and 'ansible_ssh_pass' respectively.
The plugin no longer requires whitelisting.

<!--- Please describe the change and the reason for it -->

The plugin is a wrapper around the tooks 'kinit' and 'kdestroy' and is intended to save users from having to acquire a kerberos TGT before running playbooks or modules against windows hosts.

The plugin manages the kerberos credentials separately for each ansible /ansible-playbook run so allows use by >1 user at a time.
##### Example output:

The plugin is intended to be silent in normal operation, but debug information can be obtained by running with -vv switch.  All debug lines from the plugin start 'active_directory_callback: '
