### PR TITLE
Add Slack notifications for Shippable.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -68,3 +68,11 @@ integrations:
       on_failure: always
       on_start: never
       on_pull_request: always
+    - integrationName: slack
+      type: slack
+      recipients:
+      - "#shippable"
+      on_success: change
+      on_failure: always
+      on_start: never
+      on_pull_request: never


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (slack-notifications 7635b7da45) last updated 2016/06/23 21:32:52 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 4fe583e29b) last updated 2016/06/23 14:46:45 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 709114d55f) last updated 2016/06/23 14:46:45 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Send notifications to the Ansible Slack channel #shippable on build failures and fixed builds.
