### PR TITLE
added more descriptive error when missing shebang caused by BOM

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -750,7 +750,7 @@ def modify_module(module_name, module_path, module_args, task_vars=dict(), modul
             if os.path.basename(interpreter).startswith(b'python'):
                 lines.insert(1, to_bytes(ENCODING_STRING))
         elif _check_bom(lines[0]):
-            raise AnsibleError("BOM detected in module (%s). Module scripts encoded with BOM are not supported." % module_name)
+            raise AnsibleError("Unsupported byte order mark detected, this type of file encoding is not supported for modules.")
         else:
             # No shebang, assume a binary module?
             pass


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

I add a additional check for a BOM mask in the first line of the module, if the shebang is not found.

Yesterday, I spent 1 hour guessing why my custom powershell module runs correctly in the host machine and crashes when running in a playbook. I think it's important to outline this error (it seems Powershell ISE saves powershell scripts with BOM by default)
