### PR TITLE
Added commas in documentation to increase readability

### DIFF
--- a/docsite/rst/become.rst
+++ b/docsite/rst/become.rst
@@ -97,19 +97,19 @@ is made as root.  In these cases the module file is created with permissions
 that only allow reading by the user and root.
 
 The problem occurs when the ``become_user`` is an unprivileged user.  Ansible
-2.0.x and below make the module file world readable in this case as the module
-file is written as the user that Ansible connects as but the file needs to
+2.0.x and below make the module file world readable in this case, as the module
+file is written as the user that Ansible connects as, but the file needs to
 be readable by the user Ansible is set to ``become``.
 
 .. note:: In Ansible 2.1, this window is further narrowed: If the connection
-    is made as a privileged user (root) then Ansible 2.1 and above will use
+    is made as a privileged user (root), then Ansible 2.1 and above will use
     chown to set the file's owner to the unprivileged user being switched to.
     This means both the user making the connection and the user being switched
     to via ``become`` must be unprivileged in order to trigger this problem.
 
-If any of the parameters passed to the module are sensitive in nature then
+If any of the parameters passed to the module are sensitive in nature, then
 those pieces of data are located in a world readable module file for the
-duration of the Ansible module execution.  Once the module is done executing
+duration of the Ansible module execution.  Once the module is done executing,
 Ansible will delete the temporary file.  If you trust the client machines then
 there's no problem here.  If you do not trust the client machines then this is
 a potential danger.
@@ -141,9 +141,9 @@ makes it harder to unknowingly do this insecurely.  Whereas in Ansible 2.0.x
 and below, Ansible will silently allow the insecure behaviour if it was unable
 to find another way to share the files with the unprivileged user, in Ansible
 2.1 and above Ansible defaults to issuing an error if it can't do this
-securely.  If you can't make any of the changes above to resolve the problem
+securely.  If you can't make any of the changes above to resolve the problem,
 and you decide that the machine you're running on is secure enough for the
-modules you want to run there to be world readable you can turn on
+modules you want to run there to be world readable, you can turn on
 ``allow_world_readable_tmpfiles`` in the :file:`ansible.cfg` file.  Setting
 ``allow_world_readable_tmpfiles`` will change this from an error into
 a warning and allow the task to run as it did prior to 2.1.


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

(Current docs.)

> ansible 1.9.4
>   configured module search path = None
##### SUMMARY

I have added commas in some sentences here because even as a native English speaker, they were somewhat difficult to read.
