### PR TITLE
Increase verbosity of connection tests.

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -96,7 +96,7 @@ TEST_CONNECTION_FILTER += !chroot
 endif
 
 # Connection plugin test command to repeat with each locale setting.
-TEST_CONNECTION_CMD = $(1) ansible-playbook test_connection.yml -i test_connection.inventory -l '$(TEST_CONNECTION_FILTER)' $(TEST_FLAGS)
+TEST_CONNECTION_CMD = $(1) ansible-playbook test_connection.yml -i test_connection.inventory -l '$(TEST_CONNECTION_FILTER)' -v $(TEST_FLAGS)
 
 test_connection: setup
 	$(call TEST_CONNECTION_CMD)


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (verbose-test a0361626c9) last updated 2016/03/30 06:58:17 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 0268864211) last updated 2016/03/25 15:53:55 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 6978984244) last updated 2016/03/25 15:53:55 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Set connection test verbosity to `-v` to assist with troubleshooting intermittent failures on Travis.

Here are two examples of the failures:
- https://travis-ci.org/ansible/ansible/jobs/119269024 (fedora-rawhide)
- https://travis-ci.org/ansible/ansible/jobs/118869894 (fedora23)

Both jobs failed the same way:

```
TASK [check output of raw with unicode arg and output] *************************

fatal: [paramiko_ssh-no-pipelining]: FAILED! => {"assertion": "'汉语' in command.stdout", "changed": false, "evaluated_to": false, "failed": true}
```

I already executed the connection tests successfully over 500 times in the `fedora23` docker image locally, so hopefully this will provide some insight the next time it fails on Travis.
