### PR TITLE
Create remote temp directory with search permission for all users

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -210,7 +210,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if self._play_context.become and self._play_context.become_user not in ('root', remote_user):
             use_system_tmp = True
 
-        tmp_mode = 0o700
+        tmp_mode = 0o711
 
         cmd = self._connection._shell.mkdtemp(basefile, use_system_tmp, tmp_mode)
         result = self._low_level_execute_command(cmd, sudoable=False)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

Change added on top of https://github.com/ansible/ansible/commit/005dc84.
`ansible --version` after fix:

```
ansible 2.1.0 (remote-file-permission-fix 51dfd282d2) last updated 2016/04/11 22:37:18 (GMT +200)
  lib/ansible/modules/core: (detached HEAD c52f475c64) last updated 2016/04/11 22:28:26 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 5abb914315) last updated 2016/04/11 22:28:26 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

When a playbook uses the "become" feature to switch to a user other than the one that was used to connect, the temporary files required for playbook execution are made accessible to that user. However, the directory that holds the files was previously created with mode 0o700, so the "become" user couldn't access the files within regardless of their permissions.
Changing the directory mode to 0o711 allows all users to traverse the directory, which mitigates the missing access problem. Since the files contained in the directory will have access restrictions of their own, this doesn't compromise security.
