### PR TITLE
add check_mode option for tasks

### DIFF
--- a/docsite/rst/playbooks_checkmode.rst
+++ b/docsite/rst/playbooks_checkmode.rst
@@ -30,7 +30,7 @@ be added to tasks.
 
 If the playbook is run with checkmode on the command line, you can force tasks to still run, by specifying `check_mode: no`.
 On the other hand you can setup a test section which, independetly of the command line arguments, always runs a tasks in check mode with `check_mode: yes`.
-note:: Prior to version 2.2 only the ability to turn this on per-task existed.  The notation for that was `always_run: yes`.
+.. note:: Prior to version 2.2 only the ability to turn this on per-task existed.  The notation for that was `always_run: yes`.
 
 Instead of `yes`/`no` you can use a Jinja2 expression, just like the `when` clause.
 

--- a/docsite/rst/playbooks_checkmode.rst
+++ b/docsite/rst/playbooks_checkmode.rst
@@ -25,26 +25,45 @@ Enabling or disabling check mode for tasks
 
 .. versionadded:: 2.2
 
-Sometimes you may want to modify the check mode behavior of individual tasks. This is done via the `check_mode` option, which can
-be added to tasks.
+Sometimes you may want to modify the check mode behavior of individual tasks. This is done via the ``check_mode`` option, which can
+be added to tasks. 
 
-If the playbook is run with checkmode on the command line, you can force tasks to still run, by specifying `check_mode: no`.
-On the other hand you can setup a test section which, independetly of the command line arguments, always runs a tasks in check mode with `check_mode: yes`.
-.. note:: Prior to version 2.2 only the ability to turn this on per-task existed.  The notation for that was `always_run: yes`.
+There are two options:
 
-Instead of `yes`/`no` you can use a Jinja2 expression, just like the `when` clause.
+1. Force a task to **run in check mode**, even when the playbook is called **without** ``--check``. This is called ``check_mode: yes``.
+2. Force a task to **run in normal mode** and make changes to the system, even when the playbook is called **with** ``--check``. This is called ``check_mode: no``.
+
+.. note:: Prior to version 2.2 only the the equivalent of ``check_mode: no`` existed. The notation for that was ``always_run: yes``.
+
+Instead of ``yes``/``no`` you can use a Jinja2 expression, just like the ``when`` clause.
 
 Example::
 
     tasks:
 
-      - name: this task is run even in check mode
+      - name: this task will make changes to the system even in check mode
         command: /something/to/run --even-in-check-mode
         check_mode: no
 
-Also if you want to skip, or ignore errors on some tasks in check mode
-you can use a boolean magic variable `ansible_check_mode` (added in version 2.1)
-which will be set to `True` during check mode.
+      - name: this task will always run under checkmode and not change the system
+        lineinfile: line="important config" dest=/path/to/myconfig.conf state=present
+        check_mode: yes
+
+
+Running single tasks with ``check_mode: yes`` can be useful to write tests for
+ansible modules, either to test the module itself or to the the conditions under
+which a module would make changes. 
+With ``register`` (see :doc:`playbooks_conditionals`) you can check the
+potential changes.
+
+Information about check mode in variables
+`````````````````````````````````````````
+
+.. versionadded:: 2.1
+
+If you want to skip, or ignore errors on some tasks in check mode
+you can use a boolean magic variable ``ansible_check_mode``
+which will be set to ``True`` during check mode.
 
 Example::
 

--- a/docsite/rst/playbooks_checkmode.rst
+++ b/docsite/rst/playbooks_checkmode.rst
@@ -30,6 +30,7 @@ be added to tasks.
 
 If the playbook is run with checkmode on the command line, you can force tasks to still run, by specifying `check_mode: no`.
 On the other hand you can setup a test section which, independetly of the command line arguments, always runs a tasks in check mode with `check_mode: yes`.
+note:: Prior to version 2.2 only the ability to turn this on per-task existed.  The notation for that was `always_run: yes`.
 
 Instead of `yes`/`no` you can use a Jinja2 expression, just like the `when` clause.
 

--- a/docsite/rst/playbooks_checkmode.rst
+++ b/docsite/rst/playbooks_checkmode.rst
@@ -20,15 +20,18 @@ Example::
 
 .. _forcing_to_run_in_check_mode:
 
-Running a task in check mode
-````````````````````````````
+Enabling or disabling check mode for tasks
+``````````````````````````````````````````
 
-.. versionadded:: 1.3
+.. versionadded:: 2.2
 
-Sometimes you may want to have a task to be executed even in check
-mode. To achieve this, use the `always_run` clause on the task. Its
-value is a Jinja2 expression, just like the `when` clause. In simple
-cases a boolean YAML value would be sufficient as a value.
+Sometimes you may want to modify the check mode behavior of individual tasks. This is done via the `check_mode` option, which can
+be added to tasks.
+
+If the playbook is run with checkmode on the command line, you can force tasks to still run, by specifying `check_mode: no`.
+On the other hand you can setup a test section which, independetly of the command line arguments, always runs a tasks in check mode with `check_mode: yes`.
+
+Instead of `yes`/`no` you can use a Jinja2 expression, just like the `when` clause.
 
 Example::
 
@@ -36,11 +39,7 @@ Example::
 
       - name: this task is run even in check mode
         command: /something/to/run --even-in-check-mode
-        always_run: yes
-
-As a reminder, a task with a `when` clause evaluated to false, will
-still be skipped even if it has a `always_run` clause evaluated to
-true. 
+        check_mode: no
 
 Also if you want to skip, or ignore errors on some tasks in check mode
 you can use a boolean magic variable `ansible_check_mode` (added in version 2.1)

--- a/docsite/rst/test_strategies.rst
+++ b/docsite/rst/test_strategies.rst
@@ -42,7 +42,7 @@ existing system, using the `--check` flag to the `ansible` command will report i
 bring the system into a desired state.
 
 This can let you know up front if there is any need to deploy onto the given system.  Ordinarily scripts and commands don't run in check mode, so if you
-want certain steps to always execute in check mode, such as calls to the script module, add the 'always_run' flag::
+want certain steps to always execute in check mode, such as calls to the script module, disable check mode for those tasks::
 
 
    roles:
@@ -50,7 +50,7 @@ want certain steps to always execute in check mode, such as calls to the script 
 
    tasks:
      - script: verify.sh
-       always_run: True
+       check_mode: no
 
 Modules That Are Useful for Testing
 ```````````````````````````````````

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -63,6 +63,7 @@ class Base:
     _always_run           = FieldAttribute(isa='bool')
     _run_once             = FieldAttribute(isa='bool')
     _ignore_errors        = FieldAttribute(isa='bool')
+    _check_mode = FieldAttribute(isa='bool')
 
     # param names which have been deprecated/removed
     DEPRECATED_ATTRIBUTES = [

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -434,13 +434,14 @@ class PlayContext(Base):
         # set become defaults if not previouslly set
         task.set_become_defaults(new_info.become, new_info.become_method, new_info.become_user)
 
-        if task.check_mode is not None:
-            new_info.check_mode = task.check_mode
-
-        # have always_run override check mode
         if task.always_run:
             display.deprecated("always_run is deprecated. Use check_mode = no instead.", version="2.2", removed=False)
             new_info.check_mode = False
+
+        # check_mode replaces always_run, overwrite always_run if both are given
+        if task.check_mode is not None:
+            new_info.check_mode = task.check_mode
+
 
         return new_info
 

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -434,6 +434,9 @@ class PlayContext(Base):
         # set become defaults if not previouslly set
         task.set_become_defaults(new_info.become, new_info.become_method, new_info.become_user)
 
+        if task.check_mode:
+            new_info.check_mode = True
+
         # have always_run override check mode
         if task.always_run:
             new_info.check_mode = False

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -434,11 +434,12 @@ class PlayContext(Base):
         # set become defaults if not previouslly set
         task.set_become_defaults(new_info.become, new_info.become_method, new_info.become_user)
 
-        if task.check_mode:
-            new_info.check_mode = True
+        if task.check_mode is not None:
+            new_info.check_mode = task.check_mode
 
         # have always_run override check mode
         if task.always_run:
+            display.deprecated("always_run is deprecated. Use check_mode = no instead.", version="2.2", removed=False)
             new_info.check_mode = False
 
         return new_info

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -435,7 +435,7 @@ class PlayContext(Base):
         task.set_become_defaults(new_info.become, new_info.become_method, new_info.become_user)
 
         if task.always_run:
-            display.deprecated("always_run is deprecated. Use check_mode = no instead.", version="2.2", removed=False)
+            display.deprecated("always_run is deprecated. Use check_mode = no instead.", version="2.4", removed=False)
             new_info.check_mode = False
 
         # check_mode replaces always_run, overwrite always_run if both are given

--- a/test/integration/roles/test_always_run/tasks/main.yml
+++ b/test/integration/roles/test_always_run/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: run a command while in check mode
   shell: echo "running"
-  always_run: yes
+  check_mode: no
   register: result
 
 - name: assert that the command was run

--- a/test/integration/roles/test_check_mode/tasks/main.yml
+++ b/test/integration/roles/test_check_mode/tasks/main.yml
@@ -20,20 +20,27 @@
   template: src=foo.j2 dest={{output_dir}}/foo.templated mode=0644
   register: template_result
 
+- name: check whether file exists
+  stat: path={{output_dir}}/foo.templated
+  register: foo
+
 - name: verify that the file was marked as changed in check mode
   assert: 
     that: 
-      - "template_result.changed == true"
+      - "template_result|changed"
+      - "not foo.stat.exists"
 
-- name: Actually create the file
+- name: Actually create the file, disable check mode
   template: src=foo.j2 dest={{output_dir}}/foo.templated2 mode=0644
-  always_run: True
+  check_mode: no
+  register: checkmode_disabled
 
-- name: fill in a basic template in check mode
+- name: fill in template with new content
   template: src=foo.j2 dest={{output_dir}}/foo.templated2 mode=0644
   register: template_result2
 
-- name: verify that the file was marked as not changed in check mode
+- name: verify that the file was not changed
   assert: 
     that: 
-      - "template_result2.changed == false"
+      - "checkmode_disabled|changed"
+      - "not template_result2|changed"

--- a/test/integration/roles/test_check_mode/tasks/main.yml
+++ b/test/integration/roles/test_check_mode/tasks/main.yml
@@ -17,11 +17,11 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: fill in a basic template in check mode
-  template: src=foo.j2 dest={{output_dir}}/foo.templated mode=0644
+  template: src=foo.j2 dest={{output_dir}}/checkmode_foo.templated mode=0644
   register: template_result
 
 - name: check whether file exists
-  stat: path={{output_dir}}/foo.templated
+  stat: path={{output_dir}}/checkmode_foo.templated
   register: foo
 
 - name: verify that the file was marked as changed in check mode
@@ -31,12 +31,12 @@
       - "not foo.stat.exists"
 
 - name: Actually create the file, disable check mode
-  template: src=foo.j2 dest={{output_dir}}/foo.templated2 mode=0644
+  template: src=foo.j2 dest={{output_dir}}/checkmode_foo.templated2 mode=0644
   check_mode: no
   register: checkmode_disabled
 
 - name: fill in template with new content
-  template: src=foo.j2 dest={{output_dir}}/foo.templated2 mode=0644
+  template: src=foo.j2 dest={{output_dir}}/checkmode_foo.templated2 mode=0644
   register: template_result2
 
 - name: verify that the file was not changed

--- a/test/integration/roles/test_template/tasks/main.yml
+++ b/test/integration/roles/test_template/tasks/main.yml
@@ -179,3 +179,49 @@
     that:
       - "template_result.changed == False"
 
+
+# check_mode
+
+- name: fill in a basic template in check mode
+  template: src=short.j2 dest={{output_dir}}/short.templated
+  register: template_result
+  check_mode: True
+
+- name: check file exists
+  stat: path={{output_dir}}/short.templated
+  register: templated
+
+- name: verify that the file was marked as changed in check mode but was not created
+  assert: 
+    that: 
+      - "not templated.stat.exists"
+      - "template_result|changed"
+
+- name: fill in a basic template
+  template: src=short.j2 dest={{output_dir}}/short.templated
+
+- name: fill in a basic template in check mode
+  template: src=short.j2 dest={{output_dir}}/short.templated
+  register: template_result
+  check_mode: True
+
+- name: verify that the file was marked as not changes in check mode
+  assert: 
+    that: 
+      - "not template_result|changed"
+      - "'templated_var_loaded' in lookup('file', '{{output_dir | expanduser}}/short.templated')"
+
+- name: change var for the template
+  set_fact: 
+    templated_var: "changed"
+
+- name: fill in a basic template with changed var in check mode
+  template: src=short.j2 dest={{output_dir}}/short.templated
+  register: template_result
+  check_mode: True
+
+- name: verify that the file was marked as changed in check mode but the content was not changed
+  assert: 
+    that: 
+      - "'templated_var_loaded' in lookup('file', '{{output_dir | expanduser }}/short.templated')"
+      - "template_result|changed"

--- a/test/integration/roles/test_template/templates/short.j2
+++ b/test/integration/roles/test_template/templates/short.j2
@@ -1,0 +1,1 @@
+{{ templated_var }}


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

devel, 2.2
##### SUMMARY

Introduce an option `check_mode` that can be added to tasks. Forces or prevents the module to run under check_mode.

Replaces the `always_run` option (now: `check_mode: no`) but extends it by allowing to run under check mode even if check mode is not specified on the command line (`check_mode: yes`).

Fixes #12498. See that issue and links therein also for discussion why this is nice.

Includes example testcases for the template module. One of the benefits of including per-task check_mode is that testing, both of ansible itself and external projects using ansible, becomes easier.
