### PR TITLE
Add support for merging lists when merging hashes

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -171,6 +171,7 @@ DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,   
 DEFAULT_SYSLOG_FACILITY   = get_config(p, DEFAULTS, 'syslog_facility',  'ANSIBLE_SYSLOG_FACILITY', 'LOG_USER')
 DEFAULT_KEEP_REMOTE_FILES = get_config(p, DEFAULTS, 'keep_remote_files', 'ANSIBLE_KEEP_REMOTE_FILES', False, boolean=True)
 DEFAULT_HASH_BEHAVIOUR    = get_config(p, DEFAULTS, 'hash_behaviour', 'ANSIBLE_HASH_BEHAVIOUR', 'replace')
+DEFAULT_MERGED_LISTS      = get_config(p, DEFAULTS, 'merged_lists', 'ANSIBLE_MERGED_LISTS', [], islist=True)
 DEFAULT_PRIVATE_ROLE_VARS = get_config(p, DEFAULTS, 'private_role_vars', 'ANSIBLE_PRIVATE_ROLE_VARS', False, boolean=True)
 DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBLE_JINJA2_EXTENSIONS', None)
 DEFAULT_EXECUTABLE        = get_config(p, DEFAULTS, 'executable', 'ANSIBLE_EXECUTABLE', '/bin/sh')

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -68,7 +68,7 @@ def combine_vars(a, b):
         result.update(b)
         return result
 
-def merge_hash(a, b):
+def merge_hash(a, b, key_name_root=''):
     """
     Recursively merges hash b into a so that keys from b take precedence over keys from a
     """
@@ -84,11 +84,22 @@ def merge_hash(a, b):
 
     # next, iterate over b keys and values
     for k, v in iteritems(b):
+        # keep track of the var.name style path
+        if key_name_root == '':
+            key_name = k
+        else:
+            key_name = key_name_root + '.' + k
+
         # if there's already such key in a
         # and that key contains a MutableMapping
         if k in result and isinstance(result[k], MutableMapping) and isinstance(v, MutableMapping):
             # merge those dicts recursively
-            result[k] = merge_hash(result[k], v)
+            result[k] = merge_hash(result[k], v, key_name)
+        elif k in result and isinstance(result[k], list) and key_name in C.DEFAULT_MERGED_LISTS:
+            # we should be merging these lists, so append
+            for merge_v in v:
+                if merge_v not in result[k]:
+                    result[k].append(merge_v)
         else:
             # otherwise, just copy the value from b to a
             result[k] = v

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -142,7 +142,7 @@ test_handlers:
 
 test_hash:
 	ANSIBLE_HASH_BEHAVIOUR=replace ansible-playbook test_hash.yml -i $(INVENTORY) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) -e '{"test_hash":{"extra_args":"this is an extra arg"}}'
-	ANSIBLE_HASH_BEHAVIOUR=merge ansible-playbook test_hash.yml -i $(INVENTORY) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) -e '{"test_hash":{"extra_args":"this is an extra arg"}}'
+	ANSIBLE_HASH_BEHAVIOUR=merge ANSIBLE_MERGED_LISTS=test_hash.merged_list ansible-playbook test_hash.yml -i $(INVENTORY) $(CREDENTIALS_ARG) -v $(TEST_FLAGS) -e '{"test_hash":{"extra_args":"this is an extra arg", "merged_list": ["merging", "in"]}}'
 
 test_var_precedence: setup
 	ansible-playbook test_var_precedence.yml -i $(INVENTORY) $(CREDENTIALS_ARG) $(TEST_FLAGS) -v -e outputdir=$(TEST_DIR) -e 'extra_var=extra_var' -e 'extra_var_override=extra_var_override'

--- a/test/integration/roles/test_hash_behavior/defaults/main.yml
+++ b/test/integration/roles/test_hash_behavior/defaults/main.yml
@@ -19,3 +19,4 @@
 ---
 test_hash:
   default_vars: "this is in role default/main.yml"
+  merged_list: ["this", "is"]

--- a/test/integration/roles/test_hash_behavior/vars/main.yml
+++ b/test/integration/roles/test_hash_behavior/vars/main.yml
@@ -19,3 +19,4 @@
 ---
 test_hash:
   role_vars: "this is in role vars/main.yml"
+  merged_list: ["a", "list"]

--- a/test/integration/test_hash.yml
+++ b/test/integration/test_hash.yml
@@ -12,6 +12,7 @@
       extra_args: "this is an extra arg"
       group_vars_all: "this is in group_vars/all"
       host_vars_testhost: "this is in host_vars/testhost"
+      merged_list: ["this", "is", "merging", "in", "a", "list"]
       playbook_vars: "this is a playbook variable"
       role_argument: "this is a role argument variable"
       role_vars: "this is in role vars/main.yml"

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -46,6 +46,19 @@ class TestVariableUtils(unittest.TestCase):
                 result=defaultdict(a=1, b=2, c=defaultdict(foo='bar', baz='bam'))
             ),
         )
+    test_merge_nominated_lists_data = (
+        dict(
+            a=dict(
+                a=dict(a=[1, 2, 3], b=[4, 5, 6]),
+                b=dict(a=[1, 2, 3], b=[4, 5, 6])),
+            b=dict(
+                a=dict(a=[3, 4, 5], b=[7, 8, 9]),
+                b=dict(a=[3, 4, 5], b=[7, 8, 9])),
+            result=dict(
+                a=dict(a=[1, 2, 3, 4, 5], b=[4, 5, 6, 7, 8, 9]),
+                b=dict(a=[3, 4, 5], b=[7, 8, 9])),
+        ),
+    )
     test_replace_data = (
             dict(
                 a=dict(a=1),
@@ -94,5 +107,6 @@ class TestVariableUtils(unittest.TestCase):
 
     def test_combine_vars_merge(self):
         with mock.patch('ansible.constants.DEFAULT_HASH_BEHAVIOUR', 'merge'):
-            for test in self.test_merge_data:
-                self.assertEqual(combine_vars(test['a'], test['b']), test['result'])
+            with mock.patch('ansible.constants.DEFAULT_MERGED_LISTS', ['a.a', 'a.b']):
+                for test in self.test_merge_data:
+                    self.assertEqual(combine_vars(test['a'], test['b']), test['result'])


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Problem: a 'common' role might do things such as creating users
or installing ssh keys. Group level vars might specify a list
of users to create on the target systems. When doing test
deployments to vagrant or openstack, it's common to supply
extra_vars which have a list of users to create on all instances
for access purposes. Because of how the merging currently
works, the extra_vars override those lists and the users
in them are not created.

Solution: allow the user to specify a list of variables which
are lists to be merged along with the hashes.

Example:

ANSIBLE_MERGE_LISTS=common.users

Would result in the following two lists:

```
common:
  users:
    - admin

common:
  users:
    - service_user
```

combining into

```
common:
  users:
    - admin
    - service_user
```

but all other lists would keep the original overwriting behaviour.
