### PR TITLE
Detect use of Travis tests on Shippable.

### DIFF
--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+if [ "${SHIPPABLE}" = "true" ]; then
+    echo "It appears this job is running on Shippable instead of Travis."
+    if [ "${IS_PULL_REQUEST}" = "true" ]; then
+        echo "Please rebase the branch used for this pull request."
+    else
+        echo "This branch needs to be updated to work with Shippable."
+    fi
+    exit 1
+fi
+
 set -e
 set -u
 set -x


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (detect-shippable 03597143d0) last updated 2016/06/06 13:36:26 (GMT -700)
  lib/ansible/modules/core: (detached HEAD cb1093e085) last updated 2016/06/06 12:42:49 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 66b60ce7cd) last updated 2016/06/06 12:42:49 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Detect use of Travis tests on Shippable and message accordingly. This should help avoid confusion for old branches and PRs which will try to use the Travis configuration on Shippable.
