### PR TITLE
Fixing typos in Inventory documentation

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -300,7 +300,7 @@ ansible_become
 ansible_docker_extra_args
     Could be a string with any additional arguments understood by Docker, which are not command specific. This parameter is mainly used to configure a remote Docker daemon to use.
 
-Here an example of how to instantly depoloy to created containers::
+Here is an example of how to instantly deploy to created containers::
 
   - name: create jenkins container
     docker:


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 1.9.6
```
##### SUMMARY

Fixing two grammar errors in Ansible Inventory documentation ([link](docs.ansible.com/ansible/intro_inventory.html)).
