### PR TITLE
Don't pass context to urlopen, instead add it to the handlers

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -778,6 +778,15 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
         proxyhandler = urllib2.ProxyHandler({})
         handlers.append(proxyhandler)
 
+    if HAS_SSLCONTEXT and not validate_certs:
+        # In 2.7.9, the default context validates certificates
+        context = SSLContext(ssl.PROTOCOL_SSLv23)
+        context.options |= ssl.OP_NO_SSLv2
+        context.options |= ssl.OP_NO_SSLv3
+        context.verify_mode = ssl.CERT_NONE
+        context.check_hostname = False
+        handlers.append(urllib2.HTTPSHandler(context=context))
+
     # pre-2.6 versions of python cannot use the custom https
     # handler, since the socket class is lacking create_connection.
     # Some python builds lack HTTPS support.
@@ -820,15 +829,6 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
         # urlopen in python prior to 2.6.0 did not
         # have a timeout parameter
         urlopen_args.append(timeout)
-
-    if HAS_SSLCONTEXT and not validate_certs:
-        # In 2.7.9, the default context validates certificates
-        context = SSLContext(ssl.PROTOCOL_SSLv23)
-        context.options |= ssl.OP_NO_SSLv2
-        context.options |= ssl.OP_NO_SSLv3
-        context.verify_mode = ssl.CERT_NONE
-        context.check_hostname = False
-        urlopen_args += (None, None, None, context)
 
     r = urllib2.urlopen(*urlopen_args)
     return r

--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -122,7 +122,7 @@
     state: absent
 
 - name: test https fetch to a site with mismatched hostname and certificate and validate_certs=no
-  get_url:
+  uri:
     url: "https://www.kennethreitz.org/"
     dest: "{{ output_dir }}/kreitz.html"
     validate_certs: no


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
v2
```

This will also need to be cherry picked to `2.0-stable` for the `2.0.2` release.
##### SUMMARY

This PR addresses https://github.com/ansible/ansible-modules-core/issues/3437

On some versions of python that have `SSLContext`, when passing `context` to `urllib2.urlopen` caused the global opener that we had built to be ignored and only an `HTTPSHandler` with context used instead.

Instead of pass `context` to `urlopen`, we now add it to the handlers before any other HTTPS related handlers are added.

The following fails on centos7 before this patch:

```
ansible all -i localhost, -c local -m uri -a 'url=http://httpbin.org/basic-auth/admin/password user=admin password=password validate_certs=false'
```

The failure was:

```
localhost | FAILED! => {
    "access_control_allow_credentials": "true",
    "access_control_allow_origin": "*",
    "changed": false,
    "connection": "close",
    "content": "",
    "content_length": "0",
    "date": "Fri, 15 Apr 2016 21:19:03 GMT",
    "failed": true,
    "msg": "Status code was not [200]: HTTP Error 401: UNAUTHORIZED",
    "redirected": false,
    "server": "nginx",
    "status": 401,
    "url": "http://httpbin.org/basic-auth/admin/password",
    "www_authenticate": "Basic realm=\"Fake Realm\""
}
```

With this change applied:

```
localhost | SUCCESS => {
    "access_control_allow_credentials": "true",
    "access_control_allow_origin": "*",
    "changed": false,
    "connection": "close",
    "content_length": "48",
    "content_type": "application/json",
    "date": "Fri, 15 Apr 2016 21:19:41 GMT",
    "json": {
        "authenticated": true,
        "user": "admin"
    },
    "msg": "OK (48 bytes)",
    "redirected": false,
    "server": "nginx",
    "status": 200,
    "url": "http://httpbin.org/basic-auth/admin/password"
}
```
