### PR TITLE
Make '/usr/share/ansible' default modules path

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -146,7 +146,7 @@ DEFAULT_PATTERN           = get_config(p, DEFAULTS, 'pattern', None, None)
 #### GENERALLY CONFIGURABLE THINGS ####
 DEFAULT_DEBUG             = get_config(p, DEFAULTS, 'debug',            'ANSIBLE_DEBUG',            False, boolean=True)
 DEFAULT_HOST_LIST         = get_config(p, DEFAULTS,'inventory', 'ANSIBLE_INVENTORY', DEPRECATED_HOST_LIST, ispath=True)
-DEFAULT_MODULE_PATH       = get_config(p, DEFAULTS, 'library',          'ANSIBLE_LIBRARY',          None, ispathlist=True)
+DEFAULT_MODULE_PATH       = get_config(p, DEFAULTS, 'library',          'ANSIBLE_LIBRARY',          '/usr/share/ansible', ispathlist=True)
 DEFAULT_ROLES_PATH        = get_config(p, DEFAULTS, 'roles_path',       'ANSIBLE_ROLES_PATH',       '/etc/ansible/roles', ispathlist=True, expand_relative_paths=True)
 DEFAULT_REMOTE_TMP        = get_config(p, DEFAULTS, 'remote_tmp',       'ANSIBLE_REMOTE_TEMP',      '$HOME/.ansible/tmp')
 DEFAULT_LOCAL_TMP         = get_config(p, DEFAULTS, 'local_tmp',        'ANSIBLE_LOCAL_TEMP',      '$HOME/.ansible/tmp', istmppath=True)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['', '/home/ondra/workspace/ovirt-engine-ansible/ansible']
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

I can see everywhere in documentaion that '/usr/share/ansible' directory is default directory where modules are searched, but it's not true at all. This patch adds '/usr/share/ansible' as DEFAULT_MODULE_PATH.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['', '/home/ondra/workspace/ovirt-engine-ansible/ansible']
```
