### PR TITLE
reenable apt_repository tests in ubuntu 16.04

### DIFF
--- a/test/integration/roles/test_apt_repository/tasks/apt.yml
+++ b/test/integration/roles/test_apt_repository/tasks/apt.yml
@@ -1,10 +1,10 @@
 ---
 
 - set_fact:
-    test_ppa_name: 'ppa:menulibre-dev/devel'
-    test_ppa_filename: 'menulibre-dev'
-    test_ppa_spec: 'deb http://ppa.launchpad.net/menulibre-dev/devel/ubuntu {{ansible_distribution_release}} main'
-    test_ppa_key: 'A7AD98A1' # http://keyserver.ubuntu.com:11371/pks/lookup?search=0xD06AAF4C11DAB86DF421421EFE6B20ECA7AD98A1&op=index
+    test_ppa_name: 'ppa:git-core/ppa'
+    test_ppa_filename: 'git-core'
+    test_ppa_spec: 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu {{ansible_distribution_release}} main'
+    test_ppa_key: 'E1DF1F24' # http://keyserver.ubuntu.com:11371/pks/lookup?search=0xD06AAF4C11DAB86DF421421EFE6B20ECA7AD98A1&op=index
 
 # UNINSTALL 'python-apt'
 #  The `apt_repository` module has the smarts to auto-install `python-apt`.  To

--- a/test/integration/roles/test_apt_repository/tasks/main.yml
+++ b/test/integration/roles/test_apt_repository/tasks/main.yml
@@ -17,5 +17,5 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - include: 'apt.yml'
-  when: ansible_distribution in ('Ubuntu') and ansible_distribution_version|version_compare('16.04', '<')
+  when: ansible_distribution in ('Ubuntu')
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

devel
##### SUMMARY

reenable apt_repository tests in ubuntu 16.04

Those were disabled when adding 16.04 in https://github.com/ansible/ansible/pull/15561, since the 3rd party repos were not yet available. 

fixes #15718
