### PR TITLE
Fix table width on docsite

### DIFF
--- a/docsite/_themes/srtd/static/css/theme.css
+++ b/docsite/_themes/srtd/static/css/theme.css
@@ -4738,7 +4738,17 @@ span[id*='MathJax-Span'] {
 }
 
 td {
-	word-break: break-all;
+    word-break: break-word;
+}
+
+th, td {
+    min-width: 100px;
+}
+
+table {
+       overflow-x: scroll;
+       display: block;
+       max-width: 100%;
 }
 
 @media print {


### PR DESCRIPTION
This makes it so that table columns break by word instead of in between words.  It also sets the minimum width of a column in the table to 100px, and makes tables horizontally scrollable on small screen sizes.
