### PR TITLE
opensuse image for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - env: TARGET=opensuseleap TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=ubuntu1204
     - env: TARGET=ubuntu1404
     - env: TARGET=sanity TOXENV=py26

--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -13,10 +13,10 @@
     - { role: test_yum, tags: test_yum }
     - { role: test_apt, tags: test_apt }
     - { role: test_apt_repository, tags: test_apt_repository }
-    - { role: test_postgresql, tags: test_postgresql}
-    - { role: test_mysql_db, tags: test_mysql_db}
-    - { role: test_mysql_user, tags: test_mysql_user}
-    - { role: test_mysql_variables, tags: test_mysql_variables}
+    - { role: test_postgresql, tags: test_postgresql, when: ansible_os_family != 'Suse' }
+    - { role: test_mysql_db, tags: test_mysql_db, when: ansible_os_family != 'Suse'}
+    - { role: test_mysql_user, tags: test_mysql_user, when: ansible_os_family != 'Suse'}
+    - { role: test_mysql_variables, tags: test_mysql_variables, when: ansible_os_family != 'Suse'}
     - { role: test_docker, tags: test_docker, when: ansible_distribution != "Fedora" }
     - { role: test_zypper, tags: test_zypper}
     - { role: test_zypper_repository, tags: test_zypper_repository}

--- a/test/integration/roles/setup_mysql_db/vars/Suse.yml
+++ b/test/integration/roles/setup_mysql_db/vars/Suse.yml
@@ -1,0 +1,6 @@
+mysql_service: 'mysql'
+
+mysql_packages:
+    - mariadb
+    - python-MySQL-python
+    - bzip2

--- a/test/integration/roles/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/roles/setup_postgresql_db/tasks/main.yml
@@ -13,7 +13,7 @@
   with_items: "{{postgresql_packages}}"
   loop_control:
     loop_var: postgresql_package_item
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
 - name: remove dpkg dependencies for postgresql test
   apt: name={{ postgresql_package_item }} state=absent
@@ -25,7 +25,7 @@
 - name: remove old db (red hat)
   command: rm -rf "{{ pg_dir }}"
   ignore_errors: True
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
 # Theoretically, pg_dropcluster should work but it doesn't so rm files
 - name: remove old db config (debian)
@@ -43,7 +43,7 @@
   with_items: "{{postgresql_packages}}"
   loop_control:
     loop_var: postgresql_package_item
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
 - name: install dpkg dependencies for postgresql test
   apt: name={{ postgresql_package_item }} state=latest
@@ -54,7 +54,7 @@
 
 - name: Initialize postgres (RedHat systemd)
   command: postgresql-setup initdb
-  when: ansible_distribution == "Fedora" or (ansible_os_family  == "RedHat" and ansible_distribution_major_version|int >= 7)
+  when: ansible_distribution == "Fedora" or (ansible_os_family  == "RedHat" and ansible_distribution_major_version|int >= 7) or ansible_os_family == "Suse"
 
 - name: Initialize postgres (RedHat sysv)
   command: /sbin/service postgresql initdb
@@ -79,11 +79,11 @@
 
 - name: Generate pt_BR locale (Red Hat)
   command: localedef -f ISO-8859-1 -i pt_BR pt_BR
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
 - name: Generate es_MX locale (Red Hat)
   command: localedef -f ISO-8859-1 -i es_MX es_MX
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
 - name: restart postgresql service
   service: name={{ postgresql_service }} state=restarted

--- a/test/integration/roles/test_service/tasks/main.yml
+++ b/test/integration/roles/test_service/tasks/main.yml
@@ -13,7 +13,7 @@
 - include: 'sysv_setup.yml'
   when: ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('6', '>=') and ansible_distribution_version|version_compare('7', '<'))
 - include: 'systemd_setup.yml'
-  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('7', '>=') and ansible_distribution_version|version_compare('8', '<'))) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version|version_compare('8', '>='))
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('7', '>=') and ansible_distribution_version|version_compare('8', '<'))) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version|version_compare('8', '>=')) or ansible_os_family == 'Suse'
 - include: 'upstart_setup.yml'
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '<')
 

--- a/test/integration/roles/test_zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/roles/test_zypper_repository/tasks/zypper_repository.yml
@@ -83,22 +83,28 @@
 
 - name: check repo is updated by url
   command: zypper lr oss1
-  register: zypper_result
+  register: zypper_result1
   ignore_errors: yes
+
+- name: check repo is updated by url
+  command: zypper lr oss2
+  register: zypper_result2
 
 - assert:
     that:
-      - "zypper_result.rc == 6"
-      - "'not found' in zypper_result.stderr"
+      - "zypper_result1.rc == 6"
+      - "'not found' in zypper_result1.stderr"
+      - "zypper_result2.rc == 0"
+      - "'http://download.opensuse.org/distribution/leap/42.1/repo/oss/' in zypper_result2.stdout"
 
 - name: add two repos with same name
   zypper_repository:
     name: samename
     state: present
-    repo: "http://download.opensuse.org/distribution/leap/42.1/repo/{{item}}/"
+    repo: "{{ item }}"
   with_items:
-    - oss
-    - non-oss
+    - http://download.opensuse.org/repositories/science/openSUSE_Leap_42.1/
+    - http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_42.1/
 
 - name: check repo is updated by name
   command: zypper lr samename
@@ -106,6 +112,6 @@
 
 - assert:
     that:
-      - "'/oss/' not in zypper_result.stdout"
-      - "'/non-oss/' in zypper_result.stdout"
+      - "'/science/' not in zypper_result.stdout"
+      - "'/devel:/languages:/python/' in zypper_result.stdout"
 

--- a/test/integration/roles/test_zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/roles/test_zypper_repository/tasks/zypper_repository.yml
@@ -1,3 +1,8 @@
+---
+
+- name: ensure zypper ref works
+  command: zypper -n ref
+
 - name: Delete
   zypper_repository:
     name: test
@@ -41,6 +46,11 @@
   assert:
     that:
       - "zypper_result.changed"
+
+- name: Remove repo by name (also to not mess up later tasks)
+  zypper_repository:
+    name: test
+    state: absent
 
 - name: use refresh option
   zypper_repository:
@@ -97,6 +107,15 @@
       - "zypper_result2.rc == 0"
       - "'http://download.opensuse.org/distribution/leap/42.1/repo/oss/' in zypper_result2.stdout"
 
+
+- name: reset oss repo (to not break zypper later)
+  zypper_repository:
+    name: OSS
+    state: present
+    repo: http://download.opensuse.org/distribution/leap/42.1/repo/oss/
+    priority: 99
+    refresh: yes
+
 - name: add two repos with same name
   zypper_repository:
     name: samename
@@ -115,3 +134,10 @@
       - "'/science/' not in zypper_result.stdout"
       - "'/devel:/languages:/python/' in zypper_result.stdout"
 
+- name: remove last added repos (by URL to test that)
+  zypper_repository:
+    repo: http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_42.1/
+    state: absent
+
+- name: ensure zypper ref still works
+  command: zypper -n ref

--- a/test/utils/docker/opensuseleap/Dockerfile
+++ b/test/utils/docker/opensuseleap/Dockerfile
@@ -1,4 +1,3 @@
-# Latest version of centos
 FROM opensuse:leap
 
 RUN zypper --gpg-auto-import-keys --non-interactive ref && \
@@ -7,21 +6,25 @@ RUN zypper --gpg-auto-import-keys --non-interactive ref && \
 #RUN yum -y update; yum clean all; yum -y swap fakesystemd systemd
 
 RUN zypper --non-interactive install --auto-agree-with-licenses \
+    acl \
+    asciidoc \
     dbus-1-python \
-    lsb-release \
-    glibc-locale \
+    gcc \
     git \
+    glibc-locale \
     iproute \
+    lsb-release \
     make \
     mercurial \
+    openssh \
+    rpm-build \
     ruby \
     subversion \
     sudo \
-    unzip \
-    zip \
     tar \
-    openssh \
+    unzip \
     which \
+    zip \
     python-PyYAML \
     python-coverage \
     python-httplib2 \

--- a/test/utils/docker/opensuseleap/Dockerfile
+++ b/test/utils/docker/opensuseleap/Dockerfile
@@ -1,0 +1,63 @@
+# Latest version of centos
+FROM opensuse:leap
+
+RUN zypper --gpg-auto-import-keys --non-interactive ref && \
+    zypper --gpg-auto-import-keys --non-interactive up
+
+#RUN yum -y update; yum clean all; yum -y swap fakesystemd systemd
+
+RUN zypper --non-interactive install --auto-agree-with-licenses \
+    dbus-1-python \
+    lsb-release \
+    glibc-locale \
+    git \
+    iproute \
+    make \
+    mercurial \
+    ruby \
+    subversion \
+    sudo \
+    unzip \
+    zip \
+    tar \
+    openssh \
+    which \
+    python-PyYAML \
+    python-coverage \
+    python-httplib2 \
+    python-jinja2 \
+    python-keyczar \
+    python-mock \
+    python-nose \
+    python-paramiko \
+    python-pip \
+    python-setuptools \
+    python-virtualenv
+
+# systemd path differs from rhel
+ENV LIBSYSTEMD=/usr/lib/systemd/system
+RUN (cd ${LIBSYSTEMD}/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f ${LIBSYSTEMD}/multi-user.target.wants/*; \
+rm -f /etc/systemd/system/*.wants/*; \
+rm -f ${LIBSYSTEMD}/local-fs.target.wants/*; \
+rm -f ${LIBSYSTEMD}/sockets.target.wants/*udev*; \
+rm -f ${LIBSYSTEMD}/sockets.target.wants/*initctl*; \
+rm -f ${LIBSYSTEMD}/basic.target.wants/*; 
+
+# don't create systemd-session for ssh connections
+RUN sed -i /pam_systemd/d /etc/pam.d/common-session-pc
+
+#RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8
+RUN mkdir /etc/ansible/
+RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+VOLUME /sys/fs/cgroup /run /tmp
+RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
+    ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+# explicitly enable the service, opensuse default to disabled services
+RUN systemctl enable sshd.service
+ENV container=docker
+CMD ["/sbin/init"]

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -12,9 +12,11 @@ if [ "${TARGET}" = "sanity" ]; then
     if test x"$TOXENV" != x'py24' ; then tox ; fi
     if test x"$TOXENV" = x'py24' ; then python2.4 -V && python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce|docker_common|azure_rm_common).py' lib/ansible/module_utils ; fi
 else
+    IMAGE=ansible/ansible:${TARGET}
+    if [ "${TARGET}" = "opensuseleap" ]; then IMAGE=robinro/ansible-testing:opensuseleap; fi
     export C_NAME="testAbull_$$_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
-    docker pull ansible/ansible:${TARGET}
-    docker run -d --volume="${PWD}:/root/ansible:Z"  --name "${C_NAME}" ${TARGET_OPTIONS:=''} ansible/ansible:${TARGET} > /tmp/cid_${TARGET}
+    docker pull ${IMAGE}
+    docker run -d --volume="${PWD}:/root/ansible:Z"  --name "${C_NAME}" ${TARGET_OPTIONS:=''} ${IMAGE} > /tmp/cid_${TARGET}
     docker exec -ti $(cat /tmp/cid_${TARGET}) /bin/sh -c "export TEST_FLAGS='${TEST_FLAGS:-''}'; cd /root/ansible; . hacking/env-setup; (cd test/integration; LC_ALL=en_US.utf-8 make ${MAKE_TARGET:-})"
     docker kill $(cat /tmp/cid_${TARGET})
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

2.1.0, devel
##### SUMMARY

Run the test suite also on openSUSE leap 42.1

Before merging, someone from ansible/core needs to:
- build the docker image over at ansible/ansible
- correct the docker image used in run_tests (i.e. remove the `if` line (L14) that points to my dockerhub repo)

Future ToDos:
- mysql, postgresql: disabled for now, need some fixes to use the suse-specific start/... scripts, I would leave this for some future time or someone who can do this more easily than me
