### PR TITLE
Make the facts module run on netbsd

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -663,15 +663,11 @@ class Distribution(object):
         self.facts['distribution_release'] = platform.release()
         self.facts['distribution_version'] = platform.version()
 
-        systems_platform_working = ('NetBSD', 'FreeBSD')
         systems_implemented = ('AIX', 'HP-UX', 'Darwin', 'OpenBSD')
 
-        if self.system in systems_platform_working:
-            # the distribution is provided by platform module already and needs no fixes
-            pass
+        self.facts['distribution'] = self.system
 
-        elif self.system in systems_implemented:
-            self.facts['distribution'] = self.system
+        if self.system in systems_implemented:
             cleanedname = self.system.replace('-','')
             distfunc = getattr(self, 'get_distribution_'+cleanedname)
             distfunc()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

checkout d391c53b4fda2995cd04890fbda8a05800f21ce4
##### SUMMARY

It currently fail with

 ansible/module_utils/facts.py\", line 357, in get_service_mgr_facts\r\nKeyError: 'distribution'\r\n"

Since self.facts['distribution'] is used after, we need to make sure
this is set by default and if needed, corrected somewhere for Linux.
