### PR TITLE
moved pending reboot to powershell.ps1

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -225,3 +225,20 @@ Function Get-FileChecksum($path)
     }
     return $hash
 }
+
+Function Get-PendingRebootStatus
+{
+    # Check if reboot is required, if so notify CA. The MSFT_ServerManagerTasks provider is missing on client SKUs
+    #Function returns true if computer has a pending reboot
+    $featureData = invoke-wmimethod -EA Ignore -Name GetServerFeature -namespace root\microsoft\windows\servermanager -Class MSFT_ServerManagerTasks
+    $regData = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager" "PendingFileRenameOperations" -EA Ignore
+    if(($featureData -and $featureData.RequiresReboot) -or $regData)
+    {
+        return $True
+    }
+    else 
+    {
+        return $False
+    }
+
+}


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
  ##### ANSIBLE VERSION
  2.2.0
##### SUMMARY

Discussed here: https://github.com/ansible/ansible-modules-core/pull/3795
Decided to move the code change into powershell.ps1, there will be another PR for setup.ps1 (modules-core) referencing this function to output pending reboot as a fact.
