### PR TITLE
install packages for tests in docker images

### DIFF
--- a/test/utils/docker/opensuseleap/Dockerfile
+++ b/test/utils/docker/opensuseleap/Dockerfile
@@ -9,10 +9,12 @@ RUN zypper --non-interactive install --auto-agree-with-licenses \
     acl \
     asciidoc \
     bzip2 \
+    curl \
     dbus-1-python \
     gcc \
     git \
     glibc-locale \
+    glibc-i18ndata \
     iproute \
     lsb-release \
     make \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get install -y \
     acl \
     bzip2 \
     cdbs \
+    curl \
     debhelper \
     debianutils \
     devscripts \


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

devel
##### SUMMARY

The new docker images for opensuseleap and ubuntu1604 are missing packages to pass the tests
- curl is needed for test_binary_modules
- glibc-i18ndata is needed for postgresql (localedef)
