### PR TITLE
Do not redefine set_fact task_vars during delegation

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -349,7 +349,7 @@ class StrategyBase:
                     # be a host that is not really in inventory at all
                     if task.delegate_to is not None and task.delegate_facts:
                         task_vars = self._variable_manager.get_vars(loader=self._loader, play=iterator._play, host=host, task=task)
-                        task_vars = self.add_tqm_variables(task_vars, play=iterator._play)
+                        self.add_tqm_variables(task_vars, play=iterator._play)
                         loop_var = 'item'
                         if task.loop_control:
                             loop_var = task.loop_control.loop_var or 'item'


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (FIX_15694 28744b83df) last updated 2016/05/10 12:00:29 (GMT -400)
  lib/ansible/modules/core: (devel 67de0675c3) last updated 2016/05/10 11:57:45 (GMT -400)
  lib/ansible/modules/extras: (devel e8391d6985) last updated 2016/05/10 11:57:53 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Redefining task_vars was dropping previous created keys+items, so delegation of set_fact would result in a traceback on a missing key.

Fixes #15694
