### PR TITLE
Add IRC notifications to shippable.yml.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -55,3 +55,11 @@ integrations:
       on_failure: never
       on_start: never
       on_pull_request: never
+    - integrationName: irc
+      type: irc
+      recipients:
+      - "chat.freenode.net#ansible-notices"
+      on_success: change
+      on_failure: always
+      on_start: never
+      on_pull_request: always


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (shippable-irc 7e484a56f8) last updated 2016/06/04 14:52:22 (GMT -700)
  lib/ansible/modules/core: (detached HEAD cb1093e085) last updated 2016/06/04 11:35:33 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 66b60ce7cd) last updated 2016/06/04 11:35:33 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add IRC notifications to Shippable to match existing behavior on Travis.
