### PR TITLE
Disable destructive tests in test_git role.

### DIFF
--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -86,19 +86,30 @@
 - name: clear checkout_dir
   file: state=absent path={{ checkout_dir }}
 
+# Tests below are destructive and need to be fixed before being re-enabled.
+# Correcting this would be easy if the git module supported SSH options
+# for GlobalKnownHostsFile and UserKnownHostsFile instead of hard-coded
+# paths: https://github.com/ansible/ansible-modules-core/issues/3281
+
 - name: remove known_host files
   file: state=absent path={{ item }}
   with_items: "{{known_host_files}}"
+  # disabled - see explanation above
+  when: false
 
 - name: checkout ssh://git@github.com repo without accept_hostkey (expected fail)
   git: repo={{ repo_format2 }} dest={{ checkout_dir }}
   register: git_result
   ignore_errors: true
+  # disabled - see explanation above
+  when: false
 
 - assert:
     that:
       - 'git_result.failed'
       - 'git_result.msg == "github.com has an unknown hostkey. Set accept_hostkey to True or manually add the hostkey prior to running the git module"'
+  # disabled - see explanation above
+  when: false
 
 - name: checkout git@github.com repo with accept_hostkey (expected pass)
   git:


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (disable-git-destructive a44782a7ea) last updated 2016/03/19 21:16:11 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 345d9cbca8) last updated 2016/03/19 10:45:30 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD f47b499bb9) last updated 2016/03/19 10:45:30 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

The test_git role is run from the non_destructive integration tests. However, the task "remove known_host files" in that role is destructive.

Correcting this would be easy if the git module supported SSH options for GlobalKnownHostsFile and UserKnownHostsFile instead of hard-coded paths: https://github.com/ansible/ansible-modules-core/issues/3281

Until the git module is fixed, @bcoca  suggested that the offending tests be disabled.

An alternative fix is to split out the destructive test: https://github.com/mattclay/ansible/commit/b4b805d993f6f3fb955e2ae5114c6eaa825b5abd
##### Example output:

Here's the output from the disabled tests on Ubuntu 14.04:

```
TASK [test_git : remove known_host files] **************************************
skipping: [testhost] => (item=/root/.ssh/known_hosts)  => {"changed": false, "item": "/root/.ssh/known_hosts", "skip_reason": "Conditional check failed", "skipped": true}
skipping: [testhost] => (item=/etc/ssh/ssh_known_hosts)  => {"changed": false, "item": "/etc/ssh/ssh_known_hosts", "skip_reason": "Conditional check failed", "skipped": true}

TASK [test_git : checkout ssh://git@github.com repo without accept_hostkey (expected fail)] ***
skipping: [testhost] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}

TASK [test_git : assert] *******************************************************
skipping: [testhost] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}
```
