### PR TITLE
Switch etcd lookup plugin to work with etcd v2 api

### DIFF
--- a/lib/ansible/runner/lookup_plugins/etcd.py
+++ b/lib/ansible/runner/lookup_plugins/etcd.py
@@ -33,7 +33,7 @@ if os.getenv('ANSIBLE_ETCD_URL') is not None:
 class Etcd(object):
     def __init__(self, url=ANSIBLE_ETCD_URL, validate_certs=True):
         self.url = url
-        self.baseurl = '%s/v1/keys' % (self.url)
+        self.baseurl = '%s/v2/keys' % (self.url)
         self.validate_certs = validate_certs
 
     def get(self, key):
@@ -48,10 +48,12 @@ class Etcd(object):
             return value
 
         try:
-            # {"action":"get","key":"/name","value":"Jane Jolie","index":5}
+            # {"action":"get","node":{"key":"/foo","value":"asdf","modifiedIndex":8,"createdIndex":8}}
             item = json.loads(data)
-            if 'value' in item:
-                value = item['value']
+            if 'node' in item:
+                node = item['node']
+                if 'value' in node:
+                    value = node['value']
             if 'errorCode' in item:
                 value = "ENOENT"
         except:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 1.9.4
  configured module search path = None
```
##### Summary:

etcd lookup plugin for ansible does not retrieve any value from server because etcd 2.2.1 supports only v2 api.

Test playbook:

```

---
- hosts: localhost
  tasks:
  - name: put foo
    local_action: command etcdctl set foo1 bar
  - name: print foo
    debug:
      msg: "{{ lookup('etcd','foo1') }}"
```
##### Example output:

```
PLAY [localhost] ************************************************************** 

GATHERING FACTS *************************************************************** 
ok: [localhost]

TASK: [put foo1] ************************************************************** 
changed: [localhost -> 127.0.0.1]

TASK: [print foo1] ************************************************************ 
ok: [localhost] => {
    "msg": "bar"
}

PLAY RECAP ******************************************************************** 
localhost                  : ok=3    changed=1    unreachable=0    failed=0   

```
