### PR TITLE
Do not set RDS instance hostname if hostname_variable is a tag

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -921,10 +921,7 @@ class Ec2Inventory(object):
         # Set the inventory name
         hostname = None
         if self.hostname_variable:
-            if self.hostname_variable.startswith('tag_'):
-                hostname = instance.tags.get(self.hostname_variable[4:], None)
-            else:
-                hostname = getattr(instance, self.hostname_variable)
+            hostname = getattr(instance, self.hostname_variable, None)
 
         # If we can't get a nice hostname, use the destination address
         if not hostname:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->
#14464 and #11569 are related. The problem is that boto.rds does not return RDS instance tags.

Tags can be retrieved by using boto.rds2, although there are challenges identified by @deyvsh https://github.com/ansible/ansible/issues/11569#issuecomment-175740957. This is a workaround that would at least allowing using a hostname_variable like "tag_Name" and still generate inventory. The alternative is to configure ec2.py to exclude RDS instances from inventory.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Example error before change...

```
Traceback (most recent call last):
  File "./ec2.py", line 1385, in <module>
    Ec2Inventory()
  File "./ec2.py", line 173, in __init__
    self.do_api_calls_update_cache()
  File "./ec2.py", line 446, in do_api_calls_update_cache
    self.get_rds_instances_by_region(region)
  File "./ec2.py", line 521, in get_rds_instances_by_region
    self.add_rds_instance(instance, region)
  File "./ec2.py", line 804, in add_rds_instance
    hostname = instance.tags.get(self.hostname_variable[4:], None)
AttributeError: 'DBInstance' object has no attribute 'tags'
```

boto.rds does not return RDS instance tags. Since it does not there
is no need to check for RDS tags here. Also, if the hostname_variable
is not available the default hostname (the destination address)
should be returned.
