### PR TITLE
Remove reload from arg related tests.  

### DIFF
--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -28,8 +28,6 @@ from ansible.compat.tests import unittest
 from units.mock.procenv import swap_stdin_and_argv, swap_stdout
 
 from ansible.module_utils import basic
-from ansible.module_utils.basic import heuristic_log_sanitize
-from ansible.module_utils.basic import return_values, remove_values
 
 
 empty_invocation = {u'module_args': {}}
@@ -45,7 +43,7 @@ class TestAnsibleModuleExitJson(unittest.TestCase):
         self.stdout_swap_ctx = swap_stdout()
         self.fake_stream = self.stdout_swap_ctx.__enter__()
 
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
         self.module = basic.AnsibleModule(argument_spec=dict())
 
     def tearDown(self):
@@ -126,8 +124,8 @@ class TestAnsibleModuleExitValuesRemoved(unittest.TestCase):
             params = json.dumps(params)
 
             with swap_stdin_and_argv(stdin_data=params):
-                reload(basic)
                 with swap_stdout():
+                    basic._ANSIBLE_ARGS = None
                     module = basic.AnsibleModule(
                         argument_spec = dict(
                             username=dict(),
@@ -148,8 +146,8 @@ class TestAnsibleModuleExitValuesRemoved(unittest.TestCase):
             params = dict(ANSIBLE_MODULE_ARGS=args, ANSIBLE_MODULE_CONSTANTS={})
             params = json.dumps(params)
             with swap_stdin_and_argv(stdin_data=params):
-                reload(basic)
                 with swap_stdout():
+                    basic._ANSIBLE_ARGS = None
                     module = basic.AnsibleModule(
                         argument_spec = dict(
                             username=dict(),

--- a/test/units/module_utils/basic/test_log.py
+++ b/test/units/module_utils/basic/test_log.py
@@ -28,7 +28,7 @@ from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, MagicMock
 from units.mock.procenv import swap_stdin_and_argv
 
-from ansible.module_utils import basic
+import ansible.module_utils.basic
 
 
 try:
@@ -49,20 +49,20 @@ class TestAnsibleModuleSysLogSmokeTest(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
-        reload(basic)
-        self.am = basic.AnsibleModule(
+        ansible.module_utils.basic._ANSIBLE_ARGS = None
+        self.am = ansible.module_utils.basic.AnsibleModule(
             argument_spec = dict(),
         )
 
-        self.has_journal = basic.has_journal
+        self.has_journal = ansible.module_utils.basic.has_journal
         if self.has_journal:
             # Systems with journal can still test syslog
-            basic.has_journal = False
+            ansible.module_utils.basic.has_journal = False
 
     def tearDown(self):
         # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
         self.stdin_swap.__exit__(None, None, None)
-        basic.has_journal = self.has_journal
+        ansible.module_utils.basic.has_journal = self.has_journal
 
     def test_smoketest_syslog(self):
         # These talk to the live daemons on the system.  Need to do this to
@@ -86,8 +86,8 @@ class TestAnsibleModuleJournaldSmokeTest(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
-        reload(basic)
-        self.am = basic.AnsibleModule(
+        ansible.module_utils.basic._ANSIBLE_ARGS = None
+        self.am = ansible.module_utils.basic.AnsibleModule(
             argument_spec = dict(),
         )
 
@@ -95,7 +95,7 @@ class TestAnsibleModuleJournaldSmokeTest(unittest.TestCase):
         # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
         self.stdin_swap.__exit__(None, None, None)
 
-    @unittest.skipUnless(basic.has_journal, 'python systemd bindings not installed')
+    @unittest.skipUnless(ansible.module_utils.basic.has_journal, 'python systemd bindings not installed')
     def test_smoketest_journal(self):
         # These talk to the live daemons on the system.  Need to do this to
         # show that what we send doesn't cause an issue once it gets to the
@@ -134,19 +134,19 @@ class TestAnsibleModuleLogSyslog(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
-        reload(basic)
-        self.am = basic.AnsibleModule(
+        ansible.module_utils.basic._ANSIBLE_ARGS = None
+        self.am = ansible.module_utils.basic.AnsibleModule(
             argument_spec = dict(),
         )
 
-        self.has_journal = basic.has_journal
+        self.has_journal = ansible.module_utils.basic.has_journal
         if self.has_journal:
             # Systems with journal can still test syslog
-            basic.has_journal = False
+            ansible.module_utils.basic.has_journal = False
 
     def tearDown(self):
         # teardown/reset
-        basic.has_journal = self.has_journal
+        ansible.module_utils.basic.has_journal = self.has_journal
 
         # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
         self.stdin_swap.__exit__(None, None, None)
@@ -195,13 +195,13 @@ class TestAnsibleModuleLogJournal(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
-        reload(basic)
-        self.am = basic.AnsibleModule(
+        ansible.module_utils.basic._ANSIBLE_ARGS = None
+        self.am = ansible.module_utils.basic.AnsibleModule(
             argument_spec = dict(),
         )
 
-        self.has_journal = basic.has_journal
-        basic.has_journal = True
+        self.has_journal = ansible.module_utils.basic.has_journal
+        ansible.module_utils.basic.has_journal = True
 
         self.module_patcher = None
 
@@ -210,20 +210,20 @@ class TestAnsibleModuleLogJournal(unittest.TestCase):
             self.module_patcher = patch.dict('sys.modules', {'systemd': MagicMock(), 'systemd.journal': MagicMock()})
             self.module_patcher.start()
             try:
-                reload(basic)
+                reload(ansible.module_utils.basic)
             except NameError:
-                self._fake_out_reload(basic)
+                self._fake_out_reload(ansible.module_utils.basic)
 
     def tearDown(self):
         # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
         self.stdin_swap.__exit__(None, None, None)
 
         # teardown/reset
-        basic.has_journal = self.has_journal
+        ansible.module_utils.basic.has_journal = self.has_journal
 
         if self.module_patcher:
             self.module_patcher.stop()
-            reload(basic)
+            reload(ansible.module_utils.basic)
 
     @patch('systemd.journal.send')
     def test_no_log(self, mock_func):

--- a/test/units/module_utils/basic/test_run_command.py
+++ b/test/units/module_utils/basic/test_run_command.py
@@ -67,7 +67,7 @@ class TestAnsibleModuleRunCommand(unittest.TestCase):
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
 
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
         self.module = AnsibleModule(argument_spec=dict())
         self.module.fail_json = MagicMock(side_effect=SystemExit)
 

--- a/test/units/module_utils/basic/test_safe_eval.py
+++ b/test/units/module_utils/basic/test_safe_eval.py
@@ -26,12 +26,6 @@ import json
 from ansible.compat.tests import unittest
 from units.mock.procenv import swap_stdin_and_argv
 
-try:
-    from importlib import reload
-except:
-    # Py2 has reload as a builtin
-    pass
-
 class TestAnsibleModuleExitJson(unittest.TestCase):
 
     def test_module_utils_basic_safe_eval(self):
@@ -40,7 +34,7 @@ class TestAnsibleModuleExitJson(unittest.TestCase):
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
 
         with swap_stdin_and_argv(stdin_data=args):
-            reload(basic)
+            basic._ANSIBLE_ARGS = None
             am = basic.AnsibleModule(
                 argument_spec=dict(),
             )

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -31,12 +31,6 @@ try:
 except ImportError:
     import __builtin__ as builtins
 
-try:
-    from importlib import reload
-except:
-    # Py2 has reload as a builtin
-    pass
-
 from units.mock.procenv import swap_stdin_and_argv
 
 from ansible.compat.tests import unittest
@@ -297,7 +291,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS={"foo": "hello"}, ANSIBLE_MODULE_CONSTANTS={}))
 
         with swap_stdin_and_argv(stdin_data=args):
-            reload(basic)
+            basic._ANSIBLE_ARGS = None
             am = basic.AnsibleModule(
                 argument_spec = arg_spec,
                 mutually_exclusive = mut_ex,
@@ -314,7 +308,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={}))
 
         with swap_stdin_and_argv(stdin_data=args):
-            reload(basic)
+            basic._ANSIBLE_ARGS = None
             self.assertRaises(
                 SystemExit,
                 basic.AnsibleModule,
@@ -361,7 +355,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_load_file_common_arguments(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -410,7 +404,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_selinux_mls_enabled(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -430,7 +424,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_selinux_initial_context(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -444,7 +438,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_selinux_enabled(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -476,7 +470,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_selinux_default_context(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -512,7 +506,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_selinux_context(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -554,7 +548,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_is_special_selinux_path(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}, ANSIBLE_MODULE_CONSTANTS={"SELINUX_SPECIAL_FS": "nfs,nfsd,foos"}))
 
@@ -599,7 +593,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_to_filesystem_str(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -624,7 +618,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_find_mount_point(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -648,7 +642,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_set_context_if_different(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -693,7 +687,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_set_owner_if_different(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -732,7 +726,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_set_group_if_different(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -771,7 +765,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
 
     def test_module_utils_basic_ansible_module_set_mode_if_different(self):
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -859,7 +853,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
         ):
 
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),
@@ -1037,7 +1031,7 @@ class TestModuleUtilsBasic(unittest.TestCase):
     def test_module_utils_basic_ansible_module__symbolic_mode_to_octal(self):
 
         from ansible.module_utils import basic
-        reload(basic)
+        basic._ANSIBLE_ARGS = None
 
         am = basic.AnsibleModule(
             argument_spec = dict(),


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

2.1 and 2.2
##### SUMMARY

Changes to how ziploader passes args mean we don't need reload anymore.

This change to the unittests should make py.test happier.
