### PR TITLE
add find_host_portgroup_by_name function to vmware utils

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -108,6 +108,14 @@ def find_vm_by_name(content, vm_name):
     return None
 
 
+def find_host_portgroup_by_name(host, portgroup_name):
+
+    for portgroup in host.config.network.portgroup:
+        if portgroup.spec.name == portgroup_name:
+            return portgroup
+    return None
+
+
 def vmware_argument_spec():
 
     return dict(


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel 7587c20d27) last updated 2016/03/15 16:55:08 (GMT -700)
  lib/ansible/modules/core: (detached HEAD a8841e6834) last updated 2016/03/15 16:55:14 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 45bba8ec64) last updated 2016/03/15 16:55:25 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```
##### Summary:

This is a suggestion from code review for pull request https://github.com/ansible/ansible-modules-extras/pull/1815

It adds a common function to find vmware port group by name, which is needed to fix an issue in vmware portgroup module.
##### Example output:

```
ok: [localhost] => {"changed": false, "invocation": {"module_args": {"hostname": "192.168.41.162", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "portgroup_name": "network2-", "switch_name": "switch2-", "username": "root", "validate_certs": false, "vlan_id": 0}, "module_name": "vmware_portgroup"}}
```
