### PR TITLE
support become_user with Docker's native user management

### DIFF
--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -70,7 +70,7 @@ Run commands in the background, killing the task after 'NUM' seconds.
 *--become-method=*'BECOME_METHOD'::
 
 Privilege escalation method to use (default=sudo),
-valid choices: [ sudo | su | pbrun | pfexec | runas | doas | dzdo ]
+valid choices: [ sudo | su | pbrun | pfexec | runas | doas | dzdo | dockerexec ]
 
 *--become-user=*'BECOME_USER'::
 

--- a/docsite/rst/become.rst
+++ b/docsite/rst/become.rst
@@ -29,7 +29,7 @@ become_user
     set to user with desired privileges, the user you 'become', NOT the user you login as. Does NOT imply `become: yes`, to allow it to be set at host level.
 
 become_method
-    at play or task level overrides the default method set in ansible.cfg, set to 'sudo'/'su'/'pbrun'/'pfexec'/'doas'/'dzdo'
+    at play or task level overrides the default method set in ansible.cfg, set to 'sudo'/'su'/'pbrun'/'pfexec'/'doas'/'dzdo'/'dockerexec'
 
 
 Connection variables
@@ -60,7 +60,7 @@ New command line options
 
 --become-method=BECOME_METHOD
     privilege escalation method to use (default=sudo),
-    valid choices: [ sudo | su | pbrun | pfexec | doas | dzdo ]
+    valid choices: [ sudo | su | pbrun | pfexec | doas | dzdo | dockerexec ]
 
 --become-user=BECOME_USER
     run operations as this user (default=root), does not imply --become/-b

--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -804,7 +804,7 @@ The equivalent of adding sudo: or su: to a play or task, set to true/yes to acti
 become_method
 =============
 
-Set the privilege escalation method. The default is ``sudo``, other options are ``su``, ``pbrun``, ``pfexec``, ``doas``::
+Set the privilege escalation method. The default is ``sudo``, other options are ``su``, ``pbrun``, ``pfexec``, ``doas``, ``dockerexec``::
 
     become_method=su
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -201,9 +201,9 @@ DEFAULT_SUDO_FLAGS        = get_config(p, DEFAULTS, 'sudo_flags', 'ANSIBLE_SUDO_
 DEFAULT_ASK_SUDO_PASS     = get_config(p, DEFAULTS, 'ask_sudo_pass',    'ANSIBLE_ASK_SUDO_PASS',    False, boolean=True)
 
 # Become
-BECOME_ERROR_STRINGS      = {'sudo': 'Sorry, try again.', 'su': 'Authentication failure', 'pbrun': '', 'pfexec': '', 'runas': '', 'doas': 'Permission denied', 'dzdo': ''} #FIXME: deal with i18n
-BECOME_MISSING_STRINGS    = {'sudo': 'sorry, a password is required to run sudo', 'su': '', 'pbrun': '', 'pfexec': '', 'runas': '', 'doas': 'Authorization required', 'dzdo': ''} #FIXME: deal with i18n
-BECOME_METHODS            = ['sudo','su','pbrun','pfexec','runas','doas','dzdo']
+BECOME_ERROR_STRINGS      = {'sudo': 'Sorry, try again.', 'su': 'Authentication failure', 'pbrun': '', 'pfexec': '', 'runas': '', 'doas': 'Permission denied', 'dzdo': '', 'dockerexec': ''} #FIXME: deal with i18n
+BECOME_MISSING_STRINGS    = {'sudo': 'sorry, a password is required to run sudo', 'su': '', 'pbrun': '', 'pfexec': '', 'runas': '', 'doas': 'Authorization required', 'dzdo': '', 'dockerexec': ''} #FIXME: deal with i18n
+BECOME_METHODS            = ['sudo','su','pbrun','pfexec','runas','doas','dzdo','dockerexec']
 BECOME_ALLOW_SAME_USER    = get_config(p, 'privilege_escalation', 'become_allow_same_user', 'ANSIBLE_BECOME_ALLOW_SAME_USER', False, boolean=True)
 DEFAULT_BECOME_METHOD     = get_config(p, 'privilege_escalation', 'become_method', 'ANSIBLE_BECOME_METHOD','sudo' if DEFAULT_SUDO else 'su' if DEFAULT_SU else 'sudo' ).lower()
 DEFAULT_BECOME            = get_config(p, 'privilege_escalation', 'become', 'ANSIBLE_BECOME',False, boolean=True)

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -536,6 +536,10 @@ class PlayContext(Base):
 
                 becomecmd = '%s -u %s %s -c %s' % (exe, self.become_user, executable, success_cmd)
 
+            elif self.become_method == 'dockerexec':
+
+                becomecmd = 'echo %s; %s' % (success_key, cmd)
+
             else:
                 raise AnsibleError("Privilege escalation method not found: %s" % self.become_method)
 

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -59,7 +59,7 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
     '''
 
     has_pipelining = False
-    become_methods = C.BECOME_METHODS
+    become_methods = frozenset(C.BECOME_METHODS)
     # When running over this connection type, prefer modules written in a certain language
     # as discovered by the specified file extension.  An empty string as the
     # language means any language.

--- a/lib/ansible/plugins/connection/accelerate.py
+++ b/lib/ansible/plugins/connection/accelerate.py
@@ -51,7 +51,7 @@ class Connection(ConnectionBase):
 
     transport = 'accelerate'
     has_pipelining = False
-    become_methods = frozenset(C.BECOME_METHODS).difference(['runas'])
+    become_methods = frozenset(C.BECOME_METHODS) - frozenset(('runas', 'dockerexec'))
 
     def __init__(self, *args, **kwargs):
 

--- a/lib/ansible/plugins/connection/chroot.py
+++ b/lib/ansible/plugins/connection/chroot.py
@@ -47,7 +47,7 @@ class Connection(ConnectionBase):
     # su currently has an undiagnosed issue with calculating the file
     # checksums (so copy, for instance, doesn't work right)
     # Have to look into that before re-enabling this
-    become_methods = frozenset(C.BECOME_METHODS).difference(('su',))
+    become_methods = frozenset(C.BECOME_METHODS) - frozenset(('su', 'dockerexec'))
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -157,8 +157,13 @@ class Connection(ConnectionBase):
 
         local_cmd += ['exec']
 
-        if self.remote_user is not None:
-            local_cmd += ['-u', self.remote_user]
+        if self._play_context.become and self._play_context.become_method == 'dockerexec':
+            exec_user = self._play_context.become_user
+        else:
+            exec_user = self.remote_user
+
+        if exec_user is not None:
+            local_cmd += ['-u', exec_user]
 
         # -i is needed to keep stdin open which allows pipelining to work
         local_cmd += ['-i', self._play_context.remote_addr] + cmd

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -53,7 +53,7 @@ class Connection(ConnectionBase):
     # su currently has an undiagnosed issue with calculating the file
     # checksums (so copy, for instance, doesn't work right)
     # Have to look into that before re-enabling this
-    become_methods = frozenset(C.BECOME_METHODS).difference(('su',))
+    become_methods = frozenset(C.BECOME_METHODS) - frozenset(('su',))
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)

--- a/lib/ansible/plugins/connection/libvirt_lxc.py
+++ b/lib/ansible/plugins/connection/libvirt_lxc.py
@@ -47,7 +47,7 @@ class Connection(ConnectionBase):
     # su currently has an undiagnosed issue with calculating the file
     # checksums (so copy, for instance, doesn't work right)
     # Have to look into that before re-enabling this
-    become_methods = frozenset(C.BECOME_METHODS).difference(('su',))
+    become_methods = frozenset(C.BECOME_METHODS) - frozenset(('su', 'dockerexec'))
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -45,6 +45,7 @@ class Connection(ConnectionBase):
 
     transport = 'local'
     has_pipelining = True
+    become_methods = frozenset(C.BECOME_METHODS) - frozenset(('dockerexec',))
 
     def _connect(self):
         ''' connect to the local host; nothing to do here '''

--- a/lib/ansible/plugins/connection/lxd.py
+++ b/lib/ansible/plugins/connection/lxd.py
@@ -22,6 +22,8 @@ import os
 from distutils.spawn import find_executable
 from subprocess import call, Popen, PIPE
 
+import ansible.constants as C
+
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.unicode import to_bytes, to_unicode
@@ -32,6 +34,7 @@ class Connection(ConnectionBase):
 
     transport = "lxd"
     has_pipelining = True
+    become_methods = frozenset(C.BECOME_METHODS) - frozenset(('dockerexec',))
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -127,6 +127,7 @@ class Connection(ConnectionBase):
     ''' SSH based connections with Paramiko '''
 
     transport = 'paramiko'
+    become_methods = frozenset(C.BECOME_METHODS) - frozenset(('runas', 'dockerexec'))
 
     def _cache_key(self):
         return "%s__%s__" % (self._play_context.remote_addr, self._play_context.remote_user)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -48,7 +48,7 @@ class Connection(ConnectionBase):
 
     transport = 'ssh'
     has_pipelining = True
-    become_methods = frozenset(C.BECOME_METHODS).difference(['runas'])
+    become_methods = frozenset(C.BECOME_METHODS) - frozenset(('runas', 'dockerexec'))
 
     def __init__(self, *args, **kwargs):
         super(Connection, self).__init__(*args, **kwargs)

--- a/lib/ansible/plugins/connection/zone.py
+++ b/lib/ansible/plugins/connection/zone.py
@@ -45,7 +45,7 @@ class Connection(ConnectionBase):
 
     transport = 'zone'
     has_pipelining = True
-    become_methods = frozenset(C.BECOME_METHODS).difference(('su',))
+    become_methods = frozenset(C.BECOME_METHODS) - frozenset(('su', 'dockerexec'))
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -164,6 +164,10 @@ class TestPlayContext(unittest.TestCase):
         cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
         self.assertEqual(cmd, """%s %s echo %s && %s %s env ANSIBLE=true %s""" % (doas_exe, doas_flags, play_context.success_key, doas_exe, doas_flags, default_cmd))
 
+        play_context.become_method = 'dockerexec'
+        cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
+        self.assertEqual(cmd, """echo %s; %s""" % (play_context.success_key, default_cmd))
+
         play_context.become_method = 'bad'
         self.assertRaises(AnsibleError, play_context.make_become_cmd, cmd=default_cmd, executable="/bin/bash")
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

ansible@devel
##### SUMMARY

This is basically an implementation of @ThomasSteinbach's suggestion in [#13424](https://github.com/ansible/ansible/pull/13424#issuecomment-163461619), where the use of `become_user` with `docker` connection has been considered, but eventually not implemented.
This PR introduces a new `become_method` named `dockerexec` that calls into the docker container with the configured `become_user` using Docker's own user (switching) management.

The main advantage is that Docker containers don't have to be prepared for another `become_method` like `sudo`. One could argue that using `remote_user` might be sufficient for the Docker container use case, but unfortunately if you want to use the very same Ansible playbook/role with other non-docker hosts then it is not.

Please let me know if something is missing, or if there's even an easier way to get this implemented.
