### PR TITLE
Add to_bytes to file paths for accelerate plugin.

### DIFF
--- a/lib/ansible/plugins/connection/accelerate.py
+++ b/lib/ansible/plugins/connection/accelerate.py
@@ -30,6 +30,7 @@ from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleConnectionF
 from ansible.parsing.utils.jsonify import jsonify
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.encrypt import key_for_hostname, keyczar_encrypt, keyczar_decrypt
+from ansible.utils.unicode import to_bytes
 
 try:
     from __main__ import display
@@ -210,6 +211,8 @@ class Connection(ConnectionBase):
         ''' transfer a file from local to remote '''
         display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr)
 
+        in_path = to_bytes(in_path, errors='strict')
+
         if not os.path.exists(in_path):
             raise AnsibleFileNotFound("file or module does not exist: %s" % in_path)
 
@@ -262,7 +265,7 @@ class Connection(ConnectionBase):
         if self.send_data(data):
             raise AnsibleError("failed to initiate the file fetch with %s" % self._play_context.remote_addr)
 
-        fh = open(out_path, "w")
+        fh = open(to_bytes(out_path, errors='strict'), "w")
         try:
             bytes = 0
             while True:


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (accelerate-unicode 3624f371a0) last updated 2016/03/24 16:30:03 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 7efc09ef08) last updated 2016/03/24 08:50:40 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 7f9cdc0350) last updated 2016/03/24 08:50:40 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add to_bytes to file paths for the accelerate connection plugin.

Tested on a Ubuntu 15.10 control host connecting to localhost:
1. Add "accelerate: yes" to test_connection.yml
2. Run `TEST_FLAGS='-l ssh -vvv' make test_connection`

Before the fixes, the tests fail, with the first error being:

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/home/matt/mattclay/ansible/lib/ansible/executor/task_executor.py", line 124, in run
    res = self._execute()
  File "/home/matt/mattclay/ansible/lib/ansible/executor/task_executor.py", line 426, in _execute
    result = self._handler.run(task_vars=variables)
  File "/home/matt/mattclay/ansible/lib/ansible/plugins/action/copy.py", line 215, in run
    self._transfer_file(source_full, tmp_src)
  File "/home/matt/mattclay/ansible/lib/ansible/plugins/action/__init__.py", line 257, in _transfer_file
    self._connection.put_file(local_path, remote_path)
  File "/home/matt/mattclay/ansible/lib/ansible/plugins/connection/accelerate.py", line 213, in put_file
    if not os.path.exists(in_path):
  File "/usr/lib/python2.7/genericpath.py", line 26, in exists
    os.stat(path)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 19-20: ordinal not in range(128)
```

After the fixes, the tests pass, with the play recap being:

```
PLAY RECAP *********************************************************************
ssh-no-pipelining          : ok=10   changed=7    unreachable=0    failed=0   
ssh-pipelining             : ok=10   changed=7    unreachable=0    failed=0   
```
