### PR TITLE
Add meeting info to Ansible community page

### DIFF
--- a/docsite/rst/community.rst
+++ b/docsite/rst/community.rst
@@ -227,6 +227,12 @@ which is our official conference series.
 
 To subscribe to a group from a non-google account, you can send an email to the subscription address requesting the subscription. For example: ansible-devel+subscribe@googlegroups.com
 
+IRC Meetings
+------------
+
+The Ansible community holds regular IRC meetings on various topics, and anyone who is interested is invited to 
+participate. For more information about Ansible meetings, consult the [Ansible community meeting page](https://github.com/ansible/community/blob/master/MEETINGS.md).
+
 Release Numbering
 -----------------
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

n/a
##### SUMMARY

Adding the fact that we have regular IRC meetings to the Ansible community page in the docs, with a link to the meetings page
