### PR TITLE
Temp workaround since the python module for Azure currently does not …

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -75,7 +75,7 @@ try:
     from enum import Enum
     from msrest.serialization import Serializer
     from msrestazure.azure_exceptions import CloudError
-    from azure.mgmt.compute import __version__ as azure_compute_version
+    #from azure.mgmt.compute import __version__ as azure_compute_version
     from azure.mgmt.network.models import PublicIPAddress, NetworkSecurityGroup, SecurityRule, NetworkInterface, \
         NetworkInterfaceIPConfiguration, Subnet
     from azure.common.credentials import ServicePrincipalCredentials, UserPassCredentials
@@ -136,9 +136,9 @@ class AzureRMModuleBase(object):
         if not HAS_AZURE:
             self.fail("The Azure Python SDK is not installed (try 'pip install azure') - {0}".format(HAS_AZURE_EXC))
 
-        if azure_compute_version < AZURE_MIN_VERSION:
-            self.fail("Expecting azure.mgmt.compute.__version__ to be >= {0}. Found version {1} "
-                      "Do you have Azure >= 2.0.0rc2 installed?".format(AZURE_MIN_VERSION, azure_compute_version))
+        #if azure_compute_version < AZURE_MIN_VERSION:
+        #    self.fail("Expecting azure.mgmt.compute.__version__ to be >= {0}. Found version {1} "
+        #              "Do you have Azure >= 2.0.0rc2 installed?".format(AZURE_MIN_VERSION, azure_compute_version))
 
         self._network_client = None
         self._storage_client = None


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

2.2.0

```

```
##### SUMMARY

Microsoft has in their infinite wisdom decided to not have their Azure Python module report version thru the normal `__version__` attribute. When the Ansible AzureRM module was written, this was not the case. The resulting is that users following the instructions and simply install the latest build of the Azure Python module won't get Ansible to work since the version check fails. This workaround simply disables the version checking. My rationale for this is that the number of users trying out the azure stuff from now on is a lot higher than the number of users with an existing (outdated) version on their systems - simply the lesser of two evils. Microsoft has confirmed they will add `__version__` back (https://github.com/Azure/azure-sdk-for-python/issues/612#issuecomment-223357132), and at that time we'll re-enable a version check to get things back inline.
