### PR TITLE
Remove doubled instantiation of the zipfile

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -290,8 +290,8 @@ if __name__ == '__main__':
             # may load the system-wide install of ansible rather than the one in
             # the module.  sitecustomize is the only way to override that setting.
             z = zipfile.ZipFile(zipped_mod, mode='a')
+
             # py3: zipped_mod will be text, py2: it's bytes.  Need bytes at the end
-            z = zipfile.ZipFile(zipped_mod, mode='a')
             sitecustomize = u'import sys\\nsys.path.insert(0,"%%s")\\n' %%  zipped_mod
             sitecustomize = sitecustomize.encode('utf-8')
             z.writestr('sitecustomize.py', sitecustomize)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

devel (2.2)
##### SUMMARY

Instantiated the zipfile inside of the Ansiballz wrapper twice.  Probably a copy-paste error from the past.  Doesn't cause any problems but it's good to remove extra code.
