### PR TITLE
Add python-passlib to docker images.

### DIFF
--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -23,6 +23,7 @@ RUN yum clean all && \
     python-mock \
     python-nose \
     python-paramiko \
+    python-passlib \
     python-pip \
     python-setuptools \
     python-virtualenv \

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -32,6 +32,7 @@ RUN yum clean all && \
     python-mock \
     python-nose \
     python-paramiko \
+    python-passlib \
     python-pip \
     python-setuptools \
     python-virtualenv \

--- a/test/utils/docker/fedora-rawhide/Dockerfile
+++ b/test/utils/docker/fedora-rawhide/Dockerfile
@@ -35,6 +35,7 @@ RUN dnf clean all && \
     python-mock \
     python-nose \
     python-paramiko \
+    python-passlib \
     python-pip \
     python-setuptools \
     python-virtualenv \

--- a/test/utils/docker/fedora23/Dockerfile
+++ b/test/utils/docker/fedora23/Dockerfile
@@ -34,6 +34,7 @@ RUN dnf clean all && \
     python-mock \
     python-nose \
     python-paramiko \
+    python-passlib \
     python-pip \
     python-setuptools \
     python-virtualenv \

--- a/test/utils/docker/opensuseleap/Dockerfile
+++ b/test/utils/docker/opensuseleap/Dockerfile
@@ -38,6 +38,7 @@ RUN zypper --non-interactive install --auto-agree-with-licenses \
     python-mock \
     python-nose \
     python-paramiko \
+    python-passlib \
     python-pip \
     python-setuptools \
     python-virtualenv

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update -y && \
     python-mysqldb \
     python-nose \
     python-paramiko \
+    python-passlib \
     python-pip \
     python-setuptools \
     python-virtualenv \

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
     python-mysqldb \
     python-nose \
     python-paramiko \
+    python-passlib \
     python-pip \
     python-setuptools \
     python-virtualenv \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update -y && \
     python-mysqldb \
     python-nose \
     python-paramiko \
+    python-passlib \
     python-pip \
     python-setuptools \
     python-virtualenv \


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (integration-tests-add-python-passlib e6ba324680) last updated 2016/06/21 00:56:58 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 343c3ecfb9) last updated 2016/06/21 00:53:59 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 9392943915) last updated 2016/06/21 00:53:59 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Required by #16361.
