### PR TITLE
better fix for arch version detection

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -628,6 +628,7 @@ class Distribution(object):
         'OracleLinux': 'Oracle Linux',
         'RedHat': 'Red Hat',
         'Altlinux': 'ALT Linux',
+        'Archlinux': '',
     }
 
     # A list with OS Family members
@@ -779,10 +780,6 @@ class Distribution(object):
         release = re.search('DISTRIB_CODENAME="(.*)"', data)
         if release:
             self.facts['distribution_release'] = release.groups()[0]
-
-    def get_distribution_Archlinux(self, name, data, path):
-        self.facts['distribution'] = 'Archlinux'
-        self.facts['distribution_version'] = data
 
     def get_distribution_Alpine(self, name, data, path):
         self.facts['distribution'] = 'Alpine'


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

devel
##### SUMMARY

for Arch we only set `distribution`, so it does not need it's own function but it's enough to check the existance of the arch-release file.
fixes  #15696

This restores the 2.1 case. A more complete fix might be good, see discussion at  #15695
