### PR TITLE
Improve galaxy handling of tgz roles

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -263,8 +263,17 @@ class GalaxyRole(object):
                 # next find the metadata file
                 for member in members:
                     if self.META_MAIN in member.name:
-                        meta_file = member
-                        break
+                        # Look for parent of meta/main.yml
+                        # Due to possibility of sub roles each containing meta/main.yml
+                        # look for shortest length parent
+                        meta_parent_dir = os.path.dirname(os.path.dirname(member.name))
+                        if not meta_file:
+                            archive_parent_dir = meta_parent_dir
+                            meta_file = member
+                        else:
+                            if len(meta_parent_dir) < len(archive_parent_dir):
+                                archive_parent_dir = meta_parent_dir
+                                meta_file = member
                 if not meta_file:
                     raise AnsibleError("this role does not appear to have a meta/main.yml file.")
                 else:
@@ -273,9 +282,9 @@ class GalaxyRole(object):
                     except:
                         raise AnsibleError("this role does not appear to have a valid meta/main.yml file.")
 
-                # we strip off the top-level directory for all of the files contained within
-                # the tar file here, since the default is 'github_repo-target', and change it
-                # to the specified role's name
+                # we strip off any higher-level directories for all of the files contained within
+                # the tar file here. The default is 'github_repo-target'. Gerrit instances, on the other
+                # hand, does not have a parent directory at all.
                 installed = False
                 while not installed:
                     display.display("- extracting %s to %s" % (self.name, self.path))
@@ -296,9 +305,9 @@ class GalaxyRole(object):
                         for member in members:
                             # we only extract files, and remove any relative path
                             # bits that might be in the file for security purposes
-                            # and drop the leading directory, as mentioned above
+                            # and drop any containing directory, as mentioned above
                             if member.isreg() or member.issym():
-                                parts = member.name.split(os.sep)[1:]
+                                parts = member.name.replace(archive_parent_dir, "").split(os.sep)
                                 final_parts = []
                                 for part in parts:
                                     if part != '..' and '~' not in part and '$' not in part:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 2163a24a12) last updated 2016/04/14 12:28:50 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD 99cd31140d) last updated 2016/04/14 12:29:48 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD ab2f4c4002) last updated 2016/04/14 12:29:51 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Gerrithub presents tgz downloads that do not have a containing
directory. This causes a stack trace.

As all roles must contain a meta/main.yml, change ansible-galaxy
to use that to determine the enclosing directory (in the case
of multiple meta/main.yml files, use the one with the shortest parent)

Fixes #15413
