### PR TITLE
include_vars now properly deals with hash_behaviour

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -629,6 +629,6 @@ class VariableManager:
         if host_name not in self._vars_cache:
             self._vars_cache[host_name] = dict()
         if varname in self._vars_cache[host_name] and isinstance(self._vars_cache[host_name][varname], MutableMapping) and isinstance(value, MutableMapping):
-            self._vars_cache[host_name][varname] = combine_vars(self._vars_cache[host_name][varname], value)
+            self._vars_cache[host_name] = combine_vars(self._vars_cache[host_name], {varname: value})
         else:
             self._vars_cache[host_name][varname] = value


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = /home/nicolas/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix issue #15517

The combine_vars function was called on self._vars_cache[host_name][varname] instead of self._vars_cache[host_name], resulting in the merge of hashes.
