### PR TITLE
Fix python 2.4 checks for modules

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -426,7 +426,7 @@ class AnsibleDockerClient(Client):
         '''
         try:
             response = self.images(name=name)
-        except Exception as exc:
+        except Exception, exc:
             self.fail("Error searching for image %s - %s" % (name, str(exc)))
         images = response
         if tag: 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 826190e02e) last updated 2016/04/26 17:29:36 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD 4549ea5e85) last updated 2016/04/26 13:27:28 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD 86f08bfcda) last updated 2016/04/26 13:27:28 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY
#15586 introduced a python 2.4 error causing all subsequent builds to fail.

Using `except Exception as e` fails with python 2.4, which
all modules (and thus common module code) is expected to support.

This should fix broken builds
