### PR TITLE
mysql_*: enable mysql connection via unix socket

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -36,9 +36,7 @@ except ImportError:
     mysqldb_found = False
 
 def mysql_connect(module, login_user=None, login_password=None, config_file='', ssl_cert=None, ssl_key=None, ssl_ca=None, db=None, cursor_class=None, connect_timeout=30):
-    config = {
-        'host': module.params['login_host']
-    }
+    config = {}
 
     if ssl_ca is not None or ssl_key is not None or ssl_cert is not None:
         config['ssl'] = {}
@@ -46,6 +44,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if module.params['login_unix_socket']:
         config['unix_socket'] = module.params['login_unix_socket']
     else:
+        config['host'] = module.params['login_host']
         config['port'] = module.params['login_port']
 
     if os.path.exists(config_file):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION
- 2.0.1.0
- master
- any?
##### SUMMARY

module_utils/mysql.py sets host by default, which makes unix socket connections unavailable.
This patch fixes that issue, and is backwards compatible, as unix socket connection has never
worked with ansible, seems.
