### PR TITLE
have to always run dwim() on the path to get the full absolute path.

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -30,18 +30,17 @@ from ansible import constants as C
 class ActionModule(ActionBase):
 
     def _get_absolute_path(self, path):
+        original_path = path
+
         if self._task._role is not None:
-            original_path = path
+            path = self._loader.path_dwim_relative(self._task._role._role_path, 'files', path)
+        else:
+            path = self._loader.path_dwim_relative(self._loader.get_basedir(), 'files', path)
 
-            if self._task._role is not None:
-                path = self._loader.path_dwim_relative(self._task._role._role_path, 'files', path)
-            else:
-                path = self._loader.path_dwim_relative(self._loader.get_basedir(), 'files', path)
-
-            if original_path and original_path[-1] == '/' and path[-1] != '/':
-                # make sure the dwim'd path ends in a trailing "/"
-                # if the original path did
-                path += '/'
+        if original_path and original_path[-1] == '/' and path[-1] != '/':
+            # make sure the dwim'd path ends in a trailing "/"
+            # if the original path did
+            path += '/'
 
         return path
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (synchronize-playbook-basedir 0cabd133ba) last updated 2016/03/25 12:10:05 (GMT -700)
  lib/ansible/modules/core: (devel 0268864211) last updated 2016/03/25 07:41:37 (GMT -700)
  lib/ansible/modules/extras: (devel 6978984244) last updated 2016/03/25 07:41:46 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Running a playbook in other than the current working directory with a relative path for src fails to find the src files.  Looks like it's because dwim was never applied to the path in this case.

Before:

```
fatal: [fedora22]: FAILED! => {"changed": false, "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh '/usr/bin/ssh  -S none -o StrictHostKeyChecking=no' --out-format='<<CHANGED>>%i %n%L' \"/srv/ansible/testdir/something\" \"fedora22:/var/tmp/testing\"", "failed": true, "invocation": {"module_args": {"_local_rsync_path": "rsync", "_substitute_controller": false, "archive": true, "checksum": false, "compress": true, "copy_links": null, "delete": false, "dest": "fedora22:/var/tmp/testing", "dest_port": 22, "dirs": false, "existing_only": false, "group": null, "link
s": null, "mode": "push", "owner": null, "partial": false, "perms": null, "private_key": null, "recursive": null, "rs
ync_opts": null, "rsync_path": null, "rsync_timeout": 0, "set_remote_user": true, "src": "/srv/ansible/testdir/someth
ing", "ssh_args": null, "times": null, "verify_host": false}}, "msg": "rsync: change_dir \"/srv/ansible/testdir\" fai
led: No such file or directory (2)\nrsync error: some files/attrs were not transferred (see previous errors) (code 23
) at main.c(1165) [sender=3.1.1]\n", "rc": 23}
```

After:

```
ok: [fedora22] => {"changed": false, "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh '/usr/bin/ssh  -S none -o StrictHostKeyChecking=no' --out-format='<<CHANGED>>%i %n%L' \"/srv/ansible/troubleshooting/testdir/something\" \"fedora22:/var/tmp/testing\"", "invocation": {"module_args": {"_local_rsync_path": "rsync", "_substitute_controller": false, "archive": true, "checksum": false, "compress": true, "copy_links": null, "delete": false, "dest": "fedora22:/var/tmp/testing", "dest_port": 22, "dirs": false, "existing_only": false, "group": null, "links": null, "mode": "push", "owner": null, "partial": false, "perms": null, "private_key": null, "recursive": null, "rsync_opts": null, "rsync_path": null, "rsync_timeout": 0, "set_remote_user": true, "src": "/srv/ansible/troubleshooting/testdir/something", "ssh_args": null, "times": null, "verify_host": false}}, "msg": "", "rc": 0, "stdout_lines": []}
```

The problem seems to be that we added logic to run dwim with a different path in case we were not inside of a role but failed to remove a higher level conditional that checks if we're inside of a role at the same time.  That conditional is preventing the new logic from being run.

Fixes #14944
