### PR TITLE
Drop unused imports from docker_common.py

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -32,10 +32,9 @@ try:
     from requests.exceptions import SSLError
     from docker import Client
     from docker import __version__ as docker_version
-    from docker.errors import APIError, TLSParameterError, NotFound
+    from docker.errors import APIError, TLSParameterError
     from docker.tls import TLSConfig
     from docker.constants import DEFAULT_TIMEOUT_SECONDS, DEFAULT_DOCKER_API_VERSION
-    from docker.utils.types import Ulimit, LogConfig
     from docker import auth
 except ImportError as exc:
     HAS_DOCKER_ERROR = str(exc)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

There are several unused imports which can be removed to keep the
imports lean and up-to-date.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
