### PR TITLE
Handle repeat includes in junit callback.

### DIFF
--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -237,7 +237,11 @@ class TaskData:
 
     def add_host(self, host):
         if host.uuid in self.host_data:
-            raise Exception('%s: %s: %s: duplicate host callback: %s' % (self.path, self.play, self.name, host.name))
+            if host.status == 'included':
+                # concatenate task include output from multiple items
+                host.result = '%s\n%s' % (self.host_data[host.uuid].result, host.result)
+            else:
+                raise Exception('%s: %s: %s: duplicate host callback: %s' % (self.path, self.play, self.name, host.name))
 
         self.host_data[host.uuid] = host
 


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (junit-dup ebcddf2fa3) last updated 2016/06/28 15:04:38 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 3c6f2c2db1) last updated 2016/06/27 09:05:43 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 1c36665545) last updated 2016/06/24 15:11:16 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Using include and with_items results in multiple calls to v2_playbook_on_include for a single task. This causes the junit callback plugin to raise an exception.

This can be seen when running the test role test_task_ordering:

```
2016-06-28 19:57:49 TASK [test_task_ordering : include] ********************************************
2016-06-28 19:57:49 included: /root/ansible/test/integration/roles/test_task_ordering/tasks/taskorder-include.yml for testhost
2016-06-28 19:57:49 included: /root/ansible/test/integration/roles/test_task_ordering/tasks/taskorder-include.yml for testhost
2016-06-28 19:57:49  [WARNING]: Failure using method (v2_playbook_on_include) in callback plugin
2016-06-28 19:57:49 (</root/ansible/lib/ansible/plugins/callback/junit.CallbackModule object at
2016-06-28 19:57:49 0x27ca1d0>):
2016-06-28 19:57:49 /root/ansible/test/integration/roles/test_task_ordering/tasks/main.yml:3:
2016-06-28 19:57:49 testhost: test_task_ordering : include _raw_params=taskorder-include.yml:
2016-06-28 19:57:49 duplicate host callback: include
2016-06-28 19:57:49 included: /root/ansible/test/integration/roles/test_task_ordering/tasks/taskorder-include.yml for testhost
```

This fixes the junit callback plugin to concatenate the results from mulitple includes.
