### PR TITLE
Use _connection instead of _play_context for information about the connection

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -81,7 +81,7 @@ class ActionModule(ActionBase):
             is a different host (for instance, an ssh tunnelled port or an
             alternative ssh port to a vagrant host.)
         """
-        transport = self._play_context.connection
+        transport = self._connection.transport
         if host not in C.LOCALHOST or transport != "local":
             if port_matches_localhost_port and host in C.LOCALHOST:
                 self._task.args['_substitute_controller'] = True
@@ -144,13 +144,13 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        # self._play_context.connection accounts for delegate_to so
+        # self._connection accounts for delegate_to so
         # remote_transport is the transport ansible thought it would need
         # between the controller and the delegate_to host or the controller
         # and the remote_host if delegate_to isn't set.
 
         remote_transport = False
-        if self._play_context.connection != 'local':
+        if self._connection.transport != 'local':
             remote_transport = True
 
         try:
@@ -160,9 +160,9 @@ class ActionModule(ActionBase):
 
         # ssh paramiko and local are fully supported transports.  Anything
         # else only works with delegate_to
-        if delegate_to is None and self._play_context.connection not in ('ssh', 'paramiko', 'smart', 'local'):
+        if delegate_to is None and self._connection.transport not in ('ssh', 'paramiko', 'local'):
             result['failed'] = True
-            result['msg'] = "synchronize uses rsync to function. rsync needs to connect to the remote host via ssh or a direct filesystem copy. This remote host is being accessed via %s instead so it cannot work." % self._play_context.connection
+            result['msg'] = "synchronize uses rsync to function. rsync needs to connect to the remote host via ssh or a direct filesystem copy. This remote host is being accessed via %s instead so it cannot work." % self._connection.transport
             return result
 
         use_ssh_args = self._task.args.pop('use_ssh_args', None)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel f4eb9aac24) last updated 2016/03/25 09:24:38 (GMT -700)
  lib/ansible/modules/core: (devel 0268864211) last updated 2016/03/25 07:41:37 (GMT -700)
  lib/ansible/modules/extras: (devel 6978984244) last updated 2016/03/25 07:41:46 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

If we're not delegating then we change _connection into a local
connection midway through the file but we don't change
_play_context.connection (no need to alter that).  When we later check
it in process_remote() we need to know the actual connection, not the
connection that we thought we were going to use at the start of run().
So we have to use _connection.transport in process_remote().  The rest
of the places could use either one (because we have not yet changed to
a local connection) but we go ahead and switch those to
_connection.transport as well to avoid confusion in the future.

Fixes https://github.com/ansible/ansible-modules-core/issues/3136

With inventory:

```
zm01 ansible_host=localhost
```

Before:

```
$ ansible -m synchronize -a 'src=/etc/passwd dest=/var/tmp/te' -i playbooks/inventory zm01
zm01 | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "Could not determine controller hostname for rsync to send to"
```

After:

```
$ ansible -m synchronize -a 'src=/etc/passwd dest=/var/tmp/te' -i playbooks/inventory zm01
zm01 | SUCCESS => {
    "changed": false, 
    "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh '/usr/bin/ssh  -S none -o StrictHostKeyChecking=no' --out-format='<<CHANGED>>%i %n%L' \"/etc/passwd\" \"/var/tmp/te\"", 
    "msg": "", 
    "rc": 0, 
    "stdout_lines": []
```
