### PR TITLE
Add example of checking registered variable for emptiness.

### DIFF
--- a/docsite/rst/playbooks_conditionals.rst
+++ b/docsite/rst/playbooks_conditionals.rst
@@ -248,6 +248,22 @@ fields::
             with_items: home_dirs.stdout_lines
             # same as with_items: home_dirs.stdout.split()
 
+As shown previously, the registered variable's string contents are accessible with the 'stdout' value.
+You may check the registered variable's string contents for emptiness::
+
+    - name: check registered variable for emptiness
+      hosts: all
+
+      tasks:
+
+          - name: list contents of directory
+            command: ls mydir
+            register: contents
+
+          - name: check contents for emptiness
+            debug: msg="Directory is empty"
+            when: contents.stdout == ""
+
 
 .. seealso::
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
  ansible 2.0.1.0
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

When testing for the emptiness of a registered variable, I came across a playbook using ‘when: registered_variable.stdout == “null”’.  This was not working. After a little searching I discovered the check for emptiness worked like this ‘when: registered_variable.stdout == “”’.  This change adds a short example at the end of the docs section on “conditionals” showing how to check a registered variable for emptiness.
