### PR TITLE
adding print stylesheet to theme.css for better HTML to PDF printing

### DIFF
--- a/docsite/_themes/srtd/static/css/theme.css
+++ b/docsite/_themes/srtd/static/css/theme.css
@@ -4736,3 +4736,23 @@ span[id*='MathJax-Span'] {
 .DocSiteBanner-imgWrapper {
     max-width: 100%;
 }
+
+@media print {
+    * { background: transparent !important; color: black !important; text-shadow: none !important; filter:none !important; -ms-filter: none !important; }
+    #nav,
+    a, a:visited { text-decoration: underline; }
+    a[href]:after { content: " (" attr(href) ")"; }
+    abbr[title]:after { content: " (" attr(title) ")"; }
+    .ir a:after, a[href^="javascript:"]:after, a[href^="#"]:after { content: ""; }  /* Don't show links for images, or javascript/internal links */
+    pre, blockquote { border: 0px solid #999; page-break-inside: avoid; }
+    thead { display: table-header-group; } /* h5bp.com/t */
+    tr, img { page-break-inside: avoid; }
+    img { max-width: 100% !important; }
+    @page { margin: 0.5cm; }
+    p, h2, h3 { orphans: 3; widows: 3; }
+    h2, h3 { page-break-after: avoid; }
+    .DocSiteBanner,
+    #google_image_div {
+        display: none !important;
+    }
+

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -586,7 +586,7 @@ in Ansible.  Effectively registered variables are just like facts.
 .. _accessing_complex_variable_data:
 
 Accessing Complex Variable Data
-````````````````````````````````
+```````````````````````````````
 
 We already talked about facts a little higher up in the documentation.
 

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -586,7 +586,7 @@ in Ansible.  Effectively registered variables are just like facts.
 .. _accessing_complex_variable_data:
 
 Accessing Complex Variable Data
-```````````````````````````````
+````````````````````````````````
 
 We already talked about facts a little higher up in the documentation.
 

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -758,18 +758,19 @@ If multiple variables of the same name are defined in different places, they get
 
 .. include:: ansible_ssh_changes_note.rst
 
-In 1.x, the precedence is as follows (and last listed wins prioritization):
+In 1.x the precedence is (last listed wins):
 
- * "role defaults", which lose in priority to everything
- * variables defined in inventory
- * facts discovered about a system
- * "most everything else" (command line switches, vars in play, included vars, role vars, etc.)
- * connection variables (``ansible_user``, etc.)
+ * then "role defaults", which are the most "defaulty" and lose in priority to everything.
+ * then come the variables defined in inventory
+ * then come the facts discovered about a system
+ * then comes "most everything else" (command line switches, vars in play, included vars, role vars, etc)
+ * then come connection variables (``ansible_user``, etc)
  * extra vars (``-e`` in the command line) always win
 
 .. note:: In versions prior to 1.5.4, facts discovered about a system were in the "most everything else" category above.
 
-In 2.x we have made the order of precedence more specific (and last listed wins prioritization):
+
+In 2.x we have made the order of precedence more specific (last listed wins):
 
   * role defaults [1]_
   * inventory vars [2]_

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -758,19 +758,18 @@ If multiple variables of the same name are defined in different places, they get
 
 .. include:: ansible_ssh_changes_note.rst
 
-In 1.x the precedence is (last listed wins):
+In 1.x, the precedence is as follows (and last listed wins prioritization):
 
- * then "role defaults", which are the most "defaulty" and lose in priority to everything.
- * then come the variables defined in inventory
- * then come the facts discovered about a system
- * then comes "most everything else" (command line switches, vars in play, included vars, role vars, etc)
- * then come connection variables (``ansible_user``, etc)
+ * "role defaults", which lose in priority to everything
+ * variables defined in inventory
+ * facts discovered about a system
+ * "most everything else" (command line switches, vars in play, included vars, role vars, etc.)
+ * connection variables (``ansible_user``, etc.)
  * extra vars (``-e`` in the command line) always win
 
 .. note:: In versions prior to 1.5.4, facts discovered about a system were in the "most everything else" category above.
 
-
-In 2.x we have made the order of precedence more specific (last listed wins):
+In 2.x we have made the order of precedence more specific (and last listed wins prioritization):
 
   * role defaults [1]_
   * inventory vars [2]_


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible --devel (target)
```
##### SUMMARY

```
Cleaning up my fork to submit CSS for a clean print stylesheet.
```

Had issues, but managed to revert commits that didn't need to be pulled in so that this PR (through it may reference multi-commits) only affects the theme.css static file.

When saving the HTML as a PDF for printing, the ad took up 1/3 of page and printing was less than ideal. CSS has now been tweaked so that ad/media banner is gone, color backgrounds of admonitions are now white with black text, links are exposed. 

Apologies if I've fubar'd the heck out of my first of the new PRs, but I'm happy to fix and learn what to do/not to do. :)
