### PR TITLE
Document playbook_dir

### DIFF
--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -672,6 +672,8 @@ Don't worry about any of this unless you think you need it.  You'll know when yo
 
 Also available, ``inventory_dir`` is the pathname of the directory holding Ansible's inventory host file, ``inventory_file`` is the pathname and the filename pointing to the Ansible's inventory host file.
 
+``playbook_dir`` contains the playbook base directory.
+
 We then have ``role_path`` which will return the current role's pathname (since 1.8). This will only work inside a role.
 
 And finally, ``ansible_check_mode`` (added in version 2.1), a boolean magic variable which will be set to ``True`` if you run Ansible with ``--check``.


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### SUMMARY

Document the `playbook_dir` special variable.

It was added back in 2013, in version 1.3: https://github.com/ansible/ansible/issues/4246
