### PR TITLE
Revert "Increase verbosity of connection tests."

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -96,7 +96,7 @@ TEST_CONNECTION_FILTER += !chroot
 endif
 
 # Connection plugin test command to repeat with each locale setting.
-TEST_CONNECTION_CMD = $(1) ansible-playbook test_connection.yml -i test_connection.inventory -l '$(TEST_CONNECTION_FILTER)' -v $(TEST_FLAGS)
+TEST_CONNECTION_CMD = $(1) ansible-playbook test_connection.yml -i test_connection.inventory -l '$(TEST_CONNECTION_FILTER)' $(TEST_FLAGS)
 
 test_connection: setup
 	$(call TEST_CONNECTION_CMD)


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel cca084c89d) last updated 2016/04/04 23:26:50 (GMT -700)
  lib/ansible/modules/core: (detached HEAD cf01087a30) last updated 2016/04/04 23:27:15 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 204b4bab56) last updated 2016/04/04 23:27:15 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Reverts PR #15207 now that verbose connection tests are no longer needed.

The reason for the intermittent connection test failures has been confirmed to be due to stdout being an empty string instead of containing the remote command output.

Tests that were passing resulted in:

```
TASK [raw with unicode arg and output] *****************************************
ok: [paramiko_ssh-no-pipelining] => {"changed": false, "rc": 0, "stderr": "", "stdout": "汉语\r\n", "stdout_lines": ["汉语"]}
```

While tests that were failing resulted in:

```
TASK [raw with unicode arg and output] *****************************************
ok: [paramiko_ssh-no-pipelining] => {"changed": false, "rc": 0, "stderr": "", "stdout": "", "stdout_lines": []}
```
