### PR TITLE
Integration tests for zypper repository

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -19,3 +19,4 @@
     - { role: test_mysql_variables, tags: test_mysql_variables}
     - { role: test_docker, tags: test_docker, when: ansible_distribution != "Fedora" }
     - { role: test_zypper, tags: test_zypper}
+    - { role: test_zypper_repository, tags: test_zypper_repository}

--- a/test/integration/roles/test_zypper_repository/meta/main.yml
+++ b/test/integration/roles/test_zypper_repository/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/roles/test_zypper_repository/tasks/main.yml
+++ b/test/integration/roles/test_zypper_repository/tasks/main.yml
@@ -1,0 +1,22 @@
+# test code for the zypper repository module
+#
+# (c) 2016, Guido Günther <agx@sigxcpu.org>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- include: 'zypper_repository.yml'
+  when: ansible_distribution in ['SLES', 'openSUSE']
+

--- a/test/integration/roles/test_zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/roles/test_zypper_repository/tasks/zypper_repository.yml
@@ -1,0 +1,43 @@
+- name: Delete
+  zypper_repository:
+    name: test
+    state: absent
+  register: zypper_result
+
+- name: Add repo
+  zypper_repository:
+    name: test
+    state: present
+    repo: http://dl.google.com/linux/chrome/rpm/stable/x86_64
+  register: zypper_result
+
+- debug: var=zypper_result
+
+- name: verify repo addition
+  assert:
+    that:
+      - "zypper_result.changed"
+
+- name: Add repo again
+  zypper_repository:
+    name: test
+    state: present
+    repo: http://dl.google.com/linux/chrome/rpm/stable/x86_64
+  register: zypper_result
+
+- name: verify no change on second install
+  assert:
+    that:
+      - "not zypper_result.changed"
+
+- name: Change repo URL
+  zypper_repository:
+    name: test
+    state: present
+    repo: http://download.videolan.org/pub/vlc/SuSE/Leap_42.1/
+  register: zypper_result
+
+- name: Verify change on URL only change
+  assert:
+    that:
+      - "zypper_result.changed"


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
##### Summary:

Add integration tests for zypper repository to illustrate the failures
that show without applying

```
 https://github.com/ansible/ansible-modules-extras/pull/1515
```
