### PR TITLE
galaxy info displayed 'galaxy_info' section wrong [fix for #15177]

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -152,7 +152,6 @@ class GalaxyCLI(CLI):
                 continue
 
             if isinstance(role_info[k], dict):
-                text += "\t%s: \n" % (k)
                 text.append(u"\t%s:" % (k))
                 for key in sorted(role_info[k].keys()):
                     if key in self.SKIP_INFO_KEYS:

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -1,0 +1,53 @@
+# (c) 2016, Adrian Likins <alikins@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.six import PY3
+from ansible.compat.tests import unittest
+
+from nose.plugins.skip import SkipTest
+
+if PY3:
+    raise SkipTest('galaxy is not ported to be py3 compatible yet')
+
+from ansible.cli.galaxy import GalaxyCLI
+
+class TestGalaxy(unittest.TestCase):
+    def setUp(self):
+        self.default_args = []
+
+    def test_init(self):
+        galaxy_cli = GalaxyCLI(args=self.default_args)
+        self.assertTrue(isinstance(galaxy_cli, GalaxyCLI))
+
+    def test_display_min(self):
+        gc = GalaxyCLI(args=self.default_args)
+        role_info = {'name': 'some_role_name'}
+        display_result = gc._display_role_info(role_info)
+        self.assertTrue(display_result.find('some_role_name') >-1)
+
+    def test_display_galaxy_info(self):
+        gc = GalaxyCLI(args=self.default_args)
+        galaxy_info = {}
+        role_info = {'name': 'some_role_name',
+                     'galaxy_info': galaxy_info}
+        display_result = gc._display_role_info(role_info)
+        if display_result.find('\t\tgalaxy_tags:') > -1:
+            self.fail('Expected galaxy_tags to be indented twice')


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (galaxy_info_output 10c6cb703d) last updated 2016/03/26 14:56:43 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 345d9cbca8) last updated 2016/03/26 14:27:07 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f9b96b9a8a) last updated 2016/03/26 14:27:10 (GMT -400)
  config file = /Users/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

The role info display method in cli/galaxy.py was formatting the labels for role_info  that had dicts 
for values incorrectly. The key was being +='ed to the text array in addition to being append to the text array. Judging from commit history I'm guessing the 'text += "\t%s: \n" % (k)' was left in accidentally
when the code was updated from building a '<str>' to building an array of '<unicode>' and joining.
(ie, commit fa9822df0f7a9067b6feae9d8c187f860aae1a29).

Fix is just removing that line. Patch also adds a unit test. 

```
The output of 'ansible-galaxy info' was formatting the
'galaxy_info' key with one char per line.

Previously, when building the output string, items in
role_info that had a dict for value, the label for
it's key ('galaxy_info' for ex) was being added to
the text list in addition to being appended. Only
the append is needed.

Also added a unit test in test/units/cli/test_galaxy.py

fixes #15177
```
