### PR TITLE
made ssh compression configurable

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -273,8 +273,8 @@
 
 # ssh arguments to use
 # Leaving off ControlPersist will result in poor performance, so use
-# paramiko on older platforms rather than removing it
-#ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+# paramiko on older platforms rather than removing it, -C controls compression use
+#ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s
 
 # The path to use for the ControlPath sockets. This defaults to
 # "%(directory)s/ansible-ssh-%%h-%%p-%%r", however on some systems with

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -269,7 +269,7 @@ DISPLAY_ARGS_TO_STDOUT         = get_config(p, DEFAULTS, 'display_args_to_stdout
 MAX_FILE_SIZE_FOR_DIFF         = get_config(p, DEFAULTS, 'max_diff_size', 'ANSIBLE_MAX_DIFF_SIZE', 1024*1024, integer=True)
 
 # CONNECTION RELATED
-ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', '-o ControlMaster=auto -o ControlPersist=60s')
+ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', '-C -o ControlMaster=auto -o ControlPersist=60s')
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, integer=True)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -141,8 +141,6 @@ class Connection(ConnectionBase):
                 self._add_args('disable batch mode for sshpass', ['-o', 'BatchMode=no'])
             self._command += ['-b', '-']
 
-        self._command += ['-C']
-
         if self._play_context.verbosity > 3:
             self._command += ['-vvv']
         elif binary == 'ssh':


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.1/2.2
```
##### SUMMARY

AIX ssh does not seem to like compression, moved it to ssh_args
to allow making it configurable. Note that those using ssh_args
already will need to add it explicitly to keep compression.
