### PR TITLE
break after parsing SuSE-release in facts.py

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -484,6 +484,7 @@ class Facts(object):
                                             if release:
                                                 self.facts['distribution_release'] = release.group(1)
                                                 self.facts['distribution_version'] = self.facts['distribution_version'] + '.' + release.group(1)
+                                    break
                         elif name == 'Debian':
                             data = get_file_content(path)
                             if 'Debian' in data or 'Raspbian' in data:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

devel
##### Summary:

All sections that lead to succesful parsing of the version break afterwards, for SuSE-release this break was missing.

This fixes #14837, where SLES 11.4 reported a wrong `distribution_release`. See https://github.com/ansible/ansible/issues/14837#issuecomment-199706195
