### PR TITLE
Add Ubuntu xenial 16.04 image to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=ubuntu1204
     - env: TARGET=ubuntu1404
+    - env: TARGET=ubuntu1604 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=sanity TOXENV=py26
       python: 2.6
     - env: TARGET=sanity TOXENV=py27

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -11,21 +11,31 @@ APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01buildconfig
 
 RUN apt-get install -y \
     acl \
+    asciidoc \
+    cdbs \
+    debhelper \
     debianutils \
-    python-dbus \
+    devscripts \
+    docbook-xml \
+    dpkg-dev \
+    fakeroot \
     gawk \
     git \
+    libxml2-utils \
     locales \
     lsb-release \
     make \
     mercurial \
-    ruby \
-    rsync \
-    subversion \
-    sudo \
     openssh-client \
     openssh-server \
+    python-dbus \
+    reprepro \
+    rsync \
+    ruby \
+    subversion \
+    sudo \
     unzip \
+    xsltproc \
     python-coverage \
     python-httplib2 \
     python-jinja2 \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get install -y \
     fakeroot \
     gawk \
     git \
+    iproute2 \
     libxml2-utils \
     locales \
     lsb-release \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV container docker
+
+RUN apt-get clean; apt-get update -y;
+RUN echo 'APT::Install-Recommends "0"; \n\
+APT::Get::Assume-Yes "true"; \n\
+APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01buildconfig
+
+
+RUN apt-get install -y \
+    acl \
+    debianutils \
+    python-dbus \
+    gawk \
+    git \
+    locales \
+    lsb-release \
+    make \
+    mercurial \
+    ruby \
+    rsync \
+    subversion \
+    sudo \
+    openssh-client \
+    openssh-server \
+    unzip \
+    python-coverage \
+    python-httplib2 \
+    python-jinja2 \
+    python-keyczar \
+    python-mock \
+    python-nose \
+    python-paramiko \
+    python-pip \
+    python-setuptools \
+    python-virtualenv \
+    virtualenv \
+    python-yaml
+
+# some tests assume the .deb is cached
+RUN rm /etc/apt/apt.conf.d/docker-clean
+
+RUN locale-gen en_US.UTF-8
+RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+
+RUN mkdir /etc/ansible/
+RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+VOLUME /sys/fs/cgroup /run/lock /run /tmp
+CMD ["/sbin/init"]

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -12,9 +12,11 @@ if [ "${TARGET}" = "sanity" ]; then
     if test x"$TOXENV" != x'py24' ; then tox ; fi
     if test x"$TOXENV" = x'py24' ; then python2.4 -V && python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce|docker_common|azure_rm_common).py' lib/ansible/module_utils ; fi
 else
+    IMAGE=ansible/ansible:${TARGET}
+    if [ ${TARGET} = ubuntu1604 ]; then IMAGE=robinro/ansible-testing:ubuntu1604; fi
     export C_NAME="testAbull_$$_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
-    docker pull ansible/ansible:${TARGET}
-    docker run -d --volume="${PWD}:/root/ansible:Z"  --name "${C_NAME}" ${TARGET_OPTIONS:=''} ansible/ansible:${TARGET} > /tmp/cid_${TARGET}
+    docker pull ${IMAGE}
+    docker run -d --volume="${PWD}:/root/ansible:Z"  --name "${C_NAME}" ${TARGET_OPTIONS:=''} ${IMAGE} > /tmp/cid_${TARGET}
     docker exec -ti $(cat /tmp/cid_${TARGET}) /bin/sh -c "export TEST_FLAGS='${TEST_FLAGS:-''}'; cd /root/ansible; . hacking/env-setup; (cd test/integration; LC_ALL=en_US.utf-8 make ${MAKE_TARGET:-})"
     docker kill $(cat /tmp/cid_${TARGET})
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

2.2, devel
##### SUMMARY

Adds ubuntu xenial 16.04 to the list of images run by travis.
Also fix broken tests.

Before merging the image should appear in dockerhub ansible/ansible and the IMAGE=robinro/\* hack be removed.
