### PR TITLE
Issue 15067

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -331,8 +331,14 @@ class Ec2Inventory(object):
         if not os.path.exists(cache_dir):
             os.makedirs(cache_dir)
 
-        self.cache_path_cache = cache_dir + "/ansible-ec2.cache"
-        self.cache_path_index = cache_dir + "/ansible-ec2.index"
+        cache_name = 'ansible-ec2'
+        aws_profile = lambda: (self.boto_profile or
+                              os.environ.get('AWS_PROFILE') or
+                              os.environ.get('AWS_ACCESS_KEY_ID'))
+        if aws_profile():
+            cache_name = '%s-%s' % (cache_name, aws_profile())
+        self.cache_path_cache = cache_dir + "/%s.cache" % cache_name
+        self.cache_path_index = cache_dir + "/%s.index" % cache_name
         self.cache_max_age = config.getint('ec2', 'cache_max_age')
 
         if config.has_option('ec2', 'expand_csv_tags'):


### PR DESCRIPTION
https://github.com/ansible/ansible/issues/15067

If a Boto profile is in use (either because it has been passed to the script as an argument or in the config file, or because it is being passed directly to Boto via the AWS_PROFILE environment variable), the name of the profile will be used to form the cache file that stores API lookups. 

This PR should prevent the situation where lookups for one account return cached data from another account. It should reflect the order of precedence:

arguments to CLI script > AWS_PROFILE environment variable > AWS_ACCESS_KEY_ID environment variable
