### PR TITLE
Better FreeBSD distribution facts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -675,7 +675,7 @@ class Distribution(object):
         self.facts['distribution_release'] = platform.release()
         self.facts['distribution_version'] = platform.version()
 
-        systems_implemented = ('AIX', 'HP-UX', 'Darwin', 'OpenBSD')
+        systems_implemented = ('AIX', 'HP-UX', 'Darwin', 'FreeBSD', 'OpenBSD')
 
         self.facts['distribution'] = self.system
 
@@ -763,6 +763,13 @@ class Distribution(object):
         rc, out, err = self.module.run_command("/usr/bin/sw_vers -productVersion")
         data = out.split()[-1]
         self.facts['distribution_version'] = data
+
+    def get_distribution_FreeBSD(self):
+        self.facts['distribution_release'] = platform.release()
+        data = re.search('(\d+)\.(\d+)-RELEASE.*', self.facts['distribution_release'])
+        if data:
+            self.facts['distribution_major_version'] = data.group(1)
+            self.facts['distribution_version'] = '{0}.{1}'.format(data.group(1), data.group(2))
 
     def get_distribution_OpenBSD(self):
         rc, out, err = self.module.run_command("/sbin/sysctl -n kern.version")

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -769,7 +769,7 @@ class Distribution(object):
         data = re.search('(\d+)\.(\d+)-RELEASE.*', self.facts['distribution_release'])
         if data:
             self.facts['distribution_major_version'] = data.group(1)
-            self.facts['distribution_version'] = '{0}.{1}'.format(data.group(1), data.group(2))
+            self.facts['distribution_version'] = '%s.%s' % (data.group(1), data.group(2))
 
     def get_distribution_OpenBSD(self):
         rc, out, err = self.module.run_command("/sbin/sysctl -n kern.version")


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = /home/ale/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #15865 
Make distribution_version coherent and set distribution_major_version

Before:

```
"ansible_distribution": "FreeBSD", 
        "ansible_distribution_release": "10.2-RELEASE-p9", 
        "ansible_distribution_version": "FreeBSD 10.2-RELEASE-p9 #0: Thu Jan 14 01:32:46 UTC 2016     root@amd64-builder.daemonology.net:/usr/obj/usr/src/sys/GENERIC"
```

After:

```
"ansible_distribution": "FreeBSD", 
        "ansible_distribution_major_version": "10", 
        "ansible_distribution_release": "10.2-RELEASE-p9", 
        "ansible_distribution_version": "10.2",
```
