### PR TITLE
Add missing documentation about defaults/main.yml

### DIFF
--- a/docsite/rst/playbooks_roles.rst
+++ b/docsite/rst/playbooks_roles.rst
@@ -190,6 +190,7 @@ This designates the following behaviors, for each role 'x':
 - If roles/x/tasks/main.yml exists, tasks listed therein will be added to the play
 - If roles/x/handlers/main.yml exists, handlers listed therein will be added to the play
 - If roles/x/vars/main.yml exists, variables listed therein will be added to the play
+- If roles/x/defaults/main.yml exists, variables listed therein will be added to the play
 - If roles/x/meta/main.yml exists, any role dependencies listed therein will be added to the list of roles (1.3 and later)
 - Any copy, script, template or include tasks (in the role) can reference files in roles/x/{files,templates,tasks}/ (dir depends on task) without having to path them relatively or absolutely
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 1.8.4
  configured module search path = None
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

For a beginner, it was difficult for me to see why running an ansible task `roles/x/tasks/main.yml` did not have the variables defined in `roles/x/defaults/main.yml`. This minor change to the documentation would have made it easier for me to recognize that I needed to run an ansible task that references the `x` role in order for the default variables to be defined.
