### PR TITLE
Run more connection tests in Docker.

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -23,7 +23,7 @@ VAULT_PASSWORD_FILE = vault-password
 CONSUL_RUNNING := $(shell python consul_running.py)
 EUID := $(shell id -u -r)
 
-all: setup test_test_infra parsing test_var_precedence unicode test_templating_settings environment non_destructive destructive includes blocks pull check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_connection test_gathering_facts
+all: setup test_test_infra parsing test_var_precedence unicode test_templating_settings environment test_connection non_destructive destructive includes blocks pull check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_gathering_facts
 
 test_test_infra:
 	# ensure fail/assert work locally and can stop execution with non-zero exit code
@@ -82,13 +82,21 @@ environment: setup
 non_destructive: setup
 	ansible-playbook non_destructive.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
+# For our Docker images, which identify themselves with "ENV container=docker", use the test_docker inventory group.
+# Otherwise use the test_default inventory group, which runs fewer tests, but should work on any system.
+ifeq ($(container),docker)
+TEST_CONNECTION_FILTER := 'test_docker'
+else
+TEST_CONNECTION_FILTER := 'test_default'
+endif
+
 # Skip connection plugins which require root when not running as root.
 ifneq ($(EUID),0)
-TEST_CONNECTION_FILTER := !chroot
+TEST_CONNECTION_FILTER += !chroot
 endif
 
 # Connection plugin test command to repeat with each locale setting.
-TEST_CONNECTION_CMD = $(1) ansible-playbook test_connection.yml -i test_connection.inventory -l '!skip-during-build $(TEST_CONNECTION_FILTER)' $(TEST_FLAGS)
+TEST_CONNECTION_CMD = $(1) ansible-playbook test_connection.yml -i test_connection.inventory -l '$(TEST_CONNECTION_FILTER)' $(TEST_FLAGS)
 
 test_connection: setup
 	$(call TEST_CONNECTION_CMD)

--- a/test/integration/test_connection.inventory
+++ b/test/integration/test_connection.inventory
@@ -48,9 +48,11 @@ paramiko_ssh-no-pipelining ansible_ssh_pipelining=false
 ansible_host=localhost
 ansible_connection=paramiko_ssh
 
-[skip-during-build:children]
-docker
-libvirt_lxc
-jail
+[test_default:children]
+local
+chroot
+
+[test_docker:children]
+test_default
 ssh
 paramiko_ssh


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

```
ansible 2.1.0 (travis-connection-tests 943e4d37f5) last updated 2016/03/23 21:21:53 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 7efc09ef08) last updated 2016/03/23 21:08:33 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 7f9cdc0350) last updated 2016/03/23 21:08:33 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Enable additional connection plugin tests on Travis which are currently disabled:
- ssh
- paramiko_ssh

These tests are not new, but running them on Travis is.

Running outside of our Docker images runs the same tests as before:
- local
- chroot

NOTE: Connection tests are now run before non_destructive to make sure that the known_hosts file in our Docker image has not been removed.
##### Example output:

Running `make test_connection` as non-root has a play recap of:

```
PLAY RECAP *********************************************************************
local-no-pipelining        : ok=10   changed=7    unreachable=0    failed=0   
local-pipelining           : ok=10   changed=7    unreachable=0    failed=0   
```

Running `make test_connection` as root has a play recap of:

```
PLAY RECAP *********************************************************************
chroot-no-pipelining       : ok=10   changed=7    unreachable=0    failed=0   
chroot-pipelining          : ok=10   changed=7    unreachable=0    failed=0   
local-no-pipelining        : ok=10   changed=7    unreachable=0    failed=0   
local-pipelining           : ok=10   changed=7    unreachable=0    failed=0   
```

Running `make test_connection` as non-root in docker has a play recap of:

```
PLAY RECAP *********************************************************************
local-no-pipelining        : ok=10   changed=7    unreachable=0    failed=0   
local-pipelining           : ok=10   changed=7    unreachable=0    failed=0   
paramiko_ssh-no-pipelining : ok=10   changed=7    unreachable=0    failed=0   
paramiko_ssh-pipelining    : ok=10   changed=7    unreachable=0    failed=0   
ssh-no-pipelining          : ok=10   changed=7    unreachable=0    failed=0   
ssh-pipelining             : ok=10   changed=7    unreachable=0    failed=0   
```

Running `make test_connection` as root in docker has a play recap of:

```
PLAY RECAP *********************************************************************
chroot-no-pipelining       : ok=10   changed=7    unreachable=0    failed=0   
chroot-pipelining          : ok=10   changed=7    unreachable=0    failed=0   
local-no-pipelining        : ok=10   changed=7    unreachable=0    failed=0   
local-pipelining           : ok=10   changed=7    unreachable=0    failed=0   
paramiko_ssh-no-pipelining : ok=10   changed=7    unreachable=0    failed=0   
paramiko_ssh-pipelining    : ok=10   changed=7    unreachable=0    failed=0   
ssh-no-pipelining          : ok=10   changed=7    unreachable=0    failed=0   
ssh-pipelining             : ok=10   changed=7    unreachable=0    failed=0   
```
