### PR TITLE
Add '--skip-tags' to ansible-pull

### DIFF
--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -207,6 +207,8 @@ class PullCLI(CLI):
             cmd += ' -e "%s"' % ev
         if self.options.ask_sudo_pass or self.options.ask_su_pass or self.options.become_ask_pass:
             cmd += ' --ask-become-pass'
+        if self.options.skip_tags:
+            cmd += ' --skip-tags "%s"' % self.options.skip_tags
         if self.options.tags:
             cmd += ' -t "%s"' % self.options.tags
         if self.options.subset:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

`--skip-tags` isn't forwarded to ansible-playbook by ansible-pull and is therefore ignored.
