### PR TITLE
Ignore failures in Python 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
     - env: TARGET=sanity TOXENV=py35
       python: 3.5
     - env: TARGET=sanity TOXENV=py24
+  allow_failures:
+    - env: TARGET=sanity TOXENV=py24
 addons:
   apt:
     sources:


### PR DESCRIPTION
I feel like this could be removed as it always fails. As I
understand 2.4 isn't supported, so, ignoring it makes the
feedback to GitHub clearer.
