### PR TITLE
SSH fails with '"parsed": false' error message

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -610,6 +610,7 @@ class Connection(ConnectionBase):
 
         try:
             while True:
+                poll = p.poll()
                 events = selector.select(timeout)
 
                 # We pay attention to timeouts only while negotiating a prompt.
@@ -619,7 +620,7 @@ class Connection(ConnectionBase):
                     if state <= states.index('awaiting_escalation'):
                         # If the process has already exited, then it's not really a
                         # timeout; we'll let the normal error handling deal with it.
-                        if p.poll() is not None:
+                        if poll is not None:
                             break
                         self._terminate_process(p)
                         raise AnsibleError('Timeout (%ds) waiting for privilege escalation prompt: %s' % (timeout, to_native(b_stdout)))
@@ -721,7 +722,7 @@ class Connection(ConnectionBase):
                 # Now we're awaiting_exit: has the child process exited? If it has,
                 # and we've read all available output from it, we're done.
 
-                if p.poll() is not None:
+                if poll is not None:
                     if not selector.get_map() or not events:
                         break
                     # We should not see further writes to the stdout/stderr file

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -415,7 +415,7 @@ class TestSSHConnectionRun(object):
             self.conn._flags['become_success'] = True
         return (b'', b'')
 
-    def test_pasword_with_prompt(self):
+    def test_password_with_prompt(self):
         # test with password prompting enabled
         self.pc.password = None
         self.pc.prompt = b'Password:'
@@ -440,7 +440,7 @@ class TestSSHConnectionRun(object):
         assert self.conn._send_initial_data.call_count == 1
         assert self.conn._send_initial_data.call_args[0][1] == 'this is input data'
 
-    def test_pasword_with_become(self):
+    def test_password_with_become(self):
         # test with some become settings
         self.pc.prompt = b'Password:'
         self.pc.become = True
@@ -550,8 +550,8 @@ class TestSSHConnectionRetries(object):
 
         monkeypatch.setattr('time.sleep', lambda x: None)
 
-        self.mock_popen_res.stdout.read.side_effect = [b""] * 11
-        self.mock_popen_res.stderr.read.side_effect = [b""] * 11
+        self.mock_popen_res.stdout.read.side_effect = [b""] * 10
+        self.mock_popen_res.stderr.read.side_effect = [b""] * 10
         type(self.mock_popen_res).returncode = PropertyMock(side_effect=[255] * 30)
 
         self.mock_selector.select.side_effect = [


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.4.0 (ssh f0296f2266) last updated 2017/05/27 09:31:19 (GMT +200)
  config file =
  configured module search path = [u'/Users/leki/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/leki/src/ansible-ssh/ansible/lib/ansible
  executable location = /Users/leki/src/ansible-ssh/ansible/bin/ansible
  python version = 2.7.13 (default, Jan  7 2017, 08:23:07) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```
##### SUMMARY

Fixes: #15436

##### ADDON
The error message changed from 2.0 to 2.4:
```
failed: [test] (item=29) => {"failed": true, "item": "29", "module_stderr": "", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
```