### PR TITLE
Fix openstack inventory for multiple servers

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -149,7 +149,7 @@ def get_host_groups_from_cloud(inventory):
             else:
                 for server in servers:
                     append_hostvars(
-                        hostvars, groups, server['id'], servers[0],
+                        hostvars, groups, server['id'], server,
                         namegroup=True)
     groups['_meta'] = {'hostvars': hostvars}
     return groups


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

$ ansible --version
[WARNING]: log file at /var/log/ansible.log is not writeable and we cannot create it, aborting

ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = /usr/share/ansible
##### Summary:

Fix openstack inventory for when we have multiple servers with the same
name but different IDs. Instead of giving every server with the same
name the details for the first server returned with that name add the
individual servers as they are returned.

This was a logic bug where in a loop over a list of servers we always
added the first server in that list despite having more than one server.
