### PR TITLE
Issue 15255 - ansible-galaxy install command not getting default role…

### DIFF
--- a/lib/ansible/galaxy/__init__.py
+++ b/lib/ansible/galaxy/__init__.py
@@ -26,11 +26,13 @@ __metaclass__ = type
 import os
 
 from ansible.compat.six import string_types
-
 from ansible.errors import AnsibleError
 
-#      default_readme_template
-#      default_meta_template
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
 
 
 class Galaxy(object):
@@ -40,8 +42,10 @@ class Galaxy(object):
 
         self.options = options
         roles_paths = getattr(self.options, 'roles_path', [])
+        self.roles_paths = roles_paths
         if isinstance(roles_paths, string_types):
             self.roles_paths = [os.path.expanduser(roles_path) for roles_path in roles_paths.split(os.pathsep)]
+        display.vvv("roles_paths: {0}".format(roles_paths))
 
         self.roles =  {}
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

ansible 2.1.0 (fix_issue_15255 46cc1e979f) last updated 2016/04/03 02:01:49 (GMT -400)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file =
  configured module search path = Default w/o overrides
##### SUMMARY

The ansible-galaxy install command is failing to get roles_path value defined in ansible.cfg. As a result, execution fails unless an explicit roles_path is provided on the command line. This change fixes the problem, insuring that the galaxy module initializes correctly with roles_path defaulting to the ansible.cfg value.

```
$ ansible-galaxy -vvv install bcoca.tidy
Using /Users/chouseknecht/projects/galaxy_cli/ansible.cfg as config file
Opened /Users/chouseknecht/.ansible_galaxy
# This file is part of Ansible
Validate TLS certificates: True
Connecting to galaxy_server: https://galaxy.ansible.com
Base API: https://galaxy.ansible.com/api/v1
roles_path: ['./roles']
ERROR! Unexpected Exception: 'Galaxy' object has no attribute 'roles_paths'
the full traceback was:

Traceback (most recent call last):
  File "/Users/chouseknecht/projects/galaxy_cli/ansible/bin/ansible-galaxy", line 86, in <module>
    sys.exit(cli.run())
  File "/Users/chouseknecht/projects/galaxy_cli/ansible/lib/ansible/cli/galaxy.py", line 153, in run
    self.execute()
  File "/Users/chouseknecht/projects/galaxy_cli/ansible/lib/ansible/cli/__init__.py", line 114, in execute
########################################################################
    fn()
  File "/Users/chouseknecht/projects/galaxy_cli/ansible/lib/ansible/cli/galaxy.py", line 396, in execute_install
    roles_left.append(GalaxyRole(self.galaxy, **role))
  File "/Users/chouseknecht/projects/galaxy_cli/ansible/lib/ansible/galaxy/role.py", line 70, in __init__
    for path in galaxy.roles_paths:
AttributeError: 'Galaxy' object has no attribute 'roles_paths'


$ ansible-galaxy -vvv install bcoca.tidy
roles_paths: ['./roles']
Using /Users/chouseknecht/projects/galaxy_cli/ansible.cfg as config file
Opened /Users/chouseknecht/.ansible_galaxy
Validate TLS certificates: True
Connecting to galaxy_server: https://galaxy.ansible.com
Base API: https://galaxy.ansible.com/api/v1
Installing role bcoca.tidy
Opened /Users/chouseknecht/.ansible_galaxy
Validate TLS certificates: True
Connecting to galaxy_server: https://galaxy.ansible.com
Base API: https://galaxy.ansible.com/api/v1
- downloading role 'tidy', owned by bcoca
https://galaxy.ansible.com/api/v1/roles/?owner__username=bcoca&name=tidy
https://galaxy.ansible.com/api/v1/roles/8320/versions/?page_size=50
- downloading role from https://github.com/bcoca/ansible-tidy/archive/master.tar.gz
- extracting bcoca.tidy to ./roles/bcoca.tidy
- bcoca.tidy was installed successfully
```

…s_path value.
