### PR TITLE
Fix authentication via params and env variables.

### DIFF
--- a/docsite/rst/guide_azure.rst
+++ b/docsite/rst/guide_azure.rst
@@ -8,12 +8,12 @@ Requirements
 ------------
 
 Using the Azure Resource Manager modules requires having `Azure Python SDK <https://github.com/Azure/azure-sdk-for-python>`_
-installed on the host running Ansible. You will need to have >= v2.0.0RC4 installed. The simplest way to install the
+installed on the host running Ansible. You will need to have == v2.0.0RC5 installed. The simplest way to install the
 SDK is via pip:
 
 .. code-block:: bash
 
-    $ pip install "azure>=2.0.0rc4"
+    $ pip install "azure==2.0.0rc5"
 
 
 Authenticating with Azure

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -312,21 +312,21 @@ class AzureRMModuleBase(object):
             except:
                 pass
 
-        if credentials.get('client_id') is not None or credentials.get('ad_user') is not None:
+        if credentials.get('subscription_id'):
             return credentials
 
         return None
 
     def _get_env_credentials(self):
         env_credentials = dict()
-        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
+        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.iteritems():
             env_credentials[attribute] = os.environ.get(env_variable, None)
 
-        if env_credentials['profile'] is not None:
+        if env_credentials['profile']:
             credentials = self._get_profile(env_credentials['profile'])
             return credentials
 
-        if env_credentials['client_id'] is not None:
+        if env_credentials.get('subscription_id') is not None:
             return env_credentials
 
         return None
@@ -338,7 +338,7 @@ class AzureRMModuleBase(object):
         self.log('Getting credentials')
 
         arg_credentials = dict()
-        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
+        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.iteritems():
             arg_credentials[attribute] = params.get(attribute, None)
 
         # try module params
@@ -347,7 +347,7 @@ class AzureRMModuleBase(object):
             credentials = self._get_profile(arg_credentials['profile'])
             return credentials
         
-        if arg_credentials['client_id'] is not None:
+        if arg_credentials['subscription_id']:
             self.log('Received credentials from parameters.')
             return arg_credentials
         


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (azure-rc5 7c4b239c41) last updated 2016/07/02 21:27:15 (GMT -400)
  lib/ansible/modules/core: (azure-rc5 de9959b129) last updated 2016/07/02 18:46:57 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 9392943915) last updated 2016/06/21 00:56:17 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix broken authentication. Authentication was not working when using parameters or environment variables. See [the Ansible mailing post here](https://groups.google.com/forum/#!topic/ansible-project/NMLtboyfIZk).

Update the Azure guide to require 2.0.0rc5.
