### PR TITLE
Create unique name when two hosts have the same hostname

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -723,6 +723,9 @@ class Ec2Inventory(object):
         if self.pattern_exclude and self.pattern_exclude.match(hostname):
             return
 
+        if hostname in self.index:
+            hostname = hostname + '(%s)' % instance.id
+
         # Add to index
         self.index[hostname] = [region, instance.id]
 
@@ -854,6 +857,9 @@ class Ec2Inventory(object):
             hostname = dest
 
         hostname = self.to_safe(hostname).lower()
+
+        if hostname in self.index:
+            hostname = hostname + '(%s)' % instance.id
 
         # Add to index
         self.index[hostname] = [region, instance.id]


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 1db02dfb71) last updated 2016/06/20 10:03:16 (GMT -400)
  lib/ansible/modules/core: (detached HEAD f0f5272f90) last updated 2016/06/17 14:30:25 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 6cb6829384) last updated 2016/06/17 14:26:51 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

ec2.py allows specifying a different source for the inventory_name by setting hostname_variable in ec2.ini. An example is setting hostname_variable = tag_Name. In the event where there are multiple hosts with the same tag_Name value (hostname_variable) the subsequent instances overwrite the hostvars for the instance in the inventory file.

So if I had two instances named "app" and one had tag_env_dev and the other had tag_env_production, when running ansible/ansible-playbook with --limit tag_env_dev, the play would actually run against the instance tagged production.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Before

```
{
  "_meta": {
    "hostvars": {
      "app": {
...
  }, 
  "ami_f0091d91": [
    "app", 
    "app"
  ], 
```

After

```
{
  "_meta": {
    "hostvars": {
      "app": {
...
      }, 
      "app(i-d9f43776)": {
        "ansible_ssh_host": "10.95.101.221",
...
  }, 
  "ami_f0091d91": [
    "app", 
    "app(i-d9f43776)"
  ], 
```
