### PR TITLE
Unify space around "="

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -99,7 +99,7 @@ ask_pass
 
 This controls whether an Ansible playbook should prompt for a password by default.  The default behavior is no::
 
-    ask_pass=True
+    ask_pass = True
 
 If using SSH keys for authentication, it's probably not needed to change this setting.
 
@@ -111,7 +111,7 @@ ask_sudo_pass
 Similar to ask_pass, this controls whether an Ansible playbook should prompt for a sudo password by default when
 sudoing.  The default behavior is also no::
 
-    ask_sudo_pass=True
+    ask_sudo_pass = True
 
 Users on platforms where sudo passwords are enabled should consider changing this setting.
 
@@ -122,7 +122,7 @@ ask_vault_pass
 
 This controls whether an Ansible playbook should prompt for the vault password by default.  The default behavior is no::
 
-    ask_vault_pass=True
+    ask_vault_pass = True
 
 .. _bin_ansible_callbacks:
 
@@ -135,7 +135,7 @@ Controls whether callback plugins are loaded when running /usr/bin/ansible.  Thi
 the command line, send notifications, and so on.  Callback plugins are always loaded for /usr/bin/ansible-playbook
 if present and cannot be disabled::
 
-    bin_ansible_callbacks=False
+    bin_ansible_callbacks = False
 
 Prior to 1.8, callbacks were never loaded for /usr/bin/ansible.
 
@@ -248,7 +248,7 @@ This setting defaults to ``False`` because there is a chance that you have
 sensitive values in your parameters and do not want those to be printed to
 stdout::
 
-    display_args_to_stdout=False
+    display_args_to_stdout = False
 
 If you set this to ``True`` you should be sure that you have secured your
 environment's stdout (no one can shoulder surf your screen and you aren't
@@ -263,7 +263,7 @@ display_skipped_hosts
 
 If set to `False`, ansible will not display any status for a task that is skipped. The default behavior is to display skipped tasks::
 
-    display_skipped_hosts=True
+    display_skipped_hosts = True
 
 Note that Ansible will always show the task header for any task, regardless of whether or not the task is skipped.
 
@@ -275,7 +275,7 @@ error_on_undefined_vars
 On by default since Ansible 1.3, this causes ansible to fail steps that reference variable names that are likely
 typoed::
 
-    error_on_undefined_vars=True
+    error_on_undefined_vars = True
 
 If set to False, any '{{ template_expression }}' that contains undefined variables will be rendered in a template
 or ansible action line exactly as written.
@@ -339,7 +339,7 @@ network and CPU load you think you can handle.  Many users may set this to 50, s
 have a large number of hosts, higher values will make actions across all of those hosts complete faster.  The default
 is very very conservative::
 
-    forks=5
+    forks = 5
 
 .. _gathering:
 
@@ -391,7 +391,7 @@ Some users prefer that variables that are hashes (aka 'dictionaries' in Python t
 arrays.  We generally recommend not using this setting unless you think you have an absolute need for it, and playbooks in the
 official examples repos do not use this setting::
 
-    hash_behaviour=replace
+    hash_behaviour = replace
 
 The valid values are either 'replace' (the default) or 'merge'.
 
@@ -415,7 +415,7 @@ host_key_checking
 As described in :doc:`intro_getting_started`, host key checking is on by default in Ansible 1.3 and later.  If you understand the
 implications and wish to disable it, you may do so here by setting the value to False::
 
-    host_key_checking=True
+    host_key_checking = True
 
 .. _inventory_file:
 
@@ -537,7 +537,7 @@ nocolor
 By default ansible will try to colorize output to give a better indication of failure and status information.
 If you dislike this behavior you can turn it off by setting 'nocolor' to 1::
 
-    nocolor=0
+    nocolor = 0
 
 .. _nocows:
 
@@ -548,7 +548,7 @@ By default ansible will take advantage of cowsay if installed to make /usr/bin/a
 Why?  We believe systems management should be a happy experience.  If you do not like the cows, you can disable them
 by setting 'nocows' to 1::
 
-    nocows=0
+    nocows = 0
 
 .. _pattern:
 
@@ -558,7 +558,7 @@ pattern
 This is the default group of hosts to talk to in a playbook if no "hosts:" stanza is supplied.  The default is to talk
 to all hosts.  You may wish to change this to protect yourself from surprises::
 
-    hosts=*
+    hosts = *
 
 Note that /usr/bin/ansible always requires a host pattern and does not use this setting, only /usr/bin/ansible-playbook.
 
@@ -571,7 +571,7 @@ For asynchronous tasks in Ansible (covered in :doc:`playbooks_async`), this is h
 tasks when an explicit poll interval is not supplied.  The default is a reasonably moderate 15 seconds which is a tradeoff
 between checking in frequently and providing a quick turnaround when something may have completed::
 
-    poll_interval=15
+    poll_interval = 15
 
 .. _private_key_file:
 
@@ -697,7 +697,7 @@ sudo_exe
 If using an alternative sudo implementation on remote machines, the path to sudo can be replaced here provided
 the sudo implementation is matching CLI flags with the standard sudo::
 
-   sudo_exe=sudo
+   sudo_exe = sudo
 
 .. _sudo_flags:
 
@@ -719,7 +719,7 @@ sudo_user
 This is the default user to sudo to if ``--sudo-user`` is not specified or 'sudo_user' is not specified in an Ansible
 playbook.  The default is the most logical: 'root'::
 
-   sudo_user=root
+   sudo_user = root
 
 .. _system_warnings:
 
@@ -797,7 +797,7 @@ become
 
 The equivalent of adding sudo: or su: to a play or task, set to true/yes to activate privilege escalation. The default behavior is no::
 
-    become=True
+    become = True
 
 .. _become_method:
 
@@ -806,7 +806,7 @@ become_method
 
 Set the privilege escalation method. The default is ``sudo``, other options are ``su``, ``pbrun``, ``pfexec``, ``doas``::
 
-    become_method=su
+    become_method = su
 
 .. _become_user:
 
@@ -815,7 +815,7 @@ become_user
 
 The equivalent to ansible_sudo_user or ansible_su_user, allows to set the user you become through privilege escalation. The default is 'root'::
 
-    become_user=root
+    become_user = root
 
 .. _become_ask_pass:
 
@@ -824,7 +824,7 @@ become_ask_pass
 
 Ask for privilege escalation password, the default is False::
 
-    become_ask_pass=True
+    become_ask_pass = True
 
 .. _become_allow_same_user:
 
@@ -855,7 +855,7 @@ The default setting of yes will record newly discovered and approved (if host ke
 This setting may be inefficient for large numbers of hosts, and in those situations, using the ssh transport is definitely recommended
 instead.  Setting it to False will improve performance and is recommended when host key checking is disabled::
 
-    record_host_keys=True
+    record_host_keys = True
 
 .. _paramiko_proxy_command:
 
@@ -916,7 +916,7 @@ scp_if_ssh
 Occasionally users may be managing a remote system that doesn't have SFTP enabled.  If set to True, we can
 cause scp to be used to transfer remote files instead::
 
-    scp_if_ssh=False
+    scp_if_ssh = False
 
 There's really no reason to change this unless problems are encountered, and then there's also no real drawback
 to managing the switch.  Most environments support SFTP by default and this doesn't usually need to be changed.
@@ -936,7 +936,7 @@ By default, this option is disabled to preserve compatibility with
 sudoers configurations that have requiretty (the default on many distros), but is highly
 recommended if you can enable it, eliminating the need for :doc:`playbooks_acceleration`::
 
-    pipelining=False
+    pipelining = False
 
 .. _accelerate_settings:
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- New Module Pull Request
- Bugfix Pull Request
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

The documentation has mixed usage of spaces around `=` in assignment. The commit unifies it to have a single space on each side.
