### PR TITLE
Add missing to_bytes for cmd.

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -272,6 +272,8 @@ class Connection(ConnectionBase):
 
         display.vvv("EXEC %s" % cmd, host=self._play_context.remote_addr)
 
+        cmd = to_bytes(cmd, errors='strict')
+
         no_prompt_out = ''
         no_prompt_err = ''
         become_output = ''


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (paramiko-unicode 24c4384f0e) last updated 2016/03/19 11:15:41 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 345d9cbca8) last updated 2016/03/19 10:45:30 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD f47b499bb9) last updated 2016/03/19 10:45:30 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Connection tests fail with a UnicodeEncodeError for paramiko versions prior to 1.16.0 due to the paramiko_ssh plugin sending a unicode string to chan.exec_command.

The Paramiko [Changelog](http://www.paramiko.org/changelog.html#1.16.0) references the fix for Paramiko version 1.16.0: https://github.com/paramiko/paramiko/pull/502
##### Example output:

Using CentOS 6 with Paramiko version 1.7.5 before the fix:

```
TEST_FLAGS='-l paramiko_ssh -vvv' make test_connection
```

Fails with:

```
Traceback (most recent call last):
  File "/root/ansible/lib/ansible/executor/task_executor.py", line 122, in run
    res = self._execute()
  File "/root/ansible/lib/ansible/executor/task_executor.py", line 424, in _execute
    result = self._handler.run(task_vars=variables)
  File "/root/ansible/lib/ansible/plugins/action/raw.py", line 38, in run
    result.update(self._low_level_execute_command(self._task.args.get('_raw_params'), executable=executable))
  File "/root/ansible/lib/ansible/plugins/action/__init__.py", line 557, in _low_level_execute_command
    rc, stdout, stderr = self._connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)
  File "/root/ansible/lib/ansible/plugins/connection/paramiko_ssh.py", line 280, in exec_command
    chan.exec_command(cmd)
  File "/usr/lib/python2.6/site-packages/paramiko/channel.py", line 210, in exec_command
    m.add_string(command)
  File "/usr/lib/python2.6/site-packages/paramiko/message.py", line 258, in add_string
    self.packet.write(s)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 17-18: ordinal not in range(128)
```

The tests pass after the fix.

Also successfully tested on Ubuntu 15.10 with Paramiko version 1.15.2, both before and after the fix.
