### PR TITLE
ansible-galaxy install api usage

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -149,8 +149,9 @@ class GalaxyCLI(CLI):
         
         super(GalaxyCLI, self).run()
 
+        # install will setup the API if needed later on
         # if not offline, get connect to galaxy api
-        if self.action in ("import","info","install","search","login","setup","delete") or \
+        if self.action in ("import","info","search","login","setup","delete") or \
             (self.action == 'init' and not self.options.offline):
             self.api = GalaxyAPI(self.galaxy)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.0.2
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #13991

ansible-galaxy install will only talk to the API if needed. This allows galaxy to install local roles without internet access. execute_install and role.py already only talked to the API server if needed but for some reason the API was still be contacted before the roles where even looked at.
