### PR TITLE
Restore Ansible 2.0 compatibility for include:

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -108,13 +108,14 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                 all_vars = variable_manager.get_vars(loader=loader, play=play, task=t)
                 templar = Templar(loader=loader, variables=all_vars)
 
-                # check to see if this include is static, which can be true if:
-                # 1. the user set the 'static' option to true
+                # check to see if this include is dynamic or static:
+                # 1. the user has set the 'static' option to false or true
                 # 2. one of the appropriate config options was set
-                # 3. the included file name contains no variables, and has no loop
-                is_static = t.static or \
-                            C.DEFAULT_TASK_INCLUDES_STATIC or \
-                            (use_handlers and C.DEFAULT_HANDLER_INCLUDES_STATIC)
+                if t.static is not None:
+                    is_static = t.static
+                else:
+                    is_static = C.DEFAULT_TASK_INCLUDES_STATIC or \
+                                (use_handlers and C.DEFAULT_HANDLER_INCLUDES_STATIC)
 
                 if is_static:
                     if t.loop is not None:

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -114,8 +114,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                 # 3. the included file name contains no variables, and has no loop
                 is_static = t.static or \
                             C.DEFAULT_TASK_INCLUDES_STATIC or \
-                            (use_handlers and C.DEFAULT_HANDLER_INCLUDES_STATIC) or \
-                            not templar._contains_vars(t.args.get('_raw_params')) and t.loop is None
+                            (use_handlers and C.DEFAULT_HANDLER_INCLUDES_STATIC)
 
                 if is_static:
                     if t.loop is not None:

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -41,7 +41,7 @@ class TaskInclude(Task):
     # =================================================================================
     # ATTRIBUTES
 
-    _static = FieldAttribute(isa='bool', default=False)
+    _static = FieldAttribute(isa='bool', default=None)
 
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

ansible 2.2.0 (devel 1fc44e4103) last updated 2016/05/02 12:54:17 (GMT +200)
##### SUMMARY

Since commit 2c20579 compatibility for `include:` with 2.0 is broken. Ff the include filename string does not contain variables or the include command does not contain loops, all includes are FORCIBLY treated as static. Users have no way to workaround - the "static: no" keyword does not work as it is ignored.

I consider this a merge candidate for stable-2.1. Please consider at least commit 1.)

This fix consists of two commits:
1.) 438ed70a4373f1035ae90a042bc745791b40fa76 restores 2.0 compatibility by not forcing includes to be static - all are dynamic by default
2.) 434031a0ce73c3e5b630a22a6a8c9dbaf3f241e3 treat `static: no` and `static: yes` with higher priority than `task_includes_static` in ansible.cfg. This allows using `static: no` even if  `task_includes_static = yes` is defined.

Fixes: #15687 
