### PR TITLE
Unpin yamllint now that version 1.3.2 is out.

### DIFF
--- a/test/utils/shippable/code-smell-requirements.txt
+++ b/test/utils/shippable/code-smell-requirements.txt
@@ -1,1 +1,1 @@
-yamllint==1.2.2
+yamllint


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (yamllint aa5f3cd72a) last updated 2016/06/28 11:01:13 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 3c6f2c2db1) last updated 2016/06/27 09:05:43 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 1c36665545) last updated 2016/06/24 15:11:16 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Unpin yamllint now that version 1.3.2 is out.

The newer version of yamllint fixes the UnicodeEncodeError which previously required pinning the version to 1.2.2.
