### PR TITLE
fixes issues with authenticating using ssh-agent for ios devices

### DIFF
--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -77,9 +77,14 @@ class Cli(object):
         key_filename = self.module.params['ssh_keyfile']
         timeout = self.module.params['timeout']
 
+        allow_agent = (key_filename is not None) or (key_filename is None and password is None)
+
         try:
-            self.shell = Shell(kickstart=False, prompts_re=CLI_PROMPTS_RE, errors_re=CLI_ERRORS_RE)
-            self.shell.open(host, port=port, username=username, password=password, key_filename=key_filename, timeout=timeout)
+            self.shell = Shell(kickstart=False, prompts_re=CLI_PROMPTS_RE,
+                    errors_re=CLI_ERRORS_RE)
+            self.shell.open(host, port=port, username=username,
+                    password=password, key_filename=key_filename,
+                    allow_agent=allow_agent, timeout=timeout)
         except ShellError:
             e = get_exception()
             msg = 'failed to connect to %s:%s - %s' % (host, port, str(e))

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -27,6 +27,7 @@ except ImportError:
 
 try:
     import paramiko
+    from paramiko.ssh_exception import AuthenticationException
     HAS_PARAMIKO = True
 except ImportError:
     HAS_PARAMIKO = False
@@ -111,6 +112,8 @@ class Shell(object):
             self.shell.settimeout(timeout)
         except socket.gaierror:
             raise ShellError("unable to resolve host name")
+        except AuthenticationException:
+            raise ShellError('Unable to authenticate to remote device')
 
         if self.kickstart:
             self.shell.sendall("\n")


### PR DESCRIPTION
Exception was raised when trying to use ssh-agent for authentication to
ios devices.   This fix enables ssh-agent and enable use of password
protected ssh keys.  There is one additional fix to capture authentication
exceptions nicely.

this should address the issue raised in #16017
