### PR TITLE
adds config_format to junos shared module

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -249,9 +249,13 @@ class Netconf(object):
             self.device.facts_refresh()
         return self.device.facts
 
-    def get_config(self):
-        ele = self.rpc('get_configuration', format='text')
-        return str(ele.text).strip()
+    def get_config(self, config_format="text"):
+        ele = self.rpc('get_configuration', format=config_format)
+
+        if config_format == "text" or config_format == "set":
+           return str(ele.text).strip()
+        elif config_format == "xml":
+            return ele
 
     def rpc(self, name, format='xml', **kwargs):
         meth = getattr(self.device.rpc, name)
@@ -337,4 +341,3 @@ def get_module(**kwargs):
 
     module.connect()
     return module
-

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -250,9 +250,12 @@ class Netconf(object):
         return self.device.facts
 
     def get_config(self, config_format="text"):
-        ele = self.rpc('get_configuration', format=config_format)
+        if config_format not in ['text', 'set', 'xml']:
+            msg = 'invalid config format... must be one of xml, text, set'
+            self._fail(msg=msg)
 
-        if config_format == "text" or config_format == "set":
+        ele = self.rpc('get_configuration', format=config_format)
+        if config_format in ['text', 'set']:
            return str(ele.text).strip()
         elif config_format == "xml":
             return ele


### PR DESCRIPTION
adds the option to specify the return format of the junos configuration file when called using the get_config method
