### PR TITLE
Add support for playbooks and roles in distinct directories

### DIFF
--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -136,9 +136,12 @@ class RoleDefinition(Base, Become, Conditional, Taggable):
         '''
 
         # we always start the search for roles in the base directory of the playbook
+        # and the current working directory
         role_search_paths = [
             os.path.join(self._loader.get_basedir(), u'roles'),
             self._loader.get_basedir(),
+            os.path.join(os.getcwd(), u'roles'),
+            os.getcwd(),
         ]
 
         # also search in the configured roles path


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (feature/playbook-role-directory-separation 852c34b05d) last updated 2016/05/26 21:27:52 (GMT -700)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

**TL;DR**

In addition to the parent directory of the current playbook (e.g. `./playbooks`), ansible-playbooks now also checks the current working directory for roles (i.e. `./roles`) by default.

**More Details**

My company has several dozen playbooks in our main Ansible playbooks repo, and they're starting to get unwieldy. [Ansible best practices](http://docs.ansible.com/ansible/playbooks_best_practices.html#directory-layout) suggest keeping playbooks in the root directory, but once one exceeds ~20 playbooks it becomes difficult to easily differentiate and locate playbooks. 

First we tried the obvious thing—moving our playbooks into their own `playbooks` directory—but we found Ansible always expects `roles` to be a subdirectory of the current playbook's parent directory. Unlike other differentiated configurables like `group_vars` and `hosts`, Ansible doesn't check for roles in the current working directory by default.

This seems to break the expected convention and precedent set by the location flexibility of Ansible's `group_vars`, `host_vars`, `hosts` and `playbooks` directories, so this commit simply adjusts the `roles` directory search behavior to match.

To illustrate the change, let's assume my current working directory is `/Users/byron/ansible`, and I update my `site.yml` to the following:

```
% cat site.yml

---
- include: playbooks/webservers.yml
- include: playbooks/dbservers.yml
```

I then change my Ansible playbooks directory structure from this:

```
site.yml                  # master playbook
webservers.yml            # playbook for webserver tier
dbservers.yml             # playbook for dbserver tier

roles/
    common/               # this hierarchy represents a "role"
        tasks/            #
            main.yml      #  <-- tasks file can include smaller files if warranted
```

...to this, moving all but site.yml into a dedicated `playbooks` directory:

```
site.yml                  # master playbook

playbooks/
    webservers.yml        # playbook for webserver tier
    dbservers.yml         # playbook for dbserver tier

roles/
    common/               # this hierarchy represents a "role"
        tasks/            #
            main.yml      #  <-- tasks file can include smaller files if warranted
```

I then attempt to execute my `site.yml` Ansible playbook.

**Before** [Doesn't Work]

``` shell
% ansible-playbook -i hosts/dev site.yml

ERROR! the role 'nginx' was not found in /Users/byron/ansible/playbooks/roles:/Users/byron/ansible/playbooks:/usr/local/etc/ansible/roles

The error appears to have been in '/Users/byron/ansible/playbooks/webservers.yml': line 10, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  roles:
    - role: nginx
      ^ here
```

**After** [Works as Expected]

``` shell
% ansible-playbook -i hosts/dev site.yml

PLAY ***************************************************************************

TASK [test : Run date command.] ************************************************
changed: [localhost.foobarsites.com]

PLAY RECAP *********************************************************************
localhost.foobarsites.com  : ok=0    changed=1    unreachable=0    failed=0
```

Note: We are fully aware of the `roles_path` configuration option, but that seems to have been added for a different use case (e.g. storing roles in some non-standard, central location). In our case, we'd be setting `roles_path = .` or `roles_path = roles`, which feels hacky and ultimately doesn't address the behavioral consistency issue.
