### PR TITLE
Add httptester docker container

### DIFF
--- a/test/utils/docker/httptester/Dockerfile
+++ b/test/utils/docker/httptester/Dockerfile
@@ -1,0 +1,28 @@
+FROM nginx:alpine
+
+RUN set -x && \
+    apk add -U openssl py-pip && \
+    mkdir -p /root/ca/certs /root/ca/private /root/ca/newcerts && \
+    echo 1000 > /root/ca/serial && \
+    touch /root/ca/index.txt && \
+    sed -i 's/\.\/demoCA/\/root\/ca/g' /etc/ssl/openssl.cnf && \
+    openssl req -new -x509 -days 3650 -nodes -extensions v3_ca -keyout /root/ca/private/cakey.pem -out /root/ca/cacert.pem \
+        -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=ansible.http.tests" && \
+    openssl req -new -nodes -out /root/ca/ansible.http.tests-req.pem -keyout /root/ca/private/ansible.http.tests-key.pem \
+        -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=ansible.http.tests" && \
+    yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/ansible.http.tests-cert.pem -infiles /root/ca/ansible.http.tests-req.pem && \
+    openssl req -new -nodes -out /root/ca/sni1.ansible.http.tests-req.pem -keyout /root/ca/private/sni1.ansible.http.tests-key.pem -config /etc/ssl/openssl.cnf \
+        -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=sni1.ansible.http.tests" && \
+    yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/sni1.ansible.http.tests-cert.pem -infiles /root/ca/sni1.ansible.http.tests-req.pem && \
+    openssl req -new -nodes -out /root/ca/sni2.ansible.http.tests-req.pem -keyout /root/ca/private/sni2.ansible.http.tests-key.pem -config /etc/ssl/openssl.cnf \
+        -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=sni2.ansible.http.tests" && \
+    yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/sni2.ansible.http.tests-cert.pem -infiles /root/ca/sni2.ansible.http.tests-req.pem && \
+    cp /root/ca/cacert.pem /usr/share/nginx/html/cacert.pem && \
+    pip install gunicorn httpbin
+
+ADD services.sh /services.sh
+ADD nginx.sites.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80 443
+
+CMD ["/services.sh"]

--- a/test/utils/docker/httptester/nginx.sites.conf
+++ b/test/utils/docker/httptester/nginx.sites.conf
@@ -1,0 +1,53 @@
+server {
+    listen 80 default_server;
+    listen 443 ssl default_server;
+
+    server_name ansible.http.tests _;
+
+    ssl_certificate /root/ca/ansible.http.tests-cert.pem;
+    ssl_certificate_key /root/ca/private/ansible.http.tests-key.pem;
+
+    location =/cacert.pem {
+        alias /usr/share/nginx/html/cacert.pem;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+    }
+}
+
+server {
+    listen 80;
+    listen 443 ssl;
+
+    server_name sni1.ansible.http.tests;
+
+    ssl_certificate /root/ca/sni1.ansible.http.tests-cert.pem;
+    ssl_certificate_key /root/ca/private/sni1.ansible.http.tests-key.pem;
+
+    location / {
+        return 200 "sni1.ansible.http.tests";
+    }
+}
+
+server {
+    listen 80;
+    listen 443 ssl;
+
+    server_name sni2.ansible.http.tests;
+
+    ssl_certificate /root/ca/sni2.ansible.http.tests-cert.pem;
+    ssl_certificate_key /root/ca/private/sni2.ansible.http.tests-key.pem;
+
+    location / {
+        return 200 "sni2.ansible.http.tests";
+    }
+}
+
+server {
+    listen 80;
+
+    server_name fail.ansible.http.tests;
+
+    rewrite /(.*) https://$host/$1 permanent;
+}

--- a/test/utils/docker/httptester/services.sh
+++ b/test/utils/docker/httptester/services.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+gunicorn -D httpbin:app
+nginx -g "daemon off;"

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -15,8 +15,8 @@ if [ "${TARGET}" = "sanity" ]; then
     if test x"$TOXENV" = x'py24' ; then python2.4 -V && python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce|docker_common|azure_rm_common|vca|vmware).py' lib/ansible/module_utils ; fi
 else
     if [ ! -e /tmp/cid_httptester ]; then
-        docker pull sivel/httptester
-        docker run -d --name=httptester sivel/httptester > /tmp/cid_httptester
+        docker pull ansible/httptester
+        docker run -d --name=httptester ansible/httptester > /tmp/cid_httptester
     fi
     export C_NAME="testAbull_$$_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
     docker pull ansible/ansible:${TARGET}


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
v2
```
##### SUMMARY

Adds httptester docker container files, and updates `run_tests.sh` to use `ansible/httptester`.

cc @mattclay 
