### PR TITLE
enable su support for docker connection

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -50,10 +50,7 @@ class Connection(ConnectionBase):
 
     transport = 'docker'
     has_pipelining = True
-    # su currently has an undiagnosed issue with calculating the file
-    # checksums (so copy, for instance, doesn't work right)
-    # Have to look into that before re-enabling this
-    become_methods = frozenset(C.BECOME_METHODS).difference(('su',))
+    become_methods = frozenset(C.BECOME_METHODS)
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

`ansible@devel`
##### SUMMARY

This PR adds support for `ansible_become_method=su` on `ansible_connection=docker`.

Although there was a comment in the docker connection plugin source code mentioning an undiagnosed issue with calculating the file checksum (`copy` action was mentioned as an example), I wasn't able to reproduce this. I also couldn't find any open bugs about this topic.

As a test I copied the file `apache-tomcat-8.0.35.tar.gz` into a `centos:centos6` Docker container:

```
$ docker run -t -d centos:centos6
32b45055b60d3f7e5e69c703d383f126f298a73b0dd726711c02a22d971b013b

## inventory
default ansible_host=32b45055b60d ansible_connection=docker ansible_become_method=su

## test_playbook.yml
- hosts: default

  tasks:
    - name: create become user
      user:
        name: user1
        group: users
        shell: /bin/bash
        state: present

    - name: copy some file
      copy:
        src: apache-tomcat-8.0.35.tar.gz
        dest: /tmp/apache-tomcat-8.0.35.tar.gz
        owner: user1
        group: users
        mode: 0644
      become: yes
      become_user: user1

$ ansible-playbook -i inventory test_playbook.yml
...

# md5 checksum in container
$ docker exec -ti 32b45055b60d /bin/bash
[root@32b45055b60d /]# md5sum /tmp/apache-tomcat-8.0.35.tar.gz
bb29919e136300292f8c2c2855074b1b  /tmp/apache-tomcat-8.0.35.tar.gz

# md5 checksum locally
$ md5 apache-tomcat-8.0.35.tar.gz
MD5 (apache-tomcat-8.0.35.tar.gz) = bb29919e136300292f8c2c2855074b1b
```

@abadger As you introduced the source code comment in 0e110d23, could you comment on this PR. Have I tried to reproduce it correctly? Or is there another case that still triggers a problem with `su` and `docker` connection?
