### PR TITLE
Auto install roles

### DIFF
--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -68,6 +68,25 @@ To request specific versions (tags) of a role, use this syntax in the roles file
 
 Available versions will be listed on the Ansible Galaxy webpage for that role.
 
+Automatic Role Installation
+===========================
+
+Since Ansible 2.2, you can install roles using just ansible-playbook by setting auto_install_roles to True in the ansible configuration file and specifying your roles requirements file in the playbook itself::
+
+   - hosts: localhost
+     roles_file: "{{ playbook_dir }}/rolesfile.yml"
+     roles_path: "{{ playbook_dir }}/roles"
+
+Running ansible-playbook with that playbook will install the roles under a directory called roles alongside the playbook.
+
+Each role in the ``roles_file`` will be tested against the ``auto_install_roles_whitelist`` in the ansible configuration file. Typically this will be a list containing only your internal version control service or your public space (e.g. github.com/yourcompany)
+
+e.g.::
+
+   [default]
+   auto_install_roles = True
+   auto_install_roles_whitelist = git.yourcompany.com,github.com/yourcompany
+
 Advanced Control over Role Requirements Files
 =============================================
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -402,8 +402,13 @@ class GalaxyCLI(CLI):
             # query the galaxy API for the role data
 
             if role.install_info is not None and not force:
-                display.display('- %s is already installed, skipping.' % role.name)
-                continue
+                if role.install_info['version'] != role.version:
+                    display.display('- changing role %s from %s to %s' %
+                            (role.name, role.install_info['version'], role.version or "unspecified"))
+                    role.remove()
+                else:
+                    display.display('- %s is already installed, skipping.' % role.version_string)
+                    continue
 
             try:
                 installed = role.install()
@@ -424,14 +429,18 @@ class GalaxyCLI(CLI):
                         # we know we can skip this, as it's not going to
                         # be found on galaxy.ansible.com
                         continue
-                    if dep_role.install_info is None or force:
+                    if dep_role.install_info is None:
                         if dep_role not in roles_left:
-                            display.display('- adding dependency: %s' % dep_role.name)
+                            display.display('- adding dependency: %s' % dep_role.version_string)
                             roles_left.append(dep_role)
                         else:
                             display.display('- dependency %s already pending installation.' % dep_role.name)
                     else:
-                        display.display('- dependency %s is already installed, skipping.' % dep_role.name)
+                        if dep_role.install_info['version'] != dep_role.version:
+                            display.warning('- dependency %s from role %s differs from already installed version (%s), skipping' %
+                                    (dep_role.version_string, role.name, dep_role.install_info['version']))
+                        else:
+                            display.display('- dependency %s is already installed, skipping.' % dep_role.name)
 
             if not installed:
                 display.warning("- %s was NOT installed successfully." % role.name)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -38,7 +38,7 @@ from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.role import GalaxyRole
 from ansible.galaxy.login import GalaxyLogin
 from ansible.galaxy.token import GalaxyToken
-from ansible.playbook.role.requirement import RoleRequirement
+from ansible.playbook.role.requirement import RoleRequirement, read_roles_file, install_roles
 from ansible.utils.unicode import to_unicode
 
 try:
@@ -141,12 +141,11 @@ class GalaxyCLI(CLI):
 
         self.options, self.args =self.parser.parse_args()
         display.verbosity = self.options.verbosity
-        self.galaxy = Galaxy(self.options)
-
+        self.galaxy = Galaxy(self.options.roles_path, self.options.ignore_certs, self.options.api_server)
         return True
 
     def run(self):
-        
+
         super(GalaxyCLI, self).run()
 
         # if not offline, get connect to galaxy api
@@ -155,14 +154,6 @@ class GalaxyCLI(CLI):
             self.api = GalaxyAPI(self.galaxy)
 
         self.execute()
-
-    def exit_without_ignore(self, rc=1):
-        """
-        Exits with the specified return code unless the
-        option --ignore-errors was specified
-        """
-        if not self.get_opt("ignore_errors", False):
-            raise AnsibleError('- you can use --ignore-errors to skip failed roles and finish processing the list.')
 
     def _display_role_info(self, role_info):
 
@@ -356,97 +347,24 @@ class GalaxyCLI(CLI):
             # the role name on the command line
             raise AnsibleOptionsError("- please specify a user/role name, or a roles file, but not both")
 
-        no_deps    = self.get_opt("no_deps", False)
-        force      = self.get_opt('force', False)
+        self.galaxy.no_deps       = self.get_opt("no_deps", False)
+        self.galaxy.force         = self.get_opt('force', False)
+        self.galaxy.ignore_errors = self.get_opt('ignore_errors', False)
 
-        roles_left = []
         if role_file:
-            try:
-                f = open(role_file, 'r')
-                if role_file.endswith('.yaml') or role_file.endswith('.yml'):
-                    try:
-                        required_roles =  yaml.safe_load(f.read())
-                    except Exception as e:
-                        raise AnsibleError("Unable to load data from the requirements file: %s" % role_file)
-
-                    if required_roles is None:
-                        raise AnsibleError("No roles found in file: %s" % role_file)
-
-                    for role in required_roles:
-                        role = RoleRequirement.role_yaml_parse(role)
-                        display.vvv('found role %s in yaml file' % str(role))
-                        if 'name' not in role and 'scm' not in role:
-                            raise AnsibleError("Must specify name or src for role")
-                        roles_left.append(GalaxyRole(self.galaxy, **role))
-                else:
-                    display.deprecated("going forward only the yaml format will be supported")
-                    # roles listed in a file, one per line
-                    for rline in f.readlines():
-                        if rline.startswith("#") or rline.strip() == '':
-                            continue
-                        display.debug('found role %s in text file' % str(rline))
-                        role = RoleRequirement.role_yaml_parse(rline.strip())
-                        roles_left.append(GalaxyRole(self.galaxy, **role))
-                f.close()
-            except (IOError, OSError) as e:
-                display.error('Unable to open %s: %s' % (role_file, str(e)))
+            roles_left = read_roles_file(self.galaxy, role_file)
+            for role in roles_left:
+                display.debug('found role %s in roles file' % str(role.name))
         else:
             # roles were specified directly, so we'll just go out grab them
             # (and their dependencies, unless the user doesn't want us to).
+            roles_left = []
             for rname in self.args:
                 role = RoleRequirement.role_yaml_parse(rname.strip())
                 roles_left.append(GalaxyRole(self.galaxy, **role))
 
-        for role in roles_left:
-            display.vvv('Installing role %s ' % role.name)
-            # query the galaxy API for the role data
+        install_roles(roles_left, self.galaxy)
 
-            if role.install_info is not None and not force:
-                if role.install_info['version'] != role.version:
-                    display.display('- changing role %s from %s to %s' %
-                            (role.name, role.install_info['version'], role.version or "unspecified"))
-                    role.remove()
-                else:
-                    display.display('- %s is already installed, skipping.' % role.version_string)
-                    continue
-
-            try:
-                installed = role.install()
-            except AnsibleError as e:
-                display.warning("- %s was NOT installed successfully: %s " % (role.name, str(e)))
-                self.exit_without_ignore()
-                continue
-
-            # install dependencies, if we want them
-            if not no_deps and installed:
-                role_dependencies = role.metadata.get('dependencies') or []
-                for dep in role_dependencies:
-                    display.debug('Installing dep %s' % dep)
-                    dep_req = RoleRequirement()
-                    dep_info = dep_req.role_yaml_parse(dep)
-                    dep_role = GalaxyRole(self.galaxy, **dep_info)
-                    if '.' not in dep_role.name and '.' not in dep_role.src and dep_role.scm is None:
-                        # we know we can skip this, as it's not going to
-                        # be found on galaxy.ansible.com
-                        continue
-                    if dep_role.install_info is None:
-                        if dep_role not in roles_left:
-                            display.display('- adding dependency: %s' % dep_role.version_string)
-                            roles_left.append(dep_role)
-                        else:
-                            display.display('- dependency %s already pending installation.' % dep_role.name)
-                    else:
-                        if dep_role.install_info['version'] != dep_role.version:
-                            display.warning('- dependency %s from role %s differs from already installed version (%s), skipping' %
-                                    (dep_role.version_string, role.name, dep_role.install_info['version']))
-                        else:
-                            display.display('- dependency %s is already installed, skipping.' % dep_role.name)
-
-            if not installed:
-                display.warning("- %s was NOT installed successfully." % role.name)
-                self.exit_without_ignore()
-
-        return 0
 
     def execute_remove(self):
         """
@@ -701,3 +619,5 @@ class GalaxyCLI(CLI):
         display.display(resp['status'])
 
         return True
+
+

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -288,6 +288,9 @@ GALAXY_IGNORE_CERTS            = get_config(p, 'galaxy', 'ignore_certs', 'ANSIBL
 # this can be configured to blacklist SCMS but cannot add new ones unless the code is also updated
 GALAXY_SCMS                    = get_config(p, 'galaxy', 'scms', 'ANSIBLE_GALAXY_SCMS', 'git, hg', islist=True)
 
+AUTO_INSTALL_ROLES             = get_config(p, DEFAULTS, 'auto_install_roles', 'ANSIBLE_AUTO_INSTALL_ROLES', False, boolean=True)
+AUTO_INSTALL_ROLES_WHITELIST   = get_config(p, DEFAULTS, 'auto_install_roles_whitelist', 'ANSIBLE_AUTO_INSTALL_ROLES_WHITELIST', [], islist=True)
+
 # characters included in auto-generated passwords
 DEFAULT_PASSWORD_CHARS = ascii_letters + digits + ".,:-_"
 STRING_TYPE_FILTERS = get_config(p, 'jinja2', 'dont_type_filters', 'ANSIBLE_STRING_TYPE_FILTERS', ['string', 'to_json', 'to_nice_json', 'to_yaml', 'ppretty', 'json'], islist=True )

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -25,7 +25,7 @@ from ansible.compat.six import string_types
 
 from ansible import constants as C
 from ansible.executor.task_queue_manager import TaskQueueManager
-from ansible.playbook import Playbook
+from ansible.playbook.role.requirement import read_roles_file
 from ansible.template import Templar
 from ansible.utils.unicode import to_unicode
 
@@ -63,6 +63,9 @@ class PlaybookExecutor:
         Run the given playbook, based on the settings in the play which
         may limit the runs to serialized groups, etc.
         '''
+
+        # import here to avoid a dependency loop
+        from ansible.playbook import Playbook
 
         result = 0
         entrylist = []

--- a/lib/ansible/galaxy/__init__.py
+++ b/lib/ansible/galaxy/__init__.py
@@ -36,15 +36,20 @@ from ansible.errors import AnsibleError
 class Galaxy(object):
     ''' Keeps global galaxy info '''
 
-    def __init__(self, options):
+    def __init__(self, roles_path, ignore_certs, api_server, force=False, no_deps=False, ignore_errors=False):
 
-        self.options = options
-        # self.options.roles_path needs to be a list and will be by default
-        roles_path = getattr(self.options, 'roles_path', [])
-        # cli option handling is responsible for making roles_path a list
-        self.roles_paths = roles_path
+        # self.roles_paths needs to be a list
+        if isinstance(roles_path, string_types):
+            self.roles_paths = [roles_path]
+        else:
+            self.roles_paths = roles_path or []
 
         self.roles =  {}
+        self.ignore_certs = ignore_certs
+        self.api_server = api_server
+        self.force = force
+        self.no_deps = no_deps
+        self.ignore_errors = ignore_errors
 
         # load data path for resource usage
         this_dir, this_filename = os.path.split(__file__)

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -54,13 +54,13 @@ class GalaxyAPI(object):
         self._validate_certs = not C.GALAXY_IGNORE_CERTS
 
         # set validate_certs
-        if galaxy.options.ignore_certs:
+        if galaxy.ignore_certs:
             self._validate_certs = False
         display.vvv('Validate TLS certificates: %s' % self._validate_certs)
 
         # set the API server
-        if galaxy.options.api_server != C.GALAXY_SERVER:
-            self._api_server = galaxy.options.api_server
+        if galaxy.api_server != C.GALAXY_SERVER:
+            self._api_server = galaxy.api_server
         display.vvv("Connecting to galaxy_server: %s" % self._api_server)
 
         server_version = self.get_server_api_version()

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -306,7 +306,7 @@ class GalaxyRole(object):
                    raise AnsibleError("Could not update files in %s: %s" % (self.path, str(e)))
 
                 # return the parsed yaml metadata
-                display.display("- %s was installed successfully" % self.name)
+                display.display("- %s was installed successfully" % self.version_string)
                 try:
                     os.unlink(tmp_file)
                 except (OSError,IOError) as e:
@@ -327,3 +327,14 @@ class GalaxyRole(object):
         }
         """
         return dict(scm=self.scm, src=self.src, version=self.version, name=self.name)
+
+    @property
+    def version_string(self):
+        """
+        Returns "rolename (version)" if version is not null
+        Returns "rolename" otherwise
+        """
+        if self.version:
+            return "%s (%s)" % (self.name, self.version)
+        else:
+            return self.name

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -250,8 +250,17 @@ class GalaxyRole(object):
                 # next find the metadata file
                 for member in members:
                     if self.META_MAIN in member.name:
-                        meta_file = member
-                        break
+                        # Look for parent of meta/main.yml
+                        # Due to possibility of sub roles each containing meta/main.yml
+                        # look for shortest length parent
+                        meta_parent_dir = os.path.dirname(os.path.dirname(member.name))
+                        if not meta_file:
+                            archive_parent_dir = meta_parent_dir
+                            meta_file = member
+                        else:
+                            if len(meta_parent_dir) < len(archive_parent_dir):
+                                archive_parent_dir = meta_parent_dir
+                                meta_file = member
                 if not meta_file:
                     raise AnsibleError("this role does not appear to have a meta/main.yml file.")
                 else:
@@ -260,9 +269,9 @@ class GalaxyRole(object):
                     except:
                         raise AnsibleError("this role does not appear to have a valid meta/main.yml file.")
 
-                # we strip off the top-level directory for all of the files contained within
-                # the tar file here, since the default is 'github_repo-target', and change it
-                # to the specified role's name
+                # we strip off any higher-level directories for all of the files contained within
+                # the tar file here. The default is 'github_repo-target'. Gerrit instances, on the other
+                # hand, does not have a parent directory at all.
                 display.display("- extracting %s to %s" % (self.name, self.path))
                 try:
                     if os.path.exists(self.path):
@@ -281,9 +290,9 @@ class GalaxyRole(object):
                     for member in members:
                         # we only extract files, and remove any relative path
                         # bits that might be in the file for security purposes
-                        # and drop the leading directory, as mentioned above
+                        # and drop any containing directory, as mentioned above
                         if member.isreg() or member.issym():
-                            parts = member.name.split(os.sep)[1:]
+                            parts = member.name.replace(archive_parent_dir, "").split(os.sep)
                             final_parts = []
                             for part in parts:
                                 if part != '..' and '~' not in part and '$' not in part:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -75,6 +75,8 @@ class Play(Base, Taggable, Become):
 
     # Role Attributes
     _roles               = FieldAttribute(isa='list', default=[], priority=90)
+    _roles_file          = FieldAttribute(isa='string', default='', always_post_validate=True)
+    _roles_path          = FieldAttribute(isa='string', default='', always_post_validate=True)
 
     # Block (Task) Lists Attributes
     _handlers            = FieldAttribute(isa='list', default=[])

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -26,6 +26,7 @@ import yaml
 from ansible.errors import AnsibleError
 from ansible.playbook.role.definition import RoleDefinition
 from ansible.galaxy.role import GalaxyRole
+import ansible.constants as C
 
 __all__ = ['RoleRequirement']
 
@@ -207,10 +208,15 @@ def read_roles_file(galaxy, role_file):
     return roles_left
 
 
-def install_roles(roles_left, galaxy):
+def install_roles(roles_left, galaxy, use_whitelist=False, whitelist=C.AUTO_INSTALL_ROLES_WHITELIST):
     """ Helper function to allow other CLI commands install roles """
 
     for role in roles_left:
+        if use_whitelist:
+            if not any([whitelistitem in role.src for whitelistitem in whitelist]):
+                display.warning("Role %s from %s not in whitelist %s" % (role.name, role.src, whitelist))
+                exit_without_ignore(galaxy.ignore_errors)
+                continue
         display.vvv('Installing role %s ' % role.name)
         # query the galaxy API for the role data
 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -249,7 +249,7 @@ else
 	@echo "Consul agent is not running locally. To run a cluster locally see http://github.com/sgargan/consul-vagrant"
 endif
 
-test_galaxy: test_galaxy_spec test_galaxy_yaml test_galaxy_git
+test_galaxy: test_galaxy_spec test_galaxy_yaml test_galaxy_git test_galaxy_playbook_options
 
 test_galaxy_spec: setup
 	mytmpdir=$(MYTMPDIR) ; \
@@ -274,6 +274,14 @@ test_galaxy_git: setup
 	ansible-galaxy install git+https://bitbucket.org/willthames/git-ansible-galaxy,v1.6 -p $$mytmpdir/roles -vvvv; \
     cp galaxy_playbook_git.yml $$mytmpdir ; \
     ansible-playbook -i $(INVENTORY) $$mytmpdir/galaxy_playbook_git.yml -v $(TEST_FLAGS) ; \
+    RC=$$? ; \
+    rm -rf $$mytmpdir ; \
+    exit $$RC
+
+test_galaxy_playbook_options: setup
+	mytmpdir=$(MYTMPDIR) ; \
+	cp galaxy_playbook_roles.yml galaxy_roles.yml $$mytmpdir ; \
+    ansible-playbook -i $(INVENTORY) $$mytmpdir/galaxy_playbook_roles.yml -v $(TEST_FLAGS) ; \
     RC=$$? ; \
     rm -rf $$mytmpdir ; \
     exit $$RC

--- a/test/integration/ansible.cfg
+++ b/test/integration/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+auto_install_roles = True
+auto_install_roles_whitelist = github.com:geerlingguy,bitbucket.org/willthames,briancoca.

--- a/test/integration/galaxy_playbook_roles.yml
+++ b/test/integration/galaxy_playbook_roles.yml
@@ -1,0 +1,9 @@
+- hosts: localhost
+  connection: local
+  roles_file: "{{ playbook_dir }}/galaxy_roles.yml"
+  roles_path: "{{ playbook_dir }}/roles"
+
+  roles:
+  - "git-ansible-galaxy"
+  - "http-role"
+  - "hg-ansible-galaxy"


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 9e6988c7b5) last updated 2016/04/16 23:37:26 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD 5409ed1b28) last updated 2016/04/16 23:37:29 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD 3afe117730) last updated 2016/04/16 23:37:29 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

Implementation of auto roles install ansible/proposals#7

There are some enhancements that I'd like to make
- It would be nice if `roles_path` and `roles_file` could be obtained from ansible.cfg and also be relative to e.g `playbook_dir`. I'm not sure if ansible.cfg can manage that
##### NOTES:
- Incorporates #15414 and #12904 because they're both useful to have (#12904 is the basis of this work anyway - I could split out #15414 if need be)
- Fixes to failing tests are coming along nicely. The test suite has found some odd edge cases, which is great.
