### PR TITLE
Add test for multi-options in authorized_key

### DIFF
--- a/test/integration/roles/test_authorized_key/tasks/main.yml
+++ b/test/integration/roles/test_authorized_key/tasks/main.yml
@@ -242,3 +242,31 @@
     that:
     - 'result.changed == False'
 
+# -------------------------------------------------------------
+# basic ssh-dss key with mutliple permit-open options
+# https://github.com/ansible/ansible-modules-core/issues/1715
+
+- name: add basic ssh-dss key with multi-opts
+  authorized_key: 
+    user: root 
+    key: "{{ dss_key_basic }}" 
+    key_options: 'no-agent-forwarding,no-X11-forwarding,permitopen="10.9.8.1:8080",permitopen="10.9.8.1:9001"'
+    state: present 
+    path: "{{output_dir|expanduser}}/authorized_keys"
+  register: result
+
+- name: assert that the key with multi-opts was added
+  assert:
+    that:
+    - 'result.changed == True'
+    - 'result.key == dss_key_basic'
+    - 'result.key_options == "no-agent-forwarding,no-X11-forwarding,permitopen=\"10.9.8.1:8080\",permitopen=\"10.9.8.1:9001\""'
+
+- name: get the file content
+  shell: cat "{{output_dir|expanduser}}/authorized_keys" | fgrep DATA_BASIC
+  register: content
+
+- name: validate content
+  assert:
+    that:
+        - 'content.stdout == "no-agent-forwarding,no-X11-forwarding,permitopen=\"10.9.8.1:8080\",permitopen=\"10.9.8.1:9001\" ssh-dss DATA_BASIC root@testing"'


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (TEST_AK_MULTI_OP 356e89b61b) last updated 2016/06/20 17:51:53 (GMT -400)
  lib/ansible/modules/core: (devel 343c3ecfb9) last updated 2016/06/20 17:33:58 (GMT -400)
  lib/ansible/modules/extras: (devel 713aaa1d4a) last updated 2016/06/20 17:34:03 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Addresses https://github.com/ansible/ansible-modules-core/issues/1715
