### PR TITLE
fixes minor issue with expanding blocks in netcfg

### DIFF
--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -227,10 +227,21 @@ class NetworkConfig(object):
                         updates.extend(config)
                         break
 
-        updates = self.expand(updates)
-
         if self._device_os == 'junos':
             return updates
+
+        changes = list()
+        for update in updates:
+            if replace == 'block':
+                if update.parents:
+                    changes.append(update.parents[-1])
+                    for child in update.parents[-1].children:
+                        changes.append(child)
+                else:
+                    changes.append(update)
+            else:
+                changes.append(update)
+        updates = self.expand(changes)
 
         return [item.text for item in self.expand(updates)]
 


### PR DESCRIPTION
This fixes a minor bug where blocks in netcfg where not being expanded
when replace=block was specified.
