### PR TITLE
Skip some service tests for systemd.

### DIFF
--- a/test/integration/roles/test_service/tasks/main.yml
+++ b/test/integration/roles/test_service/tasks/main.yml
@@ -38,39 +38,47 @@
 - name: find the service with a pattern
   service: name=ansible_test pattern="ansible_test_ser*" state=started
   register: start2_result
+  when: service_type != "systemd"
 
 - name: assert that the service was started via the pattern
   assert:
     that:
     - "start2_result.name == 'ansible_test'"
     - "start2_result.state == 'started'"
+  when: service_type != "systemd"
 
 - name: restart the ansible test service
   service: name=ansible_test state=restarted
   register: restart_result
+  when: service_type != "systemd"
 
 - name: assert that the service was restarted
   assert:
     that:
     - "restart_result.state == 'started'"
+  when: service_type != "systemd"
 
 - name: restart the ansible test service with a sleep
   service: name=ansible_test state=restarted sleep=2
   register: restart_sleep_result
+  when: service_type != "systemd"
 
 - name: assert that the service was restarted with a sleep
   assert:
     that:
     - "restart_sleep_result.state == 'started'"
+  when: service_type != "systemd"
 
 - name: reload the ansible test service
   service: name=ansible_test state=reloaded
   register: reload_result
+  when: service_type != "systemd"
 
 - name: assert that the service was reloaded
   assert:
     that:
     - "reload_result.state == 'started'"
+  when: service_type != "systemd"
 
 - name: stop the ansible test service
   service: name=ansible_test state=stopped
@@ -84,11 +92,13 @@
 - name: disable the ansible test service
   service: name=ansible_test enabled=no
   register: disable_result
+  when: service_type != "systemd"
 
 - name: assert that the service was disabled
   assert:
     that:
     - "disable_result.enabled == false"
+  when: service_type != "systemd"
 
 - name: try to enable a broken service
   service: name=ansible_broken_test enabled=yes

--- a/test/integration/roles/test_service/tasks/systemd_setup.yml
+++ b/test/integration/roles/test_service/tasks/systemd_setup.yml
@@ -1,3 +1,6 @@
+- name: set service_type fact
+  set_fact: service_type=systemd
+
 - name: install the systemd unit file
   copy: src=ansible.systemd dest=/etc/systemd/system/ansible_test.service
   register: install_systemd_result

--- a/test/integration/roles/test_service/tasks/sysv_setup.yml
+++ b/test/integration/roles/test_service/tasks/sysv_setup.yml
@@ -1,3 +1,6 @@
+- name: set service_type fact
+  set_fact: service_type=sysv
+
 - name: install the sysV init file
   copy: src=ansible.sysv dest=/etc/init.d/ansible_test mode=0755
   register: install_sysv_result

--- a/test/integration/roles/test_service/tasks/upstart_setup.yml
+++ b/test/integration/roles/test_service/tasks/upstart_setup.yml
@@ -1,3 +1,6 @@
+- name: set service_type fact
+  set_fact: service_type=upstart
+
 - name: install the upstart init file
   copy: src=ansible.upstart dest=/etc/init/ansible_test.conf mode=0644
   register: install_upstart_result


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (pass-tests e45b3b89a2) last updated 2016/05/31 20:13:01 (GMT -700)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/05/31 17:41:12 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/05/31 17:41:12 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Skip some tests in test_service when the service action uses the new systemd module, as the systemd module does not support all the same parameters as the original service module.
