### PR TITLE
Fix compatibility in callback plugins

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -313,7 +313,7 @@ class CallbackBase:
         self.playbook_on_no_hosts_remaining()
 
     def v2_playbook_on_task_start(self, task, is_conditional):
-        self.playbook_on_task_start(task, is_conditional)
+        self.playbook_on_task_start(task.name, is_conditional)
 
     def v2_playbook_on_cleanup_task_start(self, task):
         pass #no v1 correspondance


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

API v1 has method `playbook_on_task_start(self, name, is_conditional)`.
Ansible 2.0 tries to be backward compatible, but it passes task object instead of just name.
This pull request fixes that.
