### PR TITLE
Small changes to enable make gce to run.

### DIFF
--- a/test/integration/credentials.template
+++ b/test/integration/credentials.template
@@ -9,9 +9,9 @@ ec2_access_key:
 ec2_secret_key:
 
 # GCE Credentials
-service_account_email:
-pem_file:
-project_id:
+gce_service_account_email:
+gce_pem_file:
+gce_project_id:
 
 # Azure Credentials
 azure_subscription_id: "{{ lookup('env', 'AZURE_SUBSCRIPTION_ID') }}"

--- a/test/integration/gce_credentials.py
+++ b/test/integration/gce_credentials.py
@@ -1,5 +1,6 @@
 import collections
 import os
+import sys
 import yaml
 
 try:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
  - fixes GCE integration tests
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

ansible 2.2.0 (gce_test_fixes 166903c36b) last updated 2016/07/06 16:29:53 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 4a0a9cd1fc) last updated 2016/07/06 16:23:20 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD e0b3e2f790) last updated 2016/07/06 16:23:22 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Changes to enable `make gce` to run.  Added sys import so libcloud error is displayed; renamed credentials keys in template file so they work properly with gce_credentials.py.
