### PR TITLE
Show error context in args splitter exception

### DIFF
--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -256,6 +256,6 @@ def split_args(args):
     # If we're done and things are not at zero depth or we're still inside quotes,
     # raise an error to indicate that the args were unbalanced
     if print_depth or block_depth or comment_depth or inside_quotes:
-        raise AnsibleParserError("failed at splitting arguments, either an unbalanced jinja2 block or quotes")
+        raise AnsibleParserError("failed at splitting arguments, either an unbalanced jinja2 block or quotes: {}".format(args))
 
     return params


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
- Improvement
##### ANSIBLE VERSION

```
ansible 2.0.0.2
```
##### SUMMARY

This modification gives you some clues when args splitter rises an exception.

Sample playbook:

```
- hosts: localhost
  tasks:
    - debug: msg=' # '
```

Output before modification:

```
Unexpected Exception: error while splitting arguments, either an unbalanced jinja2 block or quotes
to see the full traceback, use -vvv
```

Using `-vvv` gives no context.

Output after modification:

```
Unexpected Exception: error while splitting arguments, either an unbalanced jinja2 block or quotes: msg='
to see the full traceback, use -vvv
```
