### PR TITLE
Add 'refresh' mode to fact gathering

### DIFF
--- a/docs/docsite/rst/intro_configuration.rst
+++ b/docs/docsite/rst/intro_configuration.rst
@@ -410,7 +410,8 @@ New in 1.6, the 'gathering' setting controls the default policy of facts gatheri
 The value 'implicit' is the default, which means that the fact cache will be ignored and facts will be gathered per play unless 'gather_facts: False' is set.
 The value 'explicit' is the inverse, facts will not be gathered unless directly requested in the play.
 The value 'smart' means each new host that has no facts discovered will be scanned, but if the same host is addressed in multiple plays it will not be contacted again in the playbook run.
-This option can be useful for those wishing to save fact gathering time. Both 'smart' and 'explicit' will use the fact cache::
+The value 'refresh' is similar to 'smart', and will behave identically when using 'memory' backed fact caching. It will ensure that the first time during a playbook run each host will have facts scanned, and then behave the same as smart. This mode is useful for those utilising a persistent fact cache store, such as 'jsonfile' or 'redis', for additional custom facts, where it is desirable to re-gather system facts on each ansible run without expiring the custom facts as well.
+This option can be useful for those wishing to save fact gathering time. 'smart', 'refresh' and 'explicit' will use the fact cache::
 
     gathering = smart
 

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -203,9 +203,12 @@ class PlayIterator:
         start_at_matched = False
         for host in inventory.get_hosts(self._play.hosts):
             self._host_states[host.name] = HostState(blocks=self._blocks)
+            # if refreshing of fact caching is not enabled and
             # if the host's name is in the variable manager's fact cache, then set
             # its _gathered_facts flag to true for smart gathering tests later
-            if host.name in variable_manager._fact_cache and variable_manager._fact_cache.get(host.name).get('module_setup', False):
+            if (C.DEFAULT_GATHERING != 'refresh'
+                    and host.name in variable_manager._fact_cache
+                    and variable_manager._fact_cache.get(host.name).get('module_setup', False)):
                 host._gathered_facts = True
             # if we're looking to start at a specific task, iterate through
             # the tasks for this host until we find the specified task
@@ -308,7 +311,7 @@ class PlayIterator:
 
                     if (gathering == 'implicit' and implied) or \
                        (gathering == 'explicit' and boolean(self._play.gather_facts)) or \
-                       (gathering == 'smart' and implied and not host._gathered_facts):
+                       (gathering in ('smart', 'refresh') and implied and not host._gathered_facts):
                         # The setup block is always self._blocks[0], as we inject it
                         # during the play compilation in __init__ above.
                         setup_block = self._blocks[0]


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
executor/play_iterator

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /home/baileybd/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Ensures that gathered facts are refreshed at the start of play
execution, still using the cache for all remaining plays same as
'smart'.

Most useful when combined with a persistent fact cache store such as
'jsonfile' or 'redis', where you may wish to persist custom facts
stored in addition that you don't wish to flush or expire as quickly as
system facts gathered.

This allows for refreshing system facts at the start of a playbook,
and then continuing to benefit from the 'smart' behaviour during the
subsequent plays executed as part of that play.

test-gathering.yml

```
- hosts: localhost
  tasks:
    - ping:
      register: ping_status

- hosts: localhost
  tasks:
    - debug:
        var: ping_status
```

ansible.cfg

```
[defaults]
gathering = smart
fact_caching = jsonfile
fact_caching_connection = ~/.ansible_fact_cache
fact_caching_timeout = 86400
```

Run 1

```
ansible-playbook test-gathering.yml 

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [ping] ********************************************************************
ok: [localhost]

PLAY [localhost] ***************************************************************

TASK [debug] *******************************************************************
ok: [localhost] => {
    "ping_status": {
        "changed": false, 
        "ping": "pong"
    }
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0
```

Run 2

```
ansible-playbook test-gathering.yml 

PLAY [localhost] ***************************************************************

TASK [ping] ********************************************************************
ok: [localhost]

PLAY [localhost] ***************************************************************

TASK [debug] *******************************************************************
ok: [localhost] => {
    "ping_status": {
        "changed": false, 
        "ping": "pong"
    }
}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0
```

Notice that for the second run in addition to skipping gather on the second play, it also skipped it on the first as well.

ansible.cfg

```
[defaults]
gathering = refresh
fact_caching = jsonfile
fact_caching_connection = ~/.ansible_fact_cache
fact_caching_timeout = 86400
```

Run 1

```
ansible-playbook test-gathering.yml 

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [ping] ********************************************************************
ok: [localhost]

PLAY [localhost] ***************************************************************

TASK [debug] *******************************************************************
ok: [localhost] => {
    "ping_status": {
        "changed": false, 
        "ping": "pong"
    }
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0
```

Run 2

```
ansible-playbook test-gathering.yml 

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [ping] ********************************************************************
ok: [localhost]

PLAY [localhost] ***************************************************************

TASK [debug] *******************************************************************
ok: [localhost] => {
    "ping_status": {
        "changed": false, 
        "ping": "pong"
    }
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0
```

With _refresh_, it will re-gather for the first play in each run, but then use the fact cache for all remaining plays. This also allows us to ensure we always have a consistent view of basic system 
state at the start of a playbook run when using fact caching that can contain additional custom 
facts set from previous runs, while benefiting from caching for the remaining plays.
