### PR TITLE
If decryption of a vaulted file failed, include the filename in the error

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -169,7 +169,7 @@ class DataLoader():
             with open(b_file_name, 'rb') as f:
                 data = f.read()
                 if self._vault.is_encrypted(data):
-                    data = self._vault.decrypt(data)
+                    data = self._vault.decrypt(data, filename=b_file_name)
                     show_content = False
 
             data = to_unicode(data, errors='strict')
@@ -339,7 +339,7 @@ class DataLoader():
                     if not self._vault_password:
                         raise AnsibleParserError("A vault password must be specified to decrypt %s" % file_path)
 
-                    data = self._vault.decrypt(data)
+                    data = self._vault.decrypt(data, filename=real_path)
                     # Make a temp file
                     real_path = self._create_content_tempfile(data)
                     self._tempfiles.add(real_path)

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -144,7 +144,7 @@ class VaultLib:
         b_tmp_data = self._format_output(b_enc_data)
         return b_tmp_data
 
-    def decrypt(self, data):
+    def decrypt(self, data, filename=None):
         """Decrypt a piece of vault encrypted data.
 
         :arg data: a string to decrypt.  Since vault encrypted data is an
@@ -157,7 +157,10 @@ class VaultLib:
             raise AnsibleError("A vault password must be specified to decrypt data")
 
         if not self.is_encrypted(b_data):
-            raise AnsibleError("input is not encrypted")
+            msg = "input is not encrypted"
+            if filename:
+                msg += "%s is not encrypted" % filename
+            raise AnsibleError(msg)
 
         # clean out header
         b_data = self._split_header(b_data)
@@ -173,7 +176,10 @@ class VaultLib:
         # try to unencrypt data
         b_data = this_cipher.decrypt(b_data, self.b_password)
         if b_data is None:
-            raise AnsibleError("Decryption failed")
+            msg = "Decryption failed"
+            if filename:
+                msg += " on %s" % filename
+            raise AnsibleError(msg)
 
         return b_data
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (FIX_16327 6f38c34112) last updated 2016/06/16 13:40:15 (GMT -400)
  lib/ansible/modules/core: (devel 1c41b6fdb2) last updated 2016/06/16 13:28:28 (GMT -400)
  lib/ansible/modules/extras: (devel 127ddc1f05) last updated 2016/06/16 13:28:32 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #16327
