### PR TITLE
Quote the azure requirement to prevent > causing file redirection

### DIFF
--- a/docsite/rst/guide_azure.rst
+++ b/docsite/rst/guide_azure.rst
@@ -13,7 +13,7 @@ SDK is via pip:
 
 .. code-block:: bash
 
-    $ pip install azure>=2.0.0rc4
+    $ pip install "azure>=2.0.0rc4"
 
 
 Authenticating with Azure


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Running the pip install command without quotes caused a file called '=2.0.0rc4' to be created, containing the stdout of pip installing the wrong version of azure (1.x)
