### PR TITLE
Move destructive git test to test_git_destructive.

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -12,6 +12,7 @@
     - { role: test_gem, tags: test_gem }
     - { role: test_yum, tags: test_yum }
     - { role: test_apt, tags: test_apt }
+    - { role: test_git_destructive, tags: test_git_destructive }
     - { role: test_apt_repository, tags: test_apt_repository }
     - { role: test_postgresql, tags: test_postgresql}
     - { role: test_mysql_db, tags: test_mysql_db}

--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -20,8 +20,6 @@
   set_fact:
     checkout_dir: '{{ output_dir }}/git'
     repo_format1: 'https://github.com/jimi-c/test_role'
-    repo_format2: 'git@github.com:jimi-c/test_role.git'
-    repo_format3: 'ssh://git@github.com/jimi-c/test_role.git'
     repo_submodules: 'https://github.com/abadger/test_submodules.git'
     repo_submodules_newer: 'https://github.com/abadger/test_submodules_newer.git'
     repo_submodule1: 'https://github.com/abadger/test_submodules_subm1.git'
@@ -29,9 +27,6 @@
     repo_submodule2: 'https://github.com/abadger/test_submodules_subm2.git'
     repo_update_url_1: 'https://github.com/ansible-test-robinro/git-test-old'
     repo_update_url_2: 'https://github.com/ansible-test-robinro/git-test-new'
-    known_host_files:
-      - "{{ lookup('env','HOME') }}/.ssh/known_hosts"
-      - '/etc/ssh/ssh_known_hosts'
 
 - name: clean out the output_dir
   shell: rm -rf {{ output_dir }}/*
@@ -77,65 +72,6 @@
   assert:
     that:
       - "not git_result2.changed"
-
-#
-# Test repo=git@github.com:/...
-# Requires variable: github_ssh_private_key
-#
-
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
-
-- name: remove known_host files
-  file: state=absent path={{ item }}
-  with_items: "{{known_host_files}}"
-
-- name: checkout ssh://git@github.com repo without accept_hostkey (expected fail)
-  git: repo={{ repo_format2 }} dest={{ checkout_dir }}
-  register: git_result
-  ignore_errors: true
-
-- assert:
-    that:
-      - 'git_result.failed'
-      - 'git_result.msg == "github.com has an unknown hostkey. Set accept_hostkey to True or manually add the hostkey prior to running the git module"'
-
-- name: checkout git@github.com repo with accept_hostkey (expected pass)
-  git:
-    repo: '{{ repo_format2 }}'
-    dest: '{{ checkout_dir }}'
-    accept_hostkey: true
-    key_file: '{{ github_ssh_private_key }}'
-  register: git_result
-  when: github_ssh_private_key is defined
-
-- assert:
-    that:
-      - 'git_result.changed'
-  when: not git_result|skipped
-
-#
-# Test repo=ssh://git@github.com/...
-# Requires variable: github_ssh_private_key
-#
-
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
-
-- name: checkout ssh://git@github.com repo with accept_hostkey (expected pass)
-  git:
-    repo: '{{ repo_format3 }}'
-    dest: '{{ checkout_dir }}'
-    version: 'master'
-    accept_hostkey: false # should already have been accepted
-    key_file: '{{ github_ssh_private_key }}'
-  register: git_result
-  when: github_ssh_private_key is defined
-
-- assert:
-    that:
-      - 'git_result.changed'
-  when: not git_result|skipped
 
 # Test a non-updating repo query with no destination specified
 

--- a/test/integration/roles/test_git_destructive/meta/main.yml
+++ b/test/integration/roles/test_git_destructive/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+

--- a/test/integration/roles/test_git_destructive/tasks/main.yml
+++ b/test/integration/roles/test_git_destructive/tasks/main.yml
@@ -1,0 +1,111 @@
+# test code for the git module
+# (c) 2014, James Tanner <tanner.jc@gmail.com>
+# (c) 2016, Matt Clay <matt@mystile.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: set role facts
+  set_fact:
+    checkout_dir: '{{ output_dir }}/git'
+    repo_format2: 'git@github.com:jimi-c/test_role.git'
+    repo_format3: 'ssh://git@github.com/jimi-c/test_role.git'
+    known_hosts_files:
+      - "{{ lookup('env','HOME') }}/.ssh/known_hosts"
+      - '/etc/ssh/ssh_known_hosts'
+
+- name: verify that git is installed so this test can continue
+  shell: which git
+
+#
+# Test repo=git@github.com:/...
+# Requires variable: github_ssh_private_key
+#
+
+- name: find known_hosts files
+  stat: path={{ item }}
+  register: found_known_hosts_files
+  with_items: "{{known_hosts_files}}"
+
+- name: backup known_hosts files
+  copy: remote_src=true src={{ item.item }} dest={{ item.item }}.bak
+  when: item.stat.exists
+  with_items: "{{found_known_hosts_files.results}}"
+
+- block:
+  - name: remove known_hosts files
+    file: state=absent path={{ item.item }}
+    when: item.stat.exists
+    with_items: "{{found_known_hosts_files.results}}"
+
+  # Test for unknown hostkey
+
+  - name: clear checkout_dir
+    file: state=absent path={{ checkout_dir }}
+
+  - name: checkout ssh://git@github.com repo without accept_hostkey (expected fail)
+    git: repo={{ repo_format2 }} dest={{ checkout_dir }}
+    register: git_result
+    ignore_errors: true
+
+  - name: make sure github.com has an unknown hostkey
+    assert:
+      that:
+      - 'git_result.failed'
+      - 'git_result.msg == "github.com has an unknown hostkey. Set accept_hostkey to True or manually add the hostkey prior to running the git module"'
+
+  # Test for accept_hostkey: true
+
+  - name: checkout git@github.com repo with accept_hostkey (expected pass)
+    git:
+      repo: '{{ repo_format2 }}'
+      dest: '{{ checkout_dir }}'
+      accept_hostkey: true
+      key_file: '{{ github_ssh_private_key }}'
+    register: git_result
+    when: github_ssh_private_key is defined
+
+  - name: make sure git checkout reports changed
+    assert:
+      that:
+        - 'git_result.changed'
+    when: not git_result|skipped
+
+  # Test for accept_hostkey: false
+
+  - name: clear checkout_dir
+    file: state=absent path={{ checkout_dir }}
+
+  - name: checkout ssh://git@github.com repo with accept_hostkey (expected pass)
+    git:
+      repo: '{{ repo_format3 }}'
+      dest: '{{ checkout_dir }}'
+      version: 'master'
+      accept_hostkey: false # should already have been accepted
+      key_file: '{{ github_ssh_private_key }}'
+    register: git_result
+    when: github_ssh_private_key is defined
+
+  - name: make sure git checkout reports changed
+    assert:
+      that:
+        - 'git_result.changed'
+    when: not git_result|skipped
+
+  always:
+    - name: restore known_hosts files
+      copy: remote_src=true src={{ item.item }}.bak dest={{ item.item }}
+      when: item.stat.exists
+      with_items: "{{found_known_hosts_files.results}}"


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (git-destructive-tests 95da1ea5fd) last updated 2016/03/20 15:08:51 (GMT -700)
  lib/ansible/modules/core: (detached HEAD d71b9bae89) last updated 2016/03/20 15:10:53 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD d5030ae555) last updated 2016/03/20 15:10:54 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

The test_git role is run from the non_destructive integration tests. However, the task "remove known_host files" in that role is destructive.

Correcting this would be easy if the git module supported SSH options for GlobalKnownHostsFile and UserKnownHostsFile instead of hard-coded paths: ansible/ansible-modules-core#3281

In the meantime, I've moved the tests depending on the destructive behaviour from test_git to test_git_destructive. I've also made the tests less destructive by backing up and restoring the known_hosts files. 
##### Example output:

Tested using the ubuntu1404 docker image.

`TEST_FLAGS='-t test_git_destructive' make destructive` without credentials has a play recap of:

```
PLAY RECAP *********************************************************************
testhost                   : ok=71   changed=3    unreachable=0    failed=0   
```

`TEST_FLAGS='-t test_git_destructive' make destructive` with credentials has a play recap of:

```
PLAY RECAP *********************************************************************
testhost                   : ok=75   changed=6    unreachable=0    failed=0   
```
