### PR TITLE
With os.path.realpath it is impossible to have ec2.py as symlink in i…

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -210,7 +210,7 @@ class Ec2Inventory(object):
             config = configparser.ConfigParser()
         else:
             config = configparser.SafeConfigParser()
-        ec2_default_ini_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ec2.ini')
+        ec2_default_ini_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ec2.ini')
         ec2_ini_path = os.path.expanduser(os.path.expandvars(os.environ.get('EC2_INI_PATH', ec2_default_ini_path)))
         config.read(ec2_ini_path)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.0.2.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

With os.path.realpath it is impossible to have ec2.py as symlink in inventories folder and separate ec2.ini per inventory.
os.path.abspath instead give an ability to have common ec2.py symlinked to every inventory with its own ec2.ini config.

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
cd inventories/TEST
ln -s ../ec2.py ec2.py
touch ec2.ini
 ./ec2.py --list
Traceback (most recent call last):
  File "./ec2.py", line 1326, in <module>
    Ec2Inventory()
  File "./ec2.py", line 163, in __init__
    self.read_settings()
  File "./ec2.py", line 224, in read_settings
    configRegions = config.get('ec2', 'regions')
  File "/usr/lib/python2.7/ConfigParser.py", line 607, in get
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'ec2'

After changes all work as expected because ec2.ini is located near symlink to ec2.py
```
