### PR TITLE
Add a jsonarg type to arg spec

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -609,6 +609,7 @@ class AnsibleModule(object):
                 'float': self._check_type_float,
                 'path': self._check_type_path,
                 'raw': self._check_type_raw,
+                'jsonarg': self._check_type_jsonarg,
             }
         if not bypass_checks:
             self._check_required_arguments()
@@ -1394,6 +1395,16 @@ class AnsibleModule(object):
     def _check_type_path(self, value):
         value = self._check_type_str(value)
         return os.path.expanduser(os.path.expandvars(value))
+
+    def _check_type_jsonarg(self, value):
+        # Return a jsonified string.  Sometimes the controller turns a json
+        # string into a dict/list so transform it back into json here
+        if isinstance(value, (unicode, bytes)):
+            return value
+        else:
+            if isinstance(value (list, tuple, dict)):
+                return json.dumps(value)
+        raise TypeError('%s cannot be converted to a json string' % type(value))
 
     def _check_type_raw(self, value):
         return value


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

For devel and stable-2.1
##### SUMMARY

A few modules take a jsonified string as input.  Unfortunately, between ansible's yaml and jinja2 templating we sometimes end up with a user-entered json string being turned into a dict or list before it is passed to the modules.  this is tricky to fix in ansible controller-side so create a new argspec type to automatically convert to a modules parameter to a json string.

This makes sure that if we get a list or dict that it is turned into
a jsonified string.
