### PR TITLE
windows: integration tests to cover https://github.com/ansible/ansible-modules-extras/pull/2436

### DIFF
--- a/test/integration/roles/test_win_regedit/tasks/main.yml
+++ b/test/integration/roles/test_win_regedit/tasks/main.yml
@@ -18,6 +18,22 @@
 
 # clear the area of the registry we are using for tests
 
+# test mangled registry key gets caught following https://github.com/ansible/ansible-modules-extras/issues/2412
+
+- name: test mangled registry key is caught (avoids bizare error message from powershell)
+  win_regedit:
+    key: HKCU\Software
+    value: invalid_key
+    data: invalid_key
+    datatype: string
+  register: check00_result
+  ignore_errors: True
+
+- assert:
+    that:
+      - "check00_result.failed == true"
+      - "check00_result.msg == 'key: HKCU\\Software is not a valid powershell path, see module documentation for examples.'"
+
 - name: remove setting
   win_regedit:
     key: 'HKCU:\SOFTWARE\Cow Corp'
@@ -372,6 +388,33 @@
 - assert:
     that:
       - "check62_result.changed == false"
+
+# test dword
+
+- name: check basic set dword works
+  win_regedit:
+    key: HKCU:\Software\Cow Corp
+    value: hello_dword
+    data: 00000000
+    datatype: dword
+  register: check71_result
+
+- assert:
+    that:
+      - "check71_result.changed == true"
+
+- name: check that setting the same dword again is not changed
+  win_regedit:
+    key: HKCU:\Software\Cow Corp
+    value: hello_dword
+    data: 00000000
+    datatype: dword
+  register: check72_result
+
+- assert:
+    that:
+      - "check72_result.changed == false"
+
 # tear down
 
 - name: remove registry key used for testing


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (more-regedit-tests 9857af2b6e) last updated 2016/06/16 06:39:04 (GMT +100)
  lib/ansible/modules/core: (detached HEAD d4eaeac8c9) last updated 2016/06/16 06:37:03 (GMT +100)
  lib/ansible/modules/extras: (devel eed9d601b5) last updated 2016/06/16 05:56:03 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This PR just adds further tests to cover the changes I made in https://github.com/ansible/ansible-modules-extras/pull/2436

Specifically adds a test of setting a registry entry of data type dword, and demonstrates the error trapping if an invalid registry key is supplied (saves a strange error message being returned by powershell).

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

to run the changed tests

```
cd test/integration
export TEST_FLAGS='-i /etc/ansible/hosts -t test_win_regedit'
make test_winrm
```
