### PR TITLE
default callback is way to verbose

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -213,6 +213,8 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_include(self, included_file):
+        if self._display.verbosity < 2:
+            return
         msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
         self._display.display(msg, color=C.COLOR_SKIP)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The v2 default callback set is way to verbose.
This is especially visible when running on a specifically tagged task: it should rather not show all in-between include statements when verbosity < 2.
(IMHO even for non-tagged run the current output is inadequate)

See below: this is using the _MINIMAL_ verbosity, for a specific given tag.

```
TASK [my.bootstrap : include] *****************************************

included: xxx/tasks/blah.yml for hostname

TASK [my.bootstrap : include] *****************************************

included: xxx/tasks/foo.yml for hostname

[tons of them]
```

This PR is just about the `included: xxx/tasks/blah.yml for hostname` lines.
It reduce their visibility toto verbosity-levels 2 and more.
(like it's already the case for `task path:` lines)

I'd like to do the same for the two others but:
1) this need to be discussed further
2) changing the TASK line for `include` only seems a bit more tricky
