### PR TITLE
Allow sphinx to use multiple cpus w -j support

### DIFF
--- a/docsite/Makefile
+++ b/docsite/Makefile
@@ -2,11 +2,12 @@
 SITELIB = $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
 FORMATTER=../hacking/module_formatter.py
 DUMPER=../hacking/dump_playbook_attributes.py
+CPUS ?= 1
 
 all: clean docs
 
 docs: clean directives modules staticmin
-	./build-site.py
+	./build-site.py -j $(CPUS)
 	-(cp *.ico htmlout/)
 	-(cp *.jpg htmlout/)
 	-(cp *.png htmlout/)
@@ -16,10 +17,10 @@ variables:
 	dot variables.dot -Tpng -o htmlout/variables.png
 
 viewdocs: clean staticmin
-	./build-site.py view
+	./build-site.py -j $(CPUS) view
 
 htmldocs: staticmin
-	./build-site.py rst
+	./build-site.py -j $(CPUS) rst
 
 webdocs: htmldocs
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request

Plumbs CPUS env var to sphinx build scripts -j option to allow sphinx to sort of use more than one processor core. 
