### PR TITLE
Add sas_address and sas_device_handle to ansible disk device facts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -351,7 +351,7 @@ class Facts(object):
                                 self.facts['distribution'] = name
                             else:
                                 self.facts['distribution'] = data.split()[0]
-                            break  
+                            break
                         elif name == 'Slackware':
                             data = get_file_content(path)
                             if 'Slackware' in data:
@@ -359,7 +359,7 @@ class Facts(object):
                                 version = re.findall('\w+[.]\w+', data)
                                 if version:
                                     self.facts['distribution_version'] = version[0]
-                            break      
+                            break
                         elif name == 'OracleLinux':
                             data = get_file_content(path)
                             if 'Oracle Linux' in data:
@@ -1148,7 +1148,7 @@ class LinuxHardware(Hardware):
                     continue
             d = {}
             diskname = os.path.basename(sysdir)
-            for key in ['vendor', 'model']:
+            for key in ['vendor', 'model', 'sas_address', 'sas_device_handle']:
                 d[key] = get_file_content(sysdir + "/device/" + key)
 
             for key,test in [ ('removable','/removable'), \
@@ -2083,7 +2083,7 @@ class LinuxNetwork(Network):
 
                         # If this is the default address, update default_ipv4
                         if 'address' in default_ipv4 and default_ipv4['address'] == address:
-                            default_ipv4['broadcast'] = broadcast 
+                            default_ipv4['broadcast'] = broadcast
                             default_ipv4['netmask'] = netmask
                             default_ipv4['network'] = network
                             default_ipv4['macaddress'] = macaddress


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
HEAD
```
##### SUMMARY

It would be great if ansible would include sas information in disk device facts

sas_address
sas_device_handle

```
            "sdb": {
                "holders": [
                    "mpath1"
                ],
                "host": "Serial Attached SCSI controller: LSI Logic / Symbios Logic SAS3008 PCI-Express Fusion-MPT SAS-3 (rev 02)",
                "model": "HUC109030CSS600",
                "partitions": {},
                "removable": "0",
                "rotational": "1",
                "sas_address": "0x5000cca0541458de",
                "sas_device_handle": "0x000c",
                "scheduler_mode": "deadline",
                "sectors": "586072368",
                "sectorsize": "512",
                "size": "279.46 GB",
                "support_discard": "0",
                "vendor": "HITACHI"
            },
```
