### PR TITLE
use __mro__ for plugin loading when we search for its base class.

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -329,8 +329,13 @@ class PluginLoader:
             obj = getattr(self._module_cache[path], self.class_name)
         else:
             obj = getattr(self._module_cache[path], self.class_name)(*args, **kwargs)
-            if self.base_class and self.base_class not in [base.__name__ for base in obj.__class__.__mro__]:
-                return None
+            if self.base_class:
+                # The import path is hardcoded and should be the right place,
+                # so we are not expecting an ImportError.
+                module = __import__(self.package, fromlist=[self.base_class])
+                # Check whether this obj has the required base class.
+                if not issubclass(obj.__class__, getattr(module, self.base_class, None)):
+                    return None
 
         return obj
 

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -329,7 +329,7 @@ class PluginLoader:
             obj = getattr(self._module_cache[path], self.class_name)
         else:
             obj = getattr(self._module_cache[path], self.class_name)(*args, **kwargs)
-            if self.base_class and self.base_class not in [base.__name__ for base in obj.__class__.__bases__]:
+            if self.base_class and self.base_class not in [base.__name__ for base in obj.__class__.__mro__]:
                 return None
 
         return obj


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

2.1.0
##### Summary:

This would relax the constraint a little bit, allowing directly subclassing existing plugins.
##### Example output:

I tried to sublcass a strategy plugin(linear), and wrote the following code:

```
class StrategyModule(Linear):

    def run(self, iterator, play_context):
        print("running our own strategy here.")

        return Linear.run(self, iterator, play_context)
```

and got the following traceback:

```
Traceback (most recent call last):
  File "run_ansible.py", line 39, in <module>
    result = tqm.run(play)
  File "/usr/local/lib/python2.7/dist-packages/ansible/executor/task_queue_manager.py", line 218, in run
    raise AnsibleError("Invalid play strategy specified: %s" % new_play.strategy, obj=play._ds)
ansible.errors.AnsibleError: ERROR! Invalid play strategy specified: ownstrategy.
```

After some digging, I found that after we've found a specified plugin, the PluginLoader will do a check to see if the obj has the right base class. This is done by:

```
if self.base_class and self.base_class not in [base.__name__ for base in obj.__class__.__bases__]:
   return None
```

which, forbid direct subclass of the plugin.

This commit changed this behavior.

Signed-off-by: 夏恺(Xia Kai) xiaket@gmail.com
