### PR TITLE
Add ip4_hex filter to convert ip-address to hex notation

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -675,6 +675,7 @@ def ip4_hex(arg):
     numbers = list(map(int, arg.split('.')))
     return '{:02x}{:02x}{:02x}{:02x}'.format(*numbers)
 
+# ---- Ansible filters ----
 
 class FilterModule(object):
     ''' IP address and network manipulation filters '''

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -670,7 +670,11 @@ def _need_netaddr(f_name, *args, **kwargs):
     raise errors.AnsibleFilterError('The {0} filter requires python-netaddr be'
             ' installed on the ansible controller'.format(f_name))
 
-# ---- Ansible filters ----
+def ip4_hex(arg):
+    ''' Convert an IPv4 address to Hexadecimal notation '''
+    numbers = list(map(int, arg.split('.')))
+    return '{:02x}{:02x}{:02x}{:02x}'.format(*numbers)
+
 
 class FilterModule(object):
     ''' IP address and network manipulation filters '''
@@ -683,6 +687,7 @@ class FilterModule(object):
         'ipsubnet': ipsubnet,
         'nthhost': nthhost,
         'slaac': slaac,
+        'ip4_hex': ip4_hex,
 
         # MAC / HW addresses
         'hwaddr': hwaddr,


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

ansible 2.1.0
##### SUMMARY

Add a filter to convert and ipv4 ipaddr to hexadecimal notation. This can for example be used in systems that use hex-notation for IP's, like PXE boot.

Signed-off-by: Mark M. Janssen mark@sig-io.nl
