### PR TITLE
Add support for integration test code coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ Vagrantfile
 .vagrant
 ansible.egg-info/
 /shippable/
+/test/integration/.coveragerc

--- a/test/utils/shippable/coverage/ansible-playbook
+++ b/test/utils/shippable/coverage/ansible-playbook
@@ -1,0 +1,5 @@
+#!/bin/bash -eux
+
+source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../../../..')))")
+
+coverage run "${source_root}/bin/ansible-playbook" "$@"


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (integration-coverage d6b457652a) last updated 2016/06/07 15:54:20 (GMT -700)
  lib/ansible/modules/core: (detached HEAD cb1093e085) last updated 2016/06/06 12:42:49 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 66b60ce7cd) last updated 2016/06/06 12:42:49 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add support for integration test code coverage.
