### PR TITLE
doc fix for delegate_to / ansible_host (issue #15546)

### DIFF
--- a/docsite/rst/playbooks_delegation.rst
+++ b/docsite/rst/playbooks_delegation.rst
@@ -130,6 +130,8 @@ Here is an example::
 Note that you must have passphrase-less SSH keys or an ssh-agent configured for this to work, otherwise rsync
 will need to ask for a passphrase.
 
+The `ansible_host` variable (`ansible_ssh_host` in 1.x) reflects the host a task is delegated to.
+
 .. _delegate_facts:
 
 Delegated facts

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -668,8 +668,6 @@ period, without the rest of the domain.
 
 ``play_hosts`` is available as a list of hostnames that are in scope for the current play. This may be useful for filling out templates with multiple hostnames or for injecting the list into the rules for a load balancer.
 
-``delegate_to`` is the inventory hostname of the host that the current task has been delegated to using ``delegate_to`` keyword.
-
 Don't worry about any of this unless you think you need it.  You'll know when you do.
 
 Also available, ``inventory_dir`` is the pathname of the directory holding Ansible's inventory host file, ``inventory_file`` is the pathname and the filename pointing to the Ansible's inventory host file.


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 008bde91a8) last updated 2016/04/26 17:40:38 (GMT +300)
  lib/ansible/modules/core: (detached HEAD 11892d5f8a) last updated 2016/04/26 17:42:19 (GMT +300)
  lib/ansible/modules/extras: (detached HEAD 470460acfc) last updated 2016/04/26 17:42:20 (GMT +300)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Proposed documentation fix as discussed in #15546.
