### PR TITLE
get ssh_keys without using distribution info

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -550,22 +550,21 @@ class Facts(object):
     def get_public_ssh_host_keys(self):
         keytypes = ('dsa', 'rsa', 'ecdsa', 'ed25519')
 
-        if self.facts['system'] == 'Darwin':
-            if self.facts['distribution'] == 'MacOSX' and LooseVersion(self.facts['distribution_version']) >= LooseVersion('10.11') :
-                keydir = '/etc/ssh'
-            else:
-                keydir = '/etc'
-        if self.facts['distribution'] == 'Altlinux':
-            keydir = '/etc/openssh'
-        else:
-            keydir = '/etc/ssh'
+        # list of directories to check for ssh keys
+        # used in the order listed here, the first one with keys is used
+        keydirs = ['/etc/ssh', '/etc/openssh', '/etc']
 
-        for type_ in keytypes:
-            key_filename = '%s/ssh_host_%s_key.pub' % (keydir, type_)
-            keydata = get_file_content(key_filename)
-            if keydata is not None:
+        for keydir in keydirs:
+            for type_ in keytypes:
                 factname = 'ssh_host_key_%s_public' % type_
-                self.facts[factname] = keydata.split()[1]
+                if factname in self.facts:
+                    # a previous keydir was already successful, stop looking
+                    # for keys
+                    return
+                key_filename = '%s/ssh_host_%s_key.pub' % (keydir, type_)
+                keydata = get_file_content(key_filename)
+                if keydata is not None:
+                    self.facts[factname] = keydata.split()[1]
 
     def get_pkg_mgr_facts(self):
         self.facts['pkg_mgr'] = 'unknown'


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

devel
##### SUMMARY

In `facts.py` the Facts class is very complicated and entangles many things. One aspect I propose is to factor out the parsing of linux distribution_version info in #15221

This factoring out is only complete, when the rest of _Facts_ does not use distribution information.

This change fills the _ssh_host_key_ variables without using distribution info, but by trying out the possible directories in the most common order. This could fail if someone has keys in one of the other directories, but I don't see a reason why this should happen.
