### PR TITLE
Typo fix: Kuraotmi -> Kuratomi

### DIFF
--- a/lib/ansible/utils/unicode.py
+++ b/lib/ansible/utils/unicode.py
@@ -1,4 +1,4 @@
-# (c) 2012-2014, Toshio Kuraotmi <a.badger@gmail.com>
+# (c) 2012-2014, Toshio Kuratomi <a.badger@gmail.com>
 #
 # This file is part of Ansible
 #


### PR DESCRIPTION
##### ISSUE TYPE
- Documentation Report
##### SUMMARY

file `lib/ansible/utils/unicode.py` contains typo in  @abadger's copyright notice
this is just copyright notice fix, no code is changed
