### PR TITLE
git: git reset with branch

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -816,7 +816,7 @@ def switch_version(git_path, module, dest, remote, version, verify_commit, depth
         if rc != 0:
             module.fail_json(msg="Failed to checkout branch %s" % branch,
                              stdout=out, stderr=err, rc=rc)
-        cmd = "%s reset --hard %s --" % (git_path, remote)
+        cmd = "%s reset --hard %s/%s --" % (git_path, remote, branch)
     else:
         # FIXME check for local_branch first, should have been fetched already
         if is_remote_branch(git_path, module, dest, remote, version):

--- a/test/integration/targets/git/tasks/ambiguous-ref.yml
+++ b/test/integration/targets/git/tasks/ambiguous-ref.yml
@@ -1,0 +1,31 @@
+---
+
+# test for https://github.com/ansible/ansible-modules-core/pull/3386
+
+- name: clone repo
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}'
+
+- name: rename remote to be ambiguous
+  command: git remote rename origin v0.1 chdir="{{ checkout_dir }}"
+
+- name: switch to HEAD
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}'
+    remote: v0.1
+
+- name: rev-parse remote HEAD
+  command: git rev-parse v0.1/HEAD chdir="{{ checkout_dir }}"
+  register: git_remote_head
+
+- name: rev-parse local HEAD
+  command: git rev-parse HEAD chdir="{{ checkout_dir }}"
+  register: git_local_head
+
+- assert:
+    that: git_remote_head.stdout == git_local_head.stdout
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -30,3 +30,4 @@
 - include: tag-verification.yml
 - include: localmods.yml
 - include: reset-origin.yml
+- include: ambiguous-ref.yml


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/git/tasks/main.yml

##### ANSIBLE VERSION
a6e8359

##### SUMMARY

Add test for ansible/ansible-modules-core#3386

`git reset <ref>` can be ambiguous and fail to switch to the correct branch. To avoid it, specify branch.
