### PR TITLE
Move comments out of code-blocks

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,8 +8,9 @@
 
 
 ##### ANSIBLE VERSION
+<!--- Paste verbatim output from “ansible --version” between quotes below -->
 ```
-<!--- Paste verbatim output from “ansible --version” between quotes -->
+
 ```
 
 ##### CONFIGURATION
@@ -33,8 +34,9 @@ For bugs, show exactly how to reproduce the problem.
 For new features, show how the feature would be used.
 -->
 
+<!--- Paste example playbooks or commands between quotes below -->
 ```
-<!--- Paste example playbooks or commands between quotes -->
+
 ```
 
 <!--- You can also paste gist.github.com links for larger files -->
@@ -43,8 +45,9 @@ For new features, show how the feature would be used.
 <!--- What did you expect to happen when running the steps above? -->
 
 ##### ACTUAL RESULTS
-<!--- What actually happened? If possible run with high verbosity (-vvvv) -->
+<!--- What actually happened? If possible run with extra verbosity (-vvvv) -->
 
+<!--- Paste verbatim command output between quotes below -->
 ```
-<!--- Paste verbatim command output between quotes -->
+
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,9 @@
  - Docs Pull Request
 
 ##### ANSIBLE VERSION
+<!--- Paste verbatim output from “ansible --version” between quotes below -->
 ```
-<!--- Paste verbatim output from “ansible --version” between quotes -->
+
 ```
 
 ##### SUMMARY
@@ -19,6 +20,7 @@ commit message and your description; but you should still explain what
 the change does.
 -->
 
+<!-- Paste verbatim command output below, e.g. before and after your change -->
 ```
-<!-- Paste verbatim command output here, e.g. before and after your change -->
+
 ```


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output here, e.g. before and after your change below -->

```

```

In hindsight, I think it is better to have empty code-blocks rather than comment placeholders when people don't replace those sections.

I modified this PR to include those empty code-blocks as they would appear if people left them intact to demonstrate what it would look like.
