### PR TITLE
Make sure we don't end up with an empty PYTHONPATH

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2031,6 +2031,8 @@ class AnsibleModule(object):
                         if not x.endswith('/ansible_modlib.zip') \
                         and not x.endswith('/debug_dir')]
             os.environ['PYTHONPATH'] = ':'.join(pypaths)
+            if not os.environ['PYTHONPATH']:
+                del os.environ['PYTHONPATH']
 
         # create a printable version of the command for use
         # in reporting later, which strips out things like


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel a42ddf981f) last updated 2016/06/11 13:15:25 (GMT -700)
  lib/ansible/modules/core: (devel d6f01d0b4f) last updated 2016/06/11 13:14:11 (GMT -700)
  lib/ansible/modules/extras: (devel 43760b2c4a) last updated 2016/06/11 13:14:22 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

When the PYTHONPATH is an empty string python will treat it as though
the cwd is in the PYTHONPATH.  This can be undesirable.  So make sure we
delete PYTHONPATH from the environment altgether in this case.

Fixes #16195
