### PR TITLE
Revert "Disable new git tests until a fix for rhel6/7 is merged."

### DIFF
--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -596,22 +596,17 @@
     depth: 1
     version: master
 
-### Commented out while @robinro figures out the best fix to the git module.
-### Probably going to disable depth for this operation when on older vresions
-### of git to address it (of what we test, currently only rhel6/7 are broken
-### (fedora and ubuntu12+ work)
+- name: switch to older branch with depth=1 (uses fetch)
+  git:
+    repo: '{{ repo_depth_url }}'
+    dest: '{{ checkout_dir }}'
+    depth: 1
+    version: earlybranch
+  register: git_fetch
 
-#- name: switch to older branch with depth=1 (uses fetch)
-#  git:
-#    repo: '{{ repo_depth_url }}'
-#    dest: '{{ checkout_dir }}'
-#    depth: 1
-#    version: earlybranch
-#  register: git_fetch
-#
-#- name: ensure the fetch succeeded
-#  assert:
-#    that: git_fetch|success
+- name: ensure the fetch succeeded
+  assert:
+    that: git_fetch|success
 
 - name: clear checkout_dir
   file: state=absent path={{ checkout_dir }}


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

devel, 2.1.0
##### SUMMARY

This reverts commit 197d3dfe9787476eb60169757c71f0acb6e68256 and enabled all git tests again.

The fix for the bug that made the test fail is in 
https://github.com/ansible/ansible-modules-core/pull/3492
