### PR TITLE
fixed plugin directories

### DIFF
--- a/docsite/rst/developing_plugins.rst
+++ b/docsite/rst/developing_plugins.rst
@@ -106,13 +106,12 @@ Distributing Plugins
 Plugins are loaded from both Python's site_packages (those that ship with ansible) and a configured plugins directory, which defaults
 to /usr/share/ansible/plugins, in a subfolder for each plugin type::
 
-    * action_plugins
-    * lookup_plugins
-    * callback_plugins
-    * connection_plugins
-    * filter_plugins
-    * vars_plugins
-    * strategy_plugins
+    * action
+    * lookup
+    * callback
+    * connection
+    * filter
+    * strategy
 
 To change this path, edit the ansible configuration file.
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

All
##### SUMMARY

The paths written in the docs for the plugins is inconsistent with [lib/ansible/constants.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/constants.py).
