### PR TITLE
set remote_user to default if none is found when using delegate_to

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -356,7 +356,7 @@ class PlayContext(Base):
 
             # and likewise for the remote user
             for user_var in MAGIC_VARIABLE_MAPPING.get('remote_user'):
-                if user_var in delegated_vars:
+                if user_var in delegated_vars and delegated_vars[user_var]:
                     break
             else:
                 delegated_vars['ansible_user'] = task.remote_user or self.remote_user


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.1.0.0
  config file = /home/ritesh/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

remote_user is ignore by ansible-playbook when using delegate_to

Fixes #14720
Fixes #13323 

```
$ cat play.yml 

    - shell: hostname
      delegate_to: "{{ remote_server }}"


$ ansible-playbook -vvv -i "127.0.0.1,"  -u rkhadgar i.yml 

```
