### PR TITLE
Check that required arguments src and dest are present.

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -266,6 +266,10 @@ class ActionModule(ActionBase):
         # MUNGE SRC AND DEST PER REMOTE_HOST INFO
         src = self._task.args.get('src', None)
         dest = self._task.args.get('dest', None)
+        if src is None or dest is None:
+            return dict(failed=True,
+                    msg="synchronize requires both src and dest parameters are set")
+
         if not dest_is_local:
             # Private key handling
             if use_delegate:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

devel and 2.1
##### SUMMARY

Currently ansible issues an unrelated traceback if src or dest is not given as a parameter.  This change fixes it to give a helpful error message instead.  (see bug report for more info)

Fixes #16301
