### PR TITLE
When walking through module directories, always follow symlinks.

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -136,7 +136,7 @@ class PluginLoader:
     def _all_directories(self, dir):
         results = []
         results.append(dir)
-        for root, subdirs, files in os.walk(dir):
+        for root, subdirs, files in os.walk(dir, followlinks=True):
            if '__init__.py' in files:
                for x in subdirs:
                    results.append(os.path.join(root,x))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (devel 30e5999812) last updated 2016/05/09 10:56:55 (GMT -400)
  lib/ansible/modules/core: (devel 1f5cf669dd) last updated 2016/05/09 10:54:28 (GMT -400)
  lib/ansible/modules/extras: (devel bb965eebee) last updated 2016/05/09 10:43:13 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Module loader can traverse multiple subdirectories for module files. Currently, it is limited by the default behavior of os.walk and can not traverse through symlinks. This makes it difficult to swap out various module checkouts under ansible without managing submodules. If I want to quickly compare a single ansible checkout with two different checkouts of modules-core, I really have to have 2 separate checkouts of ansible. 

Fixes #15783
