### PR TITLE
Fix substituting dots for underscores when using ips

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -668,8 +668,8 @@ class Ec2Inventory(object):
         # If we can't get a nice hostname, use the destination address
         if not hostname:
             hostname = dest
-
-        hostname = self.to_safe(hostname).lower()
+        else:
+            hostname = self.to_safe(hostname).lower()
 
         # if we only want to include hosts that match a pattern, skip those that don't
         if self.pattern_include and not self.pattern_include.match(hostname):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

ec2.py was substituting the dots on ip addresses inside the groups when not using hostnames like:
  "ec2": [
    "10_10_1_1", 
...
now it's:
  "ec2": [
    "10.10.1.1",
...
