### PR TITLE
add "gather_facts: ignore_restrictions"

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -181,7 +181,11 @@ class PlayIterator:
 
         self._host_states = {}
         start_at_matched = False
-        for host in inventory.get_hosts(self._play.hosts):
+        if self._play.gather_facts == 'ignore_restrictions':
+            hosts = inventory.get_hosts(self._play.hosts, ignore_limits_and_restrictions=True)
+        else:
+            hosts = inventory.get_hosts(self._play.hosts)
+        for host in hosts:
             self._host_states[host.name] = HostState(blocks=self._blocks)
             # if the host's name is in the variable manager's fact cache, then set
             # its _gathered_facts flag to true for smart gathering tests later
@@ -285,7 +289,9 @@ class PlayIterator:
                     # NOT explicitly set gather_facts to False.
 
                     gathering = C.DEFAULT_GATHERING
-                    implied = self._play.gather_facts is None or boolean(self._play.gather_facts)
+                    implied = (self._play.gather_facts is None or
+                               self._play.gather_facts == 'True' or
+                               self._play.gather_facts == 'ignore_restrictions')
 
                     if (gathering == 'implicit' and implied) or \
                        (gathering == 'explicit' and boolean(self._play.gather_facts)) or \

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -63,7 +63,7 @@ class Play(Base, Taggable, Become):
     _accelerate_port     = FieldAttribute(isa='int', default=5099, always_post_validate=True)
 
     # Connection
-    _gather_facts        = FieldAttribute(isa='bool', default=None, always_post_validate=True)
+    _gather_facts        = FieldAttribute(isa='string', default=None, always_post_validate=True)
     _gather_subset       = FieldAttribute(isa='list', default=None, always_post_validate=True)
     _hosts               = FieldAttribute(isa='list', required=True, listof=string_types, always_post_validate=True)
     _name                = FieldAttribute(isa='string', default='', always_post_validate=True)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (gather_facts_force 05f984c9c5) last updated 2016/04/13 11:15:01 (GMT -500)
  lib/ansible/modules/core: (detached HEAD 0268864211) last updated 2016/03/30 16:38:18 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 6978984244) last updated 2016/03/30 16:38:18 (GMT -500)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Adds 'gather_facts: ignore_restrictions' functionality to the free
and linear strategies.  Ignoring restrictions should effectively gather facts
on all hosts, ignoring restrictions and limits, providing facts from systems
that would otherwise be unavailable at runtime.  This allows one to limit
the scope of a play to a subset of hosts without limiting the facts available.

My test playbook:  

```

---
- name: This is a test play
  hosts: vms
  gather_facts: ignore_restrictions
  tasks:
    - name: Display a message
      debug:
        msg: Hello World!
```

Running with `ignore_restrictions` yields: 

```
$ ansible-playbook -i hosts --limit vm1 test.yml

PLAY [This is a test play] *****************************************************

TASK [setup] *******************************************************************
ok: [vm1]
ok: [vm2]
ok: [vm3]

TASK [Display a message] *******************************************************
ok: [vm1] => {
    "msg": "Hello World!"
}

PLAY RECAP *********************************************************************
vm1                        : ok=2    changed=0    unreachable=0    failed=0
vm2                        : ok=1    changed=0    unreachable=0    failed=0
vm3                        : ok=1    changed=0    unreachable=0    failed=0
```

Running with `yes` yields:

```
$ ansible-playbook -i hosts --limit vm1 test.yml

PLAY [This is a test play] *****************************************************

TASK [setup] *******************************************************************
ok: [vm1]

TASK [Display a message] *******************************************************
ok: [vm1] => {
    "msg": "Hello World!"
}

PLAY RECAP *********************************************************************
vm1                        : ok=2    changed=0    unreachable=0    failed=0
```

Running with `no` yields: 

```
$ ansible-playbook -i hosts --limit vm1 test.yml

PLAY [This is a test play] *****************************************************

TASK [Display a message] *******************************************************
ok: [vm1] => {
    "msg": "Hello World!"
}

PLAY RECAP *********************************************************************
vm1                        : ok=1    changed=0    unreachable=0    failed=0
```
