### PR TITLE
Updated facts.py to prevent Samba mounts from appearing in ansible_mounts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1086,7 +1086,9 @@ class LinuxHardware(Hardware):
         for line in mtab.split('\n'):
             if line.startswith('/'):
                 fields = line.rstrip('\n').split()
-                if(fields[2] != 'none'):
+                samba_filesystems = ['cifs', 'smbfs']
+                # Samba filesystems start with '//' but should not be included in mounts
+                if(fields[2] != 'none' and not fields[2] in samba_filesystems):
                     size_total, size_available = self._get_mount_size_facts(fields[1])
                     if fields[0] in uuids:
                         uuid = uuids[fields[0]]


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel 921e04185a) last updated 2016/03/17 12:36:27 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 345d9cbca8) last updated 2016/03/17 13:39:25 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD f47b499bb9) last updated 2016/03/17 13:39:33 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

By default the facts module generates a list of filesystems, where the device starts with a '/' Samba mounts start with '//', but should probably not be included.
##### Example output:

```
        "ansible_mounts": [
            {
                "device": "/dev/sda2",
                "fstype": "ext4",
                "mount": "/",
                "options": "rw",
                "size_available": 6786015232,
                "size_total": 11490541568,
                "uuid": "6ddc8945-1679-407c-bb31-f43e28054201"
            },
            {
                "device": "//centos6/share",
                "fstype": "cifs",
                "mount": "/mnt",
                "options": "rw",
                "size_available": 7209725952,
                "size_total": 11490541568,
                "uuid": "NA"
            }
        ],
```
