### PR TITLE
Track build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,6 @@ notifications:
     on_failure: always
     skip_join: true
     nick: ansibletravis
+  webhooks:
+    # trigger Buildtime Trend Service to parse Travis CI log
+    - https://buildtimetrend.herokuapp.com/travis


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

N/A
##### SUMMARY

As part of https://github.com/ansible/community/issues/47 it would be great to collect some extra data.

I found http://buildtimetrend.github.io/ which, which a single line, gives us a load of extra data. I'd hope that with some analysis I can find some ways to improve the perfomance.

This should allow us to see if a particular change or Operating System has a sudden increase in runtime

Here is the data for my repo, which doesn't have much going on http://buildtimetrend.herokuapp.com/dashboard/gundalow/ansible/index.html

I think this is a safe change, the only link is via a webhook, no GitHub or Travis access is requested/required

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/15708)

<!-- Reviewable:end -->
