### PR TITLE
Reflect the change for the return value done in 273a965dcc1e522fcd663…

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -537,7 +537,7 @@ class VariableManager:
             # do not parse hidden files or dirs, e.g. .svn/
             paths = [os.path.join(path, name) for name in names if not name.startswith('.')]
             for p in paths:
-                _found, results = self._load_inventory_file(path=p, loader=loader)
+                results = self._load_inventory_file(path=p, loader=loader)
                 if results is not None:
                     data = combine_vars(data, results)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (moriyoshi/_load_inventory_file 84bf866981) last updated 2016/06/03 09:02:19 (GMT +900)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/06/03 08:46:12 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/03 08:46:22 (GMT +900)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This is obviously a bug. Please apply this.
