### PR TITLE
fix facts for point-to-point IPv6 addresses

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2205,8 +2205,15 @@ class LinuxNetwork(Network):
                         if not address.startswith('127.'):
                             ips['all_ipv4_addresses'].append(address)
                     elif words[0] == 'inet6':
-                        address, prefix = words[1].split('/')
-                        scope = words[3]
+                        if '/' in words[1]:
+                            address, prefix = words[1].split('/')
+                        else:
+                            address = words[1]
+                            prefix = "128"
+                        if words[2] == 'peer':
+                            scope = words[5]
+                        else:
+                            scope = words[3]
                         if 'ipv6' not in interfaces[device]:
                             interfaces[device]['ipv6'] = []
                         interfaces[device]['ipv6'].append({


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 836137661f) last updated 2016/05/02 22:24:38 (GMT +300)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix facts.py causing fatal error while parsing point-to-point IPv6 addresses.

```
Before:

fatal: [host]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "setup"}, "module_stderr": "Pseudo-terminal will not be allocated because stdin is not a terminal.\r\nTraceback (most recent call last):\n  File \"<stdin>\", line 5221, in <module>\n  File \"<stdin>\", line 140, in main\n  File \"<stdin>\", line 84, in run_setup\n  File \"<stdin>\", line 5158, in ansible_facts\n  File \"<stdin>\", line 4052, in populate\n  File \"<stdin>\", line 4248, in get_interfaces_info\n  File \"<stdin>\", line 4219, in parse_ip_output\nValueError: need more than 1 value to unpack\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 1\r\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}

After:

"ansible_tun0": {
            "active": true,
            "device": "tun0",
            "ipv6": [
                 {
                    "address": "2aXX:XXXX:f0:fffe::2",
                    "prefix": "128",
                    "scope": "global"
                }
            ],
            "mtu": 1304,
            "promisc": false
        },
```
