### PR TITLE
Install and start up a local httpbin in tests

### DIFF
--- a/test/integration/roles/test_uri/files/run_httpbin.py
+++ b/test/integration/roles/test_uri/files/run_httpbin.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+"""helper script to run httpbin with a specified port and hostname."""
+
+# As of httpbin 0.4.1, http.core doesn't support port options on the cli
+# although it was added to upstream git master.
+import sys
+import optparse
+
+import httpbin
+import httpbin.core
+
+def main(args=None):
+    args = args or []
+    parser = optparse.OptionParser()
+    parser.add_option("--port", default=22222)
+    parser.add_option("--host", default="localhost")
+    options, args = parser.parse_args(args)
+    return httpbin.core.app.run(port=options.port,
+                                host=options.host)
+
+
+if __name__ == "__main__":
+    rc = main(sys.argv[:])
+    sys.exit(rc)

--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -22,6 +22,7 @@
       httpbin_port: 15261
       httpbin_url: "http://{{ httpbin_host }}:{{ httpbin_port }}"
       external_httpbin_ssl_url: "https://httpbin.org"
+      httpbin_pip_package: httpbin
   set_fact:
     http_port: 15260
     httpbin_host: "{{ httpbin_host }}"
@@ -30,6 +31,8 @@
     external_httpbin_ssl_url: "{{ external_httpbin_ssl_url }}"
     files_dir: '{{ output_dir|expanduser }}/files'
     checkout_dir: '{{ output_dir }}/git'
+    httpbin_pip_package: '{{ httpbin_pip_package }}'
+    httpbin_virtualenv: '{{ output_dir }}/httpbin'
 
 - name: create a directory to serve files from
   file:
@@ -50,6 +53,7 @@
     src: "testserver.py"
     dest: "{{ output_dir }}/testserver.py"
 
+
 - name: verify that python2 is installed so this test can continue
   shell: which python2
   register: py2
@@ -57,16 +61,36 @@
   #- name: dump some vars
   #debug: msg='{{ files_dir }} {{ py2.stdout }} {{ output_dir }} {{ http_port }}'
 
+- name: make sure the test virtualenv for httpbin doesn't exist
+  file: state=absent name={{ httpbin_virtualenv }}
+
 - name: pip install httpbin
-  pip: state=present name=httpbin
+  pip: name={{ httpbin_pip_package }} state=present virtualenv={{ httpbin_virtualenv }}
   tags: httpbin
   register: httpbin_installed
 
+- name: copy httpbin wrapper script into virtualenv for httpbin
+  copy:
+    src: "run_httpbin.py"
+    dest: "{{ httpbin_virtualenv }}/bin/run_httpbin.py"
+    mode: 0655
+  register: copy_out
+
+- name: debug copy_out
+  debug: msg={{ copy_out }}
+
 - name: start httpbin
-  shell: python -m httpbin.core --port={{ httpbin_port }} --host={{ httpbin_host }}
+  command: "{{ httpbin_virtualenv | expanduser }}/bin/python {{ httpbin_virtualenv | expanduser }}/bin/run_httpbin.py --port={{ httpbin_port }} --host={{ httpbin_host }}"
   async: 90
   poll: 0
   tags: httpbin
+  register: run_httpbin
+
+- name: debug run_httpbin
+  debug: msg={{ run_httpbin }}
+
+- name: wait for httpbin to start up
+  wait_for: port={{ httpbin_port }} host={{ ansible_ssh_host | default(inventory_hostname) }}
 
 - name: start SimpleHTTPServer
   shell: cd {{ files_dir }} && {{ py2.stdout }} {{ output_dir}}/testserver.py {{ http_port }}
@@ -75,7 +99,9 @@
 
   #- wait_for: port={{ http_port }}
 
-- wait_for: port={{ httpbin_port }}
+
+- name: wait for SimpleHTTPServer
+  wait_for: port={{ http_port }}
 
 - name: checksum pass_json
   stat: path={{ files_dir }}/{{ item }}.json get_checksum=yes

--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -17,8 +17,17 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: set role facts
+  vars:
+      httpbin_host: localhost
+      httpbin_port: 15261
+      httpbin_url: "http://{{ httpbin_host }}:{{ httpbin_port }}"
+      external_httpbin_ssl_url: "https://httpbin.org"
   set_fact:
     http_port: 15260
+    httpbin_host: "{{ httpbin_host }}"
+    httpbin_port: "{{ httpbin_port }}"
+    httpbin_url: "{{ httpbin_url }}"
+    external_httpbin_ssl_url: "{{ external_httpbin_ssl_url }}"
     files_dir: '{{ output_dir|expanduser }}/files'
     checkout_dir: '{{ output_dir }}/git'
 
@@ -45,13 +54,28 @@
   shell: which python2
   register: py2
 
+  #- name: dump some vars
+  #debug: msg='{{ files_dir }} {{ py2.stdout }} {{ output_dir }} {{ http_port }}'
+
+- name: pip install httpbin
+  pip: state=present name=httpbin
+  tags: httpbin
+  register: httpbin_installed
+
+- name: start httpbin
+  shell: python -m httpbin.core --port={{ httpbin_port }} --host={{ httpbin_host }}
+  async: 90
+  poll: 0
+  tags: httpbin
+
 - name: start SimpleHTTPServer
   shell: cd {{ files_dir }} && {{ py2.stdout }} {{ output_dir}}/testserver.py {{ http_port }}
   async: 60 # this test set takes ~15 seconds to run
   poll: 0
 
-- wait_for: port={{ http_port }}
+  #- wait_for: port={{ http_port }}
 
+- wait_for: port={{ httpbin_port }}
 
 - name: checksum pass_json
   stat: path={{ files_dir }}/{{ item }}.json get_checksum=yes
@@ -143,25 +167,27 @@
 
 - name: test redirect without follow_redirects
   uri:
-    url: 'http://httpbin.org/redirect/2'
+    url: '{{ httpbin_url }}/redirect/2'
     follow_redirects: 'none'
     status_code: 302
   register: result
+  tags: httpbin
 
 - name: Assert location header
   assert:
     that:
-      - 'result.location|default("") == "http://httpbin.org/relative-redirect/1"'
+      - 'result.location|default("") == "{{ httpbin_url }}/relative-redirect/1"'
 
 - name: Check SSL with redirect
   uri:
-    url: 'https://httpbin.org/redirect/2'
+    url: '{{ external_httpbin_ssl_url }}/redirect/2'
   register: result
+  tags: httpbin
 
 - name: Assert SSL with redirect
   assert:
     that:
-      - 'result.url|default("") == "https://httpbin.org/get"'
+      - 'result.url|default("") == "{{ external_httpbin_ssl_url }}/get"'
 
 - name: redirect to bad SSL site
   uri:
@@ -177,28 +203,32 @@
 
 - name: test basic auth
   uri:
-    url: 'http://httpbin.org/basic-auth/user/passwd'
+    url: '{{ httpbin_url }}/basic-auth/user/passwd'
     user: user
     password: passwd
+  tags: httpbin
 
 - name: test basic forced auth
   uri:
-    url: 'http://httpbin.org/hidden-basic-auth/user/passwd'
+    url: '{{ httpbin_url }}/hidden-basic-auth/user/passwd'
     force_basic_auth: true
     user: user
     password: passwd
+  tags: httpbin
 
 - name: test PUT
   uri:
-    url: 'http://httpbin.org/put'
+    url: '{{ httpbin_url }}/put'
     method: PUT
     body: 'foo=bar'
+  tags: httpbin
 
 - name: test OPTIONS
   uri:
-    url: 'http://httpbin.org/'
+    url: '{{ httpbin_url }}/'
     method: OPTIONS
   register: result
+  tags: httpbin
 
 - name: Assert we got an allow header
   assert:
@@ -280,9 +310,23 @@
   with_items: "{{ uri_os_packages[ansible_os_family] }}"
   when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
 
-- name: validate the status_codes are correct
+- name: validate the status_codes are correct with https
   uri:
-    url: https://httpbin.org/status/202
+    url: "{{ external_httpbin_ssl_url }}/status/202"
     status_code: 202
     method: POST
     body: foo
+
+- name: validate the status_codes are correct with http
+  uri:
+    url: "{{ httpbin_url }}/status/202"
+    status_code: 202
+    method: POST
+    body: foo
+
+- name: Uninstall httpbin
+  pip:
+    name: httpbin
+    state: absent
+  when: httpbin_installed
+  tags: httpbin


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (httpbin 33d079ec6a) last updated 2016/05/02 11:58:58 (GMT -400)
  lib/ansible/modules/core: (detached HEAD b6ad3b6773) last updated 2016/05/02 09:26:36 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 1846de2809) last updated 2016/05/02 09:26:36 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = ['/home/adrian/ansible-2.0.2-1/lib/ansible/modules/']
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

For destructive tests, pip install a local 'httpbin', and use it for the url
integration tests instead of the external 'http://httpbin.org/' url, which
has a tendency to fail and cause travis tests to fail.

Things to Note:
- This installs 'httpbin' pip package on the test system, and then removes it at the end of the test. It currently doesn't test if the package was previously installed, so likely needs some tweaks (or a virtualenv, etc)
- The local httpbin instance defaults to running on port 15261, so potentially local firewall rules may come into play.
- Currently, only the plain http tests are pointed at the local httpbin. The ssl based tests still point at https://httpbin.org.

TODO:
- add setup/teardown of a https server for sitting in front of httpbin, since httpbin itself doesn't include any ssl support.

Note: currently doesn't use a virtualenv, etc. Also, no
https support yet.
