### PR TITLE
Determine failed hosts with _check_failed_state() (#16566)

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -469,7 +469,7 @@ class PlayIterator:
         self._host_states[host.name] = s
 
     def get_failed_hosts(self):
-        return dict((host, True) for (host, state) in iteritems(self._host_states) if state.run_state == self.ITERATING_COMPLETE and state.fail_state != self.FAILED_NONE)
+        return dict((host, True) for (host, state) in iteritems(self._host_states) if self._check_failed_state(state))
 
     def _check_failed_state(self, state):
         if state is None:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 0430923647)
```
##### SUMMARY

The get_failed_hosts() function in lib/ansible/executor/play_iterator.py has not been updated to use _check_failed_state() to check the failure state of a host. This leads to ignoring failed child states and returning an exit code of 0 if a child state fails. Serious cherry-pick candidate for stable-2.1.

Fixes #16566 
