### PR TITLE
Add import ShellError to ios.py

### DIFF
--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -20,7 +20,7 @@
 import re
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.shell import Shell, Command, HAS_PARAMIKO
+from ansible.module_utils.shell import Shell, ShellError, Command, HAS_PARAMIKO
 from ansible.module_utils.netcfg import parse
 
 NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 1d7ab14b96) last updated 2016/04/12 21:01:14 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD c52f475c64) last updated 2016/04/11 07:13:36 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD 5abb914315) last updated 2016/04/11 07:13:37 (GMT +1000)
  config file = /Users/luke/OneDrive/Luke/GitHub/psn_wan/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This adds import ShellError to module_utils\ios.py so that Ansible can produce meaningful errors when ios_template module reports an incorrect Cisco IOS command.

I don't believe there is currently a bug issue for this.
##### Before

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/var/folders/h_/9dfd1qtx38d1152pr0yps0dm0000gn/T/ansible_3es31C/ansible/module_exec/ios_template/__main__.py", line 168, in <module>
  File "/var/folders/h_/9dfd1qtx38d1152pr0yps0dm0000gn/T/ansible_3es31C/ansible/module_exec/ios_template/__main__.py", line 155, in main
  File "/var/folders/h_/9dfd1qtx38d1152pr0yps0dm0000gn/T/ansible_3es31C/ansible/module_utils/ios.py", line 134, in configure
  File "/var/folders/h_/9dfd1qtx38d1152pr0yps0dm0000gn/T/ansible_3es31C/ansible/module_utils/ios.py", line 143, in execute
NameError: global name 'ShellError' is not defined
```
##### After

```
fatal: [CIT_RV01]: FAILED! => {"changed": false, "command": "ip nhrp multicast dynamic", "failed": true, "msg": "matched error in response: ip nhrp multicast dynamic\r\n                                      ^\r\n% Invalid input detected at '^' marker.\r\n\r\nCIT_RV01(config-if)#"}
```
