### PR TITLE
[WIP] Adding setUpClass to allow the option of improving thorough testing f…

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -23,6 +23,8 @@ from ansible.compat.six import PY3
 from ansible.compat.tests import unittest
 
 from nose.plugins.skip import SkipTest
+import os
+import getpass
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -30,6 +32,23 @@ if PY3:
 from ansible.cli.galaxy import GalaxyCLI
 
 class TestGalaxy(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Prompting the testing to provide credentials will not happen by default and is not required for most tests. This is simply an option to improve the thoroughness of testing.
+        if 'GALAXY_CREDS_PROMPT' in os.environ.keys():
+            try:
+                #authentication may be declined and tests inhibited will be avoided
+                cls.auth = True
+                # using getpass to ensure tester sees message (unlike raw_input)
+                cls.galaxy_username = getpass.getpass("\nPress ENTER to opt out of any of the authentication prompts.\nYour information will not be displayed.\nEnter your Ansible-Galaxy/Github username: ")
+                cls.galaxy_password = getpass.getpass("Enter your Ansible-Galaxy/Github password: ")
+                cls.github_token = getpass.getpass("Enter/Copy + paste Github Personal Access Token to login to Ansible-Galaxy: ")
+                cls.import_repo = getpass.getpass("To test importing a role please provide the name of a valid github repo (containing a role) belonging to the username provided above: ")
+            except getpass.GetPassWarning:
+                cls.auth = False
+        else:
+            cls.auth = False    
+    
     def setUp(self):
         self.default_args = []
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

I added a setUpClass to allow for the possibility of improved testing for the GalaxyCLI methods login, import, and delete. Credentials by default will not be asked for, only if the tester has 'GALAXY_CREDS_PROMPT' in their os.environ. If they do, the setUpClass asks the user once for credentials to allow more thorough testing than the default way of testing login, import and delete (mocking them out) provides. The user is given the option to decline any or all of the four following authentication prompts.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK
```

…or the following GalaxyCLI methods: login, import, and delete
