### PR TITLE
new HandlerTaskInclude Class which can run TaskIncludes inside Handlers

### DIFF
--- a/lib/ansible/playbook/handler_task_include.py
+++ b/lib/ansible/playbook/handler_task_include.py
@@ -1,0 +1,33 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+#from ansible.inventory.host import Host
+from ansible.playbook.task_include import TaskInclude
+from ansible.playbook.handler import Handler
+
+class HandlerTaskInclude(Handler, TaskInclude):
+
+    @staticmethod
+    def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
+        t = HandlerTaskInclude(block=block, role=role, task_include=task_include)
+        return t.load_data(data, variable_manager=variable_manager, loader=loader)
+


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (taskinclude_handler e700a173ec) last updated 2016/05/22 15:43:44 (GMT +200)
  lib/ansible/modules/core: (detached HEAD a64d72d7bc) last updated 2016/05/22 15:36:48 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD d2900e856b) last updated 2016/05/22 15:36:48 (GMT +200)
  config file = /Users/Michael/git/amazeeio-ansible/ansible.cfg
  configured module search path = ['./ansible-modules-extras']
```
##### SUMMARY

With 2c20579a a new `TaskInclude` Class got introduced. Unfortunately this class cannot handle being used inside a Handler (regular Tasks have a special `Handler` Class which is used when a Task should be used inside a Handler). 
So this commit adds a new `HandlerTaskInclude` which is very similary to `Handler` Class, but just inherits from `TaskInclude`.
This fixes #15915
