### PR TITLE
using ops.dc module instead of runconfig

### DIFF
--- a/lib/ansible/module_utils/openswitch.py
+++ b/lib/ansible/module_utils/openswitch.py
@@ -55,7 +55,7 @@ def to_list(val):
     else:
         return list()
 
-def get_runconfig():
+def get_opsidl():
     extschema = restparser.parseSchema(settings.get('ext_schema'))
     ovsschema = settings.get('ovs_schema')
     ovsremote = settings.get('ovs_remote')


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

```
2.1.0
```
##### SUMMARY

OpenSwitch's declarative configuration feature has now been migrated to a new module. `ops.dc` should be used as `runconfig` is deprecated.

@privateip

Signed-off-by: Mir M Ali mir.ali@hpe.com
