### PR TITLE
Update and fix typos in docker inventory docstrings.

### DIFF
--- a/contrib/inventory/docker.yml
+++ b/contrib/inventory/docker.yml
@@ -1,52 +1,65 @@
 # This is the configuration file for the Docker inventory script: docker_inventory.py.
 #
-# defaults: Defines a default connnection. Defaults will be taken from this and applied to any values not provided 
-#           for a host defined in the hosts list.
+# You can define the following in this file:
 #
-# hosts: If you wish to get inventory from more than one Docker daemon hosts, define a hosts list.
-# 
-# For a host defined in defaults or hosts, you can provided the following attributes. The only required attribute is host.
+#   defaults
+#        Defines a default connection. Defaults will be taken from this and applied to any values not provided
+#        for a host defined in the hosts list.
 #
-#   host:
-#       description: The URL or Unix socket path for the host. 
-#       required: yes
-#   tls:
-#      description: Connect using https://
-#      default: false
-#      required: false
-#   tls_verify:
-#      description: Connect using https:// and verify the host name matches the host name found in the certificate.
-#      default: false
-#      required: false
-#   cert_path:
-#      description: Path to the client's certificate .pem file.
-#      default: null
-#      required: false
-#   cacert_path:
-#      description: Path to the client's Certificate Authority .pem file.
-#      default: null
-#      required: false
-#   key_path:
-#      description: Path to the client's encryption key .pem file
-#      default: null
-#      required: false
-#   version:
-#      description: The API version the client will use.
-#      required: false
-#      default: will be supplied by the docker-py module.
-#   timeout:
-#      description: The amount of time in seconds to wait on an API response. 
-#      required: false
-#      default: will be supplied by the docker-py module.
-#   default_ip:
-#      description: The IP address to assign to ansilbe_host when the container's SSH port is mappped to 0.0.0.0
-#      required: false
-#      default: 1267.0.0.1
-#   private_ssh_port:
-#      description: The port containers use for SSH
-#      required: false
-#      default: 22
-#   
+#    hosts
+#        If you wish to get inventory from more than one Docker host, define a hosts list.
+#
+# For the default host and each host in the hosts list define the following attributes:
+#
+#  host:
+#      description: The URL or Unix socket path used to connect to the Docker API.
+#      required: yes
+#
+#  tls:
+#     description: Connect using TLS without verifying the authenticity of the Docker host server.
+#     default: false
+#     required: false
+#
+#  tls_verify:
+#     description: Connect using TLS without verifying the authenticity of the Docker host server.
+#     default: false
+#     required: false
+#
+#  cert_path:
+#     description: Path to the client's TLS certificate file.
+#     default: null
+#     required: false
+#
+#  cacert_path:
+#     description: Use a CA certificate when performing server verification by providing the path to a CA certificate file.
+#     default: null
+#     required: false
+#
+#  key_path:
+#     description: Path to the client's TLS key file.
+#     default: null
+#     required: false
+#
+#  version:
+#     description: The Docker API version.
+#     required: false
+#     default: will be supplied by the docker-py module.
+#
+#  timeout:
+#     description: The amount of time in seconds to wait on an API response.
+#     required: false
+#     default: 60
+#
+#  default_ip:
+#     description: The IP address to assign to ansible_host when the container's SSH port is mapped to interface
+#     '0.0.0.0'.
+#     required: false
+#     default: 127.0.0.1
+#
+#  private_ssh_port:
+#     description: The port containers use for SSH
+#     required: false
+#     default: 22
 
 #defaults:
 #  host: unix:///var/run/docker.sock


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (docker_doc_frag 9ddcf13661) last updated 2016/04/27 04:12:53 (GMT -400)
  lib/ansible/modules/core: (detached HEAD cf01087a30) last updated 2016/04/05 16:31:53 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 204b4bab56) last updated 2016/04/05 16:31:56 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Improving documentation in the docker inventory script. There were several typos, inconsistencies, and things that didn't make sense. It now matches the getting started guide for Docker.
