### PR TITLE
Run ansible -m ping on supported python versions.

### DIFF
--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -15,7 +15,14 @@ if [ "${TOXENV}" = 'py24' ]; then
     python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce|docker_common|azure_rm_common|vca|vmware).py' lib/ansible/module_utils
 else
     if [ "${install_deps}" != "" ]; then
-        pip install tox
+        pip install \
+            tox \
+            pyyaml \
+            jinja2 \
+            setuptools \
+            --upgrade
+
+        pip list
     fi
 
     xunit_dir="${source_root}/shippable/testresults"
@@ -28,4 +35,9 @@ else
     coverage_file="${coverage_dir}/nosetests-coverage.xml"
 
     TOX_TESTENV_PASSENV=NOSETESTS NOSETESTS="nosetests --with-xunit --xunit-file='${xunit_file}' --cover-xml --cover-xml-file='${coverage_file}'" tox
+
+    source hacking/env-setup
+    python --version
+    ansible --version
+    ansible -m ping localhost
 fi


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (expand-tests 1fea5f1929) last updated 2016/06/24 14:23:11 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 4fe583e29b) last updated 2016/06/23 14:46:45 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 709114d55f) last updated 2016/06/23 14:46:45 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Run `ansible -m ping localhost` as part of the sanity tests on Shippable, which run for each supported version of python. This will catch simple errors with Python version compatibility, such as the one which was fixed by PR #16440.
