### PR TITLE
Fix uninitialized distribution fact on FreeBSD

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -660,6 +660,7 @@ class Distribution(object):
         # The platform module provides information about the running
         # system/distribution. Use this as a baseline and fix buggy systems
         # afterwards
+        self.facts['distribution'] = self.system
         self.facts['distribution_release'] = platform.release()
         self.facts['distribution_version'] = platform.version()
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (detached HEAD ae09648068) last updated 2016/05/13 00:14:41 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 9dfed7c849) last updated 2016/05/12 23:56:16 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 2665acb257) last updated 2016/05/12 23:56:16 (GMT +200)
  config file = /users/thomas/projects/ansible-multi-interp-test/ansible.cfg
  configured module search path = ['/users/thomas/projects/ansible/lib/ansible/modules/core']

```
##### SUMMARY

Initialize facts['distribution'] with self.system so that this fact does
not remain uninitialized on systems_platform_working platforms (FreeBSD,
OpenBSD).

Fixes #15841
