### PR TITLE
Give a module the possibility to known its own name

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1253,7 +1253,7 @@ class AnsibleModule(object):
                 self.ansible_version = v
 
             elif k == '_ansible_module_name':
-                self.ansible_module_name = v
+                self._name = v
 
             elif check_invalid_arguments and k not in self._legal_inputs:
                 self.fail_json(msg="unsupported parameter for module: %s" % k)
@@ -1263,7 +1263,7 @@ class AnsibleModule(object):
                 del self.params[k]
 
         if self.check_mode and not self.supports_check_mode:
-                self.exit_json(skipped=True, msg="remote module (%s) does not support check mode" % self.ansible_module_name)
+                self.exit_json(skipped=True, msg="remote module (%s) does not support check mode" % self._name)
 
     def _count_terms(self, check):
         count = 0
@@ -1541,7 +1541,7 @@ class AnsibleModule(object):
 
     def _log_to_syslog(self, msg):
         if HAS_SYSLOG:
-            module = 'ansible-%s' % self.ansible_module_name
+            module = 'ansible-%s' % self._name
             facility = getattr(syslog, self._syslog_facility, syslog.LOG_USER)
             syslog.openlog(str(module), 0, facility)
             syslog.syslog(syslog.LOG_INFO, msg)
@@ -1557,7 +1557,7 @@ class AnsibleModule(object):
             if log_args is None:
                 log_args = dict()
 
-            module = 'ansible-%s' % self.ansible_module_name
+            module = 'ansible-%s' % self._name
             if isinstance(module, bytes):
                 module = module.decode('utf-8', 'replace')
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -608,7 +608,7 @@ class AnsibleModule(object):
         self.run_command_environ_update = {}
 
         self.aliases = {}
-        self._legal_inputs = ['_ansible_check_mode', '_ansible_no_log', '_ansible_debug', '_ansible_diff', '_ansible_verbosity', '_ansible_selinux_special_fs', '_ansible_version', '_ansible_syslog_facility']
+        self._legal_inputs = ['_ansible_check_mode', '_ansible_no_log', '_ansible_debug', '_ansible_diff', '_ansible_verbosity', '_ansible_selinux_special_fs', '_ansible_module_name', '_ansible_version', '_ansible_syslog_facility']
 
         if add_file_common_args:
             for k, v in FILE_COMMON_ARGUMENTS.items():
@@ -1229,8 +1229,6 @@ class AnsibleModule(object):
         for (k,v) in list(self.params.items()):
 
             if k == '_ansible_check_mode' and v:
-                if not self.supports_check_mode:
-                    self.exit_json(skipped=True, msg="remote module does not support check mode")
                 self.check_mode = True
 
             elif k == '_ansible_no_log':
@@ -1254,12 +1252,18 @@ class AnsibleModule(object):
             elif k == '_ansible_version':
                 self.ansible_version = v
 
+            elif k == '_ansible_module_name':
+                self.ansible_module_name = v
+
             elif check_invalid_arguments and k not in self._legal_inputs:
                 self.fail_json(msg="unsupported parameter for module: %s" % k)
 
             #clean up internal params:
             if k.startswith('_ansible_'):
                 del self.params[k]
+
+        if self.check_mode and not self.supports_check_mode:
+                self.exit_json(skipped=True, msg="remote module (%s) does not support check mode" % self.ansible_module_name)
 
     def _count_terms(self, check):
         count = 0
@@ -1537,7 +1541,7 @@ class AnsibleModule(object):
 
     def _log_to_syslog(self, msg):
         if HAS_SYSLOG:
-            module = 'ansible-%s' % os.path.basename(__file__)
+            module = 'ansible-%s' % self.ansible_module_name
             facility = getattr(syslog, self._syslog_facility, syslog.LOG_USER)
             syslog.openlog(str(module), 0, facility)
             syslog.syslog(syslog.LOG_INFO, msg)
@@ -1553,7 +1557,7 @@ class AnsibleModule(object):
             if log_args is None:
                 log_args = dict()
 
-            module = 'ansible-%s' % os.path.basename(__file__)
+            module = 'ansible-%s' % self.ansible_module_name
             if isinstance(module, bytes):
                 module = module.decode('utf-8', 'replace')
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -574,6 +574,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # give the module information about the ansible version
         module_args['_ansible_version'] = __version__
 
+        # give the module information about its name
+        module_args['_ansible_module_name'] = module_name
+
         # set the syslog facility to be used in the module
         module_args['_ansible_syslog_facility'] = task_vars.get('ansible_syslog_facility', C.DEFAULT_SYSLOG_FACILITY)
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

v2.1.0.0 and older
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This is useful for logging and reporting and fixes the longstanding problem with syslog-messages:

```
May 30 15:50:11 moria ansible-<stdin>: Invoked with ...
```

now becomes:

```
Jun  1 17:32:03 moria ansible-copy: Invoked with ...
```

This fixes #15830 and #16087
