### PR TITLE
Disable sftp batch mode if sshpass and !controlpersist.

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -133,9 +133,13 @@ class Connection(ConnectionBase):
         ## Next, additional arguments based on the configuration.
 
         # sftp batch mode allows us to correctly catch failed transfers, but can
-        # be disabled if the client side doesn't support the option.
+        # be disabled if the client side doesn't support the option. However,
+        # sftp batch mode does not prompt for passwords so it must be disabled
+        # if not using controlpersist and using sshpass
+        controlpersist, controlpath = self._persistence_controls(self._command)
         if binary == 'sftp' and C.DEFAULT_SFTP_BATCH_MODE:
-            self._command += ['-b', '-']
+            if controlpersist:
+                self._command += ['-b', '-']
 
         self._command += ['-C']
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -152,8 +152,8 @@ class Connection(ConnectionBase):
         # Next, we add [ssh_connection]ssh_args from ansible.cfg.
 
         if self._play_context.ssh_args:
-            ssh_args = self._split_ssh_args(self._play_context.ssh_args)
-            self._add_args("ansible.cfg set ssh_args", ssh_args)
+            args = self._split_ssh_args(self._play_context.ssh_args)
+            self._add_args("ansible.cfg set ssh_args", _args)
 
         # Now we add various arguments controlled by configuration file settings
         # (e.g. host_key_checking) or inventory variables (ansible_ssh_port) or

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -116,13 +116,6 @@ class Connection(ConnectionBase):
 
         self._command = []
 
-        ## Need to do a pre-emptive check for controlpersist
-        ssh_args = []
-        if self._play_context.ssh_args:
-            ssh_args = self._split_ssh_args(self._play_context.ssh_args)
-        controlpersist, controlpath = self._persistence_controls(ssh_args)
-
-
         ## First, the command name.
 
         # If we want to use password authentication, we have to set up a pipe to
@@ -144,8 +137,9 @@ class Connection(ConnectionBase):
         # sftp batch mode does not prompt for passwords so it must be disabled
         # if not using controlpersist and using sshpass
         if binary == 'sftp' and C.DEFAULT_SFTP_BATCH_MODE:
-            if controlpersist or not self._play_context.password:
-                self._command += ['-b', '-']
+            if self._play_context.password:
+                self._add_args('disable batch mode for sshpass', ['-o', 'BatchMode=no'])
+            self._command += ['-b', '-']
 
         self._command += ['-C']
 
@@ -157,7 +151,8 @@ class Connection(ConnectionBase):
 
         # Next, we add [ssh_connection]ssh_args from ansible.cfg.
 
-        if ssh_args:
+        if self._play_context.ssh_args:
+            ssh_args = self._split_ssh_args(self._play_context.ssh_args)
             self._add_args("ansible.cfg set ssh_args", ssh_args)
 
         # Now we add various arguments controlled by configuration file settings

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -153,7 +153,7 @@ class Connection(ConnectionBase):
 
         if self._play_context.ssh_args:
             args = self._split_ssh_args(self._play_context.ssh_args)
-            self._add_args("ansible.cfg set ssh_args", _args)
+            self._add_args("ansible.cfg set ssh_args", args)
 
         # Now we add various arguments controlled by configuration file settings
         # (e.g. host_key_checking) or inventory variables (ansible_ssh_port) or


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (SFTP_SSHPASS_FIX 887cc885ad) last updated 2016/05/12 09:05:48 (GMT -400)
  lib/ansible/modules/core: (devel 67de0675c3) last updated 2016/05/11 11:45:47 (GMT -400)
  lib/ansible/modules/extras: (devel e8391d6985) last updated 2016/05/11 11:45:50 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

sshpass does not receive a prompt from sftp if run in batch mode. This disabled batch mode if not using controlpersist to pre-auth.

Addresses #13401
