### PR TITLE
Remove PyPI download stats badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![PyPI version](https://img.shields.io/pypi/v/ansible.svg)](https://pypi.python.org/pypi/ansible)
-[![PyPI downloads](https://img.shields.io/pypi/dm/ansible.svg)](https://pypi.python.org/pypi/ansible)
 [![Build Status](https://api.shippable.com/projects/573f79d02a8192902e20e34b/badge?branch=devel)](https://app.shippable.com/projects/573f79d02a8192902e20e34b)
 
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

`ansible@devel`
##### SUMMARY

PyPI download stats have been disabled due to resource constraints (see Donald Stufft's comment, https://bitbucket.org/pypa/pypi/issues/396/download-stats-have-stopped-working-again#comment-27808922).

Thus the download stats badge counter does not show correct data.
