### PR TITLE
Distribution version tests

### DIFF
--- a/hacking/tests/gen_distribution_version_testcase.py
+++ b/hacking/tests/gen_distribution_version_testcase.py
@@ -12,7 +12,6 @@ import platform
 import os.path
 import subprocess
 import json
-import pprint
 
 filelist = [
         '/etc/oracle-release',
@@ -53,10 +52,14 @@ ansible_facts = {}
 for fact in facts:
     ansible_facts[fact] = parsed['ansible_facts']['ansible_'+fact]
 
+nicename = ansible_facts['distribution'] + ' ' + ansible_facts['distribution_version']
+
 output = {
+    'name': nicename,
     'input': fcont,
     'platform.dist': dist,
     'result': ansible_facts,
 }
 
-pprint.pprint(output)
+print(json.dumps(output, indent=4))
+

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -282,6 +282,11 @@ class Facts(object):
     # platform.dist() is deprecated in 2.6
     # in 2.6 and newer, you should use platform.linux_distribution()
     def get_distribution_facts(self):
+        """
+        Fills facts about the distribution name and version.
+
+        This is unit tested. Please extend the tests to cover all distributions if you have them available.
+        """
 
         # A list with OS Family members
         OS_FAMILY = dict(

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -126,8 +126,8 @@ class Facts(object):
                     ('/etc/alpine-release', 'Alpine'),
                     ('/etc/release', 'Solaris'),
                     ('/etc/arch-release', 'Archlinux'),
-                    ('/etc/SuSE-release', 'SuSE'),
                     ('/etc/os-release', 'SuSE'),
+                    ('/etc/SuSE-release', 'SuSE'),
                     ('/etc/gentoo-release', 'Gentoo'),
                     ('/etc/os-release', 'Debian'),
                     ('/etc/lsb-release', 'Mandriva'),
@@ -459,7 +459,7 @@ class Facts(object):
                                                 self.facts['distribution_release'] = release.groups()[0]
                                         elif 'enterprise' in data.lower() and 'VERSION_ID' in line:
                                              release = re.search('^VERSION_ID="?[0-9]+\.?([0-9]*)"?', line) # SLES doesn't got funny release names
-                                             if release.group(1):
+                                             if release and release.group(1):
                                                  release = release.group(1)
                                              else:
                                                  release = "0" # no minor number, so it is the first release
@@ -521,9 +521,11 @@ class Facts(object):
 
                             if self.facts['distribution'].lower() == 'coreos':
                                 data = get_file_content('/etc/coreos/update.conf')
-                                release = re.search("^GROUP=(.*)", data)
-                                if release:
-                                    self.facts['distribution_release'] = release.group(1).strip('"')
+                                if data:
+                                    release = re.search("^GROUP=(.*)", data)
+                                    if release:
+                                        self.facts['distribution_release'] = release.group(1).strip('"')
+
                     else:
                         self.facts['distribution'] = name
         machine_id = get_file_content("/var/lib/dbus/machine-id") or get_file_content("/etc/machine-id")

--- a/test/units/module_utils/gen_distribution_version_testcase.py
+++ b/test/units/module_utils/gen_distribution_version_testcase.py
@@ -3,7 +3,7 @@
 """
 This script generated test_cases for test_distribution_version.py.
 
-To do so it outputs the relevant files from /etc/*release, the ouput of platform.dist() and the current ansible_facts regarding the distribution version.
+To do so it outputs the relevant files from /etc/*release, the output of platform.dist() and the current ansible_facts regarding the distribution version.
 
 This assumes a working ansible version in the path.
 """

--- a/test/units/module_utils/gen_distribution_version_testcase.py
+++ b/test/units/module_utils/gen_distribution_version_testcase.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+"""
+This script generated test_cases for test_distribution_version.py.
+
+To do so it outputs the relevant files from /etc/*release, the ouput of platform.dist() and the current ansible_facts regarding the distribution version.
+
+This assumes a working ansible version in the path.
+"""
+
+import platform
+import os.path
+import subprocess
+import json
+import pprint
+
+filelist = [
+        '/etc/oracle-release',
+        '/etc/slackware-version',
+        '/etc/redhat-release',
+        '/etc/vmware-release',
+        '/etc/openwrt_release',
+        '/etc/system-release',
+        '/etc/alpine-release',
+        '/etc/release',
+        '/etc/arch-release',
+        '/etc/os-release',
+        '/etc/SuSE-release',
+        '/etc/gentoo-release',
+        '/etc/os-release',
+        '/etc/lsb-release',
+        '/etc/altlinux-release',
+        '/etc/os-release',
+        '/etc/coreos/update.conf',
+]
+
+fcont = {}
+
+for f in filelist:
+    if os.path.exists(f):
+        s = os.path.getsize(f)
+        if s > 0 and s < 10000:
+            with open(f) as fh:
+                fcont[f] = fh.read()
+
+dist = platform.dist()
+
+
+facts = ['distribution', 'distribution_version', 'distribution_release', 'distribution_major_version']
+ansible_out = subprocess.check_output(['ansible', 'localhost', '-m', 'setup'])
+parsed = json.loads(ansible_out[ansible_out.index('{'):])
+ansible_facts = {}
+for fact in facts:
+    ansible_facts[fact] = parsed['ansible_facts']['ansible_'+fact]
+
+output = {
+    'input': fcont,
+    'platform.dist': dist,
+    'result': ansible_facts,
+}
+
+pprint.pprint(output)

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -29,7 +29,6 @@ from ansible.utils.unicode import to_bytes
 # for testing
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch
-from nose.tools import assert_equal
 
 # the module we are actually testing
 
@@ -389,4 +388,4 @@ def _test_one_distribution(facts, module, testcase):
         assert key in generated_facts
         msg = 'Comparing value of %s on %s, should: %s, is: %s' %\
             (key, testcase['name'], val, generated_facts[key])
-        assert_equal(generated_facts[key], val, msg)
+        assert generated_facts[key] == val, msg

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -29,112 +29,94 @@ from ansible.utils.unicode import to_bytes
 # for testing
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch
+from nose.tools import assert_in, assert_equal
 
-import ansible.module_utils.facts
+# the module we are actually testing
 
 
-@unittest.skipIf(sys.version_info[0] >= 3, "Python 3 is not supported on targets (yet)")
-class TestModuleUtilsFactsDistribution(unittest.TestCase):
-
-    def setUp(self):
-        self.real_stdin = sys.stdin
-        from ansible.module_utils import basic
-
-        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
-        if PY3:
-            sys.stdin = StringIO(args)
-            sys.stdin.buffer = BytesIO(to_bytes(args))
-        else:
-            sys.stdin = BytesIO(to_bytes(args))
-        self.module = basic.AnsibleModule(argument_spec=dict())
-
-    def tearDown(self):
-        sys.stdin = self.real_stdin
-
-    def clear_modules(self, mods):
-        for mod in mods:
-            if mod in sys.modules:
-                del sys.modules[mod]
-
-    def test_distribution_from_files(self):
-        """tests the distribution parsing code of the Facts class
-
-        testsets have
-        * a name (for output/debugging only)
-        * input files that are faked
-          * those should be complete and also include "irrelevant" files that might be mistaken as coming from other distributions
-          * all files that are not listed here are assumed to not exist at all
-        * the output of pythons platform.dist()
-        * results for the ansible variables distribution*
-        """
-
-        testsets = [
-            {
-                "name" : "openSUSE Leap 42.1",
-                "input": {
-                    "/etc/os-release":
-                    """NAME="openSUSE Leap"
-                    VERSION="42.1"
-                    VERSION_ID="42.1"
-                    PRETTY_NAME="openSUSE Leap 42.1 (x86_64)"
-                    ID=opensuse
-                    ANSI_COLOR="0;32"
-                    CPE_NAME="cpe:/o:opensuse:opensuse:42.1"
-                    BUG_REPORT_URL="https://bugs.opensuse.org"
-                    HOME_URL="https://opensuse.org/"
-                    ID_LIKE="suse"
-                    """,
-                    "/etc/SuSE-release":"""
-                    openSUSE 42.1 (x86_64)
-                    VERSION = 42.1
-                    CODENAME = Malachite
-                    # /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead
-                    """
-                },
-                "platform.dist": ['SuSE', '42.1', 'x86_64'],
-                "result":{
-                    "distribution": "openSUSE Leap",
-                    "distribution_major_version": "42",
-                    "distribution_release": "x86_64",
-                    "distribution_version": "42.1",
-                }
-            },
-			{
-                'name': 'openSUSE 13.2',
-                'input': {'/etc/SuSE-release': 'openSUSE 13.2 (x86_64)\nVERSION = 13.2\nCODENAME = Harlequin\n# /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead\n',
-                          '/etc/os-release': 'NAME=openSUSE\nVERSION="13.2 (Harlequin)"\nVERSION_ID="13.2"\nPRETTY_NAME="openSUSE 13.2 (Harlequin) (x86_64)"\nID=opensuse\nANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:opensuse:opensuse:13.2"\nBUG_REPORT_URL="https://bugs.opensuse.org"\nHOME_URL="https://opensuse.org/"\nID_LIKE="suse"\n'},
-                'platform.dist': ('SuSE', '13.2', 'x86_64'),
-                'result': {'distribution': u'openSUSE',
-                           'distribution_major_version': u'13',
-                           'distribution_release': u'Harlequin',
-                           'distribution_version': u'13.2'}
-            },
-            { # see https://github.com/ansible/ansible/issues/14837
-                "name": "SLES 11.3",
-                "input": {
-                    "/etc/SuSE-release":"""
+# to generate the testcase data, you can use the script gen_distribution_version_testcase.py in hacking/tests
+TESTSETS = [
+    {
+        "name" : "openSUSE Leap 42.1",
+        "input": {
+            "/etc/os-release":
+            """
+NAME="openSUSE Leap"
+VERSION="42.1"
+VERSION_ID="42.1"
+PRETTY_NAME="openSUSE Leap 42.1 (x86_64)"
+ID=opensuse
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:opensuse:42.1"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://opensuse.org/"
+ID_LIKE="suse"
+            """,
+            "/etc/SuSE-release":"""
+openSUSE 42.1 (x86_64)
+VERSION = 42.1
+CODENAME = Malachite
+# /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead
+            """
+        },
+        "platform.dist": ['SuSE', '42.1', 'x86_64'],
+        "result":{
+            "distribution": "openSUSE Leap",
+            "distribution_major_version": "42",
+            "distribution_release": "x86_64",
+            "distribution_version": "42.1",
+        }
+    },
+                {
+        'name': 'openSUSE 13.2',
+        'input': {'/etc/SuSE-release': """openSUSE 13.2 (x86_64)
+VERSION = 13.2
+CODENAME = Harlequin
+# /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead
+""",
+                  '/etc/os-release': """NAME=openSUSE
+VERSION="13.2 (Harlequin)"
+VERSION_ID="13.2"
+PRETTY_NAME="openSUSE 13.2 (Harlequin) (x86_64)"
+ID=opensuse
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:opensuse:13.2"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://opensuse.org/"
+ID_LIKE="suse"
+"""},
+        'platform.dist': ('SuSE', '13.2', 'x86_64'),
+        'result': {'distribution': u'openSUSE',
+                   'distribution_major_version': u'13',
+                   'distribution_release': u'Harlequin',
+                   'distribution_version': u'13.2'}
+    },
+    { # see https://github.com/ansible/ansible/issues/14837
+        "name": "SLES 11.3",
+        "input": {
+            "/etc/SuSE-release":"""
 SUSE Linux Enterprise Server 11 (x86_64)
 VERSION = 11
 PATCHLEVEL = 3
-                    """
-                },
-                "platform.dist": ['SuSE', '11', 'x86_64'],
-                "result":{
-                    "distribution": "SLES",
-                    "distribution_major_version": "11",
-                    "distribution_release": "3",
-                    "distribution_version": "11.3",
-                }
-            },
-            { # see https://github.com/ansible/ansible/issues/14837
-                "name": "SLES 11.4",
-                "input": {
-                    "/etc/SuSE-release":"""
+            """
+        },
+        "platform.dist": ['SuSE', '11', 'x86_64'],
+        "result":{
+            "distribution": "SLES",
+            "distribution_major_version": "11",
+            "distribution_release": "3",
+            "distribution_version": "11.3",
+        }
+    },
+    { # see https://github.com/ansible/ansible/issues/14837
+        "name": "SLES 11.4",
+        "input": {
+            "/etc/SuSE-release":"""
 SUSE Linux Enterprise Server 11 (x86_64)
 VERSION = 11
 PATCHLEVEL = 4
-                    """,
-                    "/etc/os-release":"""
+            """,
+            "/etc/os-release":"""
 NAME="SLES"
 VERSION="11.4"
 VERSION_ID="11.4"
@@ -142,27 +124,27 @@ PRETTY_NAME="SUSE Linux Enterprise Server 11 SP4"
 ID="sles"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:suse:sles:11:4"
-                    """,
-                },
-                "platform.dist": ['SuSE', '11', 'x86_64'],
-                "result":{
-                    "distribution": "SLES",
-                    "distribution_major_version": "11",
-                    "distribution_release": "4",
-                    "distribution_version": "11.4",
-                }
-            },
-            { # see https://github.com/ansible/ansible/issues/14837
-                "name": "SLES 12 SP0",
-                "input": {
-                    "/etc/SuSE-release":"""
+            """,
+        },
+        "platform.dist": ['SuSE', '11', 'x86_64'],
+        "result":{
+            "distribution": "SLES",
+            "distribution_major_version": "11",
+            "distribution_release": "4",
+            "distribution_version": "11.4",
+        }
+    },
+    { # see https://github.com/ansible/ansible/issues/14837
+        "name": "SLES 12 SP0",
+        "input": {
+            "/etc/SuSE-release":"""
 SUSE Linux Enterprise Server 12 (x86_64)
 VERSION = 12
 PATCHLEVEL = 0
 # This file is deprecated and will be removed in a future service pack or release.
 # Please check /etc/os-release for details about this release.
-                    """,
-                    "/etc/os-release":"""
+            """,
+            "/etc/os-release":"""
 NAME="SLES"
 VERSION="12"
 VERSION_ID="12"
@@ -170,28 +152,28 @@ PRETTY_NAME="SUSE Linux Enterprise Server 12"
 ID="sles"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:suse:sles:12"
-                    """,
-                },
-                "platform.dist": ['SuSE', '12', 'x86_64'],
-                "result":{
-                    "distribution": "SLES",
-                    "distribution_major_version": "12",
-                    "distribution_release": "0",
-                    "distribution_version": "12",
-                }
-            },
+            """,
+        },
+        "platform.dist": ['SuSE', '12', 'x86_64'],
+        "result":{
+            "distribution": "SLES",
+            "distribution_major_version": "12",
+            "distribution_release": "0",
+            "distribution_version": "12",
+        }
+    },
 
-            { # see https://github.com/ansible/ansible/issues/14837
-                "name": "SLES 12 SP1",
-                "input": {
-                    "/etc/SuSE-release":"""
+    { # see https://github.com/ansible/ansible/issues/14837
+        "name": "SLES 12 SP1",
+        "input": {
+            "/etc/SuSE-release":"""
 SUSE Linux Enterprise Server 12 (x86_64)
 VERSION = 12
 PATCHLEVEL = 0
 # This file is deprecated and will be removed in a future service pack or release.
 # Please check /etc/os-release for details about this release.
-                    """,
-                    "/etc/os-release":"""
+            """,
+            "/etc/os-release":"""
 NAME="SLES"
 VERSION="12-SP1"
 VERSION_ID="12.1"
@@ -199,76 +181,105 @@ PRETTY_NAME="SUSE Linux Enterprise Server 12 SP1"
 ID="sles"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:suse:sles:12:sp1"
-                    """,
-                },
-                "platform.dist": ['SuSE', '12', 'x86_64'],
-                "result":{
-                    "distribution": "SLES",
-                    "distribution_major_version": "12",
-                    "distribution_release": "1",
-                    "distribution_version": "12.1",
-                }
-            },
+            """,
+        },
+        "platform.dist": ['SuSE', '12', 'x86_64'],
+        "result":{
+            "distribution": "SLES",
+            "distribution_major_version": "12",
+            "distribution_release": "1",
+            "distribution_version": "12.1",
+        }
+    },
 
-            {
-                "name": "Debian stretch/sid",
-                "input": {
-                    "/etc/os-release":"""
+    {
+        "name": "Debian stretch/sid",
+        "input": {
+            "/etc/os-release":"""
 PRETTY_NAME="Debian GNU/Linux stretch/sid"
 NAME="Debian GNU/Linux"
 ID=debian
 HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"
 BUG_REPORT_URL="https://bugs.debian.org/"
-                    """,
-                    "/etc/debian_version":"""
-                    stretch/sid
-                    """,
-                },
-                "platform.dist": ('debian', 'stretch/sid', ''),
-                "result":{
-                    "distribution": "Debian",
-                    "distribution_major_version": "stretch/sid",
-                    "distribution_release": "NA",
-                    "distribution_version": "stretch/sid",
-                }
-            },
-            {
-                'name': "Debian 7.9",
-                'input': {'/etc/os-release': 'PRETTY_NAME="Debian GNU/Linux 7 (wheezy)"\nNAME="Debian GNU/Linux"'
-                                             '\nVERSION_ID="7"\nVERSION="7 (wheezy)"\nID=debian\nANSI_COLOR="1;31"\n'
-                                             'HOME_URL="http://www.debian.org/"\nSUPPORT_URL="http://www.debian.org/support/'
-                                             '"\nBUG_REPORT_URL="http://bugs.debian.org/"\n'},
-                'platform.dist': ('debian', '7.9', ''),
-                'result': {'distribution': u'Debian',
-                           'distribution_major_version': u'7',
-                           'distribution_release': u'wheezy',
-                           'distribution_version': u'7.9'}
-            },
-            {
-                'name': "Ubuntu 14.04",
-                'input': {'/etc/lsb-release': 'DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=14.04\nDISTRIB_CODENAME=trusty\nDISTRIB_DESCRIPTION="Ubuntu 14.04.4 LTS"\n',
-                          '/etc/os-release': 'NAME="Ubuntu"\nVERSION="14.04.4 LTS, Trusty Tahr"\nID=ubuntu\nID_LIKE=debian\nPRETTY_NAME="Ubuntu 14.04.4 LTS"\nVERSION_ID="14.04"\nHOME_URL="http://www.ubuntu.com/"\nSUPPORT_URL="http://help.ubuntu.com/"\nBUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"\n'},
-                'platform.dist': ('Ubuntu', '14.04', 'trusty'),
-                'result': {'distribution': u'Ubuntu',
-                           'distribution_major_version': u'14',
-                           'distribution_release': u'trusty',
-                           'distribution_version': u'14.04'}
-            },
-            {
-                'name': "Ubuntu 12.04",
-                'input': {'/etc/lsb-release': 'DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=12.04\nDISTRIB_CODENAME=precise\nDISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"\n',
-                          '/etc/os-release': 'NAME="Ubuntu"\nVERSION="12.04.5 LTS, Precise Pangolin"\nID=ubuntu\nID_LIKE=debian\nPRETTY_NAME="Ubuntu precise (12.04.5 LTS)"\nVERSION_ID="12.04"\n'},
-                'platform.dist': ('Ubuntu', '12.04', 'precise'),
-                'result': {'distribution': u'Ubuntu',
-                           'distribution_major_version': u'12',
-                           'distribution_release': u'precise',
-                           'distribution_version': u'12.04'}
-            },
-            {
-                'name': 'Core OS',
-                'input': {
-                    '/etc/os-release':"""
+            """,
+            "/etc/debian_version":"""
+            stretch/sid
+            """,
+        },
+        "platform.dist": ('debian', 'stretch/sid', ''),
+        "result":{
+            "distribution": "Debian",
+            "distribution_major_version": "stretch/sid",
+            "distribution_release": "NA",
+            "distribution_version": "stretch/sid",
+        }
+    },
+    {
+        'name': "Debian 7.9",
+        'input': {'/etc/os-release': """PRETTY_NAME="Debian GNU/Linux 7 (wheezy)"
+NAME="Debian GNU/Linux"
+VERSION_ID="7"
+VERSION="7 (wheezy)"
+ID=debian
+ANSI_COLOR="1;31"
+HOME_URL="http://www.debian.org/"
+SUPPORT_URL="http://www.debian.org/support/"
+BUG_REPORT_URL="http://bugs.debian.org/"
+"""},
+        'platform.dist': ('debian', '7.9', ''),
+        'result': {'distribution': u'Debian',
+                   'distribution_major_version': u'7',
+                   'distribution_release': u'wheezy',
+                   'distribution_version': u'7.9'}
+    },
+    {
+        'name': "Ubuntu 14.04",
+        'input': {'/etc/lsb-release': """DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=14.04
+DISTRIB_CODENAME=trusty
+DISTRIB_DESCRIPTION="Ubuntu 14.04.4 LTS"
+""",
+                  '/etc/os-release': """NAME="Ubuntu"
+VERSION="14.04.4 LTS, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.4 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+"""},
+        'platform.dist': ('Ubuntu', '14.04', 'trusty'),
+        'result': {'distribution': u'Ubuntu',
+                   'distribution_major_version': u'14',
+                   'distribution_release': u'trusty',
+                   'distribution_version': u'14.04'}
+    },
+    {
+        'name': "Ubuntu 12.04",
+        'input': {'/etc/lsb-release': """DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=12.04
+DISTRIB_CODENAME=precise
+DISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"
+""",
+                  '/etc/os-release': """NAME="Ubuntu"
+VERSION="12.04.5 LTS, Precise Pangolin"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu precise (12.04.5 LTS)"
+VERSION_ID="12.04"
+"""},
+        'platform.dist': ('Ubuntu', '12.04', 'precise'),
+        'result': {'distribution': u'Ubuntu',
+                   'distribution_major_version': u'12',
+                   'distribution_release': u'precise',
+                   'distribution_version': u'12.04'}
+    },
+    {
+        'name': 'Core OS',
+        'input': {
+            '/etc/os-release':"""
 NAME=CoreOS
 ID=coreos
 VERSION=976.0.0
@@ -278,51 +289,104 @@ PRETTY_NAME="CoreOS 976.0.0 (Coeur Rouge)"
 ANSI_COLOR="1;32"
 HOME_URL="https://coreos.com/"
 BUG_REPORT_URL="https://github.com/coreos/bugs/issues"
-                    """,
-                    '/etc/lsb-release':'DISTRIB_ID=CoreOS\nDISTRIB_RELEASE=976.0.0\nDISTRIB_CODENAME="Coeur Rouge"\nDISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"\n',
-                },
-                'platform.dist': ('', '', ''),
-                'result' : {
-                    "distribution": "CoreOS",
-                    "distribution_major_version": "NA",
-                    "distribution_release": "NA",
-                    "distribution_version": "976.0.0",
-                }
-            }
+            """,
+            '/etc/lsb-release':"""DISTRIB_ID=CoreOS
+DISTRIB_RELEASE=976.0.0
+DISTRIB_CODENAME="Coeur Rouge"
+DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
+""",
+        },
+        'platform.dist': ('', '', ''),
+        'result' : {
+            "distribution": "CoreOS",
+            "distribution_major_version": "NA",
+            "distribution_release": "NA",
+            "distribution_version": "976.0.0",
+        }
+    }
 
 
-        ]
+]
 
-        for t in testsets:
+@unittest.skipIf(sys.version_info[0] >= 3, "Python 3 is not supported on targets (yet)")
+def test_distribution_version():
+    """tests the distribution parsing code of the Facts class
 
-            def mock_get_file_content(fname, default=None, strip=True):
-                data = default
-                if fname in t['input']:
-                    # for debugging
-                    print('faked '+fname+' for '+t['name'])
-                    data = t['input'][fname].strip()
-                if strip and data is not None:
-                    data = data.strip()
-                return data
+    testsets have
+    * a name (for output/debugging only)
+    * input files that are faked
+      * those should be complete and also include "irrelevant" files that might be mistaken as coming from other distributions
+      * all files that are not listed here are assumed to not exist at all
+    * the output of pythons platform.dist()
+    * results for the ansible variables distribution*
+    """
 
-            def mock_path_exists(fname):
-                return fname in t['input']
+    # needs to be in here, because the import fails with python3 still
+    import ansible.module_utils.facts
 
-            def mock_path_getsize(fname):
-                if fname in t['input']:
-                    return len(t['input'][fname])
-                else:
-                    return 0
+    real_stdin = sys.stdin
+    from ansible.module_utils import basic
+
+    args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+    if PY3:
+        sys.stdin = StringIO(args)
+        sys.stdin.buffer = BytesIO(to_bytes(args))
+    else:
+        sys.stdin = BytesIO(to_bytes(args))
+    module = basic.AnsibleModule(argument_spec=dict())
+
+    for t in TESTSETS:
+        # run individual tests via generator
+        # set nicer stdout output for nosetest
+        _test_one_distribution.description = "check distribution_version for %s" % t['name']
+        yield _test_one_distribution, module, t
 
 
-            with patch('ansible.module_utils.facts.get_file_content', side_effect=mock_get_file_content):
-                with patch('os.path.exists', side_effect=mock_path_exists):
-                    with patch('os.path.getsize', side_effect=mock_path_getsize):
-                        with patch('platform.dist', return_value=t['platform.dist']):
-                            with patch('platform.system', return_value='Linux'):
-                                generated_facts = ansible.module_utils.facts.Facts(self.module).populate()
-                                for key, val in t['result'].items():
-                                    self.assertIn(key, generated_facts)
-                                    msg = 'Comparing value of %s on %s, should: %s, is: %s' %\
-                                        (key, t['name'], val, generated_facts[key])
-                                    self.assertEqual(generated_facts[key], val, msg)
+    sys.stdin = real_stdin
+
+
+def _test_one_distribution(module, testcase):
+    """run the test on one distribution testcase
+    
+    * prepare some mock functions to get the testdata in
+    * run Facts()
+    * compare with the expected output
+    """
+
+    def mock_get_file_content(fname, default=None, strip=True):
+        """give fake content if it exists, otherwise pretend the file is empty"""
+        data = default
+        if fname in testcase['input']:
+            # for debugging
+            print('faked '+fname+' for '+testcase['name'])
+            data = testcase['input'][fname].strip()
+        if strip and data is not None:
+            data = data.strip()
+        return data
+
+    def mock_path_exists(fname):
+        return fname in testcase['input']
+
+    def mock_path_getsize(fname):
+        if fname in testcase['input']:
+            # the len is not used, but why not be honest if you can be?
+            return len(testcase['input'][fname])
+        else:
+            return 0
+
+    @patch('ansible.module_utils.facts.get_file_content', mock_get_file_content)
+    @patch('os.path.exists', mock_path_exists)
+    @patch('os.path.getsize', mock_path_getsize)
+    @patch('platform.dist', lambda: testcase['platform.dist'])
+    @patch('platform.system', lambda: 'Linux')
+    def get_facts(testcase):
+        return ansible.module_utils.facts.Facts(module).populate()
+    
+    generated_facts = get_facts(testcase)
+
+    # testcase['result'] has a list of variables and values it expects Facts() to set
+    for key, val in testcase['result'].items():
+        assert_in(key, generated_facts)
+        msg = 'Comparing value of %s on %s, should: %s, is: %s' %\
+            (key, testcase['name'], val, generated_facts[key])
+        assert_equal(generated_facts[key], val, msg)

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -113,9 +113,9 @@ class TestModuleUtilsFactsDistribution(unittest.TestCase):
                 "name": "SLES 11.3",
                 "input": {
                     "/etc/SuSE-release":"""
-                    SUSE Linux Enterprise Server 11 (x86_64)
-                    VERSION = 11
-                    PATCHLEVEL = 3
+SUSE Linux Enterprise Server 11 (x86_64)
+VERSION = 11
+PATCHLEVEL = 3
                     """
                 },
                 "platform.dist": ['SuSE', '11', 'x86_64'],
@@ -130,18 +130,18 @@ class TestModuleUtilsFactsDistribution(unittest.TestCase):
                 "name": "SLES 11.4",
                 "input": {
                     "/etc/SuSE-release":"""
-                    SUSE Linux Enterprise Server 11 (x86_64)
-                    VERSION = 11
-                    PATCHLEVEL = 4
+SUSE Linux Enterprise Server 11 (x86_64)
+VERSION = 11
+PATCHLEVEL = 4
                     """,
                     "/etc/os-release":"""
-                    NAME="SLES"
-                    VERSION="11.4"
-                    VERSION_ID="11.4"
-                    PRETTY_NAME="SUSE Linux Enterprise Server 11 SP4"
-                    ID="sles"
-                    ANSI_COLOR="0;32"
-                    CPE_NAME="cpe:/o:suse:sles:11:4"
+NAME="SLES"
+VERSION="11.4"
+VERSION_ID="11.4"
+PRETTY_NAME="SUSE Linux Enterprise Server 11 SP4"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:11:4"
                     """,
                 },
                 "platform.dist": ['SuSE', '11', 'x86_64'],

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1,0 +1,328 @@
+# -*- coding: utf-8 -*-
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division)
+__metaclass__ = type
+
+import sys
+
+# to work around basic.py reading stdin
+import json
+from io import BytesIO, StringIO
+from ansible.compat.six import PY3
+from ansible.utils.unicode import to_bytes
+
+# for testing
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch
+
+import ansible.module_utils.facts
+
+
+@unittest.skipIf(sys.version_info[0] >= 3, "Python 3 is not supported on targets (yet)")
+class TestModuleUtilsFactsDistribution(unittest.TestCase):
+
+    def setUp(self):
+        self.real_stdin = sys.stdin
+        from ansible.module_utils import basic
+
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
+        if PY3:
+            sys.stdin = StringIO(args)
+            sys.stdin.buffer = BytesIO(to_bytes(args))
+        else:
+            sys.stdin = BytesIO(to_bytes(args))
+        self.module = basic.AnsibleModule(argument_spec=dict())
+
+    def tearDown(self):
+        sys.stdin = self.real_stdin
+
+    def clear_modules(self, mods):
+        for mod in mods:
+            if mod in sys.modules:
+                del sys.modules[mod]
+
+    def test_distribution_from_files(self):
+        """tests the distribution parsing code of the Facts class
+
+        testsets have
+        * a name (for output/debugging only)
+        * input files that are faked
+          * those should be complete and also include "irrelevant" files that might be mistaken as coming from other distributions
+          * all files that are not listed here are assumed to not exist at all
+        * the output of pythons platform.dist()
+        * results for the ansible variables distribution*
+        """
+
+        testsets = [
+            {
+                "name" : "openSUSE Leap 42.1",
+                "input": {
+                    "/etc/os-release":
+                    """NAME="openSUSE Leap"
+                    VERSION="42.1"
+                    VERSION_ID="42.1"
+                    PRETTY_NAME="openSUSE Leap 42.1 (x86_64)"
+                    ID=opensuse
+                    ANSI_COLOR="0;32"
+                    CPE_NAME="cpe:/o:opensuse:opensuse:42.1"
+                    BUG_REPORT_URL="https://bugs.opensuse.org"
+                    HOME_URL="https://opensuse.org/"
+                    ID_LIKE="suse"
+                    """,
+                    "/etc/SuSE-release":"""
+                    openSUSE 42.1 (x86_64)
+                    VERSION = 42.1
+                    CODENAME = Malachite
+                    # /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead
+                    """
+                },
+                "platform.dist": ['SuSE', '42.1', 'x86_64'],
+                "result":{
+                    "distribution": "openSUSE Leap",
+                    "distribution_major_version": "42",
+                    "distribution_release": "x86_64",
+                    "distribution_version": "42.1",
+                }
+            },
+			{
+                'name': 'openSUSE 13.2',
+                'input': {'/etc/SuSE-release': 'openSUSE 13.2 (x86_64)\nVERSION = 13.2\nCODENAME = Harlequin\n# /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead\n',
+                          '/etc/os-release': 'NAME=openSUSE\nVERSION="13.2 (Harlequin)"\nVERSION_ID="13.2"\nPRETTY_NAME="openSUSE 13.2 (Harlequin) (x86_64)"\nID=opensuse\nANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:opensuse:opensuse:13.2"\nBUG_REPORT_URL="https://bugs.opensuse.org"\nHOME_URL="https://opensuse.org/"\nID_LIKE="suse"\n'},
+                'platform.dist': ('SuSE', '13.2', 'x86_64'),
+                'result': {'distribution': u'openSUSE',
+                           'distribution_major_version': u'13',
+                           'distribution_release': u'Harlequin',
+                           'distribution_version': u'13.2'}
+            },
+            { # see https://github.com/ansible/ansible/issues/14837
+                "name": "SLES 11.3",
+                "input": {
+                    "/etc/SuSE-release":"""
+                    SUSE Linux Enterprise Server 11 (x86_64)
+                    VERSION = 11
+                    PATCHLEVEL = 3
+                    """
+                },
+                "platform.dist": ['SuSE', '11', 'x86_64'],
+                "result":{
+                    "distribution": "SLES",
+                    "distribution_major_version": "11",
+                    "distribution_release": "3",
+                    "distribution_version": "11.3",
+                }
+            },
+            { # see https://github.com/ansible/ansible/issues/14837
+                "name": "SLES 11.4",
+                "input": {
+                    "/etc/SuSE-release":"""
+                    SUSE Linux Enterprise Server 11 (x86_64)
+                    VERSION = 11
+                    PATCHLEVEL = 4
+                    """,
+                    "/etc/os-release":"""
+                    NAME="SLES"
+                    VERSION="11.4"
+                    VERSION_ID="11.4"
+                    PRETTY_NAME="SUSE Linux Enterprise Server 11 SP4"
+                    ID="sles"
+                    ANSI_COLOR="0;32"
+                    CPE_NAME="cpe:/o:suse:sles:11:4"
+                    """,
+                },
+                "platform.dist": ['SuSE', '11', 'x86_64'],
+                "result":{
+                    "distribution": "SLES",
+                    "distribution_major_version": "11",
+                    "distribution_release": "4",
+                    "distribution_version": "11.4",
+                }
+            },
+            { # see https://github.com/ansible/ansible/issues/14837
+                "name": "SLES 12 SP0",
+                "input": {
+                    "/etc/SuSE-release":"""
+SUSE Linux Enterprise Server 12 (x86_64)
+VERSION = 12
+PATCHLEVEL = 0
+# This file is deprecated and will be removed in a future service pack or release.
+# Please check /etc/os-release for details about this release.
+                    """,
+                    "/etc/os-release":"""
+NAME="SLES"
+VERSION="12"
+VERSION_ID="12"
+PRETTY_NAME="SUSE Linux Enterprise Server 12"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12"
+                    """,
+                },
+                "platform.dist": ['SuSE', '12', 'x86_64'],
+                "result":{
+                    "distribution": "SLES",
+                    "distribution_major_version": "12",
+                    "distribution_release": "0",
+                    "distribution_version": "12",
+                }
+            },
+
+            { # see https://github.com/ansible/ansible/issues/14837
+                "name": "SLES 12 SP1",
+                "input": {
+                    "/etc/SuSE-release":"""
+SUSE Linux Enterprise Server 12 (x86_64)
+VERSION = 12
+PATCHLEVEL = 0
+# This file is deprecated and will be removed in a future service pack or release.
+# Please check /etc/os-release for details about this release.
+                    """,
+                    "/etc/os-release":"""
+NAME="SLES"
+VERSION="12-SP1"
+VERSION_ID="12.1"
+PRETTY_NAME="SUSE Linux Enterprise Server 12 SP1"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp1"
+                    """,
+                },
+                "platform.dist": ['SuSE', '12', 'x86_64'],
+                "result":{
+                    "distribution": "SLES",
+                    "distribution_major_version": "12",
+                    "distribution_release": "1",
+                    "distribution_version": "12.1",
+                }
+            },
+
+            {
+                "name": "Debian stretch/sid",
+                "input": {
+                    "/etc/os-release":"""
+PRETTY_NAME="Debian GNU/Linux stretch/sid"
+NAME="Debian GNU/Linux"
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"
+                    """,
+                    "/etc/debian_version":"""
+                    stretch/sid
+                    """,
+                },
+                "platform.dist": ('debian', 'stretch/sid', ''),
+                "result":{
+                    "distribution": "Debian",
+                    "distribution_major_version": "stretch/sid",
+                    "distribution_release": "NA",
+                    "distribution_version": "stretch/sid",
+                }
+            },
+            {
+                'name': "Debian 7.9",
+                'input': {'/etc/os-release': 'PRETTY_NAME="Debian GNU/Linux 7 (wheezy)"\nNAME="Debian GNU/Linux"'
+                                             '\nVERSION_ID="7"\nVERSION="7 (wheezy)"\nID=debian\nANSI_COLOR="1;31"\n'
+                                             'HOME_URL="http://www.debian.org/"\nSUPPORT_URL="http://www.debian.org/support/'
+                                             '"\nBUG_REPORT_URL="http://bugs.debian.org/"\n'},
+                'platform.dist': ('debian', '7.9', ''),
+                'result': {'distribution': u'Debian',
+                           'distribution_major_version': u'7',
+                           'distribution_release': u'wheezy',
+                           'distribution_version': u'7.9'}
+            },
+            {
+                'name': "Ubuntu 14.04",
+                'input': {'/etc/lsb-release': 'DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=14.04\nDISTRIB_CODENAME=trusty\nDISTRIB_DESCRIPTION="Ubuntu 14.04.4 LTS"\n',
+                          '/etc/os-release': 'NAME="Ubuntu"\nVERSION="14.04.4 LTS, Trusty Tahr"\nID=ubuntu\nID_LIKE=debian\nPRETTY_NAME="Ubuntu 14.04.4 LTS"\nVERSION_ID="14.04"\nHOME_URL="http://www.ubuntu.com/"\nSUPPORT_URL="http://help.ubuntu.com/"\nBUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"\n'},
+                'platform.dist': ('Ubuntu', '14.04', 'trusty'),
+                'result': {'distribution': u'Ubuntu',
+                           'distribution_major_version': u'14',
+                           'distribution_release': u'trusty',
+                           'distribution_version': u'14.04'}
+            },
+            {
+                'name': "Ubuntu 12.04",
+                'input': {'/etc/lsb-release': 'DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=12.04\nDISTRIB_CODENAME=precise\nDISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"\n',
+                          '/etc/os-release': 'NAME="Ubuntu"\nVERSION="12.04.5 LTS, Precise Pangolin"\nID=ubuntu\nID_LIKE=debian\nPRETTY_NAME="Ubuntu precise (12.04.5 LTS)"\nVERSION_ID="12.04"\n'},
+                'platform.dist': ('Ubuntu', '12.04', 'precise'),
+                'result': {'distribution': u'Ubuntu',
+                           'distribution_major_version': u'12',
+                           'distribution_release': u'precise',
+                           'distribution_version': u'12.04'}
+            },
+            {
+                'name': 'Core OS',
+                'input': {
+                    '/etc/os-release':"""
+NAME=CoreOS
+ID=coreos
+VERSION=976.0.0
+VERSION_ID=976.0.0
+BUILD_ID=2016-03-03-2324
+PRETTY_NAME="CoreOS 976.0.0 (Coeur Rouge)"
+ANSI_COLOR="1;32"
+HOME_URL="https://coreos.com/"
+BUG_REPORT_URL="https://github.com/coreos/bugs/issues"
+                    """,
+                    '/etc/lsb-release':'DISTRIB_ID=CoreOS\nDISTRIB_RELEASE=976.0.0\nDISTRIB_CODENAME="Coeur Rouge"\nDISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"\n',
+                },
+                'platform.dist': ('', '', ''),
+                'result' : {
+                    "distribution": "CoreOS",
+                    "distribution_major_version": "NA",
+                    "distribution_release": "NA",
+                    "distribution_version": "976.0.0",
+                }
+            }
+
+
+        ]
+
+        for t in testsets:
+
+            def mock_get_file_content(fname, default=None, strip=True):
+                data = default
+                if fname in t['input']:
+                    # for debugging
+                    print('faked '+fname+' for '+t['name'])
+                    data = t['input'][fname].strip()
+                if strip and data is not None:
+                    data = data.strip()
+                return data
+
+            def mock_path_exists(fname):
+                return fname in t['input']
+
+            def mock_path_getsize(fname):
+                if fname in t['input']:
+                    return len(t['input'][fname])
+                else:
+                    return 0
+
+
+            with patch('ansible.module_utils.facts.get_file_content', side_effect=mock_get_file_content):
+                with patch('os.path.exists', side_effect=mock_path_exists):
+                    with patch('os.path.getsize', side_effect=mock_path_getsize):
+                        with patch('platform.dist', return_value=t['platform.dist']):
+                            with patch('platform.system', return_value='Linux'):
+                                generated_facts = ansible.module_utils.facts.Facts(self.module).populate()
+                                for key, val in t['result'].items():
+                                    self.assertIn(key, generated_facts)
+                                    msg = 'Comparing value of %s on %s, should: %s, is: %s' %\
+                                        (key, t['name'], val, generated_facts[key])
+                                    self.assertEqual(generated_facts[key], val, msg)

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -29,7 +29,7 @@ from ansible.utils.unicode import to_bytes
 # for testing
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch
-from nose.tools import assert_in, assert_equal
+from nose.tools import assert_equal
 
 # the module we are actually testing
 
@@ -322,7 +322,7 @@ def test_distribution_version():
     """
 
     # needs to be in here, because the import fails with python3 still
-    import ansible.module_utils.facts
+    import ansible.module_utils.facts as facts
 
     real_stdin = sys.stdin
     from ansible.module_utils import basic
@@ -339,13 +339,13 @@ def test_distribution_version():
         # run individual tests via generator
         # set nicer stdout output for nosetest
         _test_one_distribution.description = "check distribution_version for %s" % t['name']
-        yield _test_one_distribution, module, t
+        yield _test_one_distribution, facts, module, t
 
 
     sys.stdin = real_stdin
 
 
-def _test_one_distribution(module, testcase):
+def _test_one_distribution(facts, module, testcase):
     """run the test on one distribution testcase
     
     * prepare some mock functions to get the testdata in
@@ -380,13 +380,13 @@ def _test_one_distribution(module, testcase):
     @patch('platform.dist', lambda: testcase['platform.dist'])
     @patch('platform.system', lambda: 'Linux')
     def get_facts(testcase):
-        return ansible.module_utils.facts.Facts(module).populate()
+        return facts.Facts(module).populate()
     
     generated_facts = get_facts(testcase)
 
     # testcase['result'] has a list of variables and values it expects Facts() to set
     for key, val in testcase['result'].items():
-        assert_in(key, generated_facts)
+        assert key in generated_facts
         msg = 'Comparing value of %s on %s, should: %s, is: %s' %\
             (key, testcase['name'], val, generated_facts[key])
         assert_equal(generated_facts[key], val, msg)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

2.1.0
##### SUMMARY

This adds testcases for the distribution_version parsing.
Those were first proposed in #15221, but are now separated from the other code changes.

To make the new tests pass, there are 2 fixes in the code:
- fix for a bug introduced in 2c28dcc5 for SLES, the testcases cover this comprehensively, this came up in #14837 and was fixed in #15088
- fix for coreos, fixes #15228
