### PR TITLE
Add validate_certs to vmware doc fragment

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/vmware.py
+++ b/lib/ansible/utils/module_docs_fragments/vmware.py
@@ -34,4 +34,11 @@ options:
             - The password of the vSphere vCenter
         required: True
         aliases: ['pass', 'pwd']
+    validate_certs: 
+        description: 
+            - Allows connection when SSL certificates are not valid. Set to 
+              false when certificates are not trusted 
+        required: False 
+        default: 'True' 
+        choices: ['True', 'False'] 
 '''


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The `validate_certs` variable has been added to the VMware module utility to allow bypassing certificate checks when connecting to vCenter or ESXi. This is to add the option information to the document fragment so people know the option is there.

See the VMware module setting here:
https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/vmware.py#L190
