### PR TITLE
Fix improper handling of machine_type in  ovirt inventory

### DIFF
--- a/contrib/inventory/ovirt.py
+++ b/contrib/inventory/ovirt.py
@@ -211,7 +211,7 @@ class OVirtInventory(object):
             'ovirt_uuid': inst.get_id(),
             'ovirt_id': inst.get_id(),
             'ovirt_image': inst.get_os().get_type(),
-            'ovirt_machine_type': inst.get_instance_type(),
+            'ovirt_machine_type': self.get_machine_type(inst),
             'ovirt_ips': ips,
             'ovirt_name': inst.get_name(),
             'ovirt_description': inst.get_description(),
@@ -229,6 +229,11 @@ class OVirtInventory(object):
         :type inst: params.VM
         """
         return [x.get_name() for x in inst.get_tags().list()]
+
+    def get_machine_type(self,inst):
+        inst_type = inst.get_instance_type()
+        if inst_type:
+            return self.driver.instancetypes.get(id=inst_type.id).name
 
     # noinspection PyBroadException,PyUnusedLocal
     def get_instance(self, instance_name):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0
```
##### SUMMARY

Currently the machine_type will not work if the instance type is set in ovirt. In that case, inst.get_instance_type will be an object and will fails while converting to json. 

```
Traceback (most recent call last):
  File "/etc/ansible/ovirt.py", line 287, in <module>
    OVirtInventory()
  File "/etc/ansible/ovirt.py", line 108, in __init__
    pretty=self.args.pretty
  File "/etc/ansible/ovirt.py", line 284, in json_format_dict
    return json.dumps(data)
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <ovirtsdk.xml.params.InstanceType object at 0x28e3310> is not JSON serializable
```

The current code only work if the instance type is not set in ovirt where inst.get_instance_type is a Null value. 

The change make sure that correct "instance type" is returned when instance type is set in ovirt and Null when it's not set in ovirt.

sample output

```
"_meta": {"hostvars": {"testing-vm": {"ovirt_ips": [], "ovirt_name": "testing-vm", "ovirt_tags": [], "ovirt_status": "down", "ovirt_description": "testing-vm", "ovirt_image": "other", "ovirt_machine_type": "Large"

"rhel-vm-to-move": {"ovirt_ips": [], "ovirt_name": "rhel-vm-to-move", "ovirt_tags": [], "ovirt_status": "up", "ovirt_description": null, "ovirt_image": "windows_2012x64", "ovirt_machine_type": null,
```
