### PR TITLE
Authentication methods for hashi_vault lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -20,6 +20,21 @@
 # You can skip setting the url if you set the VAULT_ADDR environment variable
 # or if you want it to default to localhost:8200
 #
+# The `key` argument allows a key of any depth to be specified in `dot.separated.format`
+#
+# Multiple authentication backends are supported. It is advised against specified
+# more than one authentication method, nevertheless they will take the following
+# order of preference:
+#
+# + *TLS* kwargs: `tls-cert` and `tls-key`
+# + *TOKEN* kwargs: `token`
+# + *USERNAME AND PASSWORD* kwargs: `username` and `password`
+# + *LDAP* kwargs: `ldap-user` and `ldap-pass`
+# + *GITHUB TOKEN* kwargs: `github`
+# + *APP-ID* kwargs: `app-id` and `user-id`
+#
+# Multi-Factor authentication is not yet supported.
+#
 # NOTE: Due to a current limitation in the HVAC library there won't
 # necessarily be an error if a bad endpoint is specified.
 #
@@ -48,11 +63,7 @@ class HashiVault:
             AnsibleError("Please pip install hvac to use this module")
 
         self.url = kwargs.get('url', ANSIBLE_HASHI_VAULT_ADDR)
-            
-        self.token = kwargs.get('token')
-        if self.token==None:
-            raise AnsibleError("No Vault Token specified")
-        
+
         # split secret arg, which has format 'secret/hello:value' into secret='secret/hello' and secret_field='value'
         s = kwargs.get('secret')
         if s==None:
@@ -65,25 +76,64 @@ class HashiVault:
         else:
             self.secret_field = 'value'
 
-        self.client = hvac.Client(url=self.url, token=self.token)
+        self.token = kwargs.get('token', None)
+        self.appid = kwargs.get('app-id', None)
+        self.usrid = kwargs.get('user-id', None)
+        self.username = kwargs.get('username', None)
+        self.password = kwargs.get('password', None)
+        self.github = kwargs.get('github', None)
+        self.ldapusr = kwargs.get('ldap-user', None)
+        self.ldappwd = kwargs.get('ldap-pass', None)
+        self.tlscert = kwargs.get('tls-cert', None)
+        self.tlskey = kwargs.get('tls-key', None)
+
+        if not any((self.token, self.github,
+                    self.appid and self.usrid,
+                    self.username and self.password,
+                    self.ldapusr and self.ldappwd,
+                    self.tlscert and self.tlskey)):
+            raise AnsibleError("No valid authentication method found")
+
+        if self.tlscert:
+            self.client = hvac.Client(url=self.url,
+                                      cert=(self.tlscert, self.tlskey))
+            if self.client.is_authenticated():
+                pass
+            else:
+                raise AnsibleError("Invalid TLS certificate specified")
+        else:
+            self.client = hvac.Client(url=self.url)
+
+        if self.token:
+            self.client.token = self.token
+        elif self.username:
+            self.client.auth_userpass(self.username, self.password)
+        elif self.ldapusr:
+            self.client.auth_ldap(self.ldapusr, self.ldappwd)
+        elif self.github:
+            self.client.auth_github(self.github)
+        elif self.appid:
+            self.client.auth_app_id(self.appid, self.usrid)
 
         if self.client.is_authenticated():
             pass
         else:
-            raise AnsibleError("Invalid Hashicorp Vault Token Specified")
+            raise AnsibleError("Invalid Hashicorp Vault Credentials Specified")
 
     def get(self):
         data = self.client.read(self.secret)
         if data is None:
             raise AnsibleError("The secret %s doesn't seem to exist" % self.secret)
-        
+
         if self.secret_field=='': # secret was specified with trailing ':'
             return data['data']
-        
-        if self.secret_field not in data['data']:
-            raise AnsibleError("The secret %s does not contain the field '%s'. " % (self.secret, self.secret_field))
-        
-        return data['data'][self.secret_field]
+        else:
+            try:
+                for key in ['data'] + self.secret_field.split('.'):
+                    data = data[key]
+                return data
+            except KeyError:
+                AnsibleError("The secret %s doesn't seem to have the requested key %s" % (self.secret, self.secret_field))
 
 
 class LookupModule(LookupBase):
@@ -105,6 +155,5 @@ class LookupModule(LookupBase):
            key = term.split()[0]
            value = vault_conn.get()
            ret.append(value)
-           
+
         return ret
-        


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.2.0
```
##### SUMMARY

The hashi_vault lookup only accepts token based authentication, this PR adds username and password, ldap, app-id, github, and tls authentication methods.
