### PR TITLE
fix vault-keyring.py 'No [vault] section' error

### DIFF
--- a/contrib/vault/vault-keyring.py
+++ b/contrib/vault/vault-keyring.py
@@ -47,16 +47,17 @@
 import sys
 import getpass
 import keyring
+import ConfigParser
+
 
 import ansible.constants as C
 
-
 def main():
-    parser = C.load_config_file()
+    (parser,config_path)  = C.load_config_file()
     try:
         username = parser.get('vault', 'username')
-    except:
-        sys.stderr.write('No [vault] section configured\n')
+    except ConfigParser.NoSectionError:
+        sys.stderr.write('No [vault] section configured in config file: %s\n' % config_path)
         sys.exit(1)
 
     if len(sys.argv) == 2 and sys.argv[1] == 'set':


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

See https://github.com/ansible/ansible/issues/15984
(2.1/devel)
##### SUMMARY

vault-keyring.py was using an older version of
the ansible.constants.load_config_file() API.
The newer version returns a tuple, which caused
the config load to fail and a catch all exception
to blame it on a missing section.

Update to new API, and catch the ConfigParser error
specifically.

Fixes #15984
