### PR TITLE
Fix inconsistent/missing host names in messages.

### DIFF
--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -263,11 +263,11 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
 
     def connection_lock(self):
         f = self._play_context.connection_lockfd
-        display.vvvv('CONNECTION: pid %d waiting for lock on %d' % (os.getpid(), f))
+        display.vvvv('CONNECTION: pid %d waiting for lock on %d' % (os.getpid(), f), host=self._play_context.remote_addr)
         fcntl.lockf(f, fcntl.LOCK_EX)
-        display.vvvv('CONNECTION: pid %d acquired lock on %d' % (os.getpid(), f))
+        display.vvvv('CONNECTION: pid %d acquired lock on %d' % (os.getpid(), f), host=self._play_context.remote_addr)
 
     def connection_unlock(self):
         f = self._play_context.connection_lockfd
         fcntl.lockf(f, fcntl.LOCK_UN)
-        display.vvvv('CONNECTION: pid %d released lock on %d' % (os.getpid(), f))
+        display.vvvv('CONNECTION: pid %d released lock on %d' % (os.getpid(), f), host=self._play_context.remote_addr)

--- a/lib/ansible/plugins/connection/accelerate.py
+++ b/lib/ansible/plugins/connection/accelerate.py
@@ -67,20 +67,20 @@ class Connection(ConnectionBase):
             tries = 3
             self.conn = socket.socket()
             self.conn.settimeout(C.ACCELERATE_CONNECT_TIMEOUT)
-            display.vvvv("attempting connection to %s via the accelerated port %d" % (self._play_context.remote_addr,self._play_context.accelerate_port))
+            display.vvvv("attempting connection to %s via the accelerated port %d" % (self._play_context.remote_addr, self._play_context.accelerate_port), host=self._play_context.remote_addr)
             while tries > 0:
                 try:
                     self.conn.connect((self._play_context.remote_addr,self._play_context.accelerate_port))
                     break
                 except socket.error:
-                    display.vvvv("connection to %s failed, retrying..." % self._play_context.remote_addr)
+                    display.vvvv("connection to %s failed, retrying..." % self._play_context.remote_addr, host=self._play_context.remote_addr)
                     time.sleep(0.1)
                     tries -= 1
             if tries == 0:
-                display.vvv("Could not connect via the accelerated connection, exceeded # of tries")
+                display.vvv("Could not connect via the accelerated connection, exceeded # of tries", host=self._play_context.remote_addr)
                 raise AnsibleConnectionFailure("Failed to connect to %s on the accelerated port %s" % (self._play_context.remote_addr, self._play_context.accelerate_port))
             elif wrong_user:
-                display.vvv("Restarting daemon with a different remote_user")
+                display.vvv("Restarting daemon with a different remote_user", host=self._play_context.remote_addr)
                 raise AnsibleError("The accelerated daemon was started on the remote with a different user")
 
             self.conn.settimeout(C.ACCELERATE_TIMEOUT)
@@ -102,25 +102,25 @@ class Connection(ConnectionBase):
         header_len = 8 # size of a packed unsigned long long
         data = b""
         try:
-            display.vvvv("%s: in recv_data(), waiting for the header" % self._play_context.remote_addr)
+            display.vvvv("in recv_data(), waiting for the header", host=self._play_context.remote_addr)
             while len(data) < header_len:
                 d = self.conn.recv(header_len - len(data))
                 if not d:
-                    display.vvvv("%s: received nothing, bailing out" % self._play_context.remote_addr)
+                    display.vvvv("received nothing, bailing out", host=self._play_context.remote_addr)
                     return None
                 data += d
-            display.vvvv("%s: got the header, unpacking" % self._play_context.remote_addr)
+            display.vvvv("got the header, unpacking", host=self._play_context.remote_addr)
             data_len = struct.unpack('!Q',data[:header_len])[0]
             data = data[header_len:]
-            display.vvvv("%s: data received so far (expecting %d): %d" % (self._play_context.remote_addr,data_len,len(data)))
+            display.vvvv("data received so far (expecting %d): %d" % (data_len, len(data)), host=self._play_context.remote_addr)
             while len(data) < data_len:
                 d = self.conn.recv(data_len - len(data))
                 if not d:
-                    display.vvvv("%s: received nothing, bailing out" % self._play_context.remote_addr)
+                    display.vvvv("received nothing, bailing out", host=self._play_context.remote_addr)
                     return None
-                display.vvvv("%s: received %d bytes" % (self._play_context.remote_addr, len(d)))
+                display.vvvv("received %d bytes" % (len(d)), host=self._play_context.remote_addr)
                 data += d
-            display.vvvv("%s: received all of the data, returning" % self._play_context.remote_addr)
+            display.vvvv("received all of the data, returning", host=self._play_context.remote_addr)
             return data
         except socket.timeout:
             raise AnsibleError("timed out while waiting to receive data")
@@ -132,7 +132,7 @@ class Connection(ConnectionBase):
         daemon to exit if they don't match
         '''
 
-        display.vvvv("%s: sending request for validate_user" % self._play_context.remote_addr)
+        display.vvvv("sending request for validate_user", host=self._play_context.remote_addr)
         data = dict(
             mode='validate_user',
             username=self._play_context.remote_user,
@@ -142,7 +142,7 @@ class Connection(ConnectionBase):
         if self.send_data(data):
             raise AnsibleError("Failed to send command to %s" % self._play_context.remote_addr)
 
-        display.vvvv("%s: waiting for validate_user response" % self._play_context.remote_addr)
+        display.vvvv("waiting for validate_user response", host=self._play_context.remote_addr)
         while True:
             # we loop here while waiting for the response, because a
             # long running command may cause us to receive keepalive packets
@@ -154,10 +154,10 @@ class Connection(ConnectionBase):
             response = json.loads(response)
             if "pong" in response:
                 # it's a keepalive, go back to waiting
-                display.vvvv("%s: received a keepalive packet" % self._play_context.remote_addr)
+                display.vvvv("received a keepalive packet", host=self._play_context.remote_addr)
                 continue
             else:
-                display.vvvv("%s: received the validate_user response: %s" % (self._play_context.remote_addr, response))
+                display.vvvv("received the validate_user response: %s" % (response), host=self._play_context.remote_addr)
                 break
 
         if response.get('failed'):
@@ -174,7 +174,7 @@ class Connection(ConnectionBase):
         if in_data:
             raise AnsibleError("Internal Error: this module does not support optimized module pipelining")
 
-        display.vvv("EXEC COMMAND %s" % cmd)
+        display.vvv("EXEC COMMAND %s" % cmd, host=self._play_context.remote_addr)
 
         data = dict(
             mode='command',
@@ -197,10 +197,10 @@ class Connection(ConnectionBase):
             response = json.loads(response)
             if "pong" in response:
                 # it's a keepalive, go back to waiting
-                display.vvvv("%s: received a keepalive packet" % self._play_context.remote_addr)
+                display.vvvv("received a keepalive packet", host=self._play_context.remote_addr)
                 continue
             else:
-                display.vvvv("%s: received the response" % self._play_context.remote_addr)
+                display.vvvv("received the response", host=self._play_context.remote_addr)
                 break
 
         return (response.get('rc', None), response.get('stdout', ''), response.get('stderr', ''))
@@ -216,10 +216,10 @@ class Connection(ConnectionBase):
         fd = file(in_path, 'rb')
         fstat = os.stat(in_path)
         try:
-            display.vvv("PUT file is %d bytes" % fstat.st_size)
+            display.vvv("PUT file is %d bytes" % fstat.st_size, host=self._play_context.remote_addr)
             last = False
             while fd.tell() <= fstat.st_size and not last:
-                display.vvvv("file position currently %ld, file size is %ld" % (fd.tell(), fstat.st_size))
+                display.vvvv("file position currently %ld, file size is %ld" % (fd.tell(), fstat.st_size), host=self._play_context.remote_addr)
                 data = fd.read(CHUNK_SIZE)
                 if fd.tell() >= fstat.st_size:
                     last = True
@@ -242,7 +242,7 @@ class Connection(ConnectionBase):
                     raise AnsibleError("failed to put the file in the requested location")
         finally:
             fd.close()
-            display.vvvv("waiting for final response after PUT")
+            display.vvvv("waiting for final response after PUT", host=self._play_context.remote_addr)
             response = self.recv_data()
             if not response:
                 raise AnsibleError("Failed to get a response from %s" % self._play_context.remote_addr)
@@ -290,7 +290,7 @@ class Connection(ConnectionBase):
             # point in the future or we may just have the put/fetch
             # operations not send back a final response at all
             response = self.recv_data()
-            display.vvv("FETCH wrote %d bytes to %s" % (bytes, out_path))
+            display.vvv("FETCH wrote %d bytes to %s" % (bytes, out_path), host=self._play_context.remote_addr)
             fh.close()
 
     def close(self):

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -170,7 +170,7 @@ class Connection(ConnectionBase):
         super(Connection, self)._connect()
         if not self._connected:
             display.vvv(u"ESTABLISH DOCKER CONNECTION FOR USER: {0}".format(
-                self.actual_user or '?', host=self._play_context.remote_addr)
+                self.actual_user or '?'), host=self._play_context.remote_addr
             )
             self._connected = True
 

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -55,7 +55,7 @@ class Connection(ConnectionBase):
         self._play_context.remote_user = getpass.getuser()
 
         if not self._connected:
-            display.vvv(u"ESTABLISH LOCAL CONNECTION FOR USER: {0}".format(self._play_context.remote_user, host=self._play_context.remote_addr))
+            display.vvv(u"ESTABLISH LOCAL CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self._play_context.remote_addr)
             self._connected = True
         return self
 
@@ -68,7 +68,7 @@ class Connection(ConnectionBase):
 
         executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else None
 
-        display.vvv(u"{0} EXEC {1}".format(self._play_context.remote_addr, cmd))
+        display.vvv(u"EXEC {0}".format(cmd), host=self._play_context.remote_addr)
         # FIXME: cwd= needs to be set to the basedir of the playbook
         display.debug("opening command with Popen()")
 
@@ -122,7 +122,7 @@ class Connection(ConnectionBase):
 
         super(Connection, self).put_file(in_path, out_path)
 
-        display.vvv(u"{0} PUT {1} TO {2}".format(self._play_context.remote_addr, in_path, out_path))
+        display.vvv(u"PUT {0} TO {1}".format(in_path, out_path), host=self._play_context.remote_addr)
         if not os.path.exists(to_bytes(in_path, errors='strict')):
             raise AnsibleFileNotFound("file or module does not exist: {0}".format(to_str(in_path)))
         try:
@@ -137,7 +137,7 @@ class Connection(ConnectionBase):
 
         super(Connection, self).fetch_file(in_path, out_path)
 
-        display.vvv(u"{0} FETCH {1} TO {2}".format(self._play_context.remote_addr, in_path, out_path))
+        display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self._play_context.remote_addr)
         self.put_file(in_path, out_path)
 
     def close(self):

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -608,7 +608,7 @@ class Connection(ConnectionBase):
                     else:
                         msg = "ssh_retry: attempt: %d, caught exception(%s) from cmd (%s), pausing for %d seconds" % (attempt, e, cmd_summary, pause)
 
-                    display.vv(msg)
+                    display.vv(msg, host=self.host)
 
                     time.sleep(pause)
                     continue


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (conn-msg-host 5fdc29e00f) last updated 2016/03/25 21:11:54 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 0268864211) last updated 2016/03/25 15:53:55 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 6978984244) last updated 2016/03/25 15:53:55 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixed inconsistent and missing host names in verbose messages. Changes fall into a few categories:
1. Misplaced parens, causing host to be passed to format instead of display.vvv.
2. Calling display methods without passing host.
3. Calling display with host in the message instead of passing host.

This makes host labelling work as intended, and consistent within and across all connection plugins.

All connection plugins changed were tested on Ubuntu 15.10 using make test_connection.

Output from local connection tests before the fix:

```
ESTABLISH LOCAL CONNECTION FOR USER: matt
localhost EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458968095.58-196633470599526 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458968095.58-196633470599526 `" )'
localhost PUT /tmp/tmp2MsQWx TO /home/matt/.ansible/tmp/ansible-tmp-1458968095.58-196633470599526/file
localhost EXEC /bin/sh -c 'LANG=C LC_ALL=C LC_MESSAGES=C /usr/bin/python /home/matt/.ansible/tmp/ansible-tmp-1458968095.58-196633470599526/file; rm -rf "/home/matt/.ansible/tmp/ansible-tmp-1458968095.58-196633470599526/" > /dev/null 2>&1'
```

The same output after the fix:

```
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: matt
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458968263.87-148979217778361 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458968263.87-148979217778361 `" )'
<localhost> PUT /tmp/tmptOD_jj TO /home/matt/.ansible/tmp/ansible-tmp-1458968263.87-148979217778361/file
<localhost> EXEC /bin/sh -c 'LANG=C LC_ALL=C LC_MESSAGES=C /usr/bin/python /home/matt/.ansible/tmp/ansible-tmp-1458968263.87-148979217778361/file; rm -rf "/home/matt/.ansible/tmp/ansible-tmp-1458968263.87-148979217778361/" > /dev/null 2>&1'
```

Output from docker connection tests before the fix:

```
ESTABLISH DOCKER CONNECTION FOR USER: root
<ubuntu-latest> EXEC ['/usr/bin/docker', 'exec', '-i', u'ubuntu-latest', u'/bin/sh', '-c', u'/bin/sh -c \'( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458968174.81-31889539776153 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458968174.81-31889539776153 `" )\'']
<ubuntu-latest> PUT /tmp/tmpMfK8Dn TO /root/.ansible/tmp/ansible-tmp-1458968174.81-31889539776153/file
<ubuntu-latest> EXEC ['/usr/bin/docker', 'exec', '-i', u'ubuntu-latest', u'/bin/sh', '-c', u'/bin/sh -c \'LANG=C LC_ALL=C LC_MESSAGES=C /usr/bin/python /root/.ansible/tmp/ansible-tmp-1458968174.81-31889539776153/file; rm -rf "/root/.ansible/tmp/ansible-tmp-1458968174.81-31889539776153/" > /dev/null 2>&1\'']
```

The same output after the fix:

```
<ubuntu-latest> ESTABLISH DOCKER CONNECTION FOR USER: root
<ubuntu-latest> EXEC ['/usr/bin/docker', 'exec', '-i', u'ubuntu-latest', u'/bin/sh', '-c', u'/bin/sh -c \'( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458968290.01-193535192603740 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458968290.01-193535192603740 `" )\'']
<ubuntu-latest> PUT /tmp/tmpeikhFJ TO /root/.ansible/tmp/ansible-tmp-1458968290.01-193535192603740/file
<ubuntu-latest> EXEC ['/usr/bin/docker', 'exec', '-i', u'ubuntu-latest', u'/bin/sh', '-c', u'/bin/sh -c \'LANG=C LC_ALL=C LC_MESSAGES=C /usr/bin/python /root/.ansible/tmp/ansible-tmp-1458968290.01-193535192603740/file; rm -rf "/root/.ansible/tmp/ansible-tmp-1458968290.01-193535192603740/" > /dev/null 2>&1\'']
```
