### PR TITLE
using ops.dc module instead of runconfig

### DIFF
--- a/lib/ansible/module_utils/openswitch.py
+++ b/lib/ansible/module_utils/openswitch.py
@@ -24,7 +24,6 @@ try:
     import ovs.poller
     import ops.dc
     from ops.settings import settings
-    from opsr
     from opslib import restparser
     HAS_OPS = True
 except ImportError:

--- a/lib/ansible/module_utils/openswitch.py
+++ b/lib/ansible/module_utils/openswitch.py
@@ -55,7 +55,7 @@ def to_list(val):
     else:
         return list()
 
-def get_runconfig():
+def get_opsidl():
     extschema = restparser.parseSchema(settings.get('ext_schema'))
     ovsschema = settings.get('ovs_schema')
     ovsremote = settings.get('ovs_remote')


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

```
2.1.0
```
##### SUMMARY
- OpenSwitch now uses ops.dc module for declarative config feature
- replaced all usage of `runconfig` with `ops.dc`
