### PR TITLE
Add support for full CI on shippable.com.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ venv
 Vagrantfile
 .vagrant
 ansible.egg-info/
+/shippable/

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,23 +1,33 @@
 language: python
 
-env: TOXENV=py24
+env:
+  matrix:
+    - TEST=code-smell
 
 matrix:
   include:
-    - python: 2.6
-      env: TOXENV=py26
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
+    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py24
+      python: 2.7
+    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py26
+      python: 2.6
+    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py27
+      python: 2.7
+    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py34
+      python: 3.4
+    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py35
+      python: 3.5
+    - env: TEST=integration IMAGE=ansible/ansible:centos6
+    - env: TEST=integration IMAGE=ansible/ansible:centos7
+    - env: TEST=integration IMAGE=ansible/ansible:fedora-rawhide
+    - env: TEST=integration IMAGE=ansible/ansible:fedora23
+    - env: TEST=integration IMAGE=ansible/ansible:opensuseleap
+    - env: TEST=integration IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
+    - env: TEST=integration IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
+    - env: TEST=integration IMAGE=ansible/ansible:ubuntu1604
 
 build:
   ci:
-    - if [ "${TOXENV}" = "py24" ]; then add-apt-repository ppa:fkrull/deadsnakes && apt-get update -qq && apt-get install python2.4 -qq; fi
-    - pip install tox
-    - TARGET=sanity ./test/utils/run_tests.sh
+    - test/utils/shippable/${TEST}.sh 2>&1 | gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush(); }'
 
 integrations:
   notifications:

--- a/test/utils/shippable/code-smell.sh
+++ b/test/utils/shippable/code-smell.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eux
+
+source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../../..')))")
+
+cd "${source_root}"
+
+test/code-smell/replace-urlopen.sh .
+test/code-smell/use-compat-six.sh lib
+test/code-smell/boilerplate.sh
+test/code-smell/required-and-default-attributes.sh

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -1,0 +1,91 @@
+#!/bin/bash -eux
+
+source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../../..')))")
+
+test_image="${IMAGE}"
+test_privileged="${PRIVILEGED:-false}"
+test_flags="${TEST_FLAGS:-}"
+test_target="${TARGET:-}"
+test_ansible_dir="${TEST_ANSIBLE_DIR:-/root/ansible}"
+
+http_image="${HTTP_IMAGE:-ansible/ansible:httptester}"
+
+keep_containers="${KEEP_CONTAINERS:-}"
+copy_source="${COPY_SOURCE:-}"
+
+if [ "${SHIPPABLE_BUILD_DIR:-}" ]; then
+    host_shared_dir="/home/shippable/cache/build-${BUILD_NUMBER}"
+    controller_shared_dir="/home/shippable/cache/build-${BUILD_NUMBER}"
+else
+    host_shared_dir="${source_root}"
+    controller_shared_dir=""
+fi
+
+if [ "${copy_source}" ]; then
+    test_shared_dir="/tmp/shared-dir"
+else
+    test_shared_dir="${test_ansible_dir}"
+fi
+
+container_id=
+httptester_id=
+
+function show_environment
+{
+    docker ps
+
+    if [ -d /home/shippable/cache ]; then
+        ls -l /home/shippable/cache
+    fi
+}
+
+function cleanup
+{
+    if [ "${controller_shared_dir}" ]; then
+        cp -av "${controller_shared_dir}/shippable" "${SHIPPABLE_BUILD_DIR}"
+        rm -rf "${controller_shared_dir}"
+    fi
+
+    if [ "${keep_containers}" == "" ]; then
+        if [ "${container_id}" ]; then
+            docker rm -f "${container_id}"
+        fi
+
+        if [ "${httptester_id}" ]; then
+            docker rm -f "${httptester_id}"
+        fi
+    fi
+
+    show_environment
+}
+
+trap cleanup EXIT INT TERM
+show_environment
+
+if [ "${controller_shared_dir}" ]; then
+    cp -a "${SHIPPABLE_BUILD_DIR}" "${controller_shared_dir}"
+fi
+
+httptester_id=$(docker run -d "${http_image}")
+container_id=$(docker run -d \
+    -v "/sys/fs/cgroup:/sys/fs/cgroup:ro" \
+    -v "${host_shared_dir}:${test_shared_dir}" \
+    --link="${httptester_id}:ansible.http.tests" \
+    --link="${httptester_id}:sni1.ansible.http.tests" \
+    --link="${httptester_id}:sni2.ansible.http.tests" \
+    --link="${httptester_id}:fail.ansible.http.tests" \
+    --privileged="${test_privileged}" \
+    "${test_image}")
+
+show_environment
+
+docker exec "${container_id}" pip install junit-xml
+
+if [ "${copy_source}" ]; then
+    docker exec "${container_id}" cp -a "${test_shared_dir}" "${test_ansible_dir}"
+fi
+
+docker exec "${container_id}" mkdir -p "${test_shared_dir}/shippable/testresults"
+docker exec "${container_id}" /bin/sh -c "cd '${test_ansible_dir}' && . hacking/env-setup && cd test/integration && \
+    JUNIT_OUTPUT_DIR='${test_shared_dir}/shippable/testresults' ANSIBLE_CALLBACK_WHITELIST=junit \
+    HTTPTESTER=1 TEST_FLAGS='${test_flags}' LC_ALL=en_US.utf-8 make ${test_target}"

--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eux
+
+source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../../..')))")
+
+install_deps="${INSTALL_DEPS:-}"
+
+cd "${source_root}"
+
+if [ "${TOXENV}" = 'py24' ]; then
+    if [ "${install_deps}" != "" ]; then
+        add-apt-repository ppa:fkrull/deadsnakes && apt-get update -qq && apt-get install python2.4 -qq
+    fi
+
+    python2.4 -V
+    python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce|docker_common|azure_rm_common|vca|vmware).py' lib/ansible/module_utils
+else
+    if [ "${install_deps}" != "" ]; then
+        pip install tox
+    fi
+
+    xunit_dir="${source_root}/shippable/testresults"
+    coverage_dir="${source_root}/shippable/codecoverage"
+
+    mkdir -p "${xunit_dir}"
+    mkdir -p "${coverage_dir}"
+
+    xunit_file="${xunit_dir}/nosetests-xunit.xml"
+    coverage_file="${coverage_dir}/nosetests-coverage.xml"
+
+    TOX_TESTENV_PASSENV=NOSETESTS NOSETESTS="nosetests --with-xunit --xunit-file='${xunit_file}' --cover-xml --cover-xml-file='${coverage_file}'" tox
+fi


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (shippable e9dc5600b3) last updated 2016/05/25 21:13:12 (GMT -700)
  lib/ansible/modules/core: (detached HEAD aa995806b9) last updated 2016/05/25 13:16:53 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD d1a4f703ce) last updated 2016/05/25 13:16:53 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add support for full CI on https://shippable.com.

PR created to take advantage of paid subscription on Ansible organization.

Some of the additional commits on this PR include:
- Temporary removal of .travis.yml to avoid triggering Travis.
- Cherry-picked commits from https://github.com/ansible/ansible/pull/15936 to improve test coverage.
