### PR TITLE
Add missing {cache,inventory}_plugins to ansible.cfg

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -160,9 +160,11 @@
 
 # set plugin path directories here, separate with colons
 #action_plugins     = /usr/share/ansible/plugins/action
+#cache_plugins      = /usr/share/ansible/plugins/cache
 #callback_plugins   = /usr/share/ansible/plugins/callback
 #connection_plugins = /usr/share/ansible/plugins/connection
 #lookup_plugins     = /usr/share/ansible/plugins/lookup
+#inventory_plugins  = /usr/share/ansible/plugins/inventory
 #vars_plugins       = /usr/share/ansible/plugins/vars
 #filter_plugins     = /usr/share/ansible/plugins/filter
 #test_plugins       = /usr/share/ansible/plugins/test


### PR DESCRIPTION
These are confirmed to be checked for in constants.py, but not
shown in example ansible.cfg (which should be exhaustive).

Follows discussion in freenode/#ansible with 'agaffney'
on 2016-06-27 at 13:28 PDT
