### PR TITLE
Modules: check for list-like choices in arg spec

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1322,14 +1322,14 @@ class AnsibleModule(object):
             choices = v.get('choices',None)
             if choices is None:
                 continue
-            if type(choices) == list:
+            if isinstance(choices, SEQUENCETYPE):
                 if k in self.params:
                     if self.params[k] not in choices:
                         choices_str=",".join([str(c) for c in choices])
                         msg="value of %s must be one of: %s, got: %s" % (k, choices_str, self.params[k])
                         self.fail_json(msg=msg)
             else:
-                self.fail_json(msg="internal error: do not know how to interpret argument_spec")
+                self.fail_json(msg="internal error: choices for argument %s are not iterable: %s" % (k, choices))
 
     def safe_eval(self, str, locals=None, include_exceptions=False):
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
% ansible --version                                            
ansible 2.2.0 (list-like-choices a27804eed6) last updated 2016/05/26 12:07:33 (GMT -500)
  lib/ansible/modules/core: (detached HEAD fb77ab49ab) last updated 2016/05/26 11:56:22 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 0e4a023a7e) last updated 2016/05/26 11:56:26 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

And also:

```
% ansible --version
ansible 1.9.4
  configured module search path = ./library:$ANSIBLE_HOME/library
```
##### SUMMARY

This makes it possible to use anything other than a list (e.g., a
tuple, or dict.keys() in py3k) for argument_spec choices. It also
improves the error messages if you don't use a list type.
