### PR TITLE
Jinja2 Filter: xmlescape, for escaping special characters in xml file…

### DIFF
--- a/lib/ansible/plugins/filter/xmlescape.py
+++ b/lib/ansible/plugins/filter/xmlescape.py
@@ -1,0 +1,17 @@
+from jinja2 import Environment, FileSystemLoader
+from ansible import errors
+from xml.sax.saxutils import escape
+ 
+def xmlescape(a):
+    return escape( str(a) )
+ 
+class FilterModule(object):
+    ''' xmlescape filter ''' 
+    def filters(self):
+        return {
+
+            # filter map
+            'xmlescape': xmlescape
+ 
+        }
+

--- a/lib/ansible/plugins/filter/xmlescape.py
+++ b/lib/ansible/plugins/filter/xmlescape.py
@@ -1,6 +1,9 @@
 from jinja2 import Environment, FileSystemLoader
 from ansible import errors
 from xml.sax.saxutils import escape
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
  
 def xmlescape(a):
     return escape( str(a) )

--- a/test/integration/roles/test_filters/files/foo.txt
+++ b/test/integration/roles/test_filters/files/foo.txt
@@ -52,6 +52,8 @@ files to exist and are passthrus to the python os.path functions
 /etc/motd with basename = motd
 /etc/motd with dirname  = /etc
 
+<xml_password>a&lt;&amp;&gt;b</xml_password>
+
 TODO: realpath follows symlinks.  There isn't a test for this just now.
 
 TODO: add tests for set theory operations like union

--- a/test/integration/roles/test_filters/templates/foo.j2
+++ b/test/integration/roles/test_filters/templates/foo.j2
@@ -46,6 +46,8 @@ files to exist and are passthrus to the python os.path functions
 /etc/motd with basename = {{ '/etc/motd' | basename }}
 /etc/motd with dirname  = {{ '/etc/motd' | dirname }}
 
+<xml_password>{{ 'a<&>b' | xmlescape }}</xml_password>
+
 TODO: realpath follows symlinks.  There isn't a test for this just now.
 
 TODO: add tests for set theory operations like union


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

 Jinja2 Filter: xmlescape, for escaping special characters in xml files (common problem when templating passwords)

```
N/A (unless you want the entire out put of make non_destructive)
```
