### PR TITLE
Fix pkgin detection on NetBSD 6 and 7

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -156,6 +156,7 @@ class Facts(object):
                  { 'path' : '/usr/sbin/urpmi',      'name' : 'urpmi' },
                  { 'path' : '/usr/bin/pacman',      'name' : 'pacman' },
                  { 'path' : '/bin/opkg',            'name' : 'opkg' },
+                 { 'path' : '/usr/pkg/bin/pkgin',   'name' : 'pkgin' },
                  { 'path' : '/opt/local/bin/pkgin', 'name' : 'pkgin' },
                  { 'path' : '/opt/local/bin/port',  'name' : 'macports' },
                  { 'path' : '/usr/local/bin/brew',  'name' : 'homebrew' },


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (fix_pkgin_detection 1d779f3311) last updated 2016/05/12 17:24:10 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 9dfed7c849) last updated 2016/05/12 17:07:30 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 2665acb257) last updated 2016/05/12 17:07:30 (GMT +200)
  config file = /home/misc/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Since this is now the default package manager, it got moved
to another location on Netbsd :

```
  netbsd# type pkgin
  pkgin is a tracked alias for /usr/pkg/bin/pkgin
  netbsd# uname -a
  NetBSD netbsd.example.org 6.1.4 NetBSD 6.1.4 (GENERIC) amd64
```

But since the package manager is also used outside of NetBSD, we
have to keep the /opt/local path too.

Also, this is broken on 2.1 too, and should be backported.
