### PR TITLE
Fix logging into vCloud Director and expose verify_certs argument

### DIFF
--- a/lib/ansible/module_utils/vca.py
+++ b/lib/ansible/module_utils/vca.py
@@ -46,7 +46,8 @@ def vca_argument_spec():
         api_version=dict(default=DEFAULT_VERSION),
         service_type=dict(default=DEFAULT_SERVICE_TYPE, choices=SERVICE_MAP.keys()),
         vdc_name=dict(),
-        gateway_name=dict(default='gateway')
+        gateway_name=dict(default='gateway'),
+        verify_certs=dict(type='bool', default=True)
     )
 
 class VcaAnsibleModule(AnsibleModule):
@@ -130,7 +131,11 @@ class VcaAnsibleModule(AnsibleModule):
         service_type = self.params['service_type']
         password = self.params['password']
 
-        if not self.vca.login(password=password):
+        login_org = None
+        if service_type == 'vcd':
+            login_org = self.params['org']
+
+        if not self.vca.login(password=password, org=login_org):
             self.fail('Login to VCA failed', response=self.vca.response.content)
 
         try:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel d97dbe17f9) last updated 2016/04/10 03:13:54 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 345d9cbca8) last updated 2016/03/16 11:30:54 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD f9b96b9a8a) last updated 2016/03/16 11:31:07 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

vCloud director standalone login requires an organization to login properly.
The login organization was not specified as part of the login sequence.
Also, verify_certs is referred to throughout the module, but not specified in module arguments. This fix will expose it.

Before

Login error

```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "vca_vapp"}, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_pbp_Cq/ansible_module_vca_vapp.py\", line 282, in <module>\n    main()\n  File \"/tmp/ansible_pbp_Cq/ansible_module_vca_vapp.py\", line 246, in main\n    supports_check_mode=True)\n  File \"/tmp/ansible_pbp_Cq/ansible_modlib.zip/ansible/module_utils/vca.py\", line 65, in __init__\n  File \"/tmp/ansible_pbp_Cq/ansible_modlib.zip/ansible/module_utils/vca.py\", line 133, in login\n  File \"/usr/lib/python2.7/site-packages/pyvcloud/vcloudair.py\", line 223, in login\n    result = vcloud_session.login(password=password)\n  File \"/usr/lib/python2.7/site-packages/pyvcloud/vcloudsession.py\", line 64, in login\n    self.response = Http.post(self.url, headers=headers, auth=(self.username + \"@\" + self.org, password), verify=self.verify, logger=self.logger)\nTypeError: cannot concatenate 'str' and 'NoneType' objects\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
```

verify_certs error

```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"api_version": 5.5, "catalog_name": "Public_Templates", "host": "https://vcd4.pdsea.f5net.com", "org": "Dev2", "password": "", "service_type": "vcd", "state": "present", "template_name": "ATT-MASTER-ITE-Main", "username": "akalinin", "vapp_name": "akalinin-1", "vdc_name": "Dev2", "verify_certs": false}, "module_name": "vca_vapp"}, "msg": "unsupported parameter for module: verify_certs"}
```
