### PR TITLE
Fix path_dwim_relative to handle parent dir refs

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -251,25 +251,25 @@ class DataLoader():
             cur_basedir = self._basedir
             self.set_basedir(basedir)
             # resolved base role/play path + templates/files/vars + relative filename
-            search.append(self.path_dwim(os.path.join(basedir, dirname, source)))
+            search.append(os.path.join(basedir, dirname, source))
             self.set_basedir(cur_basedir)
 
             if isrole and not source.endswith(dirname):
                 # look in role's tasks dir w/o dirname
-                search.append(self.path_dwim(os.path.join(basedir, 'tasks', source)))
+                search.append(os.path.join(basedir, 'tasks', source))
 
             # try to create absolute path for loader basedir + templates/files/vars + filename
-            search.append(self.path_dwim(os.path.join(dirname,source)))
-            search.append(self.path_dwim(os.path.join(basedir, source)))
+            search.append(os.path.join(dirname,source))
+            search.append(os.path.join(basedir, source))
 
             # try to create absolute path for loader basedir + filename
-            search.append(self.path_dwim(source))
+            search.append(source)
 
         for candidate in search:
             if os.path.exists(to_bytes(candidate, errors='strict')):
                 break
 
-        return candidate
+        return self.path_dwim(candidate)
 
     def read_vault_password_file(self, vault_password_file):
         """

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -270,8 +270,12 @@ class DataLoader():
                 os.path.exists(self.path_dwim(candidate) and
                 os.path.samefile(to_bytes(candidate, errors='strict'),
                                  self.path_dwim(candidate)):
+                return self.path_dwim(candidate)
+        # We may be dealing with a case where we've requested the parent
+        # of a non-existent directory
+        for candidate in search:
+            if os.path.exists(self.path_dwim(candidate)):
                 break
-
         return self.path_dwim(candidate)
 
     def read_vault_password_file(self, vault_password_file):

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -266,7 +266,10 @@ class DataLoader():
             search.append(source)
 
         for candidate in search:
-            if os.path.exists(to_bytes(candidate, errors='strict')):
+            if (os.path.exists(to_bytes(candidate, errors='strict')) and
+                os.path.exists(self.path_dwim(candidate) and
+                os.path.samefile(to_bytes(candidate, errors='strict'),
+                                 self.path_dwim(candidate)):
                 break
 
         return self.path_dwim(candidate)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 1b3d6df985) last updated 2016/06/06 23:51:15 (GMT +000)
  lib/ansible/modules/core: (detached HEAD cb1093e085) last updated 2016/06/06 23:51:18 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 66b60ce7cd) last updated 2016/06/06 23:51:19 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

When a playbook `/foo/ansible/main.yml` specifies a task:

```
copy: src=../ dest=/elsewhere
```

`ansible.lib.parsing.dataloader:DataLoader.path_dwim_relative` compiles a search path list of:

```
[u'/foo/ansible/files/../', u'/foo/ansible', u'/foo/ansible', u'/foo', u'/foo']
```

Obviously, `/foo` is the correct value to be searching, however because it runs `path_dwim` on `os.path.join(dirname, source)` (line 262) and `os.path.join(basedir, dirname, source)` (Line 254), it runs `os.path.abspath` in `path_dwim` before it runs `os.path.exists` at line 269. The `os.path.abspath` function does not check for existence when computing parent directories (e.g. `os.path.exists(os.path.abspath('non-existent/..'))` is `True`). However, `os.path.exists('non-existent/..')` correctly returns `False`. This patch delays execution of `path_dwim` until after the existence check has occurred.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Before:

```
changed: [my_host] => {"changed": true, "dest": "/elsewhere/", "invocation": {"module_args": {"dest": "/elsewhere", "src": "../"}, "module_name": "copy"}, "src": "/foo/ansible"}

```

After:

```
changed: [my_host] => {"changed": true, "dest": "/elsewhere/", "invocation": {"module_args": {"dest": "/elsewhere", "src": "../"}, "module_name": "copy"}, "src": "/foo"}
```
