### PR TITLE
Add storage device WWN to facts for Linux

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1274,6 +1274,20 @@ class LinuxHardware(Hardware):
         except OSError:
             return
 
+        devs_wwn = {}
+        try:
+            devs_by_id = os.listdir("/dev/disk/by-id")
+        except OSError:
+            pass
+        else:
+            for link_name in devs_by_id:
+                if link_name.startswith("wwn-"):
+                    try:
+                        wwn_link = os.readlink(os.path.join("/dev/disk/by-id", link_name))
+                    except OSError:
+                        continue
+                    devs_wwn[os.path.basename(wwn_link)] = link_name[4:]
+
         for block in block_devs:
             virtual = 1
             sysfs_no_links = 0
@@ -1305,6 +1319,9 @@ class LinuxHardware(Hardware):
                               ('support_discard','/queue/discard_granularity'),
                               ]:
                 d[key] = get_file_content(sysdir + test)
+
+            if diskname in devs_wwn:
+                d['wwn'] = devs_wwn[diskname]
 
             d['partitions'] = {}
             for folder in os.listdir(sysdir):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (disks-wwn afe35cbced) last updated 2016/07/08 12:05:30 (GMT +300)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Add devices WWN to facts for Linux

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
                "size": "931.51 GB", 
                "support_discard": "0", 
                "vendor": "ATA", 
                "wwn": "0x5000c5008c53eff9"

```

World Wide Name (WWN) is unique identifier of device.
This patch adds this identifier to facts for Linux.
