### PR TITLE
docs: {{ net_mask | ipaddr('net') }}  example is wrong

### DIFF
--- a/docsite/rst/playbooks_filters_ipaddr.rst
+++ b/docsite/rst/playbooks_filters_ipaddr.rst
@@ -311,7 +311,7 @@ This result can be canonicalised with ``ipaddr()`` to produce a subnet in CIDR f
     # {{ net_mask | ipaddr('prefix') }}
     '24'
 
-    # {{ net_mask | ipaddr('net') }}
+    # {{ net_mask | ipaddr('host') }}
     '192.168.0.0/24'
 
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Example in documentation is wrong for ipaddr('net')

To get "ipaddress/cidr" output the documentation recommends `ipaddr('net').
On my systems this gives me blank output.
After trial and error using`ipaddr('host')` seems to give the correct transformation
##### SYSINFO

centos 6.x amd64, latest updates as of today's date.
python-netaddr.noarch  0.7.5-4.el6 
