### PR TITLE
basic: omit args if default value is set

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1276,7 +1276,9 @@ class AnsibleModule(object):
         count = 0
         for term in check:
             if term in self.params:
-                count += 1
+                v = self.argument_spec[term]
+                if self.params[term] != v.get('default'):
+                    count += 1
         return count
 
     def _check_mutually_exclusive(self, spec):


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

Currently, for `required_one_of`, `mutually_exclusive`, `required_together`, etc. the checks only complain if the param was passed or not passed.

With this change, the checks `required_one_of`, `mutually_exclusive`, `required_together` will only complain if the param passed has a different value than the default value.

As the param has the default value set anyway, passing the default value again, should not be handled as an error.

This change makes it possible to omit or "reset" a param so it is not going to be handled in error checking if passed.

Let's make a simple example:

Given is a inventory having a group of web servers

``` ini
[webservers]
web01
web02
web03
```

A simple playbook:

``` yaml
# xy.yaml

---
- hosts: webservers
  tasks: 
  - local_action:
      module: test_defaults
      name: hello
      template: "{{ template | default(omit) }}"
      iso: "{{ iso | default(omit) }}"
```

We want to use a template for all webs, lets make a group_var

``` yaml
# group_vars/webservers

---
template: mytemplate
```

Works ok!

Now we realize one webserver would need an iso instead the template. This would **not** work as template is still defined,

``` yaml
# host_vars/web03

---
iso: iso
```

With the patch, you can "reset" the template with the default value, this would work:

``` yaml
# host_vars/web03

---
iso: iso
template: null
```
###### Test setup:

Dummy module:

``` python
#!/usr/bin/python

def main():
    argument_spec = dict(
        name = dict(default=None),
        display_name = dict(default=None),
        template = dict(default=None),
        iso = dict(default=None),
        domain = dict(default=None),
        account = dict(default=None),
    )

    module = AnsibleModule(
        argument_spec=argument_spec,
        required_together=(
            ['domain', 'account'],
        ),
        required_one_of = (
            ['display_name', 'name'],
        ),
        mutually_exclusive = (
            ['template', 'iso'],
        ),
        supports_check_mode=True
    )

    module.exit_json(changed=False)

# import module snippets
from ansible.module_utils.basic import *
if __name__ == '__main__':
    main()
```

Test playbook:

``` yaml

---
- hosts: localhost
  tasks:

# This task would fail in ansible 2.1 as mutually exclusive params are set.
# It does not after this change as one param value is identical to the default value.
  - local_action:
      module: test_defaults
      name: hello
      # mutually_exclusive
      template: null
      iso: foo
    register: test1
    ignore_errors: true

# This task would fail in ansible 2.1 as required_together param account is not given.
# It does not after this change as the one param value is identical to the default value.

  - local_action:
      module: test_defaults
      # requried_one_of
      name: hello
      # required_together
      domain: null
    register: test2
    ignore_errors: true

# this would not fail in 2.1 but it should as the default values are set but we expect a non-default one.

  - local_action:
      module: test_defaults
      # requried_one_of
      name: null
      display_name: null
    register: test3
    ignore_errors: true

# this fails in 2.1 and with this change, as different values then the defaults are used

  - local_action:
      module: test_defaults
      name: hello
      # mutually_exclusive
      template: my_template
      iso: my_iso
    register: test4
    ignore_errors: true

# this would not fail in 2.1 but it should.
# For the required_together the default values are set but we expect a non-default one.

  - local_action:
      module: test_defaults
      name: hello
      # required_together
      domain: root
      account: null
    register: test5
    ignore_errors: true

  - assert:
      that:
      - test1|success

      - test2|success

      - not test3|success
      - '"one of the following is required" in test3.msg'

      - not test4|success
      - '"parameters are mutually exclusive" in test4.msg'

      - not test5|success
      - '"parameters are required together" in test5.msg'
```

Test results:

```
 $ ansible-playbook test.yml -vv
No config file found; using defaults
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAYBOOK: test.yml *************************************************************
1 plays in test.yml

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [test_defaults] ***********************************************************
task path: /home/resmo/tmp/ansible-defaults-revamp/test.yml:7
ok: [localhost -> localhost] => {"changed": false}

TASK [test_defaults] ***********************************************************
task path: /home/resmo/tmp/ansible-defaults-revamp/test.yml:19
ok: [localhost -> localhost] => {"changed": false}

TASK [test_defaults] ***********************************************************
task path: /home/resmo/tmp/ansible-defaults-revamp/test.yml:30
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "one of the following is required: display_name,name"}
...ignoring

TASK [test_defaults] ***********************************************************
task path: /home/resmo/tmp/ansible-defaults-revamp/test.yml:40
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "parameters are mutually exclusive: ['template', 'iso']"}
...ignoring

TASK [test_defaults] ***********************************************************
task path: /home/resmo/tmp/ansible-defaults-revamp/test.yml:52
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "parameters are required together: ['domain', 'account']"}
...ignoring

TASK [assert] ******************************************************************
task path: /home/resmo/tmp/ansible-defaults-revamp/test.yml:61
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

PLAY RECAP *********************************************************************
localhost                  : ok=7    changed=0    unreachable=0    failed=0 
```
