### PR TITLE
 Adding a test for GalaxyCLI and two methods on which it depends. Tests execute_install method.

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -23,6 +23,14 @@ from ansible.compat.six import PY3
 from ansible.compat.tests import unittest
 
 from nose.plugins.skip import SkipTest
+import ansible
+import os
+import shutil
+import tarfile
+
+from mock import patch, call
+
+from ansible.errors import AnsibleError
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -51,3 +59,84 @@ class TestGalaxy(unittest.TestCase):
         display_result = gc._display_role_info(role_info)
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
+
+    def make_tarfile(self, output_file, source_dir):
+        ''' used for making a tarfile from an artificial role directory for testing installation with a local tar.gz file '''
+        # adding directory into a tar file
+        try:
+            tar = tarfile.open(output_file, "w:gz")
+            tar.add(source_dir, arcname=os.path.basename(source_dir))
+        except AttributeError: # tarfile obj. has no attribute __exit__ prior to python 2.7
+            pass
+        finally:  # ensuring closure of tarfile obj
+            tar.close()
+
+    def create_role(self):
+        ''' creates a "role" directory and a requirements file; used for testing installation '''
+        if os.path.exists('./delete_me'):
+            shutil.rmtree('./delete_me')
+
+        # making the directory for the role
+        os.makedirs('./delete_me')
+        os.makedirs('./delete_me/meta')
+
+        # making main.yml for meta folder
+        fd = open("./delete_me/meta/main.yml", "w")
+        fd.write("---\ngalaxy_info:\n  author: 'shertel'\n  company: Ansible\ndependencies: []")
+        fd.close()
+
+        # making the directory into a tar file
+        self.make_tarfile('./delete_me.tar.gz', './delete_me')
+
+        # removing directory
+        shutil.rmtree('./delete_me')
+
+        # creating requirements.yml for installing the role
+        fd = open("./delete_requirements.yml", "w")
+        fd.write("- 'src': './delete_me.tar.gz'\n  'name': 'delete_me'\n  'path': '/etc/ansible/roles'")
+        fd.close()
+
+    def test_execute_install(self):
+        ### testing insufficient information; no role name ###
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["-c", "-v"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.cli.CLI, "run"):  # eliminate config file message
+            self.assertRaises(AnsibleError, gc.run)
+
+        ### tests installing a role with a local tar file ###
+        # creating a tar.gz file for a fake role
+        self.create_role()
+
+        # installing role (also, removes tar.gz file)
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["--offline", "-r", "delete_requirements.yml"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display") as mock_obj:
+            super(GalaxyCLI, gc).run()
+            gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+            completed_task = gc.execute_install()
+
+            # testing correct installation
+            calls = [call('- extracting delete_me to /etc/ansible/roles/delete_me'), call('- delete_me was installed successfully')]
+            mock_obj.assert_has_calls(calls)
+            self.assertTrue(completed_task == 0)
+
+        # deleting role
+        gc.args = ["remove"]
+        with patch('sys.argv', ["-c", "delete_me"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display") as mock_obj:
+            gc.run()
+
+        # cleaning up requirements file
+        if os.path.isfile("delete_requirements.yml"):
+            os.remove("delete_requirements.yml")
+
+        # cleaning up tar.gz file
+        if os.path.exists("./delete_me.tar.gz"):
+            os.remove("./delete_me.tar.gz")
+
+        ### tests downloading a role from ansible-galaxy ###
+        # TODO/FIXME
+


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This tests the execute_install method which installs a role given a local tar.gz file containing necessary data. My test would be more thorough if I tested installing a role from galaxy.ansible.com, but I am not sure if there is a good solution for that yet (the platform of the tester needs to be determined and an role searched for). I included a # TODO comment in my code so the possibility of improving this test isn't overlooked in the future.
Like my test for execute_info (see #16647) the execute_install method needs to setup a local tar.gz file for installing a role. The two methods this test relies on are the same as the two that my test for execute_info require.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_install (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.024s

OK
```
