### PR TITLE
Do not corrupt $MANPATH when it's not present

### DIFF
--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -39,7 +39,7 @@ end
 # Set MANPATH
 if not contains $PREFIX_MANPATH $MANPATH
     if not set -q MANPATH
-        set -gx MANPATH $PREFIX_MANPATH
+        set -gx MANPATH $PREFIX_MANPATH:
     else
         set -gx MANPATH $PREFIX_MANPATH $MANPATH
     end


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 624e7dae54) 
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

In order to preserve the original `$MANPATH` we need to include the semicolon at the end (like the equivalent code in Bash's `env-setup` script.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Before:

```
source [PATH]/ansible/hacking/env-setup.fish
man man
> No manual entry for man
> See 'man 7 undocumented' for help when manual pages are not available.
```

After:

```
source [PATH]/ansible/hacking/env-setup.fish
man man
> Man page is shown
```

Fixes #16299
