### PR TITLE
fixed default version in _get_body

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -71,7 +71,7 @@ class Nxapi(object):
         self.url = None
         self._nxapi_auth = None
 
-    def _get_body(self, commands, command_type, encoding, version='1.2', chunk='0', sid=None):
+    def _get_body(self, commands, command_type, encoding, version='1.0', chunk='0', sid=None):
         """Encodes a NXAPI JSON request message
         """
         if isinstance(commands, (list, set, tuple)):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/cisco/projects/legacy']

```
##### SUMMARY

fixed defauit version of nxapi being used in _get_body method
