### PR TITLE
version_compare  argument fix

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -186,7 +186,7 @@ def ternary(value, true_val, false_val):
         return false_val
 
 
-def version_compare(value, version, operator='eq', strict=False):
+def version_compare(value, operator='eq', version='0.0', strict=False):
     ''' Perform a version comparison on a value '''
     op_map = {
         '==': 'eq', '=':  'eq', 'eq': 'eq',


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 216a845244)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
-def version_compare(value, version, operator='eq', strict=False):
 +def version_compare(value, operator='eq', version='0.0', strict=False):
```

It is difficult to understand the order
## before

{{ version | version_compare('2.5', '<=') }}

Do not know whether the "version <= '2.5'" and whether the "'2.5' <= version"

it proposes a this for difficult to understand that it is "version <= '2.5'" .
