### PR TITLE
Remote file chown: Don't rely on username to check for root privileges

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -311,18 +311,23 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if self._play_context.become and self._play_context.become_user not in ('root', remote_user):
             # Unprivileged user that's different than the ssh user.  Let's get
             # to work!
-            if remote_user == 'root':
-                # SSh'ing as root, therefore we can chown
-                res = self._remote_chown(remote_path, self._play_context.become_user, recursive=recursive)
-                if res['rc'] != 0:
-                    raise AnsibleError('Failed to set owner on remote files (rc: {0}, err: {1})'.format(res['rc'], res['stderr']))
+
+            # Try chown'ing the file. This will only work if our SSH user has
+            # root privileges, but since we can't reliably determine that from
+            # the username (think "toor" on FreeBSD), let's just try first and
+            # apologize later:
+            res = self._remote_chown(remote_path, self._play_context.become_user, recursive=recursive)
+            if res['rc'] == 0:
+                # Only continue with chmod if chown worked
                 if execute:
                     # root can read things that don't have read bit but can't
                     # execute them.
                     res = self._remote_chmod('u+x', remote_path, recursive=recursive)
                     if res['rc'] != 0:
                         raise AnsibleError('Failed to set file mode on remote files (rc: {0}, err: {1})'.format(res['rc'], res['stderr']))
+
             else:
+                # Chown'ing failed. We're probably lacking root privileges; let's try something else.
                 if execute:
                     mode = 'rx'
                 else:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

Change added on top of https://github.com/ansible/ansible/commit/005dc84.
`ansible --version` after fix:

```
ansible 2.1.0 (remote-chown-fix 7b1373480e) last updated 2016/04/11 22:57:10 (GMT +200)
  lib/ansible/modules/core: (detached HEAD c52f475c64) last updated 2016/04/11 22:28:26 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 5abb914315) last updated 2016/04/11 22:28:26 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

The SSH username isn't a reliable way to check if we've got root privileges on the remote system (think "toor" on FreeBSD). Because of this check, Ansible previously tried to use the fallback solutions for granting file access (ACLs, world-readable files) even on systems where it had root privileges when the remote username didn't match the literal string "root".

Instead of running checks on the username, just try using `chmod` in any case and fall back to the previous "non-root" solution when that fails.
