### PR TITLE
[WIP] Ssh connection stderr parsing for better ssh errors

### DIFF
--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -174,6 +174,19 @@ class AnsibleConnectionFailure(AnsibleRuntimeError):
     ''' the transport / connection_plugin had a fatal error '''
     pass
 
+class AnsibleSshConnectionFailure(AnsibleConnectionFailure):
+    ''' the ssh connection plugin had a fatal error '''
+    pass
+
+
+class AnsibleSshInitialWriteConnectionFailure(AnsibleSshConnectionFailure):
+    ''' the ssh connection plugin had a fatal error during the initial data write '''
+    pass
+
+class AnsibleSshCommandErrorConnectionFailure(AnsibleSshConnectionFailure):
+    ''' the ssh connection plugin had a fatal error (255 return code from ssh command '''
+    pass
+
 class AnsibleFilterError(AnsibleRuntimeError):
     ''' a templating failure '''
     pass

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -174,17 +174,8 @@ class AnsibleConnectionFailure(AnsibleRuntimeError):
     ''' the transport / connection_plugin had a fatal error '''
     pass
 
-class AnsibleSshConnectionFailure(AnsibleConnectionFailure):
-    ''' the ssh connection plugin had a fatal error '''
-    pass
-
-
-class AnsibleSshInitialWriteConnectionFailure(AnsibleSshConnectionFailure):
-    ''' the ssh connection plugin had a fatal error during the initial data write '''
-    pass
-
-class AnsibleSshCommandErrorConnectionFailure(AnsibleSshConnectionFailure):
-    ''' the ssh connection plugin had a fatal error (255 return code from ssh command '''
+class AnsibleTmpPathCreationConnectionFailure(AnsibleConnectionFailure):
+    ''' the transport / connection_plugin had a fatal error creating the remote tmp_path '''
     pass
 
 class AnsibleFilterError(AnsibleRuntimeError):

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -127,10 +127,12 @@ class WorkerProcess(multiprocessing.Process):
             self._rslt_q.put(task_result)
             display.debug("done sending task result")
 
-        except AnsibleConnectionFailure:
+        except AnsibleConnectionFailure as e:
             self._host.vars = dict()
             self._host.groups = []
-            task_result = TaskResult(self._host, self._task, dict(unreachable=True))
+            failure_dict = dict(unreachable=True)
+            failure_dict['_connection_failure_exception'] = e
+            task_result = TaskResult(self._host, self._task, failure_dict)
             self._rslt_q.put(task_result, block=False)
 
         except Exception as e:

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -446,7 +446,9 @@ class TaskExecutor:
             try:
                 result = self._handler.run(task_vars=variables)
             except AnsibleConnectionFailure as e:
-                return dict(unreachable=True, msg=to_unicode(e))
+                failure_dict = dict(unreachable=True, msg=to_unicode(e))
+                failure_dict['_connection_failure_exception'] = e
+                return failure_dict
             display.debug("handler run complete")
 
             # preserve no log

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -447,7 +447,11 @@ class TaskExecutor:
                 result = self._handler.run(task_vars=variables)
             except AnsibleConnectionFailure as e:
                 failure_dict = dict(unreachable=True, msg=to_unicode(e))
-                failure_dict['_connection_failure_exception'] = e
+                e_type, e_value, e_tb = sys.exc_info()
+                failure_dict['_connection_failure_excection_message'] = to_unicode(e)
+                failure_dict['_connection_failure_exception_type'] = str(e_type)
+                failure_dict['_connection_failure_exception_value'] = str(e_value)
+                failure_dict['_connection_failure_exception_tb'] = to_unicode(traceback.format_exc())
                 return failure_dict
             display.debug("handler run complete")
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import base64
+import codecs
 import json
 import subprocess
 import sys
@@ -451,7 +452,7 @@ class TaskExecutor:
                 failure_dict['_connection_failure_excection_message'] = to_unicode(e)
                 failure_dict['_connection_failure_exception_type'] = str(e_type)
                 failure_dict['_connection_failure_exception_value'] = str(e_value)
-                failure_dict['_connection_failure_exception_tb'] = to_unicode(traceback.format_exc())
+                failure_dict['_connection_failure_exception_tb'] = ''.join(traceback.format_exc())
                 return failure_dict
             display.debug("handler run complete")
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -452,7 +452,7 @@ class TaskExecutor:
                 failure_dict['_connection_failure_excection_message'] = to_unicode(e)
                 failure_dict['_connection_failure_exception_type'] = str(e_type)
                 failure_dict['_connection_failure_exception_value'] = str(e_value)
-                failure_dict['_connection_failure_exception_tb'] = ''.join(traceback.format_exc())
+                # failure_dict['_connection_failure_exception_tb'] = ''.join(traceback.format_exc())
                 return failure_dict
             display.debug("handler run complete")
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -33,7 +33,7 @@ from abc import ABCMeta, abstractmethod
 from ansible.compat.six import binary_type, text_type, iteritems, with_metaclass
 
 from ansible import constants as C
-from ansible.errors import AnsibleError, AnsibleConnectionFailure
+from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleTmpPathCreationConnectionFailure
 from ansible.executor.module_common import modify_module
 from ansible.release import __version__
 from ansible.parsing.utils.jsonify import jsonify
@@ -238,7 +238,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                         ' Failed command was: %s, exited with result %d' % (cmd, result['rc']))
             if 'stdout' in result and result['stdout'] != u'':
                 output = output + u": %s" % result['stdout']
-            raise AnsibleConnectionFailure(output)
+            raise AnsibleTmpPathCreationConnectionFailure(output)
 
         try:
             stdout_parts = result['stdout'].strip().split('%s=' % basefile, 1)

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -107,6 +107,9 @@ class CallbackBase:
         if 'exception' in abridged_result:
             del abridged_result['exception']
 
+        #if self._display_verbosity < 3:
+        #    del abridged_result['_connection_failure_exception_tb']
+
         return json.dumps(abridged_result, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
 
     def _handle_warnings(self, res):

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -72,6 +72,10 @@ with warnings.catch_warnings():
         pass
 
 
+class AnsibleParamikoConnectionFailure(AnsibleConnectionFailure):
+    ''' the Paramiko transport connection plugin had a fatal error '''
+
+
 class MyAddPolicy(object):
     """
     Based on AutoAddPolicy in paramiko so we can determine when keys are added
@@ -239,9 +243,9 @@ class Connection(ConnectionBase):
             elif "Private key file is encrypted" in msg:
                 msg = 'ssh %s@%s:%s : %s\nTo connect as a different user, use -u <username>.' % (
                     self._play_context.remote_user, self._play_context.remote_addr, port, msg)
-                raise AnsibleConnectionFailure(msg)
+                raise AnsibleParamikoConnectionFailure(msg)
             else:
-                raise AnsibleConnectionFailure(msg)
+                raise AnsibleParamikoConnectionFailure(msg)
 
         return ssh
 
@@ -262,7 +266,7 @@ class Connection(ConnectionBase):
             msg = "Failed to open session"
             if len(str(e)) > 0:
                 msg += ": %s" % str(e)
-            raise AnsibleConnectionFailure(msg)
+            raise AnsibleParamikoConnectionFailure(msg)
 
         # sudo usually requires a PTY (cf. requiretty option), therefore
         # we give it one by default (pty=True in ansble.cfg), and we try

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -95,7 +95,8 @@ class OpenSshErrorParser():
 
     error_regexes = {r"""Permissions (.*) for '(.*)' are too open.""": 'too_open',
                      r"""Load key (\".*\"): bad permissions""": 'bad_permssions',
-                     r"""could not open key file '(.*)': (.*)""": 'could_not_open_key_file'}
+                     r"""could not open key file '(.*)': (.*)""": 'could_not_open_key_file',
+                     r"""ssh: Could not resolve hostname (.*): No address associated with hostname""": 'could_not_resolve'}
 
     def __init__(self, stderr=None):
         self.stderr = stderr
@@ -104,16 +105,15 @@ class OpenSshErrorParser():
 
     def _match_errors(self):
         for error_regex in self.error_regexes:
-            print(error_regex)
-            #print(self.stderr)
+            # print(error_regex)
+            # print(self.stderr)
             match = re.search(error_regex, self.stderr)
-            print(match)
+            # print(match)
             if not match:
                 continue
 
-
             for match_group in match.groups():
-                print('error_match %s' % match_group)
+                # print('error_match %s' % match_group)
                 self._matches[self.error_regexes[error_regex]].append(match_group)
 
     def __str__(self):

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -80,23 +80,13 @@ class AnsibleSshCommandErrorConnectionFailure(AnsibleSshConnectionFailure):
 class AnsibleSshCommandErrorPermissionDenied(AnsibleSshCommandErrorConnectionFailure):
     pass
 
-# Example errors
-_example_ssh_errors = """
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-Permissions 0666 for '/home/adrian/.ssh/id_rsa' are too open.
-It is required that your private key files are NOT accessible by others.
-This private key will be ignored.
-Load key "/home/adrian/.ssh/id_rsa": bad permissions
-Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
-"""
 
 # FIXME: better enum-like
 class SshErrors:
     permission_denied = 'permission_denied'
     no_route_to_host = 'no_route_to_host'
     could_not_resolve = 'could_not_resolve'
+    connection_refused = 'connection_refused'
 
 class OpenSshStderrErrorMapper:
     # Attempt to make sense of openssh errors and warnings in hopes of generating
@@ -108,6 +98,7 @@ class OpenSshStderrErrorMapper:
                      r"""Load key (\".*\"): bad permissions""": 'bad_permssions',
                      r"""could not open key file '(.*)': (.*)""": 'could_not_open_key_file',}
     error_regexes = {r"""connect to host (.*) port (.*): No route to host""": SshErrors.no_route_to_host,
+                     r"""connect to address (.*) port (\d*): Connection refused""": SshErrors.connection_refused,
                      r"""Permission denied \((.*)\)""": SshErrors.permission_denied,
                      r"""ssh: Could not resolve hostname (.*): No address associated with hostname""":
                     SshErrors.could_not_resolve}

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -18,6 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import codecs
 import fcntl
 import textwrap
 import os
@@ -117,6 +118,9 @@ class Display:
 
         # FIXME: this needs to be implemented
         #msg = utils.sanitize_output(msg)
+        msg, _ = codecs.escape_decode(msg.encode('utf8'))
+        msg = msg.decode()
+        #print(msg)
         nocolor = msg
         if color:
             msg = stringc(msg, color)

--- a/ssh_error_tests/.bad_hosts
+++ b/ssh_error_tests/.bad_hosts
@@ -1,0 +1,30 @@
+# A non-localhost that ssh can connect to
+testhost ansible_host=192.168.1.120
+baduser ansible_host=192.168.1.120 ansible_user=kt
+noname ansible_host=noname.g.a ansible_user=adrian
+cantconnect ansible_host=192.168.1.253 ansible_user=adrian
+nokey ansible_host=192.168.1.120
+badkey ansible_host=192.168.1.120
+toomanykeys ansible_host=192.168.1.120
+privatekeytooopen ansible_host=192.168.1.120
+
+stricthostkey ansible_host=192.168.1.120
+viaproxy ansible_host=192.168.1.120
+gssapionly ansible_host=192.168.1.120
+nokey ansible_host=192.168.1.120
+emptykey ansible_host=192.168.1.120
+toopen ansible_host=192.168.1.120
+passwordonly ansible_host=192.168.1.120
+testhost ansible_host=192.168.1.120
+badalias ansible_host=192.168.1.120
+badcipher ansible_host=192.168.1.120
+badcontrolpath ansible_host=192.168.1.120
+quiethost ansible_host=192.168.1.120
+fatalhost ansible_host=192.168.1.120
+errorhost ansible_host=192.168.1.120
+infohost ansible_host=192.168.1.120
+verbosehost ansible_host=192.168.1.120
+debughost ansible_host=192.168.1.120
+debug2host ansible_host=192.168.1.120
+debug3host ansible_host=192.168.1.120
+

--- a/ssh_error_tests/ansible.cfg
+++ b/ssh_error_tests/ansible.cfg
@@ -1,5 +1,7 @@
 [defaults]
-inventory = hosts
+#inventory = hosts
+inventory = $HOME/src/ansible/ssh_error_tests/ssh_config.py
+display_args_to_stdout = True
 #log_path = $HOME/ansible/log/ansible.log
 #roles_path = $HOME/ansible/galaxy-roles:$HOME/ansible/roles
 #nocows = 1

--- a/ssh_error_tests/ansible.cfg
+++ b/ssh_error_tests/ansible.cfg
@@ -1,0 +1,43 @@
+[defaults]
+inventory = hosts
+#log_path = $HOME/ansible/log/ansible.log
+#roles_path = $HOME/ansible/galaxy-roles:$HOME/ansible/roles
+#nocows = 1
+#inventory      = /etc/ansible/hosts
+#library        = $HOME/ansible/my-modules:$HOME/ansible/lib/modules/core
+#remote_tmp     = $HOME/.ansible/tmp
+#forks          = 5
+#poll_interval  = 15
+#sudo_user      = root
+#ask_sudo_pass = True
+#ask_pass      =
+#transport      = smart
+#remote_port    = 22
+#module_lang    = C
+#roles_path = $HOME/ansible/roles
+#stdout_callback = pretty
+#callback_whitelist = timer, oneline, json, tree, profile_tasks, human_log
+#callback_whitelist = pretty, stdlog
+#callback_plugins   = $HOME/ansible/plugins/callback
+#callback_plugins = $HOME/ansible/plugins/callback/
+
+# __init__.py      default.py       log_plays.py     minimal.py
+# profile_tasks.py syslog_json.py   tree.pyc
+# actionable.py    hipchat.py       logentries.py
+# oneline.py       skippy.py        timer.py
+# context_demo.py  json.py          mail.py
+# osx_say.py       slack.py         tree.py
+#transport = paramiko
+transport = ssh
+
+[ssh_connection]
+# NOTE: Is there a way to inherit these settings?
+#pipelining = True
+#ssh_args = -F /home/adrian/src/ansible/ssh_error_tests/ssh_config -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=300s
+ssh_args = -F /home/adrian/src/ansible/ssh_error_tests/ssh_config
+[paramiko]
+record_host_keys=True
+proxy_command = ssh -W "%h:%p" bastion
+
+[vault]
+username = 'adrian'

--- a/ssh_error_tests/etc_hosts
+++ b/ssh_error_tests/etc_hosts
@@ -1,0 +1,29 @@
+192.168.1.120 testhost
+192.168.1.120 baduser
+192.168.1.120 noname
+192.168.1.253 cantconnect
+192.168.1.120 nokey
+192.168.1.120 badkey
+192.168.1.120 toomanykeys
+192.168.1.120 privatekeytooopen
+ 
+192.168.1.120 stricthostkey
+192.168.1.120 viaproxy
+192.168.1.120 gssapionly
+192.168.1.120 nokey
+192.168.1.120 emptykey
+192.168.1.120 toopen
+192.168.1.120 passwordonly
+192.168.1.120 testhost
+192.168.1.120 badalias
+192.168.1.120 badcipher
+192.168.1.120 badcontrolpath
+192.168.1.120 quiethost
+192.168.1.120 fatalhost
+192.168.1.120 errorhost
+192.168.1.120 infohost
+192.168.1.120 verbosehost
+192.168.1.120 debughost
+192.168.1.120 debug2host
+192.168.1.120 debug3host
+ 

--- a/ssh_error_tests/etc_hosts2
+++ b/ssh_error_tests/etc_hosts2
@@ -1,0 +1,30 @@
+A #
+192.168.1.120 testhost
+192.168.1.120 baduser
+noname.g.a noname
+192.168.1.253 cantconnect
+192.168.1.120 nokey
+192.168.1.120 badkey
+192.168.1.120 toomanykeys
+192.168.1.120 privatekeytooopen
+ 
+192.168.1.120 stricthostkey
+192.168.1.120 viaproxy
+192.168.1.120 gssapionly
+192.168.1.120 nokey
+192.168.1.120 emptykey
+192.168.1.120 toopen
+192.168.1.120 passwordonly
+192.168.1.120 testhost
+192.168.1.120 badalias
+192.168.1.120 badcipher
+192.168.1.120 badcontrolpath
+192.168.1.120 quiethost
+192.168.1.120 fatalhost
+192.168.1.120 errorhost
+192.168.1.120 infohost
+192.168.1.120 verbosehost
+192.168.1.120 debughost
+192.168.1.120 debug2host
+192.168.1.120 debug3host
+ 

--- a/ssh_error_tests/fail_ping.yml
+++ b/ssh_error_tests/fail_ping.yml
@@ -1,0 +1,5 @@
+---
+- hosts: cantconnect, namefailure, nokey
+  tasks:
+    - name: ping
+      ping:

--- a/ssh_error_tests/genkeys.sh
+++ b/ssh_error_tests/genkeys.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# You will need to add these to authorize_keys for the ssh testhost and
+# account. Probably shouldn't be a public machine, though these keys are
+# just as random as any other key.
+#
+# But heads up, don't put these into authorized_keys unless you understand the
+# implications.
+
+ssh-keygen -t rsa -N '' -v -f id_rsa_testhost
+ssh-keygen -t rsa -N 'password' -v -f id_rsa_testhost_password
+
+# too readable
+ssh-keygen -t rsa -N '' -v -f id_rsa_testhost_too_open
+chmod 0666 id_rsa_testhost_too_open
+
+# nothing can read it
+ssh-keygen -t rsa -N '' -v -f id_rsa_testhost_can_not_read
+chmod 0100 id_rsa_testhost_can_not_read
+# this is meant to generate a keywith a password that is unknown, so
+# we don't output it or remember it. uuid isn't a great choice, but
+# pay attention to the heads up above.
+
+UNKNOWN_PASSWORD=$(uuidgen -r)
+ssh-keygen -t rsa -N "${UNKNOWN_PASSWORD}" -v -f id_rsa_testhost_password_unknown
+
+echo "# Add the below to authorized_keys for testhost and testuser"
+cat id_rsa_testhost.pub
+cat id_rsa_testhost_password.pub
+cat id_rsa_testhost_password_unknown.pub

--- a/ssh_error_tests/hosts
+++ b/ssh_error_tests/hosts
@@ -1,0 +1,30 @@
+# non-localhost that ssh can connect to
+testhost
+baduser ansible_user=kt
+noname ansible_user=adrian
+cantconnect ansible_user=adrian
+nokey
+badkey
+toomanykeys
+privatekeytooopen
+
+stricthostkey
+viaproxy
+gssapionly
+nokey
+emptykey
+toopen
+passwordonly
+testhost
+badalias
+badcipher
+badcontrolpath
+quiethost
+fatalhost
+errorhost
+infohost
+verbosehost
+debughost
+debug2host
+debug3host
+

--- a/ssh_error_tests/hosts2
+++ b/ssh_error_tests/hosts2
@@ -1,0 +1,30 @@
+# non-localhost that ssh can connect to
+testhost
+baduser ansible_user=kt
+noname ansible_user=adrian
+cantconnect ansible_user=adrian
+nokey
+badkey
+toomanykeys
+privatekeytooopen
+
+stricthostkey
+viaproxy
+gssapionly
+nokey
+emptykey
+toopen
+passwordonly
+testhost
+badalias
+badcipher
+badcontrolpath
+quiethost
+fatalhost
+errorhost
+infohost
+verbosehost
+debughost
+debug2host
+debug3host
+

--- a/ssh_error_tests/ping.yml
+++ b/ssh_error_tests/ping.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  tasks:
+    - name: ping
+      ping:

--- a/ssh_error_tests/ssh_config
+++ b/ssh_error_tests/ssh_config
@@ -125,6 +125,7 @@ Host bastion
 
 
 HOST *
+    HostName localhost
     StrictHostKeyChecking yes
     ConnectionAttempts 1
 

--- a/ssh_error_tests/ssh_config
+++ b/ssh_error_tests/ssh_config
@@ -10,10 +10,10 @@ HOST viaproxy
     StrictHostKeyChecking no
 
 HOST gssapionly
-    GSSAPIAuthentication yes
-    GSSAPIKeyExchange no
     PreferredAuthentications gssapi-with-mic
     StrictHostKeyChecking no
+    GSSAPIAuthentication yes
+    GSSAPIKeyExchange no
     PubkeyAuthentication no
     PasswordAuthentication no
     KbdInteractiveAuthentication no
@@ -41,6 +41,12 @@ HOST tooopen
 HOST passwordonly
     PreferredAuthentications keyboard-interactive,password
     StrictHostKeyChecking no
+    GSSAPIAuthentication no
+    GSSAPIKeyExchange no
+    PubkeyAuthentication no
+    PasswordAuthentication yes
+    KbdInteractiveAuthentication no
+    ChallengeResponseAuthentication no
 
 HOST testhost
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password

--- a/ssh_error_tests/ssh_config
+++ b/ssh_error_tests/ssh_config
@@ -1,13 +1,15 @@
 
 HOST stricthostkey
     PreferredAuthentications publickey
+    PubkeyAuthentication yes
     StrictHostKeyChecking yes
     IdentitiesOnly yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa
 
 HOST viaproxy
    ProxyCommand ssh %r@sshproxyhost -W %h:%p
-    StrictHostKeyChecking no
+   StrictHostKeyChecking no
+   PubkeyAuthentication yes
 
 HOST gssapionly
     PreferredAuthentications gssapi-with-mic
@@ -23,20 +25,30 @@ HOST nokey
     IdentitiesOnly yes
     IdentityFile ~/src/ansible/ssh_error_tests/this_key_doesnt_exist
     PreferredAuthentications publickey
+    PubkeyAuthentication yes
     StrictHostKeyChecking no
 
 HOST emptykey
     IdentitiesOnly yes
     IdentityFile ~/src/ansible/ssh_error_tests/this_key_is_empty
     PreferredAuthentications publickey
+    PubkeyAuthentication yes
     StrictHostKeyChecking no
 
 
-HOST tooopen
+host tooopen
     IdentitiesOnly yes
-    IdentityFile ~/src/ansible/ssh_error_tests/this_key_has_too_open_perms
-    PreferredAuthentications publickey
-    StrictHostKeyChecking no
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost_too_open
+    preferredauthentications publickey
+    pubkeyauthentication yes
+    stricthostkeychecking no
+
+host cantread
+    IdentitiesOnly yes
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost_can_not_read
+    preferredauthentications publickey
+    pubkeyauthentication yes
+    stricthostkeychecking no
 
 HOST passwordonly
     PreferredAuthentications keyboard-interactive,password
@@ -50,14 +62,17 @@ HOST passwordonly
 
 HOST testhost
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     StrictHostKeyChecking no
 
 HOST badalias
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
-    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    PubkeyAuthentication yes
+    #IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     HostKeyAlias name_of_key_that_doesnt_exist
     StrictHostKeyChecking no
+    AddKeysToAgent no
 
 #HOST badcipher
 #    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
@@ -66,6 +81,7 @@ HOST badalias
 
 HOST badcontrolpath
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     ControlPersist yes
     ControlPath ~/a_directory_that_does_not_exist/a_path_that_does_not_exist_%h_%p%r
@@ -73,42 +89,49 @@ HOST badcontrolpath
 
 HOST quiethost
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     LogLevel QUIET
     StrictHostKeyChecking no
 
 HOST fatalhost
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     LogLevel FATAL
     StrictHostKeyChecking no
 
 HOST errorhost
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     LogLevel ERROR
     StrictHostKeyChecking no
 
 HOST infohost
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     LogLevel INFO
     StrictHostKeyChecking no
 
 HOST verbosehost
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     LogLevel VERBOSE
     StrictHostKeyChecking no
 
 HOST debughost
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     LogLevel DEBUG
     StrictHostKeyChecking no
 
 HOST debug2host
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     LogLevel DEBUG2
     StrictHostKeyChecking no
@@ -116,16 +139,25 @@ HOST debug2host
 
 HOST debug3host
     PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
     IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
     LogLevel DEBUG3
     StrictHostKeyChecking no
 
 Host bastion
     ForwardAgent yes
+    PubkeyAuthentication yes
 
 
 HOST *
     HostName localhost
     StrictHostKeyChecking yes
+    IdentitiesOnly yes
     ConnectionAttempts 1
+    GSSAPIAuthentication no
+    GSSAPIKeyExchange no
+    PubkeyAuthentication no
+    PasswordAuthentication no
+    KbdInteractiveAuthentication no
+    ChallengeResponseAuthentication no
 

--- a/ssh_error_tests/ssh_config
+++ b/ssh_error_tests/ssh_config
@@ -1,4 +1,21 @@
 
+HOST cantconnect
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking no
+    # some port that doesn't have ssh listening
+    Port 26951
+    HostName not-a-real-name-asdfadf.example.com
+
+
+HOST namefailure
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    PubkeyAuthentication yes
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking no
+    HostName namefailure
+
 HOST stricthostkey
     PreferredAuthentications publickey
     PubkeyAuthentication yes

--- a/ssh_error_tests/ssh_config
+++ b/ssh_error_tests/ssh_config
@@ -1,0 +1,124 @@
+
+HOST stricthostkey
+    PreferredAuthentications publickey
+    StrictHostKeyChecking yes
+    IdentitiesOnly yes
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa
+
+HOST viaproxy
+   ProxyCommand ssh %r@sshproxyhost -W %h:%p
+    StrictHostKeyChecking no
+
+HOST gssapionly
+    GSSAPIAuthentication yes
+    GSSAPIKeyExchange no
+    PreferredAuthentications gssapi-with-mic
+    StrictHostKeyChecking no
+    PubkeyAuthentication no
+    PasswordAuthentication no
+    KbdInteractiveAuthentication no
+    ChallengeResponseAuthentication no
+
+HOST nokey
+    IdentitiesOnly yes
+    IdentityFile ~/src/ansible/ssh_error_tests/this_key_doesnt_exist
+    PreferredAuthentications publickey
+    StrictHostKeyChecking no
+
+HOST emptykey
+    IdentitiesOnly yes
+    IdentityFile ~/src/ansible/ssh_error_tests/this_key_is_empty
+    PreferredAuthentications publickey
+    StrictHostKeyChecking no
+
+
+HOST tooopen
+    IdentitiesOnly yes
+    IdentityFile ~/src/ansible/ssh_error_tests/this_key_has_too_open_perms
+    PreferredAuthentications publickey
+    StrictHostKeyChecking no
+
+HOST passwordonly
+    PreferredAuthentications keyboard-interactive,password
+    StrictHostKeyChecking no
+
+HOST testhost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking no
+
+HOST badalias
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    HostKeyAlias name_of_key_that_doesnt_exist
+    StrictHostKeyChecking no
+
+#HOST badcipher
+#    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+#    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+#    StrictHostKeyChecking ask
+
+HOST badcontrolpath
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    ControlPersist yes
+    ControlPath ~/a_directory_that_does_not_exist/a_path_that_does_not_exist_%h_%p%r
+    StrictHostKeyChecking no
+
+HOST quiethost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    LogLevel QUIET
+    StrictHostKeyChecking no
+
+HOST fatalhost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    LogLevel FATAL
+    StrictHostKeyChecking no
+
+HOST errorhost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    LogLevel ERROR
+    StrictHostKeyChecking no
+
+HOST infohost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    LogLevel INFO
+    StrictHostKeyChecking no
+
+HOST verbosehost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    LogLevel VERBOSE
+    StrictHostKeyChecking no
+
+HOST debughost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    LogLevel DEBUG
+    StrictHostKeyChecking no
+
+HOST debug2host
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    LogLevel DEBUG2
+    StrictHostKeyChecking no
+
+
+HOST debug3host
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    LogLevel DEBUG3
+    StrictHostKeyChecking no
+
+Host bastion
+    ForwardAgent yes
+
+
+HOST *
+    StrictHostKeyChecking yes
+    ConnectionAttempts 1
+

--- a/ssh_error_tests/ssh_config.py
+++ b/ssh_error_tests/ssh_config.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+# (c) 2014, Tomas Karasek <tomas.karasek@digile.fi>
+#
+# This file is part of Ansible.
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+# Dynamic inventory script which lets you use aliases from ~/.ssh/config.
+#
+# There were some issues with various Paramiko versions. I took a deeper look
+# and tested heavily. Now, ansible parses this alright with Paramiko versions
+# 1.7.2 to 1.15.2.
+#
+# It prints inventory based on parsed ~/.ssh/config. You can refer to hosts
+# with their alias, rather than with the IP or hostname. It takes advantage
+# of the ansible_ssh_{host,port,user,private_key_file}.
+#
+# If you have in your .ssh/config:
+#   Host git
+#       HostName git.domain.org
+#       User tkarasek
+#       IdentityFile /home/tomk/keys/thekey
+#
+#   You can do
+#       $ ansible git -m ping
+#
+# Example invocation:
+#    ssh_config.py --list
+#    ssh_config.py --host <alias>
+
+import argparse
+import os.path
+import sys
+import paramiko
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+# SSH_CONF=/path/to/ssh_config ansible -i ./ssh_config.py
+SSH_CONF = os.environ.get('SSH_CONF', '~/.ssh/config')
+#SSH_CONF = '~/src/ansible/ssh_error_tests/ssh_config'
+
+_key = 'ssh_config'
+
+_ssh_to_ansible = [('user', 'ansible_ssh_user'),
+                  ('hostname', 'ansible_ssh_host'),
+                  ('identityfile', 'ansible_ssh_private_key_file'),
+                  ('port', 'ansible_ssh_port')]
+
+
+def get_config():
+    if not os.path.isfile(os.path.expanduser(SSH_CONF)):
+        return {}
+    with open(os.path.expanduser(SSH_CONF)) as f:
+        cfg = paramiko.SSHConfig()
+        cfg.parse(f)
+        ret_dict = {}
+        for d in cfg._config:
+            if type(d['host']) is list:
+                alias = d['host'][0]
+            else:
+                alias = d['host']
+            if ('?' in alias) or ('*' in alias):
+                continue
+            _copy = dict(d)
+            del _copy['host']
+            if 'config' in _copy:
+                ret_dict[alias] = _copy['config']
+            else:
+                ret_dict[alias] = _copy
+        return ret_dict
+
+
+def print_list():
+    cfg = get_config()
+    meta = {'hostvars': {}}
+    for alias, attributes in cfg.items():
+        tmp_dict = {}
+        for ssh_opt, ans_opt in _ssh_to_ansible:
+            if ssh_opt in attributes:
+                # If the attribute is a list, just take the first element.
+                # Private key is returned in a list for some reason.
+                attr = attributes[ssh_opt]
+                if type(attr) is list:
+                    attr = attr[0]
+                tmp_dict[ans_opt] = attr
+        if tmp_dict:
+            meta['hostvars'][alias] = tmp_dict
+
+    print(json.dumps({_key: list(set(meta['hostvars'].keys())), '_meta': meta}))
+
+
+def print_host(host):
+    cfg = get_config()
+    print(json.dumps(cfg[host]))
+
+
+def get_args(args_list):
+    parser = argparse.ArgumentParser(
+            description='ansible inventory script parsing .ssh/config')
+    mutex_group = parser.add_mutually_exclusive_group(required=True)
+    help_list = 'list all hosts from .ssh/config inventory'
+    mutex_group.add_argument('--list', action='store_true', help=help_list)
+    help_host = 'display variables for a host'
+    mutex_group.add_argument('--host', help=help_host)
+    return parser.parse_args(args_list)
+
+
+def main(args_list):
+
+    args = get_args(args_list)
+    if args.list:
+        print_list()
+    if args.host:
+        print_host(args.host)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/ssh_error_tests/ssh_config_bad_cipher
+++ b/ssh_error_tests/ssh_config_bad_cipher
@@ -1,0 +1,113 @@
+
+HOST stricthostkey
+    PreferredAuthentications publickey
+    StrictHostKeyChecking yes
+    IdentitiesOnly yes
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa
+
+HOST viaproxy
+   ProxyCommand ssh %r@sshproxyhost -W %h:%p
+
+HOST gssapionly
+    GSSAPIAuthentication yes
+    PreferredAuthentications gssapi-with-mic
+
+HOST nokey
+    IdentitiesOnly yes
+    IdentityFile ~/src/ansible/ssh_error_tests/this_key_doesnt_exist
+    PreferredAuthentications publickey
+
+HOST emptykey
+    IdentitiesOnly yes
+    IdentityFile ~/src/ansible/ssh_error_tests/this_key_is_empty
+    PreferredAuthentications publickey
+
+
+HOST tooopen
+    IdentitiesOnly yes
+    IdentityFile ~/src/ansible/ssh_error_tests/this_key_has_too_open_perms
+    PreferredAuthentications publickey
+
+HOST passwordonly
+    PreferredAuthentications keyboard-interactive,password
+
+HOST testhost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+
+HOST badalias
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    HostKeyAlias name_of_key_that_doesnt_exist
+
+HOST badcipher
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    HostKeyAlgorithms rot10,rot11
+
+HOST badcontrolpath
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    ControlPersist yes
+    ControlPath ~/a_directory_that_does_not_exist/a_path_that_does_not_exist_%h_%p%r
+
+HOST quiethost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    LogLevel QUIET
+
+HOST fatalhost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    LogLevel FATAL
+
+HOST errorhost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    LogLevel ERROR
+
+HOST infohost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    LogLevel INFO
+
+HOST verbosehost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    LogLevel VERBOSE
+
+HOST debughost
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    LogLevel DEBUG
+
+HOST debug2host
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    LogLevel DEBUG2
+
+
+HOST debug3host
+    PreferredAuthentications publickey,gssapi-with-mic,keyboard-interactive,password
+    IdentityFile ~/src/ansible/ssh_error_tests/id_rsa_testhost
+    StrictHostKeyChecking ask
+    LogLevel DEBUG3
+
+Host bastion
+    ForwardAgent yes
+
+
+HOST *
+    StrictHostKeyChecking yes
+

--- a/test/units/plugins/connections/test_connection_ssh.py
+++ b/test/units/plugins/connections/test_connection_ssh.py
@@ -288,10 +288,22 @@ class TestConnectionBaseClass(unittest.TestCase):
         # test multiple failures
         conn._exec_command.side_effect = [(255, '', '')]*10
         self.assertRaises(AnsibleConnectionFailure, conn.exec_command, 'ssh', 'some data')
+        
+        # test multiple failures, verify it raise ssh.AnsibleConnectionFailure
+        conn._exec_command.side_effect = [(255, '', '')]*10
+        self.assertRaises(ssh.AnsibleSshConnectionFailure, conn.exec_command, 'ssh', 'some data')
 
         # test other failure from exec_command
         conn._exec_command.side_effect = [Exception('bad')]*10
         self.assertRaises(Exception, conn.exec_command, 'ssh', 'some data')
+        
+        # test other failure from exec_command also raise AnsibleConnectionFailure
+        conn._exec_command.side_effect = [AnsibleConnectionFailure('There was an ansible connection failure')]*10
+        self.assertRaises(AnsibleConnectionFailure, conn.exec_command, 'ssh', 'some data')
+        
+        # test other failure from exec_command also raise ssh.AnsibleSshConnectionFailure
+        conn._exec_command.side_effect = [ssh.AnsibleSshConnectionFailure('There was an ansible ssh connection failure')]*10
+        self.assertRaises(ssh.AnsibleSshConnectionFailure, conn.exec_command, 'ssh', 'some data')
 
     @patch('os.path.exists')
     def test_plugins_connection_ssh_put_file(self, mock_ospe):

--- a/test/units/plugins/connections/test_connection_ssh.py
+++ b/test/units/plugins/connections/test_connection_ssh.py
@@ -22,7 +22,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pipes
-import sys
 from io import StringIO
 
 from ansible.compat.tests import unittest
@@ -33,6 +32,24 @@ from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNo
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.connection import ssh
 from ansible.utils.unicode import to_bytes, to_unicode
+
+ssh_stderr_key_too_open = """
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+Permissions 0666 for '/home/adrian/.ssh/id_rsa' are too open.
+It is required that your private key files are NOT accessible by others.
+This private key will be ignored.
+Load key "/home/adrian/.ssh/id_rsa": bad permissions
+Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
+"""
+
+class TestOpenSshErrorParser(unittest.TestCase):
+    def test_private_key_too_open(self):
+
+        error_parser = ssh.OpenSshErrorParser(stderr=ssh_stderr_key_too_open)
+
+        print(error_parser)
 
 class TestConnectionBaseClass(unittest.TestCase):
 

--- a/test/units/plugins/connections/test_connection_ssh.py
+++ b/test/units/plugins/connections/test_connection_ssh.py
@@ -44,12 +44,21 @@ Load key "/home/adrian/.ssh/id_rsa": bad permissions
 Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
 """
 
+ssh_stderr_could_not_resolve = """
+ssh: Could not resolve hostname noname.g.a: No address associated with hostname
+"""
+
 class TestOpenSshErrorParser(unittest.TestCase):
     def test_private_key_too_open(self):
 
         error_parser = ssh.OpenSshErrorParser(stderr=ssh_stderr_key_too_open)
-
+        self.assertTrue('too_open' in error_parser._matches)
         print(error_parser)
+
+    def test_could_not_resolve(self):
+        error_parser = ssh.OpenSshErrorParser(stderr=ssh_stderr_could_not_resolve)
+        self.assertTrue('could_not_resolve' in error_parser._matches)
+
 
 class TestConnectionBaseClass(unittest.TestCase):
 

--- a/test/units/plugins/connections/test_connection_ssh.py
+++ b/test/units/plugins/connections/test_connection_ssh.py
@@ -48,16 +48,24 @@ ssh_stderr_could_not_resolve = """
 ssh: Could not resolve hostname noname.g.a: No address associated with hostname
 """
 
-class TestOpenSshErrorParser(unittest.TestCase):
+ssh_stderr_no_route_to_host = """
+ssh: connect to host 192.168.1.253 port 22: No route to host
+"""
+
+class TestOpenSshStderrErrorMapper(unittest.TestCase):
     def test_private_key_too_open(self):
 
-        error_parser = ssh.OpenSshErrorParser(stderr=ssh_stderr_key_too_open)
-        self.assertTrue('too_open' in error_parser._matches)
+        error_parser = ssh.OpenSshStderrErrorMapper(stderr=ssh_stderr_key_too_open)
+        self.assertTrue('too_open' in error_parser.warnings)
         print(error_parser)
 
     def test_could_not_resolve(self):
-        error_parser = ssh.OpenSshErrorParser(stderr=ssh_stderr_could_not_resolve)
-        self.assertTrue('could_not_resolve' in error_parser._matches)
+        error_parser = ssh.OpenSshStderrErrorMapper(stderr=ssh_stderr_could_not_resolve)
+        self.assertTrue('could_not_resolve' in error_parser.errors)
+
+    def test_no_route_to_host(self):
+        error_parser = ssh.OpenSshStderrErrorMapper(stderr=ssh_stderr_no_route_to_host)
+        self.assertTrue('no_route_to_host' in error_parser.errors)
 
 
 class TestConnectionBaseClass(unittest.TestCase):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (ssh_connection_stderr_parse_for_error 9c4b6957c9) last updated 2016/07/08 13:33:05 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 799159b8ee) last updated 2016/07/07 18:09:27 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 8502d2595a) last updated 2016/07/07 18:09:27 (GMT -400)
  config file = ssh_error_tests/ansible.cfg
  configured module search path = Default w/o overrides


```
##### SUMMARY

[This is a work in progress, but looking for feedback]

This pr is a change to the ssh connection plugin that tries to improve the quality of error message when ansible fails because of underlying ssh failures.

Currently, when using 'ssh' transport, if the 'ssh' command itself fails in any fashion, the only indicator is a return code of 255. That causes all failures related to ssh config and setup to fail with the same ansible error. Examples include ssh key permission errors, connection errors, name resolution and DNS errors, and any ssh authentication related errors.

However, most of those errors do show some info about the cause of the error on stderr. This pr captures that stderr, and checks it for common errors via regex matches, and then raises exceptions that include additional info.

Changes include:
- Add an assortment of ssh specific AnsibleError subclasses
- Changing ssh plugin to raise those as needed
- Removing '-q' from the default list of args specified to the ssh command. With the -q enabled, ssh will suppress warnings and most errors. We need those errors to figure out what broke.
- misc exception plumbing to take advantage of addition info in the new exceptions.
- some tweaks to display formatting so that debug output is 'unescaped' so that embedded newlines
  and such are expanded when displaying to the console. This isn't critical, but it improves the output a lot.

Things Missing yet:

Any change in the completely unregular, unstructured, undocument, non-standard output of stderr could cause the detailed errors to miss, and potentially, to trigger in cases where they shouldnt.
- The parser is really specific to openssh output.
- The parser is really specific to openssh version.
  (That said, looking at openssh history, those messages haves haven't changed in a long time. They are also not translated or localized).
- Some support for figuring out what version of ssh is in play, and which set of parsing rules to use.
- Add support for multiple parsing rules.
- The stderr message to exception handling isn't as slick as it could be. Basically, needs a clever exception mapper.
- More info could be given to the exceptions on creation, so they can be displayed later.

Other options
- Arguably, looking for error events in the stderr output should be tied into the ssh state machine in ssh.py. The code already parses stdout/stderr for prompts to use to determine the state. The additional failure modes could be part of the state machine.

There is also a ad hoc test framework in ssh_error_tests currently (will eventually move to an integration test). This includes a ssh_config and inventory script that and test play that will connect
to testhost with a variety of ssh options and keys.
