### PR TITLE
Fixed digital ocean inventory script "bad data for host list"

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -373,8 +373,8 @@ or environment variables (DO_API_TOKEN)''')
 
             self.inventory['all']['hosts'].append(dest)
 
-            self.inventory[droplet['id']] = dest
-            self.inventory[droplet['name']] = dest
+            self.inventory[droplet['id']] = [dest]
+            self.inventory[droplet['name']] = [dest]
 
             # groups that are always present
             for group in [


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.1.0
```
##### SUMMARY

Since the changes introduced in #16102, using the digital ocean inventory script causes an error when called via ansible:

```
You defined a group "8457573" with bad data for the host list:
 {'hosts': u'IP WAS HERE'}
```

This is because the modifications to the script output the droplet name and droplet id groups as 

``` json
{"id_or_name": "IP"}
```

Instead of the correct format:

``` json
{"id_or_name": ["IP"]}
```

This fix builds on #16100.
