### PR TITLE
Show a better error message when there is too much arguments

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -74,8 +74,11 @@ class AdHocCLI(CLI):
 
         self.options, self.args = self.parser.parse_args(self.args[1:])
 
-        if len(self.args) != 1:
+        if len(self.args) < 1:
             raise AnsibleOptionsError("Missing target hosts")
+
+        if len(self.args) > 1:
+            raise AnsibleOptionsError("Extranous options or arguments")
 
         display.verbosity = self.options.verbosity
         self.validate_conflicts(runas_opts=True, vault_opts=True, fork_opts=True)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
$ ansible --version   
ansible 2.2.0 (improve_error_message_adhoc a58b0532e8) last updated 2016/06/03 14:38:07 (GMT +200)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/06/03 14:22:46 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/03 14:22:46 (GMT +200)
  config file = /home/misc/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

If someone run:

  ansible all -m file state=present

The error message is "Missing target hosts" which is misleading, since
the target hosts is here, the problem is the missing '-a'.
