### PR TITLE
Added axapi_authenticate_v3 and axapi_call_v3 for new AXAPIv3 That is.... 

### DIFF
--- a/lib/ansible/module_utils/a10.py
+++ b/lib/ansible/module_utils/a10.py
@@ -88,6 +88,43 @@ def axapi_authenticate(module, base_url, username, password):
     sessid = result['session_id']
     return base_url + '&session_id=' + sessid
 
+def axapi_authenticate_v3(module, base_url, username, password):
+    url = base_url
+    auth_payload = {"credentials": {"username": username, "password": password}}
+    result = axapi_call_v3(module, url, post=auth_payload)
+    if axapi_failure(result):
+        return module.fail_json(msg=result['response']['err']['msg'])
+    signature = result['authresponse']['signature']
+    return signature
+
+def axapi_call_v3(module, url, post=None, signature=''):
+    '''
+    Returns a datastructure based on the result of the API call
+    '''
+    if signature:
+        headers = {'content-type': 'application/json', 'signature': signature}
+    else:
+        headers = {'content-type': 'application/json'}
+    rsp, info = fetch_url(module, url, method='POST', data=json.dumps(post), headers=headers)
+    if not rsp or info['status'] >= 400:
+        module.fail_json(msg="failed to connect (status code %s), error was %s" % (info['status'], info.get('msg', 'no error given')))
+    try:
+        raw_data = rsp.read()
+        data = json.loads(raw_data)
+    except ValueError:
+        # at least one API call (system.action.write_config) returns
+        # XML even when JSON is requested, so do some minimal handling
+        # here to prevent failing even when the call succeeded
+        if 'status="ok"' in raw_data.lower():
+            data = {"response": {"status": "OK"}}
+        else:
+            data = {"response": {"status": "fail", "err": {"msg": raw_data}}}
+    except:
+        module.fail_json(msg="could not read the result from the host")
+    finally:
+        rsp.close()
+    return data
+
 def axapi_enabled_disabled(flag):
     '''
     The axapi uses 0/1 integer values for flags, rather than strings


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.0.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Added axapi_authenticate_v3 and axapi_call_v3 helper functions for a10.py. AXAPIv3 is not backward compatible to v2.1. It is currently used by A10 devices running ACOS 3.x and 4.x. Given the current install base, I have chosen to replicate the current methods, rename, and modify the necessary parameters.  

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
Not Applicable
```

… not backward compatible
