### PR TITLE
Allow ssh agent usage for junos_netconf

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -95,7 +95,7 @@ class Cli(object):
 
         try:
             self.shell = Shell()
-            self.shell.open(host, port=port, username=username, password=password, key_filename=key_filename)
+            self.shell.open(host, port=port, username=username, password=password, key_filename=key_filename, allow_agent=True)
         except ShellError:
             e = get_exception()
             msg = 'failed to connect to %s:%s - %s' % (host, port, str(e))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0 (detached HEAD 5954a82dd6) last updated 2016/05/06 15:42:58 (GMT +100)
  lib/ansible/modules/core: (detached HEAD ce79e7c72d) last updated 2016/05/06 15:43:22 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 156a8cd0b3) last updated 2016/05/06 15:43:22 (GMT +100)
```
##### SUMMARY

By default the `Shell` class disables ssh agents. The `junos_netconf`
module uses this class, but doesn't re-enable agents.
Here it's explicitly enabled again, so an ssh agent can be used to
connect to and configure Junos devices.

```
Before:
FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_FYBc7z/ansible_module_junos_netconf.py\", line 122, in <module>\n    main()\n  File \"/tmp/ansible_FYBc7z/ansible_module_junos_netconf.py\", line 92, in main\n    supports_check_mode=True)\n  File \"/export/home/m/virtualenvs/network-config/src/ansible/lib/ansible/module_utils/junos.py\", line 354, in get_module\n    module.connect()\n  File \"/export/home/m/virtualenvs/network-config/src/ansible/lib/ansible/module_utils/junos.py\", line 301, in connect\n    self.connection.connect()\n  File \"/export/home/m/virtualenvs/network-config/src/ansible/lib/ansible/module_utils/junos.py\", line 98, in connect\n    self.shell.open(host, port=port, username=username, password=password, key_filename=key_filename)\n  File \"/export/home/m/virtualenvs/network-config/src/ansible/lib/ansible/module_utils/shell.py\", line 106, in open\n    key_filename=key_filename, allow_agent=allow_agent)\n  File \"/export/home/m/virtualenvs/network-config/local/lib/python2.7/site-packages/paramiko/client.py\", line 367, in connect\n    look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host)\n  File \"/export/home/m/virtualenvs/network-config/local/lib/python2.7/site-packages/paramiko/client.py\", line 585, in _auth\n    raise saved_exception\nparamiko.ssh_exception.PasswordRequiredException: Private key file is encrypted\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
After:
It connects successfully
```
