### PR TITLE
Simplify and improve package name squashing

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -280,48 +280,33 @@ class TaskExecutor:
             task_action = templar.template(task_action, fail_on_undefined=False)
 
         if len(items) > 0 and task_action in self.SQUASH_ACTIONS:
-            if all(isinstance(o, string_types) for o in items):
-                final_items = []
+            # use list rather than set to preserve ordering
+            final_items = list()
 
-                name = None
-                for allowed in ['name', 'pkg', 'package']:
-                    name = self._task.args.pop(allowed, None)
-                    if name is not None:
-                        break
+            name = None
+            for allowed in ['name', 'pkg', 'package']:
+                name = self._task.args.pop(allowed, None)
+                if name is not None:
+                    break
 
-                # This gets the information to check whether the name field
-                # contains a template that we can squash for
-                template_no_item = template_with_item = None
-                if name:
-                    if templar._contains_vars(name):
-                        variables[loop_var] = '\0$'
-                        template_no_item = templar.template(name, variables, cache=False)
-                        variables[loop_var] = '\0@'
-                        template_with_item = templar.template(name, variables, cache=False)
-                        del variables[loop_var]
-
-                    # Check if the user is doing some operation that doesn't take
-                    # name/pkg or the name/pkg field doesn't have any variables
-                    # and thus the items can't be squashed
-                    if template_no_item != template_with_item:
-                        for item in items:
-                            variables[loop_var] = item
-                            if self._task.evaluate_conditional(templar, variables):
-                                new_item = templar.template(name, cache=False)
-                                final_items.append(new_item)
-                        self._task.args['name'] = final_items
-                        # Wrap this in a list so that the calling function loop
-                        # executes exactly once
-                        return [final_items]
-                    else:
-                        # Restore the name parameter
-                        self._task.args['name'] = name
-            #elif:
-                # Right now we only optimize single entries.  In the future we
-                # could optimize more types:
-                # * lists can be squashed together
-                # * dicts could squash entries that match in all cases except the
-                #   name or pkg field.
+            for item in items:
+                variables[loop_var] = item
+                if self._task.evaluate_conditional(templar, variables):
+                    new_item = templar.template(name, cache=False)
+                    # Do not add templated name if other task arguments
+                    # e.g. state are also templated - this could be
+                    # optimised if results of all other templates are
+                    # the same
+                    if new_item != name and \
+                            not any([v != templar.template(v, cache=False)
+                                for (k, v) in self._task.args.items()]) and \
+                            not new_item in final_items:
+                        final_items.append(new_item)
+            if final_items:
+                self._task.args['name'] = final_items
+                return [final_items]
+            else:
+                self._task.args['name'] = name
         return items
 
     def _execute(self, variables=None):

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -280,6 +280,9 @@ class TaskExecutor:
             task_action = templar.template(task_action, fail_on_undefined=False)
 
         if len(items) > 0 and task_action in self.SQUASH_ACTIONS:
+            # flatten lists of lists
+            if all([isinstance(item, list) for item in items]):
+                items = [x for y in items for x in y]
             # use list rather than set to preserve ordering
             final_items = list()
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 7af47a3886) last updated 2016/04/29 11:28:56 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD e78ee3b128) last updated 2016/04/29 11:28:58 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD ca310f3d15) last updated 2016/04/29 11:28:58 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY
- Allow variables that contain a dict lookup
- Squash names built from dictionary values  e.g.
  
  ```
  package: name="{{item.name}}-{{item.version}}"
  with_items:
  - name: hello
    version: 1.2.3
  - name: goodbye
    version: 2.3.4
  ```
  
  now works the same as
  
  ```
  package: name="{{item}}"
  with_items:
  - hello-1.2.3
  - goodbye-2.3.4
  ```
- Fix some erroneous test assumptions  e.g.
  
  ```
  package: name="{{pkg_mgr}}"
  with_items:
  - hello-1.2.3
  - goodbye-2.3.4
  ```
  
  should just install a single package with  the name `pkg_mgr` (in effect `item` is not a bound variable)

Fixes #15649
