### PR TITLE
Update ConfigureRemotingForAnsible.ps1

### DIFF
--- a/docsite/rst/intro_windows.rst
+++ b/docsite/rst/intro_windows.rst
@@ -217,6 +217,9 @@ Pass the -CertValidityDays option to customize the expiration date of the genera
 Pass the -SkipNetworkProfileCheck switch to configure winrm to listen on PUBLIC zone interfaces.  (Without this option, the script will fail if any network interface on device is in PUBLIC zone)
   powershell.exe -File ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
 
+Pass the -ForceNewSSLCert switch to force a new SSL certificate to be attached to an already existing winrm listener. (Avoids SSL winrm errors on syspreped Windows images after the CN changes)
+  powershell.exe -File ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
+
 .. note::
    On Windows 7 and Server 2008 R2 machines, due to a bug in Windows
    Management Framework 3.0, it may be necessary to install this


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
Any Version
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Set $ForceNewSSLCert if the system has been syspreped and a new SSL Cert must be forced on the winRM listener when re-running this script. This is necessary when a CN name changes and the self-signed cert is no longer valid and winRM is not allowing a connection because of winRM SSL validation errors.

Added the ForceNewSSLCert option for changing SID and CN machines/images.
