### PR TITLE
Add timeout information into async failure message

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -589,7 +589,7 @@ class TaskExecutor:
             time_left -= self._task.poll
 
         if int(async_result.get('finished', 0)) != 1:
-            return dict(failed=True, msg="async task did not complete within the requested time")
+            return dict(failed=True, msg="async task did not complete within the requested (%s) time" % self._task.async)
         else:
             return async_result
 


### PR DESCRIPTION
Add some extra information to an async failure message to reflect the actually timeout value of the failure.

Signed-off-by: Paul Belanger pabelanger@redhat.com
