### PR TITLE
Remove the ziploader provided pythonpaths from the env inside run_com…

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1985,7 +1985,7 @@ class AnsibleModule(object):
             pypaths = os.environ['PYTHONPATH'].split(':')
             pypaths = [x for x in pypaths \
                         if not x.endswith('/ansible_modlib.zip') \
-                        and not x.endswith('/debug/dir')]
+                        and not x.endswith('/debug_dir')]
             os.environ['PYTHONPATH'] = ':'.join(pypaths)
 
         # create a printable version of the command for use

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -523,7 +523,6 @@ def is_executable(path):
     return (stat.S_IXUSR & os.stat(path)[stat.ST_MODE]
             or stat.S_IXGRP & os.stat(path)[stat.ST_MODE]
             or stat.S_IXOTH & os.stat(path)[stat.ST_MODE])
- 
 
 class AnsibleFallbackNotFound(Exception):
     pass

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1975,6 +1975,16 @@ class AnsibleModule(object):
             old_env_vals['PATH'] = os.environ['PATH']
             os.environ['PATH'] = "%s:%s" % (path_prefix, os.environ['PATH'])
 
+        # Clean out python paths set by ziploader
+        if 'PYTHONPATH' in os.environ:
+            ppaths = os.environ['PYTHONPATH'].split(':')
+            ppaths = [x for x in ppaths \
+                if not x.endswith('/ansible_modlib.zip')]
+            ppaths = [x for x in ppaths \
+                if not x.endswith('/debug_dir')]
+            os.environ['PYTHONPATH'] = ':'.join(ppaths)
+
+
         # create a printable version of the command for use
         # in reporting later, which strips out things like
         # passwords from the args list
@@ -2016,7 +2026,6 @@ class AnsibleModule(object):
             stdin=st_in,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=os.environ,
         )
 
         if cwd and os.path.isdir(cwd):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2006,7 +2006,7 @@ class AnsibleModule(object):
             os.environ['PATH'] = "%s:%s" % (path_prefix, os.environ['PATH'])
 
         # Clean out python paths set by ziploader
-        if 'PYTHONPATH' in os.environ:
+        if 'PYTHONPATH' in os.environ and self._remote_temp:
             pypaths = os.environ['PYTHONPATH'].split(':')
             pypaths = [x for x in pypaths if not x.startswith(self._remote_temp)]
             os.environ['PYTHONPATH'] = ':'.join(pypaths)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -35,7 +35,6 @@ BOOLEANS = BOOLEANS_TRUE + BOOLEANS_FALSE
 # development of Python modules, the functions available here can
 # be used to do many common tasks
 
-import inspect
 import locale
 import os
 import re

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -524,6 +524,7 @@ def is_executable(path):
             or stat.S_IXGRP & os.stat(path)[stat.ST_MODE]
             or stat.S_IXOTH & os.stat(path)[stat.ST_MODE])
 
+
 class AnsibleFallbackNotFound(Exception):
     pass
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -523,35 +523,6 @@ def is_executable(path):
     return (stat.S_IXUSR & os.stat(path)[stat.ST_MODE]
             or stat.S_IXGRP & os.stat(path)[stat.ST_MODE]
             or stat.S_IXOTH & os.stat(path)[stat.ST_MODE])
-
-def get_remote_temp():
-
-    ''' Return the remote temp path where modules are stored '''
-
-    # If using test-module and explode, the remote temp will resemble ...
-    #   /tmp/test_module_scratch/debug_dir/ansible/module_utils/basic.py
-    # If using ansible or ansible-playbook with a remote system ...
-    #   /tmp/ansible_vmweLQ/ansible_modlib.zip/ansible/module_utils/basic.py
-
-    # the path to basic.py
-    thisfile = __file__
-
-    remote_temp = None
-
-    # list.index('ansible') in reverse
-    directories = thisfile.split(os.sep)
-    directories = [x for x in reversed(directories)]
-    ansible_index = None
-    for idx,x in enumerate(directories):
-        if x == 'ansible':
-            ansible_index = idx
-            break
-    if ansible_index:
-        # Keep everything up to the index
-        directories = directories[(ansible_index + 1):]        
-        directories = [x for x in reversed(directories)]
-        remote_temp = os.sep.join(directories)
-    return remote_temp
  
 
 class AnsibleFallbackNotFound(Exception):
@@ -586,7 +557,6 @@ class AnsibleModule(object):
         self._debug = False
         self._diff = False
         self._verbosity = 0
-        self._remote_temp = get_remote_temp()
         # May be used to set modifications to the environment for any
         # run_command invocation
         self.run_command_environ_update = {}
@@ -2005,10 +1975,17 @@ class AnsibleModule(object):
             old_env_vals['PATH'] = os.environ['PATH']
             os.environ['PATH'] = "%s:%s" % (path_prefix, os.environ['PATH'])
 
+        # If using test-module and explode, the remote lib path will resemble ...
+        #   /tmp/test_module_scratch/debug_dir/ansible/module_utils/basic.py
+        # If using ansible or ansible-playbook with a remote system ...
+        #   /tmp/ansible_vmweLQ/ansible_modlib.zip/ansible/module_utils/basic.py
+
         # Clean out python paths set by ziploader
-        if 'PYTHONPATH' in os.environ and self._remote_temp:
+        if 'PYTHONPATH' in os.environ:
             pypaths = os.environ['PYTHONPATH'].split(':')
-            pypaths = [x for x in pypaths if not x.startswith(self._remote_temp)]
+            pypaths = [x for x in pypaths \
+                        if not x.endswith('/ansible_modlib.zip') \
+                        and not x.endswith('/debug/dir')]
             os.environ['PYTHONPATH'] = ':'.join(pypaths)
 
         # create a printable version of the command for use


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
[jtanner@ansidev AP-15655]$ ansible --version
ansible 2.2.0 (15655_fix 97bcb318b5) last updated 2016/04/29 17:00:26 (GMT -400)
  lib/ansible/modules/core: (devel 67de0675c3) last updated 2016/04/28 16:41:35 (GMT -400)
  lib/ansible/modules/extras: (devel e8391d6985) last updated 2016/04/28 16:41:40 (GMT -400)
  config file = /workspace/issues/AP-15655/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #15655

In the copied environment created for subprocess.Popen, remove any ziploader references from the PYTHONPATH.
