### PR TITLE
Fixes #16095: Maximumly 199 filter values

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -527,7 +527,12 @@ class Ec2Inventory(object):
             instance_ids = []
             for reservation in reservations:
                 instance_ids.extend([instance.id for instance in reservation.instances])
-            tags = conn.get_all_tags(filters={'resource-type': 'instance', 'resource-id': instance_ids})
+
+            max_filter_value = 199
+            tags = []
+            for i in range(0, len(instance_ids), max_filter_value):
+                tags.extend(conn.get_all_tags(filters={'resource-type': 'instance', 'resource-id': instance_ids[i:i+max_filter_value]}))
+
             tags_by_instance_id = defaultdict(dict)
             for tag in tags:
                 tags_by_instance_id[tag.res_id][tag.name] = tag.value


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /Users/bqbn/.ansible.cfg
  configured module search path = ['/Users/bqbn/.ansible/modules/']
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

When making calls to AWS EC2 api with DescribeTags actiion and if the
number of filter values is greater than or equal to 200, it results in
400 bad request reply and the error message is:
"Error connecting to AWS backend.\n The maximum number of filter values specified on a single call is 200".

The change is so that we call get_all_tags with maximum 199 filter
values one at a time until all are consumed.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Before

```
~/.ansible/hosts/ec2.py --list
ERROR: "Error connecting to AWS backend.
The maximum number of filter values specified on a single call is 200", while: getting EC2 instances
```

After

```
<!-- Correct full list of instances. -->
```
