### PR TITLE
Vault improvements: base64 encoding, no AES-CTR padding, code cleanups

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -165,7 +165,7 @@ class DataLoader():
             with open(file_name, 'rb') as f:
                 data = f.read()
                 if self._vault.is_encrypted(data):
-                    data = self._vault.decrypt(data)
+                    data = self._vault.decrypt(data)[-1]
                     show_content = False
 
             data = to_unicode(data, errors='strict')

--- a/test/units/parsing/vault/test_vault_editor.py
+++ b/test/units/parsing/vault/test_vault_editor.py
@@ -194,21 +194,21 @@ class TestVaultEditor(unittest.TestCase):
         fdata = f.read()
         f.close()
 
-        assert error_hit == False, "error rekeying 1.0 file to 1.1"
+        self.assertEqual(error_hit, False, msg="error rekeying 1.0 file to 1.1")
 
         # ensure filedata can be decrypted, is 1.1 and is AES256
         vl = VaultLib("ansible2")
         dec_data = None
         error_hit = False
         try:
-            dec_data = vl.decrypt(fdata)
+            dec_data = vl.decrypt(fdata)[-1]
         except errors.AnsibleError as e:
             error_hit = True
 
         os.unlink(v10_file.name)
 
-        assert vl.cipher_name == "AES256", "wrong cipher name set after rekey: %s" % vl.cipher_name
-        assert error_hit == False, "error decrypting migrated 1.0 file"
-        assert dec_data.strip() == "foo", "incorrect decryption of rekeyed/migrated file: %s" % dec_data
+        self.assertIn(';AES256', fdata, msg="wrong cipher name set after rekey")
+        self.assertEqual(error_hit, False, msg="error decrypting migrated 1.0 file")
+        self.assertEqual(dec_data.strip(), "foo", msg="incorrect decryption of rekeyed/migrated file: %s" % dec_data)
 
 


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Summary:

Introduce an improved AES256 cipher version

Now we don't add spurious padding for AES-CTR (which is used as a stream cipher, and doesn't need padding) and we use base64 to encode the output message instead of blowing up its size by hexlify()ing everything twice. We also don't unnecessarily use PBKDF2 to generate the initial value for the encryption counter.

We always use the new format for output, but maintain read-compatibility with a few lines of 1.1-specific decoding in decrypt(). (Note that we do not force v1.1 files to be rewritten by ansible-vault edit unless their
contents have actually changed, in which case the new cipher version is used automatically).

Closes #10634 from graingert (which removed the padding, but added yet another cipher class for backwards compatibility)

Fixes #12121 from mgedmin (which reported the double-hexlify() problem)
