### PR TITLE
Add a get_url test for www.google.com

### DIFF
--- a/test/integration/roles/test_get_url/tasks/main.yml
+++ b/test/integration/roles/test_get_url/tasks/main.yml
@@ -205,3 +205,8 @@
     that:
       - "result.changed == true"
       - "stat_result.stat.mode == '0070'"
+
+- name: Test url split with no filename #https://github.com/ansible/ansible/issues/16191
+  get_url:
+    url: http://www.google.com
+    dest: "{{ output_dir }}/google.com"

--- a/test/integration/roles/test_get_url/tasks/main.yml
+++ b/test/integration/roles/test_get_url/tasks/main.yml
@@ -206,7 +206,8 @@
       - "result.changed == true"
       - "stat_result.stat.mode == '0070'"
 
-- name: Test url split with no filename #https://github.com/ansible/ansible/issues/16191
-  get_url:
-    url: http://www.google.com
-    dest: "{{ output_dir }}/google.com"
+#https://github.com/ansible/ansible/issues/16191
+- name: Test url split with no filename
+  get_url: 
+    url: http://www.google.com 
+    dest: "{{ output_dir }}"


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (TEST_GETURL_GOOGLE d9448980a1) last updated 2016/06/09 14:24:23 (GMT -400)
  lib/ansible/modules/core: (devel 4a3916bd46) last updated 2016/06/09 13:27:16 (GMT -400)
  lib/ansible/modules/extras: (devel 93b59ba852) last updated 2016/06/09 13:27:21 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Addresses #16191
