### PR TITLE
Fix string coercion problem in error handling code                   …

### DIFF
--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -278,7 +278,7 @@ class Display:
             wrapped = textwrap.wrap(new_msg, self.columns)
             new_msg = u"\n".join(wrapped) + u"\n"
         else:
-            new_msg = u"ERROR! " + msg
+            new_msg = u"ERROR! %s" % msg
         if new_msg not in self._errors:
             self.display(new_msg, color=C.COLOR_ERROR, stderr=True)
             self._errors[new_msg] = 1


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Bug was introduced in commit b122374

Manifests as the following stack trace

```
Traceback (most recent call last):
  File "/usr/local/Cellar/ansible/2.0.1.0/libexec/bin/ansible-playbook", line 86, in <module>
    sys.exit(cli.run())
  File "/usr/local/Cellar/ansible/2.0.1.0/libexec/lib/python2.7/site-packages/ansible/cli/playbook.py", line 150, in run
    results = pbex.run()
  File "/usr/local/Cellar/ansible/2.0.1.0/libexec/lib/python2.7/site-packages/ansible/executor/playbook_executor.py", line 140, in run
    result = self._tqm.run(play=play)
  File "/usr/local/Cellar/ansible/2.0.1.0/libexec/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py", line 238, in run
    play_return = strategy.run(iterator, play_context)
  File "/usr/local/Cellar/ansible/2.0.1.0/libexec/lib/python2.7/site-packages/ansible/plugins/strategy/linear.py", line 334, in run
    display.error(e, wrap_text=False)
  File "/usr/local/Cellar/ansible/2.0.1.0/libexec/lib/python2.7/site-packages/ansible/utils/display.py", line 259, in error
    new_msg = u"ERROR! " + msg
TypeError: coercing to Unicode: need string or buffer, AnsibleParserError found
```
