### PR TITLE
Remove break word for docsite tables

### DIFF
--- a/docsite/_themes/srtd/static/css/theme.css
+++ b/docsite/_themes/srtd/static/css/theme.css
@@ -4737,10 +4737,6 @@ span[id*='MathJax-Span'] {
     max-width: 100%;
 }
 
-td {
-    word-break: break-word;
-}
-
 th, td {
     min-width: 100px;
 }


### PR DESCRIPTION
This still allows the lines to wrap with lots of text, like comments cells.
