### PR TITLE
Fix for issue @synchronize doesn't substitute variables properly #16347

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -275,7 +275,7 @@ class ActionModule(ActionBase):
             private_key = self._play_context.private_key_file
 
             if private_key is not None:
-                private_key = format(os.path.expanduser(private_key))
+                private_key = os.path.expanduser(private_key)
                 self._task.args['private_key'] = private_key
 
             # Src and dest rsync "path" handling

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -272,13 +272,10 @@ class ActionModule(ActionBase):
 
         if not dest_is_local:
             # Private key handling
-            if use_delegate:
-                private_key = task_vars.get('ansible_ssh_private_key_file') or self._play_context.private_key_file
-            else:
-                private_key = task_vars.get('ansible_ssh_private_key_file') or self._play_context.private_key_file
+            private_key = self._play_context.private_key_file
 
             if private_key is not None:
-                private_key = os.path.expanduser(private_key)
+                private_key = format(os.path.expanduser(private_key))
                 self._task.args['private_key'] = private_key
 
             # Src and dest rsync "path" handling


### PR DESCRIPTION
#### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /tmp/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixes #16347: use proper `ansible_ssh_private_key_file` formatting.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Now test playbook works just fine:
`$ ansible-playbook test.yaml`

```
PLAY [SSH test] ****************************************************************

TASK [setup] *******************************************************************
ok: [XXX.compute-1.amazonaws.com]

TASK [ping] ********************************************************************
ok: [XXX.compute-1.amazonaws.com -> localhost]

TASK [synchronize] *************************************************************
changed: [XXX.compute-1.amazonaws.com]

PLAY RECAP *********************************************************************
XXX.compute-1.amazonaws.com : ok=3    changed=1    unreachable=0    failed=0
```
