### PR TITLE
Revert "add ignore_errors to fix keyword arg warning"

### DIFF
--- a/lib/ansible/plugins/callback/tree.py
+++ b/lib/ansible/plugins/callback/tree.py
@@ -63,7 +63,7 @@ class CallbackModule(CallbackBase):
     def v2_runner_on_ok(self, result):
         self.result_to_tree(result)
 
-    def v2_runner_on_failed(self, result, ignore_errors=False):
+    def v2_runner_on_failed(self, result):
         self.result_to_tree(result)
 
     def v2_runner_on_unreachable(self, result):


### PR DESCRIPTION
Reverts ansible/ansible#15668

wrong branch
