### PR TITLE
add krb5-user to list of packages to install for ubuntu 

### DIFF
--- a/docsite/rst/intro_windows.rst
+++ b/docsite/rst/intro_windows.rst
@@ -44,7 +44,7 @@ Installing python-kerberos dependencies
    yum -y install python-devel krb5-devel krb5-libs krb5-workstation
 
    # Via Apt (Ubuntu)
-   sudo apt-get install python-dev libkrb5-dev
+   sudo apt-get install python-dev libkrb5-dev krb5-user
 
    # Via Portage (Gentoo)
    emerge -av app-crypt/mit-krb5


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (add_ubuntu_krb5_user_to_windows_intro be928ef71a) last updated 2016/05/17 08:17:02 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 83a3c45a7d) last updated 2016/05/17 08:14:12 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 148a0ddabf) last updated 2016/05/17 08:14:12 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

Following this post on the google group: https://groups.google.com/forum/#!topic/ansible-project/dLhLtnuyzak this should improve installation experience for other ubuntu users targeting windows hosts via kerberos
