### PR TITLE
move test_git to destructive

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -21,3 +21,4 @@
     - { role: test_zypper, tags: test_zypper}
     - { role: test_zypper_repository, tags: test_zypper_repository}
     - { role: test_uri, tags: test_uri }
+    - { role: test_git, tags: test_git }

--- a/test/integration/non_destructive.yml
+++ b/test/integration/non_destructive.yml
@@ -28,7 +28,6 @@
     - { role: test_synchronize, tags: test_synchronize }
     - { role: test_assemble, tags: test_assemble }
     - { role: test_subversion, tags: test_subversion }
-    - { role: test_git, tags: test_git }
     - { role: test_hg, tags: test_hg }
     - { role: test_lineinfile, tags: test_lineinfile }
     - { role: test_unarchive, tags: test_unarchive }


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

devel
##### SUMMARY

The integration test test_git remove the ssh_known_hosts for the user and globally, see:
https://github.com/ansible/ansible/blob/08b3dbcda3f28815af3adff168f67506395d3c17/test/integration/roles/test_git/tasks/main.yml#L89-L91

That is destructive!
It should thus be in destructive and not non_destructive.
