### PR TITLE
Fix network modules for ziploader changes

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -194,16 +194,15 @@ class NetworkModule(AnsibleModule):
         return self._config
 
     def _load_params(self):
-        params = super(NetworkModule, self)._load_params()
-        provider = params.get('provider') or dict()
+        super(NetworkModule, self)._load_params()
+        provider = self.params.get('provider') or dict()
         for key, value in provider.items():
             if key in NET_COMMON_ARGS:
-                if params.get(key) is None and value is not None:
-                    params[key] = value
+                if self.params.get(key) is None and value is not None:
+                    self.params[key] = value
         for key, env_var in NET_ENV_ARGS.items():
-            if params.get(key) is None and env_var in os.environ:
-                params[key] = os.environ[env_var]
-        return params
+            if self.params.get(key) is None and env_var in os.environ:
+                self.params[key] = os.environ[env_var]
 
     def connect(self):
         try:

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -109,12 +109,12 @@ class NetworkModule(AnsibleModule):
         return self._config
 
     def _load_params(self):
-        params = super(NetworkModule, self)._load_params()
-        provider = params.get('provider') or dict()
+        super(NetworkModule, self)._load_params()
+        provider = self.params.get('provider') or dict()
         for key, value in provider.items():
             if key in NET_COMMON_ARGS.keys():
-                params[key] = value
-        return params
+                if self.params.get(key) is None and value is not None:
+                    self.params[key] = value
 
     def connect(self):
         try:

--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -99,12 +99,12 @@ class NetworkModule(AnsibleModule):
         return self._config
 
     def _load_params(self):
-        params = super(NetworkModule, self)._load_params()
-        provider = params.get('provider') or dict()
+        super(NetworkModule, self)._load_params()
+        provider = self.params.get('provider') or dict()
         for key, value in provider.items():
             if key in NET_COMMON_ARGS.keys():
-                params[key] = value
-        return params
+                if self.params.get(key) is None and value is not None:
+                    self.params[key] = value
 
     def connect(self):
         try:

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -76,12 +76,12 @@ class NetworkModule(AnsibleModule):
         return self._config
 
     def _load_params(self):
-        params = super(NetworkModule, self)._load_params()
-        provider = params.get('provider') or dict()
+        super(NetworkModule, self)._load_params()
+        provider = self.params.get('provider') or dict()
         for key, value in provider.items():
             if key in NET_COMMON_ARGS.keys():
-                params[key] = value
-        return params
+                if self.params.get(key) is None and value is not None:
+                    self.params[key] = value
 
     def connect(self):
         self.connection = Cli(self)

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -197,13 +197,12 @@ class NetworkModule(AnsibleModule):
         return self._config
 
     def _load_params(self):
-        params = super(NetworkModule, self)._load_params()
-        provider = params.get('provider') or dict()
+        super(NetworkModule, self)._load_params()
+        provider = self.params.get('provider') or dict()
         for key, value in provider.items():
             if key in NET_COMMON_ARGS.keys():
-                if not params.get(key) and value is not None:
-                    params[key] = value
-        return params
+                if self.params.get(key) is None and value is not None:
+                    self.params[key] = value
 
     def connect(self):
         if self.params['transport'] == 'nxapi':

--- a/lib/ansible/module_utils/openswitch.py
+++ b/lib/ansible/module_utils/openswitch.py
@@ -176,12 +176,12 @@ class NetworkModule(AnsibleModule):
         return self._config
 
     def _load_params(self):
-        params = super(NetworkModule, self)._load_params()
-        provider = params.get('provider') or dict()
+        super(NetworkModule, self)._load_params()
+        provider = self.params.get('provider') or dict()
         for key, value in provider.items():
             if key in NET_COMMON_ARGS.keys():
-                params[key] = value
-        return params
+                if self.params.get(key) is None and value is not None:
+                    self.params[key] = value
 
     def connect(self):
         if self.params['transport'] == 'rest':


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

ziploader (#15246) changed the behavior of _load_params such that it does not return the parameter dictionary, but rather sets it directly. This fixes the network modules so that they use this preset dictionary rather than the output of `super(...)._load_params()` (as there is now no output).

Additionally, some modules check for task-set parameters first, and others do not. This change standardizes this behavior to prefer task-set parameters.
