### PR TITLE
Regression fix: proper plugin configuration was reset

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -66,7 +66,7 @@ class PluginLoader:
 
         if config and not isinstance(config, list):
             config = [config]
-        else:
+        elif not config:
             config = []
 
         self.config = config

--- a/test/units/plugins/test_plugins.py
+++ b/test/units/plugins/test_plugins.py
@@ -75,7 +75,16 @@ class TestErrors(unittest.TestCase):
         #with patch('glob.glob', mock_glob):
         #    pass
 
-    def test_plugin__config(self):
+    def assertPluginLoaderConfigBecomes(self, arg, expected):
+        pl = PluginLoader('test', '', arg, 'test_plugin')
+        self.assertEqual(pl.config, expected)
+
+    def test_plugin__init_config_list(self):
         config = ['/one', '/two']
-        pl = PluginLoader('test', '', config, 'test_plugin')
-        self.assertEqual(pl.config, config)
+        self.assertPluginLoaderConfigBecomes(config, config)
+
+    def test_plugin__init_config_str(self):
+        self.assertPluginLoaderConfigBecomes('test', ['test'])
+
+    def test_plugin__init_config_none(self):
+        self.assertPluginLoaderConfigBecomes(None, [])

--- a/test/units/plugins/test_plugins.py
+++ b/test/units/plugins/test_plugins.py
@@ -75,3 +75,7 @@ class TestErrors(unittest.TestCase):
         #with patch('glob.glob', mock_glob):
         #    pass
 
+    def test_plugin__config(self):
+        config = ['/one', '/two']
+        pl = PluginLoader('test', '', config, 'test_plugin')
+        self.assertEqual(pl.config, config)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

  lib/ansible/modules/core: (detached HEAD cf01087a30) last updated 2016/04/05 11:48:52 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 204b4bab56) last updated 2016/04/05 11:48:52 (GMT +200)
  config file = /home/jpic/.ansible.cfg
  configured module search path = Default w/o overrides
##### SUMMARY

Before this patch, if config was ['/some/path'] then it would enter the
else block and config would be set to [].

The regression this patch fixes was introduced by 700db154.
