### PR TITLE
Provide full and filtered RDS Aurora details in ec2 inventory

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -82,6 +82,9 @@ all_instances = False
 # 'all_rds_instances' to True return all RDS instances regardless of state.
 all_rds_instances = False
 
+# Include RDS cluster information (Aurora etc)
+include_rds_clusters = True
+
 # By default, only ElastiCache clusters and nodes in the 'available' state
 # are returned. Set 'all_elasticache_clusters' and/or 'all_elastic_nodes'
 # to True return all ElastiCache clusters and nodes, regardless of state.

--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -82,7 +82,7 @@ all_instances = False
 # 'all_rds_instances' to True return all RDS instances regardless of state.
 all_rds_instances = False
 
-# Include RDS cluster information (Aurora etc)
+# Include RDS cluster information (Aurora etc.)
 include_rds_clusters = True
 
 # By default, only ElastiCache clusters and nodes in the 'available' state

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -130,7 +130,13 @@ from boto import rds
 from boto import elasticache
 from boto import route53
 import six
-import boto3
+
+HAS_BOTO3 = False
+try:
+    import boto3
+    HAS_BOTO3 = True
+except ImportError:
+    pass
 
 from six.moves import configparser
 from collections import defaultdict
@@ -579,6 +585,9 @@ class Ec2Inventory(object):
             self.fail_with_error(error, 'getting RDS instances')
 
     def include_rds_clusters_by_region(self, region):
+        if not HAS_BOTO3:
+            module.fail_json(message="This module requires boto3 be installed - please install boto3 and try again")
+        
         client = boto3.client('rds', region_name=region)
         clusters = client.describe_db_clusters()["DBClusters"]
         account_id = boto.connect_iam().get_user().arn.split(':')[4]

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -588,7 +588,7 @@ class Ec2Inventory(object):
         if not HAS_BOTO3:
             module.fail_json(message="This module requires boto3 be installed - please install boto3 and try again")
         
-        client = boto3.client('rds', region_name=region)
+        client = self.connect_to_aws(rds, region)
         clusters = client.describe_db_clusters()["DBClusters"]
         account_id = boto.connect_iam().get_user().arn.split(':')[4]
         c_dict = {}

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -130,6 +130,7 @@ from boto import rds
 from boto import elasticache
 from boto import route53
 import six
+import boto3
 
 from six.moves import configparser
 from collections import defaultdict
@@ -264,6 +265,12 @@ class Ec2Inventory(object):
         self.rds_enabled = True
         if config.has_option('ec2', 'rds'):
             self.rds_enabled = config.getboolean('ec2', 'rds')
+
+        # Include RDS cluster instances?
+        if config.has_option('ec2', 'include_rds_clusters'):
+            self.include_rds_clusters = config.getboolean('ec2', 'include_rds_clusters')
+        else:
+            self.include_rds_clusters = False
 
         # Include ElastiCache instances?
         self.elasticache_enabled = True
@@ -474,6 +481,8 @@ class Ec2Inventory(object):
             if self.elasticache_enabled:
                 self.get_elasticache_clusters_by_region(region)
                 self.get_elasticache_replication_groups_by_region(region)
+            if self.include_rds_clusters:
+                self.include_rds_clusters_by_region(region)
 
         self.write_to_cache(self.inventory, self.cache_path_cache)
         self.write_to_cache(self.index, self.cache_path_index)
@@ -568,6 +577,55 @@ class Ec2Inventory(object):
             if not e.reason == "Forbidden":
                 error = "Looks like AWS RDS is down:\n%s" % e.message
             self.fail_with_error(error, 'getting RDS instances')
+
+    def include_rds_clusters_by_region(self, region):
+        client = boto3.client('rds', region_name=region)
+        clusters = client.describe_db_clusters()["DBClusters"]
+        account_id = boto.connect_iam().get_user().arn.split(':')[4]
+        c_dict = {}
+        for c in clusters:
+            # remove these datetime objects as there is no serialisation to json
+            # currently in place and we don't need the data yet
+            if 'EarliestRestorableTime' in c:
+                del c['EarliestRestorableTime']
+            if 'LatestRestorableTime' in c:
+                del c['LatestRestorableTime']
+
+            if self.ec2_instance_filters == {}:
+                matches_filter = True
+            else:
+                matches_filter = False
+
+            try:
+                # arn:aws:rds:<region>:<account number>:<resourcetype>:<name>
+                tags = client.list_tags_for_resource(
+                    ResourceName='arn:aws:rds:' + region + ':' + account_id + ':cluster:' + c['DBClusterIdentifier'])
+                c['Tags'] = tags['TagList']
+
+                if self.ec2_instance_filters:
+                    for filter_key, filter_values in self.ec2_instance_filters.items():
+                        # get AWS tag key e.g. tag:env will be 'env'
+                        tag_name = filter_key.split(":", 1)[1]
+                        # Filter values is a list (if you put multiple values for the same tag name)
+                        matches_filter = any(d['Key'] == tag_name and d['Value'] in filter_values for d in c['Tags'])
+
+                        if matches_filter:
+                            # it matches a filter, so stop looking for further matches
+                            break
+
+            except Exception as e:
+                if e.message.find('DBInstanceNotFound') >= 0:
+                    # AWS RDS bug (2016-01-06) means deletion does not fully complete and leave an 'empty' cluster.
+                    # Ignore errors when trying to find tags for these
+                    pass
+
+            # ignore empty clusters caused by AWS bug
+            if len(c['DBClusterMembers']) == 0:
+                continue
+            elif matches_filter:
+                c_dict[c['DBClusterIdentifier']] = c
+
+        self.inventory['db_clusters'] = c_dict
 
     def get_elasticache_clusters_by_region(self, region):
         ''' Makes an AWS API call to the list of ElastiCache clusters (with


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request

> Re-submission of #15609 against latest devel
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Add db_clusters to the ec2 inventory. Show tags. Only show clusters matching tags in the .ini.

Use boto3 to get the clusters.

```
  "db_clusters": {
    "test-eu-west-1": {
      "AllocatedStorage": 1,
      "AvailabilityZones": [
        "eu-west-1a",
        "eu-west-1b",
        "eu-west-1c"
      ],
      "BackupRetentionPeriod": 3,
      "DBClusterIdentifier": "test-eu-west-1",
      "DBClusterMembers": [
        {
          "DBClusterParameterGroupStatus": "in-sync",
          "DBInstanceIdentifier": "test-eu-west-1-0",
          "IsClusterWriter": true,
          "PromotionTier": 1
        },
        {
          "DBClusterParameterGroupStatus": "in-sync",
          "DBInstanceIdentifier": "test-eu-west-1-1",
          "IsClusterWriter": false,
          "PromotionTier": 1
        }
      ],
      "DBClusterParameterGroup": "aurora-cluster-test",
      "DBSubnetGroup": "dev_test_db_group",
      "Endpoint": "test-eu-west-1.cluster-sdfsdfsd.eu-west-1.rds.amazonaws.com",
      "Engine": "aurora",
      "EngineVersion": "5.6.10a",
      "KmsKeyId": "arn:aws:kms:eu-west-1:345345345345:key/sfsdfsdfsdfsdf",
      "MasterUsername": "sdfsdfsdfs",
      "Port": 33306,
      "PreferredBackupWindow": "05:21-05:51",
      "PreferredMaintenanceWindow": "sat:03:18-sat:03:48",
      "Status": "available",
      "StorageEncrypted": true,
      "Tags": [
        {
          "Key": "env",
          "Value": "test"
        }
      ],
      "VpcSecurityGroups": [
        {
          "Status": "active",
          "VpcSecurityGroupId": "sg-234234234"
        }
      ]
    }
  }
```
