### PR TITLE
Fix missing ignore_certs

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -129,11 +129,11 @@ class GalaxyCLI(CLI):
                      'The default is the roles_path configured in your '
                      'ansible.cfg file (/etc/ansible/roles if not configured)')
 
-        if self.action in ("import","info","init","install","login","search","setup","delete"):
-            self.parser.add_option('-s', '--server', dest='api_server', default=C.GALAXY_SERVER,
-                help='The API server destination')
-            self.parser.add_option('-c', '--ignore-certs', action='store_true', dest='ignore_certs', default=False,
-                help='Ignore SSL certificate validation errors.')
+        self.parser.add_option('-s', '--server', dest='api_server', default=C.GALAXY_SERVER,
+            help='The API server destination')
+
+        self.parser.add_option('-c', '--ignore-certs', action='store_true', dest='ignore_certs', default=C.GALAXY_IGNORE_CERTS,
+            help='Ignore SSL certificate validation errors.')
 
         if self.action in ("init","install"):
             self.parser.add_option('-f', '--force', dest='force', action='store_true', default=False,

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -65,14 +65,11 @@ class GalaxyAPI(object):
         self.galaxy = galaxy
         self.token = GalaxyToken()
         self._api_server = C.GALAXY_SERVER
-        self._validate_certs = not C.GALAXY_IGNORE_CERTS
+        self._validate_certs = not galaxy.options.ignore_certs
         self.baseurl = None
         self.version = None
         self.initialized = False
 
-        # set validate_certs
-        if galaxy.options.ignore_certs:
-            self._validate_certs = False
         display.vvv('Validate TLS certificates: %s' % self._validate_certs)
 
         # set the API server

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -54,12 +54,8 @@ class GalaxyRole(object):
 
         self._metadata = None
         self._install_info = None
+        self._validate_certs = not galaxy.options.ignore_certs
 
-        self._validate_certs = not C.GALAXY_IGNORE_CERTS
-
-        # set validate_certs
-        if galaxy.options.ignore_certs:
-            self._validate_certs = False
         display.vvv('Validate TLS certificates: %s' % self._validate_certs)
 
         self.options = galaxy.options


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (fix-galaxy 00ad28e257) last updated 2016/05/26 22:18:43 (GMT -400)
  lib/ansible/modules/core: (detached HEAD fb77ab49ab) last updated 2016/05/26 21:17:07 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 0e4a023a7e) last updated 2016/05/26 21:17:07 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

`ansible-galaxy remove` was failing with traceback:

```
Traceback (most recent call last):
  File "/Users/chouseknecht/projects/ansible/bin/ansible-galaxy", line 92, in <module>
    exit_code = cli.run()
  File "/Users/chouseknecht/projects/ansible/lib/ansible/cli/galaxy.py", line 152, in run
    self.api = GalaxyAPI(self.galaxy)
  File "/Users/chouseknecht/projects/ansible/lib/ansible/galaxy/api.py", line 74, in __init__
    if galaxy.options.ignore_certs:
AttributeError: Values instance has no attribute 'ignore_certs'
```

After the change:

```
$ ansible-galaxy -p ./roles remove geerlingguy.varnish
- successfully removed geerlingguy.varnish
```
