### PR TITLE
Add a --json flag to ansible-doc to support JSON output

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -41,7 +41,7 @@ except ImportError:
 
 
 class DocCLI(CLI):
-    """ Doc command line class """
+    """ Vault command line class """
 
     def __init__(self, args):
 
@@ -126,12 +126,12 @@ class DocCLI(CLI):
 
                     if self.options.show_snippet:
                         text += self.get_snippet_text(doc)
-                    elif self.options.show_json:
+                    elif self.options.show_:
                         text += self.get_json(doc)
                     else:
                         text += self.get_man_text(doc)
                 else:
-                    # this typically means we couldn't even parse the docstring, not just that the JSON is busted,
+                    # this typically means we couldn't even parse the docstring, not just that the YAML is busted,
                     # probably a quoting issue.
                     raise AnsibleError("Parsing produced an empty object.")
             except Exception as e:

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -126,7 +126,7 @@ class DocCLI(CLI):
 
                     if self.options.show_snippet:
                         text += self.get_snippet_text(doc)
-                    elif self.options.show_:
+                    elif self.options.show_json:
                         text += self.get_json(doc)
                     else:
                         text += self.get_man_text(doc)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (feature_doc_json_output 7b9efdc535) last updated 2016/06/07 14:02:34 (GMT -400)
```
##### SUMMARY

This new argument allows ansible-doc to dump module documentation in a JSON format.

The current ansible-doc functionality works great for a human, but is not particularly easy to consume programmatically. Adding this small option could make it much easier to consume docs.

I've been playing with the idea of developing a plugin for module documentation in Atom, and having support for JSON output would make things simpler.
##### EXAMPLE OUTPUT

```
ansible-doc fetch -j

{
    "deprecated": false,
    "notes": "When running fetch with C(become), the M(slurp) module will also be used to fetch the contents of the file for determin
    "options": [
        {
            "default": null,
            "required": true,
            "name": "dest",
            "description": "A directory to save the file into. For example, if the I(dest) directory is C(/backup) a I(src) file name
        },
        {
            "default": "no",
            "choices": [
                "yes",
                "no"
            ],
            "required": false,
            "name": "fail_on_missing",
            "description": "When set to 'yes', the task will fail if the source file is missing."
        },
        {
            "required": false,
            "name": "flat",
            "description": "Allows you to override the default behavior of appending hostname/path/to/file to the destination.  If de
        },
        {
            "default": null,
            "required": true,
            "name": "src",
            "description": "The file on the remote system to fetch. This I(must) be a file, not a directory. Recursive fetching may b
        },
        {
            "default": "yes",
            "choices": [
                "yes",
                "no"
            ],
            "required": false,
            "name": "validate_checksum",
            "description": "Verify that the source and destination checksums match after the files are fetched."
        }
    ],
    "description": "This module works like M(copy), but in reverse. It is used for fetching files from remote machines and storing th
    "author": [
        "Ansible Core Team",
        "Michael DeHaan"
    ]
}
```
