### PR TITLE
Adding a test for GalaxyCLI and two methods on which it depends. Test…

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -29,7 +29,6 @@ import shutil
 import tarfile
 
 from mock import patch
-
 from ansible.errors import AnsibleError
 
 if PY3:
@@ -38,6 +37,56 @@ if PY3:
 from ansible.cli.galaxy import GalaxyCLI
 
 class TestGalaxy(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        '''creating prerequisites for installing a role; setUpClass occurs ONCE whereas setUp occurs with every method tested.'''
+        # class data for easy viewing: role_dir, role_tar, role_name, role_req, role_path
+        
+        if os.path.exists("./delete_me"):
+            shutil.rmtree("./delete_me")
+        
+        # creating framework for a role
+        gc = GalaxyCLI(args=["init"])
+        with patch('sys.argv', ["-c", "delete_me"]):
+            gc.parse()
+        gc.run()
+        cls.role_dir = "./delete_me"
+        cls.role_name = "delete_me"
+        cls.role_path = "/etc/ansible/roles"
+
+        # creating a tar file name for class data
+        cls.role_tar = './delete_me.tar.gz'
+        cls.makeTar(cls.role_tar, cls.role_dir)
+
+        # creating a temp file with installation requirements
+        cls.role_req = './delete_me_requirements.yml'
+        fd = open(cls.role_req, "w")
+        fd.write("- 'src': '%s'\n  'name': '%s'\n  'path': '%s'" % (cls.role_tar, cls.role_name, cls.role_path))
+        fd.close()
+
+    @classmethod
+    def makeTar(cls, output_file, source_dir):
+        ''' used for making a tarfile from a role directory '''
+        # adding directory into a tar file
+        try:
+            tar = tarfile.open(output_file, "w:gz")
+            tar.add(source_dir, arcname=os.path.basename(source_dir))
+        except AttributeError: # tarfile obj. has no attribute __exit__ prior to python 2.    7
+                pass
+        finally:  # ensuring closure of tarfile obj
+            tar.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        '''After tests are finished removes things created in setUpClass'''
+        # deleting the temp role directory
+        if os.path.exists(cls.role_dir):
+            shutil.rmtree(cls.role_dir)
+        if os.path.exists(cls.role_req):
+            os.remove(cls.role_req)
+        if os.path.exists(cls.role_tar):
+            os.remove(cls.role_tar)
+
     def setUp(self):
         self.default_args = []
 
@@ -60,98 +109,41 @@ class TestGalaxy(unittest.TestCase):
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
 
-    def make_tarfile(self, output_file, source_dir):
-        ''' used for making a tarfile from an artificial role directory for testing installation with a local tar.gz file '''
-        # adding directory into a tar file
-        try:
-            tar = tarfile.open(output_file, "w:gz")
-            tar.add(source_dir, arcname=os.path.basename(source_dir))
-        except AttributeError:  # tarfile obj. has no attribute __exit__ prior to python 2.7
-            pass
-        finally:  # ensuring closure of tarfile obj
-            tar.close()
-
-    def create_role(self):
-        ''' creates a "role" directory and a requirements file; used for testing installation '''
-        if os.path.exists('./delete_me'):
-            shutil.rmtree('./delete_me')
-
-        # making the directory for the role
-        os.makedirs('./delete_me')
-        os.makedirs('./delete_me/meta')
-
-        # making main.yml for meta folder
-        fd = open("./delete_me/meta/main.yml", "w")
-        fd.write("---\ngalaxy_info:\n  author: 'shertel'\n  company: Ansible\ndependencies: []")
-        fd.close()
-
-        # making the directory into a tar file
-        self.make_tarfile('./delete_me.tar.gz', './delete_me')
-
-        # removing directory
-        shutil.rmtree('./delete_me')
-
-        # creating requirements.yml for installing the role
-        fd = open("./delete_requirements.yml", "w")
-        fd.write("- 'src': './delete_me.tar.gz'\n  'name': 'delete_me'\n  'path': '/etc/ansible/roles'")
-        fd.close()
-
     def test_execute_info(self):
         ''' testing that execute_info displays information associated with a role '''
         ### testing cases when no role name is given ###
-
         gc = GalaxyCLI(args=["info"])
         with patch('sys.argv', ["-c", "-v"]):
             galaxy_parser = gc.parse()
-        with patch.object(ansible.utils.display.Display, "display"):
-            self.assertRaises(AnsibleError, gc.run)
+        self.assertRaises(AnsibleError, gc.run)
 
         ### testing case when valid role name is given ###
-
-            # creating a tar.gz file for a fake role
-        self.create_role()
-
-            # installing role (also, removes tar.gz file)
+            # installing role
         gc = GalaxyCLI(args=["install"])
-        with patch('sys.argv', ["--offline", "-r", "delete_requirements.yml"]):
+        with patch('sys.argv', ["--offline", "-r", self.role_req]):
             galaxy_parser = gc.parse()
-        with patch.object(ansible.utils.display.Display, "display") as mock_obj:
-            gc.run()
+        gc.run()
 
             # data used for testing
-            gr = ansible.galaxy.role.GalaxyRole(gc.galaxy, "delete_me")
-            install_date = gr.install_info['install_date']
+        gr = ansible.galaxy.role.GalaxyRole(gc.galaxy, self.role_name)
+        install_date = gr.install_info['install_date']
 
             # testing role for info
         gc.args = ["info"]
-        with patch('sys.argv', ["-c", "--offline", "delete_me"]):
+        with patch('sys.argv', ["-c", "--offline", self.role_name]):
             galaxy_parser = gc.parse()
         with patch.object(ansible.cli.CLI, "pager") as mock_obj:
             gc.run()
-            mock_obj.assert_called_once_with(u"\nRole: delete_me\n\tdescription: \n\tdependencies: []\n\tgalaxy_info:\n\t\tauthor: shertel\n\t\tcompany: Ansible\n\tinstall_date: %s\n\tintalled_version: \n\tpath: [\'/etc/ansible/roles\']\n\tscm: None\n\tsrc: delete_me\n\tversion: " % install_date)
+            mock_obj.assert_called_once_with(u"\nRole: %s\n\tdescription: \n\tdependencies: []\n\tgalaxy_info:\n\t\tauthor: your name\n\t\tcompany: your company (optional)\n\t\tgalaxy_tags: []\n\t\tlicense: license (GPLv2, CC-BY, etc)\n\t\tmin_ansible_version: 1.2\n\tinstall_date: %s\n\tintalled_version: \n\tpath: ['%s']\n\tscm: None\n\tsrc: %s\n\tversion: " % (self.role_name, install_date, self.role_path, self.role_name))
 
             # deleting role
         gc.args = ["remove"]
-        with patch('sys.argv', ["-c", "delete_me"]):
+        with patch('sys.argv', ["-c", self.role_name]):
             galaxy_parser = gc.parse()
-        with patch.object(ansible.utils.display.Display, "display") as mock_obj:
-            gc.run()
-
-            # testing clean up worked
-            mock_obj.assert_called_once_with("- successfully removed delete_me")
-        
-        # cleaning up requirements file
-        if os.path.isfile("delete_requirements.yml"):
-            os.remove("delete_requirements.yml")
-
-        # cleaning up local tar.gz file
-        if os.path.exists("./delete_me.tar.gz"):
-            os.remove("./delete_me.tar.gz")
-        
+        gc.run()
         
         ### testing case when the name of a role not installed is given ###
-
-            # the role "delete_me" is not installed now
+            # the role is not installed now
         gc = GalaxyCLI(args=["info"])
         with patch('sys.argv', ["-c", "--offline", "delete_me"]):
             galaxy_parser = gc.parse()
@@ -160,3 +152,26 @@ class TestGalaxy(unittest.TestCase):
         with patch.object(ansible.cli.CLI, "pager") as mock_obj:
             gc.run()
             #mock_obj.assert_called_once_with(u'\n- the role delete_me was not found') # FIXME: Uncomment
+
+    def test_execute_remove(self):
+        # installing role
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["--offline", "-r", self.role_req]):
+            galaxy_parser = gc.parse()
+        gc.run()
+        
+        # checking that installation worked
+        role_file = os.path.join(self.role_path, self.role_name)
+        self.assertTrue(os.path.exists(role_file))
+
+        # removing role
+        gc.args = ["remove"]
+        with patch('sys.argv', ["-c", self.role_name]):
+            galaxy_parser = gc.parse()
+        super(GalaxyCLI, gc).run()
+        gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+        completed_task = gc.execute_remove()
+
+        # testing role was removed
+        self.assertTrue(completed_task == 0)
+        self.assertTrue(not os.path.exists(role_file))

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -63,8 +63,13 @@ class TestGalaxy(unittest.TestCase):
     def make_tarfile(self, output_file, source_dir):
         ''' used for making a tarfile from an artificial role directory for testing installation with a local tar.gz file '''
         # adding directory into a tar file
-        with tarfile.open(output_file, "w:gz") as tar:
+        try:
+            tar = tarfile.open(output_file, "w:gz")
             tar.add(source_dir, arcname=os.path.basename(source_dir))
+        except AttributeError:  # tarfile obj. has no attribute __exit__ prior to python 2.7
+            pass
+        finally:  # ensuring closure of tarfile obj
+            tar.close()
 
     def create_role(self):
         ''' creates a "role" directory and a requirements file; used for testing installation '''

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -23,6 +23,14 @@ from ansible.compat.six import PY3
 from ansible.compat.tests import unittest
 
 from nose.plugins.skip import SkipTest
+import ansible
+import os
+import shutil
+import tarfile
+
+from mock import patch
+
+from ansible.errors import AnsibleError
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -51,3 +59,99 @@ class TestGalaxy(unittest.TestCase):
         display_result = gc._display_role_info(role_info)
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
+
+    def make_tarfile(self, output_file, source_dir):
+        ''' used for making a tarfile from an artificial role directory for testing installation with a local tar.gz file '''
+        # adding directory into a tar file
+        with tarfile.open(output_file, "w:gz") as tar:
+            tar.add(source_dir, arcname=os.path.basename(source_dir))
+
+    def create_role(self):
+        ''' creates a "role" directory and a requirements file; used for testing installation '''
+        if os.path.exists('./delete_me'):
+            shutil.rmtree('./delete_me')
+
+        # making the directory for the role
+        os.makedirs('./delete_me')
+        os.makedirs('./delete_me/meta')
+
+        # making main.yml for meta folder
+        fd = open("./delete_me/meta/main.yml", "w")
+        fd.write("---\ngalaxy_info:\n  author: 'shertel'\n  company: Ansible\ndependencies: []")
+        fd.close()
+
+        # making the directory into a tar file
+        self.make_tarfile('./delete_me.tar.gz', './delete_me')
+
+        # removing directory
+        shutil.rmtree('./delete_me')
+
+        # creating requirements.yml for installing the role
+        fd = open("./delete_requirements.yml", "w")
+        fd.write("- 'src': './delete_me.tar.gz'\n  'name': 'delete_me'\n  'path': '/etc/ansible/roles'")
+        fd.close()
+
+    def test_execute_info(self):
+        ''' testing that execute_info displays information associated with a role '''
+        ### testing cases when no role name is given ###
+
+        gc = GalaxyCLI(args=["info"])
+        with patch('sys.argv', ["-c", "-v"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display"):
+            self.assertRaises(AnsibleError, gc.run)
+
+        ### testing case when valid role name is given ###
+
+            # creating a tar.gz file for a fake role
+        self.create_role()
+
+            # installing role (also, removes tar.gz file)
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["--offline", "-r", "delete_requirements.yml"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display") as mock_obj:
+            gc.run()
+
+            # data used for testing
+            gr = ansible.galaxy.role.GalaxyRole(gc.galaxy, "delete_me")
+            install_date = gr.install_info['install_date']
+
+            # testing role for info
+        gc.args = ["info"]
+        with patch('sys.argv', ["-c", "--offline", "delete_me"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.cli.CLI, "pager") as mock_obj:
+            gc.run()
+            mock_obj.assert_called_once_with(u"\nRole: delete_me\n\tdescription: \n\tdependencies: []\n\tgalaxy_info:\n\t\tauthor: shertel\n\t\tcompany: Ansible\n\tinstall_date: %s\n\tintalled_version: \n\tpath: [\'/etc/ansible/roles\']\n\tscm: None\n\tsrc: delete_me\n\tversion: " % install_date)
+
+            # deleting role
+        gc.args = ["remove"]
+        with patch('sys.argv', ["-c", "delete_me"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display") as mock_obj:
+            gc.run()
+
+            # testing clean up worked
+            mock_obj.assert_called_once_with("- successfully removed delete_me")
+        
+        # cleaning up requirements file
+        if os.path.isfile("delete_requirements.yml"):
+            os.remove("delete_requirements.yml")
+
+        # cleaning up local tar.gz file
+        if os.path.exists("./delete_me.tar.gz"):
+            os.remove("./delete_me.tar.gz")
+        
+        
+        ### testing case when the name of a role not installed is given ###
+
+            # the role "delete_me" is not installed now
+        gc = GalaxyCLI(args=["info"])
+        with patch('sys.argv', ["-c", "--offline", "delete_me"]):
+            galaxy_parser = gc.parse()
+
+            # this won't accurately reflect the expected outcome until GalaxyCLI.execute_info's FIXME is fixed
+        with patch.object(ansible.cli.CLI, "pager") as mock_obj:
+            gc.run()
+            #mock_obj.assert_called_once_with(u'\n- the role delete_me was not found') # FIXME: Uncomment


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This tests the execute_info method which provides the user with information associated with a role. The execute_info method relies on having an installed role (otherwise there is no info to display). As the tester may not have a role installed this requires a setup and cleanup to test. Installing a role can be done with a local tar.gz file and is more simple for testing than trying to verify internet connection, determine what platform the tester is on, and download an acceptable role. I created two other methods to make this tar.gz file with the bare minimum needed to install a role successfully. I then test that the information provided during installation is made available when execute_info is called.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
testing that execute_info displays information associated with a role ... [DEPRECATION WARNING]: The comma separated role spec format, use the
yaml/explicit format instead..
This feature will be removed in a future
release. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.035s

OK
```

…s execute_info method.
