### PR TITLE
Add work-around for sshd race to test_connection.

### DIFF
--- a/test/integration/test_connection.yml
+++ b/test/integration/test_connection.yml
@@ -6,7 +6,7 @@
   ### raw with unicode arg and output
 
   - name: raw with unicode arg and output
-    raw: echo 汉语
+    raw: echo 汉语 && sleep 0
     register: command
   - name: check output of raw with unicode arg and output
     assert: { that: "'汉语' in command.stdout" }


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (connection-test-update 9552c4d8ca) last updated 2016/04/14 08:00:56 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 99cd31140d) last updated 2016/04/17 22:51:50 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD ab2f4c4002) last updated 2016/04/17 22:51:50 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Due to a race condition in sshd when using a pty, which causes loss of stdout, test_connection will occasionally fail. This is most likely to occur under high cpu load.

Adding "&& /bin/true" after the command being executed mitigates this issue, which should keep CI builds from failing due to the race condition.

Ultimately a proper long-term work-around should be implemented within the ssh and paramiko_ssh connection plugins.
