### PR TITLE
Lookup password omit salt

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -137,25 +137,23 @@ class LookupModule(LookupBase):
 
                 password = content
                 salt = None
-                if params['encrypt'] is not None:
-                    try:
-                        sep = content.rindex(' ')
-                    except ValueError:
-                        # No salt
-                        pass
-                    else:
-                        salt_field = content[sep + 1:]
-                        if salt_field.startswith('salt='):
-                            password = content[:sep]
-                            salt = salt_field[len('salt='):]
 
+                try:
+                    sep = content.rindex(' salt=')
+                except ValueError:
+                    # No salt
+                    pass
+                else:
+                    salt = password[sep + len(' salt='):]
+                    password = content[:sep]
+
+                if params['encrypt'] is not None and salt is None:
                     # crypt requested, add salt if missing
-                    if not salt:
-                        salt = self.random_salt()
-                        content = '%s salt=%s' % (password, salt)
-                        with open(path, 'w') as f:
-                            os.chmod(path, 0o600)
-                            f.write(content + '\n')
+                    salt = self.random_salt()
+                    content = '%s salt=%s' % (password, salt)
+                    with open(path, 'w') as f:
+                        os.chmod(path, 0o600)
+                        f.write(content + '\n')
 
             if params['encrypt']:
                 password = do_encrypt(password, params['encrypt'], salt=salt)

--- a/test/integration/roles/test_lookups/tasks/main.yml
+++ b/test/integration/roles/test_lookups/tasks/main.yml
@@ -39,6 +39,7 @@
   file: dest={{item}} state=absent
   with_items:
   - "{{output_dir}}/lookup/password"
+  - "{{output_dir}}/lookup/password_with_salt"
   - "{{output_dir}}/lookup"
 
 - name: create a password file
@@ -80,6 +81,48 @@
     that:
         - "wc_result.stdout == '9'"
         - "cat_result.stdout == newpass"
+        - "' salt=' not in cat_result.stdout"
+
+- name: fetch password from an existing file
+  set_fact:
+    pass2: "{{ lookup('password', output_dir + '/lookup/password length=8') }}"
+
+- name: read password (again)
+  shell: cat {{output_dir}}/lookup/password
+  register: cat_result2
+
+- debug: var=cat_result2.stdout
+
+- name: verify password (again)
+  assert:
+    that:
+        - "cat_result2.stdout == newpass"
+        - "' salt=' not in cat_result2.stdout"
+
+
+
+- name: create a password (with salt) file
+  debug: msg={{ lookup('password', output_dir + '/lookup/password_with_salt encrypt=sha256_crypt') }}
+
+- name: read password and salt
+  shell: cat {{output_dir}}/lookup/password_with_salt
+  register: cat_pass_salt
+
+- debug: var=cat_pass_salt.stdout
+
+- name: fetch unencrypted password
+  set_fact:
+    newpass: "{{ lookup('password', output_dir + '/lookup/password_with_salt') }}"
+
+- debug: var=newpass
+
+- name: verify password and salt
+  assert:
+    that:
+        - "cat_pass_salt.stdout != newpass"
+        - "cat_pass_salt.stdout.startswith(newpass)"
+        - "' salt=' in cat_pass_salt.stdout"
+        - "' salt=' not in newpass"
 
 # ENV LOOKUP
 

--- a/test/integration/roles/test_lookups/tasks/main.yml
+++ b/test/integration/roles/test_lookups/tasks/main.yml
@@ -35,8 +35,8 @@
 
 # PASSWORD LOOKUP
 
-- name: remove previous password files
-  file: dest={{output_dir}}/lookup/password state=absent
+- name: remove previous password files and directory
+  file: dest={{item}} state=absent
   with_items:
   - "{{output_dir}}/lookup/password"
   - "{{output_dir}}/lookup"

--- a/test/integration/roles/test_lookups/tasks/main.yml
+++ b/test/integration/roles/test_lookups/tasks/main.yml
@@ -124,6 +124,17 @@
         - "' salt=' in cat_pass_salt.stdout"
         - "' salt=' not in newpass"
 
+
+- name: fetch unencrypted password (using empty encrypt parameter)
+  set_fact:
+    newpass2: "{{ lookup('password', output_dir + '/lookup/password_with_salt encrypt=') }}"
+
+- name: verify lookup password behavior
+  assert:
+    that:
+        - "newpass == newpass2"
+
+
 # ENV LOOKUP
 
 - name: get first environment var name


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (lookup_password_omit_salt 75cd580e6b) last updated 2016/06/20 00:42:57 (GMT +200)
  lib/ansible/modules/core: (detached HEAD f0f5272f90) last updated 2016/06/20 00:45:51 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 6cb6829384) last updated 2016/06/20 00:45:51 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Unencrypted password lookup (password lookup with _encrypt_ parameter unset) must not return salt value.

Add two tests: one related to this issue, another about the behavior.
