### PR TITLE
Fixes #163 in galaxy-issues

### DIFF
--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -137,6 +137,7 @@ class GalaxyAPI(object):
         data = json.load(resp)
         return data
 
+    @g_connect
     def create_import_task(self, github_user, github_repo, reference=None):
         """
         Post an import request
@@ -201,6 +202,7 @@ class GalaxyAPI(object):
             url = '%s/roles/%d/%s/?page_size=50' % (self.baseurl, int(role_id), related)
             data = self.__call_galaxy(url)
             results = data['results']
+            done = (data.get('next_link', None) is None)
             done = (data.get('next_link', None) is None)
             while not done:
                 url = '%s%s' % (self._api_server, data['next_link'])

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -203,7 +203,6 @@ class GalaxyAPI(object):
             data = self.__call_galaxy(url)
             results = data['results']
             done = (data.get('next_link', None) is None)
-            done = (data.get('next_link', None) is None)
             while not done:
                 url = '%s%s' % (self._api_server, data['next_link'])
                 data = self.__call_galaxy(url)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The method uses the variable baseurl which is determined in the g_connect function. Without the g_connect decorator baseurl == None and when trying to import it results in trying to open a url of None/imports/. This doesn't work so the program tries to determine the type of the url, and then because that doesn't work either (None/imports/ is not a valid url) a ValueError is raised. I added the decorator. Fixes #163 of galaxy-issues.

```
before fix:
Succesfully logged into Galaxy as s-hertel
shertel-OSX:~ shertel$ ansible-galaxy import s-hertel test_role -vvv
No config file found; using defaults
Opened /Users/shertel/.ansible_galaxy
Validate TLS certificates: True
None/imports/
ERROR! Unexpected Exception: unknown url type: None/imports/
the full traceback was:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/2.7/bin/ansible-galaxy", line 92, in <module>
    exit_code = cli.run()
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible/cli/galaxy.py", line 153, in run
    self.execute()
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible/cli/__init__.py", line 100, in execute
    fn()
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible/cli/galaxy.py", line 596, in execute_import
    task = self.api.create_import_task(github_user, github_repo, reference=self.options.reference)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible/galaxy/api.py", line 143, in create_import_task
    data = self.__call_galaxy(url, args=args)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible/galaxy/api.py", line 56, in wrapped
    return method(self, *args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible/galaxy/api.py", line 95, in __call_galaxy
    resp = open_url(url, data=args, validate_certs=self._validate_certs, headers=headers, method=method)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible/module_utils/urls.py", line 839, in open_url
    r = urllib2.urlopen(*urlopen_args)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 422, in open
    protocol = req.get_type()
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 285, in get_type
    raise ValueError, "unknown url type: %s" % self.__original
ValueError: unknown url type: None/imports/

after fix:
Succesfully logged into Galaxy as s-hertel
shertel-OSX:~ shertel$ ansible-galaxy import s-hertel test_role -vvv
No config file found; using defaults
Opened /Users/shertel/.ansible_galaxy
Validate TLS certificates: True
https://galaxy.ansible.com/api/v1/imports/
Successfully submitted import request 19264
https://galaxy.ansible.com/api/v1/imports/?id=19264
Starting import 19264: role_name=test_role repo=s-hertel/test_role ref=
Retrieving Github repo s-hertel/test_role
https://galaxy.ansible.com/api/v1/imports/?id=19264
Accessing branch: master
Parsing and validating meta/main.yml
(and then fails, but only because I didn't put anything in meta/main.yml)
```
