### PR TITLE
Limit should not affect the calculation of host variables as the variables may be referenced by another host that is not limited.

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -591,8 +591,13 @@ class Inventory(object):
             for group in self.groups:
                 group.vars = utils.combine_vars(group.vars, self.get_group_vars(group, new_pb_basedir=True))
             # get host vars from host_vars/ files
+            ### HACK: in 2.0 subset isn't a problem.  Never port this to 2.x
+            ### Fixes: https://github.com/ansible/ansible/issues/13557
+            old_subset =  self._subset
+            self._subset = None
             for host in self.get_hosts():
                 host.vars = utils.combine_vars(host.vars, self.get_host_vars(host, new_pb_basedir=True))
+            self._subset = old_subset
             # invalidate cache
             self._vars_per_host = {}
             self._vars_per_group = {}


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 1.9.x
```
##### SUMMARY

Ansible 1.9.2-1.9.4  (at least) have bugs with --limit restricting the loading of inventory variables to be relative to the inventory where they are supposed to be referencable relative to both the inventory and the playbook.  1.9.5 attempted to fix this but caused the opposite problem.  The fix applied to 1.9.5 has been reverted and this fix should fix the original problem.

Fixes #13556
Fixes #13557
Fixes #12174
