### PR TITLE
Fix the error handling for loop squashing to restore the name argument into the task args

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -269,6 +269,7 @@ class TaskExecutor:
         Squash items down to a comma-separated list for certain modules which support it
         (typically package management modules).
         '''
+        name = None
         try:
             # _task.action could contain templatable strings (via action: and
             # local_action:)  Template it before comparing.  If we don't end up
@@ -284,7 +285,6 @@ class TaskExecutor:
                 if all(isinstance(o, string_types) for o in items):
                     final_items = []
 
-                    name = None
                     for allowed in ['name', 'pkg', 'package']:
                         name = self._task.args.pop(allowed, None)
                         if name is not None:
@@ -326,6 +326,10 @@ class TaskExecutor:
         except:
             # Squashing is an optimization.  If it fails for any reason,
             # simply use the unoptimized list of items.
+
+            # Restore the name parameter
+            if name is not None:
+                self._task.args['name'] = name
             pass
         return items
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
stable-2.1 rc4:
a0ff49194e38f0ee944b42a53c1ac536cc287056
```
##### SUMMARY

If we bail out of loop squashing because of an error we need to make sure that we restore the name argument to its original value.  Otherwise modules will error (dnf, yum) or silently not perform their action (apt if update_cache is also given).
