### PR TITLE
Allow names to include the dot character

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -110,6 +110,7 @@ cache_max_age = 300
 nested_groups = False
 
 # Replace - tags when creating groups to avoid issues with ansible
+replace_dot_in_groups = True
 replace_dash_in_groups = True
 
 # If set to true, any tag of the form "a,b,c" is expanded into a list

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -1405,7 +1405,7 @@ class Ec2Inventory(object):
 
     def to_safe(self, word):
         ''' Converts 'bad' characters in a string to underscores so they can be used as Ansible groups '''
-        regex = "[^A-Za-z0-9\_"
+        regex = "[^A-Za-z0-9\_\."
         if not self.replace_dash_in_groups:
             regex += "\-"
         return re.sub(regex + "]", "_", word)

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -379,6 +379,12 @@ class Ec2Inventory(object):
         else:
             self.nested_groups = False
 
+        # Replace dot or not in group names
+        if config.has_option('ec2', 'replace_dot_in_groups'):
+            self.replace_dot_in_groups = config.getboolean('ec2', 'replace_dot_in_groups')
+        else:
+            self.replace_dot_in_groups = True
+
         # Replace dash or not in group names
         if config.has_option('ec2', 'replace_dash_in_groups'):
             self.replace_dash_in_groups = config.getboolean('ec2', 'replace_dash_in_groups')
@@ -1405,7 +1411,9 @@ class Ec2Inventory(object):
 
     def to_safe(self, word):
         ''' Converts 'bad' characters in a string to underscores so they can be used as Ansible groups '''
-        regex = "[^A-Za-z0-9\_\."
+        regex = "[^A-Za-z0-9\_"
+        if not self.replace_dash_in_groups:
+            regex += "\."
         if not self.replace_dash_in_groups:
             regex += "\-"
         return re.sub(regex + "]", "_", word)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$  ansible --version
ansible 2.0.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

If I want to put the fqdn in the tag `Name` then the current script will convert it to have underscores. So `www.example.com` would become `www_example_com`, which is undesirable if I have a `.ssh/config` file already configured for `www.example.com`.  Instead of having to add additional entries I can now set `replace_dash_in_groups = False`.

```
ansible -i ec2.py dotted.tag.name -m ping
```

This change should be backwards compatible.
