### PR TITLE
Fix CACHE_DIR mode in contrib/inventory/spacewalk.py

### DIFF
--- a/contrib/inventory/spacewalk.py
+++ b/contrib/inventory/spacewalk.py
@@ -70,7 +70,7 @@ if not os.path.exists(SW_REPORT):
 # Pre-startup work
 if not os.path.exists(CACHE_DIR):
     os.mkdir(CACHE_DIR)
-    os.chmod(CACHE_DIR, 2775)
+    os.chmod(CACHE_DIR, 0o2775)
 
 # Helper functions
 #------------------------------


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.0.2
```
##### SUMMARY

The spacewalk inventory module passes a non-octal mode to chmod. This results in the wrong mode being set for `CACHE_DIR`, `0o5303` instead of `0o2775`. The issue is similar to ansible/ansible-modules-extras@da84e2e. Another user on the ansible localhost could create spacewalks report inside `CACHE_DIR`.
