### PR TITLE
Change the raw module's detection of environment settings.

### DIFF
--- a/lib/ansible/plugins/action/raw.py
+++ b/lib/ansible/plugins/action/raw.py
@@ -26,11 +26,9 @@ class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:
             task_vars = dict()
-        else:
-            if 'vars' in task_vars:
-                if 'environment' in task_vars['vars']:
-                    # The environment key only exists if explicitly declared in the task or in the play
-                    self._display.warning('raw module does not support the environment keyword')
+
+        if self._task.environment:
+            self._display.warning('raw module does not support the environment keyword')
 
         result = super(ActionModule, self).run(tmp, task_vars)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.1.0 (bugfix-raw-warn-env 828ce3410d) last updated 2016/04/21 17:51:59 (GMT -400)
  lib/ansible/modules/core: (devel 67de0675c3) last updated 2016/04/21 17:46:39 (GMT -400)
  lib/ansible/modules/extras: (devel e8391d6985) last updated 2016/04/21 17:46:44 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The task_vars datastructure always contains an environment key,
so use the _task.environment property to look for a non-empty
list instead.
