### PR TITLE
[Doc fix] Fixed ansible 2 python API example

### DIFF
--- a/docsite/rst/developing_api.rst
+++ b/docsite/rst/developing_api.rst
@@ -41,16 +41,25 @@ In 2.0 things get a bit more complicated to start, but you end up with much more
 
     from collections import namedtuple
     from ansible.parsing.dataloader import DataLoader
+    from ansible.cli import CLI
     from ansible.vars import VariableManager
     from ansible.inventory import Inventory
     from ansible.playbook.play import Play
     from ansible.executor.task_queue_manager import TaskQueueManager
 
-    Options = namedtuple('Options', ['connection', 'module_path', 'forks', 'become', 'become_method', 'become_user', 'check'])
     # initialize needed objects
     variable_manager = VariableManager()
     loader = DataLoader()
-    options = Options(connection='local', module_path='/path/to/mymodules', forks=100, become=None, become_method=None, become_user=None, check=False)
+    parser = CLI.base_parser(
+        connect_opts=True,
+        module_opts=True,
+        fork_opts=True,
+        runas_opts=True,
+        check_opts=True,
+    )
+    # ignore sys args for the sake of this example
+    options, args = parser.parse_args([])
+    options.connection = 'local'
     passwords = dict(vault_pass='secret')
 
     # create inventory and pass to var manager

--- a/docsite/rst/developing_api.rst
+++ b/docsite/rst/developing_api.rst
@@ -41,25 +41,16 @@ In 2.0 things get a bit more complicated to start, but you end up with much more
 
     from collections import namedtuple
     from ansible.parsing.dataloader import DataLoader
-    from ansible.cli import CLI
     from ansible.vars import VariableManager
     from ansible.inventory import Inventory
     from ansible.playbook.play import Play
+    from ansible.playbook.play_context import PlayContext
     from ansible.executor.task_queue_manager import TaskQueueManager
 
     # initialize needed objects
     variable_manager = VariableManager()
     loader = DataLoader()
-    parser = CLI.base_parser(
-        connect_opts=True,
-        module_opts=True,
-        fork_opts=True,
-        runas_opts=True,
-        check_opts=True,
-    )
-    # ignore sys args for the sake of this example
-    options, args = parser.parse_args([])
-    options.connection = 'local'
+    options = PlayContext.options_factory(connection='local')
     passwords = dict(vault_pass='secret')
 
     # create inventory and pass to var manager

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -21,6 +21,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import collections
+import copy
 import pipes
 import random
 import re
@@ -190,6 +192,57 @@ class PlayContext(Base):
     _start_at_task    = FieldAttribute(isa='string')
     _step             = FieldAttribute(isa='bool', default=False)
     _diff             = FieldAttribute(isa='bool', default=False)
+
+    DEFAULT_OPTIONS = dict(
+        verbose=0,
+        inventory=C.DEFAULT_HOST_LIST,
+        listhosts=False,
+        subset=C.DEFAULT_SUBSET,
+        module_path=C.DEFAULT_MODULE_PATH,
+        extra_vars=[],
+        forks=C.DEFAULT_FORKS,
+        ask_vault_pass=C.DEFAULT_ASK_VAULT_PASS,
+        vault_password_file=C.DEFAULT_VAULT_PASSWORD_FILE,
+        new_vault_password_file='',
+        output_file='',
+        tags='all',
+        skip_tags=False,
+        one_line=False,
+        tree=None,
+        ask_pass=C.DEFAULT_ASK_PASS,
+        private_key_file=C.DEFAULT_PRIVATE_KEY_FILE,
+        remote_user=C.DEFAULT_REMOTE_USER,
+        connection=C.DEFAULT_TRANSPORT,
+        timeout=C.DEFAULT_TIMEOUT,
+        ssh_common_args=None,
+        sftp_extra_args=None,
+        scp_extra_args=None,
+        ssh_extra_args=None,
+        sudo=False,
+        sudo_user=None,
+        su=C.DEFAULT_SU,
+        su_user=C.DEFAULT_SU_USER,
+        become=C.DEFAULT_BECOME,
+        become_method=C.DEFAULT_BECOME_METHOD,
+        become_user=C.DEFAULT_BECOME_USER,
+        ask_sudo_pass=C.DEFAULT_ASK_SUDO_PASS,
+        ask_su_pass=C.DEFAULT_ASK_SU_PASS,
+        become_ask_pass=False,
+        poll_interval=C.DEFAULT_POLL_INTERVAL,
+        seconds=0,
+        check=False,
+        syntax=False,
+        diff=False,
+        force_handlers=C.DEFAULT_FORCE_HANDLERS,
+        flush_cache=False,
+    )
+
+    @classmethod
+    def options_factory(cls, **options):
+        Options = collections.namedtuple('Options', cls.DEFAULT_OPTIONS.keys())
+        with_defaults = copy.copy(cls.DEFAULT_OPTIONS)
+        with_defaults.update(options)
+        return Options(**with_defaults)
 
     def __init__(self, play=None, options=None, passwords=None, connection_lockfd=None):
 


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
  config file = /home/jpic/.ansible.cfg
  configured module search path = /home/jpic/ansible/library:/usr/share/ansible
```
##### Summary:

The example Python API for Ansible 2.0 crashes.
##### Example output:

```
$ python test.py
Traceback (most recent call last):
  File "test.py", line 44, in <module>
    result = tqm.run(play)
  File "/home/jpic/env/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py", line 206, in run
    play_context = PlayContext(new_play, self._options, self.passwords, self._connection_lockfile.fileno())
  File "/home/jpic/env/lib/python2.7/site-packages/ansible/playbook/play_context.py", line 212, in __init__
    self.set_options(options)
  File "/home/jpic/env/lib/python2.7/site-packages/ansible/playbook/play_context.py", line 258, in set_options
    self.remote_user = options.remote_user
AttributeError: 'Options' object has no attribute 'remote_user'
```

Turns out there are a lot of default options we need and getting them from the base parser is the shortest way to do it for now ...
