### PR TITLE
Allow spaces before the filter string

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -173,7 +173,7 @@ class Templar:
         self.variable_start = self.environment.variable_start_string
         self.variable_end   = self.environment.variable_end_string
         self._clean_regex   = re.compile(r'(?:%s|%s|%s|%s)' % (self.variable_start, self.block_start, self.block_end, self.variable_end))
-        self._no_type_regex = re.compile(r'.*\|(?:%s)\s*(?:%s)?$' % ('|'.join(C.STRING_TYPE_FILTERS), self.variable_end))
+        self._no_type_regex = re.compile(r'.*\|\s*(?:%s)\s*(?:%s)?$' % ('|'.join(C.STRING_TYPE_FILTERS), self.variable_end))
 
     def _get_filters(self):
         '''


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

`Templar._no_type_regex` does not check for whitespace after the `|` and before `STRING_TYPE_FILTERS`. This potentially causes unwanted calls to `ansible.template.safe_eval` when working with dictionaries or lists.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
##### EXAMPLE

test.yml

```

---

- hosts: localhost
  connection: local
  vars:
    testlist: [a,b]
    testvar: "{{testlist| to_json}}"
  tasks:
    - template: src=template.j2 dest=./out
```

test.j2

```
{{testvar}}
```

Run ansible-playbook

```
$ ansible-playbook template.yml --diff
...
TASK [template] ****************************************************************
changed: [localhost]
--- before
+++ after: dynamically generated
@@ -0,0 +1 @@
+['a', 'b']
```

Change testvar to `"{{testlist|to_json}}"`

```
$ ansible-playbook template.yml --diff
...
TASK [template] ****************************************************************
changed: [localhost]
--- before: ./out
+++ after: dynamically generated
@@ -1 +1 @@
-['a', 'b']
+["a", "b"]
```
