### PR TITLE
[Feature Request] contrib/inventory/ec2.py support region 'auto' configuration.

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -10,9 +10,10 @@
 
 # AWS regions to make calls to. Set this to 'all' to make request to all regions
 # in AWS and merge the results together. Alternatively, set this to a comma
-# separated list of regions. E.g. 'us-east-1,us-west-1,us-west-2'
+# separated list of regions. E.g. 'us-east-1, us-west-1, us-west-2'
+# 'auto' is AWS_REGION or AWS_DEFAULT_REGION environment variable.
 regions = all
-regions_exclude = us-gov-west-1,cn-north-1
+regions_exclude = us-gov-west-1, cn-north-1
 
 # When generating inventory, Ansible needs to know how to address a server.
 # Each EC2 instance has a lot of variables associated with it. Here is the list:

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -12,6 +12,8 @@ variables needed for Boto have already been set:
     export AWS_ACCESS_KEY_ID='AK123'
     export AWS_SECRET_ACCESS_KEY='abc123'
 
+optional region environement variable if region is 'auto'
+
 This script also assumes there is an ec2.ini file alongside it.  To specify a
 different path to ec2.ini, define the EC2_INI_PATH environment variable:
 
@@ -245,6 +247,11 @@ class Ec2Inventory(object):
                         self.regions.append(regionInfo.name)
         else:
             self.regions = configRegions.split(",")
+        if 'auto' in self.regions:
+            env_region = os.environ.get('AWS_REGION')
+            if env_region == None:
+                env_region = os.environ.get('AWS_DEFAULT_REGION')
+            self.regions = [ env_region ]
 
         # Destination addresses
         self.destination_variable = config.get('ec2', 'destination_variable')


### PR DESCRIPTION
Hi, I add ec2 inventory script, support region auto configuration. auto configuration is using os environment variable AWS_REGION or AWS_DEFAULT_REGION.
