### PR TITLE
fix mail when cc and bcc are used if None

### DIFF
--- a/lib/ansible/plugins/callback/mail.py
+++ b/lib/ansible/plugins/callback/mail.py
@@ -56,9 +56,9 @@ def mail(subject='Ansible error mail', sender=None, to=None, cc=None, bcc=None, 
     b_content += b_body
 
     b_addresses = b_to.split(b',')
-    if b_cc:
+    if cc:
         b_addresses += b_cc.split(b',')
-    if b_bcc:
+    if bcc:
         b_addresses += b_bcc.split(b',')
 
     for b_address in b_addresses:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = /home/simon/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

fixes #15607 
In `./lib/ansible/plugins/callback/mail.py`, `cc` and `bcc` have default values of `None`, which are blindly copied to strings and then added to the recipient list of the email.

```
b_cc = to_bytes(cc)
b_bcc = to_bytes(bcc)
...
if b_cc:
    b_addresses += b_cc.split(b',')
if b_bcc:
    b_addresses += b_bcc.split(b',')
```

The two `if` statements are always true, because `b_cc` and `b_bcc` are both `"None"` `<type 'str'>` instead of `None` `<type 'NoneType'>`

This commit changes the two `if` statements to check against `NoneType`, not `"None"`
