### PR TITLE
vCloud module utils error handling bug fixes

### DIFF
--- a/lib/ansible/module_utils/vca.py
+++ b/lib/ansible/module_utils/vca.py
@@ -111,7 +111,7 @@ class VcaAnsibleModule(AnsibleModule):
 
     def create_instance(self):
         service_type = self.params.get('service_type', DEFAULT_SERVICE_TYPE)
-        if service_type == 'vcd': 
+        if service_type == 'vcd':
             host = self.params['host']
         else:
             host = LOGIN_HOST[service_type]
@@ -136,7 +136,7 @@ class VcaAnsibleModule(AnsibleModule):
             login_org = self.params['org']
 
         if not self.vca.login(password=password, org=login_org):
-            self.fail('Login to VCA failed', response=self.vca.response.content)
+            self.fail('Login to VCA failed', response=self.vca.response)
 
         try:
             method_name = 'login_%s' % service_type
@@ -145,7 +145,7 @@ class VcaAnsibleModule(AnsibleModule):
         except AttributeError:
             self.fail('no login method exists for service_type %s' % service_type)
         except VcaError, e:
-            self.fail(e.message, response=self.vca.response.content, **e.kwargs)
+            self.fail(e.message, response=self.vca.response, **e.kwargs)
 
     def login_vca(self):
         instance_id = self.params['instance_id']

--- a/lib/ansible/module_utils/vca.py
+++ b/lib/ansible/module_utils/vca.py
@@ -160,14 +160,14 @@ class VcaAnsibleModule(AnsibleModule):
 
         org = self.params['org']
         if not org:
-            raise VcaError('missing required or for service_type vchs')
+            raise VcaError('missing required org for service_type vchs')
 
         self.vca.login_to_org(service_id, org)
 
     def login_vcd(self):
         org = self.params['org']
         if not org:
-            raise VcaError('missing required or for service_type vchs')
+            raise VcaError('missing required org for service_type vcd')
 
         if not self.vca.token:
             raise VcaError('unable to get token for service_type vcd')


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 7b2e8d2033) last updated 2016/05/07 23:54:17 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 298fd0ae56) last updated 2016/05/07 23:57:32 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD f953d5dc0c) last updated 2016/05/07 23:57:33 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Currently, most login errors into vCloud director result in AttributeError instead of user-readable message. This happens because response in self.vca.response.content is null.
This change will pass in the whole response into the error handler to actually show provided messages instead of throwing an exception.

Output before the fix with wrong password:

```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "/usr/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:791: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html\n  InsecureRequestWarning)\nTraceback (most recent call last):\n  File \"/tmp/ansible_QdvehK/ansible_module_vca_vapp.py\", line 282, in <module>\n    main()\n  File \"/tmp/ansible_QdvehK/ansible_module_vca_vapp.py\", line 246, in main\n    supports_check_mode=True)\n  File \"/tmp/ansible_QdvehK/ansible_modlib.zip/ansible/module_utils/vca.py\", line 66, in __init__\n  File \"/tmp/ansible_QdvehK/ansible_modlib.zip/ansible/module_utils/vca.py\", line 139, in login\nAttributeError: 'NoneType' object has no attribute 'content'\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
```

Output after the fix:

```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Login to VCA failed", "response": null}
```
