### PR TITLE
Enable docker connector command override.

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -633,7 +633,8 @@ class TaskExecutor:
                 except OSError:
                     conn_type = "paramiko"
 
-        connection = self._shared_loader_obj.connection_loader.get(conn_type, self._play_context, self._new_stdin)
+        connection = self._shared_loader_obj.connection_loader.get(
+            conn_type, self._play_context, self._new_stdin, variables=variables)
         if not connection:
             raise AnsibleError("the connection plugin '%s' was not found" % conn_type)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
2.2.0 0.0.devel from VERSION file
```
##### SUMMARY

If a hostvar 'docker_command' is present, it will be used in preference
to the default 'docker' command which runs locally.  This enables, for
example, the use of ssh to connect to a remote docker daemon
instead of trying to connect to it directly, which is useful if you are using
ssh jumphosts.

Example config:

```
- name: Add containers to inventory
  add_host:
      name: "foo-{{item}}"
      groups: mygroup
      ansible_connection: docker
      docker_command: "/usr/bin/ssh {{hostvars[item].ansible_ssh_host}} docker"
  with_items: groups.containerhosts
```

This will iterate over all hosts in the 'containerhosts' group, add
a previously-created container to the inventory, and make sure it's
accessed via SSH through the original hosts.
