### PR TITLE
Streamline Arch Linux detection following systemd standard (via /etc/os-release)

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -613,7 +613,7 @@ class Distribution(object):
         {'path': '/etc/system-release', 'name': 'Amazon'},
         {'path': '/etc/alpine-release', 'name': 'Alpine'},
         {'path': '/etc/release', 'name': 'Solaris'},
-        {'path': '/etc/arch-release', 'name': 'Archlinux', 'allowempty': True},
+        {'path': '/etc/os-release', 'name': 'Archlinux'},
         {'path': '/etc/os-release', 'name': 'SuSE'},
         {'path': '/etc/SuSE-release', 'name': 'SuSE'},
         {'path': '/etc/gentoo-release', 'name': 'Gentoo'},
@@ -628,6 +628,7 @@ class Distribution(object):
         'OracleLinux': 'Oracle Linux',
         'RedHat': 'Red Hat',
         'Altlinux': 'ALT Linux',
+        'Archlinux': 'Arch Linux',
     }
 
     # A list with OS Family members


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (archlinux-os-release b22a84a996) last updated 2016/04/29 18:30:16 (GMT -500)
  lib/ansible/modules/core: (devel b6ad3b6773) last updated 2016/04/29 16:41:32 (GMT -500)
  lib/ansible/modules/extras: (devel 3a7e4b5834) last updated 2016/04/29 16:41:54 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

systemd is a first class citizen in Arch Linux variants and thus `/etc/os-release` will always have the right info [1]. We don't need to rely on `/etc/arch-release` and `allowempty` workaround.

[1] https://www.freedesktop.org/software/systemd/man/os-release.html

This is a followup to #15663 
