### PR TITLE
fix Mac chown/chmod -R issue, add error checks

### DIFF
--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -54,23 +54,29 @@ class ShellBase(object):
 
     def chmod(self, mode, path, recursive=True):
         path = pipes.quote(path)
-        cmd = ['chmod', mode, path]
+        cmd = ['chmod']
+
         if recursive:
-            cmd.append('-R')
+            cmd.append('-R') # many chmods require -R before file list
+
+        cmd.extend([mode, path])
+
         return ' '.join(cmd)
 
     def chown(self, path, user, group=None, recursive=True):
         path = pipes.quote(path)
         user = pipes.quote(user)
 
-        if group is None:
-            cmd = ['chown', user, path]
-        else:
-            group = pipes.quote(group)
-            cmd = ['chown', '%s:%s' % (user, group), path]
+        cmd = ['chown']
 
         if recursive:
-            cmd.append('-R')
+            cmd.append('-R') # many chowns require -R before file list
+
+        if group is None:
+            cmd.extend([user, path])
+        else:
+            group = pipes.quote(group)
+            cmd.extend(['%s:%s' % (user, group), path])
 
         return ' '.join(cmd)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (fix_mac_chown_chmod 124e4a22f8) last updated 2016/03/28 22:13:16 (GMT -700)
  lib/ansible/modules/core: (detached HEAD dfbf180be0) last updated 2016/03/28 22:08:24 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 33a557cc59) last updated 2016/03/28 22:08:24 (GMT -700)
```
##### SUMMARY

The changes to chown/chmod were broken on Mac (-R was being appended to the end of the command- OSX requires it before the file list).
A number of module setup commands were also blindly proceeding without checking for success. Added error raises for unrecoverable failure cases.
