### PR TITLE
Adding a test for GalaxyCLI. Tests execute_init method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Ansible Changes By Release
 - netconf_config
 - openstack
   * os_keystone_service
+  * os_stack
 - rocketchat
 - sensu_subscription
 - smartos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Ansible Changes By Release
   - ansible_totalmem (renamed to ansible_memtotal_mb, units changed to MB instead of bytes)
 
 ####New Modules:
+- asa
+  * asa_acl
+  * asa_command
+  * asa_config
+  * asa_template
 - aws
   * ec2_customer_gateway
   * ec2_vpc_nacl_facts
@@ -22,6 +27,9 @@ Ansible Changes By Release
 - cloudstack
   * cs_router
   * cs_snapshot_policy
+- ipmi
+  * ipmi_boot
+  * ipmi_power
 - letsencrypt
 - lxd
   * lxd_profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Ansible Changes By Release
   * cs_router
   * cs_snapshot_policy
 - letsencrypt
+- lxd
+  * lxd_profile
+  * lxd_container
 - netconf_config
 - openstack
   * os_keystone_service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ansible Changes By Release
 - vmware
   * vmware_local_user_manager
   * vmware_vmotion
+- wakeonlan
 
 ###Minor Changes:
 * now -vvv shows exact path from which 'currently executing module' was picked up from.

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,9 @@ deb-src-upload: deb-src
 
 # for arch or gentoo, read instructions in the appropriate 'packaging' subdirectory directory
 
-webdocs: $(MANPAGES)
+webdocs:
 	(cd docsite/; make docs)
 
 docs: $(MANPAGES)
+
+alldocs: docs webdocs

--- a/contrib/inventory/azure_rm.ini
+++ b/contrib/inventory/azure_rm.ini
@@ -9,6 +9,9 @@
 # Control which tags are included. Set tags to a comma separated list of keys or key:value pairs
 #tags=
 
+# Control which locations are included. Set locations to a comma separated list (e.g. eastus,eastus2,westus)
+#locations=
+
 # Include powerstate. If you don't need powerstate information, turning it off improves runtime performance.
 include_powerstate=yes
 

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -130,6 +130,10 @@ Select hosts for specific tag key by assigning a comma separated list of tag key
 
 AZURE_TAGS=key1,key2,key3
 
+Select hosts for specific locations:
+
+AZURE_LOCATIONS=eastus,westus,eastus2
+
 Or, select hosts for specific tag key:value pairs by assigning a comma separated list key:value pairs to:
 
 AZURE_TAGS=key1:value1,key2:value2
@@ -152,13 +156,13 @@ up. If the value is anything other than 'running', the machine is down, and will
 Examples:
 ---------
   Execute /bin/uname on all instances in the galaxy-qa resource group
-  $ ansible -i azure_rm_inventory.py galaxy-qa -m shell -a "/bin/uname -a"
+  $ ansible -i azure_rm.py galaxy-qa -m shell -a "/bin/uname -a"
 
   Use the inventory script to print instance specific information
-  $ contrib/inventory/azure_rm_inventory.py --host my_instance_host_name --pretty
+  $ contrib/inventory/azure_rm.py --host my_instance_host_name --pretty
 
   Use with a playbook
-  $ ansible-playbook -i contrib/inventory/azure_rm_inventory.py my_playbook.yml --limit galaxy-qa
+  $ ansible-playbook -i contrib/inventory/azure_rm.py my_playbook.yml --limit galaxy-qa
 
 
 Insecure Platform Warning
@@ -185,6 +189,8 @@ import os
 import re
 import sys
 
+from distutils.version import LooseVersion
+
 from os.path import expanduser
 
 HAS_AZURE = True
@@ -195,12 +201,9 @@ try:
     from azure.mgmt.compute import __version__ as azure_compute_version
     from azure.common import AzureMissingResourceHttpError, AzureHttpError
     from azure.common.credentials import ServicePrincipalCredentials, UserPassCredentials
-    from azure.mgmt.network.network_management_client import NetworkManagementClient,\
-                                                             NetworkManagementClientConfiguration
-    from azure.mgmt.resource.resources.resource_management_client import ResourceManagementClient,\
-                                                                         ResourceManagementClientConfiguration
-    from azure.mgmt.compute.compute_management_client import ComputeManagementClient,\
-                                                             ComputeManagementClientConfiguration
+    from azure.mgmt.network.network_management_client import NetworkManagementClient
+    from azure.mgmt.resource.resources.resource_management_client import ResourceManagementClient
+    from azure.mgmt.compute.compute_management_client import ComputeManagementClient
 except ImportError as exc:
     HAS_AZURE_EXC = exc
     HAS_AZURE = False
@@ -219,6 +222,7 @@ AZURE_CREDENTIAL_ENV_MAPPING = dict(
 AZURE_CONFIG_SETTINGS = dict(
     resource_groups='AZURE_RESOURCE_GROUPS',
     tags='AZURE_TAGS',
+    locations='AZURE_LOCATIONS',
     include_powerstate='AZURE_INCLUDE_POWERSTATE',
     group_by_resource_group='AZURE_GROUP_BY_RESOURCE_GROUP',
     group_by_location='AZURE_GROUP_BY_LOCATION',
@@ -226,7 +230,7 @@ AZURE_CONFIG_SETTINGS = dict(
     group_by_tag='AZURE_GROUP_BY_TAG'
 )
 
-AZURE_MIN_VERSION = "2016-03-30"
+AZURE_MIN_VERSION = "0.30.0rc5"
 
 
 def azure_id_to_dict(id):
@@ -362,8 +366,7 @@ class AzureRM(object):
     def network_client(self):
         self.log('Getting network client')
         if not self._network_client:
-            self._network_client = NetworkManagementClient(
-                NetworkManagementClientConfiguration(self.azure_credentials, self.subscription_id))
+            self._network_client = NetworkManagementClient(self.azure_credentials, self.subscription_id)
             self._register('Microsoft.Network')
         return self._network_client
 
@@ -371,16 +374,14 @@ class AzureRM(object):
     def rm_client(self):
         self.log('Getting resource manager client')
         if not self._resource_client:
-            self._resource_client = ResourceManagementClient(
-                ResourceManagementClientConfiguration(self.azure_credentials, self.subscription_id))
+            self._resource_client = ResourceManagementClient(self.azure_credentials, self.subscription_id)
         return self._resource_client
 
     @property
     def compute_client(self):
         self.log('Getting compute client')
         if not self._compute_client:
-            self._compute_client = ComputeManagementClient(
-                ComputeManagementClientConfiguration(self.azure_credentials, self.subscription_id))
+            self._compute_client = ComputeManagementClient(self.azure_credentials, self.subscription_id)
             self._register('Microsoft.Compute')
         return self._compute_client
 
@@ -403,6 +404,7 @@ class AzureInventory(object):
 
         self.resource_groups = []
         self.tags = None
+        self.locations = None
         self.replace_dash_in_groups = False
         self.group_by_resource_group = True
         self.group_by_location = True
@@ -424,6 +426,9 @@ class AzureInventory(object):
 
         if self._args.tags:
             self.tags = self._args.tags.split(',')
+
+        if self._args.locations:
+            self.locations = self._args.locations.split(',')
 
         if self._args.no_powerstate:
             self.include_powerstate = False
@@ -462,6 +467,8 @@ class AzureInventory(object):
                             help='Return inventory for comma separated list of resource group names')
         parser.add_argument('--tags', action='store',
                             help='Return inventory for comma separated list of tag key:value pairs')
+        parser.add_argument('--locations', action='store',
+                            help='Return inventory for comma separated list of locations')
         parser.add_argument('--no-powerstate', action='store_true', default=False,
                             help='Do not include the power state of each virtual host')
         return parser.parse_args()
@@ -487,7 +494,7 @@ class AzureInventory(object):
             except Exception as exc:
                 sys.exit("Error: fetching virtual machines - {0}".format(str(exc)))
 
-            if self._args.host or self.tags > 0:
+            if self._args.host or self.tags or self.locations:
                 selected_machines = self._selected_machines(virtual_machines)
                 self._load_machines(selected_machines)
             else:
@@ -524,7 +531,7 @@ class AzureInventory(object):
                 resource_group=resource_group,
                 mac_address=None,
                 plan=(machine.plan.name if machine.plan else None),
-                virtual_machine_size=machine.hardware_profile.vm_size.value,
+                virtual_machine_size=machine.hardware_profile.vm_size,
                 computer_name=machine.os_profile.computer_name,
                 provisioning_state=machine.provisioning_state,
             )
@@ -576,7 +583,7 @@ class AzureInventory(object):
                     host_vars['mac_address'] = network_interface.mac_address
                     for ip_config in network_interface.ip_configurations:
                         host_vars['private_ip'] = ip_config.private_ip_address
-                        host_vars['private_ip_alloc_method'] = ip_config.private_ip_allocation_method.value
+                        host_vars['private_ip_alloc_method'] = ip_config.private_ip_allocation_method
                         if ip_config.public_ip_address:
                             public_ip_reference = self._parse_ref_id(ip_config.public_ip_address.id)
                             public_ip_address = self._network_client.public_ip_addresses.get(
@@ -585,7 +592,7 @@ class AzureInventory(object):
                             host_vars['ansible_host'] = public_ip_address.ip_address
                             host_vars['public_ip'] = public_ip_address.ip_address
                             host_vars['public_ip_name'] = public_ip_address.name
-                            host_vars['public_ip_alloc_method'] = public_ip_address.public_ip_allocation_method.value
+                            host_vars['public_ip_alloc_method'] = public_ip_address.public_ip_allocation_method
                             host_vars['public_ip_id'] = public_ip_address.id
                             if public_ip_address.dns_settings:
                                 host_vars['fqdn'] = public_ip_address.dns_settings.fqdn
@@ -598,6 +605,8 @@ class AzureInventory(object):
             if self._args.host and self._args.host == machine.name:
                 selected_machines.append(machine)
             if self.tags and self._tags_match(machine.tags, self.tags):
+                selected_machines.append(machine)
+            if self.locations and machine.location in self.locations:
                 selected_machines.append(machine)
         return selected_machines
 
@@ -676,17 +685,17 @@ class AzureInventory(object):
         file_settings = self._load_settings()
         if file_settings:
             for key in AZURE_CONFIG_SETTINGS:
-                if key in ('resource_groups', 'tags') and file_settings.get(key, None) is not None:
+                if key in ('resource_groups', 'tags', 'locations') and file_settings.get(key):
                     values = file_settings.get(key).split(',')
                     if len(values) > 0:
                         setattr(self, key, values)
-                elif file_settings.get(key, None) is not None:
+                elif file_settings.get(key):
                     val = self._to_boolean(file_settings[key])
                     setattr(self, key, val)
         else:
             env_settings = self._get_env_settings()
             for key in AZURE_CONFIG_SETTINGS:
-                if key in('resource_groups', 'tags') and env_settings.get(key, None) is not None:
+                if key in('resource_groups', 'tags', 'locations') and env_settings.get(key):
                     values = env_settings.get(key).split(',')
                     if len(values) > 0:
                         setattr(self, key, values)
@@ -774,11 +783,11 @@ class AzureInventory(object):
 
 def main():
     if not HAS_AZURE:
-        sys.exit("The Azure python sdk is not installed (try 'pip install azure') - {0}".format(HAS_AZURE_EXC))
+        sys.exit("The Azure python sdk is not installed (try 'pip install azure==2.0.0rc5') - {0}".format(HAS_AZURE_EXC))
 
-    if azure_compute_version < AZURE_MIN_VERSION:
-        sys.exit("Expecting azure.mgmt.compute.__version__ to be >= {0}. Found version {1} "
-                 "Do you have Azure >= 2.0.0rc2 installed?".format(AZURE_MIN_VERSION, azure_compute_version))
+    if LooseVersion(azure_compute_version) != LooseVersion(AZURE_MIN_VERSION):
+        sys.exit("Expecting azure.mgmt.compute.__version__ to be {0}. Found version {1} "
+                 "Do you have Azure == 2.0.0rc5 installed?".format(AZURE_MIN_VERSION, azure_compute_version))
 
     AzureInventory()
 

--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -125,8 +125,10 @@ class GceInventory(object):
                     pretty=self.args.pretty))
             sys.exit(0)
 
+        zones = self.parse_env_zones()
+
         # Otherwise, assume user wants all instances grouped
-        print(self.json_format_dict(self.group_instances(),
+        print(self.json_format_dict(self.group_instances(zones),
             pretty=self.args.pretty))
         sys.exit(0)
 
@@ -233,6 +235,14 @@ class GceInventory(object):
         )
         return gce
 
+    def parse_env_zones(self):
+        '''returns a list of comma seperated zones parsed from the GCE_ZONE environment variable.
+        If provided, this will be used to filter the results of the grouped_instances call'''
+        import csv
+        reader = csv.reader([os.environ.get('GCE_ZONE',"")], skipinitialspace=True)
+        zones = [r for r in reader]
+        return [z for z in zones[0]]
+
     def parse_cli_args(self):
         ''' Command line argument processing '''
 
@@ -289,7 +299,7 @@ class GceInventory(object):
         except Exception as e:
             return None
 
-    def group_instances(self):
+    def group_instances(self, zones=None):
         '''Group all instances'''
         groups = {}
         meta = {}
@@ -312,6 +322,12 @@ class GceInventory(object):
             meta["hostvars"][name] = self.node_to_dict(node)
 
             zone = node.extra['zone'].name
+
+            # To avoid making multiple requests per zone
+            # we list all nodes and then filter the results
+            if zones and zone not in zones:
+                continue
+
             if groups.has_key(zone): groups[zone].append(name)
             else: groups[zone] = [name]
 

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -80,7 +80,7 @@ class VMWareInventory(object):
     host_filters = []
     groupby_patterns = []
 
-    bad_types = ['Array']
+    bad_types = ['Array', 'disabledMethod', 'declaredAlarmState']
     if (sys.version_info > (3, 0)):
         safe_types = [int, bool, str, float, None]
     else:
@@ -112,6 +112,10 @@ class VMWareInventory(object):
 
     def debugl(self, text):
         if self.args.debug:
+            try:
+                text = str(text)
+            except UnicodeEncodeError:
+                text = text.encode('ascii','ignore')                            
             print(text)
 
     def show(self):
@@ -313,18 +317,18 @@ class VMWareInventory(object):
         instances = []
 
         if hasattr(child, 'childEntity'):
-            self.debugl("CHILDREN: %s" % str(child.childEntity))
+            self.debugl("CHILDREN: %s" % child.childEntity)
             instances += self._get_instances_from_children(child.childEntity)
         elif hasattr(child, 'vmFolder'):
-            self.debugl("FOLDER: %s" % str(child))
+            self.debugl("FOLDER: %s" % child)
             instances += self._get_instances_from_children(child.vmFolder)
         elif hasattr(child, 'index'):
-            self.debugl("LIST: %s" % str(child))
+            self.debugl("LIST: %s" % child)
             for x in sorted(child):
                 self.debugl("LIST_ITEM: %s" % x)
                 instances += self._get_instances_from_children(x)
         elif hasattr(child, 'guest'):
-            self.debugl("GUEST: %s" % str(child))
+            self.debugl("GUEST: %s" % child)
             instances.append(child)
         elif hasattr(child, 'vm'):    
             # resource pools
@@ -433,7 +437,7 @@ class VMWareInventory(object):
                 newkey = t.render(v)
                 newkey = newkey.strip()
             except Exception as e:
-                self.debugl(str(e))
+                self.debugl(e)
                 #import epdb; epdb.st()
             if not newkey:
                 continue
@@ -520,13 +524,13 @@ class VMWareInventory(object):
 
         rdata = {}
 
-        self.debugl("PROCESSING: %s" % str(vobj))
+        self.debugl("PROCESSING: %s" % vobj)
 
         if type(vobj) in self.safe_types:
             try:
                 rdata = vobj
             except Exception as e:
-                self.debugl(str(e))
+                self.debugl(e)
 
         elif hasattr(vobj, 'append'):
             rdata = []

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -42,7 +42,7 @@ The 'ARGUMENTS' to pass to the module.
 Use privilege escalation (specific one depends on become_method),
 this does not imply prompting for passwords.
 
-*K*, *--ask-become-pass*::
+*-K*, *--ask-become-pass*::
 
 Ask for privilege escalation password.
 

--- a/docsite/rst/become.rst
+++ b/docsite/rst/become.rst
@@ -41,7 +41,7 @@ For example, to manage a system service (which requires ``root`` privileges) whe
 
 To run a command as the ``apache`` user::
 
-    - name: Run a command as the apache uesr
+    - name: Run a command as the apache user
       command: somecommand
       become: true
       become_user: apache

--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -72,22 +72,24 @@ Installing Multiple Roles From Multiple Files
 =============================================
 
 At a basic level, including requirements files allows you to break up bits of configuration policy into smaller files. Role includes pull in roles from other files.
-
-    ansible-galaxy install -r requirements.yml
-
-    # from galaxy
-    - src: yatesr.timezone
-
-    - include: webserver.yml
+::
+      ansible-galaxy install -r requirements.yml
+ 
+Content of requirements.yml
+::
+     # from github
+     - src: yatesr.timezone
+     
+     - include: webserver.yml
 
 
 Content of the webserver.yml file.
-
-    # from github
-    - src: https://github.com/bennojoy/nginx
-
-    # from github installing to a relative path
-    - src: https://github.com/bennojoy/nginx
+::
+     # from github
+     - src: https://github.com/bennojoy/nginx
+ 
+     # from github installing to a relative path
+     - src: https://github.com/bennojoy/nginx
       path: vagrant/roles/
 
 Advanced Control over Role Requirements Files

--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -130,7 +130,29 @@ And here's an example showing some specific version downloads from multiple sour
       version: 0.1.0
 
 As you can see in the above, there are a large amount of controls available
-to customize where roles can be pulled from, and what to save roles as.     
+to customize where roles can be pulled from, and what to save roles as. 
+
+You can also pull down multiple roles from a single source(just make sure that you have a meta/main.yml file at the root level).
+::
+     meta\main.yml
+     common-role1\tasks\main.yml
+     common-role2\tasks\main.yml
+    
+For example, if the above common roles are published to a git repo, you can pull them down using:
+::
+     # multiple roles from the same repo
+     - src: git@gitlab.company.com:mygroup/ansible-common.git
+       name: common-roles
+       scm: git
+       version: master
+
+You could then use these common roles in your plays
+::
+     ---
+     - hosts: webservers
+       roles:
+         - common-roles/common-role1
+         - common-roles/common-role2
 
 Roles pulled from galaxy work as with other SCM sourced roles above. To download a role with dependencies, and automatically install those dependencies, the role must be uploaded to the Ansible Galaxy website.
 

--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -134,7 +134,7 @@ And here's an example showing some specific version downloads from multiple sour
 As you can see in the above, there are a large amount of controls available
 to customize where roles can be pulled from, and what to save roles as. 
 
-You can also pull down multiple roles from a single source(just make sure that you have a meta/main.yml file at the root level).
+You can also pull down multiple roles from a single source (just make sure that you have a meta/main.yml file at the root level).
 ::
      meta\main.yml
      common-role1\tasks\main.yml

--- a/docsite/rst/guide_azure.rst
+++ b/docsite/rst/guide_azure.rst
@@ -320,6 +320,10 @@ Select hosts for specific tag key by assigning a comma separated list of tag key
 
 * AZURE_TAGS=key1,key2,key3
 
+Select hosts for specific locations by assigning a comma separated list of locations to:
+
+* AZURE_LOCATIONS=eastus,eastus2,westus
+
 Or, select hosts for specific tag key:value pairs by assigning a comma separated list key:value pairs to:
 
 * AZURE_TAGS=key1:value1,key2:value2
@@ -340,6 +344,9 @@ file will contain the following:
 
     # Control which tags are included. Set tags to a comma separated list of keys or key:value pairs
     #tags=
+
+    # Control which locations are included. Set locations to a comma separated list of locations.
+    #locations=
 
     # Include powerstate. If you don't need powerstate information, turning it off improves runtime performance.
     # Valid values: yes, no, true, false, True, False, 0, 1.

--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -242,7 +242,7 @@ ansible_become_method
 ansible_become_user
     Equivalent to ``ansible_sudo_user`` or ``ansible_su_user``, allows to set the user you become through privilege escalation
 ansible_become_pass
-    Equivalent to ``ansible_sudo_pass`` or ``ansible_su_pass``, allows you to set the privilege escalation password
+    Equivalent to ``ansible_sudo_pass`` or ``ansible_su_pass``, allows you to set the privilege escalation password (this is insecure, we strongly recommend using :option:`--ask-become-pass` or SSH keys)
 
 Remote host environment parameters:
 

--- a/docsite/rst/playbooks.rst
+++ b/docsite/rst/playbooks.rst
@@ -22,6 +22,7 @@ It is recommended to look at `Example Playbooks <https://github.com/ansible/ansi
    playbooks_roles
    playbooks_variables
    playbooks_filters
+   playbooks_tests
    playbooks_conditionals
    playbooks_loops
    playbooks_blocks

--- a/docsite/rst/playbooks_checkmode.rst
+++ b/docsite/rst/playbooks_checkmode.rst
@@ -20,31 +20,50 @@ Example::
 
 .. _forcing_to_run_in_check_mode:
 
-Running a task in check mode
-````````````````````````````
+Enabling or disabling check mode for tasks
+``````````````````````````````````````````
 
-.. versionadded:: 1.3
+.. versionadded:: 2.2
 
-Sometimes you may want to have a task to be executed even in check
-mode. To achieve this, use the `always_run` clause on the task. Its
-value is a Jinja2 expression, just like the `when` clause. In simple
-cases a boolean YAML value would be sufficient as a value.
+Sometimes you may want to modify the check mode behavior of individual tasks. This is done via the ``check_mode`` option, which can
+be added to tasks. 
+
+There are two options:
+
+1. Force a task to **run in check mode**, even when the playbook is called **without** ``--check``. This is called ``check_mode: yes``.
+2. Force a task to **run in normal mode** and make changes to the system, even when the playbook is called **with** ``--check``. This is called ``check_mode: no``.
+
+.. note:: Prior to version 2.2 only the the equivalent of ``check_mode: no`` existed. The notation for that was ``always_run: yes``.
+
+Instead of ``yes``/``no`` you can use a Jinja2 expression, just like the ``when`` clause.
 
 Example::
 
     tasks:
 
-      - name: this task is run even in check mode
+      - name: this task will make changes to the system even in check mode
         command: /something/to/run --even-in-check-mode
-        always_run: yes
+        check_mode: no
 
-As a reminder, a task with a `when` clause evaluated to false, will
-still be skipped even if it has a `always_run` clause evaluated to
-true. 
+      - name: this task will always run under checkmode and not change the system
+        lineinfile: line="important config" dest=/path/to/myconfig.conf state=present
+        check_mode: yes
 
-Also if you want to skip, or ignore errors on some tasks in check mode
-you can use a boolean magic variable `ansible_check_mode` (added in version 2.1)
-which will be set to `True` during check mode.
+
+Running single tasks with ``check_mode: yes`` can be useful to write tests for
+ansible modules, either to test the module itself or to the the conditions under
+which a module would make changes. 
+With ``register`` (see :doc:`playbooks_conditionals`) you can check the
+potential changes.
+
+Information about check mode in variables
+`````````````````````````````````````````
+
+.. versionadded:: 2.1
+
+If you want to skip, or ignore errors on some tasks in check mode
+you can use a boolean magic variable ``ansible_check_mode``
+which will be set to ``True`` during check mode.
 
 Example::
 

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -7,6 +7,8 @@ Jinja2 filters
 Filters in Jinja2 are a way of transforming template expressions from one kind of data into another.  Jinja2
 ships with many of these. See `builtin filters`_ in the official Jinja2 template documentation.
 
+Take into account that filters always execute on the Ansible controller, **not** on the task target, as they manipulate local data.
+
 In addition to those, Ansible supplies many more.
 
 .. _filters_for_formatting_data:
@@ -42,37 +44,6 @@ for example::
         register: result
 
       - set_fact: myvar="{{ result.stdout | from_json }}"
-
-.. _filters_used_with_conditionals:
-
-Filters Often Used With Conditionals
-------------------------------------
-
-The following tasks are illustrative of how filters can be used with conditionals::
-
-    tasks:
-
-      - shell: /usr/bin/foo
-        register: result
-        ignore_errors: True
-
-      - debug: msg="it failed"
-        when: result|failed
-
-      # in most cases you'll want a handler, but if you want to do something right now, this is nice
-      - debug: msg="it changed"
-        when: result|changed
-
-      - debug: msg="it succeeded in Ansible >= 2.1"
-        when: result|succeeded
-
-      - debug: msg="it succeeded"
-        when: result|success
-
-      - debug: msg="it was skipped"
-        when: result|skipped
-
-.. note:: From 2.1 You can also use success, failure, change, skip so the grammer matches, for those that want to be strict about it.
 
 .. _forcing_variables_to_be_defined:
 
@@ -170,30 +141,6 @@ To get the symmetric difference of 2 lists (items exclusive to each list)::
 
     {{ list1 | symmetric_difference(list2) }}
 
-.. _version_comparison_filters:
-
-Version Comparison Filters
---------------------------
-
-.. versionadded:: 1.6
-
-To compare a version number, such as checking if the ``ansible_distribution_version``
-version is greater than or equal to '12.04', you can use the ``version_compare`` filter.
-
-The ``version_compare`` filter can also be used to evaluate the ``ansible_distribution_version``::
-
-    {{ ansible_distribution_version | version_compare('12.04', '>=') }}
-
-If ``ansible_distribution_version`` is greater than or equal to 12, this filter will return True, otherwise it will return False.
-
-The ``version_compare`` filter accepts the following operators::
-
-    <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
-
-This filter also accepts a 3rd parameter, ``strict`` which defines if strict version parsing should
-be used.  The default is ``False``, and if set as ``True`` will use more strict version parsing::
-
-    {{ sample_version_var | version_compare('1.0', operator='lt', strict=True) }}
 
 .. _random_filter:
 
@@ -244,10 +191,6 @@ Math
 --------------------
 .. versionadded:: 1.9
 
-
-To see if something is actually a number::
-
-    {{ myvar | isnan }}
 
 Get the logarithm (default is e)::
 
@@ -538,20 +481,6 @@ doesn't know it is a boolean value::
 
    - debug: msg=test
      when: some_string_value | bool
-
-To match strings against a regex, use the "match" or "search" filter::
-
-    vars:
-      url: "http://example.com/users/foo/resources/bar"
-
-    tasks:
-        - shell: "msg='matched pattern 1'"
-          when: url | match("http://example.com/users/.*/resources/.*")
-
-        - debug: "msg='matched pattern 2'"
-          when: url | search("/users/.*/resources/.*")
-
-'match' will require a complete match in the string, while 'search' will require a match inside of the string.
 
 .. versionadded:: 1.6
 

--- a/docsite/rst/playbooks_roles.rst
+++ b/docsite/rst/playbooks_roles.rst
@@ -284,7 +284,7 @@ a list of roles and parameters to insert before the specified role, such as the 
     ---
     dependencies:
       - { role: common, some_parameter: 3 }
-      - { role: apache, appache_port: 80 }
+      - { role: apache, apache_port: 80 }
       - { role: postgres, dbname: blarg, other_parameter: 12 }
 
 Role dependencies can also be specified as a full path, just like top level roles::

--- a/docsite/rst/playbooks_tests.rst
+++ b/docsite/rst/playbooks_tests.rst
@@ -1,0 +1,165 @@
+Jinja2 tests
+============
+
+.. contents:: Topics
+
+
+Tests in Jinja2 are a way of evaluating template expressions and returning True or False.
+Jinja2 ships with many of these. See `builtin tests`_ in the official Jinja2 template documentation.
+Tests are very similar to filters and are used mostly the same way, but they can also be used in list
+processing filters, like C(map()) and C(select()) to choose items in the list.
+
+Like filters, tests always execute on the Ansible controller, **not** on the target of a task, as they test local data.
+
+In addition to those Jinja2 tests, Ansible supplies a few more and users can easily create their own.
+
+.. _testing_strings:
+
+Testing strings
+---------------
+
+To match strings against a substring or a regex, use the "match" or "search" filter::
+
+    vars:
+      url: "http://example.com/users/foo/resources/bar"
+
+    tasks:
+        - shell: "msg='matched pattern 1'"
+          when: url | match("http://example.com/users/.*/resources/.*")
+
+        - debug: "msg='matched pattern 2'"
+          when: url | search("/users/.*/resources/.*")
+
+        - debug: "msg='matched pattern 3'"
+          when: url | search("/users/")
+
+'match' requires a complete match in the string, while 'search' only requires matching a subset of the string.
+
+
+.. _testing_versions:
+
+Version Comparison
+------------------
+
+.. versionadded:: 1.6
+
+To compare a version number, such as checking if the ``ansible_distribution_version``
+version is greater than or equal to '12.04', you can use the ``version_compare`` filter.
+
+The ``version_compare`` filter can also be used to evaluate the ``ansible_distribution_version``::
+
+    {{ ansible_distribution_version | version_compare('12.04', '>=') }}
+
+If ``ansible_distribution_version`` is greater than or equal to 12, this filter returns True, otherwise False.
+
+The ``version_compare`` filter accepts the following operators::
+
+    <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
+
+This test also accepts a 3rd parameter, ``strict`` which defines if strict version parsing should
+be used.  The default is ``False``, but this setting as ``True`` uses more strict version parsing::
+
+    {{ sample_version_var | version_compare('1.0', operator='lt', strict=True) }}
+
+
+.. _math_tests:
+
+Group theory tests
+------------------
+
+To see if a list includes or is included by another list, you can use 'issubset' and 'issuperset'::
+
+    vars:
+        a: [1,2,3,4,5]
+        b: [2,3]
+    tasks:
+        - debug: msg="A includes B"
+          when: a|issuperset(b)
+
+        - debug: msg="B is included in A"
+          when: b|issubset(a)
+
+
+.. _path_tests:
+
+Testing paths
+-------------
+
+The following tests can provide information about a path on the controller::
+
+    - debug: msg="path is a directory"
+      when: mypath|isdir
+
+    - debug: msg="path is a file"
+      when: mypath|is_file
+
+    - debug: msg="path is a symlink"
+      when: mypath|is_link
+
+    - debug: msg="path already exists"
+      when: mypath|exists
+
+    - debug: msg="path is {{ (mypath|is_abs)|ternary('absolute','relative')}}"
+
+    - debug: msg="path is the same file as path2"
+      when: mypath|samefile(path2)
+
+    - debug: msg="path is a mount"
+      when: mypath|ismount
+
+
+.. _test_task_results:
+
+Task results
+------------
+
+The following tasks are illustrative of the tests meant to check the status of tasks::
+
+    tasks:
+
+      - shell: /usr/bin/foo
+        register: result
+        ignore_errors: True
+
+      - debug: msg="it failed"
+        when: result|failed
+
+      # in most cases you'll want a handler, but if you want to do something right now, this is nice
+      - debug: msg="it changed"
+        when: result|changed
+
+      - debug: msg="it succeeded in Ansible >= 2.1"
+        when: result|succeeded
+
+      - debug: msg="it succeeded"
+        when: result|success
+
+      - debug: msg="it was skipped"
+        when: result|skipped
+
+.. note:: From 2.1, you can also use success, failure, change, and skip so that the grammar matches, for those who need to be strict about it.
+
+
+
+.. _builtin tests: http://jinja.pocoo.org/docs/templates/#builtin-tests
+
+.. seealso::
+
+   :doc:`playbooks`
+       An introduction to playbooks
+   :doc:`playbooks_conditionals`
+       Conditional statements in playbooks
+   :doc:`playbooks_variables`
+       All about variables
+   :doc:`playbooks_loops`
+       Looping in playbooks
+   :doc:`playbooks_roles`
+       Playbook organization by roles
+   :doc:`playbooks_best_practices`
+       Best practices in playbooks
+   `User Mailing List <http://groups.google.com/group/ansible-devel>`_
+       Have a question?  Stop by the google group!
+   `irc.freenode.net <http://irc.freenode.net>`_
+       #ansible IRC chat channel
+
+

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -929,7 +929,7 @@ like so::
        - { role: app_user, name: Graham }
        - { role: app_user, name: John   }
 
-That's a bit arbitrary, but you can see how the same role was invoked multiple Times.  In that example it's quite likely there was
+That's a bit arbitrary, but you can see how the same role was invoked multiple times.  In that example it's quite likely there was
 no default for 'name' supplied at all.  Ansible can yell at you when variables aren't defined -- it's the default behavior in fact.
 
 So that's a bit about roles.

--- a/docsite/rst/porting_guide_2.0.rst
+++ b/docsite/rst/porting_guide_2.0.rst
@@ -26,7 +26,7 @@ To make an escaped string that will work on all versions you have two options::
 
 uses key=value escaping which has not changed.  The other option is to check for the ansible version::
 
-"{{ (ansible_version|version_compare('ge', '2.0'))|ternary( 'test1_junk 1\\3' | regex_replace('(.*)_junk (.*)', '\\1 \\2') , 'test1_junk 1\\\\3' | regex_replace('(.*)_junk (.*)', '\\\\1 \\\\2') ) }}"
+"{{ (ansible_version|version_compare('2.0', 'ge'))|ternary( 'test1_junk 1\\3' | regex_replace('(.*)_junk (.*)', '\\1 \\2') , 'test1_junk 1\\\\3' | regex_replace('(.*)_junk (.*)', '\\\\1 \\\\2') ) }}"
 
 * trailing newline When a string with a trailing newline was specified in the
   playbook via yaml dict format, the trailing newline was stripped. When

--- a/docsite/rst/roadmap/ROADMAP_2_1.rst
+++ b/docsite/rst/roadmap/ROADMAP_2_1.rst
@@ -49,14 +49,14 @@
      - Openstack (Community maintainers)
      - Google (Google/Community) 
      - Digital Ocean (Community)
-- Ziploader: 
+- Ansiballz (renamed from Ziploader): 
      - Write code to create the zipfile that gets passed across the wire to be run on the remote python  
-     - Port most of the functionality in module\_utils to be usage in ziploader instead
-     - Port a few essential modules to use ziploader instead of module-replacer as proof of concept  
-     - New modules will be able to use ziploader.  Old modules will need to be ported in future releases (Some modules will not need porting but others will)
+     - Port most of the functionality in module\_utils to be usage in ansiballz instead
+     - Port a few essential modules to use ansiballz instead of module-replacer as proof of concept  
+     - New modules will be able to use ansiballz.  Old modules will need to be ported in future releases (Some modules will not need porting but others will)
      - Better testing of modules, caching of modules clientside(Have not yet arrived at an architecture for this that we like), better code sharing between ansible/ansible and modules
-     - ziploader is a helpful building block for: python3 porting(high priority), better code sharing between modules(medium priority)
-     - ziploader is a good idea before: enabling users to have custom module_utils directories
+     - ansiballz is a helpful building block for: python3 porting(high priority), better code sharing between modules(medium priority)
+     - ansiballz is a good idea before: enabling users to have custom module_utils directories
 - Expand module diff support (already in progress in devel)
      - Framework done. Need to add to modules, test etc. 
      - Coordinate with community to update their modules 

--- a/docsite/rst/test_strategies.rst
+++ b/docsite/rst/test_strategies.rst
@@ -42,7 +42,7 @@ existing system, using the `--check` flag to the `ansible` command will report i
 bring the system into a desired state.
 
 This can let you know up front if there is any need to deploy onto the given system.  Ordinarily scripts and commands don't run in check mode, so if you
-want certain steps to always execute in check mode, such as calls to the script module, add the 'always_run' flag::
+want certain steps to always execute in check mode, such as calls to the script module, disable check mode for those tasks::
 
 
    roles:
@@ -50,7 +50,7 @@ want certain steps to always execute in check mode, such as calls to the script 
 
    tasks:
      - script: verify.sh
-       always_run: True
+       check_mode: no
 
 Modules That Are Useful for Testing
 ```````````````````````````````````

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -45,6 +45,13 @@
 # A minimal set of facts is always gathered.
 #gather_subset = all
 
+# some hardware related facts are collected
+# with a maximum timeout of 10 seconds. This
+# option lets you increase or decrease that
+# timeout to something more suitable for the
+# environment. 
+# gather_timeout = 10
+
 # additional paths to search for roles in, colon separated
 #roles_path    = /etc/ansible/roles
 

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -142,12 +142,12 @@ def boilerplate_module(modfile, args, interpreter, check, destfile):
         task_vars=task_vars
     )
 
-    if module_style == 'new' and 'ZIPLOADER_WRAPPER = True' in module_data:
-        module_style = 'ziploader'
+    if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in module_data:
+        module_style = 'ansiballz'
 
     modfile2_path = os.path.expanduser(destfile)
     print("* including generated source, if any, saving to: %s" % modfile2_path)
-    if module_style not in ('ziploader', 'old'):
+    if module_style not in ('ansiballz', 'old'):
         print("* this may offset any line numbers in tracebacks/debuggers!")
     modfile2 = open(modfile2_path, 'w')
     modfile2.write(module_data)
@@ -156,7 +156,7 @@ def boilerplate_module(modfile, args, interpreter, check, destfile):
 
     return (modfile2_path, modname, module_style)
 
-def ziploader_setup(modfile, modname):
+def ansiballz_setup(modfile, modname):
     os.system("chmod +x %s" % modfile)
 
     cmd = subprocess.Popen([modfile, 'explode'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -164,7 +164,7 @@ def ziploader_setup(modfile, modname):
     lines = out.splitlines()
     if len(lines) != 2 or 'Module expanded into' not in lines[0]:
         print("*" * 35)
-        print("INVALID OUTPUT FROM ZIPLOADER MODULE WRAPPER")
+        print("INVALID OUTPUT FROM ANSIBALLZ MODULE WRAPPER")
         print(out)
         sys.exit(1)
     debug_dir = lines[1].strip()
@@ -172,13 +172,13 @@ def ziploader_setup(modfile, modname):
     argsfile = os.path.join(debug_dir, 'args')
     modfile = os.path.join(debug_dir, 'ansible_module_%s.py' % modname)
 
-    print("* ziploader module detected; extracted module source to: %s" % debug_dir)
+    print("* ansiballz module detected; extracted module source to: %s" % debug_dir)
     return modfile, argsfile
 
 def runtest(modfile, argspath, modname, module_style):
     """Test run a module, piping it's output for reporting."""
-    if module_style == 'ziploader':
-        modfile, argspath = ziploader_setup(modfile, modname)
+    if module_style == 'ansiballz':
+        modfile, argspath = ansiballz_setup(modfile, modname)
 
     os.system("chmod +x %s" % modfile)
 
@@ -209,8 +209,8 @@ def runtest(modfile, argspath, modname, module_style):
 def rundebug(debugger, modfile, argspath, modname, module_style):
     """Run interactively with console debugger."""
 
-    if module_style == 'ziploader':
-        modfile, argspath = ziploader_setup(modfile, modname)
+    if module_style == 'ansiballz':
+        modfile, argspath = ansiballz_setup(modfile, modname)
 
     if argspath is not None:
         subprocess.call("%s %s %s" % (debugger, modfile, argspath), shell=True)
@@ -223,7 +223,7 @@ def main():
     (modfile, modname, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter, options.check, options.filename)
 
     argspath = None
-    if module_style not in ('new', 'ziploader'):
+    if module_style not in ('new', 'ansiballz'):
         if module_style == 'non_native_want_json':
             argspath = write_argsfile(options.module_args, json=True)
         elif module_style == 'old':

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -332,6 +332,22 @@ class ConsoleCLI(CLI, cmd.Cmd):
         else:
             display.display("Please specify a become_method, e.g. `become_method su`")
 
+    def do_check(self, arg):
+        """Toggle whether plays run with check mode"""
+        if arg:
+            self.options.check = C.mk_boolean(arg)
+            display.v("check mode changed to %s" % self.options.check)
+        else:
+            display.display("Please specify check mode value, e.g. `check yes`")
+
+    def do_diff(self, arg):
+        """Toggle whether plays run with diff"""
+        if arg:
+            self.options.diff = C.mk_boolean(arg)
+            display.v("diff mode changed to %s" % self.options.diff)
+        else:
+            display.display("Please specify a diff value , e.g. `diff yes`")
+
     def do_exit(self, args):
         """Exits from the console"""
         sys.stdout.write('\n')

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -28,7 +28,7 @@ from ansible.compat.six import iteritems
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError
-from ansible.plugins import module_loader
+from ansible.plugins import module_loader, action_loader
 from ansible.cli import CLI
 from ansible.utils import module_docs
 
@@ -105,6 +105,12 @@ class DocCLI(CLI):
                     continue
 
                 if doc is not None:
+
+                    # is there corresponding action plugin?
+                    if module in action_loader:
+                        doc['action'] = True
+                    else:
+                        doc['action'] = False
 
                     all_keys = []
                     for (k,v) in iteritems(doc['options']):
@@ -248,6 +254,9 @@ class DocCLI(CLI):
 
         if 'deprecated' in doc and doc['deprecated'] is not None and len(doc['deprecated']) > 0:
             text.append("DEPRECATED: \n%s\n" % doc['deprecated'])
+
+        if 'action' in doc and doc['action']:
+            text.append("  * note: %s\n" % "This module has a corresponding action plugin.")
 
         if 'option_keys' in doc and len(doc['option_keys']) > 0:
             text.append("Options (= is mandatory):\n")

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -34,7 +34,7 @@ def mk_boolean(value):
     if value is None:
         return False
     val = str(value)
-    if val.lower() in [ "true", "t", "y", "1", "yes" ]:
+    if val.lower() in [ "true", "t", "y", "1", "yes", "on" ]:
         return True
     else:
         return False

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -177,6 +177,7 @@ DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBL
 DEFAULT_EXECUTABLE        = get_config(p, DEFAULTS, 'executable', 'ANSIBLE_EXECUTABLE', '/bin/sh')
 DEFAULT_GATHERING         = get_config(p, DEFAULTS, 'gathering', 'ANSIBLE_GATHERING', 'implicit').lower()
 DEFAULT_GATHER_SUBSET     = get_config(p, DEFAULTS, 'gather_subset', 'ANSIBLE_GATHER_SUBSET', 'all').lower()
+DEFAULT_GATHER_TIMEOUT    = get_config(p, DEFAULTS, 'gather_timeout', 'ANSIBLE_GATHER_TIMEOUT', 10, integer=True)
 DEFAULT_LOG_PATH          = get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', '', ispath=True)
 DEFAULT_FORCE_HANDLERS    = get_config(p, DEFAULTS, 'force_handlers', 'ANSIBLE_FORCE_HANDLERS', False, boolean=True)
 DEFAULT_INVENTORY_IGNORE  = get_config(p, DEFAULTS, 'inventory_ignore_extensions', 'ANSIBLE_INVENTORY_IGNORE', ["~", ".orig", ".bak", ".ini", ".cfg", ".retry", ".pyc", ".pyo"], islist=True)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -61,9 +61,9 @@ _SNIPPET_PATH = os.path.join(os.path.dirname(__file__), '..', 'module_utils')
 
 # ******************************************************************************
 
-ZIPLOADER_TEMPLATE = u'''%(shebang)s
+ANSIBALLZ_TEMPLATE = u'''%(shebang)s
 %(coding)s
-ZIPLOADER_WRAPPER = True # For test-module script to tell this is a ZIPLOADER_WRAPPER
+ANSIBALLZ_WRAPPER = True # For test-module script to tell this is a ANSIBALLZ_WRAPPER
 # This code is part of Ansible, but is an independent component.
 # The code in this particular templatable string, and this templatable string
 # only, is BSD licensed.  Modules which end up using this snippet, which is
@@ -140,7 +140,7 @@ def debug(command, zipped_mod, json_params):
     # The code here normally doesn't run.  It's only used for debugging on the
     # remote machine.
     #
-    # The subcommands in this function make it easier to debug ziploader
+    # The subcommands in this function make it easier to debug ansiballz
     # modules.  Here's the basic steps:
     #
     # Run ansible with the environment variable: ANSIBLE_KEEP_REMOTE_FILES=1 and -vvv
@@ -262,9 +262,9 @@ if __name__ == '__main__':
     # See comments in the debug() method for information on debugging
     #
 
-    ZIPLOADER_PARAMS = %(params)s
+    ANSIBALLZ_PARAMS = %(params)s
     if PY3:
-        ZIPLOADER_PARAMS = ZIPLOADER_PARAMS.encode('utf-8')
+        ANSIBALLZ_PARAMS = ANSIBALLZ_PARAMS.encode('utf-8')
     try:
         # There's a race condition with the controller removing the
         # remote_tmpdir and this module executing under async.  So we cannot
@@ -277,7 +277,7 @@ if __name__ == '__main__':
         modlib.close()
 
         if len(sys.argv) == 2:
-            exitcode = debug(sys.argv[1], zipped_mod, ZIPLOADER_PARAMS)
+            exitcode = debug(sys.argv[1], zipped_mod, ANSIBALLZ_PARAMS)
         else:
             z = zipfile.ZipFile(zipped_mod, mode='r')
             module = os.path.join(temp_path, 'ansible_module_%(ansible_module)s.py')
@@ -297,7 +297,7 @@ if __name__ == '__main__':
             z.writestr('sitecustomize.py', sitecustomize)
             z.close()
 
-            exitcode = invoke_module(module, zipped_mod, ZIPLOADER_PARAMS)
+            exitcode = invoke_module(module, zipped_mod, ANSIBALLZ_PARAMS)
     finally:
         try:
             shutil.rmtree(temp_path)
@@ -320,10 +320,10 @@ def _strip_comments(source):
 if C.DEFAULT_KEEP_REMOTE_FILES:
     # Keep comments when KEEP_REMOTE_FILES is set.  That way users will see
     # the comments with some nice usage instructions
-    ACTIVE_ZIPLOADER_TEMPLATE = ZIPLOADER_TEMPLATE
+    ACTIVE_ANSIBALLZ_TEMPLATE = ANSIBALLZ_TEMPLATE
 else:
-    # ZIPLOADER_TEMPLATE stripped of comments for smaller over the wire size
-    ACTIVE_ZIPLOADER_TEMPLATE = _strip_comments(ZIPLOADER_TEMPLATE)
+    # ANSIBALLZ_TEMPLATE stripped of comments for smaller over the wire size
+    ACTIVE_ANSIBALLZ_TEMPLATE = _strip_comments(ANSIBALLZ_TEMPLATE)
 
 class ModuleDepFinder(ast.NodeVisitor):
     # Caveats:
@@ -526,7 +526,7 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
     # a separate arguments file needs to be sent over the wire.
     # module_substyle is extra information that's useful internally.  It tells
     # us what we have to look to substitute in the module files and whether
-    # we're using module replacer or ziploader to format the module itself.
+    # we're using module replacer or ansiballz to format the module itself.
     if _is_binary(module_data):
         module_substyle = module_style = 'binary'
     elif REPLACER in module_data:
@@ -566,33 +566,33 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
             display.warning(u'Bad module compression string specified: %s.  Using ZIP_STORED (no compression)' % module_compression)
             compression_method = zipfile.ZIP_STORED
 
-        lookup_path = os.path.join(C.DEFAULT_LOCAL_TMP, 'ziploader_cache')
+        lookup_path = os.path.join(C.DEFAULT_LOCAL_TMP, 'ansiballz_cache')
         cached_module_filename = os.path.join(lookup_path, "%s-%s" % (module_name, module_compression))
 
         zipdata = None
         # Optimization -- don't lock if the module has already been cached
         if os.path.exists(cached_module_filename):
-            display.debug('ZIPLOADER: using cached module: %s' % cached_module_filename)
+            display.debug('ANSIBALLZ: using cached module: %s' % cached_module_filename)
             zipdata = open(cached_module_filename, 'rb').read()
         else:
             if module_name in strategy.action_write_locks:
-                display.debug('ZIPLOADER: Using lock for %s' % module_name)
+                display.debug('ANSIBALLZ: Using lock for %s' % module_name)
                 lock = strategy.action_write_locks[module_name]
             else:
                 # If the action plugin directly invokes the module (instead of
                 # going through a strategy) then we don't have a cross-process
                 # Lock specifically for this module.  Use the "unexpected
                 # module" lock instead
-                display.debug('ZIPLOADER: Using generic lock for %s' % module_name)
+                display.debug('ANSIBALLZ: Using generic lock for %s' % module_name)
                 lock = strategy.action_write_locks[None]
 
-            display.debug('ZIPLOADER: Acquiring lock')
+            display.debug('ANSIBALLZ: Acquiring lock')
             with lock:
-                display.debug('ZIPLOADER: Lock acquired: %s' % id(lock))
+                display.debug('ANSIBALLZ: Lock acquired: %s' % id(lock))
                 # Check that no other process has created this while we were
                 # waiting for the lock
                 if not os.path.exists(cached_module_filename):
-                    display.debug('ZIPLOADER: Creating module')
+                    display.debug('ANSIBALLZ: Creating module')
                     # Create the module zip data
                     zipoutput = BytesIO()
                     zf = zipfile.ZipFile(zipoutput, mode='w', compression=compression_method)
@@ -613,19 +613,19 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
                         # Note -- if we have a global function to setup, that would
                         # be a better place to run this
                         os.mkdir(lookup_path)
-                    display.debug('ZIPLOADER: Writing module')
+                    display.debug('ANSIBALLZ: Writing module')
                     with open(cached_module_filename + '-part', 'wb') as f:
                         f.write(zipdata)
 
                     # Rename the file into its final position in the cache so
                     # future users of this module can read it off the
                     # filesystem instead of constructing from scratch.
-                    display.debug('ZIPLOADER: Renaming module')
+                    display.debug('ANSIBALLZ: Renaming module')
                     os.rename(cached_module_filename + '-part', cached_module_filename)
-                    display.debug('ZIPLOADER: Done creating module')
+                    display.debug('ANSIBALLZ: Done creating module')
 
             if zipdata is None:
-                display.debug('ZIPLOADER: Reading module after lock')
+                display.debug('ANSIBALLZ: Reading module after lock')
                 # Another process wrote the file while we were waiting for
                 # the write lock.  Go ahead and read the data from disk
                 # instead of re-creating it.
@@ -649,7 +649,7 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
             # string
             interpreter = u"'{0}'".format(interpreter)
 
-        output.write(to_bytes(ACTIVE_ZIPLOADER_TEMPLATE % dict(
+        output.write(to_bytes(ACTIVE_ANSIBALLZ_TEMPLATE % dict(
             zipdata=zipdata,
             ansible_module=module_name,
             params=python_repred_params,
@@ -693,7 +693,7 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
         # these strings could be included in a third-party module but
         # officially they were included in the 'basic' snippet for new-style
         # python modules (which has been replaced with something else in
-        # ziploader) If we remove them from jsonargs-style module replacer
+        # ansiballz) If we remove them from jsonargs-style module replacer
         # then we can remove them everywhere.
         python_repred_args = to_bytes(repr(module_args_json))
         module_data = module_data.replace(REPLACER_VERSION, to_bytes(repr(__version__)))

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -674,6 +674,12 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
         module_args_json = to_bytes(json.dumps(module_args))
         module_data = module_data.replace(REPLACER_JSONARGS, module_args_json)
 
+        # Powershell/winrm don't actually make use of shebang so we can
+        # safely set this here.  If we let the fallback code handle this
+        # it can fail in the presence of the UTF8 BOM commonly added by
+        # Windows text editors
+        shebang = u'#!powershell'
+
         # Sanity check from 1.x days.  This is currently useless as we only
         # get here if we are going to substitute powershell.ps1 into the
         # module anyway.  Leaving it for when/if we add other powershell

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -156,10 +156,14 @@ class PlayIterator:
 
         # Default options to gather
         gather_subset = C.DEFAULT_GATHER_SUBSET
+        gather_timeout = C.DEFAULT_GATHER_TIMEOUT
 
         # Retrieve subset to gather
         if self._play.gather_subset is not None:
             gather_subset = self._play.gather_subset
+        # Retrieve timeout for gather
+        if self._play.gather_timeout is not None:
+            gather_timeout = self._play.gather_timeout
 
         setup_block = Block(play=self._play)
         setup_task = Task(block=setup_block)
@@ -168,6 +172,8 @@ class PlayIterator:
         setup_task.args   = {
           'gather_subset': gather_subset,
         }
+        if gather_timeout:
+            setup_task.args['gather_timeout'] = gather_timeout
         setup_task.set_loader(self._play._loader)
         setup_block.block = [setup_task]
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -193,7 +193,7 @@ class TaskExecutor:
                 mylookup = self._shared_loader_obj.lookup_loader.get(self._task.loop, loader=self._loader, templar=templar)
 
                 # give lookup task 'context' for subdir (mostly needed for first_found)
-                for subdir in ['tempalte', 'var', 'file']: #TODO: move this to constants?
+                for subdir in ['template', 'var', 'file']: #TODO: move this to constants?
                     if subdir in self._task.name:
                         break
                 setattr(mylookup,'_subdir', subdir + 's')

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -316,6 +316,18 @@ class TaskQueueManager:
     def terminate(self):
         self._terminated = True
 
+    def has_dead_workers(self):
+
+        # [<WorkerProcess(WorkerProcess-2, stopped[SIGKILL])>,
+        # <WorkerProcess(WorkerProcess-2, stopped[SIGTERM])>
+
+        defunct = False
+        for idx,x in enumerate(self._workers):
+            if hasattr(x[0], 'exitcode'):
+                if x[0].exitcode in [-9, -15]:
+                    defunct = True
+        return defunct
+
     def send_callback(self, method_name, *args, **kwargs):
         for callback_plugin in [self._stdout_callback] + self._callback_plugins:
             # a plugin that set self.disabled to True will not be called

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -137,6 +137,7 @@ class GalaxyAPI(object):
         data = json.load(resp)
         return data
 
+    @g_connect
     def create_import_task(self, github_user, github_repo, reference=None):
         """
         Post an import request

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -718,13 +718,13 @@ class Inventory(object):
             self._vars_per_host = {}
             self._vars_per_group = {}
 
-    def get_host_vars(self, host, new_pb_basedir=False):
+    def get_host_vars(self, host, new_pb_basedir=False, return_results=False):
         """ Read host_vars/ files """
-        return self._get_hostgroup_vars(host=host, group=None, new_pb_basedir=new_pb_basedir)
+        return self._get_hostgroup_vars(host=host, group=None, new_pb_basedir=new_pb_basedir, return_results=return_results)
 
-    def get_group_vars(self, group, new_pb_basedir=False):
+    def get_group_vars(self, group, new_pb_basedir=False, return_results=False):
         """ Read group_vars/ files """
-        return self._get_hostgroup_vars(host=None, group=group, new_pb_basedir=new_pb_basedir)
+        return self._get_hostgroup_vars(host=None, group=group, new_pb_basedir=new_pb_basedir, return_results=return_results)
 
     def _find_group_vars_files(self, basedir):
         """ Find group_vars/ files """
@@ -746,7 +746,7 @@ class Inventory(object):
             found_vars = set(os.listdir(to_unicode(path)))
         return found_vars
 
-    def _get_hostgroup_vars(self, host=None, group=None, new_pb_basedir=False):
+    def _get_hostgroup_vars(self, host=None, group=None, new_pb_basedir=False, return_results=False):
         """
         Loads variables from group_vars/<groupname> and host_vars/<hostname> in directories parallel
         to the inventory base directory or in the same directory as the playbook.  Variables in the playbook
@@ -785,11 +785,15 @@ class Inventory(object):
             if host is None and any(map(lambda ext: group.name + ext in self._group_vars_files, C.YAML_FILENAME_EXTENSIONS)):
                 # load vars in dir/group_vars/name_of_group
                 base_path = to_unicode(os.path.abspath(os.path.join(to_bytes(basedir), b"group_vars/" + to_bytes(group.name))), errors='strict')
-                self._variable_manager.add_group_vars_file(base_path, self._loader)
+                host_results = self._variable_manager.add_group_vars_file(base_path, self._loader)
+                if return_results:
+                    results = combine_vars(results, host_results)
             elif group is None and any(map(lambda ext: host.name + ext in self._host_vars_files, C.YAML_FILENAME_EXTENSIONS)):
                 # same for hostvars in dir/host_vars/name_of_host
                 base_path = to_unicode(os.path.abspath(os.path.join(to_bytes(basedir), b"host_vars/" + to_bytes(host.name))), errors='strict')
-                self._variable_manager.add_host_vars_file(base_path, self._loader)
+                group_results = self._variable_manager.add_host_vars_file(base_path, self._loader)
+                if return_results:
+                    results = combine_vars(results, group_results)
 
         # all done, results is a dictionary of variables for this particular host.
         return results

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -27,8 +27,8 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-BOOLEANS_TRUE = ['yes', 'on', '1', 'true', 'True', 1, True]
-BOOLEANS_FALSE = ['no', 'off', '0', 'false', 'False', 0, False]
+BOOLEANS_TRUE = ['yes', 'on', '1', 'true', 1, True]
+BOOLEANS_FALSE = ['no', 'off', '0', 'false', 0, False]
 BOOLEANS = BOOLEANS_TRUE + BOOLEANS_FALSE
 
 # ansible modules can be written in any language.  To simplify

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2031,7 +2031,7 @@ class AnsibleModule(object):
         # If using ansible or ansible-playbook with a remote system ...
         #   /tmp/ansible_vmweLQ/ansible_modlib.zip/ansible/module_utils/basic.py
 
-        # Clean out python paths set by ziploader
+        # Clean out python paths set by ansiballz
         if 'PYTHONPATH' in os.environ:
             pypaths = os.environ['PYTHONPATH'].split(':')
             pypaths = [x for x in pypaths \

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -431,9 +431,10 @@ class AnsibleDockerClient(Client):
         images = response
         if tag: 
             lookup = "%s:%s" % (name, tag)
+            images = []
             for image in response:
-                self.log(image, pretty_print=True)
-                if image.get('RepoTags') and lookup in image.get('RepoTags'):
+                tags = image.get('RepoTags')
+                if tags and lookup in tags:
                     images = [image]
                     break
         return images

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -19,8 +19,15 @@
 
 import re
 
+<<<<<<< 95dea04b248f1199ee2fd5d572732abab59797af
 from ansible.module_utils.basic import json, get_exception, AnsibleModule
 from ansible.module_utils.network import Command, NetCli, NetworkError, get_module
+=======
+from ansible.module_utils.basic import json, AnsibleModule
+# We make NetworkModule available here for module code to use.  example:
+#     from ansible.module_utils.eos import NetworkModule
+from ansible.module_utils.network import NetCli, NetworkError, NetworkModule, Command
+>>>>>>> Refactor network and eos module_utils to use a subclass instead of factory function to create the NetworkModule
 from ansible.module_utils.network import add_argument, register_transport, to_list
 from ansible.module_utils.netcfg import NetworkConfig
 from ansible.module_utils.urls import fetch_url, url_argument_spec

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -19,6 +19,7 @@
 
 import re
 
+<<<<<<< 802ed0a6d766317cecd76be20d3bbccf0a80ea35
 <<<<<<< 95dea04b248f1199ee2fd5d572732abab59797af
 from ansible.module_utils.basic import json, get_exception, AnsibleModule
 from ansible.module_utils.network import Command, NetCli, NetworkError, get_module
@@ -29,6 +30,11 @@ from ansible.module_utils.basic import json, AnsibleModule
 from ansible.module_utils.network import NetCli, NetworkError, NetworkModule, Command
 >>>>>>> Refactor network and eos module_utils to use a subclass instead of factory function to create the NetworkModule
 from ansible.module_utils.network import add_argument, register_transport, to_list
+=======
+from ansible.module_utils.basic import json, get_exception
+from ansible.module_utils.network import Command, ModuleStub, NetCli, NetworkError
+from ansible.module_utils.network import add_argument, get_module, register_transport, to_list
+>>>>>>> EOS new ModuleStub
 from ansible.module_utils.netcfg import NetworkConfig
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 
@@ -207,8 +213,7 @@ class Eapi(EosConfigMixin):
 
     def __init__(self):
         self.url = None
-        self.url_args = AnsibleModule(url_argument_spec())
-        self.url_args.fail_json = self._error
+        self.url_args = ModuleStub(url_argument_spec(), self._error)
         self.enable = None
         self.default_output = 'json'
         self._connected = False

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -40,7 +40,7 @@ except ImportError:
     import configparser
 from ansible.module_utils.basic import get_all_subclasses
 
-# py2 vs py3; replace with six via ziploader
+# py2 vs py3; replace with six via ansiballz
 try:
     # python2
     from StringIO import StringIO

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -113,15 +113,21 @@ if platform.system() != 'SunOS':
 # timeout function to make sure some fact gathering
 # steps do not exceed a time limit
 
+GATHER_TIMEOUT=None
+
 class TimeoutError(Exception):
     pass
 
 def timeout(seconds=10, error_message="Timer expired"):
+
     def decorator(func):
         def _handle_timeout(signum, frame):
             raise TimeoutError(error_message)
 
         def wrapper(*args, **kwargs):
+            if 'GATHER_TIMEOUT' in globals():
+                if GATHER_TIMEOUT:
+                    seconds = GATHER_TIMEOUT
             signal.signal(signal.SIGALRM, _handle_timeout)
             signal.alarm(seconds)
             try:
@@ -3224,6 +3230,9 @@ def get_all_facts(module):
 
     # Retrieve module parameters
     gather_subset = module.params['gather_subset']
+
+    global GATHER_TIMEOUT
+    GATHER_TIMEOUT = module.params['gather_timeout']
 
     # Retrieve all facts elements
     additional_subsets = set()

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -19,8 +19,162 @@
 
 import re
 
-from ansible.module_utils.network import Command, NetCli, NetworkError, get_module
-from ansible.module_utils.network import register_transport, to_list
+from ansible.module_utils.basic import json
+from ansible.module_utils.network import Command, ModuleStub, NetCli, NetworkError
+from ansible.module_utils.network import add_argument, get_module, register_transport, to_list
+from ansible.module_utils.netcfg import NetworkConfig
+from ansible.module_utils.urls import fetch_url, url_argument_spec, urlparse
+
+add_argument('use_ssl', dict(default=True, type='bool'))
+add_argument('validate_certs', dict(default=True, type='bool'))
+
+def argument_spec():
+    return dict(
+        running_config=dict(aliases=['config']),
+        save_config=dict(default=False, aliases=['save']),
+        force=dict(type='bool', default=False)
+    )
+ios_argument_spec = argument_spec()
+
+def get_config(module, include_defaults=False):
+    config = module.params['running_config']
+    if not config and not include_defaults:
+        config = module.config.get_config()
+    else:
+        config = module.cli('show running-config all')[0]
+    return NetworkConfig(indent=1, contents=config)
+
+
+class Restconf(object):
+
+    DEFAULT_HEADERS = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    def __init__(self):
+        self.url = None
+
+        self.url_args = ModuleStub(url_argument_spec(), self._error)
+
+        self.token = None
+        self.link = None
+
+        self._connected = False
+        self.default_output = 'text'
+
+    def _error(self, msg):
+        raise NetworkError(msg, url=self.url)
+
+    def connect(self, params, **kwargs):
+        host = params['host']
+        port = params['port'] or 55443
+
+        self.url_args.params['url_username'] = params['username']
+        self.url_args.params['url_password'] = params['password']
+        self.url_args.params['validate_certs'] = params['validate_certs']
+
+        self.url = 'https://%s:%s/api/v1/' % (host, port)
+
+        response = self.post('auth/token-services')
+
+        self.token = response['token-id']
+        self.link = response['link']
+        self._connected = True
+
+    def disconnect(self):
+        self.delete(self.link)
+        self._connected = False
+
+    def authorize(self):
+        pass
+
+    ### REST methods ###
+
+    def request(self, method, path, data=None, headers=None):
+
+        headers = headers or self.DEFAULT_HEADERS
+
+        if self.token:
+            headers['X-Auth-Token'] = self.token
+
+        if path.startswith('/'):
+            path = path[1:]
+
+        url = urlparse.urljoin(self.url, path)
+
+        if data:
+            data = json.dumps(data)
+
+        response, headers = fetch_url(self.url_args, url, data=data,
+                headers=headers, method=method)
+
+        if not 200 <= headers['status'] <= 299:
+            raise NetworkError(response=response, **headers)
+
+        if int(headers['content-length']) > 0:
+            if headers['content-type'].startswith('application/json'):
+                response = json.load(response)
+            elif headers['content-type'].startswith('text/plain'):
+                response = str(response.read())
+
+        return response
+
+    def get(self, path, data=None, headers=None):
+        return self.request('GET', path, data, headers)
+
+    def put(self, path, data=None, headers=None):
+        return self.request('PUT', path, data, headers)
+
+    def post(self, path, data=None, headers=None):
+        return self.request('POST', path, data, headers)
+
+    def delete(self, path, data=None, headers=None):
+        return self.request('DELETE', path, data, headers)
+
+
+    ### implementation of Cli ###
+
+    def run_commands(self, commands):
+        responses = list()
+        for cmd in to_list(commands):
+            if str(cmd).startswith('show '):
+                cmd = str(cmd)[4:]
+            responses.append(self.execute(str(cmd)))
+        return responses
+
+    def execute(self, command):
+        data = dict(show=command)
+        response = self.put('global/cli', data=data)
+        return response['results']
+
+
+    ### implementation of Config ###
+
+    def configure(self, commands):
+        config = list()
+        for c in commands:
+            config.append(str(c))
+        data = dict(config='\n'.join(config))
+        self.put('global/cli', data=data)
+
+    def load_config(self, commands, **kwargs):
+        raise NotImplementedError
+
+    def get_config(self, **kwargs):
+        hdrs = {'Content-type': 'text/plain', 'Accept': 'text/plain'}
+        return self.get('global/running-config', headers=hdrs)
+
+    def commit_config(self, **kwargs):
+        raise NotImplementedError
+
+    def abort_config(self, **kwargs):
+        raise NotImplementedError
+
+    def save_config(self):
+        self.put('/api/v1/global/save-config')
+Restconf = register_transport('restconf')(Restconf)
+
 
 class Cli(NetCli):
     CLI_PROMPTS_RE = [
@@ -71,6 +225,9 @@ class Cli(NetCli):
 
     def abort_config(self, **kwargs):
         raise NotImplementedError
+
+    def save_config(self):
+        self.execute(['copy running-config startup-config'])
 
     def run_commands(self, commands):
         cmds = to_list(commands)

--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -26,7 +26,7 @@ import itertools
 from ansible.module_utils.basic import BOOLEANS_TRUE, BOOLEANS_FALSE
 from ansible.module_utils.network import to_list
 
-DEFAULT_COMMENT_TOKENS = ['#', '!']
+DEFAULT_COMMENT_TOKENS = ['#', '!', '/*', '*/']
 
 
 class ConfigLine(object):
@@ -119,6 +119,8 @@ def dumps(objects, output='block'):
             line.extend([p.text for p in obj.parents])
             line.append(obj.text)
             items.append(' '.join(line))
+    else:
+        raise TypeError('unknown value supplied for keyword output')
     return '\n'.join(items)
 
 class NetworkConfig(object):

--- a/lib/ansible/module_utils/network.py
+++ b/lib/ansible/module_utils/network.py
@@ -49,6 +49,13 @@ def to_list(val):
         return list()
 
 
+class ModuleStub(object):
+    def __init__(self, argument_spec, fail_json):
+        self.params = dict()
+        for key, value in argument_spec.items():
+            self.params[key] = value.get('default')
+        self.fail_json = fail_json
+
 class Command(object):
 
     def __init__(self, command, output=None, prompt=None, response=None,

--- a/lib/ansible/module_utils/network.py
+++ b/lib/ansible/module_utils/network.py
@@ -48,24 +48,6 @@ def to_list(val):
     else:
         return list()
 
-def connect(module):
-    try:
-        if not module.connected:
-            module.connection.connect(module.params)
-            if module.params['authorize']:
-                module.connection.authorize(module.params)
-    except NetworkError:
-        exc = get_exception()
-        module.fail_json(msg=exc.message)
-
-def disconnect(module):
-    try:
-        if module.connected:
-            module.connection.disconnect()
-    except NetworkError:
-        exc = get_exception()
-        module.fail_json(msg=exc.message)
-
 
 class Command(object):
 
@@ -157,15 +139,38 @@ class NetworkError(Exception):
 class NetworkModule(AnsibleModule):
 
     def __init__(self, *args, **kwargs):
+        connect_on_load = kwargs.pop('connect_on_load', True)
+
+        argument_spec = NET_TRANSPORT_ARGS.copy()
+        argument_spec['transport']['choices'] = NET_CONNECTIONS.keys()
+        argument_spec.update(NET_CONNECTION_ARGS.copy())
+
+        if kwargs.get('argument_spec'):
+            argument_spec.update(kwargs['argument_spec'])
+        kwargs['argument_spec'] = argument_spec
+
         super(NetworkModule, self).__init__(*args, **kwargs)
         self.connection = None
         self._cli = None
         self._config = None
 
+        try:
+            transport = self.params['transport'] or '__default__'
+            cls = NET_CONNECTIONS[transport]
+            self.connection = cls()
+        except KeyError:
+            self.fail_json(msg='Unknown transport or no default transport specified')
+        except (TypeError, NetworkError):
+            exc = get_exception()
+            self.fail_json(msg=exc.message)
+
+        if connect_on_load:
+            self.connect()
+
     @property
     def cli(self):
         if not self.connected:
-            connect(self)
+            self.connect(self)
         if self._cli:
             return self._cli
         self._cli = Cli(self.connection)
@@ -174,7 +179,7 @@ class NetworkModule(AnsibleModule):
     @property
     def config(self):
         if not self.connected:
-            connect(self)
+            self.connect(self)
         if self._config:
             return self._config
         self._config = Config(self.connection)
@@ -192,6 +197,24 @@ class NetworkModule(AnsibleModule):
                 if key in args:
                     if self.params.get(key) is None and value is not None:
                         self.params[key] = value
+
+    def connect(self):
+        try:
+            if not self.connected:
+                self.connection.connect(self.params)
+                if self.params['authorize']:
+                    self.connection.authorize(self.params)
+        except NetworkError:
+            exc = get_exception()
+            self.fail_json(msg=exc.message)
+
+    def disconnect(self):
+        try:
+            if self.connected:
+                self.connection.disconnect()
+        except NetworkError:
+            exc = get_exception()
+            self.fail_json(msg=exc.message)
 
 
 class NetCli(object):
@@ -248,32 +271,6 @@ class NetCli(object):
             exc = get_exception()
             raise NetworkError(exc.message, commands=commands)
 
-
-def get_module(connect_on_load=True, **kwargs):
-    argument_spec = NET_TRANSPORT_ARGS.copy()
-    argument_spec['transport']['choices'] = NET_CONNECTIONS.keys()
-    argument_spec.update(NET_CONNECTION_ARGS.copy())
-
-    if kwargs.get('argument_spec'):
-        argument_spec.update(kwargs['argument_spec'])
-    kwargs['argument_spec'] = argument_spec
-
-    module = NetworkModule(**kwargs)
-
-    try:
-        transport = module.params['transport'] or '__default__'
-        cls = NET_CONNECTIONS[transport]
-        module.connection = cls()
-    except KeyError:
-        module.fail_json(msg='Unknown transport or no default transport specified')
-    except (TypeError, NetworkError):
-        exc = get_exception()
-        module.fail_json(msg=exc.message)
-
-    if connect_on_load:
-        connect(module)
-
-    return module
 
 def register_transport(transport, default=False):
     def register(cls):

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -21,7 +21,7 @@ import socket
 
 from ansible.module_utils.basic import get_exception
 
-# py2 vs py3; replace with six via ziploader
+# py2 vs py3; replace with six via ansiballz
 try:
     from StringIO import StringIO
 except ImportError:

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -20,8 +20,8 @@
 import itertools
 import re
 
-from ansible.module_utils.network import NetworkError, get_module, get_exception
-from ansible.module_utils.network import register_transport, to_list
+from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.network import register_transport, to_list, get_exception
 from ansible.module_utils.network import Command, NetCli
 from ansible.module_utils.netcfg import NetworkConfig
 from ansible.module_utils.shell import Shell, ShellError, HAS_PARAMIKO
@@ -30,14 +30,14 @@ DEFAULT_COMMENT = 'configured by vyos_config'
 
 def argument_spec():
     return dict(
-        config=dict(),
+        running_config=dict(aliases=['config']),
         comment=dict(default=DEFAULT_COMMENT),
-        save=dict(type='bool')
+        save_config=dict(type='bool', aliases=['save'])
     )
 vyos_argument_spec = argument_spec()
 
 def get_config(module):
-    contents = module.params['config']
+    contents = module.params['running_config']
     if not contents:
         contents = str(module.config.get_config()).split('\n')
         module.params['config'] = contents
@@ -74,7 +74,7 @@ def load_candidate(module, candidate):
     updates = diff_config(candidate, config)
 
     comment = module.params['comment']
-    save = module.params['save']
+    save = module.params['save_config']
 
     result = dict(changed=False)
 

--- a/lib/ansible/parsing/__init__.py
+++ b/lib/ansible/parsing/__init__.py
@@ -1,4 +1,4 @@
-# (c) 2015, Toshio Kuratomi <tkuratomi@ansbile.com>
+# (c) 2015, Toshio Kuratomi <tkuratomi@ansible.com>
 #
 # This file is part of Ansible
 #

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -380,11 +380,11 @@ class DataLoader():
 
         try:
             with open(to_bytes(real_path), 'rb') as f:
-                data = f.read()
-                if self._vault.is_encrypted(data):
+                if self._vault.is_encrypted(f):
                     # if the file is encrypted and no password was specified,
                     # the decrypt call would throw an error, but we check first
                     # since the decrypt function doesn't know the file name
+                    data = f.read()
                     if not self._vault_password:
                         raise AnsibleParserError("A vault password must be specified to decrypt %s" % file_path)
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -115,6 +115,12 @@ class VaultLib:
         :returns: True if it is recognized.  Otherwise, False.
         """
 
+        if hasattr(data, 'read'):
+            current_position = data.tell()
+            header_part = data.read(len(b_HEADER))
+            data.seek(current_position)
+            return self.is_encrypted(header_part)
+
         if to_bytes(data, errors='strict', encoding='utf-8').startswith(b_HEADER):
             return True
         return False

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -30,6 +30,12 @@ from hashlib import sha256
 from binascii import hexlify
 from binascii import unhexlify
 
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
 # Note: Only used for loading obsolete VaultAES files.  All files are written
 # using the newer VaultAES256 which does not require md5
 from hashlib import md5
@@ -71,10 +77,9 @@ try:
 except ImportError:
     pass
 except Exception as e:
-    if e.__module__ == 'pkg_resources' and e.__class__.__name__ == 'DistributionNotFound':
-        pass
-    else:
-        raise
+    display.warning("Optional dependency 'cryptography' raised an exception, falling back to 'Crypto'")
+    import traceback
+    traceback.print_exc()
 
 from ansible.compat.six import PY3
 from ansible.utils.unicode import to_unicode, to_bytes

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -79,7 +79,7 @@ except ImportError:
 except Exception as e:
     display.warning("Optional dependency 'cryptography' raised an exception, falling back to 'Crypto'")
     import traceback
-    traceback.print_exc()
+    display.debug("Traceback from import of cryptography was {0}".format(traceback.format_exc()))
 
 from ansible.compat.six import PY3
 from ansible.utils.unicode import to_unicode, to_bytes

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -63,6 +63,7 @@ class Base:
     _always_run           = FieldAttribute(isa='bool')
     _run_once             = FieldAttribute(isa='bool')
     _ignore_errors        = FieldAttribute(isa='bool')
+    _check_mode = FieldAttribute(isa='bool')
 
     # param names which have been deprecated/removed
     DEPRECATED_ATTRIBUTES = [

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -65,6 +65,7 @@ class Play(Base, Taggable, Become):
     # Connection
     _gather_facts        = FieldAttribute(isa='bool', default=None, always_post_validate=True)
     _gather_subset       = FieldAttribute(isa='barelist', default=None, always_post_validate=True)
+    _gather_timeout      = FieldAttribute(isa='int', default=None, always_post_validate=True)
     _hosts               = FieldAttribute(isa='list', required=True, listof=string_types, always_post_validate=True)
     _name                = FieldAttribute(isa='string', default='', always_post_validate=True)
 

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -440,9 +440,14 @@ class PlayContext(Base):
         # set become defaults if not previouslly set
         task.set_become_defaults(new_info.become, new_info.become_method, new_info.become_user)
 
-        # have always_run override check mode
         if task.always_run:
+            display.deprecated("always_run is deprecated. Use check_mode = no instead.", version="2.4", removed=False)
             new_info.check_mode = False
+
+        # check_mode replaces always_run, overwrite always_run if both are given
+        if task.check_mode is not None:
+            new_info.check_mode = task.check_mode
+
 
         return new_info
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -718,7 +718,14 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 cmd = executable + ' -c ' + pipes.quote(cmd)
 
         display.debug("_low_level_execute_command(): executing: %s" % (cmd,))
-        rc, stdout, stderr = self._connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)
+
+        # Change directory to basedir of task for command execution
+        cwd = os.getcwd()
+        os.chdir(self._loader.get_basedir())
+        try:
+            rc, stdout, stderr = self._connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        finally:
+            os.chdir(cwd)
 
         # stdout and stderr may be either a file-like or a bytes object.
         # Convert either one to a text type

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -831,18 +831,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             to get back the first existing file found.
         '''
 
-        path_stack = []
-
-        dep_chain =  self._task._block.get_dep_chain()
-        # inside role: add the dependency chain
-        if dep_chain:
-            path_stack.extend(reversed([x._role_path for x in dep_chain]))
-
-
-        task_dir = os.path.dirname(self._task.get_path())
-        # include from diff directory: add it to file path
-        if not task_dir.endswith('tasks') and task_dir != self._loader.get_basedir():
-            path_stack.append(task_dir)
+        path_stack = self._task.get_search_path()
 
         result = self._loader.path_dwim_relative_stack(path_stack, dirname, needle)
 

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -26,13 +26,19 @@ class ActionModule(ActionBase):
     TRANSFERS_FILES = False
 
     def run(self, tmp=None, task_vars=None):
+
+        varname = self._task.args.get('name')
+        source = self._task.args.get('file')
+        if not source:
+            source = self._task.args.get('_raw_params')
+
         if task_vars is None:
             task_vars = dict()
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
         try:
-            source = self._find_needle('vars', self._task.args.get('_raw_params'))
+            source = self._find_needle('vars', source)
         except AnsibleError as e:
             result['failed'] = True
             result['message'] = to_str(e)
@@ -46,6 +52,10 @@ class ActionModule(ActionBase):
             result['failed'] = True
             result['message'] = "%s must be stored as a dictionary/hash" % source
         else:
+            if varname:
+                scope = {}
+                scope[varname] = data
+                data = scope
             result['ansible_facts'] = data
             result['_ansible_no_log'] = not show_content
 

--- a/lib/ansible/plugins/action/ios_config.py
+++ b/lib/ansible/plugins/action/ios_config.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass
+
+

--- a/lib/ansible/plugins/action/net_config.py
+++ b/lib/ansible/plugins/action/net_config.py
@@ -1,0 +1,123 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import time
+import glob
+import urlparse
+
+from ansible.plugins.action import ActionBase
+from ansible.utils.unicode import to_unicode
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = False
+
+    def run(self, tmp=None, task_vars=None):
+        result = super(ActionModule, self).run(tmp, task_vars)
+        result['changed'] = False
+
+        if self._task.args.get('src'):
+            try:
+                self._handle_template()
+            except ValueError as exc:
+                return dict(failed=True, msg=exc.message)
+
+        result.update(self._execute_module(module_name=self._task.action,
+            module_args=self._task.args, task_vars=task_vars))
+
+        if self._task.args.get('backup_config') and result.get('__backup__'):
+            # User requested backup and no error occurred in module.
+            # NOTE: If there is a parameter error, _backup key may not be in results.
+            self._write_backup(task_vars['inventory_hostname'], result['__backup__'])
+
+        if self._task.args.get('dest') and result.get('__config__'):
+            self._write_dest(self._task.args['dest'], result['__config__'],
+                             append=self._task.args['append'])
+
+        for key in ['__config__', '__backup__']:
+            if key in result:
+                del result[key]
+
+        return result
+
+    def _get_working_path(self):
+        cwd = self._loader.get_basedir()
+        if self._task._role is not None:
+            cwd = self._task._role._role_path
+        return cwd
+
+    def _write_backup(self, host, contents):
+        backup_path = self._get_working_path() + '/backup'
+        if not os.path.exists(backup_path):
+            os.mkdir(backup_path)
+        for fn in glob.glob('%s/%s*' % (backup_path, host)):
+            os.remove(fn)
+        tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+        filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
+        open(filename, 'w').write(contents)
+
+    def _write_dest(self, path, contents, append=False):
+        dirpath = os.path.dirname(path)
+        if not dirpath[0] == '/':
+            dirpath = self._get_working_path() + dirpath
+        if not os.path.exists(dirpath):
+            os.mkdir(dirpath)
+        if append:
+            flags = 'a'
+        else:
+            flags = 'w'
+        open(path, flags).write(contents)
+
+    def _handle_template(self):
+        src = self._task.args.get('src')
+        working_path = self._get_working_path()
+
+        if os.path.isabs(src) or urlparse.urlsplit('src').scheme:
+            source = src
+        else:
+            source = self._loader.path_dwim_relative(working_path, 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(working_path, src)
+
+        if not os.path.exists(source):
+            return
+
+        try:
+            with open(source, 'r') as f:
+                template_data = to_unicode(f.read())
+        except IOError:
+            return dict(failed=True, msg='unable to load src file')
+
+        # Create a template search path in the following order:
+        # [working_path, self_role_path, dependent_role_paths, dirname(source)]
+        searchpath = [working_path]
+        if self._task._role is not None:
+            searchpath.append(self._task._role._role_path)
+            dep_chain = self._task._block.get_dep_chain()
+            if dep_chain is not None:
+                for role in dep_chain:
+                    searchpath.append(role._role_path)
+        searchpath.append(os.path.dirname(source))
+        self._templar.environment.loader.searchpath = searchpath
+        self._task.args['src'] = self._templar.template(template_data)
+
+

--- a/lib/ansible/plugins/action/net_config.py
+++ b/lib/ansible/plugins/action/net_config.py
@@ -49,13 +49,8 @@ class ActionModule(ActionBase):
             # NOTE: If there is a parameter error, _backup key may not be in results.
             self._write_backup(task_vars['inventory_hostname'], result['__backup__'])
 
-        if self._task.args.get('dest') and result.get('__config__'):
-            self._write_dest(self._task.args['dest'], result['__config__'],
-                             append=self._task.args['append'])
-
-        for key in ['__config__', '__backup__']:
-            if key in result:
-                del result[key]
+        if '__backup__' in result:
+            del result['__backup__']
 
         return result
 
@@ -74,18 +69,6 @@ class ActionModule(ActionBase):
         tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
         filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
         open(filename, 'w').write(contents)
-
-    def _write_dest(self, path, contents, append=False):
-        dirpath = os.path.dirname(path)
-        if not dirpath[0] == '/':
-            dirpath = self._get_working_path() + dirpath
-        if not os.path.exists(dirpath):
-            os.mkdir(dirpath)
-        if append:
-            flags = 'a'
-        else:
-            flags = 'w'
-        open(path, flags).write(contents)
 
     def _handle_template(self):
         src = self._task.args.get('src')

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -25,6 +25,10 @@ class ActionModule(ActionBase):
 
     TRANSFERS_FILES = False
 
+    UNUSED_PARAMS = {
+        'systemd': ['pattern', 'runlevels', 'sleep', 'arguments'],
+    }
+
     def run(self, tmp=None, task_vars=None):
         ''' handler for package operations '''
         if task_vars is None:
@@ -58,6 +62,12 @@ class ActionModule(ActionBase):
             # for backwards compatibility
             if 'state' in new_module_args and new_module_args['state'] == 'running':
                 new_module_args['state'] = 'started'
+
+            if module in self.UNUSED_PARAMS:
+                for unused in self.UNUSED_PARAMS[module]:
+                    if unused in new_module_args:
+                        del new_module_args[unused]
+                        self._display.warning('Ignoring "%s" as it is not used in "%s"' % (unused, module))
 
             self._display.vvvv("Running %s" % module)
             result.update(self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars))

--- a/lib/ansible/plugins/action/vyos_config.py
+++ b/lib/ansible/plugins/action/vyos_config.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass
+
+

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -89,7 +89,7 @@ class CallbackBase:
         if result.get('_ansible_no_log', False):
             return json.dumps(dict(censored="the output has been hidden due to the fact that 'no_log: true' was specified for this result"))
 
-        if not indent and '_ansible_verbose_always' in result and result['_ansible_verbose_always']:
+        if not indent and (result.get('_ansible_verbose_always') or self._display.verbosity > 2):
             indent = 4
 
         # All result keys stating with _ansible_ are internal, so remove them from the result before we output anything.

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -69,7 +69,6 @@ class Connection(ConnectionBase):
         executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else None
 
         display.vvv(u"EXEC {0}".format(cmd), host=self._play_context.remote_addr)
-        # FIXME: cwd= needs to be set to the basedir of the playbook
         display.debug("opening command with Popen()")
 
         if isinstance(cmd, (text_type, binary_type)):

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -26,7 +26,6 @@ import itertools
 import json
 import os.path
 import ntpath
-import types
 import pipes
 import glob
 import re
@@ -34,13 +33,11 @@ import crypt
 import hashlib
 import string
 from functools import partial
-import operator as py_operator
 from random import SystemRandom, shuffle
 import uuid
 
 import yaml
 from jinja2.filters import environmentfilter
-from distutils.version import LooseVersion, StrictVersion
 from ansible.compat.six import iteritems, string_types
 
 from ansible import errors
@@ -186,32 +183,6 @@ def ternary(value, true_val, false_val):
         return false_val
 
 
-def version_compare(value, version, operator='eq', strict=False):
-    ''' Perform a version comparison on a value '''
-    op_map = {
-        '==': 'eq', '=':  'eq', 'eq': 'eq',
-        '<':  'lt', 'lt': 'lt',
-        '<=': 'le', 'le': 'le',
-        '>':  'gt', 'gt': 'gt',
-        '>=': 'ge', 'ge': 'ge',
-        '!=': 'ne', '<>': 'ne', 'ne': 'ne'
-    }
-
-    if strict:
-        Version = StrictVersion
-    else:
-        Version = LooseVersion
-
-    if operator in op_map:
-        operator = op_map[operator]
-    else:
-        raise errors.AnsibleFilterError('Invalid operator type')
-
-    try:
-        method = getattr(py_operator, operator)
-        return method(Version(str(value)), Version(str(version)))
-    except Exception as e:
-        raise errors.AnsibleFilterError('Version comparison: %s' % e)
 
 def regex_escape(string):
     '''Escape all regular expressions special characters from STRING.'''
@@ -261,7 +232,6 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
         'sha512':   '6',
     }
 
-    hastype = hashtype.lower()
     if hashtype in cryptmethod:
         if salt is None:
             r = SystemRandom()
@@ -461,9 +431,6 @@ class FilterModule(object):
             'ternary': ternary,
 
             # list
-            # version comparison
-            'version_compare': version_compare,
-
             # random stuff
             'random': rand,
             'shuffle': randomize_list,

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -585,7 +585,6 @@ def nthhost(value, query=''):
         return False
 
     try:
-        vsize = ipaddr(v, 'size')
         nth = int(query)
         if value.size > nth:
           return value[nth]

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -70,12 +70,6 @@ def max(a):
     _max = __builtins__.get('max')
     return _max(a);
 
-def isnotanumber(x):
-    try:
-        return math.isnan(x)
-    except TypeError:
-        return False
-
 
 def logarithm(x, base=math.e):
     try:
@@ -136,7 +130,6 @@ class FilterModule(object):
     def filters(self):
         return {
             # general math
-            'isnan': isnotanumber,
             'min' : min,
             'max' : max,
 

--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 from abc import ABCMeta, abstractmethod
 
 from ansible.compat.six import with_metaclass
+from ansible.errors import AnsibleFileNotFound
 
 try:
     from __main__ import display
@@ -101,3 +102,19 @@ class LookupBase(with_metaclass(ABCMeta, object)):
             result_string = to_unicode(result_string)
         """
         pass
+
+    def find_file_in_search_path(self, myvars, subdir, needle):
+        '''
+        Return a file (needle) in the task's expected search path.
+        '''
+
+        if 'ansible_search_path' in myvars:
+            paths = myvars['ansible_search_path']
+        else:
+            paths = self.get_basedir(myvars)
+
+        result = self._loader.path_dwim_relative_stack(paths, subdir, needle)
+        if result is None:
+            raise AnsibleFileNotFound("Unable to find '%s' in expected paths." % needle)
+
+        return result

--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -72,8 +72,6 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
 
-        basedir = self.get_basedir(variables)
-
         ret = []
 
         for term in terms:
@@ -100,7 +98,7 @@ class LookupModule(LookupBase):
             if paramvals['delimiter'] == 'TAB':
                 paramvals['delimiter'] = "\t"
 
-            lookupfile = self._loader.path_dwim_relative(basedir, 'files', paramvals['file'])
+            lookupfile = self.find_file_in_search_path(variables, 'files', paramvals['file'])
             var = self.read_csv(lookupfile, key, paramvals['delimiter'], paramvals['encoding'], paramvals['default'], paramvals['col'])
             if var is not None:
                 if type(var) is list:

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -33,18 +33,11 @@ class LookupModule(LookupBase):
 
         ret = []
 
-        basedir = self.get_basedir(variables)
-
         for term in terms:
             display.debug("File lookup term: %s" % term)
 
-            # Special handling of the file lookup, used primarily when the
-            # lookup is done from a role. If the file isn't found in the
-            # basedir of the current file, use dwim_relative to look in the
-            # role/files/ directory, and finally the playbook directory
-            # itself (which will be relative to the current working dir)
-
-            lookupfile = self._loader.path_dwim_relative(basedir, 'files', term)
+            # Find the file in the expected search path
+            lookupfile = self.find_file_in_search_path(variables, 'files', term)
             display.vvvv("File lookup using %s as file" % lookupfile)
             try:
                 if lookupfile:

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -26,12 +26,10 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
 
-        basedir = self.get_basedir(variables)
-
         ret = []
         for term in terms:
             term_file = os.path.basename(term)
-            dwimmed_path = self._loader.path_dwim_relative(basedir, 'files', os.path.dirname(term))
+            dwimmed_path = self.find_file_in_search_path(variables, 'files', os.path.dirname(term))
             globbed = glob.glob(os.path.join(dwimmed_path, term_file))
             ret.extend(g for g in globbed if os.path.isfile(g))
         return ret

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -107,7 +107,7 @@ class LookupModule(LookupBase):
             except (ValueError, AssertionError) as e:
                 raise AnsibleError(e)
 
-            path = self._loader.path_dwim_relative(basedir, 'files', paramvals['file'])
+            path = self.find_file_in_search_path(variables, 'files', paramvals['file'])
             if paramvals['type'] == "properties":
                 var = self.read_properties(path, key, paramvals['default'], paramvals['re'])
             else:

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -19,7 +19,6 @@ __metaclass__ = type
 
 import os
 
-from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.unicode import to_unicode
@@ -36,26 +35,25 @@ class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
 
         convert_data_p = kwargs.get('convert_data', True)
-        basedir = self.get_basedir(variables)
-
         ret = []
 
         for term in terms:
             display.debug("File lookup term: %s" % term)
 
-            lookupfile = self._loader.path_dwim_relative(basedir, 'templates', term)
+            lookupfile = self.find_file_in_search_path(variables, 'templates', term)
             display.vvvv("File lookup using %s as file" % lookupfile)
-            if lookupfile and os.path.exists(lookupfile):
+            if lookupfile:
                 with open(lookupfile, 'r') as f:
                     template_data = to_unicode(f.read())
 
-                    searchpath = [self._loader._basedir, os.path.dirname(lookupfile)]
-                    if 'role_path' in variables:
-                        if C.DEFAULT_ROLES_PATH:
-                            searchpath[:0] = C.DEFAULT_ROLES_PATH
-                        searchpath.insert(1, variables['role_path'])
-
+                    # set jinja2 internal search path for includes
+                    if 'ansible_search_path' in variables:
+                        searchpath = variables['ansible_search_path']
+                    else:
+                        searchpath = [self._loader._basedir, os.path.dirname(lookupfile)]
                     self._templar.environment.loader.searchpath = searchpath
+
+                    # do the templating
                     res = self._templar.template(template_data, preserve_trailing_newlines=True,convert_data=convert_data_p)
                     ret.append(res)
             else:

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -454,9 +454,14 @@ class StrategyBase:
 
         display.debug("waiting for pending results...")
         while self._pending_results > 0 and not self._tqm._terminated:
+
+            if self._tqm.has_dead_workers():
+                raise AnsibleError("A worker was found in a dead state")
+
             results = self._process_pending_results(iterator)
             ret_results.extend(results)
             time.sleep(0.005)
+
         display.debug("no more pending results, returning what we have")
 
         return ret_results

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -349,12 +349,15 @@ class StrategyModule(StrategyBase):
 
                 display.debug("checking for any_errors_fatal")
                 failed_hosts = []
+                unreachable_hosts = []
                 for res in results:
                     if res.is_failed():
                         failed_hosts.append(res._host.name)
+                    elif res.is_unreachable():
+                        unreachable_hosts.append(res._host.name)
 
                 # if any_errors_fatal and we had an error, mark all hosts as failed
-                if any_errors_fatal and (len(failed_hosts) > 0 or len(self._tqm._unreachable_hosts.keys()) > 0):
+                if any_errors_fatal and (len(failed_hosts) > 0 or len(unreachable_hosts) > 0):
                     for host in hosts_left:
                         # don't double-mark hosts, or the iterator will potentially
                         # fail them out of the rescue/always states

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -84,15 +84,6 @@ def search(value, pattern='', ignorecase=False, multiline=False):
     ''' Perform a `re.search` returning a boolean '''
     return regex(value, pattern, ignorecase, multiline, 'search')
 
-def undefined(a):
-    ''' Test if a variable is undefined '''
-    from jinja2.runtime import Undefined
-    return isinstance(a, Undefined)
-
-def defined(a):
-    ''' Test if a variable is defined '''
-    return not undefined(a)
-
 class TestModule(object):
     ''' Ansible core jinja2 tests '''
 
@@ -117,7 +108,4 @@ class TestModule(object):
             'search': search,
             'regex': regex,
 
-            # variable testing
-            'undefined': undefined,
-            'defined': defined,
         }

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -20,6 +20,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
+import operator as py_operator
+from distutils.version import LooseVersion, StrictVersion
+
 from ansible import errors
 
 def failed(*a, **kw):
@@ -84,6 +87,33 @@ def search(value, pattern='', ignorecase=False, multiline=False):
     ''' Perform a `re.search` returning a boolean '''
     return regex(value, pattern, ignorecase, multiline, 'search')
 
+def version_compare(value, version, operator='eq', strict=False):
+    ''' Perform a version comparison on a value '''
+    op_map = {
+        '==': 'eq', '=':  'eq', 'eq': 'eq',
+        '<':  'lt', 'lt': 'lt',
+        '<=': 'le', 'le': 'le',
+        '>':  'gt', 'gt': 'gt',
+        '>=': 'ge', 'ge': 'ge',
+        '!=': 'ne', '<>': 'ne', 'ne': 'ne'
+    }
+
+    if strict:
+        Version = StrictVersion
+    else:
+        Version = LooseVersion
+
+    if operator in op_map:
+        operator = op_map[operator]
+    else:
+        raise errors.AnsibleFilterError('Invalid operator type')
+
+    try:
+        method = getattr(py_operator, operator)
+        return method(Version(str(value)), Version(str(version)))
+    except Exception as e:
+        raise errors.AnsibleFilterError('Version comparison: %s' % e)
+
 class TestModule(object):
     ''' Ansible core jinja2 tests '''
 
@@ -107,5 +137,8 @@ class TestModule(object):
             'match': match,
             'search': search,
             'regex': regex,
+
+            # version comparison
+            'version_compare': version_compare,
 
         }

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -84,6 +84,15 @@ def search(value, pattern='', ignorecase=False, multiline=False):
     ''' Perform a `re.search` returning a boolean '''
     return regex(value, pattern, ignorecase, multiline, 'search')
 
+def undefined(a):
+    ''' Test if a variable is undefined '''
+    from jinja2.runtime import Undefined
+    return isinstance(a, Undefined)
+
+def defined(a):
+    ''' Test if a variable is defined '''
+    return not undefined(a)
+
 class TestModule(object):
     ''' Ansible core jinja2 tests '''
 
@@ -107,4 +116,8 @@ class TestModule(object):
             'match': match,
             'search': search,
             'regex': regex,
+
+            # variable testing
+            'undefined': undefined,
+            'defined': defined,
         }

--- a/lib/ansible/plugins/test/mathstuff.py
+++ b/lib/ansible/plugins/test/mathstuff.py
@@ -18,11 +18,19 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import math
+
 def issubset(a, b):
     return set(a) <= set(b)
 
 def issuperset(a, b):
     return set(a) >= set(b)
+
+def isnotanumber(x):
+    try:
+        return math.isnan(x)
+    except TypeError:
+        return False
 
 class TestModule:
     ''' Ansible math jinja2 tests '''
@@ -32,4 +40,5 @@ class TestModule:
             # set theory
             'issubset': issubset,
             'issuperset': issuperset,
+            'isnan': isnotanumber,
         }

--- a/lib/ansible/utils/color.py
+++ b/lib/ansible/utils/color.py
@@ -78,10 +78,10 @@ def stringc(text, color):
 
 def colorize(lead, num, color):
     """ Print 'lead' = 'num' in 'color' """
+    s = u"%s=%-4s" % (lead, str(num))
     if num != 0 and ANSIBLE_COLOR and color is not None:
-        return u"%s%s%-15s" % (stringc(lead, color), stringc("=", color), stringc(str(num), color))
-    else:
-        return u"%s=%-4s" % (lead, str(num))
+        s = stringc(s, color)
+    return s
 
 def hostcolor(host, stats, color=True):
     if ANSIBLE_COLOR and color:

--- a/lib/ansible/utils/module_docs_fragments/ios.py
+++ b/lib/ansible/utils/module_docs_fragments/ios.py
@@ -89,5 +89,33 @@ options:
         met either by individual arguments or values in this dict.
     required: false
     default: null
-
+  force:
+    description:
+      - The force argument instructs the module to not consider the
+        current devices running-config.  When set to true, this will
+        cause the module to push the contents of I(src) into the device
+        without first checking if already configured.
+    required: false
+    default: false
+    choices: ['yes', 'no']
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(config) argument allows the
+        implementer to pass in the configuruation to use as the base
+        config for comparision.
+    required: false
+    default: null
+    aliases: ['config']
+  save_config:
+    description:
+      - Specifies the current C(running-config) should be saved to
+        non-volatile memory so that configuration changes are
+        persistent if the device is restarted.
+    required: false
+    default: null
+    aliases: ['save']
 """

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -334,7 +334,7 @@ class VariableManager:
         # vars (which will look at parent blocks/task includes)
         if task:
             if task._role:
-                all_vars = combine_vars(all_vars, task._role.get_vars(include_params=False))
+                all_vars = combine_vars(all_vars, task._role.get_vars(task._block._dep_chain, include_params=False))
             all_vars = combine_vars(all_vars, task.get_vars())
 
         # next, we merge in the vars cache (include vars) and nonpersistent

--- a/packaging/release/release.yml
+++ b/packaging/release/release.yml
@@ -1,7 +1,7 @@
 - hosts: localhost
   gather_facts: no
   vars_files:
-    - versions.yml
+    - vars/versions.yml
   vars:
     release_dir: "./ansible_release"
     release_date: "{{lookup('pipe', 'date +\"%m-%d-%Y\"')}}"

--- a/packaging/release/release.yml
+++ b/packaging/release/release.yml
@@ -58,7 +58,8 @@
 
   - name: Clone the official repo
     git:
-      repo: "git@github.com:ansible/ansible.git"
+      #repo: "git@github.com:ansible/ansible.git"
+      repo: "https://github.com/ansible/ansible.git"
       dest: "{{release_dir}}"
       version: "{{ansible_release_branch}}"
       recursive: yes
@@ -99,12 +100,10 @@
         regexp: "^ansible ({{ansible_release_version}})"
         line: "{{deb_changelog_line}}"
         insertafter: "-- Ansible, Inc. <support@ansible.com>  %DATE%"
-    #- name: Update RELEASES.txt
-    #  lineinfile:
-    #    dest: "{{release_dir}}/RELEASES.txt"
-    #    regexp: "^{{ansible_release_version}}"
-    #    line: '{{ansible_release_version}} "{{ansible_release_codename}}" {{release_date}}'
-    #    insertafter: ""
+    - name: Update RELEASES.txt
+      template:
+        dest: "{{release_dir}}/RELEASES.txt"
+        src: "templates/RELEASES.tmpl"
     when: is_final|bool
 
   - name: "Make sure modules are checked out to {{ansible_release_branch}}"
@@ -141,6 +140,15 @@
       _raw_params: "git tag -fa {{new_version}} -m 'New release {{new_version}}'"
       chdir: "{{release_dir}}/"
 
+  - name: update git config for the main repo
+    lineinfile:
+      dest: "{{release_dir}}/.git/config"
+      regexp: "upstream"
+      line: |
+        [remote "upstream"]
+                url = git@github.com:ansible/ansible.git
+                fetch = +refs/heads/*:refs/remotes/origin/*
+
   - name: update git config for submodules
     lineinfile:
       dest: "{{release_dir}}/.git/modules/lib/ansible/modules/{{item}}/config"
@@ -152,6 +160,16 @@
     with_items:
     - core
     - extras
+
+  - name: create the dist tar.gz
+    command:
+      _raw_params: make sdist
+      chdir: "{{release_dir}}/"
+    environment:
+      OFFICIAL: yes
+
+  - name: rename the dist tar.gz to include the full release
+    command: "mv {{release_dir}}/dist/ansible-{{ansible_release_version}}.tar.gz {{release_dir}}/dist/ansible-{{ansible_release_version}}-{{ansible_release_string}}.tar.gz"
 
   - block:
     - pause:
@@ -167,6 +185,6 @@
 
     - name: Push the updates and/or tag
       shell:
-        _raw_params: "git push --tags origin {{ansible_release_branch}}"
+        _raw_params: "git push --tags upstream {{ansible_release_branch}}"
         chdir: "{{release_dir}}/lib/ansible/modules/{{item}}/"
     when: do_push|bool

--- a/packaging/release/templates/RELEASES.tmpl
+++ b/packaging/release/templates/RELEASES.tmpl
@@ -1,0 +1,16 @@
+Ansible Releases at a Glance
+============================
+
+VERSION  RELEASE     CODE NAME
+++++++++++++++++++++++++++++++
+
+{% for version in versions %}
+{% for vkey, vdata in version.iteritems() %}
+{% for release in vdata.releases %}
+{% for rkey, rdata in release.iteritems() %}
+{% set major_minor = vkey + "." + rkey %}
+{{"%-8s"|format(major_minor)}} {{"%-10s"|format(rdata)}}  "{{vdata.code_name}}"
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -295,7 +295,7 @@ test_lookup_paths: setup
 
 no_log: setup
 	# This test expects 7 loggable vars and 0 non loggable ones, if either mismatches it fails, run the ansible-playbook command to debug
-	[ "$$(ansible-playbook no_log_local.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -vvvvv | awk --source 'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "6/0" ]
+	[ "$$(ansible-playbook no_log_local.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -vvvvv | awk --source 'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "26/0" ]
 
 test_binary_modules:
 	mytmpdir=$(MYTMPDIR); \

--- a/test/integration/non_destructive.yml
+++ b/test/integration/non_destructive.yml
@@ -35,7 +35,7 @@
     - { role: test_filters, tags: test_filters }
     - { role: test_facts_d, tags: test_facts_d }
     - { role: test_async, tags: [test_async, test_async_status, test_async_wrapper] }
-    - { role: test_command_shell, tags: test_command_shell }
+    - { role: test_command_shell, tags: [test_command_shell, test_command, test_shell] }
     - { role: test_task_ordering, tags: test_task_ordering }
     - { role: test_script, tags: test_script }
     - { role: test_authorized_key, tags: test_authorized_key }

--- a/test/integration/roles/test_always_run/tasks/main.yml
+++ b/test/integration/roles/test_always_run/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: run a command while in check mode
   shell: echo "running"
-  always_run: yes
+  check_mode: no
   register: result
 
 - name: assert that the command was run

--- a/test/integration/roles/test_check_mode/tasks/main.yml
+++ b/test/integration/roles/test_check_mode/tasks/main.yml
@@ -17,23 +17,30 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: fill in a basic template in check mode
-  template: src=foo.j2 dest={{output_dir}}/foo.templated mode=0644
+  template: src=foo.j2 dest={{output_dir}}/checkmode_foo.templated mode=0644
   register: template_result
+
+- name: check whether file exists
+  stat: path={{output_dir}}/checkmode_foo.templated
+  register: foo
 
 - name: verify that the file was marked as changed in check mode
   assert: 
     that: 
-      - "template_result.changed == true"
+      - "template_result|changed"
+      - "not foo.stat.exists"
 
-- name: Actually create the file
-  template: src=foo.j2 dest={{output_dir}}/foo.templated2 mode=0644
-  always_run: True
+- name: Actually create the file, disable check mode
+  template: src=foo.j2 dest={{output_dir}}/checkmode_foo.templated2 mode=0644
+  check_mode: no
+  register: checkmode_disabled
 
-- name: fill in a basic template in check mode
-  template: src=foo.j2 dest={{output_dir}}/foo.templated2 mode=0644
+- name: fill in template with new content
+  template: src=foo.j2 dest={{output_dir}}/checkmode_foo.templated2 mode=0644
   register: template_result2
 
-- name: verify that the file was marked as not changed in check mode
+- name: verify that the file was not changed
   assert: 
     that: 
-      - "template_result2.changed == false"
+      - "checkmode_disabled|changed"
+      - "not template_result2|changed"

--- a/test/integration/roles/test_template/tasks/main.yml
+++ b/test/integration/roles/test_template/tasks/main.yml
@@ -179,3 +179,49 @@
     that:
       - "template_result.changed == False"
 
+
+# check_mode
+
+- name: fill in a basic template in check mode
+  template: src=short.j2 dest={{output_dir}}/short.templated
+  register: template_result
+  check_mode: True
+
+- name: check file exists
+  stat: path={{output_dir}}/short.templated
+  register: templated
+
+- name: verify that the file was marked as changed in check mode but was not created
+  assert: 
+    that: 
+      - "not templated.stat.exists"
+      - "template_result|changed"
+
+- name: fill in a basic template
+  template: src=short.j2 dest={{output_dir}}/short.templated
+
+- name: fill in a basic template in check mode
+  template: src=short.j2 dest={{output_dir}}/short.templated
+  register: template_result
+  check_mode: True
+
+- name: verify that the file was marked as not changes in check mode
+  assert: 
+    that: 
+      - "not template_result|changed"
+      - "'templated_var_loaded' in lookup('file', '{{output_dir | expanduser}}/short.templated')"
+
+- name: change var for the template
+  set_fact: 
+    templated_var: "changed"
+
+- name: fill in a basic template with changed var in check mode
+  template: src=short.j2 dest={{output_dir}}/short.templated
+  register: template_result
+  check_mode: True
+
+- name: verify that the file was marked as changed in check mode but the content was not changed
+  assert: 
+    that: 
+      - "'templated_var_loaded' in lookup('file', '{{output_dir | expanduser }}/short.templated')"
+      - "template_result|changed"

--- a/test/integration/roles/test_template/templates/short.j2
+++ b/test/integration/roles/test_template/templates/short.j2
@@ -1,0 +1,1 @@
+{{ templated_var }}

--- a/test/integration/roles/test_unarchive/tasks/main.yml
+++ b/test/integration/roles/test_unarchive/tasks/main.yml
@@ -54,7 +54,7 @@
   file: path={{output_dir}}/test-unarchive-tar state=directory
 
 - name: unarchive a tar file
-  unarchive: src={{output_dir}}/test-unarchive.tar dest="{{output_dir | expanduser}}/test-unarchive-tar" copy=no
+  unarchive: src={{output_dir}}/test-unarchive.tar dest="{{output_dir | expanduser}}/test-unarchive-tar" remote_src=yes
   register: unarchive01
 
 - name: verify that the file was marked as changed
@@ -72,7 +72,7 @@
   file: path={{output_dir}}/test-unarchive-tar-gz state=directory
 
 - name: unarchive a tar.gz file
-  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest={{output_dir | expanduser}}/test-unarchive-tar-gz copy=no
+  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest={{output_dir | expanduser}}/test-unarchive-tar-gz remote_src=yes
   register: unarchive02
 
 - name: verify that the file was marked as changed
@@ -92,7 +92,7 @@
   file: path={{output_dir}}/test-unarchive-tar-gz state=directory
 
 - name: unarchive a tar.gz file with creates set
-  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest={{output_dir | expanduser}}/test-unarchive-tar-gz copy=no creates={{output_dir}}/test-unarchive-tar-gz/foo-unarchive.txt
+  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest={{output_dir | expanduser}}/test-unarchive-tar-gz remote_src=yes creates={{output_dir}}/test-unarchive-tar-gz/foo-unarchive.txt
   register: unarchive02b
 
 - name: verify that the file was marked as changed
@@ -104,7 +104,7 @@
   file: path={{output_dir}}/test-unarchive-tar-gz/foo-unarchive.txt state=file
 
 - name: unarchive a tar.gz file with creates over an existing file
-  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest={{output_dir | expanduser}}/test-unarchive-tar-gz copy=no creates={{output_dir}}/test-unarchive-tar-gz/foo-unarchive.txt
+  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest={{output_dir | expanduser}}/test-unarchive-tar-gz remote_src=yes creates={{output_dir}}/test-unarchive-tar-gz/foo-unarchive.txt
   register: unarchive02c
 
 - name: verify that the file was not marked as changed
@@ -116,7 +116,7 @@
   unarchive:
     src: "{{output_dir}}/test-unarchive.tar.gz"
     dest: "{{output_dir | expanduser}}/test-unarchive-tar-gz"
-    copy: no
+    remote_src: yes
     creates: "{{output_dir}}/test-unarchive-tar-gz/foo-unarchive.txt"
   register: unarchive02d
 
@@ -132,7 +132,7 @@
   file: path={{output_dir}}/test-unarchive-zip state=directory
 
 - name: unarchive a zip file
-  unarchive: src={{output_dir}}/test-unarchive.zip dest={{output_dir | expanduser}}/test-unarchive-zip copy=no list_files=True
+  unarchive: src={{output_dir}}/test-unarchive.zip dest={{output_dir | expanduser}}/test-unarchive-zip remote_src=yes list_files=True
   register: unarchive03
 
 - name: verify that the file was marked as changed
@@ -163,7 +163,7 @@
   when: unarchive04.stat.exists
 
 - name: try unarchiving to /tmp
-  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest=/tmp copy=no
+  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest=/tmp remote_src=yes 
   register: unarchive05
 
 - name: verify that the file was marked as changed
@@ -184,7 +184,7 @@
   unarchive:
     src: "{{ output_dir }}/test-unarchive.tar.gz"
     dest: "{{ output_dir | expanduser }}/test-unarchive-tar-gz"
-    copy: no
+    remote_src: yes
     mode: "u+rwX,g-rwx,o-rwx"
     list_files: True
   register: unarchive06
@@ -215,7 +215,7 @@
   unarchive:
     src: "{{ output_dir }}/test-unarchive.tar.gz"
     dest: "{{ output_dir | expanduser }}/test-unarchive-tar-gz"
-    copy: no
+    remote_src: yes
     mode: "u+rwX,g-wx,o-wx,g+r,o+r"
   register: unarchive06_2
 
@@ -235,7 +235,7 @@
   unarchive:
     src: "{{ output_dir }}/test-unarchive.tar.gz"
     dest: "{{ output_dir | expanduser }}/test-unarchive-tar-gz"
-    copy: no
+    remote_src: yes
     mode: "u+rwX,g-wx,o-wx,g+r,o+r"
     list_files: True
   register: unarchive07
@@ -264,7 +264,7 @@
   unarchive:
     src: "{{ output_dir }}/test-unarchive.tar.gz"
     dest: "{{ output_dir | expanduser }}/test-quotes~root"
-    copy: no
+    remote_src: yes
   register: unarchive08
 
 - name: Test that unarchive succeeded
@@ -276,7 +276,7 @@
   unarchive:
     src: "{{ output_dir }}/test-unarchive.tar.gz"
     dest: "{{ output_dir | expanduser }}/test-quotes~root"
-    copy: no
+    remote_src: yes
   register: unarchive09
 
 - name: Test that unarchive did nothing
@@ -299,7 +299,7 @@
     src: "test-unarchive-nonascii-くらとみ.tar.gz"
     dest: "{{ output_dir }}/test-unarchive-nonascii-くらとみ-tar-gz"
     mode: "u+rwX,go+rX"
-    copy: yes
+    remote_src: yes
   register: nonascii_result0
 
 - name: Check that file is really there
@@ -326,7 +326,7 @@
     src: "{{ output_dir }}/test-unarchive-dir.tar.gz"
     dest: "{{ output_dir }}/test-unarchive-tar-gz"
     mode: "0700"
-    copy: no
+    remote_src: yes
   register: unarchive10
 
 - name: Test that unarchive succeeded
@@ -349,7 +349,7 @@
     src: "{{ output_dir }}/test-unarchive-dir.tar.gz"
     dest: "{{ output_dir }}/test-unarchive-tar-gz"
     mode: "0700"
-    copy: no
+    remote_src: yes
   register: unarchive10_1
 
 - name: Test that unarchive succeeded
@@ -380,7 +380,7 @@
     src: "{{ output_dir }}/test-unarchive.tar.gz"
     dest: "{{ output_dir | expanduser }}/link-to-unarchive-dir"
     mode: "u+rwX,go+rX"
-    copy: no
+    remote_src: yes
   register: unarchive_11
 
 - name: Check that file is really there
@@ -414,7 +414,7 @@
     src: "{{ output_dir }}/test-unarchive.tar.gz"
     dest: "{{ output_dir | expanduser }}/link-to-unarchive-file"
     mode: "u+rwX,go+rX"
-    copy: no
+    remote_src: yes
   ignore_errors: True
   register: unarchive_12
 

--- a/test/integration/roles/test_win_msi/tasks/main.yml
+++ b/test/integration/roles/test_win_msi/tasks/main.yml
@@ -26,11 +26,13 @@
   win_msi:
     path: "{{msi_product_code|default(msi_download_path,true)}}"
     state: absent
+    wait: true
   ignore_errors: true
 
 - name: install msi
   win_msi:
     path: "{{msi_download_path}}"
+    wait: true
   register: win_msi_install_result
 
 - name: check win_msi install result
@@ -42,6 +44,7 @@
 - name: install msi again with creates argument
   win_msi:
     path: "{{msi_download_path}}"
+    wait: true
     creates: "{{msi_install_path}}"
   register: win_msi_install_again_result
 
@@ -54,6 +57,7 @@
 - name: uninstall msi
   win_msi:
     path: "{{msi_download_path}}"
+    wait: true
     state: absent
   register: win_msi_uninstall_result
 

--- a/test/integration/roles/test_win_setup/tasks/main.yml
+++ b/test/integration/roles/test_win_setup/tasks/main.yml
@@ -41,7 +41,7 @@
       - "setup_result.ansible_facts.ansible_hostname"
       - "setup_result.ansible_facts.ansible_ip_addresses"
       - "setup_result.ansible_facts.ansible_system"
-      - "setup_result.ansible_facts.ansible_totalmem"
+      - "setup_result.ansible_facts.ansible_memtotal_mb"
       - "setup_result.ansible_facts.ansible_interfaces"
       - "setup_result.ansible_facts.ansible_interfaces[0]"
       - "setup_result.ansible_facts.ansible_interfaces[0].interface_name"

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -125,8 +125,8 @@ class TestGalaxy(unittest.TestCase):
             # removing the files we created
             shutil.rmtree('./delete_me')
 
-        except (SSLValidationError, AnsibleError) as e:
-            if "Failed to get data from the API server" or "Failed to validate the SSL certificate" in e.message:
-                raise SkipTest('this test requires an internet connection')
+        except AnsibleError as e:
+            if "Failed to get data from the API server" in e.message:
+                raise SkipTest('this test requires an internet connection and a valid CA certificate installed; this test is skipped when one or both of these requirements are not provided ')
             else:
                 raise

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -125,8 +125,8 @@ class TestGalaxy(unittest.TestCase):
         role_info = {'name': 'some_role_name',
                      'galaxy_info': galaxy_info}
         display_result = gc._display_role_info(role_info)
-        if display_result.find('\t\tgalaxy_tags:') > -1:
-            self.fail('Expected galaxy_tags to be indented twice')
+        if display_result.find('\n\tgalaxy_info:') == -1:
+            self.fail('Expected galaxy_info to be indented once')
 
 <<<<<<< 370a90f18ef464bc26c495dd3cefb7f9292a2ace
     def test_execute_init(self):

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -19,11 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.compat.six import PY3
-from ansible.compat.tests import unittest
-
-from nose.plugins.skip import SkipTest
-import ansible
 import os
 import shutil
 <<<<<<< 370a90f18ef464bc26c495dd3cefb7f9292a2ace
@@ -37,7 +32,17 @@ import tarfile
 import tempfile
 
 from mock import patch
+<<<<<<< b3dc925ddb987ad14efbf4ad3eafd1c14e6a2e84
 >>>>>>> Adding a test for GalaxyCLI and two methods on which it depends. Tes…  (#16651)
+=======
+from nose.plugins.skip import SkipTest
+
+from ansible.compat.six import PY3
+from ansible.compat.tests import unittest
+
+import ansible
+from ansible.errors import AnsibleError
+>>>>>>> Adding a test for GalaxyCLI. Tests exit_without_ignore method.
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -49,10 +54,10 @@ class TestGalaxy(unittest.TestCase):
     def setUpClass(cls):
         '''creating prerequisites for installing a role; setUpClass occurs ONCE whereas setUp occurs with every method tested.'''
         # class data for easy viewing: role_dir, role_tar, role_name, role_req, role_path
-        
+
         if os.path.exists("./delete_me"):
             shutil.rmtree("./delete_me")
-        
+
         # creating framework for a role
         gc = GalaxyCLI(args=["init"])
         with patch('sys.argv', ["-c", "--offline", "delete_me"]):
@@ -201,7 +206,7 @@ class TestGalaxy(unittest.TestCase):
         with patch('sys.argv', ["--offline", "-p", self.role_path, "-r", self.role_req]):
             galaxy_parser = gc.parse()
         gc.run()
-        
+
         # checking that installation worked
         role_file = os.path.join(self.role_path, self.role_name)
         self.assertTrue(os.path.exists(role_file))
@@ -217,4 +222,27 @@ class TestGalaxy(unittest.TestCase):
         # testing role was removed
         self.assertTrue(completed_task == 0)
         self.assertTrue(not os.path.exists(role_file))
+<<<<<<< b3dc925ddb987ad14efbf4ad3eafd1c14e6a2e84
 >>>>>>> Adding a test for GalaxyCLI and two methods on which it depends. Tes…  (#16651)
+=======
+
+    def test_exit_without_ignore(self):
+        ''' tests that GalaxyCLI exits with the error specified unless the --ignore-errors flag is used '''
+        gc = GalaxyCLI(args=["install"])
+
+        # testing without --ignore-errors flag
+        with patch('sys.argv', ["-c", "fake_role_name"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display", return_value=None) as mocked_display:
+            # testing that error expected is raised
+            self.assertRaises(AnsibleError, gc.run)
+            self.assertTrue(mocked_display.called_once_with("- downloading role 'fake_role_name', owned by "))
+
+        # testing with --ignore-errors flag
+        with patch('sys.argv', ["-c", "fake_role_name", "--ignore-errors"]):
+            galalxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display", return_value=None) as mocked_display:
+            # testing that error expected is not raised with --ignore-errors flag in use
+            gc.run()
+            self.assertTrue(mocked_display.called_once_with("- downloading role 'fake_role_name', owned by "))
+>>>>>>> Adding a test for GalaxyCLI. Tests exit_without_ignore method.

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -127,6 +127,6 @@ class TestGalaxy(unittest.TestCase):
 
         except AnsibleError as e:
             if "Failed to get data from the API server" in e.message:
-                raise SkipTest('this test requires an internet connection and a valid CA certificate installed; this test is skipped when one or both of these requirements are not provided ')
+                raise SkipTest(' there is a test case within this method that requires an internet connection and a valid CA cert    ificate installed; this part of the method is skipped when one or both of these requirements are not provided\n ... ok')
             else:
                 raise

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -39,10 +39,17 @@ from nose.plugins.skip import SkipTest
 
 from ansible.compat.six import PY3
 from ansible.compat.tests import unittest
+from mock import patch, call
 
 import ansible
+<<<<<<< 891f90226147c2ad264c8fd42f863f49c5592494
 from ansible.errors import AnsibleError
 >>>>>>> Adding a test for GalaxyCLI. Tests exit_without_ignore method.
+=======
+from ansible.errors import AnsibleError, AnsibleOptionsError
+
+from nose.plugins.skip import SkipTest
+>>>>>>> Test GalaxyCLI when no actions are provided
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -245,4 +252,111 @@ class TestGalaxy(unittest.TestCase):
             # testing that error expected is not raised with --ignore-errors flag in use
             gc.run()
             self.assertTrue(mocked_display.called_once_with("- downloading role 'fake_role_name', owned by "))
+<<<<<<< 891f90226147c2ad264c8fd42f863f49c5592494
 >>>>>>> Adding a test for GalaxyCLI. Tests exit_without_ignore method.
+=======
+
+    def run_parse_common(self, galaxycli_obj, action):
+        with patch.object(ansible.cli.SortedOptParser, "set_usage") as mocked_usage:
+            with patch('sys.argv', ["-c"]):
+                galaxy_parser = galaxycli_obj.parse()
+
+                # checking that the common results of parse() for all possible actions have been created/called
+                self.assertTrue(galaxy_parser)
+                self.assertTrue(isinstance(galaxycli_obj.parser, ansible.cli.SortedOptParser))
+                self.assertTrue(isinstance(galaxycli_obj.galaxy, ansible.galaxy.Galaxy))
+                if action in ['import', 'delete']:
+                    formatted_call = 'usage: %prog ' + action + ' [options] github_user github_repo'
+                elif action == 'info':
+                    formatted_call = 'usage: %prog ' + action + ' [options] role_name[,version]'
+                elif action == 'init':
+                    formatted_call = 'usage: %prog ' + action + ' [options] role_name'
+                elif action == 'install':
+                    formatted_call = 'usage: %prog ' + action + ' [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]'
+                elif action == 'list':
+                    formatted_call = 'usage: %prog ' + action + ' [role_name]'
+                elif action == 'login':
+                    formatted_call = 'usage: %prog ' + action + ' [options]'
+                elif action == 'remove':
+                    formatted_call = 'usage: %prog ' + action + ' role1 role2 ...'
+                elif action == 'search':
+                    formatted_call = 'usage: %prog ' + action + ' [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] [--author username]'
+                elif action == 'setup':
+                    formatted_call = 'usage: %prog ' + action + ' [options] source github_user github_repo secret'
+                calls = [call('usage: %prog [delete|import|info|init|install|list|login|remove|search|setup] [--help] [options] ...'), call(formatted_call)]
+                mocked_usage.assert_has_calls(calls)
+
+    def test_parse(self):
+        ''' systematically testing that the expected options parser is created '''
+        # testing no action given
+        gc = GalaxyCLI(args=[])
+        with patch('sys.argv', ["-c"]):
+            self.assertRaises(AnsibleOptionsError, gc.parse)
+
+        # testing action that doesn't exist
+        gc = GalaxyCLI(args=["NOT_ACTION"])
+        with patch('sys.argv', ["-c"]):
+            self.assertRaises(AnsibleOptionsError, gc.parse)
+
+        # testing action 'delete'
+        gc = GalaxyCLI(args=["delete"])
+        self.run_parse_common(gc, "delete")
+        self.assertTrue(gc.options.verbosity==0)
+
+        # testing action 'import'
+        gc = GalaxyCLI(args=["import"])
+        self.run_parse_common(gc, "import")
+        self.assertTrue(gc.options.wait==True)
+        self.assertTrue(gc.options.reference==None)
+        self.assertTrue(gc.options.check_status==False)
+        self.assertTrue(gc.options.verbosity==0)
+
+        # testing action 'info'
+        gc = GalaxyCLI(args=["info"])
+        self.run_parse_common(gc, "info")
+        self.assertTrue(gc.options.offline==False)
+
+        # testing action 'init'
+        gc = GalaxyCLI(args=["init"])
+        self.run_parse_common(gc, "init")
+        self.assertTrue(gc.options.offline==False)
+        self.assertTrue(gc.options.force==False)
+
+        # testing action 'install'
+        gc = GalaxyCLI(args=["install"])
+        self.run_parse_common(gc, "install")
+        self.assertTrue(gc.options.ignore_errors==False)
+        self.assertTrue(gc.options.no_deps==False)
+        self.assertTrue(gc.options.role_file==None)
+        self.assertTrue(gc.options.force==False)
+
+        # testing action 'list'
+        gc = GalaxyCLI(args=["list"])
+        self.run_parse_common(gc, "list")
+        self.assertTrue(gc.options.verbosity==0)
+
+        # testing action 'login'
+        gc = GalaxyCLI(args=["login"])
+        self.run_parse_common(gc, "login")
+        self.assertTrue(gc.options.verbosity==0)
+        self.assertTrue(gc.options.token==None)
+
+        # testing action 'remove'
+        gc = GalaxyCLI(args=["remove"])
+        self.run_parse_common(gc, "remove")
+        self.assertTrue(gc.options.verbosity==0)
+
+        # testing action 'search'
+        gc = GalaxyCLI(args=["search"])
+        self.run_parse_common(gc, "search")
+        self.assertTrue(gc.options.platforms==None)
+        self.assertTrue(gc.options.tags==None)
+        self.assertTrue(gc.options.author==None)
+
+        # testing action 'setup'
+        gc = GalaxyCLI(args=["setup"])
+        self.run_parse_common(gc, "setup")
+        self.assertTrue(gc.options.verbosity==0)
+        self.assertTrue(gc.options.remove_id==None)
+        self.assertTrue(gc.options.setup_list==False)
+>>>>>>> Test GalaxyCLI when no actions are provided

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -26,11 +26,17 @@ from nose.plugins.skip import SkipTest
 import ansible
 import os
 import shutil
+<<<<<<< 370a90f18ef464bc26c495dd3cefb7f9292a2ace
 
 from mock import patch
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.urls import SSLValidationError
+=======
+import tarfile
+
+from mock import patch
+>>>>>>> Adding a test for GalaxyCLI and two methods on which it depends. Tes…  (#16651)
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -38,6 +44,56 @@ if PY3:
 from ansible.cli.galaxy import GalaxyCLI
 
 class TestGalaxy(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        '''creating prerequisites for installing a role; setUpClass occurs ONCE whereas setUp occurs with every method tested.'''
+        # class data for easy viewing: role_dir, role_tar, role_name, role_req, role_path
+        
+        if os.path.exists("./delete_me"):
+            shutil.rmtree("./delete_me")
+        
+        # creating framework for a role
+        gc = GalaxyCLI(args=["init"])
+        with patch('sys.argv', ["-c", "delete_me"]):
+            gc.parse()
+        gc.run()
+        cls.role_dir = "./delete_me"
+        cls.role_name = "delete_me"
+        cls.role_path = "/etc/ansible/roles"
+
+        # creating a tar file name for class data
+        cls.role_tar = './delete_me.tar.gz'
+        cls.makeTar(cls.role_tar, cls.role_dir)
+
+        # creating a temp file with installation requirements
+        cls.role_req = './delete_me_requirements.yml'
+        fd = open(cls.role_req, "w")
+        fd.write("- 'src': '%s'\n  'name': '%s'\n  'path': '%s'" % (cls.role_tar, cls.role_name, cls.role_path))
+        fd.close()
+
+    @classmethod
+    def makeTar(cls, output_file, source_dir):
+        ''' used for making a tarfile from a role directory '''
+        # adding directory into a tar file
+        try:
+            tar = tarfile.open(output_file, "w:gz")
+            tar.add(source_dir, arcname=os.path.basename(source_dir))
+        except AttributeError: # tarfile obj. has no attribute __exit__ prior to python 2.    7
+                pass
+        finally:  # ensuring closure of tarfile obj
+            tar.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        '''After tests are finished removes things created in setUpClass'''
+        # deleting the temp role directory
+        if os.path.exists(cls.role_dir):
+            shutil.rmtree(cls.role_dir)
+        if os.path.exists(cls.role_req):
+            os.remove(cls.role_req)
+        if os.path.exists(cls.role_tar):
+            os.remove(cls.role_tar)
+
     def setUp(self):
         self.default_args = []
 
@@ -60,6 +116,7 @@ class TestGalaxy(unittest.TestCase):
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
 
+<<<<<<< 370a90f18ef464bc26c495dd3cefb7f9292a2ace
     def test_execute_init(self):
         ''' verifies that execute_init created a skeleton framework of a role that complies with the galaxy metadata format '''
         # testing that an error is raised if no role name is given
@@ -130,3 +187,27 @@ class TestGalaxy(unittest.TestCase):
                 raise SkipTest(' there is a test case within this method that requires an internet connection and a valid CA cert    ificate installed; this part of the method is skipped when one or both of these requirements are not provided\n ... ok')
             else:
                 raise
+=======
+    def test_execute_remove(self):
+        # installing role
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["--offline", "-r", self.role_req]):
+            galaxy_parser = gc.parse()
+        gc.run()
+        
+        # checking that installation worked
+        role_file = os.path.join(self.role_path, self.role_name)
+        self.assertTrue(os.path.exists(role_file))
+
+        # removing role
+        gc.args = ["remove"]
+        with patch('sys.argv', ["-c", self.role_name]):
+            galaxy_parser = gc.parse()
+        super(GalaxyCLI, gc).run()
+        gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+        completed_task = gc.execute_remove()
+
+        # testing role was removed
+        self.assertTrue(completed_task == 0)
+        self.assertTrue(not os.path.exists(role_file))
+>>>>>>> Adding a test for GalaxyCLI and two methods on which it depends. Tes…  (#16651)

--- a/test/units/mock/generator.py
+++ b/test/units/mock/generator.py
@@ -1,0 +1,71 @@
+# Copyright 2016 Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from collections import Mapping
+
+def make_method(func, args, kwargs):
+
+    def test_method(self):
+        func(self, *args, **kwargs)
+
+    # Format the argument string
+    arg_string = ', '.join(repr(a) for a in args)
+    kwarg_string = ', '.join('{0}={1}'.format(item[0], repr(item[1])) for item in kwargs.items())
+    arg_list = []
+    if arg_string:
+        arg_list.append(arg_string)
+    if kwarg_string:
+        arg_list.append(kwarg_string)
+
+    test_method.__name__ = 'test_{0}({1})'.format(func.__name__, ', '.join(arg_list))
+    return test_method
+
+
+def add_method(func, *combined_args):
+    """
+    Add a test case via a class decorator.
+
+    nose uses generators for this but doesn't work with unittest.TestCase
+    subclasses.  So we have to write our own.
+
+    The first argument to this decorator is a test function.  All subsequent
+    arguments are the arguments to create each generated test function with in
+    the following format:
+
+    Each set of arguments is a two-tuple.  The first element is an iterable of
+    positional arguments.  the second is a dict representing the kwargs.
+    """
+    def wrapper(cls):
+        for combined_arg in combined_args:
+            if len(combined_arg) == 2:
+                args = combined_arg[0]
+                kwargs = combined_arg[1]
+            elif isinstance(combined_arg[0], Mapping):
+                args = []
+                kwargs = combined_arg[0]
+            else:
+                args = combined_arg[0]
+                kwargs = {}
+            test_method = make_method(func, args, kwargs)
+            setattr(cls, test_method.__name__, test_method)
+        return cls
+
+    return wrapper

--- a/test/units/mock/procenv.py
+++ b/test/units/mock/procenv.py
@@ -1,4 +1,5 @@
 # (c) 2016, Matt Davis <mdavis@ansible.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
 #
 # This file is part of Ansible
 #
@@ -20,10 +21,12 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import sys
+import json
 
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 from ansible.compat.six import PY3
+from ansible.compat.tests import unittest
 from ansible.utils.unicode import to_bytes
 
 @contextmanager
@@ -55,3 +58,18 @@ def swap_stdout():
     sys.stdout = fake_stream
     yield fake_stream
     sys.stdout = old_stdout
+
+class ModuleTestCase(unittest.TestCase):
+    def setUp(self, module_args=None):
+        if module_args is None:
+            module_args = {}
+
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS=module_args))
+
+        # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
+        self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
+        self.stdin_swap.__enter__()
+
+    def tearDown(self):
+        # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
+        self.stdin_swap.__exit__(None, None, None)

--- a/test/units/module_utils/basic/test_safe_eval.py
+++ b/test/units/module_utils/basic/test_safe_eval.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2015, Toshio Kuratomi <tkuratomi@ansible.com>
+# (c) 2015-2016, Toshio Kuratomi <tkuratomi@ansible.com>
 #
 # This file is part of Ansible
 #
@@ -24,47 +24,72 @@ import sys
 import json
 
 from ansible.compat.tests import unittest
-from units.mock.procenv import swap_stdin_and_argv
+from units.mock.procenv import ModuleTestCase
+from units.mock.generator import add_method
 
-class TestAnsibleModuleExitJson(unittest.TestCase):
 
-    def test_module_utils_basic_safe_eval(self):
+# Strings that should be converted into a typed value
+VALID_STRINGS = (
+        [("'a'", 'a')],
+        [("'1'", '1')],
+        [("1", 1)],
+        [("True", True)],
+        [("False", False)],
+        [("{}", {})],
+        )
+
+# Passing things that aren't strings should just return the object
+NONSTRINGS = (
+        [({'a':1}, {'a':1})],
+        )
+
+# These strings are not basic types.  For security, these should not be
+# executed.  We return the same string and get an exception for some
+INVALID_STRINGS = (
+        [("a=1", "a=1", SyntaxError)],
+        [("a.foo()", "a.foo()", None)],
+        [("import foo", "import foo", None)],
+        [("__import__('foo')", "__import__('foo')", ValueError)],
+        )
+
+
+def _check_simple_types(self, code, expected):
+    # test some basic usage for various types
+    self.assertEqual(self.am.safe_eval(code), expected)
+
+def _check_simple_types_with_exceptions(self, code, expected):
+    # Test simple types with exceptions requested
+    self.assertEqual(self.am.safe_eval(code, include_exceptions=True), (expected, None))
+
+def _check_invalid_strings(self, code, expected):
+    self.assertEqual(self.am.safe_eval(code), expected)
+
+def _check_invalid_strings_with_exceptions(self, code, expected, exception):
+    res = self.am.safe_eval("a=1", include_exceptions=True)
+    self.assertEqual(res[0], "a=1")
+    self.assertEqual(type(res[1]), SyntaxError)
+
+@add_method(_check_simple_types, *VALID_STRINGS)
+@add_method(_check_simple_types, *NONSTRINGS)
+@add_method(_check_simple_types_with_exceptions, *VALID_STRINGS)
+@add_method(_check_simple_types_with_exceptions, *NONSTRINGS)
+@add_method(_check_invalid_strings, *[[i[0][0:-1]] for i in INVALID_STRINGS])
+@add_method(_check_invalid_strings_with_exceptions, *INVALID_STRINGS)
+class TestSafeEval(ModuleTestCase):
+
+    def setUp(self):
+        super(TestSafeEval, self).setUp()
+
         from ansible.module_utils import basic
+        self.old_ansible_args = basic._ANSIBLE_ARGS
 
-        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}))
+        basic._ANSIBLE_ARGS = None
+        self.am = basic.AnsibleModule(
+            argument_spec=dict(),
+        )
 
-        with swap_stdin_and_argv(stdin_data=args):
-            basic._ANSIBLE_ARGS = None
-            am = basic.AnsibleModule(
-                argument_spec=dict(),
-            )
+    def tearDown(self):
+        super(TestSafeEval, self).tearDown()
 
-            # test some basic usage
-            # string (and with exceptions included), integer, bool
-            self.assertEqual(am.safe_eval("'a'"), 'a')
-            self.assertEqual(am.safe_eval("'a'", include_exceptions=True), ('a', None))
-            self.assertEqual(am.safe_eval("1"), 1)
-            self.assertEqual(am.safe_eval("True"), True)
-            self.assertEqual(am.safe_eval("False"), False)
-            self.assertEqual(am.safe_eval("{}"), {})
-            # not passing in a string to convert
-            self.assertEqual(am.safe_eval({'a':1}), {'a':1})
-            self.assertEqual(am.safe_eval({'a':1}, include_exceptions=True), ({'a':1}, None))
-            # invalid literal eval
-            self.assertEqual(am.safe_eval("a=1"), "a=1")
-            res = am.safe_eval("a=1", include_exceptions=True)
-            self.assertEqual(res[0], "a=1")
-            self.assertEqual(type(res[1]), SyntaxError)
-            self.assertEqual(am.safe_eval("a.foo()"), "a.foo()")
-            res = am.safe_eval("a.foo()", include_exceptions=True)
-            self.assertEqual(res[0], "a.foo()")
-            self.assertEqual(res[1], None)
-            self.assertEqual(am.safe_eval("import foo"), "import foo")
-            res = am.safe_eval("import foo", include_exceptions=True)
-            self.assertEqual(res[0], "import foo")
-            self.assertEqual(res[1], None)
-            self.assertEqual(am.safe_eval("__import__('foo')"), "__import__('foo')")
-            res = am.safe_eval("__import__('foo')", include_exceptions=True)
-            self.assertEqual(res[0], "__import__('foo')")
-            self.assertEqual(type(res[1]), ValueError)
-
+        from ansible.module_utils import basic
+        basic._ANSIBLE_ARGS = self.old_ansible_args

--- a/test/units/module_utils/basic/test_set_mode_if_different.py
+++ b/test/units/module_utils/basic/test_set_mode_if_different.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch, MagicMock
+from ansible.module_utils import known_hosts
+
+from units.mock.procenv import ModuleTestCase
+from units.mock.generator import add_method
+
+class TestSetModeIfDifferentBase(ModuleTestCase):
+
+    def setUp(self):
+        self.mock_stat1 = MagicMock()
+        self.mock_stat1.st_mode = 0o444
+        self.mock_stat2 = MagicMock()
+        self.mock_stat2.st_mode = 0o660
+
+        super(TestSetModeIfDifferentBase, self).setUp()
+        from ansible.module_utils import basic
+        self.old_ANSIBLE_ARGS = basic._ANSIBLE_ARGS
+        basic._ANSIBLE_ARGS = None
+
+        self.am = basic.AnsibleModule(
+            argument_spec = dict(),
+        )
+
+    def tearDown(self):
+        super(TestSetModeIfDifferentBase, self).tearDown()
+        from ansible.module_utils import basic
+        basic._ANSIBLE_ARGS = self.old_ANSIBLE_ARGS
+
+
+def _check_no_mode_given_returns_previous_changes(self, previous_changes=True):
+    with patch('os.lstat', side_effect=[self.mock_stat1]):
+        self.assertEqual(self.am.set_mode_if_different('/path/to/file', None, previous_changes), previous_changes)
+
+def _check_mode_changed_to_0660(self, mode):
+    # Note: This is for checking that all the different ways of specifying
+    # 0660 mode work.  It cannot be used to check that setting a mode that is
+    # not equivalent to 0660 works.
+    with patch('os.lstat', side_effect=[self.mock_stat1, self.mock_stat2, self.mock_stat2]) as m_lstat:
+        with patch('os.lchmod', return_value=None, create=True) as m_lchmod:
+            self.assertEqual(self.am.set_mode_if_different('/path/to/file', mode, False), True)
+            m_lchmod.assert_called_with('/path/to/file', 0o660)
+
+def _check_mode_unchanged_when_already_0660(self, mode):
+    # Note: This is for checking that all the different ways of specifying
+    # 0660 mode work.  It cannot be used to check that setting a mode that is
+    # not equivalent to 0660 works.
+    with patch('os.lstat', side_effect=[self.mock_stat2, self.mock_stat2, self.mock_stat2]) as m_lstat:
+        self.assertEqual(self.am.set_mode_if_different('/path/to/file', mode, False), False)
+
+
+SYNONYMS_0660 = (
+        [[0o660]],
+        [['0o660']],
+        [['660']],
+        )
+
+@add_method(_check_no_mode_given_returns_previous_changes,
+        [dict(previous_changes=True)],
+        [dict(previous_changes=False)],
+        )
+@add_method(_check_mode_changed_to_0660,
+        *SYNONYMS_0660
+        )
+@add_method(_check_mode_unchanged_when_already_0660,
+        *SYNONYMS_0660
+        )
+class TestSetModeIfDifferent(TestSetModeIfDifferentBase):
+    def test_module_utils_basic_ansible_module_set_mode_if_different(self):
+        with patch('os.lstat') as m:
+            with patch('os.lchmod', return_value=None, create=True) as m_os:
+                m.side_effect = [self.mock_stat1, self.mock_stat2, self.mock_stat2]
+                self.am._symbolic_mode_to_octal = MagicMock(side_effect=Exception)
+                self.assertRaises(SystemExit, self.am.set_mode_if_different, '/path/to/file', 'o+w,g+w,a-r', False)
+
+        original_hasattr = hasattr
+        def _hasattr(obj, name):
+            if obj == os and name == 'lchmod':
+                return False
+            return original_hasattr(obj, name)
+
+        # FIXME: this isn't working yet
+        with patch('os.lstat', side_effect=[self.mock_stat1, self.mock_stat2]):
+            with patch.object(builtins, 'hasattr', side_effect=_hasattr):
+                with patch('os.path.islink', return_value=False):
+                    with patch('os.chmod', return_value=None) as m_chmod:
+                        self.assertEqual(self.am.set_mode_if_different('/path/to/file/no_lchmod', 0o660, False), True)
+        with patch('os.lstat', side_effect=[self.mock_stat1, self.mock_stat2]):
+            with patch.object(builtins, 'hasattr', side_effect=_hasattr):
+                with patch('os.path.islink', return_value=True):
+                    with patch('os.chmod', return_value=None) as m_chmod:
+                        with patch('os.stat', return_value=self.mock_stat2):
+                            self.assertEqual(self.am.set_mode_if_different('/path/to/file', 0o660, False), True)
+
+
+def _check_knows_to_change_to_0660_in_check_mode(self, mode):
+    # Note: This is for checking that all the different ways of specifying
+    # 0660 mode work.  It cannot be used to check that setting a mode that is
+    # not equivalent to 0660 works.
+    with patch('os.lstat', side_effect=[self.mock_stat1, self.mock_stat2, self.mock_stat2]) as m_lstat:
+        self.assertEqual(self.am.set_mode_if_different('/path/to/file', mode, False), True)
+
+@add_method(_check_no_mode_given_returns_previous_changes,
+        [dict(previous_changes=True)],
+        [dict(previous_changes=False)],
+        )
+@add_method(_check_knows_to_change_to_0660_in_check_mode,
+        *SYNONYMS_0660
+        )
+@add_method(_check_mode_unchanged_when_already_0660,
+        *SYNONYMS_0660
+        )
+class TestSetModeIfDifferentWithCheckMode(TestSetModeIfDifferentBase):
+    def setUp(self):
+        super(TestSetModeIfDifferentWithCheckMode, self).setUp()
+        self.am.check_mode = True
+
+    def tearDown(self):
+        super(TestSetModeIfDifferentWithCheckMode, self).tearDown()
+        self.am.check_mode = False

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -231,7 +231,7 @@ class TestActionBase(unittest.TestCase):
             mock_connection.module_implementation_preferences = ('.ps1',)
             (style, shebang, data, path) = action_base._configure_module('stat', mock_task.args)
             self.assertEqual(style, "new")
-            self.assertEqual(shebang, None)
+            self.assertEqual(shebang, u'#!powershell')
 
             # test module not found
             self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args)

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -607,8 +607,10 @@ class TestActionBase(unittest.TestCase):
         self.assertRaises(AnsibleError, action_base._execute_module)
 
     def test_action_base_sudo_only_if_user_differs(self):
+        fake_loader = MagicMock()
+        fake_loader.get_basedir.return_value = os.getcwd()
         play_context = PlayContext()
-        action_base = DerivedActionBase(None, None, play_context, None, None, None)
+        action_base = DerivedActionBase(None, None, play_context, fake_loader, None, None)
         action_base._connection = MagicMock(exec_command=MagicMock(return_value=(0, '', '')))
         action_base._connection._shell = MagicMock(append_command=MagicMock(return_value=('JOINED CMD')))
 

--- a/test/units/plugins/strategies/test_strategy_base.py
+++ b/test/units/plugins/strategies/test_strategy_base.py
@@ -198,6 +198,7 @@ class TestStrategyBase(unittest.TestCase):
         mock_task.ignore_errors = False
 
         mock_handler_task = MagicMock(Handler)
+        mock_handler.name = 'test handler'
         mock_handler_task.action = 'foo'
         mock_handler_task.get_name.return_value = "test handler"
         mock_handler_task.has_triggered.return_value = False

--- a/test/units/plugins/strategies/test_strategy_base.py
+++ b/test/units/plugins/strategies/test_strategy_base.py
@@ -198,7 +198,7 @@ class TestStrategyBase(unittest.TestCase):
         mock_task.ignore_errors = False
 
         mock_handler_task = MagicMock(Handler)
-        mock_handler.name = 'test handler'
+        mock_handler_task.name = 'test handler'
         mock_handler_task.action = 'foo'
         mock_handler_task.get_name.return_value = "test handler"
         mock_handler_task.has_triggered.return_value = False

--- a/test/units/plugins/strategies/test_strategy_base.py
+++ b/test/units/plugins/strategies/test_strategy_base.py
@@ -172,7 +172,7 @@ class TestStrategyBase(unittest.TestCase):
                 raise Queue.Empty
             else:
                 return queue_items.pop()
-            
+
         mock_queue = MagicMock()
         mock_queue.empty.side_effect = _queue_empty
         mock_queue.get.side_effect = _queue_get
@@ -238,6 +238,10 @@ class TestStrategyBase(unittest.TestCase):
         strategy_base._variable_manager = mock_var_mgr
         strategy_base._blocked_hosts = dict()
 
+        def _has_dead_workers():
+            return False            
+
+        strategy_base._tqm.has_dead_workers = _has_dead_workers
         results = strategy_base._wait_on_pending_results(iterator=mock_iterator)
         self.assertEqual(len(results), 0)
 

--- a/test/utils/docker/opensuseleap/Dockerfile
+++ b/test/utils/docker/opensuseleap/Dockerfile
@@ -18,6 +18,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     mariadb \
     mercurial \
     openssh \
+    postgresql-server \
     python-coverage \
     python-httplib2 \
     python-jinja2 \
@@ -28,6 +29,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     python-paramiko \
     python-passlib \
     python-pip \
+    python-psycopg2 \
     python-PyYAML \
     python-setuptools \
     python-virtualenv \

--- a/ticket_stubs/proposal.md
+++ b/ticket_stubs/proposal.md
@@ -1,0 +1,15 @@
+Switch to Proposal
+===================
+
+Hi!
+
+As of April of 2016, we have started using the Ansible Proposal process for large feature ideas or changes in current functionality, such as this. If you are still interested in seeing this new feature get into Ansible, please submit a proposal for it using this process.
+
+https://github.com/ansible/proposals/blob/master/proposals_process_proposal.md
+
+If you have any further questions, please let us know by stopping by our devel mailing list, or our devel IRC channel:
+
+   * #ansible-devel on Freenode
+   * https://groups.google.com/forum/#!forum/ansible-devel
+
+Thank you!


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The execute_init method creates a directory and files (a framework) for a role. My test checks the initial creation of the framework, tests what happens if the directory already exists with and without the force flag, and then cleans up the files. This adds a few seconds more to the testing time. Because of this, I'm not sure if it would be better to mock out the method's dir/file creation and simply test that the display message was called with the expected successful message, or keep as-is to enable more thorough testing.
Since the execute_init method relies on internet connection to run, I made the design choice to use a try/except to try to prevent a test failure if the tester is running tests without internet. Without this, if the internet is not working an error is raised that doesn't make note of this possible problem and I feel it could lead to misconstruing the reason for the failed test (there might be nothing wrong with the code at all). Instead of resulting in a failure, if the error raised contains the message 'Failed to get data from the API server' (which is true for the AnsibleError raised when I try to run this test without internet) then a SkipTest will be raised instead with an informative message to the user, explaining why the test was skipped. This is a compromise since this will also occur when there isn't a valid CA certificate installed. This is noted in the SkipTest error message for the tester.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
verifies that execute_init created a skeleton framework of a role that complies with the galaxy metadata format ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 2.745s
```
