### PR TITLE
Handle "unable to process as utf-8" errors like Ansible v2.0.1.0

### DIFF
--- a/lib/ansible/utils/template.py
+++ b/lib/ansible/utils/template.py
@@ -246,7 +246,7 @@ def template_from_file(basedir, path, vars, vault_password=None):
         environment.undefined = StrictUndefined
 
     try:
-        data = codecs.open(realpath, encoding="utf8").read()
+        data = codecs.open(realpath, encoding="utf8", errors="replace").read()
     except UnicodeDecodeError:
         raise errors.AnsibleError("unable to process as utf-8: %s" % realpath)
     except:


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Ansible Version:

v1.9.4
##### Summary:

<!--- Please describe the change and the reason for it -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

We experience this problem when running a playbook on v1.9.4, while Ansible v2.0.1.0 handles it without bailing out.

The default decode-handling in v2 is 'replace', while I would prefer 'ignore'. Which is leave the errors from the original, rather than removing data. Both (ignore and replace) have been tested and work. I chose to backport what is implemented in v2.

On the other hand, I wouldn't mind of v2 simply bails out on incorrectly encoded files. Sure this is a change in behaviour, but it is better to report encoding issues rather than silently ignoring/corrupting files.

Maybe we should report it as warnings, at least it doesn't stop, but it doesn't ignore/corrupt either.
Best of both worlds ? Let me know what you prefer to do.
