### PR TITLE
add ignore_errors to fix keyword arg warning

### DIFF
--- a/lib/ansible/plugins/callback/tree.py
+++ b/lib/ansible/plugins/callback/tree.py
@@ -63,7 +63,7 @@ class CallbackModule(CallbackBase):
     def v2_runner_on_ok(self, result):
         self.result_to_tree(result)
 
-    def v2_runner_on_failed(self, result):
+    def v2_runner_on_failed(self, result, ignore_errors=False):
         self.result_to_tree(result)
 
     def v2_runner_on_unreachable(self, result):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

When running ad hoc commands with `--tree` if the command fails no file is produced and a warning is produced. Looking at the other callback modules, tree.py does not call `v2_runner_on_failed` with the same parameter set. Adding `ignore_errors=False` (similar to other callback modules) resolves  

```
ansible-server$ ansible server1 -a "/bin/false" -t temp
server1 | FAILED | rc=1 >>


 [WARNING]: Failure when attempting to use callback plugin (</Library/Python/2.7/site-packages/ansible/plugins/callback/tree.CallbackModule object at 0x10f6f1dd0>): v2_runner_on_failed() got an unexpected keyword argument 'ignore_errors'

ansible-server$ ansible server1 -a "/bin/false" -t temp
server1 | FAILED | rc=1 >>


```

When running an ad hoc command with --tree that fails a keyword argument error is produced.

``` shell
ansible-server$ ansible server1 -a "/bin/false" -t temp
server1 | FAILED | rc=1 >>


 [WARNING]: Failure when attempting to use callback plugin (</Library/Python/2.7/site-packages/ansible/plugins/callback/tree.CallbackModule object at 0x10f6f1dd0>): v2_runner_on_failed() got an unexpected keyword argument 'ignore_errors'
```

Seems that the `v2_runner_on_failed()` call is missing "ignore_errors=False" parameter.  Without this fix --tree will not work when ad hoc commands fail.
