### PR TITLE
contrib/inventory/ec2.py can read AWS credentials from ec2.ini

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -165,3 +165,22 @@ group_by_elasticache_replication_group = True
 # A boto configuration profile may be used to separate out credentials
 # see http://boto.readthedocs.org/en/latest/boto_config_tut.html
 # boto_profile = some-boto-profile-name
+
+
+[credentials]
+
+# The AWS credentials can optionally be specified here. Credentials specified
+# here are ignored if the environment variable AWS_ACCESS_KEY_ID or
+# AWS_PROFILE is set, or if the boto_profile property above is set.
+#
+# Supplying AWS credentials here is not recommended, as it introduces
+# non-trivial security concerns. When going down this route, please make sure
+# to set access permissions for this file correctly, e.g. handle it the same
+# way as you would a private SSH key.
+#
+# Unlike the boto and AWS configure files, this section does not support
+# profiles.
+#
+# aws_access_key_id = AXXXXXXXXXXXXXX
+# aws_secret_access_key = XXXXXXXXXXXXXXXXXXX
+# aws_security_token = XXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The EC2 external inventory uses boto, which reads AWS credentials from a few hard-coded paths relative to the user's home directory.

This PR adds the ability to read AWS credentials from the `ec2.ini` file that accomplishes the EC2 inventory script. The advantage of this approach is that AWS credentials can be specified inside the Ansible project.

For example, I use a playbook to perform a MFA (multi-factor authentication) and generate an ec2.ini that contains the obtained AWS credentials, as well as a few other settings derived from the playbook. I don't want to have to modify any files outside my Ansible project.

I think this capability would be useful to others, and I hope you will consider merging it. Thank you very much for all your work on Ansible!
