### PR TITLE
Add mention of the behavior of transport on OSX

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -758,6 +758,12 @@ Users should usually leave this setting as 'smart' and let their playbooks choos
 
     transport = paramiko
 
+On OSX, sshpass v1.05 is known to cause cause kernel panics. When executing on this system 'smart' will fall-back
+to the 'paramiko' connector instead of 'ssh' by default. To override this behavior, set the ``transport`` parameter to
+'ssh' either via config or through command-line argument. See `#5007`_ for a detailed discussion of the issue.
+
+.. _#5007: https://github.com/ansible/ansible/issues/5007#issuecomment-57946035
+
 .. _vars_plugins:
 
 vars_plugins


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /Users/dkimsey/ansible/ansible.cfg
  configured module search path = ['library/']
```
##### SUMMARY

Currently there is no indication anywhere that smart actually means paramiko on OSX machines. This change adds a much needed blurb to the documentation.

Aside: Might be good if the connection type ('ssh', 'paramiko', 'winrm') was emitted in vvvvv logging. Tracing this was unexpectedly fun.
