### PR TITLE
Adding _ under CLI_PROMPTS_RE variable in lib/module_utils/shell.py t…

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -39,8 +39,8 @@ from ansible.module_utils.basic import get_exception
 ANSI_RE = re.compile(r'(\x1b\[\?1h\x1b=)')
 
 CLI_PROMPTS_RE = [
-    re.compile(r'[\r\n]?[a-zA-Z]{1}[a-zA-Z0-9-]*[>|#|%](?:\s*)$'),
-    re.compile(r'[\r\n]?[a-zA-Z]{1}[a-zA-Z0-9-]*\(.+\)#(?:\s*)$')
+    re.compile(r'[\r\n]?[a-zA-Z]{1}[a-zA-Z0-9-_]*[>|#|%](?:\s*)$'),
+    re.compile(r'[\r\n]?[a-zA-Z]{1}[a-zA-Z0-9-_]*\(.+\)#(?:\s*)$')
 ]
 
 CLI_ERRORS_RE = [


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
latest
```
##### SUMMARY

When you are configure Cisco router/switch with hostname that contains underscore the ios_command module does not work.

The hostname on the router:
`Router_1#`

```
$ ansible-playbook test_playbook.yml -i inventory

PLAY [Test playbook] ***********************************************************

TASK [setup] *******************************************************************
ok: [router]

TASK [Test IOS command module] *************************************************
fatal: [router]: FAILED! => {"changed": false, "failed": true, "msg": "failed to connecto to 192.168.35.121:22 - "}

NO MORE HOSTS LEFT *************************************************************
    to retry, use: --limit @test_playbook.retry

PLAY RECAP *********************************************************************
router                     : ok=1    changed=0    unreachable=0    failed=1
```

The module uses shell.py file and CLI_PROMPTS_RE variable. In each element in the list the underscore is missing. After adding the underscore in the regex, the ansible correctly execute the task. 

```

$ ansible-playbook test_playbook.yml -i inventory

PLAY [Test playbook] ***********************************************************

TASK [setup] *******************************************************************
ok: [router]

TASK [Test IOS command module] *************************************************
ok: [router]

PLAY RECAP *********************************************************************
router                     : ok=2    changed=0    unreachable=0    failed=0
```
