### PR TITLE
Update ec2.py with missing import [Fixes #11755]

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -27,6 +27,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
 from time import sleep
+from boto import ec2
 
 try:
     import boto3


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 5fdac707fd) last updated 2016/04/01 10:38:55 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 0268864211) last updated 2016/04/01 10:41:05 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 6978984244) last updated 2016/04/01 10:41:05 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Solves #11755.
When using profiles from the _s3_ or _cloudformation_ modules we were getting an error in the following line:

```
def boto_supports_profile_name():
    return hasattr(boto.ec2.EC2Connection, 'profile_name')
```

The import solves this issue.
