### PR TITLE
Add ssh client and server to docker containers.

### DIFF
--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -35,11 +35,11 @@ RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 #VOLUME /sys/fs/cgroup /run /tmp
-RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key
-RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key
-RUN ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
-RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
-RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
-RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
+    ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -13,6 +13,8 @@ RUN yum -y install \
     subversion \
     sudo \
     unzip \
+    openssh-clients \
+    openssh-server \
     which
 RUN yum -y install \
     PyYAML \
@@ -33,5 +35,11 @@ RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 #VOLUME /sys/fs/cgroup /run /tmp
+RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key
+RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key
+RUN ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
+RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
+RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -21,6 +21,8 @@ RUN yum -y install \
     subversion \
     sudo \
     unzip \
+    openssh-clients \
+    openssh-server \
     which
 RUN yum -y install \
     PyYAML \
@@ -38,5 +40,11 @@ RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp
+RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key
+RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key
+RUN ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
+RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
+RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -40,11 +40,11 @@ RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp
-RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key
-RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key
-RUN ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
-RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
-RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
-RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
+    ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/fedora-rawhide/Dockerfile
+++ b/test/utils/docker/fedora-rawhide/Dockerfile
@@ -37,11 +37,18 @@ RUN dnf -y install \
     tar \
     unzip \
     which \
+    openssh-clients \
+    openssh-server \
     yum
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8
 RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp
+RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key
+RUN ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
+RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
+RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/fedora-rawhide/Dockerfile
+++ b/test/utils/docker/fedora-rawhide/Dockerfile
@@ -45,10 +45,10 @@ RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp
-RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key
-RUN ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
-RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
-RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
-RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/fedora23/Dockerfile
+++ b/test/utils/docker/fedora23/Dockerfile
@@ -37,6 +37,8 @@ RUN dnf -y install \
     tar \
     unzip \
     which \
+    openssh-clients \
+    openssh-server \
     yum
 RUN localedef --quiet -f ISO-8859-1 -i pt_BR pt_BR
 RUN localedef --quiet -f ISO-8859-1 -i es_MX es_MX
@@ -44,5 +46,10 @@ RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp
+RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key
+RUN ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
+RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
+RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/fedora23/Dockerfile
+++ b/test/utils/docker/fedora23/Dockerfile
@@ -46,10 +46,10 @@ RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp
-RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key
-RUN ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
-RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
-RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
-RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -62,8 +62,8 @@ RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 RUN locale-gen en_US.UTF-8
-RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
-RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
-RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get install -y \
     rubygems \
     subversion \
     sudo \
+    openssh-client \
+    openssh-server \
     unzip
 
 # helpful things taken from the ubuntu-upstart Dockerfile:
@@ -60,5 +62,8 @@ RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 RUN locale-gen en_US.UTF-8
+RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
+RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get install -y \
     ruby \
     subversion \
     sudo \
+    openssh-client \
+    openssh-server \
     unzip
 
 # helpful things taken from the ubuntu-upstart Dockerfile:
@@ -57,5 +59,8 @@ RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 RUN locale-gen en_US.UTF-8
+RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
+RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -59,8 +59,8 @@ RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 RUN locale-gen en_US.UTF-8
-RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa
-RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
-RUN for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 ENV container docker
 CMD ["/sbin/init"]


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (travis-docker-ssh da99e4e0aa) last updated 2016/03/19 21:34:03 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 345d9cbca8) last updated 2016/03/19 10:45:30 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD f47b499bb9) last updated 2016/03/19 10:45:30 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Add ssh client and server to docker containers.

This will allow for future integration tests using ssh to localhost from docker containers running on Travis.
##### Example output:

With these updated docker images I was able to use run_test.sh to execute existing tests, along with ssh and paramiko_ssh connection tests.

Two bug fixes were necessary to make this work:
- Fix a unicode bug in paramiko_ssh: https://github.com/ansible/ansible/pull/15049
- Disable destructive tasks in the "non-destructive" test_git test: https://github.com/ansible/ansible/pull/15051

After that I only had to remove ssh and paramiko_ssh from the list of excluded connection tests.
