### PR TITLE
Fix vars precedence bug introduced in ansible 2

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -817,7 +817,12 @@ In 2.x, we have made the order of precedence more specific (with the last listed
   * role defaults [1]_
   * inventory vars [2]_
   * inventory group_vars
+     * ``group_vars/all`` file
+     * ``group_vars/<group name>`` file
+     * inventory file or script
   * inventory host_vars
+     * ``host_vars/<hostname>`` file
+     * inventory file or script
   * playbook group_vars
   * playbook host_vars
   * host facts

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -250,9 +250,7 @@ class VariableManager:
                 for item in data:
                     all_vars = combine_vars(all_vars, item)
 
-            # we merge in vars from groups specified in the inventory (INI or script)
-            all_vars = combine_vars(all_vars, host.get_group_vars())
-
+            # then we merge in the group_vars/<group name> file, if it exists
             for group in sorted(host.get_groups(), key=lambda g: (g.depth, g.name)):
                 if group.name in self._group_vars_files and group.name != 'all':
                     for data in self._group_vars_files[group.name]:
@@ -260,8 +258,8 @@ class VariableManager:
                         for item in data:
                             all_vars = combine_vars(all_vars, item)
 
-            # then we merge in vars from the host specified in the inventory (INI or script)
-            all_vars = combine_vars(all_vars, host.get_vars())
+            # then we merge in vars from groups specified in the inventory (INI or script)
+            all_vars = combine_vars(all_vars, host.get_group_vars())
 
             # then we merge in the host_vars/<hostname> file, if it exists
             host_name = host.get_name()
@@ -270,6 +268,9 @@ class VariableManager:
                     data = preprocess_vars(data)
                     for item in data:
                         all_vars = combine_vars(all_vars, item)
+
+            # then we merge in vars from the host specified in the inventory (INI or script)
+            all_vars = combine_vars(all_vars, host.get_vars())
 
             # finally, the facts caches for this host, if it exists
             try:

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -200,10 +200,10 @@ class TestVariableManager(unittest.TestCase):
             host1 host_var=host_var_from_inventory_host1
 
             [group1:vars]
-            group_var = group_var_from_inventory_group1
+            inventory_group_var = inventory_group_var_from_inventory_group1
 
             [group2:vars]
-            group_var = group_var_from_inventory_group2
+            inventory_group_var = inventory_group_var_from_inventory_group2
             """
 
         fake_loader = DictDataLoader({
@@ -225,7 +225,6 @@ class TestVariableManager(unittest.TestCase):
             '/etc/ansible/roles/defaults_only2/defaults/main.yml': """
             default_var: "default_var_from_defaults_only2"
             host_var: "host_var_from_defaults_only2"
-            group_var: "group_var_from_defaults_only2"
             group_var_all: "group_var_all_from_defaults_only2"
             extra_var: "extra_var_from_defaults_only2"
             """,
@@ -259,15 +258,19 @@ class TestVariableManager(unittest.TestCase):
         h1 = inv1.get_host('host1')
 
         res = v.get_vars(loader=fake_loader, play=play1, host=h1)
-        self.assertEqual(res['group_var'], 'group_var_from_inventory_group1')
         self.assertEqual(res['host_var'], 'host_var_from_inventory_host1')
 
         # next we test with group_vars/ files loaded
         fake_loader.push("/etc/ansible/group_vars/all", """
         group_var_all: group_var_all_from_group_vars_all
+        # Overrided by /etc/ansible/group_vars/group1
+        group_var_group1: group_var_group1_from_group_vars_all
         """)
         fake_loader.push("/etc/ansible/group_vars/group1", """
         group_var: group_var_from_group_vars_group1
+        inventory_group_var: inventory_group_var_from_group_vars_group1
+        group_var_group1: group_var_group1_from_group_vars_group1
+        host_var: host_var_from_group_vars_group1
         """)
         fake_loader.push("/etc/ansible/group_vars/group3", """
         # this is a dummy, which should not be used anywhere
@@ -278,6 +281,7 @@ class TestVariableManager(unittest.TestCase):
         """)
         fake_loader.push("group_vars/group1", """
         playbook_group_var: playbook_group_var
+        group_var: group_var_from_playbook_vars_group1
         """)
         fake_loader.push("host_vars/host1", """
         playbook_host_var: playbook_host_var
@@ -291,6 +295,7 @@ class TestVariableManager(unittest.TestCase):
         v.add_host_vars_file("host_vars/host1", loader=fake_loader)
 
         res = v.get_vars(loader=fake_loader, play=play1, host=h1)
+        self.assertEqual(res['inventory_group_var'], 'inventory_group_var_from_inventory_group1')
         self.assertEqual(res['group_var'], 'group_var_from_group_vars_group1')
         self.assertEqual(res['group_var_all'], 'group_var_all_from_group_vars_all')
         self.assertEqual(res['playbook_group_var'], 'playbook_group_var')

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -266,6 +266,10 @@ class TestVariableManager(unittest.TestCase):
         # Overrided by /etc/ansible/group_vars/group1
         group_var_group1: group_var_group1_from_group_vars_all
         """)
+        fake_loader.push("group_vars/group1", """
+        playbook_group_var: playbook_group_var
+        group_var: group_var_from_playbook_vars_group1
+        """)
         fake_loader.push("/etc/ansible/group_vars/group1", """
         group_var: group_var_from_group_vars_group1
         inventory_group_var: inventory_group_var_from_group_vars_group1
@@ -278,10 +282,6 @@ class TestVariableManager(unittest.TestCase):
         """)
         fake_loader.push("/etc/ansible/host_vars/host1", """
         host_var: host_var_from_host_vars_host1
-        """)
-        fake_loader.push("group_vars/group1", """
-        playbook_group_var: playbook_group_var
-        group_var: group_var_from_playbook_vars_group1
         """)
         fake_loader.push("host_vars/host1", """
         playbook_host_var: playbook_host_var


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.1
```
##### SUMMARY

Before ansible 2.0 inventory group vars are load after script group vars.
For people that use ansible tower to manage inventories, ansible 2.0 behavior is a big problem. We can't anymore overwrite vars define by group_by module for example.
