### PR TITLE
Fix unititests with py.test

### DIFF
--- a/test/units/module_utils/basic/test_run_command.py
+++ b/test/units/module_utils/basic/test_run_command.py
@@ -30,8 +30,7 @@ from ansible.compat.tests.mock import call, MagicMock, Mock, patch, sentinel
 
 from units.mock.procenv import swap_stdin_and_argv
 
-from ansible.module_utils import basic
-from ansible.module_utils.basic import AnsibleModule
+import ansible.module_utils.basic
 
 class OpenBytesIO(BytesIO):
     """BytesIO with dummy close() method
@@ -67,8 +66,8 @@ class TestAnsibleModuleRunCommand(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
-        basic._ANSIBLE_ARGS = None
-        self.module = AnsibleModule(argument_spec=dict())
+        ansible.module_utils.basic._ANSIBLE_ARGS = None
+        self.module = ansible.module_utils.basic.AnsibleModule(argument_spec=dict())
         self.module.fail_json = MagicMock(side_effect=SystemExit)
 
         self.os = patch('ansible.module_utils.basic.os').start()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

devel, 2.2
##### SUMMARY

This makes the unittests compatible with py.test, by using absolute imports in combination with reload. py.test is rather restrictive about the use of reload.

Also for the async test I reduce the sleep time (from 3sec to 0.1sec). For me this saves more than 50% of the total runtime of the unittests and makes them even more attractive to run.
