### PR TITLE
Update test of make_become for ssh pty race mitigation

### DIFF
--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -610,6 +610,7 @@ class TestActionBase(unittest.TestCase):
         play_context = PlayContext()
         action_base = DerivedActionBase(None, None, play_context, None, None, None)
         action_base._connection = MagicMock(exec_command=MagicMock(return_value=(0, '', '')))
+        action_base._connection._shell = MagicMock(append_command=MagicMock(return_value=('JOINED CMD')))
 
         play_context.become = True
         play_context.become_user = play_context.remote_user = 'root'


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.1.0 and devel
```
##### SUMMARY

unittests needed fixing for the ssh pty race mtigation.  A MagicMock was getting into the output instead of the expected string value.
