### PR TITLE
For `actionable` cb plugin also hide ok for itemized results

### DIFF
--- a/lib/ansible/plugins/callback/actionable.py
+++ b/lib/ansible/plugins/callback/actionable.py
@@ -50,8 +50,6 @@ class CallbackModule(CallbackModule_default):
         if result._result.get('changed', False):
             self.display_task_banner()
             self.super_ref.v2_runner_on_ok(result)
-        else:
-            pass
 
     def v2_runner_on_unreachable(self, result):
         self.display_task_banner()
@@ -64,8 +62,9 @@ class CallbackModule(CallbackModule_default):
         pass
 
     def v2_runner_item_on_ok(self, result):
-        self.display_task_banner()
-        self.super_ref.v2_runner_item_on_ok(result)
+        if result._result.get('changed', False):
+            self.display_task_banner()
+            self.super_ref.v2_runner_item_on_ok(result)
 
     def v2_runner_item_on_skipped(self, result):
         pass


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (hide_ok_items_in_actionable e51c234dde) last updated 2016/03/15 11:27:35 (GMT +200)
  lib/ansible/modules/core: (devel eef9c54874) last updated 2016/03/14 11:36:44 (GMT +200)
  lib/ansible/modules/extras: (devel be66e9d297) last updated 2016/03/14 11:36:45 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

The purpose of the `actionable` callback plugin is to hide uninteresting
results.

Also hide the ok results when the task was itemized.
##### Example output:

```
TASK [template itemized] *******************************************************
changed: [localhost] => (item=[u'baz', u'quux'])
--- before
+++ after: dynamically generated
@@ -0,0 +1 @@
+bar


PLAY RECAP *********************************************************************
localhost                  : ok=4    changed=1    unreachable=0    failed=0  
```
