### PR TITLE
New pyformat filter plugin to format python-style

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -397,6 +397,20 @@ def extract(item, container, morekeys=None):
 
     return value
 
+def pyformat(fmt, *args, **kwargs):
+    '''
+    Format a string using python name placeholders or other fancy stuff
+    Check https://pyformat.info/ for more fancy !
+    '''
+    variables = {}
+    for arg in args:
+        # Only support dictionaries at this time
+        if isinstance(arg, dict):
+            variables.update(arg)
+    variables.update(kwargs)
+    return fmt % variables
+
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -477,4 +491,7 @@ class FilterModule(object):
 
             # array and dict lookups
             'extract': extract,
+
+            # format python style
+            'pyformat': pyformat,
         }

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -408,7 +408,16 @@ def pyformat(fmt, *args, **kwargs):
         if isinstance(arg, dict):
             variables.update(arg)
     variables.update(kwargs)
-    return fmt % variables
+
+    # Attempt to use Python 2.7 or Python 3 style formatting
+    if hasattr(str, 'format'):
+        result = fmt.format(variables)
+        if result == fmt:
+            return fmt % variables
+        else:
+            return result
+    else:
+        return fmt % variables
 
 
 class FilterModule(object):

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -404,20 +404,21 @@ def pyformat(fmt, *args, **kwargs):
     '''
     variables = {}
     for arg in args:
-        # Only support dictionaries at this time
+        # Supports dictionaries
         if isinstance(arg, dict):
             variables.update(arg)
+
+    # And supports key-value pairs
     variables.update(kwargs)
 
-    # Attempt to use Python 2.7 or Python 3 style formatting
+    # Attempt to use new-style formatting (Python 2.7 or Python 3+)
     if hasattr(str, 'format'):
-        result = fmt.format(variables)
-        if result == fmt:
-            return fmt % variables
-        else:
+        result = fmt.format(**variables)
+        if result != fmt:
             return result
-    else:
-        return fmt % variables
+
+    # Perform old-style formatting using name placeholders (keywords)
+    return fmt % variables
 
 
 class FilterModule(object):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

The existing jinja2 format filter is rather limited, and cannot use name placeholders in string formatting. This filter plugin makes it easier to pass any kind of information to a format string to do exactly what you like.

For more information regarding python formatting, see this: http://pyformat.info/
##### EXAMPLE

Create a very specific date format

``` yaml
- hosts: localhost
  vars:
    # Old style formatting
    timestamp1: '{{ "%(month)s%(day)s%(year)s" | pyformat(ansible_date_time) }}'
    # Old style formatting with key-value substitution
    timestamp2: '{{ "%(month)s%(day)s%(year)s" | pyformat(ansible_date_time, year=ansible_date_time["year"][2:4]) }}'
    # New style formatting (python 2.7 and python 3+)
    timestamp3: '{{ "{month}{day}{year}" | pyformat(ansible_date_time) }}'
    # New style formatting with indentation (python 2.7 and python 3+)
    timestamp3: '{{ "{month:5}{day:5}{year:5}" | pyformat(ansible_date_time) }}'
  tasks:
  - name: Old style formatting
    debug: var=timestamp1
  - name: Old style formatting with key-value substitution
    debug: var=timestamp2
  - name: New style formatting (python 2.7 and python 3+)
    debug: var=timestamp3
  - name: New style formatting with indentation (python 2.7 and python 3+)
    debug: var=timestamp4
```
##### OUTPUT

```
PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Old style formatting] ****************************************************
ok: [localhost] => {
    "timestamp1": "05202016"
}

TASK [Old style formatting with key-value substitution] ************************
ok: [localhost] => {
    "timestamp2": "052016"
}

TASK [New style formatting (python 2.7 and python 3+)] *************************
ok: [localhost] => {
    "timestamp3": "05202016"
}

TASK [New style formatting with indentation (python 2.7 and python 3+)] *********
ok: [localhost] => {
    "timestamp4": "05   20   2016 "
}
PLAY RECAP *********************************************************************
localhost                  : ok=5    changed=0    unreachable=0    failed=0
```
