### PR TITLE
Fix test failures if 'future' package is installed

### DIFF
--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -22,15 +22,9 @@ __metaclass__ = type
 
 import os
 
-try:
-    import builtins
-except ImportError:
-    import __builtin__ as builtins
-
-
 from ansible import constants as C
 from ansible.compat.six import text_type
-from ansible.compat.six.moves import shlex_quote
+from ansible.compat.six.moves import shlex_quote, builtins
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, MagicMock, mock_open
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request

The python 'future' module provides a 'builtins' package
to emulate the py3 'builtins' modules. If installed, the
unit tests that reference builtings.**import** fail because
the future 'builtins' is imported and it is missing **import**.

So if/else based on '**builtin**' being in sys.modules for
py2/py3 differences, and only import 'builtins' on py3.

fixes #14996
