### PR TITLE
[WIP] fix for incorrect template search paths

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -208,7 +208,7 @@ class DataLoader():
         given = unquote(given)
         given = to_unicode(given, errors='strict')
 
-        if given.startswith(u"/"):
+        if given.startswith(os.path.sep):
             return os.path.abspath(given)
         elif given.startswith(u"~"):
             return os.path.abspath(os.path.expanduser(given))
@@ -228,7 +228,7 @@ class DataLoader():
         search = []
 
         # I have full path, nothing else needs to be looked at
-        if source.startswith('~') or source.startswith('/'):
+        if source.startswith(u'~') or source.startswith(os.path.sep):
             search.append(self.path_dwim(source))
         else:
             # save while we mangle basedir for searchpath 

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -71,20 +71,20 @@ class ActionModule(ActionBase):
 
         if faf:
             source = self._get_first_available_file(faf, task_vars.get('_original_file', None, 'templates'))
-            if source is None:
-                result['failed'] = True
-                result['msg'] = "could not find src in first_available_file list"
-                return result
+            paths = faf
         else:
-            if self._task._role is not None:
-                source = self._loader.path_dwim_relative(self._task._role._role_path, 'templates', source)
-                if not os.path.exists(source) and self._task._block._dep_chain:
-                    for dep in sorted(self._task._block.get_dep_chain(), reverse=True):
-                        source = self._loader.path_dwim_relative(dep, 'templates', source)
-                        if os.path.exists(source):
-                            break
-            else:
-                source = self._loader.path_dwim_relative(self._loader.get_basedir(), 'templates', source)
+            path_stack = []
+            if self._task._block._dep_chain:
+                path_stack.append(self._task._role._role_path) # append current role
+                path_stack.extend(reversed([x._role_path for x in self._task._block.get_dep_chain()])) # append role deps
+
+            # find file in all this mess
+            source, paths = self._loader.path_dwim_relative(self._loader.get_basedir(), 'templates', source, path_stack)
+
+            if source is None:
+             result['failed'] = True
+             result['msg'] = "Could not find src in:\n%s" % paths
+             return result
 
         # Expand any user home dir specification
         dest = self._remote_expand_user(dest)
@@ -126,15 +126,7 @@ class ActionModule(ActionBase):
 
             # Create a new searchpath list to assign to the templar environment's file
             # loader, so that it knows about the other paths to find template files
-            searchpath = [self._loader._basedir, os.path.dirname(source)]
-            if self._task._role is not None:
-                if self._task._block._dep_chain:
-                    new_sp = sorted(self._task._block.get_dep_chain(), reverse=True)
-                    new_sp.extend(searchpath)
-                    searchpath =  new_sp
-                searchpath.insert(1, self._task._role._role_path)
-
-            self._templar.environment.loader.searchpath = searchpath
+            self._templar.environment.loader.searchpath = paths
 
             old_vars = self._templar._available_variables
             self._templar.set_available_variables(temp_vars)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.x
```
##### SUMMARY

jinja2 loader now uses dependency chain vs role path var, which could also be `:` separated path list
also added role dep path to primary template search
