### PR TITLE
examples/ansible.cfg: add vault_password_file

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -104,6 +104,10 @@
 # if passing --private-key to ansible or ansible-playbook
 #private_key_file = /path/to/file
 
+# If set, configures the path to the Vault password file as an alternative to
+# specifying --vault-password-file on the command line.
+#vault_password_file = /path/to/vault_password_file
+
 # format of string {{ ansible_managed }} available within Jinja2
 # templates indicates to users editing templates files will be replaced.
 # replacing {file}, {host} and {uid} and strftime codes with proper values.


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.0.2
  config file = /home/l/prog/ansible/examples/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This just matches what's on http://docs.ansible.com/ansible/intro_configuration.html#vault-password-file
