### PR TITLE
[inventory] Permit to query a proxmox server with invalid certificate

### DIFF
--- a/contrib/inventory/proxmox.py
+++ b/contrib/inventory/proxmox.py
@@ -96,7 +96,8 @@ class ProxmoxAPI(object):
             'password': self.options.password,
         })
 
-        data = json.load(open_url(request_path, data=request_params))
+        data = json.load(open_url(request_path, data=request_params,
+            validate_certs=self.options.validate))
 
         self.credentials = {
             'ticket': data['data']['ticket'],
@@ -107,7 +108,8 @@ class ProxmoxAPI(object):
         request_path = '{}{}'.format(self.options.url, url)
 
         headers = {'Cookie': 'PVEAuthCookie={}'.format(self.credentials['ticket'])}
-        request = open_url(request_path, data=data, headers=headers)
+        request = open_url(request_path, data=data, headers=headers,
+                validate_certs=self.options.validate)
 
         response = json.load(request)
         return response['data']
@@ -219,6 +221,7 @@ def main():
     parser.add_option('--username', default=os.environ.get('PROXMOX_USERNAME'), dest='username')
     parser.add_option('--password', default=os.environ.get('PROXMOX_PASSWORD'), dest='password')
     parser.add_option('--pretty', action="store_true", default=False, dest='pretty')
+    parser.add_option('--trust-invalid-certificates', action="store_true", default=False, dest='validate')
     (options, args) = parser.parse_args()
 
     if options.list:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This is a patch which adds an argument to the inventory script for proxmox to permit to query the API even in the absence of valid certificate.
