### PR TITLE
Fix #14454 with_first_found fails with ansible 2

### DIFF
--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -177,7 +177,7 @@ class LookupModule(LookupBase):
         else:
             total_search = self._flatten(terms)
 
-        roledir = variables.get('roledir')
+        roledir = variables.get('role_path')
         for fn in total_search:
             try:
                 fn = self._templar.template(fn)

--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -140,6 +140,8 @@ class LookupModule(LookupBase):
                 anydict = True
 
         total_search = []
+        filelist = []
+        pathlist = []
         if anydict:
             for term in terms:
                 if isinstance(term, dict):
@@ -147,22 +149,24 @@ class LookupModule(LookupBase):
                     paths = term.get('paths', [])
                     skip  = boolean(term.get('skip', False))
 
-                    filelist = files
-                    if isinstance(files, basestring):
-                        files = files.replace(',', ' ')
-                        files = files.replace(';', ' ')
-                        filelist = files.split(' ')
-
-                    pathlist = paths
-                    if paths:
-                        if isinstance(paths, basestring):
-                            paths = paths.replace(',', ' ')
-                            paths = paths.replace(':', ' ')
-                            paths = paths.replace(';', ' ')
-                            pathlist = paths.split(' ')
+                    if not filelist:
+                        filelist = files
+                        if isinstance(files, basestring):
+                            files = files.replace(',', ' ')
+                            files = files.replace(';', ' ')
+                            filelist = files.split(' ')
 
                     if not pathlist:
-                        total_search = filelist
+                        pathlist = paths
+                        if paths:
+                            if isinstance(paths, basestring):
+                                paths = paths.replace(',', ' ')
+                                paths = paths.replace(':', ' ')
+                                paths = paths.replace(';', ' ')
+                                pathlist = paths.split(' ')
+
+                    if not pathlist:
+                        total_search = list(filelist)
                     else:
                         for path in pathlist:
                             for fn in filelist:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
"ansible 2.0.2.0"
```
##### SUMMARY

Two issues popped up while using `with_first_found` in combination with `delegate_to`.

The following works fine without `delegate_to` if file `findme` exists in `<roledir>/templates/` but fails when `delegate_to` is used.

```
- name: debugging first_found plugin
  debug: msg="looking for files and found {{ item }}"
  with_first_found:
    - files:
      - "findme"
    - paths:
      - "templates"
  delegate_to: "{{ some_server }}"
```

The following always fails, regardless of `delegate_to` if file `findme` exists in `<roledir>/templates/extra/`.

```
- name: debugging first_found plugin
  debug: msg="looking for files and found {{ item }}"
  with_first_found:
    - files:
      - "findme"
    - paths:
      - "templates/extra"
```
###### delegate_to breakage

The variable `roledir` is unavailable when using `delegate_to` and file lookups will thus only happen in basedir (the directory where the playbook lives).

https://github.com/ansible/ansible/blob/dee5dba82aa7ae9fb8da9d00df90110f1027e1aa/lib/ansible/plugins/lookup/first_found.py#L186-L197

``` python
                if roledir is not None:
                    # check the templates and vars directories too,if they exist
                    for subdir in ('templates', 'vars', 'files'):
                        path = self._loader.path_dwim_relative(roledir, subdir, fn)
                        if os.path.exists(path):
                            return [path]

                # if none of the above were found, just check the
                # current filename against the current dir
                path = self._loader.path_dwim(fn)
                if os.path.exists(path):
                    return [path]
```

**suggested fix**: It looks like the variable `role_path` is always available, so we can use that instead of `roledir`. See commit 5c86c19
###### `paths` not considered while looking for files

Provided `paths` are always ignored and searches will only happen in `templates`, `vars` and `files` directories under `roledir`.

There seem to be a few issues that cause `total_search` to be incomplete (i.e. not including the provided paths):
- If `pathlist` is set during the first iteration of `terms`, it will be reset to an empty list during any following iterations. Same thing for `filelist`.
- Appending the file path to `total_search` results in an infinite loop while iterating `filelist`, since we're really appending to `filelist`. So we should copy `filelist` using `list()` here. (The infinite loop never hit us because either `filelist` or `pathlist` has always been an empty list.)

**suggested fix**: See commit cd8c0b1
