### PR TITLE
Fixing a bug in test_display_galaxy_info

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -49,5 +49,5 @@ class TestGalaxy(unittest.TestCase):
         role_info = {'name': 'some_role_name',
                      'galaxy_info': galaxy_info}
         display_result = gc._display_role_info(role_info)
-        if display_result.find('\t\tgalaxy_tags:') > -1:
-            self.fail('Expected galaxy_tags to be indented twice')
+        if display_result.find('\n\tgalaxy_info:') == -1:
+            self.fail('Expected galaxy_info to be indented once')


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

find() returns -1 if it fails and the string 'galaxy_tags' isn't in ever in display_result in this test. The bug doesn't result in any errors because the logic is sort of inverted- i.e. if it finds galaxy_tags indented twice (which it won't, since galaxy_tags isn't there) then raise an error informing user that galaxy_tags should be indented twice.
I changed it to find something that is supposed to be there (galaxy_info) and changed the logic to raise an error if it is not found.

```
before fix:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK

after fix:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK
```
