### PR TITLE
Adding current working directory to the dataloader search paths

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -261,6 +261,9 @@ class DataLoader():
             # try to create absolute path for loader basedir + filename
             search.append(self.path_dwim(source))
 
+            # working dir + relative filename
+            search.append(os.path.join(os.getcwd(), source))
+
         for candidate in search:
             if os.path.exists(to_bytes(candidate, errors='strict')):
                 break


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/my_modules/']
```
##### SUMMARY

Adding current working directory to the dataloader search paths

In path_dwim_relative() of parsing/dataloader.py, added the current working directory also in the list of the search paths, so that files created relative to the working dir (like command module) will be picked aptly.

Fixes #15375
