### PR TITLE
Add changes necessary for enabling pipelining for local connections

### DIFF
--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -19,9 +19,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import select
 import shutil
 import subprocess
-import select
 import fcntl
 import getpass
 
@@ -44,6 +44,7 @@ class Connection(ConnectionBase):
     ''' Local based connections '''
 
     transport = 'local'
+    has_pipelining = True
 
     def _connect(self):
         ''' connect to the local host; nothing to do here '''
@@ -65,8 +66,6 @@ class Connection(ConnectionBase):
 
         display.debug("in local.exec_command()")
 
-        if in_data:
-            raise AnsibleError("Internal Error: this module does not support optimized module pipelining")
         executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else None
 
         display.vvv(u"{0} EXEC {1}".format(self._play_context.remote_addr, cmd))
@@ -112,7 +111,7 @@ class Connection(ConnectionBase):
             fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) & ~os.O_NONBLOCK)
 
         display.debug("getting output with communicate()")
-        stdout, stderr = p.communicate()
+        stdout, stderr = p.communicate(in_data)
         display.debug("done communicating")
 
         display.debug("done with local.exec_command()")


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (local-pipelining 1346c209b0) last updated 2016/03/16 12:48:10 (GMT -700)
  lib/ansible/modules/core: (devel 345d9cbca8) last updated 2016/03/16 10:53:00 (GMT -700)
  lib/ansible/modules/extras: (devel f47b499bb9) last updated 2016/03/16 12:42:25 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### Summary:

Add support for pipelining to the local connection plugin.  This allows users to enable pipelining so that modules aren't created world readable when become is an unprivileged user.
