### PR TITLE
Fix git shallow update

### DIFF
--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -19,6 +19,7 @@
 - name: set role facts
   set_fact:
     checkout_dir: '{{ output_dir }}/git'
+    repo_dir: '{{ output_dir }}/local_repos'
     repo_format1: 'https://github.com/jimi-c/test_role'
     repo_format2: 'git@github.com:jimi-c/test_role.git'
     repo_format3: 'ssh://git@github.com/jimi-c/test_role.git'
@@ -44,6 +45,11 @@
   shell: git --version | grep 'git version' | sed 's/git version //'
   register: git_version
 
+- name: set dummy git config
+  shell: git config --global user.email "noreply@example.com"; git config --global user.name "Ansible Test Runner"
+
+- name: create repo_dir
+  file: path={{repo_dir}} state=directory
 
 #
 # Test repo=https://github.com/...
@@ -607,6 +613,45 @@
 - name: ensure the fetch succeeded
   assert:
     that: git_fetch|success
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
+
+# test for https://github.com/ansible/ansible-modules-core/issues/3782
+# make sure shallow fetch works when no version is specified
+
+- name: prepare old git repo
+  shell: git init; echo "1" > a; git add a; git commit -m "1"
+  args:
+    chdir: "{{repo_dir}}"
+
+- name: checkout old repo
+  git:
+    repo: '{{ repo_dir }}'
+    dest: '{{ checkout_dir }}'
+    depth: 1
+
+- name: "update repo"
+  shell: echo "2" > a; git commit -a -m "2"
+  args:
+    chdir: "{{repo_dir}}"
+
+- name: fetch updated repo
+  git:
+    repo: '{{ repo_dir }}'
+    dest: '{{ checkout_dir }}'
+    depth: 1
+  register: git_fetch
+  ignore_errors: yes
+
+- name: read file
+  shell: cat {{ checkout_dir }}/a
+
+- name: check update arrived
+  assert:
+    that:
+      - "{{ lookup('file', checkout_dir+'/a' )}} == 2"
+      - git_fetch|changed
 
 - name: clear checkout_dir
   file: state=absent path={{ checkout_dir }}

--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -34,6 +34,7 @@
     known_host_files:
       - "{{ lookup('env','HOME') }}/.ssh/known_hosts"
       - '/etc/ssh/ssh_known_hosts'
+    git_version_supporting_depth: 1.9.1
 
 - name: clean out the output_dir
   shell: rm -rf {{ output_dir }}/*
@@ -41,7 +42,7 @@
 - name: verify that git is installed so this test can continue
   shell: which git
 
-- name: get git version, only newer than 1.8.2 has fixed git depth
+- name: get git version, only newer than {{git_version_supporting_depth}} has fixed git depth
   shell: git --version | grep 'git version' | sed 's/git version //'
   register: git_version
 
@@ -265,7 +266,7 @@
     that: 
       - checkout_shallow.rc == 1
       - checkout_shallow|failed
-  when: git_version.stdout | version_compare("1.8.2", '>=')
+  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
 
 - name: clear checkout_dir
   file: state=absent path={{ checkout_dir }}
@@ -482,7 +483,7 @@
 - name: make sure the old commit was not fetched
   assert:
     that: checkout_early.rc == 1
-  when: git_version.stdout | version_compare("1.8.2", '>=')
+  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
 
 # tests https://github.com/ansible/ansible/issues/14954
 - name: fetch repo again with depth=1
@@ -494,7 +495,7 @@
 
 - assert:
     that: "not checkout2|changed"
-  when: git_version.stdout | version_compare("1.8.2", '>=')
+  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
 
 - name: again try to access earlier commit
   shell: git checkout 79624b4
@@ -506,7 +507,7 @@
 - name: again make sure the old commit was not fetched
   assert:
     that: checkout_early.rc == 1
-  when: git_version.stdout | version_compare("1.8.2", '>=')
+  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
     
 # make sure we are still able to fetch other versions
 - name: Clone same repo with older version


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

devel, 2.2
##### SUMMARY

This replaces #16055, which failed the tests.

Compared to #16055 I raised the requires git version for use of `depth` from 1.8.2 to 1.9.1. This excludes centos7 (which failed the example test to shallow-fetch updates from a repo) but still allows ubuntu14.04 which passes those.

So far I assumed that `depth` is fixed starting with 1.8.2. In the changelog of git there is no (relevant) mention of depth after 1.8.2.

I don't have time to do the full bisect on git to find the exact version, but there is not much between 1.8.3 and 1.9.1 anyhow.

Has to be merged together with https://github.com/ansible/ansible-modules-core/pull/3912 to pass.
