### PR TITLE
Show stderr when there is an error calling setfacl

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -367,7 +367,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                         if res['rc'] != 0:
                             raise AnsibleError('Failed to set file mode on remote files (rc: {0}, err: {1})'.format(res['rc'], res['stderr']))
                     else:
-                        raise AnsibleError('Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user. For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user')
+                        raise AnsibleError('Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: {0}, err: {1}). For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user'.format(res['rc'], res['stderr']))
         elif execute:
             # Can't depend on the file being transferred with execute
             # permissions.  Only need user perms because no become was


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (show-facl-error 17372244d4) last updated 2016/06/14 09:29:32 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 1d0f408897) last updated 2016/06/14 09:36:03 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 146c969c07) last updated 2016/06/14 09:33:11 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

When the `setfacl` command introduced in #15078 fails, the error message is not exposed to the user. This PR updates the error message to include `res['stderr']`, which can help the user to determine what actually went wrong with the `setfacl` command.
