### PR TITLE
Port docker_common.py to py3 compatible syntax

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -37,7 +37,7 @@ try:
     from docker.constants import DEFAULT_TIMEOUT_SECONDS, DEFAULT_DOCKER_API_VERSION
     from docker.utils.types import Ulimit, LogConfig
     from docker import auth
-except ImportError, exc:
+except ImportError as exc:
     HAS_DOCKER_ERROR = str(exc)
     HAS_DOCKER_PY = False
 
@@ -161,9 +161,9 @@ class AnsibleDockerClient(Client):
 
         try:
             super(AnsibleDockerClient, self).__init__(**self._connect_params)
-        except APIError, exc:
+        except APIError as exc:
             self.fail("Docker API error: %s" % exc)
-        except Exception, exc:
+        except Exception as exc:
             self.fail("Error connecting: %s" % exc)
 
     def log(self, msg, pretty_print=False):
@@ -262,7 +262,7 @@ class AnsibleDockerClient(Client):
         try:
             tls_config = TLSConfig(**kwargs)
             return tls_config
-        except TLSParameterError, exc:
+        except TLSParameterError as exc:
            self.fail("TLS config error: %s" % exc)
 
     def _get_connect_params(self):
@@ -372,9 +372,9 @@ class AnsibleDockerClient(Client):
                 if container['Id'] == name:
                     result = container
                     break
-        except SSLError, exc:
+        except SSLError as exc:
             self._handle_ssl_error(exc)
-        except Exception, exc:
+        except Exception as exc:
             self.fail("Error retrieving container list: %s" % exc)
 
         if result is not None:
@@ -382,7 +382,7 @@ class AnsibleDockerClient(Client):
                 self.log("Inspecting container Id %s" % result['Id'])
                 result = self.inspect_container(container=result['Id'])
                 self.log("Completed container inspection")
-            except Exception, exc:
+            except Exception as exc:
                 self.fail("Error inspecting container: %s" % exc)
 
         return result
@@ -411,7 +411,7 @@ class AnsibleDockerClient(Client):
         if len(images) == 1:
             try:
                 inspection = self.inspect_image(images[0]['Id'])
-            except Exception, exc:
+            except Exception as exc:
                 self.fail("Error inspecting image %s:%s - %s" % (name, tag, str(exc)))
             return inspection
 
@@ -455,7 +455,7 @@ class AnsibleDockerClient(Client):
                                                                                error_detail.get('message')))
                     else:
                         self.fail("Error pulling %s - %s" % (name, line.get('error')))
-        except Exception, exc:
+        except Exception as exc:
             self.fail("Error pulling image %s:%s - %s" % (name, tag, str(exc)))
 
         return self.find_image(name, tag)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY

Since docker-py depend on python 2.6 (cf their tox.ini),
we do not need to make it python 2.4 compatible.
