### PR TITLE
Retain local tar.gz roles during galaxy install

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -188,6 +188,7 @@ class GalaxyRole(object):
     def install(self):
         # the file is a tar, so open it that way and extract it
         # to the specified (or default) roles directory
+        local_file = False
 
         if self.scm:
             # create tar file from scm url
@@ -195,6 +196,7 @@ class GalaxyRole(object):
         elif self.src:
             if  os.path.isfile(self.src):
                 # installing a local tar.gz
+                local_file = True
                 tmp_file = self.src
             elif '://' in self.src:
                 role_data = self.src
@@ -294,10 +296,11 @@ class GalaxyRole(object):
 
                 # return the parsed yaml metadata
                 display.display("- %s was installed successfully" % self.name)
-                try:
-                    os.unlink(tmp_file)
-                except (OSError,IOError) as e:
-                    display.warning("Unable to remove tmp file (%s): %s" % (tmp_file, str(e)))
+                if not local_file:
+                    try:
+                        os.unlink(tmp_file)
+                    except (OSError,IOError) as e:
+                        display.warning("Unable to remove tmp file (%s): %s" % (tmp_file, str(e)))
                 return True
 
         return False


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 7d53fd2ef2) last updated 2016/07/06 14:32:37 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD 4a0a9cd1fc) last updated 2016/07/06 14:40:08 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD e0b3e2f790) last updated 2016/07/06 14:36:12 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Don't treat local tar.gz files as temporary when cleaning
up at the end of an ansible-galaxy install

Partly addresses #16136 
