### PR TITLE
skip fixup_perms for Powershell

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -295,6 +295,11 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         If the become_user is unprivileged and different from the
         remote_user then we need to make the files we've uploaded readable by them.
         """
+        if self._connection._shell.SHELL_FAMILY == 'powershell':
+            # This won't work on Powershell as-is, so we'll just completely skip until
+            # we have a need for it, at which point we'll have to do something different.
+            return remote_path
+
         if remote_path is None:
             # Sometimes code calls us naively -- it has a var which could
             # contain a path to a tmp dir but doesn't know if it needs to

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -67,7 +67,13 @@ class ShellModule(object):
         return path.endswith('/') or path.endswith('\\')
 
     def chmod(self, mode, path, recursive=True):
-        return ''
+        raise NotImplementedError('chmod is not implemented for Powershell')
+
+    def chown(self, path, user, group=None, recursive=True):
+        raise NotImplementedError('chown is not implemented for Powershell')
+
+    def set_user_facl(self, path, user, mode, recursive=True):
+        raise NotImplementedError('set_user_facl is not implemented for Powershell')
 
     def remove(self, path, recurse=False):
         path = self._escape(self._unquote(path))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

action plugins will now skip _fixup_perms for Powershell. We'll have to come up with another way to do this at some point, but it's not necessary yet since we don't support become on Windows. Also added NotImplementedError throws to chmod/chown/set_facl operations on Powershell (instead of returning '') in case anyone tries to use them in the future.

fixes #15312

cc @abadger
