### PR TITLE
wrong year in releases file

### DIFF
--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -10,7 +10,7 @@ Released
 ++++++++
 
 2.1.0  "The Song Remains the Same" in progress
-2.0.2  "Over the Hills and Far Away" 04-19-2015
+2.0.2  "Over the Hills and Far Away" 04-19-2016
 2.0.1  "Over the Hills and Far Away" 02-24-2016
 2.0.0  "Over the Hills and Far Away" 01-12-2016
 1.9.6  "Dancing In the Streets" 04-15-2016


### PR DESCRIPTION
##### ISSUE TYPE

 - Docs Pull Request

##### SUMMARY

 - 2.0.2 was released in 2016, not 2015