### PR TITLE
[Inventory] Cache the result of enumerating groups and host names

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -561,6 +561,9 @@ class StrategyBase:
         # patterns may have referenced the group
         self._inventory.clear_pattern_cache()
 
+        # clear cache of group dict, which is used in magic host variables
+        self._inventory.clear_group_dict_cache()
+
         # also clear the hostvar cache entry for the given play, so that
         # the new hosts are available if hostvars are referenced
         self._variable_manager.invalidate_hostvars_cache(play=iterator._play)
@@ -581,6 +584,9 @@ class StrategyBase:
         group_name = result_item.get('add_group')
         new_group = self._inventory.get_group(group_name)
         if not new_group:
+            # clear cache of group dict, which is used in magic host variables
+            self._inventory.clear_group_dict_cache()
+
             # create the new group and add it to inventory
             new_group = Group(name=group_name)
             self._inventory.add_group(new_group)

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -393,10 +393,9 @@ class VariableManager:
         if host:
             variables['group_names'] = sorted([group.name for group in host.get_groups() if group.name != 'all'])
 
-            if self._inventory is not None:
-                variables['groups']  = dict()
-                for (group_name, group) in iteritems(self._inventory.groups):
-                    variables['groups'][group_name] = [h.name for h in group.get_hosts()]
+            if self._inventory:
+                variables['groups']  = self._inventory.get_group_dict()
+
         if play:
             variables['role_names'] = [r._role_name for r in play.roles]
 

--- a/test/units/plugins/strategies/test_strategy_base.py
+++ b/test/units/plugins/strategies/test_strategy_base.py
@@ -238,6 +238,7 @@ class TestStrategyBase(unittest.TestCase):
         mock_inventory.get_host.side_effect = _get_host
         mock_inventory.get_group.side_effect = _get_group
         mock_inventory.clear_pattern_cache.return_value = None
+        mock_inventory.clear_group_dict_cache.return_value = None
         mock_inventory.get_host_vars.return_value = {}
 
         mock_var_mgr = MagicMock()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible-playbook 2.2.0 (cache_group_dict 2e1b613c7e) last updated 2016/06/09 15:56:02 (GMT +200)
  lib/ansible/modules/core: (devel a8072f9ef0) last updated 2016/06/07 09:13:22 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/01 14:11:22 (GMT +200)
```
##### SUMMARY

Cache the result of enumerating groups and host names used inside `VariableManager._get_magic_variables()` to generate `vars['groups']`.

This saves a lot of time re-iterating the nearly always constant global
list of groups and their members.

Generate once and cache, and invalidate cache in case `add_host:` or
`group_by:` are used.
# Before: 485.37 s

```
Total time: 485.37 s
File: /home/towolf/src/local/ansible/lib/ansible/vars/__init__.py
Function: _get_magic_variables at line 374

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   374                                               @profile
   375                                               def _get_magic_variables(self, loader, play, host, task, include_hostvars, include_delegate_to):
   376                                                   '''
   377                                                   Returns a dictionary of so-called "magic" variables in Ansible,
   378                                                   which are special variables we set internally for use.
   379                                                   '''
   380                                           
   381      3010        10132      3.4      0.0          variables = dict()
   382      3010        51137     17.0      0.0          variables['playbook_dir'] = loader.get_basedir()
   383                                           
   384      3010         5181      1.7      0.0          if host:
   385     47808      1080418     22.6      0.2              variables['group_names'] = sorted([group.name for group in host.get_groups() if group.name != 'all'])
   386                                           
   387      2574         5605      2.2      0.0              if self._inventory is not None:
   388      2574         6046      2.3      0.0                  variables['groups']  = dict()
   389  23155704     46359530      2.0      9.6                  for (group_name, group) in iteritems(self._inventory.groups):
   390 171155556    435879828      2.5     89.8                      variables['groups'][group_name] = [h.name for h in group.get_hosts()]
   391      3010         5512      1.8      0.0          if play:
   392      6016        77879     12.9      0.0              variables['role_names'] = [r._role_name for r in play.roles]
   393                                           
   394      3010         5422      1.8      0.0          if task:
   395      3006         6596      2.2      0.0              if task._role:
   396      2863        11964      4.2      0.0                  variables['role_name'] = task._role.get_name()
   397      2863        11069      3.9      0.0                  variables['role_path'] = task._role._role_path
   398      2863        51752     18.1      0.0                  variables['role_uuid'] = text_type(task._role._uuid)
   399                                           
   400      3010         7532      2.5      0.0          if self._inventory is not None:
   401      3010       351708    116.8      0.1              variables['inventory_dir'] = self._inventory.basedir()
   402      3010        75596     25.1      0.0              variables['inventory_file'] = self._inventory.src()
   403      3010         5813      1.9      0.0              if play:
   404                                                           # add the list of hosts in the play, as adjusted for limit/filters
   405                                                           # DEPRECATED: play_hosts should be deprecated in favor of ansible_play_hosts,
   406                                                           #             however this would take work in the templating engine, so for now
   407                                                           #             we'll add both so we can give users something transitional to use
   408    451950      1159038      2.6      0.2                  host_list = [x.name for x in self._inventory.get_hosts()]
   409      3010         5423      1.8      0.0                  variables['play_hosts'] = host_list
   410      3010         5010      1.7      0.0                  variables['ansible_play_hosts'] = host_list
   411                                           
   412                                                   # the 'omit' value alows params to be left out if the variable they are based on is undefined
   413      3010        10783      3.6      0.0          variables['omit'] = self._omit_token
   414      3010       130188     43.3      0.0          variables['ansible_version'] = CLI.version_info(gitinfo=False)
   415                                                   # Set options vars
   416      6020        28844      4.8      0.0          for option, option_value in iteritems(self._options_vars):
   417      3010         5882      2.0      0.0              variables[option] = option_value
   418                                           
   419      3010         6659      2.2      0.0          if self._hostvars is not None and include_hostvars:
   420      3004         5735      1.9      0.0              variables['hostvars'] = self._hostvars
   421                                           
   422      3010         4190      1.4      0.0          return variables
```
# After: 15 seconds

```
Total time: 14.9396 s
File: /home/towolf/src/local/ansible/lib/ansible/vars/__init__.py
Function: _get_magic_variables at line 385

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   385                                               def _get_magic_variables(self, loader, play, host, task, include_hostvars, include_delegate_to):
   386                                                   '''
   387                                                   Returns a dictionary of so-called "magic" variables in Ansible,
   388                                                   which are special variables we set internally for use.
   389                                                   '''
   390
   391       3073        72288     23.5      0.5          variables = dict()
   392       3073       193975     63.1      1.3          variables['playbook_dir'] = loader.get_basedir()
   393
   394       3073         6814      2.2      0.0          if host:
   395      48978      4164175     85.0     27.9              variables['group_names'] = sorted([group.name for group in host.get_groups() if group.name != 'all'])
   396
   397       2628        27409     10.4      0.2              if self._inventory:
   398       2628       209298     79.6      1.4                  variables['groups']  = self._inventory.get_group_dict()
   399
   400       3073        10087      3.3      0.1          if play:
   401       6142       229651     37.4      1.5              variables['role_names'] = [r._role_name for r in play.roles]
   402
   403       3073         5559      1.8      0.0          if task:
   404       3069         6333      2.1      0.0              if task._role:
   405       2923        83104     28.4      0.6                  variables['role_name'] = task._role.get_name()
   406       2923        81817     28.0      0.5                  variables['role_path'] = task._role._role_path
   407       2923       103889     35.5      0.7                  variables['role_uuid'] = text_type(task._role._uuid)
   408
   409       3073        13729      4.5      0.1          if self._inventory is not None:
   410       3073      1419979    462.1      9.5              variables['inventory_dir'] = self._inventory.basedir()
   411       3073       494898    161.0      3.3              variables['inventory_file'] = self._inventory.src()
   412       3073        34374     11.2      0.2              if play:
   413                                                            # add the list of hosts in the play, as adjusted for limit/filters
   414                                                            # DEPRECATED: play_hosts should be deprecated in favor of ansible_play_hosts,
   415                                                            #             however this would take work in the templating engine, so for now
   416                                                            #             we'll add both so we can give users something transitional to use
   417     470276      6751722     14.4     45.2                  host_list = [x.name for x in self._inventory.get_hosts()]
   418       3073        12900      4.2      0.1                  variables['play_hosts'] = host_list
   419       3073        13149      4.3      0.1                  variables['ansible_play_hosts'] = host_list
   420
   421                                                    # the 'omit' value alows params to be left out if the variable they are based on is undefined
   422       3073        59040     19.2      0.4          variables['omit'] = self._omit_token
   423       3073       772767    251.5      5.2          variables['ansible_version'] = CLI.version_info(gitinfo=False)
   424                                                    # Set options vars
   425       6146        53857      8.8      0.4          for option, option_value in iteritems(self._options_vars):
   426       3073        31243     10.2      0.2              variables[option] = option_value
   427
   428       3073        66860     21.8      0.4          if self._hostvars is not None and include_hostvars:
   429       3067        15350      5.0      0.1              variables['hostvars'] = self._hostvars
   430       3067        15350      5.0      0.1  
   431                                                   return variables
```
