### PR TITLE
Avoid duplicate system related fact calls.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -169,10 +169,13 @@ class Facts(object):
                  { 'path' : '/usr/local/sbin/pkg',  'name' : 'pkgng' },
                 ]
 
-    def __init__(self, module, load_on_init=True):
+    def __init__(self, module, load_on_init=True, cached_facts={}):
 
         self.module = module
-        self.facts = {}
+        if not cached_facts:
+            self.facts = {}
+        else:
+            self.facts = cached_facts    
         ### TODO: Eventually, these should all get moved to populate().  But
         # some of the values are currently being used by other subclasses (for
         # instance, os_family and distribution).  Have to sort out what to do
@@ -3177,7 +3180,9 @@ def ansible_facts(module, gather_subset):
     facts['gather_subset'] = list(gather_subset)
     facts.update(Facts(module).populate())
     for subset in gather_subset:
-        facts.update(FACT_SUBSETS[subset](module).populate())
+        facts.update(FACT_SUBSETS[subset](module,
+                                         load_on_init=False,
+                                         cached_facts=facts).populate())
     return facts
 
 def get_all_facts(module):

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -169,7 +169,7 @@ class Facts(object):
                  { 'path' : '/usr/local/sbin/pkg',  'name' : 'pkgng' },
                 ]
 
-    def __init__(self, module, load_on_init=True, cached_facts={}):
+    def __init__(self, module, load_on_init=True, cached_facts=None):
 
         self.module = module
         if not cached_facts:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (FACTS_TUNE cd1a660bad) last updated 2016/05/04 00:06:50 (GMT -400)
  lib/ansible/modules/core: (devel 67de0675c3) last updated 2016/05/03 22:14:46 (GMT -400)
  lib/ansible/modules/extras: (devel e8391d6985) last updated 2016/05/03 22:14:54 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

When getting each "subset" of facts, some will load/run all the generic fact calls again. This patch attempts to eliminate that behavior and reuse previously collected facts.

Addresses https://github.com/ansible/ansible-modules-core/issues/1461
