### PR TITLE
Adding a test for GalaxyCLI. Tests run method.

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -23,6 +23,9 @@ from ansible.compat.six import PY3
 from ansible.compat.tests import unittest
 
 from nose.plugins.skip import SkipTest
+import ansible
+
+from mock import patch, MagicMock
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -51,3 +54,14 @@ class TestGalaxy(unittest.TestCase):
         display_result = gc._display_role_info(role_info)
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
+
+    def test_run(self):
+        ''' verifies that the GalaxyCLI object's api is created and that execute() is called. '''
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["-c", "-v", '--ignore-errors', 'imaginary_role']):
+            galaxy_parser = gc.parse()
+        gc.execute = MagicMock()
+        with patch.object(ansible.cli.CLI, "run", return_value=None) as mock_obj:  # to eliminate config or default file used message
+            gc.run()
+        self.assertTrue(gc.execute.called)
+        self.assertTrue(isinstance(gc.api, ansible.galaxy.api.GalaxyAPI))

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -60,8 +60,11 @@ class TestGalaxy(unittest.TestCase):
         gc = GalaxyCLI(args=["install"])
         with patch('sys.argv', ["-c", "-v", '--ignore-errors', 'imaginary_role']):
             galaxy_parser = gc.parse()
-        gc.execute = MagicMock()
-        with patch.object(ansible.cli.CLI, "run", return_value=None) as mock_obj:  # to eliminate config or default file used message
-            gc.run()
-        self.assertTrue(gc.execute.called)
-        self.assertTrue(isinstance(gc.api, ansible.galaxy.api.GalaxyAPI))
+        with patch.object(ansible.cli.CLI, "execute", return_value=None) as mock_ex:
+            with patch.object(ansible.cli.CLI, "run", return_value=None) as mock_run:
+                gc.run()
+                
+                # testing
+                self.assertEqual(mock_run.call_count, 1)
+                self.assertTrue(isinstance(gc.api, ansible.galaxy.api.GalaxyAPI))
+                self.assertEqual(mock_ex.call_count, 1)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The run method is supposed to create a GalaxyAPI instance and call the CLI execute method. My test uses mock to assert that the correct things are created/called.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok
verifies that the GalaxyCLI object's api is created and that execute() is called. ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.007s

OK
```
