### PR TITLE
[WIP] Extra test and build dependencies in Docker images

### DIFF
--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -1,14 +1,19 @@
 # Latest version of centos
 FROM centos:centos6
-RUN yum -y update; yum clean all; 
+RUN yum -y update; yum clean all;
 RUN yum -y install \
     acl \
+    asciidoc \
+    bzip2 \
     epel-release \
     file \
     gcc \
     git \
     make \
     mercurial \
+    mysql \
+    MySQL-python \
+    rpm-build \
     rubygems \
     sed \
     subversion \
@@ -16,7 +21,8 @@ RUN yum -y install \
     unzip \
     openssh-clients \
     openssh-server \
-    which
+    which \
+    zip
 RUN yum -y install \
     PyYAML \
     python-coverage \

--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -12,6 +12,7 @@ RUN yum -y install \
     make \
     mercurial \
     mysql \
+    mysql-server \
     MySQL-python \
     rpm-build \
     rubygems \

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -11,13 +11,18 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 RUN yum -y install \
     acl \
+    asciidoc \
     dbus-python \
+    bzip2 \
     epel-release \
     file \
     git \
     iproute \
     make \
     mercurial \
+    mariadb-server \
+    MySQL-python \
+    rpm-build \
     rubygems \
     subversion \
     sudo \

--- a/test/utils/docker/fedora-rawhide/Dockerfile
+++ b/test/utils/docker/fedora-rawhide/Dockerfile
@@ -11,7 +11,9 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 RUN dnf -y install \
     acl \
+    asciidoc \
     dbus-python \
+    bzip2 \
     file \
     findutils \
     git \
@@ -19,6 +21,8 @@ RUN dnf -y install \
     iproute \
     make \
     mercurial \
+    mariadb-server \
+    MySQL-python \
     procps \
     PyYAML \
     python-coverage \
@@ -32,6 +36,7 @@ RUN dnf -y install \
     python-pip \
     python-setuptools \
     python-virtualenv \
+    rpm-build \
     rubygems \
     subversion \
     sudo \
@@ -40,7 +45,8 @@ RUN dnf -y install \
     which \
     openssh-clients \
     openssh-server \
-    yum
+    yum \
+    zip
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8
 RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/

--- a/test/utils/docker/fedora23/Dockerfile
+++ b/test/utils/docker/fedora23/Dockerfile
@@ -1,4 +1,4 @@
-# Latest version of centos
+# Latest version of fedora 23
 FROM fedora:23
 RUN dnf -y update; dnf clean all
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
@@ -11,7 +11,9 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 RUN dnf -y install \
     acl \
+    asciidoc \
     dbus-python \
+    bzip2 \
     file \
     findutils \
     glibc-common \
@@ -19,6 +21,8 @@ RUN dnf -y install \
     iproute \
     make \
     mercurial \
+    mariadb-server \
+    MySQL-python \
     procps \
     PyYAML \
     python-coverage \
@@ -32,6 +36,7 @@ RUN dnf -y install \
     python-pip \
     python-setuptools \
     python-virtualenv \
+    rpm-build \
     rubygems \
     subversion \
     sudo \
@@ -40,7 +45,8 @@ RUN dnf -y install \
     which \
     openssh-clients \
     openssh-server \
-    yum
+    yum \
+    zip
 RUN localedef --quiet -f ISO-8859-1 -i pt_BR pt_BR
 RUN localedef --quiet -f ISO-8859-1 -i es_MX es_MX
 RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers

--- a/test/utils/docker/opensuseleap/Dockerfile
+++ b/test/utils/docker/opensuseleap/Dockerfile
@@ -18,7 +18,7 @@ RUN zypper --non-interactive install --auto-agree-with-licenses \
     make \
     mercurial \
     mariadb \
-    MySQL-python \
+    python-mysql \
     openssh \
     rpm-build \
     ruby \
@@ -48,7 +48,7 @@ rm -f /etc/systemd/system/*.wants/*; \
 rm -f ${LIBSYSTEMD}/local-fs.target.wants/*; \
 rm -f ${LIBSYSTEMD}/sockets.target.wants/*udev*; \
 rm -f ${LIBSYSTEMD}/sockets.target.wants/*initctl*; \
-rm -f ${LIBSYSTEMD}/basic.target.wants/*; 
+rm -f ${LIBSYSTEMD}/basic.target.wants/*;
 
 # don't create systemd-session for ssh connections
 RUN sed -i /pam_systemd/d /etc/pam.d/common-session-pc

--- a/test/utils/docker/opensuseleap/Dockerfile
+++ b/test/utils/docker/opensuseleap/Dockerfile
@@ -1,0 +1,69 @@
+FROM opensuse:leap
+
+RUN zypper --gpg-auto-import-keys --non-interactive ref && \
+    zypper --gpg-auto-import-keys --non-interactive up
+
+#RUN yum -y update; yum clean all; yum -y swap fakesystemd systemd
+
+RUN zypper --non-interactive install --auto-agree-with-licenses \
+    acl \
+    asciidoc \
+    bzip2 \
+    dbus-1-python \
+    gcc \
+    git \
+    glibc-locale \
+    iproute \
+    lsb-release \
+    make \
+    mercurial \
+    mariadb \
+    MySQL-python \
+    openssh \
+    rpm-build \
+    ruby \
+    subversion \
+    sudo \
+    tar \
+    unzip \
+    which \
+    zip \
+    python-PyYAML \
+    python-coverage \
+    python-httplib2 \
+    python-jinja2 \
+    python-keyczar \
+    python-mock \
+    python-nose \
+    python-paramiko \
+    python-pip \
+    python-setuptools \
+    python-virtualenv
+
+# systemd path differs from rhel
+ENV LIBSYSTEMD=/usr/lib/systemd/system
+RUN (cd ${LIBSYSTEMD}/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f ${LIBSYSTEMD}/multi-user.target.wants/*; \
+rm -f /etc/systemd/system/*.wants/*; \
+rm -f ${LIBSYSTEMD}/local-fs.target.wants/*; \
+rm -f ${LIBSYSTEMD}/sockets.target.wants/*udev*; \
+rm -f ${LIBSYSTEMD}/sockets.target.wants/*initctl*; \
+rm -f ${LIBSYSTEMD}/basic.target.wants/*; 
+
+# don't create systemd-session for ssh connections
+RUN sed -i /pam_systemd/d /etc/pam.d/common-session-pc
+
+#RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8
+RUN mkdir /etc/ansible/
+RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+VOLUME /sys/fs/cgroup /run /tmp
+RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
+    ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+# explicitly enable the service, opensuse default to disabled services
+RUN systemctl enable sshd.service
+ENV container=docker
+CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -1,20 +1,34 @@
 FROM ubuntu:precise
 RUN apt-get clean; apt-get update -y;
 RUN apt-get install -y \
+    apache2 \
+    asciidoc \
     acl \
+    bzip2 \
+    cdbs \
+    debhelper \
     debianutils \
+    devscripts \
+    docbook-xml \
+    dpkg-dev \
+    fakeroot \
     gawk \
     git \
+    libxml2-utils \
     locales \
     make \
     mercurial \
+    mysql-server \
+    reprepro \
     ruby \
     rubygems \
     subversion \
     sudo \
     openssh-client \
     openssh-server \
-    unzip
+    unzip \
+    zip \
+    xsltproc
 
 # helpful things taken from the ubuntu-upstart Dockerfile:
 # https://github.com/tianon/dockerfiles/blob/4d24a12b54b75b3e0904d8a285900d88d3326361/sbin-init/ubuntu/upstart/14.04/Dockerfile
@@ -51,6 +65,7 @@ RUN apt-get install -y \
     python-jinja2 \
     python-keyczar \
     python-mock \
+    python-mysqldb \
     python-nose \
     python-paramiko \
     python-pip \

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -1,19 +1,33 @@
 FROM ubuntu:trusty
 RUN apt-get clean; apt-get update -y;
 RUN apt-get install -y \
+    apache2 \
+    asciidoc \
     acl \
+    bzip2 \
+    cdbs \
+    debhelper \
     debianutils \
+    devscripts \
+    docbook-xml \
+    dpkg-dev \
+    fakeroot \
     gawk \
     git \
+    libxml2-utils \
     locales \
     make \
     mercurial \
+    mysql-server \
+    reprepro \
     ruby \
     subversion \
     sudo \
     openssh-client \
     openssh-server \
-    unzip
+    unzip \
+    zip \
+    xsltproc
 
 # helpful things taken from the ubuntu-upstart Dockerfile:
 # https://github.com/tianon/dockerfiles/blob/4d24a12b54b75b3e0904d8a285900d88d3326361/sbin-init/ubuntu/upstart/14.04/Dockerfile
@@ -49,6 +63,7 @@ RUN apt-get install -y \
     python-jinja2 \
     python-keyczar \
     python-mock \
+    python-mysqldb \
     python-nose \
     python-paramiko \
     python-pip \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -1,0 +1,70 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV container docker
+
+RUN apt-get clean; apt-get update -y;
+RUN echo 'APT::Install-Recommends "0"; \n\
+APT::Get::Assume-Yes "true"; \n\
+APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01buildconfig
+
+
+RUN apt-get install -y \
+    apache2 \
+    asciidoc \
+    acl \
+    bzip2 \
+    cdbs \
+    debhelper \
+    debianutils \
+    devscripts \
+    docbook-xml \
+    dpkg-dev \
+    fakeroot \
+    gawk \
+    git \
+    iproute2 \
+    libxml2-utils \
+    locales \
+    lsb-release \
+    make \
+    mercurial \
+    mysql-server \
+    openssh-client \
+    openssh-server \
+    python-dbus \
+    reprepro \
+    rsync \
+    ruby \
+    subversion \
+    sudo \
+    unzip \
+    zip \
+    xsltproc \
+    python-coverage \
+    python-httplib2 \
+    python-jinja2 \
+    python-keyczar \
+    python-mock \
+    python-mysqldb \
+    python-nose \
+    python-paramiko \
+    python-pip \
+    python-setuptools \
+    python-virtualenv \
+    virtualenv \
+    python-yaml
+
+# some tests assume the .deb is cached
+RUN rm /etc/apt/apt.conf.d/docker-clean
+
+RUN locale-gen en_US.UTF-8
+RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+
+RUN mkdir /etc/ansible/
+RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+VOLUME /sys/fs/cgroup /run/lock /run /tmp
+CMD ["/sbin/init"]

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -18,10 +18,9 @@ else
         docker pull sivel/httptester
         docker run -d --name=httptester sivel/httptester > /tmp/cid_httptester
     fi
-    IMAGE="gundalow/ansible:${TARGET}"
     export C_NAME="testAbull_$$_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
-    docker pull "${IMAGE}"
-    docker run -d --volume="${PWD}:/root/ansible:Z" $LINKS --name "${C_NAME}" ${TARGET_OPTIONS:=''} "${IMAGE}" > /tmp/cid_${TARGET}
+    docker pull ansible/ansible:${TARGET}
+    docker run -d --volume="${PWD}:/root/ansible:Z" $LINKS --name "${C_NAME}" ${TARGET_OPTIONS:=''} ansible/ansible:${TARGET} > /tmp/cid_${TARGET}
     docker exec -ti $(cat /tmp/cid_${TARGET}) /bin/sh -c "export TEST_FLAGS='${TEST_FLAGS:-''}'; cd /root/ansible; . hacking/env-setup; (cd test/integration; LC_ALL=en_US.utf-8 make ${MAKE_TARGET:-})"
     docker kill $(cat /tmp/cid_${TARGET})
 

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -18,9 +18,10 @@ else
         docker pull sivel/httptester
         docker run -d --name=httptester sivel/httptester > /tmp/cid_httptester
     fi
+    IMAGE="gundalow/ansible:${TARGET}"
     export C_NAME="testAbull_$$_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
-    docker pull ansible/ansible:${TARGET}
-    docker run -d --volume="${PWD}:/root/ansible:Z" $LINKS --name "${C_NAME}" ${TARGET_OPTIONS:=''} ansible/ansible:${TARGET} > /tmp/cid_${TARGET}
+    docker pull "${IMAGE}"
+    docker run -d --volume="${PWD}:/root/ansible:Z" $LINKS --name "${C_NAME}" ${TARGET_OPTIONS:=''} "${IMAGE}" > /tmp/cid_${TARGET}
     docker exec -ti $(cat /tmp/cid_${TARGET}) /bin/sh -c "export TEST_FLAGS='${TEST_FLAGS:-''}'; cd /root/ansible; . hacking/env-setup; (cd test/integration; LC_ALL=en_US.utf-8 make ${MAKE_TARGET:-})"
     docker kill $(cat /tmp/cid_${TARGET})
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

N/A
##### SUMMARY

As suggested in https://github.com/ansible/ansible/pull/15304 install the dependencies to build debs and RPMs

Also to speed up a number of the integration tests we can install the needed dependencies in the base docker image.

Previously running the integration tests using the Ansible 14.04 image on a high spec machine with SSD

```
TASK: setup_mysql_db : install mysqldb_test debian dependencies ------- 134.92s
TASK: setup_postgresql_db : install dpkg dependencies for postgresql test -- 39.58s
TASK: test_unarchive : Ensure zip is present to create test archive (apt) -- 29.42s
TASK: test_apache2_module : install apache via apt --------------------- 17.47s

```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/15692)

<!-- Reviewable:end -->
