### PR TITLE
Update shippable shared dir for COPY_SOURCE.

### DIFF
--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -22,7 +22,7 @@ else
 fi
 
 if [ "${copy_source}" ]; then
-    test_shared_dir="/tmp/shared-dir"
+    test_shared_dir="/shared"
 else
     test_shared_dir="${test_ansible_dir}"
 fi


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (shippable-fix 1b0564fb43) last updated 2016/06/29 14:53:47 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 2f0f04437b) last updated 2016/06/29 12:25:17 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD f5b7b3b2f2) last updated 2016/06/29 12:25:20 (GMT -700)
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Tests now use '/shared' instead of '/tmp/shared-dir' when using COPY_SOURCE. This avoids issues with containers purging '/tmp'.
