### PR TITLE
Fix ziploader for the cornercase of ansible invoking ansible.

### DIFF
--- a/lib/ansible/__init__.py
+++ b/lib/ansible/__init__.py
@@ -19,5 +19,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-__version__ = '2.2.0'
-__author__  = 'Ansible, Inc.'
+# Note: Do not add any code to this file.  The ansible module may be
+# a namespace package when using Ansible-2.1+ Anything in this file may not be
+# available if one of the other packages in the namespace is loaded first.
+#
+# This is for backwards compat.  Code should be ported to get these from
+# ansible.release instead of from here.
+from ansible.release import __version__, __author__

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -30,7 +30,7 @@ import getpass
 import signal
 import subprocess
 
-from ansible import __version__
+from ansible.release import __version__
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.utils.unicode import to_bytes, to_unicode

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -30,7 +30,7 @@ import zipfile
 from io import BytesIO
 
 # from Ansible
-from ansible import __version__
+from ansible.release import __version__, __author__
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.utils.unicode import to_bytes, to_unicode
@@ -533,6 +533,7 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
         constants = dict(
                 SELINUX_SPECIAL_FS=C.DEFAULT_SELINUX_SPECIAL_FS,
                 SYSLOG_FACILITY=_get_facility(task_vars),
+                ANSIBLE_VERSION=__version__,
                 )
         params = dict(ANSIBLE_MODULE_ARGS=module_args,
                 ANSIBLE_MODULE_CONSTANTS=constants,
@@ -562,8 +563,8 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
                     # Create the module zip data
                     zipoutput = BytesIO()
                     zf = zipfile.ZipFile(zipoutput, mode='w', compression=compression_method)
-                    zf.writestr('ansible/__init__.py', b''.join((b"__version__ = '", to_bytes(__version__), b"'\n")))
-                    zf.writestr('ansible/module_utils/__init__.py', b'')
+                    zf.writestr('ansible/__init__.py', b'from pkgutil import extend_path\n__path__=extend_path(__path__,__name__)\ntry:\n    from ansible.release import __version__,__author__\nexcept ImportError:\n    __version__="' + to_bytes(__version__) + b'"\n    __author__="' + to_bytes(__author__) + b'"\n')
+                    zf.writestr('ansible/module_utils/__init__.py', b'from pkgutil import extend_path\n__path__=extend_path(__path__,__name__)\n')
 
                     zf.writestr('ansible_module_%s.py' % module_name, module_data)
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -219,10 +219,6 @@ except ImportError:
 
 _literal_eval = literal_eval
 
-from ansible import __version__
-# Backwards compat. New code should just import and use __version__
-ANSIBLE_VERSION = __version__
-
 # Internal global holding passed in params and constants.  This is consulted
 # in case multiple AnsibleModules are created.  Otherwise each AnsibleModule
 # would attempt to read from stdin.  Other code should not use this directly

--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -32,7 +32,6 @@ import os
 import re
 from uuid import UUID
 
-from ansible import __version__
 from ansible.module_utils.basic import BOOLEANS
 
 FINAL_STATUSES = ('ACTIVE', 'ERROR')
@@ -264,7 +263,7 @@ def rax_required_together():
 
 def setup_rax_module(module, rax_module, region_required=True):
     """Set up pyrax in a standard way for all modules"""
-    rax_module.USER_AGENT = 'ansible/%s %s' % (__version__,
+    rax_module.USER_AGENT = 'ansible/%s %s' % (module.constants['ANSIBLE_VERSION'],
                                                rax_module.USER_AGENT)
 
     api_key = module.params.get('api_key')

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -145,15 +145,15 @@ class PluginLoader:
     def _get_package_paths(self):
         ''' Gets the path of a Python package '''
 
-        paths = []
         if not self.package:
             return []
         if not hasattr(self, 'package_path'):
             m = __import__(self.package)
             parts = self.package.split('.')[1:]
-            self.package_path = os.path.join(os.path.dirname(m.__file__), *parts)
-        paths.extend(self._all_directories(self.package_path))
-        return paths
+            for parent_mod in parts:
+                m = getattr(m, parent_mod)
+            self.package_path = os.path.dirname(m.__file__)
+        return self._all_directories(self.package_path)
 
     def _get_paths(self):
         ''' Return a list of paths to search for plugins in '''

--- a/lib/ansible/release.py
+++ b/lib/ansible/release.py
@@ -1,4 +1,4 @@
-# 2013, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
 #
 # This file is part of Ansible
 #
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# Note: Do not add any code to this file.  module_utils may be a namespace
-# package when using Ansible-2.1+ Anything in this file may not be available
-# if one of the other packages in the namespace is loaded first.
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+__version__ = '2.2.0'
+__author__  = 'Ansible, Inc.'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath('lib'))
-from ansible import __version__, __author__
+from ansible.release import __version__, __author__
 try:
     from setuptools import setup, find_packages
 except ImportError:

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     import __builtin__ as builtins
 
-from ansible import __version__ as ansible_version
+from ansible.release import __version__ as ansible_version
 from ansible import constants as C
 from ansible.compat.six import text_type
 from ansible.compat.tests import unittest

--- a/test/units/plugins/test_plugins.py
+++ b/test/units/plugins/test_plugins.py
@@ -53,11 +53,15 @@ class TestErrors(unittest.TestCase):
         # python library, and then uses the __file__ attribute of
         # the result for that to get the library path, so we mock
         # that here and patch the builtin to use our mocked result
-        m = MagicMock()
-        m.return_value.__file__ = '/path/to/my/test.py'
+        foo = MagicMock()
+        bar = MagicMock()
+        bam = MagicMock()
+        bam.__file__ = '/path/to/my/foo/bar/bam/__init__.py'
+        bar.bam = bam
+        foo.return_value.bar = bar
         pl = PluginLoader('test', 'foo.bar.bam', 'test', 'test_plugin')
-        with patch('{0}.__import__'.format(BUILTINS), m):
-            self.assertEqual(pl._get_package_paths(), ['/path/to/my/bar/bam'])
+        with patch('{0}.__import__'.format(BUILTINS), foo):
+            self.assertEqual(pl._get_package_paths(), ['/path/to/my/foo/bar/bam'])
 
     def test_plugins__get_paths(self):
         pl = PluginLoader('test', '', 'test', 'test_plugin')


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

Ansible invoking ansible was broken by ziploader.  The ansible python library inside of ziploader was taking precedence over the version from the system and therefore /usr/bin/ansible couldn't find many of the submodules that it needed.

This change keeps the precedence but makes the version in the ziploader wrapper a namespace module.  That allows the version on the system to use modules from the system when they are not present in the ziploader bundle.  It won't prevent mismatched versions between ansible.module_utils.basic and what's in ziploader but it will allow the system copy to find ansible.module_utils.something_else if it isn't present in the ziploader bundle.
- Make ziploader's ansible and ansible.module_utils libraries into
  namespace packages.
- Move **version** and **author** from ansible/**init** to
  ansible/release.py.  This is because namespace packages only load one
  **init**.py.  If that is not the **init**.py with the author and
  version info then those won't be available.
- In ziplaoder, move the version ito ANSIBLE_CONSTANTS.
- Change PluginLoader to properly construct the path to the plugins even
  when namespace packages are present.
