### PR TITLE
Convert byte strings to unicode strings in our task results

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -26,7 +26,7 @@ import sys
 import time
 import traceback
 
-from ansible.compat.six import iteritems, string_types
+from ansible.compat.six import iteritems, string_types, binary_type
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleConnectionFailure
@@ -137,6 +137,8 @@ class TaskExecutor:
                         res[idx] = _clean_res(item)
                 elif isinstance(res, UnsafeProxy):
                     return res._obj
+                elif isinstance(res, binary_type):
+                    return to_unicode(res, errors='strict')
                 return res
 
             display.debug("dumping result to json")


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

byte strings received from the worker process's results weren't being transformed into a text type when they came back to the main process.  This could lead to problems later (in this case, in a callback) where code assumes everything is a text type unless specifically working with byte strings.

Fixes #15367
