### PR TITLE
Feature Pull Request : Add speed link in gathered facts for Linux.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2022,6 +2022,10 @@ class LinuxNetwork(Network):
                         interfaces[device]['all_slaves_active'] = get_file_content(path) == '1'
             if os.path.exists(os.path.join(path,'device')):
                 interfaces[device]['pciid'] = os.path.basename(os.readlink(os.path.join(path,'device')))
+            if os.path.exists(os.path.join(path, 'speed')):
+                speed = get_file_content(os.path.join(path, 'speed'))
+                if speed is not None:
+                    interfaces[device]['speed'] = int(speed)
 
             # Check whether an interface is in promiscuous mode
             if os.path.exists(os.path.join(path,'flags')):


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel_network_speed ba1c65230c) last updated 2016/04/09 11:59:29 (GMT +200)
  lib/ansible/modules/core: (detached HEAD c52f475c64) last updated 2016/04/09 11:47:06 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 5abb914315) last updated 2016/04/09 11:47:06 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This PR implements the following feature idea: https://github.com/ansible/ansible/issues/15325

It read the content of /sys/class/net/*/speed files and convert it into integer to get the speed (in Mb) of network interface. If the file is empty (like for lo interface), it does not add speed fact.

Before:

```
        "ansible_eth0": {
            "active": true, 
            "device": "eth0", 
...
            "macaddress": "f4:6d:04:1e:61:c3", 
            "module": "r8169", 
            "mtu": 1500, 
            "pciid": "0000:01:00.0", 
            "promisc": false, 
            "type": "ether"
        }, 
```

After:

```
        "ansible_eth0": {
            "active": true, 
            "device": "eth0", 
...
            "macaddress": "f4:6d:04:1e:61:c3", 
            "module": "r8169", 
            "mtu": 1500, 
            "pciid": "0000:01:00.0", 
            "promisc": false, 
            "speed": 1000, 
            "type": "ether"
        }, 
```
