### PR TITLE
better fix for stubbing AnsibleModule

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -19,7 +19,7 @@
 
 import re
 
-from ansible.module_utils.basic import json, get_exception, AnsibleModule
+from ansible.module_utils.basic import json, get_exception
 from ansible.module_utils.network import NetCli, NetworkError, get_module, Command
 from ansible.module_utils.network import add_argument, register_transport, to_list
 from ansible.module_utils.netcfg import NetworkConfig
@@ -32,7 +32,13 @@ EAPI_FORMATS = ['json', 'text']
 add_argument('use_ssl', dict(default=True, type='bool'))
 add_argument('validate_certs', dict(default=True, type='bool'))
 
-ModuleStub = AnsibleModule
+class ModuleStub(object):
+    def __init__(self, argument_spec, fail_json):
+        self.params = dict()
+        for key, value in argument_spec.items():
+            self.params[key] = value.get('default')
+        self.fail_json = fail_json
+
 
 def argument_spec():
     return dict(
@@ -204,8 +210,9 @@ class Eapi(EosConfigMixin):
 
     def __init__(self):
         self.url = None
-        self.url_args = ModuleStub(url_argument_spec())
-        self.url_args.fail_json = self._error
+
+        self.url_args = ModuleStub(url_argument_spec(), self._error)
+
         self.enable = None
         self.default_output = 'json'
         self._connected = False


### PR DESCRIPTION
This is a better fix for stubbing AnsibleModule to make use of fetch_url
from module_utils/urls.py
