### PR TITLE
Fix non-200 responses with json content.

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -897,11 +897,10 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     except (ConnectionError, ValueError), e:
         module.fail_json(msg=str(e))
     except urllib2.HTTPError, e:
-        try:
-            body = e.read()
-        except AttributeError:
-            body = ''
-        info.update(dict(msg=str(e), status=e.code, body=body, **e.info()))
+        info.update(dict(msg=str(e), status=e.code, **e.info()))
+        # urllib.HTTPError can be treated as a Response, so
+        # use it for the response object as well.
+        r = e
     except urllib2.URLError, e:
         code = int(getattr(e, 'code', -1))
         info.update(dict(msg="Request failed: %s" % str(e), status=code))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

ansible 2.1.0 (http_error_non_200_json 33a2564d03) last updated 2016/04/25 14:57:32 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 804a8e6378) last updated 2016/04/25 15:02:08 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 3031105e78) last updated 2016/04/25 14:57:42 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Further fix for https://github.com/ansible/ansible/issues/15555

With the first fix for that, the 'resp' from fetch_url would be None, which would
cause some of the response handling to be skipped. This included things like setting the 
'json' attribute.

On HTTPError in fetch_url, return the HTTPError
itself as the 'resp', as well as updating the
'info' member of the response tuple.

fixes #15555
