### PR TITLE
Make -q flag totally quiet for env-setup.fish

### DIFF
--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -8,6 +8,15 @@ set PREFIX_PYTHONPATH $ANSIBLE_HOME/lib
 set PREFIX_PATH $ANSIBLE_HOME/bin 
 set PREFIX_MANPATH $ANSIBLE_HOME/docs/man
 
+# set quiet flag
+if set -q argv
+    switch $argv
+    case '-q' '--quiet'
+        set QUIET "true"
+    case '*'
+    end
+end
+
 # Set PYTHONPATH
 if not set -q PYTHONPATH
     set -gx PYTHONPATH $PREFIX_PYTHONPATH
@@ -15,7 +24,9 @@ else
     switch PYTHONPATH
         case "$PREFIX_PYTHONPATH*"
         case "*"
-            echo "Appending PYTHONPATH"
+            if not [ $QUIET ]
+                echo "Appending PYTHONPATH"
+            end
             set -gx PYTHONPATH "$PREFIX_PYTHONPATH:$PYTHONPATH"
     end
 end
@@ -38,7 +49,11 @@ set -gx ANSIBLE_LIBRARY $ANSIBLE_HOME/library
 
 # Generate egg_info so that pkg_resources works
 pushd $ANSIBLE_HOME
-python setup.py egg_info
+if [ $QUIET ]
+    python setup.py -q egg_info
+else
+    python setup.py egg_info
+end
 if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
     rm -r $PREFIX_PYTHONPATH/ansible*.egg-info
 end
@@ -47,22 +62,19 @@ find . -type f -name "*.pyc" -delete
 popd
 
 
-if set -q argv 
-    switch $argv
-    case '-q' '--quiet'
-    case '*'
-        echo ""
-        echo "Setting up Ansible to run out of checkout..."
-        echo ""
-        echo "PATH=$PATH"
-        echo "PYTHONPATH=$PYTHONPATH"
-        echo "ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY"
-        echo "MANPATH=$MANPATH"
-        echo ""
-
-        echo "Remember, you may wish to specify your host file with -i"
-        echo ""
-        echo "Done!"
-        echo ""
-   end
+if not [ $QUIET ]
+    echo ""
+    echo "Setting up Ansible to run out of checkout..."
+    echo ""
+    echo "PATH=$PATH"
+    echo "PYTHONPATH=$PYTHONPATH"
+    echo "ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY"
+    echo "MANPATH=$MANPATH"
+    echo ""
+    echo "Remember, you may wish to specify your host file with -i"
+    echo ""
+    echo "Done!"
+    echo ""
 end
+
+set -e QUIET


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.2.0 (stable-2.0 24d9e5e0b4) last updated 2016/04/19 15:40:15 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 87b2094bbd) last updated 2016/04/26 17:04:17 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 4eb177e545) last updated 2016/04/26 17:03:29 (GMT -700)
```
##### SUMMARY

The first "echo" and the setup.py step are not quiet even when using the '-q' flag. This results in output that is annoying if your Fish is configured to source the file - every time you open a terminal, you'll see a lot of output. This fixes that. There is no effect on output if you're not using the "-q" flag.
