### PR TITLE
Output stderr_lines

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -663,10 +663,12 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # parse the main result
         data = self._parse_returned_data(res)
 
-        # pre-split stdout into lines, if stdout is in the data and there
-        # isn't already a stdout_lines value there
+        # pre-split stdout and stderr into lines
         if 'stdout' in data and 'stdout_lines' not in data:
             data['stdout_lines'] = data.get('stdout', u'').splitlines()
+
+        if 'stderr' in data and 'stderr_lines' not in data:
+            data['stderr_lines'] = data.get('stderr', u'').splitlines()
 
         display.debug("done with _execute_module (%s, %s)" % (module_name, module_args))
         return data
@@ -747,7 +749,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         out = self._strip_success_message(out)
 
         display.debug("_low_level_execute_command() done: rc=%d, stdout=%s, stderr=%s" % (rc, stdout, stderr))
-        return dict(rc=rc, stdout=out, stdout_lines=out.splitlines(), stderr=err)
+        return dict(rc=rc, stdout=out, stdout_lines=out.splitlines(), stderr=err, stderr_lines=err.splitlines())
 
     def _get_first_available_file(self, faf, of=None, searchdir='files'):
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Stdout_lines exists and shows pretty output. Stderr did not previously have the same feature. It makes it easier to see certain command output from the shell.

Before

```
ok: [test] => {
    "msg": {
        "changed": true, 
        "cmd": "apachectl -t", 
        "delta": "0:00:00.041603", 
        "end": "2016-06-15 00:59:42.204139", 
        "rc": 0, 
        "start": "2016-06-15 00:59:42.162536", 
        "stderr": "AH00112: Warning: DocumentRoot [/var/www/phil/public_html] does not exist\nAH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 127.0.0.1. Set the 'ServerName' directive globally to suppress this message\nSyntax OK", 
        "stdout": "", 
        "stdout_lines": [], 
        "warnings": []
    }
}
```

After

```
ok: [test] => {
    "msg": {
        "changed": true, 
        "cmd": "apachectl -t", 
        "delta": "0:00:00.039094", 
        "end": "2016-06-15 00:35:41.612449", 
        "rc": 0, 
        "start": "2016-06-15 00:35:41.573355", 
        "stderr": AH00112: Warning: DocumentRoot [/var/www/phil/public_html] does not exist\nAH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 127.0.0.1. Set the 'ServerName' directive globally to suppress this message\nSyntax OK", 
        "stderr_lines": [
            "AH00112: Warning: DocumentRoot [/var/www/phil/public_html] does not exist", 
            "AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 127.0.0.1. Set the 'ServerName' directive globally to suppress this message", 
            "Syntax OK"
        ], 
        "stdout": "", 
        "stdout_lines": [], 
        "warnings": []
    }
}
```
