### PR TITLE
Colorize around text

### DIFF
--- a/lib/ansible/utils/color.py
+++ b/lib/ansible/utils/color.py
@@ -78,10 +78,10 @@ def stringc(text, color):
 
 def colorize(lead, num, color):
     """ Print 'lead' = 'num' in 'color' """
+    s = u"%s=%-4s" % (lead, str(num))
     if num != 0 and ANSIBLE_COLOR and color is not None:
-        return u"%s%s%-15s" % (stringc(lead, color), stringc("=", color), stringc(str(num), color))
-    else:
-        return u"%s=%-4s" % (lead, str(num))
+        s = stringc(s, color)
+    return s
 
 def hostcolor(host, stats, color=True):
     if ANSIBLE_COLOR and color:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (devel dae0b833f5) last updated 2016/06/23 16:07:47 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 4fe583e29b) last updated 2016/06/23 14:58:51 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 709114d55f) last updated 2016/06/23 14:58:53 (GMT +200)
  config file = /cygdrive/c/Users/ag32c53n/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Avoid to colorize separately `lead`, equals sign and `num` and separate
them by coloring characters.
This allow to grep for things like `changed=[^0]` even if the output is colorized (forced in my case)

Before:

```
'\x1b[0;32mchanged\x1b[0m\x1b[0;32m=\x1b[0m\x1b[0;32m9\x1b[0m   '
```

After:

```
'\x1b[0;32mchanged=9   \x1b[0m'
```
