### PR TITLE
Sort groups by depth then by name

### DIFF
--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -138,6 +138,6 @@ class Host:
     def get_group_vars(self):
         results = {}
         groups = self.get_groups()
-        for group in sorted(groups, key=lambda g: g.depth):
+        for group in sorted(groups, key=lambda g: (g.depth, g.priority, g.name)):
             results = combine_vars(results, group.get_vars())
         return results

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -252,7 +252,7 @@ class VariableManager:
             # we merge in vars from groups specified in the inventory (INI or script)
             all_vars = combine_vars(all_vars, host.get_group_vars())
 
-            for group in sorted(host.get_groups(), key=lambda g: g.depth):
+            for group in sorted(host.get_groups(), key=lambda g: (g.depth, g.priority, g.name)):
                 if group.name in self._group_vars_files and group.name != 'all':
                     for data in self._group_vars_files[group.name]:
                         data = preprocess_vars(data)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
2.2.0
```
##### SUMMARY

Actually group vars load order is random.
The goal is to predict vars precedence between two groups.
