### PR TITLE
updates action plugin junos_template to guess file format

### DIFF
--- a/lib/ansible/plugins/action/junos_template.py
+++ b/lib/ansible/plugins/action/junos_template.py
@@ -23,6 +23,22 @@ from ansible.plugins.action import ActionBase
 from ansible.plugins.action.net_template import ActionModule as NetActionModule
 
 class ActionModule(NetActionModule, ActionBase):
-    pass
 
+    def run(self, tmp=None, task_vars=None):
+        src = self._task.args.get('src')
+
+        if self._task.args.get('config_format') is None:
+            if src.endswith('.xml'):
+                fmt = 'xml'
+            elif src.endswith('.set'):
+                fmt = 'set'
+            else:
+                fmt = 'text'
+
+            self._task.args['config_format'] = fmt
+
+        if self._task.args.get('comment') is None:
+            self._task.args['comment'] = self._task.name
+
+        return super(ActionModule, self).run(tmp, task_vars)
 


### PR DESCRIPTION
This update will attempt to guess the file format based on the template
extension if the format argument isnt set.  It will also set the commit
comment to the task name if the comment isnt' explicitly defined.
