### PR TITLE
Allow to work with latest Azure Python SDK

### DIFF
--- a/contrib/inventory/windows_azure.py
+++ b/contrib/inventory/windows_azure.py
@@ -49,9 +49,7 @@ except ImportError:
 try:
     from azure.servicemanagement import ServiceManagementService
 except ImportError as e:
-    print("ImportError: {0}".format(str(e)))
-    sys.exit(1)
-
+    sys.exit("ImportError: {0}".format(str(e)))
 
 # Imports for ansible
 import ConfigParser
@@ -193,8 +191,7 @@ class AzureInventory(object):
             for cloud_service in self.sms.list_hosted_services():
                 self.add_deployments(cloud_service)
         except Exception as e:
-            print("Error: Failed to access cloud services - {0}".format(str(e)))
-            sys.exit(1)
+            sys.exit("Error: Failed to access cloud services - {0}".format(str(e)))
 
     def add_deployments(self, cloud_service):
         """Makes an Azure API call to get the list of virtual machines
@@ -204,8 +201,7 @@ class AzureInventory(object):
             for deployment in self.sms.get_hosted_service_properties(cloud_service.service_name,embed_detail=True).deployments.deployments:
                 self.add_deployment(cloud_service, deployment)
         except Exception as e:
-            print("Error: Failed to access deployments - {0}".format(str(e)))
-            sys.exit(1)
+            sys.exit("Error: Failed to access deployments - {0}".format(str(e)))
 
     def add_deployment(self, cloud_service, deployment):
         """Adds a deployment to the inventory and index"""

--- a/contrib/inventory/windows_azure.py
+++ b/contrib/inventory/windows_azure.py
@@ -47,11 +47,9 @@ except ImportError:
     import simplejson as json
 
 try:
-    import azure
-    from azure import WindowsAzureError
     from azure.servicemanagement import ServiceManagementService
 except ImportError as e:
-    print("failed=True msg='`azure` library required for this script'")
+    print("ImportError: {0}".format(str(e)))
     sys.exit(1)
 
 
@@ -194,10 +192,8 @@ class AzureInventory(object):
         try:
             for cloud_service in self.sms.list_hosted_services():
                 self.add_deployments(cloud_service)
-        except WindowsAzureError as e:
-            print("Looks like Azure's API is down:")
-            print("")
-            print(e)
+        except Exception as e:
+            print("Error: Failed to access cloud services - {0}".format(str(e)))
             sys.exit(1)
 
     def add_deployments(self, cloud_service):
@@ -207,10 +203,8 @@ class AzureInventory(object):
         try:
             for deployment in self.sms.get_hosted_service_properties(cloud_service.service_name,embed_detail=True).deployments.deployments:
                 self.add_deployment(cloud_service, deployment)
-        except WindowsAzureError as e:
-            print("Looks like Azure's API is down:")
-            print("")
-            print(e)
+        except Exception as e:
+            print("Error: Failed to access deployments - {0}".format(str(e)))
             sys.exit(1)
 
     def add_deployment(self, cloud_service, deployment):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (windows_azure 7f3ea66c2b) last updated 2016/04/18 18:17:11 (GMT -400)
  lib/ansible/modules/core: (detached HEAD c52f475c64) last updated 2016/04/10 08:32:14 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 5abb914315) last updated 2016/04/10 08:23:55 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Allow the old azure inventory script to work with the latest Azure Python SDK.

```
~/projects/azure/azurerm $ ./windows_azure.py
{
  "Cloud_services": [
    "jlaska-u1204"
  ],
  "East_US": [
    "jlaska-u1204"
  ],
  "_meta": {
    "hostvars": {
      "jlaska-u1204": {
        "ansible_ssh_host": "jlaska-u1204.cloudapp.net",
        "ansible_ssh_port": 22,
        "instance_status": "ReadyRole",
        "private_id": "87411751b8c14afe85804828dae115c4"
      }
    }
  },
  "azure": [
    "jlaska-u1204"
  ],
  "jlaska-u1204": [
    "jlaska-u1204"
  ]
}
```
