### PR TITLE
fix default/main.yml to defaults/main.yml

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -188,7 +188,7 @@ class Role(Base, Become, Conditional, Taggable):
         if self._default_vars is None:
             self._default_vars = dict()
         elif not isinstance(self._default_vars, dict):
-            raise AnsibleParserError("The default/main.yml file for role '%s' must contain a dictionary of variables" % self._role_name)
+            raise AnsibleParserError("The defaults/main.yml file for role '%s' must contain a dictionary of variables" % self._role_name)
 
     def _load_role_yaml(self, subdir):
         file_path = os.path.join(self._role_path, subdir)

--- a/test/integration/roles/test_hash_behavior/defaults/main.yml
+++ b/test/integration/roles/test_hash_behavior/defaults/main.yml
@@ -18,4 +18,4 @@
 
 ---
 test_hash:
-  default_vars: "this is in role default/main.yml"
+  default_vars: "this is in role defaults/main.yml"

--- a/test/integration/test_hash.yml
+++ b/test/integration/test_hash.yml
@@ -8,7 +8,7 @@
     replaced_hash:
       extra_args: "this is an extra arg"
     merged_hash:
-      default_vars: "this is in role default/main.yml"
+      default_vars: "this is in role defaults/main.yml"
       extra_args: "this is an extra arg"
       group_vars_all: "this is in group_vars/all"
       host_vars_testhost: "this is in host_vars/testhost"


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

fix error message `default/main.yml` => `deafults/main.yml`

http://docs.ansible.com/ansible/playbooks_roles.html#roles

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
