### PR TITLE
Stop list contents being wrapped mid-word.

### DIFF
--- a/docsite/_themes/srtd/static/css/theme.css
+++ b/docsite/_themes/srtd/static/css/theme.css
@@ -3315,6 +3315,7 @@ code.code-large, .rst-content tt.code-large {
 .wy-plain-list-disc li, .rst-content .section ul li, .rst-content .toctree-wrapper ul li {
     list-style: disc;
     margin-left: 24px;
+    word-break: normal;
 }
 
 .wy-plain-list-disc li ul, .rst-content .section ul li ul, .rst-content .toctree-wrapper ul li ul {


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### SUMMARY

Fixes a styling issue on the docs site:

Before:

<img width="1060" alt="ansible_before" src="https://cloud.githubusercontent.com/assets/447579/16170044/652d19fa-353c-11e6-9be5-be11099dabeb.png">

After:

<img width="1054" alt="ansible_after" src="https://cloud.githubusercontent.com/assets/447579/16170045/67a081ae-353c-11e6-8ab9-5b822119962d.png">
