### PR TITLE
Fix misleading error about args unsupported by pywinrm

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -111,21 +111,21 @@ class Connection(ConnectionBase):
         if unsupported_transports:
             raise AnsibleError('The installed version of WinRM does not support transport(s) %s' % list(unsupported_transports))
 
+        # arg names we're going to handle separately
+        internal_kwarg_mask = set(['self', 'endpoint', 'transport', 'username', 'password', 'scheme', 'path'])
+
         self._winrm_kwargs = dict(username=self._winrm_user, password=self._winrm_pass)
         argspec = inspect.getargspec(Protocol.__init__)
-        supported_winrm_args = set(argspec.args)
-        passed_winrm_args = set([v.replace('ansible_winrm_', '') for v in hostvars if v.startswith('ansible_winrm_')])
+        supported_winrm_args = set(argspec.args).difference(internal_kwarg_mask)
+        passed_winrm_args = set([v.replace('ansible_winrm_', '') for v in hostvars if v.startswith('ansible_winrm_')]).difference(internal_kwarg_mask)
         unsupported_args = passed_winrm_args.difference(supported_winrm_args)
 
         # warn for kwargs unsupported by the installed version of pywinrm
         for arg in unsupported_args:
             display.warning("ansible_winrm_{0} unsupported by pywinrm (is an up-to-date version of pywinrm installed?)".format(arg))
 
-        # arg names we're going passing directly
-        internal_kwarg_mask = set(['self', 'endpoint', 'transport', 'username', 'password'])
-
         # pass through matching kwargs, excluding the list we want to treat specially
-        for arg in passed_winrm_args.difference(internal_kwarg_mask).intersection(supported_winrm_args):
+        for arg in passed_winrm_args.intersection(supported_winrm_args):
             self._winrm_kwargs[arg] = hostvars['ansible_winrm_%s' % arg]
 
     def _winrm_connect(self):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This fixes #16380 and #15772, a more detailed explanation can be found in the former bug report. In short:

When you specify ansible_winrm_path, you will be greeted by a warning:

```
 [WARNING]: ansible_winrm_path unsupported by pywinrm (is an up-to-date version of pywinrm installed?)
```

The warning is misleading since the option actually works.

By shuffling some sets around and adding `ansible_winrm_path` and `ansible_winrm_scheme` to the list of internal args, I got rid of that warning.

Before:

```
 [WARNING]: ansible_winrm_path unsupported by pywinrm (is an up-to-date version of pywinrm installed?)

 [WARNING]: ansible_winrm_path unsupported by pywinrm (is an up-to-date version of pywinrm installed?)

winko.example.com | UNREACHABLE! => {
    "changed": false, 
    "msg": "kerberos: (u'http', u'Bad HTTP response returned from server. Code 404'), ssl: (u'http', u'Bad HTTP response returned from server. Code 404')", 
    "unreachable": true
}
winok.example.com | SUCCESS => {
    "changed": false, 
    "ping": "pong"
}
```

After:

```
winko.example.com | UNREACHABLE! => {
    "changed": false, 
    "msg": "kerberos: (u'http', u'Bad HTTP response returned from server. Code 404'), ssl: (u'http', u'Bad HTTP response returned from server. Code 404')", 
    "unreachable": true
}
winok.examle.com | SUCCESS => {
    "changed": false, 
    "ping": "pong"
}
```
