### PR TITLE
#15026 - Rare MySQLdb exception raised when remote host mysql client lacks SSL support!

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -61,6 +61,14 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if connect_timeout is not None:
         config['connect_timeout'] = connect_timeout
 
+    # If config['ssl'] is still empty at this point then a ssl connection is not
+    # being requested. We remove config['ssl'] because passing the 'ssl' argument to
+    # MySQLdb, even if empty, will still make MySQLdb attempt to initiate a SSL connection
+    # (as per documentation). In the rare case that MySQL SSL support is disabled on
+    # the server this will raise an exception.
+    if 'ssl' in config and not config['ssl']:
+        del config['ssl']
+
     db_connection = MySQLdb.connect(**config)
     if cursor_class is not None:
         return db_connection.cursor(cursorclass=MySQLdb.cursors.DictCursor)


### PR DESCRIPTION
##### Issue Type:
- Bug Report
##### Ansible Version:

```
ansible 2.1.0 (devel 2dd6bae9e1) last updated 2016/03/17 11:31:25 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 345d9cbca8) last updated 2016/03/16 14:49:13 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f9b96b9a8a) last updated 2016/03/16 14:49:16 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### Summary:

Issue #15026  

In the case where SSL support is requested with the mysql_db module, then all is fine and we should receive an exception. 

The problem occurs in the rare case where a remote host machine's client library may not have SSL support, or it's disabled - but we're not even asking for SSL through our mysql_db tasks. 

The _mysql_connect_ utility function creates a config 'ssl' key with empty dict and then processes configuration requests and populates the 'ssl' dict with required parameters, if needed. In the case where no ssl parameters are sent (no ssl_ca, ssl_cert, or ssl_key parameters through mysql_db module) the config still passes an empty 'ssl' key with empty dict.

As per MySQLdb documentation:
http://mysql-python.sourceforge.net/MySQLdb.html

```
ssl
This parameter takes a dictionary or mapping, where the keys are parameter names used by the mysql_ssl_set MySQL C API call. If this is set, it initiates an SSL connection to the server; if there is no SSL support in the client, an exception is raised. This must be a keyword parameter. 
```

We are passing a config with the 'ssl' key set, albeit empty, and this is forcing MySQLdb to initiate an SSL connection to server. As per docs an exception occurs if there is no SSL support in the client. 

BUT...we are not even requesting an SSL connection so this exception should not be occurring! 
##### Steps To Reproduce:

1) Using core _mysql_db_ module create a simple task such as database dump.

```
- name: Dump database(s).
  mysql_db: login_user="{{ item.user }}" login_host="{{ item.host }}" login_password={{ item.pass }} name={{ item.name }} state=dump target={{ temporary_backup_folder }}{{ item.filename }}.sql.gz
  with_items: "{{ databases }}"
```

2) Note that no SSL parameters are set, so we are **not** requesting an SSL connection.

3) Attempt to run this task against a remote host where there is no SSL support in the client.

4) The task will fail with msg: 

```
"msg": "unable to connect to database, check login_user and login_password are correct or /home2/your_home/.my.cnf has the credentials. Exception message: client library does not have SSL support"
```
