### PR TITLE
Fix issue with latest pyvmomi and certificate validation

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -196,7 +196,7 @@ def connect_to_api(module, disconnect_atexit=True):
         service_instance = connect.SmartConnect(host=hostname, user=username, pwd=password)
     except vim.fault.InvalidLogin as invalid_login:
         module.fail_json(msg=invalid_login.msg, apierror=str(invalid_login))
-    except requests.ConnectionError as  connection_error:
+    except (requests.ConnectionError, ssl.SSLError) as connection_error:
         if '[SSL: CERTIFICATE_VERIFY_FAILED]' in str(connection_error) and not validate_certs:
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             context.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 1d113c384e) last updated 2016/05/14 11:02:07 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 298fd0ae56) last updated 2016/05/07 23:57:32 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD f953d5dc0c) last updated 2016/05/07 23:57:33 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

We've started experiencing errors with ansible vmware playbooks after upgrading pyvmomi from 6.0.0 to 6.0.0.2016.4
When certificate validation is turned off (validate_certs is false), the error that's getting thrown is ssl.SSLError, which is not handled. The fix is to handle catch both requests.ConnectionError and ssl.SSLError, so ansible works for both versions of pyvmomi.

Error message:

```
TASK [Remove vSwitch] **********************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_LHSboo/ansible_module_vmware_vswitch.py\", line 229, in <module>\n    main()\n  File \"/tmp/ansible_LHSboo/ansible_module_vmware_vswitch.py\", line 222, in main\n    host_virtual_switch = VMwareHostVirtualSwitch(module)\n  File \"/tmp/ansible_LHSboo/ansible_module_vmware_vswitch.py\", line 104, in __init__\n    self.content = connect_to_api(self.module)\n  File \"/tmp/ansible_LHSboo/ansible_modlib.zip/ansible/module_utils/vmware.py\", line 196, in connect_to_api\n  File \"/usr/lib/python2.7/site-packages/pyVim/connect.py\", line 786, in SmartConnect\n    sslContext)\n  File \"/usr/lib/python2.7/site-packages/pyVim/connect.py\", line 671, in __FindSupportedVersion\n    sslContext)\n  File \"/usr/lib/python2.7/site-packages/pyVim/connect.py\", line 591, in __GetServiceVersionDescription\n    path + \"/vimServiceVersions.xml\", sslContext)\n  File \"/usr/lib/python2.7/site-packages/pyVim/connect.py\", line 557, in __GetElementTree\n    conn.request(\"GET\", path)\n  File \"/usr/lib/python2.7/httplib.py\", line 1057, in request\n    self._send_request(method, url, body, headers)\n  File \"/usr/lib/python2.7/httplib.py\", line 1097, in _send_request\n    self.endheaders(body)\n  File \"/usr/lib/python2.7/httplib.py\", line 1053, in endheaders\n    self._send_output(message_body)\n  File \"/usr/lib/python2.7/httplib.py\", line 897, in _send_output\n    self.send(msg)\n  File \"/usr/lib/python2.7/httplib.py\", line 859, in send\n    self.connect()\n  File \"/usr/lib/python2.7/httplib.py\", line 1278, in connect\n    server_hostname=server_hostname)\n  File \"/usr/lib/python2.7/ssl.py\", line 352, in wrap_socket\n    _context=self)\n  File \"/usr/lib/python2.7/ssl.py\", line 579, in __init__\n    self.do_handshake()\n  File \"/usr/lib/python2.7/ssl.py\", line 808, in do_handshake\n    self._sslobj.do_handshake()\nssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
```
