### PR TITLE
Fix galaxy roles_path cli usage. (#15255)

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -228,6 +228,18 @@ class CLI(object):
         setattr(parser.values, option.dest, os.path.expanduser(value))
 
     @staticmethod
+    def expand_paths(option, opt, value, parser):
+        """optparse action callback to convert a PATH style string arg to a list of path strings.
+
+        For ex, cli arg of '-p /blip/foo:/foo/bar' would be split on the
+        default os.pathsep and the option value would be set to
+        the list ['/blip/foo', '/foo/bar']. Each path string in the list
+        will also have '~/' values expand via os.path.expanduser()."""
+        path_entries = value.split(os.pathsep)
+        expanded_path_entries = [os.path.expanduser(path_entry) for path_entry in path_entries]
+        setattr(parser.values, option.dest, expanded_path_entries)
+
+    @staticmethod
     def base_parser(usage="", output_opts=False, runas_opts=False, meta_opts=False, runtask_opts=False, vault_opts=False, module_opts=False,
             async_opts=False, connect_opts=False, subset_opts=False, check_opts=False, inventory_opts=False, epilog=None, fork_opts=False, runas_prompt_opts=False):
         ''' create an options parser for most ansible scripts '''
@@ -544,6 +556,8 @@ class CLI(object):
             data = getattr(self.options, k)
         except:
             return defval
+        # FIXME: Can this be removed if cli and/or constants ensures it's a
+        # list?
         if k == "roles_path":
             if os.pathsep in data:
                 data = data.split(os.pathsep)[0]

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -120,7 +120,11 @@ class GalaxyCLI(CLI):
 
         # options that apply to more than one action
         if not self.action in ("delete","import","init","login","setup"):
-            self.parser.add_option('-p', '--roles-path', dest='roles_path', default=C.DEFAULT_ROLES_PATH,
+            # NOTE: while the option type=str, the default is a list, and the
+            # callback will set the value to a list.
+            self.parser.add_option('-p', '--roles-path', dest='roles_path',
+                                   action="callback", callback=CLI.expand_paths,
+                                   type=str, default=C.DEFAULT_ROLES_PATH,
                 help='The path to the directory containing your roles. '
                      'The default is the roles_path configured in your '
                      'ansible.cfg file (/etc/ansible/roles if not configured)')

--- a/lib/ansible/galaxy/__init__.py
+++ b/lib/ansible/galaxy/__init__.py
@@ -39,9 +39,10 @@ class Galaxy(object):
     def __init__(self, options):
 
         self.options = options
-        roles_paths = getattr(self.options, 'roles_path', [])
-        if isinstance(roles_paths, string_types):
-            self.roles_paths = [os.path.expanduser(roles_path) for roles_path in roles_paths.split(os.pathsep)]
+        # self.options.roles_path needs to be a list and will be by default
+        roles_path = getattr(self.options, 'roles_path', [])
+        # cli option handling is responsible for making roles_path a list
+        self.roles_paths = roles_path
 
         self.roles =  {}
 

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -67,8 +67,8 @@ class GalaxyRole(object):
                 path = os.path.join(path, self.name)
             self.path = path
         else:
-            for path in galaxy.roles_paths:
-                role_path = os.path.join(path, self.name)
+            for role_path_dir in galaxy.roles_paths:
+                role_path = os.path.join(role_path_dir, self.name)
                 if os.path.exists(role_path):
                     self.path = role_path
                     break


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

https://github.com/ansible/ansible/issues/15255 describes the issue.

The init for Galaxy() was not setting roles_path if it was not an instrance of 'stringtypes', and
the default is now to be a list of path strings. The cli would then throw an attribute error on
the missing self.roles_path.

This branch fixes by adding a optparse callback to CLI, that knows how to
expand a string to a list of paths (ie, '-r /tmp/foo:/tmp:bar' to a list ['/tmp/foo', '/tmp/bar'].

Then the default option value for roles_path in the galaxy cli ends up always being a path list.
The type checking in Galaxy()'s init was removed so that self.roles_path always gets set, either
to just the cli paths or DEFAULT_ROLES_PATH from constants or an empty list.

The optparse change is maybe overboard for a fix, especially since it seems like the handling for path lists is in flux at the moment. A simpler variation would be to just set galaxy.Galaxy()'s self.role_path to a empty list if failed otherwise.
