### PR TITLE
Adding Config Encoder filters

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -457,6 +457,46 @@ which will produce this output::
     # host: myhost
     #
 
+.. _config_encoders:
+
+Config Encoder Filters
+----------------------
+
+.. versionadded:: 2.2
+
+Config Encoder filters were developed to facilitate creation of configuration
+files from a YAML data structure. Imagine the following INI file::
+
+    [section1]
+    option11=value11
+    option12=value12
+
+Such configuration file can be described as a YAML data structure::
+
+    myapp_config:
+      section1:
+        option11: value11
+        option12: value12
+
+The variable is then used together with the ``encode_ini`` Config Encoder
+filter in the template file ``myapp.cfg.j2`` like this::
+
+    {{ myapp_config | encode_ini }}
+
+And finally, the template file is used in a task like this::
+
+    - name: Create config file
+      template:
+        src: myapp.cfg.j2
+        dest: /etc/myapp/myapp.cfg
+
+When the task is executed, it creates exactly the same file as the
+original INI file.
+
+More information about Config Encoder filters including all supported
+configuration file formats and complete usage guide can be found in
+:doc:`playbooks_filters_config_encoders`.
+
 .. _other_useful_filters:
 
 Other Useful Filters

--- a/docsite/rst/playbooks_filters_config_encoders.rst
+++ b/docsite/rst/playbooks_filters_config_encoders.rst
@@ -1,0 +1,1154 @@
+Config Encoder Filters
+======================
+
+.. versionadded:: 2.2
+
+
+Motivation
+----------
+
+Ansible Galaxy contains a lot of useful roles. Some of them exist in
+many variations which differ only by their parameterization. The
+parameterization is often used mainly in templates which generate the
+configuration file. A good example such issues are roles for Nginx of
+which you can find almost 200 in the Ansible Galaxy.
+
+Nginx is possible to configure in infinite number of ways and therefore
+is almost impossible to create an Ansible template file which would
+capture all possible variations of the configuration. Even if a suitable
+roles is found, users often want to customize even more. This is where
+people normally clone the role and add parameters they are missing. Some
+people try to get the change back into the original role by creating a
+pull request (PR) but sometimes such change is not accepted by the
+maintainer of the original role and the user ends up maintaining his/her
+own clone forever.
+
+This is why the Config Encoder filters were developed to facilitate the
+creation of Ansible roles with universal configuration. The structure of
+the configuration file is described as a YAML data structure stored in a
+variable. The variable together with he Config Encoder filter is then
+used in the template file which is used to generate the final
+configuration file. This approach allows to shift the paradigm of
+thinking about configuration files as templates to thinking about them as
+data structures. The data structure can be dynamically generated which
+allows to create truly universal configuration.
+
+
+Example
+-------
+
+Imagine the following INI file::
+
+    [section1]
+    option11=value11
+    option12=value12
+
+Such configuration file can be described as a YAML data structure::
+
+    myapp_config:
+      section1:
+        option11: value11
+        option12: value12
+
+The variable is then used together with the ``encode_ini`` Config Encoder
+filter in the template file ``myapp.cfg.j2`` like this::
+
+    {{ myapp_config | encode_ini }}
+
+And finally, the template file is used in a task like this::
+
+    - name: Create config file
+      template:
+        src: myapp.cfg.j2
+        dest: /etc/myapp/myapp.cfg
+
+When the task is executed, it creates exactly the same file as the
+original INI file.
+
+So we can describe the configuration as a data structure which is then
+converted into the final configuration file format with the Config
+Encoder filter.
+
+In order to change the above configuration, we would have to overwrite
+the ``myapp_config`` which is not very practical. Therefore we break the
+monolithic variable into a set of variables which will allow us to change
+any part of the configuration without the need to overwrite the whole
+data structure::
+
+    myapp_config_section1_option11: value11
+    myapp_config_section1_option12: value12
+
+    myapp_config_section1__default:
+      option11: "{{ myapp_config_section1_option11 }}"
+      option12: "{{ myapp_config_section1_option12 }}"
+
+    myapp_config_section1__custom: {}
+
+    myapp_config_default:
+      section1: "{{
+        myapp_config_section1__default.update(myapp_config_section1__custom) }}{{
+        myapp_config_section1__default }}"
+
+    myapp_config__custom: {}
+
+    myapp_config: "{{
+      myapp_config__default.update(myapp_config__custom) }}{{
+      myapp_config__default }}"
+
+Like this, if we want to change the value of the ``option11``, we only
+override the variable ``myapp_config_section1_option11``::
+
+    myapp_config_section1_option11: My new value
+
+If we want to add a new option into the ``section1``, we add it into the
+variable ``myapp_config_section1__custom`` which is then merged with the
+default list of options::
+
+    myapp_config_section1__custom:
+      section13: value13
+
+And if we want to add a new section, we add it into the variable
+``myapp_config__custom`` which is then merged with the default list of
+sections::
+
+    myapp_config__custom:
+      section2:
+        option21: value21
+
+The above is showing an example for INI configuration files only but the
+same principle is possible to use for all the supported Config Encoders
+listed bellow.
+
+
+Supported encoders
+------------------
+
+The following is the list of supported Config Encoder filters. Each
+filter requires special data structure as its input. Each filter also has
+a set of parameters which can modify the behaviour of the filter.
+
+
+encode_apache
+^^^^^^^^^^^^^
+
+This filter helps to create configuration in the format used by Apache
+web server. The expected data structure is the following::
+
+    my_apache_vhost:
+      content:
+        - sections:
+          - name: VirtualHost
+            param: "*:80"
+            content:
+              - options:
+                - DocumentRoot: /www/example1
+                - ServerName: www.example.com
+                - ErrorLog: /var/log/httpd/www.example.com-error_log
+                - CustomLog:
+                  - /var/log/httpd/www.example.com-access_log
+                  - common
+                - "#": Other directives here ...
+
+The variable starts with ``content`` which can contain list of
+``sections`` or ``options``. ``sections`` then contain list of individual
+sections which has the ``name``, ``param`` and ``content`` parameter. The
+``content`` can again contain a list of `sections`` or ``options``.
+
+The above variable can be used in the template file like this::
+
+    {{ my_apache_vhost | encode_apache }}
+
+The output of such template would be::
+
+    <VirtualHost *:80>
+      DocumentRoot /www/example1
+      ServerName www.example.com
+      ErrorLog /var/log/httpd/www.example.com-error_log
+      CustomLog /var/log/httpd/www.example.com-access_log common
+      # "Other directives here ..."
+    </VirtualHost>
+
+The filter can have the following parameters:
+
+- ``convert_bools=false``
+
+  Indicates whether Boolean values presented as a string should be
+  converted to a real Boolean value. For example ``var1: 'True'`` would
+  be represented as a string but by using the ``convert_bools=true`` it
+  will be converted into Boolean like it would be defined like ``var1:
+  true``.
+
+- ``convert_nums=false``
+
+  Indicates whether number presented as a string should be converted to
+  number. For example ``var1: '123'`` would be represented as a string
+  but by using the ``convert_nums=true`` it will be converted it to a
+  number like it would be defined like ``var1: 123``. It's also possible
+  to use the YAML type casting to convert string to number (e.g. ``!!int
+  "1234"``, ``!!float "3.14"``).
+
+- ``indent="  "``
+
+  Defines the indentation unit.
+
+- ``level=0``
+
+  Indicates the initial level of the indentation. Value ``0`` starts
+  indenting from the beginning of the line. Setting the value to higher
+  than ``0`` indents the content by ``indent * level``.
+
+- ``quote_all_nums=false``
+
+  Number values are not quoted by default. This parameter will force to
+  quote all numbers.
+
+- ``quote_all_strings=false``
+
+  String values are quoted only if they contain a space. This parameter
+  will force to quote all strings regardless if the they contain the
+  space or not.
+
+
+encode_erlang
+^^^^^^^^^^^^^
+
+This filter helps to create configuration in the Erlang format. The
+expected data structure is the following::
+
+    my_rabbitmq_config:
+      - rabbit:
+        - tcp_listeners:
+          - '"127.0.0.1"': 5672
+        - ssl_listeners:
+          - 5671
+        - ssl_options:
+          - cacertfile: /path/to/testca/cacert.pem
+          - certfile: /path/to/server/cert.pem
+          - keyfile: /path/to/server/key.pem
+          - verify: verify_peer
+          - fail_if_no_peer_cert: true
+
+The variable consists of a lists of dictionaries. The value of the key-value
+pair can be another list or simple value like a string or a number. Erlang
+tuples can be enforced by prepending the value with the special character
+specified in the ``atom_value_indicator``.
+
+The above variable can be used in the template file like this::
+
+    {{ my_rabbitmq_config | encode_erlang }}
+
+The output of such template would be::
+
+    [
+      {rabbit, [
+          {tcp_listeners, [
+              {"127.0.0.1", 5672}
+          ]},
+          {ssl_listeners, [
+            5671
+          ]},
+          {ssl_options, [
+              {cacertfile, "/path/to/testca/cacert.pem"},
+              {certfile, "/path/to/server/cert.pem"},
+              {keyfile, "/path/to/server/key.pem"},
+              {verify, "verify_peer"},
+              {fail_if_no_peer_cert, true}
+          ]}
+      ]}
+    ].
+
+The filter can have the following parameters:
+
+- ``atom_value_indicator=":"``
+
+  The value of this parameter indicates the string which must be
+  prepended to a string value to treat it as an atom value.
+
+- ``convert_bools=false``
+
+  Indicates whether Boolean values presented as a string should be
+  converted to a real Boolean value. For example ``var1: 'True'`` would
+  be represented as a string but by using the ``convert_bools=true`` it
+  will be converted into Boolean like it would be defined like ``var1:
+  true``.
+
+- ``convert_nums=false``
+
+  Indicates whether number presented as a string should be converted to
+  number. For example ``var1: '123'`` would be represented as a string
+  but by using the ``convert_nums=true`` it will be converted it to a
+  number like it would be defined like ``var1: 123``. It's also possible
+  to use the YAML type casting to convert string to number (e.g. ``!!int
+  "1234"``, ``!!float "3.14"``).
+
+- ``indent="  "``
+
+  Defines the indentation unit.
+
+- ``level=0``
+
+  Indicates the initial level of the indentation. Value ``0`` starts
+  indenting from the beginning of the line. Setting the value to higher
+  than ``0`` indents the content by ``indent * level``.
+
+
+encode_haproxy
+^^^^^^^^^^^^^^
+
+This filter helps to create configuration in the format used in Haproxy.
+The expected data structure is the following::
+
+    my_haproxy_config:
+      - global:
+        - daemon
+        - maxconn 256
+      - "# This is the default section"
+      - defaults:
+        - mode http
+        - timeout connect 5000ms
+        - timeout client 50000ms
+        - timeout server 50000ms
+      - frontend http-in:
+        - "# This is the bind address/port"
+        - bind *:80
+        - default_backend servers
+        - backend servers
+        - server server1 127.0.0.1:8000 maxconn 32
+
+The variable is a list which can contain a simple string value or a dictionary
+which indicates a section.
+
+The above variable can be used in the template file like this::
+
+    {{ my_haproxy_config | encode_haproxy }}
+
+The output of such template would be::
+
+    global
+      daemon
+      maxconn 256
+
+    # This is the default section
+    defaults
+      mode http
+      timeout connect 5000ms
+      timeout client 50000ms
+      timeout server 50000ms
+
+    frontend http-in
+      # This is the bind address/port
+      bind *:80
+      default_backend servers
+      backend servers
+      server server1 127.0.0.1:8000 maxconn 32
+
+The filter can have the following parameters:
+
+- ``indent="  "``
+
+  Defines the indentation unit.
+
+
+encode_ini
+^^^^^^^^^^
+
+This filter helps to create configuration in the INI format. The expected
+data structure is the following::
+
+    my_rsyncd_config:
+      uid: nobody
+      gid: nobody
+      use chroot: no
+      max connections: 4
+      syslog facility: local5
+      pid file: /run/rsyncd.pid
+      ftp:
+        path: /srv/ftp
+        comment: ftp area
+
+The variable consist of dictionaries which can be nested. If the value of the
+key-value pair on the first level is of a simple type (string, number, boolean),
+such pair is considered to be global and gets processed first. If the value of
+the key-value pair on the first level is another dictionary, the key is
+considered to be the name of the section and the inner dictionary as properties
+of the section.
+
+The above variable can be used in the template file like this::
+
+    {{ my_rsyncd_config | encode_ini }}
+
+The output of such template would be::
+
+    gid=nobody
+    max connections=4
+    pid file=/run/rsyncd.pid
+    syslog facility=local5
+    uid=nobody
+    use chroot=False
+
+    [ftp]
+    comment=ftp area
+    path=/srv/ftp
+
+The filter can have the following parameters:
+
+- ``delimiter="="``
+
+  Sign separating the *property* and the *value*. By default it's set to
+  ``'='`` but it can also be set for example to ``' = '``.
+
+- ``quote=""``
+
+  Sets the quoting of the value. Use ``quote="'"`` or ``quote='"'``.
+
+- ``section_is_comment=false``
+
+  If this parameter is set to ``true``, the section value will be used as
+  a comment for the following properties of the section.
+
+- ``ucase_prop=false``
+
+  Indicates whether the *property* should be made upper case.
+
+
+encode_json
+^^^^^^^^^^^
+
+This filter helps to create configuration in the JSON format. The
+expected data structure is the following::
+
+    my_sensu_client_config:
+      client:
+        name: localhost
+        address: 127.0.0.1
+        subscriptions:
+          - test
+
+Because JSON is very similar to YAML, the variable consists of
+dictionaries of which value can be either an simple type (number, string,
+boolean), list or another dictionary. All can be nested in any number of
+levels.
+
+The above variable can be used in the template file like this::
+
+    {{ my_sensu_client_config | encode_json }}
+
+The output of such template would be::
+
+    {
+      "client": {
+        "address": "127.0.0.1",
+        "name": "localhost",
+        "subscriptions": [
+          "test"
+        ]
+      }
+    }
+
+The filter can have the following parameters:
+
+- ``convert_bools=false``
+
+  Indicates whether Boolean values presented as a string should be
+  converted to a real Boolean value. For example ``var1: 'True'`` would
+  be represented as a string but by using the ``convert_bools=true`` it
+  will be converted into Boolean like it would be defined like ``var1:
+  true``.
+
+- ``convert_nums=false``
+
+  Indicates whether number presented as a string should be converted to
+  number. For example ``var1: '123'`` would be represented as a string
+  but by using the ``convert_nums=true`` it will be converted it to a
+  number like it would be defined like ``var1: 123``. It's also possible
+  to use the YAML type casting to convert string to number (e.g. ``!!int
+  "1234"``, ``!!float "3.14"``).
+
+- ``indent="  "``
+
+  Defines the indentation unit.
+
+- ``level=0``
+
+  Indicates the initial level of the indentation. Value ``0`` starts
+  indenting from the beginning of the line. Setting the value to higher
+  than ``0`` indents the content by ``indent * level``.
+
+
+encode_logstash
+^^^^^^^^^^^^^^^
+
+This filter helps to create configuration in the format used by Logstash.
+The expected data structure is the following::
+
+    my_logstash_config:
+      - :input:
+          - :file:
+              path: /tmp/access_log
+              start_position: beginning
+      - :filter:
+          - ':if [path] =~ "access"':
+              - :mutate:
+                  replace:
+                    type: apache_access
+              - :grok:
+                  match:
+                    message: "%{COMBINEDAPACHELOG}"
+      - :date:
+          - match:
+              - timestamp
+              - dd/MMM/yyyy:HH:mm:ss Z
+      - :output:
+          - :elasticsearch:
+              hosts:
+                - localhost:9200
+          - :stdout:
+              codec: rubydebug
+
+The variable consists of a list of sections where each section is
+prefixed by a special character specified by the ``section_prefix``
+(``:`` by default). The value of the top level sections can be either
+another section or a dictionary. The value of the dictionary can be a
+simple value, list or another dictionary.
+
+The above variable can be used in the template file like this::
+
+    {{ my_logstash_config | encode_logstash }}
+
+The output of such template would be::
+
+    input {
+      file {
+        path => "/tmp/access_log"
+        start_position => "beginning"
+      }
+    }
+    filter {
+      if [path] =~ "access" {
+        mutate {
+          replace => {
+            "type" => "apache_access"
+          }
+        }
+        grok {
+          match => {
+            "message" => "%{COMBINEDAPACHELOG}"
+          }
+        }
+      }
+    }
+    date {
+      match => [
+        "timestamp",
+        "dd/MMM/yyyy:HH:mm:ss Z"
+      ]
+    }
+    output {
+      elasticsearch {
+        hosts => [
+          "localhost:9200"
+        ]
+      }
+      stdout {
+        codec => "rubydebug"
+      }
+    }
+
+The filter can have the following parameters:
+
+- ``convert_bools=false``
+
+  Indicates whether Boolean values presented as a string should be
+  converted to a real Boolean value. For example ``var1: 'True'`` would
+  be represented as a string but by using the ``convert_bools=true`` it
+  will be converted into Boolean like it would be defined like ``var1:
+  true``.
+
+- ``convert_nums=false``
+
+  Indicates whether number presented as a string should be converted to
+  number. For example ``var1: '123'`` would be represented as a string
+  but by using the ``convert_nums=true`` it will be converted it to a
+  number like it would be defined like ``var1: 123``. It's also possible
+  to use the YAML type casting to convert string to number (e.g. ``!!int
+  "1234"``, ``!!float "3.14"``).
+
+- ``indent="  "``
+
+  Defines the indentation unit.
+
+- ``level=0``
+
+  Indicates the initial level of the indentation. Value ``0`` starts
+  indenting from the beginning of the line. Setting the value to higher
+  than ``0`` indents the content by ``indent * level``.
+
+- ``section_prefix=":"``
+
+  This parameter specifies which character will be used to identify the
+  Logstash section.
+
+
+encode_nginx
+^^^^^^^^^^^^
+
+This filter helps to create configuration in the format used by Nginx
+wweb server. The expected data structure is the following::
+
+    my_nginx_vhost_config:
+      - server:
+        - listen 80
+        - server_name $hostname
+        - "location /":
+          - root /srv/www/myapp
+          - index index.html
+
+As Nginx configuration is order sensitive, the all configuration is
+defined as a nested list. As it would be difficult to recognize how many
+elements each configuration definition has, the list item value is no
+further separated into key/value dictionary. Every line of the
+configuration is treated either as a key indicating another nested list
+or simply as a string.
+
+The above variable can be used in the template file like this::
+
+    {{ my_nginx_vhost | encode_nginx }}
+
+The output of such template would be::
+
+    server {
+      listen 80;
+      server_name $hostname;
+
+      location / {
+        root /srv/www/myapp;
+        index index.html;
+      }
+    }
+
+The filter can have the following parameters:
+
+- ``indent="  "``
+
+  Defines the indentation unit.
+
+- ``level=0``
+
+  Indicates the initial level of the indentation. Value ``0`` starts
+  indenting from the beginning of the line. Setting the value to higher
+  than ``0`` indents the content by ``indent * level``.
+
+
+encode_pam
+^^^^^^^^^^
+
+This filter helps to create configuration in the format user by Linux
+Pluggable Authentication Modules (PAM). The expected data structure is
+the following::
+
+    my_system_auth_config:
+      aa:
+        type: auth
+        control: required
+        path: pam_unix.so
+        args:
+          - try_first_pass
+          - nullok
+      bb:
+        type: auth
+        control: optional
+        path: pam_permit.so
+      cc:
+        type: auth
+        control: required
+        path: pam_env.so
+      dd:
+        type: account
+        control: required
+        path: pam_unix.so
+      ee:
+        type: account
+        control: optional
+        path: pam_permit.so
+      ff:
+        type: account
+        control: required
+        path: pam_time.so
+      gg:
+        type: password
+        control: required
+        path: pam_unix.so
+        args:
+          - try_first_pass
+          - nullok
+          - sha512
+          - shadow
+      hh:
+        type: password
+        control: optional
+        path: pam_permit.so
+        args:
+      ii:
+        type: session
+        control: required
+        path: pam_limits.so
+      jj:
+        type: session
+        control: required
+        path: pam_unix.so
+      kk:
+        type: session
+        control: optional
+        path: pam_permit.so
+
+The variable is a dictionary of which the key is a labels and the value
+is the PAM rule. The label is used to order the PAM rules. Using labels
+with even number of characters allows to insert another rule in between
+of any two rules.
+
+The above variable can be used in the template file like this::
+
+    {{ my_system_auth_config | encode_pam }}
+
+The output of such template would be::
+
+    auth  required  pam_unix.so  try_first_pass nullok
+    auth  optional  pam_permit.so
+    auth  required  pam_env.so
+
+    account  required  pam_unix.so
+    account  optional  pam_permit.so
+    account  required  pam_time.so
+
+    password  required  pam_unix.so  try_first_pass nullok sha512 shadow
+    password  optional  pam_permit.so
+
+    session  required  pam_limits.so
+    session  required  pam_unix.so
+    session  optional  pam_permit.so
+
+The filter can have the following parameters:
+
+- ``print_label=false``
+
+  Print labels as a comment in the output.
+
+- ``separate_types=true``
+
+  Add a newline between the groups of types.
+
+- ``separator="  "``
+
+  Separator between the collection of tokens.
+
+
+encode_toml
+^^^^^^^^^^^
+
+This filter helps to create configuration in the TOML format. The
+expected data structure is the following::
+
+    my_grafana_ldap_config:
+      verbose_logging: false
+      servers:
+        - host: 127.0.0.1
+          port: 389
+          use_ssl: false
+          ssl_skip_verify: false
+          bind_dn: cn=admin,dc=grafana,dc=org
+          bind_password: grafana
+          search_filter: "(cn=%s)"
+          search_base_dns:
+            - dc=grafana,dc=org
+      servers.attributes:
+        name: givenName
+        surname: sn
+        username: cn
+        member_of: memberOf
+        email: email
+      servers.group_mappings:
+        - group_dn: cn=admins,dc=grafana,dc=org
+          org_role: Admin
+        - group_dn: cn=users,dc=grafana,dc=org
+          org_role: Editor
+        - group_dn: "*"
+          org_role: Viewer
+
+The variable is a dictionary of which value can be either a simple type
+(number, string, boolean), list or another dictionary. The dictionaries
+and lists can be nested.
+
+The above variable can be used in the template file like this::
+
+    {{ my_grafana_ldap_config | encode_toml }}
+
+The output of such template would be::
+
+    verbose_logging = false
+
+      [[servers]]
+      bind_dn = "cn=admin,dc=grafana,dc=org"
+      bind_password = "grafana"
+      host = "127.0.0.1"
+      port = 389
+      search_base_dns = ["dc=grafana,dc=org"]
+      search_filter = "(cn=%s)"
+      ssl_skip_verify = false
+      use_ssl = false
+
+    [servers.attributes]
+    email = "email"
+    member_of = "memberOf"
+    name = "givenName"
+    surname = "sn"
+    username = "cn"
+
+      [[servers.group_mappings]]
+      group_dn = "cn=admins,dc=grafana,dc=org"
+      org_role = "Admin"
+
+      [[servers.group_mappings]]
+      group_dn = "cn=users,dc=grafana,dc=org"
+      org_role = "Editor"
+
+      [[servers.group_mappings]]
+      group_dn = "*"
+      org_role = "Viewer"
+
+The filter can have the following parameters:
+
+- ``convert_bools=false``
+
+  Indicates whether Boolean values presented as a string should be
+  converted to a real Boolean value. For example ``var1: 'True'`` would
+  be represented as a string but by using the ``convert_bools=true`` it
+  will be converted into Boolean like it would be defined like ``var1:
+  true``.
+
+- ``convert_nums=false``
+
+  Indicates whether number presented as a string should be converted to
+  number. For example ``var1: '123'`` would be represented as a string
+  but by using the ``convert_nums=true`` it will be converted it to a
+  number like it would be defined like ``var1: 123``. It's also possible
+  to use the YAML type casting to convert string to number (e.g. ``!!int
+  "1234"``, ``!!float "3.14"``).
+
+- ``indent="  "``
+
+  Defines the indentation unit.
+
+- ``level=0``
+
+  Indicates the initial level of the indentation. Value ``0`` starts
+  indenting from the beginning of the line. Setting the value to higher
+  than ``0`` indents the content by ``indent * level``.
+
+- ``quote='"'``
+
+  Sets the quoting of the value. Use ``quote="'"`` or ``quote='"'``.
+
+
+encode_xml
+^^^^^^^^^^
+
+This filter helps to create configuration in the XML format. The expected
+data structure is the following::
+
+    my_oddjob_config:
+      - oddjobconfig:
+        - service:
+          - ^name: com.redhat.oddjob
+          - object:
+            - ^name: /com/redhat/oddjob
+            - interface:
+              - ^name: com.redhat.oddjob
+              - method:
+                - ^name: listall
+                - allow:
+                  - ^min_uid: 0
+                  - ^max_uid: 0
+              - method:
+                - ^name: list
+                - allow: null
+              - method:
+                - ^name: quit
+                - allow:
+                  - ^user: root
+              - method:
+                - ^name: reload
+                - allow:
+                  - ^user: root
+        - include:
+          - ^ignore_missing: "yes"
+          - /etc/oddjobd.conf.d/*.conf
+        - include:
+          - ^ignore_missing: "yes"
+          - /etc/oddjobd-local.conf
+
+The variable can be a list of dictionaries, lists or strings. This config
+encoder does not handle mixed content very well so the safest way how to
+include mixed content is to define it as a string and use the parameter
+``escape_xml=false``. This config encoder also produces no XML declaration.
+Any XML declaration or DOCTYPE must be a part of the template file.
+
+The above variable can be used in the template file like this::
+
+    {{ my_oddjob_config | encode_xml }}
+
+The output of such template would be::
+
+    <oddjobconfig>
+      <service name="com.redhat.oddjob">
+        <object name="/com/redhat/oddjob">
+          <interface name="com.redhat.oddjob">
+            <method name="listall">
+              <allow min_uid="0" max_uid="0" />
+            </method>
+            <method name="list">
+              <allow />
+            </method>
+            <method name="quit">
+              <allow user="root" />
+            </method>
+            <method name="reload">
+              <allow user="root" />
+            </method>
+          </interface>
+        </object>
+      </service>
+      <include ignore_missing="yes">/etc/oddjobd.conf.d/*.conf</include>
+      <include ignore_missing="yes">/etc/oddjobd-local.conf</include>
+    </oddjobconfig>
+
+The filter can have the following parameters:
+
+- ``attribute_sign="^"``
+
+  XML attribute indicator.
+
+- ``indent="  "``
+
+  Defines the indentation unit.
+
+- ``level=0``
+
+  Indicates the initial level of the indentation. Value ``0`` starts
+  indenting from the beginning of the line. Setting the value to higher
+  than ``0`` indents the content by ``indent * level``.
+
+
+encode_yaml
+^^^^^^^^^^^
+
+This filter helps to create configuration in the YAML format. The
+expected data structure is the following::
+
+    my_mongodb_config:
+      systemLog:
+        destination: file
+        logAppend: true
+        path: /var/log/mongodb/mongod.log
+      storage:
+        dbPath: /var/lib/mongo
+        journal:
+          enabled: true
+      processManagement:
+        fork: true
+        pidFilePath: /var/run/mongodb/mongod.pid
+      net:
+        port: 27017
+        bindIp: 127.0.0.1
+
+The variable is ordinary YAML. The only purpose of this encoder filter is
+to be able to convert YAML data structure into the string in a template
+file in unified way compatible with the other config encoders.
+
+The above variable can be used in the template file like this::
+
+    {{ my_mongodb_config | encode_yaml }}
+
+The output of such template would be::
+
+    net:
+      bindIp: "127.0.0.1"
+      port: 27017
+    processManagement:
+      fork: true
+      pidFilePath: "/var/run/mongodb/mongod.pid"
+    storage:
+      dbPath: "/var/lib/mongo"
+      journal:
+        enabled: true
+    systemLog:
+      destination: "file"
+      logAppend: true
+      path: "/var/log/mongodb/mongod.log"
+
+The filter can have the following parameters:
+
+- ``convert_bools=false``
+
+  Indicates whether Boolean values presented as a string should be
+  converted to a real Boolean value. For example ``var1: 'True'`` would
+  be represented as a string but by using the ``convert_bools=true`` it
+  will be converted into Boolean like it would be defined like ``var1:
+  true``.
+
+- ``convert_nums=false``
+
+  Indicates whether number presented as a string should be converted to
+  number. For example ``var1: '123'`` would be represented as a string
+  but by using the ``convert_nums=true`` it will be converted it to a
+  number like it would be defined like ``var1: 123``. It's also possible
+  to use the YAML type casting to convert string to number (e.g. ``!!int
+  "1234"``, ``!!float "3.14"``).
+
+- ``indent="  "``
+
+  Defines the indentation unit.
+
+- ``level=0``
+
+  Indicates the initial level of the indentation. Value ``0`` starts
+  indenting from the beginning of the line. Setting the value to higher
+  than ``0`` indents the content by ``indent * level``.
+
+- ``quote='"'``
+
+  Sets the quoting of the value. Use ``quote="'"`` or ``quote='"'``.
+
+
+Utilities
+---------
+
+The followng is a list of utilities that can be used in conjunction with the
+Config Encoder filters.
+
+
+template_replace
+^^^^^^^^^^^^^^^^
+
+This filter allows to use extra templating layer which gets processed during
+the template file processing. That can be useful if it's necessary to create
+repetitive but slightly different definitions inside the template file.
+
+The extra templating layer is represented by a templating variable which
+contains specially decorated variables which get replaced by its real value at
+the time of template file processing. The template variable can be composed
+dynamically which provides extra flexibility that would otherwise have to be
+hardcoded in the template file.
+
+The filter expects the template variable containing the specially decorated
+variables as its input. The filter has one parameter which is used to replaced
+the specially decorated variables in the template variable.
+
+Let's have a look at an example of such usage::
+
+    # The variable used as the replacement in the template variable
+    my_clients:
+      - host: myclient01
+        jobdefs: Default
+        password: Passw0rd1
+        file_retention: 30 days
+      - host: myclient02
+        jobdefs: HomeOnly
+        password: Passw0rd2
+        file_retention: 90 days
+
+    # The actual template variable used in the template file
+    bacula_director_config_job_client:
+      # First template variable containing the specially decorated variables
+      - template:
+          - Job:
+            - Name = Job-{[{ item['jobdefs'] }]}-{[{ item['host'] }]}
+            - Client = {[{ item['host'] }]}-fd
+            - JobDefs = {[{ item['jobdefs'] }]}
+        # Variable used to replace the specially decorated variables
+        items: "{{ my_clients }}"
+      # Second template and its items
+      - template:
+          - Client:
+            - Name = {[{ item['host'] }]}-fd
+            - Address = {[{ item['host'] }]}
+            - FD Port = 9102
+            - Catalog = Default
+            - Password = {[{ item['password'] }]}
+            - File Retention = {[{ item['file_retention'] }]}
+            - Job Retention = 3 months
+            - AutoPrune = yes
+        items: "{{ my_clients }}"
+
+The above variable can be used together with the `template_replace` filter in
+the template file (``bacula-dir.conf.j2``) like this::
+
+    {% for record in bacula_director_config_job_client %}
+      {%- for item in record['items'] -%}
+        {{ record['template'] | template_replace(item) | encode_nginx }}{{ "\n" }}
+      {%- endfor -%}
+    {% endfor %}
+
+The template file can be called from the playbook/role like this::
+
+    - name: Configure Bacula Director
+      template:
+        src: bacula-dir.conf.j2
+        dest: /etc/bacula/bacula-dir.conf
+
+And the result of such usage is the following::
+
+    Job {
+      Name = Job-Default-myclient01;
+      Client = myclient01-fd;
+      JobDefs = Default;
+    }
+
+    Job {
+      Name = Job-HomeOnly-myclient02;
+      Client = myclient02-fd;
+      JobDefs = HomeOnly;
+    }
+
+    Client {
+      Name = myclient01-fd;
+      Address = myclient01;
+      FD Port = 9102;
+      Catalog = Default;
+      Password = Passw0rd1;
+      File Retention = 30 days;
+      Job Retention = 3 months;
+      AutoPrune = yes;
+    }
+
+    Client {
+      Name = myclient02-fd;
+      Address = myclient02;
+      FD Port = 9102;
+      Catalog = Default;
+      Password = Passw0rd2;
+      File Retention = 90 days;
+      Job Retention = 3 months;
+      AutoPrune = yes;
+    }
+
+
+.. seealso::
+
+   :doc:`playbooks`
+       An introduction to playbooks
+   :doc:`playbooks_filters`
+       Introduction to Jinja2 filters and their uses
+   :doc:`playbooks_conditionals`
+       Conditional statements in playbooks
+   :doc:`playbooks_variables`
+       All about variables
+   :doc:`playbooks_loops`
+       Looping in playbooks
+   :doc:`playbooks_roles`
+       Playbook organization by roles
+   :doc:`playbooks_best_practices`
+       Best practices in playbooks
+   `User Mailing List <http://groups.google.com/group/ansible-devel>`_
+       Have a question?  Stop by the google group!
+   `irc.freenode.net <http://irc.freenode.net>`_
+       #ansible IRC chat channel

--- a/lib/ansible/plugins/filter/config_encoders.py
+++ b/lib/ansible/plugins/filter/config_encoders.py
@@ -1,0 +1,1050 @@
+# (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+from copy import copy
+import re
+
+
+def _str_is_bool(data):
+    """Verify if data is boolean."""
+
+    return re.match("^(true|false)$", str(data), flags=re.IGNORECASE)
+
+
+def _str_is_int(data):
+    """Verify if data is integer."""
+
+    return re.match("^[-+]?(0|[1-9][0-9]*)$", str(data))
+
+
+def _str_is_float(data):
+    """Verify if data is float."""
+
+    return re.match(
+        "^[-+]?(0|[1-9][0-9]*)(\.[0-9]*)?(e[-+]?[0-9]+)?$",
+        str(data), flags=re.IGNORECASE)
+
+
+def _str_is_num(data):
+    """Verify if data is either integer or float."""
+
+    return _str_is_int(data) or _str_is_float(data)
+
+
+def _is_num(data):
+    """Verify if data is either int or float.
+
+    Could be replaced by:
+
+        from numbers import Number as number
+        isinstance(data, number)
+
+    but that requires Python v2.6+.
+    """
+
+    return isinstance(data, int) or isinstance(data, float)
+
+
+def _escape(data, quote='"', format=None):
+    """Escape special characters in a string."""
+
+    if format == 'xml':
+        return (
+            str(data).
+            replace('&', '&amp;').
+            replace('<', '&lt;').
+            replace('>', '&gt;'))
+    elif quote is not None and len(quote):
+        return str(data).replace('\\', '\\\\').replace(quote, "\\%s" % quote)
+    else:
+        return data
+
+
+def encode_apache(
+        data, convert_bools=False, convert_nums=False, indent="  ", level=0,
+        quote_all_nums=False, quote_all_strings=False, block_type='sections'):
+    """Convert Python data structure to Apache format."""
+
+    # Return value
+    rv = ""
+
+    if block_type == 'sections':
+        for c in data['content']:
+            # First check if this section has options
+            if 'options' in c:
+                rv += encode_apache(
+                    c['options'],
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    indent=indent,
+                    level=level+1,
+                    quote_all_nums=quote_all_nums,
+                    quote_all_strings=quote_all_strings,
+                    block_type='options')
+
+            is_empty = False
+
+            # Check if this section has some sub-sections
+            if 'sections' in c:
+                for s in c['sections']:
+                    # Check for empty sub-sections
+                    for i in s['content']:
+                        if (
+                                ('options' in i and len(i['options']) > 0) or
+                                ('sections' in i and len(i['sections']) > 0)):
+                            is_empty = True
+
+                    if is_empty:
+                        rv += "%s<%s " % (indent * level,  s['name'])
+
+                        if 'operator' in s:
+                            rv += "%s " % s['operator']
+
+                        if 'param' in s:
+                            rv += encode_apache(
+                                s['param'],
+                                convert_bools=convert_bools,
+                                convert_nums=convert_nums,
+                                indent=indent,
+                                level=level+1,
+                                quote_all_nums=quote_all_nums,
+                                quote_all_strings=quote_all_strings,
+                                block_type='value')
+
+                        rv += ">\n"
+                        rv += encode_apache(
+                            s,
+                            convert_bools=convert_bools,
+                            convert_nums=convert_nums,
+                            indent=indent,
+                            level=level+1,
+                            quote_all_nums=quote_all_nums,
+                            quote_all_strings=quote_all_strings,
+                            block_type='sections')
+                        rv += "%s</%s>\n" % (indent * level, s['name'])
+
+                        # If not last item of the loop
+                        if c['sections'][-1] != s:
+                            rv += "\n"
+
+            if (
+                    data['content'][-1] != c and (
+                        'options' in c and len(c['options']) > 0 or (
+                            'sections' in c and
+                            len(c['sections']) > 0 and
+                            is_empty))):
+                rv += "\n"
+
+    elif block_type == 'options':
+        for o in data:
+            for key, val in sorted(o.iteritems()):
+                rv += "%s%s " % (indent * (level-1),  key)
+                rv += encode_apache(
+                    val,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    indent=indent,
+                    level=level+1,
+                    quote_all_nums=quote_all_nums,
+                    quote_all_strings=quote_all_strings,
+                    block_type='value')
+                rv += "\n"
+
+    elif block_type == 'value':
+        if isinstance(data, bool) or convert_bools and _str_is_bool(data):
+            # Value is a boolean
+
+            rv += str(data).lower()
+
+        elif (
+                _is_num(data) or
+                (convert_nums and _str_is_num(data))):
+            # Value is a number
+            if quote_all_nums:
+                rv += '"%s"' % data
+            else:
+                rv += str(data)
+
+        elif isinstance(data, basestring):
+            # Value is a string
+            if (
+                    quote_all_strings or
+                    " " in data or
+                    "\t" in data or
+                    "\n" in data or
+                    "\r" in data or
+                    data == ""):
+
+                rv += '"%s"' % _escape(data)
+            else:
+                rv += data
+
+        elif isinstance(data, list):
+            # Value is a list
+            for v in data:
+                rv += encode_apache(
+                    v,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    indent=indent,
+                    level=level+1,
+                    quote_all_nums=quote_all_nums,
+                    quote_all_strings=quote_all_strings,
+                    block_type='value')
+
+                # If not last item of the loop
+                if data[-1] != v:
+                    rv += " "
+
+    return rv
+
+
+def encode_erlang(
+        data, atom_value_indicator=":", convert_bools=False,
+        convert_nums=False, indent="  ", level=0):
+    """Convert Python data structure to Erlang format."""
+
+    # Return value
+    rv = ""
+
+    if isinstance(data, dict):
+        # It's a dict
+
+        rv += "\n"
+
+        for key, val in sorted(data.iteritems()):
+            rv += "%s{%s," % (indent*level, key)
+
+            if not isinstance(val, dict):
+                rv += " "
+
+            rv += encode_erlang(
+                val,
+                convert_bools=convert_bools,
+                convert_nums=convert_nums,
+                indent=indent,
+                level=level+1)
+
+            rv += "}"
+    elif (
+            data == "null" or
+            _is_num(data) or
+            isinstance(data, bool) or
+            (convert_nums and _str_is_num(data)) or
+            (convert_bools and _str_is_bool(data))):
+        # It's null, number or boolean
+
+        rv += str(data).lower()
+
+    elif isinstance(data, basestring):
+        # It's a string
+
+        atom_len = len(atom_value_indicator)
+
+        if (
+                len(data) > atom_len and
+                data[0:atom_len] == atom_value_indicator):
+
+            # Atom configuration value
+            rv += data[atom_len:]
+        else:
+            rv += '"%s"' % _escape(data)
+
+    else:
+        # It's a list
+
+        rv += "["
+
+        for val in data:
+            if (
+                    isinstance(val, basestring) or
+                    _is_num(val)):
+                rv += "\n%s" % (indent*level)
+
+            rv += encode_erlang(
+                val,
+                convert_bools=convert_bools,
+                convert_nums=convert_nums,
+                indent=indent,
+                level=level+1)
+
+            if data[-1] == val:
+                # Last item of the loop
+                rv += "\n"
+            else:
+                rv += ","
+
+        if len(data) > 0:
+            rv += "%s]" % (indent * (level-1))
+        else:
+            rv += "]"
+
+        if level == 0:
+            rv += ".\n"
+
+    return rv
+
+
+def encode_haproxy(data, indent="  "):
+    """Convert Python data structure to HAProxy format."""
+
+    # Return value
+    rv = ""
+    # Indicates first loop
+    first = True
+    # Indicates whether the previous section was a comment
+    prev_comment = False
+
+    for section in data:
+        if first:
+            first = False
+        elif prev_comment:
+            prev_comment = False
+        else:
+            # Print empty line between sections
+            rv += "\n"
+
+        if isinstance(section, dict):
+            # It's a section
+            rv += "%s\n" % section.keys()[0]
+
+            # Process all parameters of the section
+            for param in section.values()[0]:
+                rv += "%s%s\n" % (indent, param)
+        else:
+            # It's a comment of a parameter
+            rv += "%s\n" % section
+            prev_comment = True
+
+    return rv
+
+
+def encode_ini(
+        data, delimiter="=", quote="", section_is_comment=False,
+        ucase_prop=False):
+    """Convert Python data structure to INI format."""
+
+    # Return value
+    rv = ""
+
+    # First process all standalone properties
+    for prop, val in sorted(data.iteritems()):
+        if ucase_prop:
+            prop = prop.upper()
+
+        vals = []
+
+        if isinstance(val, list):
+            vals = val
+        elif not isinstance(val, dict):
+            vals = [val]
+
+        for item in vals:
+            if (
+                    len(quote) == 0 and
+                    isinstance(item, basestring) and
+                    len(item) == 0):
+                item = '""'
+
+            rv += "%s%s%s%s%s\n" % (
+                prop, delimiter, quote, _escape(item, quote), quote)
+
+    # Then process all sections
+    for section, props in sorted(data.iteritems()):
+        if isinstance(props, dict):
+            if rv != "":
+                rv += "\n"
+
+            if section_is_comment:
+                rv += "# %s\n" % (section)
+            else:
+                rv += "[%s]\n" % (section)
+
+            # Let process all section options as standalone properties
+            rv += encode_ini(
+                props,
+                delimiter=delimiter,
+                quote=quote,
+                section_is_comment=section_is_comment,
+                ucase_prop=ucase_prop)
+
+    return rv
+
+
+def encode_json(
+        data, convert_bools=False, convert_nums=False, indent="  ", level=0):
+    """Convert Python data structure to JSON format."""
+
+    # Return value
+    rv = ""
+
+    if isinstance(data, dict):
+        # It's a dict
+
+        rv += "{"
+
+        if len(data) > 0:
+            rv += "\n"
+
+        items = sorted(data.iteritems())
+
+        for key, val in items:
+            rv += '%s"%s": ' % (indent * (level+1),  key)
+            rv += encode_json(
+                val,
+                convert_bools=convert_bools,
+                convert_nums=convert_nums,
+                indent=indent,
+                level=level+1)
+
+            # Last item of the loop
+            if items[-1] == (key, val):
+                rv += "\n"
+            else:
+                rv += ",\n"
+
+        if len(data) > 0:
+            rv += "%s}" % (indent * level)
+        else:
+            rv += "}"
+
+        if level == 0:
+            rv += "\n"
+
+    elif (
+            data == "null" or
+            _is_num(data) or
+            (convert_nums and _str_is_num(data)) or
+            (convert_bools and _str_is_bool(data))):
+        # It's a number, null or boolean
+
+        rv += str(data).lower()
+
+    elif isinstance(data, basestring):
+        # It's a string
+
+        rv += '"%s"' % _escape(data)
+
+    else:
+        # It's a list
+
+        rv += "["
+
+        if len(data) > 0:
+            rv += "\n"
+
+        for val in data:
+            rv += indent * (level+1)
+            rv += encode_json(
+                val,
+                convert_bools=convert_bools,
+                convert_nums=convert_nums,
+                indent=indent,
+                level=level+1)
+
+            # Last item of the loop
+            if data[-1] == val:
+                rv += "\n"
+            else:
+                rv += ",\n"
+
+        if len(data) > 0:
+            rv += "%s]" % (indent * level)
+        else:
+            rv += "]"
+
+    return rv
+
+
+def encode_logstash(
+        data, convert_bools=False, convert_nums=False, indent="  ", level=0,
+        prevtype="", section_prefix=":"):
+    """Convert Python data structure to Logstash format."""
+
+    # Return value
+    rv = ""
+
+    if isinstance(data, dict):
+        # The item is a dict
+
+        if prevtype in ('value', 'value_hash', 'array'):
+            rv += "{\n"
+
+        items = sorted(data.iteritems())
+
+        for key, val in items:
+            if key[0] == section_prefix:
+                rv += "%s%s {\n" % (indent * level, key[1:])
+                rv += encode_logstash(
+                    val,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    indent=indent,
+                    level=level+1,
+                    prevtype='block')
+
+                # Last item of the loop
+                if items[-1] == (key, val):
+                    if (
+                            isinstance(val, basestring) or
+                            _is_num(val) or
+                            isinstance(val, bool) or (
+                                isinstance(val, dict) and
+                                val.keys()[0][0] != section_prefix)):
+                        rv += "\n%s}\n" % (indent * level)
+                    else:
+                        rv += "%s}\n" % (indent * level)
+            else:
+                rv += indent * level
+
+                if prevtype == 'value_hash':
+                    rv += '"%s" => ' % key
+                else:
+                    rv += "%s => " % key
+
+                rv += encode_logstash(
+                    val,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    indent=indent,
+                    level=level+1,
+                    prevtype=(
+                        'value_hash' if isinstance(val, dict) else 'value'))
+
+            if (
+                    items[-1] != (key, val) and (
+                        isinstance(val, basestring) or
+                        _is_num(val) or
+                        isinstance(val, bool))):
+                rv += "\n"
+
+        if prevtype in ('value', 'value_hash', 'array'):
+            rv += "\n%s}" % (indent * (level-1))
+
+            if prevtype in ('value', 'value_array'):
+                rv += "\n"
+
+    elif (
+            _is_num(data) or
+            isinstance(data, bool) or
+            (convert_nums and _str_is_num(data)) or
+            (convert_bools and _str_is_bool(data))):
+        # It's number or boolean
+
+        rv += str(data).lower()
+
+    elif isinstance(data, basestring):
+        # It's a string
+
+        rv += '"%s"' % _escape(data)
+
+    else:
+        # It's a list
+
+        for val in data:
+            if isinstance(val, dict) and val.keys()[0][0] == section_prefix:
+                # Value is a block
+
+                rv += encode_logstash(
+                    val,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    indent=indent,
+                    level=level,
+                    prevtype='block')
+            else:
+                # First item of the loop
+                if data[0] == val:
+                    rv += "[\n"
+
+                rv += indent * level
+                rv += encode_logstash(
+                    val,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    indent=indent,
+                    level=level+1,
+                    prevtype='array')
+
+                # Last item of the loop
+                if data[-1] == val:
+                    rv += "\n%s]" % (indent * (level-1))
+                else:
+                    rv += ",\n"
+
+    return rv
+
+
+def encode_nginx(data, indent="  ", level=0):
+    """Convert Python data structure to Nginx format."""
+
+    # Return value
+    rv = ""
+    # Indicates the item type [section|line]
+    item_type = ""
+
+    for item in data:
+        if isinstance(item, dict):
+            # Section
+            if item_type in ('section', 'line'):
+                rv += "\n"
+
+            rv += "%s%s {\n" % (level*indent, item.keys()[0])
+            rv += encode_nginx(item.values()[0], level=level+1)
+            rv += "%s}\n" % (level*indent)
+
+            item_type = 'section'
+
+        elif isinstance(item, basestring):
+            # Normal line
+            if item_type == 'section':
+                rv += "\n"
+
+            item_type = 'line'
+
+            rv += "%s%s" % (level*indent, item)
+
+            # Do not finish comments with semicolon
+            if item.startswith("# "):
+                rv += "\n"
+            else:
+                rv += ";\n"
+
+        else:
+            raise errors.AnsibleFilterError(
+                "Unexpected data type: %s" % (type(item)))
+
+    return rv
+
+
+def encode_pam(
+        data, print_label=False, separate_types=True, separator="  "):
+    """Convert Python data structure to PAM format."""
+
+    # Return value
+    rv = ""
+    # Remember previous type to make newline between type blocks
+    prev_type = None
+
+    for label, rule in sorted(data.iteritems()):
+        if separate_types:
+            # Add extra newline to separate blocks of the same type
+            if prev_type is not None and prev_type != rule['type']:
+                rv += "\n"
+
+            prev_type = rule['type']
+
+        if print_label:
+            rv += "# %s\n" % label
+
+        if 'service' in rule:
+            rv += "%s%s" % (rule['service'], separator)
+
+        if 'silent' in rule and rule['silent']:
+            rv += '-'
+
+        rv += "%s%s" % (rule['type'], separator)
+
+        if isinstance(rule['control'], list):
+            "[%s]%s" % (
+                " ".join(
+                    map(
+                        lambda k: "=".join(map(str, k)),
+                        map(lambda x: x.items()[0], rule['control']))),
+                separator)
+        else:
+            rv += "%s%s" % (rule['control'], separator)
+
+        rv += rule['path']
+
+        if 'args' in rule and rule['args']:
+            rv += separator
+
+            for i, arg in enumerate(rule['args']):
+                if i > 0:
+                    rv += ' '
+
+                if isinstance(arg, dict):
+                    rv += "=".join(map(str, arg.items()[0]))
+                else:
+                    rv += arg
+
+        rv += "\n"
+
+    return rv
+
+
+def encode_toml(
+        data, convert_bools=False, convert_nums=False, first=True,
+        indent="  ", level=0, prevkey="", prevtype="", quote='"'):
+    """Convert Python data structure to TOML format."""
+
+    # Return value
+    rv = ""
+
+    if isinstance(data, dict):
+        # It's a dict
+
+        # First process all standalone strings, numbers, booleans and lists
+        for key, val in sorted(data.iteritems()):
+            if (
+                    isinstance(val, basestring) or
+                    _is_num(val) or
+                    isinstance(val, bool) or (
+                        isinstance(val, list) and
+                        len(val) > 0 and
+                        not isinstance(val[0], dict))):
+                # The value is string, number, boolean or list
+
+                rv += "%s%s = " % (indent * level, key)
+                rv += encode_toml(
+                    val,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    first=first,
+                    indent=indent,
+                    level=level,
+                    prevkey=prevkey)
+
+                first = False
+
+        # Then process all data structures
+        for key, val in sorted(data.iteritems()):
+            if (
+                    isinstance(val, dict) or
+                    isinstance(val, list) and isinstance(val[0], dict)):
+
+                # Values for the next recursive call
+                tmp_prevkey = prevkey
+                tmp_level = level
+
+                if isinstance(val, dict):
+                    # The val is a dict
+                    if prevkey != "" and prevkey != key:
+                        tmp_level += 1
+
+                    if re.match(r'^[a-zA-Z0-9_-]+$', key) is None:
+                        key = '"%s"' % key
+
+                    if prevkey == "":
+                        tmp_prevkey = key
+                    else:
+                        tmp_prevkey = "%s.%s" % (prevkey, key)
+
+                    if not first:
+                        rv += "\n"
+
+                    rv += "%s[%s]\n" % (indent * tmp_level, tmp_prevkey)
+                elif isinstance(val[0], dict):
+                    # The val is a table
+                    if re.match(r'^[a-zA-Z0-9_-]+$', key) is None:
+                        key = '"%s"' % key
+
+                    if prevkey == "":
+                        tmp_prevkey = key
+                    else:
+                        tmp_prevkey = "%s.%s" % (prevkey, key)
+
+                    tmp_level += 1
+
+                rv += encode_toml(
+                    val,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    first=first,
+                    indent=indent,
+                    level=tmp_level,
+                    prevkey=tmp_prevkey)
+
+                first = False
+
+    elif (
+            _is_num(data) or
+            isinstance(data, bool) or
+            (convert_nums and _str_is_num(data)) or
+            (convert_bools and _str_is_bool(data))):
+        # It's number or boolean
+
+        rv += str(data).lower()
+
+        if prevtype != 'list':
+            rv += "\n"
+
+    elif isinstance(data, basestring):
+        # It's a string
+
+        rv += "%s%s%s" % (
+            quote, _escape(data, quote), quote)
+
+        if prevtype != 'list':
+            rv += "\n"
+
+    else:
+        # It's a list
+
+        if isinstance(data[0], dict):
+            for d in data:
+                rv += "\n%s[[%s]]\n" % (indent * level, prevkey)
+                rv += encode_toml(
+                    d,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    first=first,
+                    indent=indent,
+                    level=level)
+        else:
+            rv += "["
+
+            for d in data:
+                rv += encode_toml(
+                    d,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    first=first,
+                    indent=indent,
+                    level=level,
+                    prevtype='list')
+
+                # Last item of the loop
+                if data[-1] != d:
+                    rv += ", "
+
+            rv += "]"
+
+            if prevtype != 'list':
+                rv += "\n"
+
+    return rv
+
+
+def encode_xml(
+        data, attribute_sign="^", escape_xml=True, indent="  ", level=0):
+    """Convert Python data structure to XML format."""
+
+    # Return value
+    rv = ""
+
+    if isinstance(data, list):
+        # Pocess anything what's not attribute
+        for item in data:
+            if (
+                    not (
+                        isinstance(item, dict) and
+                        item.keys()[0].startswith(attribute_sign))):
+                rv += encode_xml(
+                    item,
+                    attribute_sign=attribute_sign,
+                    indent=indent,
+                    level=level,
+                    escape_xml=escape_xml)
+    elif isinstance(data, dict):
+        # It's eiher an attribute or an element
+
+        key, val = data.items()[0]
+
+        if key.startswith(attribute_sign):
+            # Process attribute
+            rv += ' %s="%s"' % (key[1:], _escape(val))
+        else:
+            # Process element
+            rv = '%s<%s' % (level*indent, key)
+
+            # Check if there are any attributes
+            if isinstance(val, list):
+                has_element = False
+                num_attrs = 0
+
+                for item in val:
+                    if (
+                            isinstance(item, dict) and
+                            item.keys()[0].startswith(attribute_sign)):
+                        num_attrs += 1
+                        rv += encode_xml(
+                            item,
+                            attribute_sign=attribute_sign,
+                            indent=indent,
+                            level=level)
+
+            if val == '' or (isinstance(val, list) and num_attrs == len(val)):
+                # Close the element as empty
+                rv += " />\n"
+            else:
+                # Close the element as normal
+                rv += ">"
+
+                # Check if the value is text
+                val_not_text = False
+                if isinstance(val, list) or isinstance(val, dict):
+                    val_not_text = True
+
+                if val_not_text:
+                    rv += "\n"
+
+                # Process inner content of the element
+                rv += encode_xml(
+                    val,
+                    attribute_sign=attribute_sign,
+                    indent=indent,
+                    level=level+1,
+                    escape_xml=escape_xml)
+
+                if val_not_text:
+                    rv += level*indent
+
+                rv += "</%s>\n" % key
+    else:
+        # It's a string
+
+        rv += "%s" % _escape(data, format=('xml' if escape_xml else None))
+
+    return rv
+
+
+def encode_yaml(
+        data, convert_bools=False, convert_nums=False, indent="  ", level=0,
+        quote='"', skip_indent=False):
+    """Convert Python data structure to YAML format."""
+
+    # Return value
+    rv = ""
+
+    if isinstance(data, dict):
+        # It's a dictionary
+
+        if len(data.keys()) == 0:
+            rv += "{}\n"
+        else:
+            for key, val in sorted(data.iteritems()):
+                rv += "%s%s:" % ("" if skip_indent else level*indent, key)
+
+                if isinstance(val, dict) and len(val.keys()) == 0:
+                    rv += " {}\n"
+                else:
+                    if (
+                            isinstance(val, dict) or (
+                                isinstance(val, list) and
+                                len(val) != 0)):
+                        rv += "\n"
+                    else:
+                        rv += " "
+
+                    rv += encode_yaml(
+                        val,
+                        convert_bools=convert_bools,
+                        convert_nums=convert_nums,
+                        indent=indent,
+                        level=level+1,
+                        quote=quote)
+
+    elif isinstance(data, list):
+        # It's a list
+
+        if len(data) == 0:
+            rv += "[]\n"
+        else:
+            for item in data:
+                list_indent = "%s- " % (level*indent)
+
+                rv += "%s%s" % (list_indent, encode_yaml(
+                    item,
+                    convert_bools=convert_bools,
+                    convert_nums=convert_nums,
+                    indent=indent,
+                    level=level+1,
+                    quote=quote,
+                    skip_indent=True))
+
+    elif isinstance(data, bool) or (convert_bools and _str_is_bool(data)):
+        # It's a boolean
+
+        rv += "%s\n" % str(data).lower()
+
+    elif (
+            _is_num(data) or
+            (convert_nums and _str_is_num(data))):
+        # It's a number
+
+        rv += "%s\n" % str(data)
+
+    else:
+        # It's a string
+
+        rv += "%s%s%s\n" % (quote, _escape(data, quote), quote)
+
+    return rv
+
+
+def __eval_replace(match):
+    """Evaluate the real value of the variable specified as a string."""
+
+    ret = '__item'
+    ret += ''.join(match.groups()[1:])
+
+    # Try to evaluate the value of the special string
+    try:
+        ret = eval(ret)
+    except Exception, e:
+        # Return empty string if something went wrong
+        ret = ''
+
+    return str(ret)
+
+
+def template_replace(data, replacement):
+    """Replace special template decorated variable with its real value."""
+
+    # Make the replacement variable visible for the __eval_replace function
+    global __item
+    __item = replacement
+
+    # Clone the data to keep the original untouched
+    local_data = copy(data)
+
+    # Walk through the data structure and try to replace all special strings
+    if isinstance(local_data, list):
+        local_data = map(
+            lambda x: template_replace(x, replacement), local_data)
+    elif isinstance(local_data, dict):
+        for key, val in local_data.iteritems():
+            local_data[key] = template_replace(val, replacement)
+    elif isinstance(local_data, basestring):
+        # Replace the special string by it's evaluated value
+        p = re.compile(r'\{\[\{\s*(\w+)([^}\s]+|)\s*\}\]\}')
+        local_data = p.sub(__eval_replace, local_data)
+
+    return local_data
+
+
+class FilterModule(object):
+    """Ansible encoder Jinja2 filters."""
+
+    def filters(self):
+        return {
+            'encode_apache': encode_apache,
+            'encode_erlang': encode_erlang,
+            'encode_haproxy': encode_haproxy,
+            'encode_ini': encode_ini,
+            'encode_json': encode_json,
+            'encode_logstash': encode_logstash,
+            'encode_nginx': encode_nginx,
+            'encode_pam': encode_pam,
+            'encode_toml': encode_toml,
+            'encode_xml': encode_xml,
+            'encode_yaml': encode_yaml,
+            'template_replace': template_replace,
+        }


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

For Ansible v2.2
##### SUMMARY

This is a set of Jinja2 filters which allows to create configuration files in various formats from a variable. The benefit of using these filters is that the variable can be dynamically built (merging dicts, lists) and therefore there is no need to update the template file, only to override the variable. This allows to create Ansible roles with truly universal configuration that helps to reduce fragmentation of Ansible roles.

More details about the [motivation](https://github.com/jtyr/ansible/blob/jtyr-config_encoders/docsite/rst/playbooks_filters_config_encoders.rst#motivation) together with [examples](https://github.com/jtyr/ansible/blob/jtyr-config_encoders/docsite/rst/playbooks_filters_config_encoders.rst#example) and full [documentation](https://github.com/jtyr/ansible/blob/jtyr-config_encoders/docsite/rst/playbooks_filters_config_encoders.rst#supported-encoders) of all the filters is part of the PR.
