### PR TITLE
Remove trailing whitespace from the galaxy init Jinja2 template. Defa…

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -251,6 +251,7 @@ class GalaxyCLI(CLI):
 
                 inject = dict(
                     author = 'your name',
+                    description = 'your description',
                     company = 'your company (optional)',
                     license = 'license (GPLv2, CC-BY, etc)',
                     issue_tracker_url = 'http://example.com/issue/tracker',

--- a/lib/ansible/galaxy/data/metadata_template.j2
+++ b/lib/ansible/galaxy/data/metadata_template.j2
@@ -1,12 +1,12 @@
 galaxy_info:
   author: {{ author }}
-  description: {{description}}
+  description: {{ description }}
   company: {{ company }}
-  
+
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
   # issue_tracker_url: {{ issue_tracker_url }}
-  
+
   # Some suggested licenses:
   # - BSD (default)
   # - MIT
@@ -15,7 +15,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: {{ license }}
-  
+
   min_ansible_version: {{ min_ansible_version }}
 
   # Optionally specify the branch Galaxy will use when accessing the GitHub
@@ -25,7 +25,7 @@ galaxy_info:
   # branch will be accepted. Otherwise, in all cases, the repo's default branch
   # (usually master) will be used.
   #github_branch:
-  
+
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your
@@ -38,9 +38,9 @@ galaxy_info:
   #  - all
     {%- for version in versions %}
   #  - {{ version }}
-    {%- endfor %}
+    {%- endfor -%}
   {%- endfor %}
-  
+
   galaxy_tags: []
     # List tags for your role here, one per line. A tag is
     # a keyword that describes and categorizes the role.


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

<!--- Please describe the change and the reason for it -->

Fixes #14881 

Removes any trailing whitespace from the metadata Jinja2 template. Also adds a default description to avoid trailing whitespace. The default description added was `your description` to follow existing conventions. Also updated the Jinja2 variable style from `{{var}}` to `{{ var }}` to match the rest of the file.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
##### Example output:

``````
galaxy_info:
  author: your name
  description: your description
  company: your company (optional)

  # If the issue tracker for your role is not on github, uncomment the
  # next line and provide a value
  # issue_tracker_url: http://example.com/issue/tracker

  # Some suggested licenses:
  # - BSD (default)
  # - MIT
  # - GPLv2
  # - GPLv3
  # - Apache
  # - CC-BY
  license: license (GPLv2, CC-BY, etc)

  min_ansible_version: 1.2

  # Optionally specify the branch Galaxy will use when accessing the GitHub
  # repo for this role. During role install, if no tags are available,
  # Galaxy will use this branch. During import Galaxy will access files on
  # this branch. If travis integration is cofigured, only notification for this
  # branch will be accepted. Otherwise, in all cases, the repo's default branch
  # (usually master) will be used.
  #github_branch:

  #
  # Below are all platforms currently available. Just uncomment
  # the ones that apply to your role. If you don't see your
  # platform on this list, let us know and we'll get it added!
  #
  #platforms:
  #- name: EL
  #  versions:
  #  - all
  #  - 5
  #  - 6
  #  - 7
  #- name: GenericUNIX
  #  versions:
  #  - all
  #  - any
  #- name: Solaris
  #  versions:
  #  - all
  #  - 10
  #  - 11.0
  #  - 11.1
  #  - 11.2
  #  - 11.3
  #- name: Fedora
  #  versions:
  #  - all
  #  - 16
  #  - 17
  #  - 18
  #  - 19
  #  - 20
  #  - 21
  #  - 22
  #  - 23
  #- name: opensuse
  #  versions:
  #  - all
  #  - 12.1
  #  - 12.2
  #  - 12.3
  #  - 13.1
  #  - 13.2
  #- name: IOS
  #  versions:
  #  - all
  #  - any
  #- name: SmartOS
  #  versions:
  #  - all
  #  - any
  #- name: eos
  #  versions:
  #  - all
  #  - Any
  #- name: Windows
  #  versions:
  #  - all
  #  - 2012R2
  #- name: Amazon
  #  versions:
  #  - all
  #  - 2013.03
  #  - 2013.09
  #- name: GenericBSD
  #  versions:
  #  - all
  #  - any
  #- name: Junos
  #  versions:
  #  - all
  #  - any
  #- name: FreeBSD
  #  versions:
  #  - all
  #  - 10.0
  #  - 10.1
  #  - 10.2
  #  - 8.0
  #  - 8.1
  #  - 8.2
  #  - 8.3
  #  - 8.4
  #  - 9.0
  #  - 9.1
  #  - 9.1
  #  - 9.2
  #  - 9.3
  #- name: Ubuntu
  #  versions:
  #  - all
  #  - lucid
  #  - maverick
  #  - natty
  #  - oneiric
  #  - precise
  #  - quantal
  #  - raring
  #  - saucy
  #  - trusty
  #  - utopic
  #  - vivid
  #  - wily
  #  - xenial
  #- name: SLES
  #  versions:
  #  - all
  #  - 10SP3
  #  - 10SP4
  #  - 11
  #  - 11SP1
  #  - 11SP2
  #  - 11SP3
  #- name: GenericLinux
  #  versions:
  #  - all
  #  - any
  #- name: NXOS
  #  versions:
  #  - all
  #  - any
  #- name: Debian
  #  versions:
  #  - all
  #  - etch
  #  - jessie
  #  - lenny
  #  - squeeze
  #  - wheezy

  galaxy_tags: []
    # List tags for your role here, one per line. A tag is
    # a keyword that describes and categorizes the role.
    # Users find roles by searching for tags. Be sure to
    # remove the '[]' above if you add tags to this list.
    #
    # NOTE: A tag is limited to a single word comprised of
    # alphanumeric characters. Maximum 20 tags per role.

dependencies: []
  # List your role dependencies here, one per line.
  # Be sure to remove the '[]' above if you add dependencies
  # to this list.```
``````
