### PR TITLE
hashi_vault: Support self-signed certificates

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -17,6 +17,10 @@
 #
 # USAGE: {{ lookup('hashi_vault', 'secret=secret/hello:value token=c975b780-d1be-8016-866b-01d0f9b688a5 url=http://myvault:8200')}}
 #
+# To skip SSL certificate verification you can either set the VAUL_SKIP_VERIFY
+# environment variable or set skip_verify to False:
+# {{ lookup('hashi_vault', 'secret=secret/hello:value token=c975b780-d1be-8016-866b-01d0f9b688a5 ssl_verify=False url=https://myvault:8200')}}
+#
 # You can skip setting the url if you set the VAULT_ADDR environment variable
 # or if you want it to default to localhost:8200
 #

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -40,6 +40,11 @@ ANSIBLE_HASHI_VAULT_ADDR = 'http://127.0.0.1:8200'
 if os.getenv('VAULT_ADDR') is not None:
     ANSIBLE_HASHI_VAULT_ADDR = os.environ['VAULT_ADDR']
 
+ANSIBLE_HASHI_VAULT_SKIP_VERIFY = False
+
+if os.getenv('VAULT_SKIP_VERIFY') is not None:
+    ANSIBLE_HASHI_VAULT_SKIP_VERIFY = True
+
 class HashiVault:
     def __init__(self, **kwargs):
         try:
@@ -48,6 +53,8 @@ class HashiVault:
             AnsibleError("Please pip install hvac to use this module")
 
         self.url = kwargs.get('url', ANSIBLE_HASHI_VAULT_ADDR)
+
+        self.skip_verify = kwargs.get('skip_verify', ANSIBLE_HASHI_VAULT_SKIP_VERIFY)
 
         self.token = kwargs.get('token')
         if self.token==None:
@@ -65,7 +72,7 @@ class HashiVault:
         else:
             self.secret_field = 'value'
 
-        self.client = hvac.Client(url=self.url, token=self.token)
+        self.client = hvac.Client(url=self.url, token=self.token, verify=not self.skip_verify)
 
         if self.client.is_authenticated():
             pass

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -48,11 +48,11 @@ class HashiVault:
             AnsibleError("Please pip install hvac to use this module")
 
         self.url = kwargs.get('url', ANSIBLE_HASHI_VAULT_ADDR)
-            
+
         self.token = kwargs.get('token')
         if self.token==None:
             raise AnsibleError("No Vault Token specified")
-        
+
         # split secret arg, which has format 'secret/hello:value' into secret='secret/hello' and secret_field='value'
         s = kwargs.get('secret')
         if s==None:
@@ -76,13 +76,13 @@ class HashiVault:
         data = self.client.read(self.secret)
         if data is None:
             raise AnsibleError("The secret %s doesn't seem to exist" % self.secret)
-        
+
         if self.secret_field=='': # secret was specified with trailing ':'
             return data['data']
-        
+
         if self.secret_field not in data['data']:
             raise AnsibleError("The secret %s does not contain the field '%s'. " % (self.secret, self.secret_field))
-        
+
         return data['data'][self.secret_field]
 
 
@@ -105,6 +105,6 @@ class LookupModule(LookupBase):
            key = term.split()[0]
            value = vault_conn.get()
            ret.append(value)
-           
+
         return ret
-        
+


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Currently it is not possible to communicate with a Vault that uses a self-signed certificate. To fix this I added support for the `VAULT_SKIP_VERIFY` environment variable. If set or `skip_verify=True` is provided the SSL certificate verification is turned off.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Before:

```
TASK [pirm : Test] *************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
fatal: [pirm]: FAILED! => {"failed": true, "msg": "Unexpected failure during module execution.", "stdout": ""}
```

After:

```
TASK [pirm : Test] *************************************************************
ok: [pirm] => {
    "msg": "MYSECRET"
}
```
