### PR TITLE
removes python requirement to script

### DIFF
--- a/test/integration/roles/test_script/tasks/main.yml
+++ b/test/integration/roles/test_script/tasks/main.yml
@@ -66,4 +66,4 @@
 - name: assert that the file was removed by the script
   assert:
     that:
-      - "script_result1.changed != True"
+      - "script_result1|changed"


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
2.x
```
##### Summary:

dependency on python mistakenly added when checksum was made to use stat module
