### PR TITLE
Bugfix: (re)allow ansible_python_interpreter to contain more than 1 arg

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -639,15 +639,10 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
         if shebang is None:
             shebang = u'#!/usr/bin/python'
 
-        executable = interpreter.split(u' ', 1)
-        if len(executable) == 2 and executable[0].endswith(u'env'):
-            # Handle /usr/bin/env python style interpreter settings
-            interpreter = u"'{0}', '{1}'".format(*executable)
-        else:
-            # Still have to enclose the parts of the interpreter in quotes
-            # because we're substituting it into the template as a python
-            # string
-            interpreter = u"'{0}'".format(interpreter)
+        # Enclose the parts of the interpreter in quotes because we're
+        # substituting it into the template as a Python string
+        interpreter_parts = interpreter.split(u' ')
+        interpreter = u"'{0}'".format(u"', '".join(interpreter_parts))
 
         output.write(to_bytes(ACTIVE_ZIPLOADER_TEMPLATE % dict(
             zipdata=zipdata,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (ansible_python_interpreter-with-args 8fb75fb7e1) last updated 2016/06/13 09:53:28 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 138430f116) last updated 2016/06/13 09:50:39 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 883ccbefe5) last updated 2016/06/13 09:50:46 (GMT +200)
  config file = /home/lukas/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Allows `ansible_python_interpreter` to contain args again (e.g. `nice -n10 python2 -OO`).
This used to work and stopped working somewhere between 2.0 and 2.1.
This patch uses `shlex` to split the value of `ansible_python_interpreter` accordingly.

The output is unchanged, except that Ansible does fail upon the execution of the first module.
