### PR TITLE
User reports that adding PID to the name prevents parallel runs of /usr/bin/ansible-playbook from removing the tmp directory prematurely.

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -76,7 +76,8 @@ def get_config(p, section, key, env_var, default, boolean=False, integer=False, 
             value = shell_expand(value)
             if not os.path.exists(value):
                 os.makedirs(value, 0o700)
-            value = tempfile.mkdtemp(prefix='ansible-local-tmp', dir=value)
+            prefix = 'ansible-local-%s' % os.getpid()
+            value = tempfile.mkdtemp(prefix=prefix, dir=value)
         elif ispathlist:
             if isinstance(value, string_types):
                 value = [shell_expand(x, expand_relative_paths=expand_relative_paths) \


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.1.0 and devel
```
##### SUMMARY

From the code I'm not sure why that would help but it doesn't do any
harm.  Proposing this pull request to make that change inside of
ansible.

Possible Fixes #16489
