### PR TITLE
IAM role support for EC2 dynamic inventory

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -181,7 +181,7 @@ stack_filters = False
 
 # An IAM role can be assumed, so all requests are run as that role.
 # This can be useful for connecting across different accounts, or to limit user
-#  access
+# access
 # iam_role = role-arn
 
 # A boto configuration profile may be used to separate out credentials

--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -179,6 +179,11 @@ stack_filters = False
 # (ex. webservers15, webservers1a, webservers123 etc)
 # instance_filters = tag:Name=webservers1*
 
+# An IAM role can be assumed, so all requests are run as that role.
+# This can be useful for connecting across different accounts, or to limit user
+#  access
+# iam_role = role-arn
+
 # A boto configuration profile may be used to separate out credentials
 # see http://boto.readthedocs.org/en/latest/boto_config_tut.html
 # boto_profile = some-boto-profile-name

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -132,6 +132,7 @@ from boto import ec2
 from boto import rds
 from boto import elasticache
 from boto import route53
+from boto import sts
 import six
 
 from ansible.module_utils import ec2 as ec2_utils

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -421,6 +421,10 @@ class Ec2Inventory(object):
         else:
             self.replace_dash_in_groups = True
 
+        # IAM role to assume for connection
+        if config.has_option('ec2', 'iam_role'):
+            self.iam_role = config.get('ec2', 'iam_role')
+
         # Configure which groups should be created.
         group_by_options = [
             'group_by_instance_id',
@@ -547,6 +551,13 @@ class Ec2Inventory(object):
         if self.boto_profile:
             connect_args['profile_name'] = self.boto_profile
             self.boto_fix_security_token_in_profile(connect_args)
+
+        if self.iam_role:
+            sts_conn = sts.connect_to_region(region, **connect_args)
+            role = sts_conn.assume_role(self.iam_role, 'ansible_dynamic_inventory')
+            connect_args['aws_access_key_id'] = role.credentials.access_key
+            connect_args['aws_secret_access_key'] = role.credentials.secret_key
+            connect_args['security_token'] = role.credentials.session_token
 
         conn = module.connect_to_region(region, **connect_args)
         # connect_to_region will fail "silently" by returning None if the region name is wrong or not supported

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -424,6 +424,8 @@ class Ec2Inventory(object):
         # IAM role to assume for connection
         if config.has_option('ec2', 'iam_role'):
             self.iam_role = config.get('ec2', 'iam_role')
+        else:
+            self.iam_role = None
 
         # Configure which groups should be created.
         group_by_options = [


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

Tested on both `2.1.0` and `1.9.4`
##### SUMMARY

This change allows the EC2 dynamic inventory to assume an IAM role prior to connecting to the AWS modules.
We needed this functionality at my company due to how we have structured our AWS setup, and I thought others might find it useful.
