### PR TITLE
Revert "Add prefixing and suffixing fuctionality to assemble module"

### DIFF
--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -32,18 +32,13 @@ class ActionModule(ActionBase):
 
     TRANSFERS_FILES = True
 
-    def _assemble_from_fragments(self, src_path, delimiter=None, compiled_regexp=None, ignore_hidden=False, header=None, footer=None):
+    def _assemble_from_fragments(self, src_path, delimiter=None, compiled_regexp=None, ignore_hidden=False):
         ''' assemble a file from a directory of fragments '''
 
         tmpfd, temp_path = tempfile.mkstemp()
         tmp = os.fdopen(tmpfd,'w')
         delimit_me = False
         add_newline = False
-
-        if header is not None:
-            if not header.endswith('\n'):
-                header += '\n'
-            tmp.write(header)
 
         for f in sorted(os.listdir(src_path)):
             if compiled_regexp and not compiled_regexp.search(f):
@@ -75,13 +70,6 @@ class ActionModule(ActionBase):
             else:
                 add_newline = True
 
-        if footer is not None:
-            if add_newline:  # last fragment did not end with \n
-                footer = '\n' + footer
-            if not footer.endswith('\n'):
-                footer += '\n'
-            tmp.write(footer)
-
         tmp.close()
         return temp_path
 
@@ -99,8 +87,6 @@ class ActionModule(ActionBase):
         src        = self._task.args.get('src', None)
         dest       = self._task.args.get('dest', None)
         delimiter  = self._task.args.get('delimiter', None)
-        header     = self._task.args.get('header', None)
-        footer     = self._task.args.get('footer', None)
         remote_src = self._task.args.get('remote_src', 'yes')
         regexp     = self._task.args.get('regexp', None)
         follow     = self._task.args.get('follow', False)
@@ -135,7 +121,7 @@ class ActionModule(ActionBase):
             return result
 
         # Does all work assembling the file
-        path = self._assemble_from_fragments(src, delimiter, _re, ignore_hidden, header, footer)
+        path = self._assemble_from_fragments(src, delimiter, _re, ignore_hidden)
 
         path_checksum = checksum_s(path)
         dest = self._remote_expand_user(dest)

--- a/test/integration/roles/test_assemble/tasks/main.yml
+++ b/test/integration/roles/test_assemble/tasks/main.yml
@@ -91,13 +91,3 @@
     - "result.state == 'file'"
     - "result.checksum == '505359f48c65b3904127cf62b912991d4da7ed6d'"
 
-- name: test assemble with a header and a footer
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled6" header="prefix" footer="suffix"
-  register: result
-
-- name: assert the fragments were assembled with a header and a footer
-  assert:
-    that:
-    - "result.state == 'file'"
-    - "result.checksum == 'c5cca6452da7b193427ea17583188f7a17df3b60'"
-


### PR DESCRIPTION
Reverts ansible/ansible#10399

this is missing docs and should deal with conflicting delimiter settings
