### PR TITLE
playbook, include: fix Unexpected Exception: 'NoneType' object has no…

### DIFF
--- a/lib/ansible/playbook/playbook_include.py
+++ b/lib/ansible/playbook/playbook_include.py
@@ -135,6 +135,9 @@ class PlaybookInclude(Base, Conditional, Taggable):
         Splits the include line up into filename and parameters
         '''
 
+        if v is None:
+           raise AnsibleParserError("include parameter is missing", obj=ds)
+
         # The include line must include at least one item, which is the filename
         # to include. Anything after that should be regarded as a parameter to the include
         items = split_args(v)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.0.2
2.1
```
##### SUMMARY

If `include:` statement is used without argument, we get a traceback.

```
 $ cat playbooks/site.yml 

---
- include: setup.yml
- include: infra.yml
- include: platform.yml
- include:
```

Before:

```
ERROR! Unexpected Exception: 'NoneType' object has no attribute 'strip'
the full traceback was:

Traceback (most recent call last):
  File "/home/resmo/Projects/resmo/ansible/bin/ansible-playbook", line 92, in <module>
    exit_code = cli.run()
  File "/home/resmo/Projects/resmo/ansible/lib/ansible/cli/playbook.py", line 154, in run
    results = pbex.run()
  File "/home/resmo/Projects/resmo/ansible/lib/ansible/executor/playbook_executor.py", line 72, in run
    pb = Playbook.load(playbook_path, variable_manager=self._variable_manager, loader=self._loader)
  File "/home/resmo/Projects/resmo/ansible/lib/ansible/playbook/__init__.py", line 53, in load
    pb._load_playbook_data(file_name=file_name, variable_manager=variable_manager)
  File "/home/resmo/Projects/resmo/ansible/lib/ansible/playbook/__init__.py", line 87, in _load_playbook_data
    pb = PlaybookInclude.load(entry, basedir=self._basedir, variable_manager=variable_manager, loader=self._loader)
  File "/home/resmo/Projects/resmo/ansible/lib/ansible/playbook/playbook_include.py", line 42, in load
    return PlaybookInclude().load_data(ds=data, basedir=basedir, variable_manager=variable_manager, loader=loader)
  File "/home/resmo/Projects/resmo/ansible/lib/ansible/playbook/playbook_include.py", line 56, in load_data
    new_obj = super(PlaybookInclude, self).load_data(ds, variable_manager, loader)
  File "/home/resmo/Projects/resmo/ansible/lib/ansible/playbook/base.py", line 195, in load_data
    ds = self.preprocess_data(ds)
  File "/home/resmo/Projects/resmo/ansible/lib/ansible/playbook/playbook_include.py", line 123, in preprocess_data
    self._preprocess_include(ds, new_ds, k, v)
  File "/home/resmo/Projects/resmo/ansible/lib/ansible/playbook/playbook_include.py", line 143, in _preprocess_include
    items = split_args(v)
  File "/home/resmo/Projects/resmo/ansible/lib/ansible/parsing/splitter.py", line 156, in split_args
    args = args.strip()

```

After:

```
ERROR! include parameter is missing

The error appears to have been in '/home/resmo/Projects/swisstxt/swisstxt-mesos/playbooks/site.yml': line 5, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

- include: platform.yml
- include:
  ^ here
```
