### PR TITLE
Port the module snippet to python3

### DIFF
--- a/lib/ansible/module_utils/vca.py
+++ b/lib/ansible/module_utils/vca.py
@@ -144,7 +144,7 @@ class VcaAnsibleModule(AnsibleModule):
             meth()
         except AttributeError:
             self.fail('no login method exists for service_type %s' % service_type)
-        except VcaError, e:
+        except VcaError as e:
             self.fail(e.message, response=self.vca.response, **e.kwargs)
 
     def login_vca(self):
@@ -318,7 +318,7 @@ def vca_login(module):
             _vchs_login(vca, password, service, org)
         elif service_type == 'vcd':
             _vcd_login(vca, password, org)
-    except VcaError, e:
+    except VcaError as e:
         module.fail_json(msg=e.message, **e.kwargs)
 
     return vca

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -194,9 +194,9 @@ def connect_to_api(module, disconnect_atexit=True):
 
     try:
         service_instance = connect.SmartConnect(host=hostname, user=username, pwd=password)
-    except vim.fault.InvalidLogin, invalid_login:
+    except vim.fault.InvalidLogin as invalid_login:
         module.fail_json(msg=invalid_login.msg, apierror=str(invalid_login))
-    except requests.ConnectionError, connection_error:
+    except requests.ConnectionError as  connection_error:
         if '[SSL: CERTIFICATE_VERIFY_FAILED]' in str(connection_error) and not validate_certs:
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             context.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY

vca depend on pyvcloud, who depend on PyYAML 3.10, which
support python 2.5 as a minimum, cf https://github.com/vmware/pyvcloud/blob/master/requirements.txt
and http://pyyaml.org/wiki/PyYAML

vmware.py depend on PyVIM, who depend on python 2.6.

So we can use the modern syntax for both of them.
