### PR TITLE
Filter tags

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -165,6 +165,13 @@ group_by_elasticache_replication_group = True
 # (ex. webservers15, webservers1a, webservers123 etc)
 # instance_filters = tag:Name=webservers1*
 
+# Filter instances exclusively by tags
+# Comma separated values that will be ANDed
+# Each value have the format: TagName=TagValue
+# This is a complement to instance_filters, which can only do OR because it uses AWS API call.
+# filter_tags = Name=my_instance_name
+# filter_tags = Name=my_instance_name,Environment=production
+
 # A boto configuration profile may be used to separate out credentials
 # see http://boto.readthedocs.org/en/latest/boto_config_tut.html
 # boto_profile = some-boto-profile-name


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

 Add filter_tags option to filter tags after retrieve them.

This is complement to instance_filters which can only do OR when it have more than one rule.
This filter will be executed after retrieving all tags (instance_filters is send with the
AWS API call so the instances are filtered server-side). only if all tags specified exist
and the value of the tag match they will be included  in the final list.
