### PR TITLE
Adding ip address to ansible-playbook RECAP

### DIFF
--- a/lib/ansible/executor/stats.py
+++ b/lib/ansible/executor/stats.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 class AggregateStats:
     ''' holds stats about per-host activity during playbook runs '''
 
-    def __init__(self):
+    def __init__(self, inventory=None):
 
         self.processed = {}
         self.failures  = {}
@@ -30,6 +30,7 @@ class AggregateStats:
         self.dark      = {}
         self.changed   = {}
         self.skipped   = {}
+        self.inventory = inventory
 
     def increment(self, what, host):
         ''' helper function to bump a statistic '''
@@ -48,4 +49,3 @@ class AggregateStats:
             changed     = self.changed.get(host, 0),
             skipped     = self.skipped.get(host, 0)
         )
-

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -62,7 +62,7 @@ class TaskQueueManager:
         self._variable_manager = variable_manager
         self._loader           = loader
         self._options          = options
-        self._stats            = AggregateStats()
+        self._stats            = AggregateStats(inventory)
         self.passwords         = passwords
         self._stdout_callback  = stdout_callback
         self._run_additional_callbacks = run_additional_callbacks

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -222,7 +222,9 @@ class CallbackModule(CallbackBase):
         hosts = sorted(stats.processed.keys())
         for h in hosts:
             t = stats.summarize(h)
-
+            h_ip = stats.inventory.get_host(h)
+            if h_ip.vars.get('ansible_host'):
+                h = '%s - %s' % (h, h_ip.vars['ansible_host'])
             self._display.display(u"%s : %s %s %s %s" % (
                 hostcolor(h, t),
                 colorize(u'ok', t['ok'], C.COLOR_OK),


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
"ansible 2.1.0"
```
##### SUMMARY

Sometimes the host information is added in memory
with add_host module (and the host is a VM with a
random ip), and it would be nice to have
an easy way to get the ip address to connect to
the machine when something goes wrong, in order to
debug, without need to go through logs to check
what's the ip address for the specifc machine

**Before:**

```
PLAY RECAP *********************************************************************
localhost                   : ok=2    changed=1    unreachable=0    failed=0
```

**After:**

```
PLAY RECAP *********************************************************************
localhost - 127.0.0.1      : ok=2    changed=1    unreachable=0    failed=0
```
