### PR TITLE
Add 'external_url' tags intg tests and skip them.

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -162,12 +162,13 @@ test_winrm: setup
 	ansible-playbook test_winrm.yml -i inventory.winrm -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
 test_tags: setup
+	# Note these tests don't use TEST_FLAGS, since any tag related flags will cause the tests to fail.
 	# Run everything by default
-	[ "$$(ansible-playbook --list-tasks test_tags.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | fgrep Task_with | xargs)" = "Task_with_tag TAGS: [tag] Task_with_always_tag TAGS: [always] Task_without_tag TAGS: []" ]
+	[ "$$(ansible-playbook  --list-tasks test_tags.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v | fgrep Task_with | xargs)" = "Task_with_tag TAGS: [tag] Task_with_always_tag TAGS: [always] Task_without_tag TAGS: []" ]
 	# Run the exact tags, and always
-	[ "$$(ansible-playbook --list-tasks --tags tag test_tags.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | fgrep Task_with | xargs)" = "Task_with_tag TAGS: [tag] Task_with_always_tag TAGS: [always]" ]
+	[ "$$(ansible-playbook --list-tasks --tags tag test_tags.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v| fgrep Task_with | xargs)" = "Task_with_tag TAGS: [tag] Task_with_always_tag TAGS: [always]" ]
 	# Skip one tag
-	[ "$$(ansible-playbook --list-tasks --skip-tags tag test_tags.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) | fgrep Task_with | xargs)" = "Task_with_always_tag TAGS: [always] Task_without_tag TAGS: []" ]
+	[ "$$(ansible-playbook --list-tasks --skip-tags tag test_tags.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v | fgrep Task_with | xargs)" = "Task_with_always_tag TAGS: [always] Task_without_tag TAGS: []" ]
 
 blocks: setup
 	# remove old output log

--- a/test/integration/roles/test_get_url/tasks/main.yml
+++ b/test/integration/roles/test_get_url/tasks/main.yml
@@ -68,12 +68,14 @@
 - name: test https fetch
   get_url: url="https://raw.githubusercontent.com/ansible/ansible/devel/README.md" dest={{output_dir}}/get_url.txt force=yes
   register: result
+  tags: ['external_url', 'githubusercontent.com']
 
 - name: assert the get_url call was successful
   assert:
     that:
     - result.changed 
     - '"OK" in result.msg'
+  tags: ['external_url', 'raw.githubusercontent.com']
 
 - name: test https fetch to a site with mismatched hostname and certificate
   get_url:
@@ -87,10 +89,12 @@
   until: "'read operation timed out' not in result.msg"
   retries: 30
   delay: 10
+  tags: ['external_url', 'www.kennethreitz.org']
 
 - stat:
     path: "{{ output_dir }}/shouldnotexist.html"
   register: stat_result
+  tags: ['external_url', 'www.kennethreitz.org']
 
 - name: Assert that the file was not downloaded
   assert:
@@ -98,6 +102,7 @@
       - "result.failed == true"
       - "'Failed to validate the SSL certificate' in result.msg"
       - "stat_result.stat.exists == false"
+  tags: ['external_url', 'www.kennethreitz.org']
 
 - name: test https fetch to a site with mismatched hostname and certificate and validate_certs=no
   get_url:
@@ -108,16 +113,19 @@
   until: "'read operation timed out' not in result.msg"
   retries: 30
   delay: 10
+  tags: ['external_url', 'www.kennethreitz.org']
 
 - stat:
     path: "{{ output_dir }}/kreitz.html"
   register: stat_result
+  tags: ['external_url', 'www.kennethreitz.org']
 
 - name: Assert that the file was downloaded
   assert:
     that:
       - "result.changed == true"
       - "stat_result.stat.exists == true"
+  tags: ['external_url', 'www.kennethreitz.org']
 
 # At the moment, AWS can't make an https request to velox.ch... connection
 # timed out.  So we'll use a different test until/unless the problem is resolved
@@ -159,10 +167,12 @@
     dest: "{{ output_dir }}/sni.html"
   register: get_url_result
   ignore_errors: True
+  tags: ['external_url', 'www.mnot.net']
 
 - command: "grep '<h2>If You Can Read This, You.re SNIing</h2>' {{ output_dir}}/sni.html"
   register: data_result
   when: "{{ python_has_ssl_context }}"
+  tags: ['external_url', 'www.mnot.net']
 
 - debug: var=get_url_result
 - name: Assert that SNI works with this python version
@@ -171,6 +181,7 @@
       - 'data_result.rc == 0'
       - '"failed" not in get_url_result'
   when: "{{ python_has_ssl_context }}"
+  tags: ['external_url', 'www.mnot.net']
 
 # If the client doesn't support SNI then get_url should have failed with a certificate mismatch
 - name: Assert that hostname verification failed because SNI is not supported on this version of python
@@ -178,12 +189,14 @@
     that:
       - 'get_url_result["failed"]'
   when: "{{ not python_has_ssl_context }}"
+  tags: ['external_url', 'www.mnot.net']
 # End hacky SNI test section
 
 - name: Test get_url with redirect
   get_url:
     url: 'http://httpbin.org/redirect/6'
     dest: "{{ output_dir }}/redirect.json"
+  tags: ['external_url', 'httpbin.org']
 
 - name: Test that setting file modes work
   get_url:
@@ -191,16 +204,19 @@
     dest: '{{ output_dir }}/test'
     mode: '0707'
   register: result
+  tags: ['external_url', 'httpbin.org']
 
 - stat:
     path: "{{ output_dir }}/test"
   register: stat_result
+  tags: ['external_url', 'httpbin.org']
 
 - name: Assert that the file has the right permissions
   assert:
     that:
       - "result.changed == true"
       - "stat_result.stat.mode == '0707'"
+  tags: ['external_url', 'httpbin.org']
 
 - name: Test that setting file modes on an already downlaoded file work
   get_url:
@@ -208,13 +224,16 @@
     dest: '{{ output_dir }}/test'
     mode: '0070'
   register: result
+  tags: ['external_url', 'httpbin.org']
 
 - stat:
     path: "{{ output_dir }}/test"
   register: stat_result
+  tags: ['external_url', 'httpbin.org']
 
 - name: Assert that the file has the right permissions
   assert:
     that:
       - "result.changed == true"
       - "stat_result.stat.mode == '0070'"
+  tags: ['external_url', 'httpbin.org']

--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -104,6 +104,7 @@
   until: "'read operation timed out' not in result.msg"
   retries: 30
   delay: 10
+  tags: ['external_url', 'www.kennethreitz.org']
 
 - stat:
     path: "{{ output_dir }}/shouldnotexist.html"
@@ -115,11 +116,13 @@
       - "result.failed == true"
       - "'Failed to validate the SSL certificate' in result.msg"
       - "stat_result.stat.exists == false"
+  tags: ['external_url', 'sni.velox.ch']
 
 - name: Clean up any cruft from the results directory
   file:
     name: "{{ output_dir }}/kreitz.html"
     state: absent
+  tags: ['external_url', 'www.kennethreitz.org']
 
 - name: test https fetch to a site with mismatched hostname and certificate and validate_certs=no
   uri:
@@ -130,16 +133,19 @@
   until: "'read operation timed out' not in result.msg"
   retries: 30
   delay: 10
+  tags: ['external_url', 'www.kennethreitz.org']
 
 - stat:
     path: "{{ output_dir }}/kreitz.html"
   register: stat_result
+  tags: ['external_url', 'www.kennethreitz.org']
 
 - name: Assert that the file was downloaded
   assert:
     that:
       - "stat_result.stat.exists == true"
       - "result.changed == true"
+  tags: ['external_url', 'www.kennethreitz.org']
 
 - name: test redirect without follow_redirects
   uri:
@@ -147,39 +153,46 @@
     follow_redirects: 'none'
     status_code: 302
   register: result
+  tags: ['external_url', 'httpbin.org']
 
 - name: Assert location header
   assert:
     that:
       - 'result.location|default("") == "http://httpbin.org/relative-redirect/1"'
+  tags: ['external_url', 'httpbin.org']
 
 - name: Check SSL with redirect
   uri:
     url: 'https://httpbin.org/redirect/2'
   register: result
+  tags: ['external_url', 'httpbin.org']
 
 - name: Assert SSL with redirect
   assert:
     that:
       - 'result.url|default("") == "https://httpbin.org/get"'
+  tags: ['external_url', 'httpbin.org']
 
 - name: redirect to bad SSL site
   uri:
     url: 'http://wrong.host.badssl.com'
   register: result
   ignore_errors: true
+  tags: ['external_url', 'badssl.com']
 
 - name: Ensure bad SSL site reidrect fails
   assert:
     that:
       - result|failed
       - '"wrong.host.badssl.com" in result.msg'
+  tags: ['external_url', 'badssl.com']
 
 - name: test basic auth
   uri:
     url: 'http://httpbin.org/basic-auth/user/passwd'
     user: user
     password: passwd
+  tags: ['external_url', 'httpbin.org']
 
 - name: test basic forced auth
   uri:
@@ -187,23 +200,27 @@
     force_basic_auth: true
     user: user
     password: passwd
+  tags: ['external_url', 'httpbin.org']
 
 - name: test PUT
   uri:
     url: 'http://httpbin.org/put'
     method: PUT
     body: 'foo=bar'
+  tags: ['external_url', 'httpbin.org']
 
 - name: test OPTIONS
   uri:
     url: 'http://httpbin.org/'
     method: OPTIONS
   register: result
+  tags: ['external_url', 'httpbin.org']
 
 - name: Assert we got an allow header
   assert:
     that:
       - 'result.allow|default("") == "HEAD, OPTIONS, GET"'
+  tags: ['external_url', 'httpbin.org']
 
 # Ubuntu12.04 doesn't have python-urllib3, this makes handling required dependencies a pain across all variations
 # We'll use this to just skip 12.04 on those tests.  We should be sufficiently covered with other OSes and versions
@@ -217,6 +234,7 @@
     return_content: true
   when: ansible_python.has_sslcontext
   register: result
+  tags: ['external_url', 'sni.velox.ch']
 
 - name: Assert SNI verification succeeds on new python
   assert:
@@ -224,6 +242,7 @@
       - result|success
       - '"Great! Your client" in result.content'
   when: ansible_python.has_sslcontext
+  tags: ['external_url', 'sni.velox.ch']
 
 - name: Verify SNI verification fails on old python without urllib3 contrib
   uri:
@@ -231,12 +250,14 @@
   ignore_errors: true
   when: not ansible_python.has_sslcontext
   register: result
+  tags: ['external_url', 'sni.velox.ch']
 
 - name: Assert SNI verification fails on old python
   assert:
     that:
       - result|failed
   when: not result|skipped
+  tags: ['external_url', 'sni.velox.ch']
 
 - name: install OS packages that are needed for SNI on old python
   package:
@@ -257,6 +278,7 @@
     return_content: true
   when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
   register: result
+  tags: ['external_url', 'sni.velox.ch']
 
 - name: Assert SNI verification succeeds on old python
   assert:
@@ -264,6 +286,7 @@
       - result|success
       - '"Great! Your client" in result.content'
   when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
+  tags: ['external_url', 'sni.velox.ch']
 
 - name: Uninstall ndg-httpsclient and urllib3
   pip:
@@ -286,3 +309,4 @@
     status_code: 202
     method: POST
     body: foo
+  tags: ['external_url', 'https', 'httpbin']

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -4,6 +4,12 @@ set -e
 set -u
 set -x
 
+# On pull request builds, skip any tests that we know make external url requests
+TEST_FLAGS="${TEST_FLAGS:-}"
+if [ "${TRAVIS_PULL_REQUEST:-"false"}" != "false" ] ; then
+    TEST_FLAGS="${TEST_FLAGS} --skip-tags external_url"
+fi
+
 if [ "${TARGET}" = "sanity" ]; then
     ./test/code-smell/replace-urlopen.sh .
     ./test/code-smell/use-compat-six.sh lib


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

In Travis, the test_uri integration tests fail a lot.
Almost always because of temporary failures to external
urls.

This adds a 'external_url' tag to those tests, and defaults
run_tests.sh to set TEST_FLAGS to '--skip-tags external_url'
