### PR TITLE
Make the template lookup match the template action

### DIFF
--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -17,12 +17,15 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import datetime
 import os
+import pwd
+import time
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.utils.unicode import to_unicode
+from ansible.utils.unicode import to_bytes, to_unicode
 
 try:
     from __main__ import display
@@ -49,13 +52,42 @@ class LookupModule(LookupBase):
                 with open(lookupfile, 'r') as f:
                     template_data = to_unicode(f.read())
 
+                    try:
+                        template_uid = pwd.getpwuid(os.stat(lookupfile).st_uid).pw_name
+                    except:
+                        template_uid = os.stat(lookupfile).st_uid
+
+                    temp_vars = self._templar._available_variables.copy()
+
+                    temp_vars['template_host']     = os.uname()[1]
+                    temp_vars['template_path']     = lookupfile
+                    temp_vars['template_mtime']    = datetime.datetime.fromtimestamp(os.path.getmtime(lookupfile))
+                    temp_vars['template_uid']      = template_uid
+                    temp_vars['template_fullpath'] = os.path.abspath(lookupfile)
+                    temp_vars['template_run_date'] = datetime.datetime.now()
+
+                    managed_default = C.DEFAULT_MANAGED_STR
+                    managed_str = managed_default.format(
+                        host = temp_vars['template_host'],
+                        uid  = temp_vars['template_uid'],
+                        file = to_bytes(temp_vars['template_path'])
+                    )
+                    temp_vars['ansible_managed'] = time.strftime(
+                        managed_str,
+                        time.localtime(os.path.getmtime(lookupfile))
+                    )
+
                     searchpath = [self._loader._basedir, os.path.dirname(lookupfile)]
                     if 'role_path' in variables:
                         searchpath.insert(1, C.DEFAULT_ROLES_PATH)
                         searchpath.insert(1, variables['role_path'])
 
                     self._templar.environment.loader.searchpath = searchpath
+
+                    old_vars = self._templar._available_variables
+                    self._templar.set_available_variables(temp_vars)
                     res = self._templar.template(template_data, preserve_trailing_newlines=True,convert_data=convert_data_p)
+                    self._templar.set_available_variables(old_vars)
                     ret.append(res)
             else:
                 raise AnsibleError("the template file %s could not be found for the lookup" % term)

--- a/test/integration/roles/test_special_vars/tasks/main.yml
+++ b/test/integration/roles/test_special_vars/tasks/main.yml
@@ -16,11 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: veryfiy ansible_managed
+- name: verify ansible_managed in template action
   template: src=foo.j2 dest={{output_dir}}/special_vars.yaml
 
-- name: read the file into facts
+- name: read the action file into facts
   include_vars: "{{output_dir}}/special_vars.yaml"
+
+- name: verify ansible_managed in template lookup
+  copy: content={{lookup('template', 'foo_lookup.j2')}} dest={{output_dir}}/special_vars_lookup.yaml
+
+- name: read the lookup file into facts
+  include_vars: "{{output_dir}}/special_vars_lookup.yaml"
 
 
 - name: veriy all test vars are defined
@@ -35,3 +41,10 @@
     - test_template_fullpath
     - test_template_run_date
     - test_ansible_managed
+    - test_lookup_template_host
+    - test_lookup_template_path
+    - test_lookup_template_mtime
+    - test_lookup_template_uid
+    - test_lookup_template_fullpath
+    - test_lookup_template_run_date
+    - test_lookup_ansible_managed

--- a/test/integration/roles/test_special_vars/templates/foo_lookup.j2
+++ b/test/integration/roles/test_special_vars/templates/foo_lookup.j2
@@ -1,0 +1,7 @@
+test_lookup_template_host: "{{template_host}}"
+test_lookup_template_path: "{{template_path}}"
+test_lookup_template_mtime: "{{template_mtime}}"
+test_lookup_template_uid: "{{template_uid}}"
+test_lookup_template_fullpath: "{{template_fullpath}}"
+test_lookup_template_run_date: "{{template_run_date}}"
+test_lookup_ansible_managed: "{{ansible_managed}}"


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel 723139900e) last updated 2016/03/21 22:28:33 (GMT +100)
  lib/ansible/modules/core: (detached HEAD d71b9bae89) last updated 2016/03/21 22:17:11 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD d5030ae555) last updated 2016/03/21 22:17:16 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Fixes #15044. I've copied functionality from the `template` action into the `template` lookup so that the same pre-set Ansible variables are available in both.

The `template` action sets variables (such as `ansible_managed`) which are not set for the equivalent `template` lookup. This change remedies this and is covered by matching integration tests.
