### PR TITLE
Fix OS version check for RHEL 4 to prevent execution of ipv6 ip route…

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2565,8 +2565,8 @@ class LinuxNetwork(Network):
         )
         interface = dict(v4 = {}, v6 = {})
         for v in 'v4', 'v6':
-            if (v == 'v6' and self.facts['os_family'] == 'RedHat' and
-                    self.facts['distribution_version'].startswith('4.')):
+            if v == 'v6' and self.facts['os_family'] == 'RedHat' \
+                and self.facts['distribution_version'].startswith('4'):
                 continue
             if v == 'v6' and not socket.has_ipv6:
                 continue

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2566,7 +2566,9 @@ class LinuxNetwork(Network):
         interface = dict(v4 = {}, v6 = {})
         for v in 'v4', 'v6':
             if v == 'v6' and self.facts['os_family'] == 'RedHat' \
-                and self.facts['distribution_version'].startswith('4'):
+                and (self.facts['distribution_version'].startswith('4.') \
+                     or (self.facts['distribution_version'].startswith('4') \
+                         and self.facts['kernel'].startswith('2.6.9'))):
                 continue
             if v == 'v6' and not socket.has_ipv6:
                 continue

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2568,7 +2568,7 @@ class LinuxNetwork(Network):
             if v == 'v6' and self.facts['os_family'] == 'RedHat' \
                 and (self.facts['distribution_version'].startswith('4.') \
                      or (self.facts['distribution_version'].startswith('4') \
-                         and self.facts['kernel'].startswith('2.6.9'))):
+                         and self.facts['kernel'].startswith('2.6.9-'))):
                 continue
             if v == 'v6' and not socket.has_ipv6:
                 continue


### PR DESCRIPTION
… command that causes kernel panics on RedHat/CentOS 4.8 (kernel 2.6.9-89)
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.2.0
and
ansible 1.9.4
```
##### COMPONENT NAME
lib/ansible/module_utils/facts.py
##### SUMMARY

RedHat OS version check for version 4 was checking that distribution_version startswith '4.' <- note the '.'.  This works fine with CentOS 4.8, but RHEL 4.8 returns just '4' - so the check fails to prevent the ipv6 ip route command from being run, which triggers a kernel panic.  
