### PR TITLE
Defined children for get_vm

### DIFF
--- a/lib/ansible/module_utils/vca.py
+++ b/lib/ansible/module_utils/vca.py
@@ -103,6 +103,7 @@ class VcaAnsibleModule(AnsibleModule):
 
     def get_vm(self, vapp_name, vm_name):
         vapp = self.get_vapp(vapp_name)
+        children = vapp.me.get_Children()
         vms = [vm for vm in children.get_Vm() if vm.name == vm_name]
         try:
             return vms[0]


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel cdef2f5db6) last updated 2016/05/16 13:24:40 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 127d518011) last updated 2016/05/16 13:24:57 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD f953d5dc0c) last updated 2016/05/16 13:25:17 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

As per incident #15903 'children' is not currently defined in vca.py causing erros when making use of the vca_vapp functionality to interact with VM's. This fix need validation, it's worked in our scenario but i'm not familiar with the codebase.
