### PR TITLE
prepare packaging for newer Debian/Ubuntu releases

### DIFF
--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -4,7 +4,7 @@ Ansible Debian Package
 To create an Ansible DEB package:
 
     sudo apt-get install python-paramiko python-yaml python-jinja2 python-httplib2 python-setuptools python-six sshpass
-    sudo apt-get install cdbs debhelper dpkg-dev git-core reprepro python-support fakeroot asciidoc devscripts docbook-xml xsltproc
+    sudo apt-get install cdbs debhelper dpkg-dev git-core reprepro dh-python fakeroot asciidoc devscripts docbook-xml xsltproc libxml2-utils
     git clone git://github.com/ansible/ansible.git
     cd ansible
     make deb

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -4,10 +4,15 @@ Ansible Debian Package
 To create an Ansible DEB package:
 
     sudo apt-get install python-paramiko python-yaml python-jinja2 python-httplib2 python-setuptools python-six sshpass
-    sudo apt-get install cdbs debhelper dpkg-dev git-core reprepro dh-python fakeroot asciidoc devscripts docbook-xml xsltproc libxml2-utils
+    sudo apt-get install cdbs debhelper dpkg-dev git-core reprepro fakeroot asciidoc devscripts docbook-xml xsltproc libxml2-utils
+    sudo apt-get install dh-python
     git clone git://github.com/ansible/ansible.git
     cd ansible
     make deb
+
+On older releases that do not have `dh-python` (like Ubuntu 12.04), install `python-support` instead:
+
+    sudo apt-get install python-support
 
 The debian package file will be placed in the `../` directory. This can then be added to an APT repository or installed with `dpkg -i <package-file>`.
 

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -17,3 +17,7 @@ To install the Ansible DEB package and resolve dependencies:
 
     sudo dpkg -i <package-file>
     sudo apt-get -fy install
+
+Or, if you are running Debian Stretch (or later) or Ubuntu Xenial (or later):
+
+    sudo apt install <package-file>

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,12 +3,12 @@ Section: admin
 Priority: optional
 Standards-Version: 3.9.3
 Maintainer: Ansible, Inc. <support@ansible.com>
-Build-Depends: cdbs, debhelper (>= 5.0.0), asciidoc, python, python-support, python-setuptools
+Build-Depends: cdbs, debhelper (>= 5.0.0), asciidoc, python, dh-python, python-setuptools
 Homepage: http://ansible.github.com/
 
 Package: ansible
 Architecture: all
-Depends: python, python-support (>= 0.90), python-jinja2, python-yaml, python-paramiko, python-httplib2, python-six, python-crypto (>= 2.6), python-setuptools, sshpass, ${misc:Depends}
+Depends: python-jinja2, python-yaml, python-paramiko, python-httplib2, python-six, python-crypto (>= 2.6), python-setuptools, sshpass, ${misc:Depends}, ${python:Depends}
 Description: A radically simple IT automation platform
  A radically simple IT automation platform that makes your applications and
  systems easier to deploy. Avoid writing scripts or custom code to deploy and

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Standards-Version: 3.9.3
 Maintainer: Ansible, Inc. <support@ansible.com>
-Build-Depends: cdbs, debhelper (>= 5.0.0), asciidoc, python, dh-python, python-setuptools
+Build-Depends: cdbs, debhelper (>= 5.0.0), asciidoc, python, dh-python | python-support, python-setuptools
 Homepage: http://ansible.github.com/
 
 Package: ansible

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 # -- makefile --
 
+DEB_PYTHON2_MODULE_PACKAGES=ansible
+
 include /usr/share/cdbs/1/rules/debhelper.mk
-DEB_PYTHON_SYSTEM = pysupport
 include /usr/share/cdbs/1/class/python-distutils.mk

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -2,6 +2,9 @@
 # -- makefile --
 
 DEB_PYTHON2_MODULE_PACKAGES=ansible
+ifneq ($(shell dpkg-query -f '$${Version}' -W python-support 2>/dev/null),)
+DEB_PYTHON_SYSTEM=pysupport
+endif
 
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/python-distutils.mk


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Summary:

Ubuntu removes support for `python-support` in 16.04 LTS (Xenial), Debian does so in 9 (Stetch). The desired migration path is to `dh-python` (https://wiki.debian.org/Python/TransitionToDHPython2).

While at it, document new `apt` command in Xenial/Stetch.
##### Warning:

This breaks compat with Debian 7 and Ubuntu 12.04 LTS. If you want to keep compat with those we'd have to come up with a bit of fallback code/deps
