### PR TITLE
Fix synchronize module incorrect remote host processing.

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -85,7 +85,8 @@ class ActionModule(ActionBase):
             alternative ssh port to a vagrant host.)
         """
         transport = self._connection.transport
-        if host not in C.LOCALHOST or transport != "local":
+        if host not in C.LOCALHOST or transport != "local" or \
+                (host in C.LOCALHOST and not port_matches_localhost_port):
             if port_matches_localhost_port and host in C.LOCALHOST:
                 self._task.args['_substitute_controller'] = True
             return self._format_rsync_rsh_target(host, path, user)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

Synchronize module was not sending files to the remote machine in cases where local port forwarding is used to reach the remote host (for example, when using an Ansible playbook as a provisioner in Vagrant). This is due to incorrect formatting of rsync rsh targets in such cases.

Fixes  #15539
