### PR TITLE
Fixup perms dont rely on privileged user named root

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -311,18 +311,23 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if self._play_context.become and self._play_context.become_user not in ('root', remote_user):
             # Unprivileged user that's different than the ssh user.  Let's get
             # to work!
-            if remote_user == 'root':
-                # SSh'ing as root, therefore we can chown
-                res = self._remote_chown(remote_path, self._play_context.become_user, recursive=recursive)
-                if res['rc'] != 0:
-                    raise AnsibleError('Failed to set owner on remote files (rc: {0}, err: {1})'.format(res['rc'], res['stderr']))
+
+            # Try chown'ing the file. This will only work if our SSH user has
+            # root privileges, but since we can't reliably determine that from
+            # the username (think "toor" on FreeBSD), let's just try first and
+            # apologize later:
+            res = self._remote_chown(remote_path, self._play_context.become_user, recursive=recursive)
+            if res['rc'] == 0:
+                # Only continue with chmod if chown worked
                 if execute:
                     # root can read things that don't have read bit but can't
                     # execute them.
                     res = self._remote_chmod('u+x', remote_path, recursive=recursive)
                     if res['rc'] != 0:
                         raise AnsibleError('Failed to set file mode on remote files (rc: {0}, err: {1})'.format(res['rc'], res['stderr']))
+
             else:
+                # Chown'ing failed. We're probably lacking root privileges; let's try something else.
                 if execute:
                     mode = 'rx'
                 else:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

On some systems, the privileged administrative user is not named "root".  For these, fixup_perms fails to try chowning the file even though chowning would work. Changed fixup_perms to try chown'ing before checking for root privileges.  If chown'ing fails, we check whether we're "root" and fail if so.  If we're not root we try our other methods of making the file readable to the unprivileged user.

Thanks to @n-st for most of the work towards this fix.
