### PR TITLE
[Travis.yml fix] Install coveralls, required by after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
     packages:
       - python2.4
 install:
-  - pip install tox
+  - pip install tox coveralls
 script:
   - ./test/utils/run_tests.sh
 after_success:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (fix_coveralls 2da4f04269) last updated 2016/03/16 18:13:07 (GMT +200)
  lib/ansible/modules/core: (detached HEAD a8841e6834) last updated 2016/03/16 18:12:18 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 45bba8ec64) last updated 2016/03/16 18:12:18 (GMT +200)
  config file = /home/jpic/.ansible.cfg
  configured module search path = /home/jpic/ansible/library:/usr/share/ansible
```
##### Summary:

coveralls command fails in all travis builds:

```
The command "./test/utils/run_tests.sh" exited with 0.
after_success
0.30s$ coveralls
coveralls: command not found
```

ie: https://travis-ci.org/ansible/ansible/jobs/116412646#L774

This patch installs coveralls.
