### PR TITLE
Add winrm tests and fix exposed unicode errors.

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -247,9 +247,9 @@ class Connection(ConnectionBase):
 
     # FUTURE: determine buffer size at runtime via remote winrm config?
     def _put_file_stdin_iterator(self, in_path, out_path, buffer_size=250000):
-        in_size = os.path.getsize(in_path)
+        in_size = os.path.getsize(to_bytes(in_path, errors='strict'))
         offset = 0
-        with open(in_path, 'rb') as in_file:
+        with open(to_bytes(in_path, errors='strict'), 'rb') as in_file:
             for out_data in iter((lambda:in_file.read(buffer_size)), ''):
                 offset += len(out_data)
                 self._display.vvvvv('WINRM PUT "%s" to "%s" (offset=%d size=%d)' % (in_path, out_path, offset, len(out_data)), host=self._winrm_host)
@@ -265,7 +265,7 @@ class Connection(ConnectionBase):
         super(Connection, self).put_file(in_path, out_path)
         out_path = self._shell._unquote(out_path)
         display.vvv('PUT "%s" TO "%s"' % (in_path, out_path), host=self._winrm_host)
-        if not os.path.exists(in_path):
+        if not os.path.exists(to_bytes(in_path, errors='strict')):
             raise AnsibleFileNotFound('file or module does not exist: "%s"' % in_path)
 
         script_template = u'''
@@ -366,9 +366,9 @@ class Connection(ConnectionBase):
                     else:
                         if not out_file:
                             # If out_path is a directory and we're expecting a file, bail out now.
-                            if os.path.isdir(out_path):
+                            if os.path.isdir(to_bytes(out_path, errors='strict')):
                                 break
-                            out_file = open(out_path, 'wb')
+                            out_file = open(to_bytes(out_path, errors='strict'), 'wb')
                         out_file.write(data)
                         if len(data) < buffer_size:
                             break

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -102,6 +102,13 @@ test_connection: setup
 	$(call TEST_CONNECTION_CMD)
 	$(call TEST_CONNECTION_CMD, LC_ALL=C LANG=C)
 
+# Connection plugin test command to repeat with each locale setting. WinRM specific version.
+TEST_CONNECTION_WINRM_CMD = $(1) ansible-playbook test_connection_winrm.yml -i inventory.winrm $(TEST_FLAGS)
+
+test_connection_winrm: setup
+	$(call TEST_CONNECTION_WINRM_CMD)
+	$(call TEST_CONNECTION_WINRM_CMD, LC_ALL=C LANG=C)
+
 destructive: setup
 	ansible-playbook destructive.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 

--- a/test/integration/inventory.winrm.template
+++ b/test/integration/inventory.winrm.template
@@ -5,3 +5,15 @@ server ansible_ssh_host=10.10.10.10 ansible_ssh_user=Administrator ansible_ssh_p
 ansible_connection=winrm
 # HTTPS uses 5986, HTTP uses 5985
 ansible_ssh_port=5985
+
+[winrm]
+winrm-pipelining    ansible_ssh_pipelining=true
+winrm-no-pipelining ansible_ssh_pipelining=false
+
+[winrm:vars]
+ansible_connection=winrm
+ansible_host=somehost
+ansible_user=someuser
+ansible_password=somepassword
+ansible_port=5986
+ansible_winrm_server_cert_validation=ignore

--- a/test/integration/test_connection_winrm.yml
+++ b/test/integration/test_connection_winrm.yml
@@ -1,0 +1,37 @@
+- hosts: winrm
+  gather_facts: no
+  serial: 1
+  tasks:
+
+  ### raw with unicode arg and output
+
+  - name: raw with unicode arg and output
+    raw: echo 汉语
+    register: command
+  - name: check output of raw with unicode arg and output
+    assert: { that: "'汉语' in command.stdout" }
+
+  ### copy local file with unicode filename and content
+
+  - name: create local file with unicode filename and content
+    local_action: lineinfile dest=/tmp/ansible-local-汉语/汉语.txt create=true line=汉语
+  - name: remove remote file with unicode filename and content
+    win_file: path=c:/windows/temp/ansible-remote-汉语/汉语.txt state=absent
+  - name: create remote directory with unicode name
+    win_file: path=c:/windows/temp/ansible-remote-汉语 state=directory
+  - name: copy local file with unicode filename and content
+    win_copy: src=/tmp/ansible-local-汉语/汉语.txt dest=c:/windows/temp/ansible-remote-汉语/汉语.txt
+
+  ### fetch remote file with unicode filename and content
+
+  - name: remove local file with unicode filename and content
+    local_action: file path=/tmp/ansible-local-汉语/汉语.txt state=absent
+  - name: fetch remote file with unicode filename and content
+    fetch: src=c:/windows/temp/ansible-remote-汉语/汉语.txt dest=/tmp/ansible-local-汉语/汉语.txt fail_on_missing=true validate_checksum=true flat=true
+
+  ### remove local and remote temp files
+
+  - name: remove local temp file
+    local_action: file path=/tmp/ansible-local-汉语 state=absent
+  - name: remove remote temp file
+    win_file: path=c:/windows/temp/ansible-remote-汉语 state=absent


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (winrm-test 35c2b45fbe) last updated 2016/03/24 10:46:43 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 7efc09ef08) last updated 2016/03/24 08:50:40 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 7f9cdc0350) last updated 2016/03/24 08:50:40 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add winrm version of connection tests and add missing to_bytes on file paths exposed by the tests.

Tests were run on a Ubuntu 15.10 control host against a Windows Server 2012 R2 install.

The test command used was: `TEST_FLAGS='-vvvvv' make test_connection_winrm`

Before adding the missing to_bytes calls, the tests failed. The first failure was:

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/home/matt/mattclay/ansible/lib/ansible/executor/task_executor.py", line 124, in run
    res = self._execute()
  File "/home/matt/mattclay/ansible/lib/ansible/executor/task_executor.py", line 426, in _execute
    result = self._handler.run(task_vars=variables)
  File "/home/matt/mattclay/ansible/lib/ansible/plugins/action/copy.py", line 215, in run
    self._transfer_file(source_full, tmp_src)
  File "/home/matt/mattclay/ansible/lib/ansible/plugins/action/__init__.py", line 257, in _transfer_file
    self._connection.put_file(local_path, remote_path)
  File "/home/matt/mattclay/ansible/lib/ansible/plugins/connection/winrm.py", line 268, in put_file
    if not os.path.exists(in_path):
  File "/usr/lib/python2.7/genericpath.py", line 26, in exists
    os.stat(path)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 19-20: ordinal not in range(128)
```

After the to_bytes calls were added, the tests passed, with a play recap of:

```
PLAY RECAP *********************************************************************
winrm-no-pipelining        : ok=10   changed=7    unreachable=0    failed=0   
winrm-pipelining           : ok=10   changed=7    unreachable=0    failed=0 
```

Each change made to winrm was the result of encountering an error while running the tests.

NOTE: When porting the connection tests to winrm, the pipelining test was kept in case winrm gains pipelining support in the future.
