### PR TITLE
Ziploader subprocess.Popen

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -104,7 +104,7 @@ def debug(command, zipped_mod):
             os.environ['PYTHONPATH'] = ':'.join((basedir, pythonpath))
         else:
             os.environ['PYTHONPATH'] = basedir
-        p = subprocess.Popen(['%(interpreter)s', '-m', 'ansible.module_exec.%(ansible_module)s'], env=os.environ, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(['%(interpreter)s', '-m', 'ansible.module_exec.%(ansible_module)s.__main__'], env=os.environ, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = p.communicate()
         if not isinstance(stderr, (bytes, unicode)):
             stderr = stderr.read()
@@ -128,7 +128,7 @@ try:
             os.environ['PYTHONPATH'] = ':'.join((temp_path, pythonpath))
         else:
             os.environ['PYTHONPATH'] = temp_path
-        p = subprocess.Popen(['%(interpreter)s', '-m', 'ansible.module_exec.%(ansible_module)s'], env=os.environ, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(['%(interpreter)s', '-m', 'ansible.module_exec.%(ansible_module)s.__main__'], env=os.environ, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = p.communicate()
         if not isinstance(stderr, (bytes, unicode)):
             stderr = stderr.read()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

ziploader currently executes a module by importing the main function from the module and then running that function in the same process as the wrapper.  This has a few theoretical drawbacks and one that we've already seen in the wild:
- Seen in previous version of os_object: If the module uses the threading or multiprocessing libraries (likely because another library uses it) then we can end up hanging when waiting for those to exit if the module doesn't protect its own call to main() with a conditional (`if __name__ == '__main__':`)  Not quite sure why that happens -- there's some issues about this on Windows and multiprocessing but nothing that's supposed to affect POSIX systems and threading.  However, it does occur.  The workaround is to add the conditional to the module but this is a backwards incompatibility so it's best to close it if we can.
- At a basic level, new-style python modules are just python scripts which import our boilerplate to run and output json on exit.  There's nothing except convention to say they need to implement their entrypoint in a main() function.  If the module doesn't have a main() function then importing main won't work.
- It looks to me like there's small cornercase where a module's `main()` could get executed twice.  If the module doesn't use `exit_json()` and `fail_json()` but instead formats its own json and then falls off the end of the `main()` function (in other words, nothing calls `sys.exit()`) and the module executes `main()` at its toplevel instead of in a conditional block then we'd end up with the wrapper executing `main()` once when it imports the module and a second time when it runs `main()` explicitly.
- Prior to ziploader, we just treat the module as a script and invoke it by passing it to /usr/bin/python. .  I haven't thought of other ways in which importing main and running that is backwards incompatible with invoking the module as a script but it's probably better for compatibility to replicate that environment as much as possible.
