### PR TITLE
Extract a censor_args method to module_utils

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -86,6 +86,7 @@ import tempfile
 import traceback
 import grp
 import pwd
+import pipes
 import platform
 import errno
 import datetime

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -651,6 +651,45 @@ def human_to_bytes(number, default_unit=None, isbits=False):
     return int(round(num * limit))
 
 
+def censor_args(args, no_log_values):
+    """create a printable version of the command for use
+    in reporting later, which strips out things like
+    passwords from the args list"""
+
+    to_clean_args = args
+
+    if PY2:
+        if isinstance(args, text_type):
+            to_clean_args = args.encode('utf-8')
+    else:
+        if isinstance(args, binary_type):
+            to_clean_args = args.decode('utf-8', errors='replace')
+
+    if isinstance(args, (text_type, binary_type)):
+        to_clean_args = shlex.split(to_clean_args)
+
+    clean_args = []
+    is_passwd = False
+
+    for arg in to_clean_args:
+        if is_passwd:
+            is_passwd = False
+            clean_args.append('********')
+            continue
+
+        if PASSWD_ARG_RE.match(arg):
+            sep_idx = arg.find('=')
+            if sep_idx > -1:
+                clean_args.append('%s=********' % arg[:sep_idx])
+                continue
+            else:
+                is_passwd = True
+
+        arg = heuristic_log_sanitize(arg, no_log_values)
+        clean_args.append(arg)
+    clean_args = ' '.join(pipes.quote(arg) for arg in clean_args)
+    return clean_args
+
 def is_executable(path):
     '''is the given path executable?
 
@@ -1046,6 +1085,7 @@ class AnsibleModule(object):
             f.close()
         except:
             return (False, None)
+
         path_mount_point = self.find_mount_point(path)
         for line in mount_data:
             (device, mount_point, fstype, options, rest) = line.split(' ', 4)
@@ -2500,36 +2540,7 @@ class AnsibleModule(object):
             if not os.environ['PYTHONPATH']:
                 del os.environ['PYTHONPATH']
 
-        # create a printable version of the command for use
-        # in reporting later, which strips out things like
-        # passwords from the args list
-        to_clean_args = args
-        if PY2:
-            if isinstance(args, text_type):
-                to_clean_args = to_bytes(args)
-        else:
-            if isinstance(args, binary_type):
-                to_clean_args = to_text(args)
-        if isinstance(args, (text_type, binary_type)):
-            to_clean_args = shlex.split(to_clean_args)
-
-        clean_args = []
-        is_passwd = False
-        for arg in to_clean_args:
-            if is_passwd:
-                is_passwd = False
-                clean_args.append('********')
-                continue
-            if PASSWD_ARG_RE.match(arg):
-                sep_idx = arg.find('=')
-                if sep_idx > -1:
-                    clean_args.append('%s=********' % arg[:sep_idx])
-                    continue
-                else:
-                    is_passwd = True
-            arg = heuristic_log_sanitize(arg, self.no_log_values)
-            clean_args.append(arg)
-        clean_args = ' '.join(shlex_quote(arg) for arg in clean_args)
+        clean_args = censor_args(args, self.no_log_values)
 
         if data:
             st_in = subprocess.PIPE

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -112,7 +112,7 @@ class TestReturnValues(object):
                       [u'a unicode', 'another string'],
                       [{'j': [False, True]}],
                       [{'A': [], 'B': {}}],
-                      [{'B': ['C',b'D', u'E', ('Ff', 'Gg'), {'H': ['h', 'hh', 'hhh']}]}],
+                      [{'B': ['C', b'D', u'E', ('Ff', 'Gg'), {'H': ['h', 'hh', 'hhh']}]}],
                       ]
 
     test_data_fails = [Ellipsis,
@@ -149,8 +149,6 @@ class BaseTestModuleUtilsBasic(unittest.TestCase):
         # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
         self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
         self.stdin_swap.__enter__()
-
-class TestModuleUtilsBasic(ModuleTestCase):
 
 
 class TestModuleUtilsBasic(BaseTestModuleUtilsBasic):
@@ -746,17 +744,6 @@ class TestModuleUtilsBasicSelinux(BaseTestModuleUtilsBasic):
 
 
 class TestModuleUtilsBasicFileSystem(BaseTestModuleUtilsBasic):
-
-    def test_module_utils_basic_ansible_module_to_filesystem_str(self):
-        from ansible.module_utils import basic
-        basic._ANSIBLE_ARGS = None
-
-        am = basic.AnsibleModule(
-            argument_spec = dict(),
-        )
-
-        self.assertEqual(am._to_filesystem_str(u'foo'), b'foo')
-        self.assertEqual(am._to_filesystem_str(u'föö'), b'f\xc3\xb6\xc3\xb6')
 
     def test_module_utils_basic_ansible_module_user_and_group(self):
         from ansible.module_utils import basic

--- a/test/units/module_utils/test_basic_imports.py
+++ b/test/units/module_utils/test_basic_imports.py
@@ -1,0 +1,155 @@
+
+import json
+import logging
+import sys
+
+from units.mock.procenv import swap_stdin_and_argv
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch, Mock
+
+log = logging.getLogger(__name__)
+
+realimport = __import__
+
+
+class TestModuleUtilsBasicImporting(unittest.TestCase):
+    builtin_import_name = '__builtin__.__import__'
+
+    def setUp(self):
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}))
+        # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
+        self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
+        self.stdin_swap.__enter__()
+        self._imports_before = []
+        self._wrapped_imports = []
+        self.mods_to_fail = []
+        self.mods_to_fake = []
+        self.clear_basic()
+
+    def tearDown(self):
+        # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
+        self.stdin_swap.__exit__(None, None, None)
+        self.clear_modules(self._wrapped_imports)
+        self._wrapped_imports = []
+        self.mods_to_fail = []
+        self.mods_to_fake = []
+        self.clear_basic()
+
+    def clear_modules(self, mods):
+        for mod in mods:
+            if mod in sys.modules or mod in self.mods_to_fake:
+                del sys.modules[mod]
+
+    def clear_basic(self):
+        return self.clear_modules(['ansible.module_utils.basic'])
+
+    def _import_wrapper(self, name, *args, **kwargs):
+        if name not in sys.modules:
+            self._wrapped_imports.append(name)
+
+        return realimport(name, *args, **kwargs)
+
+    def _mock_import(self, name, *args, **kwargs):
+        if name in self.mods_to_fail:
+            raise ImportError
+        if name in self.mods_to_fake:
+            mock_module = Mock()
+            return mock_module
+        return self._import_wrapper(name, *args, **kwargs)
+
+    @patch('__builtin__.__import__')
+    def test_import_syslog_has_syslog(self, mock_import):
+        mock_import.side_effect = self._mock_import
+        self.mods_to_fake = ['syslog']
+
+        import ansible.module_utils.basic as mod
+        self.assertTrue(mod.HAS_SYSLOG)
+
+    @patch('__builtin__.__import__')
+    def test_import_syslog_no_syslog(self, mock_import):
+        mock_import.side_effect = self._mock_import
+        self.mods_to_fail = ['syslog']
+
+        import ansible.module_utils.basic as mod
+        self.assertFalse(mod.HAS_SYSLOG)
+
+    @patch('__builtin__.__import__')
+    def test_import_selinux_has_selinux(self, mock_import):
+        # if not HAS_SELINUX:
+        #    raise SkipTest('No selinux module to tests import of')
+        self.mods_to_fake = ['selinux']
+
+        mock_import.side_effect = self._mock_import
+
+        import ansible.module_utils.basic as mod
+        self.assertTrue(mod.HAVE_SELINUX)
+
+    @patch('__builtin__.__import__')
+    def test_import_selinux_no_selinux(self, mock_import):
+        mock_import.side_effect = self._mock_import
+        self.mods_to_fail = ["selinux"]
+
+        import ansible.module_utils.basic as mod
+        self.assertFalse(mod.HAVE_SELINUX)
+
+    @patch('__builtin__.__import__')
+    def test_import_json_has_json(self, mock_import):
+        mock_import.side_effect = self._mock_import
+
+        import ansible.module_utils.basic as mod
+        self.assertTrue(hasattr(mod, 'json'))
+
+    @patch('__builtin__.__import__')
+    def test_import_json_no_json(self, mock_import):
+        mock_import.side_effect = self._mock_import
+        self.mods_to_fail = ['json']
+
+        try:
+            import ansible.module_utils.basic
+            self.assertTrue(ansible.module_utils.basic is not None)
+        except SystemExit as e:
+            log.debug(e)
+
+    @patch('__builtin__.__import__')
+    @unittest.skipIf(sys.version_info[0] >= 3, "literal_eval is available in every version of Python3")
+    def test_import_literal_eval(self, mock_import):
+        def _mock_import(name, *args, **kwargs):
+            try:
+                fromlist = kwargs.get('fromlist', args[2])
+            except IndexError:
+                fromlist = []
+            if name == 'ast' and 'literal_eval' in fromlist:
+                raise ImportError
+            log.debug('name=%s', name)
+            return self._import_wrapper(name, *args, **kwargs)
+
+        mock_import.side_effect = _mock_import
+        import ansible.module_utils.basic as mod
+
+        # TODO: move tests of literal_eval to a different test class
+        self.assertEqual(mod.literal_eval("'1'"), "1")
+        self.assertEqual(mod.literal_eval("1"), 1)
+        self.assertEqual(mod.literal_eval("-1"), -1)
+        self.assertRaises(ValueError, mod.literal_eval, "asdfasdfasdf")
+        self.assertEqual(mod.literal_eval("(1,2,3)"), (1,2,3))
+        self.assertEqual(mod.literal_eval("[1]"), [1])
+        self.assertEqual(mod.literal_eval("True"), True)
+        self.assertEqual(mod.literal_eval("False"), False)
+        self.assertEqual(mod.literal_eval("None"), None)
+        # self.assertEqual(mod.module_utils.basic.literal_eval('{"a": 1}'), dict(a=1))
+
+    @patch('__builtin__.__import__')
+    def test_import_has_systemd_journal(self, mock_import):
+        mock_import.side_effect = self._mock_import
+        self.mods_to_fake = ['systemd', 'systemd.journal']
+        import ansible.module_utils.basic as mod
+        self.assertTrue(mod.has_journal)
+
+    @patch('__builtin__.__import__')
+    def test_import_no_systemd_journal(self, mock_import):
+        mock_import.side_effect = self._mock_import
+        self.mods_to_fail = ['systemd']
+
+        import ansible.module_utils.basic as mod
+        self.assertFalse(mod.has_journal)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- Bugfix Pull Request
##### SUMMARY

Some refactoring of module_utils.basic.py and add some tests.

This was existing code, just moved out of the
innards of AnsibleModule to a module level
method. Mostly for easier testing.

Add test cases for censor_args.

Split module_utils. import tests into new test module:
test_basic.py is now test_basic.py and test_basic_imports.py
