### PR TITLE
Port rax.py to python3 compatible syntax

### DIFF
--- a/lib/ansible/module_utils/rax.py
+++ b/lib/ansible/module_utils/rax.py
@@ -163,7 +163,7 @@ def rax_find_volume(module, rax_module, name):
             volume = cbs.find(name=name)
         except rax_module.exc.NotFound:
             volume = None
-        except Exception, e:
+        except Exception as e:
             module.fail_json(msg='%s' % e)
     return volume
 
@@ -302,7 +302,7 @@ def setup_rax_module(module, rax_module, region_required=True):
                        os.environ.get('RAX_CREDS_FILE'))
         region = (region or os.environ.get('RAX_REGION') or
                   rax_module.get_setting('region'))
-    except KeyError, e:
+    except KeyError as e:
         module.fail_json(msg='Unable to load %s' % e.message)
 
     try:
@@ -317,7 +317,7 @@ def setup_rax_module(module, rax_module, region_required=True):
             rax_module.set_credential_file(credentials, region=region)
         else:
             raise Exception('No credentials supplied!')
-    except Exception, e:
+    except Exception as e:
         if e.message:
             msg = str(e.message)
         else:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY

Since the pyrax website say that only python 2.7 is tested,
I do not think it is worth to aim for python 2.4 compatibility
for the various rackspace modules.
