### PR TITLE
bug fix changes Config class in network to only raise exceptions

### DIFF
--- a/lib/ansible/module_utils/network.py
+++ b/lib/ansible/module_utils/network.py
@@ -116,11 +116,6 @@ class Config(object):
         except AttributeError:
             exc = get_exception()
             raise NetworkError('undefined method "%s"' % method.__name__, exc=str(exc))
-        except NetworkError:
-            if raise_exc:
-                raise
-            exc = get_exception()
-            self.fail_json(msg=exc.message, **exc.kwargs)
         except NotImplementedError:
             raise NetworkError('method not supported "%s"' % method.__name__)
 


### PR DESCRIPTION
The Config class should only raise exceptions and allow the implementor to handle them since the instance of Config doesn't have a reference to the module instance
