### PR TITLE
remove double read of "path" (/etc/SuSE-release) in facts.py

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -466,7 +466,7 @@ class Facts(object):
                                 elif path == '/etc/SuSE-release':
                                     if 'open' in data.lower():
                                         data = data.splitlines()
-                                        distdata = get_file_content(path).split('\n')[0]
+                                        distdata = data[0]
                                         self.facts['distribution'] = distdata.split()[0]
                                         for line in data:
                                             release = re.search('CODENAME *= *([^\n]+)', line)


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

devel
##### Summary:

remove unnecessary (duplicated) file read
