### PR TITLE
Handle color on multiple line in a cleaner way

### DIFF
--- a/lib/ansible/utils/color.py
+++ b/lib/ansible/utils/color.py
@@ -70,7 +70,7 @@ def stringc(text, color):
     """String in color."""
 
     if ANSIBLE_COLOR:
-        return u"\033[%sm%s\033[0m" % (codeCodes[color], text)
+        return "\n".join([u"\033[%sm%s\033[0m" % (codeCodes[color], t) for t in text.split('\n')])
     else:
         return text
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY

When using ansible deployment on git push, git insert "remote:"
at the start of ansible output. If you force the color on ansible,
the "remote:" also get colored if the string to display is on
more than 1 line.

This change make sure that each end of line reset the color, instead
of reseting only at the end of the string.
