### PR TITLE
Change the default of module_set_locale to False.

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -501,12 +501,13 @@ module_set_locale
 =================
 
 This boolean value controls whether or not Ansible will prepend locale-specific environment variables (as specified
-via the :ref:`module_lang` configuration option). By default this is enabled, and results in the LANG and LC_MESSAGES
-being set when the module is executed on the given remote system.
+via the :ref:`module_lang` configuration option). If enabled, it results in the LANG, LC_MESSAGES, and LC_ALL
+being set when the module is executed on the given remote system.  By default this is disabled.
 
 .. note::
 
-    The module_set_locale option was added in Ansible 2.1.
+    The module_set_locale option was added in Ansible-2.1 and defaulted to
+    True.  The default was changed to False in Ansible-2.2
 
 .. _module_lang:
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -23,7 +23,7 @@
 #transport      = smart
 #remote_port    = 22
 #module_lang    = C
-#module_set_locale = True
+#module_set_locale = False
 
 # plays will gather facts by default, which contain information about
 # the remote system.

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -154,7 +154,7 @@ DEFAULT_MODULE_NAME       = get_config(p, DEFAULTS, 'module_name',      None,   
 DEFAULT_FORKS             = get_config(p, DEFAULTS, 'forks',            'ANSIBLE_FORKS',            5, integer=True)
 DEFAULT_MODULE_ARGS       = get_config(p, DEFAULTS, 'module_args',      'ANSIBLE_MODULE_ARGS',      '')
 DEFAULT_MODULE_LANG       = get_config(p, DEFAULTS, 'module_lang',      'ANSIBLE_MODULE_LANG',      os.getenv('LANG', 'en_US.UTF-8'))
-DEFAULT_MODULE_SET_LOCALE = get_config(p, DEFAULTS, 'module_set_locale','ANSIBLE_MODULE_SET_LOCALE',True, boolean=True)
+DEFAULT_MODULE_SET_LOCALE = get_config(p, DEFAULTS, 'module_set_locale','ANSIBLE_MODULE_SET_LOCALE',False, boolean=True)
 DEFAULT_MODULE_COMPRESSION= get_config(p, DEFAULTS, 'module_compression', None, 'ZIP_DEFLATED')
 DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE_TIMEOUT',          10, integer=True)
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15, integer=True)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible-2.2
```
##### SUMMARY

This makes Ansible no longer set LC_ALL for remote systems.  It is up to
the individual modules to set LC_ALL if they need it for screenscraping
the output from a program.

This is the 2.2 followup for #15138
