### PR TITLE
Use .code instead of .getcode() as py24 does not have .getcode()

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -893,7 +893,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
                      url_password=password, http_agent=http_agent, force_basic_auth=force_basic_auth,
                      follow_redirects=follow_redirects)
         info.update(r.info())
-        info.update(dict(msg="OK (%s bytes)" % r.headers.get('Content-Length', 'unknown'), url=r.geturl(), status=r.getcode()))
+        info.update(dict(msg="OK (%s bytes)" % r.headers.get('Content-Length', 'unknown'), url=r.geturl(), status=r.code))
     except NoSSLError:
         e = get_exception()
         distribution = get_distribution()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
v2.0/v2.1/v2.2
```
##### SUMMARY

Python 2.4 does not have `r.getcode()`.  `.getcode()` was introduced in 2.6.  Use `r.code` instead, which works in py2.4-py2.7

This will need cherry picked into stable-2.1 also.

Fixes https://github.com/ansible/ansible-modules-core/issues/3608
