### PR TITLE
Refactor inventory group 'list' data structures to 'sets'

### DIFF
--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -142,17 +142,17 @@ class InventoryDirectory(object):
                 # iterate on a copy of the lists, as those lists get changed in
                 # the loop
                 # list with group's child group objects:
-                for child in group.child_groups[:]:
+                for child in group.child_groups.copy():
                     if child != self.groups[child.name]:
                         group.child_groups.remove(child)
-                        group.child_groups.append(self.groups[child.name])
+                        group.child_groups.add(self.groups[child.name])
                 # list with group's parent group objects:
-                for parent in group.parent_groups[:]:
+                for parent in group.parent_groups.copy():
                     if parent != self.groups[parent.name]:
                         group.parent_groups.remove(parent)
                         group.parent_groups.append(self.groups[parent.name])
                 # list with group's host objects:
-                for host in group.hosts[:]:
+                for host in group.hosts.copy():
                     if host != self.hosts[host.name]:
                         group.hosts.remove(host)
                         group.hosts.append(self.hosts[host.name])
@@ -177,7 +177,7 @@ class InventoryDirectory(object):
         if 'all' in self.groups:
             allgroup = self.groups['all' ]
             # loop on a copy of all's  child groups, as we want to change that list
-            for group in allgroup.child_groups[:]:
+            for group in allgroup.child_groups.copy():
                 # groups might once have beeen added to all, and later be added
                 # to another group: we need to remove the link wit all then
                 if len(group.parent_groups) > 1 and allgroup in group.parent_groups:

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -49,9 +49,9 @@ class Host:
         return hash(self.name)
 
     def serialize(self):
-        groups = []
+        groups = set()
         for group in self.groups:
-            groups.append(group.serialize())
+            groups.add(group.serialize())
 
         return dict(
             name=self.name,
@@ -76,13 +76,13 @@ class Host:
         for group_data in groups:
             g = Group()
             g.deserialize(group_data)
-            self.groups.append(g)
+            self.groups.add(g)
 
     def __init__(self, name=None, port=None):
 
         self.name = name
         self.vars = {}
-        self.groups = []
+        self.groups = set()
 
         self.address = name
 
@@ -108,7 +108,7 @@ class Host:
 
     def add_group(self, group):
 
-        self.groups.append(group)
+        self.groups.add(group)
 
     def set_variable(self, key, value):
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible-playbook 2.2.0 (group_lists_to_group_sets 78ab5206a7) last updated 2016/06/22 17:38:59 (GMT +200)
  lib/ansible/modules/core: (devel a8072f9ef0) last updated 2016/06/07 09:13:22 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/01 14:11:22 (GMT +200)

```
##### SUMMARY

As a follow up to my inventory performance tuning PR in https://github.com/ansible/ansible/pull/13957 I suggest to make use of `set` instead of `list` in places where it makes more sense.

In particular Group object lists and lists of unique Host objects do benefit from faster membership checks _vis-a-vis_ appends or adds. Membership checks (`x in s`) are much faster for sets than for lists.

The parsing time of our ["large inventory test case"](https://github.com/towolf/ansible-large-inventory-testcase) went from 4 to 3 seconds. Benefits during playbook execution are expected. Further tuning in this area in follow-up PRs.

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
git clone https://github.com/towolf/ansible-large-inventory-testcase.git
cd ansible-large-inventory-testcase
time ansible-playbook -i inventory.sh playbook.yml
```

Results (difference in function internal execution time):

``` json
 before  2140824 function calls (2114230 primitive calls) in 4.251 seconds
 after   2209086 function calls (2182492 primitive calls) in 3.263 seconds


ncalls tottime percall cumtime percall filename:lineno(function)
  8535  -1.013   0.000  -1.016   0.000 devel/lib/ansible/inventory/group.py:80(add_child_group)                    
 25607  -0.003   0.000  -0.010   0.000 devel/lib/ansible/inventory/__init__.py:744(_get_hostgroup_vars)            
 68286  -0.001   0.000   0.015   0.000 devel/lib/ansible/inventory/group.py:127(get_hosts)                         
     1  -0.001  -0.001  -1.004  -1.004 devel/lib/ansible/inventory/__init__.py:103(parse_inventory)                
  8534  -0.001   0.000  -0.006   0.000 devel/lib/ansible/inventory/__init__.py:551(get_host_variables)             
 17072  -0.001   0.000  -0.004   0.000 devel/lib/ansible/inventory/__init__.py:720(get_group_vars)                 
  8534  -0.001   0.000  -0.006   0.000 devel/lib/ansible/inventory/__init__.py:557(_get_host_variables)            
     1   0.000   0.000  -0.989  -0.989 devel/bin/ansible-playbook:21(<module>)                                     
     1   0.000   0.000   0.003   0.003 devel/lib/ansible/cli/playbook.py:22(<module>)                              
     1   0.000   0.000  -0.992  -0.992 devel/lib/ansible/cli/playbook.py:89(run)                                   
     1   0.000   0.000   0.004   0.004 devel/lib/ansible/executor/playbook_executor.py:19(<module>)                
     1   0.000   0.000   0.004   0.004 devel/lib/ansible/executor/playbook_executor.py:223(_get_serialized_batches)
     1   0.000   0.000   0.014   0.014 devel/lib/ansible/executor/playbook_executor.py:61(run)                     
     1   0.000   0.000   0.004   0.004 devel/lib/ansible/executor/play_iterator.py:19(<module>)                    
     1   0.000   0.000   0.004   0.004 devel/lib/ansible/executor/task_queue_manager.py:19(<module>)               
     1   0.000   0.000   0.018   0.018 devel/lib/ansible/executor/task_queue_manager.py:206(run)                   
     1   0.000   0.000  -0.993  -0.993 devel/lib/ansible/inventory/dir.py:36(get_file_parser)                      
  8536   0.000   0.000  -0.001   0.000 devel/lib/ansible/inventory/__init__.py:176(_match_list)                    
    20   0.000   0.000   0.015   0.001 devel/lib/ansible/inventory/__init__.py:191(get_hosts)                      
     4   0.000   0.000   0.015   0.004 devel/lib/ansible/inventory/__init__.py:302(_evaluate_patterns)             
     4   0.000   0.000   0.016   0.004 devel/lib/ansible/inventory/__init__.py:326(_match_one_pattern)             
     2   0.000   0.000   0.015   0.007 devel/lib/ansible/inventory/__init__.py:441(_enumerate_matches)             
  8536   0.000   0.000  -0.002   0.000 devel/lib/ansible/inventory/__init__.py:520(get_group_variables)            
  8536   0.000   0.000  -0.001   0.000 devel/lib/ansible/inventory/__init__.py:525(_get_group_variables)           
     1   0.000   0.000  -1.005  -1.005 devel/lib/ansible/inventory/__init__.py:54(__init__)                        
  8535   0.000   0.000  -0.007   0.000 devel/lib/ansible/inventory/__init__.py:716(get_host_vars)                  
     1   0.000   0.000  -0.993  -0.993 devel/lib/ansible/inventory/script.py:40(__init__)                          
     1   0.000   0.000  -0.993  -0.993 devel/lib/ansible/inventory/script.py:72(_parse)                            
     2   0.000   0.000  -0.001   0.000 devel/lib/ansible/parsing/dataloader.py:72(load)                            
     6   0.000   0.000   0.013   0.003 devel/lib/ansible/plugins/strategy/__init__.py:453(_wait_on_pending_results)
     1   0.000   0.000   0.013   0.013 devel/lib/ansible/plugins/strategy/linear.py:152(run)                       
 34172   0.000   0.000  -0.004   0.000 devel/lib/ansible/utils/vars.py:34(_validate_mutable_mappings)              
    39   0.000   0.000   0.009   0.000 {__import__}                                                                                         
117270   0.000   0.000  -0.004   0.000 {isinstance}                                                                                         
 34172   0.001   0.000  -0.006   0.000 devel/lib/ansible/utils/vars.py:57(combine_vars)                            
 60092   0.002   0.000   0.000   0.000 {map}                                                                                                
  8538   0.005   0.000  -0.053   0.000 devel/lib/ansible/inventory/host.py:81(__init__)                            
   171   0.011   0.000   0.011   0.000 {time.sleep}    

```
