### PR TITLE
Adds a general purpose Exception class for F5 modules

### DIFF
--- a/lib/ansible/module_utils/f5.py
+++ b/lib/ansible/module_utils/f5.py
@@ -60,6 +60,7 @@ def f5_parse_arguments(module):
 
     return (module.params['server'],module.params['user'],module.params['password'],module.params['state'],module.params['partition'],module.params['validate_certs'],module.params['server_port'])
 
+
 def bigip_api(bigip, user, password, validate_certs, port=443):
     try:
         if bigsuds.__version__ >= '1.0.4':
@@ -86,14 +87,20 @@ def bigip_api(bigip, user, password, validate_certs, port=443):
 
     return api
 
+
 # Fully Qualified name (with the partition)
 def fq_name(partition,name):
     if name is not None and not name.startswith('/'):
         return '/%s/%s' % (partition,name)
     return name
 
-# Fully Qualified name (with partition) for a list 
+
+# Fully Qualified name (with partition) for a list
 def fq_list_names(partition,list_names):
     if list_names is None:
         return None
     return map(lambda x: fq_name(partition,x),list_names)
+
+
+class F5ModuleError(Exception):
+    pass


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Adds a general purpose F5ModuleError class.

This class can be used by F5 modules for raising exceptions.
This should be used to handle known errors and raise them so
that they can be printed in the fail_json method.

The common Exception class built-in should not be used because
it hides tracebacks that are necessary to have when debugging
problems with the module.
