### PR TITLE
Optional Use of urllib3 for SNI verification

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -20,3 +20,4 @@
     - { role: test_docker, tags: test_docker, when: ansible_distribution != "Fedora" }
     - { role: test_zypper, tags: test_zypper}
     - { role: test_zypper_repository, tags: test_zypper_repository}
+    - { role: test_uri, tags: test_uri }

--- a/test/integration/non_destructive.yml
+++ b/test/integration/non_destructive.yml
@@ -40,7 +40,6 @@
     - { role: test_authorized_key, tags: test_authorized_key }
     - { role: test_get_url, tags: test_get_url }
     - { role: test_embedded_module, tags: test_embedded_module }
-    - { role: test_uri, tags: test_uri }
     - { role: test_add_host, tags: test_add_host }
     # Turn on test_binary when we start testing v2
     #- { role: test_binary, tags: test_binary }

--- a/test/integration/roles/test_get_url/tasks/main.yml
+++ b/test/integration/roles/test_get_url/tasks/main.yml
@@ -62,7 +62,7 @@
   assert:
     that:
       - "result.failed == true"
-      - "'Certificate does not belong to ' in result.msg"
+      - "'Failed to validate the SSL certificate' in result.msg"
       - "stat_result.stat.exists == false"
 
 - name: test https fetch to a site with mismatched hostname and certificate and validate_certs=no

--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -113,7 +113,7 @@
   assert:
     that:
       - "result.failed == true"
-      - "'SSL Certificate does not belong' in result.msg"
+      - "'Failed to validate the SSL certificate' in result.msg"
       - "stat_result.stat.exists == false"
 
 - name: Clean up any cruft from the results directory
@@ -204,3 +204,78 @@
   assert:
     that:
       - 'result.allow|default("") == "HEAD, OPTIONS, GET"'
+
+# Ubuntu12.04 doesn't have python-urllib3, this makes handling required dependencies a pain across all variations
+# We'll use this to just skip 12.04 on those tests.  We should be sufficiently covered with other OSes and versions
+- name: Set fact if running on Ubuntu 12.04
+  set_fact:
+    is_ubuntu_precise: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'precise' }}"
+
+- name: Test that SNI succeeds on python versions that have SNI
+  uri:
+    url: 'https://sni.velox.ch'
+    return_content: true
+  when: ansible_python.has_sslcontext
+  register: result
+
+- name: Assert SNI verification succeeds on new python
+  assert:
+    that:
+      - result|success
+      - '"Great! Your client" in result.content'
+  when: ansible_python.has_sslcontext
+
+- name: Verify SNI verification fails on old python without urllib3 contrib
+  uri:
+    url: 'https://sni.velox.ch'
+  ignore_errors: true
+  when: not ansible_python.has_sslcontext
+  register: result
+
+- name: Assert SNI verification fails on old python
+  assert:
+    that:
+      - result|failed
+  when: not result|skipped
+
+- name: install OS packages that are needed for SNI on old python
+  package:
+    name: "{{ item }}"
+  with_items: "{{ uri_os_packages[ansible_os_family] }}"
+  when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
+
+- name: install python modules for Older Python SNI verification
+  pip:
+    name: "{{ item }}"
+  with_items:
+    - ndg-httpsclient
+  when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
+
+- name: Verify SNI verificaiton succeeds on old python with urllib3 contrib
+  uri:
+    url: 'https://sni.velox.ch'
+    return_content: true
+  when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
+  register: result
+
+- name: Assert SNI verification succeeds on old python
+  assert:
+    that:
+      - result|success
+      - '"Great! Your client" in result.content'
+  when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
+
+- name: Uninstall ndg-httpsclient and urllib3
+  pip:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - ndg-httpsclient
+  when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
+
+- name: uninstall OS packages that are needed for SNI on old python
+  package:
+    name: "{{ item }}"
+    state: absent
+  with_items: "{{ uri_os_packages[ansible_os_family] }}"
+  when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool

--- a/test/integration/roles/test_uri/vars/main.yml
+++ b/test/integration/roles/test_uri/vars/main.yml
@@ -1,0 +1,9 @@
+uri_os_packages:
+  RedHat:
+    - python-pyasn1
+    - pyOpenSSL
+    - python-urllib3
+  Debian:
+    - python-pyasn1
+    - python-openssl
+    - python-urllib3


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
v2.1
```
##### SUMMARY

This change adds optional support to `urls.py` to utilize `urllib3.contrib.pyopenssl` for SNI verification.

If the deps are not installed, things work as they do now, except the error message mentions that if installed, you can do SNI verification on older python versions.

To activate this functionality, the following python modules would need to be installed:
1. urllib3 or requests with urllib3 vendored (although urllib3 is listed as the dep)
2. pyopenssl
3. ndg-httpsclient
4. pyasn1
