### PR TITLE
Fix linux 'ip' stdout parsing.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2231,8 +2231,13 @@ class LinuxNetwork(Network):
                         if not address.startswith('127.'):
                             ips['all_ipv4_addresses'].append(address)
                     elif words[0] == 'inet6':
-                        address, prefix = words[1].split('/')
-                        scope = words[3]
+                        if 'peer' == words[2]:
+                            address = words[1]
+                            _, prefix = words[3].split('/')
+                            scope = words[5]
+                        else:
+                            address, prefix = words[1].split('/')
+                            scope = words[3]
                         if 'ipv6' not in interfaces[device]:
                             interfaces[device]['ipv6'] = []
                         interfaces[device]['ipv6'].append({


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix linux 'ip' stdout parsing.

With network-manager in debian (stretch) and openvpn connection enabled the output for ipv6 is different and include a 'peer' keyword.

This closes #15448

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
# Add a point-to-point IPv6 link on your machine
$ ansible localhost -m setup
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: need more than 1 value to unpack
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_wHFcAb/ansible_module_setup.py\", line 127, in <module>\n    main()\n  File \"/tmp/ansible_wHFcAb/ansible_module_setup.py\", line 119, in main\n    data = get_all_facts(module)\n  File \"/tmp/ansible_wHFcAb/ansible_modlib.zip/ansible/module_utils/facts.py\", line 3177, in get_all_facts\n  File \"/tmp/ansible_wHFcAb/ansible_modlib.zip/ansible/module_utils/facts.py\", line 3123, in ansible_facts\n  File \"/tmp/ansible_wHFcAb/ansible_modlib.zip/ansible/module_utils/facts.py\", line 1988, in populate\n  File \"/tmp/ansible_wHFcAb/ansible_modlib.zip/ansible/module_utils/facts.py\", line 2184, in get_interfaces_info\n  File \"/tmp/ansible_wHFcAb/ansible_modlib.zip/ansible/module_utils/facts.py\", line 2155, in parse_ip_output\nValueError: need more than 1 value to unpack\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "parsed": false
}
```

With the patch:

```
# Add a point-to-point IPv6 link on your machine
$ ansible localhost -m setup
 localhost | SUCCESS => {
    "ansible_facts": { 
         ...
}
```
