### PR TITLE
WARN if the play or the task attempts to pass environment to the raw module

### DIFF
--- a/lib/ansible/plugins/action/raw.py
+++ b/lib/ansible/plugins/action/raw.py
@@ -26,6 +26,11 @@ class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:
             task_vars = dict()
+        else:
+            if 'vars' in task_vars:
+                if 'environment' in task_vars['vars']:
+                    # The environment key only exists if explicitly declared in the task or in the play
+                    self._display.warning('raw module does not support the environment keyword')
 
         result = super(ActionModule, self).run(tmp, task_vars)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
[jtanner@ansidev amc-32]$ ansible --version
ansible 2.1.0 (AMC-32 095ec760ac) last updated 2016/04/19 22:42:18 (GMT -400)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

https://github.com/ansible/ansible-modules-core/issues/32 requested setting environment variables with the raw module. The core team discussed this and tentatively decided that setting the environment is not within the scope of the raw module and that the user should be given a warning

Example:

```
[jtanner@ansidev amc-32]$ ./runtest.sh
PLAY [localhost] ***************************************************************

TASK [raw] *********************************************************************
 [WARNING]: raw module does not support the environment keyword

ok: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0
```
