### PR TITLE
Fixes #3661 - Return the connection type so we can better handle ftp connections…

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -837,7 +837,8 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
         urlopen_args.append(timeout)
 
     r = urllib2.urlopen(*urlopen_args)
-    return r
+    conn_type = parsed[0]
+    return r, conn_type
 
 #
 # Module-related functions
@@ -887,7 +888,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     r = None
     info = dict(url=url)
     try:
-        r = open_url(url, data=data, headers=headers, method=method,
+        r, conn_type = open_url(url, data=data, headers=headers, method=method,
                      use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout,
                      validate_certs=validate_certs, url_username=username,
                      url_password=password, http_agent=http_agent, force_basic_auth=force_basic_auth,
@@ -923,4 +924,4 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         e = get_exception()
         info.update(dict(msg="An unknown error occurred: %s" % str(e), status=-1))
 
-    return r, info
+    return r, info, conn_type


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel d08fda9320) last updated 2016/05/24 21:03:58 (GMT -700)
  lib/ansible/modules/core: (detached HEAD aa995806b9) last updated 2016/05/24 21:04:04 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD d1a4f703ce) last updated 2016/05/24 21:04:09 (GMT -700)
  config file = /Users/ronnietaylor/Documents/Development/ansible-experiments/vangrants/ubuntu1404/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #3661

Added a return variable to open_url and fetch_url that contains the output from `urlparse.urlparse(url)` (i.e. 'ftp', 'http' or 'https').

This ultimately lets get_url check against something other than just HTTP status codes since successful FTP connections don't return status codes in the response headers like HTTP does. By passing along the connection type we can prevent incorrectly throwing errors for successful FTP connections.

Since the parsing of the url already happens at this level then it seemed best to just capture it once and pass it through to get_url instead of parsing the url again later.

This new variable will contain a string like the following:

```
>>> conn_type
'ftp'
```

… in the get_url module.
