### PR TITLE
actionable.py: Do not print next task banner in handler callback

### DIFF
--- a/lib/ansible/plugins/callback/actionable.py
+++ b/lib/ansible/plugins/callback/actionable.py
@@ -33,6 +33,10 @@ class CallbackModule(CallbackModule_default):
         self.last_task = None
         self.shown_title = False
 
+    def v2_playbook_on_handler_task_start(self, task):
+        self.super_ref.v2_playbook_on_handler_task_start(task)
+        self.shown_title = True
+
     def v2_playbook_on_task_start(self, task, is_conditional):
         self.last_task = task
         self.shown_title = False


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (actionable_cb_handler_banner 1782e9e08a) last updated 2016/05/03 12:55:37 (GMT +200)
  lib/ansible/modules/core: (devel 82aeaed45d) last updated 2016/05/02 11:29:22 (GMT +200)
  lib/ansible/modules/extras: (devel 85c1440ede) last updated 2016/04/13 15:34:06 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix actionable callback plugin to not print the banner of the previous
task.

When a handler is executed there is no task banner, so in case it is run,
it will reference the banner from the preceding task.

Author: @hvhaugwitz

Test case:

```
  ---

  - name: actionable filter
    hosts: all
    handlers:
      - name: handler
        command: "true"
    tasks:
      - name: task 1
        file: path=/tmp/test state=touch
        notify: handler
      - name: task 2
        file: path=/tmp/test state=absent
      - name: task 3
        file: path=/tmp/test state=absent
      - name: task 4
        file: path=/tmp/test state=absent
      - name: task 5
        file: path=/tmp/test state=absent
      - name: task 6
        file: path=/tmp/test state=absent
```

Example output:
## BEFORE

```
  PLAY [actionable filter] *******************************************************

  TASK [task 1] ******************************************************************
  changed: [localhost]

  TASK [task 2] ******************************************************************
  changed: [localhost]

  RUNNING HANDLER [handler] ******************************************************

  TASK [task 6] ******************************************************************
  changed: [localhost]

  PLAY RECAP *********************************************************************
  localhost                  : ok=8    changed=3    unreachable=0    failed=0
```
## AFTER

```
  PLAY [actionable filter] *******************************************************

  TASK [task 1] ******************************************************************
  changed: [localhost]

  TASK [task 2] ******************************************************************
  changed: [localhost]

  RUNNING HANDLER [handler] ******************************************************
  changed: [localhost]

  PLAY RECAP *********************************************************************
  localhost                  : ok=8    changed=3    unreachable=0    failed=0
```
