### PR TITLE
Update the Mac warning in intro_installation.rst

### DIFF
--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -52,7 +52,7 @@ This includes Red Hat, Debian, CentOS, OS X, any of the BSDs, and so on.
 .. note::
 
     As of 2.0 ansible uses a few more file handles to manage its forks, OS X has a very low setting so if you want to use 15 or more forks
-    you'll need to raise the ulimit, like so ``sudo launchctl limit maxfiles 1024 unlimited``. Or just any time you see a "Too many open files" error.
+    you'll need to raise the ulimit, like so ``sudo launchctl limit maxfiles unlimited``. Or just any time you see a "Too many open files" error.
 
 
 .. warning::


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Docs Pull Request
##### Ansible Version:

```
Alteration to core documentation
```
##### Summary:

<!--- Please describe the change and the reason for it -->

In the docs it is suggested Mac users run `sudo launchctl limit maxfiles 1024 unlimited` to resolve an open file handle limit. I'm not sure if this is a typo but it causes issues with other running programs (In my case I couldn't start a VM and was getting a cryptic error from VMware).

Changing the command to just "unlimited" as per suggestion seems to resolve this.
