### PR TITLE
fixed dzdo command to work like sudo and properly detect a prompt by …

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -531,10 +531,12 @@ class PlayContext(Base):
                 becomecmd = '%s %s echo %s && %s %s env ANSIBLE=true %s' % (exe, flags, success_key, exe, flags, cmd)
 
             elif self.become_method == 'dzdo':
-
-                exe = self.become_exe or 'dzdo'
-
-                becomecmd = '%s -u %s %s -c %s' % (exe, self.become_user, executable, success_cmd)
+		exe = 'dzdo'
+                if self.become_pass:
+                    prompt = '[dzdo via ansible, key=%s] password: ' % randbits
+                    becomecmd = '%s %s -p "%s" -u %s %s -c %s' % (exe,  flags.replace('-n',''), prompt, self.become_user, executable, success_cmd)
+                else:
+                    becomecmd = '%s %s -u %s %s -c %s' % (exe, flags, self.become_user, executable, success_cmd)
 
             else:
                 raise AnsibleError("Privilege escalation method not found: %s" % self.become_method)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0
```
##### SUMMARY

<!---
Previously was unable to detect a dzdo prompt and pass the password to elevate.
-->

```
Command being ran: 
ansible -i hosts all -m "ping"  -bK --become-user=root --become-method=dzdo -u username --ask-pass

Before changes:
Timeout (12s) waiting for privilege escalation prompt: 

After changes: 
hostname.domain.com | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
```

…setting the -p option to a known string

 Committer: Ryan Ballanger  rybal06@gmail.com
