### PR TITLE
Fix order of version_compare arguments in porting guide

### DIFF
--- a/docsite/rst/porting_guide_2.0.rst
+++ b/docsite/rst/porting_guide_2.0.rst
@@ -26,7 +26,7 @@ To make an escaped string that will work on all versions you have two options::
 
 uses key=value escaping which has not changed.  The other option is to check for the ansible version::
 
-"{{ (ansible_version|version_compare('ge', '2.0'))|ternary( 'test1_junk 1\\3' | regex_replace('(.*)_junk (.*)', '\\1 \\2') , 'test1_junk 1\\\\3' | regex_replace('(.*)_junk (.*)', '\\\\1 \\\\2') ) }}"
+"{{ (ansible_version|version_compare('2.0', 'ge'))|ternary( 'test1_junk 1\\3' | regex_replace('(.*)_junk (.*)', '\\1 \\2') , 'test1_junk 1\\\\3' | regex_replace('(.*)_junk (.*)', '\\\\1 \\\\2') ) }}"
 
 * trailing newline When a string with a trailing newline was specified in the
   playbook via yaml dict format, the trailing newline was stripped. When


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 1.9.6 and 2.0.2.0
```
##### SUMMARY

The example in the porting guide for making substitutions work across Ansible 1.x and 2.x versions didn't work. I struggled with this for quite a while trying to figure out the right quoting before I discovered that the arguments to `version_compare` were reversed.
