### PR TITLE
Allow timeout to be configurable

### DIFF
--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -33,7 +33,8 @@ NET_COMMON_ARGS = dict(
     ssh_keyfile=dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
     authorize=dict(default=False, fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     auth_pass=dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
-    provider=dict()
+    provider=dict(),
+    timeout=dict(default=10, type='int')
 )
 
 CLI_PROMPTS_RE = [
@@ -74,11 +75,12 @@ class Cli(object):
         username = self.module.params['username']
         password = self.module.params['password']
         key_filename = self.module.params['ssh_keyfile']
+        timeout = self.module.params['timeout']
 
         try:
             self.shell = Shell(kickstart=False, prompts_re=CLI_PROMPTS_RE,
                     errors_re=CLI_ERRORS_RE)
-            self.shell.open(host, port=port, username=username, password=password, key_filename=key_filename)
+            self.shell.open(host, port=port, username=username, password=password, key_filename=key_filename, timeout=timeout)
         except Exception, exc:
             msg = 'failed to connect to %s:%s - %s' % (host, port, str(exc))
             self.module.fail_json(msg=msg)
@@ -175,4 +177,3 @@ def get_module(**kwargs):
         module.fail_json(msg='paramiko is required but does not appear to be installed')
 
     return module
-

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -106,7 +106,7 @@ class Shell(object):
                     key_filename=key_filename, allow_agent=allow_agent)
 
         self.shell = self.ssh.invoke_shell()
-        self.shell.settimeout(10)
+        self.shell.settimeout(timeout)
 
         if self.kickstart:
             self.shell.sendall("\n")
@@ -184,4 +184,3 @@ class Shell(object):
             if match:
                 self._matched_prompt = match.group()
                 return True
-

--- a/lib/ansible/utils/module_docs_fragments/ios.py
+++ b/lib/ansible/utils/module_docs_fragments/ios.py
@@ -76,6 +76,12 @@ options:
         environment variable ANSIBLE_NET_AUTH_PASS will be used instead.
     required: false
     default: none
+  timeout:
+    description:
+      - Specifies idle timeout for the connection. Useful if the console
+        freezes before continuing. For example when saving configurations.
+    required: false
+    default: 10
   provider:
     description:
       - Convience method that allows all M(ios) arguments to be passed as


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
```
##### Summary:

Some times devices takes a long time to process a command. For example when you save the configuration it could complete within a few seconds some times, while other times it might take 15 seconds. This causes the commands to fail as the timeout is hardcoded to 10 seconds.
