### PR TITLE
Port the gce snippet to a python 2.6 to 3 compatible syntax

### DIFF
--- a/lib/ansible/module_utils/gce.py
+++ b/lib/ansible/module_utils/gce.py
@@ -100,7 +100,7 @@ def gce_connect(module, provider=None):
                 module.fail_json(msg='Using JSON credentials but libcloud minimum version not met. '
                                      'Upgrade to libcloud>=0.17.0.')
                 return None
-        except ValueError, e:
+        except ValueError as e:
             # Not JSON
             pass
 
@@ -114,9 +114,9 @@ def gce_connect(module, provider=None):
                 project=project_id)
         gce.connection.user_agent_append("%s/%s" % (
             USER_AGENT_PRODUCT, USER_AGENT_VERSION))
-    except (RuntimeError, ValueError), e:
+    except (RuntimeError, ValueError) as e:
         module.fail_json(msg=str(e), changed=False)
-    except Exception, e:
+    except Exception as e:
         module.fail_json(msg=unexpected_error_msg(e), changed=False)
 
     return gce


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY

Since it depend on libcloud and libcloud requirements are python 2.6
since libcloud 0.4.0 (https://libcloud.apache.org/about.html), which
was released in 2011 Q2.

GCE drivers were added in 2013, so we can't run a libcloud version
wit GCE support on 2.4.
