### PR TITLE
Fixes ovirt inventory to only override credentials when keys exist

### DIFF
--- a/contrib/inventory/ovirt.py
+++ b/contrib/inventory/ovirt.py
@@ -172,9 +172,9 @@ class OVirtInventory(object):
 
         # If the appropriate environment variables are set, they override
         # other configuration; process those into our args and kwargs.
-        kwargs['url'] = os.environ.get('OVIRT_URL')
-        kwargs['username'] = os.environ.get('OVIRT_EMAIL')
-        kwargs['password'] = os.environ.get('OVIRT_PASS')
+	 kwargs['url'] = os.environ.get('OVIRT_URL', kwargs['url'])
+	 kwargs['username'] = next(val for val in [os.environ.get('OVIRT_EMAIL'), os.environ.get('OVIRT_USERNAME'), kwargs['username']] if val is not None)
+	 kwargs['password'] = next(val for val in [os.environ.get('OVIRT_PASS'), os.environ.get('OVIRT_PASSWORD'), kwargs['password']] if val is not None)
 
         # Retrieve and return the ovirt driver.
         return API(insecure=True, **kwargs)


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Ansible Version:

ansible 2.1.0 (devel 86080fbaa9) last updated 2016/03/15 17:52:46 (GMT +200)
##### Summary:

<!--- Please describe the change and the reason for it -->

Fixes ovirt inventory to only override credentials when keys exist as environment variables
instead of current behaviour when they dont get populated.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
