### PR TITLE
Fix the copy action to not send the content as a param.

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -245,6 +245,8 @@ class ActionModule(ActionBase):
                         original_basename=source_rel,
                     )
                 )
+                if 'content' in new_module_args:
+                    del new_module_args['content']
 
                 module_return = self._execute_module(module_name='copy', module_args=new_module_args, task_vars=task_vars, tmp=tmp, delete_remote_tmp=delete_remote_tmp)
                 module_executed = True


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.1.0 and devel
```
##### SUMMARY

content has already been transferred as a tempfile.

This fixes the error in https://github.com/ansible/ansible/issues/16125
but there may be higher level issues that should be fixed as well (other
modules might be able to cause status fields like failed and changed to
return a censored string instead of a bool).  So leaving 16125 open for
now.
