### PR TITLE
Add a way to specify default argument to action using variable dict a…

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -314,6 +314,16 @@ class PlayContext(Base):
                 if attr_val is not None:
                     setattr(new_info, attr, attr_val)
 
+        # Checking if ansible_module_args exist in current context
+        if 'ansible_module_args' in variables:
+            # If current action have default value
+            if task.action in variables['ansible_module_args']:
+                # Put default value of ansible_module_args into current task
+                # if not already set
+                for key, value in variables['ansible_module_args'][task.action].iteritems():
+                    if key not in task._attributes['args']:
+                        task._attributes['args'][key] = value
+
         # next, use the MAGIC_VARIABLE_MAPPING dictionary to update this
         # connection info object with 'magic' variables from the variable list.
         # If the value 'ansible_delegated_vars' is in the variables, it means


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel_ansible_modules_args 56b40a5bb5) last updated 2016/06/04 15:18:04 (GMT +200)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/06/02 19:40:09 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/02 19:40:09 (GMT +200)
  config file = /etc/ansible/ansible.cfg
```
##### SUMMARY

This patch add a way to easily specify default values to any Ansible action in order to avoid to specify each time the same values.

To get an idea of what can be done with it, you can grab an example at the following location: https://github.com/Yannig/yannig-ansible-playbooks/tree/master/ansible_modules_args

Let's take the following inventory:

``` ini
host1
host2
host3

[all:vars]
ansible_connection=local
```

For the host **host1**, we will define the following default values:

``` yaml
ansible_module_args:
  copy:
    mode: "0624"
```

For **host2**, we will define the following default values:

``` yaml
ansible_module_args:
  copy:
    mode: "0644"
```

Now, let's play the following playbook:

``` yaml
- name: "Simple example"
  hosts: all
  gather_facts: no
  tasks:
    - copy: content={{inventory_hostname}} dest=/tmp/force-mode-{{  inventory_hostname}} mode=0600
    - copy: content={{inventory_hostname}} dest=/tmp/default-mode-{{inventory_hostname}}
    - shell: ls -l /tmp/*-mode-{{inventory_hostname}}
      register: _
      changed_when: no
    - debug: var=_.stdout_lines
```

You will get the following result:

```
TASK [debug] *******************************************************************
ok: [host1] => {
    "_.stdout_lines": [
        "-rw--w-r-- 1 yannig yannig 5 juin   4 15:15 /tmp/default-mode-host1", 
        "-rw------- 1 yannig yannig 5 juin   4 15:15 /tmp/force-mode-host1"
    ]
}
ok: [host2] => {
    "_.stdout_lines": [
        "-rw-r--r-- 1 yannig yannig 5 juin   4 15:15 /tmp/default-mode-host2", 
        "-rw------- 1 yannig yannig 5 juin   4 15:15 /tmp/force-mode-host2"
    ]
}
ok: [host3] => {
    "_.stdout_lines": [
        "-rw-rw-r-- 1 yannig yannig 5 juin   4 15:15 /tmp/default-mode-host3", 
        "-rw------- 1 yannig yannig 5 juin   4 15:15 /tmp/force-mode-host3"
    ]
}
```

You can see that forcing the mode option in copy module result in the same value for all. If you do not specify the value, you get a value driven by the ansible_module_args content.

Another good example could be to use this to specify http_proxy for every yum action. Here's an example:

``` yaml
ansible_module_args:
  yum:
    environment: { http_proxy: "http://127.0.0.1:8080" }
```
