### PR TITLE
Fewer deps for 'make webdocs' from top level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ deb-src-upload: deb-src
 
 # for arch or gentoo, read instructions in the appropriate 'packaging' subdirectory directory
 
-webdocs: $(MANPAGES)
+webdocs:
 	(cd docsite/; make docs)
 
 docs: $(MANPAGES)

--- a/hacking/dump_playbook_attributes.py
+++ b/hacking/dump_playbook_attributes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import optparse
 from jinja2 import Environment, FileSystemLoader


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

Previously it also built the MANPAGES target
requiring asciidoc and libxml, before starting
a 'make docs' in docsite.

Also change the #! line in
hacking/dump_playbook_attributes.py to not specify
python2... yet.
