### PR TITLE
Extend the get_url integration tests to include file schemas.

### DIFF
--- a/test/integration/roles/test_get_url/tasks/main.yml
+++ b/test/integration/roles/test_get_url/tasks/main.yml
@@ -31,6 +31,40 @@
     python_has_ssl_context: False
   when: python_test.rc != 0
 
+- name: Define test files for file schema
+  set_fact:
+    geturl_srcfile: "{{ output_dir | expanduser }}/aurlfile.txt"
+    geturl_dstfile: "{{ output_dir | expanduser }}/aurlfile_copy.txt"
+
+- name: Create source file
+  copy: 
+    dest: "{{ geturl_srcfile }}" 
+    content: "foobar" 
+
+- name: test file fetch
+  get_url:
+    url: "{{ 'file://' + geturl_srcfile }}"
+    dest: "{{ geturl_dstfile }}"  
+  register: result  
+
+- name: assert success and change
+  assert:
+    that:
+        - result.changed
+        - '"OK" in result.msg'
+
+- name: test nonexisting file fetch
+  get_url:
+    url: "{{ 'file://' + geturl_srcfile + 'NOFILE' }}"
+    dest: "{{ geturl_dstfile + 'NOFILE' }}"  
+  register: result  
+  ignore_errors: True
+
+- name: assert success and change
+  assert:
+    that:
+        - result.failed
+
 - name: test https fetch
   get_url: url="https://raw.githubusercontent.com/ansible/ansible/devel/README.md" dest={{output_dir}}/get_url.txt force=yes
   register: result


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.1.0 (get_url_file_integration_test 6995cf5f0f) last updated 2016/04/21 16:30:09 (GMT -400)
  lib/ansible/modules/core: (AMC_3511 e4fd824dc2) last updated 2016/04/21 15:34:40 (GMT -400)
  lib/ansible/modules/extras: (devel e8391d6985) last updated 2016/04/21 15:37:37 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Now that get_url properly handles file:/// schemas, this will prevent the feature from regressing.

Addresses https://github.com/ansible/ansible-modules-core/issues/3511
