### PR TITLE
increase coverage for test_connection_ssh.py

### DIFF
--- a/test/units/plugins/connections/test_connection_ssh.py
+++ b/test/units/plugins/connections/test_connection_ssh.py
@@ -36,6 +36,12 @@ from ansible.utils.unicode import to_bytes, to_unicode
 
 class TestConnectionBaseClass(unittest.TestCase):
 
+    def setUp(self):
+        """
+        Make sure this global variable is not set whenever a connection is made
+        """
+        ssh.SSHPASS_AVAILABLE = None
+
     def test_plugins_connection_ssh_basic(self):
         pc = PlayContext()
         new_stdin = StringIO()
@@ -69,6 +75,54 @@ class TestConnectionBaseClass(unittest.TestCase):
         new_stdin = StringIO()
         conn = ssh.Connection(pc, new_stdin)
         conn._build_command('ssh')
+
+    def test_plugins_connection_ssh__build_command_sshpass_not_available(self):
+
+        passwords = {'conn_pass': 'somepassword'}
+        pc = PlayContext(passwords=passwords)
+        new_stdin = StringIO()
+        conn = ssh.Connection(pc, new_stdin)
+
+        with patch('subprocess.Popen') as mock_popen:
+            mock_popen.side_effect = OSError(
+                "expected to fail to pretend sshpass is missing")
+            with self.assertRaises(AnsibleError):
+                conn._build_command('ssh')
+
+    def test_plugins_connection_ssh__build_command_sftp_binary(self):
+
+        passwords = {'conn_pass': 'somepassword'}
+        pc = PlayContext(passwords=passwords)
+        new_stdin = StringIO()
+        conn = ssh.Connection(pc, new_stdin)
+
+        with patch('subprocess.Popen'):
+            command = conn._build_command('sftp')
+            command_str = ' '.join(command)
+            self.assertIn("-b -", command_str)
+            self.assertIn("-o BatchMode=no", command_str)
+
+    def test_plugins_connection_ssh__build_command_verbose(self):
+
+        pc = PlayContext()
+        pc.verbosity = 4
+        new_stdin = StringIO()
+        conn = ssh.Connection(pc, new_stdin)
+
+        command = conn._build_command('ssh')
+        self.assertIn("-vvv", command)
+
+    def test_plugins_connection_ssh__build_command_ssh_common_args(self):
+
+        test_ssh_args = "-o Foo=1"
+        pc = PlayContext()
+        pc.ssh_common_args = test_ssh_args
+        new_stdin = StringIO()
+        conn = ssh.Connection(pc, new_stdin)
+
+        command = conn._build_command('ssh')
+        command_str = ' '.join(command)
+        self.assertIn(test_ssh_args, command_str)
 
     def test_plugins_connection_ssh__exec_command(self):
         pc = PlayContext()
@@ -365,4 +419,3 @@ class TestConnectionBaseClass(unittest.TestCase):
         # test that a non-zero rc raises an error
         conn._run.return_value = (1, 'stdout', 'some errors')
         self.assertRaises(AnsibleError, conn.fetch_file, '/path/to/bad/file', '/remote/path/to/file')
-


### PR DESCRIPTION
##### ISSUE TYPE
- Unit Test Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (ansible_sprint_pycon_ssh_tests 12fb35aebb) last updated 2016/06/02 16:37:08 (GMT -700)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/06/02 16:34:13 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/02 16:34:22 (GMT -700)
  config file = /Users/hsebastian/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Increased test coverage for `ansible.plugins.connection.ssh`.

```

Name                                         Stmts   Miss Branch BrPart  Cover
------------------------------------------------------------------------------
ansible/plugins.py                             231     47    105     13    78%
ansible/plugins/action.py                      441    155    226     20    61%
ansible/plugins/action/synchronize.py          167     40    102     30    70%
ansible/plugins/cache.py                        41     10      4      2    73%
ansible/plugins/cache/base.py                   25      7      0      0    72%
ansible/plugins/cache/memory.py                 24      5      0      0    79%
ansible/plugins/callback.py                    236    141     68      3    34%
ansible/plugins/connection.py                  111     34     30      8    62%
ansible/plugins/connection/local.py             80     54     20      0    26%
ansible/plugins/connection/paramiko_ssh.py     260    209     88      0    15%
ansible/plugins/connection/ssh.py              325     59    156     31    80%
ansible/plugins/filter.py                        2      0      0      0   100%
ansible/plugins/lookup.py                       40     22     12      0    35%
ansible/plugins/lookup/password.py              93     51     36      2    42%
ansible/plugins/shell.py                       100     72     34      1    22%
ansible/plugins/shell/sh.py                     22      6      0      0    73%
ansible/plugins/strategy.py                    416    113    190     43    65%
------------------------------------------------------------------------------
TOTAL                                         2614   1025   1071    153    57%
----------------------------------------------------------------------
Ran 76 tests in 0.317s

OK (SKIP=2)
```
