### PR TITLE
Provide options for SSH key checking

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+import os
 import re
 import socket
 import time
@@ -72,14 +73,14 @@ class Shell(object):
 
     def open(self, host, port=22, username=None, password=None, timeout=10,
              key_filename=None, pkey=None, look_for_keys=None,
-             allow_agent=False, key_policy="ignore"):
+             allow_agent=False, key_policy="loose"):
 
         self.ssh = paramiko.SSHClient()
         if key_policy != "ignore":
             self.ssh.load_system_host_keys()
             try:
-                self.ssh.load_host_keys('~/.ssh/known_hosts')
-            except:
+                self.ssh.load_host_keys(os.path.expanduser('~/.ssh/known_hosts'))
+            except IOError:
                 pass
 
         if key_policy == "strict":

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -70,12 +70,22 @@ class Shell(object):
         self.prompts = prompts_re or list()
         self.errors = errors_re or list()
 
-    def open(self, host, port=22, username=None, password=None,
-            timeout=10, key_filename=None, pkey=None, look_for_keys=None,
-            allow_agent=False):
+    def open(self, host, port=22, username=None, password=None, timeout=10,
+             key_filename=None, pkey=None, look_for_keys=None,
+             allow_agent=False, key_policy="ignore"):
 
         self.ssh = paramiko.SSHClient()
-        self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        if key_policy != "ignore":
+            self.ssh.load_system_host_keys()
+            try:
+                self.ssh.load_host_keys('~/.ssh/known_hosts')
+            except:
+                pass
+
+        if key_policy == "strict":
+            self.ssh.set_missing_host_key_policy(paramiko.RejectPolicy())
+        else:
+            self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         # unless explicitly set, disable look for keys if a password is
         # present. this changes the default search order paramiko implements
@@ -83,9 +93,11 @@ class Shell(object):
             look_for_keys = password is None
 
         try:
-            self.ssh.connect(host, port=port, username=username, password=password,
-                        timeout=timeout, look_for_keys=look_for_keys, pkey=pkey,
-                        key_filename=key_filename, allow_agent=allow_agent)
+            self.ssh.connect(
+                host, port=port, username=username, password=password,
+                timeout=timeout, look_for_keys=look_for_keys, pkey=pkey,
+                key_filename=key_filename, allow_agent=allow_agent,
+            )
 
             self.shell = self.ssh.invoke_shell()
             self.shell.settimeout(timeout)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.x
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Addresses #15702 by adding key_policy parameter to Shell.open

A value of "ignore" preserves the current behavior of automatically adding unknown host keys with no known hosts defined
A value of "strict" loads known host keys from the host and rejects hosts it does not recognize.
Any other value loads the system host keys, but does not reject unknown hosts, only changed hosts.
