### PR TITLE
avoid processing bad mtab entries

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1211,6 +1211,8 @@ class LinuxHardware(Hardware):
         mtab = get_file_content('/etc/mtab', '')
         for line in mtab.split('\n'):
             fields = line.rstrip('\n').split()
+            if len(fields) < 4:
+                continue
             if fields[0].startswith('/') or ':/' in fields[0]:
                 if(fields[2] != 'none'):
                     size_total, size_available = self._get_mount_size_facts(fields[1])


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
>=2.1
```
##### SUMMARY

Avoids mtab lines that don't have the required columns.

fixes #16174
