### PR TITLE
Don't assume a task with non-dict loop results has been skipped.

### DIFF
--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -41,11 +41,8 @@ class TaskResult:
 
     def is_skipped(self):
         if 'results' in self._result and self._task.loop:
-            flag = True
-            for res in self._result.get('results', []):
-                if isinstance(res, dict):
-                    flag &= res.get('skipped', False)
-            return flag
+            results = self._result['results']
+            return results and all(isinstance(res, dict) and res.get('skipped', False) for res in results)
         else:
             return self._result.get('skipped', False)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.2.0
```
##### SUMMARY

This pull request addresses the issue reported here:

  https://github.com/ansible/ansible-modules-core/issues/1765

The yum module (at least) includes its task results as strings, rather than dicts, and the code this changeset replaces assumed that in that instance the task was skipped. The updated behaviour assumes that the task has been skipped only if:
- results exist, and
- all results are dicts that include a truthy skipped value
