### PR TITLE
PEP8ish for new modules

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -20,6 +20,7 @@ PEP8 and basic style checks
   * PEP8 is a great Python style guide, which you should read.
   * PEP8 must not be strictly followed in all aspects, but most of it is good advice
   * In particular, we don't really care about line lengths.  Buy a bigger monitor!
+  * New modules must be "PEP8ish" - See https://docs.ansible.com/ansible/developing_modules.html#module-checklist
   * To run checks for things we care about, run "make pep8"
   * Similarly, additional checks can be made with "make pyflakes"
   * There is no need to submit code changes for pep8 and pyflake fixes, as these break attribution history.  Project leadership will make these periodically.

--- a/docsite/rst/community.rst
+++ b/docsite/rst/community.rst
@@ -182,6 +182,7 @@ backwards-compatible improvements.  Code developed for Ansible needs to support 
 while code in modules must run under Python 2.4 or higher.  Please also use a 4-space indent
 and no tabs, we do not enforce 80 column lines, we are fine with 120-140. We do not take 'style only'
 requests unless the code is nearly unreadable, we are "PEP8ish", but not strictly compliant.
+The exception to this is new modules, whos standard is defined at `module development checklist <http://docs.ansible.com/developing_modules.html#module-checklist>`_.
 
 You can also contribute by testing and revising other requests, specially if it is one you are interested
 in using. Please keep your comments clear and to the point, courteous and constructive, tickets are not a

--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -702,7 +702,7 @@ The following  checklist items are important guidelines for people who want to c
         main()
 
 * Try to normalize parameters with other modules, you can have aliases for when user is more familiar with underlying API name for the option
-* Being pep8 compliant is nice, but not a requirement. Specifically, the 80 column limit now hinders readability more that it improves it
+* pep8: All new modules must be "PEP8ish" this is defined as ``ansible/Makefile``. This will shortly be enforced by ``ansible-validate-modules``. Changes to exising modules to make them pep8(ish) compliant will not be accepted unless they are done as part of refactoring of that particular area of the code. This is to prevent noise in the git history.
 * Avoid '`action`/`command`', they are imperative and not declarative, there are other ways to express the same thing
 * Do not add `list` or `info` state options to an existing module - create a new `_facts` module.
 * If you are asking 'how can I have a module execute other modules' ... you want to write a role
@@ -711,8 +711,8 @@ The following  checklist items are important guidelines for people who want to c
   serializable.  A common pitfall is to try returning an object via
   exit_json().  Instead, convert the fields you need from the object into the
   fields of a dictionary and return the dictionary.
-* When fetching URLs, please use either fetch_url or open_url from ansible.module_utils.urls 
-  rather than urllib2; urllib2 does not natively verify TLS certificates and so is insecure for https. 
+* When fetching URLs, please use either ``fetch_url`` or ``open_url from ansible.module_utils.urls``
+  rather than ``urllib2``; urllib2 does not natively verify TLS certificates and so is insecure for https.
 
 
 Windows modules checklist


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

N/A
##### SUMMARY

As agreed in New Modules meeting 2016-05-18 new modules should be "PEP8ish"

The pep8 command in the Makefile doesn't seem to currently complain about lines over 160, so we will accept modules with very long lines. 

Enforcing this in Travis will be done in a follow up PR by @gundalow

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/15928)

<!-- Reviewable:end -->
