### PR TITLE
Fix for bash process substitution usage in inventory/extra-vars

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -125,7 +125,7 @@ class DataLoader():
 
     def is_file(self, path):
         path = self.path_dwim(path)
-        return os.path.isfile(to_bytes(path, errors='strict')) or path == os.devnull
+        return (os.path.exists(to_bytes(path, errors='strict')) and not os.path.isdir(to_bytes(path, errors='strict'))) or path == os.devnull
 
     def is_directory(self, path):
         path = self.path_dwim(path)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
~ $ ansible --version
ansible 2.2.0
```
##### SUMMARY

The bug occurs when using an inventory from a process substitution as
described in #15143 or when using extra-vars e.g. `-e @<(echo 'foo: "bar"')`
on ansible-playbook.
