### PR TITLE
Enable Shippable email notifications.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -56,8 +56,10 @@ integrations:
   notifications:
     - integrationName: email
       type: email
-      on_success: never
-      on_failure: never
+      recipients:
+        --last_committer
+      on_success: change
+      on_failure: always
       on_start: never
       on_pull_request: never
     - integrationName: irc


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (shippable-email 76ef5bbfe2) last updated 2016/06/23 22:47:45 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 4fe583e29b) last updated 2016/06/23 14:46:45 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 709114d55f) last updated 2016/06/23 14:46:45 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Enable email notifications for failed and recovered builds, notifying the last committer.
