### PR TITLE
show where plugins were loaded in vvvv/vvvvv

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -123,15 +123,18 @@ class PluginLoader:
             PLUGIN_PATH_CACHE = PLUGIN_PATH_CACHE[self.class_name],
         )
 
-    def print_paths(self):
+    def format_paths(self, paths):
         ''' Returns a string suitable for printing of the search path '''
 
         # Uses a list to get the order right
         ret = []
-        for i in self._get_paths():
+        for i in paths:
             if i not in ret:
                 ret.append(i)
         return os.pathsep.join(ret)
+
+    def print_paths(self):
+        return self.format_paths(self._get_paths())
 
     def _all_directories(self, dir):
         results = []
@@ -201,7 +204,6 @@ class PluginLoader:
         # cache and return the result
         self._paths = reordered_paths
         return reordered_paths
-
 
     def add_directory(self, directory, with_subdir=False):
         ''' Adds an additional directory to the search path '''
@@ -322,6 +324,7 @@ class PluginLoader:
     def get(self, name, *args, **kwargs):
         ''' instantiates a plugin of the given name using arguments '''
 
+        found_in_cache = True
         class_only = kwargs.pop('class_only', False)
         if name in self.aliases:
             name = self.aliases[name]
@@ -331,6 +334,7 @@ class PluginLoader:
 
         if path not in self._module_cache:
             self._module_cache[path] = self._load_module_source('.'.join([self.package, name]), path)
+            found_in_cache = False
 
         obj = getattr(self._module_cache[path], self.class_name)
         if self.base_class:
@@ -345,16 +349,31 @@ class PluginLoader:
             if not issubclass(obj, plugin_class):
                 return None
 
+        self._display_plugin_load(self.class_name, name, self._searched_paths, path,
+                                  found_in_cache=found_in_cache, class_only=class_only)
         if not class_only:
             obj = obj(*args, **kwargs)
 
         return obj
+
+    def _display_plugin_load(self, class_name, name, searched_paths, path, found_in_cache=None, class_only=None):
+        searched_msg = 'Searching for plugin type %s named \'%s\' in paths: %s' % (class_name, name, self.format_paths(searched_paths))
+        loading_msg = 'Loading plugin type %s named \'%s\' from %s' % (class_name, name, path)
+
+        if found_in_cache or class_only:
+            extra_msg = 'found_in_cache=%s, class_only=%s' % (found_in_cache, class_only)
+            display.debug('%s %s' % (searched_msg, extra_msg))
+            display.debug('%s %s' % (loading_msg, extra_msg))
+        else:
+            display.vvvv(searched_msg)
+            display.vvv(loading_msg)
 
     def all(self, *args, **kwargs):
         ''' instantiates all plugins with the same arguments '''
 
         class_only = kwargs.pop('class_only', False)
         all_matches = []
+        found_in_cache = True
 
         for i in self._get_paths():
             all_matches.extend(glob.glob(os.path.join(i, "*.py")))
@@ -366,6 +385,7 @@ class PluginLoader:
 
             if path not in self._module_cache:
                 self._module_cache[path] = self._load_module_source(name, path)
+                found_in_cache = False
 
             try:
                 obj = getattr(self._module_cache[path], self.class_name)
@@ -384,6 +404,8 @@ class PluginLoader:
                 if not issubclass(obj, plugin_class):
                    continue
 
+            self._display_plugin_load(self.class_name, name, self._searched_paths, path,
+                                      found_in_cache=found_in_cache, class_only=class_only)
             if not class_only:
                 obj = obj(*args, **kwargs)
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -68,7 +68,7 @@ class CallbackBase:
             name = getattr(self, 'CALLBACK_NAME', 'unnamed')
             ctype = getattr(self, 'CALLBACK_TYPE', 'old')
             version = getattr(self, 'CALLBACK_VERSION', '1.0')
-            self._display.vvvv('Loaded callback %s of type %s, v%s' % (name, ctype, version))
+            self._display.vvvv('Loading callback plugin %s of type %s, v%s from %s' % (name, ctype, version, __file__))
 
     ''' helper for callbacks, so they don't all have to include deepcopy '''
     _copy_result = deepcopy


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (log_plugin_path_info 6dd66b1b9d) last updated 2016/05/06 16:09:56 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 1f5cf669dd) last updated 2016/05/06 15:53:17 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 431591c2b4) last updated 2016/05/06 15:53:17 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Add some info about which plugins were loaded, the path of the loaded plugin, and the paths that were searched for the plugin.

Before:

```
[fedora-23:ansible-setup (master % u=)]$ ansible-playbook -vvvvv -i hosts site.yml
Using /home/adrian/ansible/ansible.cfg as config file
Loaded callback default of type stdout, v2.0
Loaded callback stdlog of type notification, v2.0
```

After:

```
[fedora-23:ansible-setup (master % u=)]$ ansible-playbook -vvvvv -i hosts site.yml
Using /home/adrian/ansible/ansible.cfg as config file
Searched for CacheModule plugins 'memory' in paths: /home/adrian/src/ansible/lib/ansible/plugins/cache
Loading plugin CacheModule of type 'memory' from /home/adrian/src/ansible/lib/ansible/plugins/cache/memory.py
Searched for CallbackModule plugins 'default' in paths: /home/adrian/ansible-setup/callback_plugins:/home/adrian/ansible/my-plugins/callback:/home/adrian/src/ansible/lib/ansible/plugins/callback
Loading plugin CallbackModule of type 'default' from /home/adrian/src/ansible/lib/ansible/plugins/callback/default.py
Loading callback plugin default of type stdout, v2.0 from /home/adrian/src/ansible/lib/ansible/plugins/callback/__init__.py
Loading callback plugin stdlog of type notification, v2.0 from /home/adrian/src/ansible/lib/ansible/plugins/callback/__init__.py
```
