### PR TITLE
Updated rax guide for handling RackConnect

### DIFF
--- a/docsite/rst/guide_rax.rst
+++ b/docsite/rst/guide_rax.rst
@@ -637,6 +637,19 @@ Using a Control Machine
           retries: 30
           delay: 10
     
+    - name: Update new_web hosts with IP that RackConnect assigns
+      hosts: new_web
+      gather_facts: false
+      tasks:
+        - name: Get facts about servers
+          local_action:
+            module: rax_facts
+            name: "{{ inventory_hostname }}"
+            region: DFW
+        - name: Map some facts
+          set_fact:
+            ansible_host: "{{ rax_accessipv4 }}"
+        
     - name: Base Configure Servers
       hosts: web
       roles:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.0.0.2
  config file = /home/nelly/code/ascendant/acm-ops/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Since RackConnect assigns a new public IP after configuration, the `ansible_host` that's set in the "Add servers to in memory groups" play is not valid. This adds a new play that will set it to the proper IP after RackConnect is done.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```
