### PR TITLE
Fix: create retry_files_save_path if it doesn't exist

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -27,6 +27,7 @@ from ansible import constants as C
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook import Playbook
 from ansible.template import Templar
+from ansible.utils.path import makedirs_safe
 from ansible.utils.unicode import to_unicode
 
 try:
@@ -247,9 +248,7 @@ class PlaybookExecutor:
         re-running on ONLY the failed hosts.  This may duplicate some variable
         information in group_vars/host_vars but that is ok, and expected.
         '''
-        dirname = os.path.dirname(retry_path)
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
+        makedirs_safe(os.path.dirname(retry_path))
 
         try:
             with open(retry_path, 'w') as fd:

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -247,6 +247,9 @@ class PlaybookExecutor:
         re-running on ONLY the failed hosts.  This may duplicate some variable
         information in group_vars/host_vars but that is ok, and expected.
         '''
+        dirname = os.path.dirname(retry_path)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
 
         try:
             with open(retry_path, 'w') as fd:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

``````
ansible 2.2.0 (devel b9a546b703) last updated 2016/04/28 20:38:09 (GMT -700)
  lib/ansible/modules/core: (detached HEAD e78ee3b128) last updated 2016/04/28 20:38:15 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD ca310f3d15) last updated 2016/04/28 20:38:16 (GMT -700)
  config file = /path/to/my/ansible/config/ansible.cfg
  configured module search path = Default w/o overrides```
``````
##### SUMMARY

Ansible documentation states that retry_files_save_path directory will be created if it does not already exist. It currently doesn't, so this patch fixes it :)  (Fixes #14951)
