### PR TITLE
fix error message using fail_json

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -151,7 +151,7 @@ def get_aws_connection_info(module, boto3=False):
                 # here we don't need to make an additional call, will default to 'us-east-1' if the below evaluates to None.
                 region = botocore.session.get_session().get_config_variable('region')
             else:
-                module.fail_json("Boto3 is required for this module. Please install boto3 and try again")
+                module.fail_json(msg="Boto3 is required for this module. Please install boto3 and try again")
 
     if not security_token:
         if 'AWS_SECURITY_TOKEN' in os.environ:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
fix use of fail_json
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: fail_json() takes exactly 1 argument (2 given)
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_Tca57R/ansible_module_route53_facts.py\", line 436, in <module>\n    main()\n  File \"/tmp/ansible_Tca57R/ansible_module_route53_facts.py\", line 414, in main\n    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)\n  File \"/tmp/ansible_Tca57R/ansible_modlib.zip/ansible/module_utils/ec2.py\", line 154, in get_aws_connection_info\nTypeError: fail_json() takes exactly 1 argument (2 given)\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}

AFTER:

fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "Boto3 is required for this module. Please install boto3 and try again"}
```

The error was: TypeError: fail_json() takes exactly 1 argument (2 given)
