### PR TITLE
Remove need for unnecessary boto.ec2 import

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -85,10 +85,6 @@ def ec2_argument_spec():
     return spec
 
 
-def boto_supports_profile_name():
-    return hasattr(boto.ec2.EC2Connection, 'profile_name')
-
-
 def get_aws_connection_info(module, boto3=False):
 
     # Check module args for credentials, then check environment vars
@@ -172,15 +168,11 @@ def get_aws_connection_info(module, boto3=False):
                            aws_secret_access_key=secret_key,
                            security_token=security_token)
 
-        # profile_name only works as a key in boto >= 2.24
-        # so only set profile_name if passed as an argument
+        # only set profile_name if passed as an argument
         if profile_name:
-            if not boto_supports_profile_name():
-                module.fail_json("boto does not support profile_name before 2.24")
             boto_params['profile_name'] = profile_name
 
-        if HAS_LOOSE_VERSION and LooseVersion(boto.Version) >= LooseVersion("2.6.0"):
-            boto_params['validate_certs'] = validate_certs
+        boto_params['validate_certs'] = validate_certs
 
     for param, value in boto_params.items():
         if isinstance(value, str):


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel 7460f76f8d) last updated 2016/03/21 10:33:05 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD d71b9bae89) last updated 2016/03/21 10:51:13 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD d5030ae555) last updated 2016/03/21 10:51:16 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides

```
##### Summary:

Modules shouldn't need to import boto.ec2. The check was to test if profile_name was supported by boto. Two years after the introduction of the support, we will now assume that if people are passing `profile`, they are using a version of boto that supports it (this requirement is already documented in the aws documentation fragment).

Fixes ansible/ansible-modules-core#1901
Supersedes ansible/ansible-modules-core#2405
Supersedes ansible/ansible-modules-core#2272

This change also removes the version check for the even older `validate_certs` parameter.
