### PR TITLE
make netcfg preserve command order

### DIFF
--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -229,7 +229,7 @@ class NetworkConfig(object):
         if self._device_os == 'junos':
             return updates
 
-        diffs = dict()
+        diffs = collections.OrderedDict()
         for update in updates:
             if replace == 'block' and update.parents:
                 update = update.parents[-1]


### PR DESCRIPTION
changed to using OrderedDict to preserve order of lines

fixes  #15496
