### PR TITLE
Update integration test runner on shippable.

### DIFF
--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -60,6 +60,7 @@ function cleanup
 }
 
 trap cleanup EXIT INT TERM
+docker images ansible/ansible
 show_environment
 
 if [ "${controller_shared_dir}" ]; then
@@ -78,8 +79,6 @@ container_id=$(docker run -d \
     "${test_image}")
 
 show_environment
-
-docker exec "${container_id}" pip install junit-xml
 
 if [ "${copy_source}" ]; then
     docker exec "${container_id}" cp -a "${test_shared_dir}" "${test_ansible_dir}"


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (integration-update 2f1fc5a324) last updated 2016/06/13 18:07:26 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 1d0f408897) last updated 2016/06/13 15:10:20 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 146c969c07) last updated 2016/06/13 15:10:20 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Update integration test runner on shippable:
- Display available docker images from ansible/ansible repository for debugging.
- Rely on the junit-xml module installed in the docker images.
