### PR TITLE
Get Runner._remote_checksum() to work when it is used in combination with privilege escalation.

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -18,6 +18,7 @@
 import multiprocessing
 import signal
 import os
+import re
 import pwd
 import Queue
 import random
@@ -1263,7 +1264,9 @@ class Runner(object):
         else:
             sudoable = False
         data = self._low_level_exec_command(conn, cmd, tmp, sudoable=sudoable)
-        data2 = utils.last_non_blank_line(data['stdout'])
+        if data.get('stdout','').strip().startswith('BECOME-SUCCESS-'):
+            data['stdout'] = re.sub(r'^((\r)?\n)?BECOME-SUCCESS.*(\r)?\n', '', data['stdout'])
+        data2 = data['stdout'].splitlines()[0]
         try:
             if data2 == '':
                 # this may happen if the connection to the remote server


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 1.9.6 (stable-1.9 e7c4ea4d1c) last updated 2016/04/12 12:21:44 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 0f85390d21) last updated 2016/04/12 10:47:27 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD ddbb32c30a) last updated 2016/04/12 10:47:30 (GMT +000)
  configured module search path = None
```
##### SUMMARY

This is a bug fix for the issue that unarchive module fails to run when the operation is privileged, i.e. `become: yes` put alongside.

The issue was already address in 2.0 branch, by the application of the following patch: https://github.com/ansible/ansible/commit/b9d0662faf2910dea503c0c8c35ad9951a4c6e9c
