### PR TITLE
Add new "display include tasks" option

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -256,6 +256,15 @@ saving stdout to an insecure file) or made sure that all of your playbooks
 explicitly added the ``no_log: True`` parameter to tasks which have sensistive
 values   See :ref:`keep_secret_data` for more information.
 
+.. _display_include_tasks:
+
+display_include_tasks
+=====================
+
+If set to `False`, ansible will not display any status nor task header lines for an include task that is skipped. The default behavior is to display include tasks:
+
+    display_include_tasks=True
+
 .. _display_skipped_hosts:
 
 display_skipped_hosts

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -110,6 +110,10 @@
 # task is skipped.
 #display_skipped_hosts = True
 
+# by default, ansible-playbook will display a header line and a task line for each include task.
+# Set this to "False" if you don't want to see these "Include" messages.
+#display_include_tasks = True
+
 # by default, if a task in a playbook does not include a name: field then
 # ansible-playbook will construct a header that includes the task's action but
 # not the task's args.  This is a security feature because ansible cannot know

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -229,6 +229,7 @@ ANSIBLE_NOCOWS                 = get_config(p, DEFAULTS, 'nocows', 'ANSIBLE_NOCO
 ANSIBLE_COW_SELECTION          = get_config(p, DEFAULTS, 'cow_selection', 'ANSIBLE_COW_SELECTION', 'default')
 ANSIBLE_COW_WHITELIST          = get_config(p, DEFAULTS, 'cow_whitelist', 'ANSIBLE_COW_WHITELIST', DEFAULT_COW_WHITELIST, islist=True)
 DISPLAY_ARGS_TO_STDOUT         = get_config(p, DEFAULTS, 'display_args_to_stdout', 'DISPLAY_ARGS_TO_STDOUT', False, boolean=True)
+DISPLAY_INCLUDE_TASKS          = get_config(p, DEFAULTS, 'display_include_tasks', 'DISPLAY_INCLUDE_TASKS', True, boolean=True)
 DISPLAY_SKIPPED_HOSTS          = get_config(p, DEFAULTS, 'display_skipped_hosts', 'DISPLAY_SKIPPED_HOSTS', True, boolean=True)
 DEFAULT_UNDEFINED_VAR_BEHAVIOR = get_config(p, DEFAULTS, 'error_on_undefined_vars', 'ANSIBLE_ERROR_ON_UNDEFINED_VARS', True, boolean=True)
 HOST_KEY_CHECKING              = get_config(p, DEFAULTS, 'host_key_checking',  'ANSIBLE_HOST_KEY_CHECKING',    True, boolean=True)

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -214,7 +214,7 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_include(self, included_file):
-        if C.DISPLAY_INCLUDE TASKS:
+        if C.DISPLAY_INCLUDE_TASKS:
             msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
             self._display.display(msg, color=C.COLOR_SKIP)
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -157,7 +157,7 @@ class CallbackModule(CallbackBase):
                         self._display.display(diff)
         elif 'diff' in result._result and result._result['diff'] and result._result.get('changed', False):
             diff = self._get_diff(result._result['diff'])
-if diff:
+            if diff:
                 self._display.display(diff)
 
     def v2_playbook_item_on_ok(self, result):

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -126,7 +126,8 @@ class CallbackModule(CallbackBase):
         if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
             args = ', '.join(('%s=%s' % a for a in task.args.items()))
             args = ' %s' % args
-        self._display.banner("TASK [%s%s]" % (task.get_name().strip(), args))
+        if C.DISPLAY_INCLUDE_TASKS or task.action != 'include':
+            self._display.banner("TASK [%s%s]" % (task.get_name().strip(), args))
         if self._display.verbosity >= 2:
             path = task.get_path()
             if path:
@@ -156,7 +157,7 @@ class CallbackModule(CallbackBase):
                         self._display.display(diff)
         elif 'diff' in result._result and result._result['diff'] and result._result.get('changed', False):
             diff = self._get_diff(result._result['diff'])
-            if diff:
+if diff:
                 self._display.display(diff)
 
     def v2_playbook_item_on_ok(self, result):
@@ -213,8 +214,9 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_include(self, included_file):
-        msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
-        self._display.display(msg, color=C.COLOR_SKIP)
+        if C.DISPLAY_INCLUDE TASKS:
+            msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
+            self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_stats(self, stats):
         self._display.banner("PLAY RECAP")

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -126,7 +126,8 @@ class CallbackModule(CallbackBase):
         if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
             args = ', '.join(('%s=%s' % a for a in task.args.items()))
             args = ' %s' % args
-        self._display.banner("TASK [%s%s]" % (task.get_name().strip(), args))
+        if C.DISPLAY_INCLUDE_TASKS or task.action != 'include':
+            self._display.banner("TASK [%s%s]" % (task.get_name().strip(), args))
         if self._display.verbosity >= 2:
             path = task.get_path()
             if path:
@@ -213,8 +214,9 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_include(self, included_file):
-        msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
-        self._display.display(msg, color=C.COLOR_SKIP)
+        if C.DISPLAY_INCLUDE TASKS:
+            msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
+            self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_stats(self, stats):
         self._display.banner("PLAY RECAP")


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
```
##### Summary:

This adds an option "display include tasks", similar to "display skipped hosts".
It allows for suppressing all output (header and task line) generated by include tasks. Especially if you use a lot of includes, sometimes playbook output gets cluttered up with messages from include tasks which one might not be interested in.
The default stays as before (include tasks are shown), but it allows for different behavior if desired.

This is an alternative implementation proposal for #14285 and an alternative to pull request #14300.
