### PR TITLE
Bug fix for GalaxyCLI.execute_info FIXME

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -144,7 +144,7 @@ class GalaxyCLI(CLI):
 
         text = [u"", u"Role: %s" % to_unicode(role_info['name'])]
         text.append(u"\tdescription: %s" % role_info.get('description', ''))
-
+        
         for k in sorted(role_info.keys()):
 
             if k in self.SKIP_INFO_KEYS:
@@ -158,7 +158,7 @@ class GalaxyCLI(CLI):
                     text.append(u"\t\t%s: %s" % (key, role_info[k][key]))
             else:
                 text.append(u"\t%s: %s" % (k, role_info[k]))
-
+        
         return u'\n'.join(text)
 
 ############################
@@ -174,7 +174,7 @@ class GalaxyCLI(CLI):
         init_path  = self.get_opt('init_path', './')
         force      = self.get_opt('force', False)
         offline    = self.get_opt('offline', False)
-
+        
         role_name = self.args.pop(0).strip() if self.args else None
         if not role_name:
             raise AnsibleOptionsError("- no role name specified for init")
@@ -305,9 +305,9 @@ class GalaxyCLI(CLI):
                 role_info.update(role_spec)
 
             data = self._display_role_info(role_info)
-            ### FIXME: This is broken in both 1.9 and 2.0 as
-            # _display_role_info() always returns something
-            if not data:
+            
+            role_location = os.path.join(roles_path[0], role)
+            if (os.path.exists(role_location) == False):
                 data = u"\n- the role %s was not found" % role
 
         self.pager(data)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -306,7 +306,10 @@ class GalaxyCLI(CLI):
 
             data = self._display_role_info(role_info)
             
-            role_location = os.path.join(roles_path[0], role)
+            for path in roles_path:
+                role_location = os.path.join(path, role)
+                if (os.path.exists(role_location == True):
+                    break  # if it exists, stop looking
             if (os.path.exists(role_location) == False):
                 data = u"\n- the role %s was not found" % role
 

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -55,8 +55,8 @@ class TestGalaxy(unittest.TestCase):
         role_info = {'name': 'some_role_name',
                      'galaxy_info': galaxy_info}
         display_result = gc._display_role_info(role_info)
-        if display_result.find('\t\tgalaxy_tags:') > -1:
-            self.fail('Expected galaxy_tags to be indented twice')
+        if display_result.find('\n\tgalaxy_info:') == -1:
+            self.fail('Expected galaxy_info to be indented once')
 
     @patch.object(GalaxyToken, "__init__", return_value=None)  # mocks file being opened/created
     def test_parse(self, mocked_token):
@@ -68,19 +68,19 @@ class TestGalaxy(unittest.TestCase):
                 if arg in gc.VALID_ACTIONS:
                     first_arg = arg  # used for testing after a parser is created
                     break  # stop after a valid action is identified
-        if first_arg == False:  # checking right error is raised
-            with patch('sys.argv', ["-c"]):
-                self.assertRaises(AnsibleOptionsError, gc.parse)
-        else:
-            with patch('sys.argv', ["-c"]):
-                created_parser = gc.parse()
-            self.assertTrue(created_parser)
-            self.assertTrue(isinstance(gc.parser, ansible.cli.SortedOptParser))
-            self.assertTrue(isinstance(gc.galaxy, ansible.galaxy.Galaxy))
-            self.assertTrue(gc.action)
-            self.assertTrue(gc.options.roles_path == ['/etc/ansible/roles'])
-            self.assertTrue(gc.action == first_arg)
-            self.assertNotIn(first_arg, arguments)
+            if first_arg == False:  # checking right error is raised
+                with patch('sys.argv', ["-c"]):
+                    self.assertRaises(AnsibleOptionsError, gc.parse)
+            else:
+                with patch('sys.argv', ["-c"]):
+                    created_parser = gc.parse()
+                self.assertTrue(created_parser)
+                self.assertTrue(isinstance(gc.parser, ansible.cli.SortedOptParser))
+                self.assertTrue(isinstance(gc.galaxy, ansible.galaxy.Galaxy))
+                self.assertTrue(gc.action)
+                self.assertTrue(gc.options.roles_path == ['/etc/ansible/roles'])
+                self.assertTrue(gc.action == first_arg)
+                self.assertNotIn(first_arg, arguments)
 
     @patch.object(GalaxyToken, "__init__", return_value=None)  # mocks file being opened/created
     def test_run(self, mocked_token):

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -24,6 +24,12 @@ from ansible.compat.tests import unittest
 
 from nose.plugins.skip import SkipTest
 
+from ansible.galaxy.token import GalaxyToken
+from ansible.cli import CLI
+from mock import patch, MagicMock
+from ansible.errors import AnsibleError, AnsibleOptionsError
+import ansible
+
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
 
@@ -51,3 +57,49 @@ class TestGalaxy(unittest.TestCase):
         display_result = gc._display_role_info(role_info)
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
+
+    @patch.object(GalaxyToken, "__init__", return_value=None)  # mocks file being opened/created
+    def test_parse(self, mocked_token):
+        ''' tests that an options parser is created for bin/ansible '''
+        for arguments in [[], ["list", "info"], ["bad_arg", "list"], ["bad_arg", "invalid"]]:
+            gc = GalaxyCLI(args=arguments)
+            first_arg = False
+            for arg in arguments:
+                if arg in gc.VALID_ACTIONS:
+                    first_arg = arg  # used for testing after a parser is created
+                    break  # stop after a valid action is identified
+        if first_arg == False:  # checking right error is raised
+            with patch('sys.argv', ["-c"]):
+                self.assertRaises(AnsibleOptionsError, gc.parse)
+        else:
+            with patch('sys.argv', ["-c"]):
+                created_parser = gc.parse()
+            self.assertTrue(created_parser)
+            self.assertTrue(isinstance(gc.parser, ansible.cli.SortedOptParser))
+            self.assertTrue(isinstance(gc.galaxy, ansible.galaxy.Galaxy))
+            self.assertTrue(gc.action)
+            self.assertTrue(gc.options.roles_path == ['/etc/ansible/roles'])
+            self.assertTrue(gc.action == first_arg)
+            self.assertNotIn(first_arg, arguments)
+
+    @patch.object(GalaxyToken, "__init__", return_value=None)  # mocks file being opened/created
+    def test_run(self, mocked_token):
+        ''' verifies that the GalaxyCLI object's api is created and that execute() is called. '''
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["-c", "-v", '--ignore-errors', 'imaginary_role']):
+            galaxy_parser = gc.parse()
+        gc.execute = MagicMock()
+        with patch.object(CLI, "run", return_value=None) as mock_obj:  # to eliminate config or default file used message
+            gc.run()
+        self.assertTrue(gc.execute.called)
+        self.assertTrue(isinstance(gc.api, ansible.galaxy.api.GalaxyAPI))
+
+    @patch.object(GalaxyToken, "__init__", return_value=None)  # mocks file being opened/created
+    def test_exit_without_ignore(self, mocked_toekn):
+        ''' tests that GalaxyCLI exits with the error specified'''
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["-c", "-v"]):
+            galaxy_parser = gc.parse()
+        with patch.object(CLI, "run", return_value=None) as mock_obj:  # to eliminate config or default file used message
+            self.assertRaises(AnsibleError, gc.run)
+


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The initial code was broken for both 1.9 and 2.0 because another method (GalaxyCLI._display_role_info) was changed (to always return something). The intention of the old code was trying to identify whether or not the role existed (by the returned value from the aforementioned method). My fix for the code looks at the role's path and checks that the directory for the role actually exists.
