### PR TITLE
Do not test vca and vmware.py for py2.4

### DIFF
--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -12,7 +12,7 @@ if [ "${TARGET}" = "sanity" ]; then
     ./test/code-smell/boilerplate.sh
     ./test/code-smell/required-and-default-attributes.sh
     if test x"$TOXENV" != x'py24' ; then tox ; fi
-    if test x"$TOXENV" = x'py24' ; then python2.4 -V && python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce|docker_common|azure_rm_common).py' lib/ansible/module_utils ; fi
+    if test x"$TOXENV" = x'py24' ; then python2.4 -V && python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce|docker_common|azure_rm_common|vca|vmware).py' lib/ansible/module_utils ; fi
 else
     if [ ! -e /tmp/cid_httptester ]; then
         docker pull sivel/httptester


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

Since both of them depend on libraries not
working on python 2.4, we shouldn't restrict
ourself on 2.4, cf https://github.com/ansible/ansible/pull/15870
