### PR TITLE
WIP: Travis to defend "make deb" and "make rpm"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ services:
 language: python
 matrix:
   include:
-    - env: TARGET=centos6
-    - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    - env: TARGET=ubuntu1204
-    - env: TARGET=ubuntu1404
+    - env: TARGET=centos6 MAKETARGETS="rpm"
+    - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
+    - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
+    - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
+    - env: TARGET=ubuntu1204 MAKETARGETS="deb"
+    - env: TARGET=ubuntu1404 MAKETARGETS="deb"
     - env: TARGET=sanity TOXENV=py26
       python: 2.6
     - env: TARGET=sanity TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ matrix:
     - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
     - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
     - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
+    - env: TARGET=opensuseleap TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
     - env: TARGET=ubuntu1204 MAKETARGETS="deb"
     - env: TARGET=ubuntu1404 MAKETARGETS="deb"
+    - env: TARGET=ubuntu1604 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="deb"
     - env: TARGET=sanity TOXENV=py26
       python: 2.6
     - env: TARGET=sanity TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ services:
 language: python
 matrix:
   include:
-    - env: TARGET=centos6 RELEASE_MAKE_TARGET="rpm"
-    - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGET="rpm"
-    - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGET="rpm"
-    - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGET="rpm"
-    - env: TARGET=opensuseleap TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGET="rpm"
-    - env: TARGET=ubuntu1204 RELEASE_MAKE_TARGET="deb"
-    - env: TARGET=ubuntu1404 RELEASE_MAKE_TARGET="deb"
-    - env: TARGET=ubuntu1604 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGET="deb"
+    - env: TARGET=centos6 RELEASE_MAKE_TARGETS="rpm"
+    - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGETS="rpm"
+    - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGETS="rpm"
+    - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGETS="rpm"
+    - env: TARGET=opensuseleap TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGETS="rpm"
+    - env: TARGET=ubuntu1204 RELEASE_MAKE_TARGETS="deb"
+    - env: TARGET=ubuntu1404 RELEASE_MAKE_TARGETS="deb"
+    - env: TARGET=ubuntu1604 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGETS="deb"
     - env: TARGET=sanity TOXENV=py26
       python: 2.6
     - env: TARGET=sanity TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ services:
 language: python
 matrix:
   include:
-    - env: TARGET=centos6 MAKETARGETS="rpm"
-    - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
-    - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
-    - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
-    - env: TARGET=opensuseleap TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="rpm"
-    - env: TARGET=ubuntu1204 MAKETARGETS="deb"
-    - env: TARGET=ubuntu1404 MAKETARGETS="deb"
-    - env: TARGET=ubuntu1604 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKETARGETS="deb"
+    - env: TARGET=centos6 RELEASE_MAKE_TARGET="rpm"
+    - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGET="rpm"
+    - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGET="rpm"
+    - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGET="rpm"
+    - env: TARGET=opensuseleap TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGET="rpm"
+    - env: TARGET=ubuntu1204 RELEASE_MAKE_TARGET="deb"
+    - env: TARGET=ubuntu1404 RELEASE_MAKE_TARGET="deb"
+    - env: TARGET=ubuntu1604 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" RELEASE_MAKE_TARGET="deb"
     - env: TARGET=sanity TOXENV=py26
       python: 2.6
     - env: TARGET=sanity TOXENV=py27

--- a/shippable.yml
+++ b/shippable.yml
@@ -16,8 +16,8 @@ matrix:
       python: 3.4
     - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py35
       python: 3.5
-    - env: TEST=integration IMAGE=ansible/ansible:centos6
-    - env: TEST=integration IMAGE=ansible/ansible:centos7
+    - env: TEST=integration IMAGE=ansible/ansible:centos6 TOPLEVEL_MAKE_TARGETS=rpm
+    - env: TEST=integration IMAGE=ansible/ansible:centos7  TOPLEVEL_MAKE_TARGETS=foobar
     - env: TEST=integration IMAGE=ansible/ansible:fedora-rawhide
     - env: TEST=integration IMAGE=ansible/ansible:fedora23
     - env: TEST=integration IMAGE=ansible/ansible:opensuseleap

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -25,7 +25,7 @@ else
     fi
 
     # Should we test "make deb" or "make rpm"?
-    if [ "X${RELEASE_MAKE_TARGETS:-""}" -ne "X" ]; then
+    if [ "X${RELEASE_MAKE_TARGETS:-""}" != "X" ]; then
         # Excute the following command before conditionally running integration tests
         RELEASE_BUILD_CMD="make ${RELEASE_MAKE_TARGETS} && "
     fi

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -15,13 +15,19 @@ if [ "${TARGET}" = "sanity" ]; then
     if test x"$TOXENV" = x'py24' ; then python2.4 -V && python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce|docker_common|azure_rm_common|vca|vmware).py' lib/ansible/module_utils ; fi
 else
     if [ ! -e /tmp/cid_httptester ]; then
-        docker pull ansible/ansible:httptester
-        docker run -d --name=httptester ansible/ansible:httptester > /tmp/cid_httptester
+        docker pull sivel/httptester
+        docker run -d --name=httptester sivel/httptester > /tmp/cid_httptester
+
+    # Should we test "make deb" or "make rpm"?
+    if [ "X${MAKETARGETS:-""}" -ne "X" ]; then
+        RELEASE_BUILD_CMD="make ${MAKETARGETS}"
+    else
+        RELEASE_BUILD_CMD="true"
     fi
     export C_NAME="testAbull_$$_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
     docker pull ansible/ansible:${TARGET}
-    docker run -d --volume="${PWD}:/root/ansible:Z" $LINKS --name "${C_NAME}" --env HTTPTESTER=1 ${TARGET_OPTIONS:=''} ansible/ansible:${TARGET} > /tmp/cid_${TARGET}
-    docker exec -ti $(cat /tmp/cid_${TARGET}) /bin/sh -c "export TEST_FLAGS='${TEST_FLAGS:-''}'; cd /root/ansible; . hacking/env-setup; (cd test/integration; LC_ALL=en_US.utf-8 make ${MAKE_TARGET:-})"
+    docker run -d --volume="${PWD}:/root/ansible:Z" $LINKS --name "${C_NAME}" ${TARGET_OPTIONS:=''} ansible/ansible:${TARGET} > /tmp/cid_${TARGET}
+    docker exec -ti $(cat /tmp/cid_${TARGET}) /bin/sh -c "export TEST_FLAGS='${TEST_FLAGS:-''}'; cd /root/ansible; . hacking/env-setup; ${RELEASE_BUILD_CMD} && (cd test/integration; LC_ALL=en_US.utf-8 make ${MAKE_TARGET:-})"
     docker kill $(cat /tmp/cid_${TARGET})
 
     if [ "X${TESTS_KEEP_CONTAINER:-""}" = "X" ]; then

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -25,9 +25,9 @@ else
     fi
 
     # Should we test "make deb" or "make rpm"?
-    if [ "X${MAKETARGETS:-""}" -ne "X" ]; then
+    if [ "X${RELEASE_MAKE_TARGETS:-""}" -ne "X" ]; then
         # Excute the following command before conditionally running integration tests
-        RELEASE_BUILD_CMD="make ${MAKETARGETS} && "
+        RELEASE_BUILD_CMD="make ${RELEASE_MAKE_TARGETS} && "
     fi
 
     export C_NAME="testAbull_$$_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -67,7 +67,7 @@ if [ "${controller_shared_dir}" ]; then
     cp -a "${SHIPPABLE_BUILD_DIR}" "${controller_shared_dir}"
 fi
 
-if [ "${toplevel_make_targets}" ]; then
+if [ "${toplevel_make_targets}" != "" ]; then
     make_targets="make ${toplevel_make_targets} && "
 fi
 

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -68,7 +68,7 @@ if [ "${controller_shared_dir}" ]; then
 fi
 
 if [ "${toplevel_make_targets}" ]; then
-    make_targets="time make ${toplevel_make_targets} && "
+    make_targets="make ${toplevel_make_targets} && "
 fi
 
 httptester_id=$(docker run -d "${http_image}")

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -7,6 +7,7 @@ test_privileged="${PRIVILEGED:-false}"
 test_flags="${TEST_FLAGS:-}"
 test_target="${TARGET:-}"
 test_ansible_dir="${TEST_ANSIBLE_DIR:-/root/ansible}"
+toplevel_make_targets="${TOPLEVEL_MAKE_TARGETS}"
 
 http_image="${HTTP_IMAGE:-ansible/ansible:httptester}"
 
@@ -66,6 +67,10 @@ if [ "${controller_shared_dir}" ]; then
     cp -a "${SHIPPABLE_BUILD_DIR}" "${controller_shared_dir}"
 fi
 
+if [ "${toplevel_make_targets}" ]; then
+    make_targets="time make ${toplevel_make_targets} && "
+fi
+
 httptester_id=$(docker run -d "${http_image}")
 container_id=$(docker run -d \
     -v "/sys/fs/cgroup:/sys/fs/cgroup:ro" \
@@ -86,6 +91,6 @@ if [ "${copy_source}" ]; then
 fi
 
 docker exec "${container_id}" mkdir -p "${test_shared_dir}/shippable/testresults"
-docker exec "${container_id}" /bin/sh -c "cd '${test_ansible_dir}' && . hacking/env-setup && cd test/integration && \
+docker exec "${container_id}" /bin/sh -c "cd '${test_ansible_dir}' && . hacking/env-setup && ${make_targets:-} cd test/integration && \
     JUNIT_OUTPUT_DIR='${test_shared_dir}/shippable/testresults' ANSIBLE_CALLBACK_WHITELIST=junit \
     HTTPTESTER=1 TEST_FLAGS='${test_flags}' LC_ALL=en_US.utf-8 make ${test_target}"

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -7,7 +7,7 @@ test_privileged="${PRIVILEGED:-false}"
 test_flags="${TEST_FLAGS:-}"
 test_target="${TARGET:-}"
 test_ansible_dir="${TEST_ANSIBLE_DIR:-/root/ansible}"
-toplevel_make_targets="${TOPLEVEL_MAKE_TARGETS}"
+toplevel_make_targets="${TOPLEVEL_MAKE_TARGETS:-}"
 
 http_image="${HTTP_IMAGE:-ansible/ansible:httptester}"
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /home/johnb/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

As part of my ongoing effort to improve testing.

I recently noticed that `make deb` (or rpm) were broken even when Travis was green.

I've opted to only install the extra dependencies within the script (rather than in `.travis.yml`) so the installation doesn't slow down the other 11 Travis subjobs

This adds in approx 90 second test to ensure that we catch these issues as soon as they occur. Placed between functional and sanity tests so longest tests are run first (based on @abadger recent investigation) to get a performance boost.

Also taken the opportunity to get `test/utils/run_tests.sh` shellcheck (bash linter) clean (apart from one line)

An example of a recent issue that I needed to fix as the build was failing:
https://github.com/ansible/ansible-modules-extras/pull/1935

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/15304)

<!-- Reviewable:end -->
