### PR TITLE
Fix YAML source and check it on Shippable

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,22 @@
+extends: default
+
+# Disable all cosmetic rules
+# (see https://github.com/ansible/ansible/pull/15470#issuecomment-214437876)
+# Only keep 'key-duplicates' and 'new-lines: {type: unix}' checks enabled.
+
+rules:
+  braces: disable
+  brackets: disable
+  colons: disable
+  commas: disable
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines: disable
+  hyphens: disable
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: {type: unix}
+  trailing-spaces: disable

--- a/shippable.yml
+++ b/shippable.yml
@@ -2,7 +2,7 @@ language: python
 
 env:
   matrix:
-    - TEST=code-smell
+    - TEST=code-smell INSTALL_DEPS=1
 
 matrix:
   include:

--- a/test/integration/roles/test_rax_cdb/tasks/main.yml
+++ b/test/integration/roles/test_rax_cdb/tasks/main.yml
@@ -192,7 +192,6 @@
     volume: 3
     wait: true
     wait_timeout: "{{ rackspace_wait_timeout }}"
-    wait_timeout: 600
   register: rax_cdb
 
 - name: Validate rax_cdb resize volume 2
@@ -251,7 +250,6 @@
     flavor: 2
     wait: true
     wait_timeout: "{{ rackspace_wait_timeout }}"
-    wait_timeout: 600
   register: rax_cdb
 
 - name: Validate rax_cdb resize flavor 2

--- a/test/integration/test_environment.yml
+++ b/test/integration/test_environment.yml
@@ -25,7 +25,6 @@
             - '"val1" in test_env2.stdout_lines'
 
 - hosts: testhost
-  tasks:
   vars:
     - test1:
         key1: val1

--- a/test/utils/shippable/code-smell.sh
+++ b/test/utils/shippable/code-smell.sh
@@ -2,8 +2,15 @@
 
 source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../../..')))")
 
+install_deps="${INSTALL_DEPS:-}"
+
 cd "${source_root}"
 
+if [ "${install_deps}" != "" ]; then
+    pip install yamllint
+fi
+
+yamllint .
 test/code-smell/replace-urlopen.sh .
 test/code-smell/use-compat-six.sh lib
 test/code-smell/boilerplate.sh


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY
###### 1) Fix problems in YAML source

This change removes key duplicates reported by the yamllint linter.

Example:

```
  rax_cdb:
    wait_timeout: "{{ rackspace_wait_timeout }}"
    wait_timeout: 600
```

---
###### 2) Check YAML files for syntax errors and key duplicates

This commit enables YAML linting in Travis tests using the [`yamllint` tool](http://yamllint.readthedocs.org/), and configures it to check only for syntax errors and key duplicates (but not for cosmetic problems).

The goal is to **prevent future errors to enter the code base without being noticed**.

See original pull request at #15470, which included cosmetic linting      (trailing spaces, extra lines etc.)
