### PR TITLE
Docker Connection Plugin Remote fix

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -74,6 +74,9 @@ class Connection(ConnectionBase):
             if not self.docker_cmd:
                 raise AnsibleError("docker command not found in PATH")
 
+        if self._play_context.docker_extra_args:
+            self.docker_cmd += self._play_context.docker_extra_args.split(' ')
+
         docker_version = self._get_docker_version()
         if LooseVersion(docker_version) < LooseVersion('1.3'):
             raise AnsibleError('docker connection type requires docker 1.3 or higher')
@@ -107,9 +110,6 @@ class Connection(ConnectionBase):
     def _get_docker_version(self):
 
         cmd = [self.docker_cmd]
-
-        if self._play_context.docker_extra_args:
-            cmd += self._play_context.docker_extra_args.split(' ')
 
         cmd += ['version']
 
@@ -151,9 +151,6 @@ class Connection(ConnectionBase):
         """
 
         local_cmd = [self.docker_cmd]
-
-        if self._play_context.docker_extra_args:
-            local_cmd += self._play_context.docker_extra_args.split(' ')
 
         local_cmd += ['exec']
 

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -115,7 +115,7 @@ class Connection(ConnectionBase):
 
     def _get_docker_version(self):
 
-        cmd = self._get_docker_cmd
+        cmd = self._get_docker_cmd()
 
         cmd += ['version']
 
@@ -126,7 +126,7 @@ class Connection(ConnectionBase):
                 return self._sanitize_version(line.split()[2])
 
         # no result yet, must be newer Docker version
-        new_docker_cmd = self._get_docker_cmd + [
+        new_docker_cmd = self._get_docker_cmd() + [
             'version', '--format', "'{{.Server.Version}}'"
         ]
 
@@ -136,7 +136,7 @@ class Connection(ConnectionBase):
 
     def _get_docker_remote_user(self):
         """ Get the default user configured in the docker container """
-        p = subprocess.Popen(self._get_docker_cmd + ['inspect', '--format', '{{.Config.User}}', self._play_context.remote_addr],
+        p = subprocess.Popen(self._get_docker_cmd() + ['inspect', '--format', '{{.Config.User}}', self._play_context.remote_addr],
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         out, err = p.communicate()
@@ -155,7 +155,7 @@ class Connection(ConnectionBase):
             version we are using, it will be provided to docker exec.
         """
 
-        local_cmd = self._get_docker_cmd
+        local_cmd = self._get_docker_cmd()
 
         local_cmd += ['exec']
 
@@ -242,7 +242,7 @@ class Connection(ConnectionBase):
         # file path
         out_dir = os.path.dirname(out_path)
 
-        args = self._get_docker_cmd + ["cp", "%s:%s" % (self._play_context.remote_addr, in_path), out_dir]
+        args = self._get_docker_cmd() + ["cp", "%s:%s" % (self._play_context.remote_addr, in_path), out_dir]
         args = [to_bytes(i, errors='strict') for i in args]
 
         p = subprocess.Popen(args, stdin=subprocess.PIPE,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

Commit dd4c56e4d68664e4a50292aa19ea61b15c92287c
##### SUMMARY

The `docker_extra_vars` were not applied to all Docker calls within the [docker.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/connection/docker.py) connection. Now they will be.
