### PR TITLE
Fix mock loader for osx /etc symlinks

### DIFF
--- a/test/units/executor/test_play_iterator.py
+++ b/test/units/executor/test_play_iterator.py
@@ -29,6 +29,8 @@ from ansible.playbook.task import Task
 from ansible.playbook.play_context import PlayContext
 
 from units.mock.loader import DictDataLoader
+from units.mock.path import mock_unfrackpath_noop
+
 
 class TestPlayIterator(unittest.TestCase):
 
@@ -55,7 +57,10 @@ class TestPlayIterator(unittest.TestCase):
 
         new_hs = hs.copy()
 
+
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_play_iterator(self):
+        #import epdb; epdb.st()
         fake_loader = DictDataLoader({
             "test_play.yml": """
             - hosts: all

--- a/test/units/mock/loader.py
+++ b/test/units/mock/loader.py
@@ -32,7 +32,6 @@ class DictDataLoader(DataLoader):
         super(DictDataLoader, self).__init__()
 
         self._file_mapping = file_mapping
-        self._build_unfracked_paths()
         self._build_known_directories()
 
     def load_from_file(self, path):
@@ -61,15 +60,6 @@ class DictDataLoader(DataLoader):
     def is_executable(self, path):
         # FIXME: figure out a way to make paths return true for this
         return False
-
-    def _build_unfracked_paths(self):
-        new_items = []
-        for path in self._file_mapping:
-            unfracked = os.path.normpath(os.path.realpath(path))
-            if unfracked != path:
-                new_items.append((unfracked, self._file_mapping[path]))
-        for ni in new_items:
-            self._file_mapping[ni[0]] = ni[1]
 
     def _add_known_directory(self, directory):
         if directory not in self._known_directories:

--- a/test/units/mock/loader.py
+++ b/test/units/mock/loader.py
@@ -32,6 +32,7 @@ class DictDataLoader(DataLoader):
         super(DictDataLoader, self).__init__()
 
         self._file_mapping = file_mapping
+        self._build_unfracked_paths()
         self._build_known_directories()
 
     def load_from_file(self, path):
@@ -60,6 +61,15 @@ class DictDataLoader(DataLoader):
     def is_executable(self, path):
         # FIXME: figure out a way to make paths return true for this
         return False
+
+    def _build_unfracked_paths(self):
+        new_items = []
+        for path in self._file_mapping:
+            unfracked = os.path.normpath(os.path.realpath(path))
+            if unfracked != path:
+                new_items.append((unfracked, self._file_mapping[path]))
+        for ni in new_items:
+            self._file_mapping[ni[0]] = ni[1]
 
     def _add_known_directory(self, directory):
         if directory not in self._known_directories:

--- a/test/units/mock/path.py
+++ b/test/units/mock/path.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+def mock_unfrackpath_noop(path):
+    ''' Do not expand the path '''
+    return path

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -28,6 +28,8 @@ from ansible.playbook.play import Play
 from ansible.playbook.role import Role
 
 from units.mock.loader import DictDataLoader
+from units.mock.path import mock_unfrackpath_noop
+
 
 class TestPlay(unittest.TestCase):
 
@@ -102,6 +104,7 @@ class TestPlay(unittest.TestCase):
             post_tasks=[dict(action='shell echo "hello world"')],
         ))
 
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_play_with_roles(self):
         fake_loader = DictDataLoader({
             '/etc/ansible/roles/foo/tasks.yml': """

--- a/test/units/playbook/test_role.py
+++ b/test/units/playbook/test_role.py
@@ -29,6 +29,7 @@ from ansible.playbook.role.include import RoleInclude
 from ansible.playbook.task import Task
 
 from units.mock.loader import DictDataLoader
+from units.mock.path import mock_unfrackpath_noop
 
 class TestRole(unittest.TestCase):
 
@@ -38,6 +39,7 @@ class TestRole(unittest.TestCase):
     def tearDown(self):
         pass
 
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_load_role_with_tasks(self):
 
         fake_loader = DictDataLoader({
@@ -56,6 +58,7 @@ class TestRole(unittest.TestCase):
         self.assertEqual(len(r._task_blocks), 1)
         assert isinstance(r._task_blocks[0], Block)
 
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_load_role_with_handlers(self):
 
         fake_loader = DictDataLoader({
@@ -74,6 +77,7 @@ class TestRole(unittest.TestCase):
         self.assertEqual(len(r._handler_blocks), 1)
         assert isinstance(r._handler_blocks[0], Block)
 
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_load_role_with_vars(self):
 
         fake_loader = DictDataLoader({
@@ -94,6 +98,7 @@ class TestRole(unittest.TestCase):
         self.assertEqual(r._default_vars, dict(foo='bar'))
         self.assertEqual(r._role_vars, dict(foo='bam'))
 
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_load_role_with_metadata(self):
 
         fake_loader = DictDataLoader({
@@ -161,6 +166,7 @@ class TestRole(unittest.TestCase):
         i = RoleInclude.load('recursive1_metadata', play=mock_play, loader=fake_loader)
         self.assertRaises(AnsibleError, Role.load, i, play=mock_play)
 
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_load_role_complex(self):
 
         # FIXME: add tests for the more complex uses of

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -29,6 +29,7 @@ from ansible.playbook.play import Play
 from ansible.vars import VariableManager
 
 from units.mock.loader import DictDataLoader
+from units.mock.path import mock_unfrackpath_noop
 
 class TestVariableManager(unittest.TestCase):
 
@@ -181,6 +182,7 @@ class TestVariableManager(unittest.TestCase):
         self.assertEqual(v.get_vars(loader=fake_loader, task=mock_task, use_cache=False).get("foo"), "bar")
 
     @patch.object(Inventory, 'basedir')
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_variable_manager_precedence(self, mock_basedir):
         '''
         Tests complex variations and combinations of get_vars() with different


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (FIX_OSX_TESTS a681f51948) last updated 2016/05/31 15:22:50 (GMT -400)
  lib/ansible/modules/core: (devel d30040f9dc) last updated 2016/05/31 15:19:52 (GMT -400)
  lib/ansible/modules/extras: (devel b0aec50b9a) last updated 2016/05/31 15:19:57 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

OSX symlinks /etc to /private by default and various tests fail beause the unfracker expands /etc to /private/etc
