### PR TITLE
Ziploader "recursive imports" and caching

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -33,6 +33,7 @@ except Exception:
     pass
 
 import os
+import shutil
 import sys
 import traceback
 
@@ -40,6 +41,7 @@ import traceback
 from multiprocessing import Lock
 debug_lock = Lock()
 
+import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.utils.display import Display
 from ansible.utils.unicode import to_unicode
@@ -87,28 +89,28 @@ if __name__ == '__main__':
 
         cli = mycli(sys.argv)
         cli.parse()
-        sys.exit(cli.run())
+        exit_code = cli.run()
 
     except AnsibleOptionsError as e:
         cli.parser.print_help()
         display.error(to_unicode(e), wrap_text=False)
-        sys.exit(5)
+        exit_code = 5
     except AnsibleParserError as e:
         display.error(to_unicode(e), wrap_text=False)
-        sys.exit(4)
+        exit_code = 4
 # TQM takes care of these, but leaving comment to reserve the exit codes
 #    except AnsibleHostUnreachable as e:
 #        display.error(str(e))
-#        sys.exit(3)
+#        exit_code = 3
 #    except AnsibleHostFailed as e:
 #        display.error(str(e))
-#        sys.exit(2)
+#        exit_code = 2
     except AnsibleError as e:
         display.error(to_unicode(e), wrap_text=False)
-        sys.exit(1)
+        exit_code = 1
     except KeyboardInterrupt:
         display.error("User interrupted execution")
-        sys.exit(99)
+        exit_code = 99
     except Exception as e:
         have_cli_options = cli is not None and cli.options is not None
         display.error("Unexpected Exception: %s" % to_unicode(e), wrap_text=False)
@@ -116,4 +118,9 @@ if __name__ == '__main__':
             display.display(u"the full traceback was:\n\n%s" % to_unicode(traceback.format_exc()))
         else:
             display.display("to see the full traceback, use -vvv")
-        sys.exit(250)
+        exit_code = 250
+    finally:
+        # Remove ansible tempdir
+        shutil.rmtree(C.DEFAULT_LOCAL_TMP, True)
+
+    sys.exit(exit_code)

--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -452,6 +452,22 @@ This is the default location Ansible looks to find modules::
 Ansible knows how to look in multiple locations if you feed it a colon separated path, and it also will look for modules in the
 "./library" directory alongside a playbook.
 
+.. _local_tmp:
+
+local_tmp
+=========
+
+When Ansible gets ready to send a module to a remote machine it usually has to
+add a few things to the module: Some boilerplate code, the module's
+parameters, and a few constants from the config file.  This combination of
+things gets stored in a temporary file until ansible exits and cleans up after
+itself.  The default location is a subdirectory of the user's home directory.
+If you'd like to change that, you can do so by altering this setting::
+
+    local_tmp = $HOME/.ansible/tmp
+
+Ansible will then choose a random directory name inside this location.
+
 .. _log_path:
 
 log_path

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -14,6 +14,7 @@
 #inventory      = /etc/ansible/hosts
 #library        = /usr/share/my_modules/
 #remote_tmp     = $HOME/.ansible/tmp
+#local_tmp      = $HOME/.ansible/tmp
 #forks          = 5
 #poll_interval  = 15
 #sudo_user      = root

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -29,12 +29,14 @@
 #    test-module -m ../library/file/lineinfile -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
 #    test-module -m ../library/commands/command -a "echo hello" -n -o "test_hello"
 
-import sys
 import base64
+from multiprocessing import Lock
+import optparse
 import os
 import subprocess
+import sys
 import traceback
-import optparse
+
 import ansible.utils.vars as utils_vars
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.utils.jsonify import jsonify
@@ -133,10 +135,12 @@ def boilerplate_module(modfile, args, interpreter, check, destfile):
 
     modname = os.path.basename(modfile)
     modname = os.path.splitext(modname)[0]
+    action_write_lock = Lock()
     (module_data, module_style, shebang) = module_common.modify_module(
         modname,
         modfile,
         complex_args,
+        action_write_lock,
         task_vars=task_vars
     )
 

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -180,7 +180,7 @@ def debug(command, zipped_mod, json_params):
         # ansible modules)
         sys.stdin = IOStream(json_params)
         sys.path.insert(0, basedir)
-        from ansible.module_exec.%(ansible_module)s.__main__ import main
+        from ansible_module_%(ansible_module)s import main
         main()
         print('WARNING: Module returned to wrapper instead of exiting')
         sys.exit(1)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -48,7 +48,7 @@ REPLACER_SELINUX  = b"<<SELINUX_SPECIAL_FILESYSTEMS>>"
 
 # We could end up writing out parameters with unicode characters so we need to
 # specify an encoding for the python source file
-ENCODING_STRING = b'# -*- coding: utf-8 -*-'
+ENCODING_STRING = u'# -*- coding: utf-8 -*-'
 
 # we've moved the module_common relative to the snippets, so fix the path
 _SNIPPET_PATH = os.path.join(os.path.dirname(__file__), '..', 'module_utils')
@@ -56,7 +56,7 @@ _SNIPPET_PATH = os.path.join(os.path.dirname(__file__), '..', 'module_utils')
 # ******************************************************************************
 
 ZIPLOADER_TEMPLATE = u'''%(shebang)s
-# -*- coding: utf-8 -*-'
+%(coding)s
 # This code is part of Ansible, but is an independent component.
 # The code in this particular templatable string, and this templatable string
 # only, is BSD licensed.  Modules which end up using this snippet, which is
@@ -333,6 +333,7 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
             constants=python_repred_constants,
             shebang=shebang,
             interpreter=interpreter,
+            coding=ENCODING_STRING,
             )))
         module_data = output.getvalue()
 
@@ -440,7 +441,7 @@ def modify_module(module_name, module_path, module_args, task_vars=dict(), modul
                 lines[0] = shebang = new_shebang
 
             if os.path.basename(interpreter).startswith(b'python'):
-                lines.insert(1, ENCODING_STRING)
+                lines.insert(1, to_bytes(ENCODING_STRING))
         else:
             # No shebang, assume a binary module?
             pass

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -96,9 +96,10 @@ import subprocess
 
 if sys.version_info < (3,):
     bytes = str
+    PY3 = False
 else:
     unicode = str
-
+    PY3 = True
 try:
     # Python-2.6+
     from io import BytesIO as IOStream
@@ -122,9 +123,12 @@ def invoke_module(module, modlib_path, json_params):
         stderr = stderr.read()
     if not isinstance(stdout, (bytes, unicode)):
         stdout = stdout.read()
-    sys.stderr.write(stderr)
-    sys.stdout.write(stdout)
-
+    if PY3:
+        sys.stderr.buffer.write(stderr)
+        sys.stdout.buffer.write(stdout)
+    else:
+        sys.stderr.write(stderr)
+        sys.stdout.write(stdout)
     return p.returncode
 
 def debug(command, zipped_mod, json_params):
@@ -192,7 +196,8 @@ def debug(command, zipped_mod, json_params):
 
 if __name__ == '__main__':
     ZIPLOADER_PARAMS = %(params)s
-
+    if PY3:
+        ZIPLOADER_PARAMS = ZIPLOADER_PARAMS.encode('utf-8')
     try:
         temp_path = tempfile.mkdtemp(prefix='ansible_')
         zipped_mod = os.path.join(temp_path, 'ansible_modlib.zip')

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -95,12 +95,9 @@ class WorkerProcess(multiprocessing.Process):
 
     def run(self):
         '''
-        Called when the process is started, and loops indefinitely
-        until an error is encountered (typically an IOerror from the
-        queue pipe being disconnected). During the loop, we attempt
-        to pull tasks off the job queue and run them, pushing the result
-        onto the results queue. We also remove the host from the blocked
-        hosts list, to signify that they are ready for their next task.
+        Called when the process is started.  Pushes the result onto the
+        results queue. We also remove the host from the blocked hosts list, to
+        signify that they are ready for their next task.
         '''
 
         if HAS_ATFORK:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1447,6 +1447,9 @@ class AnsibleModule(object):
             print('{"msg": "Error: Module unable to decode valid JSON on stdin.  Unable to figure out what parameters were passed", "failed": true}')
             sys.exit(1)
 
+        if sys.version_info < (3,):
+            params = json_dict_unicode_to_bytes(params)
+
         try:
             self.params = params['ANSIBLE_MODULE_ARGS']
             self.constants = params['ANSIBLE_MODULE_CONSTANTS']

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -223,23 +223,6 @@ from ansible import __version__
 # Backwards compat. New code should just import and use __version__
 ANSIBLE_VERSION = __version__
 
-try:
-    # MODULE_COMPLEX_ARGS is an old name kept for backwards compat
-    MODULE_COMPLEX_ARGS = os.environ.pop('ANSIBLE_MODULE_ARGS')
-except KeyError:
-    # This file might be used for its utility functions.  So don't fail if
-    # running outside of a module environment (will fail in _load_params()
-    # instead)
-    MODULE_COMPLEX_ARGS = None
-
-try:
-    # ARGS are for parameters given in the playbook.  Constants are for things
-    # that ansible needs to configure controller side but are passed to all
-    # modules.
-    MODULE_CONSTANTS = os.environ.pop('ANSIBLE_MODULE_CONSTANTS')
-except KeyError:
-    MODULE_CONSTANTS = None
-
 FILE_COMMON_ARGUMENTS=dict(
     src = dict(),
     mode = dict(type='raw'),
@@ -560,7 +543,6 @@ class AnsibleModule(object):
                 if k not in self.argument_spec:
                     self.argument_spec[k] = v
 
-        self._load_constants()
         self._load_params()
         self._set_fallbacks()
 
@@ -1452,32 +1434,47 @@ class AnsibleModule(object):
                     continue
 
     def _load_params(self):
-        ''' read the input and set the params attribute'''
-        if MODULE_COMPLEX_ARGS is None:
+        ''' read the input and set the params attribute.  Sets the constants as well.'''
+        buffer = sys.stdin.read()
+        try:
+            params = json.loads(buffer)
+        except ValueError:
             # This helper used too early for fail_json to work.
-            print('{"msg": "Error: ANSIBLE_MODULE_ARGS not found in environment.  Unable to figure out what parameters were passed", "failed": true}')
+            print('{"msg": "Error: Module unable to decode valid JSON on stdin.  Unable to figure out what parameters were passed", "failed": true}')
             sys.exit(1)
 
-        params = json_dict_unicode_to_bytes(json.loads(MODULE_COMPLEX_ARGS))
-        if params is None:
-            params = dict()
-        self.params = params
-
-    def _load_constants(self):
-        ''' read the input and set the constants attribute'''
-        if MODULE_CONSTANTS is None:
+        try:
+            self.params = params['ANSIBLE_MODULE_ARGS']
+            self.constants = params['ANSIBLE_MODULE_CONSTANTS']
+        except KeyError:
             # This helper used too early for fail_json to work.
-            print('{"msg": "Error: ANSIBLE_MODULE_CONSTANTS not found in environment.  Unable to figure out what constants were passed", "failed": true}')
+            print('{"msg": "Error: Module unable to locate ANSIBLE_MODULE_ARGS and ANSIBLE_MODULE_CONSTANTS in json data from stdin.  Unable to figure out what parameters were passed", "failed": true}')
             sys.exit(1)
 
-        # Make constants into "native string"
-        if sys.version_info >= (3,):
-            constants = json_dict_bytes_to_unicode(json.loads(MODULE_CONSTANTS))
-        else:
-            constants = json_dict_unicode_to_bytes(json.loads(MODULE_CONSTANTS))
-        if constants is None:
-            constants = dict()
-        self.constants = constants
+#        import select
+#        buffer = ''
+#        while True:
+#            input_list = select.select([sys.stdin], [],  [], 5.0)[0]
+#            if sys.stdin not in input_list:
+#                # This helper used too early for fail_json to work.
+#                print('{"msg": "Error: Module unable to read arguments from stdin.  Unable to figure out what parameters were passed", "failed": true}')
+#                sys.exit(1)
+#            buffer += sys.stdin.read()
+#            if json.loads(buffer):
+#
+#        for line in sys.stdin:
+#            if line is None:
+#                print('s')
+#        data = sys.stdin.read()
+#        if MODULE_COMPLEX_ARGS is None:
+#            # This helper used too early for fail_json to work.
+#            print('{"msg": "Error: ANSIBLE_MODULE_ARGS not found in environment.  Unable to figure out what parameters were passed", "failed": true}')
+#            sys.exit(1)
+#
+#        params = json_dict_unicode_to_bytes(json.loads(data))
+#        if params is None:
+#            params = dict()
+#        self.params = params
 
     def _log_to_syslog(self, msg):
         if HAS_SYSLOG:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1435,9 +1435,13 @@ class AnsibleModule(object):
 
     def _load_params(self):
         ''' read the input and set the params attribute.  Sets the constants as well.'''
-        buffer = sys.stdin.read()
+        # Avoid tracebacks when locale is non-utf8
+        if sys.version_info < (3,):
+            buffer = sys.stdin.read()
+        else:
+            buffer = sys.stdin.buffer.read()
         try:
-            params = json.loads(buffer)
+            params = json.loads(buffer.decode('utf-8'))
         except ValueError:
             # This helper used too early for fail_json to work.
             print('{"msg": "Error: Module unable to decode valid JSON on stdin.  Unable to figure out what parameters were passed", "failed": true}')
@@ -1450,31 +1454,6 @@ class AnsibleModule(object):
             # This helper used too early for fail_json to work.
             print('{"msg": "Error: Module unable to locate ANSIBLE_MODULE_ARGS and ANSIBLE_MODULE_CONSTANTS in json data from stdin.  Unable to figure out what parameters were passed", "failed": true}')
             sys.exit(1)
-
-#        import select
-#        buffer = ''
-#        while True:
-#            input_list = select.select([sys.stdin], [],  [], 5.0)[0]
-#            if sys.stdin not in input_list:
-#                # This helper used too early for fail_json to work.
-#                print('{"msg": "Error: Module unable to read arguments from stdin.  Unable to figure out what parameters were passed", "failed": true}')
-#                sys.exit(1)
-#            buffer += sys.stdin.read()
-#            if json.loads(buffer):
-#
-#        for line in sys.stdin:
-#            if line is None:
-#                print('s')
-#        data = sys.stdin.read()
-#        if MODULE_COMPLEX_ARGS is None:
-#            # This helper used too early for fail_json to work.
-#            print('{"msg": "Error: ANSIBLE_MODULE_ARGS not found in environment.  Unable to figure out what parameters were passed", "failed": true}')
-#            sys.exit(1)
-#
-#        params = json_dict_unicode_to_bytes(json.loads(data))
-#        if params is None:
-#            params = dict()
-#        self.params = params
 
     def _log_to_syslog(self, msg):
         if HAS_SYSLOG:

--- a/test/units/module_utils/basic/test_log.py
+++ b/test/units/module_utils/basic/test_log.py
@@ -21,7 +21,12 @@ from __future__ import (absolute_import, division)
 __metaclass__ = type
 
 import sys
+import json
 import syslog
+from io import BytesIO, StringIO
+
+from ansible.compat.six import PY3
+from ansible.utils.unicode import to_bytes
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, MagicMock
@@ -41,10 +46,14 @@ except ImportError:
 class TestAnsibleModuleSysLogSmokeTest(unittest.TestCase):
 
     def setUp(self):
-        self.complex_args_token = basic.MODULE_COMPLEX_ARGS
-        self.constants_sentinel = basic.MODULE_CONSTANTS
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        self.real_stdin = sys.stdin
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         self.am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -55,8 +64,7 @@ class TestAnsibleModuleSysLogSmokeTest(unittest.TestCase):
             basic.has_journal = False
 
     def tearDown(self):
-        basic.MODULE_COMPLEX_ARGS = self.complex_args_token
-        basic.MODULE_CONSTANTS = self.constants_sentinel
+        sys.stdin = self.real_stdin
         basic.has_journal = self.has_journal
 
     def test_smoketest_syslog(self):
@@ -75,17 +83,21 @@ class TestAnsibleModuleSysLogSmokeTest(unittest.TestCase):
 class TestAnsibleModuleJournaldSmokeTest(unittest.TestCase):
 
     def setUp(self):
-        self.complex_args_token = basic.MODULE_COMPLEX_ARGS
-        self.constants_sentinel = basic.MODULE_CONSTANTS
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        self.real_stdin = sys.stdin
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
+
         self.am = basic.AnsibleModule(
             argument_spec = dict(),
         )
 
     def tearDown(self):
-        basic.MODULE_COMPLEX_ARGS = self.complex_args_token
-        basic.MODULE_CONSTANTS = self.constants_sentinel
+        sys.stdin = self.real_stdin
 
     @unittest.skipUnless(basic.has_journal, 'python systemd bindings not installed')
     def test_smoketest_journal(self):
@@ -121,10 +133,15 @@ class TestAnsibleModuleLogSyslog(unittest.TestCase):
             }
 
     def setUp(self):
-        self.complex_args_token = basic.MODULE_COMPLEX_ARGS
-        self.constants_sentinel = basic.MODULE_CONSTANTS
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        self.real_stdin = sys.stdin
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
+
         self.am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -134,8 +151,7 @@ class TestAnsibleModuleLogSyslog(unittest.TestCase):
             basic.has_journal = False
 
     def tearDown(self):
-        basic.MODULE_COMPLEX_ARGS = self.complex_args_token
-        basic.MODULE_CONSTANTS = self.constants_sentinel
+        sys.stdin = self.real_stdin
         basic.has_journal = self.has_journal
 
     @patch('syslog.syslog', autospec=True)
@@ -176,10 +192,14 @@ class TestAnsibleModuleLogJournal(unittest.TestCase):
             }
 
     def setUp(self):
-        self.complex_args_token = basic.MODULE_COMPLEX_ARGS
-        self.constants_sentinel = basic.MODULE_CONSTANTS
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        self.real_stdin = sys.stdin
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         self.am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -198,8 +218,8 @@ class TestAnsibleModuleLogJournal(unittest.TestCase):
                 self._fake_out_reload(basic)
 
     def tearDown(self):
-        basic.MODULE_COMPLEX_ARGS = self.complex_args_token
-        basic.MODULE_CONSTANTS = self.constants_sentinel
+        sys.stdin = self.real_stdin
+
         basic.has_journal = self.has_journal
         if self.module_patcher:
             self.module_patcher.stop()

--- a/test/units/module_utils/basic/test_safe_eval.py
+++ b/test/units/module_utils/basic/test_safe_eval.py
@@ -20,16 +20,32 @@
 from __future__ import (absolute_import, division)
 __metaclass__ = type
 
-from ansible.compat.tests import unittest
+import sys
+import json
+from io import BytesIO, StringIO
 
+from ansible.compat.tests import unittest
+from ansible.compat.six import PY3
+from ansible.utils.unicode import to_bytes
 
 class TestAnsibleModuleExitJson(unittest.TestCase):
+
+    def setUp(self):
+        self.real_stdin = sys.stdin
+
+    def tearDown(self):
+        sys.stdin = self.real_stdin
 
     def test_module_utils_basic_safe_eval(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec=dict(),
         )

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -21,13 +21,18 @@ from __future__ import (absolute_import, division)
 __metaclass__ = type
 
 import errno
+import json
 import os
 import sys
+from io import BytesIO, StringIO
 
 try:
     import builtins
 except ImportError:
     import __builtin__ as builtins
+
+from ansible.compat.six import PY3
+from ansible.utils.unicode import to_bytes
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, MagicMock, mock_open, Mock, call
@@ -37,10 +42,10 @@ realimport = builtins.__import__
 class TestModuleUtilsBasic(unittest.TestCase):
  
     def setUp(self):
-        pass
+        self.real_stdin = sys.stdin
 
     def tearDown(self):
-        pass
+        sys.stdin = self.real_stdin
 
     def clear_modules(self, mods):
         for mod in mods:
@@ -266,8 +271,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_creation(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec=dict(),
         )
@@ -282,8 +292,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
         req_to = (('bam', 'baz'),)
 
         # should test ok
-        basic.MODULE_COMPLEX_ARGS = '{"foo":"hello"}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={"foo": "hello"}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = arg_spec,
             mutually_exclusive = mut_ex,
@@ -297,8 +312,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
         # FIXME: add asserts here to verify the basic config
 
         # fail, because a required param was not specified
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         self.assertRaises(
             SystemExit,
             basic.AnsibleModule,
@@ -312,8 +332,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
         )
 
         # fail because of mutually exclusive parameters
-        basic.MODULE_COMPLEX_ARGS = '{"foo":"hello", "bar": "bad", "bam": "bad"}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={"foo":"hello", "bar": "bad", "bam": "bad"}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         self.assertRaises(
             SystemExit, 
             basic.AnsibleModule,
@@ -327,8 +352,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
         )
 
         # fail because a param required due to another param was not specified
-        basic.MODULE_COMPLEX_ARGS = '{"bam":"bad"}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={"bam": "bad"}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         self.assertRaises(
             SystemExit,
             basic.AnsibleModule,
@@ -344,8 +374,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_load_file_common_arguments(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -394,8 +429,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_selinux_mls_enabled(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -415,8 +455,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_selinux_initial_context(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -430,8 +475,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_selinux_enabled(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -463,8 +513,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_selinux_default_context(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -500,8 +555,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_selinux_context(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -543,8 +603,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_is_special_selinux_path(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{"SELINUX_SPECIAL_FS": "nfs,nfsd,foos"}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={"SELINUX_SPECIAL_FS": "nfs,nfsd,foos"}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -585,20 +650,30 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_to_filesystem_str(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
 
         self.assertEqual(am._to_filesystem_str(u'foo'), b'foo')
         self.assertEqual(am._to_filesystem_str(u'föö'), b'f\xc3\xb6\xc3\xb6')
-        
+
     def test_module_utils_basic_ansible_module_user_and_group(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -613,8 +688,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_find_mount_point(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -638,8 +718,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_set_context_if_different(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -684,8 +769,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_set_owner_if_different(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -724,7 +814,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_set_group_if_different(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -763,8 +859,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module_set_mode_if_different(self):
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -852,8 +953,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -1031,8 +1137,13 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
         from ansible.module_utils import basic
 
-        basic.MODULE_COMPLEX_ARGS = '{}'
-        basic.MODULE_CONSTANTS = '{}'
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -212,14 +212,15 @@ class TestActionBase(unittest.TestCase):
 
         # test python module formatting
         with patch.object(builtins, 'open', mock_open(read_data=to_bytes(python_module_replacers.strip(), encoding='utf-8'))) as m:
-            mock_task.args = dict(a=1, foo='fö〩')
-            mock_connection.module_implementation_preferences = ('',)
-            (style, shebang, data) = action_base._configure_module(mock_task.action, mock_task.args)
-            self.assertEqual(style, "new")
-            self.assertEqual(shebang, b"#!/usr/bin/python")
+            with patch.object(os, 'rename') as m:
+                mock_task.args = dict(a=1, foo='fö〩')
+                mock_connection.module_implementation_preferences = ('',)
+                (style, shebang, data) = action_base._configure_module(mock_task.action, mock_task.args)
+                self.assertEqual(style, "new")
+                self.assertEqual(shebang, b"#!/usr/bin/python")
 
-            # test module not found
-            self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args)
+                # test module not found
+                self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args)
 
         # test powershell module formatting
         with patch.object(builtins, 'open', mock_open(read_data=to_bytes(powershell_module_replacers.strip(), encoding='utf-8'))) as m:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY

The first version of ziploader is able to find module_utils files that are listed in the module itself and make sure that those files are included in the zipfile that is sent to the remote machine.  This is suboptimal as the equivalent python import will also find the module_utils files that the module_utils files have a need for.  This set of commits adds that capability to ziploader and implements a simple controller-side cache to offset the increase in time that searching for the module_utils causes.  The cache cleans itself up and auto-invalidates when the main ansible/ansible-playbook process ends.

Caveats to the recusive feature:
- relative imports (py2.6+) are not handled (example: `from . import urls`).  Imports must be absolute imports coming from ansible.module_utils.
- python packages (directories with `__init__.py` in them).  module_utils will only be searched for *.py files right now, not directories.  (example: `from ansible.module_utils.basic import AnsibleModule` will look for `ansible/module_utils/basic.py`.  It will not look for `ansible/module_utils/basic/__init__.py` even though python itself would.)

There's also a couple unrelated bug fixes (Fixing encoding string in the wrapper which was being lost when we implemented comment stripping of the wrapper and a correction to the process.worker.run documentation since worker no longer loops).
