### PR TITLE
Handle case of both Key and key

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -364,7 +364,10 @@ def boto3_tag_list_to_ansible_dict(tags_list):
 
     tags_dict = {}
     for tag in tags_list:
-        tags_dict[tag['Key']] = tag['Value']
+        if 'key' in tag:
+            tags_dict[tag['key']] = tag['value']
+        elif 'Key' in tag:
+            tags_dict[tag['Key']] = tag['Value']
 
     return tags_dict
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

If someone uses the ec2 helper function to convert to snake_case for boto3 results before handling their tags, they may end up passing a dict with keys in lower case rather than upper case.

This small PR handles both 'Key' and 'key'
