### PR TITLE
fix TypeError: coercing to Unicode: need string or buffer, AnsiblePar…

### DIFF
--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -29,6 +29,7 @@ from ansible.playbook.task import Task
 from ansible.plugins import action_loader
 from ansible.plugins.strategy import StrategyBase
 from ansible.template import Templar
+from ansible.utils.unicode import to_unicode
 
 try:
     from __main__ import display
@@ -330,7 +331,7 @@ class StrategyModule(StrategyBase):
                             for host in included_file._hosts:
                                 self._tqm._failed_hosts[host.name] = True
                                 iterator.mark_host_failed(host)
-                            display.error(e, wrap_text=False)
+                            display.error(to_unicode(e), wrap_text=False)
                             include_failure = True
                             continue
 

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -108,7 +108,7 @@ class Display:
         """ Display a message to the user
 
         Note: msg *must* be a unicode string to prevent UnicodeError tracebacks.
-        """
+        """ 
 
         # FIXME: this needs to be implemented
         #msg = utils.sanitize_output(msg)
@@ -273,7 +273,7 @@ class Display:
             wrapped = textwrap.wrap(new_msg, self.columns)
             new_msg = u"\n".join(wrapped) + u"\n"
         else:
-            new_msg = u"ERROR! %s" % msg
+            new_msg = u"ERROR! " + msg
         if new_msg not in self._errors:
             self.display(new_msg, color=C.COLOR_ERROR, stderr=True)
             self._errors[new_msg] = 1

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -108,7 +108,7 @@ class Display:
         """ Display a message to the user
 
         Note: msg *must* be a unicode string to prevent UnicodeError tracebacks.
-        """ 
+        """
 
         # FIXME: this needs to be implemented
         #msg = utils.sanitize_output(msg)
@@ -273,7 +273,7 @@ class Display:
             wrapped = textwrap.wrap(new_msg, self.columns)
             new_msg = u"\n".join(wrapped) + u"\n"
         else:
-            new_msg = u"ERROR! " + msg
+            new_msg = u"ERROR! %s" % msg
         if new_msg not in self._errors:
             self.display(new_msg, color=C.COLOR_ERROR, stderr=True)
             self._errors[new_msg] = 1


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

ansible 2.0.1.0
##### Summary:

This fixes exception that prevented to view the exact syntax error in playbook. My vim also catched the extra whitespace, sorry for that.

Full trace:

ERROR! Unexpected Exception: coercing to Unicode: need string or buffer, AnsibleParserError found
the full traceback was:

Traceback (most recent call last):
  File "/usr/bin/ansible-playbook", line 86, in <module>
    sys.exit(cli.run())
  File "/usr/lib/python2.7/dist-packages/ansible/cli/playbook.py", line 150, in run
    results = pbex.run()
  File "/usr/lib/python2.7/dist-packages/ansible/executor/playbook_executor.py", line 140, in run
    result = self._tqm.run(play=play)
  File "/usr/lib/python2.7/dist-packages/ansible/executor/task_queue_manager.py", line 238, in run
    play_return = strategy.run(iterator, play_context)
  File "/usr/lib/python2.7/dist-packages/ansible/plugins/strategy/linear.py", line 334, in run
    display.error(e, wrap_text=False)
  File "/usr/lib/python2.7/dist-packages/ansible/utils/display.py", line 259, in error
    new_msg = u"ERROR! " + msg
TypeError: coercing to Unicode: need string or buffer, AnsibleParserError found

A
