### PR TITLE
New "dense" callback plugin

### DIFF
--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -110,7 +110,13 @@ class ansi:
 
     default = '\033[0;0m'
 
-colors = dict(ok=ansi.darkgreen, changed=ansi.darkyellow, failed=ansi.darkred, unreachable=ansi.darkred)
+colors = dict(
+    ok=ansi.darkgreen,
+    changed=ansi.darkyellow,
+    skipped=ansi.darkcyan,
+    failed=ansi.darkred,
+    unreachable=ansi.redbg+ansi.white
+)
 
 class CallbackModule(CallbackModule_default):
 
@@ -125,10 +131,7 @@ class CallbackModule(CallbackModule_default):
     def __init__(self):
 
         # From CallbackModule
-        if display:
-            self._display = display
-        else:
-            self._display = global_display
+        self._display = display
 
         if self._display.verbosity >= 4:
             name = getattr(self, 'CALLBACK_NAME', 'unnamed')
@@ -288,22 +291,28 @@ class CallbackModule(CallbackModule_default):
             self.super_ref.v2_playbook_item_on_ok(result)
 
         # TBD
+        if result._result.get('changed', False):
+            self._add_host(result, 'changed')
+        else:
+            self._add_host(result, 'ok')
 
     def v2_playbook_item_on_failed(self, result):
         if self._display.verbosity >= 2:
             self.super_ref.v2_playbook_item_on_failed(result)
 
         # TBD
+        self._add_host(result, 'failed')
 
     def v2_playbook_item_on_skipped(self, result):
         if self._display.verbosity >= 2:
             self.super_ref.v2_playbook_item_on_skipped(result)
 
         # TBD
+        self._add_host(result, 'skipped')
 
     def v2_playbook_on_no_hosts_remaining(self):
         if self._display.verbosity >= 2:
-            self.super_ref.v2_runner_on_no_hosts_remaining()
+            self.super_ref.v2_playbook_on_no_hosts_remaining()
             return
 
         # TBD

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -210,9 +210,6 @@ class CallbackModule_dense(CallbackModule_default):
                 if not result[attr]:
                     del(result[attr])
 
-        if 'cmd' in result:
-            result['cmd'] = ' '.join(result['cmd'])
-
     def _handle_exceptions(self, result):
         if 'exception' in result:
             if self._display.verbosity < 3:

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -349,6 +349,7 @@ class CallbackModule_dense(CallbackModule_default):
 
         # Write the next task on screen (behind the prompt is the previous output)
         sys.stdout.write('%s %d.' % (self.type, self.count[self.type]))
+        sys.stdout.write(v100.reset)
         sys.stdout.flush()
 
     def v2_playbook_on_handler_task_start(self, task):
@@ -371,6 +372,7 @@ class CallbackModule_dense(CallbackModule_default):
 
         # Write the next task on screen (behind the prompt is the previous output)
         sys.stdout.write('%s %d.' % (self.type, self.count[self.type]))
+        sys.stdout.write(v100.reset)
         sys.stdout.flush()
 
     def v2_playbook_on_cleanup_task_start(self, task):

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -411,16 +411,28 @@ class CallbackModule_dense(CallbackModule_default):
         self.super_ref.v2_on_file_diff(result)
         sys.stdout.write(vt100.reset)
 
+    # Old definition in v2.0
     def v2_playbook_item_on_ok(self, result):
+        self.v2_runner_item_on_ok(result)
+
+    def v2_runner_item_on_ok(self, result):
         if result._result.get('changed', False):
             self._add_host(result, 'changed')
         else:
             self._add_host(result, 'ok')
 
+    # Old definition in v2.0
     def v2_playbook_item_on_failed(self, result):
+        self.v2_runner_item_on_failed(result)
+
+    def v2_runner_item_on_failed(self, result):
         self._add_host(result, 'failed')
 
+    # Old definition in v2.0
     def v2_playbook_item_on_skipped(self, result):
+        self.v2_runner_item_on_skipped(result)
+
+    def v2_runner_item_on_skipped(self, result):
         self._add_host(result, 'skipped')
 
     def v2_playbook_on_no_hosts_remaining(self):

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -1,0 +1,221 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
+
+import sys
+import time
+
+
+# Design goals:
+#
+#  + On screen there should only be relevant stuff
+#    - How far are we ? (during run, last line)
+#    - What issues did we have
+#    - What changes have occured
+#    - Diff output
+#
+#  + If verbosity increases, act as default output
+#    So that users can easily switch to default for troubleshooting
+#
+#  + Leave previous task output on screen
+#    - If we would clear the line at the start of a task, there would often
+#      be no information at all
+#
+#    - We use the cursor to indicate where in the task we are.
+#      Output after the prompt is the output of the previous task
+#
+#    - Use the same color-conventions of Ansible
+
+
+# TODO:
+#
+#  + Ensure all other output is properly displayed
+#  + Properly test for terminal capabilities, and fall back to default
+#  + Modify Ansible mechanism so we don't need to use sys.stdout directly
+#  + Check verbosity 1, display task details on change/failure !
+#  + Check verbosity 2, use default callback for everything
+
+
+# Taken from Dstat
+class ansi:
+    black = '\033[0;30m'
+    darkred = '\033[0;31m'
+    darkgreen = '\033[0;32m'
+    darkyellow = '\033[0;33m'
+    darkblue = '\033[0;34m'
+    darkmagenta = '\033[0;35m'
+    darkcyan = '\033[0;36m'
+    gray = '\033[0;37m'
+
+    darkgray = '\033[1;30m'
+    red = '\033[1;31m'
+    green = '\033[1;32m'
+    yellow = '\033[1;33m'
+    blue = '\033[1;34m'
+    magenta = '\033[1;35m'
+    cyan = '\033[1;36m'
+    white = '\033[1;37m'
+
+    blackbg = '\033[40m'
+    redbg = '\033[41m'
+    greenbg = '\033[42m'
+    yellowbg = '\033[43m'
+    bluebg = '\033[44m'
+    magentabg = '\033[45m'
+    cyanbg = '\033[46m'
+    whitebg = '\033[47m'
+
+    reset = '\033[0;0m'
+    bold = '\033[1m'
+    reverse = '\033[2m'
+    underline = '\033[4m'
+
+    clear = '\033[2J'
+#   clearline = '\033[K'
+    clearline = '\033[2K'
+#   save = '\033[s'
+#   restore = '\033[u'
+    save = '\0337'
+    restore = '\0338'
+    linewrap = '\033[7h'
+    nolinewrap = '\033[7l'
+
+    up = '\033[1A'
+    down = '\033[1B'
+    right = '\033[1C'
+    left = '\033[1D'
+
+    default = '\033[0;0m'
+
+
+class CallbackModule(CallbackModule_default):
+
+    '''
+    This is the dense callback interface, which tries to save screen estate.
+    '''
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'dense'
+
+    hosts = []
+    keep = False
+#    task = ''
+    tasknr = 0
+
+    def __init__(self):
+        sys.stdout.write(ansi.save + ansi.clearline)
+        sys.stdout.flush()
+ 
+    def _add_host(self, name, status):
+        # Ensure that tasks with changes/failures stay on-screen
+        if not self.keep and status in ['changed', 'failed', 'unreachable']:
+            self.keep = True
+        self.hosts.append((name, status))
+        self._print_status()
+
+    def _print_status(self):
+        # Always rewrite the complete line
+        sys.stdout.write(ansi.restore)
+        sys.stdout.write(ansi.clearline)
+        sys.stdout.write('- task %d:  ' % self.tasknr)
+        sys.stdout.flush()
+
+        # Print out each host with its own status-color
+        for name, status in self.hosts:
+            if status == 'ok':
+                color = ansi.darkgreen
+            elif status == 'changed':
+                color = ansi.yellow
+            elif status == 'skipped':
+                color = ansi.darkcyan
+            elif status == 'failed':
+                color = ansi.darkred
+            elif status == 'unreachable':
+                color = ansi.white + ansi.redbg
+#        if self.hosts and self.hosts[-1][1] in ['changed', 'failed']:
+#            sys.stdout.write('<-' + ansi.restore + '\n' + ansi.save)
+            sys.stdout.write(color + name + ansi.default + ' ')
+            sys.stdout.flush()
+
+        # Place cursor at start of the line
+        sys.stdout.write(ansi.default)
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        self._add_host(result._host.get_name(), 'failed')
+
+    def v2_runner_on_ok(self, result):
+        if result._result.get('changed', False):
+            self._add_host(result._host.get_name(), 'changed')
+        else:
+            self._add_host(result._host.get_name(), 'ok')
+
+    def v2_runner_on_skipped(self, result):
+        self._add_host(result._host.get_name(), 'skipped')
+
+    def v2_runner_on_unreachable(self, result):
+        self._add_host(result._host.get_name(), 'unreachable')
+
+    def v2_playbook_item_on_skipped(self, result):
+        pass
+
+    def v2_playbook_on_no_hosts_remaining(self):
+        # TBD
+        if self.keep:
+            sys.stdout.write(ansi.restore + '\n' + ansi.save)
+        else:
+            sys.stdout.write(ansi.restore + ansi.clearline)
+
+        sys.stdout.write(ansi.white + ansi.redbg + 'NO MORE HOSTS LEFT' + ansi.default)
+        sys.stdout.write(ansi.reset)
+        sys.stdout.flush()
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        # Leave the previous task on screen (as it has changes/errors)
+        if self.keep:
+            sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline)
+        # Reset counters at the start of each new task
+        self.keep = False
+        self.hosts = []
+        # Enumerate task (task names are too long for dense output)
+        self.tasknr += 1
+#        self.task = task.get_name().strip()
+        # Write the next task on screen (behind the prompt is the previous output)
+        sys.stdout.write(ansi.restore)
+        sys.stdout.write('- task %d|' % self.tasknr)
+        sys.stdout.flush()
+
+    def v2_playbook_on_play_start(self, play):
+        self.tasknr = 0
+        # Leave the previous task on screen (as it has changes/errors)
+        if self.keep:
+            sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline)
+        else:
+            sys.stdout.write(ansi.restore + ansi.clearline)
+        name = play.get_name().strip()
+        if name:
+            sys.stdout.write('PLAY [%s]' % name)
+        else:
+            sys.stdout.write('PLAY')
+        # Always leave the PLAY output on screen
+        sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline)
+        sys.stdout.flush()

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -21,9 +21,13 @@ __metaclass__ = type
 
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 
-import sys
-import time
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
 
+import sys
 
 # Design goals:
 #
@@ -43,7 +47,7 @@ import time
 #    - We use the cursor to indicate where in the task we are.
 #      Output after the prompt is the output of the previous task
 #
-#    - Use the same color-conventions of Ansible
+#  + Use the same color-conventions of Ansible
 
 
 # TODO:
@@ -51,8 +55,8 @@ import time
 #  + Ensure all other output is properly displayed
 #  + Properly test for terminal capabilities, and fall back to default
 #  + Modify Ansible mechanism so we don't need to use sys.stdout directly
-#  + Check verbosity 1, display task details on change/failure !
-#  + Check verbosity 2, use default callback for everything
+#  + Remove items from result to compact the json output when using -v
+#  + Make colored output nicer
 
 
 # Taken from Dstat
@@ -117,27 +121,64 @@ class CallbackModule(CallbackModule_default):
     CALLBACK_TYPE = 'stdout'
     CALLBACK_NAME = 'dense'
 
-    hosts = []
-    keep = False
-#    task = ''
-    tasknr = 0
-
     def __init__(self):
+
+        # From CallbackModule
+        if display:
+            self._display = display
+        else:
+            self._display = global_display
+
+        if self._display.verbosity >= 4:
+            name = getattr(self, 'CALLBACK_NAME', 'unnamed')
+            ctype = getattr(self, 'CALLBACK_TYPE', 'old')
+            version = getattr(self, 'CALLBACK_VERSION', '1.0')
+            self._display.vvvv('Loaded callback %s of type %s, v%s' % (name, ctype, version))
+
+        self.super_ref = super(CallbackModule, self)
+        self.super_ref.__init__()
+
+        if self._display.verbosity > 1:
+            return
+        self.hosts = []
+        self.keep = False
+        self.shown_title = False
+        self.tasknr = 0
+        self.playnr = 0
         sys.stdout.write(ansi.save + ansi.clearline)
         sys.stdout.flush()
  
-    def _add_host(self, name, status):
+    def _add_host(self, result, status):
+        self.hosts.append((result._host.get_name(), status))
+        self._display_progress()
         # Ensure that tasks with changes/failures stay on-screen
-        if not self.keep and status in ['changed', 'failed', 'unreachable']:
+        if status in ['changed', 'failed', 'unreachable']:
             self.keep = True
-        self.hosts.append((name, status))
-        self._print_status()
+            if self._display.verbosity == 1:
+                self._display_task_banner()
+                # TODO: clean up result output, eg. remove changed, delta, end, start, ...
+                if status == 'changed':
+                    self.super_ref.v2_runner_on_ok(result)
+                elif status == 'failed':
+                    self.super_ref.v2_runner_on_failed(result)
+                elif status == 'unreachable':
+                    self.super_ref.v2_runner_on_unreachable(result)
 
-    def _print_status(self):
+    def _display_task_banner(self):
+        if not self.shown_title:
+            self.shown_title = True
+            sys.stdout.write(ansi.restore + ansi.clearline)
+            sys.stdout.write(ansi.underline + 'task %d: %s' % (self.tasknr, self.task.get_name().strip()))
+            sys.stdout.write(ansi.restore + '\n' + ansi.reset + ansi.clearline)
+            sys.stdout.flush()
+        else:
+            sys.stdout.write(ansi.restore + ansi.clearline)
+
+    def _display_progress(self):
         # Always rewrite the complete line
-        sys.stdout.write(ansi.restore)
-        sys.stdout.write(ansi.clearline)
-        sys.stdout.write('- task %d:  ' % self.tasknr)
+        sys.stdout.write(ansi.restore + ansi.clearline + ansi.underline)
+        sys.stdout.write('task %d:' % self.tasknr)
+        sys.stdout.write(ansi.reset + '  ')
         sys.stdout.flush()
 
         # Print out each host with its own status-color
@@ -145,7 +186,7 @@ class CallbackModule(CallbackModule_default):
             if status == 'ok':
                 color = ansi.darkgreen
             elif status == 'changed':
-                color = ansi.yellow
+                color = ansi.darkyellow
             elif status == 'skipped':
                 color = ansi.darkcyan
             elif status == 'failed':
@@ -160,62 +201,117 @@ class CallbackModule(CallbackModule_default):
         # Place cursor at start of the line
         sys.stdout.write(ansi.default)
 
+    def v2_playbook_on_play_start(self, play):
+        if self._display.verbosity > 1:
+            self.super_ref.v2_playbook_on_play_start(play)
+            return
+
+        self.tasknr = 0
+        self.playnr += 1
+        self.play = play
+        # Leave the previous task on screen (as it has changes/errors)
+        if self.keep:
+            sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline + ansi.bold)
+        else:
+            sys.stdout.write(ansi.restore + ansi.clearline + ansi.bold)
+        name = play.get_name().strip()
+        if name:
+            sys.stdout.write('PLAY %d: %s' % (self.playnr, name.upper()))
+        else:
+            sys.stdout.write('PLAY %d' % self.playnr)
+        # Always leave the PLAY output on screen
+        sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.reset + ansi.clearline)
+        sys.stdout.flush()
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        if self._display.verbosity > 1:
+            self.super_ref.v2_playbook_on_task_start(task, is_conditional)
+            return
+
+        # Leave the previous task on screen (as it has changes/errors)
+        if self._display.verbosity == 0 and self.keep:
+            sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline)
+
+        # Reset counters at the start of each new task
+        self.keep = False
+        self.shown_title = False
+        self.hosts = []
+        self.task = task
+
+        # Enumerate task if not setup (task names are too long for dense output)
+        if task.get_name() != 'setup':
+            self.tasknr += 1
+#        self.task = task.get_name().strip()
+        # Write the next task on screen (behind the prompt is the previous output)
+        sys.stdout.write(ansi.restore + ansi.underline)
+        sys.stdout.write('task %d' % self.tasknr)
+        sys.stdout.write(ansi.reset)
+        sys.stdout.flush()
+
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        self._add_host(result._host.get_name(), 'failed')
+        if self._display.verbosity > 1:
+            self.super_ref.v2_runner_on_failed(result, ignore_errors)
+            return
+
+        self._add_host(result, 'failed')
 
     def v2_runner_on_ok(self, result):
+        if self._display.verbosity > 1:
+            self.super_ref.v2_runner_on_ok(result)
+            return
+
         if result._result.get('changed', False):
-            self._add_host(result._host.get_name(), 'changed')
+            self._add_host(result, 'changed')
         else:
-            self._add_host(result._host.get_name(), 'ok')
+            self._add_host(result, 'ok')
 
     def v2_runner_on_skipped(self, result):
-        self._add_host(result._host.get_name(), 'skipped')
+        if self._display.verbosity > 1:
+            self.super_ref.v2_runner_on_skipped(result)
+            return
+
+        self._add_host(result, 'skipped')
 
     def v2_runner_on_unreachable(self, result):
-        self._add_host(result._host.get_name(), 'unreachable')
+        if self._display.verbosity > 1:
+            self.super_ref.v2_runner_on_unreachable(result)
+            return
+
+        self._add_host(result, 'unreachable')
+
+    def v2_runner_on_include(self, included_file):
+        if self._display.verbosity > 1:
+            self.super_ref.v2_runner_on_include(included_file)
+
+    def v2_playbook_item_on_ok(self, result):
+        if self._display.verbosity > 1:
+            self.super_ref.v2_playbook_item_on_ok(result)
+
+        # TBD
+
+    def v2_playbook_item_on_failed(self, result):
+        if self._display.verbosity > 1:
+            self.super_ref.v2_playbook_item_on_failed(result)
+
+        # TBD
 
     def v2_playbook_item_on_skipped(self, result):
-        pass
+        if self._display.verbosity > 1:
+            self.super_ref.v2_playbook_item_on_skipped(result)
+
+        # TBD
 
     def v2_playbook_on_no_hosts_remaining(self):
+        if self._display.verbosity > 1:
+            self.super_ref.v2_runner_on_no_hosts_remaining()
+            return
+
         # TBD
         if self.keep:
-            sys.stdout.write(ansi.restore + '\n' + ansi.save)
+            sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline)
         else:
             sys.stdout.write(ansi.restore + ansi.clearline)
 
         sys.stdout.write(ansi.white + ansi.redbg + 'NO MORE HOSTS LEFT' + ansi.default)
         sys.stdout.write(ansi.reset)
-        sys.stdout.flush()
-
-    def v2_playbook_on_task_start(self, task, is_conditional):
-        # Leave the previous task on screen (as it has changes/errors)
-        if self.keep:
-            sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline)
-        # Reset counters at the start of each new task
-        self.keep = False
-        self.hosts = []
-        # Enumerate task (task names are too long for dense output)
-        self.tasknr += 1
-#        self.task = task.get_name().strip()
-        # Write the next task on screen (behind the prompt is the previous output)
-        sys.stdout.write(ansi.restore)
-        sys.stdout.write('- task %d|' % self.tasknr)
-        sys.stdout.flush()
-
-    def v2_playbook_on_play_start(self, play):
-        self.tasknr = 0
-        # Leave the previous task on screen (as it has changes/errors)
-        if self.keep:
-            sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline)
-        else:
-            sys.stdout.write(ansi.restore + ansi.clearline)
-        name = play.get_name().strip()
-        if name:
-            sys.stdout.write('PLAY [%s]' % name)
-        else:
-            sys.stdout.write('PLAY')
-        # Always leave the PLAY output on screen
-        sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline)
         sys.stdout.flush()

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -35,9 +35,9 @@ import sys
 #
 #  + On screen there should only be relevant stuff
 #    - How far are we ? (during run, last line)
-#    - What issues did we have
-#    - What changes have occured
-#    - Diff output
+#    - What issues occurred
+#    - What changes occurred
+#    - Diff output (in diff-mode)
 #
 #  + If verbosity increases, act as default output
 #    So that users can easily switch to default for troubleshooting
@@ -424,15 +424,16 @@ class CallbackModule_dense(CallbackModule_default):
         sys.stdout.flush()
 
     def v2_playbook_on_stats(self, stats):
-        # In normal mode screen output should be sufficient
+        if self.keep:
+            sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.reset + ansi.clearline)
+        else:
+            sys.stdout.write(ansi.restore + ansi.reset + ansi.clearline)
+
+        # In normal mode screen output should be sufficient, summary is redundant
         if self._display.verbosity == 0:
             return
 
-        if self.keep:
-            sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline + ansi.bold)
-        else:
-            sys.stdout.write(ansi.restore + ansi.clearline + ansi.bold)
-
+        sys.stdout.write(ansi.bold + ansi.underline)
         sys.stdout.write('SUMMARY')
 
         sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.reset + ansi.clearline)

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -58,9 +58,7 @@ import sys
 #
 #  + Properly test for terminal capabilities, and fall back to default
 #  + Modify Ansible mechanism so we don't need to use sys.stdout directly
-#  + Find an elegant solution for line wrapping
-#  + Support notification handlers
-#  + Better support for item-loops (in -v mode)
+#  + Find an elegant solution for progress bar line wrapping
 
 # When using -vv or higher, simply do the default action
 
@@ -133,8 +131,8 @@ colors = dict(
     ok = ansi.darkgreen,
     changed = ansi.darkyellow,
     skipped = ansi.darkcyan,
-    ignored = ansi.redbg + ansi.cyan,
-    failed = ansi.redbg + ansi.darkred,
+    ignored = ansi.cyanbg + ansi.red,
+    failed = ansi.darkred,
     unreachable = ansi.red,
 )
 
@@ -162,9 +160,8 @@ class CallbackModule_dense(CallbackModule_default):
         self.hosts = OrderedDict()
         self.keep = False
         self.shown_title = False
-        self.playnr = 0
-        self.tasknr = 0
-        self.handlernr = 0
+        self.count = dict(play=0, handler=0, task=0)
+        self.type = 'foo'
 
         # Start immediately on the first line
         sys.stdout.write(ansi.save + ansi.reset + ansi.clearline)
@@ -173,6 +170,7 @@ class CallbackModule_dense(CallbackModule_default):
     def _add_host(self, result, status):
         name = result._host.get_name()
 
+        # Add a new status in case a failed task is ignored
         if status == 'failed' and result._task.ignore_errors:
             status = 'ignored'
 
@@ -187,11 +185,11 @@ class CallbackModule_dense(CallbackModule_default):
         if delegated_vars:
             self.hosts[name]['delegate'] = delegated_vars['ansible_host']
 
-
+        # Print progress bar
         self._display_progress(result)
 
+        # Ensure that tasks with changes/failures stay on-screen
         if status in ['changed', 'failed', 'unreachable']:
-            # Ensure that tasks with changes/failures stay on-screen
             self.keep = True
 
             if self._display.verbosity == 1:
@@ -228,11 +226,26 @@ class CallbackModule_dense(CallbackModule_default):
             del result['exception']
             return msg
 
+    def _display_progress(self, result=None):
+        # Always rewrite the complete line
+        sys.stdout.write(ansi.restore + ansi.clearline + ansi.underline)
+        sys.stdout.write('%s %d:' % (self.type, self.count[self.type]))
+        sys.stdout.write(ansi.reset)
+        sys.stdout.flush()
+
+        # Print out each host in its own status-color
+        for name in self.hosts:
+            sys.stdout.write(' ')
+            if self.hosts[name].get('delegate', None):
+                sys.stdout.write(self.hosts[name]['delegate'] + '>')
+            sys.stdout.write(colors[self.hosts[name]['state']] + name + ansi.reset)
+            sys.stdout.flush()
+
     def _display_task_banner(self):
         if not self.shown_title:
             self.shown_title = True
             sys.stdout.write(ansi.restore + ansi.clearline)
-            sys.stdout.write(ansi.underline + 'task %d: %s' % (self.tasknr, self.task.get_name().strip()))
+            sys.stdout.write(ansi.underline + '%s %d: %s' % (self.type, self.count[self.type], self.task.get_name().strip()))
             sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.reset + ansi.clearline)
             sys.stdout.flush()
         else:
@@ -240,15 +253,17 @@ class CallbackModule_dense(CallbackModule_default):
 
     def _display_results(self, result, status):
         dump = ''
-        self._handle_warnings(result._result)
         self._clean_results(result._result)
 
         if result._task.action == 'include':
             return
-        elif status == 'ignored':
+        elif status == 'ok':
             return
         elif status == 'changed':
             color = C.COLOR_CHANGED
+        elif status == 'ignored':
+            color = C.COLOR_SKIPPED
+            dump = self._handle_exceptions(result._result)
         elif status == 'failed':
             color = C.COLOR_ERROR
             dump = self._handle_exceptions(result._result)
@@ -264,38 +279,23 @@ class CallbackModule_dense(CallbackModule_default):
             msg = "%s: %s>%s: %s" % (status, result._host.get_name(), delegated_vars['ansible_host'], dump)
         else:
             msg = "%s: %s: %s" % (status, result._host.get_name(), dump)
-        self._display.display(msg, color=color)
 
-        if result._task.ignore_errors:
-            self._display.display("...ignoring", color=C.COLOR_SKIP)
+        if result._task.loop and 'results' in result._result:
+            self._process_items(result)
+        else:
+            self._display.display(msg, color=color)
 
-    def _display_progress(self, result=None):
-        # Always rewrite the complete line
-        sys.stdout.write(ansi.restore + ansi.clearline + ansi.underline)
-        sys.stdout.write('task %d:' % self.tasknr)
-        sys.stdout.write(ansi.reset)
-        sys.stdout.flush()
-
-        # Print out each host in its own status-color
-        for name in self.hosts:
-            sys.stdout.write(' ')
-            if self.hosts[name].get('delegate', None):
-                sys.stdout.write(self.hosts[name]['delegate'] + '>')
-            sys.stdout.write(colors[self.hosts[name]['state']] + name + ansi.reset)
-            sys.stdout.flush()
-
-        # Reset color
-        sys.stdout.write(ansi.reset)
+        if status == 'changed':
+            self._handle_warnings(result._result)
 
     def v2_playbook_on_play_start(self, play):
         if self._display.verbosity > 1:
             self.super_ref.v2_playbook_on_play_start(play)
             return
 
-        # Reset counters at the start of each play
-        self.tasknr = 0
-        self.handlernr = 0
-        self.playnr += 1
+        # Reset at the start of each play
+        self.count.update(dict(handler=0, task=0))
+        self.count['play'] += 1
         self.play = play
 
         # Leave the previous task on screen (as it has changes/errors)
@@ -308,7 +308,7 @@ class CallbackModule_dense(CallbackModule_default):
         name = play.get_name().strip()
         if not name:
             name = 'unnamed'
-        sys.stdout.write('PLAY %d: %s' % (self.playnr, name.upper()))
+        sys.stdout.write('PLAY %d: %s' % (self.count['play'], name.upper()))
         sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.reset + ansi.clearline)
         sys.stdout.flush()
 
@@ -319,18 +319,19 @@ class CallbackModule_dense(CallbackModule_default):
         else:
             sys.stdout.write(ansi.restore + ansi.underline)
 
-        # Reset counters at the start of each task
+        # Reset at the start of each task
         self.keep = False
         self.shown_title = False
         self.hosts = OrderedDict()
         self.task = task
+        self.type = 'task'
 
         # Enumerate task if not setup (task names are too long for dense output)
         if task.get_name() != 'setup':
-            self.tasknr += 1
+            self.count['task'] += 1
 
         # Write the next task on screen (behind the prompt is the previous output)
-        sys.stdout.write('task %d.' % self.tasknr)
+        sys.stdout.write('%s %d.' % (self.type, self.count[self.type]))
         sys.stdout.write(ansi.reset)
         sys.stdout.flush()
 
@@ -341,17 +342,19 @@ class CallbackModule_dense(CallbackModule_default):
         else:
             sys.stdout.write(ansi.restore + ansi.reset + ansi.underline)
 
-        # Reset counters at the start of each handler
+        # Reset at the start of each handler
         self.keep = False
         self.shown_title = False
         self.hosts = OrderedDict()
         self.task = task
+        self.type = 'handler'
 
+        # Enumerate handler if not setup (handler names may be too long for dense output)
         if task.get_name() != 'setup':
-            self.handlernr += 1
+            self.count[self.type] += 1
 
         # Write the next task on screen (behind the prompt is the previous output)
-        sys.stdout.write('handler %d.' % self.handlernr)
+        sys.stdout.write('%s %d.' % (self.type, self.count[self.type]))
         sys.stdout.write(ansi.reset)
         sys.stdout.flush()
 
@@ -380,27 +383,24 @@ class CallbackModule_dense(CallbackModule_default):
         pass
 
     def v2_playbook_item_on_ok(self, result):
-        # TBD
         if result._result.get('changed', False):
             self._add_host(result, 'changed')
         else:
             self._add_host(result, 'ok')
 
     def v2_playbook_item_on_failed(self, result):
-        # TBD
         self._add_host(result, 'failed')
 
     def v2_playbook_item_on_skipped(self, result):
-        # TBD
         self._add_host(result, 'skipped')
 
     def v2_playbook_on_no_hosts_remaining(self):
-        # TBD
         if self._display.verbosity == 0 and self.keep:
             sys.stdout.write(ansi.restore + '\n' + ansi.save + ansi.clearline)
         else:
             sys.stdout.write(ansi.restore + ansi.clearline)
 
+        # Reset keep
         self.keep = False
 
         sys.stdout.write(ansi.white + ansi.redbg + 'NO MORE HOSTS LEFT' + ansi.reset)

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -180,6 +180,9 @@ class CallbackModule_dense(CallbackModule_default):
         sys.stdout.write(vt100.reset + vt100.save + vt100.clearline)
         sys.stdout.flush()
 
+    def __del__(self):
+        sys.stdout.write(vt100.restore + vt100.reset + '\n' + vt100.save + vt100.clearline)
+
     def _add_host(self, result, status):
         name = result._host.get_name()
 
@@ -349,7 +352,7 @@ class CallbackModule_dense(CallbackModule_default):
 
         # Write the next task on screen (behind the prompt is the previous output)
         sys.stdout.write('%s %d.' % (self.type, self.count[self.type]))
-        sys.stdout.write(v100.reset)
+        sys.stdout.write(vt100.reset)
         sys.stdout.flush()
 
     def v2_playbook_on_handler_task_start(self, task):
@@ -372,7 +375,7 @@ class CallbackModule_dense(CallbackModule_default):
 
         # Write the next task on screen (behind the prompt is the previous output)
         sys.stdout.write('%s %d.' % (self.type, self.count[self.type]))
-        sys.stdout.write(v100.reset)
+        sys.stdout.write(vt100.reset)
         sys.stdout.flush()
 
     def v2_playbook_on_cleanup_task_start(self, task):


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Feature Pull Request
##### Ansible Version:

v2
##### Summary:

<!--- Please describe the change and the reason for it -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

The goal for the "dense" output is to only show changes and failures on-screen (the Unix-way).
However, since we still want to have a sense of progress, we use terminal capabilities to display progress.
##### Design goals
- Only relevant stuff on-screen
  - How far are we ? (during run, last line)
  - What issues occurred
  - What changes occurred
  - Diff output (in diff-mode)
- If verbosity increases, act as default output
  So that users can easily switch to default for troubleshooting
- Rewrite the output during processing                                                                                               
  - We use the cursor to indicate where in the task we are.
    Output after the prompt is the output of the previous task.
  - If we would clear the line at the start of a task, there would often
    be no information at all, so we leave it until it gets updated
- Use the same color-conventions of Ansible
- Ensure the verbose output (-v) is also dense.
  Remove information that is not essential (eg. timestamps, status)
##### Installation

You have to copy `dense.py` into your callback plugins directory (e.g. _lib/ansible/plugins/callback/_) and then configure your `ansible.cfg` as follows:

``` ini
[defaults]
stdout_callback = dense
```
