### PR TITLE
Update porting_guide_2.0.rst

### DIFF
--- a/docsite/rst/porting_guide_2.0.rst
+++ b/docsite/rst/porting_guide_2.0.rst
@@ -245,7 +245,7 @@ populates the callback with them.  Here's a short snippet that shows you how::
 
         def v2_playbook_on_start(self, playbook):
             self.playbook = playbook
-            self.playbook_name = os.path.basename(self.playbook._filename)
+            self.playbook_name = os.path.basename(self.playbook._file_name)
 
         def v2_playbook_on_play_start(self, play):
             self.play = play


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
```
##### SUMMARY

```
Small fix to the porting guide on how to get self.playbook_name in Ansible 2.0
```
