### PR TITLE
fixed memoryerror when coping huge file

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -331,11 +331,11 @@ class DataLoader():
 
         try:
             with open(to_bytes(real_path), 'rb') as f:
-                data = f.read()
-                if self._vault.is_encrypted(data):
+                if self._vault.is_encrypted(f):
                     # if the file is encrypted and no password was specified,
                     # the decrypt call would throw an error, but we check first
                     # since the decrypt function doesn't know the file name
+                    data = f.read()
                     if not self._vault_password:
                         raise AnsibleParserError("A vault password must be specified to decrypt %s" % file_path)
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -110,6 +110,12 @@ class VaultLib:
         :returns: True if it is recognized.  Otherwise, False.
         """
 
+        if isinstance(data, file):
+            current_position = data.tell()
+            header_part = data.read(len(b_HEADER))
+            data.seek(current_position)
+            return self.is_encrypted(header_part)
+
         if to_bytes(data, errors='strict', encoding='utf-8').startswith(b_HEADER):
             return True
         return False

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -110,7 +110,7 @@ class VaultLib:
         :returns: True if it is recognized.  Otherwise, False.
         """
 
-        if isinstance(data, file):
+        if hasattr(data, 'read'):
             current_position = data.tell()
             header_part = data.read(len(b_HEADER))
             data.seek(current_position)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->
- vault.is_encrypted accept file object
- dataloader call vault.is_encrypted with file object in order to avoid memory error

Fixes #16391

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
$ ansible-playbook -i hosts huge_copy.yml 

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
ok: [192.168.80.129]

TASK [Copy huge file] **********************************************************
changed: [192.168.80.129]

PLAY RECAP *********************************************************************
192.168.80.129             : ok=2    changed=1    unreachable=0    failed=0   
```
