### PR TITLE
reduce async timeout in unittests

### DIFF
--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -372,8 +372,8 @@ class TestTaskExecutor(unittest.TestCase):
         mock_host = MagicMock()
 
         mock_task = MagicMock()
-        mock_task.async = 3
-        mock_task.poll  = 1
+        mock_task.async = 0.1
+        mock_task.poll  = 0.05
 
         mock_play_context = MagicMock()
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

devel
##### SUMMARY

reduce from 3 sec to 0.1 sec; the 3 sec sleep was about half of the total unittest time on my development machine...
