### PR TITLE
Run longest running tests first to see if we shave off a few minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ services:
 language: python
 matrix:
   include:
-    - env: TARGET=sanity TOXENV=py24
+    - env: TARGET=centos6
+    - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - env: TARGET=ubuntu1204
+    - env: TARGET=ubuntu1404
     - env: TARGET=sanity TOXENV=py26
       python: 2.6
     - env: TARGET=sanity TOXENV=py27
@@ -14,12 +19,7 @@ matrix:
       python: 3.4
     - env: TARGET=sanity TOXENV=py35
       python: 3.5
-    - env: TARGET=centos6
-    - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    - env: TARGET=ubuntu1204
-    - env: TARGET=ubuntu1404
+    - env: TARGET=sanity TOXENV=py24
 addons:
   apt:
     sources:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY

Reordering the travis tests so that longest running are first shaves off a little over a minute for running the tests.  A small savings but a very small change to achieve it.
