### PR TITLE
Pin paramiko to < 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='ansible',
       license='GPLv3',
       # Ansible will also make use of a system copy of python-six if installed but use a
       # Bundled copy if it's not.
-      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
+      install_requires=['paramiko < 2.0.0', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
       package_dir={ '': 'lib' },
       packages=find_packages('lib'),
       package_data={


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.0.2.0
  config file = /home/admin/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Pins the paramiko dependency to < 2.0.0, since the 2.0.0 release introduced breaking changes and prevents successful installs of ansible unless paramiko is already installed at 1.x or the necessary crypto libs are already present and compiled on the system.

Fixes #15665

Signed-off-by: Jesse Szwedko jesse.szwedko@getbraintree.com
