### PR TITLE
add initial test for GalaxyCLI function

### DIFF
--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -45,13 +45,13 @@ class GalaxyToken(object):
         
     def __open_config_for_read(self):
         if os.path.isfile(self.file):
-            display.vvv('Opened %s' % self.file)
+            display.display('Opened %s' % self.file)
             return open(self.file, 'r')
         # config.yml not found, create and chomd u+rw
         f = open(self.file,'w')
         f.close()
         os.chmod(self.file,S_IRUSR|S_IWUSR) # owner has +rw
-        display.vvv('Created %s' % self.file) 
+        display.display('Created %s' % self.file) 
         return open(self.file, 'r')
 
     def set(self, token): 

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -1,4 +1,3 @@
-"""
 import unittest
 from ansible.cli.galaxy import GalaxyCLI
 
@@ -10,4 +9,3 @@ class TestGalaxyCli(unittest.TestCase):
         y = x._display_role_info(role_info)
         
         assert(y == u'\nRole: foo\n\tdescription: bar')
-"""

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -1,0 +1,13 @@
+"""
+import unittest
+from ansible.cli.galaxy import GalaxyCLI
+
+class TestGalaxyCli(unittest.TestCase):
+
+    def test_display_role_info(self):
+        x = GalaxyCLI("foo")
+        role_info = {'name':'foo', 'description':'bar'}
+        y = x._display_role_info(role_info)
+        
+        assert(y == u'\nRole: foo\n\tdescription: bar')
+"""


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible --version
ansible 2.2.0 (Galaxy_Unittest 64f45cdb10) last updated 2016/05/31 11:35:07 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 90e8a36d4c) last updated 2016/05/31 11:09:46 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 0e4a023a7e) last updated 2016/05/31 11:09:49 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This tests the _display_role_info() function in the GalaxyCLI class.
