### PR TITLE
Enable pipelining for jail connection plugin

### DIFF
--- a/lib/ansible/plugins/connection/jail.py
+++ b/lib/ansible/plugins/connection/jail.py
@@ -45,7 +45,7 @@ class Connection(ConnectionBase):
     transport = 'jail'
     # Pipelining may work.  Someone needs to test by setting this to True and
     # having pipelining=True in their ansible.cfg
-    has_pipelining = False
+    has_pipelining = True
     # Some become_methods may work in v2 (sudo works for other chroot-based
     # plugins while su seems to be failing).  If some work, check chroot.py to
     # see how to disable just some methods.
@@ -118,13 +118,6 @@ class Connection(ConnectionBase):
     def exec_command(self, cmd, in_data=None, sudoable=False):
         ''' run a command on the jail '''
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
-
-        # TODO: Check whether we can send the command to stdin via
-        # p.communicate(in_data)
-        # If we can, then we can change this plugin to has_pipelining=True and
-        # remove the error if in_data is given.
-        if in_data:
-            raise AnsibleError("Internal Error: this module does not support optimized module pipelining")
 
         p = self._buffered_exec_command(cmd)
 


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel de306eb5da) last updated 2016/03/16 11:23:16 (GMT -700)
  lib/ansible/modules/core: (devel 345d9cbca8) last updated 2016/03/16 10:53:00 (GMT -700)
  lib/ansible/modules/extras: (devel f9b96b9a8a) last updated 2016/03/16 10:19:38 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

When the chroot style conneciton plugins were rewritten for 2.0.0 we made it so that pipelining probably worked for all of them.  chroot, docker, zone, and libvirt_lxc were tested and working so we enabled all of those.  jail (for BSD jails) were not tested so we did not enable it.

Due to the relatively low number of users we're probably never going to get testing on jails if we leave it disabled so we should enable it now and disable/fix it if a user reports problems.
