### PR TITLE
Support remote_user in jail connection plugin.

### DIFF
--- a/lib/ansible/plugins/connection/jail.py
+++ b/lib/ansible/plugins/connection/jail.py
@@ -94,7 +94,7 @@ class Connection(ConnectionBase):
         ''' connect to the jail; nothing to do here '''
         super(Connection, self)._connect()
         if not self._connected:
-            display.vvv("THIS IS A LOCAL JAIL DIR", host=self.jail)
+            display.vvv(u"ESTABLISH JAIL CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self.jail)
             self._connected = True
 
     def _buffered_exec_command(self, cmd, stdin=subprocess.PIPE):
@@ -105,8 +105,16 @@ class Connection(ConnectionBase):
         compared to exec_command() it looses some niceties like being able to
         return the process's exit code immediately.
         '''
-        executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else '/bin/sh'
-        local_cmd = [self.jexec_cmd, self.jail, executable, '-c', cmd]
+
+        local_cmd = [self.jexec_cmd]
+        set_env = ''
+
+        if self._play_context.remote_user is not None:
+            local_cmd += ['-U', self._play_context.remote_user]
+            # update HOME since -U does not update the jail environment
+            set_env = 'HOME=~' + self._play_context.remote_user + ' '
+
+        local_cmd += [self.jail, self._play_context.executable, '-c', set_env + cmd]
 
         display.vvv("EXEC %s" % (local_cmd,), host=self.jail)
         local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (issue6072 b60062bdf9) last updated 2016/03/26 03:52:08 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 0268864211) last updated 2016/03/26 03:51:44 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 6978984244) last updated 2016/03/26 03:51:51 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes issue #6072 by adding support for remote_user to the jail connection plugin.

Tested on FreeBSD 10.2.

Output without specifying a user:

```
# ansible -m raw -a 'id' all -i freebsd_10_2, -e 'ansible_connection=jail ansible_python_interpreter=/usr/local/bin/python'
freebsd_10_2 | SUCCESS | rc=0 >>
uid=0(root) gid=0(wheel) groups=0(wheel),5(operator)
```

Output specifying a user:

```
# ansible -m raw -a 'id' all -i freebsd_10_2, -e 'ansible_connection=jail ansible_python_interpreter=/usr/local/bin/python ansible_user=testing'
freebsd_10_2 | SUCCESS | rc=0 >>
uid=1001(testing) gid=1001(testing) groups=1001(testing)
```

Partial output from `TEST_FLAGS='-l jail -vvvvv' gmake test_connection` is:

```
TASK [remove remote temp file] *************************************************
task path: /root/ansible/test/integration/test_connection.yml:36
<freebsd_10_2> ESTABLISH JAIL CONNECTION FOR USER: None
<freebsd_10_2> EXEC ['/usr/sbin/jexec', u'freebsd_10_2', u'/bin/sh', '-c', u'/bin/sh -c \'( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458964369.4-122106073830790 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458964369.4-122106073830790 `" )\'']
<freebsd_10_2> PUT /tmp/tmp9_ocKi TO /root/.ansible/tmp/ansible-tmp-1458964369.4-122106073830790/file
<freebsd_10_2> EXEC ['/usr/sbin/jexec', u'freebsd_10_2', u'/bin/sh', '-c', u'dd of=/root/.ansible/tmp/ansible-tmp-1458964369.4-122106073830790/file bs=65536']
<freebsd_10_2> EXEC ['/usr/sbin/jexec', u'freebsd_10_2', u'/bin/sh', '-c', u'/bin/sh -c \'LANG=C LC_ALL=C LC_MESSAGES=C /usr/local/bin/python /root/.ansible/tmp/ansible-tmp-1458964369.4-122106073830790/file; rm -rf "/root/.ansible/tmp/ansible-tmp-1458964369.4-122106073830790/" > /dev/null 2>&1\'']
changed: [jail-no-pipelining] => {"changed": true, "diff": {"after": {"path": "/tmp/ansible-remote-??", "state": "absent"}, "before": {"path": "/tmp/ansible-remote-??", "state": "directory"}}, "invocation": {"module_args": {"backup": null, "content": null, "delimiter": null, "diff_peek": null, "directory_mode": null, "follow": false, "force": false, "group": null, "mode": null, "original_basename": null, "owner": null, "path": "/tmp/ansible-remote-??", "recurse": false, "regexp": null, "remote_src": null, "selevel": null, "serole": null, "setype": null, "seuser": null, "src": null, "state": "absent", "validate": null}, "module_name": "file"}, "path": "/tmp/ansible-remote-??", "state": "absent"}

PLAY RECAP *********************************************************************
jail-no-pipelining         : ok=10   changed=7    unreachable=0    failed=0   
jail-pipelining            : ok=10   changed=7    unreachable=0    failed=0
```

Partial output from `TEST_FLAGS='-l jail -vvvvv -e ansible_user=testing' gmake test_connection` is:

```
TASK [remove remote temp file] *************************************************
task path: /root/ansible/test/integration/test_connection.yml:36
<freebsd_10_2> ESTABLISH JAIL CONNECTION FOR USER: testing
<freebsd_10_2> EXEC ['/usr/sbin/jexec', '-U', u'testing', u'freebsd_10_2', u'/bin/sh', '-c', u'HOME=~testing /bin/sh -c \'( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458964411.5-121541798766539 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458964411.5-121541798766539 `" )\'']
<freebsd_10_2> PUT /tmp/tmpA7S3wW TO /home/testing/.ansible/tmp/ansible-tmp-1458964411.5-121541798766539/file
<freebsd_10_2> EXEC ['/usr/sbin/jexec', '-U', u'testing', u'freebsd_10_2', u'/bin/sh', '-c', u'HOME=~testing dd of=/home/testing/.ansible/tmp/ansible-tmp-1458964411.5-121541798766539/file bs=65536']
<freebsd_10_2> EXEC ['/usr/sbin/jexec', '-U', u'testing', u'freebsd_10_2', u'/bin/sh', '-c', u'HOME=~testing /bin/sh -c \'LANG=C LC_ALL=C LC_MESSAGES=C /usr/local/bin/python /home/testing/.ansible/tmp/ansible-tmp-1458964411.5-121541798766539/file; rm -rf "/home/testing/.ansible/tmp/ansible-tmp-1458964411.5-121541798766539/" > /dev/null 2>&1\'']
changed: [jail-no-pipelining] => {"changed": true, "diff": {"after": {"path": "/tmp/ansible-remote-??", "state": "absent"}, "before": {"path": "/tmp/ansible-remote-??", "state": "directory"}}, "invocation": {"module_args": {"backup": null, "content": null, "delimiter": null, "diff_peek": null, "directory_mode": null, "follow": false, "force": false, "group": null, "mode": null, "original_basename": null, "owner": null, "path": "/tmp/ansible-remote-??", "recurse": false, "regexp": null, "remote_src": null, "selevel": null, "serole": null, "setype": null, "seuser": null, "src": null, "state": "absent", "validate": null}, "module_name": "file"}, "path": "/tmp/ansible-remote-??", "state": "absent"}

PLAY RECAP *********************************************************************
jail-no-pipelining         : ok=10   changed=7    unreachable=0    failed=0   
jail-pipelining            : ok=10   changed=7    unreachable=0    failed=0
```
