### PR TITLE
Extend OpenStack related hypervisor detection

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2740,6 +2740,11 @@ class LinuxVirtual(Virtual):
             self.facts['virtualization_role'] = 'guest'
             return
 
+        if product_name == 'OpenStack Nova':
+            self.facts['virtualization_type'] = 'openstack'
+            self.facts['virtualization_role'] = 'guest'
+            return
+
         bios_vendor = get_file_content('/sys/devices/virtual/dmi/id/bios_vendor')
 
         if bios_vendor == 'Xen':
@@ -2772,6 +2777,11 @@ class LinuxVirtual(Virtual):
 
         if sys_vendor == 'oVirt':
             self.facts['virtualization_type'] = 'kvm'
+            self.facts['virtualization_role'] = 'guest'
+            return
+
+        if sys_vendor == 'OpenStack Foundation':
+            self.facts['virtualization_type'] = 'openstack'
             self.facts['virtualization_role'] = 'guest'
             return
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
- Bugfix Pull Request
##### ANSIBLE VERSION
- ansible 1.9.2
- ansible 2.0.1.0
##### SUMMARY

Fixes #15165

In addition to already existing hypervisor detection, checks 
- /sys/devices/virtual/dmi/id/product_name
- /sys/devices/virtual/dmi/id/sys_vendor

for Openstack related strings.

fixed detection of ansible_virtualization_(role|path) facts for VM's
running in OpenStack Instances
- NOTE: this will break detection of ansible_virtualization_(role|path) facts
      if you are using Openstack Instaces with nested virtualization
