### PR TITLE
add openstack.yml to CONFIG_FILES to be consistent with documentation

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -55,7 +55,7 @@ import os_client_config
 import shade
 import shade.inventory
 
-CONFIG_FILES = ['/etc/ansible/openstack.yaml']
+CONFIG_FILES = ['/etc/ansible/openstack.yaml', '/etc/ansible/openstack.yml']
 
 
 def get_groups_from_server(server_vars, namegroup=True):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This patch adds /etc/ansible/openstack.yml to the CONFIG_FILES list in the openstack.py dynamic inventory script.

It adds the yml version in order to be consistent with the docs at https://docs.ansible.com/ansible/intro_dynamic_inventory.html#example-openstack-external-inventory-script and the documentation included in the script itself, both of which reference /etc/ansible/openstack.yml. Having both the yaml and yml version seems preferable so as not to break things for people already using the yaml version.

This patch means that someone who follows the instructions in the docs will get the expected result without having to read the source of the inventory script. It also will not break existing setups using the yaml version.

Running `pep8 openstack.py` on the new version has no output. 

When only `/etc/ansible/openstack.yml` exists, with the following content;

```
ansible:
  use_hostnames: True
  expand_hostvars: True
```

withe the following playbook:

```
#!/usr/bin/env ansible-playbook

---

- name: Ping cloud instances
  hosts: foobar
  remote_user: ubuntu
  tasks:
    - name: Test connection to instance
      ping:
```

BEFORE:

```
$ ansible-playbook -i ~/src/ansible/contrib/inventory/openstack.py ping.yml

PLAY [Ping cloud instances] ****************************************************

TASK [setup] *******************************************************************
ok: [6ae00f5d-1ba0-429d-a5af-232d5056d9e3]

TASK [Test connection to instance] *********************************************
ok: [6ae00f5d-1ba0-429d-a5af-232d5056d9e3]

PLAY RECAP *********************************************************************
6ae00f5d-1ba0-429d-a5af-232d5056d9e3 : ok=2    changed=0    unreachable=0    failed=0
```

AFTER:

```
$ ansible-playbook -i ~/src/ansible/contrib/inventory/openstack.py ping.yml

PLAY [Ping cloud instances] ****************************************************

TASK [setup] *******************************************************************
ok: [por-instance]

TASK [Test connection to instance] *********************************************
ok: [por-instance]

PLAY RECAP *********************************************************************
```
