### PR TITLE
extend env plugin to accept a default value as parameter

### DIFF
--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -25,7 +25,7 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables, **kwargs):
 
-        default_v = kwargs.get('default', None)
+        default_v = kwargs.get('default', '')
         ret = []
         for term in terms:
             var = term.split()[0]

--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -25,9 +25,10 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables, **kwargs):
 
+        default_v = kwargs.get('default', None)
         ret = []
         for term in terms:
             var = term.split()[0]
-            ret.append(os.getenv(var, ''))
+            ret.append(os.getenv(var, default_v))
 
         return ret


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

I have extended the env plugin to accept a parameter "default" as a default value if the environment variable is not set.

In this way,  an ansible variable can be defined as:
ANSIBLEVAR: "{{ lookup('env','ENVVAR', default='DEFAULTVALUE') }}"
