### PR TITLE
Fix boolean choices in module docs fragments

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/eos.py
+++ b/lib/ansible/utils/module_docs_fragments/eos.py
@@ -56,8 +56,8 @@ options:
         before sending any commands.  If not specified, the device will
         attempt to excecute all commands in non-priviledged mode.
     required: false
-    default: false
-    choices: BOOLEANS
+    default: no
+    choices: ['yes', 'no']
   auth_pass:
     description:
       - Specifies the password to use if required to enter privileged mode
@@ -78,8 +78,8 @@ options:
         I(transport) argument is configured as eapi.  If the transport
         argument is not eapi, this value is ignored
     required: false
-    default: true
-    choices: BOOLEANS
+    default: yes
+    choices: ['yes', 'no']
   provider:
     description:
       - Convience method that allows all M(eos) arguments to be passed as

--- a/lib/ansible/utils/module_docs_fragments/ios.py
+++ b/lib/ansible/utils/module_docs_fragments/ios.py
@@ -54,8 +54,8 @@ options:
         before sending any commands.  If not specified, the device will
         attempt to excecute all commands in non-priviledged mode.
     required: false
-    default: false
-    choices: BOOLEANS
+    default: no
+    choices: ['yes', 'no']
   auth_pass:
     description:
       - Specifies the password to use if required to enter privileged mode

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -63,8 +63,8 @@ options:
         I(transport) argument is configured as nxapi.  If the transport
         argument is not nxapi, this value is ignored
     required: false
-    default: false
-    choices: BOOLEANS
+    default: no
+    choices: ['yes', 'no']
   provider:
     description:
       - Convience method that allows all M(nxos) arguments to be passed as

--- a/lib/ansible/utils/module_docs_fragments/openswitch.py
+++ b/lib/ansible/utils/module_docs_fragments/openswitch.py
@@ -68,8 +68,8 @@ options:
         I(transport) argument is configured as rest.  If the transport
         argument is not rest, this value is ignored
     required: false
-    default: true
-    choices: BOOLEANS
+    default: yes
+    choices: ['yes', 'no']
   provider:
     description:
       - Convience method that allows all M(openswitch) arguments to be passed as


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

N/A
##### SUMMARY

A few of the docs fragments have the available choices for some params defined as "BOOLEANS". Because choices accepts a list, it treats "BOOLEANS" as an iterable and then generates a list composed of each letter. Here's what this looks like on the docs page:

![image](https://cloud.githubusercontent.com/assets/714287/14067746/78be2c4e-f431-11e5-9dcd-529108efc607.png)

Instead, this commit defines the available choices as a list of `['yes', 'no']`, as is common in most other modules.
