### PR TITLE
Split integration tests into multiple groups.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -16,15 +16,33 @@ matrix:
       python: 3.4
     - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py35
       python: 3.5
-    - env: TEST=integration IMAGE=ansible/ansible:centos6
-    - env: TEST=integration IMAGE=ansible/ansible:centos7
-    - env: TEST=integration IMAGE=ansible/ansible:fedora-rawhide
-    - env: TEST=integration IMAGE=ansible/ansible:fedora23
-    - env: TEST=integration IMAGE=ansible/ansible:opensuseleap
-    - env: TEST=integration IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
-    - env: TEST=integration IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
-    - env: TEST=integration IMAGE=ansible/ansible:ubuntu1604
 
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos6
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos7
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora-rawhide
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora23
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuseleap
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604
+
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:centos6
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:centos7
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora-rawhide
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora23
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:opensuseleap
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1604
+
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos6
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos7
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora-rawhide
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora23
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:opensuseleap
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1604
 build:
   ci:
     - test/utils/shippable/ci.sh

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -25,7 +25,9 @@ EUID := $(shell id -u -r)
 
 UNAME := $(shell uname | tr '[:upper:]' '[:lower:]')
 
-all: setup test_test_infra parsing test_var_precedence unicode test_templating_settings environment test_connection non_destructive destructive includes blocks pull check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_gathering_facts test_binary_modules
+all: setup other non_destructive destructive
+
+other: test_test_infra parsing test_var_precedence unicode test_templating_settings environment test_connection includes blocks pull check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_gathering_facts test_binary_modules
 
 test_test_infra:
 	# ensure fail/assert work locally and can stop execution with non-zero exit code


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (fast-integration 4196692f5f) last updated 2016/06/02 13:39:51 (GMT -700)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/06/02 00:00:36 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/02 00:00:36 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Split integration tests into multiple groups to speed up tests on CI.
