### PR TITLE
Enabling possibility to use different configuration modes for juniper modules #16433

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -120,7 +120,7 @@ class Cli(object):
         commands.insert(0, 'configure')
 
         if kwargs.get('comment'):
-            commands.append('commit comment "%s"' % kwargs.get('comment'))
+            commands.append('commit and-quit comment "%s"' % kwargs.get('comment'))
         else:
             commands.append('commit and-quit')
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Enable the possibility to use different configuration modes than just the shared candidate file on juniper devices. Fixes #16433 

load_config now accept the argument mode and will open a Config object with mode set to either default None, private, dynamic, batch or exclusive.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

netconf debug output from device:

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
# mode: "private"
<open-configuration><private/></open-configuration>
```
