### PR TITLE
Cascade ssh_*args configurations in synchronize

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -318,7 +318,12 @@ class ActionModule(ActionBase):
             self._task.args['rsync_path'] = '"%s"' % rsync_path
 
         if use_ssh_args:
-            self._task.args['ssh_args'] = C.ANSIBLE_SSH_ARGS
+            ssh_args = [
+                getattr(self._play_context, 'ssh_args', ''),
+                getattr(self._play_context, 'ssh_common_args', ''),
+                getattr(self._play_context, 'ssh_extra_args', ''),
+            ]
+            self._task.args['ssh_args'] = ' '.join([a for a in ssh_args if a])
 
         # run the module and store the result
         result.update(self._execute_module('synchronize', task_vars=task_vars))


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
v2/v2.1
```
##### SUMMARY

Currently in the synchronize action plugin, `use_ssh_args` only results in copying in `ssh_args` from ansible.cfg.  It should cascade `ssh_args`, `ssh_common_args`, and `ssh_extra_args` from `_play_context`.  This PR addresses this.

See https://github.com/ansible/ansible-modules-core/issues/3370
