### PR TITLE
cleanup test_binary_modules

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -289,14 +289,12 @@ no_log: setup
 
 test_binary_modules:
 	mytmpdir=$(MYTMPDIR); \
-	ls -al $$mytmpdir; \
 	curl https://storage.googleapis.com/golang/go1.6.2.$(UNAME)-amd64.tar.gz | tar -xz -C $$mytmpdir; \
 	[ $$? != 0 ] && wget -qO- https://storage.googleapis.com/golang/go1.6.2.$(UNAME)-amd64.tar.gz | tar -xz -C $$mytmpdir; \
-	ls -al $$mytmpdir; \
 	cd library; \
 	GOROOT=$$mytmpdir/go GOOS=linux GOARCH=amd64 $$mytmpdir/go/bin/go build -o helloworld_linux helloworld.go; \
 	GOROOT=$$mytmpdir/go GOOS=windows GOARCH=amd64 $$mytmpdir/go/bin/go build -o helloworld_win32nt.exe helloworld.go; \
 	GOROOT=$$mytmpdir/go GOOS=darwin GOARCH=amd64 $$mytmpdir/go/bin/go build -o helloworld_darwin helloworld.go; \
 	cd ..; \
 	rm -rf $$mytmpdir; \
-	ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook test_binary_modules.yml -i $(INVENTORY) -v $(TEST_FLAGS)
+	ansible-playbook test_binary_modules.yml -i $(INVENTORY) -v $(TEST_FLAGS)

--- a/test/integration/test_binary_modules.yml
+++ b/test/integration/test_binary_modules.yml
@@ -1,4 +1,4 @@
-- hosts: all
+- hosts: testhost
   roles:
     - role: test_binary_modules
       tags:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

devel
##### SUMMARY

Cleans up the current use of test_binary_modules
- remove overly verbose output (ls)
- run only once and not via different connections, the other inventory entries are mostly for testing connection plugins

besides making the code and it's output more readable this reduces the runtime (with hot cache) of 

```
TARGET=centos7 TARGET_OPTIONS="--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro" MAKE_TARGET="test_binary_modules" TEST_FLAGS="" test/utils/run_tests.sh
```

from 41 to 23 seconds.
