### PR TITLE
win_regedit integration test to cover change to allow empty string comparison

### DIFF
--- a/test/integration/roles/test_win_regedit/tasks/main.yml
+++ b/test/integration/roles/test_win_regedit/tasks/main.yml
@@ -349,11 +349,35 @@
     that:
       - "check56_result.changed == true"
 
+# test empty data value (some things depend on this, having no data is not equivalent)
+
+- name: set an empty data value
+  win_regedit:
+    key: HKCU:\Software\Cow Corp
+    value: helloempty
+    data: ""
+  register: check61_result
+
+- assert:
+    that:
+      - "check61_result.changed == true"
+
+- name: set an empty data value again (should not change)
+  win_regedit:
+    key: HKCU:\Software\Cow Corp
+    value: helloempty
+    data: ""
+  register: check62_result
+
+- assert:
+    that:
+      - "check62_result.changed == false"
 # tear down
 
 - name: remove registry key used for testing
   win_regedit:
     key: 'HKCU:\SOFTWARE\Cow Corp'
     state: absent
+
 
 # END OF win_regedit tests


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel ba74f5f3e5) last updated 2016/04/20 23:46:56 (GMT +100)
  lib/ansible/modules/core: (devel 36755e5fe2) last updated 2016/04/24 16:06:03 (GMT +100)
  lib/ansible/modules/extras: (devel de22b721db) last updated 2016/04/24 16:03:40 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Add integration test to ensure empty strings, which are legitimate registry data entry values to be compared.

See the conversation on https://github.com/ansible/ansible-modules-extras/pull/2034 for background.

Test covers the fix in https://github.com/ansible/ansible-modules-extras/commit/7d9b73ec5ab987f2b16da67a3a2abb25f9792443 (which was accidentally pushed straight to devel instead of via a PR 

```
n/a only affects integration test output for make test_winrm -t test_win_regedit
```
