### PR TITLE
Switch test_lookups to badssl/local testing.

### DIFF
--- a/test/integration/roles/prepare_http_tests/defaults/main.yml
+++ b/test/integration/roles/prepare_http_tests/defaults/main.yml
@@ -1,3 +1,4 @@
 badssl_host: wrong.host.badssl.com
 httpbin_host: httpbin.org
 sni_host: sni.velox.ch
+badssl_host_substring: wrong.host.badssl.com

--- a/test/integration/roles/prepare_http_tests/vars/httptester.yml
+++ b/test/integration/roles/prepare_http_tests/vars/httptester.yml
@@ -2,3 +2,4 @@
 badssl_host: fail.ansible.http.tests
 httpbin_host: ansible.http.tests
 sni_host: sni1.ansible.http.tests
+badssl_host_substring: HTTP Client Testing Service

--- a/test/integration/roles/test_lookups/meta/main.yml
+++ b/test/integration/roles/test_lookups/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies: 
   - prepare_tests
+  - prepare_http_tests
 

--- a/test/integration/roles/test_lookups/tasks/main.yml
+++ b/test/integration/roles/test_lookups/tasks/main.yml
@@ -231,7 +231,7 @@
 
 - name: Test that retrieving a url with invalid cert fails
   set_fact:
-    web_data: "{{ lookup('url', 'https://www.kennethreitz.org/') }}"
+    web_data: "{{ lookup('url', 'https://{{ badssl_host }}/') }}"
   ignore_errors: True
   register: url_invalid_cert
 
@@ -242,12 +242,12 @@
 
 - name: Test that retrieving a url with invalid cert with validate_certs=False works
   set_fact:
-    web_data: "{{ lookup('url', 'https://www.kennethreitz.org/', validate_certs=False) }}"
+    web_data: "{{ lookup('url', 'https://{{ badssl_host }}/', validate_certs=False) }}"
   register: url_no_validate_cert
 
 - assert:
     that:
-      - "'www.kennethreitz.org' in web_data"
+      - "'{{ badssl_host }}' in web_data"
 
 - name: Test cartesian lookup
   debug: var={{item}}

--- a/test/integration/roles/test_lookups/tasks/main.yml
+++ b/test/integration/roles/test_lookups/tasks/main.yml
@@ -247,7 +247,7 @@
 
 - assert:
     that:
-      - "'{{ badssl_host }}' in web_data"
+      - "'{{ badssl_host_substring }}' in web_data"
 
 - name: Test cartesian lookup
   debug: var={{item}}


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (lookup-tests ad1df0a44a) last updated 2016/06/27 18:01:33 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 3c6f2c2db1) last updated 2016/06/27 09:05:43 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 1c36665545) last updated 2016/06/24 15:11:16 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Switch test_lookups to badssl/local testing.
