### PR TITLE
Fix quoting of args for old-style modules

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -608,7 +608,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 # the remote system, which can be read and parsed by the module
                 args_data = ""
                 for k,v in iteritems(module_args):
-                    args_data += '%s="%s" ' % (k, pipes.quote(text_type(v)))
+                    args_data += '%s=%s ' % (k, pipes.quote(text_type(v)))
                 self._transfer_data(args_file_path, args_data)
             elif module_style in ('non_native_want_json', 'binary'):
                 self._transfer_data(args_file_path, json.dumps(module_args))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This removes the extra layer of quotes around values in the 'args' file. These quotes were there before the pipes.quote() call was added (in 30d481ac571f1c95bcc7c69a09100c1af935445a), but were not removed, resulting in too much quoting.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

The `args` file in 2.1.0:

```
_ansible_version="2.1.0.0" _ansible_selinux_special_fs="'['"'"'fuse'"'"', '"'"'nfs'"'"', '"'"'vboxsf'"'"', '"'"'ramfs'"'"']'" _ansible_no_log="False" _ansible_diff="True" _ansible_verbosity="3" value="OpenWrt" _ansible_syslog_facility="LOG_USER" command="set" key="'system.@system[0].hostname'" _ansible_debug="False" _ansible_check_mode="False" 
```

And with this fix:

```
_ansible_version=2.2.0 _ansible_selinux_special_fs='['"'"'fuse'"'"', '"'"'nfs'"'"', '"'"'vboxsf'"'"', '"'"'ramfs'"'"']' _ansible_no_log=False _ansible_module_name=uci _ansible_diff=True _ansible_verbosity=3 value=OpenWrt2 _ansible_syslog_facility=LOG_USER command=set key='system.@system[0].hostname' _ansible_debug=False _ansible_check_mode=True 
```
