### PR TITLE
Quite a few individually minor changes to ziploader

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -35,6 +35,7 @@ import os
 import subprocess
 import sys
 import traceback
+import shutil
 
 import ansible.utils.vars as utils_vars
 from ansible.parsing.dataloader import DataLoader
@@ -141,18 +142,43 @@ def boilerplate_module(modfile, args, interpreter, check, destfile):
         task_vars=task_vars
     )
 
+    if module_style == 'new' and 'ZIPLOADER_WRAPPER = True' in module_data:
+        module_style = 'ziploader'
+
     modfile2_path = os.path.expanduser(destfile)
     print("* including generated source, if any, saving to: %s" % modfile2_path)
-    print("* this may offset any line numbers in tracebacks/debuggers!")
+    if module_style not in ('ziploader', 'old'):
+        print("* this may offset any line numbers in tracebacks/debuggers!")
     modfile2 = open(modfile2_path, 'w')
     modfile2.write(module_data)
     modfile2.close()
     modfile = modfile2_path
 
-    return (modfile2_path, module_style)
+    return (modfile2_path, modname, module_style)
 
-def runtest( modfile, argspath):
+def ziploader_setup(modfile, modname):
+    os.system("chmod +x %s" % modfile)
+
+    cmd = subprocess.Popen([modfile, 'explode'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = cmd.communicate()
+    lines = out.splitlines()
+    if len(lines) != 2 or 'Module expanded into' not in lines[0]:
+        print("*" * 35)
+        print("INVALID OUTPUT FROM ZIPLOADER MODULE WRAPPER")
+        print(out)
+        sys.exit(1)
+    debug_dir = lines[1].strip()
+
+    argsfile = os.path.join(debug_dir, 'args')
+    modfile = os.path.join(debug_dir, 'ansible_module_%s.py' % modname)
+
+    print("* ziploader module detected; extracted module source to: %s" % debug_dir)
+    return modfile, argsfile
+
+def runtest(modstyle, modfile, argspath, modname, module_style):
     """Test run a module, piping it's output for reporting."""
+    if module_style == 'ziploader':
+        modfile, argspath = ziploader_setup(modfile, modname)
 
     os.system("chmod +x %s" % modfile)
 
@@ -164,24 +190,27 @@ def runtest( modfile, argspath):
     (out, err) = cmd.communicate()
 
     try:
-        print("***********************************")
+        print("*" * 35)
         print("RAW OUTPUT")
         print(out)
         print(err)
         results = json.loads(out)
     except:
-        print("***********************************")
+        print("*" * 35)
         print("INVALID OUTPUT FORMAT")
         print(out)
         traceback.print_exc()
         sys.exit(1)
 
-    print("***********************************")
+    print("*" * 35)
     print("PARSED OUTPUT")
     print(jsonify(results,format=True))
 
-def rundebug(debugger, modfile, argspath):
+def rundebug(debugger, modfile, argspath, modname, module_style):
     """Run interactively with console debugger."""
+
+    if module_style == 'ziploader':
+        modfile, argspath = ziploader_setup(modfile, modname)
 
     if argspath is not None:
         subprocess.call("%s %s %s" % (debugger, modfile, argspath), shell=True)
@@ -191,10 +220,10 @@ def rundebug(debugger, modfile, argspath):
 def main():
 
     options, args = parse()
-    (modfile, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter, options.check, options.filename)
+    (modfile, modname, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter, options.check, options.filename)
 
     argspath = None
-    if module_style != 'new':
+    if module_style not in ('new', 'ziploader'):
         if module_style == 'non_native_want_json':
             argspath = write_argsfile(options.module_args, json=True)
         elif module_style == 'old':
@@ -203,10 +232,13 @@ def main():
             raise Exception("internal error, unexpected module style: %s" % module_style)
     if options.execute:
         if options.debugger:
-            rundebug(options.debugger, modfile, argspath)
+            rundebug(options.debugger, modfile, argspath, modname, module_style)
         else:
-            runtest(modfile, argspath)
+            runtest(modfile, argspath, modname, module_style)
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    finally:
+        shutil.rmtree(C.DEFAULT_LOCAL_TMP, True)
 

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -60,6 +60,7 @@ _SNIPPET_PATH = os.path.join(os.path.dirname(__file__), '..', 'module_utils')
 
 ZIPLOADER_TEMPLATE = u'''%(shebang)s
 %(coding)s
+ZIPLOADER_WRAPPER = True # For test-module script to tell this is a ZIPLOADER_WRAPPER
 # This code is part of Ansible, but is an independent component.
 # The code in this particular templatable string, and this templatable string
 # only, is BSD licensed.  Modules which end up using this snippet, which is

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -197,7 +197,7 @@ def debug(command, zipped_mod, json_params):
         f.close()
 
         print('Module expanded into:')
-        print('%%s' %% os.path.join(basedir, 'ansible'))
+        print('%%s' %% basedir)
         exitcode = 0
 
     elif command == 'execute':

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -134,12 +134,36 @@ def invoke_module(module, modlib_path, json_params):
 
 def debug(command, zipped_mod, json_params):
     # The code here normally doesn't run.  It's only used for debugging on the
-    # remote machine. Run with ANSIBLE_KEEP_REMOTE_FILES=1 envvar and -vvv
-    # to save the module file remotely.  Login to the remote machine and use
-    # /path/to/module explode to extract the ZIPDATA payload into source
-    # files.  Edit the source files to instrument the code or experiment with
-    # different values.  Then use /path/to/module execute to run the extracted
-    # files you've edited instead of the actual zipped module.
+    # remote machine.
+    #
+    # The subcommands in this function make it easier to debug ziploader
+    # modules.  Here's the basic steps:
+    #
+    # Run ansible with the environment variable: ANSIBLE_KEEP_REMOTE_FILES=1 and -vvv
+    # to save the module file remotely::
+    #   $ ANSIBLE_KEEP_REMOTE_FILES=1 ansible host1 -m ping -a 'data=october' -vvv
+    #
+    # Part of the verbose output will tell you where on the remote machine the
+    # module was written to::
+    #   [...]
+    #   <host1> SSH: EXEC ssh -C -q -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o
+    #   PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o
+    #   ControlPath=/home/badger/.ansible/cp/ansible-ssh-%%h-%%p-%%r -tt rhel7 '/bin/sh -c '"'"'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+    #   LC_MESSAGES=en_US.UTF-8 /usr/bin/python /home/badger/.ansible/tmp/ansible-tmp-1461173013.93-9076457629738/ping'"'"''
+    #   [...]
+    #
+    # Login to the remote machine and run the module file via from the previous
+    # step with the explode subcommand to extract the module payload into
+    # source files::
+    #   $ ssh host1
+    #   $ /usr/bin/python /home/badger/.ansible/tmp/ansible-tmp-1461173013.93-9076457629738/ping explode
+    #   Module expanded into:
+    #   /home/badger/.ansible/tmp/ansible-tmp-1461173408.08-279692652635227/ansible
+    #
+    # You can now edit the source files to instrument the code or experiment with
+    # different parameter values.  When you're ready to run the code you've modified
+    # (instead of the code from the actual zipped module), use the execute subcommand like this::
+    #   $ /usr/bin/python /home/badger/.ansible/tmp/ansible-tmp-1461173013.93-9076457629738/ping execute
 
     # Okay to use __file__ here because we're running from a kept file
     basedir = os.path.abspath(os.path.dirname(__file__))
@@ -225,6 +249,10 @@ def debug(command, zipped_mod, json_params):
     return exitcode
 
 if __name__ == '__main__':
+    #
+    # See comments in the debug() method for information on debugging
+    #
+
     ZIPLOADER_PARAMS = %(params)s
     if PY3:
         ZIPLOADER_PARAMS = ZIPLOADER_PARAMS.encode('utf-8')
@@ -251,6 +279,24 @@ if __name__ == '__main__':
             pass
     sys.exit(exitcode)
 '''
+
+def _strip_comments(source):
+    # Strip comments and blank lines from the wrapper
+    buf = []
+    for line in source.splitlines():
+        l = line.strip()
+        if not l or l.startswith(u'#'):
+            continue
+        buf.append(line)
+    return u'\n'.join(buf)
+
+if C.DEFAULT_KEEP_REMOTE_FILES:
+    # Keep comments when KEEP_REMOTE_FILES is set.  That way users will see
+    # the comments with some nice usage instructions
+    ACTIVE_ZIPLOADER_TEMPLATE = ZIPLOADER_TEMPLATE
+else:
+    # ZIPLOADER_TEMPLATE stripped of comments for smaller over the wire size
+    ACTIVE_ZIPLOADER_TEMPLATE = _strip_comments(ZIPLOADER_TEMPLATE)
 
 class ModuleDepFinder(ast.NodeVisitor):
     # Caveats:
@@ -300,19 +346,6 @@ class ModuleDepFinder(ast.NodeVisitor):
                     self.submodules.add((alias.name,))
         self.generic_visit(node)
 
-
-def _strip_comments(source):
-    # Strip comments and blank lines from the wrapper
-    buf = []
-    for line in source.splitlines():
-        l = line.strip()
-        if not l or l.startswith(u'#'):
-            continue
-        buf.append(line)
-    return u'\n'.join(buf)
-
-# ZIPLOADER_TEMPLATE stripped of comments for smaller over the wire size
-STRIPPED_ZIPLOADER_TEMPLATE = _strip_comments(ZIPLOADER_TEMPLATE)
 
 def _slurp(path):
     if not os.path.exists(path):
@@ -555,10 +588,11 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
                     raise AnsibleError('A different worker process failed to create module file.  Look at traceback for that process for debugging information.')
                 # Fool the check later... I think we should just remove the check
                 py_module_names.add(('basic',))
+
         shebang, interpreter = _get_shebang(u'/usr/bin/python', task_vars)
         if shebang is None:
             shebang = u'#!/usr/bin/python'
-        output.write(to_bytes(STRIPPED_ZIPLOADER_TEMPLATE % dict(
+        output.write(to_bytes(ACTIVE_ZIPLOADER_TEMPLATE % dict(
             zipdata=zipdata,
             ansible_module=module_name,
             params=python_repred_params,

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -45,6 +45,7 @@ class TestAnsibleModuleExitJson(unittest.TestCase):
         self.stdout_swap_ctx = swap_stdout()
         self.fake_stream = self.stdout_swap_ctx.__enter__()
 
+        reload(basic)
         self.module = basic.AnsibleModule(argument_spec=dict())
 
     def tearDown(self):
@@ -125,6 +126,7 @@ class TestAnsibleModuleExitValuesRemoved(unittest.TestCase):
             params = json.dumps(params)
 
             with swap_stdin_and_argv(stdin_data=params):
+                reload(basic)
                 with swap_stdout():
                     module = basic.AnsibleModule(
                         argument_spec = dict(
@@ -146,6 +148,7 @@ class TestAnsibleModuleExitValuesRemoved(unittest.TestCase):
             params = dict(ANSIBLE_MODULE_ARGS=args, ANSIBLE_MODULE_CONSTANTS={})
             params = json.dumps(params)
             with swap_stdin_and_argv(stdin_data=params):
+                reload(basic)
                 with swap_stdout():
                     module = basic.AnsibleModule(
                         argument_spec = dict(

--- a/test/units/module_utils/basic/test_log.py
+++ b/test/units/module_utils/basic/test_log.py
@@ -49,6 +49,7 @@ class TestAnsibleModuleSysLogSmokeTest(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
+        reload(basic)
         self.am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -85,6 +86,7 @@ class TestAnsibleModuleJournaldSmokeTest(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
+        reload(basic)
         self.am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -132,6 +134,7 @@ class TestAnsibleModuleLogSyslog(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
+        reload(basic)
         self.am = basic.AnsibleModule(
             argument_spec = dict(),
         )
@@ -192,6 +195,7 @@ class TestAnsibleModuleLogJournal(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
+        reload(basic)
         self.am = basic.AnsibleModule(
             argument_spec = dict(),
         )

--- a/test/units/module_utils/basic/test_run_command.py
+++ b/test/units/module_utils/basic/test_run_command.py
@@ -67,6 +67,7 @@ class TestAnsibleModuleRunCommand(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
+        reload(basic)
         self.module = AnsibleModule(argument_spec=dict())
         self.module.fail_json = MagicMock(side_effect=SystemExit)
 

--- a/test/units/module_utils/basic/test_safe_eval.py
+++ b/test/units/module_utils/basic/test_safe_eval.py
@@ -26,6 +26,12 @@ import json
 from ansible.compat.tests import unittest
 from units.mock.procenv import swap_stdin_and_argv
 
+try:
+    from importlib import reload
+except:
+    # Py2 has reload as a builtin
+    pass
+
 class TestAnsibleModuleExitJson(unittest.TestCase):
 
     def test_module_utils_basic_safe_eval(self):
@@ -34,6 +40,7 @@ class TestAnsibleModuleExitJson(unittest.TestCase):
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
 
         with swap_stdin_and_argv(stdin_data=args):
+            reload(basic)
             am = basic.AnsibleModule(
                 argument_spec=dict(),
             )

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -31,6 +31,12 @@ try:
 except ImportError:
     import __builtin__ as builtins
 
+try:
+    from importlib import reload
+except:
+    # Py2 has reload as a builtin
+    pass
+
 from units.mock.procenv import swap_stdin_and_argv
 
 from ansible.compat.tests import unittest
@@ -291,6 +297,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS={"foo": "hello"}, ANSIBLE_MODULE_CONSTANTS={}))
 
         with swap_stdin_and_argv(stdin_data=args):
+            reload(basic)
             am = basic.AnsibleModule(
                 argument_spec = arg_spec,
                 mutually_exclusive = mut_ex,
@@ -307,6 +314,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
 
         with swap_stdin_and_argv(stdin_data=args):
+            reload(basic)
             self.assertRaises(
                 SystemExit,
                 basic.AnsibleModule,
@@ -353,6 +361,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_load_file_common_arguments(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -401,6 +410,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_selinux_mls_enabled(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -420,6 +430,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_selinux_initial_context(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -433,6 +444,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_selinux_enabled(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -464,6 +476,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_selinux_default_context(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -499,6 +512,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_selinux_context(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -540,6 +554,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_is_special_selinux_path(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={"SELINUX_SPECIAL_FS": "nfs,nfsd,foos"}))
 
@@ -584,6 +599,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_to_filesystem_str(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -608,6 +624,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_find_mount_point(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -631,18 +648,19 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_set_context_if_different(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
         )
 
-        basic.HAS_SELINUX = False
+        basic.HAVE_SELINUX = False
 
         am.selinux_enabled = MagicMock(return_value=False)
         self.assertEqual(am.set_context_if_different('/path/to/file', ['foo_u', 'foo_r', 'foo_t', 's0'], True), True)
         self.assertEqual(am.set_context_if_different('/path/to/file', ['foo_u', 'foo_r', 'foo_t', 's0'], False), False)
 
-        basic.HAS_SELINUX = True
+        basic.HAVE_SELINUX = True
 
         am.selinux_enabled = MagicMock(return_value=True)
         am.selinux_context = MagicMock(return_value=['bar_u', 'bar_r', None, None])
@@ -675,6 +693,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_set_owner_if_different(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -713,6 +732,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_set_group_if_different(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -751,6 +771,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_set_mode_if_different(self):
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -838,6 +859,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
         ):
 
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -1015,6 +1037,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module__symbolic_mode_to_octal(self):
 
         from ansible.module_utils import basic
+        reload(basic)
 
         am = basic.AnsibleModule(
             argument_spec = dict(),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY
- Get hacking/test-module's debug switch to do something useful.  This change makes test-module extract the module from the ziploader wrapper and then invoke the module (old behaviour was to invoke the wrapper instead.)  This allows running pdb on the actual module code instead of running it on the wrapper's code.
- Add new documentation on how to debug ziploader modules
- Push the wrapper's debug files into a subdirectory as we now have several different file and shouldn't be polluting the filesystem.
- Add debug usage to the comments of the wrapper and do not strip comments from the wrapper when ANSIBLE_KEEP_REMOTE_FILES=1
- Allow AnsibleModules to be instantiated more than once in a process's lifetime.  The problem was that we only pass the arguments on stdin once but each time `__init__` was run it tried to read them fro stdin.  The new code reads from stdin the first time and then saves the information in a global variable.
- Update Program Flow docs for the changes in ziploader
