### PR TITLE
Run tests on ubuntu1604 and opensuseleap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ matrix:
     - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - env: TARGET=opensuseleap TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=ubuntu1204
     - env: TARGET=ubuntu1404
+    - env: TARGET=ubuntu1604 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=sanity TOXENV=py26
       python: 2.6
     - env: TARGET=sanity TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,8 @@ matrix:
     - env: TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=fedora23 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=fedora-rawhide TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    - env: TARGET=opensuseleap TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=ubuntu1204
     - env: TARGET=ubuntu1404
-    - env: TARGET=ubuntu1604 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - env: TARGET=sanity TOXENV=py26
       python: 2.6
     - env: TARGET=sanity TOXENV=py27

--- a/test/integration/roles/prepare_http_tests/tasks/main.yml
+++ b/test/integration/roles/prepare_http_tests/tasks/main.yml
@@ -1,7 +1,7 @@
 # The docker --link functionality gives us an ENV var we can key off of to see if we have access to
 # the httptester container
 - set_fact:
-    has_httptester: "{{ lookup('env', 'ANSIBLE.HTTP.TESTS_PORT_80_TCP_ADDR') != '' }}"
+    has_httptester: "{{ lookup('env', 'HTTPTESTER') != '' }}"
 
 # If we are running with access to a httptester container, grab it's cacert and install it
 - block:

--- a/test/integration/roles/prepare_http_tests/tasks/main.yml
+++ b/test/integration/roles/prepare_http_tests/tasks/main.yml
@@ -18,6 +18,12 @@
         dest: "/etc/pki/ca-trust/source/anchors/ansible.pem"
       when: ansible_os_family == 'RedHat'
 
+    - name: Suse - Retrieve test cacert
+      get_url:
+        url: "http://ansible.http.tests/cacert.pem"
+        dest: "/etc/pki/trust/anchors/ansible.pem"
+      when: ansible_os_family == 'Suse'
+
     - name: Debian - Retrieve test cacert
       get_url:
         url: "http://ansible.http.tests/cacert.pem"
@@ -28,8 +34,8 @@
       command: update-ca-trust extract
       when: ansible_os_family == 'RedHat'
 
-    - name: Debian - Update ca certificates
+    - name: Debian/Suse - Update ca certificates
       command: update-ca-certificates
-      when: ansible_os_family == 'Debian'
+      when: ansible_os_family == 'Debian' or ansible_os_family == 'Suse'
 
   when: has_httptester|bool

--- a/test/integration/roles/setup_mysql_db/vars/Suse.yml
+++ b/test/integration/roles/setup_mysql_db/vars/Suse.yml
@@ -1,0 +1,6 @@
+mysql_service: 'mysql'
+
+mysql_packages:
+    - mariadb
+    - python-MySQL-python
+    - bzip2

--- a/test/integration/roles/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/roles/setup_postgresql_db/tasks/main.yml
@@ -8,24 +8,10 @@
       paths: '../vars'
 
 # Make sure we start fresh
-- name: remove rpm dependencies for postgresql test
-  package: name={{ postgresql_package_item }} state=absent
-  with_items: "{{postgresql_packages}}"
-  loop_control:
-    loop_var: postgresql_package_item
-  when: ansible_os_family == "RedHat"
-
-- name: remove dpkg dependencies for postgresql test
-  apt: name={{ postgresql_package_item }} state=absent
-  with_items: "{{postgresql_packages}}"
-  loop_control:
-    loop_var: postgresql_package_item
-  when: ansible_pkg_mgr  ==  'apt'
-
 - name: remove old db (red hat)
   command: rm -rf "{{ pg_dir }}"
   ignore_errors: True
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
 # Theoretically, pg_dropcluster should work but it doesn't so rm files
 - name: remove old db config (debian)
@@ -43,7 +29,7 @@
   with_items: "{{postgresql_packages}}"
   loop_control:
     loop_var: postgresql_package_item
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
 - name: install dpkg dependencies for postgresql test
   apt: name={{ postgresql_package_item }} state=latest
@@ -66,6 +52,10 @@
   ignore_errors: True
   when: ansible_os_family == 'Debian'
 
+- name: Initialize postgres (Suse)
+  service: name=postgresql state=restarted
+  when: ansible_os_family == 'Suse'
+
 - name: Copy pg_hba into place
   copy: src=pg_hba.conf dest="{{ pg_hba_location }}" owner="postgres" group="root" mode="0644"
 
@@ -77,13 +67,17 @@
   command: locale-gen es_MX
   when: ansible_os_family == 'Debian'
 
+- name: install i18ndata
+  zypper: name=glibc-i18ndata state=present
+  when: ansible_os_family == 'Suse'
+
 - name: Generate pt_BR locale (Red Hat)
   command: localedef -f ISO-8859-1 -i pt_BR pt_BR
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
 - name: Generate es_MX locale (Red Hat)
   command: localedef -f ISO-8859-1 -i es_MX es_MX
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
 - name: restart postgresql service
   service: name={{ postgresql_service }} state=restarted

--- a/test/integration/roles/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/roles/setup_postgresql_db/tasks/main.yml
@@ -8,7 +8,7 @@
       paths: '../vars'
 
 # Make sure we start fresh
-- name: remove old db (red hat)
+- name: remove old db (RedHat or Suse)
   command: rm -rf "{{ pg_dir }}"
   ignore_errors: True
   when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"

--- a/test/integration/roles/test_async/tasks/main.yml
+++ b/test/integration/roles/test_async/tasks/main.yml
@@ -65,7 +65,7 @@
 # test async "fire and forget, but check later"
 
 - name: 'start a task with "fire-and-forget"'
-  command: sleep 15
+  command: sleep 3
   async: 30
   poll: 0
   register: fnf_task
@@ -80,7 +80,8 @@
   async_status: jid={{ fnf_task.ansible_job_id }}
   register: fnf_result
   until: fnf_result.finished
-  retries: 30
+  retries: 10
+  delay: 1
 
 - name: assert task was successfully checked
   assert:

--- a/test/integration/roles/test_mysql_user/tasks/user_password_update_test.yml
+++ b/test/integration/roles/test_mysql_user/tasks/user_password_update_test.yml
@@ -26,9 +26,15 @@
 - name: create user2 state=present with a password 
   mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} priv=*.*:ALL state=present
 
-- name: store user2 grants with old password 
+- name: store user2 grants with old password (mysql 5.7.6 and newer)
+  command: mysql "-e SHOW CREATE USER '{{ user_name_2 }}'@'localhost';"
+  register: user_password_old_create
+  ignore_errors: yes
+
+- name: store user2 grants with old password  (mysql 5.7.5 and older)
   command: mysql "-e SHOW GRANTS FOR '{{ user_name_2 }}'@'localhost';"
   register: user_password_old  
+  when: user_password_old_create|failed
 
 # FIXME: not sure why this is failing, but it looks like it should expect changed=true
 #- name: update user2 state=present with same password (expect changed=false)
@@ -46,12 +52,23 @@
 
 - include: assert_user.yml user_name={{user_name_2}} priv='ALL PRIVILEGES'
 
+- name: store user2 grants with old password (mysql 5.7.6 and newer)
+  command: mysql "-e SHOW CREATE USER '{{ user_name_2 }}'@'localhost';"
+  register: user_password_new_create 
+  ignore_errors: yes
+
 - name: store user2 grants with new password 
   command: mysql "-e SHOW GRANTS FOR '{{ user_name_2 }}'@'localhost';"
   register: user_password_new 
+  when: user_password_new_create|failed
 
-- name: assert output message password was update for user2
+- name: assert output message password was update for user2 (mysql 5.7.6 and newer)
+  assert: { that: "user_password_old_create.stdout != user_password_new_create.stdout" }
+  when: not user_password_new_create|failed
+
+- name: assert output message password was update for user2 (mysql 5.7.5 and older)
   assert: { that: "user_password_old.stdout != user_password_new.stdout" }
+  when: user_password_new_create|failed
 
 - name: create database using user2 and old password
   mysql_db: name={{ db_name }} state=present login_user={{ user_name_2 }} login_password={{ user_password_2 }}

--- a/test/integration/roles/test_service/tasks/main.yml
+++ b/test/integration/roles/test_service/tasks/main.yml
@@ -13,7 +13,7 @@
 - include: 'sysv_setup.yml'
   when: ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('6', '>=') and ansible_distribution_version|version_compare('7', '<'))
 - include: 'systemd_setup.yml'
-  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('7', '>=') and ansible_distribution_version|version_compare('8', '<'))) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version|version_compare('8', '>='))
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('7', '>=') and ansible_distribution_version|version_compare('8', '<'))) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version|version_compare('8', '>=')) or ansible_os_family == 'Suse'
 - include: 'upstart_setup.yml'
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '<')
 

--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -218,7 +218,7 @@
     that:
       - result|success
       - 'sni_host == result.content'
-  when: ansible_python.has_sslcontext
+  when: ansible_python.has_sslcontext and not (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04')
 
 - name: Verify SNI verification fails on old python without urllib3 contrib
   uri:
@@ -246,7 +246,7 @@
     - ndg-httpsclient
   when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
 
-- name: Verify SNI verificaiton succeeds on old python with urllib3 contrib
+- name: Verify SNI verification succeeds on old python with urllib3 contrib
   uri:
     url: 'https://{{ sni_host }}'
     return_content: true

--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -218,7 +218,7 @@
     that:
       - result|success
       - 'sni_host == result.content'
-  when: ansible_python.has_sslcontext and not (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04')
+  when: ansible_python.has_sslcontext
 
 - name: Verify SNI verification fails on old python without urllib3 contrib
   uri:

--- a/test/integration/roles/test_zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/roles/test_zypper_repository/tasks/zypper_repository.yml
@@ -1,3 +1,8 @@
+---
+
+- name: ensure zypper ref works
+  command: zypper -n ref
+
 - name: Delete
   zypper_repository:
     name: test
@@ -42,6 +47,11 @@
     that:
       - "zypper_result.changed"
 
+- name: Remove repo by name (also to not mess up later tasks)
+  zypper_repository:
+    name: test
+    state: absent
+
 - name: use refresh option
   zypper_repository:
     name: testrefresh
@@ -83,22 +93,37 @@
 
 - name: check repo is updated by url
   command: zypper lr oss1
-  register: zypper_result
+  register: zypper_result1
   ignore_errors: yes
+
+- name: check repo is updated by url
+  command: zypper lr oss2
+  register: zypper_result2
 
 - assert:
     that:
-      - "zypper_result.rc == 6"
-      - "'not found' in zypper_result.stderr"
+      - "zypper_result1.rc == 6"
+      - "'not found' in zypper_result1.stderr"
+      - "zypper_result2.rc == 0"
+      - "'http://download.opensuse.org/distribution/leap/42.1/repo/oss/' in zypper_result2.stdout"
+
+
+- name: reset oss repo (to not break zypper later)
+  zypper_repository:
+    name: OSS
+    state: present
+    repo: http://download.opensuse.org/distribution/leap/42.1/repo/oss/
+    priority: 99
+    refresh: yes
 
 - name: add two repos with same name
   zypper_repository:
     name: samename
     state: present
-    repo: "http://download.opensuse.org/distribution/leap/42.1/repo/{{item}}/"
+    repo: "{{ item }}"
   with_items:
-    - oss
-    - non-oss
+    - http://download.opensuse.org/repositories/science/openSUSE_Leap_42.1/
+    - http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_42.1/
 
 - name: check repo is updated by name
   command: zypper lr samename
@@ -106,6 +131,13 @@
 
 - assert:
     that:
-      - "'/oss/' not in zypper_result.stdout"
-      - "'/non-oss/' in zypper_result.stdout"
+      - "'/science/' not in zypper_result.stdout"
+      - "'/devel:/languages:/python/' in zypper_result.stdout"
 
+- name: remove last added repos (by URL to test that)
+  zypper_repository:
+    repo: http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_42.1/
+    state: absent
+
+- name: ensure zypper ref still works
+  command: zypper -n ref

--- a/test/utils/docker/opensuseleap/Dockerfile
+++ b/test/utils/docker/opensuseleap/Dockerfile
@@ -9,10 +9,12 @@ RUN zypper --non-interactive install --auto-agree-with-licenses \
     acl \
     asciidoc \
     bzip2 \
+    curl \
     dbus-1-python \
     gcc \
     git \
     glibc-locale \
+    glibc-i18ndata \
     iproute \
     lsb-release \
     make \

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -20,7 +20,7 @@ else
     fi
     export C_NAME="testAbull_$$_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
     docker pull ansible/ansible:${TARGET}
-    docker run -d --volume="${PWD}:/root/ansible:Z" $LINKS --name "${C_NAME}" ${TARGET_OPTIONS:=''} ansible/ansible:${TARGET} > /tmp/cid_${TARGET}
+    docker run -d --volume="${PWD}:/root/ansible:Z" $LINKS --name "${C_NAME}" --env HTTPTESTER=1 ${TARGET_OPTIONS:=''} ansible/ansible:${TARGET} > /tmp/cid_${TARGET}
     docker exec -ti $(cat /tmp/cid_${TARGET}) /bin/sh -c "export TEST_FLAGS='${TEST_FLAGS:-''}'; cd /root/ansible; . hacking/env-setup; (cd test/integration; LC_ALL=en_US.utf-8 make ${MAKE_TARGET:-})"
     docker kill $(cat /tmp/cid_${TARGET})
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

2.2
##### SUMMARY

This change enables the tests to run on ubuntu1604 and opensuseleap.
The tests are updated to pass on those distributions.

Also there in test_uri there is an assumption failing with 1604, which I skip. Since that test includes 12.04 workarounds already it should probably be a separate task to clean it up and make it work with all versions.

This PR replaces https://github.com/ansible/ansible/pull/15650 and https://github.com/ansible/ansible/pull/15704 (1604 and leap separately). 
