### PR TITLE
Fix typo in the VMware section

### DIFF
--- a/docsite/rst/roadmap/ROADMAP_2_2.rst
+++ b/docsite/rst/roadmap/ROADMAP_2_2.rst
@@ -50,7 +50,7 @@ Target: September 2016
     - Support LBaaS load balancers
   - Azure load balancer: Feature parity for AWS ELB (Stretch Goal)
 
-- **VMWare (Brian, Jtanner)**
+- **VMware (Brian, Jtanner)**
 
   - module/inventory script: port to pyvmomi (jtanner, bcoca)
   - inventory script: allow filtering ala ec2 (jtanner) (undergoing PR process)


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

2.2 
##### SUMMARY

Updates 'VMWare' to the correct spelling of the company, VMware.

```
- **VMWare (Brian, Jtanner)**
- **VMware (Brian, Jtanner)** 

```
