### PR TITLE
fixes-#15685-tools-that-paginate-show-spurious-less-output: less --ve…

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -476,7 +476,7 @@ class CLI(object):
                 display.display(text)
             else:
                 self.pager_pipe(text, os.environ['PAGER'])
-        elif subprocess.call('(less --version) 2> /dev/null', shell = True) == 0:
+        elif subprocess.call('(less --version) &> /dev/null', shell = True) == 0:
             self.pager_pipe(text, 'less')
         else:
             display.display(text)


### PR DESCRIPTION
fixes-#15685-tools-that-paginate-show-spurious-less-output: 

As mentioned in the issue #15685 : 
less --version outputs to standard out not to standard error so this changes the redirect from 2> to >
which does not show the less version anymore when running commands.

Before fix : 

```
$ ansible-galaxy search json
less 458 (POSIX regular expressions)
Copyright (C) 1984-2012 Mark Nudelman

less comes with NO WARRANTY, to the extent permitted by law.
For information about the terms of redistribution,
see the file named README in the less distribution.
Homepage: http://www.greenwoodsoftware.com/less

Found 2 roles matching your search:

 Name                            Description
 ----                            -----------
 dereulenspiegel.alfred-json     Installs alfred-json
 minderaswcraft.chef_solo_runner Runs chef-solo giving the cookbooks archive, the json attributes (usually called node.json) file and optionaly the location of databags, environment
(END)
```

After fix:  

```
$ ./bin/ansible-galaxy search json

Found 2 roles matching your search:

 Name                            Description
 ----                            -----------
 dereulenspiegel.alfred-json     Installs alfred-json
 minderaswcraft.chef_solo_runner Runs chef-solo giving the cookbooks archive, the json attributes (usually called node.json) file and optionaly the location of databags, environment
(END)

```
