### PR TITLE
cloudstack: fix bug, api_secret always None

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -112,7 +112,7 @@ class AnsibleCloudStack(object):
 
     def _connect(self):
         api_key = self.module.params.get('api_key')
-        api_secret = self.module.params.get('secret_key')
+        api_secret = self.module.params.get('api_secret')
         api_url = self.module.params.get('api_url')
         api_http_method = self.module.params.get('api_http_method')
         api_timeout = self.module.params.get('api_timeout')


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.0.x
```
##### SUMMARY

In case if api args are used, api_secret is always None. 

As this is defined as argument_spec in every cloudstack module, every cloudstack module is related (aka my test setup screwed up, it only uses the cloudstack.ini for passing the credentials).

Needs backport to 2.0

fixes https://github.com/ansible/ansible-modules-extras/issues/1929
