### PR TITLE
Add accelerate mode setting to inventory.

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -244,6 +244,18 @@ ansible_become_user
 ansible_become_pass
     Equivalent to ``ansible_sudo_pass`` or ``ansible_su_pass``, allows you to set the privilege escalation password
 
+Accelerated Mode (see :doc:`Accelerated Mode<playbooks_acceleration>` for further details):
+
+.. versionadded:: 2.0
+
+ansible_accelerate_port
+    Set the port used for the accelerated connection. Equivalent to ``accelerate_port`` in your playbook.
+
+.. versionadded:: 2.1
+
+ansible_accelerate
+    Enable accelerated mode. Equivalent to ``accelerate`` in your playbook.
+
 Remote host environment parameters:
 
 ansible_shell_type

--- a/docsite/rst/playbooks_acceleration.rst
+++ b/docsite/rst/playbooks_acceleration.rst
@@ -56,6 +56,8 @@ In order to use accelerated mode, simply add `accelerate: true` to your play::
         - bar
         - baz
 
+As of Ansible version `2.1`, you can also set `ansible_accelerate` in your inventory file.
+
 If you wish to change the port Ansible will use for the accelerated connection, just add the `accelerated_port` option::
 
     ---
@@ -69,6 +71,8 @@ The `accelerate_port` option can also be specified in the environment variable A
 
     [accelerate]
     accelerate_port = 5099
+
+As of Ansible version `2.0`, you can also set `ansible_accelerate_port` in your inventory file.
 
 As noted above, accelerated mode also supports running tasks via sudo, however there are two important caveats:
 

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -53,6 +53,7 @@ MAGIC_VARIABLE_MAPPING = dict(
    remote_addr      = ('ansible_ssh_host', 'ansible_host'),
    remote_user      = ('ansible_ssh_user', 'ansible_user'),
    port             = ('ansible_ssh_port', 'ansible_port'),
+   accelerate       = ('ansible_accelerate',),
    accelerate_port  = ('ansible_accelerate_port',),
    password         = ('ansible_ssh_pass', 'ansible_password'),
    private_key_file = ('ansible_ssh_private_key_file', 'ansible_private_key_file'),


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (accelerate-config d051d70dfc) last updated 2016/03/24 18:01:18 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 7efc09ef08) last updated 2016/03/24 08:50:40 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 7f9cdc0350) last updated 2016/03/24 08:50:40 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add an `ansible_accelerate` inventory variable to control accelerate mode from inventory. This joins the already existing `ansible_accelerate_port` inventory variable.

This allows use of accelerate mode without enabling it for an entire playbook. This will be useful for easily adding accelerate mode to connection tests, including the ability to run them on Travis.

Tested on Ubuntu 15.10.
