### PR TITLE
Fix duplicate host with different uuid created after add_host

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -399,10 +399,9 @@ class StrategyBase:
 
         host_name = host_info.get('host_name')
 
-        # Check if host in cache, add if not
-        if host_name in self._inventory._hosts_cache:
-            new_host = self._inventory._hosts_cache[host_name]
-        else:
+        # Check if host in inventory, add if not
+        new_host = self._inventory.get_host(host_name)
+        if not new_host:
             new_host = Host(name=host_name)
             self._inventory._hosts_cache[host_name] = new_host
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.0.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

If `add_host` is performed with hostname existing in inventory, but
not yet accessed and put in inventory cache, additional host with
same hostname and different uuid is created, causing patterns to
misbehave.

Reproduced with new host created by `ec2` module and then adding it to temporary group with add_host. Workaround exists though: performing `set_fact` on this host before making actual `add_host` implicitly calls `get_host` causing it appear in cache.
