### PR TITLE
[docker_container] image lookup should default to returning an empty list before searching

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -156,7 +156,7 @@ class AnsibleDockerClient(Client):
                                                                                            MIN_DOCKER_VERSION))
 
         self.debug = self.module.params.get('debug')
-        self.check_mode = self.module.check_mode
+        self.check_mode = self.module.check_mode  
         self._connect_params = self._get_connect_params()
 
         try:
@@ -398,9 +398,9 @@ class AnsibleDockerClient(Client):
         images = self._image_lookup(name, tag)
         if len(images) == 0:
             # In API <= 1.20 seeing 'docker.io/<name>' as the name of images pulled from docker hub
-            registry, repo_name = auth.resolve_repository_name(name)
+            registry, repo_name = auth.resolve_repository_name(name) 
             if registry == 'docker.io':
-                # the name does not contain a registry, so let's see if docker.io works
+                # the name does not contain a registry, so let's see if docker.io works 
                 lookup = "docker.io/%s" % name
                 self.log("Check for docker.io image: %s" % lookup)
                 images = self._image_lookup(lookup, tag)
@@ -424,7 +424,7 @@ class AnsibleDockerClient(Client):
         work consistently. Instead, get the result set for name and manually check if the tag
         exists.
         '''
-        images = list()
+        images = []
         try:
             response = self.images(name=name)
         except Exception as exc:

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -156,7 +156,7 @@ class AnsibleDockerClient(Client):
                                                                                            MIN_DOCKER_VERSION))
 
         self.debug = self.module.params.get('debug')
-        self.check_mode = self.module.check_mode  
+        self.check_mode = self.module.check_mode   
         self._connect_params = self._get_connect_params()
 
         try:

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -156,7 +156,7 @@ class AnsibleDockerClient(Client):
                                                                                            MIN_DOCKER_VERSION))
 
         self.debug = self.module.params.get('debug')
-        self.check_mode = self.module.check_mode   
+        self.check_mode = self.module.check_mode
         self._connect_params = self._get_connect_params()
 
         try:
@@ -398,9 +398,9 @@ class AnsibleDockerClient(Client):
         images = self._image_lookup(name, tag)
         if len(images) == 0:
             # In API <= 1.20 seeing 'docker.io/<name>' as the name of images pulled from docker hub
-            registry, repo_name = auth.resolve_repository_name(name) 
+            registry, repo_name = auth.resolve_repository_name(name)
             if registry == 'docker.io':
-                # the name does not contain a registry, so let's see if docker.io works 
+                # the name does not contain a registry, so let's see if docker.io works
                 lookup = "docker.io/%s" % name
                 self.log("Check for docker.io image: %s" % lookup)
                 images = self._image_lookup(lookup, tag)
@@ -418,24 +418,26 @@ class AnsibleDockerClient(Client):
         self.log("Image %s:%s not found." % (name, tag))
         return None
 
-    def _image_lookup(self, name, tag): 
+    def _image_lookup(self, name, tag):
         '''
-        Including a tag in the name parameter sent to the docker-py images method does not 
+        Including a tag in the name parameter sent to the docker-py images method does not
         work consistently. Instead, get the result set for name and manually check if the tag
         exists.
         '''
+        images = list()
         try:
             response = self.images(name=name)
         except Exception as exc:
             self.fail("Error searching for image %s - %s" % (name, str(exc)))
-        images = response
-        if tag: 
+        if tag:
             lookup = "%s:%s" % (name, tag)
             for image in response:
                 self.log(image, pretty_print=True)
                 if image.get('RepoTags') and lookup in image.get('RepoTags'):
                     images = [image]
                     break
+        else:
+            images = response
         return images
 
     def pull_image(self, name, tag="latest"):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

When pulling multiple tags of the same image, `_image_lookup()` was returning all existing images, without respect to the passed tag

**Example playbook:**

```

---

- docker_container:
    name: one
    image: alpine:3.1
    command: 'true'

- docker_container:
    name: two
    image: alpine:3.2
    command: 'true'
```

Expected outcome:
  Both images should be pulled and started

Current outcome:
  The second image is erroneously matched and attempted to be started

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
