### PR TITLE
If an inventory script throws an error, don't try to parse it as an ini

### DIFF
--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -39,6 +39,7 @@ def get_file_parser(hostsfile, groups, loader):
     # class we can show a more apropos error
 
     shebang_present = False
+    exec_failed = False
     processed = False
     myerr = []
     parser = None
@@ -61,6 +62,7 @@ def get_file_parser(hostsfile, groups, loader):
             processed = True
         except Exception as e:
             myerr.append(str(e))
+            exec_failed = True
     elif shebang_present:
         myerr.append("The file %s looks like it should be an executable inventory script, but is not marked executable. Perhaps you want to correct this with `chmod +x %s`?" % (hostsfile, hostsfile))
 
@@ -73,7 +75,7 @@ def get_file_parser(hostsfile, groups, loader):
             myerr.append(str(e))
 
     # ini
-    if not processed:
+    if not processed and not exec_failed and not shebang_present:
         try:
             parser = InventoryINIParser(loader=loader, groups=groups, filename=hostsfile)
             processed = True


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = /home/ec2-user/repos/infosec-ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

It's a script. We ran it and and threw and error; no need to be naive and hope against hope it was really an ini file. Most of the time this is just going to result in another indecipherable 'Error parsing host definition' message that obscures the initial script failure.
##### Before:

```
(ansible-env)[ec2-user@l257387-vm infosec-ansible]$ ansible localhost -m ping
ERROR! Inventory script (/home/ec2-user/repos/infosec-ansible/inventory/ec2.py) had an execution error: ERROR: "Error connecting to AWS backend.
Request has expired", while: getting EC2 instances
/home/ec2-user/repos/infosec-ansible/inventory/ec2.py:3: Error parsing host definition ''''': No closing quotation
(ansible-env)[ec2-user@l257387-vm infosec-ansible]$ head -n 3 /home/ec2-user/repos/infosec-ansible/inventory/ec2.py
#!/usr/bin/env python

'''
```
##### After:

```
(ansible-env)[ec2-user@l257387-vm infosec-ansible]$ ansible localhost -m ping
ERROR! Inventory script (/home/ec2-user/repos/infosec-ansible/inventory/ec2.py) had an execution error: ERROR: "Error connecting to AWS backend.
Request has expired", while: getting EC2 instances
```
