### PR TITLE
Stop utils.role_yaml_parse modifying content of its arg

### DIFF
--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -426,6 +426,7 @@ def role_spec_parse(role_spec):
 
 
 def role_yaml_parse(role):
+    role = role.copy()
     if 'role' in role:
         # Old style: {role: "galaxy.role,version,name", other_vars: "here" }
         role_info = role_spec_parse(role['role'])


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 1.9.6
  configured module search path = None
```
##### SUMMARY

Fixes #15464

Although any caller of the function probably doesn't expect it, the
function modifies a dict that is passed as its arg to hold key-values
of role specs (name, version, src and scm).

In the issue #15464, the function is called at Play#_get_role_path [1]
and the behavior described above causes role vars are contaminated by
the role specs.

This patch addresses the issue by making the function keep its
original arg unchanged. It first copies content of the passed dict
and the remaining of the function goes on the copy.

[1] https://github.com/ansible/ansible/blob/3509e9cdd4a087e3243f505569f23e01612e7095/lib/ansible/playbook/play.py#L216-L220
