### PR TITLE
Force relative role paths to be absolute and correct errors about missing path(s)

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -123,7 +123,6 @@ class GalaxyCLI(CLI):
         self.options, self.args =self.parser.parse_args()
         display.verbosity = self.options.verbosity
         self.galaxy = Galaxy(self.options)
-
         return True
 
     def run(self):
@@ -468,9 +467,9 @@ class GalaxyCLI(CLI):
             for path in roles_path:
                 role_path = os.path.expanduser(path)
                 if not os.path.exists(role_path):
-                    raise AnsibleOptionsError("- the path %s does not exist. Please specify a valid path with --roles-path" % roles_path)
+                    raise AnsibleOptionsError("- the path %s does not exist. Please specify a valid path with --roles-path" % role_path)
                 elif not os.path.isdir(role_path):
-                    raise AnsibleOptionsError("- %s exists, but it is not a directory. Please specify a valid path with --roles-path" % roles_path)
+                    raise AnsibleOptionsError("- %s exists, but it is not a directory. Please specify a valid path with --roles-path" % role_path)
                 path_files = os.listdir(role_path)
                 for path_file in path_files:
                     gr = GalaxyRole(self.galaxy, path_file)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (FIX_10811 dd6aa9109f) last updated 2016/06/01 13:12:44 (GMT -400)
  lib/ansible/modules/core: (devel d3a9a90d2d) last updated 2016/06/01 11:28:36 (GMT -400)
  lib/ansible/modules/extras: (devel 5a278a8ecd) last updated 2016/06/01 11:28:40 (GMT -400)
  config file = /home/jtanner/workspace/issues/AP-10811/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Addresses #10811
