### PR TITLE
Be more lenient of symlinked /bin/sh inside the chroot

### DIFF
--- a/lib/ansible/plugins/connection/chroot.py
+++ b/lib/ansible/plugins/connection/chroot.py
@@ -63,7 +63,11 @@ class Connection(ConnectionBase):
             raise AnsibleError("%s is not a directory" % self.chroot)
 
         chrootsh = os.path.join(self.chroot, 'bin/sh')
-        if not is_executable(chrootsh):
+        # Want to check for a usable bourne shell inside the chroot.
+        # is_executable() == True is sufficient.  For symlinks it
+        # gets really complicated really fast.  So we punt on finding that
+        # out.  As long as it's a symlink we assume that it will work
+        if not (is_executable(chrootsh) or (os.path.lexists(chrootsh) and os.path.islink(chrootsh))):
             raise AnsibleError("%s does not look like a chrootable dir (/bin/sh missing)" % self.chroot)
 
         self.chroot_cmd = distutils.spawn.find_executable('chroot')


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel a42ddf981f) last updated 2016/06/11 13:15:25 (GMT -700)
  lib/ansible/modules/core: (devel d6f01d0b4f) last updated 2016/06/11 13:14:11 (GMT -700)
  lib/ansible/modules/extras: (devel 43760b2c4a) last updated 2016/06/11 13:14:22 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

```
Symlinks inside of the chroot were failng because we weren't able to
determine if they were pointing to a real file or not.  We could write
some complicated code to walk the symlink path taking into account where
the root of the tree is but that could be fragile.  Since this is just
a sanity check, instead we just assume that the chroot is fine if we
find that /bin/sh in the chroot is a symlink.  Can revisit if it turns
out that many chroots have a /bin/sh that's a broken symlink.
```

Fixes #16097
