### PR TITLE
docker_common - Fix image_lookup Tag Matching

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -430,6 +430,7 @@ class AnsibleDockerClient(Client):
             self.fail("Error searching for image %s - %s" % (name, str(exc)))
         images = response
         if tag: 
+            images = list()
             lookup = "%s:%s" % (name, tag)
             for image in response:
                 self.log(image, pretty_print=True)


### PR DESCRIPTION
**ISSUE TYPE**
- Bugfix Pull Request

**ANSIBLE VERSION**

```
ansible 2.1.0.0 (detached HEAD b599477242) last updated 2016/05/31 22:32:16 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 04a871d007) last updated 2016/05/31 22:32:28 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD b5fa2b3416) last updated 2016/05/31 22:32:34 (GMT +000)
  config file = /ansible/ansible.cfg
  configured module search path = ['/opt/ansible/ansible/library']
```

**SUMMARY**

`_image_lookup` incorrectly defaults the return value to a list of all
images matching a name (aka all tags). if the tag does not match any
of the images, the entire list is returned, resulting in the following
error:

```
Registry returned more than one result for...
```

example: if using docker_container with state=present and image=foo:3,
if the destination host has foo:2 and foo:1 on disk, then
[foo:1, foo:2] will be returned from `_image_lookup` and ansible will
present the error: "Registry returned more than one result for foo:3".
if an empty list was returned, then find_image would correctly return
None, resulting in the pull of the missing image.

example: if using docker_container with state=present and image=foo:3,
if the destination host has foo:1 on disk, then [foo:1] will be
returned from `_image_lookup` and ansible will inspect the _wrong_
image and return the inspection!

solution: if the tag is not found in the image list, return an empty
list as expected.
