### PR TITLE
Add a alias for 'long' since python3 do not have it

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -67,6 +67,12 @@ else:
     def iteritems(d):
         return d.iteritems()
 
+try:
+    # Python 2
+    long
+except NameError:
+    # Python 3
+    long = int
 
 try:
     import selinux


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY

That's a commit I cherry picked from my fix_py3 branch. That's the easiest and most uncontroversial code so I hope it wouldn't be hard to review and merge.

Long is used for get_memory_facts on various platforms.
