### PR TITLE
net_template.py: Fix j2 file search path

### DIFF
--- a/lib/ansible/plugins/action/net_template.py
+++ b/lib/ansible/plugins/action/net_template.py
@@ -93,6 +93,17 @@ class ActionModule(ActionBase):
         except IOError:
             return dict(failed=True, msg='unable to load src file')
 
+        # Create a template search path in the following order:
+        # [working_path, self_role_path, dependent_role_paths, dirname(source)]
+        searchpath = [working_path]
+        if self._task._role is not None:
+            searchpath.append(self._task._role._role_path)
+            dep_chain = self._task._block.get_dep_chain()
+            if dep_chain is not None:
+                for role in dep_chain:
+                    searchpath.append(role._role_path)
+        searchpath.append(os.path.dirname(source))
+        self._templar.environment.loader.searchpath = searchpath
         self._task.args['src'] = self._templar.template(template_data)
 
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
air$ ansible-playbook --version
ansible-playbook 2.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #15133

```
air$ play site.yaml

PLAY [fabric switches] *********************************************************

TASK [setup] *******************************************************************
ok: [fab1]

TASK [switch : print JSON input for this play] *********************************
skipping: [fab1]

TASK [switch : configure the switch] *******************************************
changed: [fab1]

TASK [switch : result from the switch] *****************************************
skipping: [fab1]

PLAY [spine switches] **********************************************************

TASK [setup] *******************************************************************
ok: [spine2]
ok: [spine1]

TASK [switch : print JSON input for this play] *********************************
skipping: [spine1]
skipping: [spine2]

TASK [switch : configure the switch] *******************************************
changed: [spine1]
changed: [spine2]

TASK [switch : result from the switch] *****************************************
skipping: [spine1]
skipping: [spine2]

PLAY [leaf switches] ***********************************************************

TASK [setup] *******************************************************************
ok: [leaf1]
ok: [leaf2]
ok: [leaf3]

TASK [switch : print JSON input for this play] *********************************
skipping: [leaf1]
skipping: [leaf3]
skipping: [leaf2]

TASK [switch : configure the switch] *******************************************
changed: [leaf3]
changed: [leaf1]
changed: [leaf2]

TASK [switch : result from the switch] *****************************************
skipping: [leaf2]
skipping: [leaf1]
skipping: [leaf3]

PLAY RECAP *********************************************************************
fab1                       : ok=2    changed=1    unreachable=0    failed=0
leaf1                      : ok=2    changed=1    unreachable=0    failed=0
leaf2                      : ok=2    changed=1    unreachable=0    failed=0
leaf3                      : ok=2    changed=1    unreachable=0    failed=0
spine1                     : ok=2    changed=1    unreachable=0    failed=0
spine2                     : ok=2    changed=1    unreachable=0    failed=0
```

This allows to '{% include ['another.j2'] %}' work inside j2 file.
