### PR TITLE
On change in diff-mode we don't need to see file content in task output

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -99,6 +99,10 @@ class CallbackBase:
         if not keep_invocation and self._display.verbosity < 3 and 'invocation' in result:
             del abridged_result['invocation']
 
+        # remove diff information from screen output
+        if self._display.verbosity < 3 and 'diff' in result:
+            del abridged_result['diff']
+
         return json.dumps(abridged_result, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
 
     def _handle_warnings(self, res):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible-playbook 2.0.2.0
  config file = /home/dag/home-made/ansible.testing/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

I was surprised to see complete file content in the (JSON) task output when
in diff-mode. Since we see the diff anyhow, there's no need to send everything
on screen.
##### EXAMPLE PLAYBOOK AND OUTPUT

``` yaml
- hosts: localhost
  tasks:
  - template:
      src: files/dos-file.txt
      dest: /tmp/dos-file-{{ ansible_date_time.iso8601 }}.txt
```

results in the complete file content in the task output (just before the actual diff):

```
[dag@moria ansible.testing]$ ansible-playbook -CD test85.yml -vv
Using /home/dag/home-made/ansible.testing/ansible.cfg as config file

PLAYBOOK: test85.yml ***********************************************************
1 plays in test85.yml

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [template] ****************************************************************
task path: /home/dag/home-made/ansible.testing/test85.yml:3
changed: [localhost] => {"changed": true, "diff": {"after": "This is a simple unicode DOS text file.\r\nIt's aim is to test compatibility\r\nbetween Ansible v1.9 and v2.\r\n\r\nJust for fun some non-ascii characters:\r\n  º¹²³ª©®¤\r\n  åßçÐê£øµïìÞ¤¢×ñõ÷", "after_header": "dynamically generated", "before": ""}}
--- before 
+++ after: dynamically generated 
@@ -1,0 +1,7 @@
+This is a simple unicode DOS text file.
+It's aim is to test compatibility
+between Ansible v1.9 and v2.
+
+Just for fun some non-ascii characters:
+  º¹²³ª©®¤
+  åßçÐê£øµïìÞ¤¢×ñõ÷

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   
```
