### PR TITLE
Improve grammar for 'Setting any var or directive makes no implications' note

### DIFF
--- a/docsite/rst/become.rst
+++ b/docsite/rst/become.rst
@@ -15,7 +15,7 @@ privilege escalation tools, which you probably already use or have configured, l
     and execute tasks, create resources with the 2nd user's permissions. As of 1.9 `become` supersedes the old sudo/su, while still being backwards compatible.
     This new system also makes it easier to add other privilege escalation tools like `pbrun` (Powerbroker), `pfexec`, `dzdo` (Centrify), and others.
 
-.. note:: Setting any var or directive makes no implications on the values of the other related directives, i.e. setting become_user does not set become.
+.. note:: Become vars & directives are independent, i.e. setting `become_user` does not set `become`.
 
 
 Directives


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /home/duncan/dev/tools/cluster_provisioning/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

'makes no implications on the values of the other' is, really, just a clumsy and verbose way of saying 'independent'.
