### PR TITLE
Update how shippable scripts are called.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -27,7 +27,7 @@ matrix:
 
 build:
   ci:
-    - test/utils/shippable/${TEST}.sh 2>&1 | gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush(); }'
+    - test/utils/shippable/ci.sh
 
 integrations:
   notifications:

--- a/test/utils/shippable/ci.sh
+++ b/test/utils/shippable/ci.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+set -o pipefail
+
+source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../../..')))")
+
+"${source_root}/test/utils/shippable/${TEST}.sh" 2>&1 | gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush(); }'


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (shippable-fix 6bb1a798a1) last updated 2016/06/03 09:06:48 (GMT -700)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/06/02 00:00:36 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/02 00:00:36 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Update how shippable scripts are called. This fixes an issue with errors not being detected on build failures. Thanks to @gundalow for finding the issue.
