### PR TITLE
Refresh TREE_DIR

### DIFF
--- a/lib/ansible/plugins/callback/tree.py
+++ b/lib/ansible/plugins/callback/tree.py
@@ -23,7 +23,7 @@ import os
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.path import makedirs_safe
 from ansible.utils.unicode import to_bytes
-from ansible.constants import TREE_DIR
+
 
 
 class CallbackModule(CallbackBase):
@@ -39,6 +39,8 @@ class CallbackModule(CallbackBase):
     def __init__(self):
         super(CallbackModule, self).__init__()
 
+        from ansible.constants import TREE_DIR
+        
         self.tree = TREE_DIR
         if not self.tree:
             self.tree = os.path.expanduser("~/.ansible/tree")


### PR DESCRIPTION
If run ad-hoc in multiple process, the TREE_DIR will keep the same
value. So refresh this value in **init** function.
