### PR TITLE
Use find instead of -R for recursive setfacl

### DIFF
--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -91,10 +91,11 @@ class ShellBase(object):
         mode = pipes.quote(mode)
         user = pipes.quote(user)
 
-        cmd = ['setfacl']
+        cmd = ['setfacl', '-m', 'u:%s:%s' % (user, mode)]
         if recursive:
-            cmd.append('-R')
-        cmd.extend(('-m', 'u:%s:%s %s' % (user, mode, path)))
+            cmd = ['find', path, '-exec'] + cmd + ["'{}'", "';'"]
+        else:
+            cmd.append(path)
 
         return ' '.join(cmd)
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible devel and 2.1.0
```
##### SUMMARY

-R is not present on Solaris or freebsd setfacl so we have to use something else to recursively set the acl on the temporary files.

Fixes #16322
