### PR TITLE
Force an include to be a static task if no vars or loops are being used.

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -118,7 +118,8 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     is_static = t.static
                 else:
                     is_static = C.DEFAULT_TASK_INCLUDES_STATIC or \
-                                (use_handlers and C.DEFAULT_HANDLER_INCLUDES_STATIC)
+                                (use_handlers and C.DEFAULT_HANDLER_INCLUDES_STATIC) or \
+                                (not templar._contains_vars(t.args['_raw_params']) and not t.loop)
 
                 if is_static:
                     if t.loop is not None:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (FIX_15735 716f96367f) last updated 2016/06/08 15:40:45 (GMT -400)
  lib/ansible/modules/core: (devel e2d6b8e288) last updated 2016/06/08 14:41:21 (GMT -400)
  lib/ansible/modules/extras: (devel 0e9a820628) last updated 2016/06/08 14:41:25 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

include tasks were not being evaluated as static in the case where no vars or loops were being used, thereby skipping them and not including other task files.

The current behavior is a regression in 2.x, and was not intentional.

Fixes #15735
